### PR TITLE
Fix blank labels in history tab

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -78,8 +78,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				if (found != default) // if found
 				{
 					txRecordList.Remove(found);
-					var foundLabel = found.label != string.Empty ? found.label + ", " : "";
-					var newRecord = (found.height, found.amount + coin.Amount, $"{foundLabel}{coin.Label}", coin.TransactionId);
+					var newRecord = (found.height, found.amount + coin.Amount, $"{found.label}, {coin.Label}", coin.TransactionId);
 					txRecordList.Add(newRecord);
 				}
 				else
@@ -102,7 +101,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 					else
 					{
-						txRecordList.Add((guessHeight, (Money.Zero - coin.Amount), "", coin.SpenderTransactionId));
+						txRecordList.Add((guessHeight, (Money.Zero - coin.Amount), coin.Label, coin.SpenderTransactionId));
 					}
 				}
 			}


### PR DESCRIPTION
If more than one input is spent in a transaction the label shows as
blank in the history tab. This was because the first input had its label
set to an empty string on line 104.
Removed `string.Empty` check as the fix mentioned removes the need for
this check.