### PR TITLE
Fix hanging block download

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -23,15 +23,15 @@ namespace NBitcoin
 				var getdata = new GetDataPayload(new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_BLOCK), hash));
 				await node.SendMessageAsync(getdata);
 
-				// Bitcoin Core processes the messages sequentially and does not send a NOTFOUND message if the remote node is pruned and the data not available
+				// Bitcoin Core processes the messages sequentially and does not send a NOTFOUND message if the remote node is pruned and the data not available.
 				// A good way to get any feedback about whether the node knows the block or not is to send a ping request.
-				// If blocks is not known by the remote node, the pong will be sent immediately, else it will be sent after the block download
+				// If block is not known by the remote node, the pong will be sent immediately, else it will be sent after the block download.
 				ulong pingNonce = RandomUtils.GetUInt64();
 				await node.SendMessageAsync(new PingPayload() { Nonce = pingNonce });
 				while (true)
 				{
 					var message = listener.ReceiveMessage(cancellationToken);
-					if (message.Message.Payload is NotFoundPayload || 
+					if (message.Message.Payload is NotFoundPayload ||
 						(message.Message.Payload is PongPayload p && p.Nonce == pingNonce))
 					{
 						throw new InvalidOperationException($"Disconnected local node, because it does not have the block data.");
@@ -43,6 +43,7 @@ namespace NBitcoin
 				}
 			}
 		}
+
 		public static TxoRef ToTxoRef(this OutPoint me) => new TxoRef(me);
 
 		public static IEnumerable<TxoRef> ToTxoRefs(this TxInList me)

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -5,6 +5,7 @@ using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
@@ -15,6 +16,33 @@ namespace NBitcoin
 {
 	public static class NBitcoinExtensions
 	{
+		public static async Task<Block> DownloadBlockAsync(this Node node, uint256 hash, CancellationToken cancellationToken = default)
+		{
+			using (var listener = node.CreateListener())
+			{
+				var getdata = new GetDataPayload(new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_BLOCK), hash));
+				await node.SendMessageAsync(getdata);
+
+				// Bitcoin Core processes the messages sequentially and does not send a NOTFOUND message if the remote node is pruned and the data not available
+				// A good way to get any feedback about whether the node knows the block or not is to send a ping request.
+				// If blocks is not known by the remote node, the pong will be sent immediately, else it will be sent after the block download
+				ulong pingNonce = RandomUtils.GetUInt64();
+				await node.SendMessageAsync(new PingPayload() { Nonce = pingNonce });
+				while (true)
+				{
+					var message = listener.ReceiveMessage(cancellationToken);
+					if (message.Message.Payload is NotFoundPayload || 
+						(message.Message.Payload is PongPayload p && p.Nonce == pingNonce))
+					{
+						throw new InvalidOperationException($"Disconnected local node, because it does not have the block data.");
+					}
+					else if (message.Message.Payload is BlockPayload b && b.Object?.GetHash() == hash)
+					{
+						return b.Object;
+					}
+				}
+			}
+		}
 		public static TxoRef ToTxoRef(this OutPoint me) => new TxoRef(me);
 
 		public static IEnumerable<TxoRef> ToTxoRefs(this TxInList me)

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -791,16 +791,12 @@ namespace WalletWasabi.Services
 
 							Block blockFromLocalNode = null;
 							// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64))) // 1/2 ADSL	512 kbit/s	00:00:32
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
 							{
-								blockFromLocalNode = LocalBitcoinCoreNode.GetBlocks(new uint256[] { hash }, cts.Token)?.Single();
+								blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
 							}
 
-							if (blockFromLocalNode is null)
-							{
-								throw new InvalidOperationException($"Disconnected local node, because couldn't parse received block.");
-							}
-							else if (!blockFromLocalNode.Check())
+							if (!blockFromLocalNode.Check())
 							{
 								throw new InvalidOperationException($"Disconnected node, because block invalid block received!");
 							}
@@ -850,14 +846,7 @@ namespace WalletWasabi.Services
 
 							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
 							{
-								block = node.GetBlocks(new uint256[] { hash }, cts.Token)?.Single();
-							}
-
-							if (block is null)
-							{
-								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because couldn't parse received block.");
-								node.DisconnectAsync("Couldn't parse block.");
-								continue;
+								block = await node.DownloadBlockAsync(hash, cts.Token);
 							}
 
 							if (!block.Check())

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -791,7 +791,7 @@ namespace WalletWasabi.Services
 
 							Block blockFromLocalNode = null;
 							// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout)))
 							{
 								blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
 							}
@@ -844,7 +844,7 @@ namespace WalletWasabi.Services
 						{
 							ConcurrentBlockDownloadNumberChanged?.Invoke(this, Interlocked.Increment(ref ConcurrentBlockDownload));
 
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout)))
 							{
 								block = await node.DownloadBlockAsync(hash, cts.Token);
 							}
@@ -1555,7 +1555,9 @@ namespace WalletWasabi.Services
 				Encoding.UTF8);
 		}
 
-		// Current timeout used when downloading a block from the remote node. It is defined in seconds.
+		/// <summary>
+		/// Current timeout used when downloading a block from the remote node. It is defined in seconds.
+		/// </summary>
 		private async Task NodeTimeoutsAsync(bool increaseDecrease)
 		{
 			if (increaseDecrease)


### PR DESCRIPTION
BTCPayServer users run a pruned node, which mean that without this pull request, the block download would hang 64 seconds before connecting to another peer.

This PR disconnects immediately if the remote node does not have the block.

NBitcoin `GetBlocks` method has been developed to download the most blocks simultaneously, it is overkill if you only want one block.