### PR TITLE
Fix rendering artifacts on Coinjoin status label

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -124,7 +124,7 @@
                 </Border>
 
                 <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left"  BorderThickness="1" CornerRadius="0,6,6,0">
-                  <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
+                  <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
                 </Border>
                 <TextBlock Grid.Column="3" Text="{Binding AmountBtc}" />
                 <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4672627/48974128-3659d000-f047-11e8-8852-4048ed818d15.png)

Notice the corners of the textblocks background are square and paint over the rounded edges.

![image](https://user-images.githubusercontent.com/4672627/48974150-9486b300-f047-11e8-8d05-234110e29050.png)
