### PR TITLE
Make Global a singleton instead of static class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,4 @@ lcov.info
 \.DS_Store
 *.DS_Store
 /WalletWasabi.Backend/wwwroot/onion-index.html
+/NuGet.Config

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Backend.Controllers
 
 			var knownHash = new uint256(bestKnownBlockHash);
 
-			(Height bestHeight, IEnumerable<FilterModel> filters) = Global.IndexBuilderService.GetFilterLinesExcluding(knownHash, maxNumberOfFilters, out bool found);
+			(Height bestHeight, IEnumerable<FilterModel> filters) = Global.Instance.IndexBuilderService.GetFilterLinesExcluding(knownHash, maxNumberOfFilters, out bool found);
 
 			var response = new SynchronizeResponse();
 			response.Filters = Enumerable.Empty<FilterModel>();

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using NBitcoin.RPC;
@@ -23,9 +23,9 @@ namespace WalletWasabi.Backend.Controllers
 	{
 		private IMemoryCache Cache { get; }
 
-		private static RPCClient RpcClient => Global.RpcClient;
+		private static RPCClient RpcClient => Global.Instance.RpcClient;
 
-		private static Network Network => Global.Config.Network;
+		private static Network Network => Global.Instance.Config.Network;
 
 		public BlockchainController(IMemoryCache memoryCache)
 		{
@@ -182,7 +182,7 @@ namespace WalletWasabi.Backend.Controllers
 
 			if (!Cache.TryGetValue(cacheKey, out IEnumerable<string> hashes))
 			{
-				uint256[] transactionHashes = await Global.RpcClient.GetRawMempoolAsync();
+				uint256[] transactionHashes = await Global.Instance.RpcClient.GetRawMempoolAsync();
 
 				hashes = transactionHashes.Select(x => x.ToString());
 
@@ -278,7 +278,7 @@ namespace WalletWasabi.Backend.Controllers
 
 			var knownHash = new uint256(bestKnownBlockHash);
 
-			(Height bestHeight, IEnumerable<FilterModel> filters) = Global.IndexBuilderService.GetFilterLinesExcluding(knownHash, count, out bool found);
+			(Height bestHeight, IEnumerable<FilterModel> filters) = Global.Instance.IndexBuilderService.GetFilterLinesExcluding(knownHash, count, out bool found);
 
 			if (!found)
 			{

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -34,11 +34,11 @@ namespace WalletWasabi.Backend.Controllers
 	[Route("api/v" + Constants.BackendMajorVersion + "/btc/[controller]")]
 	public class ChaumianCoinJoinController : Controller
 	{
-		private static RPCClient RpcClient => Global.RpcClient;
+		private static RPCClient RpcClient => Global.Instance.RpcClient;
 
-		private static Network Network => Global.Config.Network;
+		private static Network Network => Global.Instance.Config.Network;
 
-		private static CcjCoordinator Coordinator => Global.Coordinator;
+		private static CcjCoordinator Coordinator => Global.Instance.Coordinator;
 
 		/// <summary>
 		/// Satoshi gets various status information.

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using System;
@@ -13,32 +13,33 @@ using WalletWasabi.Services;
 
 namespace WalletWasabi.Backend
 {
-	public static class Global
+	public class Global
 	{
-		public static string DataDir { get; }
+		public static Global Instance { get; } = new Global();
+		public string DataDir { get; }
 
-		public static RPCClient RpcClient { get; private set; }
+		public RPCClient RpcClient { get; private set; }
 
-		public static Node LocalNode { get; private set; }
+		public Node LocalNode { get; private set; }
 
-		public static TrustedNodeNotifyingBehavior TrustedNodeNotifyingBehavior { get; private set; }
+		public TrustedNodeNotifyingBehavior TrustedNodeNotifyingBehavior { get; private set; }
 
-		public static IndexBuilderService IndexBuilderService { get; private set; }
+		public IndexBuilderService IndexBuilderService { get; private set; }
 
-		public static CcjCoordinator Coordinator { get; private set; }
+		public CcjCoordinator Coordinator { get; private set; }
 
-		public static ConfigWatcher RoundConfigWatcher { get; private set; }
+		public ConfigWatcher RoundConfigWatcher { get; private set; }
 
-		public static Config Config { get; private set; }
+		public Config Config { get; private set; }
 
-		public static CcjRoundConfig RoundConfig { get; private set; }
+		public CcjRoundConfig RoundConfig { get; private set; }
 
-		static Global()
+		public Global()
 		{
 			DataDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Backend"));
 		}
 
-		public static async Task InitializeAsync(Config config, CcjRoundConfig roundConfig, RPCClient rpc)
+		public async Task InitializeAsync(Config config, CcjRoundConfig roundConfig, RPCClient rpc)
 		{
 			Config = Guard.NotNull(nameof(config), config);
 			RoundConfig = Guard.NotNull(nameof(roundConfig), roundConfig);
@@ -84,7 +85,7 @@ namespace WalletWasabi.Backend
 			}
 		}
 
-		public static void DisconnectDisposeNullLocalNode()
+		public void DisconnectDisposeNullLocalNode()
 		{
 			if (LocalNode != null)
 			{
@@ -122,7 +123,7 @@ namespace WalletWasabi.Backend
 			}
 		}
 
-		private static async Task InitializeP2pAsync(Network network, EndPoint endPoint)
+		private async Task InitializeP2pAsync(Network network, EndPoint endPoint)
 		{
 			Guard.NotNull(nameof(network), network);
 			Guard.NotNull(nameof(endPoint), endPoint);
@@ -130,8 +131,7 @@ namespace WalletWasabi.Backend
 			using (var handshakeTimeout = new CancellationTokenSource())
 			{
 				handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
-				var nodeConnectionParameters = new NodeConnectionParameters()
-				{
+				var nodeConnectionParameters = new NodeConnectionParameters() {
 					ConnectCancellation = handshakeTimeout.Token,
 					IsRelay = true
 				};
@@ -169,7 +169,7 @@ namespace WalletWasabi.Backend
 			}
 		}
 
-		private static async Task AssertRpcNodeFullyInitializedAsync()
+		private async Task AssertRpcNodeFullyInitializedAsync()
 		{
 			try
 			{

--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -25,17 +25,17 @@ namespace WalletWasabi.Backend
 		{
 			try
 			{
-				Logger.InitializeDefaults(Path.Combine(Global.DataDir, "Logs.txt"));
+				Logger.InitializeDefaults(Path.Combine(Global.Instance.DataDir, "Logs.txt"));
 				Logger.LogStarting("Wasabi Backend");
 
 				AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 				TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
-				var configFilePath = Path.Combine(Global.DataDir, "Config.json");
+				var configFilePath = Path.Combine(Global.Instance.DataDir, "Config.json");
 				var config = new Config(configFilePath);
 				await config.LoadOrCreateDefaultFileAsync();
 				Logger.LogInfo<Config>("Config is successfully initialized.");
 
-				var roundConfigFilePath = Path.Combine(Global.DataDir, "CcjRoundConfig.json");
+				var roundConfigFilePath = Path.Combine(Global.Instance.DataDir, "CcjRoundConfig.json");
 				var roundConfig = new CcjRoundConfig(roundConfigFilePath);
 				await roundConfig.LoadOrCreateDefaultFileAsync();
 				Logger.LogInfo<CcjRoundConfig>("RoundConfig is successfully initialized.");
@@ -44,7 +44,7 @@ namespace WalletWasabi.Backend
 						credentials: RPCCredentialString.Parse(config.BitcoinRpcConnectionString),
 						network: config.Network);
 
-				await Global.InitializeAsync(config, roundConfig, rpc);
+				await Global.Instance.InitializeAsync(config, roundConfig, rpc);
 
 				try
 				{
@@ -52,14 +52,14 @@ namespace WalletWasabi.Backend
 					UnversionedWebBuilder.CreateDownloadTextWithVersionHtml();
 					UnversionedWebBuilder.CloneAndUpdateOnionIndexHtml();
 
-					if (File.Exists(Global.Coordinator.CoinJoinsFilePath))
+					if (File.Exists(Global.Instance.Coordinator.CoinJoinsFilePath))
 					{
-						string[] allLines = File.ReadAllLines(Global.Coordinator.CoinJoinsFilePath);
+						string[] allLines = File.ReadAllLines(Global.Instance.Coordinator.CoinJoinsFilePath);
 						Last5CoinJoins = allLines.TakeLast(5).Reverse().ToList();
 						UnversionedWebBuilder.UpdateCoinJoinsHtml(Last5CoinJoins);
 					}
 
-					Global.Coordinator.CoinJoinBroadcasted += Coordinator_CoinJoinBroadcasted;
+					Global.Instance.Coordinator.CoinJoinBroadcasted += Coordinator_CoinJoinBroadcasted;
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,8 +33,7 @@ namespace WalletWasabi.Backend
 			// Register the Swagger generator, defining one or more Swagger documents
 			services.AddSwaggerGen(c =>
 			{
-				c.SwaggerDoc($"v{Constants.BackendMajorVersion}", new Info
-				{
+				c.SwaggerDoc($"v{Constants.BackendMajorVersion}", new Info {
 					Version = $"v{Constants.BackendMajorVersion}",
 					Title = "Wasabi Wallet API",
 					Description = "Privacy focused, ZeroLink compliant Bitcoin Web API.",
@@ -91,24 +90,24 @@ namespace WalletWasabi.Backend
 
 		private async Task CleanupAsync()
 		{
-			Global.Coordinator?.Dispose();
+			Global.Instance.Coordinator?.Dispose();
 			Logger.LogInfo<Startup>("Coordinator is disposed.");
 
-			if (Global.IndexBuilderService != null)
+			if (Global.Instance.IndexBuilderService != null)
 			{
-				await Global.IndexBuilderService.StopAsync();
+				await Global.Instance.IndexBuilderService.StopAsync();
 				Logger.LogInfo<Startup>("IndexBuilderService is disposed.");
 			}
 
-			if (Global.RoundConfigWatcher != null)
+			if (Global.Instance.RoundConfigWatcher != null)
 			{
-				await Global.RoundConfigWatcher.StopAsync();
+				await Global.Instance.RoundConfigWatcher.StopAsync();
 				Logger.LogInfo<Startup>("RoundConfigWatcher is disposed.");
 			}
 
-			if (Global.LocalNode != null)
+			if (Global.Instance.LocalNode != null)
 			{
-				Global.DisconnectDisposeNullLocalNode();
+				Global.Instance.DisconnectDisposeNullLocalNode();
 				Logger.LogInfo<Startup>("LocalNode is disposed.");
 			}
 

--- a/WalletWasabi.Backend/UnversionedWebBuilder.cs
+++ b/WalletWasabi.Backend/UnversionedWebBuilder.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Backend
 			var endContent = "</ul>";
 			string blockstreamPath;
 			string onionBlockstreamPath;
-			if (Global.Config.Network == Network.TestNet)
+			if (Global.Instance.Config.Network == Network.TestNet)
 			{
 				blockstreamPath = "https://blockstream.info/testnet/tx/";
 				onionBlockstreamPath = "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet/tx/";

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.Gui.Behaviors
 			text = text.Trim();
 			try
 			{
-				var bitcoinAddress = BitcoinAddress.Create(text, Global.Network);
+				var bitcoinAddress = BitcoinAddress.Create(text, Global.Instance.Network);
 				return (true, bitcoinAddress.ToString());
 			}
 			catch (FormatException)

--- a/WalletWasabi.Gui/CommandLine/CommandInterpreter.cs
+++ b/WalletWasabi.Gui/CommandLine/CommandInterpreter.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.Gui.CommandLine
 			var showHelp = false;
 			var showVersion = false;
 
-			Logger.InitializeDefaults(Path.Combine(Global.DataDir, "Logs.txt"));
+			Logger.InitializeDefaults(Path.Combine(Global.Instance.DataDir, "Logs.txt"));
 
 			if (args.Length == 0)
 			{

--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -50,14 +50,14 @@ namespace WalletWasabi.Gui.CommandLine
 
 				Logger.LogInfo("Correct password.");
 
-				await Global.InitializeNoWalletAsync();
-				if (Global.KillRequested)
+				await Global.Instance.InitializeNoWalletAsync();
+				if (Global.Instance.KillRequested)
 				{
 					return;
 				}
 
-				await Global.InitializeWalletServiceAsync(keyManager);
-				if (Global.KillRequested)
+				await Global.Instance.InitializeWalletServiceAsync(keyManager);
+				if (Global.Instance.KillRequested)
 				{
 					return;
 				}
@@ -67,25 +67,25 @@ namespace WalletWasabi.Gui.CommandLine
 				bool mixing;
 				do
 				{
-					if (Global.KillRequested)
+					if (Global.Instance.KillRequested)
 					{
 						break;
 					}
 
 					await Task.Delay(3000);
-					if (Global.KillRequested)
+					if (Global.Instance.KillRequested)
 					{
 						break;
 					}
 
-					bool anyCoinsQueued = Global.ChaumianClient.State.AnyCoinsQueued();
+					bool anyCoinsQueued = Global.Instance.ChaumianClient.State.AnyCoinsQueued();
 
 					if (!anyCoinsQueued && keepMixAlive) // If no coins queued and mixing is asked to be kept alive then try to queue coins.
 					{
 						await TryQueueCoinsToMixAsync(mixAll, password);
 					}
 
-					if (Global.KillRequested)
+					if (Global.Instance.KillRequested)
 					{
 						break;
 					}
@@ -93,14 +93,14 @@ namespace WalletWasabi.Gui.CommandLine
 					mixing = anyCoinsQueued || keepMixAlive;
 				} while (mixing);
 
-				if (!Global.KillRequested) // This only has to run if it finishes by itself. Otherwise the Ctrl+c runs it.
+				if (!Global.Instance.KillRequested) // This only has to run if it finishes by itself. Otherwise the Ctrl+c runs it.
 				{
-					await Global.ChaumianClient?.DequeueAllCoinsFromMixAsync("Stopping Wasabi.");
+					await Global.Instance.ChaumianClient?.DequeueAllCoinsFromMixAsync("Stopping Wasabi.");
 				}
 			}
 			catch
 			{
-				if (!Global.KillRequested)
+				if (!Global.Instance.KillRequested)
 				{
 					throw;
 				}
@@ -118,8 +118,8 @@ namespace WalletWasabi.Gui.CommandLine
 				KeyManager keyManager = null;
 				if (walletName != null)
 				{
-					var walletFullPath = Global.GetWalletFullPath(walletName);
-					var walletBackupFullPath = Global.GetWalletBackupFullPath(walletName);
+					var walletFullPath = Global.Instance.GetWalletFullPath(walletName);
+					var walletBackupFullPath = Global.Instance.GetWalletBackupFullPath(walletName);
 					if (!File.Exists(walletFullPath) && !File.Exists(walletBackupFullPath))
 					{
 						// The selected wallet is not available any more (someone deleted it?).
@@ -129,7 +129,7 @@ namespace WalletWasabi.Gui.CommandLine
 
 					try
 					{
-						keyManager = Global.LoadKeyManager(walletFullPath, walletBackupFullPath);
+						keyManager = Global.Instance.LoadKeyManager(walletFullPath, walletBackupFullPath);
 					}
 					catch (Exception ex)
 					{
@@ -159,11 +159,11 @@ namespace WalletWasabi.Gui.CommandLine
 			{
 				if (mixAll)
 				{
-					await Global.ChaumianClient.QueueCoinsToMixAsync(password, Global.WalletService.Coins.Where(x => !x.Unavailable).ToArray());
+					await Global.Instance.ChaumianClient.QueueCoinsToMixAsync(password, Global.Instance.WalletService.Coins.Where(x => !x.Unavailable).ToArray());
 				}
 				else
 				{
-					await Global.ChaumianClient.QueueCoinsToMixAsync(password, Global.WalletService.Coins.Where(x => !x.Unavailable && x.AnonymitySet < Global.WalletService.ServiceConfiguration.MixUntilAnonymitySet).ToArray());
+					await Global.Instance.ChaumianClient.QueueCoinsToMixAsync(password, Global.Instance.WalletService.Coins.Where(x => !x.Unavailable && x.AnonymitySet < Global.Instance.WalletService.ServiceConfiguration.MixUntilAnonymitySet).ToArray());
 				}
 			}
 			catch (Exception ex)

--- a/WalletWasabi.Gui/Controls/MultiTextBox.cs
+++ b/WalletWasabi.Gui/Controls/MultiTextBox.cs
@@ -199,7 +199,7 @@ namespace WalletWasabi.Gui.Controls
 			{
 				var eventArgs = eventPattern?.EventArgs as PointerPressedEventArgs;
 
-				if (Global.UiConfig?.Autocopy is true && eventArgs?.MouseButton == MouseButton.Left)
+				if (Global.Instance.UiConfig?.Autocopy is true && eventArgs?.MouseButton == MouseButton.Left)
 				{
 					if (CopyOnClick)
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -301,7 +301,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					return;
 				}
-				//await Global.ChaumianClient.QueueCoinsToMixAsync()
+				//await Global.Instance.ChaumianClient.QueueCoinsToMixAsync()
 			});
 
 			DequeueCoin = ReactiveCommand.Create(() =>
@@ -317,7 +317,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			SelectAllCheckBoxCommand = ReactiveCommand.Create(() =>
 			{
-				//Global.WalletService.Coins.First(c => c.Unspent).Unspent = false;
+				//Global.Instance.WalletService.Coins.First(c => c.Unspent).Unspent = false;
 				switch (SelectAllCheckBoxState)
 				{
 					case true:
@@ -340,15 +340,15 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				switch (SelectPrivateCheckBoxState)
 				{
 					case true:
-						SelectAllCoins(true, x => x.AnonymitySet >= Global.Config.PrivacyLevelStrong);
+						SelectAllCoins(true, x => x.AnonymitySet >= Global.Instance.Config.PrivacyLevelStrong);
 						break;
 
 					case false:
-						SelectAllCoins(false, x => x.AnonymitySet >= Global.Config.PrivacyLevelStrong);
+						SelectAllCoins(false, x => x.AnonymitySet >= Global.Instance.Config.PrivacyLevelStrong);
 						break;
 
 					case null:
-						SelectAllCoins(false, x => x.AnonymitySet >= Global.Config.PrivacyLevelStrong);
+						SelectAllCoins(false, x => x.AnonymitySet >= Global.Instance.Config.PrivacyLevelStrong);
 						SelectPrivateCheckBoxState = false;
 						break;
 				}
@@ -359,15 +359,15 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				switch (SelectNonPrivateCheckBoxState)
 				{
 					case true:
-						SelectAllCoins(true, x => x.AnonymitySet < Global.Config.PrivacyLevelStrong);
+						SelectAllCoins(true, x => x.AnonymitySet < Global.Instance.Config.PrivacyLevelStrong);
 						break;
 
 					case false:
-						SelectAllCoins(false, x => x.AnonymitySet < Global.Config.PrivacyLevelStrong);
+						SelectAllCoins(false, x => x.AnonymitySet < Global.Instance.Config.PrivacyLevelStrong);
 						break;
 
 					case null:
-						SelectAllCoins(false, x => x.AnonymitySet < Global.Config.PrivacyLevelStrong);
+						SelectAllCoins(false, x => x.AnonymitySet < Global.Instance.Config.PrivacyLevelStrong);
 						SelectNonPrivateCheckBoxState = false;
 						break;
 				}
@@ -378,14 +378,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			Disposables = new CompositeDisposable();
 
-			foreach (var sc in Global.WalletService.Coins.Where(sc => sc.Unspent))
+			foreach (var sc in Global.Instance.WalletService.Coins.Where(sc => sc.Unspent))
 			{
 				var newCoinVm = new CoinViewModel(this, sc);
 				newCoinVm.SubscribeEvents();
 				RootList.Add(newCoinVm);
 			}
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 			{
@@ -399,7 +399,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				IsAnyCoinSelected = x > 0m;
 			});
 
-			Observable.FromEventPattern<NotifyCollectionChangedEventArgs>(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
+			Observable.FromEventPattern<NotifyCollectionChangedEventArgs>(Global.Instance.WalletService.Coins, nameof(Global.Instance.WalletService.Coins.CollectionChanged))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x =>
 				{
@@ -455,8 +455,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private void SetSelections()
 		{
 			SelectAllCheckBoxState = GetCheckBoxesSelectedState(x => true);
-			SelectPrivateCheckBoxState = GetCheckBoxesSelectedState(x => x.AnonymitySet >= Global.Config.PrivacyLevelStrong);
-			SelectNonPrivateCheckBoxState = GetCheckBoxesSelectedState(x => x.AnonymitySet < Global.Config.PrivacyLevelStrong);
+			SelectPrivateCheckBoxState = GetCheckBoxesSelectedState(x => x.AnonymitySet >= Global.Instance.Config.PrivacyLevelStrong);
+			SelectNonPrivateCheckBoxState = GetCheckBoxesSelectedState(x => x.AnonymitySet < Global.Instance.Config.PrivacyLevelStrong);
 		}
 
 		private void SetCoinJoinStatusWidth()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -79,22 +79,22 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.DisposeWith(Disposables);
 
 			Observable.FromEventPattern(
-				Global.ChaumianClient,
-				nameof(Global.ChaumianClient.StateUpdated))
+				Global.Instance.ChaumianClient,
+				nameof(Global.Instance.ChaumianClient.StateUpdated))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 				{
 					RefreshSmartCoinStatus();
 				}).DisposeWith(Disposables);
 
-			Global.BitcoinStore.HashChain.WhenAnyValue(x => x.ServerTipHeight)
+			Global.Instance.BitcoinStore.HashChain.WhenAnyValue(x => x.ServerTipHeight)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 				{
 					this.RaisePropertyChanged(nameof(Confirmations));
 				}).DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 			{
@@ -119,10 +119,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public bool Unspent => _unspent?.Value ?? false;
 
-		public string Address => Model.ScriptPubKey.GetDestinationAddress(Global.Network).ToString();
+		public string Address => Model.ScriptPubKey.GetDestinationAddress(Global.Instance.Network).ToString();
 
 		public int Confirmations => Model.Height.Type == HeightType.Chain
-			? Global.BitcoinStore.HashChain.TipHeight - Model.Height.Value + 1
+			? Global.Instance.BitcoinStore.HashChain.TipHeight - Model.Height.Value + 1
 			: 0;
 
 		public bool IsSelected
@@ -192,7 +192,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				return SmartCoinStatus.MixingBanned;
 			}
 
-			CcjClientState clientState = Global.ChaumianClient.State;
+			CcjClientState clientState = Global.Instance.ChaumianClient.State;
 
 			if (Model.CoinJoinInProgress)
 			{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			this.WhenAnyValue(x => x.SelectedTransaction).Subscribe(async transaction =>
 			{
-				if (Global.UiConfig?.Autocopy is false || transaction is null)
+				if (Global.Instance.UiConfig?.Autocopy is false || transaction is null)
 				{
 					return;
 				}
@@ -58,15 +58,15 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Disposables = new CompositeDisposable();
 
-			Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
-				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.NewBlockProcessed)))
-				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.CoinSpentOrSpenderConfirmed)))
+			Observable.FromEventPattern(Global.Instance.WalletService.Coins, nameof(Global.Instance.WalletService.Coins.CollectionChanged))
+				.Merge(Observable.FromEventPattern(Global.Instance.WalletService, nameof(Global.Instance.WalletService.NewBlockProcessed)))
+				.Merge(Observable.FromEventPattern(Global.Instance.WalletService, nameof(Global.Instance.WalletService.CoinSpentOrSpenderConfirmed)))
 				.Throttle(TimeSpan.FromSeconds(5))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(async _ => await TryRewriteTableAsync())
 				.DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(x =>
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(x =>
 			{
 				foreach (var transaction in Transactions)
 				{
@@ -123,7 +123,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private static List<(DateTimeOffset dateTime, Height height, Money amount, string label, uint256 transactionId)> BuildTxRecordList()
 		{
-			var walletService = Global.WalletService;
+			var walletService = Global.Instance.WalletService;
 
 			List<Transaction> trs = new List<Transaction>();
 			var txRecordList = new List<(DateTimeOffset dateTime, Height height, Money amount, string label, uint256 transactionId)>();

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				Dispatcher.UIThread.PostLogException(() =>
 				{
 					var label = Label;
-					HdPubKey newKey = Global.WalletService.GetReceiveKey(label, Addresses.Select(x => x.Model).Take(7)); // Never touch the first 7 keys.
+					HdPubKey newKey = Global.Instance.WalletService.GetReceiveKey(label, Addresses.Select(x => x.Model).Take(7)); // Never touch the first 7 keys.
 
 					AddressViewModel found = Addresses.FirstOrDefault(x => x.Model == newKey);
 					if (found != default)
@@ -82,7 +82,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			this.WhenAnyValue(x => x.SelectedAddress).Subscribe(async address =>
 			{
-				if (Global.UiConfig?.Autocopy is false || address is null)
+				if (Global.Instance.UiConfig?.Autocopy is false || address is null)
 				{
 					return;
 				}
@@ -149,8 +149,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Disposables = new CompositeDisposable();
 
-			Observable.FromEventPattern(Global.WalletService.Coins,
-				nameof(Global.WalletService.Coins.CollectionChanged))
+			Observable.FromEventPattern(Global.Instance.WalletService.Coins,
+				nameof(Global.Instance.WalletService.Coins.CollectionChanged))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(o => InitializeAddresses())
 				.DisposeWith(Disposables);
@@ -168,7 +168,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private void InitializeAddresses()
 		{
 			_addresses?.Clear();
-			var walletService = Global.WalletService;
+			var walletService = Global.Instance.WalletService;
 
 			if(walletService == null)
 			{
@@ -244,7 +244,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				return;
 			}
 
-			string[] nonSpecialLabels = Global.WalletService.GetNonSpecialLabels().ToArray();
+			string[] nonSpecialLabels = Global.Instance.WalletService.GetNonSpecialLabels().ToArray();
 			IEnumerable<string> suggestedWords = nonSpecialLabels.Where(w => w.StartsWith(lastWord, StringComparison.InvariantCultureIgnoreCase))
 				.Union(nonSpecialLabels.Where(w => w.Contains(lastWord, StringComparison.InvariantCultureIgnoreCase)))
 				.Except(enteredWordList)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -71,7 +71,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set
 			{
 				_feeDisplayFormat = value;
-				Global.UiConfig.FeeDisplayFormat = (int)value;
+				Global.Instance.UiConfig.FeeDisplayFormat = (int)value;
 			}
 		}
 
@@ -82,7 +82,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Label = "";
 			Password = "";
 			AllSelectedAmount = Money.Zero;
-			UsdExchangeRate = Global.Synchronizer?.UsdExchangeRate ?? UsdExchangeRate;
+			UsdExchangeRate = Global.Instance.Synchronizer?.UsdExchangeRate ?? UsdExchangeRate;
 			IsMax = false;
 			LabelToolTip = "Start labelling today and your privacy will thank you tomorrow!";
 			Amount = "0.0";
@@ -106,8 +106,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(_ => OnCoinsListDequeueCoinsPressedAsync());
 
 			SetFeeTargetLimits();
-			FeeTarget = Global.UiConfig.FeeTarget ?? MinimumFeeTarget;
-			FeeDisplayFormat = (FeeDisplayFormat)(Enum.ToObject(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat) ?? FeeDisplayFormat.SatoshiPerByte);
+			FeeTarget = Global.Instance.UiConfig.FeeTarget ?? MinimumFeeTarget;
+			FeeDisplayFormat = (FeeDisplayFormat)(Enum.ToObject(typeof(FeeDisplayFormat), Global.Instance.UiConfig.FeeDisplayFormat) ?? FeeDisplayFormat.SatoshiPerByte);
 			SetFeesAndTexts();
 
 			this.WhenAnyValue(x => x.Amount)
@@ -260,7 +260,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					BitcoinAddress address;
 					try
 					{
-						address = BitcoinAddress.Create(Address.Trim(), Global.Network);
+						address = BitcoinAddress.Create(Address.Trim(), Global.Instance.Network);
 					}
 					catch (FormatException)
 					{
@@ -293,7 +293,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						TxoRef[] toDequeue = selectedCoinViewModels.Where(x => x.CoinJoinInProgress).Select(x => x.Model.GetTxoRef()).ToArray();
 						if (toDequeue != null && toDequeue.Any())
 						{
-							await Global.ChaumianClient.DequeueCoinsFromMixAsync(toDequeue, "Coin is used in a spending transaction built by the user.");
+							await Global.Instance.ChaumianClient.DequeueCoinsFromMixAsync(toDequeue, "Coin is used in a spending transaction built by the user.");
 						}
 					}
 					catch
@@ -306,7 +306,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.DequeuingSelectedCoins);
 					}
 
-					var result = await Task.Run(() => Global.WalletService.BuildTransaction(Password, new[] { operation }, FeeTarget, allowUnconfirmed: true, allowedInputs: selectedCoinReferences));
+					var result = await Task.Run(() => Global.Instance.WalletService.BuildTransaction(Password, new[] { operation }, FeeTarget, allowUnconfirmed: true, allowedInputs: selectedCoinReferences));
 
 					if (IsTransactionBuilder)
 					{
@@ -375,7 +375,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 
 					MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.BroadcastingTransaction);
-					await Task.Run(async () => await Global.WalletService.SendTransactionAsync(signedTransaction));
+					await Task.Run(async () => await Global.Instance.WalletService.SendTransactionAsync(signedTransaction));
 
 					TryResetInputsOnSuccess("Transaction is successfully sent!");
 				}
@@ -546,7 +546,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private void SetFeesAndTexts()
 		{
-			AllFeeEstimate allFeeEstimate = Global.Synchronizer?.AllFeeEstimate;
+			AllFeeEstimate allFeeEstimate = Global.Instance.Synchronizer?.AllFeeEstimate;
 
 			var feeTarget = FeeTarget;
 
@@ -709,7 +709,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private void SetFeeTargetLimits()
 		{
-			var allFeeEstimate = Global.Synchronizer?.AllFeeEstimate;
+			var allFeeEstimate = Global.Instance.Synchronizer?.AllFeeEstimate;
 
 			if (allFeeEstimate != null)
 			{
@@ -771,7 +771,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			try
 			{
-				await Global.ChaumianClient.DequeueCoinsFromMixAsync(selectedCoins.Select(c => c.Model).ToArray(), "Dequeued by the user.");
+				await Global.Instance.ChaumianClient.DequeueCoinsFromMixAsync(selectedCoins.Select(c => c.Model).ToArray(), "Dequeued by the user.");
 			}
 			catch (Exception ex)
 			{
@@ -825,7 +825,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set
 			{
 				this.RaiseAndSetIfChanged(ref _feeTarget, value);
-				Global.UiConfig.FeeTarget = value;
+				Global.Instance.UiConfig.FeeTarget = value;
 			}
 		}
 
@@ -924,7 +924,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				return;
 			}
 
-			string[] nonSpecialLabels = Global.WalletService.GetNonSpecialLabels().ToArray();
+			string[] nonSpecialLabels = Global.Instance.WalletService.GetNonSpecialLabels().ToArray();
 			IEnumerable<string> suggestedWords = nonSpecialLabels.Where(w => w.StartsWith(lastWord, StringComparison.InvariantCultureIgnoreCase))
 				.Union(nonSpecialLabels.Where(w => w.Contains(lastWord, StringComparison.InvariantCultureIgnoreCase)))
 				.Except(enteredWordList)
@@ -967,7 +967,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				var trimmed = Address.Trim();
 				try
 				{
-					BitcoinAddress.Create(trimmed, Global.Network);
+					BitcoinAddress.Create(trimmed, Global.Instance.Network);
 					return "";
 				}
 				catch
@@ -1031,7 +1031,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Disposables = new CompositeDisposable();
 
-			Global.Synchronizer.WhenAnyValue(x => x.AllFeeEstimate).Subscribe(_ =>
+			Global.Instance.Synchronizer.WhenAnyValue(x => x.AllFeeEstimate).Subscribe(_ =>
 			{
 				SetFeeTargetLimits();
 
@@ -1047,9 +1047,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				SetFeesAndTexts();
 			}).DisposeWith(Disposables);
 
-			Global.Synchronizer.WhenAnyValue(x => x.UsdExchangeRate).Subscribe(_ =>
+			Global.Instance.Synchronizer.WhenAnyValue(x => x.UsdExchangeRate).Subscribe(_ =>
 			{
-				var exchangeRate = Global.Synchronizer.UsdExchangeRate;
+				var exchangeRate = Global.Instance.Synchronizer.UsdExchangeRate;
 
 				if (exchangeRate != 0)
 				{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
@@ -110,7 +110,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				SmartTransaction transaction;
 				try
 				{
-					var signedPsbt = PSBT.Parse(TransactionString, Global.Network ?? Network.Main);
+					var signedPsbt = PSBT.Parse(TransactionString, Global.Instance.Network ?? Network.Main);
 
 					if (!signedPsbt.IsAllFinalized())
 					{
@@ -121,11 +121,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 				catch
 				{
-					transaction = new SmartTransaction(Transaction.Parse(TransactionString, Global.Network ?? Network.Main), WalletWasabi.Models.Height.Unknown);
+					transaction = new SmartTransaction(Transaction.Parse(TransactionString, Global.Instance.Network ?? Network.Main), WalletWasabi.Models.Height.Unknown);
 				}
 
 				MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.BroadcastingTransaction);
-				await Task.Run(async () => await Global.WalletService.SendTransactionAsync(transaction));
+				await Task.Run(async () => await Global.Instance.WalletService.SendTransactionAsync(transaction));
 
 				SetSuccessMessage("Transaction is successfully sent!");
 				TransactionString = "";

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -55,10 +55,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					var secret = KeyManager.GetMasterExtKey(Password);
 					Password = "";
 
-					string master = secret.GetWif(Global.Network).ToWif();
-					string account = secret.Derive(KeyManager.AccountKeyPath).GetWif(Global.Network).ToWif();
-					string masterZ = secret.ToZPrv(Global.Network);
-					string accountZ = secret.Derive(KeyManager.AccountKeyPath).ToZPrv(Global.Network);
+					string master = secret.GetWif(Global.Instance.Network).ToWif();
+					string account = secret.Derive(KeyManager.AccountKeyPath).GetWif(Global.Instance.Network).ToWif();
+					string masterZ = secret.ToZPrv(Global.Instance.Network);
+					string accountZ = secret.Derive(KeyManager.AccountKeyPath).ToZPrv(Global.Instance.Network);
 					SetSensitiveData(master, account, masterZ, accountZ);
 				}
 				catch (Exception ex)
@@ -83,8 +83,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public CancellationTokenSource Closing { private set; get; }
 
-		public string ExtendedAccountPublicKey => KeyManager.ExtPubKey.ToString(Global.Network);
-		public string ExtendedAccountZpub => KeyManager.ExtPubKey.ToZpub(Global.Network);
+		public string ExtendedAccountPublicKey => KeyManager.ExtPubKey.ToString(Global.Instance.Network);
+		public string ExtendedAccountZpub => KeyManager.ExtPubKey.ToZpub(Global.Instance.Network);
 		public string AccountKeyPath => $"m/{KeyManager.AccountKeyPath.ToString()}";
 		public string MasterKeyFingerprint => KeyManager.MasterFingerprint.ToString();
 		public ReactiveCommand<Unit, Unit> ShowSensitiveKeysCommand { get; }
@@ -154,7 +154,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Closing = new CancellationTokenSource();
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
 			{
 				this.RaisePropertyChanged(nameof(ExtendedAccountPublicKey));
 				this.RaisePropertyChanged(nameof(ExtendedAccountZpub));

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -87,8 +87,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
-				Global.UiConfig.LurkingWifeMode = !Global.UiConfig.LurkingWifeMode;
-				await Global.UiConfig.ToFileAsync();
+				Global.Instance.UiConfig.LurkingWifeMode = !Global.Instance.UiConfig.LurkingWifeMode;
+				await Global.Instance.UiConfig.ToFileAsync();
 			});
 		}
 
@@ -101,13 +101,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Disposables = new CompositeDisposable();
 
-			Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
-				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.CoinSpentOrSpenderConfirmed)))
+			Observable.FromEventPattern(Global.Instance.WalletService.Coins, nameof(Global.Instance.WalletService.Coins.CollectionChanged))
+				.Merge(Observable.FromEventPattern(Global.Instance.WalletService, nameof(Global.Instance.WalletService.CoinSpentOrSpenderConfirmed)))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(o => SetBalance(Name))
 				.DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(x =>
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(x =>
 			{
 				SetBalance(Name);
 			}).DisposeWith(Disposables);
@@ -142,7 +142,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
 
-			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode.Value ? "#########" : balance.ToString(false, true))} BTC)";
+			Title = $"{walletName} ({(Global.Instance.UiConfig.LurkingWifeMode.Value ? "#########" : balance.ToString(false, true))} BTC)";
 		}
 	}
 }

--- a/WalletWasabi.Gui/Converters/LurkingWifeModeStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/LurkingWifeModeStringConverter.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Gui.Converters
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
-			if (Global.UiConfig.LurkingWifeMode is true)
+			if (Global.Instance.UiConfig.LurkingWifeMode is true)
 			{
 				int len = 10;
 				if (int.TryParse(parameter.ToString(), out int newLength))

--- a/WalletWasabi.Gui/Converters/PhaseColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/PhaseColorConverter.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Data.Converters;
+using Avalonia.Data.Converters;
 using Avalonia.Media;
 using System;
 using System.Collections.Generic;
@@ -17,7 +17,7 @@ namespace WalletWasabi.Gui.Converters
 				throw new ArgumentException($"Unknown '{parameter}' value");
 			}
 
-			var phaseError = Global.ChaumianClient.State.IsInErrorState;
+			var phaseError = Global.Instance.ChaumianClient.State.IsInErrorState;
 
 			return ((CcjRoundPhase)p <= (CcjRoundPhase)value)
 				? (phaseError ? Brushes.IndianRed : Brushes.Green)

--- a/WalletWasabi.Gui/Converters/PrivacyLevelValueConverter.cs
+++ b/WalletWasabi.Gui/Converters/PrivacyLevelValueConverter.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 using AvalonStudio.Commands;
@@ -37,15 +37,15 @@ namespace WalletWasabi.Gui.Converters
 			if (value is int integer)
 			{
 				string shield;
-				if (integer < Global.Config.PrivacyLevelSome)
+				if (integer < Global.Instance.Config.PrivacyLevelSome)
 				{
 					shield = "Critical";
 				}
-				else if (integer < Global.Config.PrivacyLevelFine)
+				else if (integer < Global.Instance.Config.PrivacyLevelFine)
 				{
 					shield = "Some";
 				}
-				else if (integer < Global.Config.PrivacyLevelStrong)
+				else if (integer < Global.Instance.Config.PrivacyLevelStrong)
 				{
 					shield = "Fine";
 				}

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Threading;
+using Avalonia.Threading;
 using AvalonStudio.Extensibility.Dialogs;
 using ReactiveUI;
 using System;
@@ -132,12 +132,12 @@ namespace WalletWasabi.Gui.Dialogs
 
 					try
 					{
-						if (Global.WalletService is null || Global.ChaumianClient is null)
+						if (Global.Instance.WalletService is null || Global.Instance.ChaumianClient is null)
 						{
 							return;
 						}
 
-						SmartCoin[] enqueuedCoins = Global.WalletService.Coins.Where(x => x.CoinJoinInProgress).ToArray();
+						SmartCoin[] enqueuedCoins = Global.Instance.WalletService.Coins.Where(x => x.CoinJoinInProgress).ToArray();
 						Exception latestException = null;
 						foreach (var coin in enqueuedCoins)
 						{
@@ -148,7 +148,7 @@ namespace WalletWasabi.Gui.Dialogs
 									break;
 								}
 
-								await Global.ChaumianClient.DequeueCoinsFromMixAsync(new SmartCoin[] { coin }, "Closing Wasabi."); // Dequeue coins one-by-one to check cancel flag more frequently.
+								await Global.Instance.ChaumianClient.DequeueCoinsFromMixAsync(new SmartCoin[] { coin }, "Closing Wasabi."); // Dequeue coins one-by-one to check cancel flag more frequently.
 							}
 							catch (Exception ex)
 							{

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -81,9 +81,9 @@ namespace WalletWasabi.Gui
 			bool closeApplication = false;
 			try
 			{
-				if (Global.ChaumianClient != null)
+				if (Global.Instance.ChaumianClient != null)
 				{
-					Global.ChaumianClient.IsQuitPending = true; // indicate -> do not add any more alices to the coinjoin
+					Global.Instance.ChaumianClient.IsQuitPending = true; // indicate -> do not add any more alices to the coinjoin
 				}
 
 				if (!MainWindowViewModel.Instance.CanClose)
@@ -101,12 +101,12 @@ namespace WalletWasabi.Gui
 				{
 					try
 					{
-						if (Global.UiConfig != null) // UiConfig not yet loaded.
+						if (Global.Instance.UiConfig != null) // UiConfig not yet loaded.
 						{
-							Global.UiConfig.WindowState = WindowState;
-							Global.UiConfig.Width = Width;
-							Global.UiConfig.Height = Height;
-							await Global.UiConfig.ToFileAsync();
+							Global.Instance.UiConfig.WindowState = WindowState;
+							Global.Instance.UiConfig.Width = Width;
+							Global.Instance.UiConfig.Height = Height;
+							await Global.Instance.UiConfig.ToFileAsync();
 							Logging.Logger.LogInfo<UiConfig>("UiConfig is saved.");
 						}
 
@@ -118,7 +118,7 @@ namespace WalletWasabi.Gui
 							Logging.Logger.LogInfo<MainWindowViewModel>($"{nameof(WalletManagerViewModel)} closed, hwi enumeration stopped.");
 						}
 
-						await Global.DisposeAsync();
+						await Global.Instance.DisposeAsync();
 					}
 					catch (Exception ex)
 					{
@@ -140,9 +140,9 @@ namespace WalletWasabi.Gui
 				if (!closeApplication) //we are not closing the application for some reason
 				{
 					Interlocked.Exchange(ref _closingState, 0);
-					if (Global.ChaumianClient != null)
+					if (Global.Instance.ChaumianClient != null)
 					{
-						Global.ChaumianClient.IsQuitPending = false; //re-enable enqueuing coins
+						Global.Instance.ChaumianClient.IsQuitPending = false; //re-enable enqueuing coins
 					}
 				}
 			}
@@ -157,10 +157,10 @@ namespace WalletWasabi.Gui
 			{
 				Activated -= OnActivated;
 
-				var uiConfigFilePath = Path.Combine(Global.DataDir, "UiConfig.json");
+				var uiConfigFilePath = Path.Combine(Global.Instance.DataDir, "UiConfig.json");
 				var uiConfig = new UiConfig(uiConfigFilePath);
 				await uiConfig.LoadOrCreateDefaultFileAsync();
-				Global.InitializeUiConfig(uiConfig);
+				Global.Instance.InitializeUiConfig(uiConfig);
 				Logging.Logger.LogInfo<UiConfig>("UiConfig is successfully initialized.");
 
 				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -186,7 +186,7 @@ namespace WalletWasabi.Gui
 			var walletManagerViewModel = new WalletManagerViewModel();
 			IoC.Get<IShell>().AddDocument(walletManagerViewModel);
 
-			var isAnyDesktopWalletAvailable = Directory.Exists(Global.WalletsDir) && Directory.EnumerateFiles(Global.WalletsDir).Any();
+			var isAnyDesktopWalletAvailable = Directory.Exists(Global.Instance.WalletsDir) && Directory.EnumerateFiles(Global.Instance.WalletsDir).Any();
 
 			if (isAnyDesktopWalletAvailable)
 			{

--- a/WalletWasabi.Gui/Models/ShieldLevelHelper.cs
+++ b/WalletWasabi.Gui/Models/ShieldLevelHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -16,37 +16,37 @@ namespace WalletWasabi.Gui.Models
 
 		public static TargetPrivacy GetTargetPrivacy(int? mixUntilAnonymitySet)
 		{
-			if (mixUntilAnonymitySet == Global.Config.PrivacyLevelSome)
+			if (mixUntilAnonymitySet == Global.Instance.Config.PrivacyLevelSome)
 			{
 				return TargetPrivacy.Some;
 			}
 
-			if (mixUntilAnonymitySet == Global.Config.PrivacyLevelFine)
+			if (mixUntilAnonymitySet == Global.Instance.Config.PrivacyLevelFine)
 			{
 				return TargetPrivacy.Fine;
 			}
 
-			if (mixUntilAnonymitySet == Global.Config.PrivacyLevelStrong)
+			if (mixUntilAnonymitySet == Global.Instance.Config.PrivacyLevelStrong)
 			{
 				return TargetPrivacy.Strong;
 			}
 			//the levels changed in the config file, adjust
-			if (mixUntilAnonymitySet < Global.Config.PrivacyLevelSome)
+			if (mixUntilAnonymitySet < Global.Instance.Config.PrivacyLevelSome)
 			{
 				return TargetPrivacy.None; //choose the lower
 			}
 
-			if (mixUntilAnonymitySet < Global.Config.PrivacyLevelFine)
+			if (mixUntilAnonymitySet < Global.Instance.Config.PrivacyLevelFine)
 			{
 				return TargetPrivacy.Some;
 			}
 
-			if (mixUntilAnonymitySet < Global.Config.PrivacyLevelStrong)
+			if (mixUntilAnonymitySet < Global.Instance.Config.PrivacyLevelStrong)
 			{
 				return TargetPrivacy.Fine;
 			}
 
-			if (mixUntilAnonymitySet > Global.Config.PrivacyLevelFine)
+			if (mixUntilAnonymitySet > Global.Instance.Config.PrivacyLevelFine)
 			{
 				return TargetPrivacy.Strong;
 			}
@@ -62,13 +62,13 @@ namespace WalletWasabi.Gui.Models
 					return 0;
 
 				case TargetPrivacy.Some:
-					return Global.Config.PrivacyLevelSome.Value;
+					return Global.Instance.Config.PrivacyLevelSome.Value;
 
 				case TargetPrivacy.Fine:
-					return Global.Config.PrivacyLevelFine.Value;
+					return Global.Instance.Config.PrivacyLevelFine.Value;
 
 				case TargetPrivacy.Strong:
-					return Global.Config.PrivacyLevelStrong.Value;
+					return Global.Instance.Config.PrivacyLevelStrong.Value;
 			}
 			return 0;
 		}

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Gui
 			bool runGui = false;
 			try
 			{
-				Platform.BaseDirectory = Path.Combine(Global.DataDir, "Gui");
+				Platform.BaseDirectory = Path.Combine(Global.Instance.DataDir, "Gui");
 				AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 				TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
@@ -42,13 +42,13 @@ namespace WalletWasabi.Gui
 						statusBar = new StatusBarViewModel();
 						MainWindowViewModel.Instance.StatusBar = statusBar;
 
-						await Global.InitializeNoWalletAsync();
+						await Global.Instance.InitializeNoWalletAsync();
 
-						statusBar.Initialize(Global.Nodes.ConnectedNodes, Global.Synchronizer, Global.UpdateChecker);
+						statusBar.Initialize(Global.Instance.Nodes.ConnectedNodes, Global.Instance.Synchronizer, Global.Instance.UpdateChecker);
 
-						if (Global.Network != Network.Main)
+						if (Global.Instance.Network != Network.Main)
 						{
-							MainWindowViewModel.Instance.Title += $" - {Global.Network}";
+							MainWindowViewModel.Instance.Title += $" - {Global.Instance.Network}";
 						}
 
 						Dispatcher.UIThread.Post(() =>
@@ -65,7 +65,7 @@ namespace WalletWasabi.Gui
 			finally
 			{
 				statusBar?.Dispose();
-				await Global.DisposeAsync();
+				await Global.Instance.DisposeAsync();
 				AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
 				TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
 

--- a/WalletWasabi.Gui/Shell/Commands/DiskCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/DiskCommands.cs
@@ -1,4 +1,4 @@
-﻿using AvalonStudio.Commands;
+using AvalonStudio.Commands;
 using ReactiveUI;
 using System;
 using System.Composition;
@@ -54,12 +54,12 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnOpenDataFolder()
 		{
-			IoHelpers.OpenFolderInFileExplorer(Global.DataDir);
+			IoHelpers.OpenFolderInFileExplorer(Global.Instance.DataDir);
 		}
 
 		private void OnOpenWalletsFolder()
 		{
-			IoHelpers.OpenFolderInFileExplorer(Global.WalletsDir);
+			IoHelpers.OpenFolderInFileExplorer(Global.Instance.WalletsDir);
 		}
 
 		private void OnOpenLogFile()
@@ -69,12 +69,12 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnOpenTorLogFile()
 		{
-			IoHelpers.OpenFileInTextEditor(Global.TorLogsFile);
+			IoHelpers.OpenFileInTextEditor(Global.Instance.TorLogsFile);
 		}
 
 		private void OnOpenConfigFile()
 		{
-			IoHelpers.OpenFileInTextEditor(Global.Config.FilePath);
+			IoHelpers.OpenFileInTextEditor(Global.Instance.Config.FilePath);
 		}
 
 		private void OnFileOpenException(Exception ex)

--- a/WalletWasabi.Gui/Shell/Commands/ToolCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/ToolCommands.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 		private void OnWalletManager()
 		{
 			var walletManagerViewModel = IoC.Get<IShell>().GetOrCreate<WalletManagerViewModel>();
-			if (Directory.Exists(Global.WalletsDir) && Directory.EnumerateFiles(Global.WalletsDir).Any())
+			if (Directory.Exists(Global.Instance.WalletsDir) && Directory.EnumerateFiles(Global.Instance.WalletsDir).Any())
 			{
 				walletManagerViewModel.SelectLoadWallet();
 			}

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -38,8 +38,8 @@ namespace WalletWasabi.Gui.Tabs
 
 		public SettingsViewModel() : base("Settings")
 		{
-			var config = new Config(Global.Config.FilePath);
-			Autocopy = Global.UiConfig?.Autocopy is true;
+			var config = new Config(Global.Instance.Config.FilePath);
+			Autocopy = Global.Instance.UiConfig?.Autocopy is true;
 
 			this.WhenAnyValue(x => x.Network,
 				x => x.TorHost, x => x.TorPort, x => x.UseTor)
@@ -54,8 +54,8 @@ namespace WalletWasabi.Gui.Tabs
 			{
 				Dispatcher.UIThread.PostLogException(async () =>
 				{
-					Global.UiConfig.Autocopy = x;
-					await Global.UiConfig.ToFileAsync();
+					Global.Instance.UiConfig.Autocopy = x;
+					await Global.Instance.UiConfig.ToFileAsync();
 
 					AutocopyText = x ? "On" : "Off";
 				});
@@ -81,15 +81,15 @@ namespace WalletWasabi.Gui.Tabs
 
 				DustThreshold = config.DustThreshold.ToString();
 
-				IsModified = await Global.Config.CheckFileChangeAsync();
+				IsModified = await Global.Instance.Config.CheckFileChangeAsync();
 			});
 
 			OpenConfigFileCommand = ReactiveCommand.Create(OpenConfigFile);
 
 			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
-				Global.UiConfig.LurkingWifeMode = !LurkingWifeMode;
-				await Global.UiConfig.ToFileAsync();
+				Global.Instance.UiConfig.LurkingWifeMode = !LurkingWifeMode;
+				await Global.Instance.UiConfig.ToFileAsync();
 			});
 		}
 
@@ -102,7 +102,7 @@ namespace WalletWasabi.Gui.Tabs
 
 			Disposables = new CompositeDisposable();
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
 			{
 				this.RaisePropertyChanged(nameof(LurkingWifeMode));
 				this.RaisePropertyChanged(nameof(LurkingWifeModeText));
@@ -204,9 +204,9 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _dustThreshold, value);
 		}
 
-		public bool LurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool LurkingWifeMode => Global.Instance.UiConfig.LurkingWifeMode is true;
 
-		public string LurkingWifeModeText => Global.UiConfig.LurkingWifeMode is true ? "On" : "Off";
+		public string LurkingWifeModeText => Global.Instance.UiConfig.LurkingWifeMode is true ? "On" : "Off";
 
 		private void Save()
 		{
@@ -226,7 +226,7 @@ namespace WalletWasabi.Gui.Tabs
 				return;
 			}
 
-			var config = new Config(Global.Config.FilePath);
+			var config = new Config(Global.Instance.Config.FilePath);
 
 			Dispatcher.UIThread.PostLogException(async () =>
 			{
@@ -261,7 +261,7 @@ namespace WalletWasabi.Gui.Tabs
 
 					await config.ToFileAsync();
 
-					IsModified = await Global.Config.CheckFileChangeAsync();
+					IsModified = await Global.Instance.Config.CheckFileChangeAsync();
 				}
 			});
 		}
@@ -347,7 +347,7 @@ namespace WalletWasabi.Gui.Tabs
 
 		private void OpenConfigFile()
 		{
-			IoHelpers.OpenFileInTextEditor(Global.Config.FilePath);
+			IoHelpers.OpenFileInTextEditor(Global.Instance.Config.FilePath);
 		}
 	}
 }

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
@@ -1,4 +1,4 @@
-﻿using AvalonStudio.Extensibility;
+using AvalonStudio.Extensibility;
 using AvalonStudio.Shell;
 using NBitcoin;
 using ReactiveUI;
@@ -65,7 +65,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				return;
 			}
 
-			string walletFilePath = Path.Combine(Global.WalletsDir, $"{WalletName}.json");
+			string walletFilePath = Path.Combine(Global.Instance.WalletsDir, $"{WalletName}.json");
 			Password = Guard.Correct(Password); // Don't let whitespaces to the beginning and to the end.
 
 			if (!TermsAccepted)

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -258,7 +258,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				Password = "";
 				SetValidationMessage("");
 
-				var directoryInfo = new DirectoryInfo(Global.WalletsDir);
+				var directoryInfo = new DirectoryInfo(Global.Instance.WalletsDir);
 				var walletFiles = directoryInfo.GetFiles("*.json", SearchOption.TopDirectoryOnly).OrderByDescending(t => t.LastAccessTimeUtc);
 				foreach (var file in walletFiles)
 				{
@@ -288,7 +288,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				IsWalletSelected = SelectedWallet != null;
 				CanTestPassword = IsWalletSelected;
 
-				IsWalletOpened = Global.WalletService != null;
+				IsWalletOpened = Global.Instance.WalletService != null;
 				// If not busy loading.
 				// And wallet is selected.
 				// And no wallet is opened.
@@ -500,13 +500,13 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 						Logger.LogInfo<LoadWalletViewModel>("Hardware wallet wasn't used previously on this computer. Creating new wallet file.");
 
 						walletName = Utils.GetNextHardwareWalletName(selectedWallet.HardwareWalletInfo);
-						var path = Global.GetWalletFullPath(walletName);
+						var path = Global.Instance.GetWalletFullPath(walletName);
 						KeyManager.CreateNewHardwareWalletWatchOnly(selectedWallet.HardwareWalletInfo.MasterFingerprint.Value, extPubKey, path);
 					}
 				}
 
-				var walletFullPath = Global.GetWalletFullPath(walletName);
-				var walletBackupFullPath = Global.GetWalletBackupFullPath(walletName);
+				var walletFullPath = Global.Instance.GetWalletFullPath(walletName);
+				var walletBackupFullPath = Global.Instance.GetWalletBackupFullPath(walletName);
 				if (!File.Exists(walletFullPath) && !File.Exists(walletBackupFullPath))
 				{
 					// The selected wallet is not available any more (someone deleted it?).
@@ -515,7 +515,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					return null;
 				}
 
-				KeyManager keyManager = Global.LoadKeyManager(walletFullPath, walletBackupFullPath);
+				KeyManager keyManager = Global.Instance.LoadKeyManager(walletFullPath, walletBackupFullPath);
 				keyManager.HardwareWalletInfo = selectedWallet.HardwareWalletInfo;
 
 				if (!requirePassword && keyManager.PasswordVerified == false)
@@ -567,8 +567,8 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			// Start searching for the real wallet name.
 			walletName = null;
 
-			var walletFiles = new DirectoryInfo(Global.WalletsDir);
-			var walletBackupFiles = new DirectoryInfo(Global.WalletBackupsDir);
+			var walletFiles = new DirectoryInfo(Global.Instance.WalletsDir);
+			var walletBackupFiles = new DirectoryInfo(Global.Instance.WalletBackupsDir);
 
 			List<FileInfo> walletFileNames = new List<FileInfo>();
 
@@ -618,19 +618,19 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				{
 					await Task.Run(async () =>
 					{
-						await Global.InitializeWalletServiceAsync(keyManager);
+						await Global.Instance.InitializeWalletServiceAsync(keyManager);
 					});
 					// Successffully initialized.
 					Owner.OnClose();
 					// Open Wallet Explorer tabs
-					if (Global.WalletService.Coins.Any())
+					if (Global.Instance.WalletService.Coins.Any())
 					{
 						// If already have coins then open with History tab first.
-						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.WalletService, receiveDominant: false);
+						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.Instance.WalletService, receiveDominant: false);
 					}
 					else // Else open with Receive tab first.
 					{
-						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.WalletService, receiveDominant: true);
+						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.Instance.WalletService, receiveDominant: true);
 					}
 				}
 				catch (Exception ex)
@@ -641,7 +641,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					{
 						Logger.LogError<LoadWalletViewModel>(ex);
 					}
-					await Global.DisposeInWalletDependentServicesAsync();
+					await Global.Instance.DisposeInWalletDependentServicesAsync();
 				}
 			}
 			finally
@@ -655,7 +655,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 		public void OpenWalletsFolder()
 		{
-			var path = Global.WalletsDir;
+			var path = Global.Instance.WalletsDir;
 			IoHelpers.OpenFolderInFileExplorer(path);
 		}
 	}

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -37,7 +37,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				MnemonicWords = Guard.Correct(MnemonicWords);
 				Password = Guard.Correct(Password); // Don't let whitespaces to the beginning and to the end.
 
-				string walletFilePath = Path.Combine(Global.WalletsDir, $"{WalletName}.json");
+				string walletFilePath = Path.Combine(Global.Instance.WalletsDir, $"{WalletName}.json");
 
 				if (string.IsNullOrWhiteSpace(WalletName))
 				{

--- a/WalletWasabi.Gui/Utils.cs
+++ b/WalletWasabi.Gui/Utils.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Threading;
+using Avalonia.Threading;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -12,7 +12,7 @@ namespace WalletWasabi.Gui
 		{
 			for (int i = 0; i < int.MaxValue; i++)
 			{
-				if (!File.Exists(Path.Combine(Global.WalletsDir, $"Wallet{i}.json")))
+				if (!File.Exists(Path.Combine(Global.Instance.WalletsDir, $"Wallet{i}.json")))
 				{
 					return $"Wallet{i}";
 				}
@@ -26,7 +26,7 @@ namespace WalletWasabi.Gui
 			for (int i = 0; i < int.MaxValue; i++)
 			{
 				var name = $"{hwi.Type}{i}";
-				if (!File.Exists(Path.Combine(Global.WalletsDir, $"{name}.json")))
+				if (!File.Exists(Path.Combine(Global.Instance.WalletsDir, $"{name}.json")))
 				{
 					return name;
 				}

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Threading;
 using Gma.QrCodeNet.Encoding;
 using ReactiveUI;
@@ -39,7 +39,7 @@ namespace WalletWasabi.Gui.ViewModels
 				QrCode = x.Result;
 			});
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
+			Global.Instance.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
 			{
 				this.RaisePropertyChanged(nameof(Address));
 				this.RaisePropertyChanged(nameof(Label));
@@ -66,7 +66,7 @@ namespace WalletWasabi.Gui.ViewModels
 
 		public string Label => Model.Label;
 
-		public string Address => Model.GetP2wpkhAddress(Global.Network).ToString();
+		public string Address => Model.GetP2wpkhAddress(Global.Instance.Network).ToString();
 
 		public string Pubkey => Model.PubKey.ToString();
 

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui.ViewModels
 			Nodes = nodes;
 			Synchronizer = synchronizer;
 			HashChain = synchronizer.BitcoinStore.HashChain;
-			UseTor = Global.Config.UseTor.Value; // Don't make it dynamic, because if you change this config settings only next time will it activate.
+			UseTor = Global.Instance.Config.UseTor.Value; // Don't make it dynamic, because if you change this config settings only next time will it activate.
 
 			_status = ActiveStatuses.WhenAnyValue(x => x.CurrentStatus)
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Tests/Global.cs
+++ b/WalletWasabi.Tests/Global.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -8,15 +8,17 @@ using WalletWasabi.Logging;
 
 namespace WalletWasabi.Tests
 {
-	public static class Global
+	public class Global
 	{
-		public static IPEndPoint TorSocks5Endpoint { get; }
+		public static Global Instance { get; } = new Global();
 
-		public static string DataDir { get; }
+		public IPEndPoint TorSocks5Endpoint { get; }
 
-		public static string TorLogsFile { get; }
+		public string DataDir { get; }
 
-		static Global()
+		public string TorLogsFile { get; }
+
+		public Global()
 		{
 			TorSocks5Endpoint = new IPEndPoint(IPAddress.Loopback, 9050);
 

--- a/WalletWasabi.Tests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/KeyManagementTests.cs
@@ -88,7 +88,7 @@ namespace WalletWasabi.Tests
 		{
 			string password = "password";
 
-			var filePath = Path.Combine(Global.DataDir, nameof(CanSerialize), "Wallet.json");
+			var filePath = Path.Combine(Global.Instance.DataDir, nameof(CanSerialize), "Wallet.json");
 			DeleteFileAndDirectoryIfExists(filePath);
 
 			Logger.TurnOff();

--- a/WalletWasabi.Tests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/LiveServerTests.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tests
 		{
 			LiveServerTestsFixture = liveServerTestsFixture;
 
-			var torManager = new TorProcessManager(Global.TorSocks5Endpoint, Global.TorLogsFile);
+			var torManager = new TorProcessManager(Global.Instance.TorSocks5Endpoint, Global.Instance.TorLogsFile);
 			torManager.Start(ensureRunning: true, dataDir: Path.GetFullPath(AppContext.BaseDirectory));
 			Task.Delay(3000).GetAwaiter().GetResult();
 		}
@@ -35,7 +35,7 @@ namespace WalletWasabi.Tests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetFeesAsync(NetworkType networkType)
 		{
-			using (var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.TorSocks5Endpoint))
+			using (var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint))
 			{
 				var feeEstimationPairs = await client.GetFeesAsync(1000);
 
@@ -48,7 +48,7 @@ namespace WalletWasabi.Tests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetFiltersAsync(NetworkType networkType)
 		{
-			using (var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.TorSocks5Endpoint))
+			using (var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint))
 			{
 				var filterModel = StartingFilters.GetStartingFilter(Network.GetNetwork(networkType.ToString()));
 
@@ -64,7 +64,7 @@ namespace WalletWasabi.Tests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetAllRoundStatesAsync(NetworkType networkType)
 		{
-			using (var client = new SatoshiClient(LiveServerTestsFixture.UriMappings[networkType], Global.TorSocks5Endpoint))
+			using (var client = new SatoshiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint))
 			{
 				var states = await client.GetAllRoundStatesAsync();
 				Assert.True(states.NotNullAndNotEmpty());
@@ -81,7 +81,7 @@ namespace WalletWasabi.Tests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetExchangeRateAsync(NetworkType networkType) // xunit wtf: If this function is called GetExchangeRatesAsync, it'll stuck on 1 CPU VMs (Manjuro, Fedora)
 		{
-			using (var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.TorSocks5Endpoint))
+			using (var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint))
 			{
 				var exchangeRates = await client.GetExchangeRatesAsync();
 

--- a/WalletWasabi.Tests/NodeBuilding/NodeBuilder.cs
+++ b/WalletWasabi.Tests/NodeBuilding/NodeBuilder.cs
@@ -26,7 +26,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 		{
 			using (await Lock.LockAsync())
 			{
-				WorkingDirectory = Path.Combine(Global.DataDir, caller);
+				WorkingDirectory = Path.Combine(Global.Instance.DataDir, caller);
 				version = version ?? "0.18.0";
 				var path = await EnsureDownloadedAsync(version);
 				return new NodeBuilder(WorkingDirectory, path);
@@ -61,7 +61,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			string bitcoindFolderName = $"bitcoin-{version}";
 
 			// Remove old bitcoind folders.
-			IEnumerable<string> existingBitcoindFolderPaths = Directory.EnumerateDirectories(Global.DataDir, "bitcoin-*", SearchOption.TopDirectoryOnly);
+			IEnumerable<string> existingBitcoindFolderPaths = Directory.EnumerateDirectories(Global.Instance.DataDir, "bitcoin-*", SearchOption.TopDirectoryOnly);
 			foreach (string dirPath in existingBitcoindFolderPaths)
 			{
 				string dirName = Path.GetFileName(dirPath);
@@ -73,13 +73,13 @@ namespace WalletWasabi.Tests.NodeBuilding
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
-				bitcoind = Path.Combine(Global.DataDir, bitcoindFolderName, "bin", "bitcoind.exe");
+				bitcoind = Path.Combine(Global.Instance.DataDir, bitcoindFolderName, "bin", "bitcoind.exe");
 				if (File.Exists(bitcoind))
 				{
 					return bitcoind;
 				}
 
-				zip = Path.Combine(Global.DataDir, $"bitcoin-{version}-win64.zip");
+				zip = Path.Combine(Global.Instance.DataDir, $"bitcoin-{version}-win64.zip");
 				string url = string.Format("https://bitcoincore.org/bin/bitcoin-core-{0}/" + Path.GetFileName(zip), version);
 				using (var client = new HttpClient())
 				{
@@ -91,15 +91,15 @@ namespace WalletWasabi.Tests.NodeBuilding
 			}
 			else
 			{
-				bitcoind = Path.Combine(Global.DataDir, bitcoindFolderName, "bin", "bitcoind");
+				bitcoind = Path.Combine(Global.Instance.DataDir, bitcoindFolderName, "bin", "bitcoind");
 				if (File.Exists(bitcoind))
 				{
 					return bitcoind;
 				}
 
 				zip = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-					Path.Combine(Global.DataDir, $"bitcoin-{version}-x86_64-linux-gnu.tar.gz")
-					: Path.Combine(Global.DataDir, $"bitcoin-{version}-osx64.tar.gz");
+					Path.Combine(Global.Instance.DataDir, $"bitcoin-{version}-x86_64-linux-gnu.tar.gz")
+					: Path.Combine(Global.Instance.DataDir, $"bitcoin-{version}-osx64.tar.gz");
 
 				string url = string.Format("https://bitcoincore.org/bin/bitcoin-core-{0}/" + Path.GetFileName(zip), version);
 				using (var client = new HttpClient())
@@ -108,7 +108,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 					var data = await client.GetByteArrayAsync(url);
 					await File.WriteAllBytesAsync(zip, data);
 
-					using (var process = Process.Start("tar", "-zxvf " + zip + " -C " + Global.DataDir))
+					using (var process = Process.Start("tar", "-zxvf " + zip + " -C " + Global.Instance.DataDir))
 					{
 						process.WaitForExit();
 					}

--- a/WalletWasabi.Tests/P2pTests.cs
+++ b/WalletWasabi.Tests/P2pTests.cs
@@ -49,9 +49,9 @@ namespace WalletWasabi.Tests
 				throw new NotSupportedException(network.ToString());
 			}
 
-			var addressManagerFolderPath = Path.Combine(Global.DataDir, "AddressManager");
+			var addressManagerFolderPath = Path.Combine(Global.Instance.DataDir, "AddressManager");
 			var addressManagerFilePath = Path.Combine(addressManagerFolderPath, $"AddressManager{network}.dat");
-			var blocksFolderPath = Path.Combine(Global.DataDir, "Blocks", network.ToString());
+			var blocksFolderPath = Path.Combine(Global.Instance.DataDir, "Blocks", network.ToString());
 			var connectionParameters = new NodeConnectionParameters();
 			AddressManager addressManager = null;
 			try
@@ -79,18 +79,18 @@ namespace WalletWasabi.Tests
 			var nodes = new NodesGroup(network, connectionParameters, requirements: Helpers.Constants.NodeRequirements);
 
 			BitcoinStore bitcoinStore = new BitcoinStore();
-			await bitcoinStore.InitializeAsync(Path.Combine(Global.DataDir, nameof(TestServicesAsync)), network);
+			await bitcoinStore.InitializeAsync(Path.Combine(Global.Instance.DataDir, nameof(TestServicesAsync)), network);
 
 			KeyManager keyManager = KeyManager.CreateNew(out _, "password");
-			WasabiSynchronizer syncer = new WasabiSynchronizer(network, bitcoinStore, new Uri("http://localhost:12345"), Global.TorSocks5Endpoint);
+			WasabiSynchronizer syncer = new WasabiSynchronizer(network, bitcoinStore, new Uri("http://localhost:12345"), Global.Instance.TorSocks5Endpoint);
 			WalletService walletService = new WalletService(
 			   bitcoinStore,
 			   keyManager,
 			   syncer,
-			   new CcjClient(syncer, network, keyManager, new Uri("http://localhost:12345"), Global.TorSocks5Endpoint),
+			   new CcjClient(syncer, network, keyManager, new Uri("http://localhost:12345"), Global.Instance.TorSocks5Endpoint),
 			   memPoolService,
 			   nodes,
-			   Global.DataDir,
+			   Global.Instance.DataDir,
 			   new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(0.0001m)));
 			Assert.True(Directory.Exists(blocksFolderPath));
 

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Tests
 
 		private async Task AssertFiltersInitializedAsync()
 		{
-			var firstHash = await Backend.Global.RpcClient.GetBlockHashAsync(0);
+			var firstHash = await Backend.Global.Instance.RpcClient.GetBlockHashAsync(0);
 			while (true)
 			{
 				using (var client = new WasabiClient(new Uri(RegTestFixture.BackendEndPoint), null))
@@ -77,16 +77,16 @@ namespace WalletWasabi.Tests
 			await AssertFiltersInitializedAsync(); // Make sure fitlers are created on the server side.
 			if (numberOfBlocksToGenerate != 0)
 			{
-				await Backend.Global.RpcClient.GenerateAsync(numberOfBlocksToGenerate); // Make sure everything is confirmed.
+				await Backend.Global.Instance.RpcClient.GenerateAsync(numberOfBlocksToGenerate); // Make sure everything is confirmed.
 			}
-			Backend.Global.Coordinator.UtxoReferee.Clear();
+			Backend.Global.Instance.Coordinator.UtxoReferee.Clear();
 
-			var network = Backend.Global.RpcClient.Network;
+			var network = Backend.Global.Instance.RpcClient.Network;
 			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, Money.Coins(0.0001m));
 			var bitcoinStore = new BitcoinStore();
 			var dir = Path.Combine(Global.Instance.DataDir, caller);
 			await bitcoinStore.InitializeAsync(dir, network);
-			return ("password", Backend.Global.RpcClient, network, Backend.Global.Coordinator, serviceConfiguration, bitcoinStore);
+			return ("password", Backend.Global.Instance.RpcClient, network, Backend.Global.Instance.Coordinator, serviceConfiguration, bitcoinStore);
 		}
 
 		#region BackendTests
@@ -166,7 +166,7 @@ namespace WalletWasabi.Tests
 			var indexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{rpc.Network}.dat");
 			var utxoSetFilePath = Path.Combine(indexBuilderServiceDir, $"UtxoSet{rpc.Network}.dat");
 
-			var indexBuilderService = new IndexBuilderService(rpc, Backend.Global.TrustedNodeNotifyingBehavior, indexFilePath, utxoSetFilePath);
+			var indexBuilderService = new IndexBuilderService(rpc, Backend.Global.Instance.TrustedNodeNotifyingBehavior, indexFilePath, utxoSetFilePath);
 			try
 			{
 				indexBuilderService.Synchronize();
@@ -404,7 +404,7 @@ namespace WalletWasabi.Tests
 				var tipBlock = await rpc.GetBlockHeaderAsync(tip);
 				Assert.Equal(tipBlock.HashPrevBlock, bitcoinStore.HashChain.GetChain().Select(x => x.hash).ToArray()[bitcoinStore.HashChain.HashCount - 2]);
 
-				var utxoPath = Backend.Global.IndexBuilderService.Bech32UtxoSetFilePath;
+				var utxoPath = Backend.Global.Instance.IndexBuilderService.Bech32UtxoSetFilePath;
 				var utxoLines = await File.ReadAllTextAsync(utxoPath);
 				Assert.Contains(tx1.ToString(), utxoLines);
 				Assert.Contains(tx2.ToString(), utxoLines);
@@ -489,7 +489,7 @@ namespace WalletWasabi.Tests
 
 		private async Task WaitForIndexesToSyncAsync(TimeSpan timeout, BitcoinStore bitcoinStore)
 		{
-			var bestHash = await Backend.Global.RpcClient.GetBestBlockHashAsync();
+			var bestHash = await Backend.Global.Instance.RpcClient.GetBestBlockHashAsync();
 
 			var times = 0;
 			while (bitcoinStore.HashChain.TipHash != bestHash)
@@ -522,7 +522,7 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.
@@ -751,7 +751,7 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.
@@ -1194,7 +1194,7 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.
@@ -1357,7 +1357,7 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.
@@ -1521,7 +1521,7 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.
@@ -1687,7 +1687,7 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.
@@ -1809,7 +1809,7 @@ namespace WalletWasabi.Tests
 				mempoolTxId.ToString()
 			});
 
-			using (var coordinatorToTest = new CcjCoordinator(network, Backend.Global.TrustedNodeNotifyingBehavior, folder, rpc, coordinator.RoundConfig))
+			using (var coordinatorToTest = new CcjCoordinator(network, Backend.Global.Instance.TrustedNodeNotifyingBehavior, folder, rpc, coordinator.RoundConfig))
 			{
 				var txIds = await File.ReadAllLinesAsync(cjfile);
 
@@ -1824,7 +1824,7 @@ namespace WalletWasabi.Tests
 				"This line is invalid (the file is corrupted)",
 				offchainTxId.ToString(),
 			});
-				var coordinatorToTest2 = new CcjCoordinator(network, Backend.Global.TrustedNodeNotifyingBehavior, folder, rpc, coordinatorToTest.RoundConfig);
+				var coordinatorToTest2 = new CcjCoordinator(network, Backend.Global.Instance.TrustedNodeNotifyingBehavior, folder, rpc, coordinatorToTest.RoundConfig);
 				coordinatorToTest2?.Dispose();
 				txIds = await File.ReadAllLinesAsync(cjfile);
 				Assert.Single(txIds);
@@ -3298,10 +3298,10 @@ namespace WalletWasabi.Tests
 
 			// Create the services.
 			// 1. Create connection service.
-			var nodes = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
-			var nodes2 = new NodesGroup(Backend.Global.Config.Network, requirements: Constants.NodeRequirements);
+			var nodes2 = new NodesGroup(Backend.Global.Instance.Config.Network, requirements: Constants.NodeRequirements);
 			nodes2.ConnectedNodes.Add(await RegTestFixture.BackendRegTestNode.CreateNodeClientAsync());
 
 			// 2. Create mempool service.

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -84,7 +84,7 @@ namespace WalletWasabi.Tests
 			var network = Backend.Global.RpcClient.Network;
 			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, Money.Coins(0.0001m));
 			var bitcoinStore = new BitcoinStore();
-			var dir = Path.Combine(Global.DataDir, caller);
+			var dir = Path.Combine(Global.Instance.DataDir, caller);
 			await bitcoinStore.InitializeAsync(dir, network);
 			return ("password", Backend.Global.RpcClient, network, Backend.Global.Coordinator, serviceConfiguration, bitcoinStore);
 		}
@@ -162,7 +162,7 @@ namespace WalletWasabi.Tests
 		{
 			(string password, RPCClient rpc, Network network, CcjCoordinator coordinator, ServiceConfiguration serviceConfiguration, BitcoinStore bitcoinStore) = await InitializeTestEnvironmentAsync(1);
 
-			var indexBuilderServiceDir = Path.Combine(Global.DataDir, nameof(IndexBuilderService));
+			var indexBuilderServiceDir = Path.Combine(Global.Instance.DataDir, nameof(IndexBuilderService));
 			var indexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{rpc.Network}.dat");
 			var utxoSetFilePath = Path.Combine(indexBuilderServiceDir, $"UtxoSet{rpc.Network}.dat");
 
@@ -541,7 +541,7 @@ namespace WalletWasabi.Tests
 			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 5. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(WalletTestsAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(WalletTestsAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
@@ -769,7 +769,7 @@ namespace WalletWasabi.Tests
 			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 6. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(SendTestsFromHiddenWalletAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(SendTestsFromHiddenWalletAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
@@ -1212,7 +1212,7 @@ namespace WalletWasabi.Tests
 			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 6. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(SendTestsFromHiddenWalletAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(SendTestsFromHiddenWalletAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
@@ -1375,7 +1375,7 @@ namespace WalletWasabi.Tests
 			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 6. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(SendTestsFromHiddenWalletAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(SendTestsFromHiddenWalletAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
@@ -1539,7 +1539,7 @@ namespace WalletWasabi.Tests
 			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 6. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(SendTestsFromHiddenWalletAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(SendTestsFromHiddenWalletAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
@@ -1705,7 +1705,7 @@ namespace WalletWasabi.Tests
 			var chaumianClient = new CcjClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 6. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(SendTestsFromHiddenWalletAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(SendTestsFromHiddenWalletAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
@@ -1799,7 +1799,7 @@ namespace WalletWasabi.Tests
 			var offchainTxId = network.Consensus.ConsensusFactory.CreateTransaction().GetHash();
 			var mempoolTxId = rpc.SendToAddress(new Key().PubKey.GetSegwitAddress(network), Money.Coins(1));
 
-			var folder = Path.Combine(Global.DataDir, nameof(CcjCoordinatorCtorTestsAsync));
+			var folder = Path.Combine(Global.Instance.DataDir, nameof(CcjCoordinatorCtorTestsAsync));
 			await IoHelpers.DeleteRecursivelyWithMagicDustAsync(folder);
 			Directory.CreateDirectory(folder);
 			var cjfile = Path.Combine(folder, $"CoinJoins{network}.txt");
@@ -1850,7 +1850,7 @@ namespace WalletWasabi.Tests
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
 			Uri baseUri = new Uri(RegTestFixture.BackendEndPoint);
-			using (var torClient = new TorHttpClient(baseUri, Global.TorSocks5Endpoint))
+			using (var torClient = new TorHttpClient(baseUri, Global.Instance.TorSocks5Endpoint))
 			using (var satoshiClient = new SatoshiClient(baseUri, null))
 			{
 				#region PostInputsGetStates
@@ -2369,7 +2369,7 @@ namespace WalletWasabi.Tests
 			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
 
 			Uri baseUri = new Uri(RegTestFixture.BackendEndPoint);
-			using (var torClient = new TorHttpClient(baseUri, Global.TorSocks5Endpoint))
+			using (var torClient = new TorHttpClient(baseUri, Global.Instance.TorSocks5Endpoint))
 			using (var satoshiClient = new SatoshiClient(baseUri, null))
 			{
 				var round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
@@ -3316,7 +3316,7 @@ namespace WalletWasabi.Tests
 			// 3. Create wasabi synchronizer service.
 			var synchronizer = new WasabiSynchronizer(network, bitcoinStore, new Uri(RegTestFixture.BackendEndPoint), null);
 
-			var indexFilePath2 = Path.Combine(Global.DataDir, nameof(CoinJoinMultipleRoundTestsAsync), $"Index{network}2.dat");
+			var indexFilePath2 = Path.Combine(Global.Instance.DataDir, nameof(CoinJoinMultipleRoundTestsAsync), $"Index{network}2.dat");
 			var synchronizer2 = new WasabiSynchronizer(network, bitcoinStore, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 4. Create key manager service.
@@ -3330,11 +3330,11 @@ namespace WalletWasabi.Tests
 			var chaumianClient2 = new CcjClient(synchronizer, network, keyManager2, new Uri(RegTestFixture.BackendEndPoint), null);
 
 			// 6. Create wallet service.
-			var workDir = Path.Combine(Global.DataDir, nameof(CoinJoinMultipleRoundTestsAsync));
+			var workDir = Path.Combine(Global.Instance.DataDir, nameof(CoinJoinMultipleRoundTestsAsync));
 			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, memPoolService, nodes, workDir, serviceConfiguration);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
-			var workDir2 = Path.Combine(Global.DataDir, $"{nameof(CoinJoinMultipleRoundTestsAsync)}2");
+			var workDir2 = Path.Combine(Global.Instance.DataDir, $"{nameof(CoinJoinMultipleRoundTestsAsync)}2");
 			var wallet2 = new WalletService(bitcoinStore, keyManager2, synchronizer2, chaumianClient2, memPoolService2, nodes2, workDir2, serviceConfiguration);
 
 			// Get some money, make it confirm.

--- a/WalletWasabi.Tests/StoreTests.cs
+++ b/WalletWasabi.Tests/StoreTests.cs
@@ -174,7 +174,7 @@ namespace WalletWasabi.Tests
 		{
 			var indexStore = new IndexStore();
 
-			var dir = Path.Combine(Global.DataDir, nameof(IndexStoreTestsAsync));
+			var dir = Path.Combine(Global.Instance.DataDir, nameof(IndexStoreTestsAsync));
 			var network = Network.Main;
 			await indexStore.InitializeAsync(dir, network, new HashChain());
 		}
@@ -339,8 +339,8 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task IoManagerTestsAsync()
 		{
-			var file1 = Path.Combine(Global.DataDir, nameof(IoManagerTestsAsync), $"file1.dat");
-			var file2 = Path.Combine(Global.DataDir, nameof(IoManagerTestsAsync), $"file2.dat");
+			var file1 = Path.Combine(Global.Instance.DataDir, nameof(IoManagerTestsAsync), $"file1.dat");
+			var file2 = Path.Combine(Global.Instance.DataDir, nameof(IoManagerTestsAsync), $"file2.dat");
 
 			Random random = new Random();
 			List<string> lines = new List<string>();
@@ -540,7 +540,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task IoTestsAsync()
 		{
-			var file = Path.Combine(Global.DataDir, nameof(IoTestsAsync), $"file.dat");
+			var file = Path.Combine(Global.Instance.DataDir, nameof(IoTestsAsync), $"file.dat");
 
 			IoManager ioman = new IoManager(file);
 			ioman.DeleteMe();

--- a/WalletWasabi.Tests/TorTests.cs
+++ b/WalletWasabi.Tests/TorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -16,7 +16,7 @@ namespace WalletWasabi.Tests
 	{
 		public TorTests()
 		{
-			var torManager = new TorProcessManager(Global.TorSocks5Endpoint, Global.TorLogsFile);
+			var torManager = new TorProcessManager(Global.Instance.TorSocks5Endpoint, Global.Instance.TorLogsFile);
 			torManager.Start(ensureRunning: true, dataDir: Path.GetFullPath(AppContext.BaseDirectory));
 			Task.Delay(3000).GetAwaiter().GetResult();
 		}
@@ -24,7 +24,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanDoRequestManyDifferentAsync()
 		{
-			using (var client = new TorHttpClient(new Uri("http://api.qbit.ninja"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("http://api.qbit.ninja"), Global.Instance.TorSocks5Endpoint))
 			{
 				await QBitTestAsync(client, 10, alterRequests: true);
 			}
@@ -33,7 +33,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanRequestChunkEncodedAsync()
 		{
-			using (var client = new TorHttpClient(new Uri("https://jigsaw.w3.org/"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("https://jigsaw.w3.org/"), Global.Instance.TorSocks5Endpoint))
 			{
 				var response = await client.SendAsync(HttpMethod.Get, "/HTTP/ChunkedScript");
 				var content = await response.Content.ReadAsStringAsync();
@@ -55,7 +55,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanDoBasicPostHttpsRequestAsync()
 		{
-			using (var client = new TorHttpClient(new Uri("https://api.smartbit.com.au"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("https://api.smartbit.com.au"), Global.Instance.TorSocks5Endpoint))
 			{
 				HttpContent content = new StringContent("{\"hex\": \"01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2d03a58605204d696e656420627920416e74506f6f6c20757361311f10b53620558903d80272a70c0000724c0600ffffffff010f9e5096000000001976a9142ef12bd2ac1416406d0e132e5bc8d0b02df3861b88ac00000000\"}");
 
@@ -82,7 +82,7 @@ namespace WalletWasabi.Tests
 			}
 
 			// 2. Get Tor IP
-			using (var client = new TorHttpClient(new Uri(requestUri), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri(requestUri), Global.Instance.TorSocks5Endpoint))
 			{
 				var content = await (await client.SendAsync(HttpMethod.Get, "")).Content.ReadAsStringAsync();
 				var gotIp = IPAddress.TryParse(content.Replace("\n", ""), out torIp);
@@ -95,7 +95,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanDoHttpsAsync()
 		{
-			using (var client = new TorHttpClient(new Uri("https://slack.com"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("https://slack.com"), Global.Instance.TorSocks5Endpoint))
 			{
 				var content =
 					await (await client.SendAsync(HttpMethod.Get, "api/api.test")).Content.ReadAsStringAsync();
@@ -107,7 +107,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanDoIpAddressAsync()
 		{
-			using (var client = new TorHttpClient(new Uri("http://172.217.6.142"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("http://172.217.6.142"), Global.Instance.TorSocks5Endpoint))
 			{
 				var content = await (await client.SendAsync(HttpMethod.Get, "")).Content.ReadAsStringAsync();
 
@@ -118,7 +118,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanRequestInRowAsync()
 		{
-			using (var client = new TorHttpClient(new Uri("http://api.qbit.ninja"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("http://api.qbit.ninja"), Global.Instance.TorSocks5Endpoint))
 			{
 				await (await client.SendAsync(HttpMethod.Get, "/transactions/38d4cfeb57d6685753b7a3b3534c3cb576c34ca7344cd4582f9613ebf0c2b02a?format=json&headeronly=true")).Content.ReadAsStringAsync();
 				await (await client.SendAsync(HttpMethod.Get, "/balances/15sYbVpRh6dyWycZMwPdxJWD4xbfxReeHe?unspentonly=true")).Content.ReadAsStringAsync();
@@ -129,7 +129,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanRequestOnionV2Async()
 		{
-			using (var client = new TorHttpClient(new Uri("http://expyuzz4wqqyqhjn.onion/"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("http://expyuzz4wqqyqhjn.onion/"), Global.Instance.TorSocks5Endpoint))
 			{
 				HttpResponseMessage response = await client.SendAsync(HttpMethod.Get, "");
 				var content = await response.Content.ReadAsStringAsync();
@@ -143,7 +143,7 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task CanRequestOnionV3Async()
 		{
-			using (var client = new TorHttpClient(new Uri("http://dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion"), Global.TorSocks5Endpoint))
+			using (var client = new TorHttpClient(new Uri("http://dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion"), Global.Instance.TorSocks5Endpoint))
 			{
 				HttpResponseMessage response = await client.SendAsync(HttpMethod.Get, "");
 				var content = await response.Content.ReadAsStringAsync();
@@ -157,9 +157,9 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task DoesntIsolateStreamsAsync()
 		{
-			using (var c1 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.TorSocks5Endpoint))
-			using (var c2 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.TorSocks5Endpoint))
-			using (var c3 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.TorSocks5Endpoint))
+			using (var c1 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.Instance.TorSocks5Endpoint))
+			using (var c2 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.Instance.TorSocks5Endpoint))
+			using (var c3 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.Instance.TorSocks5Endpoint))
 			{
 				var t1 = c1.SendAsync(HttpMethod.Get, "");
 				var t2 = c2.SendAsync(HttpMethod.Get, "");
@@ -179,9 +179,9 @@ namespace WalletWasabi.Tests
 		[Fact]
 		public async Task IsolatesStreamsAsync()
 		{
-			using (var c1 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.TorSocks5Endpoint, isolateStream: true))
-			using (var c2 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.TorSocks5Endpoint, isolateStream: true))
-			using (var c3 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.TorSocks5Endpoint, isolateStream: true))
+			using (var c1 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.Instance.TorSocks5Endpoint, isolateStream: true))
+			using (var c2 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.Instance.TorSocks5Endpoint, isolateStream: true))
+			using (var c3 = new TorHttpClient(new Uri("http://api.ipify.org"), Global.Instance.TorSocks5Endpoint, isolateStream: true))
 			{
 				var t1 = c1.SendAsync(HttpMethod.Get, "");
 				var t2 = c2.SendAsync(HttpMethod.Get, "");
@@ -216,7 +216,7 @@ namespace WalletWasabi.Tests
 				var task = client.SendAsync(HttpMethod.Get, relativetUri);
 				if (alterRequests)
 				{
-					using (var ipClient = new TorHttpClient(new Uri("https://api.ipify.org/"), Global.TorSocks5Endpoint))
+					using (var ipClient = new TorHttpClient(new Uri("https://api.ipify.org/"), Global.Instance.TorSocks5Endpoint))
 					{
 						var task2 = ipClient.SendAsync(HttpMethod.Get, "/");
 						tasks.Add(task2);

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 
 			var roundConfig = new CcjRoundConfig(Money.Coins(0.1m), 144, 0.7, 0.1m, 100, 120, 60, 60, 60, 1, 24, true, 11);
 
-			Backend.Global.InitializeAsync(config, roundConfig, rpc).GetAwaiter().GetResult();
+			Backend.Global.Instance.InitializeAsync(config, roundConfig, rpc).GetAwaiter().GetResult();
 
 			BackendEndPoint = $"http://localhost:{new Random().Next(37130, 38000)}/";
 			BackendHost = WebHost.CreateDefaultBuilder()


### PR DESCRIPTION
I am trying to refactor the code to limit the use of global singleton/god object which is an anti pattern.

By series of refactoring I will discover many bug along the way as the compiler will detect when I am accessing fields when I should not (such bug [like this one](https://github.com/zkSNACKs/WalletWasabi/pull/1585/files#r294717275) should be discoverable by the compiler if there was not this huge Global)

Another cool thing, is that we would be able to run the tests in parallel, or easily create several instance of wasabi wallet in test which mix with one another in tests.

This PR is automatic `Global` => `Global.Instance` this will allow me to refactor the rest in an incremental way.