### PR TITLE
Add advanced options on Recover Wallet tab

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
@@ -30,12 +30,12 @@
             </ItemsControl.ItemTemplate>
           </ItemsControl>
           <StackPanel Spacing="16">
-            <CheckBox IsChecked="{Binding ShowAdvancedOptions,Mode=TwoWay}">
-              <TextBlock Text="Show advanced options" />
+            <CheckBox IsChecked="{Binding ShowAdvancedOptions, Mode=TwoWay}">
+              <TextBlock Text="Show Advanced Options" />
             </CheckBox>
             <StackPanel IsVisible="{Binding ShowAdvancedOptions}">
               <controls:ExtendedTextBox Text="{Binding AccountKeyPath}" Watermark="Account Key Path" UseFloatingWatermark="True" />
-              <TextBlock Text="Note that, Wasabi can only monitor native SegWit (bech32) addresses." />
+              <TextBlock Text="Note that, Wasabi can only monitor native SegWit (bech32) addresses." Classes="warningMessage" />
             </StackPanel>
             <StackPanel IsVisible="{Binding ShowAdvancedOptions}">
               <controls:ExtendedTextBox Text="{Binding MinGapLimit}" Watermark="Minimum Gap Limit" UseFloatingWatermark="True" />

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
@@ -29,6 +29,18 @@
               </DataTemplate>
             </ItemsControl.ItemTemplate>
           </ItemsControl>
+          <StackPanel Spacing="16">
+            <CheckBox IsChecked="{Binding ShowAdvancedOptions,Mode=TwoWay}">
+              <TextBlock Text="Show advanced options"/>
+            </CheckBox>
+            <StackPanel IsVisible="{Binding ShowAdvancedOptions}">
+              <controls:ExtendedTextBox Text="{Binding AccountKeyPath}" Watermark="Account Key Path" UseFloatingWatermark="True"/>
+              <TextBlock Text="Note that, Wasabi can only monitor native SegWit (bech32) addresses."/>
+            </StackPanel>
+            <StackPanel IsVisible="{Binding ShowAdvancedOptions}">
+              <controls:ExtendedTextBox Text="{Binding MinGapLimit}" Watermark="Minimum Gap Limit" UseFloatingWatermark="True"/>
+            </StackPanel>
+          </StackPanel>
         </StackPanel>
       </Grid>
     </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
@@ -31,14 +31,14 @@
           </ItemsControl>
           <StackPanel Spacing="16">
             <CheckBox IsChecked="{Binding ShowAdvancedOptions,Mode=TwoWay}">
-              <TextBlock Text="Show advanced options"/>
+              <TextBlock Text="Show advanced options" />
             </CheckBox>
             <StackPanel IsVisible="{Binding ShowAdvancedOptions}">
-              <controls:ExtendedTextBox Text="{Binding AccountKeyPath}" Watermark="Account Key Path" UseFloatingWatermark="True"/>
-              <TextBlock Text="Note that, Wasabi can only monitor native SegWit (bech32) addresses."/>
+              <controls:ExtendedTextBox Text="{Binding AccountKeyPath}" Watermark="Account Key Path" UseFloatingWatermark="True" />
+              <TextBlock Text="Note that, Wasabi can only monitor native SegWit (bech32) addresses." />
             </StackPanel>
             <StackPanel IsVisible="{Binding ShowAdvancedOptions}">
-              <controls:ExtendedTextBox Text="{Binding MinGapLimit}" Watermark="Minimum Gap Limit" UseFloatingWatermark="True"/>
+              <controls:ExtendedTextBox Text="{Binding MinGapLimit}" Watermark="Minimum Gap Limit" UseFloatingWatermark="True" />
             </StackPanel>
           </StackPanel>
         </StackPanel>

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -55,9 +55,9 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				{
 					ValidationMessage = "The account key path is not valid.";
 				}
-				else if (MinGapLimit < KeyManager.AbsoluteMinGapLimit - 1)
+				else if (MinGapLimit < KeyManager.AbsoluteMinGapLimit)
 				{
-					ValidationMessage = $"Min Gap Limit cannot be smaller than {KeyManager.AbsoluteMinGapLimit - 1}.";
+					ValidationMessage = $"Min Gap Limit cannot be smaller than {KeyManager.AbsoluteMinGapLimit}.";
 				}
 				else if (MinGapLimit > 1_000_000)
 				{
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					try
 					{
 						var mnemonic = new Mnemonic(MnemonicWords);
-						KeyManager.Recover(mnemonic, Password, walletFilePath, keyPath, MinGapLimit + 1);
+						KeyManager.Recover(mnemonic, Password, walletFilePath, keyPath, MinGapLimit);
 
 						owner.SelectLoadWallet();
 					}
@@ -197,7 +197,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			ValidationMessage = null;
 			ShowAdvancedOptions = false;
 			AccountKeyPath = $"m/{KeyManager.DefaultAccountKeyPath}";
-			MinGapLimit = KeyManager.AbsoluteMinGapLimit - 1;
+			MinGapLimit = KeyManager.AbsoluteMinGapLimit;
 		}
 
 		private void UpdateSuggestions(string words)

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -1,4 +1,4 @@
-﻿using AvalonStudio.Extensibility;
+using AvalonStudio.Extensibility;
 using AvalonStudio.Shell;
 using NBitcoin;
 using ReactiveUI;
@@ -151,7 +151,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			get => _caretIndex;
 			set => this.RaiseAndSetIfChanged(ref _caretIndex, value);
 		}
-		
+
 		public bool ShowAdvancedOptions
 		{
 			get => _showAdvancedOptions;

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -22,6 +22,9 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 		private string _mnemonicWords;
 		private string _walletName;
 		private string _validationMessage;
+		private bool _showAdvancedOptions;
+		private string _accountKeyPath;
+		private int _minGapLimit;
 		private ObservableCollection<SuggestionViewModel> _suggestions;
 
 		public RecoverWalletViewModel(WalletManagerViewModel owner) : base("Recover Wallet")
@@ -46,14 +49,31 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				}
 				else if (string.IsNullOrWhiteSpace(MnemonicWords))
 				{
-					ValidationMessage = $"Recovery Words were not supplied.";
+					ValidationMessage = "Recovery Words were not supplied.";
+				}
+				else if (string.IsNullOrWhiteSpace(AccountKeyPath))
+				{
+					ValidationMessage = "The account key path is not valid.";
+				}
+				else if (MinGapLimit < KeyManager.AbsoluteMinGapLimit - 1)
+				{
+					ValidationMessage = $"Min Gap Limit cannot be smaller than {KeyManager.AbsoluteMinGapLimit - 1}.";
+				}
+				else if (MinGapLimit > KeyManager.AbsoluteMaxGapLimit)
+				{
+					ValidationMessage = $"Min Gap Limit cannot be larger than {KeyManager.AbsoluteMaxGapLimit}.";
+				}
+				else if (!TryParseKeyPath(AccountKeyPath))
+				{
+					ValidationMessage = "The account key path is not a valid derivation path.";
 				}
 				else
 				{
+					KeyPath keyPath = KeyPath.Parse(AccountKeyPath);
 					try
 					{
 						var mnemonic = new Mnemonic(MnemonicWords);
-						KeyManager.Recover(mnemonic, Password, walletFilePath);
+						KeyManager.Recover(mnemonic, Password, walletFilePath, keyPath, MinGapLimit + 1);
 
 						owner.SelectLoadWallet();
 					}
@@ -131,6 +151,24 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			get => _caretIndex;
 			set => this.RaiseAndSetIfChanged(ref _caretIndex, value);
 		}
+		
+		public bool ShowAdvancedOptions
+		{
+			get => _showAdvancedOptions;
+			set => this.RaiseAndSetIfChanged(ref _showAdvancedOptions, value);
+		}
+
+		public string AccountKeyPath
+		{
+			get => _accountKeyPath;
+			set => this.RaiseAndSetIfChanged(ref _accountKeyPath, value);
+		}
+
+		public int MinGapLimit
+		{
+			get => _minGapLimit;
+			set => this.RaiseAndSetIfChanged(ref _minGapLimit, value);
+		}
 
 		public ReactiveCommand<Unit, Unit> RecoverCommand { get; }
 
@@ -157,6 +195,9 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			MnemonicWords = "";
 			WalletName = Utils.GetNextWalletName();
 			ValidationMessage = null;
+			ShowAdvancedOptions = false;
+			AccountKeyPath = $"m/{KeyManager.DefaultAccountKeyPath}";
+			MinGapLimit = KeyManager.AbsoluteMinGapLimit - 1;
 		}
 
 		private void UpdateSuggestions(string words)
@@ -201,6 +242,19 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			CaretIndex = MnemonicWords.Length;
 
 			Suggestions.Clear();
+		}
+
+		private bool TryParseKeyPath(string keyPath)
+		{
+			try
+			{
+				KeyPath.Parse(keyPath);
+				return true;
+			}
+			catch (FormatException)
+			{
+				return false;
+			}
 		}
 
 		private static IEnumerable<string> EnglishWords { get; } = Wordlist.English.GetWords();

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -59,9 +59,9 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				{
 					ValidationMessage = $"Min Gap Limit cannot be smaller than {KeyManager.AbsoluteMinGapLimit - 1}.";
 				}
-				else if (MinGapLimit > KeyManager.AbsoluteMaxGapLimit)
+				else if (MinGapLimit > 1_000_000)
 				{
-					ValidationMessage = $"Min Gap Limit cannot be larger than {KeyManager.AbsoluteMaxGapLimit}.";
+					ValidationMessage = $"Min Gap Limit cannot be larger than {1_000_000}.";
 				}
 				else if (!TryParseKeyPath(AccountKeyPath))
 				{

--- a/WalletWasabi.Tests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/KeyManagementTests.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using System;
 using System.IO;
 using System.Security;

--- a/WalletWasabi.Tests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/KeyManagementTests.cs
@@ -72,10 +72,15 @@ namespace WalletWasabi.Tests
 			Assert.Equal(manager.EncryptedSecret, sameManager.EncryptedSecret);
 			Assert.Equal(manager.ExtPubKey, sameManager.ExtPubKey);
 
-			var differentManager = KeyManager.Recover(mnemonic, "differentPassword");
+			var differentManager = KeyManager.Recover(mnemonic, "differentPassword", null, KeyPath.Parse("m/999'/999'/999'"), 55);
 			Assert.NotEqual(manager.ChainCode, differentManager.ChainCode);
 			Assert.NotEqual(manager.EncryptedSecret, differentManager.EncryptedSecret);
 			Assert.NotEqual(manager.ExtPubKey, differentManager.ExtPubKey);
+
+			differentManager.AssertCleanKeysIndexed();
+			var newKey = differentManager.GenerateNewKey("some-label", KeyState.Clean, true, false);
+			Assert.Equal(newKey.Index, differentManager.MinGapLimit);
+			Assert.Equal("999'/999'/999'/1/55", newKey.FullKeyPath.ToString());
 		}
 
 		[Fact]

--- a/WalletWasabi/JsonConverters/KeyPathJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/KeyPathJsonConverter.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.JsonConverters
+{
+	public class KeyPathJsonConverter : JsonConverter
+	{
+		/// <inheritdoc />
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(KeyPath);
+		}
+
+		/// <inheritdoc />
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var s = (string)reader.Value;
+			if (string.IsNullOrWhiteSpace(s))
+			{
+				return null;
+			}
+			var kp = KeyPath.Parse(s.Trim());
+
+			return kp;
+		}
+
+		/// <inheritdoc />
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var kp = (KeyPath)value;
+
+			var s = kp.ToString();
+			writer.WriteValue(s);
+		}
+	}
+}

--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -1,5 +1,4 @@
-﻿using NBitcoin;
-using NBitcoin.JsonConverters;
+using NBitcoin;
 using Newtonsoft.Json;
 using System;
 using WalletWasabi.Helpers;
@@ -125,15 +124,9 @@ namespace WalletWasabi.KeyManagement
 
 		public override int GetHashCode() => HashCode;
 
-		public static bool operator ==(HdPubKey x, HdPubKey y)
-		{
-			return x?.PubKeyHash == y?.PubKeyHash;
-		}
+		public static bool operator ==(HdPubKey x, HdPubKey y) => x?.PubKeyHash == y?.PubKeyHash;
 
-		public static bool operator !=(HdPubKey x, HdPubKey y)
-		{
-			return !(x == y);
-		}
+		public static bool operator !=(HdPubKey x, HdPubKey y) => !(x == y);
 
 		#endregion Equality
 	}

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -75,7 +75,6 @@ namespace WalletWasabi.KeyManagement
 		public HardwareWalletInfo HardwareWalletInfo { get; set; }
 
 		public const int AbsoluteMinGapLimit = 21;
-		public const int AbsoluteMaxGapLimit = 1_000_000;
 
 		[JsonConstructor]
 		public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, HDFingerprint? masterFingerprint, ExtPubKey extPubKey, bool? passwordVerified, int? minGapLimit, BlockchainState blockchainState, string filePath = null, KeyPath accountKeyPath = null)

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.KeyManagement
 
 		[JsonProperty(Order = 8)]
 		private List<HdPubKey> HdPubKeys { get; }
-		
+
 		[JsonProperty(Order = 9)]
 		[JsonConverter(typeof(KeyPathJsonConverter))]
 		public KeyPath AccountKeyPath { get; private set; }
@@ -177,7 +177,7 @@ namespace WalletWasabi.KeyManagement
 			var encryptedSecret = extKey.PrivateKey.GetEncryptedBitcoinSecret(password, Network.Main);
 
 			HDFingerprint masterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			
+
 			KeyPath keyPath = accountKeyPath ?? DefaultAccountKeyPath;
 			ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
 			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, true, minGapLimit, new BlockchainState(), filePath, keyPath);

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -12,7 +12,6 @@ using WalletWasabi.Hwi.Models;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
-using HDFingerprintJsonConverter = WalletWasabi.JsonConverters.HDFingerprintJsonConverter;
 
 namespace WalletWasabi.KeyManagement
 {
@@ -28,7 +27,7 @@ namespace WalletWasabi.KeyManagement
 		public byte[] ChainCode { get; }
 
 		[JsonProperty(Order = 3)]
-		[JsonConverter(typeof(HDFingerprintJsonConverter))]
+		[JsonConverter(typeof(JsonConverters.HDFingerprintJsonConverter))]
 		public HDFingerprint? MasterFingerprint { get; private set; }
 
 		[JsonProperty(Order = 4)]

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -40,16 +40,16 @@ namespace WalletWasabi.KeyManagement
 		public int? MinGapLimit { get; private set; }
 
 		[JsonProperty(Order = 7)]
+		[JsonConverter(typeof(KeyPathJsonConverter))]
+		public KeyPath AccountKeyPath { get; private set; }
+
+		[JsonProperty(Order = 8)]
 		private BlockchainState BlockchainState { get; }
 
 		private object BlockchainStateLock { get; }
 
-		[JsonProperty(Order = 8)]
-		private List<HdPubKey> HdPubKeys { get; }
-
 		[JsonProperty(Order = 9)]
-		[JsonConverter(typeof(KeyPathJsonConverter))]
-		public KeyPath AccountKeyPath { get; private set; }
+		private List<HdPubKey> HdPubKeys { get; }
 
 		private object HdPubKeysLock { get; }
 
@@ -310,7 +310,7 @@ namespace WalletWasabi.KeyManagement
 
 			// Example text to handle: "ExtPubKey": "03BF8271268000000013B9013C881FE456DDF524764F6322F611B03CF6".
 			var extpubkeyline = File.ReadLines(filePath) // Enumerated read.
-				.Take(10) // Limit reads to x lines.
+				.Take(21) // Limit reads to x lines.
 				.FirstOrDefault(line => line.Contains("\"ExtPubKey\": \"", StringComparison.InvariantCulture));
 
 			if (string.IsNullOrEmpty(extpubkeyline))
@@ -342,7 +342,7 @@ namespace WalletWasabi.KeyManagement
 
 			// Example text to handle: "ExtPubKey": "03BF8271268000000013B9013C881FE456DDF524764F6322F611B03CF6".
 			var masterfpline = File.ReadLines(filePath) // Enumerated read.
-				.Take(10) // Limit reads to x lines.
+				.Take(21) // Limit reads to x lines.
 				.FirstOrDefault(line => line.Contains("\"MasterFingerprint\": \"", StringComparison.InvariantCulture));
 
 			if (string.IsNullOrEmpty(masterfpline))

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Security;
 using System.Text;
-using NBitcoin.JsonConverters;
 using WalletWasabi.Helpers;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.JsonConverters;
@@ -27,7 +26,7 @@ namespace WalletWasabi.KeyManagement
 		public byte[] ChainCode { get; }
 
 		[JsonProperty(Order = 3)]
-		[JsonConverter(typeof(JsonConverters.HDFingerprintJsonConverter))]
+		[JsonConverter(typeof(HDFingerprintJsonConverter))]
 		public HDFingerprint? MasterFingerprint { get; private set; }
 
 		[JsonProperty(Order = 4)]


### PR DESCRIPTION
This PR adds two new "advanced options" to the tab "Recover Wallet":
* "**Account Key Path**": Useful if an existing BIP39 wallet should be imported that was created with a different software and used a different derivation path.
* "**Number of keys to generate**": Determines how many keys will be generated/derived when the wallet is created. Useful if a wallet should be imported/restored that has been used a lot already.

## Preview
![Screenshot from 2019-04-30 22-54-01](https://user-images.githubusercontent.com/1008879/56992773-16e94500-6b9b-11e9-8619-45cd8287bb0d.png)

I plan to add additional PRs with more advanced options in the "Recover Wallet" tab to support different derivation methods used by other wallet software. I hope that's in the general interest of the project since people might want to import their existing wallet rather than create a new one and send funds to it.