### PR TITLE
Ban coins if proof verifycation fails

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -229,6 +229,8 @@ namespace WalletWasabi.Backend.Controllers
 						}
 						if (!validProof)
 						{
+							await Coordinator.UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, round.RoundId, outpoint);
+
 							return BadRequest("Provided proof is invalid.");
 						}
 


### PR DESCRIPTION
This PR is for preventing DoS attacks by reusing/posting coins with invalid proof, because the pubkey extraction from compact signature and the signature verification is expensive. This makes this attacks more expensive. 