### PR TITLE
Optimize confirmation times

### DIFF
--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -136,7 +136,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 		public UtxoReferee UtxoReferee { get; }
 
-		public CcjRound(RPCClient rpc, UtxoReferee utxoReferee, CcjRoundConfig config)
+		public CcjRound(RPCClient rpc, UtxoReferee utxoReferee, CcjRoundConfig config, int confirmationTarget)
 		{
 			try
 			{
@@ -146,7 +146,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				UtxoReferee = Guard.NotNull(nameof(utxoReferee), utxoReferee);
 				Guard.NotNull(nameof(config), config);
 
-				ConfirmationTarget = (int)config.ConfirmationTarget;
+				ConfirmationTarget = confirmationTarget;
 				CoordinatorFeePercent = (decimal)config.CoordinatorFeePercent;
 				AnonymitySet = (int)config.AnonymitySet;
 				InputRegistrationTimeout = TimeSpan.FromSeconds((long)config.InputRegistrationTimeout);


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/1155

@lontivero this attempts to resolve your "Coinjoin Transactions Network Fee" with your "Alternative 2."

The idea is: depending on the number of unconfirmed coinjoins I halven the fee target every time a new round is created.