### PR TITLE
Fix incorrect balance

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -28,8 +28,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			: base(name)
 		{
 			var coinsChanged = Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.HashSetChanged));
+			var newBlockProcessed = Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.NewBlockProcessed));
+			var coinSpent = Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.CoinSpentOrSpenderConfirmed));
 
 			coinsChanged
+				.Merge(newBlockProcessed)
+				.Merge(coinSpent)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(o =>
 				{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -28,11 +28,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			: base(name)
 		{
 			var coinsChanged = Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.HashSetChanged));
-			var newBlockProcessed = Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.NewBlockProcessed));
 			var coinSpent = Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.CoinSpentOrSpenderConfirmed));
 
 			coinsChanged
-				.Merge(newBlockProcessed)
 				.Merge(coinSpent)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(o =>


### PR DESCRIPTION
Event listener now listens for new processed blocks and spent or confirmed coins.

Fixes: #499