### PR TITLE
[WIP] Smartcoin history refresh optimization

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -361,18 +361,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						_rootlist.Clear();
 						break;
 				}
-				RefreshCoinsHistories();
 			});
-		}
-
-		private void RefreshCoinsHistories()
-		{
-			foreach (var coin in Coins)
-			{
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-				coin.RefreshHistoryAsync();
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-			}
 		}
 
 		private void SetSelections()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -56,6 +56,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				this.RaisePropertyChanged(nameof(Unspent));
 			});
 
+			model.WhenAnyValue(x => x.History).ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
+			{
+				this.RaisePropertyChanged(nameof(History));
+			});
+
 			this.WhenAnyValue(x => x.Status).Subscribe(_ =>
 			{
 				this.RaisePropertyChanged(nameof(ToolTip));
@@ -68,10 +73,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			});
 
 			Global.ChaumianClient.StateUpdated += ChaumianClient_StateUpdated;
-
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-			RefreshHistoryAsync();
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 		}
 
 		private void ChaumianClient_StateUpdated(object sender, EventArgs e)
@@ -138,23 +139,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string InCoinJoin => Model.CoinJoinInProgress ? "Yes" : "No";
 
-		public string History
-		{
-			get => _history;
-			set
-			{
-				this.RaiseAndSetIfChanged(ref _history, value);
-			}
-		}
-
-		public async Task RefreshHistoryAsync()
-		{
-			History = await Task.Run(() =>
-				{
-					return string.Join(", ", Global.WalletService.GetHistory(Model, Enumerable.Empty<SmartCoin>()).Select(x => x.Label).Distinct());
-				}
-			);
-		}
+		public string History => Model.History;
 
 		public SmartCoinStatus Status
 		{

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -200,7 +200,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 						await Global.InitializeWalletServiceAsync(keyManager);
 					});
-
+					Global.WalletService.RefreshCoinsHistoriesAsync();
 					// Successffully initialized.
 					IoC.Get<IShell>().RemoveDocument(Owner);
 					// Open Wallet Explorer tabs

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -47,6 +47,7 @@ namespace WalletWasabi.Models
 		private bool _unspent;
 		private bool _isBanned;
 		private int _anonymitySet;
+		private string _history;
 
 		#endregion Fields
 
@@ -277,6 +278,19 @@ namespace WalletWasabi.Models
 			}
 		}
 
+		public string History
+		{
+			get => _history;
+			private set
+			{
+				if (value != _history)
+				{
+					_history = value;
+					OnPropertyChanged(nameof(History));
+				}
+			}
+		}
+
 		#endregion NonSerializableProperties
 
 		#region DependentProperties
@@ -448,6 +462,11 @@ namespace WalletWasabi.Models
 		}
 
 		public bool HasLabel() => !string.IsNullOrWhiteSpace(Label);
+
+		public void SetHistory(string history)
+		{
+			History = history;
+		}
 
 		#endregion Methods
 


### PR DESCRIPTION
- [x] Move history to SmartCoin and avoid double calculation in CoinViewModel (both SEND and COINJOIN tab lists are calculated separately).
- [x] Limit simultaneous task creation into Threadpool to ensure GUI responsiveness
- [ ] Optimize WalletService GetHistory function 