### PR TITLE
Obsolate warning removal from console.

### DIFF
--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.KeyManagement
 
 		public bool HasLabel { get; private set; }
 
-		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => PubKey.GetAddress(network);
+		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetAddress(ScriptPubKeyType.Legacy, network);
 
 		public BitcoinWitPubKeyAddress GetP2wpkhAddress(Network network) => PubKey.GetSegwitAddress(network);
 

--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.KeyManagement
 
 		public bool HasLabel { get; private set; }
 
-		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetAddress(ScriptPubKeyType.Legacy, network);;
+		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetAddress(ScriptPubKeyType.Legacy, network);
 
 		public BitcoinWitPubKeyAddress GetP2wpkhAddress(Network network) => PubKey.GetSegwitAddress(network);
 

--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.KeyManagement
 
 		public bool HasLabel { get; private set; }
 
-		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetSegwitAddress(network);
+		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetAddress(ScriptPubKeyType.Legacy, network);;
 
 		public BitcoinWitPubKeyAddress GetP2wpkhAddress(Network network) => PubKey.GetSegwitAddress(network);
 

--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.KeyManagement
 
 		public bool HasLabel { get; private set; }
 
-		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetAddress(ScriptPubKeyType.Legacy, network);
+		public BitcoinPubKeyAddress GetP2pkhAddress(Network network) => (BitcoinPubKeyAddress)PubKey.GetSegwitAddress(network);
 
 		public BitcoinWitPubKeyAddress GetP2wpkhAddress(Network network) => PubKey.GetSegwitAddress(network);
 


### PR DESCRIPTION
I got this on console.
```
PS C:\WORK\WalletWasabi\WalletWasabi.Gui> dotnet run
KeyManagement\HdPubKey.cs(111,67): warning CS0618: 'PubKey.GetAddress(Network)' is obsolete: 'Use GetAddress(ScriptPubKeyType.Legacy, network) instead' [C:\WORK\WalletWasabi\WalletWasabi\WalletWasabi.csproj]
2019-06-03 14:42:47 INFO 3b5e1cd5-edad-4fc3-8df1-f46766993b18: Wasabi GUI is starting...
2019-06-03 14:42:50 INFO Config: Config is successfully initialized.
```
Function only used in tests, runs fine after the fix.