### PR TITLE
Add more client side checks

### DIFF
--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -358,7 +358,8 @@ namespace WalletWasabi.Services
 				var mineCount = myOutputs.Count(x => x.Value == denomPair.value);
 
 				Money denomination = denomPair.value;
-				Money expectedCoordinatorFee = denomination.Percentage(ongoingRound.State.CoordinatorFeePercent * denomPair.count);
+				int anonset = Math.Min(110, denomPair.count); // https://github.com/zkSNACKs/WalletWasabi/issues/1379
+				Money expectedCoordinatorFee = denomination.Percentage(ongoingRound.State.CoordinatorFeePercent * anonset);
 				for (int i = 0; i < mineCount; i++)
 				{
 					minAmountBack -= expectedCoordinatorFee; // Minus expected coordinator fee.


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/1379

The quickfix suggested by @NicolasDorier for issue https://github.com/zkSNACKs/WalletWasabi/issues/1379 to upper cap the peer limit and check that on the client side.

Such client side limitations can be problematic in the future and it's clear this is not the best way to go about it, yet I wonder if there're any downsides doing this anyway. We won't be able to go over 100 peers like ever. There are just so many practical issues (IsStandard, Tor, too-long-mempool-chain) with this.  

Note I did 110 instead of 100 to give some wiggle room.