### PR TITLE
Alternative RBF detection (checking ancestors)

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -120,8 +120,12 @@
                 </Grid.ColumnDefinitions>
 
                 <CheckBox HorizontalContentAlignment="Left" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />
-                <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="1" ToolTip.Tip="Confirmed">
-                  <Path HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16"  Stretch="Fill" />
+
+                <Border Background="Transparent" Grid.Column="1">
+                  <StackPanel>
+                  <Path IsVisible="{Binding Confirmed}" HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16"  Stretch="Fill" />
+                  <Path IsVisible="{Binding IsReplaceable}" HorizontalAlignment="Left" Data="F1 M 35,13L 35,30.5L 27,21L 27,30.75L 38,43.25L 49,30.75L 49,21L 41,30.5L 41,13L 35,13 Z M 17,38L 30,38L 33.75,42L 21,42L 21,53L 55,53L 55,42L 42.25,42L 46,38L 59,38L 59,57L 17,57L 17,38 Z M 33,46L 43,46L 43,49L 33,49L 33,46 Z" Fill="#22BFFF" Height="16" Width="16"  Stretch="Fill" />
+                  </StackPanel>
                 </Border>
 
                 <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left"  BorderThickness="1" CornerRadius="0,6,6,0">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -34,6 +34,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				this.RaisePropertyChanged(nameof(Confirmed));
 			}).DisposeWith(Disposables);
 
+			model.WhenAnyValue(x => x.IsReplaceable).ObserveOn(RxApp.MainThreadScheduler).Subscribe(replaceable =>
+			{
+				RefreshSmartCoinStatus();
+				this.RaisePropertyChanged(nameof(IsReplaceable));
+			}).DisposeWith(Disposables);
+
 			model.WhenAnyValue(x => x.Unavailable).ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
 			{
 				this.RaisePropertyChanged(nameof(Unavailable));
@@ -87,6 +93,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public SmartCoin Model { get; }
 
 		public bool Confirmed => Model.Confirmed;
+		public bool IsReplaceable => Model.IsReplaceable;
 
 		public bool CoinJoinInProgress => Model.CoinJoinInProgress;
 

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -297,6 +297,7 @@ namespace WalletWasabi.Tests
 			Logger.LogDebug<RegTests>($"Mempool transaction received: {e.GetHash()}.");
 		}
 
+
 		[Fact]
 		public async Task FilterDownloaderTestAsync()
 		{
@@ -1652,6 +1653,112 @@ namespace WalletWasabi.Tests
 		}
 
 		[Fact]
+		public async Task ReplaceByFeeTxTestAsync()
+		{
+			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator, ServiceConfiguration serviceConfiguration) = await InitializeTestEnvironmentAsync(1);
+
+			// Create the services.
+			// 1. Create connection service.
+			var nodes = new NodesGroup(Global.Config.Network, requirements: Constants.NodeRequirements);
+			nodes.ConnectedNodes.Add(RegTestFixture.BackendRegTestNode.CreateNodeClient());
+
+			// 2. Create mempool service.
+			var memPoolService = new MemPoolService();
+			Node node = RegTestFixture.BackendRegTestNode.CreateNodeClient();
+			node.Behaviors.Add(new MemPoolBehavior(memPoolService));
+
+			// 3. Create wasabi synchronizer service.
+			var indexFilePath = Path.Combine(SharedFixture.DataDir, nameof(SendTestsFromHiddenWalletAsync),
+				$"Index{rpc.Network}.dat");
+			var synchronizer =
+				new WasabiSynchronizer(rpc.Network, indexFilePath, new Uri(RegTestFixture.BackendEndPoint), null);
+
+			// 4. Create key manager service.
+			var keyManager = KeyManager.CreateNew(out _, password);
+
+			// 5. Create chaumian coinjoin client.
+			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
+
+			// 6. Create wallet service.
+			var workDir = Path.Combine(SharedFixture.DataDir, nameof(SendTestsFromHiddenWalletAsync));
+			var wallet = new WalletService(keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
+			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
+
+			Assert.Empty(wallet.Coins);
+
+			// Get some money, make it confirm.
+			var key = wallet.GetReceiveKey("foo label");
+
+			try
+			{
+				nodes.Connect(); // Start connection service.
+				node.VersionHandshake(); // Start mempool service.
+				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
+				chaumianClient.Start(); // Start chaumian coinjoin client.
+
+				// Wait until the filter our previous transaction is present.
+				var blockCount = await rpc.GetBlockCountAsync();
+				await WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), blockCount);
+
+				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+				{
+					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+				}
+
+				Assert.Empty(wallet.Coins);
+
+				var tx0Id = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(1m), replaceable: true);
+				while (wallet.Coins.Count == 0)
+					await Task.Delay(500); // Waits for the funding transaction get to the mempool.
+				Assert.Single(wallet.Coins);
+				Assert.True(wallet.Coins.First().IsReplaceable);
+
+				var bfr = await rpc.BumpFeeAsync(tx0Id);
+				var tx1Id = bfr.TransactionId;
+				await Task.Delay(2000); // Waits for the replacement transaction get to the mempool.
+				Assert.Single(wallet.Coins);
+				Assert.True(wallet.Coins.First().IsReplaceable);
+				Assert.Equal(tx1Id, wallet.Coins.First().TransactionId);
+
+				bfr = await rpc.BumpFeeAsync(tx1Id);
+				var tx2Id = bfr.TransactionId;
+				await Task.Delay(2000); // Waits for the replacement transaction get to the mempool.
+				Assert.Single(wallet.Coins);
+				Assert.True(wallet.Coins.First().IsReplaceable);
+				Assert.Equal(tx2Id, wallet.Coins.First().TransactionId);
+
+				await rpc.GenerateAsync(1);
+				await WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 2);
+				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+				{
+					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+				}
+				await Task.Delay(2000);
+
+				var coin = wallet.Coins.First();
+				Assert.Single(wallet.Coins);
+				Assert.True(coin.Confirmed);
+				Assert.False(coin.IsReplaceable);
+				Assert.Equal(tx2Id, coin.TransactionId);
+			}
+			finally
+			{
+				wallet?.Dispose();
+				// Dispose wasabi synchronizer service.
+				synchronizer?.Dispose();
+				// Dispose connection service.
+				nodes?.Dispose();
+				// Dispose mempool serving node.
+				node?.Disconnect();
+				// Dispose chaumian coinjoin client.
+				if (chaumianClient != null)
+				{
+					await chaumianClient.StopAsync();
+				}
+			}
+		}
+
+		[Fact]
 		public async Task CcjCoordinatorCtorTestsAsync()
 		{
 			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator, ServiceConfiguration serviceConfiguration) = await InitializeTestEnvironmentAsync(1);
@@ -2941,7 +3048,7 @@ namespace WalletWasabi.Tests
 				var height = await rpc.GetBlockCountAsync();
 				var bechCoin = tx.Outputs.GetCoins(bech.ScriptPubKey).Single();
 
-				var smartCoin = new SmartCoin(bechCoin, tx.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height + 1, rbf: false, anonymitySet: tx.GetAnonymitySet(bechCoin.Outpoint.N));
+				var smartCoin = new SmartCoin(bechCoin, tx.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height + 1, replaceable: false, anonymitySet: tx.GetAnonymitySet(bechCoin.Outpoint.N));
 
 				var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
@@ -3046,10 +3153,10 @@ namespace WalletWasabi.Tests
 			var bech3Coin = tx3.Outputs.GetCoins(bech3.ScriptPubKey).Single();
 			var bech4Coin = tx4.Outputs.GetCoins(bech4.ScriptPubKey).Single();
 
-			var smartCoin1 = new SmartCoin(bech1Coin, tx1.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, rbf: false, anonymitySet: tx1.GetAnonymitySet(bech1Coin.Outpoint.N));
-			var smartCoin2 = new SmartCoin(bech2Coin, tx2.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, rbf: false, anonymitySet: tx2.GetAnonymitySet(bech2Coin.Outpoint.N));
-			var smartCoin3 = new SmartCoin(bech3Coin, tx3.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, rbf: false, anonymitySet: tx3.GetAnonymitySet(bech3Coin.Outpoint.N));
-			var smartCoin4 = new SmartCoin(bech4Coin, tx4.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, rbf: false, anonymitySet: tx4.GetAnonymitySet(bech4Coin.Outpoint.N));
+			var smartCoin1 = new SmartCoin(bech1Coin, tx1.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, replaceable: false, anonymitySet: tx1.GetAnonymitySet(bech1Coin.Outpoint.N));
+			var smartCoin2 = new SmartCoin(bech2Coin, tx2.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, replaceable: false, anonymitySet: tx2.GetAnonymitySet(bech2Coin.Outpoint.N));
+			var smartCoin3 = new SmartCoin(bech3Coin, tx3.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, replaceable: false, anonymitySet: tx3.GetAnonymitySet(bech3Coin.Outpoint.N));
+			var smartCoin4 = new SmartCoin(bech4Coin, tx4.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, replaceable: false, anonymitySet: tx4.GetAnonymitySet(bech4Coin.Outpoint.N));
 
 			var chaumianClient1 = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 			var chaumianClient2 = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
@@ -3072,7 +3179,7 @@ namespace WalletWasabi.Tests
 				Assert.True(smartCoin2.CoinJoinInProgress);
 
 				// Make sure it doesn't throw.
-				await chaumianClient1.DequeueCoinsFromMixAsync(new SmartCoin((network.Consensus.ConsensusFactory.CreateTransaction()).GetHash(), 1, new Script(), Money.Parse("3"), new TxoRef[] { new TxoRef((network.Consensus.ConsensusFactory.CreateTransaction()).GetHash(), 0) }, Height.MemPool, rbf: false, anonymitySet: 1));
+				await chaumianClient1.DequeueCoinsFromMixAsync(new SmartCoin((network.Consensus.ConsensusFactory.CreateTransaction()).GetHash(), 1, new Script(), Money.Parse("3"), new TxoRef[] { new TxoRef((network.Consensus.ConsensusFactory.CreateTransaction()).GetHash(), 0) }, Height.MemPool, replaceable: false, anonymitySet: 1));
 
 				Assert.True(2 == (await chaumianClient1.QueueCoinsToMixAsync(password, smartCoin1, smartCoin2)).Count());
 				await chaumianClient1.DequeueCoinsFromMixAsync(smartCoin1);

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -169,7 +169,7 @@ namespace WalletWasabi.Models
 		[JsonConverter(typeof(FunnyBoolJsonConverter))]
 		public bool IsReplaceable
 		{
-			get => _replaceable && !Confirmed;
+			get => _replaceable;
 			set
 			{
 				if (value != _replaceable)
@@ -340,6 +340,8 @@ namespace WalletWasabi.Models
 				{
 					_confirmed = value;
 					OnPropertyChanged(nameof(Confirmed));
+					if(_confirmed) 
+						IsReplaceable = false;
 				}
 			}
 		}

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.Models
 		private Height _height;
 		private string _label;
 		private TxoRef[] _spentOutputs;
-		private bool _rbf;
+		private bool _replaceable;
 		private int _anonymitySet;
 		private uint256 _spenderTransactionId;
 		private bool _coinJoinInProgress;
@@ -167,15 +167,15 @@ namespace WalletWasabi.Models
 
 		[JsonProperty]
 		[JsonConverter(typeof(FunnyBoolJsonConverter))]
-		public bool RBF
+		public bool IsReplaceable
 		{
-			get => _rbf;
+			get => _replaceable && !Confirmed;
 			set
 			{
-				if (value != _rbf)
+				if (value != _replaceable)
 				{
-					_rbf = value;
-					OnPropertyChanged(nameof(RBF));
+					_replaceable = value;
+					OnPropertyChanged(nameof(IsReplaceable));
 				}
 			}
 		}
@@ -424,12 +424,12 @@ namespace WalletWasabi.Models
 		#region Constructors
 
 		[JsonConstructor]
-		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, int anonymitySet, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
+		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
-			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, rbf, anonymitySet, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
+			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
 		}
 
-		public SmartCoin(Coin coin, TxoRef[] spentOutputs, Height height, bool rbf, int anonymitySet, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
+		public SmartCoin(Coin coin, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
 			OutPoint outpoint = Guard.NotNull($"{coin}.{coin?.Outpoint}", coin?.Outpoint);
 			uint256 transactionId = outpoint.Hash;
@@ -437,10 +437,10 @@ namespace WalletWasabi.Models
 			Script scriptPubKey = Guard.NotNull($"{coin}.{coin?.ScriptPubKey}", coin?.ScriptPubKey);
 			Money amount = Guard.NotNull($"{coin}.{coin?.Amount}", coin?.Amount);
 
-			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, rbf, anonymitySet, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
+			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
 		}
 
-		private void Create(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool rbf, int anonymitySet, string label, uint256 spenderTransactionId, bool coinJoinInProgress, DateTimeOffset? bannedUntilUtc, bool spentAccordingToBackend, HdPubKey pubKey)
+		private void Create(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label, uint256 spenderTransactionId, bool coinJoinInProgress, DateTimeOffset? bannedUntilUtc, bool spentAccordingToBackend, HdPubKey pubKey)
 		{
 			TransactionId = Guard.NotNull(nameof(transactionId), transactionId);
 			Index = Guard.NotNull(nameof(index), index);
@@ -449,7 +449,7 @@ namespace WalletWasabi.Models
 			Height = height;
 			Label = Guard.Correct(label);
 			SpentOutputs = Guard.NotNullOrEmpty(nameof(spentOutputs), spentOutputs);
-			RBF = rbf;
+			IsReplaceable = replaceable;
 			AnonymitySet = Guard.InRangeAndNotNull(nameof(anonymitySet), anonymitySet, 1, int.MaxValue);
 
 			SpenderTransactionId = spenderTransactionId;

--- a/WalletWasabi/Models/SmartTransaction.cs
+++ b/WalletWasabi/Models/SmartTransaction.cs
@@ -37,6 +37,14 @@ namespace WalletWasabi.Models
 		[JsonConverter(typeof(BlockCypherDateTimeOffsetJsonConverter))]
 		public DateTimeOffset? FirstSeenIfMemPoolTime { get; private set; }
 
+		public bool IsReplacement { get; internal set; }
+
+		/// <summary>
+		/// A transaction can signal that is replaceable by fee in two ways: 
+		/// * Explicitly by using a nSequence &lt; (0xffffffff - 1) or,
+		/// * Implicitly in case one of its unconfirmed ancestors are replaceable
+		/// </summary>
+		public bool IsRBF => !Confirmed && (Transaction.RBF || IsReplacement);
 		#endregion Members
 
 		#region Constructors
@@ -56,6 +64,7 @@ namespace WalletWasabi.Models
 			{
 				FirstSeenIfMemPoolTime = firstSeenIfMemPoolTime;
 			}
+			IsReplacement = false;
 		}
 
 		public void SetHeight(Height height)

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -209,6 +209,7 @@ namespace WalletWasabi.Services
 			}
 
 			Coins.TryRemove(toRemove);
+			MemPool.TransactionHashes.TryRemove(toRemove.SpenderTransactionId);
 		}
 
 		private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)
@@ -502,6 +503,7 @@ namespace WalletWasabi.Services
 							{
 								RemoveCoinRecursively(doubleSpentCoin);
 							}
+							tx.IsReplacement = true;
 						}
 						else
 						{
@@ -540,7 +542,7 @@ namespace WalletWasabi.Services
 						}
 					}
 
-					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.Transaction.RBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Don't inherit locked status from key, that's different.
+					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Don't inherit locked status from key, that's different.
 																																																															 // If we didn't have it.
 					if (Coins.TryAdd(newCoin))
 					{
@@ -579,6 +581,7 @@ namespace WalletWasabi.Services
 							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
 							{
 								oldCoin.Height = newCoin.Height;
+								oldCoin.RBF = false;
 							}
 						}
 					}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -495,7 +495,7 @@ namespace WalletWasabi.Services
 						// if the received transaction is spending at least one input already
 						// spent by a previous unconfirmed transaction signaling RBF then it is not a double
 						// spanding transaction but a replacement transaction. 
-						if(doubleSpends.Any(x => x.RBF && !x.Confirmed))
+						if(doubleSpends.Any(x => x.IsReplaceable))
 						{
 							// remove double spent coins (if other coin spends it, remove that too and so on)
 							// will add later if they came to our keys
@@ -581,7 +581,6 @@ namespace WalletWasabi.Services
 							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
 							{
 								oldCoin.Height = newCoin.Height;
-								oldCoin.RBF = false;
 							}
 						}
 					}


### PR DESCRIPTION
This is only for discussion. What I want to show here is mostly in the last commit https://github.com/zkSNACKs/WalletWasabi/commit/fd84cb252e9dc14cb21d6864ac8426a9fb44a57d where you can see the code iterates over the transaction ancestors as bitcoin core does in order to determinate whether a transaction inherits replaceability from its ancestors or not.

This method has pros and cons:
* each time we invoke it it reevaluates the replaceability. This is good in cases where child transaction arrives before the parent one.
* It is theoretically a bit slower (even when i did not see any visible impact even using a huge wallet)

Please ignore the UI part, this is for sharing the rfb detection part only.

**Edit**: I am sharing this because I know you need to detect replaceable transaction on the server side too and that we should use the same mechanism on both client and server side. I suspect this approach could me more suitable in that scenario. 