### PR TITLE
Load AddressManager asynchronously

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -1,5 +1,6 @@
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
This gains 500ms in startup time, since the address manager loading happens now in parallel with other tasks.

The main takeaway here is that I copied Nicolas's NBitcoin code and changed 2 stream read operation from Read to ReadAsync.