### PR TITLE
Remove redundant conditional statements

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -153,10 +153,7 @@ namespace WalletWasabi.Backend.Controllers
 							{
 								return BadRequest($"Input is banned from participation for {banLeft} minutes: {inputProof.Input.N}:{inputProof.Input.Hash}.");
 							}
-							else
-							{
-								await Coordinator.UtxoReferee.UnbanAsync(bannedElem.Key);
-							}
+							await Coordinator.UtxoReferee.UnbanAsync(bannedElem.Key);
 						}
 
 						GetTxOutResponse getTxOutResponse = await RpcClient.GetTxOutAsync(inputProof.Input.Hash, (int)inputProof.Input.N, includeMempool: true);
@@ -495,10 +492,7 @@ namespace WalletWasabi.Backend.Controllers
 
 				return NoContent();
 			}
-			else
-			{
-				return BadRequest("Invalid signature provided.");
-			}
+			return BadRequest("Invalid signature provided.");
 		}
 
 		/// <summary>

--- a/WalletWasabi/Backend/Models/FilterModel.cs
+++ b/WalletWasabi/Backend/Models/FilterModel.cs
@@ -44,15 +44,12 @@ namespace WalletWasabi.Backend.Models
 					Filter = null
 				};
 			}
-			else
+			return new FilterModel
 			{
-				return new FilterModel
-				{
-					BlockHeight = Guard.NotNull(nameof(height), height),
-					BlockHash = new uint256(parts[0]),
-					Filter = GolombRiceFilter.Parse(parts[1])
-				};
-			}
+				BlockHeight = Guard.NotNull(nameof(height), height),
+				BlockHash = new uint256(parts[0]),
+				Filter = GolombRiceFilter.Parse(parts[1])
+			};
 		}
 	}
 }

--- a/WalletWasabi/Bases/ByteArraySerializableBase.cs
+++ b/WalletWasabi/Bases/ByteArraySerializableBase.cs
@@ -29,10 +29,7 @@ namespace WalletWasabi.Bases
 			{
 				return $"X'{ByteHelpers.ToHex(ToBytes())}'";
 			}
-			else
-			{
-				return ByteHelpers.ToHex(ToBytes());
-			}
+			return ByteHelpers.ToHex(ToBytes());
 		}
 
 		public void FromHex(string hex)

--- a/WalletWasabi/Bases/OctetSerializableBase.cs
+++ b/WalletWasabi/Bases/OctetSerializableBase.cs
@@ -34,10 +34,7 @@ namespace WalletWasabi.Bases
 			{
 				return $"X'{ByteHelpers.ToHex(ToByte())}'";
 			}
-			else
-			{
-				return ByteHelpers.ToHex(ToByte());
-			}
+			return ByteHelpers.ToHex(ToByte());
 		}
 
 		public void FromHex(string hex)

--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -10,7 +10,7 @@ namespace System.IO
 			var buf = new byte[1];
 			var len = await stream.ReadAsync(buf, 0, 1, ctsToken);
 			if (len == 0) return -1;
-			else return buf[0];
+			return buf[0];
 		}
 
 		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken ctsToken = default)

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -10,22 +10,13 @@
 				{
 					return string.CompareOrdinal(source.Trim(), value.Trim()) == 0;
 				}
-				else
-				{
-					return string.CompareOrdinal(source, value) == 0;
-				}
+				return string.CompareOrdinal(source, value) == 0;
 			}
-			else
+			if (trimmed)
 			{
-				if (trimmed)
-				{
-					return source.Trim().Equals(value.Trim(), comparisonType);
-				}
-				else
-				{
-					return source.Equals(value, comparisonType);
-				}
+				return source.Trim().Equals(value.Trim(), comparisonType);
 			}
+			return source.Equals(value, comparisonType);
 		}
 
 		public static bool Contains(this string source, string toCheck, StringComparison comp)

--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -100,11 +100,8 @@ namespace System.Net.Http
 					{
 						return bab.ToString(encoding);
 					}
-					else
-					{
-						bab.Append(new byte[] { (byte)ch, (byte)ch2 });
-						continue;
-					}
+					bab.Append(new byte[] { (byte)ch, (byte)ch2 });
+					continue;
 				}
 				bab.Append((byte)ch);
 			}
@@ -135,10 +132,7 @@ namespace System.Net.Http
 				// the final encoding, the message body length cannot be determined
 				// reliably; the server MUST respond with the 400(Bad Request)
 				// status code and then close the connection.
-				else
-				{
-					return await GetContentTillEndAsync(stream, ctsToken);
-				}
+				return await GetContentTillEndAsync(stream, ctsToken);
 			}
 			// https://tools.ietf.org/html/rfc7230#section-3.3.3
 			// 5.If a valid Content - Length header field is present without
@@ -147,7 +141,7 @@ namespace System.Net.Http
 			// the recipient times out before the indicated number of octets are
 			// received, the recipient MUST consider the message to be
 			// incomplete and close the connection.
-			else if (headerStruct.ContentHeaders.Contains("Content-Length"))
+			if (headerStruct.ContentHeaders.Contains("Content-Length"))
 			{
 				long? contentLength = headerStruct.ContentHeaders?.ContentLength;
 				return await GetContentTillLengthAsync(stream, contentLength, ctsToken);
@@ -186,7 +180,7 @@ namespace System.Net.Http
 			// line that concludes the header fields.A client MUST ignore any
 			// Content - Length or Transfer-Encoding header fields received in
 			// such a message.
-			else if (requestMethod == new HttpMethod("CONNECT"))
+			if (requestMethod == new HttpMethod("CONNECT"))
 			{
 				if (HttpStatusCodeHelper.IsSuccessful(statusLine.StatusCode))
 				{
@@ -215,10 +209,7 @@ namespace System.Net.Http
 				// the final encoding, the message body length cannot be determined
 				// reliably; the server MUST respond with the 400(Bad Request)
 				// status code and then close the connection.
-				else
-				{
-					return await GetContentTillEndAsync(stream, ctsToken);
-				}
+				return await GetContentTillEndAsync(stream, ctsToken);
 			}
 			// https://tools.ietf.org/html/rfc7230#section-3.3.3
 			// 5.If a valid Content - Length header field is present without
@@ -227,7 +218,7 @@ namespace System.Net.Http
 			// the recipient times out before the indicated number of octets are
 			// received, the recipient MUST consider the message to be
 			// incomplete and close the connection.
-			else if (headerStruct.ContentHeaders.Contains("Content-Length"))
+			if (headerStruct.ContentHeaders.Contains("Content-Length"))
 			{
 				long? contentLength = headerStruct.ContentHeaders?.ContentLength;
 
@@ -496,10 +487,7 @@ namespace System.Net.Http
 			{
 				return new ByteArrayContent(new byte[] { }); // dummy empty content
 			}
-			else
-			{
-				return null;
-			}
+			return null;
 		}
 
 		public static void CopyHeaders(HttpHeaders source, HttpHeaders destination)

--- a/WalletWasabi/Http/Models/HeaderSection.cs
+++ b/WalletWasabi/Http/Models/HeaderSection.cs
@@ -51,10 +51,7 @@ namespace WalletWasabi.Http.Models
 					{
 						break;
 					}
-					else
-					{
-						hs.Fields.Add(HeaderField.CreateNew(field));
-					}
+					hs.Fields.Add(HeaderField.CreateNew(field));
 				}
 
 				ValidateAndCorrectHeaders(hs);

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -194,7 +194,7 @@ namespace WalletWasabi.KeyManagement
 				{
 					return HdPubKeys;
 				}
-				else if (keyState != null && isInternal == null)
+				if (keyState != null && isInternal == null)
 				{
 					return HdPubKeys.Where(x => x.KeyState == keyState);
 				}
@@ -202,10 +202,7 @@ namespace WalletWasabi.KeyManagement
 				{
 					return HdPubKeys.Where(x => x.IsInternal() == isInternal);
 				}
-				else // Neither of them null.
-				{
-					return HdPubKeys.Where(x => x.KeyState == keyState && x.IsInternal() == isInternal);
-				}
+				return HdPubKeys.Where(x => x.KeyState == keyState && x.IsInternal() == isInternal);
 			}
 		}
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
@@ -159,10 +159,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				{
 					return 0;
 				}
-				else
-				{
-					return Rounds.Min(x => x.State.RegistrationTimeout);
-				}
+				return Rounds.Min(x => x.State.RegistrationTimeout);
 			}
 		}
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -490,10 +490,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					return Alices.Count;
 				}
 			}
-			else
-			{
-				return Alices.Count;
-			}
+			return Alices.Count;
 		}
 
 		public bool AllAlices(AliceState state)
@@ -519,14 +516,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				}
 			}
 
-			if (alices.Count > 0)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return alices.Count > 0;
 		}
 
 		public bool ContainsInput(OutPoint input, out List<Alice> alices)
@@ -556,10 +546,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					return Bobs.Count;
 				}
 			}
-			else
-			{
-				return Alices.Count;
-			}
+			return Alices.Count;
 		}
 
 		public IEnumerable<Alice> GetAlicesBy(AliceState state)
@@ -587,10 +574,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					return Alices.Where(x => x.State != state).ToList();
 				}
 			}
-			else
-			{
-				return Alices.Where(x => x.State != state).ToList();
-			}
+			return Alices.Where(x => x.State != state).ToList();
 		}
 
 		public void StartAliceTimeout(Guid uniqueId)

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundPhase.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundPhase.cs
@@ -9,6 +9,6 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		InputRegistration,
 		ConnectionConfirmation,
 		OutputRegistration,
-		Signing,
+		Signing
 	}
 }

--- a/WalletWasabi/Models/Height.cs
+++ b/WalletWasabi/Models/Height.cs
@@ -117,7 +117,7 @@ namespace WalletWasabi.Models
 		public override string ToString()
 		{
 			if (Type == HeightType.Chain) return Value.ToString();
-			else return Type.ToString();
+			return Type.ToString();
 		}
 
 		#region EqualityAndComparison

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -313,10 +313,7 @@ namespace WalletWasabi.Services
 			{
 				throw new NotSupportedException("Coordinator didn't gave us the expected roundHash, even though it's in ConnectionConfirmation phase.");
 			}
-			else
-			{
-				ongoingRound.RoundHash = roundHash;
-			}
+			ongoingRound.RoundHash = roundHash;
 		}
 
 		private async Task TryConfirmConnectionAsync(CcjClientRound inputRegistrableRound)
@@ -626,7 +623,8 @@ namespace WalletWasabi.Services
 			{
 				throw exceptions.Single();
 			}
-			else if (exceptions.Count > 0)
+			
+			if (exceptions.Count > 0)
 			{
 				throw new AggregateException(exceptions);
 			}

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -292,32 +292,29 @@ namespace WalletWasabi.Services
 				{
 					return false;
 				}
-				else
+				foreach (var cjHash in UnconfirmedCoinJoins.ToArray())
 				{
-					foreach (var cjHash in UnconfirmedCoinJoins.ToArray())
+					try
 					{
-						try
-						{
-							var txInfo = await RpcClient.GetRawTransactionInfoAsync(cjHash);
+						var txInfo = await RpcClient.GetRawTransactionInfoAsync(cjHash);
 
-							// if confirmed remove only from unconfirmed
-							if (txInfo.Confirmations > 0)
-							{
-								UnconfirmedCoinJoins.Remove(cjHash);
-							}
-						}
-						catch (Exception ex)
+						// if confirmed remove only from unconfirmed
+						if (txInfo.Confirmations > 0)
 						{
-							// if failed remove from everywhere (should not happen normally)
 							UnconfirmedCoinJoins.Remove(cjHash);
-							CoinJoins.Remove(cjHash);
-							await File.WriteAllLinesAsync(CoinJoinsFilePath, CoinJoins.Select(x => x.ToString()));
-							Logger.LogWarning<CcjCoordinator>(ex);
 						}
+					}
+					catch (Exception ex)
+					{
+						// if failed remove from everywhere (should not happen normally)
+						UnconfirmedCoinJoins.Remove(cjHash);
+						CoinJoins.Remove(cjHash);
+						await File.WriteAllLinesAsync(CoinJoinsFilePath, CoinJoins.Select(x => x.ToString()));
+						Logger.LogWarning<CcjCoordinator>(ex);
 					}
 				}
 
-				return UnconfirmedCoinJoins.Count() >= 24;
+				return UnconfirmedCoinJoins.Count >= 24;
 			}
 		}
 

--- a/WalletWasabi/Services/IndexBuilderService.cs
+++ b/WalletWasabi/Services/IndexBuilderService.cs
@@ -102,18 +102,15 @@ namespace WalletWasabi.Services
 			{
 				return new Height(481824);
 			}
-			else if (network == Network.TestNet)
+			if (network == Network.TestNet)
 			{
 				return new Height(828575);
 			}
-			else if (network == Network.RegTest)
+			if (network == Network.RegTest)
 			{
 				return new Height(0);
 			}
-			else
-			{
-				throw new NotSupportedException($"{network} is not supported.");
-			}
+			throw new NotSupportedException($"{network} is not supported.");
 		}
 
 		public Height StartingHeight => GetStartingHeight(RpcClient.Network);

--- a/WalletWasabi/Services/IndexDownloader.cs
+++ b/WalletWasabi/Services/IndexDownloader.cs
@@ -41,18 +41,15 @@ namespace WalletWasabi.Services
 			{
 				return FilterModel.FromLine("0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893:02832810ec08a0", GetStartingHeight(network));
 			}
-			else if (network == Network.TestNet)
+			if (network == Network.TestNet)
 			{
 				return FilterModel.FromLine("00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:017821b8", GetStartingHeight(network));
 			}
-			else if (network == Network.RegTest)
+			if (network == Network.RegTest)
 			{
 				return FilterModel.FromLine("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", GetStartingHeight(network));
 			}
-			else
-			{
-				throw new NotSupportedException($"{network} is not supported.");
-			}
+			throw new NotSupportedException($"{network} is not supported.");
 		}
 
 		public FilterModel StartingFilter => GetStartingFilter(Network);

--- a/WalletWasabi/TorSocks5/Models/Fields/ByteArrayFields/AddrField.cs
+++ b/WalletWasabi/TorSocks5/Models/Fields/ByteArrayFields/AddrField.cs
@@ -23,19 +23,16 @@ namespace WalletWasabi.TorSocks5.Models.TorSocks5.Fields.ByteArrayFields
 				{
 					return Encoding.ASCII.GetString(Bytes.Skip(1).ToArray()); // UTF8 result in general SOCKS server failure
 				}
-				else if (Atyp == AtypField.IPv4)
-				{
-					var values = new string[4];
-					for (int i = 0; i < 4; i++)
-					{
-						values[i] = Bytes[i].ToString(); // it's ok ASCII here, these are always numbers
-					}
-					return string.Join(".", values);
-				}
-				else
-				{
+
+				if (Atyp != AtypField.IPv4) 
 					throw new NotSupportedException($"{nameof(Atyp)} is not supported. Value: {Atyp}.");
+
+				var values = new string[4];
+				for (int i = 0; i < 4; i++)
+				{
+					values[i] = Bytes[i].ToString(); // it's ok ASCII here, these are always numbers
 				}
+				return string.Join(".", values);
 			}
 		}
 

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -40,14 +40,7 @@ namespace WalletWasabi.TorSocks5
 			{
 				try
 				{
-					if (TcpClient == null || !TcpClient.Connected || TcpClient.GetStream() == null)
-					{
-						return false;
-					}
-					else
-					{
-						return true;
-					}
+					return TcpClient != null && TcpClient.Connected;
 				}
 				catch (Exception ex)
 				{
@@ -377,10 +370,8 @@ namespace WalletWasabi.TorSocks5
 					}
 					return await SendAsync(sendBuffer, receiveBufferSize, fallback: true);
 				}
-				else
-				{
-					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
-				}
+
+				throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
 			}
 		}
 

--- a/WalletWasabi/WebClients/ChaumianCoinJoin/AliceClient.cs
+++ b/WalletWasabi/WebClients/ChaumianCoinJoin/AliceClient.cs
@@ -40,14 +40,8 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 					if (response.StatusCode != HttpStatusCode.OK)
 					{
 						string error = await response.Content.ReadAsJsonAsync<string>();
-						if (error == null)
-						{
-							throw new HttpRequestException(response.StatusCode.ToReasonString());
-						}
-						else
-						{
-							throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-						}
+						var errorMessage = error == null ? string.Empty : $"\n{error}";
+						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 					}
 
 					var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>();
@@ -88,24 +82,17 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 					Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection.");
 					return null;
 				}
-				else if (response.StatusCode == HttpStatusCode.OK)
+				
+				if (response.StatusCode == HttpStatusCode.OK)
 				{
 					string roundHash = await response.Content.ReadAsJsonAsync<string>();
 					Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Acquired roundHash: {roundHash}.");
 					return roundHash;
 				}
-				else
-				{
-					string error = await response.Content.ReadAsJsonAsync<string>();
-					if (error == null)
-					{
-						throw new HttpRequestException(response.StatusCode.ToReasonString());
-					}
-					else
-					{
-						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-					}
-				}
+
+				string error = await response.Content.ReadAsJsonAsync<string>();
+				var errorMessage = error == null ? string.Empty : $"\n{error}";
+				throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 			}
 		}
 
@@ -117,14 +104,8 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 				if (!response.IsSuccessStatusCode)
 				{
 					string error = await response.Content.ReadAsJsonAsync<string>();
-					if (error == null)
-					{
-						throw new HttpRequestException(response.StatusCode.ToReasonString());
-					}
-					else
-					{
-						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-					}
+					var errorMessage = error == null ? string.Empty : $"\n{error}";
+					throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 				}
 				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
 			}
@@ -137,14 +118,8 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
 					string error = await response.Content.ReadAsJsonAsync<string>();
-					if (error == null)
-					{
-						throw new HttpRequestException(response.StatusCode.ToReasonString());
-					}
-					else
-					{
-						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-					}
+					var errorMessage = error == null ? string.Empty : $"\n{error}";
+					throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 				}
 
 				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
@@ -170,14 +145,8 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 				if (response.StatusCode != HttpStatusCode.NoContent)
 				{
 					string error = await response.Content.ReadAsJsonAsync<string>();
-					if (error == null)
-					{
-						throw new HttpRequestException(response.StatusCode.ToReasonString());
-					}
-					else
-					{
-						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-					}
+					var errorMessage = error == null ? string.Empty : $"\n{error}";
+					throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 				}
 				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
 			}

--- a/WalletWasabi/WebClients/ChaumianCoinJoin/BobClient.cs
+++ b/WalletWasabi/WebClients/ChaumianCoinJoin/BobClient.cs
@@ -31,14 +31,8 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 				if (response.StatusCode != HttpStatusCode.NoContent)
 				{
 					string error = await response.Content.ReadAsJsonAsync<string>();
-					if (error == null)
-					{
-						throw new HttpRequestException(response.StatusCode.ToReasonString());
-					}
-					else
-					{
-						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-					}
+					var errorMessage = error == null ? string.Empty : $"\n{error}";
+					throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 				}
 			}
 		}

--- a/WalletWasabi/WebClients/ChaumianCoinJoin/SatoshiClient.cs
+++ b/WalletWasabi/WebClients/ChaumianCoinJoin/SatoshiClient.cs
@@ -28,14 +28,8 @@ namespace WalletWasabi.WebClients.ChaumianCoinJoin
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
 					string error = await response.Content.ReadAsJsonAsync<string>();
-					if (error == null)
-					{
-						throw new HttpRequestException(response.StatusCode.ToReasonString());
-					}
-					else
-					{
-						throw new HttpRequestException($"{response.StatusCode.ToReasonString()}\n{error}");
-					}
+					var errorMessage = error == null ? string.Empty : $"\n{error}";
+					throw new HttpRequestException($"{response.StatusCode.ToReasonString()}{errorMessage}");
 				}
 
 				var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.WebClients
 {
 	public class ExchangeRateProvider : IExchangeRateProvider
 	{
-		private readonly IExchangeRateProvider[] _exchangeRateProviders = new IExchangeRateProvider[]{
+		private readonly IExchangeRateProvider[] _exchangeRateProviders = {
 			new SmartBitExchangeRateProvider(new SmartBitClient(Network.Main, disposeHandler: true)),
 			new BlockchainInfoExchangeRateProvider(),
 			new CoinbaseExchangeRateProvider(),


### PR DESCRIPTION
This PR removes many lines of code containing redundant `else` statements. Also, reduces the level of indentation in those methods that start with an `if` statement. By last, it simplifies the a bit teh Satoshi, Alice and Bob clients in the way they check errors and create exception messages.