### PR TITLE
Test wallet after reorgs - Fixed

### DIFF
--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -288,7 +288,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			return tasks.Select(b => b.GetAwaiter().GetResult()).ToArray();
 		}
 
-		public async Task<Block[]> GenerateEmptyBlocks(int height, BitcoinAddress minerAddress, int blockCount)
+		public async Task<Block[]> GenerateEmptyBlocksAsync(int height, BitcoinAddress minerAddress, int blockCount)
 		{
 			var rpc = CreateRpcClient();
 			var bestBlock = await rpc.GetBlockAsync(height);
@@ -321,7 +321,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			return blocks.ToArray();
 		}
 
-		public async Task<Block[]> GenerateEmptyBlock(int height, BitcoinAddress minerAddress, int blockCount)
+		public async Task<Block[]> GenerateEmptyBlockAsync(int height, BitcoinAddress minerAddress, int blockCount)
 		{
 			var now = DateTimeOffset.UtcNow;
 			var rpc = CreateRpcClient();

--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -294,11 +294,12 @@ namespace WalletWasabi.Tests.NodeBuilding
 			var bestBlock = await rpc.GetBlockAsync(height);
 			ConcurrentChain chain = null;
 			var blocks = new List<Block>();
-			var now = MockTime == null ? DateTimeOffset.UtcNow : MockTime.Value;
+			var now = MockTime ?? DateTimeOffset.UtcNow;
 			using(var node = CreateNodeClient())
 			{
 				node.VersionHandshake();
-				chain = node.GetChain();
+				chain = node.GetChain(bestBlock.Header.GetHash());
+
 				for(var i = 0; i < blockCount; i++)
 				{
 					uint nonce = 0;

--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -287,63 +287,6 @@ namespace WalletWasabi.Tests.NodeBuilding
 			rpc.SendBatch();
 			return tasks.Select(b => b.GetAwaiter().GetResult()).ToArray();
 		}
-
-		public async Task<Block[]> GenerateEmptyBlocksAsync(int height, BitcoinAddress minerAddress, int blockCount)
-		{
-			var rpc = CreateRpcClient();
-			var bestBlock = await rpc.GetBlockAsync(height);
-			ConcurrentChain chain = null;
-			var blocks = new List<Block>();
-			var now = MockTime ?? DateTimeOffset.UtcNow;
-			using(var node = CreateNodeClient())
-			{
-				node.VersionHandshake();
-				chain = node.GetChain(bestBlock.Header.GetHash());
-
-				for(var i = 0; i < blockCount; i++)
-				{
-					uint nonce = 0;
-					var block = rpc.Network.Consensus.ConsensusFactory.CreateBlock();
-					block.Header.HashPrevBlock = chain.Tip.HashBlock;
-					block.Header.Bits = block.Header.GetWorkRequired(rpc.Network, chain.Tip);
-					block.Header.UpdateTime(now, rpc.Network, chain.Tip);
-					var coinbase = new Transaction();
-					coinbase.AddInput(TxIn.CreateCoinbase(chain.Height + 1));
-					coinbase.AddOutput(new TxOut(rpc.Network.GetReward(chain.Height + 1), minerAddress));
-					block.AddTransaction(coinbase);
-					block.UpdateMerkleRoot();
-					while(!block.CheckProofOfWork())
-						block.Header.Nonce = ++nonce;
-					blocks.Add(block);
-					chain.SetTip(block.Header);
-				}
-				BroadcastBlocks(blocks.ToArray(), node);
-			}
-			return blocks.ToArray();
-		}
-
-		public async Task<Block[]> GenerateEmptyBlockAsync(int height, BitcoinAddress minerAddress, int blockCount)
-		{
-			var now = DateTimeOffset.UtcNow;
-			var rpc = CreateRpcClient();
-			var curBlock = await rpc.GetBlockAsync(height);
-			
-			var blocks = new List<Block>(blockCount);
-			
-			for (var i = 0; i < blockCount; i++)
-			{
-				var prevBlock = curBlock;
-				var blockTime = now + TimeSpan.FromMinutes(i + 1);
-				curBlock = curBlock.CreateNextBlockWithCoinbase(minerAddress, height + i + 1, blockTime);
-				curBlock.Header.Bits = curBlock.Header.GetWorkRequired(rpc.Network, new ChainedBlock(prevBlock.Header, height + i + 1));
-
-				MineBlock(curBlock);
-				blocks.Add(curBlock);
-			}
-
-			BroadcastBlocks(blocks);
-			return blocks.ToArray();
-		}
 		
 		private List<uint256> _toMalleate = new List<uint256>();
 		public void Malleate(uint256 txId)

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1172,7 +1172,7 @@ namespace WalletWasabi.Tests
 			var wallet = new WalletService(keyManager, indexDownloader, memPoolService, nodes, blocksFolderPath);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
-			Assert.Equal(0, wallet.Coins.Count);
+			Assert.Empty(wallet.Coins);
 
 			// Generate script
 			var scp = new Key().ScriptPubKey;
@@ -1198,7 +1198,7 @@ namespace WalletWasabi.Tests
 				{
 					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
 				}
-				Assert.Equal(1, wallet.Coins.Count);
+				Assert.Single(wallet.Coins);
 
 				// Send money before reorg.
 				var operations = new[]{

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1236,7 +1236,7 @@ namespace WalletWasabi.Tests
 				// Test synchronization after fork with different transactions.
 				// Create a fork that invalidates the blocks containing the funding transaction
 				_filtersProcessedByWalletCount = 0;
-				var winningFork = await RegTestFixture.BackendRegTestNode.GenerateEmptyBlocks(100,
+				var winningFork = await RegTestFixture.BackendRegTestNode.GenerateEmptyBlocksAsync(100,
 					new Key().PubKey.GetAddress(Global.RpcClient.Network), 10);
 
 				tip = await Global.RpcClient.GetBestBlockHashAsync();

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1241,12 +1241,9 @@ namespace WalletWasabi.Tests
 				// Test synchronization after fork with different transactions.
 				// Create a fork that invalidates the blocks containing the funding transaction
 				_filtersProcessedByWalletCount = 0;
-				var bc1 = Global.RpcClient.GetBlockCount();
 				await Global.RpcClient.InvalidateBlockAsync(baseTip);
-				var bc2 = Global.RpcClient.GetBlockCount();
 				await Global.RpcClient.SendCommandAsync("abandontransaction", fundingTxid.ToString());
 				await Global.RpcClient.GenerateAsync(10);
-				var bc3 = Global.RpcClient.GetBlockCount();
 				await WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 10);
 
 				var curBlockHash = await Global.RpcClient.GetBestBlockHashAsync();

--- a/WalletWasabi.Tests/SmartModelTests.cs
+++ b/WalletWasabi.Tests/SmartModelTests.cs
@@ -33,16 +33,16 @@ namespace WalletWasabi.Tests
 			var height = Height.MemPool;
 			var label = "foo";
 
-			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, label, txId);
+			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, label, txId);
 			// If the txid or the index differs, equality should think it's a different coin.
-			var differentCoin = new SmartCoin(txId, index + 1, scriptPubKey, amount, spentOutputs, height, label, txId);
+			var differentCoin = new SmartCoin(txId, index + 1, scriptPubKey, amount, spentOutputs, height, tx.RBF, label, txId);
 			var differentOutput = tx.Outputs[1];
 			var differentSpentOutputs = new[]
 			{
 				new TxoRef(txId, 0)
 			};
 			// If the txid and the index is the same, equality should think it's the same coin.
-			var sameCoin = new SmartCoin(txId, index, differentOutput.ScriptPubKey, differentOutput.Value, differentSpentOutputs, Height.Unknown, "boo", null);
+			var sameCoin = new SmartCoin(txId, index, differentOutput.ScriptPubKey, differentOutput.Value, differentSpentOutputs, Height.Unknown, tx.RBF, "boo", null);
 
 			Assert.Equal(coin, sameCoin);
 			Assert.NotEqual(coin, differentCoin);
@@ -61,7 +61,7 @@ namespace WalletWasabi.Tests
 			var height = Height.MemPool;
 			var label = "foo";
 
-			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, label, txId);
+			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, label, txId);
 
 			var serialized = JsonConvert.SerializeObject(coin);
 			Debug.WriteLine(serialized);

--- a/WalletWasabi/Converters/FunnyBoolConverter.cs
+++ b/WalletWasabi/Converters/FunnyBoolConverter.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Converters
+{
+	public class FunnyBoolConverter : JsonConverter
+	{
+		/// <inheritdoc />
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(bool);
+		}
+
+		/// <inheritdoc />
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			// check additional strings those are not checked by GetNetwork
+			string canSpendUnconfirmedString = ((string)reader.Value).Trim();
+			if ("true".Equals(canSpendUnconfirmedString, StringComparison.OrdinalIgnoreCase)
+				|| "yes".Equals(canSpendUnconfirmedString, StringComparison.OrdinalIgnoreCase)
+				|| "fuckyeah".Equals(canSpendUnconfirmedString, StringComparison.OrdinalIgnoreCase)
+				|| "1" == canSpendUnconfirmedString)
+				return true;
+			if ("false".Equals(canSpendUnconfirmedString, StringComparison.OrdinalIgnoreCase)
+				|| "no".Equals(canSpendUnconfirmedString, StringComparison.OrdinalIgnoreCase)
+				|| "nah".Equals(canSpendUnconfirmedString, StringComparison.OrdinalIgnoreCase)
+				|| "0" == canSpendUnconfirmedString)
+				return false;
+
+			return bool.Parse(canSpendUnconfirmedString);
+		}
+
+		/// <inheritdoc />
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(((bool)value).ToString());
+		}
+	}
+}

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -45,11 +45,15 @@ namespace WalletWasabi.Models
 		[JsonProperty(Order = 8)]
 		public TxoRef[] SpentOutputs { get; }
 
+		[JsonProperty(Order = 9)]
+		[JsonConverter(typeof(FunnyBoolConverter))]
+		public bool RBF { get; }
+
 		public bool Unspent => SpenderTransactionId == null;
 		public bool Confirmed => Height != Height.MemPool && Height != Height.Unknown;
 
 		[JsonConstructor]
-		public SmartCoin(uint256 transactionId, int index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, string label = "", uint256 spenderTransactionId = null)
+		public SmartCoin(uint256 transactionId, int index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, string label = "", uint256 spenderTransactionId = null)
 		{
 			TransactionId = Guard.NotNull(nameof(transactionId), transactionId);
 			Index = Guard.NotNull(nameof(index), index);
@@ -59,6 +63,7 @@ namespace WalletWasabi.Models
 			Height = height;
 			Label = Guard.Correct(label);
 			SpenderTransactionId = spenderTransactionId;
+			RBF = rbf;
 		}
 
 		public Coin ToCoin()

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -253,68 +253,83 @@ namespace WalletWasabi.Services
 
 		private void ProcessTransaction(SmartTransaction tx, List<HdPubKey> keys = null)
 		{
+			//iterate tx
+			//	if already have the coin
+			//		if NOT mempool
+			//			update height
+
+			//if double spend
+			//	if mempool
+			//		if all double spent coins are mempool and RBF
+			//			remove double spent coins(if other coin spends it, remove that too and so on) // will add later if they came to our keys
+			//		else 
+			//			return
+			//	else // new confirmation always enjoys priority
+			//		remove double spent coins recursively(if other coin spends it, remove that too and so on)// will add later if they came to our keys
+
+			//iterate tx
+			//	if came to our keys
+			//		add coin
+
 			// If key list is not provided refresh the key list.
 			if (keys == null)
 			{
 				keys = KeyManager.GetKeys().ToList();
-			}
+			}			
 
-			// Check double spending tx (invalid transactions has to be rejected)
-			var spentTxOuts = Coins.SelectMany(x=>x.SpentOutputs);
-			var txSpendingOutputs = tx.Transaction.Inputs.ToTxoRefs();
-
-			var alreadySpentOutputs = spentTxOuts.Intersect(txSpendingOutputs).ToArray();
-
-			// if the received tx spends any already-spent outputs and this is a RBF tx 
-			// then remove the coins in order to replace them for those in the new tx (RBF) 
-			if (alreadySpentOutputs.Any())
-			{
-				if (tx.Transaction.RBF)
-				{
-					foreach (var spentOutput in alreadySpentOutputs)
-					{
-						var coinsToreplace = Coins.Where(x => x.SpentOutputs.Contains(spentOutput)).ToArray();
-						for (var j = 0; j < coinsToreplace.Length; j++)
-						{
-							if (!Coins.TryRemove(coinsToreplace[j]))
-							{
-								// what here? retry?
-							}
-						}
-					}
-				}
-				else // tx is double spending at least one output
-				{
-					// just discard it
-					return;
-				}
-			}
-			
-			// If transaction received to any of the wallet keys:
 			for (var i = 0; i < tx.Transaction.Outputs.Count; i++)
 			{
+				// If we already had it, just update the height. Maybe got from mempool to block or reorged.
+				var foundCoin = Coins.SingleOrDefault(x => x.TransactionId == tx.GetHash() && x.Index == i);
+				if (foundCoin != default)
+				{
+					// If tx height is mempool then don't, otherwise update the height.
+					if (tx.Height != Height.MemPool)
+					{
+						foundCoin.Height = tx.Height;
+					}
+				}
+			}
+
+			// If double spend:
+			IEnumerable<SmartCoin> doubleSpends = Coins.Where(x => tx.Transaction.Inputs.Any(y => x.SpentOutputs.Select(z => z.ToOutPoint()).Contains(y.PrevOut)));
+			if(doubleSpends.Count() > 0)
+			{
+				if (tx.Height == Height.MemPool)
+				{
+					// if all double spent coins are mempool and RBF
+					if (doubleSpends.All(x => x.Height == Height.MemPool && x.RBF))
+					{
+						// remove double spent coins(if other coin spends it, remove that too and so on) // will add later if they came to our keys
+						foreach (var doubleSpentCoin in doubleSpends)
+						{
+							RemoveCoinRecursively(doubleSpentCoin);
+						}
+					}
+					else
+					{
+						return;
+					}
+				}
+				else // new confirmation always enjoys priority
+				{
+					// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
+					foreach(var doubleSpentCoin in doubleSpends)
+					{
+						RemoveCoinRecursively(doubleSpentCoin);
+					}
+				}
+			}
+
+			for (var i = 0; i < tx.Transaction.Outputs.Count; i++)
+			{
+				// If transaction received to any of the wallet keys:
 				var output = tx.Transaction.Outputs[i];
 				HdPubKey foundKey = keys.SingleOrDefault(x => x.GetP2wpkhScript() == output.ScriptPubKey);
 				if (foundKey != default)
 				{
-					// If we already had it, just update the height. Maybe got from mempool to block or reorged.
-					var foundCoin = Coins.SingleOrDefault(x => x.TransactionId == tx.GetHash() && x.Index == i);
-					if (foundCoin != default)
-					{
-						// If tx height is mempool then don't, otherwise update the height.
-						if (tx.Height == Height.MemPool)
-						{
-							continue;
-						}
-						else
-						{
-							foundCoin.Height = tx.Height;
-							continue;
-						}
-					}
-					
 					foundKey.KeyState = KeyState.Used;
-					var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, foundKey.Label, null);
+					var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.Transaction.RBF, foundKey.Label, null);
 					Coins.Add(coin);
 
 					// Make sure there's always 21 clean keys generated and indexed.
@@ -725,7 +740,7 @@ namespace WalletWasabi.Services
 			for (var i = 0; i < tx.Outputs.Count; i++)
 			{
 				TxOut output = tx.Outputs[i];
-				var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, spentOutputs, Height.Unknown);
+				var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, spentOutputs, Height.Unknown, tx.RBF);
 				if (KeyManager.GetKeys(KeyState.Clean).Select(x => x.GetP2wpkhScript()).Contains(coin.ScriptPubKey))
 				{
 					coin.Label = changeLabel;


### PR DESCRIPTION
This PR aims to fix this PR: https://github.com/zkSNACKs/WalletWasabi/pull/152

There was 2 problems.  

### 1. More complex algo was needed

Originally the coin list was updated like this:
```
iterate tx
	if came to our keys
		if already have the coin
			if mempool
				continue
			else
				update height
				continue
		else 
			add coin
```

The new algo to update the coinlist is this:

```
iterate tx
	if already have the coin
		if NOT mempool
			update height
			
if double spend
	if mempool
		if all double spent coins are mempool and RBF
			remove double spent coins (if other coin spends it, remove that too and so on) // will add later if they came to our keys
		else 
			return
	else // new confirmation always enjoys priority
		remove double spent coins recursively (if other coin spends it, remove that too and so on)// will add later if they came to our keys

iterate tx
	if came to our keys
		add coin
```

### Generate empty blocks function was buggy

Tests were running one by one, but not together. What's the problem?  
I figured tests were running in these order:
```
1. Reorg test - PASS

1. Validations test - PASS
2. Reorg test - FAIL

1. Wallet test - PASS
2. Reorg test - FAIL

1. Wallet test - PASS
2. Reorg test - FAIL
3. Send test - FAIL

1. Reorg test - PASS
2. Send test - PASS
```

Therefore the reorg test caused the problem.
I checked RPC block counts before and after the empty blocks were created and it turned out empty blocks were not created if another test was run previously.

```
Block counts if a test comes before it:
106
102
102

Block counts test in itself:
104
100
110
```

Removed Nicolas's generate empty blocks and solved it without that, because that had a bug, which caused all this.