### PR TITLE
Update to Bitcoin 18

### DIFF
--- a/WalletWasabi.Tests/NodeBuilding/NodeBuilder.cs
+++ b/WalletWasabi.Tests/NodeBuilding/NodeBuilder.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.RPC;
 using Nito.AsyncEx;
 using System;
@@ -21,12 +21,12 @@ namespace WalletWasabi.Tests.NodeBuilding
 		public static readonly AsyncLock Lock = new AsyncLock();
 		public static string WorkingDirectory { get; private set; }
 
-		public static async Task<NodeBuilder> CreateAsync([CallerMemberName]string caller = null, string version = "0.17.1")
+		public static async Task<NodeBuilder> CreateAsync([CallerMemberName]string caller = null, string version = "0.18.0")
 		{
 			using (await Lock.LockAsync())
 			{
 				WorkingDirectory = Path.Combine(Global.DataDir, caller);
-				version = version ?? "0.17.1";
+				version = version ?? "0.18.0";
 				var path = await EnsureDownloadedAsync(version);
 				return new NodeBuilder(WorkingDirectory, path);
 			}
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 					return bitcoind;
 				}
 
-				zip = Path.Combine(Global.DataDir, $"bitcoin-{version}-win32.zip");
+				zip = Path.Combine(Global.DataDir, $"bitcoin-{version}-win64.zip");
 				string url = string.Format("https://bitcoincore.org/bin/bitcoin-core-{0}/" + Path.GetFileName(zip), version);
 				using (var client = new HttpClient())
 				{

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="NBitcoin" Version="4.1.2.7" />
+	<PackageReference Include="NBitcoin" Version="4.1.2.12" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />  </ItemGroup>
   <ItemGroup>
     <Folder Include="Gma\QrCodeNet\Encoding\ReedSolomon\" />


### PR DESCRIPTION
Bitcoin Core 18 is out: https://bitcoincore.org/en/releases/0.18.0/

The first blocker issue I encountered is that they removed the `generate` RPC (there may be more.) https://github.com/bitcoin/bitcoin/pull/15492

> generate is deprecated and will be fully removed in a subsequent major version. This RPC is only used for testing, but its implementation reached across multiple subsystems (wallet and mining), so it is being deprecated to simplify the wallet-node interface. Projects that are using generate for testing purposes should transition to using the generatetoaddress RPC, which does not require or use the wallet component. Calling generatetoaddress with an address returned by the getnewaddress RPC gives the same functionality as the old generate RPC. To continue using generate in this version, restart bitcoind with the -deprecatedrpc=generate configuration option.

We need to add to NBitcoin and make the `Generate` and `GenerateAsync` do `getnewaddress` before `generatetoaddress` so we can keep compatibility.