### PR TITLE
[WIP] Checks for clipboard malware

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -232,14 +232,20 @@ namespace WalletWasabi.Gui
 
 		private static void OnCoinReceived(object sender, SmartCoin coin)
 		{
+			NotifyUser($"Received {coin.Amount.ToString(false, true)} BTC");
+		}
+
+		internal static void NotifyUser(string message)
+		{
 			try
 			{
+				var title = "Wasabi";
 				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 				{
 					Process.Start(new ProcessStartInfo
 					{
 						FileName = "notify-send",
-						Arguments = $"--expire-time=3000 \"Wasabi\" \"Received {coin.Amount.ToString(false, true)} BTC\"",
+						Arguments = $"--expire-time=3000 \"{title}\" \"{message}\"",
 						CreateNoWindow = true
 					});
 				}
@@ -248,7 +254,7 @@ namespace WalletWasabi.Gui
 					Process.Start(new ProcessStartInfo
 					{
 						FileName = "osascript",
-						Arguments = $"-e display notification \"Received {coin.Amount.ToString(false, true)} BTC\" with title \"Wasabi\"",
+						Arguments = $"-e display notification \"{message}\" with title \"Wasabi\"",
 						CreateNoWindow = true
 					});
 				}

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Input.Platform;
 using AvalonStudio.Shell;
 using AvalonStudio.Shell.Extensibility.Platforms;
 using NBitcoin;
@@ -52,6 +53,21 @@ namespace WalletWasabi.Gui
 					{
 						MainWindowViewModel.Instance.Title += $" - {Global.IndexDownloader.Network}";
 					}
+
+					var key = new Key();
+					var address = key.PubKey.GetSegwitAddress(Network.Main).ToString();
+					var clipboard = (IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard));
+					await clipboard.SetTextAsync(address);
+
+					Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith((t) =>
+					{
+						var text = clipboard.GetTextAsync().GetAwaiter().GetResult();
+						if(address != text){
+							Global.NotifyUser("WARNING: probably clipboard compromissed by malware!!!");
+						}
+					});
+
+
 				}).StartShellApp<AppBuilder, MainWindow>("Wasabi Wallet", null, () => MainWindowViewModel.Instance);
 			}
 			catch (Exception ex)


### PR DESCRIPTION
This PR is just for sharing an idea we could use in the future in order to prevent the threat of clipboard hijacking attack. The idea is simply copy an address to the clipboard and check whether the pasted clipboard content is equal to the copied address or not.

In case of detecting the original address has been replaced we alert to the user or take some other action.

![image](https://user-images.githubusercontent.com/127973/46314702-a85eed00-c5a1-11e8-9848-7d15dc3f7fdd.png)

You can test the this with the following python sctipt (you need to have xclip installed).

```python
import subprocess

destination_address = 'bc1qm0f0xz5kfsqxegngp98zlru80x35xmj537mn9v'.encode()

def get_clipboard():
    p = subprocess.Popen(['xclip','-selection', 'clipboard', '-o'], stdout=subprocess.PIPE)
    retcode = p.wait()
    data = p.stdout.read().encode()
    if data[:3] == "bc1":
        swap_address()
        
def swap_address():
    p = subprocess.Popen(['xclip','-selection','clipboard'], stdin=subprocess.PIPE)
    p.stdin.write(destination_address)
    p.stdin.close()
    retcode = p.wait()

while True:
    get_clipboard()    
```    
