### PR TITLE
Make RPC calls in batch

### DIFF
--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -51,14 +51,23 @@ namespace WalletWasabi.Backend
 					UnversionedWebBuilder.CreateDownloadTextWithVersionHtml();
 					UnversionedWebBuilder.CloneAndUpdateOnionIndexHtml();
 
+					var getTxTasks = new List<Task<Transaction>>();
+					var batch = Global.RpcClient.PrepareBatch();
+
 					string[] allLines = File.ReadAllLines(Global.Coordinator.CoinJoinsFilePath);
-					foreach (string line in allLines)
+					foreach (string txId in allLines)
+					{
+						getTxTasks.Add(batch.GetRawTransactionAsync(uint256.Parse(txId)));
+					}
+					var waiting = Task.WhenAll(getTxTasks);
+					await batch.SendBatchAsync();
+					await waiting;
+
+					foreach(var task in getTxTasks)
 					{
 						try
 						{
-							var txHash = new uint256(line);
-							Transaction tx = Global.RpcClient.GetRawTransaction(txHash);
-
+							var tx = await task; 
 							var volume = tx.GetIndistinguishableOutputs(includeSingle: false).Sum(x => x.count * x.value);
 							TotalVolume += volume;
 						}


### PR DESCRIPTION
closes #1217 
If this is not fast enough we should consider to save the coinjoin transaction instead of the txid.