### PR TITLE
Fix: peer count zero on RegTest

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -61,7 +61,9 @@ namespace WalletWasabi.Gui.ViewModels
 					SetPeers(Nodes.Count);
 				}).DisposeWith(Disposables);
 
-			Observable.FromEventPattern<int>(typeof(WalletService), nameof(WalletService.ConcurrentBlockDownloadNumberChanged))
+            SetPeers(Nodes.Count);
+
+            Observable.FromEventPattern<int>(typeof(WalletService), nameof(WalletService.ConcurrentBlockDownloadNumberChanged))
 				.Subscribe(x =>
 				{
 					BlocksLeft = x.EventArgs;


### PR DESCRIPTION
There was a bug in the ViewModel of the status bar. Local variable was used inside the Subscribe() function. [Data were taken from outside of the Observable stream.](https://medium.com/@paynoattn/3-common-mistakes-i-see-people-use-in-rx-and-the-observable-pattern-ba55fee3d031). It is a bad practice.