### PR TITLE
update avalonia with text encoding fixes affecting clipboard.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <AvaloniaVersion>0.7.0</AvaloniaVersion>
+    <AvaloniaVersion>0.7.1-build566-beta</AvaloniaVersion>
     <AvaloniaBehaviorsVersion>0.6.2-build562</AvaloniaBehaviorsVersion>    
   </PropertyGroup>
 


### PR DESCRIPTION
This fixes the seemingly random failure of paste operations.

The cause was two-fold as stated here: 

1) strings being gced by objective c runtime before .net code could access it.
2) strings being treated as ansi strings when they are really utf8.

See https://github.com/AvaloniaUI/Avalonia/pull/2082/files for fix.