### PR TITLE
Simplify fee calculations

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -61,5 +61,10 @@ namespace NBitcoin
 			bool notEmpty = me.WitScript != WitScript.Empty;
 			return notNull && notEmpty;
 		}
+
+		public static Money Percentange(this Money me, decimal perc)
+		{
+			return Money.Satoshis((me.Satoshi / 100m) * perc);
+		}
 	}
 }

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -263,7 +263,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						}
 
 						// 4. Start building Coordinator fee.
-						Money coordinatorFeePerAlice = Money.Coins((CoordinatorFeePercent * 0.01m) * decimal.Parse(newDenomination.ToString(false, true)));
+						Money coordinatorFeePerAlice = newDenomination.Percentange(CoordinatorFeePercent);
 						Money coordinatorFee = Alices.Count * coordinatorFeePerAlice;
 
 						// 5. Add the inputs and the changes of Alices.
@@ -277,7 +277,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 							if (changeAmount > Money.Zero) // If the coordinator fee would make change amount to be negative or zero then no need to pay it.
 							{
 								Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
-								Money onePercentOfDenomination = Money.Coins(newDenomination.ToDecimal(MoneyUnit.BTC) * 0.01m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
+								Money onePercentOfDenomination = newDenomination.Percentange(1m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
 								Money minimumChangeAmount = Math.Max(minimumOutputAmount, onePercentOfDenomination);
 								if (changeAmount < minimumChangeAmount)
 								{

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -257,14 +257,14 @@ namespace WalletWasabi.Services
 			Money minAmountBack = ongoingRound.CoinsRegistered.Sum(x => x.Amount); // Start with input sum.
 			minAmountBack -= ongoingRound.State.FeePerOutputs * 2 + ongoingRound.State.FeePerInputs * ongoingRound.CoinsRegistered.Count; // Minus miner fee.
 			Money actualDenomination = unsignedCoinJoin.GetIndistinguishableOutputs().OrderByDescending(x => x.count).First().value; // Denomination may grow.
-			Money expectedCoordinatorFee = Money.Coins((ongoingRound.State.CoordinatorFeePercent * 0.01m) * decimal.Parse(actualDenomination.ToString(false, true)));
+			Money expectedCoordinatorFee = actualDenomination.Percentange(ongoingRound.State.CoordinatorFeePercent);
 			minAmountBack -= expectedCoordinatorFee; // Minus expected coordinator fee.
 
 			// If there's no change output then coordinator protection may happened:
 			if (unsignedCoinJoin.Outputs.All(x => x.ScriptPubKey != ongoingRound.ChangeOutputAddress.ScriptPubKey))
 			{
 				Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
-				Money onePercentOfDenomination = Money.Coins(actualDenomination.ToDecimal(MoneyUnit.BTC) * 0.01m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
+				Money onePercentOfDenomination = actualDenomination.Percentange(1m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
 				Money minimumChangeAmount = Math.Max(minimumOutputAmount, onePercentOfDenomination);
 
 				minAmountBack -= minimumChangeAmount; // Minus coordinator protections (so it won't create bad coinjoins.)


### PR DESCRIPTION
This PR introduces a new `NBitcoin.Money` extension method called `Percentage` to simplify the calculation of fees and, at the same time, improve the code readability such that the following expression:

```c#
var onePercent = Money.Coins(actualDenomination.ToDecimal(MoneyUnit.BTC) * 0.01m);
```

can be rewritten as:

```c#
var onePercent = actualDenomination.Percentange(1m);
```
