### PR TITLE
Mac deadlock fix.

### DIFF
--- a/WalletWasabi/Extensions/ProcessExtensions.cs
+++ b/WalletWasabi/Extensions/ProcessExtensions.cs
@@ -5,15 +5,15 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace WalletWasabi.Helpers
+namespace System.Diagnostics
 {
-	public static class ProcessHelpers
+	public static class ProcessExtensions
 	{
 		public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken)
 		{
 			while (!cancellationToken.IsCancellationRequested)
 			{
-				await Task.Delay(500);
+				await Task.Delay(500, cancellationToken);
 				if (process.HasExited) break;
 			}
 		}

--- a/WalletWasabi/Extensions/ProcessExtensions.cs
+++ b/WalletWasabi/Extensions/ProcessExtensions.cs
@@ -11,10 +11,9 @@ namespace System.Diagnostics
 	{
 		public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken)
 		{
-			while (!cancellationToken.IsCancellationRequested)
+			while (!process.HasExited)
 			{
-				await Task.Delay(500, cancellationToken);
-				if (process.HasExited) break;
+				await Task.Delay(100, cancellationToken);
 			}
 		}
 	}

--- a/WalletWasabi/Helpers/ProcessHelpers.cs
+++ b/WalletWasabi/Helpers/ProcessHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -15,7 +15,7 @@ namespace WalletWasabi.Helpers
 
 			void Process_Exited(object sender, EventArgs e)
 			{
-				tcs.TrySetResult(true);
+				Task.Run(() => tcs.TrySetResult(true));
 			}
 
 			process.EnableRaisingEvents = true;
@@ -28,7 +28,7 @@ namespace WalletWasabi.Helpers
 					return;
 				}
 
-				using (cancellationToken.Register(() => tcs.TrySetCanceled()))
+				using (cancellationToken.Register(() => Task.Run(() => tcs.TrySetCanceled())))
 				{
 					await tcs.Task;
 				}

--- a/WalletWasabi/Helpers/ProcessHelpers.cs
+++ b/WalletWasabi/Helpers/ProcessHelpers.cs
@@ -9,33 +9,12 @@ namespace WalletWasabi.Helpers
 {
 	public static class ProcessHelpers
 	{
-		public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken = default)
+		public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken)
 		{
-			var tcs = new TaskCompletionSource<bool>();
-
-			void Process_Exited(object sender, EventArgs e)
+			while (!cancellationToken.IsCancellationRequested)
 			{
-				Task.Run(() => tcs.TrySetResult(true));
-			}
-
-			process.EnableRaisingEvents = true;
-			process.Exited += Process_Exited;
-
-			try
-			{
-				if (process.HasExited)
-				{
-					return;
-				}
-
-				using (cancellationToken.Register(() => Task.Run(() => tcs.TrySetCanceled())))
-				{
-					await tcs.Task;
-				}
-			}
-			finally
-			{
-				process.Exited -= Process_Exited;
+				await Task.Delay(500);
+				if (process.HasExited) break;
 			}
 		}
 	}

--- a/WalletWasabi/Hwi/HwiProcessManager.cs
+++ b/WalletWasabi/Hwi/HwiProcessManager.cs
@@ -127,123 +127,132 @@ namespace WalletWasabi.Hwi
 		/// <param name="cancellationToken">Cancel the current operation.</param>
 		/// <param name="command">Command to send in string format.</param>
 		/// <param name="isMutexPriority">You can add priority to your command among hwi calls. For example if multiply wasabi instances are running both use the same hwi process with isMutexPriority you will more likely to get it.</param>
-		/// <returns></returns>
+		/// <returns>JToken the answer recevied from hwi process.</returns>
+		/// <exception cref="TimeoutException">Thrown when the process cannot be finished in time.</exception>
+		/// <exception cref="IOException">Thrown when Mutex on hwi process could not be acquired.</exception>
 		public static async Task<JToken> SendCommandAsync(string command, CancellationToken cancellationToken, bool isMutexPriority = false)
 		{
-			using (await AsyncLock.LockAsync(cancellationToken))
-			using (var mutex = new Mutex(false, MutexName)) // It could be even improved more if this Mutex would also look at which hardware wallet the operation is going towards (enumerate sends to all.)
+			try
 			{
-				var mutexAcquired = false;
-				try
+				using (await AsyncLock.LockAsync())
+				using (var mutex = new Mutex(false, MutexName)) // It could be even improved more if this Mutex would also look at which hardware wallet the operation is going towards (enumerate sends to all.)
 				{
-					// acquire the mutex (or timeout after 60 seconds)
-					// will return false if it timed out
-					var start = DateTime.Now;
-					while (DateTime.Now - start < TimeSpan.FromSeconds(90))
+					var mutexAcquired = false;
+					try
 					{
-						mutexAcquired = mutex.WaitOne(1);
-						if (!mutexAcquired)
+						// acquire the mutex (or timeout after 60 seconds)
+						// will return false if it timed out
+						var start = DateTime.Now;
+						while (DateTime.Now - start < TimeSpan.FromSeconds(90))
 						{
-							var rand = Random.Next(1, 100);
-							await Task.Delay(isMutexPriority ? (100 + rand) : (1000 + rand), cancellationToken);
-						}
-						else
-						{
-							break;
-						}
-					}
-				}
-				catch (AbandonedMutexException)
-				{
-					// abandoned mutexes are still acquired, we just need
-					// to handle the exception and treat it as acquisition
-					mutexAcquired = true;
-				}
-
-				if (mutexAcquired == false)
-				{
-					throw new IOException("Couldn't acquire Mutex on the file.");
-				}
-
-				try
-				{
-					if (!File.Exists(HwiPath))
-					{
-						var exeName = Path.GetFileName(HwiPath);
-						throw new FileNotFoundException($"{exeName} not found at {HwiPath}. Maybe it was removed by antivirus software!");
-					}
-
-					using (var process = Process.Start(
-						new ProcessStartInfo {
-							FileName = HwiPath,
-							Arguments = command,
-							RedirectStandardOutput = true,
-							UseShellExecute = false,
-							CreateNoWindow = true,
-							WindowStyle = ProcessWindowStyle.Hidden
-						}
-					))
-					{
-						await process.WaitForExitAsync(cancellationToken);
-
-						if (process.ExitCode != 0)
-						{
-							throw new IOException($"Command: {command} exited with exit code: {process.ExitCode}, instead of 0.");
-						}
-
-						string response = await process.StandardOutput.ReadToEndAsync();
-						var jToken = JToken.Parse(response);
-						if (jToken is JObject json)
-						{
-							if (json.TryGetValue("error", out JToken err))
+							mutexAcquired = mutex.WaitOne(1);
+							if (!mutexAcquired)
 							{
-								var errString = err.ToString();
-								throw new IOException(errString);
+								var rand = Random.Next(1, 100);
+								await Task.Delay(isMutexPriority ? (100 + rand) : (1000 + rand), cancellationToken);
+							}
+							else
+							{
+								break;
 							}
 						}
+					}
+					catch (AbandonedMutexException)
+					{
+						// abandoned mutexes are still acquired, we just need
+						// to handle the exception and treat it as acquisition
+						mutexAcquired = true;
+					}
 
-						return jToken;
+					if (mutexAcquired == false)
+					{
+						throw new IOException("Couldn't acquire Mutex on the file.");
+					}
 
-						//if (command == "enumerate")
-						//{
-						//	//string response = "[{\"fingerprint\": \"8038ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"coldcard\", \"path\": \"0001:0005:00\"},{\"fingerprint\": \"8338ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"keepkey\", \"path\": \"0001:0005:00\"},{\"fingerprint\": \"8038ecd2\", \"serial_number\": \"205A32753042\", \"type\": \"coldcard\", \"path\": \"0001:0005:00\"}]";
-						//	string response = "[{\"fingerprint\": \"8038ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"coldcard\", \"path\": \"0001:0005:00\"},{\"fingerprint\": \"8338ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"keepkey\", \"path\": \"0001:0005:00\"}]";
-						//	var jToken = JToken.Parse(response);
-						//	return jToken;
-						//}
-						//if (command.Contains("getxpub", StringComparison.OrdinalIgnoreCase))
-						//{
-						//	string response = "{\"xpub\": \"xpub6DP9afdc7qsz7s7mwAvciAR2dV6vPC3gyiQbqKDzDcPAq3UQChKPimHc3uCYfTTkpoXdwRTFnVTBdFpM9ysbf6KV34uMqkD3zXr6FzkJtcB\"}";
-						//	var jToken = JToken.Parse(response);
-						//	return jToken;
-						//}
-						//else
-						//{
-						//	string response = await process.StandardOutput.ReadToEndAsync();
-						//	var jToken = JToken.Parse(response);
-						//	string err = null;
-						//	try
-						//	{
-						//		JObject json = jToken as JObject;
-						//		err = json.Value<string>("error");
-						//	}
-						//	catch (Exception ex)
-						//	{
-						//		Logger.LogTrace(ex, nameof(HwiProcessManager));
-						//	}
-						//	if (err != null)
-						//	{
-						//		throw new IOException(err);
-						//	}
+					try
+					{
+						if (!File.Exists(HwiPath))
+						{
+							var exeName = Path.GetFileName(HwiPath);
+							throw new FileNotFoundException($"{exeName} not found at {HwiPath}. Maybe it was removed by antivirus software!");
+						}
 
-						//	return jToken;
-						//}
+						using (var process = Process.Start(
+							new ProcessStartInfo {
+								FileName = HwiPath,
+								Arguments = command,
+								RedirectStandardOutput = true,
+								UseShellExecute = false,
+								CreateNoWindow = true,
+								WindowStyle = ProcessWindowStyle.Hidden
+							}
+						))
+						{
+							await process.WaitForExitAsync(cancellationToken);
+
+							if (process.ExitCode != 0)
+							{
+								throw new IOException($"Command: {command} exited with exit code: {process.ExitCode}, instead of 0.");
+							}
+
+							string response = await process.StandardOutput.ReadToEndAsync();
+							var jToken = JToken.Parse(response);
+							if (jToken is JObject json)
+							{
+								if (json.TryGetValue("error", out JToken err))
+								{
+									var errString = err.ToString();
+									throw new IOException(errString);
+								}
+							}
+
+							return jToken;
+
+							//if (command == "enumerate")
+							//{
+							//	//string response = "[{\"fingerprint\": \"8038ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"coldcard\", \"path\": \"0001:0005:00\"},{\"fingerprint\": \"8338ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"keepkey\", \"path\": \"0001:0005:00\"},{\"fingerprint\": \"8038ecd2\", \"serial_number\": \"205A32753042\", \"type\": \"coldcard\", \"path\": \"0001:0005:00\"}]";
+							//	string response = "[{\"fingerprint\": \"8038ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"coldcard\", \"path\": \"0001:0005:00\"},{\"fingerprint\": \"8338ecd9\", \"serial_number\": \"205A32753042\", \"type\": \"keepkey\", \"path\": \"0001:0005:00\"}]";
+							//	var jToken = JToken.Parse(response);
+							//	return jToken;
+							//}
+							//if (command.Contains("getxpub", StringComparison.OrdinalIgnoreCase))
+							//{
+							//	string response = "{\"xpub\": \"xpub6DP9afdc7qsz7s7mwAvciAR2dV6vPC3gyiQbqKDzDcPAq3UQChKPimHc3uCYfTTkpoXdwRTFnVTBdFpM9ysbf6KV34uMqkD3zXr6FzkJtcB\"}";
+							//	var jToken = JToken.Parse(response);
+							//	return jToken;
+							//}
+							//else
+							//{
+							//	string response = await process.StandardOutput.ReadToEndAsync();
+							//	var jToken = JToken.Parse(response);
+							//	string err = null;
+							//	try
+							//	{
+							//		JObject json = jToken as JObject;
+							//		err = json.Value<string>("error");
+							//	}
+							//	catch (Exception ex)
+							//	{
+							//		Logger.LogTrace(ex, nameof(HwiProcessManager));
+							//	}
+							//	if (err != null)
+							//	{
+							//		throw new IOException(err);
+							//	}
+
+							//	return jToken;
+							//}
+						}
+					}
+					finally
+					{
+						mutex.ReleaseMutex();
 					}
 				}
-				finally
-				{
-					mutex.ReleaseMutex();
-				}
+			}
+			catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException || ex is TimeoutException)
+			{
+				throw new TimeoutException("Timeout occured during the hwi operation.", ex);
 			}
 		}
 

--- a/WalletWasabi/Hwi/HwiProcessManager.cs
+++ b/WalletWasabi/Hwi/HwiProcessManager.cs
@@ -161,7 +161,11 @@ namespace WalletWasabi.Hwi
 						}
 					))
 					{
-						await process.WaitForExitAsync();
+						using (var cancel = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
+						{
+							await process.WaitForExitAsync(cancel.Token);
+						}
+
 						if (process.ExitCode != 0)
 						{
 							throw new IOException($"Command: {command} exited with exit code: {process.ExitCode}, instead of 0.");


### PR DESCRIPTION
Closes: https://github.com/zkSNACKs/WalletWasabi/issues/1363

## Reproduce issue:

1. Checkout Tag 1.1.4.
2. Delete .walletwasabi folder (backup your wallets before doing that!).
3. Dotnet run.
4. Wait for the UI hangs while searching for Hardware Wallets.

## Issue:

For some reason on Mac we get a deadlock randomly with this line:
https://github.com/zkSNACKs/WalletWasabi/blob/0fb49c8b6145acf1bd2402b765ed1edcd1e8a895/WalletWasabi/Helpers/ProcessHelpers.cs#L18
According to my experience it is happening more often if the Filters are being downloaded meanwhile so there is another operation which is refreshing the UI and put some tasks to UI dispatcher. That is the reason why it is not likely to happen after the first run. After some investigation I have found that this is not an unknown issue.

http://blog.stephencleary.com/2012/12/dont-block-in-asynchronous-code.html

## Solution

Seem smelly but the solution is to wrap the `SetResult` in a `Task.Run` to force it onto a separate thread. It is suggested by: [Stephen Cleary](https://stackoverflow.com/questions/19481964/calling-taskcompletionsource-setresult-in-a-non-blocking-manner).
Tried [this](https://github.com/StephenCleary/AsyncEx/blob/76b27a3ee531554c0c81e55ab8425ac7caefaccb/src/Nito.AsyncEx.Tasks/TaskCompletionSourceExtensions.cs#L82) but it did not work on mac I got the same deadlock so I used `Task.Run()`.
