### PR TITLE
[WIP] Paste bitcoin address automatically

### DIFF
--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Xaml.Interactivity;

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -38,9 +38,12 @@ namespace WalletWasabi.Gui.Behaviors
 		{
 			_disposables = new CompositeDisposable
 			{
-				Observable.FromEventPattern<RoutedEventArgs>(AssociatedObject, nameof(AssociatedObject.LostFocus)).Subscribe(args=>
+				AssociatedObject.GetObservable(TextBox.IsFocusedProperty).Subscribe(focused =>
 				{
-					PasteClipboardContentIfBitcoinAddress();
+					if(focused && string.IsNullOrWhiteSpace(AssociatedObject.Text))
+					{
+						PasteClipboardContentIfBitcoinAddress();
+					}
 				})
 			};
 

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -1,0 +1,57 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+using NBitcoin;
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace WalletWasabi.Gui.Behaviors
+{
+	internal class PasteAddressOnClickBehavior : Behavior<TextBox>
+	{
+		private CompositeDisposable _disposables = new CompositeDisposable();
+
+		public void PasteClipboardContentIfBitcoinAddress()
+		{
+			var clipboard = (IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard)); 
+			var text = clipboard.GetTextAsync().GetAwaiter().GetResult();
+
+			try
+			{
+				var address = BitcoinAddress.Create(text, Global.Network);
+				if(address is BitcoinWitPubKeyAddress)
+				{
+					if(string.IsNullOrWhiteSpace(AssociatedObject.Text) )
+						AssociatedObject.Text = text;
+				}
+			}
+			catch(FormatException)
+			{
+			}
+		} 
+
+		protected override void OnAttached()
+		{
+			_disposables = new CompositeDisposable
+			{
+				Observable.FromEventPattern<RoutedEventArgs>(AssociatedObject, nameof(AssociatedObject.LostFocus)).Subscribe(args=>
+				{
+					PasteClipboardContentIfBitcoinAddress();
+				})
+			};
+
+			base.OnAttached();
+ 		}
+
+		protected override void OnDetaching()
+		{
+			base.OnDetaching();
+
+			_disposables.Dispose();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -24,7 +24,11 @@
       <DockPanel LastChildFill="True" Margin="20">
         <StackPanel DockPanel.Dock="Bottom" Margin="0 10" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Note that, you must select coins you want to spend from.</TextBlock>
-          <controls:ExtendedTextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True" />
+          <controls:ExtendedTextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True" >
+            <i:Interaction.Behaviors>
+              <behaviors:PasteAddressOnClickBehavior />
+            </i:Interaction.Behaviors>
+          </controls:ExtendedTextBox>
           <controls:ExtendedTextBox Text="{Binding Label}" Watermark="Label" UseFloatingWatermark="True">
             <ToolTip.Tip>
               Start labelling today and your privacy will thank you tomorrow!

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -24,7 +24,7 @@
       <DockPanel LastChildFill="True" Margin="20">
         <StackPanel DockPanel.Dock="Bottom" Margin="0 10" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Note that, you must select coins you want to spend from.</TextBlock>
-          <controls:ExtendedTextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True" >
+          <controls:ExtendedTextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True">
             <i:Interaction.Behaviors>
               <behaviors:PasteAddressOnClickBehavior />
             </i:Interaction.Behaviors>


### PR DESCRIPTION
This PR close issue #807. The idea is to paste the clipboard content (if it is a bitcoin address) automatically when the user click on the `Address` textbox (Send tab).

@danwalmsley for some reason this implementation only works for the `LostFocus` event and do nothing if we hook to other events as `GotFocus` or `PointerPressed`. We need to hook to the `GotFocus` event, could you give me a clue why any other event works? How could I make it work? 