### PR TITLE
Made some validation changes

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -11,7 +11,7 @@
         <Grid RowDefinitions="Auto,*" DockPanel.Dock="Top">
           <DockPanel LastChildFill="True">
             <Button Content="Generate Receive Address" Command="{Binding GenerateCommand}" DockPanel.Dock="Right" VerticalAlignment="Top" />
-            <TextBox Text="{Binding Label, Mode=TwoWay}" Watermark="Label" UseFloatingWatermark="True" DockPanel.Dock="Left" MinWidth="300">
+            <TextBox Text="{Binding Label, Mode=TwoWay}" Watermark="Label (Required)" UseFloatingWatermark="True" DockPanel.Dock="Left" MinWidth="300">
               <i:Interaction.Behaviors>
                 <behaviors:CommandOnEnterBehavior Command="{Binding GenerateCommand}" />
               </i:Interaction.Behaviors>
@@ -19,6 +19,7 @@
                 Start labelling today and your privacy will thank you tomorrow!
               </ToolTip.Tip>
             </TextBox>
+            <TextBox Text="{Binding WarningMessage}" Classes="warningMessage" Margin="5" BorderThickness="0" />
             <Grid IsVisible="{Binding ClipboardNotificationVisible}">
               <Grid Opacity="{Binding ClipboardNotificationOpacity}">
                 <Grid.Transitions>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -20,6 +20,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private string _label;
 		private double _clipboardNotificationOpacity;
 		private bool _clipboardNotificationVisible;
+		private string _warningMessage;
 
 		public ReceiveTabViewModel(WalletViewModel walletViewModel)
 			: base("Receive", walletViewModel)
@@ -37,22 +38,33 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			GenerateCommand = ReactiveCommand.Create(() =>
 			{
-				HdPubKey newKey = Global.WalletService.GetReceiveKey(Label);
-
-				AddressViewModel found = Addresses.FirstOrDefault(x => x.Model == newKey);
-				if (found != default)
+				if (string.IsNullOrWhiteSpace(Label))
 				{
-					Addresses.Remove(found);
+					WarningMessage = "Label cannot be empty";
 				}
+				else
+				{
+					WarningMessage = string.Empty;
 
-				var newAddress = new AddressViewModel(newKey);
+					HdPubKey newKey = Global.WalletService.GetReceiveKey(Label);
 
-				Addresses.Insert(0, newAddress);
+					AddressViewModel found = Addresses.FirstOrDefault(x => x.Model == newKey);
+					if (found != default)
+					{
+						Addresses.Remove(found);
+					}
 
-				SelectedAddress = newAddress;
+					var newAddress = new AddressViewModel(newKey);
 
-				Label = string.Empty;
-			}, this.WhenAnyValue(x => x.Label, label => !string.IsNullOrWhiteSpace(label)));
+					Addresses.Insert(0, newAddress);
+
+					SelectedAddress = newAddress;
+
+					Label = string.Empty;
+				}
+			});
+
+			this.WhenAnyValue(x => x.Label).Subscribe(label => { WarningMessage = string.Empty; });
 
 			this.WhenAnyValue(x => x.SelectedAddress).Subscribe(async address =>
 			{
@@ -101,6 +113,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set { this.RaiseAndSetIfChanged(ref _label, value); }
 		}
 
+		public string WarningMessage
+		{
+			get { return _warningMessage; }
+			set { this.RaiseAndSetIfChanged(ref _warningMessage, value); }
+		}
 		public double ClipboardNotificationOpacity
 		{
 			get { return _clipboardNotificationOpacity; }


### PR DESCRIPTION
Updated the watermark to : "Label (Required)".

Updated `GenerateCommand` to create a warning message if label is blank (I think this is better than the red outline as it's consistent with other validation warning messages in the app).

Added subscriber to clear warning message.

Note: the logic that disables the button has been removed so that the validation check can run inside the create method. This now changed the display of the Generate Address Button to not look disabled but it shouldn't make that much of a difference seeing as users didn't notice it in the first place.

Ref: #459 