### PR TITLE
WIP - Small UI improvements

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -10,10 +10,11 @@
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
     </UserControl.Styles>
+
     <ListBox Items="{Binding Coins}" SelectedItems="{Binding SelectedCoins}">
         <ListBox.ItemTemplate>
             <DataTemplate>
-                <Grid ColumnDefinitions="50,50,200,200,100,150,Auto">
+                <Grid ColumnDefinitions="40,80,100,600,100,150,Auto">
                     <!--<Grid.ToolTip>
                         <StackPanel Gap="4" MaxWidth="800">
                             <StackPanel Orientation="Horizontal" Gap="4">
@@ -62,11 +63,11 @@
                             </StackPanel>
                         </StackPanel>
                     </Grid.ToolTip>-->
-                    <CheckBox IsChecked="{Binding IsSelected}" />
+                    <CheckBox IsChecked="{Binding IsSelected}" HorizontalAlignment="Center" />
                     <Path Grid.Column="1" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" IsVisible="{Binding Confirmed}" Stretch="Fill" />
                     <TextBlock Grid.Column="2" Text="{Binding AmountBtc}" />
                     <TextBlock Grid.Column="3" Text="{Binding Label}" />
-                    <TextBlock Grid.Column="4" Text="{Binding PrivacyLevel, Converter={StaticResource PrivacyLevelValueConverter}}" />
+                    <TextBlock Grid.Column="4" Text="{Binding PrivacyLevel, Converter={StaticResource PrivacyLevelValueConverter}}" Margin="20 0 0 0" />
                     <Button Content="More..." Command="{Binding MoreCommand}" Grid.Column="5" />
                     <TextBlock Text="{Binding History}" Grid.Column="6" />
                 </Grid>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -14,11 +14,11 @@
     <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
         <Grid Classes="content">
             <DockPanel LastChildFill="True">
-                <Grid ColumnDefinitions="100, 200, 200, *" Margin="5 0" DockPanel.Dock="Top">
-                    <TextBlock Text="Confirmed:" />
-                    <TextBlock Text="Amount:" Grid.Column="1"/>
-                    <TextBlock Text="Label:" Grid.Column="2" />
-                    <TextBlock Text="Transaction Id:" Grid.Column="3" Margin="20 0 0 0" />
+                <Grid ColumnDefinitions="100, 100, 400, *" Margin="5 0" DockPanel.Dock="Top">
+                    <TextBlock Text="Confirmed" />
+                    <TextBlock Text="Amount" Grid.Column="1"/>
+                    <TextBlock Text="Transaction Id" Grid.Column="2" />
+                    <TextBlock Text="Label" Grid.Column="3"  Margin="20 0 0 0"/>
                     <Grid IsVisible="{Binding ClipboardNotificationVisible}" Grid.ColumnSpan="4">
                         <Grid Opacity="{Binding ClipboardNotificationOpacity}">
                             <Grid.Transitions>
@@ -35,16 +35,16 @@
                 <ListBox Items="{Binding Transactions}" SelectedItem="{Binding SelectedTransaction, Mode=TwoWay}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <Grid ColumnDefinitions="100, 200, 200, *">
+                            <Grid ColumnDefinitions="100, 100, 400, *">
                                 <Grid.Styles>
                                     <Style Selector="TextBlock">
                                         <Setter Property="VerticalAlignment" Value="Center" />
                                     </Style>
                                 </Grid.Styles>
-                                <Path Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" IsVisible="{Binding Confirmed}" Stretch="Fill" />
+                                <Path HorizontalAlignment="Center" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" IsVisible="{Binding Confirmed}" Stretch="Fill" />
                                 <TextBlock Text="{Binding AmountBtc}" Grid.Column="1" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
-                                <TextBlock Text="{Binding Label}" Grid.Column="2" />
-                                <TextBlock Text="{Binding TransactionId}" Grid.Column="3"  Margin="20 0 0 0" />
+                                <TextBlock Text="{Binding TransactionId}" Grid.Column="2" />
+                                <TextBlock Text="{Binding Label}" Grid.Column="3" Margin="20 0 0 0"/>
                             </Grid>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -7,11 +7,11 @@
         <converters:FeeConfirmationTargetConverter x:Key="FeeConfirmationTargetConverter" />
     </UserControl.Resources>
     <DockPanel LastChildFill="True">
-        <StackPanel DockPanel.Dock="Bottom" Margin="20 10" Gap="10" HorizontalAlignment="Center" MinWidth="1000">
+        <StackPanel DockPanel.Dock="Bottom" Margin="20 10" Gap="10" HorizontalAlignment="Left" MinWidth="1000">
             <TextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True" />
             <StackPanel Orientation="Horizontal" Gap="10">
                 <Button Content="Max" Command="{Binding MaxCommand}" />
-                <TextBox Text="{Binding Amount}" Watermark="Amount" UseFloatingWatermark="True" />
+                <TextBox Text="{Binding Amount}" Watermark="Amount" UseFloatingWatermark="True" MinWidth="100" />
                 <StackPanel>
                     <Slider Minimum="0" Maximum="10" Value="{Binding Fee}" />
                     <StackPanel Orientation="Horizontal" Gap="4">
@@ -33,10 +33,22 @@
             <TextBlock Text="{Binding WarningMessage}" Classes="warningMessage" />
             <TextBlock Text="{Binding ValidationMessage}" Classes="errorMessage" />
         </StackPanel>
-        <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20">
-            <Grid Classes="content">
-                <local:CoinListView DataContext="{Binding CoinList}" />
-            </Grid>
+        <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
+
+        <Grid Classes="content">
+            <DockPanel LastChildFill="True">
+                <Grid ColumnDefinitions="40,80,100,600,100,150,Auto" Margin="5 0" DockPanel.Dock="Top">
+                    <TextBlock Text="Select" />
+                    <TextBlock Text="Confirmed" Grid.Column="1"/>
+                    <TextBlock Text="Amount" Grid.Column="2" />
+                    <TextBlock Text="Label" Grid.Column="3" />
+                    <TextBlock Text="Privacy Level" Grid.Column="4" Margin="20 0 0 0"/>
+                    <TextBlock Text="" Grid.Column="5"/>
+                    <TextBlock Text="" Grid.Column="6"/>
+                </Grid>
+            <local:CoinListView DataContext="{Binding CoinList}" />
+            </DockPanel> 
+        </Grid>
         </controls:GroupBox>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
This PR contains the following small improvements:

* Change the columns order for Transaction Id and Label
* Resize the columns width in Send and History tabs
* Align the Build Transaction panel to the right
* Increase the Amount textbox width
* Add header to the coin selection list 