### PR TITLE
Re-create the file to force the creation date

### DIFF
--- a/WalletWasabi/Hwi/HwiProcessManager.cs
+++ b/WalletWasabi/Hwi/HwiProcessManager.cs
@@ -232,6 +232,10 @@ namespace WalletWasabi.Hwi
 				{
 					string hwiLinuxZip = Path.Combine(hwiSoftwareDir, "hwi-linux64.zip");
 					await IoHelpers.BetterExtractZipToDirectoryAsync(hwiLinuxZip, hwiDir);
+					var hwiPath = Path.Combine(hwiDir, "hwi");
+					var bytes = File.ReadAllBytes(hwiPath);
+					File.Delete(hwiPath);
+					File.WriteAllBytes(hwiPath, bytes);
 					Logger.LogInfo($"Extracted {hwiLinuxZip} to {hwiDir}.", nameof(HwiProcessManager));
 				}
 				else // OSX


### PR DESCRIPTION
The problem is that the extracted file preserves the creation date (the one it has inside the zip file) and there is not option to update it when decompressed. I couldn't find any other way to do this. `File.SetCreationTimeUtc` doesn't work on Linux.
Close #1344