### PR TITLE
Increase QR code size and border

### DIFF
--- a/WalletWasabi.Gui/Controls/QrCode.cs
+++ b/WalletWasabi.Gui/Controls/QrCode.cs
@@ -46,8 +46,8 @@ namespace WalletWasabi.Gui.Controls
 					for (var j = 0; j < w; j++)
 					{
 						var cellValue = source[i, j];
-						var color = cellValue ? Brushes.Black : Brushes.White;
 						var rect = new Rect(i * factor, j * factor, factor, factor);
+						var color = cellValue ? Brushes.Black : Brushes.White;
 						context.FillRectangle(color, rect);
 					}
 				}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -94,8 +94,8 @@
                 <Grid>
                   <Expander Name="coinExpander" ExpandDirection="Down" IsExpanded="{Binding IsExpanded}" Classes="coloredExpander" Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
                     <StackPanel Orientation="Horizontal" Spacing="16" Margin="35 10 0 25">
-                      <Panel Height="180" Background="#FFFEFEFE">
-                        <controls:QrCode Matrix="{Binding QrCode}" HorizontalAlignment="Left" Margin="14" />
+                      <Panel Height="220" Background="#FFFEFEFE">
+                        <controls:QrCode Matrix="{Binding QrCode}" HorizontalAlignment="Left" Margin="20" />
                       </Panel>
                       <Grid ColumnDefinitions="140, *" RowDefinitions="22,22" Margin="6">
                         <TextBlock Text="Public key:" Grid.Row="0" Grid.Column="0" />

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Gui.ViewModels
 			// TODO fix this performance issue this should only be generated when accessed.
 			Task.Run(() =>
 			{
-				var encoder = new QrEncoder(ErrorCorrectionLevel.M);
+				var encoder = new QrEncoder();
 				encoder.TryEncode(Address, out var qrCode);
 
 				return qrCode.Matrix.InternalArray;


### PR DESCRIPTION
This PR increases the QR code size by increasing a bit the white border around the code. This is one of the reason mentioned in several sites why a qr code can fail to be decoded. Anyway, I tested it with different mobile wallets and it works okay.