### PR TITLE
Refoctoring UtxoReferee to make it testeable

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -180,7 +180,7 @@ namespace WalletWasabi.Backend.Controllers
 						var bannedElem = await Coordinator.UtxoReferee.TryGetBannedAsync(outpoint, notedToo: false);
 						if (bannedElem != null)
 						{
-							return BadRequest($"Input is banned from participation for {(int)bannedElem.Value.bannedRemaining.TotalMinutes} minutes: {inputProof.Input.Index}:{inputProof.Input.TransactionId}.");
+							return BadRequest($"Input is banned from participation for {(int)bannedElem.BannedRemaining.TotalMinutes} minutes: {inputProof.Input.Index}:{inputProof.Input.TransactionId}.");
 						}
 
 						var txoutResponseTask = batch.GetTxOutAsync(inputProof.Input.TransactionId, (int)inputProof.Input.Index, includeMempool: true);

--- a/WalletWasabi.Tests/ModelTests.cs
+++ b/WalletWasabi.Tests/ModelTests.cs
@@ -116,26 +116,26 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public void UtxoRefereeSerialization()
 		{
-			var record = UtxoReferee.BannedRecordFromLine("2018-11-23 15-23-14:1:44:2716e680f47d74c1bc6f031da22331564dd4c6641d7216576aad1b846c85d492:True:195");
+			var record = BannedUtxoRecord.FromString("2018-11-23 15-23-14:1:44:2716e680f47d74c1bc6f031da22331564dd4c6641d7216576aad1b846c85d492:True:195");
 
-			Assert.Equal(new DateTimeOffset(2018, 11, 23, 15, 23, 14, TimeSpan.Zero), record.timeOfBan);
-			Assert.Equal(1, record.severity);
-			Assert.Equal(44u, record.utxo.N);
-			Assert.Equal(new uint256("2716e680f47d74c1bc6f031da22331564dd4c6641d7216576aad1b846c85d492"), record.utxo.Hash);
-			Assert.True(record.isNoted);
-			Assert.Equal(195, record.bannedForRound);
+			Assert.Equal(new DateTimeOffset(2018, 11, 23, 15, 23, 14, TimeSpan.Zero), record.TimeOfBan);
+			Assert.Equal(1, record.Severity);
+			Assert.Equal(44u, record.Utxo.N);
+			Assert.Equal(new uint256("2716e680f47d74c1bc6f031da22331564dd4c6641d7216576aad1b846c85d492"), record.Utxo.Hash);
+			Assert.True(record.IsNoted);
+			Assert.Equal(195, record.BannedForRound);
 
 			DateTimeOffset dateTime = DateTimeOffset.UtcNow;
 			DateTimeOffset now = new DateTimeOffset(dateTime.Ticks - (dateTime.Ticks % TimeSpan.TicksPerSecond), TimeSpan.Zero);
-			string record2Line = UtxoReferee.BannedRecordToLine(record.utxo, 3, now, false, 99);
-			var record2 = UtxoReferee.BannedRecordFromLine(record2Line);
+			string record2Line = new BannedUtxoRecord(record.Utxo, 3, now, false, 99).ToString();
+			var record2 = BannedUtxoRecord.FromString(record2Line);
 
-			Assert.Equal(now, record2.timeOfBan);
-			Assert.Equal(3, record2.severity);
-			Assert.Equal(44u, record2.utxo.N);
-			Assert.Equal(new uint256("2716e680f47d74c1bc6f031da22331564dd4c6641d7216576aad1b846c85d492"), record2.utxo.Hash);
-			Assert.False(record2.isNoted);
-			Assert.Equal(99, record2.bannedForRound);
+			Assert.Equal(now, record2.TimeOfBan);
+			Assert.Equal(3, record2.Severity);
+			Assert.Equal(44u, record2.Utxo.N);
+			Assert.Equal(new uint256("2716e680f47d74c1bc6f031da22331564dd4c6641d7216576aad1b846c85d492"), record2.Utxo.Hash);
+			Assert.False(record2.IsNoted);
+			Assert.Equal(99, record2.BannedForRound);
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UtxoRefereeTests.cs
+++ b/WalletWasabi.Tests/UtxoRefereeTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.IO;
+using System.Linq;
+using FakeItEasy;
+using NBitcoin;
+using WalletWasabi.Models;
+using WalletWasabi.Models.ChaumianCoinJoin;
+using WalletWasabi.Services;
+using Xunit;
+
+namespace WalletWasabi.Tests
+{
+	public class BannedUtxoRepositoryTests
+	{
+		[Fact]
+		public async void TestAsync()
+		{
+			string repoFile = Path.Combine("./test", Path.GetRandomFileName());
+
+			var repo = new BannedUtxoRepository(repoFile);
+			Assert.Empty(repo.Enumerate());
+
+			var outpoint1 = new OutPoint(uint256.One, 13);
+			var bannedUtxo1 = new BannedUtxoRecord(outpoint1, 0, DateTimeOffset.UtcNow, false, 0);
+			Assert.True(repo.TryAddOrUpdate(bannedUtxo1));
+
+			Assert.True(repo.TryGet(outpoint1, out var retrieved1));
+			Assert.Equal(retrieved1, bannedUtxo1);
+			Assert.Single(repo.Enumerate());
+
+			var outpoint2 = new OutPoint(uint256.One, 67);
+			var bannedUtxo2 = new BannedUtxoRecord(outpoint2, 0, DateTimeOffset.UtcNow, false, 0);
+			Assert.True(repo.TryAddOrUpdate(bannedUtxo2));
+
+			Assert.True(repo.TryGet(outpoint2, out var retrieved2));
+			Assert.Equal(retrieved2, bannedUtxo2);
+			Assert.Equal(2, (int)repo.Enumerate().Count());
+
+			await repo.SaveChangesAsync();
+
+			var lines = File.ReadAllLines(repoFile);
+			Assert.Equal(bannedUtxo1.ToString(), lines[0]);
+			Assert.Equal(bannedUtxo2.ToString(), lines[1]);
+
+			Assert.True(repo.TryRemove(outpoint1));
+			Assert.False(repo.TryRemove(outpoint1));
+			Assert.Single(repo.Enumerate());
+
+			Assert.False( repo.TryGet(outpoint1, out var _));
+			Assert.True( repo.TryGet(outpoint2, out var _));
+
+			await repo.SaveChangesAsync();
+
+			lines = File.ReadAllLines(repoFile);
+			Assert.Single(lines);
+			Assert.Equal(bannedUtxo2.ToString(), lines[0]);
+
+			repo.Clear();
+			Assert.False(repo.TryRemove(outpoint2));
+		}
+	}
+
+	public class UtxoRefereeTests
+	{
+		public static UtxoReferee CreateUtxoReferee(int severity, long durationHours, bool noteBeforeBan, out BannedUtxoRepository repo, out IUtxoProvider utxoProvider)
+		{
+			string repoFile = Path.Combine("./test", Path.GetRandomFileName());
+			repo = new BannedUtxoRepository(repoFile);
+			utxoProvider = A.Fake<IUtxoProvider>();
+			var dosConfig = new CcjDenialOfServiceConfig(severity, durationHours, noteBeforeBan);
+
+			var referee = new UtxoReferee(repo, utxoProvider, dosConfig);
+			return referee;
+		}
+
+		[Fact]
+		public async void TestBanNotedAsync()
+		{
+			var referee = CreateUtxoReferee(1, 24, true, out var repo, out var _);
+
+			var outpoint = new OutPoint(uint256.One, 67);
+			Assert.Null(await referee.TryGetBannedAsync(outpoint, true));
+
+			var now = DateTimeOffset.UtcNow;
+			// Ban coin for round 1 (noted first)
+			await referee.BanUtxosAsync(1, now, false, 1, outpoint);
+			var bannedUtxo = await referee.TryGetBannedAsync(outpoint, notedToo: false);
+			Assert.Null(bannedUtxo);
+
+			bannedUtxo = await referee.TryGetBannedAsync(outpoint, notedToo: true);
+			Assert.NotNull(bannedUtxo);
+			Assert.Equal(1, bannedUtxo.Severity);
+			Assert.Equal(now, bannedUtxo.TimeOfBan);
+			Assert.Equal(true, bannedUtxo.IsNoted);
+			Assert.Equal(1, bannedUtxo.BannedForRound);
+			Assert.Equal(outpoint, bannedUtxo.Utxo);
+
+			// Ban same coin for round 2
+			await referee.BanUtxosAsync(1, now, false, 2, outpoint);
+			bannedUtxo = await referee.TryGetBannedAsync(outpoint, notedToo: false);
+			Assert.NotNull(bannedUtxo);
+			Assert.Equal(1, bannedUtxo.Severity);
+			Assert.Equal(now, bannedUtxo.TimeOfBan);
+			Assert.False(bannedUtxo.IsNoted);
+			Assert.Equal(2, bannedUtxo.BannedForRound);
+			Assert.Equal(outpoint, bannedUtxo.Utxo);
+
+			// Ban coin and test expiration
+			var coin = new OutPoint(uint256.Zero, 331);
+			await referee.BanUtxosAsync(1, now.AddHours(-25), false, 2, coin);
+			bannedUtxo = await referee.TryGetBannedAsync(coin, notedToo: true);
+			Assert.Null(bannedUtxo);
+		}
+
+		[Fact]
+		public async void TestBanAsync()
+		{
+			var referee = CreateUtxoReferee(1, 24, false, out var repo, out var _);
+
+			var outpoint = new OutPoint(uint256.One, 67);
+			Assert.Null(await referee.TryGetBannedAsync(outpoint, true));
+
+			var now = DateTimeOffset.UtcNow;
+			// Ban coin for round 1
+			await referee.BanUtxosAsync(1, now, false, 1, outpoint);
+			var bannedUtxo = await referee.TryGetBannedAsync(outpoint, notedToo: false);
+			Assert.NotNull(bannedUtxo);
+			Assert.Equal(1, bannedUtxo.Severity);
+			Assert.Equal(now, bannedUtxo.TimeOfBan);
+			Assert.False(bannedUtxo.IsNoted);
+			Assert.Equal(1, bannedUtxo.BannedForRound);
+			Assert.Equal(outpoint, bannedUtxo.Utxo);
+
+			// Ban same coin for round 2
+			await referee.BanUtxosAsync(1, now, false, 2, outpoint);
+			bannedUtxo = await referee.TryGetBannedAsync(outpoint, notedToo: false);
+			Assert.NotNull(bannedUtxo);
+			Assert.Equal(1, bannedUtxo.Severity);
+			Assert.Equal(now, bannedUtxo.TimeOfBan);
+			Assert.False(bannedUtxo.IsNoted);
+			Assert.Equal(2, bannedUtxo.BannedForRound);
+			Assert.Equal(outpoint, bannedUtxo.Utxo);
+
+			// Ban a coin and force noted
+			var outpoint1 = new OutPoint(uint256.Parse("bb36dd56f2818641dcd94fad34845745cf3f3b4e6189f5fda174a1d2a72a42c3"), 67);
+			await referee.BanUtxosAsync(1, now, true, 2, outpoint1);
+			bannedUtxo = await referee.TryGetBannedAsync(outpoint1, notedToo: true);
+			Assert.NotNull(bannedUtxo);
+			Assert.Equal(1, bannedUtxo.Severity);
+			Assert.Equal(now, bannedUtxo.TimeOfBan);
+			Assert.True(bannedUtxo.IsNoted);
+			Assert.Equal(2, bannedUtxo.BannedForRound);
+			Assert.Equal(outpoint1, bannedUtxo.Utxo);
+
+		}
+
+		[Fact]
+		public async void TestBanDosProtectionDisabledAsync()
+		{
+			var referee = CreateUtxoReferee(0, 24, false, out var repo, out var _);
+
+			var outpoint = new OutPoint(uint256.One, 67);
+			await referee.BanUtxosAsync(1, DateTimeOffset.UtcNow, false, 1, outpoint);
+			var bannedUtxo = await referee.TryGetBannedAsync(outpoint, notedToo: true);
+			Assert.Null(bannedUtxo);
+		}
+
+		[Fact]
+		public async void TestInitialLoadingAsync()
+		{
+			var referee = CreateUtxoReferee(1, 24, false, out var repo, out var _);
+
+			var now = DateTimeOffset.UtcNow;
+			var yesterday = now.AddHours(-25);
+
+			var outpoint1 = new OutPoint(uint256.Parse("1d4d1670361fdd39695b04f98e8f5f761eee7def54e89378f67fa989291a9e92"), 67);
+			var outpoint2 = new OutPoint(uint256.Parse("c185e0bfb10ee84a7cb413cd2713497251cf1403c1a487420e51c842aa7ecbfe"), 12);
+			var outpoint3 = new OutPoint(uint256.Parse("5b04f98e8f5f761eee7def54e89371d4d1670361fdd39695b04f98e8f5f761ee"), 55);
+			var outpoint4 = new OutPoint(uint256.Parse("7fa989291a9e92fdd39695b04f98e8f5f761eee7def54e89378f67fa989291a9"), 18);
+
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint1, 2, yesterday, true, 10));
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint2, 2, yesterday, false, 10));
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint3, 1, now, false, 10));
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint4, 3, now, true, 10));
+
+			Assert.Null(await referee.TryGetBannedAsync(outpoint1, true));
+			Assert.Null(await referee.TryGetBannedAsync(outpoint2, true));
+			Assert.NotNull(await referee.TryGetBannedAsync(outpoint3, true));
+			Assert.NotNull(await referee.TryGetBannedAsync(outpoint4, true));
+		}
+
+		[Fact]
+		public async void TestInitialLoading2Async()
+		{
+			var referee = CreateUtxoReferee(1, 24, false, out var repo, out var utxoProvider);
+
+			var now = DateTimeOffset.UtcNow;
+			var yesterday = now.AddHours(-25);
+
+			var outpoint1 = new OutPoint(uint256.Parse("1d4d1670361fdd39695b04f98e8f5f761eee7def54e89378f67fa989291a9e92"), 67);
+			var outpoint2 = new OutPoint(uint256.Parse("c185e0bfb10ee84a7cb413cd2713497251cf1403c1a487420e51c842aa7ecbfe"), 12);
+			var outpoint3 = new OutPoint(uint256.Parse("5b04f98e8f5f761eee7def54e89371d4d1670361fdd39695b04f98e8f5f761ee"), 55);
+			var outpoint4 = new OutPoint(uint256.Parse("7fa989291a9e92fdd39695b04f98e8f5f761eee7def54e89378f67fa989291a9"), 18);
+			A.CallTo(()=> utxoProvider.GetUtxoAsync(outpoint1.Hash, (int)outpoint1.N)).Returns((TxOut)null); // txout not found
+			A.CallTo(()=> utxoProvider.GetUtxoAsync(outpoint3.Hash, (int)outpoint3.N)).Returns((TxOut)null); // txout not found
+
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint1, 2, now, true, 10));
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint2, 2, now, false, 10));
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint3, 1, now, false, 10));
+			repo.TryAddOrUpdate(new BannedUtxoRecord(outpoint4, 3, now, true, 10));
+
+			Assert.Null(await referee.TryGetBannedAsync(outpoint1, true));
+			Assert.NotNull(await referee.TryGetBannedAsync(outpoint2, true));
+			Assert.Null(await referee.TryGetBannedAsync(outpoint3, true));
+			Assert.NotNull(await referee.TryGetBannedAsync(outpoint4, true));
+		}
+	}
+}

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="AltCover" Version="5.2.667" />
+    <PackageReference Include="FakeItEasy" Version="5.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/WalletWasabi/Models/BannedUtxoRecord.cs
+++ b/WalletWasabi/Models/BannedUtxoRecord.cs
@@ -1,0 +1,53 @@
+using NBitcoin;
+using System;
+using System.Linq;
+
+namespace WalletWasabi.Models
+{
+	/// <summary>
+	/// Represents a banned coin record storedthat can be serialized/deserialized to 
+	/// be persisted on disk or keept in memory. 
+	/// </summary>
+	public class BannedUtxoRecord
+	{
+		public OutPoint Utxo { get; }
+		public int Severity { get; }
+		public DateTimeOffset TimeOfBan { get; }
+		public bool IsNoted { get; }
+		public long BannedForRound { get; }
+		public TimeSpan BannedRemaining => DateTimeOffset.UtcNow - TimeOfBan;
+
+		public BannedUtxoRecord(OutPoint utxo, int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound)
+		{
+			Utxo = utxo;
+			Severity = severity;
+			TimeOfBan = timeOfBan;
+			IsNoted = isNoted;
+			BannedForRound = bannedForRound;
+		}
+
+		/// <summary>
+		/// Deserializes an instance from its text representation.
+		/// </summary>
+		public static BannedUtxoRecord FromString(string str)
+		{
+			var parts = str.Split(':');
+			var isNoted = bool.Parse(parts[4]);
+			var bannedForRound = long.Parse(parts[5]);
+			var utxo = new OutPoint(new uint256(parts[3]), int.Parse(parts[2]));
+			var severity = int.Parse(parts[1]);
+			var timeParts = parts[0].Split('-', ' ').Select(x => int.Parse(x)).ToArray();
+			var timeOfBan = new DateTimeOffset(timeParts[0], timeParts[1], timeParts[2], timeParts[3], timeParts[4], timeParts[5], TimeSpan.Zero);
+
+			return new BannedUtxoRecord(utxo, severity, timeOfBan, isNoted, bannedForRound);
+		}
+
+		/// <summary>
+		/// Serializes the instance to its text representation.
+		/// </summary>
+		public override string ToString()
+		{
+			return $"{TimeOfBan.ToString("yyyy-MM-dd HH-mm-ss")}:{Severity}:{Utxo.N}:{Utxo.Hash}:{IsNoted}:{BannedForRound}";
+		}
+	}
+}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjDenialOfServiceConfig.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjDenialOfServiceConfig.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.Backend.Models.Responses;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Models.ChaumianCoinJoin
+{
+	/// <summary>
+	/// Represents the DoS protection parameters used by the coordinator
+	/// to enforce the DoS protection policy.
+	/// This info is extracted from the CcjRoundConfig instance to isolate
+	/// and encapsulate the info that is specific to the DoS protection mechanism. 
+	/// </summary>
+	public class CcjDenialOfServiceConfig
+	{
+		public int Severity { get; internal set; }
+		public long DurationHours { get; internal set; }
+		public bool NoteBeforeBan { get; internal set; }
+
+		public CcjDenialOfServiceConfig(int severity, long durationHours, bool noteBeforeBan)
+		{
+			Severity = severity;
+			DurationHours = durationHours;
+			NoteBeforeBan = noteBeforeBan;
+		}
+
+		/// <summary>
+		/// Extracts the DoS policy config items from a CcjRoundConfig instance.
+		/// </summary>
+		public static CcjDenialOfServiceConfig FromCcjRoundConfig(CcjRoundConfig cfg)
+		{
+			return new CcjDenialOfServiceConfig(cfg.DosSeverity ?? 1, cfg.DosDurationHours ?? 24, cfg.DosNoteBeforeBan ?? true);
+		}
+	}
+}

--- a/WalletWasabi/Services/BannedUtxoRepository.cs
+++ b/WalletWasabi/Services/BannedUtxoRepository.cs
@@ -1,0 +1,187 @@
+using NBitcoin;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+using WalletWasabi.Models;
+
+namespace WalletWasabi.Services
+{
+	/// <summary>
+	/// BannedUtxoRepository provides access to the stored utxo from disk.
+	/// </summary>
+	/// <remarks>
+	/// It abstracts the access to the stored utxo from file system and keeps the 
+	/// items in an in memory (internal cache) for fast access.
+	/// All changes to the internal in-memory list need to be persisted by calling
+	/// SaveChangesAsync() method.
+	/// </remarks>
+	public class BannedUtxoRepository
+	{
+		private ConcurrentDictionary<OutPoint, BannedUtxoRecord> _bannedUtxos; // in-memory cache
+		private string _filePath;
+		private bool _initialized = false;
+		private bool _isDirty = false;		// indicates whether changes are in memory but not persisted yet.
+
+		public BannedUtxoRepository(string filePath)
+		{
+			_filePath = Guard.NotNullOrEmptyOrWhitespace(nameof(filePath), filePath, trim: true);
+			_bannedUtxos = new ConcurrentDictionary<OutPoint, BannedUtxoRecord>();
+		}
+
+		/// <summary>
+		/// TryAddOrUpdate tries to replace an existing item or add it in case it is not already banned.
+		/// </summary>
+		/// <remarks>
+		/// TryAddOrUpdate tries to replace an existing item with the one passes or add it in case
+		/// the coin is not banned already.
+		/// This acts on the in-memory cache only and SaveChangesAsync has to be called to persist the
+		/// changes to disk.
+		/// </remarks>
+		/// <param name="utxo">The BannedUtxoRecord record containing the coin banning info.</param>
+		/// <returns>True if was able to update or add the item; otherwise false.</returns>
+		public bool TryAddOrUpdate(BannedUtxoRecord utxo)
+		{
+			EnsureInitialized();
+			if(_bannedUtxos.ContainsKey(utxo.Utxo))
+			{
+				_bannedUtxos[utxo.Utxo] = utxo;
+				return true;
+			}
+			else if(_bannedUtxos.TryAdd(utxo.Utxo, utxo))
+			{
+				_isDirty = true;
+				return true;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// TryRemove tries to remove an item..
+		/// </summary>
+		/// <remarks>
+		/// TryRemove tries to remove an item from the internal cache. 
+		/// SaveChangesAsync has to be called to persist the changes to disk.
+		/// </remarks>
+		/// <param name="utxo">The outpoint which has to be removed from the banned coin list.</param>
+		/// <returns>True if was able to remove the item; otherwise false.</returns>
+		public bool TryRemove(OutPoint utxo)
+		{
+			EnsureInitialized();
+			if(_bannedUtxos.TryRemove(utxo, out var _))
+			{
+				_isDirty = true;
+				return true;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// TryGet tries to return an item from the in-memory cache.
+		/// </summary>
+		/// <remarks>
+		/// TryGet tries to return the requested item from the internal cache.
+		/// </remarks>
+		/// <param name="key">The outpoint we want to search in the banned coin list.</param>
+		/// <param name="bannedUtxo">The BannedUtxoRecord record containing the coin banning info.</param>
+		/// <returns>True if was able to find the item; otherwise false.</returns>
+		public bool TryGet(OutPoint key, out BannedUtxoRecord bannedUtxo)
+		{
+			EnsureInitialized();
+			return _bannedUtxos.TryGetValue(key, out bannedUtxo);
+		}
+
+		/// <summary>
+		/// SaveChangesAsync persists the changes to disk.
+		/// </summary>
+		/// <remarks>
+		/// Dumps the serialized representation of the in-memory cache to the file system only
+		/// if there are changes that need to be saved.
+		/// </remarks>
+		public async Task SaveChangesAsync()
+		{
+			if(_isDirty)
+			{
+				EnsureInitialized();
+				var lines = _bannedUtxos.OrderBy(x=>x.Value.TimeOfBan).Select(x=>x.Value.ToString());
+				await File.WriteAllLinesAsync(_filePath, lines);
+				_isDirty = false;
+			}
+		}
+
+		/// <summary>
+		/// Enumerates the current state of the internal cache.
+		/// </summary>
+		public IEnumerable<BannedUtxoRecord> Enumerate()
+		{
+			EnsureInitialized();
+			foreach(var record in _bannedUtxos)
+			{
+				yield return record.Value;
+			}
+		}
+
+		/// <summary>
+		/// Drops the content of the internal cache and deletes the file.
+		/// </summary>
+		public void Clear()
+		{
+			_bannedUtxos.Clear();
+			_isDirty = false;
+			File.Delete(_filePath);
+		}
+
+		/// <summary>
+		/// Ensures to load the list of banned coins from disk before to do anything else.
+		/// </summary>
+		private void EnsureInitialized()
+		{
+			if(_initialized)
+			{
+				return;
+			}
+			Directory.CreateDirectory(Path.GetDirectoryName(_filePath));
+
+			Load();
+			_initialized = true;
+		}
+
+		/// <summary>
+		/// Loads the serialized banned coins from the file system.
+		/// </summary>
+		/// <remarks>
+		/// This method is invoked automatically before any other action is performed. 
+		/// In case the file is corrupted this method stops processing it and deletes 
+		/// the file. 
+		/// </remarks>
+		private void Load()
+		{
+			try
+			{
+				using(var file = new StreamReader(_filePath))
+				{
+					string line;
+					while((line = file.ReadLine()) != null)
+					{
+						var record = BannedUtxoRecord.FromString(line);
+						_bannedUtxos.TryAdd(record.Utxo, record);
+					}
+				}
+				Logger.LogInfo<UtxoReferee>($"{_bannedUtxos.Count()} banned UTXOs are loaded from {_filePath}.");
+			}
+			catch(FileNotFoundException)
+			{
+				Logger.LogInfo<UtxoReferee>($"No banned UTXOs are loaded from {_filePath}.");
+			}
+			catch(Exception ex)
+			{
+				Logger.LogWarning<UtxoReferee>($"Banned UTXO file got corrupted. Deleting {_filePath}. {ex.GetType()}: {ex.Message}");
+				Clear();
+			}
+		}
+	}
+}

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -309,7 +309,7 @@ namespace WalletWasabi.Services
 							feePerInputs = fees.feePerInputs;
 							feePerOutputs = fees.feePerOutputs;
 
-							Money newDenominationToGetInWithactiveOutputs = activeOutputAmount - (feePerInputs + 2 * feePerOutputs);
+							Money newDenominationToGetInWithactiveOutputs = activeOutputAmount - (feePerInputs + (2 * feePerOutputs));
 							if (newDenominationToGetInWithactiveOutputs < RoundConfig.Denomination)
 							{
 								if (newDenominationToGetInWithactiveOutputs > Money.Coins(0.01m))

--- a/WalletWasabi/Services/IUtxoProvider.cs
+++ b/WalletWasabi/Services/IUtxoProvider.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using NBitcoin;
+
+namespace WalletWasabi.Services
+{
+	/// <summary>
+	/// Abstracts the way the utxo are fetch.  
+	/// </summary>
+	public interface IUtxoProvider
+	{
+		Task<TxOut> GetUtxoAsync(uint256 txid, int index);
+	}
+}

--- a/WalletWasabi/Services/UtxoProvider.cs
+++ b/WalletWasabi/Services/UtxoProvider.cs
@@ -1,0 +1,29 @@
+using NBitcoin;
+using NBitcoin.RPC;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Services
+{
+	/// <summary>
+	/// UtxoProvider implements the mechanism for querying for utxo using the rpc interface.
+	/// </summary>
+	public class UtxoProvider : IUtxoProvider 
+	{
+		private RPCClient _rpc;
+
+		public UtxoProvider(RPCClient rpc)
+		{
+			_rpc = rpc;
+		}
+
+		/// <summary>
+		/// Get the requested utxo info from an rpc interface.
+		/// </summary>
+		/// <returns>The corresponding transaction output or null if it is not found</returns>
+		public async Task<TxOut> GetUtxoAsync(uint256 txid, int index)
+		{
+			var getTxOutResponse = await _rpc.GetTxOutAsync(txid, index);
+			return getTxOutResponse?.TxOut ?? null;
+		}
+	}
+}

--- a/WalletWasabi/Services/UtxoReferee.cs
+++ b/WalletWasabi/Services/UtxoReferee.cs
@@ -10,7 +10,6 @@ using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.Services
 {
-
 	public class UtxoReferee
 	{
 		private IUtxoProvider _utxoProvider;

--- a/WalletWasabi/Services/UtxoReferee.cs
+++ b/WalletWasabi/Services/UtxoReferee.cs
@@ -1,105 +1,46 @@
 ﻿using NBitcoin;
-using NBitcoin.RPC;
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.Models;
 using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.Services
 {
+
 	public class UtxoReferee
 	{
-		/// <summary>
-		/// Key: banned utxo, Value: severity level, time of ban, if it's only in noted status, which round it disrupted
-		/// </summary>
-		private ConcurrentDictionary<OutPoint, (int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound)> BannedUtxos { get; }
+		private IUtxoProvider _utxoProvider;
+		private CcjDenialOfServiceConfig _dosConfig;
+		private BannedUtxoRepository _repository;
+		private bool _initialized = false;
 
-		public string BannedUtxosFilePath => Path.Combine(FolderPath, $"BannedUtxos{Network}.txt");
-
-		public RPCClient RpcClient { get; }
-		public Network Network { get; }
-
-		public CcjRoundConfig RoundConfig { get; }
-
-		public string FolderPath { get; }
-
-		public UtxoReferee(Network network, string folderPath, RPCClient rpc, CcjRoundConfig roundConfig)
+		public UtxoReferee(BannedUtxoRepository repository, IUtxoProvider utxoProvider, CcjDenialOfServiceConfig dosConfig)
 		{
-			Network = Guard.NotNull(nameof(network), network);
-			FolderPath = Guard.NotNullOrEmptyOrWhitespace(nameof(folderPath), folderPath, trim: true);
-			RpcClient = Guard.NotNull(nameof(rpc), rpc);
-			RoundConfig = Guard.NotNull(nameof(roundConfig), roundConfig);
-
-			BannedUtxos = new ConcurrentDictionary<OutPoint, (int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound)>();
-
-			Directory.CreateDirectory(FolderPath);
-
-			if (File.Exists(BannedUtxosFilePath))
-			{
-				try
-				{
-					var toRemove = new List<string>(); // what's been confirmed
-					string[] allLines = File.ReadAllLines(BannedUtxosFilePath);
-					foreach (string line in allLines)
-					{
-						var bannedRecord = BannedRecordFromLine(line);
-
-						GetTxOutResponse getTxOutResponse = RpcClient.GetTxOut(bannedRecord.utxo.Hash, (int)bannedRecord.utxo.N, includeMempool: true);
-
-						// Check if inputs are unspent.
-						if (getTxOutResponse is null)
-						{
-							toRemove.Add(line);
-						}
-						else
-						{
-							BannedUtxos.TryAdd(bannedRecord.utxo, (bannedRecord.severity, bannedRecord.timeOfBan, bannedRecord.isNoted, bannedRecord.bannedForRound));
-						}
-					}
-
-					if (toRemove.Count != 0) // a little performance boost, often it'll be empty
-					{
-						var newAllLines = allLines.Where(x => !toRemove.Contains(x));
-						File.WriteAllLines(BannedUtxosFilePath, newAllLines);
-					}
-
-					Logger.LogInfo<UtxoReferee>($"{allLines.Length} banned UTXOs are loaded from {BannedUtxosFilePath}.");
-				}
-				catch (Exception ex)
-				{
-					Logger.LogWarning<UtxoReferee>($"Banned UTXO file got corrupted. Deleting {BannedUtxosFilePath}. {ex.GetType()}: {ex.Message}");
-					File.Delete(BannedUtxosFilePath);
-				}
-			}
-			else
-			{
-				Logger.LogInfo<UtxoReferee>($"No banned UTXOs are loaded from {BannedUtxosFilePath}.");
-			}
+			_utxoProvider = Guard.NotNull(nameof(utxoProvider), utxoProvider);
+			_dosConfig = Guard.NotNull(nameof(dosConfig), dosConfig);
+			_repository = Guard.NotNull(nameof(repository), repository);
 		}
 
 		public async Task BanUtxosAsync(int severity, DateTimeOffset timeOfBan, bool forceNoted, long bannedForRound, params OutPoint[] toBan)
 		{
-			if (RoundConfig.DosSeverity == 0)
+			if (_dosConfig.Severity == 0)
 			{
 				return;
 			}
 
-			var lines = new List<string>();
-			var updated = false;
+			await EnsureInitializedAsync();
 			foreach (var utxo in toBan)
 			{
-				(int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound)? foundElem = null;
-				if (BannedUtxos.TryGetValue(utxo, out (int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound) fe))
+				BannedUtxoRecord foundElem = null;
+				if (_repository.TryGet(utxo, out var fe))
 				{
 					foundElem = fe;
-					bool bannedForTheSameRound = foundElem.Value.bannedForRound == bannedForRound;
-					if (bannedForTheSameRound && (!forceNoted || foundElem.Value.isNoted))
+					bool bannedForTheSameRound = foundElem.BannedForRound == bannedForRound;
+					if (bannedForTheSameRound && (!forceNoted || foundElem.IsNoted))
 					{
 						continue; // We would be simply duplicating this ban.
 					}
@@ -112,9 +53,9 @@ namespace WalletWasabi.Services
 				}
 				else
 				{
-					if (RoundConfig.DosNoteBeforeBan.Value)
+					if (_dosConfig.NoteBeforeBan)
 					{
-						if (foundElem.HasValue)
+						if (foundElem != null)
 						{
 							isNoted = false;
 						}
@@ -124,59 +65,37 @@ namespace WalletWasabi.Services
 						isNoted = false;
 					}
 				}
-				if (BannedUtxos.TryAdd(utxo, (severity, timeOfBan, isNoted, bannedForRound)))
-				{
-					string line = BannedRecordToLine(utxo, severity, timeOfBan, isNoted, bannedForRound);
-					lines.Add(line);
-				}
-				else
-				{
-					var elem = BannedUtxos[utxo];
-					if (elem.isNoted != isNoted || elem.bannedForRound != bannedForRound)
-					{
-						BannedUtxos[utxo] = (elem.severity, elem.timeOfBan, isNoted, bannedForRound);
-						updated = true;
-					}
-				}
+				_repository.TryAddOrUpdate(new BannedUtxoRecord(utxo, severity, timeOfBan, isNoted, bannedForRound));
 
 				Logger.LogInfo<UtxoReferee>($"UTXO {(isNoted ? "noted" : "banned")} with severity: {severity}. UTXO: {utxo.N}:{utxo.Hash} for disrupting Round {bannedForRound}.");
 			}
-
-			if (updated) // If at any time we set updated then we must update the whole thing.
-			{
-				var allLines = BannedUtxos.Select(x => $"{x.Value.timeOfBan.ToString(CultureInfo.InvariantCulture)}:{x.Value.severity}:{x.Key.N}:{x.Key.Hash}:{x.Value.isNoted}:{x.Value.bannedForRound}");
-				await File.WriteAllLinesAsync(BannedUtxosFilePath, allLines);
-			}
-			else if (lines.Count != 0) // If we don't have to update the whole thing, we must check if we added a line and so only append.
-			{
-				await File.AppendAllLinesAsync(BannedUtxosFilePath, lines);
-			}
+			await _repository.SaveChangesAsync();
 		}
 
 		public async Task UnbanAsync(OutPoint output)
 		{
-			if (BannedUtxos.TryRemove(output, out _))
+			await EnsureInitializedAsync();
+			if (_repository.TryRemove(output))
 			{
-				IEnumerable<string> lines = BannedUtxos.Select(x => BannedRecordToLine(x.Key, x.Value.severity, x.Value.timeOfBan, x.Value.isNoted, x.Value.bannedForRound));
-				await File.WriteAllLinesAsync(BannedUtxosFilePath, lines);
+				await _repository.SaveChangesAsync();
 				Logger.LogInfo<UtxoReferee>($"UTXO unbanned: {output.N}:{output.Hash}.");
 			}
 		}
 
-		public async Task<(int severity, TimeSpan bannedRemaining, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound)?> TryGetBannedAsync(OutPoint outpoint, bool notedToo)
+		public async Task<BannedUtxoRecord> TryGetBannedAsync(OutPoint outpoint, bool notedToo)
 		{
-			if (BannedUtxos.TryGetValue(outpoint, out (int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound) bannedElem))
+			await EnsureInitializedAsync();
+			if (_repository.TryGet(outpoint, out var bannedElem))
 			{
-				int maxBan = (int)TimeSpan.FromHours(RoundConfig.DosDurationHours.Value).TotalMinutes;
-				var bannedRemaining = DateTimeOffset.UtcNow - bannedElem.timeOfBan;
-				int banLeftMinutes = maxBan - (int)bannedRemaining.TotalMinutes;
+				int maxBan = (int)TimeSpan.FromHours(_dosConfig.DurationHours).TotalMinutes;
+				int banLeftMinutes = maxBan - (int)bannedElem.BannedRemaining.TotalMinutes;
 				if (banLeftMinutes > 0)
 				{
-					if (bannedElem.isNoted)
+					if (bannedElem.IsNoted)
 					{
 						if (notedToo)
 						{
-							return (bannedElem.severity, bannedRemaining, bannedElem.timeOfBan, true, bannedElem.bannedForRound);
+							return new BannedUtxoRecord(outpoint, bannedElem.Severity, bannedElem.TimeOfBan, true, bannedElem.BannedForRound);
 						}
 						else
 						{
@@ -185,7 +104,7 @@ namespace WalletWasabi.Services
 					}
 					else
 					{
-						return (bannedElem.severity, bannedRemaining, bannedElem.timeOfBan, false, bannedElem.bannedForRound);
+						return new BannedUtxoRecord(outpoint, bannedElem.Severity, bannedElem.TimeOfBan, false, bannedElem.BannedForRound);
 					}
 				}
 				else
@@ -196,40 +115,48 @@ namespace WalletWasabi.Services
 			return null;
 		}
 
+		/// <summary>Method used for testing only</summary>
 		public int CountBanned(bool notedToo)
 		{
+			var banned = _repository.Enumerate();
 			if (notedToo)
 			{
-				return BannedUtxos.Count;
+				return banned.Count();
 			}
 			else
 			{
-				return BannedUtxos.Count(x => !x.Value.isNoted);
+				return banned.Count(x => !x.IsNoted);
 			}
 		}
 
 		public void Clear()
 		{
-			BannedUtxos.Clear();
-			File.Delete(BannedUtxosFilePath);
+			_repository.Clear();
 		}
 
-		internal static string BannedRecordToLine(OutPoint utxo, int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound)
+		private async Task LoadAsync()
 		{
-			return $"{timeOfBan.ToString("yyyy-MM-dd HH-mm-ss")}:{severity}:{utxo.N}:{utxo.Hash}:{isNoted}:{bannedForRound}";
+			foreach(var bannedUtxo in _repository.Enumerate())
+			{
+				var utxo = await _utxoProvider.GetUtxoAsync(bannedUtxo.Utxo.Hash, (int)bannedUtxo.Utxo.N);
+
+				// Check if inputs are unspent.
+				if (utxo is null)
+				{
+					_repository.TryRemove(bannedUtxo.Utxo);
+				}
+			}
+			await _repository.SaveChangesAsync();
 		}
 
-		internal static (OutPoint utxo, int severity, DateTimeOffset timeOfBan, bool isNoted, long bannedForRound) BannedRecordFromLine(string line)
+		private async Task EnsureInitializedAsync()
 		{
-			var parts = line.Split(':');
-			var isNoted = bool.Parse(parts[4]);
-			var bannedForRound = long.Parse(parts[5]);
-			var utxo = new OutPoint(new uint256(parts[3]), int.Parse(parts[2]));
-			var severity = int.Parse(parts[1]);
-			var timeParts = parts[0].Split('-', ' ').Select(x => int.Parse(x)).ToArray();
-			var timeOfBan = new DateTimeOffset(timeParts[0], timeParts[1], timeParts[2], timeParts[3], timeParts[4], timeParts[5], TimeSpan.Zero);
-
-			return (utxo, severity, timeOfBan, isNoted, bannedForRound);
+			if(_initialized)
+			{
+				return;
+			}
+			await LoadAsync();
+			_initialized = true;
 		}
 	}
 }


### PR DESCRIPTION
This PR is part of the effort to reduce the cost of maintainability of Wasabi by:

### Writing more unit tests

The idea is to achieve more coverage with unit tests and be able to verify paths that are no so easy to cover with integration tests. 

### Refactor the code to make it more testable

To test specific scenarios it is necessary to break/inject dependencies and at the same time organize the code in such a way that each component has only one responsibility (this also has the side effect that make the code simpler and cleaner)
