### PR TITLE
Added password validation for coinjoin enqueue

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -14,6 +14,7 @@
       <Grid Classes="content">
         <DockPanel LastChildFill="True">
           <StackPanel Gap="10" Orientation="Horizontal" DockPanel.Dock="Bottom" Margin="0 10 0 0" HorizontalAlignment="Right">
+            <TextBlock Text="{Binding WarningMessage}" Classes="warningMessage" />
             <TextBox Text="{Binding Password}" PasswordChar="*" Watermark="Password" UseFloatingWatermark="True" MinWidth="173" />
             <DockPanel LastChildFill="True">
               <Button Content="Enqueue" Command="{Binding EnqueueCommand}" DockPanel.Dock="Right" />


### PR DESCRIPTION
If a user enters the wrong password when trying to enqueue some coins, there is no feedback given, and the selected coins are deselected. The user won't know what went wrong and will have to reselect the same coins.

Changes:
Added TextBlock for WarningMessage.
Wrapped invocation of QueueCoinsToMixAsync in a try/catch.
Deselecting selected coins is only done after password is verified.