### PR TITLE
Update WasabiCodingGuidelines.md

### DIFF
--- a/WalletWasabi.Documentation/Guides/WasabiCodingGuidelines.md
+++ b/WalletWasabi.Documentation/Guides/WasabiCodingGuidelines.md
@@ -289,3 +289,19 @@ DO NOT use `==null`
 	if (FeeService == null) return;
 ```
 
+DO NOT use local variables in `.Subscribe()`.
+
+```c#
+
+	public MyConstructor(NodesCollection nodes)
+	{
+	
+		Observable.FromEventPattern<NodeEventArgs>(myList, nameof(nodes.Removed))
+			.Subscribe(x =>
+			{
+				Refresh(nodes.Count); //Bad code. Nodes should be a class member!
+			}).DisposeWith(Disposables);
+			
+	}
+
+```


### PR DESCRIPTION
It is about the bad practice of the usage of a local variable inside the `.Subscribe()` method.