### PR TITLE
Remove anti-dos mechanism

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -216,8 +216,6 @@ namespace WalletWasabi.Backend.Controllers
 						// Check if proofs are valid.
 						if (!address.VerifyMessage(request.BlindedOutputScript, inputProof.Proof))
 						{
-							await Coordinator.UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, round.RoundId, outpoint);
-
 							return BadRequest("Provided proof is invalid.");
 						}
 

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1791,16 +1791,6 @@ namespace WalletWasabi.Tests
 				httpRequestException = await Assert.ThrowsAsync<HttpRequestException>(async () => await AliceClient.CreateNewAsync(network, inputsRequest, baseUri));
 				Assert.Equal($"{HttpStatusCode.BadRequest.ToReasonString()}\nProvided proof is invalid.", httpRequestException.Message);
 
-				httpRequestException = await Assert.ThrowsAsync<HttpRequestException>(async () => await AliceClient.CreateNewAsync(network, inputsRequest, baseUri));
-				Assert.StartsWith($"{HttpStatusCode.BadRequest.ToReasonString()}\nInput is banned from participation for", httpRequestException.Message);
-
-				key = new Key();
-				witnessAddress = key.PubKey.GetSegwitAddress(network);
-				hash = await rpc.SendToAddressAsync(witnessAddress, Money.Coins(0.01m));
-				await rpc.GenerateAsync(1);
-				tx = await rpc.GetRawTransactionAsync(hash);
-				coin = tx.Outputs.GetCoins(witnessAddress.ScriptPubKey).Single();
-				inputsRequest.Inputs = new List<InputProofModel> { new InputProofModel { Input = coin.Outpoint.ToTxoRef(), Proof = null } };
 				CcjRound round = coordinator.GetCurrentInputRegisterableRound();
 				var requester = new Requester();
 				uint256 msg = new uint256(Hashes.SHA256(network.Consensus.ConsensusFactory.CreateTransaction().ToBytes()));


### PR DESCRIPTION
Removes code that could be use by attackers to make the coordinator to ban somebody else's coins.