### PR TITLE
Change dust control

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -368,7 +368,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						switch (e.Action)
 						{
 							case NotifyCollectionChangedAction.Add:
-								foreach (SmartCoin c in e.NewItems.Cast<SmartCoin>().Where(sc => sc.Unspent && !sc.IsDust))
+								foreach (SmartCoin c in e.NewItems.Cast<SmartCoin>().Where(sc => sc.Unspent))
 								{
 									var newCoinVm = new CoinViewModel(this, c);
 									newCoinVm.SubscribeEvents();

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -105,7 +105,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private void SetBalance(string walletName)
 		{
-			Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.IsDust && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
+			Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
 
 			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode.Value ? "#########" : balance.ToString(false, true))} BTC)";
 		}

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -43,7 +43,6 @@ namespace WalletWasabi.Models
 		private HdPubKey _hdPubKey;
 
 		private ISecret _secret;
-		private bool _isDust;
 		private string _clusters;
 
 		private bool _confirmed;
@@ -298,22 +297,6 @@ namespace WalletWasabi.Models
 			}
 		}
 
-		[JsonProperty]
-		public bool IsDust
-		{
-			get => _isDust;
-			private set
-			{
-				if (value != _isDust)
-				{
-					_isDust = value;
-					OnPropertyChanged(nameof(IsDust));
-
-					SetUnavailable();
-				}
-			}
-		}
-
 		public string Clusters
 		{
 			get => _clusters;
@@ -409,12 +392,7 @@ namespace WalletWasabi.Models
 
 		private void SetUnavailable()
 		{
-			Unavailable = !Unspent || SpentAccordingToBackend || CoinJoinInProgress || IsDust;
-		}
-
-		private void SetIsDust(Money dustThreshold)
-		{
-			IsDust = Amount <= dustThreshold;
+			Unavailable = !Unspent || SpentAccordingToBackend || CoinJoinInProgress;
 		}
 
 		#endregion PropertySetters
@@ -464,7 +442,6 @@ namespace WalletWasabi.Models
 			SetUnspent();
 			SetIsBanned();
 			SetUnavailable();
-			SetIsDust(Constants.DustThreshold);
 		}
 
 		#endregion Constructors

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -612,6 +612,11 @@ namespace WalletWasabi.Services
 						}
 					}
 
+					if(output.Value <= Constants.DustThreshold)
+					{
+						continue;
+					}
+
 					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Don't inherit locked status from key, that's different.
 																																																												   // If we didn't have it.
 					if (Coins.TryAdd(newCoin))
@@ -619,7 +624,7 @@ namespace WalletWasabi.Services
 						TransactionCache.TryAdd(tx);
 
 						// If it's being mixed and anonset is not sufficient, then queue it.
-						if (newCoin.Unspent && !newCoin.IsDust && ChaumianClient.HasIngredients && newCoin.Label.StartsWith("ZeroLink", StringComparison.Ordinal) && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet)
+						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.Label.StartsWith("ZeroLink", StringComparison.Ordinal) && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet)
 						{
 							Task.Run(async () =>
 							{
@@ -1519,7 +1524,7 @@ namespace WalletWasabi.Services
 
 			try
 			{
-				var unspentCoins = Coins.Where(c => c.Unspent && !c.IsDust); //refreshing unspent coins clusters only
+				var unspentCoins = Coins.Where(c => c.Unspent); //refreshing unspent coins clusters only
 				if (unspentCoins.Any())
 				{
 					ILookup<Script, SmartCoin> lookupScriptPubKey = Coins.ToLookup(c => c.ScriptPubKey, c => c);


### PR DESCRIPTION
This PR is for changing the way Wasabi deals with dust coins. Currently Wasabi keeps the dust coins but with a mark that can be queried to know when it is relevant or not. With this PR dust coins are completely ignored by Wasabi as if they have never existed.

Close #1383