### PR TITLE
Disable low-importance log activity

### DIFF
--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -40,6 +40,8 @@ namespace WalletWasabi.Backend
 				c.IncludeXmlComments(xmlPath);
 			});
 
+			services.AddLogging(Logging=> Logging.AddFilter((s, level)=> level >= Microsoft.Extensions.Logging.LogLevel.Warning));
+
 			services.AddSingleton<IExchangeRateProvider>(new ExchangeRateProvider() );
 		}
 


### PR DESCRIPTION
This PR turns off the info, debug, trace, none logging leaving the warn, err and critical logs on. (Issue
https://github.com/zkSNACKs/WalletWasabi/issues/182)

Final logs now looks much more usefuls:

![image](https://user-images.githubusercontent.com/127973/39737678-ece22144-525c-11e8-9799-9ee2cc808f6e.png)
