### PR TITLE
Remove Interlocked.Read for 32 bits fields

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private TransactionViewModel _selectedTransaction;
 		private double _clipboardNotificationOpacity;
 		private bool _clipboardNotificationVisible;
-		private long _disableClipboard;
+		private int _disableClipboard;
 		private SortOrder _dateSortDirection;
 		private SortOrder _amountSortDirection;
 		private SortOrder _transactionSortDirection;
@@ -51,7 +51,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			this.WhenAnyValue(x => x.SelectedTransaction).Subscribe(async transaction =>
 			{
-				if (Interlocked.Read(ref _disableClipboard) == 0)
+				if (_disableClipboard == 0)
 				{
 					if (!(transaction is null))
 					{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -87,13 +87,13 @@ namespace WalletWasabi.Gui
 			UiConfig = Guard.NotNull(nameof(uiConfig), uiConfig);
 		}
 
-		private static long _triedDesperateDequeuing = 0;
+		private static int _triedDesperateDequeuing = 0;
 
 		private static async Task TryDesperateDequeueAllCoinsAsync()
 		{
 			try
 			{
-				if (Interlocked.Read(ref _triedDesperateDequeuing) == 1)
+				if (_triedDesperateDequeuing == 1)
 				{
 					return;
 				}

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -146,8 +146,8 @@ namespace WalletWasabi.Gui.ViewModels
 			set { this.RaiseAndSetIfChanged(ref _status, value); }
 		}
 
-		private long _clientOutOfDate;
-		private long _backendIncompatible;
+		private int _clientOutOfDate;
+		private int _backendIncompatible;
 
 		public StatusBarViewModel(NodesCollection nodes, WasabiSynchronizer synchronizer, UpdateChecker updateChecker)
 		{
@@ -287,12 +287,12 @@ namespace WalletWasabi.Gui.ViewModels
 
 		private void SetStatusAndDoUpdateActions()
 		{
-			if (Interlocked.Read(ref _backendIncompatible) != 0)
+			if (_backendIncompatible != 0)
 			{
 				Status = "THE BACKEND WAS UPGRADED WITH BREAKING CHANGES - PLEASE UPDATE YOUR SOFTWARE";
 				UpdateStatus = UpdateStatus.Critical;
 			}
-			else if (Interlocked.Read(ref _clientOutOfDate) != 0)
+			else if (_clientOutOfDate != 0)
 			{
 				Status = "New Version Is Available";
 				UpdateStatus = UpdateStatus.Optional;

--- a/WalletWasabi.Tests/ModelTests.cs
+++ b/WalletWasabi.Tests/ModelTests.cs
@@ -246,13 +246,13 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		private long _set_CollectionChanged_InvokeCount = 0;
+		private int _set_CollectionChanged_InvokeCount = 0;
 
 		private void Set_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			Interlocked.Increment(ref _set_CollectionChanged_InvokeCount);
 
-			switch (Interlocked.Read(ref _set_CollectionChanged_InvokeCount))
+			switch (_set_CollectionChanged_InvokeCount)
 			{
 				case 1:
 					{

--- a/WalletWasabi.Tests/P2pTests.cs
+++ b/WalletWasabi.Tests/P2pTests.cs
@@ -103,7 +103,7 @@ namespace WalletWasabi.Tests
 				// Using the interlocked, not because it makes sense in this context, but to
 				// set an example that these values are often concurrency sensitive
 				var times = 0;
-				while (Interlocked.Read(ref _nodeCount) < 3)
+				while (_nodeCount < 3)
 				{
 					if (times > 4200) // 7 minutes
 					{
@@ -114,7 +114,7 @@ namespace WalletWasabi.Tests
 				}
 
 				times = 0;
-				while (Interlocked.Read(ref _mempoolTransactionCount) < 3)
+				while (_mempoolTransactionCount < 3)
 				{
 					if (times > 3000) // 3 minutes
 					{
@@ -159,18 +159,18 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		private long _nodeCount = 0;
+		private int _nodeCount = 0;
 
 		private void ConnectedNodes_Added(object sender, NodeEventArgs e)
 		{
 			var nodes = sender as NodesCollection;
 			Interlocked.Increment(ref _nodeCount);
-			if (Interlocked.Read(ref _nodeCount) == 8)
+			if (_nodeCount == 8)
 			{
-				Logger.LogTrace<P2pTests>($"Max node count reached: {Interlocked.Read(ref _nodeCount)}.");
+				Logger.LogTrace<P2pTests>($"Max node count reached: {_nodeCount}.");
 			}
 
-			Logger.LogTrace<P2pTests>($"Node count: {Interlocked.Read(ref _nodeCount)}.");
+			Logger.LogTrace<P2pTests>($"Node count: {_nodeCount}.");
 		}
 
 		private void ConnectedNodes_Removed(object sender, NodeEventArgs e)
@@ -178,10 +178,10 @@ namespace WalletWasabi.Tests
 			var nodes = sender as NodesCollection;
 			Interlocked.Decrement(ref _nodeCount);
 			// Trace is fine here, building the connections is more exciting than removing them.
-			Logger.LogTrace<P2pTests>($"Node count: {Interlocked.Read(ref _nodeCount)}.");
+			Logger.LogTrace<P2pTests>($"Node count: {_nodeCount}.");
 		}
 
-		private long _mempoolTransactionCount = 0;
+		private int _mempoolTransactionCount = 0;
 
 		private void MemPoolService_TransactionReceived(object sender, SmartTransaction e)
 		{

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -267,7 +267,7 @@ namespace WalletWasabi.Tests
 				}
 
 				var times = 0;
-				while (Interlocked.Read(ref _mempoolTransactionCount) < 10)
+				while (_mempoolTransactionCount < 10)
 				{
 					if (times > 100) // 10 seconds
 					{
@@ -283,7 +283,7 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		private long _mempoolTransactionCount = 0;
+		private int _mempoolTransactionCount = 0;
 
 		private void MempoolAsync_MemPoolService_TransactionReceived(object sender, SmartTransaction e)
 		{
@@ -443,7 +443,7 @@ namespace WalletWasabi.Tests
 					}
 
 					// Assert reorg happened exactly as many times as we reorged.
-					Assert.Equal(2, Interlocked.Read(ref _reorgTestAsync_ReorgCount));
+					Assert.Equal(2, _reorgTestAsync_ReorgCount);
 				}
 				finally
 				{
@@ -468,7 +468,7 @@ namespace WalletWasabi.Tests
 			}
 		}
 
-		private long _reorgTestAsync_ReorgCount;
+		private int _reorgTestAsync_ReorgCount;
 
 		private void ReorgTestAsync_Downloader_Reorged(object sender, FilterModel e)
 		{
@@ -688,18 +688,18 @@ namespace WalletWasabi.Tests
 		private async Task WaitForFiltersToBeProcessedAsync(TimeSpan timeout, int numberOfFiltersToWaitFor)
 		{
 			var times = 0;
-			while (Interlocked.Read(ref _filtersProcessedByWalletCount) < numberOfFiltersToWaitFor)
+			while (_filtersProcessedByWalletCount < numberOfFiltersToWaitFor)
 			{
 				if (times > timeout.TotalSeconds)
 				{
-					throw new TimeoutException($"{nameof(WalletService)} test timed out. Filter wasn't processed. Needed: {numberOfFiltersToWaitFor}, got only: {Interlocked.Read(ref _filtersProcessedByWalletCount)}.");
+					throw new TimeoutException($"{nameof(WalletService)} test timed out. Filter wasn't processed. Needed: {numberOfFiltersToWaitFor}, got only: {_filtersProcessedByWalletCount}.");
 				}
 				await Task.Delay(TimeSpan.FromSeconds(1));
 				times++;
 			}
 		}
 
-		private long _filtersProcessedByWalletCount;
+		private int _filtersProcessedByWalletCount;
 
 		private void Wallet_NewFilterProcessed(object sender, FilterModel e)
 		{

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Logging
 	{
 		#region PropertiesAndMembers
 
-		private static long On = 1;
+		private static int On = 1;
 
 		public static LogLevel MinimumLevel { get; private set; } = LogLevel.Critical;
 
@@ -24,7 +24,7 @@ namespace WalletWasabi.Logging
 
 		public static string FileEntryEncryptionPassword { get; private set; } = null;
 
-		private static long _loggerFailed = 0;
+		private static int _loggerFailed = 0;
 
 		private static readonly object Lock = new object();
 
@@ -91,7 +91,7 @@ namespace WalletWasabi.Logging
 
 		public static void TurnOn() => Interlocked.Exchange(ref On, 1);
 
-		public static bool IsOn() => Interlocked.Read(ref On) == 1;
+		public static bool IsOn() => On == 1;
 
 		public static void DecryptLogEntries(string destination)
 		{
@@ -209,7 +209,7 @@ namespace WalletWasabi.Logging
 			catch (Exception ex)
 			{
 				Interlocked.Increment(ref _loggerFailed);
-				if (Interlocked.Read(ref _loggerFailed) > 1)
+				if (_loggerFailed > 1)
 				{
 					Interlocked.Exchange(ref _loggerFailed, 0);
 					return;

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 {
 	public class CcjRound
 	{
-		public static long RoundCount;
+		public static int RoundCount;
 		public long RoundId { get; }
 
 		public RPCClient RpcClient { get; }
@@ -136,7 +136,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			try
 			{
 				Interlocked.Increment(ref RoundCount);
-				RoundId = Interlocked.Read(ref RoundCount);
+				RoundId = RoundCount;
 
 				RpcClient = Guard.NotNull(nameof(rpc), rpc);
 				UtxoReferee = Guard.NotNull(nameof(utxoReferee), utxoReferee);

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -52,17 +52,17 @@ namespace WalletWasabi.Services
 
 		public event EventHandler<SmartCoin> CoinDequeued;
 
-		private long _frequentStatusProcessingIfNotMixing;
+		private int _frequentStatusProcessingIfNotMixing;
 
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
-		private long _statusProcessing;
+		private int _statusProcessing;
 
 		private CancellationTokenSource Cancel { get; }
 
@@ -134,7 +134,7 @@ namespace WalletWasabi.Services
 									int delaySeconds = new Random().Next(2, 7);
 									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
 								}
-								else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Any() || State.GetWaitingListCount() > 0)
+								else if (_frequentStatusProcessingIfNotMixing == 1 || State.GetPassivelyMixingRounds().Any() || State.GetWaitingListCount() > 0)
 								{
 									double rand = double.Parse($"0.{new Random().Next(2, 7)}"); // randomly between every 0.2 * connConfTimeout - 7 and 0.7 * connConfTimeout
 									int delaySeconds = Math.Max(0, (int)(rand * State.GetSmallestRegistrationTimeout() - 7));
@@ -176,7 +176,7 @@ namespace WalletWasabi.Services
 
 		private async Task ProcessStatusAsync(IEnumerable<CcjRunningRoundState> states)
 		{
-			if (Interlocked.Read(ref _statusProcessing) == 1) // It's ok to wait for status processing next time.
+			if (_statusProcessing == 1) // It's ok to wait for status processing next time.
 			{
 				return;
 			}

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -113,7 +113,7 @@ namespace WalletWasabi.Services
 				if (File.Exists(roundCountFilePath))
 				{
 					string roundCount = File.ReadAllText(roundCountFilePath);
-					CcjRound.RoundCount = long.Parse(roundCount);
+					CcjRound.RoundCount = int.Parse(roundCount);
 				}
 				else
 				{

--- a/WalletWasabi/Services/ConfigWatcher.cs
+++ b/WalletWasabi/Services/ConfigWatcher.cs
@@ -12,10 +12,10 @@ namespace WalletWasabi.Services
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
 		private CancellationTokenSource Stop { get; }
 

--- a/WalletWasabi/Services/IndexBuilderService.cs
+++ b/WalletWasabi/Services/IndexBuilderService.cs
@@ -121,10 +121,10 @@ namespace WalletWasabi.Services
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
 		public IndexBuilderService(RPCClient rpc, string indexFilePath, string bech32UtxoSetFilePath)
 		{

--- a/WalletWasabi/Services/MemPoolService.cs
+++ b/WalletWasabi/Services/MemPoolService.cs
@@ -24,11 +24,11 @@ namespace WalletWasabi.Services
 			_cleanupInProcess = 0;
 		}
 
-		private long _cleanupInProcess;
+		private int _cleanupInProcess;
 
 		public void TryPerformMempoolCleanupAsync(NodesGroup nodes, CancellationToken cancel)
 		{
-			if (Interlocked.Read(ref _cleanupInProcess) == 1) return; // If already cleaning, then no need to run it that often.
+			if (_cleanupInProcess == 1) return; // If already cleaning, then no need to run it that often.
 			Interlocked.Exchange(ref _cleanupInProcess, 1);
 			Task.Run(async () =>
 			{

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -12,10 +12,10 @@ namespace WalletWasabi.Services
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
 		private CancellationTokenSource Stop { get; }
 

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -66,10 +66,10 @@ namespace WalletWasabi.Services
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
 		public WalletService(KeyManager keyManager, WasabiSynchronizer syncer, CcjClient chaumianClient, MemPoolService memPool, NodesGroup nodes, string workFolderDir)
 		{

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -146,10 +146,10 @@ namespace WalletWasabi.Services
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
 		private CancellationTokenSource Cancel { get; set; }
 

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -204,10 +204,10 @@ namespace WalletWasabi.TorSocks5
 		/// <summary>
 		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
 		/// </summary>
-		private long _running;
+		private int _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-		public bool IsStopping => Interlocked.Read(ref _running) == 2;
+		public bool IsRunning => _running == 1;
+		public bool IsStopping => _running == 2;
 
 		private CancellationTokenSource Stop { get; }
 


### PR DESCRIPTION
This PR is for cleaning up the code a bit. It removes the `Interlocked.Read()` calls for 32 bit fields/variables because reading 32 bits (U/Int32) values is always an atomic operation. `Interlocked.Read(ref long value)` is only defined for 64bits values (`long`) because when running on 32 bits architecture machines, 64 bits operations are not atomic.  