### PR TITLE
Dequeue coins when process is killed

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Threading;
 using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.Protocol.Behaviors;
@@ -8,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -106,6 +108,10 @@ namespace WalletWasabi.Gui
 				e.Cancel = true;
 				Logger.LogWarning("Process was signaled for killing.", nameof(Global));
 				await TryDequeueAllCoinsAsync();
+				Dispatcher.UIThread.Post(() =>
+				{
+					Application.Current.MainWindow.Close();
+				});
 			};
 
 			var addressManagerFolderPath = Path.Combine(DataDir, "AddressManager");

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -78,10 +78,10 @@ namespace WalletWasabi.Gui
 		private static async Task DequeueAllCoinsAsync()
 		{
 			Logger.LogWarning("Process was signaled for killing.");
-			if(WalletService == null || ChaumianClient == null) 
+			if (WalletService == null || ChaumianClient == null)
 				return;
 			Logger.LogWarning("Unregistering coins in coinjoin process.");
-			var enqueuedCoins = WalletService.Coins.Where(x=>x.CoinJoinInProgress);
+			var enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress);
 			await ChaumianClient.DequeueCoinsFromMixAsync(enqueuedCoins.ToArray());
 		}
 
@@ -90,8 +90,9 @@ namespace WalletWasabi.Gui
 			WalletService = null;
 			ChaumianClient = null;
 
-			System.AppDomain.CurrentDomain.ProcessExit += async (s, e) => await DequeueAllCoinsAsync();
-			Console.CancelKeyPress += async (s, e) => {
+			AppDomain.CurrentDomain.ProcessExit += async (s, e) => await DequeueAllCoinsAsync();
+			Console.CancelKeyPress += async (s, e) =>
+			{
 				e.Cancel = true;
 				await DequeueAllCoinsAsync();
 			};

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -80,7 +80,7 @@ namespace WalletWasabi.Gui
 			Logger.LogWarning("Process was signaled for killing.");
 			if (WalletService == null || ChaumianClient == null)
 				return;
-			Logger.LogWarning("Unregistering coins in coinjoin process.");
+			Logger.LogWarning("Unregistering coins in CoinJoin process.");
 			var enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress);
 			await ChaumianClient.DequeueCoinsFromMixAsync(enqueuedCoins.ToArray());
 		}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -15,6 +15,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Helpers;
 using WalletWasabi.KeyManagement;
 using WalletWasabi.Logging;
+using WalletWasabi.Models;
 using WalletWasabi.Services;
 using WalletWasabi.TorSocks5;
 
@@ -81,7 +82,7 @@ namespace WalletWasabi.Gui
 			if (WalletService == null || ChaumianClient == null)
 				return;
 			Logger.LogWarning("Unregistering coins in CoinJoin process.");
-			var enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress);
+			IEnumerable<SmartCoin> enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress);
 			await ChaumianClient.DequeueCoinsFromMixAsync(enqueuedCoins.ToArray());
 		}
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -80,12 +80,14 @@ namespace WalletWasabi.Gui
 		{
 			try
 			{
-				Logger.LogWarning("Process was signaled for killing.", nameof(Global));
 				if (WalletService == null || ChaumianClient == null)
 					return;
-				Logger.LogWarning("Unregistering coins in CoinJoin process.", nameof(Global));
-				IEnumerable<SmartCoin> enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress);
-				await ChaumianClient.DequeueCoinsFromMixAsync(enqueuedCoins.ToArray());
+				SmartCoin[] enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress).ToArray();
+				if (enqueuedCoins.Any())
+				{
+					Logger.LogWarning("Unregistering coins in CoinJoin process.", nameof(Global));
+					await ChaumianClient.DequeueCoinsFromMixAsync(enqueuedCoins);
+				}
 			}
 			catch (Exception ex)
 			{
@@ -102,6 +104,7 @@ namespace WalletWasabi.Gui
 			Console.CancelKeyPress += async (s, e) =>
 			{
 				e.Cancel = true;
+				Logger.LogWarning("Process was signaled for killing.", nameof(Global));
 				await TryDequeueAllCoinsAsync();
 			};
 


### PR DESCRIPTION
This PR dequeue coins registered for coinjoin when the Wallet Wasabi process receives a signal indicating it will be killed. 

![image](https://user-images.githubusercontent.com/127973/45331197-cc4d8680-b53f-11e8-98c7-06a0e0963355.png)
