### PR TITLE
Remove reliance on "ZeroLink" special label

### DIFF
--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
@@ -73,12 +73,9 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			{
 				foreach (TxoRef txo in txos)
 				{
-					if (WaitingList.Keys.Any(x => x.GetTxoRef() == txo))
-					{
-						return true;
-					}
-
-					if (Rounds.Any(x => x.CoinsRegistered.Any(y => y.GetTxoRef() == txo)))
+					if (WaitingList.Keys
+						.Concat(Rounds.SelectMany(x => x.CoinsRegistered))
+						.Any(x => x.GetTxoRef() == txo))
 					{
 						return true;
 					}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -65,6 +65,27 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			{
 				return WaitingList.ContainsKey(coin) || Rounds.Any(x => x.CoinsRegistered.Contains(coin));
 			}
+		}
+
+		public bool Contains(params TxoRef[] txos)
+		{
+			lock (StateLock)
+			{
+				foreach (TxoRef txo in txos)
+				{
+					if (WaitingList.Keys.Any(x => x.GetTxoRef() == txo))
+					{
+						return true;
+					}
+
+					if (Rounds.Any(x => x.CoinsRegistered.Any(y => y.GetTxoRef() == txo)))
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
 		}
 
 		public SmartCoin GetSingleOrDefaultFromWaitingList(SmartCoin coin)

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -619,7 +619,7 @@ namespace WalletWasabi.Services
 						TransactionCache.TryAdd(tx);
 
 						// If it's being mixed and anonset is not sufficient, then queue it.
-						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && SpendsEnqueued(tx.Transaction))
+						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && SpendsEnqueued(newCoin.SpentOutputs))
 						{
 							Task.Run(async () =>
 							{
@@ -679,12 +679,12 @@ namespace WalletWasabi.Services
 		/// <summary>
 		/// Tests if a transaction already spends an enqueued coin or not.
 		/// </summary>
-		private bool SpendsEnqueued(Transaction transaction)
+		private bool SpendsEnqueued(IEnumerable<TxoRef> spentInputs)
 		{
-			foreach (var input in transaction.Inputs)
+			foreach (var input in spentInputs)
 			{
 				// If it's enqueued.
-				var enqueued = ChaumianClient.State.GetSingleOrDefaultCoin(new TxoRef(input.PrevOut.Hash, input.PrevOut.N));
+				var enqueued = ChaumianClient.State.GetSingleOrDefaultCoin(new TxoRef(input.TransactionId, input.Index));
 				if (enqueued != null)
 				{
 					return true;

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -619,7 +619,7 @@ namespace WalletWasabi.Services
 						TransactionCache.TryAdd(tx);
 
 						// If it's being mixed and anonset is not sufficient, then queue it.
-						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && SpendsEnqueued(newCoin.SpentOutputs))
+						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && ChaumianClient.State.Contains(newCoin.SpentOutputs))
 						{
 							Task.Run(async () =>
 							{
@@ -674,24 +674,6 @@ namespace WalletWasabi.Services
 			}
 
 			return walletRelevant;
-		}
-
-		/// <summary>
-		/// Tests if a transaction already spends an enqueued coin or not.
-		/// </summary>
-		private bool SpendsEnqueued(IEnumerable<TxoRef> spentInputs)
-		{
-			foreach (var input in spentInputs)
-			{
-				// If it's enqueued.
-				var enqueued = ChaumianClient.State.GetSingleOrDefaultCoin(new TxoRef(input.TransactionId, input.Index));
-				if (enqueued != null)
-				{
-					return true;
-				}
-			}
-
-			return false;
 		}
 
 		public Node LocalBitcoinCoreNode


### PR DESCRIPTION
Checking the "ZeroLink" special label is not only a code smell, but it actually enables Attack 1 (Remix Attacks), that Udi described in his presentation on Breaking Bitcoin. https://www.youtube.com/watch?v=DqhxPWsJFZE  

This change removes the label reliance and tries to check if the new coin that arrived spends a coin that is already enqueued instead.