### PR TITLE
Transalate errors in send message

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -383,6 +384,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					Money needed = ex.Minimum - ex.Actual;
 					SetWarningMessage($"Not enough coins selected. You need an estimated {needed.ToString(false, true)} BTC more to make this transaction.");
+				}
+				catch (HttpRequestException ex)
+				{
+					SetWarningMessage(ex.ToUserFriendlyString())
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi/Extensions/ExceptionExtensions.cs
+++ b/WalletWasabi/Extensions/ExceptionExtensions.cs
@@ -1,10 +1,33 @@
-﻿namespace System
+﻿using System.Collections.Generic;
+using System.Net.Http;
+
+namespace System
 {
 	public static class ExceptionExtensions
 	{
 		public static string ToTypeMessageString(this Exception ex)
 		{
 			return $"{ex.GetType().Name}: {ex.Message}";
+		}
+
+		public static string ToUserFriendlyString(this HttpRequestException ex)
+		{
+			var transalations = new Dictionary<string, string>
+			{
+				["too-long-mempool-chain"] = "At least one coin you are trying to spend is part of long chain of unconfirmed transactions. You must wait for some previous transactions to confirm.",
+				["bad-txns-inputs-missingorspent"] = "At least one coin you are trying to spend is already spent.",
+				["missing-inputs"] = "At least one coin you are trying to spend is already spent.",
+				["bad-txns-inputs-duplicate"] = "The transaction contains duplicated inputs.",
+				["bad-txns-nonfinal"] = "The transaction is not final and cannot be broadcasted.",
+				["bad-txns-oversize"] = "The transaction is too big."
+			};
+
+			var msg = ex.Message.Substring(0, ex.Message.IndexOf(','));
+			if(transalations.ContainsKey(msg))
+			{
+				return transalations[msg];
+			}
+			return ex.ToTypeMessageString();
 		}
 	}
 }


### PR DESCRIPTION
This PR is for displaying a bit less scary messages to the final user. For example, instead of displaying **too-long-mempool-chain** we display the more human **At least one coin you are trying to spend is part of long chain of unconfirmed transactions. You must wait for some previous transactions to confirm.**