### PR TITLE
Status Page Integration: Included all bits for suggested Status Page, fixes #1559

### DIFF
--- a/WalletWasabi.Gui/Icons/Icons.xaml
+++ b/WalletWasabi.Gui/Icons/Icons.xaml
@@ -88,6 +88,15 @@
         </DrawingGroup.Children>
       </DrawingGroup>
 
+      <DrawingGroup x:Key="StatusPage">
+        <DrawingGroup.Children>
+          <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+          <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M8,0C3.589,0 0,3.589 0,8 0,12.411 3.589,16 8,16 12.411,16 16,12.411 16,8 16,3.589 12.411,0 8,0" />
+          <GeometryDrawing Brush="#FFFFFFFF" Geometry="F1M14,8C14,11.309 11.309,14 8,14 4.691,14 2,11.309 2,8 2,4.691 4.691,2 8,2 11.309,2 14,4.691 14,8" />
+          <GeometryDrawing Brush="#FF1BA1E2" Geometry="F1M7,7.5L9,7.5 9,12 7,12z M7,4L9,4 9,5.5 7,5.5z M8,14C4.691,14 2,11.309 2,8 2,4.691 4.691,2 8,2 11.309,2 14,4.691 14,8 14,11.309 11.309,14 8,14 M8,1C4.14,1 1,4.14 1,8 1,11.859 4.14,15 8,15 11.859,15 15,11.859 15,8 15,4.14 11.859,1 8,1" />
+        </DrawingGroup.Children>
+      </DrawingGroup>
+
       <DrawingGroup x:Key="CustomerSupport">
         <DrawingGroup.Children>
           <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />

--- a/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
@@ -37,7 +37,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 			{
 				try
 				{
-					IoHelpers.OpenBrowser("https://status.wasabiwallet.io/");
+					IoHelpers.OpenBrowser("https://stats.uptimerobot.com/W7q65in4y");
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
@@ -30,21 +30,21 @@ namespace WalletWasabi.Gui.Shell.Commands
 					IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 				}));
 
-				StatusPageCommand = new CommandDefinition(
-				"Status Page",
-				commandIconService.GetCompletionKindImage("StatusPage"),
-				ReactiveCommand.Create(() =>
+			StatusPageCommand = new CommandDefinition(
+			"Status Page",
+			commandIconService.GetCompletionKindImage("StatusPage"),
+			ReactiveCommand.Create(() =>
+			{
+				try
 				{
-					try
-					{
-						IoHelpers.OpenBrowser("https://status.wasabiwallet.io/");
-					}
-					catch (Exception ex)
-					{
-						Logging.Logger.LogWarning<HelpCommands>(ex);
-						IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
-					}
-				}));
+					IoHelpers.OpenBrowser("https://status.wasabiwallet.io/");
+				}
+				catch (Exception ex)
+				{
+					Logging.Logger.LogWarning<HelpCommands>(ex);
+					IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
+				}
+			}));
 
 			CustomerSupportCommand = new CommandDefinition(
 				"Customer Support",

--- a/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
@@ -30,6 +30,22 @@ namespace WalletWasabi.Gui.Shell.Commands
 					IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 				}));
 
+				StatusPageCommand = new CommandDefinition(
+				"Status Page",
+				commandIconService.GetCompletionKindImage("StatusPage"),
+				ReactiveCommand.Create(() =>
+				{
+					try
+					{
+						IoHelpers.OpenBrowser("https://status.wasabiwallet.io/");
+					}
+					catch (Exception ex)
+					{
+						Logging.Logger.LogWarning<HelpCommands>(ex);
+						IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
+					}
+				}));
+
 			CustomerSupportCommand = new CommandDefinition(
 				"Customer Support",
 				commandIconService.GetCompletionKindImage("CustomerSupport"),
@@ -127,6 +143,9 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		[ExportCommandDefinition("Help.About")]
 		public CommandDefinition AboutCommand { get; }
+
+		[ExportCommandDefinition("Help.StatusPage")]
+		public CommandDefinition StatusPageCommand { get; }
 
 		[ExportCommandDefinition("Help.CustomerSupport")]
 		public CommandDefinition CustomerSupportCommand { get; }

--- a/WalletWasabi.Gui/Shell/MainMenu/HelpMainMenuItems.cs
+++ b/WalletWasabi.Gui/Shell/MainMenu/HelpMainMenuItems.cs
@@ -57,33 +57,38 @@ namespace WalletWasabi.Gui.Shell.MainMenu
 
 #endif
 
-		[ExportMainMenuItem("Help", "Customer Support")]
+		[ExportMainMenuItem("Help", "Status Page")]
 		[DefaultOrder(2)]
+		[DefaultGroup("Support")]
+		public IMenuItem StatusPage => MenuItemFactory.CreateCommandMenuItem("Help.StatusPage");
+
+		[ExportMainMenuItem("Help", "Customer Support")]
+		[DefaultOrder(3)]
 		[DefaultGroup("Support")]
 		public IMenuItem CustomerSupport => MenuItemFactory.CreateCommandMenuItem("Help.CustomerSupport");
 
 		[ExportMainMenuItem("Help", "Report Bug")]
-		[DefaultOrder(3)]
+		[DefaultOrder(4)]
 		[DefaultGroup("Support")]
 		public IMenuItem ReportBug => MenuItemFactory.CreateCommandMenuItem("Help.ReportBug");
 
 		[ExportMainMenuItem("Help", "FAQ")]
-		[DefaultOrder(4)]
+		[DefaultOrder(5)]
 		[DefaultGroup("Support")]
 		public IMenuItem Faq => MenuItemFactory.CreateCommandMenuItem("Help.Faq");
 
 		[ExportMainMenuItem("Help", "Privacy Policy")]
-		[DefaultOrder(5)]
+		[DefaultOrder(6)]
 		[DefaultGroup("Legal")]
 		public IMenuItem PrivacyPolicy => MenuItemFactory.CreateCommandMenuItem("Help.PrivacyPolicy");
 
 		[ExportMainMenuItem("Help", "Terms And Conditions")]
-		[DefaultOrder(6)]
+		[DefaultOrder(7)]
 		[DefaultGroup("Legal")]
 		public IMenuItem TermsAndConditions => MenuItemFactory.CreateCommandMenuItem("Help.TermsAndConditions");
 
 		[ExportMainMenuItem("Help", "Legal Issues")]
-		[DefaultOrder(7)]
+		[DefaultOrder(8)]
 		[DefaultGroup("Legal")]
 		public IMenuItem LegalIssues => MenuItemFactory.CreateCommandMenuItem("Help.LegalIssues");
 

--- a/WalletWasabi.Gui/Tabs/AboutView.xaml
+++ b/WalletWasabi.Gui/Tabs/AboutView.xaml
@@ -22,7 +22,7 @@
           </StackPanel>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="Status Page: " />
-            <controls:ExtendedTextBox Text="https://status.wasabiwallet.io/" Classes="selectableTextBlock hyperLink" />
+            <controls:ExtendedTextBox Text="https://stats.uptimerobot.com/W7q65in4y" Classes="selectableTextBlock hyperLink" />
           </StackPanel>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="Customer Support: " />

--- a/WalletWasabi.Gui/Tabs/AboutView.xaml
+++ b/WalletWasabi.Gui/Tabs/AboutView.xaml
@@ -21,6 +21,10 @@
             <controls:ExtendedTextBox Text="https://github.com/zkSNACKs/WalletWasabi/" Classes="selectableTextBlock hyperLink" />
           </StackPanel>
           <StackPanel Orientation="Horizontal">
+            <TextBlock Text="Status Page: " />
+            <controls:ExtendedTextBox Text="https://status.wasabiwallet.io/" Classes="selectableTextBlock hyperLink" />
+          </StackPanel>
+          <StackPanel Orientation="Horizontal">
             <TextBlock Text="Customer Support: " />
             <controls:ExtendedTextBox Text="https://www.reddit.com/r/WasabiWallet/" Classes="selectableTextBlock hyperLink" />
           </StackPanel>

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -67,5 +67,11 @@
     <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Controls\BusyIndicator.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+  </ItemGroup>
+
 </Project>
 


### PR DESCRIPTION
Link added to help menu and to the about panel. The link points to https://status.wasabiwallet.io/ .
Of course this site can’t be reached currently. StatusPage.io allows custom DNS, see issue for details.