### PR TITLE
Test wallet after reorgs (for review)

### DIFF
--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -288,7 +288,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			return tasks.Select(b => b.GetAwaiter().GetResult()).ToArray();
 		}
 
-		public async Task<Block[]> GenerateEmptyBlocks(int height, BitcoinAddress minerAddress, int blockCount)
+		public async Task<Block[]> GenerateEmptyBlocksAsync(int height, BitcoinAddress minerAddress, int blockCount)
 		{
 			var rpc = CreateRpcClient();
 			var bestBlock = await rpc.GetBlockAsync(height);
@@ -321,7 +321,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			return blocks.ToArray();
 		}
 
-		public async Task<Block[]> GenerateEmptyBlock(int height, BitcoinAddress minerAddress, int blockCount)
+		public async Task<Block[]> GenerateEmptyBlockAsync(int height, BitcoinAddress minerAddress, int blockCount)
 		{
 			var now = DateTimeOffset.UtcNow;
 			var rpc = CreateRpcClient();

--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -294,11 +294,12 @@ namespace WalletWasabi.Tests.NodeBuilding
 			var bestBlock = await rpc.GetBlockAsync(height);
 			ConcurrentChain chain = null;
 			var blocks = new List<Block>();
-			var now = MockTime == null ? DateTimeOffset.UtcNow : MockTime.Value;
+			var now = MockTime ?? DateTimeOffset.UtcNow;
 			using(var node = CreateNodeClient())
 			{
 				node.VersionHandshake();
-				chain = node.GetChain();
+				chain = node.GetChain(bestBlock.Header.GetHash());
+
 				for(var i = 0; i < blockCount; i++)
 				{
 					uint nonce = 0;

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1172,7 +1172,7 @@ namespace WalletWasabi.Tests
 			var wallet = new WalletService(keyManager, indexDownloader, memPoolService, nodes, blocksFolderPath);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
-			Assert.Equal(0, wallet.Coins.Count);
+			Assert.Empty(wallet.Coins);
 
 			// Generate script
 			var scp = new Key().ScriptPubKey;
@@ -1198,7 +1198,7 @@ namespace WalletWasabi.Tests
 				{
 					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
 				}
-				Assert.Equal(1, wallet.Coins.Count);
+				Assert.Single(wallet.Coins);
 
 				// Send money before reorg.
 				var operations = new[]{

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1236,7 +1236,7 @@ namespace WalletWasabi.Tests
 				// Test synchronization after fork with different transactions.
 				// Create a fork that invalidates the blocks containing the funding transaction
 				_filtersProcessedByWalletCount = 0;
-				var winningFork = await RegTestFixture.BackendRegTestNode.GenerateEmptyBlocks(100,
+				var winningFork = await RegTestFixture.BackendRegTestNode.GenerateEmptyBlocksAsync(100,
 					new Key().PubKey.GetAddress(Global.RpcClient.Network), 10);
 
 				tip = await Global.RpcClient.GetBestBlockHashAsync();


### PR DESCRIPTION
@nopara73 could you please take a look at this test? I'm not sure if i am understanding well here but i think after we have a fork, the wallet's coins in the now orphan chain should not be in the `Wallet.Coins` collection.

This test does the following:

1. Creates a chain with 102 blocks.  In the block 102 we send 1 BTC to our wallet and so, it is listed in the `Wallet.Coins` collection 
```
98 ---> 99 ---> 100 ---> 101 ---> 102 (coin)
```

2. Creates a larger (and more difficult) chain of 10 blocks from block 100, this is a fork.
```
98 ---> 99  ---> 100 ---> 101 ---> 102 (coin)    // this is orphan
                           \
                             + ---> 101 ---> 102 ---> 103 ---> .... ---> 110
```

After this, the wallet still contains the coin in the orphan chain. Probably that coin should go back to the mempool (i'm not sure) but the wallet says that coin is confirmed when it is not in the current chain. Am I understanding this right?