### PR TITLE
Reduce the filters request interval

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -136,7 +136,7 @@ namespace WalletWasabi.Gui
 				Logger.LogInfo("Start connecting to mempool serving regtest node...");
 			}
 
-			IndexDownloader.Synchronize(requestInterval: TimeSpan.FromSeconds(21));
+			IndexDownloader.Synchronize(requestInterval: TimeSpan.FromSeconds(2.5));
 			Logger.LogInfo("Start synchronizing filters...");
 		}
 


### PR DESCRIPTION
During the live demo it was evident the time required for downloading the filters was too much (aprox 30 minutes). The specified request interval was 21 seconds what means 18 minutes were wasted time waiting.  The new request interval value is 2.5 seconds and the filters are downloaded in round 15 minutes.  