### PR TITLE
Support Tor socks proxy over IPv6

### DIFF
--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -118,7 +118,7 @@ namespace WalletWasabi.Gui.Tabs
 			}
 			if (IPAddress.TryParse(torHost, out var ip))
 			{
-				if(ip.AddressFamily == AddressFamily.InterNetworkV6 && !Socket.OSSupportsIPv6)
+				if (ip.AddressFamily == AddressFamily.InterNetworkV6 && !Socket.OSSupportsIPv6)
 				{
 					return "OS does not support IPv6 addresses.";
 				}

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.Threading;
 using WalletWasabi.Gui.ViewModels.Validation;
 using System.Net;
 using System.Threading.Tasks;
+using System.Net.Sockets;
 
 namespace WalletWasabi.Gui.Tabs
 {
@@ -117,6 +118,10 @@ namespace WalletWasabi.Gui.Tabs
 			}
 			if (IPAddress.TryParse(torHost, out var ip))
 			{
+				if(ip.AddressFamily == AddressFamily.InterNetworkV6 && !Socket.OSSupportsIPv6)
+				{
+					return "OS does not support IPv6 addresses.";
+				}
 				return string.Empty;
 			}
 

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -110,7 +110,7 @@ namespace WalletWasabi.TorSocks5
 							Logger.LogInfo<TorProcessManager>($"Tor instance found at {torPath}.");
 						}
 
-						string torArguments = $"--SOCKSPort {TorSocks5EndPoint.Port}";
+						string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
 						if (!string.IsNullOrEmpty(LogFile))
 						{
 							IoHelpers.EnsureContainingDirectoryExists(LogFile);

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -60,9 +60,7 @@ namespace WalletWasabi.TorSocks5
 		internal TorSocks5Client(IPEndPoint ipEndPoint)
 		{
 			TorSocks5EndPoint = ipEndPoint;
-			TcpClient = ipEndPoint != null 
-				? new TcpClient(ipEndPoint.AddressFamily)
-				: new TcpClient();
+			TcpClient = ipEndPoint is null ? new TcpClient() : new TcpClient(ipEndPoint.AddressFamily);
 			AsyncLock = new AsyncLock();
 		}
 
@@ -237,7 +235,7 @@ namespace WalletWasabi.TorSocks5
 				using (await AsyncLock.LockAsync())
 				{
 					TcpClient?.Dispose();
-					if(IPAddress.TryParse(host, out IPAddress ip))
+					if (IPAddress.TryParse(host, out IPAddress ip))
 					{
 						TcpClient = new TcpClient(ip.AddressFamily);
 					}

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.TorSocks5
 		internal TorSocks5Client(IPEndPoint ipEndPoint)
 		{
 			TorSocks5EndPoint = ipEndPoint;
-			TcpClient = new TcpClient();
+			TcpClient = new TcpClient(ipEndPoint.AddressFamily);
 			AsyncLock = new AsyncLock();
 		}
 
@@ -235,7 +235,14 @@ namespace WalletWasabi.TorSocks5
 				using (await AsyncLock.LockAsync())
 				{
 					TcpClient?.Dispose();
-					TcpClient = new TcpClient();
+					if(IPAddress.TryParse(host, out IPAddress ip))
+					{
+						TcpClient = new TcpClient(ip.AddressFamily);
+					}
+					else
+					{
+						TcpClient = new TcpClient();
+					}
 					await TcpClient.ConnectAsync(host, port);
 					Stream = TcpClient.GetStream();
 					RemoteEndPoint = TcpClient.Client.RemoteEndPoint as IPEndPoint;

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -60,7 +60,9 @@ namespace WalletWasabi.TorSocks5
 		internal TorSocks5Client(IPEndPoint ipEndPoint)
 		{
 			TorSocks5EndPoint = ipEndPoint;
-			TcpClient = new TcpClient(ipEndPoint.AddressFamily);
+			TcpClient = ipEndPoint != null 
+				? new TcpClient(ipEndPoint.AddressFamily)
+				: new TcpClient();
 			AsyncLock = new AsyncLock();
 		}
 


### PR DESCRIPTION
Closes #853
Closes #852

It allows to connect to Tor Socks proxy over IPv4 and IPv6. It also can start the Tor client bound to given IP address. I've tested it with IPv4 addresses 127.0.0.1 and 192.168.100.5 and IPv6 [::1]

Note: the Setting window allowed us to specify an IP address or a host name but currently specifying a host name doesn't work (it fails when Wasabi starts) and the user have to edit the config file manually; otherwise he cannot launch the wallet again. Should we allow host names too or only IP addresses?