### PR TITLE
Unsubscribe coin events

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -424,6 +424,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 									if (toRemove != default)
 									{
 										RootList.Remove(toRemove);
+										toRemove.UnsubscribeEvents();
 									}
 								}
 								break;

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -108,19 +108,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public decimal TotalAmount
 		{
 			get => _totalAmount;
-			set
-			{
-				this.RaiseAndSetIfChanged(ref _totalAmount, value);
-			}
+			set => this.RaiseAndSetIfChanged(ref _totalAmount, value);
 		}
 
 		public bool IsAnyCoinSelected
 		{
 			get => _isAnyCoinSelected;
-			set
-			{
-				this.RaiseAndSetIfChanged(ref _isAnyCoinSelected, value);
-			}
+			set => this.RaiseAndSetIfChanged(ref _isAnyCoinSelected, value);
 		}
 
 		private void RefreshOrdering()
@@ -239,7 +233,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			RootList = new SourceList<CoinViewModel>();
 			RootList.Connect()
-				.OnItemRemoved(x => x.UnsubscribeEvents())
 				.Sort(MyComparer, comparerChanged: sortChanged, resetThreshold: 5)
 				.Bind(out _coinViewModels)
 				.ObserveOn(RxApp.MainThreadScheduler)
@@ -430,7 +423,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 								break;
 
 							case NotifyCollectionChangedAction.Reset:
-								ClearRootList();
+								{
+									ClearRootList();
+								}
 								break;
 						}
 					}
@@ -444,13 +439,23 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			SetCoinJoinStatusWidth();
 		}
 
-		private void ClearRootList() => RootList.Clear();
+		private void ClearRootList()
+		{
+			IEnumerable<CoinViewModel> toRemoves = RootList?.Items?.ToList() ?? Enumerable.Empty<CoinViewModel>(); // Clone so we can unsubscribe after clear.
+			RootList?.Clear();
+
+			foreach (CoinViewModel toRemove in toRemoves)
+			{
+				toRemove.UnsubscribeEvents();
+			}
+		}
 
 		public void OnClose()
 		{
 			ClearRootList();
 
 			Disposables?.Dispose();
+			Disposables = null;
 		}
 
 		private void SetSelections()
@@ -482,7 +487,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			SetSelections();
 			SelectionChanged?.Invoke(this, cvm);
-			TotalAmount = Coins.Where(x=>x.IsSelected).Sum(x=>x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC));
+			TotalAmount = Coins.Where(x => x.IsSelected).Sum(x => x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC));
 		}
 
 		public void OnCoinStatusChanged()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -41,17 +41,19 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			//TODO defer subscription to when accessed (will be faster in ui.)
 			_coinJoinInProgress = Model.WhenAnyValue(x => x.CoinJoinInProgress)
-				.ObserveOn(RxApp.MainThreadScheduler)
-				.ToProperty(this, x => x.CoinJoinInProgress)
+				.ToProperty(this, x => x.CoinJoinInProgress, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
-			_unspent = Model.WhenAnyValue(x => x.Unspent).ToProperty(this, x => x.Unspent, scheduler: RxApp.MainThreadScheduler)
+			_unspent = Model.WhenAnyValue(x => x.Unspent)
+				.ToProperty(this, x => x.Unspent, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
-			_confirmed = Model.WhenAnyValue(x => x.Confirmed).ToProperty(this, x => x.Confirmed, scheduler: RxApp.MainThreadScheduler)
+			_confirmed = Model.WhenAnyValue(x => x.Confirmed)
+				.ToProperty(this, x => x.Confirmed, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
-			_unavailable = Model.WhenAnyValue(x => x.Unavailable).ToProperty(this, x => x.Unavailable, scheduler: RxApp.MainThreadScheduler)
+			_unavailable = Model.WhenAnyValue(x => x.Unavailable)
+				.ToProperty(this, x => x.Unavailable, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
 			this.WhenAnyValue(x => x.Status)


### PR DESCRIPTION
This PR unsubscribe the coins events after they are removed from the `CoinListViewModel`. Please review.
Related https://github.com/zkSNACKs/WalletWasabi/issues/1594