### PR TITLE
Do not send getdata messages with 0 items

### DIFF
--- a/WalletWasabi/Services/MemPoolBehavior.cs
+++ b/WalletWasabi/Services/MemPoolBehavior.cs
@@ -78,7 +78,7 @@ namespace WalletWasabi.Services
 				payload.Inventory.Add(inv);
 			}
 
-			if (node.IsConnected)
+			if (node.IsConnected && payload.Inventory.Any())
 			{
 				// ask for the whole transaction
 				await node.SendMessageAsync(payload);


### PR DESCRIPTION
When Wasabi receives an `inventory` message without transactions or with transactions that it already has in the mempool, it responde with a `getdata` message with 0 items. We can see it in the traffic dump  in issue https://github.com/zkSNACKs/WalletWasabi/issues/1273.

This is not a big problem at all because it doesn't use any significant bandwidth but it something to fix anyway. 