### PR TITLE
Hide Log message on console when --version

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -627,14 +627,17 @@ namespace WalletWasabi.Gui
 					Logger.LogInfo($"{nameof(TorManager)} is stopped.", nameof(Global));
 				}
 
-				try
+				if (AsyncMutex.IsAny)
 				{
-					await AsyncMutex.WaitForAllMutexToCloseAsync();
-					Logger.LogInfo($"{nameof(AsyncMutex)}(es) are stopped.", nameof(Global));
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError($"Error during stopping {nameof(AsyncMutex)}: {ex}", nameof(Global));
+					try
+					{
+						await AsyncMutex.WaitForAllMutexToCloseAsync();
+						Logger.LogInfo($"{nameof(AsyncMutex)}(es) are stopped.", nameof(Global));
+					}
+					catch (Exception ex)
+					{
+						Logger.LogError($"Error during stopping {nameof(AsyncMutex)}: {ex}", nameof(Global));
+					}
 				}
 			}
 			catch (Exception ex)

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -61,6 +61,14 @@ namespace Nito.AsyncEx
 
 		private static object AsyncMutexesLock { get; } = new object();
 
+		public static bool IsAny
+		{
+			get
+			{
+				return AsyncMutexes.Any();
+			}
+		}
+
 		public AsyncMutex(string name)
 		{
 			// https://docs.microsoft.com/en-us/dotnet/api/system.threading.mutex?view=netframework-4.8

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -61,13 +61,7 @@ namespace Nito.AsyncEx
 
 		private static object AsyncMutexesLock { get; } = new object();
 
-		public static bool IsAny
-		{
-			get
-			{
-				return AsyncMutexes.Any();
-			}
-		}
+		public static bool IsAny => AsyncMutexes.Any();
 
 		public AsyncMutex(string name)
 		{


### PR DESCRIPTION
fixes: https://github.com/zkSNACKs/WalletWasabi/issues/1519

We have `Logger.TurnOff()` which completely disable logging. Instead of that I prefer checking if there any mutex to release and if not then there is no log message on console.
Why? 

1. I want to keep the logging system on in any case of error there.
2. At `Global.DisposeAsync()` we are doing the same with Managers so better do something similar -> Only execute dispose/close/release if required else no Log message. 