### PR TITLE
Implement local disk Bitcoin Core block fetch from last 100-200 blocks.

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -47,6 +47,24 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "TorSocks5Port")]
 		public int? TorSocks5Port { get; internal set; }
 
+		[JsonProperty(PropertyName = "BitcoinCoreDataDir")]
+		public string BitcoinCoreDataDir
+		{
+			get => _bitcoinCoreDataDir;
+			internal set
+			{
+				if (_bitcoinCoreDataDir != value)
+				{
+					_bitcoinCoreDataDir = value;
+
+					if (!string.IsNullOrWhiteSpace(value) && ServiceConfiguration != default)
+					{
+						ServiceConfiguration.BitcoinCoreDataDir = value;
+					}
+				}
+			}
+		}
+
 		[JsonProperty(PropertyName = "MixUntilAnonymitySet")]
 		public int? MixUntilAnonymitySet
 		{
@@ -170,6 +188,7 @@ namespace WalletWasabi.Gui
 		private int? _privacyLevelSome;
 		private int? _privacyLevelFine;
 		private int? _privacyLevelStrong;
+		private string _bitcoinCoreDataDir;
 
 		public IPEndPoint GetTorSocks5EndPoint()
 		{
@@ -200,6 +219,7 @@ namespace WalletWasabi.Gui
 			string mainNetFallbackBackendUri,
 			string testNetFallbackBackendUri,
 			string regTestBackendUriV3,
+			string bitcoinCoreDataDir,
 			string torHost,
 			int? torSocks5Port,
 			int? mixUntilAnonymitySet,
@@ -219,12 +239,14 @@ namespace WalletWasabi.Gui
 			TorHost = Guard.NotNullOrEmptyOrWhitespace(nameof(torHost), torHost);
 			TorSocks5Port = Guard.NotNull(nameof(torSocks5Port), torSocks5Port);
 
+			BitcoinCoreDataDir = Guard.NotNullOrEmptyOrWhitespace(nameof(bitcoinCoreDataDir), bitcoinCoreDataDir);
+
 			MixUntilAnonymitySet = Guard.NotNull(nameof(mixUntilAnonymitySet), mixUntilAnonymitySet);
 			PrivacyLevelSome = Guard.NotNull(nameof(privacyLevelSome), privacyLevelSome);
 			PrivacyLevelFine = Guard.NotNull(nameof(privacyLevelFine), privacyLevelFine);
 			PrivacyLevelStrong = Guard.NotNull(nameof(privacyLevelStrong), privacyLevelStrong);
 
-			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value);
+			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, BitcoinCoreDataDir);
 		}
 
 		/// <inheritdoc />
@@ -250,6 +272,7 @@ namespace WalletWasabi.Gui
 			MainNetFallbackBackendUri = "https://wasabiwallet.io/";
 			TestNetFallbackBackendUri = "https://wasabiwallet.co/";
 			RegTestBackendUriV3 = "http://localhost:37127/";
+			BitcoinCoreDataDir = EnvironmentHelpers.TryGetDefaultBitcoinCoreDataDir() ?? "/bitcoin"; // whatever
 
 			TorHost = IPAddress.Loopback.ToString();
 			TorSocks5Port = 9050;
@@ -259,7 +282,7 @@ namespace WalletWasabi.Gui
 			PrivacyLevelFine = 21;
 			PrivacyLevelStrong = 50;
 
-			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value);
+			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, BitcoinCoreDataDir);
 
 			if (!File.Exists(FilePath))
 			{
@@ -288,6 +311,7 @@ namespace WalletWasabi.Gui
 			MainNetFallbackBackendUri = config.MainNetFallbackBackendUri ?? MainNetFallbackBackendUri;
 			TestNetFallbackBackendUri = config.TestNetFallbackBackendUri ?? TestNetFallbackBackendUri;
 			RegTestBackendUriV3 = config.RegTestBackendUriV3 ?? RegTestBackendUriV3;
+			BitcoinCoreDataDir = config.BitcoinCoreDataDir ?? BitcoinCoreDataDir;
 
 			TorHost = config.TorHost ?? TorHost;
 			TorSocks5Port = config.TorSocks5Port ?? TorSocks5Port;
@@ -347,6 +371,11 @@ namespace WalletWasabi.Gui
 				return true;
 			}
 			if (TorSocks5Port != config.TorSocks5Port)
+			{
+				return true;
+			}
+
+			if (BitcoinCoreDataDir != config.BitcoinCoreDataDir) // case sensitive
 			{
 				return true;
 			}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -162,11 +162,18 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					SmartTransaction foundSpenderTransaction = Global.WalletService.TransactionCache.First(x => x.GetHash() == coin.SpenderTransactionId);
 					if (foundSpenderTransaction.Height.Type == HeightType.Chain)
 					{
-						if (Global.WalletService.ProcessedBlocks.Any(x => x.Value.height == foundSpenderTransaction.Height))
+						if (Global.WalletService?.ProcessedBlocks != null) // NullReferenceException appeared here.
 						{
-							if (Global.WalletService?.ProcessedBlocks != null) // NullReferenceException appeared here.
+							if (Global.WalletService.ProcessedBlocks.Any(x => x.Value.height == foundSpenderTransaction.Height))
 							{
-								dateTime = Global.WalletService.ProcessedBlocks.First(x => x.Value.height == foundSpenderTransaction.Height).Value.dateTime;
+								if (Global.WalletService?.ProcessedBlocks != null) // NullReferenceException appeared here.
+								{
+									dateTime = Global.WalletService.ProcessedBlocks.First(x => x.Value.height == foundSpenderTransaction.Height).Value.dateTime;
+								}
+								else
+								{
+									dateTime = DateTimeOffset.UtcNow;
+								}
 							}
 							else
 							{

--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -70,6 +70,55 @@ namespace WalletWasabi.Helpers
 			return directory;
 		}
 
+		public static string TryGetDefaultBitcoinCoreDataDir()
+		{
+			string directory = null;
+
+			// https://en.bitcoin.it/wiki/Data_directory
+			try
+			{
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				{
+					var localAppData = Environment.GetEnvironmentVariable("APPDATA");
+					if (!string.IsNullOrEmpty(localAppData))
+					{
+						directory = Path.Combine(localAppData, "Bitcoin");
+					}
+					else
+					{
+						throw new DirectoryNotFoundException("Could not find suitable default Bitcoin Core datadir.");
+					}
+				}
+				else
+				{
+					var home = Environment.GetEnvironmentVariable("HOME");
+					if (!string.IsNullOrEmpty(home))
+					{
+						if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+						{
+							directory = Path.Combine(home, "Library", "Application Support", "Bitcoin");
+						}
+						else // Linux
+						{
+							directory = Path.Combine(home, ".bitcoin");
+						}
+					}
+					else
+					{
+						throw new DirectoryNotFoundException("Could not find suitable default Bitcoin Core datadir.");
+					}
+				}
+
+				return directory;
+			}
+			catch (Exception ex)
+			{
+				Logger.LogDebug(ex, nameof(EnvironmentHelpers));
+			}
+
+			return directory;
+		}
+
 		/// <summary>
 		/// Executes a command with bash.
 		/// https://stackoverflow.com/a/47918132/2061103

--- a/WalletWasabi/Models/ServiceConfiguration.cs
+++ b/WalletWasabi/Models/ServiceConfiguration.cs
@@ -11,17 +11,20 @@ namespace WalletWasabi.Models
 		public int PrivacyLevelSome { get; set; }
 		public int PrivacyLevelFine { get; set; }
 		public int PrivacyLevelStrong { get; set; }
+		public string BitcoinCoreDataDir { get; set; }
 
 		public ServiceConfiguration(
 			int mixUntilAnonymitySet,
 			int privacyLevelSome,
 			int privacyLevelFine,
-			int privacyLevelStrong)
+			int privacyLevelStrong,
+			string bitcoinCoreDataDir)
 		{
 			MixUntilAnonymitySet = Guard.NotNull(nameof(mixUntilAnonymitySet), mixUntilAnonymitySet);
 			PrivacyLevelSome = Guard.NotNull(nameof(privacyLevelSome), privacyLevelSome);
 			PrivacyLevelFine = Guard.NotNull(nameof(privacyLevelFine), privacyLevelFine);
 			PrivacyLevelStrong = Guard.NotNull(nameof(privacyLevelStrong), privacyLevelStrong);
+			BitcoinCoreDataDir = Guard.NotNull(nameof(bitcoinCoreDataDir), bitcoinCoreDataDir);
 		}
 	}
 }

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -689,8 +689,9 @@ namespace WalletWasabi.Services
 						{
 							if (foundBlockFromCore != null && !foundBlockFromCore.HeaderOnly)
 							{
-								Logger.LogInfo<WalletService>($"Block acquired from disk (source: Bitcoin Core): {block.GetHash()}");
-								return foundBlockFromCore;
+								Logger.LogInfo<WalletService>($"Block acquired from disk (source: Bitcoin Core): {hash}");
+								block = foundBlockFromCore;
+								break;
 							}
 						}
 


### PR DESCRIPTION
If the user has Bitcoin Core blocks on the disk, then autodetect it and parse the last 100-200 blocks so we fetch blocks from there instead of random nodes.

There are two issues. But even without them this PR is very useful. 
One issue is that I couldn't figure out how to quickly find old blocks, since blks are quite hard to index and we won't add leveldb dependency. Also the leveldb index is not intended to be touched from the outside. In the future they may break it.

The other issue is that @NicolasDorier's `StoredBlock.EnumerateFile` doesn't work on TestNet and RegTest, only on Mainnet.

@lontivero Could you take a look and try it out on Linux? Someone who has Bitcoin Core setup and synchronized should also test on OSX.

You can check if it works by

1. Starting Bitcoin Core, wait until it synchronizes.
2. Build Wasabi from source: https://github.com/zkSNACKs/WalletWasabi#build-from-source-code
3. Pull and checkout this PR: `git fetch origin pull/ID/head:core && git checkout core`
4. `dotnet run` from WalletWasabi.Gui folder.
5. Send some money to yourself and see if `019-01-23 01:49:50 INFO WalletService: Block acquired from disk (source: Bitcoin Core): 00000000000000000006f58e6b360e3bf99ca0607e123db1adfce9fc91bdd03c` appears in your logs when confirmation happens.