### PR TITLE
Reduce error correction level

### DIFF
--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.Gui.ViewModels
 
 					QrCode = await Task.Run(() =>
 					{
-						var encoder = new QrEncoder(ErrorCorrectionLevel.H);
+						var encoder = new QrEncoder(ErrorCorrectionLevel.M);
 						encoder.TryEncode(Address, out var qrCode);
 
 						return qrCode.Matrix.InternalArray;


### PR DESCRIPTION
Because it seems that a higher level of redundancy makes it harder
for some devices/apps to decode it. Anyway, gioven this QR is displayed
in the screen and not printed, we don't need such a high redundancy.

Tested manually with 20 addresses.

Closes #869 