### PR TITLE
[WIP] Improve fee estimation

### DIFF
--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -2,6 +2,7 @@
 using AvalonStudio.Shell;
 using AvalonStudio.Shell.Extensibility.Platforms;
 using NBitcoin;
+using NBitcoin.RPC;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -17,6 +18,15 @@ namespace WalletWasabi.Gui
 		private static async Task Main(string[] args)
 #pragma warning restore IDE1006 // Naming Styles
 		{
+			var rpc = new RPCClient(new RPCCredentialString { UserPassword = new System.Net.NetworkCredential("bitcoinuser", "Polip69") }, Network.Main);
+			WalletWasabi.Models.AllFeeEstimate estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, true);
+			foreach (var est in estimations.Estimations)
+			{
+				Console.WriteLine($"{est.Key} {est.Value}");
+			}
+
+			Console.ReadKey();
+			return;
 			Logger.InitializeDefaults(Path.Combine(Global.DataDir, "Logs.txt"));
 			StatusBarViewModel statusBar = null;
 			try
@@ -71,12 +81,12 @@ namespace WalletWasabi.Gui
 			}
 		}
 
-		static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
 		{
 			Logger.LogWarning(e?.Exception, "UnobservedTaskException");
 		}
 
-		static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
 		{
 			Logger.LogWarning(e?.ExceptionObject as Exception, "UnhandledException");
 		}

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -18,15 +18,6 @@ namespace WalletWasabi.Gui
 		private static async Task Main(string[] args)
 #pragma warning restore IDE1006 // Naming Styles
 		{
-			var rpc = new RPCClient(new RPCCredentialString { UserPassword = new System.Net.NetworkCredential("bitcoinuser", "Polip69") }, Network.Main);
-			WalletWasabi.Models.AllFeeEstimate estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, true);
-			foreach (var est in estimations.Estimations)
-			{
-				Console.WriteLine($"{est.Key} {est.Value}");
-			}
-
-			Console.ReadKey();
-			return;
 			Logger.InitializeDefaults(Path.Combine(Global.DataDir, "Logs.txt"));
 			StatusBarViewModel statusBar = null;
 			try

--- a/WalletWasabi.Tests/ModelTests.cs
+++ b/WalletWasabi.Tests/ModelTests.cs
@@ -1,6 +1,8 @@
 ﻿using NBitcoin;
+using NBitcoin.RPC;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
@@ -179,6 +181,28 @@ namespace WalletWasabi.Tests
 			{
 				Assert.Equal(coin.SpentOutputs[0], deserialized.SpentOutputs[0]);
 			}
+		}
+
+		[Fact]
+		[Trait("Category", "RunOnCi")]
+		public void AllFeeEstimateSerialization()
+		{
+			var estimations = new Dictionary<int, decimal>
+			{
+				{ 2, 102.3m },
+				{ 3, 20.3m },
+				{ 19, 1.223m }
+			};
+
+			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations);
+
+			var serialized = JsonConvert.SerializeObject(allFee);
+			var deserialized = JsonConvert.DeserializeObject<AllFeeEstimate>(serialized);
+
+			Assert.Equal(estimations[2], deserialized.Estimations[2]);
+			Assert.Equal(estimations[3], deserialized.Estimations[3]);
+			Assert.Equal(estimations[19], deserialized.Estimations[19]);
+			Assert.Equal(EstimateSmartFeeMode.Conservative, deserialized.Type);
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/RpcMethodTests.cs
+++ b/WalletWasabi.Tests/RpcMethodTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using WalletWasabi.Tests.XunitConfiguration;
+using WalletWasabi.Logging;
 
 namespace WalletWasabi.Tests
 {
@@ -50,6 +51,37 @@ namespace WalletWasabi.Tests
 				var latestBlock = await latestBlockTask;
 				Assert.True(latestBlockTask.IsCompleted && !latestBlockTask.IsFaulted);
 				Assert.Equal(latestBlockHash, latestBlock.hash);
+			}
+		}
+
+		[Fact]
+		[Trait("Category", "RunOnCi")]
+		public async Task AllFeeEstimateRpcAsync()
+		{
+			using (var builder = await NodeBuilder.CreateAsync())
+			{
+				var rpc = (await builder.CreateNodeAsync()).CreateRpcClient();
+				await builder.StartAllAsync();
+
+				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true);
+				Assert.Equal(144, estimations.Estimations.Count);
+				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
+				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
+				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
+
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true);
+				Assert.Equal(145, estimations.Estimations.Count);
+				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
+				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
+				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);
+
+				await Assert.ThrowsAsync<NoEstimationException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: false, tolerateBitcoinCoreBrainfuck: true));
+
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: false);
+				Assert.Equal(145, estimations.Estimations.Count);
+				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
+				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
+				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);
 			}
 		}
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
@@ -43,7 +45,7 @@ namespace NBitcoin.RPC
 				{
 					return await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode);
 				}
-				catch (Exception ex)
+				catch (RPCException ex)
 				{
 					Logger.LogTrace<RPCClient>(ex);
 					// Hopefully Bitcoin Core brainfart: https://github.com/bitcoin/bitcoin/issues/14431
@@ -53,7 +55,7 @@ namespace NBitcoin.RPC
 						{
 							return await rpc.EstimateSmartFeeAsync(i, estimateMode);
 						}
-						catch (Exception ex2)
+						catch (RPCException ex2)
 						{
 							Logger.LogTrace<RPCClient>(ex2);
 						}
@@ -95,6 +97,22 @@ namespace NBitcoin.RPC
 			}
 
 			return await rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode);
+		}
+
+		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this RPCClient rpc, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false, bool tolerateBitcoinCoreBrainfuck = true)
+		{
+			var estimations = new Dictionary<int, decimal>();
+
+			for (int i = 1008; i >= 2; i--)
+			{
+				EstimateSmartFeeResponse estimation = await rpc.EstimateSmartFeeAsync(i, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+				estimations.TryAdd(estimation.Blocks, estimation.FeeRate.SatoshiPerByte);
+				i = estimation.Blocks; // So the next estimation will be minus 1.
+			}
+
+			var allFeeEstimate = new AllFeeEstimate(estimateMode, estimations);
+
+			return allFeeEstimate;
 		}
 
 		private static EstimateSmartFeeResponse SimulateRegTestFeeEstimation(int confirmationTarget, EstimateSmartFeeMode estimateMode)

--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -73,6 +73,30 @@ namespace WalletWasabi.Helpers
 			return value;
 		}
 
+		public static IDictionary<TKey, TValue> NotNullOrEmpty<TKey, TValue>(string parameterName, IDictionary<TKey, TValue> value)
+		{
+			NotNull(parameterName, value);
+
+			if (!value.Any())
+			{
+				throw new ArgumentException("Parameter cannot be empty.", parameterName);
+			}
+
+			return value;
+		}
+
+		public static Dictionary<TKey, TValue> NotNullOrEmpty<TKey, TValue>(string parameterName, Dictionary<TKey, TValue> value)
+		{
+			NotNull(parameterName, value);
+
+			if (!value.Any())
+			{
+				throw new ArgumentException("Parameter cannot be empty.", parameterName);
+			}
+
+			return value;
+		}
+
 		public static string NotNullOrEmptyOrWhitespace(string parameterName, string value, bool trim = false)
 		{
 			NotNullOrEmpty(parameterName, value);

--- a/WalletWasabi/Models/AllFeeEstimate.cs
+++ b/WalletWasabi/Models/AllFeeEstimate.cs
@@ -1,0 +1,41 @@
+﻿using NBitcoin;
+using NBitcoin.RPC;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.Models
+{
+	[JsonObject(MemberSerialization.OptIn)]
+	public class AllFeeEstimate
+	{
+		[JsonProperty]
+		public EstimateSmartFeeMode Type { get; }
+
+		/// <summary>
+		/// int: fee target, decimal: satoshi/bytes
+		/// </summary>
+		[JsonProperty]
+		public Dictionary<int, decimal> Estimations { get; }
+
+		[JsonConstructor]
+		public AllFeeEstimate(EstimateSmartFeeMode type, IDictionary<int, decimal> estimations)
+		{
+			Type = type;
+			Guard.NotNullOrEmpty(nameof(estimations), estimations);
+			Estimations = new Dictionary<int, decimal>();
+			var valueSet = new HashSet<decimal>();
+			// Make sure values are unique and in the correct order.
+			foreach (KeyValuePair<int, decimal> estimation in estimations.OrderBy(x => x.Key))
+			{
+				if (valueSet.Add(estimation.Value))
+				{
+					Estimations.TryAdd(estimation.Key, estimation.Value);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/zkSNACKs/WalletWasabi/issues/420

This PR would eventually lead to two new periodic query to the backend: fee query and exchange rate query.  
We should batch all the periodic queries to the backend into a `synchronize` query:  

- The `GET all-fees` query this PR would introduce.
- `GET Blockchain/filters`
- `GET ChaumianClient/states`
- `GET Offchain/exchange-rates`
- `GET Software/versions` - The issue with this is that it works even if there are breaking changes. This behavior shouldn't be ruined. Maybe it shouldn't be batched.