### PR TITLE
Use enum instead of strings + fix status gets stucked issue

### DIFF
--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -11,6 +11,7 @@
     <converters:ShowCursorConverter x:Key="ShowCursorConverter" />
     <converters:ShouldDisplayValueConverter x:Key="ShouldDisplayValueConverter" />
     <converters:PascalToPhraseConverter x:Key="PascalToPhraseConverter" />
+    <converters:StatusBarStatusStringConverter x:Key="StatusBarStatusStringConverter" />
   </UserControl.Resources>
 
   <Grid Cursor="{Binding UpdateAvailable, Converter={StaticResource ShowCursorConverter}}" Background="{Binding UpdateStatus, Converter={StaticResource UpdateStatusBrushConverter}}">
@@ -159,7 +160,7 @@
             </DrawingPresenter.Drawing>
           </DrawingPresenter>
         </Grid>
-        <TextBlock Text="{Binding Status}" />
+        <TextBlock Text="{Binding StatusText}" />
       </StackPanel>
     </DockPanel>
   </Grid>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
@@ -7,6 +7,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using WalletWasabi.Gui.Models;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Models;
 
@@ -101,7 +102,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private async Task OnDoTransactionBroadcastAsync()
 		{
-			const string broadcastingTransactionStatusText = "Broadcasting transaction...";
 			try
 			{
 				IsBusy = true;
@@ -124,7 +124,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					transaction = new SmartTransaction(Transaction.Parse(TransactionString, Global.Network ?? Network.Main), WalletWasabi.Models.Height.Unknown);
 				}
 
-				MainWindowViewModel.Instance.StatusBar.TryAddStatus(broadcastingTransactionStatusText);
+				MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.BroadcastingTransaction);
 				await Task.Run(async () => await Global.WalletService.SendTransactionAsync(transaction));
 
 				SetSuccessMessage("Transaction is successfully sent!");
@@ -136,7 +136,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 			finally
 			{
-				MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(broadcastingTransactionStatusText);
+				MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.BroadcastingTransaction);
 				IsBusy = false;
 				ButtonText = "Broadcast Transaction";
 			}

--- a/WalletWasabi.Gui/Converters/StatusBarStatusStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/StatusBarStatusStringConverter.cs
@@ -1,0 +1,53 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using WalletWasabi.Gui.Models;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class StatusBarStatusStringConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is StatusBarStatus status)
+			{
+				return Convert(status);
+			}
+
+			throw new InvalidOperationException($"Given value isn't a {nameof(StatusBarStatus)} enum.");
+		}
+
+		public static string Convert(StatusBarStatus status)
+		{
+			switch (status)
+			{
+				case StatusBarStatus.Ready: return "Ready";
+				case StatusBarStatus.CriticalUpdate: return "THE BACKEND WAS UPGRADED WITH BREAKING CHANGES - PLEASE UPDATE YOUR SOFTWARE";
+				case StatusBarStatus.OptionalUpdate: return "New Version Is Available";
+				case StatusBarStatus.Connecting: return "Connecting...";
+				case StatusBarStatus.Synchronizing: return "Synchronizing...";
+				case StatusBarStatus.Loading: return "Loading...";
+				case StatusBarStatus.SettingUpHardwareWallet: return "Setting up hardware wallet...";
+				case StatusBarStatus.ConnectingToHardwareWallet: return "Connecting to hardware wallet...";
+				case StatusBarStatus.AcquiringXpubFromHardwareWallet: return "Acquiring xpub from hardware wallet...";
+				case StatusBarStatus.AcquiringSignatureFromHardwareWallet: return "Acquiring signature from hardware wallet...";
+				case StatusBarStatus.BuildingTransaction: return "Building transaction...";
+				case StatusBarStatus.SigningTransaction: return "Signing transaction...";
+				case StatusBarStatus.BroadcastingTransaction: return "Broadcasting transaction...";
+				case StatusBarStatus.DequeuingSelectedCoins: return "Dequeueing selected coins...";
+				default:
+					{
+						Logging.Logger.LogWarning<StatusBarStatusStringConverter>("Status don't have conversion string specified. Calling ToString() on enum.");
+						return status.ToString();
+					}
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Models/StatusBarStatus.cs
+++ b/WalletWasabi.Gui/Models/StatusBarStatus.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Gui.Models
+{
+	public enum StatusBarStatus
+	{
+		Ready,
+		CriticalUpdate,
+		OptionalUpdate,
+		Connecting,
+		Synchronizing,
+		Loading,
+		SettingUpHardwareWallet,
+		ConnectingToHardwareWallet,
+		AcquiringXpubFromHardwareWallet,
+		AcquiringSignatureFromHardwareWallet,
+		BuildingTransaction,
+		SigningTransaction,
+		BroadcastingTransaction,
+		DequeuingSelectedCoins
+	}
+}

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -388,25 +388,23 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 					if (!selectedWallet.HardwareWalletInfo.Initialized)
 					{
-						const string settingUpHardwareWalletStatusText = "Setting up hardware wallet...";
-						const string connectingToHardwareWalletStatusText = "Connecting to hardware wallet...";
 						IEnumerable<HardwareWalletInfo> hwis;
 						try
 						{
 							IsHardwareBusy = true;
-							MainWindowViewModel.Instance.StatusBar.TryAddStatus(settingUpHardwareWalletStatusText);
+							MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.SettingUpHardwareWallet);
 							if (!await HwiProcessManager.SetupAsync(selectedWallet.HardwareWalletInfo))
 							{
 								throw new Exception("Setup failed.");
 							}
 
-							MainWindowViewModel.Instance.StatusBar.TryAddStatus(connectingToHardwareWalletStatusText);
+							MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.ConnectingToHardwareWallet);
 							hwis = await HwiProcessManager.EnumerateAsync();
 						}
 						finally
 						{
 							IsHardwareBusy = false;
-							MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(settingUpHardwareWalletStatusText, connectingToHardwareWalletStatusText);
+							MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.SettingUpHardwareWallet, StatusBarStatus.ConnectingToHardwareWallet);
 						}
 
 						TryRefreshHardwareWallets(hwis);
@@ -420,16 +418,15 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 					if (!TryFindWalletByMasterFingerprint(selectedWallet.HardwareWalletInfo.MasterFingerprint.Value, out walletName))
 					{
-						const string acquiringXpubFromHardwareWalletStatusText = "Acquiring xpub from hardware wallet...";
 						ExtPubKey extPubKey;
 						try
 						{
-							MainWindowViewModel.Instance.StatusBar.TryAddStatus(acquiringXpubFromHardwareWalletStatusText);
+							MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.AcquiringXpubFromHardwareWallet);
 							extPubKey = await HwiProcessManager.GetXpubAsync(selectedWallet.HardwareWalletInfo);
 						}
 						finally
 						{
-							MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(acquiringXpubFromHardwareWalletStatusText);
+							MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.AcquiringXpubFromHardwareWallet);
 						}
 
 						Logger.LogInfo<LoadWalletViewModel>("Hardware wallet wasn't used previously on this computer. Creating new wallet file.");
@@ -529,11 +526,10 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 		public async Task LoadWalletAsync()
 		{
-			const string loadingStatusText = "Loading...";
 			try
 			{
 				IsBusy = true;
-				MainWindowViewModel.Instance.StatusBar.TryAddStatus(loadingStatusText);
+				MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.Loading);
 
 				var keyManager = await LoadKeyManagerAsync(IsPasswordRequired, IsHardwareWallet);
 				if (keyManager is null)
@@ -570,7 +566,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			}
 			finally
 			{
-				MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(loadingStatusText);
+				MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.Loading);
 				IsBusy = false;
 			}
 		}

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -160,7 +160,7 @@ namespace WalletWasabi.Gui.ViewModels
 						{
 							nextAnimation = status.TrimEnd("..", StringComparison.Ordinal);
 						}
-						else if (status.EndsWith("..") || status.EndsWith("."))
+						else if (status.EndsWith("."))
 						{
 							nextAnimation = $"{status}.";
 						}


### PR DESCRIPTION
In the StatusBar, for statuses, it'd be better to use enum instead of strings and the converter.  

I also added a lock to the animation, which fixes an annoying bug, where the Loading... got stuck often.