### PR TITLE
Allow paste passwords

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
@@ -9,8 +9,8 @@
             <TextBlock Text="You cannot recover your wallet without your password. Therefore we strongly advise you to use a password that you will not forget." TextWrapping="Wrap" />
           </StackPanel>
           <controls:ExtendedTextBox Text="{Binding WalletName}" Watermark="Wallet Name" UseFloatingWatermark="True" />
-          <TextBox Text="{Binding Password}" Watermark="Choose a password" PasswordChar="*" UseFloatingWatermark="True" />
-          <TextBox Text="{Binding PasswordConfirmation}" Watermark="Confirm password" PasswordChar="*" UseFloatingWatermark="True" />
+          <controls:ExtendedTextBox Text="{Binding Password}" Watermark="Choose a password" PasswordChar="*" UseFloatingWatermark="True" />
+          <controls:ExtendedTextBox Text="{Binding PasswordConfirmation}" Watermark="Confirm password" PasswordChar="*" UseFloatingWatermark="True" />
         </StackPanel>
       </Grid>
     </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
@@ -11,7 +11,7 @@
             <TextBlock Text="At recovery, the wallet is unable to check if your password is correct or not. If you provide the wrong password, a wallet will be recovered with the provided mnemonic and password combination." TextWrapping="Wrap" />
           </StackPanel>
           <controls:ExtendedTextBox Text="{Binding WalletName}" Watermark="Wallet Name" UseFloatingWatermark="True" />
-          <TextBox Text="{Binding Password}" Watermark="Password" PasswordChar="*" UseFloatingWatermark="True" />
+          <controls:ExtendedTextBox Text="{Binding Password}" Watermark="Password" PasswordChar="*" UseFloatingWatermark="True" />
           <controls:ExtendedTextBox Text="{Binding MnemonicWords}" Watermark="MnemonicWords" UseFloatingWatermark="True" CaretIndex="{Binding CaretIndex, Mode=TwoWay}">
             <i:Interaction.Behaviors>
               <behaviors:SuggestionBehavior SuggestionItems="{Binding Suggestions}" />


### PR DESCRIPTION
Closes #849.

Allow to paste clipboard content on passwords controls in the same way that is implemented in other places. 