### PR TITLE
Use unused CancelationToken

### DIFF
--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -454,7 +454,7 @@ namespace System.Net.Http
 			}
 
 			var allData = new byte[(int)length];
-			var num = await stream.ReadBlockAsync(allData, (int)length);
+			var num = await stream.ReadBlockAsync(allData, (int)length, ctsToken);
 			if (num < (int)length)
 			{
 				// https://tools.ietf.org/html/rfc7230#section-3.3.3


### PR DESCRIPTION
I've didn't changed the commit included in this PR because i still think it is the correct thing to do (in case of disagreement we can skip it)

The point is that the method `ReadBytesTillLengthAsync` receives a `CancellationToken` that is never used in the method's body. So, there are two alternatives:

* We can use it, as we do in all the rest of the methods belonging to the same class (this PR) or,
* We can remove the CancellationToken from the method's parameter list.

Removing this parameter form the parameter list moves the problem to the calling method `GetContentTillLengthAsync` and so on, I mean, it requires a short chain of changes.

@nopara73 please take a look at this and let me know.
The last alternative requires we remove the cancelation token in all the chain of methods that 