### PR TITLE
Allow to specify --datadir

### DIFF
--- a/WalletWasabi.Gui/CommandLine/CommandInterpreter.cs
+++ b/WalletWasabi.Gui/CommandLine/CommandInterpreter.cs
@@ -33,6 +33,8 @@ namespace WalletWasabi.Gui.CommandLine
 						x => showHelp = x != null},
 					{ "v|version", "Displays Wasabi version and exit.",
 						x => showVersion = x != null},
+					{ "d|datadir=", "Directory path where store all the Wasabi data.",
+						x => Global.SetDataDir(x) },
 					"",
 					"Available commands are:",
 					"",
@@ -56,7 +58,7 @@ namespace WalletWasabi.Gui.CommandLine
 				return false;
 			}
 
-			return false;
+			return true;
 		}
 
 		private static void EnsureBackwardCompatibilityWithOldParameters(ref string[] args)

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -31,10 +31,10 @@ namespace WalletWasabi.Gui
 {
 	public static class Global
 	{
-		public static string DataDir { get; }
-		public static string TorLogsFile { get; }
-		public static string WalletsDir { get; }
-		public static string WalletBackupsDir { get; }
+		public static string DataDir { get; internal set; }
+		public static string TorLogsFile { get; private set;}
+		public static string WalletsDir { get; private set;}
+		public static string WalletBackupsDir { get; private set;}
 
 		public static string IndexFilePath { get; private set; }
 		public static Config Config { get; private set; }
@@ -59,7 +59,12 @@ namespace WalletWasabi.Gui
 
 		static Global()
 		{
-			DataDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client"));
+			SetDataDir(EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client")));
+		}
+
+		public static void SetDataDir(string datadir)
+		{
+			DataDir = datadir;
 			TorLogsFile = Path.Combine(DataDir, "TorLogs.txt");
 			WalletsDir = Path.Combine(DataDir, "Wallets");
 			WalletBackupsDir = Path.Combine(DataDir, "WalletBackups");

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -32,9 +32,9 @@ namespace WalletWasabi.Gui
 	public static class Global
 	{
 		public static string DataDir { get; internal set; }
-		public static string TorLogsFile { get; private set;}
-		public static string WalletsDir { get; private set;}
-		public static string WalletBackupsDir { get; private set;}
+		public static string TorLogsFile { get; private set; }
+		public static string WalletsDir { get; private set; }
+		public static string WalletBackupsDir { get; private set; }
 
 		public static string IndexFilePath { get; private set; }
 		public static Config Config { get; private set; }

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -24,7 +24,6 @@ namespace WalletWasabi.Gui
 			bool runGui = false;
 			try
 			{
-				Platform.BaseDirectory = Path.Combine(Global.DataDir, "Gui");
 				AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 				TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
@@ -33,6 +32,7 @@ namespace WalletWasabi.Gui
 				{
 					return;
 				}
+				Platform.BaseDirectory = Path.Combine(Global.DataDir, "Gui");
 				Logger.LogStarting("Wasabi GUI");
 
 				BuildAvaloniaApp()

--- a/WalletWasabi/Mono/CommandSet.cs
+++ b/WalletWasabi/Mono/CommandSet.cs
@@ -450,10 +450,6 @@ namespace Mono.Options
 				{
 					return await Help.InvokeAsync(extra);
 				}
-				if (arguments.All(x => !x.Contains("version")))
-				{
-					Out.WriteLine(Options.MessageLocalizer($"Use `{Suite} help` for usage."));
-				}
 				return 1;
 			}
 			var command = GetCommand(extra);

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -186,7 +186,7 @@ namespace WalletWasabi.Services
 					DeleteBlock(invalidBlockHash);
 					var blockState = KeyManager.TryRemoveBlockState(invalidBlockHash);
 					ProcessedBlocks.TryRemove(invalidBlockHash, out _);
-					if (blockState.BlockHeight != default(Height))
+					if (blockState != null && blockState.BlockHeight != default(Height))
 					{
 						foreach (var toRemove in Coins.Where(x => x.Height == blockState.BlockHeight).Distinct().ToList())
 						{


### PR DESCRIPTION
**Disclaimer:** This PR is for validating the idea and the code was not tested enough.
Related to: #763

-----

This allow us to specify `--datadir` for all the options (gui, deamon, password finder). For example, to lunch the Wasabi GUI client and use the `/home/007/topsecret` folder we use: 
```
$ wassabee --datadir:/home/007/topsecret
```

To lunch the daemon:
```
$ wassabee mix --datadir:/home/007/topsecret --wallet:chaos --keepalive --mixall
```

And so on.
