### PR TITLE
Using FirstOrDefault in place of SingleOrDefault on unique collections for performance

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -218,7 +218,7 @@ namespace WalletWasabi.Backend.Controllers
 
 					// Check if inputs have enough coins.
 					Money inputSum = inputs.Select(x => x.Output.Value).Sum();
-					Money networkFeeToPay = (inputs.Count() * round.FeePerInputs + 2 * round.FeePerOutputs);
+					Money networkFeeToPay = (inputs.Count() * round.FeePerInputs) + (2 * round.FeePerOutputs);
 					Money changeAmount = inputSum - (round.Denomination + networkFeeToPay);
 					if (changeAmount < Money.Zero)
 					{

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -145,7 +145,7 @@ namespace WalletWasabi.Backend.Controllers
 							}
 						}
 
-						var bannedElem = Coordinator.UtxoReferee.BannedUtxos.SingleOrDefault(x => x.Key == inputProof.Input);
+						var bannedElem = Coordinator.UtxoReferee.BannedUtxos.FirstOrDefault(x => x.Key == inputProof.Input);
 						if (bannedElem.Key != default)
 						{
 							int maxBan = (int)TimeSpan.FromDays(30).TotalMinutes;

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -2664,7 +2664,7 @@ namespace WalletWasabi.Tests
 				}
 
 				var times = 0;
-				while (wallet.Coins.Where(x => x.Label == "ZeroLink Change" && x.Unspent).SingleOrDefault() == null)
+				while (wallet.Coins.Where(x => x.Label == "ZeroLink Change" && x.Unspent).FirstOrDefault() == null)
 				{
 					await Task.Delay(1000);
 					times++;

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -2664,7 +2664,7 @@ namespace WalletWasabi.Tests
 				}
 
 				var times = 0;
-				while (wallet.Coins.Where(x => x.Label == "ZeroLink Change" && x.Unspent).FirstOrDefault() == null)
+				while (wallet.Coins.Where(x => x.Label == "ZeroLink Change" && x.Unspent).SingleOrDefault() == null)
 				{
 					await Task.Delay(1000);
 					times++;

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -129,7 +129,7 @@ namespace WalletWasabi.Services
 				{
 					OutPoint prevOut = input.PrevOut;
 
-					var found = UtxoReferee.BannedUtxos.SingleOrDefault(x => x.Key == prevOut);
+					var found = UtxoReferee.BannedUtxos.FirstOrDefault(x => x.Key == prevOut);
 					if (found.Key == default) continue; // if coin is not banned
 
 					if (!AnyRunningRoundContainsInput(prevOut, out _))

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -128,19 +128,19 @@ namespace WalletWasabi.Services
 				foreach (TxIn input in tx.Inputs)
 				{
 					OutPoint prevOut = input.PrevOut;
-
-					var found = UtxoReferee.BannedUtxos.FirstOrDefault(x => x.Key == prevOut);
-					if (found.Key == default) continue; // if coin is not banned
+					
+					// if coin is not banned
+					if (!UtxoReferee.BannedUtxos.TryGetValue(prevOut, out (int severity, DateTimeOffset timeOfBan) found)) continue;
 
 					if (!AnyRunningRoundContainsInput(prevOut, out _))
 					{
-						int newSeverity = found.Value.severity + 1;
+						int newSeverity = found.severity + 1;
 						await UtxoReferee.UnbanAsync(prevOut); // since it's not an UTXO anymore
 
 						if (RoundConfig.DosSeverity >= newSeverity)
 						{
 							var txCoins = tx.Outputs.AsIndexedOutputs().Select(x => x.ToCoin().Outpoint);
-							await UtxoReferee.BanUtxosAsync(newSeverity, found.Value.timeOfBan, txCoins.ToArray());
+							await UtxoReferee.BanUtxosAsync(newSeverity, found.timeOfBan, txCoins.ToArray());
 						}
 					}
 				}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -104,7 +104,7 @@ namespace WalletWasabi.Services
 			using (HandleFiltersLock.Lock())
 			using (WalletBlocksLock.Lock())
 			{
-				var elem = WalletBlocks.FirstOrDefault(x => x.Value == invalidBlockHash);
+				var elem = WalletBlocks.SingleOrDefault(x => x.Value == invalidBlockHash);
 				await DeleteBlockAsync(invalidBlockHash);
 				WalletBlocks.RemoveByValue(invalidBlockHash);
 				ProcessedBlocks.Remove(invalidBlockHash);

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -104,7 +104,7 @@ namespace WalletWasabi.Services
 			using (HandleFiltersLock.Lock())
 			using (WalletBlocksLock.Lock())
 			{
-				var elem = WalletBlocks.SingleOrDefault(x => x.Value == invalidBlockHash);
+				var elem = WalletBlocks.FirstOrDefault(x => x.Value == invalidBlockHash);
 				await DeleteBlockAsync(invalidBlockHash);
 				WalletBlocks.RemoveByValue(invalidBlockHash);
 				ProcessedBlocks.Remove(invalidBlockHash);
@@ -288,7 +288,7 @@ namespace WalletWasabi.Services
 			for (var i = 0; i < tx.Transaction.Outputs.Count; i++)
 			{
 				// If we already had it, just update the height. Maybe got from mempool to block or reorged.
-				var foundCoin = Coins.SingleOrDefault(x => x.TransactionId == tx.GetHash() && x.Index == i);
+				var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == tx.GetHash() && x.Index == i);
 				if (foundCoin != default)
 				{
 					// If tx height is mempool then don't, otherwise update the height.
@@ -374,7 +374,7 @@ namespace WalletWasabi.Services
 			{
 				var input = tx.Transaction.Inputs[i];
 
-				var foundCoin = Coins.SingleOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
+				var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
 				if (foundCoin != null)
 				{
 					foundCoin.SpenderTransactionId = tx.GetHash();


### PR DESCRIPTION
Done for performance as no duplicate items are guaranteed due to the collection types, so the entire list does not need to be enumerated to find duplicates.

For #275 