### PR TITLE
Code improvements to reduce method size by abstracting out some repeated logic to helper methods

### DIFF
--- a/WalletWasabi/Helpers/CcjRoundHelper.cs
+++ b/WalletWasabi/Helpers/CcjRoundHelper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using WalletWasabi.Models.ChaumianCoinJoin;
+
+namespace WalletWasabi.Helpers
+{
+    public class CcjRoundHelper
+    {
+		public static bool ActionDisallowed(CcjRoundAction action, CcjRoundPhase phase, CcjRoundStatus status)
+		{
+			bool disallowed = false;
+
+			switch (action)
+			{
+				case CcjRoundAction.AddingAlice:
+				case CcjRoundAction.RemovingAlice:
+				case CcjRoundAction.UpdatingAnonyminity:
+					{
+						disallowed = (phase != CcjRoundPhase.InputRegistration && phase != CcjRoundPhase.ConnectionConfirmation) || status != CcjRoundStatus.Running;
+						return disallowed;
+					}
+				case CcjRoundAction.AddingBob:
+					{
+						disallowed = phase != CcjRoundPhase.OutputRegistration || status != CcjRoundStatus.Running;
+						return disallowed;
+					}
+				default:
+					return disallowed;
+			}
+		}
+    }
+}

--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -140,5 +140,14 @@ namespace WalletWasabi.Helpers
 				? string.Empty
 				: str.Trim();
 		}
+
+		public static void ThrowIf(bool condition, Type exceptionType, params object[] exceptionArguments)
+		{
+			if (condition)
+			{
+				var exceptionToThrow = Activator.CreateInstance(exceptionType, exceptionArguments);
+				throw (SystemException) exceptionToThrow;
+			}
+		}
 	}
 }

--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -146,7 +146,7 @@ namespace WalletWasabi.Helpers
 			if (condition)
 			{
 				var exceptionToThrow = Activator.CreateInstance(exceptionType, exceptionArguments);
-				throw (SystemException) exceptionToThrow;
+				throw (Exception) exceptionToThrow;
 			}
 		}
 	}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -687,7 +687,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Updating anonymity set is only allowed in InputRegistration and ConnectionConfirmation phases.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.UpdatingAnonyminity, Phase, Status), typeof(InvalidOperationException), "Updating anonymity set is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				AnonymitySet = anonymitySet;
 			}
 			Logger.LogInfo<CcjRound>($"Round ({RoundId}): {nameof(AnonymitySet)} updated: {AnonymitySet}.");
@@ -697,7 +697,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf(Phase != CcjRoundPhase.InputRegistration || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Adding Alice is only allowed in InputRegistration phase.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.AddingAlice, Phase, Status), typeof(InvalidOperationException), "Adding Alice is only allowed in InputRegistration phase.");
 				Alices.Add(alice);
 			}
 
@@ -710,7 +710,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf(Phase != CcjRoundPhase.OutputRegistration || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Adding Bob is only allowed in OutputRegistration phase.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.AddingBob, Phase, Status), typeof(InvalidOperationException), "Adding Bob is only allowed in OutputRegistration phase.");
 				if (Bobs.Any(x => x.ActiveOutputAddress == bob.ActiveOutputAddress))
 				{
 					return; // Bob is already added.
@@ -727,7 +727,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			int numberOfRemovedAlices = 0;
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.RemovingAlice, Phase, Status), typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				numberOfRemovedAlices = Alices.RemoveAll(x => x.State == state);
 			}
 			if (numberOfRemovedAlices != 0)
@@ -743,7 +743,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.RemovingAlice, Phase, Status), typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 
 				foreach (Alice alice in Alices)
 				{
@@ -774,7 +774,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			var numberOfRemovedAlices = 0;
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.RemovingAlice, Phase, Status), typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				foreach (var id in ids)
 				{
 					numberOfRemovedAlices = Alices.RemoveAll(x => x.UniqueId == id);
@@ -792,7 +792,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			using (RoundSyncronizerLock.Lock())
 			{
-				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
+				Guard.ThrowIf(CcjRoundHelper.ActionDisallowed(CcjRoundAction.RemovingAlice, Phase, Status), typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				numberOfRemovedAlices = Alices.RemoveAll(x => x.Inputs.Any(y => y.OutPoint == input));
 			}
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -187,7 +187,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						try
 						{
 							var estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
-							if (estimateSmartFeeResponse == null) throw new InvalidOperationException("FeeRate is not yet initialized");
+							Guard.ThrowIf(estimateSmartFeeResponse == null, typeof(InvalidOperationException), "FeeRate is not yet initialized");
 							var feeRate = estimateSmartFeeResponse.FeeRate;
 							Money feePerBytes = (feeRate.FeePerK / 1000);
 
@@ -687,10 +687,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			using (RoundSyncronizerLock.Lock())
 			{
-				if ((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Updating anonymity set is only allowed in InputRegistration and ConnectionConfirmation phases.");
-				}
+				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Updating anonymity set is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				AnonymitySet = anonymitySet;
 			}
 			Logger.LogInfo<CcjRound>($"Round ({RoundId}): {nameof(AnonymitySet)} updated: {AnonymitySet}.");
@@ -700,10 +697,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			using (RoundSyncronizerLock.Lock())
 			{
-				if (Phase != CcjRoundPhase.InputRegistration || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Adding Alice is only allowed in InputRegistration phase.");
-				}
+				Guard.ThrowIf(Phase != CcjRoundPhase.InputRegistration || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Adding Alice is only allowed in InputRegistration phase.");
 				Alices.Add(alice);
 			}
 
@@ -716,10 +710,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			using (RoundSyncronizerLock.Lock())
 			{
-				if (Phase != CcjRoundPhase.OutputRegistration || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Adding Bob is only allowed in OutputRegistration phase.");
-				}
+				Guard.ThrowIf(Phase != CcjRoundPhase.OutputRegistration || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Adding Bob is only allowed in OutputRegistration phase.");
 				if (Bobs.Any(x => x.ActiveOutputAddress == bob.ActiveOutputAddress))
 				{
 					return; // Bob is already added.
@@ -736,10 +727,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			int numberOfRemovedAlices = 0;
 			using (RoundSyncronizerLock.Lock())
 			{
-				if ((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
-				}
+				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				numberOfRemovedAlices = Alices.RemoveAll(x => x.State == state);
 			}
 			if (numberOfRemovedAlices != 0)
@@ -755,10 +743,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			using (RoundSyncronizerLock.Lock())
 			{
-				if ((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
-				}
+				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 
 				foreach (Alice alice in Alices)
 				{
@@ -789,10 +774,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			var numberOfRemovedAlices = 0;
 			using (RoundSyncronizerLock.Lock())
 			{
-				if ((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
-				}
+				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				foreach (var id in ids)
 				{
 					numberOfRemovedAlices = Alices.RemoveAll(x => x.UniqueId == id);
@@ -810,10 +792,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			using (RoundSyncronizerLock.Lock())
 			{
-				if ((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running)
-				{
-					throw new InvalidOperationException("Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
-				}
+				Guard.ThrowIf((Phase != CcjRoundPhase.InputRegistration && Phase != CcjRoundPhase.ConnectionConfirmation) || Status != CcjRoundStatus.Running, typeof(InvalidOperationException), "Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				numberOfRemovedAlices = Alices.RemoveAll(x => x.Inputs.Any(y => y.OutPoint == input));
 			}
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundAction.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundAction.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace WalletWasabi.Models.ChaumianCoinJoin
+{
+	public enum CcjRoundAction
+	{
+		AddingAlice,
+		AddingBob,
+		RemovingAlice,
+		UpdatingAnonyminity
+	}
+}


### PR DESCRIPTION
Changes made as part of increasing the codefactor score rating, especially the C rating of WalletService.cs, B rating of CcjRound.cs, and B rating of CcjClient.cs.

Guard.cs now has a ThrowIf method that creates and throws an exception based on a bool, to replace the repeated if checks that result in an exception being thrown.

Created CcjRoundHelper to check if an action is allowed for the current phase and status. The helper also keeps these rules sets in once place.