### PR TITLE
Disable peer discovery if cache exists

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -140,6 +140,7 @@ namespace WalletWasabi.Gui
 
 			Logger.LogInfo<TorProcessManager>($"{nameof(TorProcessManager)} is initialized.");
 
+			var needsToDiscoverPeers = true;
 			if (Network == Network.RegTest)
 			{
 				AddressManager = new AddressManager();
@@ -150,6 +151,7 @@ namespace WalletWasabi.Gui
 				try
 				{
 					AddressManager = AddressManager.LoadPeerFile(AddressManagerFilePath);
+					needsToDiscoverPeers = AddressManager.Count < 200;
 					Logger.LogInfo<AddressManager>($"Loaded {nameof(AddressManager)} from `{AddressManagerFilePath}`.");
 				}
 				catch (DirectoryNotFoundException ex)
@@ -184,7 +186,9 @@ namespace WalletWasabi.Gui
 				}
 			}
 
-			connectionParameters.TemplateBehaviors.Add(new AddressManagerBehavior(AddressManager));
+			var addressManagerBehavior = new AddressManagerBehavior(AddressManager);
+			addressManagerBehavior.Mode = needsToDiscoverPeers ? AddressManagerBehaviorMode.Discover : AddressManagerBehaviorMode.None;
+			connectionParameters.TemplateBehaviors.Add(addressManagerBehavior);
 			MemPoolService = new MemPoolService();
 			connectionParameters.TemplateBehaviors.Add(new MemPoolBehavior(MemPoolService));
 


### PR DESCRIPTION
This PR closes #748. 

## Problem ##

When we kill internet Wasabi cannot connect to peers and that's why  after one minute it tries to discover new peers aggressively, that process uses a lot of cpu because the not IO operations happening when no internet is available.

## Solution ##

AddressManager works as a nodes address' cache that make unnecessary to rediscover peers again and again. The discovery process is only needed the first time we run Wasabi after a clean installation. 

For this reason, if we can load the peers addresses from the file (cache) we can disable the discovery mechanism.  