### PR TITLE
fixes 'copied to clipboard' message

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -69,7 +69,7 @@
                             Duration="0:0:0.5" />
                     </Transitions>
                 </Grid.Transitions>
-                <TextBlock Text="Address Copied to Clipboard!" Foreground="#22B14C" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                <TextBlock Text="Transaction ID Copied to Clipboard!" Foreground="#22B14C" VerticalAlignment="Center" HorizontalAlignment="Center" />
             </Grid>
         </Grid>    
         <Grid ColumnDefinitions="60,100,100,600,100,Auto" Margin="5 0" DockPanel.Dock="Top">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -57,6 +57,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public int AnonymitySet => _model.AnonymitySet;
 
+		public string InCoinJoin => _model.CoinJoinInProcess ? "Yes" : "No";
+
 		public string History
 		{
 			get { return _history; }


### PR DESCRIPTION
This PR changes the 'Address copied to clipboard' message by 'Transaction ID copied to clipboard' message.

Add `CoinJoin in progress` info to the coin list tooltip.