### PR TITLE
[WIP] Ideas to close hanging AsyncMutexes (do not merge)

### DIFF
--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -86,6 +86,19 @@ namespace WalletWasabi.Gui
 					Global.ChaumianClient.IsQuitPending = true; // indicate -> do not add any more alices to the coinjoin
 				}
 
+				foreach (var mut in Nito.AsyncEx.AsyncMutex.AsyncMutexes)
+				{
+					mut.Value.IsDisposed = true;
+				}
+
+				bool end = false;
+				do
+				{
+					end = !Nito.AsyncEx.AsyncMutex.AsyncMutexes.Where(x => x.Value.IsLocked).Any();
+					await Task.Delay(10);
+				}
+				while (!end);
+
 				if (!MainWindowViewModel.Instance.CanClose)
 				{
 					var dialog = new CannotCloseDialogViewModel();

--- a/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerViewModel.cs
@@ -95,9 +95,15 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 			Dispatcher.UIThread.PostLogException(async () =>
 			{
-				await RefreshHardwareWalletListAsync();
-				HardwareWalletRefreshCancel?.Dispose();
-				HardwareWalletRefreshCancel = null;
+				try
+				{
+					await RefreshHardwareWalletListAsync();
+					HardwareWalletRefreshCancel?.Dispose();
+					HardwareWalletRefreshCancel = null;
+				}
+				catch (Exception)
+				{
+				}
 			});
 		}
 

--- a/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Dialogs;
 using AvalonStudio.Shell;

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -59,7 +59,7 @@ namespace WalletWasabi.Logging
 			SetModes(LogMode.Console, LogMode.File);
 
 #else
-			SetMinimumLevel(LogLevel.Debug);
+			SetMinimumLevel(LogLevel.Trace);
 			SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
 #endif
 		}

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -121,8 +121,7 @@ namespace WalletWasabi.TorSocks5
 
 						if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 						{
-							TorProcess = Process.Start(new ProcessStartInfo
-							{
+							TorProcess = Process.Start(new ProcessStartInfo {
 								FileName = torPath,
 								Arguments = torArguments,
 								UseShellExecute = false,


### PR DESCRIPTION
It working like this now: tasks on the UI thread is just killed silently when the application closes. Until now this wasn't a problem. But now we have the AsyncMutex class with async using blocks. If the underlying thread (UiThread) killed during, the await inside these blocks cannot resume the context and task killed there silently - without calling the dispose at the end of the using block. So the AsyncMutex thread will run and the application cannot close.

In this PR I tried a few solutions which are very dirty but now I am just curious if it solves anything or not.

So the main point is wait for the AsyncMutex to be released before we close the UI thread.

Resources:
https://stackoverflow.com/questions/44032931/net-core-finally-block-not-called-on-unhandled-exception-on-linux
https://github.com/dotnet/coreclr/issues/11695