### PR TITLE
Fix chaumian coinjoin controller test

### DIFF
--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1679,9 +1679,9 @@ namespace WalletWasabi.Tests
 					Assert.Equal(1, status.RegisteredPeerCount);
 				}
 
-				var blindingKey = new BlindingRsaKey();
+				var blindingPubKey = Global.RsaKey.PubKey;
 				byte[] scriptHash = HashHelpers.GenerateSha256Hash(key.ScriptPubKey.ToBytes());
-				var (BlindingFactor, BlindedData) = blindingKey.PubKey.Blind(scriptHash);
+				var (BlindingFactor, BlindedData) = blindingPubKey.Blind(scriptHash);
 				request.BlindedOutputHashHex = ByteHelpers.ToHex(BlindedData);
 				proof = key.SignMessage(request.BlindedOutputHashHex);
 				request.Inputs.First().Proof = proof;


### PR DESCRIPTION
This fixes the #169 issue. The crypto is okay but the test was doing it wrong. The client (in this case, the test) has to blind the message using the pubkey corresponding to the server privkey otherwise it wll fail at the end of the process. It used to fail randomly because from time to time the blinded message generated by the client was out of the server privkey finite field (blindeddata > server_priv_key_module)