### PR TITLE
Use Collection Count property when possible

### DIFF
--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -55,7 +55,7 @@ namespace WalletWasabi.Tests
 				{
 					Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 					var filters = await response.Content.ReadAsJsonAsync<List<string>>();
-					var filterCount = filters.Count();
+					var filterCount = filters.Count;
 					if (filterCount >= 101)
 					{
 						break;
@@ -2171,7 +2171,7 @@ namespace WalletWasabi.Tests
 			}
 
 			var mempool = await rpc.GetRawMempoolAsync();
-			Assert.Equal(inputRegistrationUsers.SelectMany(x => x.userInputData).Count(), mempool.Count());
+			Assert.Equal(inputRegistrationUsers.SelectMany(x => x.userInputData).Count(), mempool.Length);
 
 			while ((await rpc.GetRawMempoolAsync()).Length != 0)
 			{
@@ -2209,7 +2209,7 @@ namespace WalletWasabi.Tests
 
 			Logger.TurnOn();
 
-			Assert.Equal(users.Count(), roundConfig.AnonymitySet);
+			Assert.Equal(users.Count, roundConfig.AnonymitySet);
 
 			var confirmationRequests = new List<Task<string>>();
 

--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -37,7 +37,7 @@ namespace System.Net.Http
 			}
 
 			var startLine = bab.ToString(Encoding.ASCII);
-			if (startLine == null || startLine == "") throw new FormatException($"{nameof(startLine)} cannot be null or empty.");
+			if (string.IsNullOrEmpty(startLine)) throw new FormatException($"{nameof(startLine)} cannot be null or empty.");
 			return startLine;
 		}
 
@@ -77,9 +77,9 @@ namespace System.Net.Http
 				builder.Append(header + CRLF); // CRLF is part of the headerstring
 			}
 			headers = builder.ToString();
-			if (headers == null || headers == "")
+			if (string.IsNullOrEmpty(headers))
 			{
-				headers = "";
+				headers = string.Empty;
 			}
 
 			return headers;
@@ -486,7 +486,7 @@ namespace System.Net.Http
 			if (contentHeaders.Contains("Content-Length"))
 			{
 				if (contentHeaders.ContentLength < 0)
-					throw new HttpRequestException("Content-Length MUST be bigger than zero.");
+					throw new HttpRequestException("Content-Length MUST be larger than zero.");
 			}
 		}
 

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -288,7 +288,7 @@ namespace WalletWasabi.Services
 		{
 			using (await CoinJoinsLock.LockAsync())
 			{
-				if (UnconfirmedCoinJoins.Count() < 24)
+				if (UnconfirmedCoinJoins.Count < 24)
 				{
 					return false;
 				}

--- a/WalletWasabi/Services/MemPoolBehavior.cs
+++ b/WalletWasabi/Services/MemPoolBehavior.cs
@@ -54,13 +54,11 @@ namespace WalletWasabi.Services
 			catch (OperationCanceledException ex)
 			{
 				Logger.LogDebug<MemPoolBehavior>(ex);
-				return;
 			}
 			catch (Exception ex)
 			{
 				Logger.LogInfo<MemPoolBehavior>($"Ignoring {ex.GetType()}: {ex.Message}");
 				Logger.LogDebug<MemPoolBehavior>(ex);
-				return;
 			}
 		}
 

--- a/WalletWasabi/Services/UtxoReferee.cs
+++ b/WalletWasabi/Services/UtxoReferee.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Services
 						File.WriteAllLines(BannedUtxosFilePath, newAllLines);
 					}
 
-					Logger.LogInfo<UtxoReferee>($"{allLines.Count()} banned UTXOs are loaded from {BannedUtxosFilePath}.");
+					Logger.LogInfo<UtxoReferee>($"{allLines.Length} banned UTXOs are loaded from {BannedUtxosFilePath}.");
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -628,7 +628,7 @@ namespace WalletWasabi.Services
 			int inNum;
 			if (spendAll)
 			{
-				inNum = allowedSmartCoinInputs.Count();
+				inNum = allowedSmartCoinInputs.Count;
 			}
 			else
 			{


### PR DESCRIPTION
This PR changes replaces calls to `IEnumerable.Count()` method by `List<>.Count` property or `Array.Length` property depending on the concrete type. There are also a few other minor changes.