### PR TITLE
Doing O(1) instead of  O(N)  for utxo set

### DIFF
--- a/WalletWasabi/Services/IndexBuilderService.cs
+++ b/WalletWasabi/Services/IndexBuilderService.cs
@@ -292,7 +292,8 @@ namespace WalletWasabi.Services
 										Bech32UtxoSet.Add(outpoint, output.ScriptPubKey);
 										if (!isIIB)
 										{
-											Bech32UtxoSetHistory.Last().StoreAction(ActionHistoryHelper.Operation.Add, outpoint, output.ScriptPubKey);
+											var lastUtxo = Bech32UtxoSetHistory[Bech32UtxoSetHistory.Count-1];
+											lastUtxo.StoreAction(ActionHistoryHelper.Operation.Add, outpoint, output.ScriptPubKey);
 										}
 										scripts.Add(output.ScriptPubKey);
 									}
@@ -306,7 +307,8 @@ namespace WalletWasabi.Services
 										Bech32UtxoSet.Remove(prevOut);
 										if (!isIIB)
 										{
-											Bech32UtxoSetHistory.Last().StoreAction(ActionHistoryHelper.Operation.Remove, prevOut, foundScript);
+											var lastUtxo = Bech32UtxoSetHistory[Bech32UtxoSetHistory.Count-1];
+											lastUtxo.StoreAction(ActionHistoryHelper.Operation.Remove, prevOut, foundScript);
 										}
 										scripts.Add(foundScript);
 									}


### PR DESCRIPTION
Instead of getting the last utxo element by doing `Bech32UtxoSetHistory.Last()` that is O(n) [[See the source code here](https://referencesource.microsoft.com/#System.Core/System/Linq/Enumerable.cs,1109)] we get the last element simply by doing `Bech32UtxoSetHistory[Bech32UtxoSetHistory.Count -1]` 