### PR TITLE
Fix 876 context menu in coinlist blocking item selection

### DIFF
--- a/WalletWasabi.Gui/Controls/ExtendedListBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedListBox.cs
@@ -1,0 +1,33 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Styling;
+using System;
+
+namespace WalletWasabi.Gui.Controls
+{
+	public class ExtendedListBox : ListBox, IStyleable
+	{
+		Type IStyleable.StyleKey => typeof(ListBox);
+
+		public ExtendedListBox()
+		{
+			AddHandler<PointerPressedEventArgs>(PointerPressedEvent, (sender, e) =>
+			{
+				if (e.MouseButton == MouseButton.Left || e.MouseButton == MouseButton.Right)
+				{
+					UpdateSelectionFromEventSource(
+						e.Source,
+						true,
+						(e.InputModifiers & InputModifiers.Shift) != 0,
+						(e.InputModifiers & InputModifiers.Control) != 0);
+
+					
+				}
+			}, Avalonia.Interactivity.RoutingStrategies.Tunnel, true);
+		}
+
+		protected override void OnPointerPressed(PointerPressedEventArgs e)
+		{
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -57,8 +57,8 @@
           <TextBlock Text = "BTC" />
         </StackPanel>
       </StackPanel>
-      <ListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
-        <ListBox.ContextMenu>
+      <controls:ExtendedListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
+        <controls:ExtendedListBox.ContextMenu>
           <ContextMenu>
             <!--Enqueuing needs password, TODO: jump to password box OR display pw box in context menu + send button-->
             <MenuItem  Command="{Binding EnqueueCoin}" IsVisible="false">
@@ -81,8 +81,8 @@
               </MenuItem.Icon>
             </MenuItem>
           </ContextMenu>
-        </ListBox.ContextMenu>
-        <ListBox.ItemTemplate>
+        </controls:ExtendedListBox.ContextMenu>
+        <controls:ExtendedListBox.ItemTemplate>
           <DataTemplate>
             <Grid>
               <Expander Name="coinExpander" ExpandDirection="Down" Classes="coloredExpander"  Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
@@ -142,8 +142,8 @@
               </Grid>
             </Grid>
           </DataTemplate>
-        </ListBox.ItemTemplate>
-      </ListBox>
+        </controls:ExtendedListBox.ItemTemplate>
+      </controls:ExtendedListBox>
     </DockPanel>
   </Grid>
 </UserControl>


### PR DESCRIPTION
This fix can be back ported to Avalonia in time for the release, but this fixes it inside Wasabi.