### PR TITLE
Simplify http calls backend

### DIFF
--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.Tests
 			while (true)
 			{
 				using (var torClient = new TorHttpClient(new Uri(RegTestFixture.BackendEndPoint)))
-				using (var client = new WasabiClient(torClient))
+				using (var client = new WasabiApiClient(torClient))
 				{
 					var filters = await client.GetFiltersAsync(firstHash, 200);
 					var filterCount = filters.Count();
@@ -106,7 +106,7 @@ namespace WalletWasabi.Tests
 
 			Logger.TurnOff();
 			using (var torClient = new TorHttpClient(new Uri(RegTestFixture.BackendEndPoint)))
-			using (var client = new WasabiClient(torClient))
+			using (var client = new WasabiApiClient(torClient))
 			{
 				var ex = await Assert.ThrowsAsync<HttpRequestException>(async ()=>await client.BroadcastAsync(signedTx));
 				Assert.EndsWith("relay fee not met", ex.Message);
@@ -124,7 +124,7 @@ namespace WalletWasabi.Tests
 
 			Logger.TurnOff();
 			using (var torClient = new TorHttpClient(new Uri(RegTestFixture.BackendEndPoint)))
-			using (var client = new WasabiClient(torClient))
+			using (var client = new WasabiApiClient(torClient))
 			{
 //				Assert.Equal("Transaction is already in the blockchain.", await response.Content.ReadAsJsonAsync<string>());
 				await client.BroadcastAsync(tx);
@@ -137,7 +137,7 @@ namespace WalletWasabi.Tests
 		{
 			Logger.TurnOff();
 			using (var torClient = new TorHttpClient(new Uri(RegTestFixture.BackendEndPoint)))
-			using (var client = new WasabiClient(torClient))
+			using (var client = new WasabiApiClient(torClient))
 			{
 				try
 				{
@@ -1488,7 +1488,7 @@ namespace WalletWasabi.Tests
 			coordinator.FailAllRoundsInInputRegistration();			
 
 			using (var torClient = new TorHttpClient(new Uri(RegTestFixture.BackendEndPoint)))
-			using (var client = new WasabiClient(torClient))
+			using (var client = new WasabiApiClient(torClient))
 			{
 				#region PostInputsGetStates
 				// <-------------------------->

--- a/WalletWasabi/Extensions/HttpContentExtensions.cs
+++ b/WalletWasabi/Extensions/HttpContentExtensions.cs
@@ -10,6 +10,9 @@ namespace System.Net.Http
     {
 		public static async Task<T> ReadAsJsonAsync<T>(this HttpContent me)
 		{
+			if(me == null)
+				return default(T);
+				
 			var jsonString = await me.ReadAsStringAsync();
 			return JsonConvert.DeserializeObject<T>(jsonString);
 		}

--- a/WalletWasabi/Services/IndexDownloader.cs
+++ b/WalletWasabi/Services/IndexDownloader.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Services
 
 		public TorHttpClient TorClient { get; }
 
-		public WasabiClient Client { get; }
+		public WasabiApiClient Client { get; }
 
 		public string IndexFilePath { get; }
 		private List<FilterModel> Index { get; }
@@ -71,7 +71,7 @@ namespace WalletWasabi.Services
 		{
 			Network = Guard.NotNull(nameof(network), network);
 			TorClient = new TorHttpClient(indexHostUri, torSocks5EndPoint, isolateStream: false);
-			Client = new WasabiClient(TorClient);
+			Client = new WasabiApiClient(TorClient);
 			IndexFilePath = Guard.NotNullOrEmptyOrWhitespace(nameof(indexFilePath), indexFilePath);
 
 			Index = new List<FilterModel>();

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -586,7 +586,7 @@ namespace WalletWasabi.Services
 			Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
 			Money feePerBytes = null;
 			using (var torClient = new TorHttpClient(IndexDownloader.TorClient.DestinationUri, IndexDownloader.TorClient.TorSocks5EndPoint, isolateStream: true))
-			using (var client = new WasabiClient( torClient ))
+			using (var client = new WasabiApiClient( torClient ))
 			{
 				feePerBytes = (await client.GetFeePerByteAsync(feeTarget)).Single();
 			}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -19,6 +19,7 @@ using NBitcoin;
 using NBitcoin.Policy;
 using NBitcoin.Protocol;
 using Nito.AsyncEx;
+using WalletWasabi.WebClients;
 
 namespace WalletWasabi.Services
 {
@@ -584,17 +585,10 @@ namespace WalletWasabi.Services
 			// 4. Get and calculate fee
 			Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
 			Money feePerBytes = null;
-			using (var torClient = new TorHttpClient(IndexDownloader.Client.DestinationUri, IndexDownloader.Client.TorSocks5EndPoint, isolateStream: true))
-			using (var response = await torClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v1/btc/blockchain/fees/{feeTarget}"))
+			using (var torClient = new TorHttpClient(IndexDownloader.TorClient.DestinationUri, IndexDownloader.TorClient.TorSocks5EndPoint, isolateStream: true))
+			using (var client = new WasabiClient( torClient ))
 			{
-				if (response.StatusCode != HttpStatusCode.OK)
-					throw new HttpRequestException($"Couldn't query network fees. Reason: {response.StatusCode.ToReasonString()}");
-
-				using (var content = response.Content)
-				{
-					var json = await content.ReadAsJsonAsync<SortedDictionary<int, FeeEstimationPair>>();
-					feePerBytes = new Money(json.Single().Value.Conservative);
-				}
+				feePerBytes = (await client.GetFeePerByteAsync(feeTarget)).Single();
 			}
 
 			bool spendAll = spendAllCount == 1;
@@ -793,7 +787,7 @@ namespace WalletWasabi.Services
 
 		public async Task SendTransactionAsync(SmartTransaction transaction)
 		{
-			using (var torClient = new TorHttpClient(IndexDownloader.Client.DestinationUri, IndexDownloader.Client.TorSocks5EndPoint, isolateStream: true))
+			using (var torClient = new TorHttpClient(IndexDownloader.TorClient.DestinationUri, IndexDownloader.TorClient.TorSocks5EndPoint, isolateStream: true))
 			using (var content = new StringContent($"'{transaction.Transaction.ToHex()}'", Encoding.UTF8, "application/json"))
 			using (var response = await torClient.SendAsync(HttpMethod.Post, "/api/v1/btc/blockchain/broadcast", content))
 			{

--- a/WalletWasabi/WebClients/WasabiApiClient.cs
+++ b/WalletWasabi/WebClients/WasabiApiClient.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using NBitcoin;
+using Newtonsoft.Json;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Requests;
 using WalletWasabi.Backend.Models.Responses;
@@ -79,6 +81,18 @@ namespace WalletWasabi.WebClients
 			}
         }
 
+        public async Task RegisterOutputAsync(string roundHash, OutputRequest request)
+        {
+			using (var response = await _torClient.SendAsync(HttpMethod.Post, $"/api/v1/btc/chaumiancoinjoin/output?roundHash={roundHash}", request.ToHttpStringContent()))
+			{
+				if (!response.IsSuccessStatusCode)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message);
+                }
+			}
+        }
+
         public async Task<IEnumerable<CcjRunningRoundState>> GetStatesAsync()
         {
 			using (var response = await _torClient.SendAsync(HttpMethod.Get, "/api/v1/btc/chaumiancoinjoin/states/"))
@@ -108,6 +122,40 @@ namespace WalletWasabi.WebClients
 					return string.Empty;
 
 				return await response.Content.ReadAsJsonAsync<string>();
+			}
+        }
+
+        public async Task<Transaction> CoinJoin(Guid uid, long roundId)
+        {
+			var queryString = $"/api/v1/btc/chaumiancoinjoin/coinjoin?uniqueId={uid}&roundId={roundId}";
+
+			using (var response = await _torClient.SendAsync(HttpMethod.Get, queryString))
+			{
+				if (!response.IsSuccessStatusCode)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message ?? string.Empty);
+                }
+
+				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
+				return new Transaction(coinjoinHex);
+			}
+        }
+
+        public async Task Signature(Guid uid, long roundId, IDictionary<int, TxIn> inputs )
+        {
+			var queryString = $"/api/v1/btc/chaumiancoinjoin/signatures?uniqueId={uid}&roundId={roundId}";
+			var inputsToSign =	inputs.ToDictionary(x=>x.Key, y=>y.Value.WitScript.ToString());
+			var json = JsonConvert.SerializeObject(inputsToSign, Formatting.None);
+			var requestBody = new StringContent(json, Encoding.UTF8, "application/json");
+			
+			using (var response = await _torClient.SendAsync(HttpMethod.Post, queryString, requestBody))
+			{
+				if (!response.IsSuccessStatusCode)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message ?? string.Empty);
+                }
 			}
         }
 

--- a/WalletWasabi/WebClients/WasabiApiClient.cs
+++ b/WalletWasabi/WebClients/WasabiApiClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -13,11 +13,11 @@ using WalletWasabi.TorSocks5;
 
 namespace WalletWasabi.WebClients
 {
-    public class WasabiClient : IDisposable
+    public class WasabiApiClient : IDisposable
     {
         public readonly TorHttpClient _torClient;
 
-        public WasabiClient(TorHttpClient torClient)
+        public WasabiApiClient(TorHttpClient torClient)
         {
             _torClient = torClient;
         }

--- a/WalletWasabi/WebClients/WasabiClient.cs
+++ b/WalletWasabi/WebClients/WasabiClient.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Backend.Models;
+using WalletWasabi.Backend.Models.Requests;
+using WalletWasabi.Backend.Models.Responses;
+using WalletWasabi.Services;
+using WalletWasabi.TorSocks5;
+
+namespace WalletWasabi.WebClients
+{
+    public class WasabiClient : IDisposable
+    {
+        public readonly TorHttpClient _torClient;
+
+        public WasabiClient(TorHttpClient torClient)
+        {
+            _torClient = torClient;
+        }
+
+        public async Task<IEnumerable<Money>> GetFeePerByteAsync(params int[] confirmationTargets)
+        {
+            var ct = string.Join(",", confirmationTargets);
+			using (var response = await _torClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v1/btc/blockchain/fees/{ct}"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+					throw new HttpRequestException($"Couldn't query network fees. Reason: {response.StatusCode.ToReasonString()}");
+
+				using (var content = response.Content)
+				{
+					var json = await content.ReadAsJsonAsync<SortedDictionary<int, FeeEstimationPair>>();
+					return json.Select(x=> Money.Satoshis(x.Value.Conservative));
+				}
+			}
+        }
+
+        public async Task<IEnumerable<string>> GetFiltersAsync(uint256 bestKnownBlockHash, int count)
+        {
+			using (var response = await _torClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v1/btc/blockchain/filters/{bestKnownBlockHash}"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+					throw new HttpRequestException($"Couldn't query network fees. Reason: {response.StatusCode.ToReasonString()}");
+
+				using (var content = response.Content)
+				{
+					var json = await content.ReadAsJsonAsync<List<string>>();
+					return json.Select(x=>x);
+				}
+			}
+        }
+
+        public async Task BroadcastAsync(Transaction tx)
+        {
+            var content = new StringContent($"'{tx.ToHex()}'", System.Text.Encoding.UTF8, "application/json");
+			using (var response = await _torClient.SendAsync(HttpMethod.Post, $"/api/v1/btc/blockchain/broadcast", content))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message);
+                }
+			}
+        }
+
+        public async Task<InputsResponse> RegisterInputAsync(InputsRequest request)
+        {
+			using (var response = await _torClient.SendAsync(HttpMethod.Post, "/api/v1/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message);
+                }
+                return await response.Content.ReadAsJsonAsync<InputsResponse>();
+			}
+        }
+
+        public async Task<IEnumerable<CcjRunningRoundState>> GetStatesAsync()
+        {
+			using (var response = await _torClient.SendAsync(HttpMethod.Get, "/api/v1/btc/chaumiancoinjoin/states/"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message);
+                }
+				return await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();
+			}
+        }
+
+        public async Task<string> GetConfirmationAsync(Guid uid, long roundId)
+        {
+			var queryString = $"/api/v1/btc/chaumiancoinjoin/confirmation?uniqueId={uid}&roundId={roundId}";
+
+			using (var response = await _torClient.SendAsync(HttpMethod.Post, queryString))
+			{
+				if (!response.IsSuccessStatusCode)
+                {
+					string message = await response.Content.ReadAsJsonAsync<string>();
+					throw new HttpRequestException(message ?? string.Empty);
+                }
+
+				if(response.StatusCode == HttpStatusCode.NoContent)
+					return string.Empty;
+
+				return await response.Content.ReadAsJsonAsync<string>();
+			}
+        }
+
+        public void Dispose()
+        {
+            _torClient.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This PR includes an http API client `WasabiApiClient` that allows us to abstract away the http calls against the backend controllers. We can see how using this class the tests gain in readability and are more clean.