### PR TITLE
Serialize loop referenced during serialization

### DIFF
--- a/WalletWasabi.Tests/SmartModelTests.cs
+++ b/WalletWasabi.Tests/SmartModelTests.cs
@@ -90,13 +90,16 @@ namespace WalletWasabi.Tests
 			var smartTx2 = new SmartTransaction(tx2, height);
 			var smartTx3 = new SmartTransaction(tx3, height);
 
-			var serialized = JsonConvert.SerializeObject(smartTx);
+			var settings = new JsonSerializerSettings{ 
+				ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+			};
+			var serialized = JsonConvert.SerializeObject(smartTx, settings);
 			var deserialized = JsonConvert.DeserializeObject<SmartTransaction>(serialized);
 
-			var serialized2 = JsonConvert.SerializeObject(smartTx2);
+			var serialized2 = JsonConvert.SerializeObject(smartTx2, settings);
 			var deserialized2 = JsonConvert.DeserializeObject<SmartTransaction>(serialized2);
 
-			var serialized3 = JsonConvert.SerializeObject(smartTx3);
+			var serialized3 = JsonConvert.SerializeObject(smartTx3, settings);
 			var deserialized3 = JsonConvert.DeserializeObject<SmartTransaction>(serialized3);
 
 			Assert.Equal(smartTx, deserialized);
@@ -109,7 +112,8 @@ namespace WalletWasabi.Tests
 			Assert.True(smartTx.Equals(sto));
 			object to = deserialized.Transaction;
 			Assert.True(smartTx.Equals(deserialized.Transaction));
-			// ToDo: Assert.True(smartTx.Equals(to));
+			
+			Assert.True(smartTx.Equals(to));
 		}
 
 		[Fact]

--- a/WalletWasabi/Models/SmartTransaction.cs
+++ b/WalletWasabi/Models/SmartTransaction.cs
@@ -64,12 +64,25 @@ namespace WalletWasabi.Models
 
 		#region Equality
 
-		public bool Equals(SmartTransaction other) => GetHash().Equals(other?.GetHash());
+		public bool Equals(SmartTransaction other) => Equals((object)other);
 
-		public bool Equals(Transaction other) => GetHash().Equals(other?.GetHash());
+		public bool Equals(Transaction other) => Equals((object)other);
 
-		public override bool Equals(object obj) =>
-			(obj is SmartTransaction && this == (SmartTransaction)obj);
+		public override bool Equals(object obj)
+		{
+			if(object.ReferenceEquals(this, obj))
+				return true;
+			
+			if(obj is SmartTransaction st)
+			{
+				return st.Transaction.GetHash() == this.GetHash();
+			}
+			else if(obj is Transaction t)
+			{
+				return t.GetHash() == this.GetHash();
+			}
+			return false;
+		}
 
 		public override int GetHashCode()
 		{
@@ -83,35 +96,12 @@ namespace WalletWasabi.Models
 
 		public static bool operator ==(SmartTransaction tx1, SmartTransaction tx2)
 		{
-			bool rc;
-
-			if (ReferenceEquals(tx1, tx2)) rc = true;
-			else if ((object)tx1 == null || (object)tx2 == null)
-			{
-				rc = false;
-			}
-			else
-			{
-				rc = tx1.GetHash().Equals(tx2.GetHash());
-			}
-
-			return rc;
+			return tx1.Equals(tx2);
 		}
 
 		public static bool operator ==(Transaction tx1, SmartTransaction tx2)
 		{
-			bool rc;
-
-			if ((object)tx1 == null || (object)tx2 == null)
-			{
-				rc = false;
-			}
-			else
-			{
-				rc = tx1.GetHash().Equals(tx2.GetHash());
-			}
-
-			return rc;
+			return tx2.Equals(tx1);
 		}
 
 		public static bool operator !=(Transaction tx1, SmartTransaction tx2)
@@ -121,18 +111,7 @@ namespace WalletWasabi.Models
 
 		public static bool operator ==(SmartTransaction tx1, Transaction tx2)
 		{
-			bool rc;
-
-			if ((object)tx1 == null || (object)tx2 == null)
-			{
-				rc = false;
-			}
-			else
-			{
-				rc = tx1.GetHash().Equals(tx2.GetHash());
-			}
-
-			return rc;
+			return tx1.Equals(tx2);
 		}
 
 		public static bool operator !=(SmartTransaction tx1, Transaction tx2)


### PR DESCRIPTION
This PR is for discussion.

The _Self referencing loop detected for type_ error is because the `Transaction` property is equal to `this` so, the loop reference control mechanism believes the `Transaction` property is a self referenced property.

So, if we want to be able to compare `SmartTransaction` and `Transaction` then, the only way to solve this indicating to the Serializer to serialize the reference loop. 