### PR TITLE
Elevate mingaplimit at recovery

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -196,7 +196,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			ValidationMessage = null;
 			ShowAdvancedOptions = false;
 			AccountKeyPath = $"m/{KeyManager.DefaultAccountKeyPath}";
-			MinGapLimit = KeyManager.AbsoluteMinGapLimit;
+			MinGapLimit = KeyManager.AbsoluteMinGapLimit * 3;
 		}
 
 		private void UpdateSuggestions(string words)


### PR DESCRIPTION
We had many recovery issues lately. In this PR I propose to elevate the MinGapLimit at recovery. @lontivero @guggero thoughts?

Turns out the last issue (incorrect balance) with the Mac Stability was that the user was trying to work with recovered wallet, not with the original wallet file. https://github.com/zkSNACKs/WalletWasabi/issues/1404

Other recent issue regarding this: https://github.com/zkSNACKs/WalletWasabi/issues/1470