### PR TITLE
Remove Splitter and set minWidth in WalletExplorer

### DIFF
--- a/WalletWasabi.Gui/DefaultLayoutFactory.cs
+++ b/WalletWasabi.Gui/DefaultLayoutFactory.cs
@@ -57,12 +57,6 @@ namespace WalletWasabi.Gui
 				Views = new ObservableCollection<IView>
 				{
 					RightDock,
-					new SplitterDock()
-					{
-						Id = "RightSplitter",
-						Dock = "Right",
-						Title = "RightSplitter"
-					},
 					DocumentDock
 				}
 			};

--- a/WalletWasabi.Gui/Styles/Styles.xaml
+++ b/WalletWasabi.Gui/Styles/Styles.xaml
@@ -58,6 +58,10 @@
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
     </Style>
 
+    <Style Selector="dock|DockToolChrome">
+        <Setter Property="MinWidth" Value="300" />
+    </Style>
+
     <Style Selector="ListBox">
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}" />
     </Style>


### PR DESCRIPTION
I've removed the `Splitter` control that splits the WalletExplorer and the DocumentControls.