### PR TITLE
Don't check double spending when tx is coinbase

### DIFF
--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -464,7 +464,7 @@ namespace WalletWasabi.Services
 				return; // We don't care about non-witness transactions for other than mempool cleanup.
 			}
 
-			if (!justUpdate) // Transactions we already have and processed would be "double spends" but they shouldn't.
+			if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
 			{
 				var doubleSpends = new List<SmartCoin>();
 				foreach (SmartCoin coin in Coins)


### PR DESCRIPTION
This PR fixes a problem when a coinbase output belongs to our wallet, all next coinbase transactions are detected as double pending attempts. This problem only affected users that are also miners. 