### PR TITLE
Remove IDE/Editor folders and files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-	"editor.detectIndentation": false,
-	"editor.insertSpaces": false
-}


### PR DESCRIPTION
There isn't a real reason for a `.vscode` folder or a `.editorconfig` to be in the repo.  If you want these to be excluded from something like `git add -A` then you can follow [this guide](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#ignoring-ideeditor-files) to exclude desired files/folders.