### PR TITLE
Do not cancel disposed TokenSource

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -468,6 +468,7 @@ namespace WalletWasabi.Gui
 			}
 			catch(ObjectDisposedException)
 			{
+				Logger.LogWarning($"{nameof(CancelWalletServiceInitialization)} is disposed. This can occur due to an error while processing the wallet.");
 			}
 			CancelWalletServiceInitialization = null;
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -466,7 +466,7 @@ namespace WalletWasabi.Gui
 			{
 				CancelWalletServiceInitialization?.Cancel();
 			}
-			catch(ObjectDisposedException)
+			catch (ObjectDisposedException)
 			{
 				Logger.LogWarning($"{nameof(CancelWalletServiceInitialization)} is disposed. This can occur due to an error while processing the wallet.");
 			}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -464,7 +464,7 @@ namespace WalletWasabi.Gui
 			}
 			try
 			{
-				CancelWalletServiceInitialization.Cancel();
+				CancelWalletServiceInitialization?.Cancel();
 			}
 			catch(ObjectDisposedException)
 			{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -462,8 +462,9 @@ namespace WalletWasabi.Gui
 			{
 				WalletService.Coins.CollectionChanged -= Coins_CollectionChanged;
 			}
-			try{
-				CancelWalletServiceInitialization?.Cancel();
+			try
+			{
+				CancelWalletServiceInitialization.Cancel();
 			}
 			catch(ObjectDisposedException)
 			{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -468,7 +468,7 @@ namespace WalletWasabi.Gui
 			}
 			catch (ObjectDisposedException)
 			{
-				Logger.LogWarning($"{nameof(CancelWalletServiceInitialization)} is disposed. This can occur due to an error while processing the wallet.");
+				Logger.LogWarning($"{nameof(CancelWalletServiceInitialization)} is disposed. This can occur due to an error while processing the wallet.", nameof(Global));
 			}
 			CancelWalletServiceInitialization = null;
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -462,7 +462,12 @@ namespace WalletWasabi.Gui
 			{
 				WalletService.Coins.CollectionChanged -= Coins_CollectionChanged;
 			}
-			CancelWalletServiceInitialization?.Cancel();
+			try{
+				CancelWalletServiceInitialization?.Cancel();
+			}
+			catch(ObjectDisposedException)
+			{
+			}
 			CancelWalletServiceInitialization = null;
 
 			if (WalletService != null)


### PR DESCRIPTION
When something wrong happens while processing a wallet (inside `WalletService.InitializeAsync`) the exception bubbles and disposes the `CancelWalletServiceInitialization` so, we ends with an unprocessed `WalletService` but, given it is not `null` Wasabi displays "There is an already opened wallet".

In other words: when there is an exception while processing the wallet, it doesn't display the correct exception message but the misleading "There is an already opened wallet" error instead.
Related #1413