### PR TITLE
Fix NRE when clipboard is empty

### DIFF
--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.Gui.Behaviors
 			var clipboard = (IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard));
 			Task<string> clipboardTask = clipboard.GetTextAsync();
 			string text = await clipboardTask;
-			if (text.Length > 50) return (false, null);
+			if (string.IsNullOrEmpty(text) || text.Length > 50) return (false, null);
 			text = text.Trim();
 			try
 			{


### PR DESCRIPTION
Fixes a NRE

<details><summary>Stack trace:</summary>

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at WalletWasabi.Gui.Behaviors.PasteAddressOnClickBehavior.IsThereABitcoinAddressOnTheClipboardAsync() in /home/lontivero/GitHub/WalletWasabi/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs:line 68
   at WalletWasabi.Gui.Behaviors.PasteAddressOnClickBehavior.<OnAttached>b__9_1(PointerEventArgs pointerEnter) in /home/lontivero/GitHub/WalletWasabi/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs:line 127
   at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in D:\a\1\s\src\Avalonia.Base\Threading\JobRunner.cs:line 40
   at Avalonia.Gtk3.Gtk3Platform.<>c__DisplayClass29_0.<Signal>b__0() in D:\a\1\s\src\Gtk\Avalonia.Gtk3\Gtk3Platform.cs:line 136
   at Avalonia.Gtk3.Interop.GlibTimeout.Handler(IntPtr data) in D:\a\1\s\src\Gtk\Avalonia.Gtk3\Interop\GlibTimeout.cs:line 11
   at Avalonia.Gtk3.Gtk3Platform.RunLoop(CancellationToken cancellationToken) in D:\a\1\s\src\Gtk\Avalonia.Gtk3\Gtk3Platform.cs:line 107
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in D:\a\1\s\src\Avalonia.Base\Threading\Dispatcher.cs:line 65
   at Avalonia.Application.Run(Window mainWindow) in D:\a\1\s\src\Avalonia.Controls\Application.cs:line 237
   at AvalonStudio.Shell.Shell.StartShellApp[TAppBuilder,TMainWindow](TAppBuilder builder, String appName, IDockFactory layoutFactory, Func`1 dataContextProvider) in /home/lontivero/GitHub/WalletWasabi/WalletWasabi.Dependencies/AvalonStudio.Shell/src/AvalonStudio.Shell/Shell.cs:line 14
   at WalletWasabi.Gui.Program.Main(String[] args) in /home/lontivero/GitHub/WalletWasabi/WalletWasabi.Gui/Program.cs:line 26
```

</details>