### PR TITLE
update avalonia with minor osx fixes

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <AvaloniaVersion>0.7.1-build989-beta</AvaloniaVersion>
+    <AvaloniaVersion>0.7.1-build1011-beta</AvaloniaVersion>
     <AvaloniaBehaviorsVersion>0.7.0</AvaloniaBehaviorsVersion>    
   </PropertyGroup>
 


### PR DESCRIPTION
1. Fixes occasionally wasabi would start and minimise instantly on load (osx)
2. Fixes occasionally the app can be closed and the process stays running (osx)