### PR TITLE
Confirm password with 'enter' for sending and enqueueing coinjoins

### DIFF
--- a/WalletWasabi.Gui/Behaviors/CommandOnEnterBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnEnterBehavior.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using System.Reactive.Disposables;
 
 namespace WalletWasabi.Gui.Behaviors
@@ -19,7 +20,7 @@ namespace WalletWasabi.Gui.Behaviors
 				{
 					e.Handled = ExecuteCommand();
 				}
-			}));
+			}, RoutingStrategies.Tunnel));
 		}
 
 		protected override void OnDetaching()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -3,6 +3,8 @@
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui">
   <UserControl.Resources>
     <converters:CoinJoinedVisibilityConverter x:Key="CoinJoinedVisibilityConverter" />
@@ -101,7 +103,11 @@
             </StackPanel>
           </StackPanel>
           <StackPanel IsVisible="{Binding !IsWatchOnly}" Grid.Column="0" Spacing="10">
-            <controls:NoparaPasswordBox Password="{Binding Password}" Watermark="Password" UseFloatingWatermark="True" MinWidth="173" Margin="0 20 0 0" />
+            <controls:NoparaPasswordBox Password="{Binding Password}" Watermark="Password" UseFloatingWatermark="True" MinWidth="173" Margin="0 20 0 0" >
+              <i:Interaction.Behaviors>
+                <behaviors:CommandOnEnterBehavior Command="{Binding EnqueueCommand}" />
+              </i:Interaction.Behaviors>
+            </controls:NoparaPasswordBox>
             <DockPanel Grid.Row="0" Grid.Column="1" LastChildFill="True" IsEnabled="{Binding !IsEnqueueBusy}">
               <Button Command="{Binding EnqueueCommand}" DockPanel.Dock="Right">
                 <StackPanel Orientation="Horizontal">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -98,7 +98,11 @@
             </StackPanel>
           </StackPanel>
           <StackPanel Spacing="10" Orientation="Horizontal">
-            <controls:NoparaPasswordBox Password="{Binding Password}" IsVisible="{Binding !IsWatchOnly}" Watermark="Password" UseFloatingWatermark="True" MinWidth="173" MaxWidth="173" />
+            <controls:NoparaPasswordBox Password="{Binding Password}" IsVisible="{Binding !IsWatchOnly}" Watermark="Password" UseFloatingWatermark="True" MinWidth="173" MaxWidth="173">
+              <i:Interaction.Behaviors>
+                <behaviors:CommandOnEnterBehavior Command="{Binding BuildTransactionCommand}" />
+              </i:Interaction.Behaviors>
+            </controls:NoparaPasswordBox>
             <DockPanel VerticalAlignment="Top" LastChildFill="True">
               <Button Command="{Binding BuildTransactionCommand}" DockPanel.Dock="Right">
                 <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
Closes #1450 

@Transisto [commented](https://github.com/zkSNACKs/WalletWasabi/issues/1450#issuecomment-493221365) that return characters that are copy pasted should not be read, this is done automatically by the textbox it seems.

I added `65ac1e6` so it can be tested with the bugfix.