### PR TITLE
Fix connected status when not.

### DIFF
--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
@@ -302,7 +302,7 @@ namespace WalletWasabi.Services
 							catch (Exception ex)
 							{
 								TorStatus = TorStatus.Running;
-								BackendStatus = BackendStatus.NotConnected;
+								BackendStatus = BackendStatus.Connected;
 								HandleIfGenSocksServFail(ex);
 								throw;
 							}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -302,7 +302,7 @@ namespace WalletWasabi.Services
 							catch (Exception ex)
 							{
 								TorStatus = TorStatus.Running;
-								BackendStatus = BackendStatus.Connected;
+								BackendStatus = BackendStatus.NotConnected;
 								HandleIfGenSocksServFail(ex);
 								throw;
 							}

--- a/WalletWasabi/TorSocks5/TorHttpClient.cs
+++ b/WalletWasabi/TorSocks5/TorHttpClient.cs
@@ -1,9 +1,10 @@
-﻿using Nito.AsyncEx;
+using Nito.AsyncEx;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -132,6 +133,10 @@ namespace WalletWasabi.TorSocks5
 							{
 								throw new OperationCanceledException(tce.Message, tce, cancel);
 							}
+						}
+						catch (SocketException ex3) when (ex3.ErrorCode == (int)SocketError.ConnectionRefused)
+						{
+							throw new ConnectionException("Connection was refused.", ex3);
 						}
 
 						cancel.ThrowIfCancellationRequested();


### PR DESCRIPTION
When I am on RegTest and my local Backend is not running, my Wasabi still indicating that my Backend is connected. It is better to set the connected state only if we got the first synchronization packet. Despite of the solution is trivial for some reason it was not fixed until now. This fact leads me to think there is hidden complexity behind this. 