### PR TITLE
[WIP] Fix leading comma bug

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -78,7 +78,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				if (found != default) // if found
 				{
 					txRecordList.Remove(found);
-					var newRecord = (found.height, found.amount + coin.Amount, $"{found.label}, {coin.Label}", coin.TransactionId);
+					var foundLabel = found.label != string.Empty ? found.label + ", " : "";
+					var newRecord = (found.height, found.amount + coin.Amount, $"{foundLabel}{coin.Label}", coin.TransactionId);
 					txRecordList.Add(newRecord);
 				}
 				else


### PR DESCRIPTION
Tested this locally and it works.

The space and comma need to only be present if `found.label` is not empty.

![capture](https://user-images.githubusercontent.com/20197359/42115452-499a8734-7c36-11e8-9323-c63b8fa80b59.PNG)
