### PR TITLE
Configureawait Everywhere In Library Project

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -292,7 +292,7 @@ namespace WalletWasabi.Gui.ViewModels
 		public StatusBarStatus Status
 		{
 			get => _status;
-			set => this.RaiseAndSetIfChanged(ref _status, value);
+			set => Dispatcher.UIThread.PostLogException(() => this.RaiseAndSetIfChanged(ref _status, value));
 		}
 
 		public string StatusText

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -292,7 +292,7 @@ namespace WalletWasabi.Gui.ViewModels
 		public StatusBarStatus Status
 		{
 			get => _status;
-			set => Dispatcher.UIThread.PostLogException(() => this.RaiseAndSetIfChanged(ref _status, value));
+			set => this.RaiseAndSetIfChanged(ref _status, value);
 		}
 
 		public string StatusText

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -103,8 +103,6 @@ namespace WalletWasabi.Gui.ViewModels
 					}
 				}
 			});
-
-			Status = StatusBarStatus.Loading;
 		}
 
 		public void Initialize(NodesCollection nodes, WasabiSynchronizer synchronizer, UpdateChecker updateChecker)
@@ -408,14 +406,17 @@ namespace WalletWasabi.Gui.ViewModels
 
 		private void SetCustomStatusOrReady()
 		{
-			if (StatusQueue.Any())
+			Dispatcher.UIThread.PostLogException(() =>
 			{
-				Status = StatusQueue.Last();
-			}
-			else
-			{
-				Status = StatusBarStatus.Ready;
-			}
+				if (StatusQueue.Any())
+				{
+					Status = StatusQueue.Last();
+				}
+				else
+				{
+					Status = StatusBarStatus.Ready;
+				}
+			});
 		}
 
 		private bool TrySetPriorityStatus()

--- a/WalletWasabi/Extensions/HttpContentExtensions.cs
+++ b/WalletWasabi/Extensions/HttpContentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
@@ -12,7 +12,7 @@ namespace System.Net.Http
 				return default;
 			}
 
-			var jsonString = await me.ReadAsStringAsync();
+			var jsonString = await me.ReadAsStringAsync().ConfigureAwait(false);
 			return JsonConvert.DeserializeObject<T>(jsonString);
 		}
 	}

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,18 +30,18 @@ namespace System.Net.Http
 			//					CRLF
 			//					[message - body]
 
-			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken);
+			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken).ConfigureAwait(false);
 
 			var requestLine = RequestLine.CreateNew(startLine);
 			var request = new HttpRequestMessage(requestLine.Method, requestLine.URI);
 
-			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken);
+			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken).ConfigureAwait(false);
 
 			var headerSection = HeaderSection.CreateNew(headers);
 			var headerStruct = headerSection.ToHttpRequestHeaders();
 
 			HttpMessageHelper.AssertValidHeaders(headerStruct.RequestHeaders, headerStruct.ContentHeaders);
-			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(requestStream, headerStruct, ctsToken);
+			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(requestStream, headerStruct, ctsToken).ConfigureAwait(false);
 			contentBytes = HttpMessageHelper.HandleGzipCompression(headerStruct.ContentHeaders, contentBytes);
 			request.Content = contentBytes is null ? null : new ByteArrayContent(contentBytes);
 
@@ -95,7 +95,7 @@ namespace System.Net.Http
 					headers += headerSection.ToString(endWithTwoCRLF: false);
 				}
 
-				messageBody = await me.Content.ReadAsStringAsync();
+				messageBody = await me.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}
 
 			return startLine + headers + CRLF + messageBody;
@@ -103,8 +103,7 @@ namespace System.Net.Http
 
 		public static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage me)
 		{
-			var newMessage = new HttpRequestMessage(me.Method, me.RequestUri)
-			{
+			var newMessage = new HttpRequestMessage(me.Method, me.RequestUri) {
 				Version = me.Version
 			};
 
@@ -119,7 +118,7 @@ namespace System.Net.Http
 			}
 
 			var ms = new MemoryStream();
-			await me.Content.CopyToAsync(ms);
+			await me.Content.CopyToAsync(ms).ConfigureAwait(false);
 			ms.Position = 0;
 			var newContent = new StreamContent(ms);
 

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -30,18 +30,18 @@ namespace System.Net.Http
 			//					CRLF
 			//					[message - body]
 
-			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream);
+			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream).ConfigureAwait(false);
 
 			var statusLine = StatusLine.CreateNew(startLine);
 			var response = new HttpResponseMessage(statusLine.StatusCode);
 
-			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream);
+			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream).ConfigureAwait(false);
 
 			var headerSection = HeaderSection.CreateNew(headers);
 			var headerStruct = headerSection.ToHttpResponseHeaders();
 
 			HttpMessageHelper.AssertValidHeaders(headerStruct.ResponseHeaders, headerStruct.ContentHeaders);
-			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(responseStream, headerStruct, requestMethod, statusLine);
+			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(responseStream, headerStruct, requestMethod, statusLine).ConfigureAwait(false);
 			contentBytes = HttpMessageHelper.HandleGzipCompression(headerStruct.ContentHeaders, contentBytes);
 			response.Content = contentBytes is null ? null : new ByteArrayContent(contentBytes);
 
@@ -55,7 +55,7 @@ namespace System.Net.Http
 
 		public static async Task<Stream> ToStreamAsync(this HttpResponseMessage me)
 		{
-			return new MemoryStream(Encoding.UTF8.GetBytes(await me.ToHttpStringAsync()));
+			return new MemoryStream(Encoding.UTF8.GetBytes(await me.ToHttpStringAsync().ConfigureAwait(false)));
 		}
 
 		public static async Task<string> ToHttpStringAsync(this HttpResponseMessage me)
@@ -78,7 +78,7 @@ namespace System.Net.Http
 					headers += headerSection.ToString(endWithTwoCRLF: false);
 				}
 
-				messageBody = await me.Content.ReadAsStringAsync();
+				messageBody = await me.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}
 
 			return startLine + headers + CRLF + messageBody;
@@ -86,7 +86,7 @@ namespace System.Net.Http
 
 		public static async Task ThrowRequestExceptionFromContentAsync(this HttpResponseMessage me)
 		{
-			var error = await me.Content.ReadAsJsonAsync<string>();
+			var error = await me.Content.ReadAsJsonAsync<string>().ConfigureAwait(false);
 			string errorMessage = error is null ? string.Empty : $"\n{error}";
 			throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}");
 		}

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -208,7 +208,7 @@ namespace NBitcoin
 
 		public static async Task StopAsync(this RPCClient rpc)
 		{
-			await rpc.SendCommandAsync("stop");
+			await rpc.SendCommandAsync("stop").ConfigureAwait(false);
 		}
 
 		public static SmartTransaction ExtractSmartTransaction(this PSBT psbt)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -19,7 +19,7 @@ namespace NBitcoin.RPC
 		/// <returns>Returns the current block on timeout or exit</returns>
 		public static async Task<(Height height, uint256 hash)> WaitForNewBlockAsync(this RPCClient rpc, long timeout = 0)
 		{
-			var resp = await rpc.SendCommandAsync("waitfornewblock", timeout);
+			var resp = await rpc.SendCommandAsync("waitfornewblock", timeout).ConfigureAwait(false);
 			return (int.Parse(resp.Result["height"].ToString()), uint256.Parse(resp.Result["hash"].ToString()));
 		}
 
@@ -31,7 +31,7 @@ namespace NBitcoin.RPC
 		/// <returns>Returns the current block on timeout or exit</returns>
 		public static async Task<(Height height, uint256 hash)> WaitForBlockAsync(this RPCClient rpc, uint256 blockhash, long timeout = 0)
 		{
-			var resp = await rpc.SendCommandAsync("waitforblock", blockhash, timeout);
+			var resp = await rpc.SendCommandAsync("waitforblock", blockhash, timeout).ConfigureAwait(false);
 			return (int.Parse(resp.Result["height"].ToString()), uint256.Parse(resp.Result["hash"].ToString()));
 		}
 
@@ -46,7 +46,7 @@ namespace NBitcoin.RPC
 			{
 				try
 				{
-					return await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode);
+					return await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode).ConfigureAwait(false);
 				}
 				catch (RPCException ex)
 				{
@@ -56,7 +56,7 @@ namespace NBitcoin.RPC
 					{
 						try
 						{
-							return await rpc.EstimateSmartFeeAsync(i, estimateMode);
+							return await rpc.EstimateSmartFeeAsync(i, estimateMode).ConfigureAwait(false);
 						}
 						catch (RPCException ex2)
 						{
@@ -79,7 +79,7 @@ namespace NBitcoin.RPC
 
 			if (tryOtherFeeRates)
 			{
-				EstimateSmartFeeResponse response = await rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode);
+				EstimateSmartFeeResponse response = await rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode).ConfigureAwait(false);
 				if (response != null)
 				{
 					return response;
@@ -89,7 +89,7 @@ namespace NBitcoin.RPC
 					// Hopefully Bitcoin Core brainfart: https://github.com/bitcoin/bitcoin/issues/14431
 					for (int i = 2; i <= 1008; i++)
 					{
-						response = await rpc.TryEstimateSmartFeeAsync(i, estimateMode);
+						response = await rpc.TryEstimateSmartFeeAsync(i, estimateMode).ConfigureAwait(false);
 						if (response != null)
 						{
 							return response;
@@ -99,7 +99,7 @@ namespace NBitcoin.RPC
 				// Let's try one more time, whatever.
 			}
 
-			return await rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode);
+			return await rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode).ConfigureAwait(false);
 		}
 
 		private static EstimateSmartFeeResponse SimulateRegTestFeeEstimation(int confirmationTarget, EstimateSmartFeeMode estimateMode)
@@ -122,7 +122,7 @@ namespace NBitcoin.RPC
 
 		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this RPCClient rpc, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false, bool tolerateBitcoinCoreBrainfuck = true)
 		{
-			var estimations = await rpc.EstimateHalfFeesAsync(new Dictionary<int, int>(), 2, 0, 1008, 0, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+			var estimations = await rpc.EstimateHalfFeesAsync(new Dictionary<int, int>(), 2, 0, 1008, 0, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck).ConfigureAwait(false);
 			var allFeeEstimate = new AllFeeEstimate(estimateMode, estimations);
 			return allFeeEstimate;
 		}
@@ -142,28 +142,28 @@ namespace NBitcoin.RPC
 
 			if (smallFee == 0)
 			{
-				var smallFeeResult = await rpc.EstimateSmartFeeAsync(smallTarget, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+				var smallFeeResult = await rpc.EstimateSmartFeeAsync(smallTarget, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck).ConfigureAwait(false);
 				smallFee = (int)Math.Ceiling(smallFeeResult.FeeRate.SatoshiPerByte);
 				newEstimations.TryAdd(smallTarget, smallFee);
 			}
 
 			if (largeFee == 0)
 			{
-				var largeFeeResult = await rpc.EstimateSmartFeeAsync(largeTarget, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+				var largeFeeResult = await rpc.EstimateSmartFeeAsync(largeTarget, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck).ConfigureAwait(false);
 				largeFee = (int)Math.Ceiling(largeFeeResult.FeeRate.SatoshiPerByte);
 				largeTarget = largeFeeResult.Blocks;
 				newEstimations.TryAdd(largeTarget, largeFee);
 			}
 
 			int halfTarget = (smallTarget + largeTarget) / 2;
-			var halfFeeResult = await rpc.EstimateSmartFeeAsync(halfTarget, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+			var halfFeeResult = await rpc.EstimateSmartFeeAsync(halfTarget, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck).ConfigureAwait(false);
 			int halfFee = (int)Math.Ceiling(halfFeeResult.FeeRate.SatoshiPerByte);
 			halfTarget = halfFeeResult.Blocks;
 			newEstimations.TryAdd(halfTarget, halfFee);
 
 			if (smallFee != halfFee)
 			{
-				var smallEstimations = await rpc.EstimateHalfFeesAsync(newEstimations, smallTarget, smallFee, halfTarget, halfFee, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+				var smallEstimations = await rpc.EstimateHalfFeesAsync(newEstimations, smallTarget, smallFee, halfTarget, halfFee, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck).ConfigureAwait(false);
 				foreach (var est in smallEstimations)
 				{
 					newEstimations.TryAdd(est.Key, est.Value);
@@ -171,7 +171,7 @@ namespace NBitcoin.RPC
 			}
 			if (largeFee != halfFee)
 			{
-				var largeEstimations = await rpc.EstimateHalfFeesAsync(newEstimations, halfTarget, halfFee, largeTarget, largeFee, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck);
+				var largeEstimations = await rpc.EstimateHalfFeesAsync(newEstimations, halfTarget, halfFee, largeTarget, largeFee, estimateMode, simulateIfRegTest, tolerateBitcoinCoreBrainfuck).ConfigureAwait(false);
 				foreach (var est in largeEstimations)
 				{
 					newEstimations.TryAdd(est.Key, est.Value);
@@ -190,7 +190,7 @@ namespace NBitcoin.RPC
 			fakeTransaction.Inputs.AddRange(coins.Select(coin => new TxIn(coin.Outpoint)));
 			Money fakeOutputValue = NBitcoinHelpers.TakeAReasonableFee(coins.Sum(coin => coin.TxOut.Value));
 			fakeTransaction.Outputs.Add(fakeOutputValue, new Key());
-			MempoolAcceptResult testMempoolAcceptResult = await rpc.TestMempoolAcceptAsync(fakeTransaction, allowHighFees: true);
+			MempoolAcceptResult testMempoolAcceptResult = await rpc.TestMempoolAcceptAsync(fakeTransaction, allowHighFees: true).ConfigureAwait(false);
 
 			if (!testMempoolAcceptResult.IsAllowed)
 			{
@@ -211,7 +211,7 @@ namespace NBitcoin.RPC
 		/// </summary>
 		public static async Task<IEnumerable<uint256>> GetUnconfirmedAsync(this RPCClient rpc, IEnumerable<uint256> transactionHashes)
 		{
-			uint256[] unconfirmedTransactionHashes = await rpc.GetRawMempoolAsync();
+			uint256[] unconfirmedTransactionHashes = await rpc.GetRawMempoolAsync().ConfigureAwait(false);
 			// If there are common elements, then there's unconfirmed.
 			return transactionHashes.Intersect(unconfirmedTransactionHashes);
 		}
@@ -228,7 +228,7 @@ namespace NBitcoin.RPC
 			IEnumerable<uint256> workingTxHashes;
 			if (likelyProvidedManyConfirmedOnes) // If confirmed txids are provided, then do a big check first.
 			{
-				workingTxHashes = await rpc.GetUnconfirmedAsync(transactionHashes);
+				workingTxHashes = await rpc.GetUnconfirmedAsync(transactionHashes).ConfigureAwait(false);
 			}
 			else
 			{
@@ -239,7 +239,7 @@ namespace NBitcoin.RPC
 			foreach (var txid in workingTxHashes)
 			{
 				// Go through all the txids provided and getmempoolentry to get the dependents and the confirmation status.
-				var entry = await rpc.GetMempoolEntryAsync(txid, throwIfNotFound: false);
+				var entry = await rpc.GetMempoolEntryAsync(txid, throwIfNotFound: false).ConfigureAwait(false);
 				if (entry != null)
 				{
 					// If we asked to include the provided transaction hashes into the result then check which ones are confirmed and do so.
@@ -250,7 +250,7 @@ namespace NBitcoin.RPC
 
 					// Get all the dependents of all the dependents except the ones we already know of.
 					var except = entry.Depends.Except(hashSet);
-					var dependentsOfDependents = await rpc.GetAllDependentsAsync(except, includingProvided: true, likelyProvidedManyConfirmedOnes: false);
+					var dependentsOfDependents = await rpc.GetAllDependentsAsync(except, includingProvided: true, likelyProvidedManyConfirmedOnes: false).ConfigureAwait(false);
 
 					// Add them to the hashset.
 					hashSet.UnionWith(dependentsOfDependents);

--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.IO
@@ -8,7 +8,7 @@ namespace System.IO
 		public static async Task<int> ReadByteAsync(this Stream stream, CancellationToken ctsToken = default)
 		{
 			var buf = new byte[1];
-			var len = await stream.ReadAsync(buf, 0, 1, ctsToken);
+			var len = await stream.ReadAsync(buf, 0, 1, ctsToken).ConfigureAwait(false);
 			if (len == 0)
 			{
 				return -1;
@@ -22,7 +22,7 @@ namespace System.IO
 			var left = count;
 			while (left != 0)
 			{
-				var read = await stream.ReadAsync(buffer, count - left, left, ctsToken);
+				var read = await stream.ReadAsync(buffer, count - left, left, ctsToken).ConfigureAwait(false);
 				left -= read;
 			}
 			return count - left;

--- a/WalletWasabi/Extensions/TaskExtensions.cs
+++ b/WalletWasabi/Extensions/TaskExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace System.Threading.Tasks
+namespace System.Threading.Tasks
 {
 	public static class TaskExtensions
 	{
@@ -16,7 +16,7 @@
 						s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
 			{
 				// If the task waited on is the cancellation token...
-				if (me != await Task.WhenAny(me, tcs.Task))
+				if (me != await Task.WhenAny(me, tcs.Task).ConfigureAwait(false))
 				{
 					if (waitForGracefulTermination <= 0)
 					{
@@ -26,14 +26,14 @@
 					{
 						using (var cts = new CancellationTokenSource(waitForGracefulTermination))
 						{
-							return await me.WithAwaitCancellationAsync(cts.Token);
+							return await me.WithAwaitCancellationAsync(cts.Token).ConfigureAwait(false);
 						}
 					}
 				}
 			}
 
 			// Wait for one or the other to complete.
-			return await me;
+			return await me.ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/Extensions/TorHttpClientExtensions.cs
+++ b/WalletWasabi/Extensions/TorHttpClientExtensions.cs
@@ -17,14 +17,14 @@ public static class TorHttpClientExtensions
 		{
 			response?.Dispose();
 			cancel.ThrowIfCancellationRequested();
-			response = await client.SendAsync(method, relativeUri, content, cancel: cancel);
+			response = await client.SendAsync(method, relativeUri, content, cancel: cancel).ConfigureAwait(false);
 			if (response.StatusCode == expectedCode)
 			{
 				break;
 			}
 			try
 			{
-				await Task.Delay(1000, cancel);
+				await Task.Delay(1000, cancel).ConfigureAwait(false);
 			}
 			catch (TaskCanceledException ex)
 			{

--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -29,7 +29,7 @@ namespace System.Net.Http
 			int read = 0;
 			while (read >= 0)
 			{
-				read = await stream.ReadByteAsync(ctsToken);
+				read = await stream.ReadByteAsync(ctsToken).ConfigureAwait(false);
 				bab.Append((byte)read);
 				if (Encoding.ASCII.GetBytes(LF)[0] == (byte)read)
 				{
@@ -54,7 +54,7 @@ namespace System.Net.Http
 			builder.Append(headers);
 			while (true)
 			{
-				string header = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken);
+				string header = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken).ConfigureAwait(false);
 
 				if (header is null)
 				{
@@ -99,7 +99,7 @@ namespace System.Net.Http
 			var bab = new ByteArrayBuilder();
 			while (true)
 			{
-				int ch = await stream.ReadByteAsync(ctsToken);
+				int ch = await stream.ReadByteAsync(ctsToken).ConfigureAwait(false);
 				if (ch == -1)
 				{
 					break;
@@ -107,7 +107,7 @@ namespace System.Net.Http
 
 				if (ch == '\r')
 				{
-					var ch2 = await stream.ReadByteAsync(ctsToken);
+					var ch2 = await stream.ReadByteAsync(ctsToken).ConfigureAwait(false);
 					if (ch2 == '\n')
 					{
 						return bab.ToString(encoding);
@@ -161,7 +161,7 @@ namespace System.Net.Http
 				// All transfer-coding names are case-insensitive
 				if ("chunked".Equals(headerStruct.RequestHeaders.TransferEncoding.Last().Value, StringComparison.OrdinalIgnoreCase))
 				{
-					return await GetDecodedChunkedContentBytesAsync(stream, headerStruct, ctsToken);
+					return await GetDecodedChunkedContentBytesAsync(stream, headerStruct, ctsToken).ConfigureAwait(false);
 				}
 				// https://tools.ietf.org/html/rfc7230#section-3.3.3
 				// If a Transfer - Encoding header field is present in a response and
@@ -172,7 +172,7 @@ namespace System.Net.Http
 				// the final encoding, the message body length cannot be determined
 				// reliably; the server MUST respond with the 400(Bad Request)
 				// status code and then close the connection.
-				return await GetBytesTillEndAsync(stream, ctsToken);
+				return await GetBytesTillEndAsync(stream, ctsToken).ConfigureAwait(false);
 			}
 			// https://tools.ietf.org/html/rfc7230#section-3.3.3
 			// 5.If a valid Content - Length header field is present without
@@ -184,7 +184,7 @@ namespace System.Net.Http
 			if (headerStruct.ContentHeaders.Contains("Content-Length"))
 			{
 				long? contentLength = headerStruct.ContentHeaders?.ContentLength;
-				return await ReadBytesTillLengthAsync(stream, contentLength, ctsToken);
+				return await ReadBytesTillLengthAsync(stream, contentLength, ctsToken).ConfigureAwait(false);
 			}
 
 			// https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -239,7 +239,7 @@ namespace System.Net.Http
 				// All transfer-coding names are case-insensitive
 				if ("chunked".Equals(headerStruct.ResponseHeaders.TransferEncoding.Last().Value, StringComparison.OrdinalIgnoreCase))
 				{
-					return await GetDecodedChunkedContentBytesAsync(stream, headerStruct, ctsToken);
+					return await GetDecodedChunkedContentBytesAsync(stream, headerStruct, ctsToken).ConfigureAwait(false);
 				}
 				// https://tools.ietf.org/html/rfc7230#section-3.3.3
 				// If a Transfer - Encoding header field is present in a response and
@@ -250,7 +250,7 @@ namespace System.Net.Http
 				// the final encoding, the message body length cannot be determined
 				// reliably; the server MUST respond with the 400(Bad Request)
 				// status code and then close the connection.
-				return await GetBytesTillEndAsync(stream, ctsToken);
+				return await GetBytesTillEndAsync(stream, ctsToken).ConfigureAwait(false);
 			}
 			// https://tools.ietf.org/html/rfc7230#section-3.3.3
 			// 5.If a valid Content - Length header field is present without
@@ -263,7 +263,7 @@ namespace System.Net.Http
 			{
 				long? contentLength = headerStruct.ContentHeaders?.ContentLength;
 
-				return await ReadBytesTillLengthAsync(stream, contentLength, ctsToken);
+				return await ReadBytesTillLengthAsync(stream, contentLength, ctsToken).ConfigureAwait(false);
 			}
 
 			// https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -273,17 +273,17 @@ namespace System.Net.Http
 			// body length, so the message body length is determined by the
 			// number of octets received prior to the server closing the
 			// connection.
-			return await GetBytesTillEndAsync(stream, ctsToken);
+			return await GetBytesTillEndAsync(stream, ctsToken).ConfigureAwait(false);
 		}
 
 		private static async Task<byte[]> GetDecodedChunkedContentBytesAsync(Stream stream, HttpRequestContentHeaders headerStruct, CancellationToken ctsToken = default)
 		{
-			return await GetDecodedChunkedContentBytesAsync(stream, headerStruct, null, ctsToken);
+			return await GetDecodedChunkedContentBytesAsync(stream, headerStruct, null, ctsToken).ConfigureAwait(false);
 		}
 
 		private static async Task<byte[]> GetDecodedChunkedContentBytesAsync(Stream stream, HttpResponseContentHeaders headerStruct, CancellationToken ctsToken = default)
 		{
-			return await GetDecodedChunkedContentBytesAsync(stream, null, headerStruct, ctsToken);
+			return await GetDecodedChunkedContentBytesAsync(stream, null, headerStruct, ctsToken).ConfigureAwait(false);
 		}
 
 		private static async Task<byte[]> GetDecodedChunkedContentBytesAsync(Stream stream, HttpRequestContentHeaders requestHeaders, HttpResponseContentHeaders responseHeaders, CancellationToken ctsToken = default)
@@ -321,7 +321,7 @@ namespace System.Net.Http
 			// Remove "chunked" from Transfer-Encoding
 			// Remove Trailer from existing header fields
 			long length = 0;
-			var firstChunkLine = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken: ctsToken);
+			var firstChunkLine = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken: ctsToken).ConfigureAwait(false);
 			ParseFistChunkLine(firstChunkLine, out long chunkSize, out _);
 			// We will not do anything with the chunk extensions, because:
 			// https://tools.ietf.org/html/rfc7230#section-4.1.1
@@ -334,8 +334,8 @@ namespace System.Net.Http
 			// by a trailer, and finally terminated by an empty line.
 			while (chunkSize > 0)
 			{
-				var chunkData = await ReadBytesTillLengthAsync(stream, chunkSize, ctsToken);
-				if (await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken) != "")
+				var chunkData = await ReadBytesTillLengthAsync(stream, chunkSize, ctsToken).ConfigureAwait(false);
+				if (await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken).ConfigureAwait(false) != "")
 				{
 					throw new FormatException("Chunk does not end with CRLF.");
 				}
@@ -344,7 +344,7 @@ namespace System.Net.Http
 
 				length += chunkSize;
 
-				firstChunkLine = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken: ctsToken);
+				firstChunkLine = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken: ctsToken).ConfigureAwait(false);
 				ParseFistChunkLine(firstChunkLine, out long cs, out _);
 				chunkSize = cs;
 			}
@@ -353,7 +353,7 @@ namespace System.Net.Http
 			// A trailer allows the sender to include additional fields at the end
 			// of a chunked message in order to supply metadata that might be
 			// dynamically generated while the message body is sent
-			string trailerHeaders = await ReadHeadersAsync(stream, ctsToken);
+			string trailerHeaders = await ReadHeadersAsync(stream, ctsToken).ConfigureAwait(false);
 			var trailerHeaderSection = HeaderSection.CreateNew(trailerHeaders);
 			RemoveInvalidTrailers(trailerHeaderSection);
 			if (responseHeaders != null)
@@ -463,7 +463,7 @@ namespace System.Net.Http
 			var bab = new ByteArrayBuilder();
 			while (true)
 			{
-				int read = await stream.ReadByteAsync(ctsToken);
+				int read = await stream.ReadByteAsync(ctsToken).ConfigureAwait(false);
 				if (read == -1)
 				{
 					return bab.ToArray();
@@ -487,7 +487,7 @@ namespace System.Net.Http
 			}
 
 			var allData = new byte[(int)length];
-			var num = await stream.ReadBlockAsync(allData, (int)length, ctsToken);
+			var num = await stream.ReadBlockAsync(allData, (int)length, ctsToken).ConfigureAwait(false);
 			if (num < (int)length)
 			{
 				// https://tools.ietf.org/html/rfc7230#section-3.3.3

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -40,7 +40,7 @@ namespace System.IO
 					Logger.LogDebug($"Gnomes prevent deletion of {destinationDir}! Applying magic dust, attempt #{gnomes}.", nameof(IoHelpers));
 
 					// see http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true for more magic
-					await Task.Delay(100);
+					await Task.Delay(100).ConfigureAwait(false);
 					continue;
 				}
 				catch (UnauthorizedAccessException)
@@ -53,7 +53,7 @@ namespace System.IO
 					Logger.LogDebug($"Gnomes prevent deletion of {destinationDir}! Applying magic dust, attempt #{gnomes}.", nameof(IoHelpers));
 
 					// see http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true for more magic
-					await Task.Delay(100);
+					await Task.Delay(100).ConfigureAwait(false);
 					continue;
 				}
 				return;
@@ -69,7 +69,7 @@ namespace System.IO
 			}
 			catch (UnauthorizedAccessException)
 			{
-				await Task.Delay(100);
+				await Task.Delay(100).ConfigureAwait(false);
 				ZipFile.ExtractToDirectory(src, dest);
 			}
 		}

--- a/WalletWasabi/Helpers/RuntimeParams.cs
+++ b/WalletWasabi/Helpers/RuntimeParams.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Nito.AsyncEx;
 using System;
 using System.IO;
@@ -53,7 +53,7 @@ namespace WalletWasabi.Helpers
 		{
 			try
 			{
-				using (await AsyncLock.LockAsync())
+				using (await AsyncLock.LockAsync().ConfigureAwait(false))
 				{
 					if (!Directory.Exists(FileDir))
 					{
@@ -63,7 +63,7 @@ namespace WalletWasabi.Helpers
 					string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
 					await File.WriteAllTextAsync(FilePath,
 					jsonString,
-					Encoding.UTF8);
+					Encoding.UTF8).ConfigureAwait(false);
 				}
 			}
 			catch (Exception ex)
@@ -79,10 +79,10 @@ namespace WalletWasabi.Helpers
 				if (!File.Exists(FilePath))
 				{
 					var file = new RuntimeParams();
-					await file.SaveAsync();
+					await file.SaveAsync().ConfigureAwait(false);
 				}
 
-				string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+				string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8).ConfigureAwait(false);
 				InternalInstance = JsonConvert.DeserializeObject<RuntimeParams>(jsonString);
 				return;
 			}

--- a/WalletWasabi/Hwi/HwiProcessManager.cs
+++ b/WalletWasabi/Hwi/HwiProcessManager.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Hwi
 			JToken jtok = null;
 			using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
 			{
-				jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" promptpin", cts.Token);
+				jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" promptpin", cts.Token).ConfigureAwait(false);
 			}
 			JObject json = jtok as JObject;
 			var success = json.Value<bool>("success");
@@ -45,7 +45,7 @@ namespace WalletWasabi.Hwi
 			JToken jtok = null;
 			using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
 			{
-				jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" sendpin {pin}", cts.Token);
+				jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" sendpin {pin}", cts.Token).ConfigureAwait(false);
 			}
 			JObject json = jtok as JObject;
 			var success = json.Value<bool>("success");
@@ -58,7 +58,7 @@ namespace WalletWasabi.Hwi
 			JToken jtok = null;
 			using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
 			{
-				jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" --interactive setup", cts.Token);
+				jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" --interactive setup", cts.Token).ConfigureAwait(false);
 			}
 			JObject json = jtok as JObject;
 			var success = json.Value<bool>("success");
@@ -74,7 +74,7 @@ namespace WalletWasabi.Hwi
 				JToken jtok = null;
 				using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
 				{
-					jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" signtx {psbtString}", cts.Token, isMutexPriority: true);
+					jtok = await SendCommandAsync($"{networkString} --device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" signtx {psbtString}", cts.Token, isMutexPriority: true).ConfigureAwait(false);
 				}
 				JObject json = jtok as JObject;
 				var signedPsbtString = json.Value<string>("psbt");
@@ -110,7 +110,7 @@ namespace WalletWasabi.Hwi
 			JToken jtok = null;
 			using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
 			{
-				jtok = await SendCommandAsync($"{networkString}--device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" getxpub m/84h/0h/0h", cts.Token);
+				jtok = await SendCommandAsync($"{networkString}--device-type \"{hardwareWalletInfo.Type.ToString().ToLowerInvariant()}\" --device-path \"{hardwareWalletInfo.Path}\" getxpub m/84h/0h/0h", cts.Token).ConfigureAwait(false);
 			}
 			JObject json = jtok as JObject;
 			string xpub = json.Value<string>("xpub");
@@ -125,7 +125,7 @@ namespace WalletWasabi.Hwi
 			JToken jtok = null;
 			using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
 			{
-				jtok = await SendCommandAsync("enumerate", cts.Token);
+				jtok = await SendCommandAsync("enumerate", cts.Token).ConfigureAwait(false);
 			}
 			JArray jarr = jtok as JArray;
 			var hwis = new List<HardwareWalletInfo>();
@@ -161,7 +161,7 @@ namespace WalletWasabi.Hwi
 			{
 				var rand = Random.Next(1, 100);
 				var delay = isMutexPriority ? (100 + rand) : (1000 + rand);
-				using (await AsyncMutex.LockAsync(cancellationToken, delay)) // It could be even improved more if this Mutex would also look at which hardware wallet the operation is going towards (enumerate sends to all.)
+				using (await AsyncMutex.LockAsync(cancellationToken, delay).ConfigureAwait(false)) // It could be even improved more if this Mutex would also look at which hardware wallet the operation is going towards (enumerate sends to all.)
 				{
 					if (!File.Exists(HwiPath))
 					{
@@ -187,7 +187,7 @@ namespace WalletWasabi.Hwi
 							throw new IOException($"Command: {command} exited with exit code: {process.ExitCode}, instead of 0.");
 						}
 
-						string response = await process.StandardOutput.ReadToEndAsync();
+						string response = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
 						var jToken = JToken.Parse(response);
 						if (jToken is JObject json)
 						{
@@ -234,7 +234,7 @@ namespace WalletWasabi.Hwi
 			if (!File.Exists(hwiPath))
 			{
 				Logger.LogInfo($"HWI instance NOT found at {hwiPath}. Attempting to acquire it...", nameof(HwiProcessManager));
-				await InstallHwiAsync(fullBaseDirectory, hwiDir);
+				await InstallHwiAsync(fullBaseDirectory, hwiDir).ConfigureAwait(false);
 			}
 			else if (!IoHelpers.CheckExpectedHash(hwiPath, Path.Combine(fullBaseDirectory, "Hwi", "Software")))
 			{
@@ -247,7 +247,7 @@ namespace WalletWasabi.Hwi
 				}
 				Directory.Move(hwiDir, backupHwiDir);
 
-				await InstallHwiAsync(fullBaseDirectory, hwiDir);
+				await InstallHwiAsync(fullBaseDirectory, hwiDir).ConfigureAwait(false);
 			}
 			else
 			{
@@ -267,13 +267,13 @@ namespace WalletWasabi.Hwi
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 			{
 				string hwiLinuxZip = Path.Combine(hwiSoftwareDir, "hwi-linux64.zip");
-				await IoHelpers.BetterExtractZipToDirectoryAsync(hwiLinuxZip, hwiDir);
+				await IoHelpers.BetterExtractZipToDirectoryAsync(hwiLinuxZip, hwiDir).ConfigureAwait(false);
 				Logger.LogInfo($"Extracted {hwiLinuxZip} to {hwiDir}.", nameof(HwiProcessManager));
 			}
 			else // OSX
 			{
 				string hwiOsxZip = Path.Combine(hwiSoftwareDir, "hwi-osx64.zip");
-				await IoHelpers.BetterExtractZipToDirectoryAsync(hwiOsxZip, hwiDir);
+				await IoHelpers.BetterExtractZipToDirectoryAsync(hwiOsxZip, hwiDir).ConfigureAwait(false);
 				Logger.LogInfo($"Extracted {hwiOsxZip} to {hwiDir}.", nameof(HwiProcessManager));
 			}
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundConfig.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRoundConfig.cs
@@ -92,7 +92,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
 			await File.WriteAllTextAsync(FilePath,
 			jsonString,
-			Encoding.UTF8);
+			Encoding.UTF8).ConfigureAwait(false);
 		}
 
 		/// <inheritdoc />
@@ -120,13 +120,13 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			}
 			else
 			{
-				string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+				string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8).ConfigureAwait(false);
 				var config = JsonConvert.DeserializeObject<CcjRoundConfig>(jsonString);
 
 				UpdateOrDefault(config);
 			}
 
-			await ToFileAsync();
+			await ToFileAsync().ConfigureAwait(false);
 		}
 
 		public void UpdateOrDefault(CcjRoundConfig config)
@@ -156,7 +156,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				throw new FileNotFoundException($"{nameof(CcjRoundConfig)} file did not exist at path: `{FilePath}`.");
 			}
 
-			string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+			string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8).ConfigureAwait(false);
 			var config = JsonConvert.DeserializeObject<CcjRoundConfig>(jsonString);
 
 			if (Denomination != config.Denomination)

--- a/WalletWasabi/Mono/CommandSet.cs
+++ b/WalletWasabi/Mono/CommandSet.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Options.cs
 //
 // Authors:
@@ -448,7 +448,7 @@ namespace Mono.Options
 			{
 				if (ShowHelp)
 				{
-					return await Help.InvokeAsync(extra);
+					return await Help.InvokeAsync(extra).ConfigureAwait(false);
 				}
 				if (arguments.All(x => !x.Contains("version")))
 				{
@@ -467,12 +467,12 @@ namespace Mono.Options
 				if (command.Options?.Contains("help") ?? true)
 				{
 					extra.Add("--help");
-					return await command.InvokeAsync(extra);
+					return await command.InvokeAsync(extra).ConfigureAwait(false);
 				}
 				command.Options.WriteOptionDescriptions(Out);
 				return 0;
 			}
-			return await command.InvokeAsync(extra);
+			return await command.InvokeAsync(extra).ConfigureAwait(false);
 		}
 
 		public Command GetCommand(List<string> extra)

--- a/WalletWasabi/Mono/HelpCommand.cs
+++ b/WalletWasabi/Mono/HelpCommand.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Options.cs
 //
 // Authors:
@@ -208,7 +208,7 @@ namespace Mono.Options
 				command.Options.WriteOptionDescriptions(CommandSet.Out);
 				return 0;
 			}
-			return await command.InvokeAsync(new[] { "--help" });
+			return await command.InvokeAsync(new[] { "--help" }).ConfigureAwait(false);
 		}
 
 		private List<KeyValuePair<string, Command>> GetCommands()

--- a/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
@@ -36,9 +36,9 @@ namespace Nito.AsyncEx
 	/// private readonly AsyncLock _mutex = new AsyncLock();
 	/// public async Task DoStuffAsync()
 	/// {
-	///     using (await _mutex.LockAsync())
+	///     using (await _mutex.LockAsync().ConfigureAwait(false))
 	///     {
-	///         await Task.Delay(TimeSpan.FromSeconds(1));
+	///         await Task.Delay(TimeSpan.FromSeconds(1).ConfigureAwait(false));
 	///     }
 	/// }
 	/// </code>

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -290,7 +290,7 @@ namespace Nito.AsyncEx
 				try
 				{
 					// Create the mutex and acquire it.
-					await SetCommandAsync(1, cancellationToken, pollInterval).ConfigureAwait(false);;
+					await SetCommandAsync(1, cancellationToken, pollInterval).ConfigureAwait(false);
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -202,7 +202,7 @@ namespace Nito.AsyncEx
 			while (!Done.WaitOne(1))
 			{
 				// Waiting for Done asynchronously.
-				await Task.Delay(pollInterval, cancellationToken);
+				await Task.Delay(pollInterval, cancellationToken).ConfigureAwait(false);
 			}
 			lock (LatestHoldLockExceptionLock)
 			{
@@ -234,7 +234,7 @@ namespace Nito.AsyncEx
 			try
 			{
 				// Local lock for thread safety.
-				await AsyncLock.LockAsync(cancellationToken);
+				await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false);
 
 				if (MutexThread?.IsAlive == true)
 				{
@@ -248,7 +248,7 @@ namespace Nito.AsyncEx
 				MutexThread.Start(cancellationToken);
 
 				// Create the mutex and acquire it.
-				await SetCommandAsync(1, cancellationToken, pollInterval);
+				await SetCommandAsync(1, cancellationToken, pollInterval).ConfigureAwait(false);
 
 				return new Key(this);
 			}

--- a/WalletWasabi/Services/ConfigWatcher.cs
+++ b/WalletWasabi/Services/ConfigWatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
@@ -42,13 +42,16 @@ namespace WalletWasabi.Services
 					{
 						try
 						{
-							await Task.Delay(period, Stop.Token);
+							await Task.Delay(period, Stop.Token).ConfigureAwait(false);
 
-							if (await Config.CheckFileChangeAsync())
+							if (await Config.CheckFileChangeAsync().ConfigureAwait(false))
 							{
-								await Config.LoadOrCreateDefaultFileAsync();
+								await Config.LoadOrCreateDefaultFileAsync().ConfigureAwait(false);
 
-								await executeWhenChangedAsync?.Invoke();
+								if (executeWhenChangedAsync != null)
+								{
+									await executeWhenChangedAsync.Invoke().ConfigureAwait(false);
+								}
 							}
 						}
 						catch (TaskCanceledException ex)
@@ -74,7 +77,7 @@ namespace WalletWasabi.Services
 			Stop?.Cancel();
 			while (IsStopping)
 			{
-				await Task.Delay(50);
+				await Task.Delay(50).ConfigureAwait(false);
 			}
 			Stop?.Dispose();
 		}

--- a/WalletWasabi/Services/MemPoolBehavior.cs
+++ b/WalletWasabi/Services/MemPoolBehavior.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.Protocol.Behaviors;
 using System;
@@ -37,7 +37,7 @@ namespace WalletWasabi.Services
 			{
 				if (message.Message.Payload is GetDataPayload getDataPayload)
 				{
-					await ProcessGetDataAsync(node, getDataPayload);
+					await ProcessGetDataAsync(node, getDataPayload).ConfigureAwait(false);
 					return;
 				}
 
@@ -49,7 +49,7 @@ namespace WalletWasabi.Services
 
 				if (message.Message.Payload is InvPayload invPayload)
 				{
-					await ProcessInvAsync(node, invPayload);
+					await ProcessInvAsync(node, invPayload).ConfigureAwait(false);
 					return;
 				}
 			}
@@ -90,7 +90,7 @@ namespace WalletWasabi.Services
 						}
 						else
 						{
-							await node.SendMessageAsync(txPayload);
+							await node.SendMessageAsync(txPayload).ConfigureAwait(false);
 							entry.MakeBroadcasted();
 							Logger.LogInfo<MemPoolBehavior>($"Successfully served transaction to node ({node.RemoteSocketEndpoint}): {entry.TransactionId}.");
 						}
@@ -143,7 +143,7 @@ namespace WalletWasabi.Services
 			if (getDataPayload.Inventory.Any() && node.IsConnected)
 			{
 				// ask for the whole transaction
-				await node.SendMessageAsync(getDataPayload);
+				await node.SendMessageAsync(getDataPayload).ConfigureAwait(false);
 			}
 		}
 

--- a/WalletWasabi/Services/MemPoolService.cs
+++ b/WalletWasabi/Services/MemPoolService.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Protocol;
 using System;
 using System.Collections.Generic;
@@ -119,7 +119,7 @@ namespace WalletWasabi.Services
 				using (var client = new WasabiClient(destAction, torSocks))
 				{
 					var compactness = 10;
-					var allMempoolHashes = await client.GetMempoolHashesAsync(compactness);
+					var allMempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
 
 					var toRemove = TransactionHashes.Where(x => !allMempoolHashes.Any(y => y == x.ToString().Substring(0, compactness)));
 					foreach (uint256 tx in toRemove)
@@ -177,7 +177,7 @@ namespace WalletWasabi.Services
 					}
 
 					Logger.LogInfo<MemPoolService>($"Not all nodes were in a connected state. Delaying mempool cleanup for {delay.TotalSeconds} seconds...");
-					await Task.Delay(delay, cancel);
+					await Task.Delay(delay, cancel).ConfigureAwait(false);
 				}
 
 				Logger.LogInfo<MemPoolService>("Start cleaning out mempool...");

--- a/WalletWasabi/Services/TrustedNodeNotifyingBehavior.cs
+++ b/WalletWasabi/Services/TrustedNodeNotifyingBehavior.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.Protocol.Behaviors;
 using System;
@@ -57,7 +57,7 @@ namespace WalletWasabi.Services
 					if (payload.Inventory.Any() && node.IsConnected)
 					{
 						// ask for the whole transaction
-						await node.SendMessageAsync(payload);
+						await node.SendMessageAsync(payload).ConfigureAwait(false);
 					}
 				}
 				else if (message.Message.Payload is TxPayload txPayload)

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Exceptions;
@@ -40,26 +40,26 @@ namespace WalletWasabi.Services
 					{
 						try
 						{
-							(bool backendCompatible, bool clientUpToDate) updates = await WasabiClient.CheckUpdatesAsync(Stop.Token);
+							(bool backendCompatible, bool clientUpToDate) updates = await WasabiClient.CheckUpdatesAsync(Stop.Token).ConfigureAwait(false);
 
-							if (!updates.backendCompatible)
+							if (!updates.backendCompatible && executeIfBackendIncompatible != null)
 							{
-								await executeIfBackendIncompatible?.Invoke();
+								await executeIfBackendIncompatible.Invoke().ConfigureAwait(false);
 							}
 
-							if (!updates.clientUpToDate)
+							if (!updates.clientUpToDate && executeIfClientOutOfDate != null)
 							{
-								await executeIfClientOutOfDate?.Invoke();
+								await executeIfClientOutOfDate.Invoke().ConfigureAwait(false);
 							}
 
-							await Task.Delay(period, Stop.Token);
+							await Task.Delay(period, Stop.Token).ConfigureAwait(false);
 						}
 						catch (ConnectionException ex)
 						{
 							Logger.LogError<UpdateChecker>(ex);
 							try
 							{
-								await Task.Delay(period, Stop.Token); // Give other threads time to do stuff, update check is not crucial.
+								await Task.Delay(period, Stop.Token).ConfigureAwait(false); // Give other threads time to do stuff, update check is not crucial.
 							}
 							catch (TaskCanceledException ex2)
 							{

--- a/WalletWasabi/Services/UtxoReferee.cs
+++ b/WalletWasabi/Services/UtxoReferee.cs
@@ -145,11 +145,11 @@ namespace WalletWasabi.Services
 			if (updated) // If at any time we set updated then we must update the whole thing.
 			{
 				var allLines = BannedUtxos.Select(x => $"{x.Value.TimeOfBan.ToString(CultureInfo.InvariantCulture)}:{x.Value.Severity}:{x.Key.N}:{x.Key.Hash}:{x.Value.IsNoted}:{x.Value.BannedForRound}");
-				await File.WriteAllLinesAsync(BannedUtxosFilePath, allLines);
+				await File.WriteAllLinesAsync(BannedUtxosFilePath, allLines).ConfigureAwait(false);
 			}
 			else if (lines.Count != 0) // If we don't have to update the whole thing, we must check if we added a line and so only append.
 			{
-				await File.AppendAllLinesAsync(BannedUtxosFilePath, lines);
+				await File.AppendAllLinesAsync(BannedUtxosFilePath, lines).ConfigureAwait(false);
 			}
 		}
 
@@ -158,7 +158,7 @@ namespace WalletWasabi.Services
 			if (BannedUtxos.TryRemove(output, out _))
 			{
 				IEnumerable<string> lines = BannedUtxos.Select(x => x.ToString());
-				await File.WriteAllLinesAsync(BannedUtxosFilePath, lines);
+				await File.WriteAllLinesAsync(BannedUtxosFilePath, lines).ConfigureAwait(false);
 				Logger.LogInfo<UtxoReferee>($"UTXO unbanned: {output.N}:{output.Hash}.");
 			}
 		}
@@ -189,7 +189,7 @@ namespace WalletWasabi.Services
 				}
 				else
 				{
-					await UnbanAsync(outpoint);
+					await UnbanAsync(outpoint).ConfigureAwait(false);
 				}
 			}
 			return null;

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -180,7 +180,7 @@ namespace WalletWasabi.Services
 						{
 							while (AreRequestsBlocked())
 							{
-								await Task.Delay(3000, Cancel.Token);
+								await Task.Delay(3000, Cancel.Token).ConfigureAwait(false);
 							}
 
 							EstimateSmartFeeMode? estimateMode = null;
@@ -198,7 +198,7 @@ namespace WalletWasabi.Services
 									return;
 								}
 
-								response = await WasabiClient.GetSynchronizeAsync(BitcoinStore.HashChain.TipHash, maxFiltersToSyncAtInitialization, estimateMode, Cancel.Token).WithAwaitCancellationAsync(Cancel.Token, 300);
+								response = await WasabiClient.GetSynchronizeAsync(BitcoinStore.HashChain.TipHash, maxFiltersToSyncAtInitialization, estimateMode, Cancel.Token).WithAwaitCancellationAsync(Cancel.Token, 300).ConfigureAwait(false);
 								// NOT GenSocksServErr
 								BackendStatus = BackendStatus.Connected;
 								TorStatus = TorStatus.Running;
@@ -252,7 +252,7 @@ namespace WalletWasabi.Services
 							{
 								var filters = response.Filters;
 
-								await BitcoinStore.IndexStore.AddNewFiltersAsync(filters, Cancel.Token);
+								await BitcoinStore.IndexStore.AddNewFiltersAsync(filters, Cancel.Token).ConfigureAwait(false);
 
 								if (filters.Count() == 1)
 								{
@@ -267,7 +267,7 @@ namespace WalletWasabi.Services
 							{
 								// Reorg happened
 								// 1. Rollback index
-								FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token);
+								FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token).ConfigureAwait(false);
 								Logger.LogInfo<WasabiSynchronizer>($"REORG Invalid Block: {reorgedFilter.BlockHash}");
 
 								ignoreRequestInterval = true;
@@ -285,7 +285,7 @@ namespace WalletWasabi.Services
 							Logger.LogError<CcjClient>(ex);
 							try
 							{
-								await Task.Delay(3000, Cancel.Token); // Give other threads time to do stuff.
+								await Task.Delay(3000, Cancel.Token).ConfigureAwait(false); // Give other threads time to do stuff.
 							}
 							catch (TaskCanceledException ex2)
 							{
@@ -309,7 +309,7 @@ namespace WalletWasabi.Services
 								try
 								{
 									int delay = (int)Math.Min(requestInterval.TotalMilliseconds, MaxRequestIntervalForMixing.TotalMilliseconds);
-									await Task.Delay(delay, Cancel.Token); // Ask for new index in every requestInterval.
+									await Task.Delay(delay, Cancel.Token).ConfigureAwait(false); // Ask for new index in every requestInterval.
 								}
 								catch (TaskCanceledException ex)
 								{

--- a/WalletWasabi/Stores/BitcoinStore.cs
+++ b/WalletWasabi/Stores/BitcoinStore.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.Stores
 			IndexStore = new IndexStore();
 			var indexStoreFolderPath = Path.Combine(WorkFolderPath, Network.ToString());
 			HashChain = new HashChain();
-			await IndexStore.InitializeAsync(indexStoreFolderPath, Network, HashChain);
+			await IndexStore.InitializeAsync(indexStoreFolderPath, Network, HashChain).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/Stores/IoManager.cs
+++ b/WalletWasabi/Stores/IoManager.cs
@@ -181,7 +181,7 @@ namespace WalletWasabi.Stores
 				ContinueBuildHash(byteArrayBuilder, line);
 			}
 
-			var res = await WorkWithHashAsync(byteArrayBuilder, cancellationToken);
+			var res = await WorkWithHashAsync(byteArrayBuilder, cancellationToken).ConfigureAwait(false);
 			if (res.same)
 			{
 				return;
@@ -189,9 +189,9 @@ namespace WalletWasabi.Stores
 
 			IoHelpers.EnsureContainingDirectoryExists(NewFilePath);
 
-			await File.WriteAllLinesAsync(NewFilePath, lines, cancellationToken);
+			await File.WriteAllLinesAsync(NewFilePath, lines, cancellationToken).ConfigureAwait(false);
 			SafeMoveNewToOriginal();
-			await WriteOutHashAsync(res.hash);
+			await WriteOutHashAsync(res.hash).ConfigureAwait(false);
 		}
 
 		private async Task<(bool same, byte[] hash)> WorkWithHashAsync(ByteArrayBuilder byteArrayBuilder, CancellationToken cancellationToken)
@@ -203,7 +203,7 @@ namespace WalletWasabi.Stores
 				hash = HashHelpers.GenerateSha256Hash(bytes);
 				if (File.Exists(DigestFilePath))
 				{
-					var digest = await File.ReadAllBytesAsync(DigestFilePath, cancellationToken);
+					var digest = await File.ReadAllBytesAsync(DigestFilePath, cancellationToken).ConfigureAwait(false);
 					if (ByteHelpers.CompareFastUnsafe(hash, digest))
 					{
 						if (File.Exists(NewFilePath))
@@ -229,7 +229,7 @@ namespace WalletWasabi.Stores
 			{
 				IoHelpers.EnsureContainingDirectoryExists(DigestFilePath);
 
-				await File.WriteAllBytesAsync(DigestFilePath, hash);
+				await File.WriteAllBytesAsync(DigestFilePath, hash).ConfigureAwait(false);
 			}
 			catch (Exception ex)
 			{
@@ -266,7 +266,7 @@ namespace WalletWasabi.Stores
 				// 1. First copy.
 				while (!sr.EndOfStream)
 				{
-					var line = await sr.ReadLineAsync();
+					var line = await sr.ReadLineAsync().ConfigureAwait(false);
 
 					if (linesArray[linesIndex] == line) // If the line is a line we want to write, then we know that someone else have worked into the file.
 					{
@@ -274,12 +274,12 @@ namespace WalletWasabi.Stores
 						continue;
 					}
 
-					await sw.WriteLineAsync(line);
+					await sw.WriteLineAsync(line).ConfigureAwait(false);
 
 					lineCounter++;
 					if (lineCounter > 1000)
 					{
-						await sw.FlushAsync();
+						await sw.FlushAsync().ConfigureAwait(false);
 						lineCounter = 0;
 					}
 
@@ -291,24 +291,24 @@ namespace WalletWasabi.Stores
 				// 2. Then append.
 				foreach (var line in lines)
 				{
-					await sw.WriteLineAsync(line);
+					await sw.WriteLineAsync(line).ConfigureAwait(false);
 
 					ContinueBuildHash(byteArrayBuilder, line);
 
 					cancellationToken.ThrowIfCancellationRequested();
 				}
 
-				await sw.FlushAsync();
+				await sw.FlushAsync().ConfigureAwait(false);
 			}
 
-			var res = await WorkWithHashAsync(byteArrayBuilder, cancellationToken);
+			var res = await WorkWithHashAsync(byteArrayBuilder, cancellationToken).ConfigureAwait(false);
 			if (res.same)
 			{
 				return;
 			}
 
 			SafeMoveNewToOriginal();
-			await WriteOutHashAsync(res.hash);
+			await WriteOutHashAsync(res.hash).ConfigureAwait(false);
 		}
 
 		public async Task<string[]> ReadAllLinesAsync(CancellationToken cancellationToken = default)
@@ -318,7 +318,7 @@ namespace WalletWasabi.Stores
 			{
 				filePath = safestFilePath;
 			}
-			return await File.ReadAllLinesAsync(filePath, cancellationToken);
+			return await File.ReadAllLinesAsync(filePath, cancellationToken).ConfigureAwait(false);
 		}
 
 		public StreamReader OpenText(int bufferSize)

--- a/WalletWasabi/TorSocks5/TorHttpClient.cs
+++ b/WalletWasabi/TorSocks5/TorHttpClient.cs
@@ -95,11 +95,11 @@ namespace WalletWasabi.TorSocks5
 
 			try
 			{
-				using (await AsyncLock.LockAsync(cancel))
+				using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
 				{
 					try
 					{
-						HttpResponseMessage ret = await SendAsync(request);
+						HttpResponseMessage ret = await SendAsync(request).ConfigureAwait(false);
 						TorDoesntWorkSince = null;
 						return ret;
 					}
@@ -113,7 +113,7 @@ namespace WalletWasabi.TorSocks5
 						cancel.ThrowIfCancellationRequested();
 						try
 						{
-							HttpResponseMessage ret2 = await SendAsync(request);
+							HttpResponseMessage ret2 = await SendAsync(request).ConfigureAwait(false);
 							TorDoesntWorkSince = null;
 							return ret2;
 						}
@@ -127,7 +127,7 @@ namespace WalletWasabi.TorSocks5
 
 							try
 							{
-								await Task.Delay(1000, cancel);
+								await Task.Delay(1000, cancel).ConfigureAwait(false);
 							}
 							catch (TaskCanceledException tce)
 							{
@@ -141,7 +141,7 @@ namespace WalletWasabi.TorSocks5
 
 						cancel.ThrowIfCancellationRequested();
 
-						HttpResponseMessage ret3 = await SendAsync(request);
+						HttpResponseMessage ret3 = await SendAsync(request).ConfigureAwait(false);
 						TorDoesntWorkSince = null;
 						return ret3;
 					}
@@ -194,9 +194,9 @@ namespace WalletWasabi.TorSocks5
 			if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
 			{
 				TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
-				await TorSocks5Client.ConnectAsync();
-				await TorSocks5Client.HandshakeAsync(IsolateStream);
-				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port);
+				await TorSocks5Client.ConnectAsync().ConfigureAwait(false);
+				await TorSocks5Client.HandshakeAsync(IsolateStream).ConfigureAwait(false);
+				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port).ConfigureAwait(false);
 
 				Stream stream = TorSocks5Client.TcpClient.GetStream();
 				if (request.RequestUri.Scheme == "https")
@@ -226,7 +226,7 @@ namespace WalletWasabi.TorSocks5
 							host,
 							new X509CertificateCollection(),
 							SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
-							checkCertificateRevocation: true);
+							checkCertificateRevocation: true).ConfigureAwait(false);
 					stream = sslStream;
 				}
 
@@ -256,21 +256,21 @@ namespace WalletWasabi.TorSocks5
 					{
 						if (request.Content.Headers.ContentLength is null)
 						{
-							request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync()).Length;
+							request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync().ConfigureAwait(false)).Length;
 						}
 					}
 				}
 			}
 
-			var requestString = await request.ToHttpStringAsync();
+			var requestString = await request.ToHttpStringAsync().ConfigureAwait(false);
 
 			var bytes = Encoding.UTF8.GetBytes(requestString);
 
-			await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length);
-			await TorSocks5Client.Stream.FlushAsync();
+			await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+			await TorSocks5Client.Stream.FlushAsync().ConfigureAwait(false);
 			using (var httpResponseMessage = new HttpResponseMessage())
 			{
-				return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method);
+				return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method).ConfigureAwait(false);
 			}
 		}
 

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -121,8 +121,7 @@ namespace WalletWasabi.TorSocks5
 
 						if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 						{
-							TorProcess = Process.Start(new ProcessStartInfo
-							{
+							TorProcess = Process.Start(new ProcessStartInfo {
 								FileName = torPath,
 								Arguments = torArguments,
 								UseShellExecute = false,
@@ -203,8 +202,8 @@ namespace WalletWasabi.TorSocks5
 			{
 				try
 				{
-					await client.ConnectAsync();
-					await client.HandshakeAsync();
+					await client.ConnectAsync().ConfigureAwait(false);
+					await client.HandshakeAsync().ConfigureAwait(false);
 				}
 				catch (ConnectionException)
 				{
@@ -225,8 +224,8 @@ namespace WalletWasabi.TorSocks5
 			{
 				try
 				{
-					await client.ConnectAsync();
-					await client.HandshakeAsync();
+					await client.ConnectAsync().ConfigureAwait(false);
+					await client.HandshakeAsync().ConfigureAwait(false);
 				}
 				catch (ConnectionException)
 				{
@@ -282,7 +281,7 @@ namespace WalletWasabi.TorSocks5
 											using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
 											{
 												var message = new HttpRequestMessage(HttpMethod.Get, fallBackTestRequestUri);
-												await client.SendAsync(message, Stop.Token);
+												await client.SendAsync(message, Stop.Token).ConfigureAwait(false);
 											}
 
 											// Check if it changed in the meantime...

--- a/WalletWasabi/WebClients/BlockCypher/BlockCypherClient.cs
+++ b/WalletWasabi/WebClients/BlockCypher/BlockCypherClient.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using Newtonsoft.Json;
 using Nito.AsyncEx;
 using System;
@@ -44,16 +44,16 @@ namespace WalletWasabi.WebClients.BlockCypher
 
 		public async Task<BlockCypherGeneralInformation> GetGeneralInformationAsync(CancellationToken cancel)
 		{
-			using (await AsyncLock.LockAsync())
+			using (await AsyncLock.LockAsync().ConfigureAwait(false))
 			using (HttpResponseMessage response =
-					 await HttpClient.GetAsync("", HttpCompletionOption.ResponseContentRead, cancel))
+					 await HttpClient.GetAsync("", HttpCompletionOption.ResponseContentRead, cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
 					throw new HttpRequestException(response.StatusCode.ToString());
 				}
 
-				string jsonString = await response.Content.ReadAsStringAsync();
+				string jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 				return JsonConvert.DeserializeObject<BlockCypherGeneralInformation>(jsonString);
 			}
 		}

--- a/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -26,8 +26,8 @@ namespace WalletWasabi.WebClients.BlockchainInfo
 			using (var httpClient = new HttpClient())
 			{
 				httpClient.BaseAddress = new Uri("https://blockchain.info");
-				var response = await httpClient.GetAsync("/ticker");
-				var rates = await response.Content.ReadAsJsonAsync<BlockchainInfoExchangeRates>();
+				var response = await httpClient.GetAsync("/ticker").ConfigureAwait(false);
+				var rates = await response.Content.ReadAsJsonAsync<BlockchainInfoExchangeRates>().ConfigureAwait(false);
 
 				var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -29,8 +29,8 @@ namespace WalletWasabi.WebClients.Coinbase
 			using (var httpClient = new HttpClient())
 			{
 				httpClient.BaseAddress = new Uri("https://api.coinbase.com");
-				var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC");
-				var wrapper = await response.Content.ReadAsJsonAsync<DataWrapper>();
+				var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC").ConfigureAwait(false);
+				var wrapper = await response.Content.ReadAsJsonAsync<DataWrapper>().ConfigureAwait(false);
 
 				var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.WebClients
 			{
 				try
 				{
-					exchangeRates = await provider.GetExchangeRateAsync();
+					exchangeRates = await provider.GetExchangeRateAsync().ConfigureAwait(false);
 					break;
 				}
 				catch (Exception ex)

--- a/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -19,8 +19,8 @@ namespace WalletWasabi.WebClients.Gemini
 			using (var httpClient = new HttpClient())
 			{
 				httpClient.BaseAddress = new Uri("https://api.gemini.com");
-				var response = await httpClient.GetAsync("/v1/pubticker/btcusd");
-				var data = await response.Content.ReadAsJsonAsync<GeminiExchangeRateInfo>();
+				var response = await httpClient.GetAsync("/v1/pubticker/btcusd").ConfigureAwait(false);
+				var data = await response.Content.ReadAsJsonAsync<GeminiExchangeRateInfo>().ConfigureAwait(false);
 
 				var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -19,8 +19,8 @@ namespace WalletWasabi.WebClients.ItBit
 			using (var httpClient = new HttpClient())
 			{
 				httpClient.BaseAddress = new Uri("https://api.itbit.com");
-				var response = await httpClient.GetAsync("v1/markets/XBTUSD/ticker");
-				var data = await response.Content.ReadAsJsonAsync<ItBitExchangeRateInfo>();
+				var response = await httpClient.GetAsync("v1/markets/XBTUSD/ticker").ConfigureAwait(false);
+				var data = await response.Content.ReadAsJsonAsync<ItBitExchangeRateInfo>().ConfigureAwait(false);
 
 				var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/SmartBit/SmartBitClient.cs
+++ b/WalletWasabi/WebClients/SmartBit/SmartBitClient.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Nito.AsyncEx;
@@ -47,7 +47,7 @@ namespace WalletWasabi.WebClients.SmartBit
 
 		public async Task PushTransactionAsync(Transaction transaction, CancellationToken cancel)
 		{
-			using (await AsyncLock.LockAsync(cancel))
+			using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
 			{
 				var content = new StringContent(
 					new JObject(new JProperty("hex", transaction.ToHex())).ToString(),
@@ -55,30 +55,30 @@ namespace WalletWasabi.WebClients.SmartBit
 					"application/json");
 
 				HttpResponseMessage response =
-						await HttpClient.PostAsync("blockchain/pushtx", content, cancel);
+						await HttpClient.PostAsync("blockchain/pushtx", content, cancel).ConfigureAwait(false);
 
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
 					throw new HttpRequestException(response.StatusCode.ToString());
 				}
 
-				string responseString = await response.Content.ReadAsStringAsync();
+				string responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 				AssertSuccess(responseString);
 			}
 		}
 
 		public async Task<IEnumerable<SmartBitExchangeRate>> GetExchangeRatesAsync(CancellationToken cancel)
 		{
-			using (await AsyncLock.LockAsync(cancel))
+			using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
 			using (HttpResponseMessage response =
-					await HttpClient.GetAsync("exchange-rates", HttpCompletionOption.ResponseContentRead, cancel))
+					await HttpClient.GetAsync("exchange-rates", HttpCompletionOption.ResponseContentRead, cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
 					throw new HttpRequestException(response.StatusCode.ToString());
 				}
 
-				string responseString = await response.Content.ReadAsStringAsync();
+				string responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 				AssertSuccess(responseString);
 
 				var exchangeRates = JObject.Parse(responseString).Value<JArray>("exchange_rates");

--- a/WalletWasabi/WebClients/SmartBit/SmartBitExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/SmartBit/SmartBitExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +18,7 @@ namespace WalletWasabi.WebClients.SmartBit
 
 		public async Task<List<ExchangeRate>> GetExchangeRateAsync()
 		{
-			var rates = await Client.GetExchangeRatesAsync(CancellationToken.None);
+			var rates = await Client.GetExchangeRatesAsync(CancellationToken.None).ConfigureAwait(false);
 			var rate = rates.Single(x => x.Code == "USD");
 
 			var exchangeRates = new List<ExchangeRate>

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Crypto;
 using Newtonsoft.Json;
@@ -59,7 +59,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 			Uri baseUri,
 			IPEndPoint torSocks5EndPoint)
 		{
-			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, () => baseUri, torSocks5EndPoint);
+			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, () => baseUri, torSocks5EndPoint).ConfigureAwait(false);
 		}
 
 		public static async Task<AliceClient> CreateNewAsync(long roundId,
@@ -86,14 +86,14 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 						throw new NotSupportedException($"InputRequest roundId doesn't match to the provided roundId: {request.RoundId} != {roundId}.");
 					}
 				}
-				using (HttpResponseMessage response = await client.TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()))
+				using (HttpResponseMessage response = await client.TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()).ConfigureAwait(false))
 				{
 					if (response.StatusCode != HttpStatusCode.OK)
 					{
-						await response.ThrowRequestExceptionFromContentAsync();
+						await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 					}
 
-					var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>();
+					var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>().ConfigureAwait(false);
 
 					if (inputsResponse.RoundId != roundId) // This should never happen. If it does, that's a bug in the coordinator.
 					{
@@ -125,7 +125,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 			Uri baseUri,
 			IPEndPoint torSocks5EndPoint)
 		{
-			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, changeOutput, blindedOutputScriptHashes, inputs, () => baseUri, torSocks5EndPoint);
+			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, changeOutput, blindedOutputScriptHashes, inputs, () => baseUri, torSocks5EndPoint).ConfigureAwait(false);
 		}
 
 		public static async Task<AliceClient> CreateNewAsync(long roundId,
@@ -139,26 +139,25 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 			Func<Uri> baseUriAction,
 			IPEndPoint torSocks5EndPoint)
 		{
-			var request = new InputsRequest
-			{
+			var request = new InputsRequest {
 				RoundId = roundId,
 				BlindedOutputScripts = blindedOutputScriptHashes,
 				ChangeOutputAddress = changeOutput,
 				Inputs = inputs
 			};
-			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, baseUriAction, torSocks5EndPoint);
+			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, baseUriAction, torSocks5EndPoint).ConfigureAwait(false);
 		}
 
 		public async Task<(CcjRoundPhase currentPhase, IEnumerable<(BitcoinAddress output, UnblindedSignature signature, int level)> activeOutputs)> PostConfirmationAsync()
 		{
-			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/confirmation?uniqueId={UniqueId}&roundId={RoundId}"))
+			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/confirmation?uniqueId={UniqueId}&roundId={RoundId}").ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
-				ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>();
+				ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>().ConfigureAwait(false);
 				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
 
 				var activeOutputs = new List<(BitcoinAddress output, UnblindedSignature signature, int level)>();
@@ -203,11 +202,11 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 			{
 				try
 				{
-					using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/unconfirmation?uniqueId={UniqueId}&roundId={RoundId}", cancel: cts.Token))
+					using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/unconfirmation?uniqueId={UniqueId}&roundId={RoundId}", cancel: cts.Token).ConfigureAwait(false))
 					{
 						if (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Gone) // Otherwise maybe some internet connection issue there's. Let's consider that as timed out.
 						{
-							await response.ThrowRequestExceptionFromContentAsync();
+							await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 						}
 					}
 				}
@@ -231,14 +230,14 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 
 		public async Task<Transaction> GetUnsignedCoinJoinAsync()
 		{
-			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/coinjoin?uniqueId={UniqueId}&roundId={RoundId}"))
+			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/coinjoin?uniqueId={UniqueId}&roundId={RoundId}").ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
-				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
+				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>().ConfigureAwait(false);
 
 				Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
 				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
@@ -253,11 +252,11 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 			var jsonSignatures = JsonConvert.SerializeObject(myDic, Formatting.None);
 			var signatureRequestContent = new StringContent(jsonSignatures, Encoding.UTF8, "application/json");
 
-			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/signatures?uniqueId={UniqueId}&roundId={RoundId}", signatureRequestContent))
+			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/signatures?uniqueId={UniqueId}&roundId={RoundId}", signatureRequestContent).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.NoContent)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
 			}

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/BobClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/BobClient.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Crypto;
 using System;
 using System.Net;
@@ -31,7 +31,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 			Guard.MinimumAndNotNull(nameof(level), level, 0);
 
 			var request = new OutputRequest { OutputAddress = activeOutputAddress, UnblindedSignature = unblindedSignature, Level = level };
-			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Constants.BackendMajorVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()))
+			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Constants.BackendMajorVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()).ConfigureAwait(false))
 			{
 				if (response.StatusCode == HttpStatusCode.Conflict)
 				{
@@ -39,7 +39,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 				}
 				else if (response.StatusCode != HttpStatusCode.NoContent)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				return true;

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/SatoshiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/SatoshiClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -24,14 +24,14 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 
 		public async Task<IEnumerable<CcjRunningRoundState>> GetAllRoundStatesAsync()
 		{
-			using (var response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/states/"))
+			using (var response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/states/").ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
-				var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();
+				var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>().ConfigureAwait(false);
 
 				return states;
 			}
@@ -39,13 +39,13 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 
 		public async Task<CcjRunningRoundState> GetRoundStateAsync(long roundId)
 		{
-			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
+			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync().ConfigureAwait(false);
 			return states.Single(x => x.RoundId == roundId);
 		}
 
 		public async Task<CcjRunningRoundState> GetRegistrableRoundStateAsync()
 		{
-			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
+			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync().ConfigureAwait(false);
 			return states.First(x => x.Phase == CcjRoundPhase.InputRegistration);
 		}
 	}

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
@@ -43,16 +43,16 @@ namespace WalletWasabi.WebClients.Wasabi
 			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
 																	HttpStatusCode.OK,
 																	relativeUri,
-																	cancel: cancel))
+																	cancel: cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var ret = await content.ReadAsJsonAsync<SynchronizeResponse>();
+					var ret = await content.ReadAsJsonAsync<SynchronizeResponse>().ConfigureAwait(false);
 					return ret;
 				}
 			}
@@ -70,7 +70,7 @@ namespace WalletWasabi.WebClients.Wasabi
 			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
 																	HttpStatusCode.OK,
 																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
-																	cancel: cancel))
+																	cancel: cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode == HttpStatusCode.NoContent)
 				{
@@ -78,12 +78,12 @@ namespace WalletWasabi.WebClients.Wasabi
 				}
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var ret = await content.ReadAsJsonAsync<FiltersResponse>();
+					var ret = await content.ReadAsJsonAsync<FiltersResponse>().ConfigureAwait(false);
 					return ret;
 				}
 			}
@@ -93,16 +93,16 @@ namespace WalletWasabi.WebClients.Wasabi
 		{
 			var confirmationTargetsString = string.Join(",", confirmationTargets);
 
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/fees/{confirmationTargetsString}"))
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/fees/{confirmationTargetsString}").ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>();
+					var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>().ConfigureAwait(false);
 					return ret;
 				}
 			}
@@ -111,23 +111,23 @@ namespace WalletWasabi.WebClients.Wasabi
 		public async Task BroadcastAsync(string hex)
 		{
 			using (var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json"))
-			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/broadcast", content))
+			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/broadcast", content).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 			}
 		}
 
 		public async Task BroadcastAsync(Transaction transaction)
 		{
-			await BroadcastAsync(transaction.ToHex());
+			await BroadcastAsync(transaction.ToHex()).ConfigureAwait(false);
 		}
 
 		public async Task BroadcastAsync(SmartTransaction transaction)
 		{
-			await BroadcastAsync(transaction.Transaction);
+			await BroadcastAsync(transaction.Transaction).ConfigureAwait(false);
 		}
 
 		public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
@@ -135,16 +135,16 @@ namespace WalletWasabi.WebClients.Wasabi
 			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
 																	HttpStatusCode.OK,
 																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
-																	cancel: cancel))
+																	cancel: cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
+					var strings = await content.ReadAsJsonAsync<IEnumerable<string>>().ConfigureAwait(false);
 					var ret = strings.Select(x => new uint256(x));
 					return ret;
 				}
@@ -160,16 +160,16 @@ namespace WalletWasabi.WebClients.Wasabi
 			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
 																	HttpStatusCode.OK,
 																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
-																	cancel: cancel))
+																	cancel: cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
+					var strings = await content.ReadAsJsonAsync<IEnumerable<string>>().ConfigureAwait(false);
 					return strings;
 				}
 			}
@@ -181,16 +181,16 @@ namespace WalletWasabi.WebClients.Wasabi
 
 		public async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync()
 		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/offchain/exchange-rates"))
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/offchain/exchange-rates").ConfigureAwait(false))
 			{
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var ret = await content.ReadAsJsonAsync<IEnumerable<ExchangeRate>>();
+					var ret = await content.ReadAsJsonAsync<IEnumerable<ExchangeRate>>().ConfigureAwait(false);
 					return ret;
 				}
 			}
@@ -202,7 +202,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 		public async Task<(Version ClientVersion, int BackendMajorVersion)> GetVersionsAsync(CancellationToken cancel)
 		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, "/api/software/versions", cancel: cancel))
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, "/api/software/versions", cancel: cancel).ConfigureAwait(false))
 			{
 				if (response.StatusCode == HttpStatusCode.NotFound)
 				{
@@ -212,12 +212,12 @@ namespace WalletWasabi.WebClients.Wasabi
 
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync();
+					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
 				}
 
 				using (HttpContent content = response.Content)
 				{
-					var resp = await content.ReadAsJsonAsync<VersionsResponse>();
+					var resp = await content.ReadAsJsonAsync<VersionsResponse>().ConfigureAwait(false);
 					return (Version.Parse(resp.ClientVersion), int.Parse(resp.BackenMajordVersion));
 				}
 			}
@@ -225,7 +225,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 		public async Task<(bool backendCompatible, bool clientUpToDate)> CheckUpdatesAsync(CancellationToken cancel)
 		{
-			var versions = await GetVersionsAsync(cancel);
+			var versions = await GetVersionsAsync(cancel).ConfigureAwait(false);
 			var clientUpToDate = Helpers.Constants.ClientVersion >= versions.ClientVersion; // If the client version locally is greater or equal to the backend's reported client version, then good.
 			var backendCompatible = int.Parse(Helpers.Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major equals, then our softwares are compatible.
 


### PR DESCRIPTION
This PR is not for merging. I'm just curious how the software would behave if we'd ConfigureAwait(false) everywhere in the library project.  

The old recommendation was to ConfigureAwait(false) everywhere in libraries, but I didn't follow, because I've read in the new .NET Core it doesn't matter anymore. Well, turns out I was wrong, it's not the new .NET Core, but the new ASP.NET Core. In our test projects, in our console projects and in our GUI projects it still matters.  

At the very least we can be assured even if we'd decide to do this, this'd not have any affect on the server side.

Anyway, I'm just curious how would for example the CI behave by configure awaiting in the library project (WalletWasabi.WalletWasabi project.)