### PR TITLE
Fix gramatical error in GenerateWalletView

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
@@ -20,7 +20,7 @@
           <Button Content="Terms and Conditions" Classes="activeHyperLink" Command="{Binding OnTermsClicked}" />
           <TextBlock Text=", " />
           <Button Content="Privacy Policy" Classes="activeHyperLink" Command="{Binding OnPrivacyClicked}" />
-          <TextBlock Text=" and " />
+          <TextBlock Text=", and " />
           <Button Content="Legal Issues" Classes="activeHyperLink" Command="{Binding OnLegalClicked}" />
           <TextBlock Text=" documents." />
         </StackPanel>


### PR DESCRIPTION
The current line signifies that the Privacy Policy and the Legal Issues are 1 item, by adding the comma after Privacy Policy it signifies that the two are separate.