### PR TITLE
Make network fees dependent on number of outputs

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -275,6 +275,7 @@ namespace WalletWasabi.Backend.Controllers
 						}
 
 						changeAmount -= (denomination + round.FeePerOutputs + (denomination.Percentange(round.CoordinatorFeePercent) * round.AnonymitySet)); // It should be the number of bobs, but we must make sure they'd have money to pay all.
+						networkFeeToPay += round.FeePerOutputs;
 
 						if (changeAmount < Money.Zero)
 						{


### PR DESCRIPTION
This PR is for increasing the network fees paid by Alices when they add more outputs. In other words, more outputs you add, more network fee you paid because you are making the transaction bigger (using more space)