### PR TITLE
Display Public key and Key path

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -78,10 +78,10 @@
         <ListBox.ItemTemplate>
           <DataTemplate>
             <Grid>
-              <Expander Name="coinExpander" ExpandDirection="Down"  Classes="coloredExpander"  Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
+              <Expander Name="coinExpander" ExpandDirection="Down" Classes="coloredExpander"  Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
 
                 <StackPanel>
-                  <Grid HorizontalAlignment="Left" ColumnDefinitions="150, *" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" MaxWidth="800">
+                  <Grid HorizontalAlignment="Left" ColumnDefinitions="150, *" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" MaxWidth="800" Margin="35 10 0 25" >
                     <TextBlock Text="Transaction Id:" Grid.Row="0" />
                     <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding TransactionId}" Background="Transparent" Grid.Column="1" Grid.Row="0" />
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -99,6 +99,12 @@
 
                     <TextBlock Text="Anonymity Set:" Grid.Row="5" />
                     <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding AnonymitySet}"  Grid.Column="1" Grid.Row="5" />
+
+                    <TextBlock Text="Key Path:" Grid.Row="6" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding KeyPath}"  Grid.Column="1" Grid.Row="6" />
+
+                    <TextBlock Text="Public Key:" Grid.Row="7" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding PubKey}"  Grid.Column="1" Grid.Row="7" />
                   </Grid>
                 </StackPanel>
               </Expander>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -143,6 +143,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string History => Model.History;
 
+		public string PubKey => Model.HdPubKey.PubKey.ToString();
+
+		public string KeyPath => Model.HdPubKey.FullKeyPath.ToString();
+
 		public SmartCoinStatus Status
 		{
 			get

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -74,11 +74,17 @@
               <DataTemplate>
                 <Grid>
                   <Expander ExpandDirection="Down" IsExpanded="{Binding IsExpanded}">
-                    <Panel>
-                      <Panel Width="240" Background="#FFFEFEFE">
-                        <controls:QrCode Matrix="{Binding QrCode}" HorizontalAlignment="Center" Margin="20" />
+                    <StackPanel Orientation="Horizontal" Spacing="16" Margin="35 10 0 25">
+                      <Panel Height="180" Background="#FFFEFEFE">
+                        <controls:QrCode Matrix="{Binding QrCode}" HorizontalAlignment="Left" Margin="14" />
                       </Panel>
-                    </Panel>
+                      <Grid ColumnDefinitions="140, *" RowDefinitions="22,22" Margin="6">
+                        <TextBlock Text="Public key:" Grid.Row="0" Grid.Column="0" />
+                        <TextBlock Text="{Binding Pubkey}" Grid.Row="0" Grid.Column="1" />
+                        <TextBlock Text="Key path:" Grid.Row="1" Grid.Column="0" />
+                        <TextBlock Text="{Binding KeyPath}" Grid.Row="1" Grid.Column="1" />
+                      </Grid>
+                    </StackPanel>
                   </Expander>
                   <Grid ColumnDefinitions="400, *, 100" Margin="30 0 0 0">
                     <TextBlock Text="{Binding Address}">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -1,9 +1,14 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions.Custom"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              Name="ReceiveTabViewerUserControl">
+  <UserControl.Resources>
+    <converters:CoinItemExpanderColorConverter x:Key="CoinItemExpanderColorConverter" />
+  </UserControl.Resources>
   <i:Interaction.Behaviors>
     <behaviors:ClearPropertyOnLostFocusBehavior TargetProperty="{Binding SelectedAddress}" />
   </i:Interaction.Behaviors>
@@ -73,16 +78,16 @@
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Grid>
-                  <Expander ExpandDirection="Down" IsExpanded="{Binding IsExpanded}">
+                  <Expander Name="coinExpander" ExpandDirection="Down" IsExpanded="{Binding IsExpanded}" Classes="coloredExpander" Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
                     <StackPanel Orientation="Horizontal" Spacing="16" Margin="35 10 0 25">
                       <Panel Height="180" Background="#FFFEFEFE">
                         <controls:QrCode Matrix="{Binding QrCode}" HorizontalAlignment="Left" Margin="14" />
                       </Panel>
                       <Grid ColumnDefinitions="140, *" RowDefinitions="22,22" Margin="6">
                         <TextBlock Text="Public key:" Grid.Row="0" Grid.Column="0" />
-                        <TextBlock Text="{Binding Pubkey}" Grid.Row="0" Grid.Column="1" />
+                        <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Pubkey}" Grid.Row="0" Grid.Column="1" />
                         <TextBlock Text="Key path:" Grid.Row="1" Grid.Column="0" />
-                        <TextBlock Text="{Binding KeyPath}" Grid.Row="1" Grid.Column="1" />
+                        <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent"  Text="{Binding KeyPath}" Grid.Row="1" Grid.Column="1" />
                       </Grid>
                     </StackPanel>
                   </Expander>

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -39,6 +39,10 @@ namespace WalletWasabi.Gui.ViewModels
 
 		public string Address => Model.GetP2wpkhAddress(Global.Network).ToString();
 
+		public string Pubkey => Model.PubKey.ToString();
+
+		public string KeyPath => Model.FullKeyPath.ToString();
+
 		public bool[,] QrCode
 		{
 			get => _qrCode;

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -4,6 +4,7 @@ using System;
 using System.ComponentModel;
 using WalletWasabi.Helpers;
 using WalletWasabi.JsonConverters;
+using WalletWasabi.KeyManagement;
 
 namespace WalletWasabi.Models
 {
@@ -48,6 +49,8 @@ namespace WalletWasabi.Models
 		private bool _isBanned;
 		private int _anonymitySet;
 		private string _history;
+
+		private HdPubKey _hdPubKey;
 
 		#endregion Fields
 
@@ -291,6 +294,19 @@ namespace WalletWasabi.Models
 			}
 		}
 
+		public HdPubKey HdPubKey
+		{
+			get => _hdPubKey;
+			private set
+			{
+				if (value != _hdPubKey)
+				{
+					_hdPubKey = value;
+					OnPropertyChanged(nameof(HdPubKey));
+				}
+			}
+		}
+
 		#endregion NonSerializableProperties
 
 		#region DependentProperties
@@ -401,12 +417,12 @@ namespace WalletWasabi.Models
 		#region Constructors
 
 		[JsonConstructor]
-		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, int mixin, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false)
+		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, int mixin, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
-			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, rbf, mixin, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend);
+			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, rbf, mixin, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
 		}
 
-		public SmartCoin(Coin coin, TxoRef[] spentOutputs, Height height, bool rbf, int mixin, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false)
+		public SmartCoin(Coin coin, TxoRef[] spentOutputs, Height height, bool rbf, int mixin, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
 			OutPoint outpoint = Guard.NotNull($"{coin}.{coin?.Outpoint}", coin?.Outpoint);
 			uint256 transactionId = outpoint.Hash;
@@ -414,10 +430,10 @@ namespace WalletWasabi.Models
 			Script scriptPubKey = Guard.NotNull($"{coin}.{coin?.ScriptPubKey}", coin?.ScriptPubKey);
 			Money amount = Guard.NotNull($"{coin}.{coin?.Amount}", coin?.Amount);
 
-			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, rbf, mixin, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend);
+			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, rbf, mixin, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
 		}
 
-		private void Create(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, int mixin, string label, uint256 spenderTransactionId, bool coinJoinInProgress, DateTimeOffset? bannedUntilUtc, bool spentAccordingToBackend)
+		private void Create(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, int mixin, string label, uint256 spenderTransactionId, bool coinJoinInProgress, DateTimeOffset? bannedUntilUtc, bool spentAccordingToBackend, HdPubKey pubKey)
 		{
 			TransactionId = Guard.NotNull(nameof(transactionId), transactionId);
 			Index = Guard.NotNull(nameof(index), index);
@@ -428,12 +444,14 @@ namespace WalletWasabi.Models
 			SpentOutputs = Guard.NotNullOrEmpty(nameof(spentOutputs), spentOutputs);
 			RBF = rbf;
 			Mixin = Guard.InRangeAndNotNull(nameof(mixin), mixin, 0, int.MaxValue);
-
+			
 			SpenderTransactionId = spenderTransactionId;
 
 			CoinJoinInProgress = coinJoinInProgress;
 			BannedUntilUtc = bannedUntilUtc;
 			SpentAccordingToBackend = spentAccordingToBackend;
+
+			HdPubKey = pubKey;
 
 			SetConfirmed();
 			SetAnonymitySet();

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -40,6 +40,7 @@ namespace WalletWasabi.Models
 		private bool _coinJoinInProgress;
 		private DateTimeOffset? _bannedUntilUtc;
 		private bool _spentAccordingToBackend;
+		private HdPubKey _hdPubKey;
 
 		private ISecret _secret;
 
@@ -49,8 +50,6 @@ namespace WalletWasabi.Models
 		private bool _isBanned;
 		private int _anonymitySet;
 		private string _history;
-
-		private HdPubKey _hdPubKey;
 
 		#endregion Fields
 
@@ -260,6 +259,20 @@ namespace WalletWasabi.Models
 			}
 		}
 
+		[JsonProperty]
+		public HdPubKey HdPubKey
+		{
+			get => _hdPubKey;
+			private set
+			{
+				if (value != _hdPubKey)
+				{
+					_hdPubKey = value;
+					OnPropertyChanged(nameof(HdPubKey));
+				}
+			}
+		}
+
 		#endregion SerializableProperties
 
 		#region NonSerializableProperties
@@ -290,19 +303,6 @@ namespace WalletWasabi.Models
 				{
 					_history = value;
 					OnPropertyChanged(nameof(History));
-				}
-			}
-		}
-
-		public HdPubKey HdPubKey
-		{
-			get => _hdPubKey;
-			private set
-			{
-				if (value != _hdPubKey)
-				{
-					_hdPubKey = value;
-					OnPropertyChanged(nameof(HdPubKey));
 				}
 			}
 		}
@@ -444,7 +444,7 @@ namespace WalletWasabi.Models
 			SpentOutputs = Guard.NotNullOrEmpty(nameof(spentOutputs), spentOutputs);
 			RBF = rbf;
 			Mixin = Guard.InRangeAndNotNull(nameof(mixin), mixin, 0, int.MaxValue);
-			
+
 			SpenderTransactionId = spenderTransactionId;
 
 			CoinJoinInProgress = coinJoinInProgress;

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -538,7 +538,7 @@ namespace WalletWasabi.Services
 						}
 					}
 
-					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.Transaction.RBF, mixin, foundKey.Label, spenderTransactionId: null, false); // Don't inherit locked status from key, that's different.
+					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.Transaction.RBF, mixin, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Don't inherit locked status from key, that's different.
 																																																										 // If we didn't have it.
 					if (Coins.TryAdd(newCoin))
 					{
@@ -1151,8 +1151,10 @@ namespace WalletWasabi.Services
 			{
 				TxOut output = tx.Outputs[i];
 				var mixin = tx.GetMixin(i) + spentCoins.Min(x => x.Mixin);
-				var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Inputs.ToTxoRefs().ToArray(), Height.Unknown, tx.RBF, mixin);
-				if (KeyManager.GetKeys(KeyState.Clean).Select(x => x.GetP2wpkhScript()).Contains(coin.ScriptPubKey))
+				var foundKey = KeyManager.GetKeys(KeyState.Clean).FirstOrDefault(x => output.ScriptPubKey == x.GetP2wpkhScript());
+				var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Inputs.ToTxoRefs().ToArray(), Height.Unknown, tx.RBF, mixin, pubKey: foundKey);
+
+				if (foundKey != null)
 				{
 					coin.Label = changeLabel;
 					innerWalletOutputs.Add(coin);


### PR DESCRIPTION
This PR is for adding more info in the receive address details where previously we only displayed the QR code. This is useful IMO because it can help users to understand the derivation scheme and prevent misunderstanding and let them find an address in tools such as the [Ian Coleman bip39 tool]( https://iancoleman.io/bip39/).

![image](https://user-images.githubusercontent.com/127973/52287013-1c424500-2948-11e9-8158-a3bc2bddce76.png)
