### PR TITLE
Update status text color for filters, blocks, peers

### DIFF
--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -35,7 +35,7 @@
                         </DrawingPresenter>
                     </Grid>
                     <TextBlock>Tor:</TextBlock>
-                    <TextBlock Text="{Binding Tor}" Foreground="{Binding Tor, Converter={StaticResource StatusColorConvertor}}" />
+                    <TextBlock Text="{Binding Tor}" Foreground="{Binding Tor, ConverterParameter=Tor, Converter={StaticResource StatusColorConvertor}}" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Gap="4">
@@ -66,7 +66,7 @@
                         </DrawingPresenter>
                     </Grid>
                     <TextBlock>Backend:</TextBlock>
-                    <TextBlock Text="{Binding Backend}" Foreground="{Binding Backend, Converter={StaticResource StatusColorConvertor}}" />
+                    <TextBlock Text="{Binding Backend}" Foreground="{Binding Backend, ConverterParameter=Backend, Converter={StaticResource StatusColorConvertor}}" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Gap="4">
@@ -85,7 +85,7 @@
                         </DrawingPresenter>
                     </Grid>
                     <TextBlock>Peers:</TextBlock>
-                    <TextBlock Text="{Binding Peers}" />
+                    <TextBlock Text="{Binding Peers}" Foreground="{Binding Peers, ConverterParameter=Peers, Converter={StaticResource StatusColorConvertor}}" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Gap="4">
@@ -104,7 +104,7 @@
                         </DrawingPresenter>
                     </Grid>
                     <TextBlock>Filters Left:</TextBlock>
-                    <TextBlock Text="{Binding FiltersLeft, Converter={StaticResource FilterLeftValueConverter}}" />
+                    <TextBlock Text="{Binding FiltersLeft, Converter={StaticResource FilterLeftValueConverter}}" Foreground="{Binding FiltersLeft, ConverterParameter=FiltersLeft, Converter={StaticResource StatusColorConvertor}}" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Gap="4">
@@ -125,7 +125,7 @@
                         </DrawingPresenter>
                     </Grid>
                     <TextBlock>Blocks Left:</TextBlock>
-                    <TextBlock Text="{Binding BlocksLeft}" />
+                    <TextBlock Text="{Binding BlocksLeft}" Foreground="{Binding BlocksLeft, ConverterParameter=BlocksLeft, Converter={StaticResource StatusColorConvertor}}" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Gap="4">

--- a/WalletWasabi.Gui/Converters/StatusColorConvertor.cs
+++ b/WalletWasabi.Gui/Converters/StatusColorConvertor.cs
@@ -13,19 +13,17 @@ namespace WalletWasabi.Gui.Converters
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
-			bool isTor = Enum.TryParse(value.ToString(), out TorStatus tor);
-			if (isTor && tor == TorStatus.NotRunning)
+			switch (parameter.ToString())
 			{
-				return Brushes.Yellow;
+				case "Tor" when Enum.Parse<TorStatus>(value.ToString()) == TorStatus.NotRunning:
+				case "Backend" when Enum.Parse<BackendStatus>(value.ToString()) == BackendStatus.NotConnected:
+				case "Peers" when (int)value == 0:
+				case "FiltersLeft" when value.ToString() != "0": // need to cover "--"
+				case "BlocksLeft" when (int)value != 0:
+					return Brushes.Yellow;
+				default:
+					return ColorTheme.CurrentTheme.Foreground;
 			}
-
-			bool isBackend = Enum.TryParse(value.ToString(), out BackendStatus backend);
-			if (isBackend && backend == BackendStatus.NotConnected)
-			{
-				return Brushes.Yellow;
-			}
-
-			return ColorTheme.CurrentTheme.Foreground;
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
Using `ConverterParameter` to get value of item being checked, as cannot rely on type for filters, blocks, or peers.
`FiltersLeft` is being cast to a string to handle "--".

Ref: #371 