### PR TITLE
Bugfix: Fix focus on NoparaPasswordBox that selects text instead of navigating to next field

### DIFF
--- a/WalletWasabi.Gui/Controls/NoparaPasswordBox.xaml
+++ b/WalletWasabi.Gui/Controls/NoparaPasswordBox.xaml
@@ -30,7 +30,7 @@
               </TextBlock.IsVisible>
             </TextBlock>
 
-            <Button Name="PART_MaskedButton" DockPanel.Dock="Right" Padding="5 0 5 0" Margin="0" Background="Transparent" BorderThickness="0" ToolTip.Tip="Show password.">
+            <Button Name="PART_MaskedButton" Focusable="False" DockPanel.Dock="Right" Padding="5 0 5 0" Margin="0" Background="Transparent" BorderThickness="0" ToolTip.Tip="Show password.">
               <Grid Height="15" Width="15">
                 <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center">
                   <DrawingPresenter.Drawing>


### PR DESCRIPTION
Fixes #1430.

Background: The small button that is used to show the password is focusable but when it gets the focus for some reason the whole text is selected.
Quick fix is to not give the "Show password" button the focus.
If this button should be usable when navigating the forms with the keyboard, then a more elaborate fix needs to be implemented.