### PR TITLE
Fix logo on Linux

### DIFF
--- a/WalletWasabi.Gui/MainWindow.xaml
+++ b/WalletWasabi.Gui/MainWindow.xaml
@@ -10,7 +10,7 @@
                       xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
                       xmlns:beh="clr-namespace:AvalonStudio.Utils.Behaviors;assembly=AvalonStudio.Utils"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      Icon="resm:WalletWasabi.Gui.Assets.WasabiLogo.png?assembly=WalletWasabi.Gui"
+                      Icon="resm:WalletWasabi.Gui.Assets.WasabiLogo256.png?assembly=WalletWasabi.Gui"
                       Title="{Binding Title}"
                       MinWidth="1100" MinHeight="530"
                       FontFamily="{DynamicResource UiFont}" FontSize="14"


### PR DESCRIPTION
Resolves https://github.com/zkSNACKs/WalletWasabi/issues/1146

I changed the `WasabiLogo.png` to `WasabiLogo256.png`, because I saw that's how @danwalmsley's AvalonStudio is doing. This fixed #1146. @danwalmsley could I get an ACK to merge?