### PR TITLE
Assumes segwit tx when txin.ScriptSig is empty

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -34,7 +34,20 @@ namespace NBitcoin
 			me.FromBytes(ByteHelpers.FromHex(hex));
 		}
 
-		public static bool SpendsOrReceivesWitness(this Transaction me) => me.HasWitness || me.Outputs.Any(x => x.ScriptPubKey.IsWitness);
+		public static bool SpendsOrReceivesWitness(this Transaction me)
+		{
+			foreach(TxIn input in me.Inputs)
+			{
+				if(input.ScriptSig == null || input.ScriptSig == Script.Empty)
+					return true;
+			}
+			foreach(TxOut output in me.Outputs)
+			{
+				if(output.ScriptPubKey.IsWitness) 
+					return true;
+			}
+			return false;
+		}
 
 		public static IEnumerable<(Money value, int count)> GetIndistinguishableOutputs(this Transaction me)
 		{

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -397,7 +397,11 @@ namespace WalletWasabi.Services
 					}
 				}
 			}
-			if (!tx.Transaction.SpendsOrReceivesWitness()) return; // We don't care about non-witness transactions for other than mempool cleanup.
+			else
+			{
+				if (!tx.Transaction.SpendsOrReceivesWitness()) 
+					return; // We don't care about non-witness transactions for other than mempool cleanup.
+			}
 
 			//iterate tx
 			//	if already have the coin


### PR DESCRIPTION
This PR is for finxing a problem with the identification, and filtering, of segwit transactions.  