### PR TITLE
Prevents NRE with WalletService

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -168,8 +168,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private void InitializeAddresses()
 		{
 			_addresses?.Clear();
+			var walletService = Global.WalletService;
 
-			foreach (HdPubKey key in Global.WalletService.KeyManager.GetKeys(x =>
+			if(walletService == null)
+			{
+				return;
+			}
+
+			foreach (HdPubKey key in walletService.KeyManager.GetKeys(x =>
 																		x.HasLabel
 																		&& !x.IsInternal
 																		&& x.KeyState == KeyState.Clean)


### PR DESCRIPTION
Closes #1542 
There are other places where this same thing can happen, specially when invoke `WalletService`. However I am not sure adding this check everywhere is the best.