### PR TITLE
simplify clone and build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ HiddenWallet's code is archived in the [hiddenwallet-v0.6](https://github.com/zk
 Clone & Restore & Build
 
 ```sh
-git clone https://github.com/zkSNACKs/WalletWasabi.git
+git clone https://github.com/zkSNACKs/WalletWasabi --recursive
 cd WalletWasabi
-git submodule update --init --recursive
 cd WalletWasabi.Gui
-dotnet restore && dotnet build
+dotnet build
 ```
 
 ## Run Wasabi

--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ HiddenWallet's code is archived in the [hiddenwallet-v0.6](https://github.com/zk
 Clone & Restore & Build
 
 ```sh
-git clone https://github.com/zkSNACKs/WalletWasabi --recursive
-cd WalletWasabi
-cd WalletWasabi.Gui
+git clone https://github.com/zkSNACKs/WalletWasabi.git --recursive
+cd WalletWasabi/WalletWasabi.Gui
 dotnet build
 ```
 


### PR DESCRIPTION
no need for submodule update --init if you clone with --recursive.

done build will also do a restore for you, so remove explicit restore command.



btw worth noting, that dotnet run = compile and run.

app would load much faster if you run dotnet WalletWasabi.Gui.dll from the bin directory.