### PR TITLE
Uses RPC cookie file instead of rpcuser:rpcpassword

### DIFF
--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -21,11 +21,8 @@ namespace WalletWasabi.Backend
 		[JsonConverter(typeof(NetworkJsonConverter))]
 		public Network Network { get; private set; }
 
-		[JsonProperty(PropertyName = "BitcoinRpcUser")]
-		public string BitcoinRpcUser { get; private set; }
-
-		[JsonProperty(PropertyName = "BitcoinRpcPassword")]
-		public string BitcoinRpcPassword { get; private set; }
+		[JsonProperty(PropertyName = "BitcoinRpcConnectionString")]
+		public string BitcoinRpcConnectionString { get; private set; }
 
 		public Config()
 		{
@@ -36,11 +33,10 @@ namespace WalletWasabi.Backend
 			SetFilePath(filePath);
 		}
 
-		public Config(Network network, string bitcoinRpcUser, string bitcoinRpcPassword)
+		public Config(Network network, string BitcoinRpcConnectionString)
 		{
 			Network = Guard.NotNull(nameof(network), network);
-			BitcoinRpcUser = Guard.NotNullOrEmptyOrWhitespace(nameof(bitcoinRpcUser), bitcoinRpcUser);
-			BitcoinRpcPassword = Guard.NotNull(nameof(bitcoinRpcPassword), bitcoinRpcPassword);
+			BitcoinRpcConnectionString = Guard.NotNullOrEmptyOrWhitespace(nameof(BitcoinRpcConnectionString), BitcoinRpcConnectionString);
 		}
 
 		/// <inheritdoc />
@@ -60,8 +56,7 @@ namespace WalletWasabi.Backend
 			AssertFilePathSet();
 
 			Network = Network.Main;
-			BitcoinRpcUser = "user";
-			BitcoinRpcPassword = "password";
+			BitcoinRpcConnectionString = "user:password";
 
 			if (!File.Exists(FilePath))
 			{
@@ -73,8 +68,7 @@ namespace WalletWasabi.Backend
 				var config = JsonConvert.DeserializeObject<Config>(jsonString);
 
 				Network = config.Network ?? Network;
-				BitcoinRpcUser = config.BitcoinRpcUser ?? BitcoinRpcUser;
-				BitcoinRpcPassword = config.BitcoinRpcPassword ?? BitcoinRpcPassword;
+				BitcoinRpcConnectionString = config.BitcoinRpcConnectionString ?? BitcoinRpcConnectionString;
 			}
 
 			await ToFileAsync();
@@ -97,11 +91,7 @@ namespace WalletWasabi.Backend
 			{
 				return true;
 			}
-			if (BitcoinRpcPassword != config.BitcoinRpcPassword)
-			{
-				return true;
-			}
-			if (BitcoinRpcUser != config.BitcoinRpcUser)
+			if (BitcoinRpcConnectionString != config.BitcoinRpcConnectionString)
 			{
 				return true;
 			}

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -56,7 +56,7 @@ namespace WalletWasabi.Backend
 			AssertFilePathSet();
 
 			Network = Network.Main;
-			BitcoinRpcConnectionString = "user:password";
+			BitcoinRpcConnectionString = "cookiefile=/home/user/.bitcoin/.cookie";
 
 			if (!File.Exists(FilePath))
 			{

--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -40,10 +40,7 @@ namespace WalletWasabi.Backend
 				Logger.LogInfo<CcjRoundConfig>("RoundConfig is successfully initialized.");
 
 				var rpc = new RPCClient(
-						credentials: new RPCCredentialString
-						{
-							UserPassword = new NetworkCredential(config.BitcoinRpcUser, config.BitcoinRpcPassword)
-						},
+						credentials: RPCCredentialString.Parse(config.BitcoinRpcConnectionString),
 						network: config.Network);
 
 				await Global.InitializeAsync(config, roundConfig, rpc);

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -155,8 +155,6 @@ testnet=[0/1]
 
 [main/test].daemon=1
 [main/test].server=1
-[main/test].rpcuser=bitcoinuser
-[main/test].rpcpassword=password
 ```
 https://bitcoincore.org/en/releases/0.17.0/
 https://medium.com/@loopring/how-to-run-lighting-btc-node-and-start-mining-b55c4bab8ad  

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -29,9 +29,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 
 			var rpc = BackendRegTestNode.CreateRpcClient();
 
-			var authString = rpc.Authentication.Split(':');
-
-			var config = new Config(rpc.Network, authString[0], authString[1]);
+			var config = new Config(rpc.Network, rpc.Authentication);
 
 			var roundConfig = new CcjRoundConfig(Money.Coins(0.1m), 144, 0.1m, 100, 120, 60, 60, 60, 1, 24, true, 11);
 


### PR DESCRIPTION
Since `rpcuser` and `rpcpassword` are deprecated we should use the cookie file instead.

The backend `Config.json` file should look like the one below:

```json
﻿{
  "Network": "RegTest",
  "BitcoinRpcConnectionString": "cookiefile=/home/<username>/.bitcoin/.cookie"
}
``` 

**Note**: NBitcoin allows us to use `rpcuser` and `rpcpassword` here as follow:

```json
﻿{
  "Network": "RegTest",
  "BitcoinRpcConnectionString": "user:password"
}
``` 
