### PR TITLE
Added Coverlet

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -1,0 +1,8 @@
+COLLECT_COVERAGE="//p:CollectCoverage=true"
+OUTPUT_FORMAT="//p:CoverletOutputFormat=lcov"
+FILE_NAME="//p:CoverletOutputName=lcov"
+
+dotnet restore && dotnet build
+
+cd WalletWasabi.Tests
+dotnet test --no-build $COLLECT_COVERAGE $OUTPUT_FORMAT $FILE_NAME

--- a/.gitignore
+++ b/.gitignore
@@ -263,7 +263,5 @@ paket-files/
 __pycache__/
 *.pyc
 
-#AltCover
-__Saved/
-coverage.xml
+# Coverlet
 lcov.info

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -8,9 +8,14 @@
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
 
 test_script:
   - cd WalletWasabi.Tests
-  - dotnet test
+  - dotnet test /p:CollectCoverage=true
 
 on_finish:
   - ps: Stop-Process -Id $TorProcess.Id


### PR DESCRIPTION
Added Coverlet dep.
Added back a coverage script.
Set CopyLocalLockFileAssemblies to true.
Updated .gitignore

Note: use the shell script as the output file name/type needs to be changed from  `coverage.json` to `lcov.info` for the Visual Studio Code extension Coverage Gutters to work.

Ref: #316 