### PR TITLE
Shows alternative for different badgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
 Wallet Wasabi, formerly known as HiddenWallet is a [ZeroLink](https://github.com/nopara73/ZeroLink) compliant Bitcoin wallet. We are dedicated to restore Bitcoin's fungibility and provide the highest possible privacy for our users.  
 HiddenWallet's code is archived in the [hiddenwallet-v0.6](https://github.com/zkSNACKs/WalletWasabi/tree/hiddenwallet-v0.6) branch of this repository.
 
-| Windows Build | Linux & OSX Build | License |
-| :---- | :------ | :------ |
-| [![Windows build status][1]][2] | [![Linux & OSX build status][3]][4] |[![GitHub license][5]][6] |
+| Windows Build | Linux Build | OSX Build | License |
+| :---- | :------ | :------| :------ |
+| [![Windows build status][1]][2] | [![Linux build status][3]][4] | [![OSX build status][5]][6] |[![GitHub license][7]][8] |
 
 [1]: https://ci.appveyor.com/api/projects/status/70j293muovayg516?svg=true
 [2]: https://ci.appveyor.com/project/zkSNACKs/walletwasabi
-[3]: https://travis-ci.org/zkSNACKs/WalletWasabi.svg?branch=master
+[3]: https://travis-matrix-badges.herokuapp.com/repos/zkSNACKs/WalletWasabi/branches/master/1
 [4]: https://travis-ci.org/zkSNACKs/WalletWasabi
-[5]: https://img.shields.io/github/license/zkSNACKs/WalletWasabi.svg
-[6]: https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md
+[5]: https://travis-matrix-badges.herokuapp.com/repos/zkSNACKs/WalletWasabi/branches/master/2
+[6]: https://travis-ci.org/zkSNACKs/WalletWasabi
+[7]: https://img.shields.io/github/license/zkSNACKs/WalletWasabi.svg
+[8]: https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md
 
 ## Build & Test
 


### PR DESCRIPTION
This PR shows one possible alternative fo displaying separated badges for Linux ans OSX (issue https://github.com/zkSNACKs/WalletWasabi/issues/183). This is how it looks like:

![image](https://user-images.githubusercontent.com/127973/39735018-13771da8-5250-11e8-8cf4-adbf3bd0993b.png)
