### PR TITLE
Update NBitcoin version

### DIFF
--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1674,7 +1674,7 @@ namespace WalletWasabi.Tests
 				{
 					// Never changes.
 					Assert.True(0 < rs.RoundId);
-					Assert.Equal(Money.Coins(0.00009792m), rs.FeePerInputs);
+					Assert.Equal(Money.Coins(0.00009648m), rs.FeePerInputs);
 					Assert.Equal(Money.Coins(0.00004752m), rs.FeePerOutputs);
 					Assert.Equal(7, rs.MaximumInputCountPerPeer);
 					// Changes per rounds.

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.Helpers
 		public const uint ProtocolVersion_WITNESS_VERSION = 70012;
 
 		public const int P2wpkhInputSizeInBytes = 41;
-		public const int P2pkhInputSizeInBytes = 146;
+		public const int P2pkhInputSizeInBytes = 145;
 		public const int OutputSizeInBytes = 33;
 
 		// https://en.bitcoin.it/wiki/Bitcoin

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
-    <PackageReference Include="NBitcoin" Version="4.1.1.45" />
+    <PackageReference Include="NBitcoin" Version="4.1.1.46" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.2" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates the NBitcoin version which contains the [change](https://github.com/MetacoSA/NBitcoin/pull/510) for making sure DER-encoded digital ECDSA signatures are at most 71 bytes length (before that change they were able to be 72 bytes length).

we already discussed about this in the issue https://github.com/zkSNACKs/WalletWasabi/issues/222#issuecomment-413549499. Please review it.