### PR TITLE
Optimize CoinJoin Fees

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -149,7 +149,7 @@ pico ~/.bitcoin/bitcoin.conf
 ```sh
 testnet=[0/1]
 
-[main/test].maxuploadtarget=144
+[main/test].rpcworkqueue=64
 
 [main/test].txindex=1
 

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -1840,7 +1840,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.2m;
 			int anonymitySet = 2;
 			int connectionConfirmationTimeout = 50;
-			var roundConfig = new CcjRoundConfig(denomination, 2, coordinatorFeePercent, anonymitySet, 100, connectionConfirmationTimeout, 50, 50, 2, 24, false, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 2, 0.7, coordinatorFeePercent, anonymitySet, 100, connectionConfirmationTimeout, 50, 50, 2, 24, false, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
@@ -2359,7 +2359,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.0002m;
 			int anonymitySet = 4;
 			int connectionConfirmationTimeout = 50;
-			var roundConfig = new CcjRoundConfig(denomination, 2, coordinatorFeePercent, anonymitySet, 100, connectionConfirmationTimeout, 50, 50, 2, 24, false, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 2, 0.7, coordinatorFeePercent, anonymitySet, 100, connectionConfirmationTimeout, 50, 50, 2, 24, false, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
@@ -2508,7 +2508,7 @@ namespace WalletWasabi.Tests
 			int anonymitySet = 2;
 			int connectionConfirmationTimeout = 1;
 			bool doesNoteBeforeBan = true;
-			CcjRoundConfig roundConfig = new CcjRoundConfig(denomination, 140, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 1, 1, 1, 24, doesNoteBeforeBan, 11);
+			CcjRoundConfig roundConfig = new CcjRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 1, 1, 1, 24, doesNoteBeforeBan, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
@@ -2588,7 +2588,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.1m;
 			int anonymitySet = 3;
 			int connectionConfirmationTimeout = 120;
-			var roundConfig = new CcjRoundConfig(denomination, 140, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 1, 1, 1, 24, true, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 1, 1, 1, 24, true, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
@@ -2790,7 +2790,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.003m;
 			int anonymitySet = 100;
 			int connectionConfirmationTimeout = 120;
-			var roundConfig = new CcjRoundConfig(denomination, 144, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 144, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 			await rpc.GenerateAsync(100); // So to make sure we have enough money.
@@ -3010,7 +3010,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.1m;
 			int anonymitySet = 7;
 			int connectionConfirmationTimeout = 14;
-			var roundConfig = new CcjRoundConfig(denomination, 140, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
@@ -3134,7 +3134,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.1m;
 			int anonymitySet = 2;
 			int connectionConfirmationTimeout = 14;
-			var roundConfig = new CcjRoundConfig(denomination, 140, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 			await rpc.GenerateAsync(3); // So to make sure we have enough money.
@@ -3234,7 +3234,7 @@ namespace WalletWasabi.Tests
 
 				// Make sure if times out, it  tries again.
 				connectionConfirmationTimeout = 1;
-				roundConfig = new CcjRoundConfig(denomination, 140, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
+				roundConfig = new CcjRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 				coordinator.UpdateRoundConfig(roundConfig);
 				coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 				Assert.NotEmpty(chaumianClient1.State.GetAllQueuedCoins());
@@ -3287,7 +3287,7 @@ namespace WalletWasabi.Tests
 			decimal coordinatorFeePercent = 0.1m;
 			int anonymitySet = 2;
 			int connectionConfirmationTimeout = 14;
-			var roundConfig = new CcjRoundConfig(denomination, 140, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
+			var roundConfig = new CcjRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			coordinator.UpdateRoundConfig(roundConfig);
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using NBitcoin;
 using System;
@@ -33,7 +33,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 
 			var config = new Config(rpc.Network, rpc.Authentication, IPAddress.Loopback.ToString(), IPAddress.Loopback.ToString(), BackendRegTestNode.Endpoint.Address.ToString(), Network.Main.DefaultPort, Network.TestNet.DefaultPort, BackendRegTestNode.Endpoint.Port);
 
-			var roundConfig = new CcjRoundConfig(Money.Coins(0.1m), 144, 0.1m, 100, 120, 60, 60, 60, 1, 24, true, 11);
+			var roundConfig = new CcjRoundConfig(Money.Coins(0.1m), 144, 0.7, 0.1m, 100, 120, 60, 60, 60, 1, 24, true, 11);
 
 			Backend.Global.InitializeAsync(config, roundConfig, rpc).GetAwaiter().GetResult();
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -206,20 +206,58 @@ namespace NBitcoin.RPC
 		}
 
 		/// <summary>
-		/// Decides if any of the transactions are unconfirmed using getrawmempool.
+		/// Gets the transactions those are unconfirmed using getrawmempool.
 		/// This is efficient when many transaction ids are provided.
 		/// </summary>
-		public static async Task<bool> AnyUnconfirmedAsync(this RPCClient rpcClient, ISet<uint256> transactionHashes)
+		public static async Task<IEnumerable<uint256>> GetUnconfirmedAsync(this RPCClient rpc, IEnumerable<uint256> transactionHashes)
 		{
-			uint256[] unconfirmedTransactionHashes = await rpcClient.GetRawMempoolAsync();
-			if (transactionHashes.Intersect(unconfirmedTransactionHashes).Any()) // If there are common elements, then there's unconfirmed.
+			uint256[] unconfirmedTransactionHashes = await rpc.GetRawMempoolAsync();
+			// If there are common elements, then there's unconfirmed.
+			return transactionHashes.Intersect(unconfirmedTransactionHashes);
+		}
+
+		/// <summary>
+		/// Recursively gathers all the dependents of the mempool transactions provided.
+		/// </summary>
+		/// <param name="transactionHashes">Mempool transactions to gather their dependents.</param>
+		/// <param name="includingProvided">Should it include in the result the unconfirmed ones from the provided transactionHashes.</param>
+		/// <param name="likelyProvidedManyConfirmedOnes">If many provided transactionHashes are not confirmed then it optimizes by doing a check in the beginning of which ones are unconfirmed.</param>
+		/// <returns>All the dependents of the provided transactionHashes.</returns>
+		public static async Task<ISet<uint256>> GetAllDependentsAsync(this RPCClient rpc, IEnumerable<uint256> transactionHashes, bool includingProvided, bool likelyProvidedManyConfirmedOnes)
+		{
+			IEnumerable<uint256> workingTxHashes;
+			if (likelyProvidedManyConfirmedOnes) // If confirmed txids are provided, then do a big check first.
 			{
-				return true;
+				workingTxHashes = await rpc.GetUnconfirmedAsync(transactionHashes);
 			}
 			else
 			{
-				return false;
+				workingTxHashes = transactionHashes;
 			}
+
+			var hashSet = new HashSet<uint256>();
+			foreach (var txid in workingTxHashes)
+			{
+				// Go through all the txids provided and getmempoolentry to get the dependents and the confirmation status.
+				var entry = await rpc.GetMempoolEntryAsync(txid, throwIfNotFound: false);
+				if (entry != null)
+				{
+					// If we asked to include the provided transaction hashes into the result then check which ones are confirmed and do so.
+					if (includingProvided)
+					{
+						hashSet.Add(txid);
+					}
+
+					// Get all the dependents of all the dependents except the ones we already know of.
+					var except = entry.Depends.Except(hashSet);
+					var dependentsOfDependents = await rpc.GetAllDependentsAsync(except, includingProvided: true, likelyProvidedManyConfirmedOnes: false);
+
+					// Add them to the hashset.
+					hashSet.UnionWith(dependentsOfDependents);
+				}
+			}
+
+			return hashSet;
 		}
 	}
 }

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -212,7 +212,7 @@ namespace NBitcoin.RPC
 		public static async Task<bool> AnyUnconfirmedAsync(this RPCClient rpcClient, ISet<uint256> transactionHashes)
 		{
 			uint256[] unconfirmedTransactionHashes = await rpcClient.GetRawMempoolAsync();
-			if (unconfirmedTransactionHashes.Any(x => transactionHashes.Contains(x)))
+			if (transactionHashes.Intersect(unconfirmedTransactionHashes).Any()) // If there are common elements, then there's unconfirmed.
 			{
 				return true;
 			}

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -204,5 +204,22 @@ namespace NBitcoin.RPC
 			}
 			return (true, "");
 		}
+
+		/// <summary>
+		/// Decides if any of the transactions are unconfirmed using getrawmempool.
+		/// This is efficient when many transaction ids are provided.
+		/// </summary>
+		public static async Task<bool> AnyUnconfirmedAsync(this RPCClient rpcClient, ISet<uint256> transactionHashes)
+		{
+			uint256[] unconfirmedTransactionHashes = await rpcClient.GetRawMempoolAsync();
+			if (unconfirmedTransactionHashes.Any(x => transactionHashes.Contains(x)))
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
 	}
 }

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -24,7 +24,16 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		public RPCClient RpcClient { get; }
 		public Network Network => RpcClient.Network;
 
-		public int ConfirmationTarget { get; }
+		/// <summary>
+		/// The confirmation target that will be used and possibly modified before final build.
+		/// </summary>
+		public int AdjustedConfirmationTarget { get; private set; }
+
+		/// <summary>
+		/// The confirmation target that is present in the config file.
+		/// </summary>
+		public int ConfiguredConfirmationTarget { get; }
+
 		public decimal CoordinatorFeePercent { get; }
 		public int AnonymitySet { get; private set; }
 
@@ -136,7 +145,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 		public UtxoReferee UtxoReferee { get; }
 
-		public CcjRound(RPCClient rpc, UtxoReferee utxoReferee, CcjRoundConfig config, int confirmationTarget)
+		public CcjRound(RPCClient rpc, UtxoReferee utxoReferee, CcjRoundConfig config, int adjustedConfirmationTarget, int configuredConfirmationTarget)
 		{
 			try
 			{
@@ -146,7 +155,8 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				UtxoReferee = Guard.NotNull(nameof(utxoReferee), utxoReferee);
 				Guard.NotNull(nameof(config), config);
 
-				ConfirmationTarget = confirmationTarget;
+				AdjustedConfirmationTarget = adjustedConfirmationTarget;
+				ConfiguredConfirmationTarget = configuredConfirmationTarget;
 				CoordinatorFeePercent = (decimal)config.CoordinatorFeePercent;
 				AnonymitySet = (int)config.AnonymitySet;
 				InputRegistrationTimeout = TimeSpan.FromSeconds((long)config.InputRegistrationTimeout);
@@ -178,7 +188,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 				Logger.LogInfo<CcjRound>($"New round ({RoundId}) is created.\n\t" +
 					$"BaseDenomination: {MixingLevels.GetBaseDenomination().ToString(false, true)} BTC.\n\t" +
-					$"{nameof(ConfirmationTarget)}: {ConfirmationTarget}.\n\t" +
+					$"{nameof(AdjustedConfirmationTarget)}: {AdjustedConfirmationTarget}.\n\t" +
 					$"{nameof(CoordinatorFeePercent)}: {CoordinatorFeePercent}%.\n\t" +
 					$"{nameof(AnonymitySet)}: {AnonymitySet}.");
 			}
@@ -210,7 +220,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						// Calculate fees.
 						if (feePerInputs is null || feePerOutputs is null)
 						{
-							(Money feePerInputs, Money feePerOutputs) fees = await CalculateFeesAsync(RpcClient, ConfirmationTarget);
+							(Money feePerInputs, Money feePerOutputs) fees = await CalculateFeesAsync(RpcClient, AdjustedConfirmationTarget);
 							FeePerInputs = feePerInputs ?? fees.feePerInputs;
 							FeePerOutputs = feePerOutputs ?? fees.feePerOutputs;
 						}
@@ -383,7 +393,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 							.BuildTransaction(false);
 
 						// 8. Try optimize fees.
-						await OptimizeFeesAsync(spentCoins);
+						await TryOptimizeFeesAsync(spentCoins);
 
 						SignedCoinJoin = Transaction.Parse(UnsignedCoinJoin.ToHex(), Network);
 
@@ -670,10 +680,12 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			return acceptedBlindedOutputScriptsCount;
 		}
 
-		private async Task OptimizeFeesAsync(IEnumerable<Coin> spentCoins)
+		private async Task TryOptimizeFeesAsync(IEnumerable<Coin> spentCoins)
 		{
 			try
 			{
+				await TryOptimizeConfirmationTargetAsync(spentCoins.Select(x => x.Outpoint.Hash).ToHashSet());
+
 				// 8.1. Estimate the current FeeRate. Note, there are no signatures yet!
 				int estimatedSigSizeBytes = UnsignedCoinJoin.Inputs.Count * Constants.P2wpkhInputSizeInBytes;
 				int estimatedFinalTxSize = UnsignedCoinJoin.GetSerializedSize() + estimatedSigSizeBytes;
@@ -682,7 +694,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				FeeRate currentFeeRate = fee is null ? null : new FeeRate(fee, estimatedFinalTxSize);
 
 				// 8.2. Get the most optimal FeeRate.
-				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true);
+				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true);
 				if (estimateSmartFeeResponse is null)
 				{
 					throw new InvalidOperationException("FeeRate is not yet initialized");
@@ -726,7 +738,32 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CcjRound>("Couldn't optimize fees. Fallback to normal fees.");
+				Logger.LogWarning<CcjRound>("Failed to optimize fees. Fallback to normal fees.");
+				Logger.LogWarning<CcjRound>(ex);
+			}
+		}
+
+		private async Task TryOptimizeConfirmationTargetAsync(ISet<uint256> transactionHashes)
+		{
+			try
+			{
+				// If the transaction doesn't spend unconfirmed coins then the confirmation target can be the one that's been set in the config.
+				var originalConfirmationTarget = AdjustedConfirmationTarget;
+
+				if (await RpcClient.AnyUnconfirmedAsync(transactionHashes))
+				{
+					return;
+				}
+				else
+				{
+					AdjustedConfirmationTarget = ConfiguredConfirmationTarget;
+				}
+
+				Logger.LogInfo<CcjRound>($"Confirmation target is optimized from {originalConfirmationTarget} sat/b to {AdjustedConfirmationTarget} sat/b.");
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<CcjRound>($"Failed to optimize confirmation target. Fallback using the original one: {AdjustedConfirmationTarget} sat/b.");
 				Logger.LogWarning<CcjRound>(ex);
 			}
 		}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -758,7 +758,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 				// Note that only dependents matter, spenders doesn't matter much or at all, they just make this transaction to be faster to confirm faster.
 				var dependents = await RpcClient.GetAllDependentsAsync(transactionHashes, includingProvided: true, likelyProvidedManyConfirmedOnes: true);
-				AdjustedConfirmationTarget = AdjustConfirmationTarget(dependents.Count, ConfiguredConfirmationTarget, ConfiguredConfirmationTargetReductionRate); ;
+				AdjustedConfirmationTarget = AdjustConfirmationTarget(dependents.Count, ConfiguredConfirmationTarget, ConfiguredConfirmationTargetReductionRate);
 
 				if (originalConfirmationTarget != AdjustedConfirmationTarget)
 				{

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -760,7 +760,10 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				var dependents = await RpcClient.GetAllDependentsAsync(transactionHashes, includingProvided: true, likelyProvidedManyConfirmedOnes: true);
 				AdjustedConfirmationTarget = AdjustConfirmationTarget(dependents.Count, ConfiguredConfirmationTarget, ConfiguredConfirmationTargetReductionRate); ;
 
-				Logger.LogInfo<CcjRound>($"Confirmation target is optimized from {originalConfirmationTarget} sat/b to {AdjustedConfirmationTarget} sat/b.");
+				if (originalConfirmationTarget != AdjustedConfirmationTarget)
+				{
+					Logger.LogInfo<CcjRound>($"Confirmation target is optimized from {originalConfirmationTarget} sat/b to {AdjustedConfirmationTarget} sat/b.");
+				}
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundConfig.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundConfig.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using Newtonsoft.Json;
 using System;
 using System.IO;
@@ -23,6 +23,9 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 		[JsonProperty(PropertyName = "ConfirmationTarget")]
 		public int? ConfirmationTarget { get; internal set; }
+
+		[JsonProperty(PropertyName = "ConfirmationTargetReductionRate")]
+		public double? ConfirmationTargetReductionRate { get; internal set; }
 
 		[JsonProperty(PropertyName = "CoordinatorFeePercent")]
 		public decimal? CoordinatorFeePercent { get; internal set; }
@@ -63,11 +66,12 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			SetFilePath(filePath);
 		}
 
-		public CcjRoundConfig(Money denomination, int? confirmationTarget, decimal? coordinatorFeePercent, int? anonymitySet, long? inputRegistrationTimeout, long? connectionConfirmationTimeout, long? outputRegistrationTimeout, long? signingTimeout, int? dosSeverity, long? dosDurationHours, bool? dosNoteBeforeBan, int? maximumMixingLevelCount)
+		public CcjRoundConfig(Money denomination, int? confirmationTarget, double? confirmationTargetReductionRate, decimal? coordinatorFeePercent, int? anonymitySet, long? inputRegistrationTimeout, long? connectionConfirmationTimeout, long? outputRegistrationTimeout, long? signingTimeout, int? dosSeverity, long? dosDurationHours, bool? dosNoteBeforeBan, int? maximumMixingLevelCount)
 		{
 			FilePath = null;
 			Denomination = Guard.NotNull(nameof(denomination), denomination);
 			ConfirmationTarget = Guard.NotNull(nameof(confirmationTarget), confirmationTarget);
+			ConfirmationTargetReductionRate = Guard.NotNull(nameof(confirmationTargetReductionRate), confirmationTargetReductionRate);
 			CoordinatorFeePercent = Guard.NotNull(nameof(coordinatorFeePercent), coordinatorFeePercent);
 			AnonymitySet = Guard.NotNull(nameof(anonymitySet), anonymitySet);
 			InputRegistrationTimeout = Guard.NotNull(nameof(inputRegistrationTimeout), inputRegistrationTimeout);
@@ -98,6 +102,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			Denomination = Money.Coins(0.1m);
 			ConfirmationTarget = 144; // 1 day
+			ConfirmationTargetReductionRate = 0.7;
 			CoordinatorFeePercent = 0.003m; // Coordinator fee percent is per anonymity set.
 			AnonymitySet = 100;
 			InputRegistrationTimeout = 604800; // One week
@@ -128,6 +133,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 		{
 			Denomination = config.Denomination ?? Denomination;
 			ConfirmationTarget = config.ConfirmationTarget ?? ConfirmationTarget;
+			ConfirmationTargetReductionRate = config.ConfirmationTargetReductionRate ?? ConfirmationTargetReductionRate;
 			CoordinatorFeePercent = config.CoordinatorFeePercent ?? CoordinatorFeePercent;
 			AnonymitySet = config.AnonymitySet ?? AnonymitySet;
 			InputRegistrationTimeout = config.InputRegistrationTimeout ?? InputRegistrationTimeout;
@@ -158,6 +164,10 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				return true;
 			}
 			if (ConfirmationTarget != config.ConfirmationTarget)
+			{
+				return true;
+			}
+			if (ConfirmationTargetReductionRate != config.ConfirmationTargetReductionRate)
 			{
 				return true;
 			}

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -257,7 +257,7 @@ namespace WalletWasabi.Services
 				int confirmationTarget = RoundConfig.ConfirmationTarget.Value;
 				for (int i = 0; i < unconfirmedCoinJoinsCount; i++)
 				{
-					confirmationTarget = (int)(confirmationTarget * 0.7);
+					confirmationTarget = (int)(confirmationTarget * RoundConfig.ConfirmationTargetReductionRate.Value);
 				}
 
 				confirmationTarget = Math.Max(confirmationTarget, 2); // Conf target should never be less than 2.

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -209,13 +209,13 @@ namespace WalletWasabi.Services
 
 				if (runningRoundCount == 0)
 				{
-					var round = new CcjRound(RpcClient, UtxoReferee, RoundConfig, confirmationTarget);
+					var round = new CcjRound(RpcClient, UtxoReferee, RoundConfig, confirmationTarget, RoundConfig.ConfirmationTarget.Value);
 					round.CoinJoinBroadcasted += Round_CoinJoinBroadcasted;
 					round.StatusChanged += Round_StatusChangedAsync;
 					await round.ExecuteNextPhaseAsync(CcjRoundPhase.InputRegistration, feePerInputs, feePerOutputs);
 					Rounds.Add(round);
 
-					var round2 = new CcjRound(RpcClient, UtxoReferee, RoundConfig, confirmationTarget);
+					var round2 = new CcjRound(RpcClient, UtxoReferee, RoundConfig, confirmationTarget, RoundConfig.ConfirmationTarget.Value);
 					round2.StatusChanged += Round_StatusChangedAsync;
 					round2.CoinJoinBroadcasted += Round_CoinJoinBroadcasted;
 					await round2.ExecuteNextPhaseAsync(CcjRoundPhase.InputRegistration, feePerInputs, feePerOutputs);
@@ -223,7 +223,7 @@ namespace WalletWasabi.Services
 				}
 				else if (runningRoundCount == 1)
 				{
-					var round = new CcjRound(RpcClient, UtxoReferee, RoundConfig, confirmationTarget);
+					var round = new CcjRound(RpcClient, UtxoReferee, RoundConfig, confirmationTarget, RoundConfig.ConfirmationTarget.Value);
 					round.StatusChanged += Round_StatusChangedAsync;
 					round.CoinJoinBroadcasted += Round_CoinJoinBroadcasted;
 					await round.ExecuteNextPhaseAsync(CcjRoundPhase.InputRegistration, feePerInputs, feePerOutputs);
@@ -257,7 +257,7 @@ namespace WalletWasabi.Services
 				int confirmationTarget = RoundConfig.ConfirmationTarget.Value;
 				for (int i = 0; i < unconfirmedCoinJoinsCount; i++)
 				{
-					confirmationTarget /= 2;
+					confirmationTarget = (int)(confirmationTarget * 0.7);
 				}
 
 				confirmationTarget = Math.Max(confirmationTarget, 2); // Conf target should never be less than 2.


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/1155

# Motivation

- CoinJoin fees may be getting unbearable with the current mempool state: https://old.reddit.com/r/WasabiWallet/comments/bqy2sw/got_charged_000115_for_one_mix/
- We pay high fees when we have many unconfirmed transactions, even when only confirmed outputs are spent in a CJ. (https://github.com/zkSNACKs/WalletWasabi/issues/1155)

There are 2 changes here.

# Change 1: Multiply by 0.7

As described and implemented in issue https://github.com/zkSNACKs/WalletWasabi/issues/1155 we halvened coinjoin fee target based on the number of unconfirmed coinjoins. In this PR I multiply by 0.7 instead of halvening. This may be somewhat controversial in itself, but I believe change 2 justifies it.

# Change 2: Optimize CJ Fee Target

The problem with optimizing CJ fee target when a round is created is that we don't know if there'll be unconfirmed coin registered in the round or not. Thus we need to optimize the fee target at transaction building phase.  
Currently we have a fee optimization in case the fee for the fee target is lowered from the time of round creation to the final CJ propagation. In this case we split the final fee difference between the base denomination's active outputs.  
The optimization in this PR fits into this current optimization in a way that not only the final fee is optimized, but also the final fee target if no unconfirmed output is spent.  
In that case we don't use the higher adjusted feerate, but rather we default back to use the low feerate and passes this feerate to the original fee optimization algorithm.  

## Change 2, Note 1

I don't actually send RPC commands for every CJ outputs to check confirmation, rather send one RPC command (`getrawmempool`) that will tell us all the unconfirmed CJ txids. If there's intersection between our CJ and theirs then there's unconfirmed tx so we cannot default back.

## Change 2, Note 2

As I said change 2 also justifies change 1, because change 2 will result in high number of unconfirmed coinjoins those aren't built on each other. So normally the coordinator doesn't know this and would end up suggesting high fees all the time, even though it somewhat optimizes them out with change 2, we should lowball the fees more at the beginning, because change 2 is not an individual fee optimization, but rather a communist fee optimization. It doesn't take account who should pay how much, it splits the diff between the active outputs equally.  

# Side Effect

Another problem is that the base denomination is going down way too fast, sometimes resulting with overcharging (0.7% would be change sanity limit) and often resulting in toxic change (passes the 0.7% would be change sanity limit.) It'll help slow the rate of base denomination lowering.