### PR TITLE
Small refactoring for centralizing feedback

### DIFF
--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -141,7 +141,7 @@ namespace WalletWasabi.Services
 						{
 							using (await MixLock.LockAsync())
 							{
-								await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+								await DequeueSpentCoinsFromMixNoLockAsync();
 
 								// If stop was requested return.
 								if (IsRunning == false)
@@ -218,7 +218,7 @@ namespace WalletWasabi.Services
 						DelayedRoundRegistration = null; // Don't dispose.
 					}
 
-					await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+					await DequeueSpentCoinsFromMixNoLockAsync();
 
 					State.UpdateRoundsByStates(ExposedLinks, states.ToArray());
 
@@ -258,7 +258,7 @@ namespace WalletWasabi.Services
 						await TryProcessRoundStateAsync(ongoingRoundId);
 					}
 
-					await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+					await DequeueSpentCoinsFromMixNoLockAsync();
 					CcjClientRound inputRegistrableRound = State.GetRegistrableRoundOrDefault();
 					if (inputRegistrableRound != null)
 					{
@@ -763,7 +763,7 @@ namespace WalletWasabi.Services
 			var successful = new List<SmartCoin>();
 			using (await MixLock.LockAsync())
 			{
-				await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+				await DequeueSpentCoinsFromMixNoLockAsync();
 
 				// Every time the user enqueues (intentionally writes in password) then the coordinator fee percent must be noted and dequeue later if changes.
 				CcjClientRound latestRound = State.GetLatestRoundOrDefault();
@@ -824,7 +824,7 @@ namespace WalletWasabi.Services
 				{
 					using (await MixLock.LockAsync(cts.Token))
 					{
-						await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+						await DequeueSpentCoinsFromMixNoLockAsync();
 
 						await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray());
 					}
@@ -882,14 +882,14 @@ namespace WalletWasabi.Services
 				{
 					using (await MixLock.LockAsync(cts.Token))
 					{
-						await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+						await DequeueSpentCoinsFromMixNoLockAsync();
 
 						await DequeueCoinsFromMixNoLockAsync(coins);
 					}
 				}
 				catch (TaskCanceledException)
 				{
-					await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+					await DequeueSpentCoinsFromMixNoLockAsync();
 
 					await DequeueCoinsFromMixNoLockAsync(coins);
 				}
@@ -904,12 +904,12 @@ namespace WalletWasabi.Services
 				{
 					using (await MixLock.LockAsync(cts.Token))
 					{
-						await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray());
+						await DequeueAllCoinsFromMixNoLockAsync();
 					}
 				}
 				catch (TaskCanceledException)
 				{
-					await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray());
+					await DequeueAllCoinsFromMixNoLockAsync();
 				}
 			}
 		}
@@ -917,6 +917,11 @@ namespace WalletWasabi.Services
 		private async Task DequeueAllCoinsFromMixNoLockAsync()
 		{
 			await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray());
+		}
+
+		private async Task DequeueSpentCoinsFromMixNoLockAsync()
+		{
+			await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
 		}
 
 		private async Task DequeueCoinsFromMixNoLockAsync(params TxoRef[] coins)
@@ -1037,7 +1042,7 @@ namespace WalletWasabi.Services
 
 			using (await MixLock.LockAsync())
 			{
-				await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+				await DequeueSpentCoinsFromMixNoLockAsync();
 
 				State.DisposeAllAliceClients();
 


### PR DESCRIPTION
Currently we are not providing good enough feedback to the users when Wasabi dequeue coins for reasons other than banned. This PR will address the issue https://github.com/zkSNACKs/WalletWasabi/issues/1244 but it would be good to know how to give visual feedback (if https://github.com/zkSNACKs/WalletWasabi/pull/1260 is merged I will use it).