### PR TITLE
[WIP] Client-side filters stored in binary

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -58,7 +58,7 @@ namespace WalletWasabi.Gui
 		public static string WalletsDir => Path.Combine(DataDir, "Wallets");
 		public static string WalletBackupsDir => Path.Combine(DataDir, "WalletBackups");
 		public static Network Network => Config.Network;
-		public static string IndexFilePath => Path.Combine(DataDir, $"Index{Network}.dat");
+		public static string IndexFilePath => Path.Combine(DataDir, $"Index{Network}.bin");
 
 		public static string AddressManagerFilePath { get; private set; }
 		public static AddressManager AddressManager { get; private set; }

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -149,7 +149,7 @@ namespace System.IO
 			}
 		}
 
-		public static void SafeWriteAllLines(string path, IEnumerable<string> content)
+		public static void SafeWriteAllBytes(string path, IEnumerable<byte[]> content)
 		{
 			var newPath = path + NewExtension;
 			var mutexName = $"Global\\4AA0E5A2-A94F-4B92-B962-F2BBC7A68323-{Path.GetFileNameWithoutExtension(path)}";
@@ -176,7 +176,13 @@ namespace System.IO
 
 				try
 				{
-					File.WriteAllLines(newPath, content);
+					using(var file = File.Open(newPath, FileMode.Create))
+					{
+						foreach(var buffer in content)
+						{
+							file.Write(buffer);
+						}
+					}
 					SafeMove(newPath, path);
 				}
 				finally


### PR DESCRIPTION
This is for closing #969. It stores and load the client-side compact filters in binary what reduces the file a 50%. 

The code for **converting** the filters file from the current format to the binary format can be found here:
https://gist.github.com/lontivero/0ee229c81f9c48c42b84697b780cdf4d (should I add that project to this repository?)
