### PR TITLE
Uses class name instead of fullyqualified name

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -192,7 +192,7 @@ namespace WalletWasabi.Logging
             }
         }
 
-        private static void Log<T>(LogLevel level, string message) => Log(level, message, typeof(T).ToString());
+        private static void Log<T>(LogLevel level, string message) => Log(level, message, typeof(T).Name);
 
 		#endregion
 


### PR DESCRIPTION
That's how a log entry looks now:

```
2018-04-13 04:58:45Z INFO IndexDownloader: Downloaded filters for blocks from 101 to 102.
```