### PR TITLE
Fix rpc calls

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -1,5 +1,7 @@
 NUGET_PACKAGES_PATH=$HOME/.nuget/packages
 FRAMEWORK=netcoreapp2.0
+FILTER=FullyQualifiedName~WalletWasabi.Tests$1
+
 
 ALTCOVER_VERSION=3.0.466
 ALTCOVER_PACKAGE_PATH=$NUGET_PACKAGES_PATH/altcover
@@ -16,5 +18,5 @@ dotnet restore && dotnet build -f $FRAMEWORK
 cp $NBITCOIN_DLL $COVERAGE_WORKING_PATH
 
 dotnet $ALTCOVER_DLL --save --inplace "-i=$COVERAGE_WORKING_PATH"
-dotnet test --no-build
+dotnet test --no-build --filter $FILTER
 dotnet $ALTCOVER_DLL runner --collect "-r=$COVERAGE_WORKING_PATH" --lcovReport=lcov.info

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using WalletWasabi.Models;
 
@@ -48,6 +49,27 @@ namespace NBitcoin.RPC
 			return await rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode);
 		}
 
+
+		public static async Task<RawTransactionInfo> GetRawTransactionInfoAsync(this RPCClient rpc, uint256 txId)
+		{
+			var request = new RPCRequest(RPCOperations.getrawtransaction, new object[]{ txId.ToString(), true });
+			var response = await rpc.SendCommandAsync(request);
+			var json = response.Result;
+			return new RawTransactionInfo{
+				Transaction = Transaction.Parse(json.Value<string>("hex")),
+				TransactionId = uint256.Parse(json.Value<string>("txid")),
+				TransactionTime = json["time"] != null ? NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("time")): (DateTimeOffset?)null,
+				Hash = uint256.Parse(json.Value<string>("hash")),
+				Size = json.Value<uint>("size"),
+				VirtualSize = json.Value<uint>("vsize"),
+				Version = json.Value<uint>("version"),
+				LockTime = new LockTime(json.Value<uint>("locktime")),
+				BlockHash = json["blockhash"] != null ? uint256.Parse(json.Value<string>("blockhash")): null,
+				Confirmations = json.Value<uint>("confirmations"),
+				BlockTime = json["blocktime"] != null ? NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("blocktime")) : (DateTimeOffset?)null
+			};
+		}
+
 		private static EstimateSmartFeeResponse SimulateRegTestFeeEstimation(int confirmationTarget, EstimateSmartFeeMode estimateMode)
 		{
 			int staoshiPerBytes;
@@ -64,4 +86,25 @@ namespace NBitcoin.RPC
 			return resp;
 		}
 	}
+
+	public class BlockInfo
+	{
+		public int Height { get; internal set; }
+		public uint256 Hash { get; internal set; }
+	}
+
+	public class RawTransactionInfo
+	{
+		public Transaction Transaction {get; internal set;}
+		public uint256 TransactionId {get; internal set;}
+		public uint256 Hash {get; internal set;}
+		public uint Size {get; internal set;}
+		public uint VirtualSize {get; internal set;}
+		public uint Version {get; internal set;}
+		public LockTime LockTime {get; internal set;}
+		public uint256 BlockHash {get; internal set;}
+		public uint Confirmations {get; internal set;}
+		public DateTimeOffset? TransactionTime {get; internal set;}
+		public DateTimeOffset? BlockTime {get; internal set;}
+	} 
 }


### PR DESCRIPTION
This PR consists of two parts:

* The `GetRawTransactionInfo` RPC method introduced into NBitcoin. This is temporary and once we get a new NBitcoin version we can remove it. Anyway, it also replaces the `SendCommandAsync` calls with the new method.

* Fixes the comparison `if(string.IsNullOrWhiteSpace(getRawTransactionResponse?.ResultString)` because it  is always `false`. Given we use exceptions instead, we use a catch block for handling the errors.

Note: I've modified the `.coverage.sh` script in order to be able to run the tests that i need because the full test suite takes a lot of time. (if you don't want the script as part of this pr, i can remove it) 