### PR TITLE
Add Local node host & port settings

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -69,6 +69,15 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
 		public int? RegTestBitcoinCorePort { get; internal set; }
 
+		[JsonProperty(PropertyName = "MainNetFetchFromLocalOnly")]
+		public bool MainNetFetchFromLocalOnly { get; internal set; }
+
+		[JsonProperty(PropertyName = "TestNetFetchFromLocalOnly")]
+		public bool TestNetFetchFromLocalOnly { get; internal set; }
+
+		[JsonProperty(PropertyName = "RegTestFetchFromLocalOnly")]
+		public bool RegTestFetchFromLocalOnly { get; internal set; }
+
 		[JsonProperty(PropertyName = "MixUntilAnonymitySet")]
 		public int? MixUntilAnonymitySet
 		{
@@ -450,7 +459,18 @@ namespace WalletWasabi.Gui
 			{
 				return true;
 			}
-
+			if (MainNetFetchFromLocalOnly != config.MainNetFetchFromLocalOnly)
+			{
+				return true;
+			}
+			if (TestNetFetchFromLocalOnly != config.TestNetFetchFromLocalOnly)
+			{
+				return true;
+			}
+			if (RegTestFetchFromLocalOnly != config.RegTestFetchFromLocalOnly)
+			{
+				return true;
+			}
 			if (UseTor != config.UseTor)
 			{
 				return true;

--- a/WalletWasabi.Gui/Converters/BooleanOnOffConverter.cs
+++ b/WalletWasabi.Gui/Converters/BooleanOnOffConverter.cs
@@ -1,0 +1,31 @@
+﻿using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace WalletWasabi.Gui.Converters
+{
+    public class BooleanOnOffConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool boolean)
+			{
+				if (boolean)
+				{
+					return "On";
+				}
+				else
+				{
+					return "Off";
+				}
+			}
+
+			throw new InvalidOperationException();
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -1,5 +1,11 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui">
+  <UserControl.Resources>
+    <converters:BooleanOnOffConverter x:Key="BooleanOnOffConverter" />
+  </UserControl.Resources>
+
   <ScrollViewer>
     <StackPanel Margin="30" Spacing="10">
       <Grid Classes="content">
@@ -15,13 +21,32 @@
                 <TextBlock>Network</TextBlock>
                 <DropDown Items="{Binding Networks}" SelectedItem="{Binding Network}" />
               </StackPanel>
+
+              <controls:GroupBox Title="{Binding Network, StringFormat=My Node for \{0\} }" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
+                <StackPanel Orientation="Vertical" Spacing="5">
+                  <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
+                    <ToggleButton IsChecked="{Binding FetchBlocksFromMyNodeOnly}" Content="{Binding FetchBlocksFromMyNodeOnly, Converter={StaticResource BooleanOnOffConverter}}" Margin="0 0 10 0" />
+                    <TextBlock VerticalAlignment="Center">Only fetch blocks from my node.</TextBlock>
+                  </StackPanel>
+                  <StackPanel Margin="0 10" Spacing="5">
+                    <TextBlock>Host</TextBlock>
+                    <TextBox Text="{Binding LocalNodeHost}" />
+                  </StackPanel>
+                  <Separator/>
+                  <StackPanel Spacing="5">
+                    <TextBlock>Port</TextBlock>
+                    <TextBox Text="{Binding LocalNodePort}" />
+                  </StackPanel>
+                </StackPanel>
+              </controls:GroupBox>
+
             </StackPanel>
           </controls:GroupBox>
 
           <controls:GroupBox Title="Tor" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
             <StackPanel Orientation="Vertical" Spacing="5">
               <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
-                <ToggleButton IsChecked="{Binding UseTor}" Content="{Binding UseTorText}" Margin="0 0 10 0" />
+                <ToggleButton IsChecked="{Binding UseTor}" Content="{Binding UseTor, Converter={StaticResource BooleanOnOffConverter}}" Margin="0 0 10 0" />
                 <TextBlock VerticalAlignment="Center">Tor can be turned off for debugging.</TextBlock>
               </StackPanel>
               <StackPanel Margin="0 10" Spacing="5">
@@ -38,11 +63,11 @@
           <controls:GroupBox Title="UI" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
             <StackPanel Orientation="Vertical" Spacing="5">
               <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
-                <ToggleButton IsChecked="{Binding Autocopy}" Content="{Binding AutocopyText}" Margin="0 0 10 0" />
+                <ToggleButton IsChecked="{Binding Autocopy}" Content="{Binding Autocopy, Converter={StaticResource BooleanOnOffConverter}}}" Margin="0 0 10 0" />
                 <TextBlock VerticalAlignment="Center">Autocopy on Receive and History wallet tabs.</TextBlock>
               </StackPanel>
               <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
-                <ToggleButton IsChecked="{Binding LurkingWifeMode}" Content="{Binding LurkingWifeModeText}" Margin="0 0 10 0" Command="{Binding LurkingWifeModeCommand}" />
+                <ToggleButton IsChecked="{Binding LurkingWifeMode}" Content="{Binding LurkingWifeMode, Converter={StaticResource BooleanOnOffConverter}}}" Margin="0 0 10 0" Command="{Binding LurkingWifeModeCommand}" />
                 <TextBlock VerticalAlignment="Center">Lurking Wife Mode hides sensitive content.</TextBlock>
               </StackPanel>
             </StackPanel>


### PR DESCRIPTION
This PR allows the users to specify the Local Node endpoint host:port for the selected network and  to enforce the block fetching from their local nodes too.

![image](https://user-images.githubusercontent.com/127973/59959293-d4e9ca80-948a-11e9-9956-e615683317e5.png)

This PR is required before finalizing another one to display a visual indicator to let the user know whether the blocks are being fetched from the local node or random remote nodes. 

![image](https://user-images.githubusercontent.com/127973/59959333-72dd9500-948b-11e9-8b2f-819f5724029a.png)
