### PR TITLE
Safe wallet write

### DIFF
--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -105,31 +105,39 @@ namespace System.IO
 			SafeMove(newPath, path);
 		}
 
+		// https://stackoverflow.com/a/7957634/2061103
 		public static bool TryGetSafestFileVersion(string path, out string safestFilePath)
 		{
 			var newPath = path + NewExtension;
 			var oldPath = path + OldExtension;
 
+			// If foo.data and foo.data.new exist, load foo.data; foo.data.new may be broken (e.g. power off during write).
 			if (File.Exists(path) && File.Exists(newPath))
 			{
 				safestFilePath = path;
 				return true;
 			}
+
+			// If foo.data.old and foo.data.new exist, both should be valid, but something died very shortly afterwards - you may want to load the foo.data.old version anyway.
 			if (File.Exists(oldPath) && File.Exists(newPath))
 			{
 				safestFilePath = oldPath;
 				return true;
 			}
+
+			// If foo.data and foo.data.old exist, then foo.data should be fine, but again something went wrong, or possibly the file couldn't be deleted.
 			if (File.Exists(oldPath) && File.Exists(path))
 			{
 				safestFilePath = path;
 				return true;
 			}
+
 			if (File.Exists(path))
 			{
 				safestFilePath = path;
 				return true;
 			}
+
 			safestFilePath = null;
 			return false;
 		}

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -49,7 +49,7 @@ namespace System.IO
 		}
 
 		// https://stackoverflow.com/a/7957634/2061103
-		private static void Replace(string newPath, string path)
+		private static void SafeMove(string newPath, string path)
 		{
 			var oldPath = path + ".old";
 			if (File.Exists(oldPath))
@@ -67,39 +67,39 @@ namespace System.IO
 			File.Delete(oldPath);
 		}
 
-		public static void WriteAllText(string path, string content)
+		public static void SafeWriteAllText(string path, string content)
 		{
 			var newPath = path + ".new";
 			File.WriteAllText(newPath, content, Encoding.UTF8);
-			Replace(newPath, path);
+			SafeMove(newPath, path);
 		}
 
-		public static async Task WriteAllTextAsync(string path, string content)
+		public static async Task SafeWriteAllTextAsync(string path, string content)
 		{
 			var newPath = path + ".new";
 			await File.WriteAllTextAsync(newPath, content, Encoding.UTF8);
-			Replace(newPath, path);
+			SafeMove(newPath, path);
 		}
 
 		public static void WriteAllLines(string path, IEnumerable<string> content)
 		{
 			var newPath = path + ".new";
 			File.WriteAllLines(newPath, content);
-			Replace(newPath, path);
+			SafeMove(newPath, path);
 		}
 
-		public static async Task WriteAllLinesAsync(string path, IEnumerable<string> content)
+		public static async Task SafeWriteAllLinesAsync(string path, IEnumerable<string> content)
 		{
 			var newPath = path + ".new";
 			await File.WriteAllLinesAsync(newPath, content);
-			Replace(newPath, path);
+			SafeMove(newPath, path);
 		}
 
-		public static async Task WriteAllBytesAsync(string path, byte[] content)
+		public static async Task SafeWriteAllBytesAsync(string path, byte[] content)
 		{
 			var newPath = path + ".new";
 			await File.WriteAllBytesAsync(newPath, content);
-			Replace(newPath, path);
+			SafeMove(newPath, path);
 		}
 
 		public static bool TryGetSafestFileVersion(string path, out string safestFilePath)

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -48,9 +48,10 @@ namespace System.IO
 			// depending on your use case, consider throwing an exception here
 		}
 
+		// https://stackoverflow.com/a/7957634/2061103
 		private static void Replace(string newPath, string path)
 		{
-			var oldPath = path + ".bak";
+			var oldPath = path + ".old";
 			if (File.Exists(oldPath))
 			{
 				File.Delete(oldPath);
@@ -60,7 +61,9 @@ namespace System.IO
 			{
 				File.Move(path, oldPath);
 			}
+
 			File.Move(newPath, path);
+
 			File.Delete(newPath);
 		}
 
@@ -102,7 +105,7 @@ namespace System.IO
 		public static bool TryGetSafestFileVersion(string path, out string safestFilePath)
 		{
 			var newPath = path + ".new";
-			var oldPath = path + ".bak";
+			var oldPath = path + ".old";
 
 			if (File.Exists(path) && File.Exists(newPath))
 			{

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -73,14 +73,28 @@ namespace System.IO
 		public static void SafeWriteAllText(string path, string content)
 		{
 			var newPath = path + NewExtension;
-			File.WriteAllText(newPath, content, Encoding.UTF8);
+			File.WriteAllText(newPath, content);
+			SafeMove(newPath, path);
+		}
+
+		public static void SafeWriteAllText(string path, string content, Encoding encoding)
+		{
+			var newPath = path + NewExtension;
+			File.WriteAllText(newPath, content, encoding);
 			SafeMove(newPath, path);
 		}
 
 		public static async Task SafeWriteAllTextAsync(string path, string content)
 		{
 			var newPath = path + NewExtension;
-			await File.WriteAllTextAsync(newPath, content, Encoding.UTF8);
+			await File.WriteAllTextAsync(newPath, content);
+			SafeMove(newPath, path);
+		}
+
+		public static async Task SafeWriteAllTextAsync(string path, string content, Encoding encoding)
+		{
+			var newPath = path + NewExtension;
+			await File.WriteAllTextAsync(newPath, content, encoding);
 			SafeMove(newPath, path);
 		}
 

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -7,6 +7,9 @@ namespace System.IO
 {
 	public static class IoHelpers
 	{
+		private const string OldExtension = ".old";
+		private const string NewExtension = ".new";
+
 		// http://stackoverflow.com/a/14933880/2061103
 		public static async Task DeleteRecursivelyWithMagicDustAsync(string destinationDir)
 		{
@@ -51,7 +54,7 @@ namespace System.IO
 		// https://stackoverflow.com/a/7957634/2061103
 		private static void SafeMove(string newPath, string path)
 		{
-			var oldPath = path + ".old";
+			var oldPath = path + OldExtension;
 			if (File.Exists(oldPath))
 			{
 				File.Delete(oldPath);
@@ -69,43 +72,43 @@ namespace System.IO
 
 		public static void SafeWriteAllText(string path, string content)
 		{
-			var newPath = path + ".new";
+			var newPath = path + NewExtension;
 			File.WriteAllText(newPath, content, Encoding.UTF8);
 			SafeMove(newPath, path);
 		}
 
 		public static async Task SafeWriteAllTextAsync(string path, string content)
 		{
-			var newPath = path + ".new";
+			var newPath = path + NewExtension;
 			await File.WriteAllTextAsync(newPath, content, Encoding.UTF8);
 			SafeMove(newPath, path);
 		}
 
 		public static void WriteAllLines(string path, IEnumerable<string> content)
 		{
-			var newPath = path + ".new";
+			var newPath = path + NewExtension;
 			File.WriteAllLines(newPath, content);
 			SafeMove(newPath, path);
 		}
 
 		public static async Task SafeWriteAllLinesAsync(string path, IEnumerable<string> content)
 		{
-			var newPath = path + ".new";
+			var newPath = path + NewExtension;
 			await File.WriteAllLinesAsync(newPath, content);
 			SafeMove(newPath, path);
 		}
 
 		public static async Task SafeWriteAllBytesAsync(string path, byte[] content)
 		{
-			var newPath = path + ".new";
+			var newPath = path + NewExtension;
 			await File.WriteAllBytesAsync(newPath, content);
 			SafeMove(newPath, path);
 		}
 
 		public static bool TryGetSafestFileVersion(string path, out string safestFilePath)
 		{
-			var newPath = path + ".new";
-			var oldPath = path + ".old";
+			var newPath = path + NewExtension;
+			var oldPath = path + OldExtension;
 
 			if (File.Exists(path) && File.Exists(newPath))
 			{

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
 using WalletWasabi.Logging;
 
 namespace System.IO
@@ -44,6 +46,85 @@ namespace System.IO
 				return;
 			}
 			// depending on your use case, consider throwing an exception here
+		}
+
+		private static void Replace(string newPath, string path)
+		{
+			var oldPath = path + ".bak";
+			if(File.Exists(oldPath))
+			{
+				File.Delete(oldPath);
+			}
+
+			if(File.Exists(path))
+			{
+				File.Move(path, oldPath);
+			}
+			File.Move(newPath, path);
+			File.Delete(newPath);
+		}
+
+		public static void WriteAllText(string path, string content)
+		{
+			var newPath = path + ".new";
+			File.WriteAllText(newPath, content, Encoding.UTF8);
+			Replace(newPath, path);
+		}
+
+		public static async Task WriteAllTextAsync(string path, string content)
+		{
+			var newPath = path + ".new";
+			await File.WriteAllTextAsync(newPath, content, Encoding.UTF8);
+			Replace(newPath, path);
+		}
+
+		public static void WriteAllLines(string path, IEnumerable<string> content)
+		{
+			var newPath = path + ".new";
+			File.WriteAllLines(newPath, content);
+			Replace(newPath, path);
+		}
+
+		public static async Task WriteAllLinesAsync(string path, IEnumerable<string> content)
+		{
+			var newPath = path + ".new";
+			await File.WriteAllLinesAsync(newPath, content);
+			Replace(newPath, path);
+		}
+
+		public static async Task WriteAllBytesAsync(string path, byte[] content)
+		{
+			var newPath = path + ".new";
+			await File.WriteAllBytesAsync(newPath, content);
+			Replace(newPath, path);
+		}
+
+		public static bool TryGetSafestFileVersion(string path, out string safestFilePath)
+		{
+			var newPath = path + ".new";
+			var oldPath = path + ".bak";
+
+			if(File.Exists(path) && File.Exists(newPath)){
+				safestFilePath = path;
+				return true;
+			}
+			if(File.Exists(oldPath) && File.Exists(newPath))
+			{
+				safestFilePath = oldPath;
+				return true;
+			}
+			if(File.Exists(oldPath) && File.Exists(path))
+			{
+				safestFilePath = path;
+				return true;
+			}
+			if(File.Exists(path))
+			{
+				safestFilePath = path;
+				return true;
+			}
+			safestFilePath = null;
+			return false;
 		}
 	}
 }

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -51,12 +51,12 @@ namespace System.IO
 		private static void Replace(string newPath, string path)
 		{
 			var oldPath = path + ".bak";
-			if(File.Exists(oldPath))
+			if (File.Exists(oldPath))
 			{
 				File.Delete(oldPath);
 			}
 
-			if(File.Exists(path))
+			if (File.Exists(path))
 			{
 				File.Move(path, oldPath);
 			}
@@ -104,21 +104,22 @@ namespace System.IO
 			var newPath = path + ".new";
 			var oldPath = path + ".bak";
 
-			if(File.Exists(path) && File.Exists(newPath)){
+			if (File.Exists(path) && File.Exists(newPath))
+			{
 				safestFilePath = path;
 				return true;
 			}
-			if(File.Exists(oldPath) && File.Exists(newPath))
+			if (File.Exists(oldPath) && File.Exists(newPath))
 			{
 				safestFilePath = oldPath;
 				return true;
 			}
-			if(File.Exists(oldPath) && File.Exists(path))
+			if (File.Exists(oldPath) && File.Exists(path))
 			{
 				safestFilePath = path;
 				return true;
 			}
-			if(File.Exists(path))
+			if (File.Exists(path))
 			{
 				safestFilePath = path;
 				return true;

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -64,7 +64,7 @@ namespace System.IO
 
 			File.Move(newPath, path);
 
-			File.Delete(newPath);
+			File.Delete(oldPath);
 		}
 
 		public static void WriteAllText(string path, string content)

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -126,9 +126,7 @@ namespace WalletWasabi.KeyManagement
 			lock (ToFileLock)
 			{
 				string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
-				File.WriteAllText(filePath,
-					jsonString,
-					Encoding.UTF8);
+				IoHelpers.WriteAllText(filePath, jsonString);
 			}
 		}
 
@@ -136,12 +134,12 @@ namespace WalletWasabi.KeyManagement
 		{
 			filePath = Guard.NotNullOrEmptyOrWhitespace(nameof(filePath), filePath);
 
-			if (!File.Exists(filePath))
+			if (!IoHelpers.TryGetSafestFileVersion(filePath, out var safestFile))
 			{
 				throw new FileNotFoundException($"Wallet file not found at: `{filePath}`.");
 			}
 
-			string jsonString = File.ReadAllText(filePath, Encoding.UTF8);
+			string jsonString = File.ReadAllText(safestFile, Encoding.UTF8);
 			var km = JsonConvert.DeserializeObject<KeyManager>(jsonString);
 			km.SetFilePath(filePath);
 			return km;

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -126,7 +126,7 @@ namespace WalletWasabi.KeyManagement
 			lock (ToFileLock)
 			{
 				string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
-				IoHelpers.SafeWriteAllText(filePath, jsonString);
+				IoHelpers.SafeWriteAllText(filePath, jsonString, Encoding.UTF8);
 			}
 		}
 

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -126,7 +126,7 @@ namespace WalletWasabi.KeyManagement
 			lock (ToFileLock)
 			{
 				string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
-				IoHelpers.WriteAllText(filePath, jsonString);
+				IoHelpers.SafeWriteAllText(filePath, jsonString);
 			}
 		}
 


### PR DESCRIPTION
Prevent broken wallet files after unexpected problems. Uses the _Safe file write_ technique described by Jon Skeet's answer in StackOverflow https://stackoverflow.com/questions/7957544/how-to-ensure-that-data-doesnt-get-corrupted-when-saving-to-file

**Note:**  the IoHelpers static class contains more methods than what are necessary for this PR but the idea is using them for fixing the broken filters issue (working on that one right now)