### PR TITLE
Increase code coverage of WalletService.BuildTransactionAsync for #144

### DIFF
--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1021,7 +1021,15 @@ namespace WalletWasabi.Tests
 				var allowedInputs = wallet.Coins.Where(x => !x.SpentOrLocked).Select(x => new TxoRef(x.TransactionId, x.Index)).Take(1);
 				var toSend = new[]{ new WalletService.Operation(receive, Money.Zero, "fizz")};
 
-				res = await wallet.BuildTransactionAsync("password", toSend, 1008, false, allowedInputs: allowedInputs);
+				// covers:
+				// feeTarget < 2
+				// disallow unconfirmed
+				// allowed inputs
+				res = await wallet.BuildTransactionAsync("password", toSend, 0, false, allowedInputs: allowedInputs);
+
+				// covers:
+				// customchange
+				res2 = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(new Key().ScriptPubKey, new Money(0.05m, MoneyUnit.BTC), "label")}, 0, customChange: new Key().ScriptPubKey);
 				
 
 				activeOutput = res.InnerWalletOutputs.Single(x => x.ScriptPubKey == receive);

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1029,7 +1029,8 @@ namespace WalletWasabi.Tests
 
 				// covers:
 				// customchange
-				res2 = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(new Key().ScriptPubKey, new Money(0.05m, MoneyUnit.BTC), "label")}, 0, customChange: new Key().ScriptPubKey);
+				// feePc > 1
+				res2 = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(new Key().ScriptPubKey, new Money(100, MoneyUnit.MilliBTC), "outgoing")}, 1008, customChange: new Key().ScriptPubKey);
 				
 
 				activeOutput = res.InnerWalletOutputs.Single(x => x.ScriptPubKey == receive);

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -644,7 +644,7 @@ namespace WalletWasabi.Tests
 		{
 		}
 
-		[Fact(DisplayName = "InvokesBuildTransactionAsync")]
+		[Fact]
 		public async Task SendTestsFromHiddenWalletAsync() // These tests are taken from HiddenWallet, they were tests on the testnet.
 		{
 			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator) = await InitializeTestEnvironmentAsync(1);
@@ -1024,20 +1024,18 @@ namespace WalletWasabi.Tests
 				// covers:
 				// disallow unconfirmed with allowed inputs
 				// feeTarget < 2 // NOTE: need to correct alowing 0 and 1
-				res = await wallet.BuildTransactionAsync("password", toSend, 0, false, allowedInputs: allowedInputs);
+				res = await wallet.BuildTransactionAsync(password, toSend, 0, false, allowedInputs: allowedInputs);
 
 				activeOutput = res.InnerWalletOutputs.Single(x => x.ScriptPubKey == receive);
 				Assert.Single(res.InnerWalletOutputs);
 				Assert.Empty(res.OuterWalletOutputs);
 
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
-
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
-				Logger.LogInfo<RegTests>($"Fee: {res.Fee}");
-				Logger.LogInfo<RegTests>($"FeePercentOfSent: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"SpendsUnconfirmed: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogDebug<RegTests>($"Fee: {res.Fee}");
+				Logger.LogDebug<RegTests>($"FeePercentOfSent: {res.FeePercentOfSent} %");
+				Logger.LogDebug<RegTests>($"SpendsUnconfirmed: {res.SpendsUnconfirmed}");
+				Logger.LogDebug<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogDebug<RegTests>($"TxId: {res.Transaction.GetHash()}");
 
 				Assert.True(inputCountBefore >= res.SpentCoins.Count());
 				Assert.False(res.SpendsUnconfirmed);
@@ -1056,17 +1054,15 @@ namespace WalletWasabi.Tests
 				// covers:
 				// customchange
 				// feePc > 1
-				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(new Key().ScriptPubKey, new Money(100, MoneyUnit.MilliBTC), "outgoing")}, 1008, customChange: new Key().ScriptPubKey);
+				res = await wallet.BuildTransactionAsync(password, new[] { new WalletService.Operation(new Key().ScriptPubKey, new Money(100, MoneyUnit.MilliBTC), "outgoing")}, 1008, customChange: new Key().ScriptPubKey);
 
 				Assert.True(res.FeePercentOfSent > 1);
 
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
-
-				Logger.LogInfo<RegTests>($"Fee: {res.Fee}");
-				Logger.LogInfo<RegTests>($"FeePercentOfSent: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"SpendsUnconfirmed: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogDebug<RegTests>($"Fee: {res.Fee}");
+				Logger.LogDebug<RegTests>($"FeePercentOfSent: {res.FeePercentOfSent} %");
+				Logger.LogDebug<RegTests>($"SpendsUnconfirmed: {res.SpendsUnconfirmed}");
+				Logger.LogDebug<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogDebug<RegTests>($"TxId: {res.Transaction.GetHash()}");
 
 				#endregion
 			}
@@ -1089,7 +1085,7 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		[Fact(DisplayName = "InvokesBuildTransactionAsync")]
+		[Fact]
 		public async Task BuildTransactionValidationsTestAsync()
 		{
 			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator) = await InitializeTestEnvironmentAsync(1);
@@ -1174,14 +1170,13 @@ namespace WalletWasabi.Tests
 			// "Only one element can contain Money.Zero
 			var toSendWithTwoZeros = new[]{
 				new WalletService.Operation(scp, Money.Zero, "zero"),
-				new WalletService.Operation(scp, Money.Zero, "zero")};
-			await Assert.ThrowsAsync<ArgumentException>(async () => await wallet.BuildTransactionAsync("password", toSendWithTwoZeros, 1008, false));
+				new WalletService.Operation(scp, Money.Zero, "zero") };
+			await Assert.ThrowsAsync<ArgumentException>(async () => await wallet.BuildTransactionAsync(password, toSendWithTwoZeros, 1008, false));
 
 			// cannot specify spend all and custom change
 			var spendAll = new[]{
-				new WalletService.Operation(scp, Money.Zero, "spendAll")
-			};
-			await Assert.ThrowsAsync<ArgumentException>(async () => await wallet.BuildTransactionAsync("password", spendAll, 1008, false, customChange: new Key().ScriptPubKey));
+				new WalletService.Operation(scp, Money.Zero, "spendAll") };
+			await Assert.ThrowsAsync<ArgumentException>(async () => await wallet.BuildTransactionAsync(password, spendAll, 1008, false, customChange: new Key().ScriptPubKey));
 
 			// Get some money, make it confirm.
 			var key = wallet.GetReceiveKey("foo label");
@@ -1270,7 +1265,7 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		[Fact(DisplayName = "InvokesBuildTransactionAsync")]
+		[Fact]
 		public async Task BuildTransactionReorgsTestAsync()
 		{
 			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator) = await InitializeTestEnvironmentAsync(1);
@@ -1441,7 +1436,7 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		[Fact(DisplayName = "InvokesBuildTransactionAsync")]
+		[Fact]
 		public async Task SpendUnconfirmedTxTestAsync()
 		{
 			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator) = await InitializeTestEnvironmentAsync(1);


### PR DESCRIPTION
This PR is part of #144 to increase code coverage of WalletService.BuildTransactionAsync

The only code coverage excluded currently is the exception path when checking the HttpStatusCode when connecting to the tor client, and the following check:
`			TransactionPolicyError[] checkResults = builder.Check(tx, fee);
			if (checkResults.Length > 0)
			{
				throw new InvalidTxException(tx, checkResults);
			}`

SelectCoinsToSpend (invoked like 610) seems to block being able to assert InvalidTxException is thrown as it already checks whether enough fees are present, leading to a InsufficientBalanceException getting in the way.

Tests that invoke BuildTransactionAsync have had a DisplayName added to isolate tests if needed.

To run just the test that invoke BuildTransactionAsync, modify line 19 of coverage.sh to the following:

`dotnet test --no-build --filter DisplayName~InvokesBuildTransactionAsync`