### PR TITLE
do not wait for exit  when opening log file

### DIFF
--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -268,7 +268,7 @@ namespace System.IO
 				{
 					// If no associated application/json MimeType is found xdg-open opens retrun error
 					// but it tries to open it anyway using the console editor (nano, vim, other..)
-					EnvironmentHelpers.ShellExec($"gedit {filePath} || xdg-open {filePath}");
+					EnvironmentHelpers.ShellExec($"gedit {filePath} || xdg-open {filePath}", waitForExit: false);
 				}
 				else
 				{


### PR DESCRIPTION
When opening files in Linux Wasabi was waiting for forked process to finish while in Windows and OSX that was different. This PR changes that. 

Closes #1206