### PR TITLE
Minor improvemnet in multiples Money additions

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -219,7 +219,7 @@ namespace WalletWasabi.Backend.Controllers
 					}
 
 					// Check if inputs have enough coins.
-					Money inputSum = inputs.Sum(x => x.Output.Value);
+					Money inputSum = inputs.Select(x=>x.Output.Value).Sum();
 					Money networkFeeToPay = (inputs.Count() * round.FeePerInputs + 2 * round.FeePerOutputs);
 					Money changeAmount = inputSum - (round.Denomination + networkFeeToPay);
 					if (changeAmount < Money.Zero)

--- a/WalletWasabi/Models/ChaumianCoinJoin/Alice.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/Alice.cs
@@ -47,7 +47,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			UniqueId = Guid.NewGuid();
 
-			InputSum = inputs.Sum(x => x.Output.Value);
+			InputSum = inputs.Select(x => x.Output.Value).Sum();
 
 			OutputSumWithoutCoordinatorFeeAndDenomination = InputSum - NetworkFeeToPay;
 

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -252,7 +252,8 @@ namespace WalletWasabi.Services
 			}
 			Money amountBack = unsignedCoinJoin.Outputs
 				.Where(x => x.ScriptPubKey == ongoingRound.ActiveOutputAddress.ScriptPubKey || x.ScriptPubKey == ongoingRound.ChangeOutputAddress.ScriptPubKey)
-				.Sum(y => y.Value);
+				.Select(y => y.Value)
+				.Sum();
 			Money minAmountBack = ongoingRound.CoinsRegistered.Sum(x => x.Amount); // Start with input sum.
 			minAmountBack -= ongoingRound.State.FeePerOutputs * 2 + ongoingRound.State.FeePerInputs * ongoingRound.CoinsRegistered.Count; // Minus miner fee.
 			Money actualDenomination = unsignedCoinJoin.GetIndistinguishableOutputs().OrderByDescending(x => x.count).First().value; // Denomination may grow.


### PR DESCRIPTION
This PR is for preventing the creation of new Money instances when we sum collections of Money.

Money class overload arithmetical operations (+, -, *, /, etc) such that they returns a new Money instance as result. At the same time, the Money class constructors performs some minimal validations so, if we have a collection `c` with 1000 Money instances and we sum them with `c.Sum()` we are creating (and destroying) 1000 new Money instances just for storing the intermediate results. This is could be important if we work with many collections of money. 

For that reason NBitcoin provides its own `Money Sum(IEnumerable<Money>)` method which sums the satoshis and creates only one Money instance with the result.