### PR TITLE
Fix meaningless OrderBy chain

### DIFF
--- a/WalletWasabi/Helpers/NBitcoinHelpers.cs
+++ b/WalletWasabi/Helpers/NBitcoinHelpers.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Helpers
 		public static string HashOutpoints(IEnumerable<OutPoint> outPoints)
 		{
 			var sb = new StringBuilder();
-			foreach (OutPoint input in outPoints.OrderBy(x => x.Hash.ToString()).OrderBy(x => x.N))
+			foreach (OutPoint input in outPoints.OrderBy(x => x.Hash.ToString()).ThenBy(x => x.N))
 			{
 				sb.Append(ByteHelpers.ToHex(input.ToBytes()));
 			}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
@@ -114,7 +114,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				foreach (SmartCoin coin in WaitingList
 								.Where(x => x.Confirmed || x.Label.StartsWith("ZeroLink", StringComparison.Ordinal)) // Where our label contains CoinJoin, CoinJoins can be registered even if not confirmed, our label will likely be CoinJoin only if it was a previous CoinJoin, otherwise the server will refuse us.
 								.OrderByDescending(y => y.Amount) // First order by amount.
-								.OrderByDescending(z => z.Confirmed)) // Then order by the amount ordered ienumerable by confirmation, so first try to register confirmed coins.
+								.ThenByDescending(z => z.Confirmed)) // Then order by the amount ordered ienumerable by confirmation, so first try to register confirmed coins.
 				{
 					coinsToRegister.Add(coin);
 


### PR DESCRIPTION
This PR fixes situations where `IEnumeration.OrderBy` calls are chained because the last one overrides all the previous ones. That's why `IOrderedEnumerable` enumerables provide the `IOrderedEnumerable.ThenBy' and `IOrderedEnumerable.ThenByDescending` extensions.