### PR TITLE
Improve Alice removal

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -191,7 +191,7 @@ namespace WalletWasabi.Backend.Controllers
 
 							// Check if mempool would accept a fake transaction created with the registered inputs.
 							// This will catch ascendant/descendant count and size limits for example.
-							var result = await RpcClient.TestMempoolAcceptAsync(new Coin(inputProof.Input.ToOutPoint(), getTxOutResponse.TxOut));
+							var result = await RpcClient.TestMempoolAcceptAsync(new[] { new Coin(inputProof.Input.ToOutPoint(), getTxOutResponse.TxOut) });
 
 							if (!result.accept)
 							{

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -182,13 +182,13 @@ namespace NBitcoin.RPC
 		}
 
 		/// <returns>(allowed, reject-reason)</returns>
-		public static async Task<(bool accept, string rejectReason)> TestMempoolAcceptAsync(this RPCClient rpc, Coin coin)
+		public static async Task<(bool accept, string rejectReason)> TestMempoolAcceptAsync(this RPCClient rpc, IEnumerable<Coin> coins)
 		{
 			// Check if mempool would accept a fake transaction created with the registered inputs.
 			// This will catch ascendant/descendant count and size limits for example.
 			var fakeTransaction = rpc.Network.CreateTransaction();
-			fakeTransaction.Inputs.Add(new TxIn(coin.Outpoint));
-			Money fakeOutputValue = NBitcoinHelpers.TakeAReasonableFee(coin.TxOut.Value);
+			fakeTransaction.Inputs.AddRange(coins.Select(coin=> new TxIn(coin.Outpoint)));
+			Money fakeOutputValue = NBitcoinHelpers.TakeAReasonableFee(coins.Sum(coin=>coin.TxOut.Value));
 			fakeTransaction.Outputs.Add(fakeOutputValue, new Key());
 			MempoolAcceptResult testMempoolAcceptResult = await rpc.TestMempoolAcceptAsync(fakeTransaction, allowHighFees: true);
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -864,19 +864,25 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					throw new InvalidOperationException("Removing Alice is only allowed in InputRegistration and ConnectionConfirmation phases.");
 				}
 
+				var checkingTasks = new List<(Alice alice, Task<(bool accepted, string reason)> task)>();
+				var batch = RpcClient.PrepareBatch();
 				foreach (Alice alice in Alices)
 				{
-					foreach (Coin input in alice.Inputs)
-					{
-						// Check if mempool would accept a fake transaction created with the registered inputs.
-						// This will catch ascendant/descendant count and size limits for example.
-						var result = await RpcClient.TestMempoolAcceptAsync(input);
+					// Check if mempool would accept a fake transaction created with the registered inputs.
+					// This will catch ascendant/descendant count and size limits for example.
+					checkingTasks.Add( (alice, batch.TestMempoolAcceptAsync(alice.Inputs)) );
+				}
+				var waiting = Task.WhenAll(checkingTasks.Select(t=>t.task));
+				await batch.SendBatchAsync();
+				await waiting;
 
-						if (!result.accept)
-						{
-							alicesRemoved.Add(alice);
-							Alices.Remove(alice);
-						}
+				foreach(var t in checkingTasks)
+				{
+					var result = await t.task; 
+					if(!result.accepted)
+					{
+						alicesRemoved.Add(t.alice);
+						Alices.Remove(t.alice);
 					}
 				}
 			}


### PR DESCRIPTION
This PR is for refactoring the `RemoveAlicesIfAnInputRefusedByMempoolAsync` in order to make it more efficient en the use of the resources.

Currently this method iterates over the Alices and their coins in an inner loop, this means that if there are 38 Alices with 1.2 coins each on average then this method performs ~46 RPC call. After this refactoring it performs only one.
