### PR TITLE
Add client config entries for specifying tor end point ip address and port

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -123,7 +123,7 @@ namespace WalletWasabi.Gui
 				RegTestMemPoolServingNode = null;
 			}
 
-			IndexDownloader = new IndexDownloader(Network, IndexFilePath, Config.GetCurrentBackendUri());
+			IndexDownloader = new IndexDownloader(Network, IndexFilePath, Config.GetCurrentBackendUri(), Config.GetTorEndPoint());
 
 			UpdateChecker = new UpdateChecker(IndexDownloader.WasabiClient);
 
@@ -144,7 +144,7 @@ namespace WalletWasabi.Gui
 
 		public static async Task InitializeWalletServiceAsync(KeyManager keyManager)
 		{
-			ChaumianClient = new CcjClient(Network, BlindingPubKey, keyManager, Config.GetCurrentBackendUri());
+			ChaumianClient = new CcjClient(Network, BlindingPubKey, keyManager, Config.GetCurrentBackendUri(), Config.GetTorEndPoint());
 			WalletService = new WalletService(keyManager, IndexDownloader, ChaumianClient, MemPoolService, Nodes, DataDir);
 
 			ChaumianClient.Start(0, 7);

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -123,7 +123,7 @@ namespace WalletWasabi.Gui
 				RegTestMemPoolServingNode = null;
 			}
 
-			IndexDownloader = new IndexDownloader(Network, IndexFilePath, Config.GetCurrentBackendUri(), Config.GetTorEndPoint());
+			IndexDownloader = new IndexDownloader(Network, IndexFilePath, Config.GetCurrentBackendUri(), Config.GetTorSocks5EndPoint());
 
 			UpdateChecker = new UpdateChecker(IndexDownloader.WasabiClient);
 
@@ -144,7 +144,7 @@ namespace WalletWasabi.Gui
 
 		public static async Task InitializeWalletServiceAsync(KeyManager keyManager)
 		{
-			ChaumianClient = new CcjClient(Network, BlindingPubKey, keyManager, Config.GetCurrentBackendUri(), Config.GetTorEndPoint());
+			ChaumianClient = new CcjClient(Network, BlindingPubKey, keyManager, Config.GetCurrentBackendUri(), Config.GetTorSocks5EndPoint());
 			WalletService = new WalletService(keyManager, IndexDownloader, ChaumianClient, MemPoolService, Nodes, DataDir);
 
 			ChaumianClient.Start(0, 7);


### PR DESCRIPTION
Initially I neglected to modify LoadOrCreateDefault method on Config to also copy the parameters, so my config file kept getting mysteriously overwritten.

Maybe this method should be moved outside the IConfig interface?  Because it's essentially the same method for any IConfig implementation.  Anyway for this commit I moved the copy stuff to OverwriteWith, but would be nice to get rid of it completely somehow.