### PR TITLE
Disable Label textbox when spend whole coins

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -25,7 +25,7 @@
         <StackPanel DockPanel.Dock="Bottom" Margin="0 10" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Note that, you must select coins you want to spend from.</TextBlock>
           <controls:ExtendedTextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True" />
-          <controls:ExtendedTextBox Text="{Binding Label}" Watermark="Label" UseFloatingWatermark="True">
+          <controls:ExtendedTextBox Text="{Binding Label}" Watermark="Label" UseFloatingWatermark="True" IsEnabled="{Binding !IsMax}">
             <ToolTip.Tip>
               Start labelling today and your privacy will thank you tomorrow!
             </ToolTip.Tip>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -93,7 +93,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				try
 				{
 					Password = Guard.Correct(Password);
-					if (string.IsNullOrWhiteSpace(Label))
+					if (!IsMax && string.IsNullOrWhiteSpace(Label))
 					{
 						throw new InvalidOperationException("Label is required.");
 					}


### PR DESCRIPTION
This PR closes #806. When you press the `Max` button it disable the `Label` textbox. Should it clear the `Label` content if it contains text?