### PR TITLE
Change static field initialization

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Logging
 
 		public static string FileEntryEncryptionPassword { get; private set; } = null;
 
-		private static long _logerFailed = Interlocked.Exchange(ref _logerFailed, 0);
+		private static long _logerFailed = 0;
 
 		private static readonly object Lock = new object();
 


### PR DESCRIPTION
This PR change the way the `_logerFailed` static field is initialized. Given static fields are initialized to their default value the first time the class is referenced, the previous initialization was using the field's initial value as base value to initialize it.