### PR TITLE
Revert the revert hanging block, and fix the issues

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -5,6 +5,7 @@ using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
@@ -15,6 +16,36 @@ namespace NBitcoin
 {
 	public static class NBitcoinExtensions
 	{
+		public static async Task<Block> DownloadBlockAsync(this Node node, uint256 hash, CancellationToken cancellationToken)
+		{
+			using (var listener = node.CreateListener())
+			{
+				var getdata = new GetDataPayload(new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_BLOCK), hash));
+				await node.SendMessageAsync(getdata);
+				cancellationToken.ThrowIfCancellationRequested();
+
+				// Bitcoin Core processes the messages sequentially and does not send a NOTFOUND message if the remote node is pruned and the data not available.
+				// A good way to get any feedback about whether the node knows the block or not is to send a ping request.
+				// If block is not known by the remote node, the pong will be sent immediately, else it will be sent after the block download.
+				ulong pingNonce = RandomUtils.GetUInt64();
+				await node.SendMessageAsync(new PingPayload() { Nonce = pingNonce });
+				while (true)
+				{
+					cancellationToken.ThrowIfCancellationRequested();
+					var message = listener.ReceiveMessage(cancellationToken);
+					if (message.Message.Payload is NotFoundPayload ||
+						(message.Message.Payload is PongPayload p && p.Nonce == pingNonce))
+					{
+						throw new InvalidOperationException($"Disconnected local node, because it does not have the block data.");
+					}
+					else if (message.Message.Payload is BlockPayload b && b.Object?.GetHash() == hash)
+					{
+						return b.Object;
+					}
+				}
+			}
+		}
+
 		public static TxoRef ToTxoRef(this OutPoint me) => new TxoRef(me);
 
 		public static IEnumerable<TxoRef> ToTxoRefs(this TxInList me)

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -18,6 +18,8 @@ namespace NBitcoin
 	{
 		public static async Task<Block> DownloadBlockAsync(this Node node, uint256 hash, CancellationToken cancellationToken)
 		{
+			if (node.State == NodeState.Connected)
+				node.VersionHandshake(cancellationToken);
 			using (var listener = node.CreateListener())
 			{
 				var getdata = new GetDataPayload(new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_BLOCK), hash));

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -806,7 +806,7 @@ namespace WalletWasabi.Services
 
 							Block blockFromLocalNode = null;
 							// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout)))
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
 							{
 								blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
 							}


### PR DESCRIPTION
Two issues were found:

* Misbehaving clients because we were not properly handshaking before downloading blocks (https://github.com/zkSNACKs/WalletWasabi/issues/1582)
* Tests error caused by this line https://github.com/zkSNACKs/WalletWasabi/pull/1585/files#r294717275

Somehow in tests the runtime params are not set and make tests fail.