### PR TITLE
Small performance and readability improvements for count checks done against collections

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -180,7 +180,7 @@ namespace WalletWasabi.Backend.Controllers
 				return NotFound($"Provided {nameof(bestKnownBlockHash)} is not found: {bestKnownBlockHash}.");
 			}
 
-			if (filters.Count() == 0)
+			if (!filters.Any())
 			{
 				return NoContent();
 			}

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -87,7 +87,7 @@ namespace WalletWasabi.Backend.Controllers
 				|| string.IsNullOrWhiteSpace(request.BlindedOutputScriptHex)
 				|| string.IsNullOrWhiteSpace(request.ChangeOutputAddress)
 				|| request.Inputs == null
-				|| request.Inputs.Count() == 0
+			    || !request.Inputs.Any()
 				|| request.Inputs.Any(x => x.Input == null
 					|| x.Input.Hash == null
 					|| string.IsNullOrWhiteSpace(x.Proof)))
@@ -329,7 +329,7 @@ namespace WalletWasabi.Backend.Controllers
 						{
 							IEnumerable<Alice> alicesToBan = await round.RemoveAlicesIfInputsSpentAsync(); // So ban only those who confirmed participation, yet spent their inputs.
 
-							if (alicesToBan.Count() > 0)
+							if (alicesToBan.Any())
 							{
 								await Coordinator.UtxoReferee.BanUtxosAsync(1, DateTimeOffset.Now, alicesToBan.SelectMany(x => x.Inputs).Select(y => y.OutPoint).ToArray());
 							}
@@ -569,7 +569,7 @@ namespace WalletWasabi.Backend.Controllers
 		{
 			if (roundId <= 0
 				|| signatures == null
-				|| signatures.Count() <= 0
+			    || !signatures.Any()
 				|| signatures.Any(x => x.Key < 0 || string.IsNullOrWhiteSpace(x.Value))
 				|| !ModelState.IsValid)
 			{

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -2368,7 +2368,7 @@ namespace WalletWasabi.Tests
 				chaumianClient2.Start();
 
 				smartCoin1.Locked = true;
-				Assert.True(0 == (await chaumianClient1.QueueCoinsToMixAsync(password, smartCoin1)).Count());
+				Assert.True(!(await chaumianClient1.QueueCoinsToMixAsync(password, smartCoin1)).Any());
 				Assert.True(smartCoin1.Locked);
 
 				await Assert.ThrowsAsync<SecurityException>(async () => await chaumianClient1.QueueCoinsToMixAsync("asdasdasd", smartCoin1, smartCoin2));

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -81,7 +81,7 @@ namespace System.Net.Http
 			var startLine = new RequestLine(me.Method, me.RequestUri, new HttpProtocol($"HTTP/{me.Version.Major}.{me.Version.Minor}")).ToString();
 
 			string headers = "";
-			if (me.Headers != null && me.Headers.Any())
+			if (me.Headers.NotNullAndNotEmpty())
 			{
 				var headerSection = HeaderSection.CreateNew(me.Headers);
 				headers += headerSection.ToString(endWithTwoCRLF: false);
@@ -90,7 +90,7 @@ namespace System.Net.Http
 			string messageBody = "";
 			if (me.Content != null)
 			{
-				if (me.Content.Headers != null && me.Content.Headers.Any())
+				if (me.Content.Headers.NotNullAndNotEmpty())
 				{
 					var headerSection = HeaderSection.CreateNew(me.Content.Headers);
 					headers += headerSection.ToString(endWithTwoCRLF: false);

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -81,7 +81,7 @@ namespace System.Net.Http
 			var startLine = new RequestLine(me.Method, me.RequestUri, new HttpProtocol($"HTTP/{me.Version.Major}.{me.Version.Minor}")).ToString();
 
 			string headers = "";
-			if (me.Headers != null && me.Headers.Count() != 0)
+			if (me.Headers != null && me.Headers.Any())
 			{
 				var headerSection = HeaderSection.CreateNew(me.Headers);
 				headers += headerSection.ToString(endWithTwoCRLF: false);
@@ -90,7 +90,7 @@ namespace System.Net.Http
 			string messageBody = "";
 			if (me.Content != null)
 			{
-				if (me.Content.Headers != null && me.Content.Headers.Count() != 0)
+				if (me.Content.Headers != null && me.Content.Headers.Any())
 				{
 					var headerSection = HeaderSection.CreateNew(me.Content.Headers);
 					headers += headerSection.ToString(endWithTwoCRLF: false);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -65,7 +65,7 @@ namespace System.Net.Http
 			var startLine = new StatusLine(new HttpProtocol($"HTTP/{me.Version.Major}.{me.Version.Minor}"), me.StatusCode).ToString();
 
 			var headers = "";
-			if (me.Headers != null && me.Headers.Any())
+			if (me.Headers.NotNullAndNotEmpty())
 			{
 				var headerSection = HeaderSection.CreateNew(me.Headers);
 				headers += headerSection.ToString(endWithTwoCRLF: false);
@@ -74,7 +74,7 @@ namespace System.Net.Http
 			var messageBody = "";
 			if (me.Content != null)
 			{
-				if (me.Content.Headers != null && me.Content.Headers.Any())
+				if (me.Content.Headers.NotNullAndNotEmpty())
 				{
 					var headerSection = HeaderSection.CreateNew(me.Content.Headers);
 					headers += headerSection.ToString(endWithTwoCRLF: false);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -65,7 +65,7 @@ namespace System.Net.Http
 			var startLine = new StatusLine(new HttpProtocol($"HTTP/{me.Version.Major}.{me.Version.Minor}"), me.StatusCode).ToString();
 
 			var headers = "";
-			if (me.Headers != null && me.Headers.Count() != 0)
+			if (me.Headers != null && me.Headers.Any())
 			{
 				var headerSection = HeaderSection.CreateNew(me.Headers);
 				headers += headerSection.ToString(endWithTwoCRLF: false);
@@ -74,7 +74,7 @@ namespace System.Net.Http
 			var messageBody = "";
 			if (me.Content != null)
 			{
-				if (me.Content.Headers != null && me.Content.Headers.Count() != 0)
+				if (me.Content.Headers != null && me.Content.Headers.Any())
 				{
 					var headerSection = HeaderSection.CreateNew(me.Content.Headers);
 					headers += headerSection.ToString(endWithTwoCRLF: false);

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -56,5 +56,10 @@ namespace System.Linq
 				me.Remove(item);
 			}
 		}
+
+		public static bool NotNullAndNotEmpty<T>(this IEnumerable<T> source)
+		{
+			return source != null && source.Any();
+		}
 	}
 }

--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Helpers
 		{
 			NotNull(parameterName, value);
 
-			if (value.Count() == 0)
+			if (!value.Any())
 			{
 				throw new ArgumentException("Parameter cannot be empty.", parameterName);
 			}
@@ -65,7 +65,7 @@ namespace WalletWasabi.Helpers
 		{
 			NotNull(parameterName, value);
 
-			if (value.Count() == 0)
+			if (!value.Any())
 			{
 				throw new ArgumentException("Parameter cannot be empty.", parameterName);
 			}

--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -492,7 +492,7 @@ namespace System.Net.Http
 
 		public static HttpContent GetDummyOrNullContent(HttpContentHeaders contentHeaders)
 		{
-			if (contentHeaders != null && contentHeaders.Any())
+			if (contentHeaders.NotNullAndNotEmpty())
 			{
 				return new ByteArrayContent(new byte[] { }); // dummy empty content
 			}
@@ -504,7 +504,7 @@ namespace System.Net.Http
 
 		public static void CopyHeaders(HttpHeaders source, HttpHeaders destination)
 		{
-			if (source != null && source.Any())
+			if (source.NotNullAndNotEmpty())
 			{
 				foreach (var header in source)
 				{

--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -492,7 +492,7 @@ namespace System.Net.Http
 
 		public static HttpContent GetDummyOrNullContent(HttpContentHeaders contentHeaders)
 		{
-			if (contentHeaders != null && contentHeaders.Count() != 0)
+			if (contentHeaders != null && contentHeaders.Any())
 			{
 				return new ByteArrayContent(new byte[] { }); // dummy empty content
 			}
@@ -504,7 +504,7 @@ namespace System.Net.Http
 
 		public static void CopyHeaders(HttpHeaders source, HttpHeaders destination)
 		{
-			if (source != null && source.Count() != 0)
+			if (source != null && source.Any())
 			{
 				foreach (var header in source)
 				{

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -160,7 +160,7 @@ namespace WalletWasabi.KeyManagement
 				}
 
 				KeyPath path;
-				if (relevantHdPubKeys.Count() == 0)
+				if (!relevantHdPubKeys.Any())
 				{
 					path = new KeyPath($"{change}/0");
 				}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -400,7 +400,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 									IEnumerable<OutPoint> inputsToBan = alicesToBan1.SelectMany(x => x.Inputs).Select(y => y.OutPoint).Concat(alicesToBan2.SelectMany(x => x.Inputs).Select(y => y.OutPoint).ToArray()).Distinct();
 
-									if (inputsToBan.Count() != 0)
+									if (inputsToBan.Any())
 									{
 										await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.Now, inputsToBan.ToArray());
 									}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -433,7 +433,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 							case CcjRoundPhase.Signing:
 								{
 									var alicesToBan = await RemoveAlicesIfInputsSpentAsync();
-									if (alicesToBan.Count() != 0)
+									if (alicesToBan.Any())
 									{
 										await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.Now, alicesToBan.SelectMany(x => x.Inputs).Select(y => y.OutPoint).ToArray());
 									}

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -106,11 +106,11 @@ namespace WalletWasabi.Services
 								if (IsRunning == false) return;
 
 								// if mixing >= connConf: delay = new Random().Next(2, 7);
-								if (State.GetActivelyMixingRounds().Count() > 0)
+								if (State.GetActivelyMixingRounds().Any())
 								{
 									delay = new Random().Next(2, 7);
 								}
-								else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Count() > 0 || State.GetWaitingListCount() > 0)
+								else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Any()|| State.GetWaitingListCount() > 0)
 								{
 									double rand = double.Parse($"0.{new Random().Next(2, 8)}"); // randomly between every 0.2 * connConfTimeout - 7 and 0.8 * connConfTimeout
 									delay = Math.Max(0, (int)(rand * State.GetSmallestRegistrationTimeout() - 7));

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -350,7 +350,7 @@ namespace WalletWasabi.Services
 					inputRegistrableRound.State.FeePerInputs,
 					inputRegistrableRound.State.FeePerOutputs);
 
-				if (registrableCoins.Count() > 0)
+				if (registrableCoins.Any())
 				{
 					BitcoinAddress changeAddress = null;
 					BitcoinAddress activeAddress = null;

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -300,7 +300,7 @@ namespace WalletWasabi.Services
 
 			// If double spend:
 			IEnumerable<SmartCoin> doubleSpends = Coins.Where(x => tx.Transaction.Inputs.Any(y => x.SpentOutputs.Select(z => z.ToOutPoint()).Contains(y.PrevOut)));
-			if (doubleSpends.Count() > 0)
+			if (doubleSpends.Any())
 			{
 				if (tx.Height == Height.MemPool)
 				{


### PR DESCRIPTION
Replaced all calls to IEnumerable.Count() with IEnumerable.Any() where the collection was of type IEnumerable and the intention was to only check whether the collection was empty or not, ignoring the count returned from calling iEnumerable.Count().

This was done for the performance benefits ([StackOverflow](https://stackoverflow.com/questions/305092/which-method-performs-better-any-vs-count-0)), and to better communicate what is being checked

Also created an extension method that will check whether an IEnumerable is not null and not empty for convince and to reduce repetition.