### PR TITLE
Promoting Matt Odell and Marty Bent

### DIFF
--- a/WalletWasabi.Community/Dojo.md
+++ b/WalletWasabi.Community/Dojo.md
@@ -48,6 +48,8 @@ You can only be promoted by someone two belts above you. Consequently you can pr
 | canalfixe        | [Twitter][25]               | [Video: How to anonymize your Bitcoin with Wasabi wallet][26] | 2019-01: white belt by nopara73 |
 | 402PaymentReq    | [Twitter][27]               | [In-Depth, Funny And Addictive Wasabi Video Series][28] | 2019-01: white belt by Max Hillebrand |
 | Transisto        | [GitHub][31]                | [Extensive Wasabi Testing][32]           | 2019-02: white belt by nopara73 |
+| Matt Odell    | [Twitter][38]               | [Interview  with Nopara][39] and starting [#WasabiWednesday][40]| 2019-04: white belt by Max Hillebrand |
+| Marty Bent    | [Twitter][41]               | [Interview  with Nopara][39]| 2019-04: white belt by Max Hillebrand |
 
 [1]: https://twitter.com/NicolasDorier/
 [2]: https://github.com/NicolasDorier/
@@ -83,4 +85,8 @@ You can only be promoted by someone two belts above you. Consequently you can pr
 [34]: https://www.youtube.com/playlist?list=PLPj3KCksGbSYCFAf3SZbzaJ3ud_nfjlSq
 [35]: https://www.youtube.com/playlist?list=PLPj3KCksGbSZcK35ftoBUcPvYuOHdWQss
 [36]: https://www.youtube.com/playlist?list=PLPj3KCksGbSZG8f4_ubui5I1VB7VGX2Cy
-[37]: http://github.com/maxhillebrand/
+[37]: https://github.com/maxhillebrand/
+[38]: https://twitter.com/matt_odell
+[39]: https://anchor.fm/tales-from-the-crypt/episodes/Rabbit-Hole-Recap-Week-of-2019-03-11-e3f6ef
+[40]: https://twitter.com/matt_odell/status/1098280232308654080?s=20
+[41]: https://twitter.com/martybent


### PR DESCRIPTION
Matt and Marty have been educating the listeners of the Tales from the Crypt podcast about the importance of privacy and the nuances of Wasabi. Not only do they break down the best practices of this complex software to be accessible for regular users, but they also provide compelling arguments for privacy focused Bitcoin tools in general.
They have repeatedly proven their honor, and have well earned their part in the Dojo.