### PR TITLE
Fix annoying freeze when you have too much coin

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -57,7 +57,7 @@
           <TextBlock Text = "BTC" />
         </StackPanel>
       </StackPanel>
-      <ListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
+      <ListBox Items="{Binding Coins}" VirtualizationMode="Simple" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
         <ListBox.ContextMenu>
           <ContextMenu>
             <!--Enqueuing needs password, TODO: jump to password box OR display pw box in context menu + send button-->


### PR DESCRIPTION
When you have too much coin, opening for the first time the Coinjoin or Send tab is freezing for 10-20 seconds.

Activating Virtualization fix a bit the experience: 10 coins appears at first, then the other get loaded 3-5 sec after. The UI stays responsive.