### PR TITLE
Display loading animation for CoinList and History list.

### DIFF
--- a/WalletWasabi.Gui/App.xaml
+++ b/WalletWasabi.Gui/App.xaml
@@ -21,6 +21,7 @@
     <StyleInclude Source="resm:WalletWasabi.Gui.Icons.Icons.xaml?assembly=WalletWasabi.Gui" />
     <StyleInclude Source="resm:WalletWasabi.Gui.Controls.NoparaPasswordBox.xaml?assembly=WalletWasabi.Gui" />
     <StyleInclude Source="resm:WalletWasabi.Gui.Controls.MultiTextBox.xaml?assembly=WalletWasabi.Gui" />
+    <StyleInclude Source="resm:WalletWasabi.Gui.Controls.BusyIndicator.xaml?assembly=WalletWasabi.Gui" />
   </Application.Styles>
   <Application.DataTemplates>
     <DataTemplate DataType="Views:MainView">

--- a/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
@@ -1,0 +1,33 @@
+using Avalonia.Input;
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace WalletWasabi.Gui.Behaviors
+{
+	internal class CommandOnFirstVisible : CommandBasedBehavior<InputElement>
+	{
+		private CompositeDisposable Disposables { get; set; }
+
+		protected override void OnAttached()
+		{
+			Disposables = new CompositeDisposable();
+
+			base.OnAttached();
+
+			Observable.FromEventPattern(AssociatedObject, nameof(AssociatedObject.AttachedToVisualTree))
+			.Take(1) // Only on first appearance.
+			.Subscribe(_ =>
+			{
+				ExecuteCommand();
+			}).DisposeWith(Disposables);
+		}
+
+		protected override void OnDetaching()
+		{
+			base.OnDetaching();
+
+			Disposables?.Dispose();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/BusyIndicator.cs
+++ b/WalletWasabi.Gui/Controls/BusyIndicator.cs
@@ -1,0 +1,30 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Styling;
+using System;
+
+namespace WalletWasabi.Gui.Controls
+{
+	public class BusyIndicator : ContentControl, IStyleable
+	{
+		Type IStyleable.StyleKey => typeof(BusyIndicator);
+
+		public static readonly StyledProperty<string> TextProperty =
+			AvaloniaProperty.Register<BusyIndicator, string>(nameof(Text));
+
+		public static readonly StyledProperty<bool> IsBusyProperty =
+			AvaloniaProperty.Register<BusyIndicator, bool>(nameof(IsBusy));
+
+		public string Text
+		{
+			get => GetValue(TextProperty);
+			set => SetValue(TextProperty, value);
+		}
+
+		public bool IsBusy
+		{
+			get => GetValue(IsBusyProperty);
+			set => SetValue(IsBusyProperty, value);
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/BusyIndicator.xaml
+++ b/WalletWasabi.Gui/Controls/BusyIndicator.xaml
@@ -1,0 +1,28 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+  <Style Selector="local|BusyIndicator">
+    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid>
+          <StackPanel ZIndex="2" Orientation="Horizontal" VerticalAlignment="Top" IsVisible="{TemplateBinding IsBusy}">
+            <controls:Spinner Height="20" Width="20" IsVisible="True" Margin ="8" />
+            <TextBlock Text="{TemplateBinding Text}" VerticalAlignment="Center" />
+          </StackPanel>
+          <Border Name="PART_Border"  BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{DynamicResource ThemeBorderLowBrush}">
+            <ContentPresenter Name="PART_ContentPresenter"
+                        Background="{TemplateBinding Background}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        Content="{TemplateBinding Content}"
+                        Padding="{TemplateBinding Padding}"
+                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+          </Border>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+</Styles>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -124,8 +124,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public override void OnOpen()
 		{
-			CoinsList.OnOpen();
-
 			if (Disposables != null)
 			{
 				throw new Exception("CoinJoin tab opened before previous closed.");

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -93,28 +93,28 @@
                     <TextBlock Text="Transaction Id:" Grid.Row="0" />
                     <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding TransactionId}" Background="Transparent" Grid.Column="1" Grid.Row="0" />
 
-                  <TextBlock Text="Output Index:" Grid.Row="1" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding OutputIndex}"  Grid.Column="1" Grid.Row="1" />
+                    <TextBlock Text="Output Index:" Grid.Row="1" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding OutputIndex}"  Grid.Column="1" Grid.Row="1" />
 
-                  <TextBlock Text="Label:" Grid.Row="2" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Label}"  Grid.Column="1" Grid.Row="2" />
+                    <TextBlock Text="Label:" Grid.Row="2" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Label}"  Grid.Column="1" Grid.Row="2" />
 
-                  <TextBlock Text="Address:" Grid.Row="3" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Address}"  Grid.Column="1" Grid.Row="3" />
+                    <TextBlock Text="Address:" Grid.Row="3" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Address}"  Grid.Column="1" Grid.Row="3" />
 
-                  <TextBlock Text="Confirmations:" Grid.Row="4" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Confirmations}"  Grid.Column="1" Grid.Row="4" />
+                    <TextBlock Text="Confirmations:" Grid.Row="4" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding Confirmations}"  Grid.Column="1" Grid.Row="4" />
 
-                  <TextBlock Text="Anonymity Set:" Grid.Row="5" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding AnonymitySet}"  Grid.Column="1" Grid.Row="5" />
+                    <TextBlock Text="Anonymity Set:" Grid.Row="5" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding AnonymitySet}"  Grid.Column="1" Grid.Row="5" />
 
-                  <TextBlock Text="Key Path:" Grid.Row="6" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding KeyPath}"  Grid.Column="1" Grid.Row="6" />
+                    <TextBlock Text="Key Path:" Grid.Row="6" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding KeyPath}"  Grid.Column="1" Grid.Row="6" />
 
-                  <TextBlock Text="Public Key:" Grid.Row="7" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding PubKey}"  Grid.Column="1" Grid.Row="7" />
-                </Grid>
-              </Expander>
+                    <TextBlock Text="Public Key:" Grid.Row="7" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding PubKey}"  Grid.Column="1" Grid.Row="7" />
+                  </Grid>
+                </Expander>
 
                 <Grid Margin="30 0 0 0" VerticalAlignment="Top">
                   <Grid.ColumnDefinitions>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -23,6 +23,7 @@
   </UserControl.Styles>
   <i:Interaction.Behaviors>
     <behaviors:ClearPropertyOnLostFocusBehavior TargetProperty="{Binding SelectedCoin}" />
+    <behaviors:CommandOnFirstVisible  Command="{Binding InitList}" />
   </i:Interaction.Behaviors>
   <Grid IsSharedSizeScope="True">
     <DockPanel LastChildFill="True">
@@ -57,36 +58,37 @@
           <TextBlock Text = "BTC" />
         </StackPanel>
       </StackPanel>
-      <controls:ExtendedListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
-        <controls:ExtendedListBox.ContextMenu>
-          <ContextMenu>
-            <!--Enqueuing needs password, TODO: jump to password box OR display pw box in context menu + send button-->
-            <MenuItem  Command="{Binding EnqueueCoin}" IsVisible="false">
-              <MenuItem.Header>
-                <Grid>
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition />
-                  </Grid.ColumnDefinitions>
-                  <TextBlock Text="Enqueue Coin, password:" VerticalAlignment="Center" />
-                  <TextBox Width="50" Grid.Column="1" />
-                </Grid>
-              </MenuItem.Header>
-            </MenuItem>
-            <MenuItem Header="Dequeue from CoinJoin" Command="{Binding DequeueCoin}">
-              <MenuItem.Icon>
-                <Path HorizontalAlignment="Left"
+      <controls:BusyIndicator IsBusy ="{Binding IsCoinListLoading}" Text="Loading...">
+        <controls:ExtendedListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
+          <controls:ExtendedListBox.ContextMenu>
+            <ContextMenu>
+              <!--Enqueuing needs password, TODO: jump to password box OR display pw box in context menu + send button-->
+              <MenuItem  Command="{Binding EnqueueCoin}" IsVisible="false">
+                <MenuItem.Header>
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition />
+                      <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Enqueue Coin, password:" VerticalAlignment="Center" />
+                    <TextBox Width="50" Grid.Column="1" />
+                  </Grid>
+                </MenuItem.Header>
+              </MenuItem>
+              <MenuItem Header="Dequeue from CoinJoin" Command="{Binding DequeueCoin}">
+                <MenuItem.Icon>
+                  <Path HorizontalAlignment="Left"
                       Data="M3.24,7.51c-0.146,0.142-0.146,0.381,0,0.523l5.199,5.193c0.234,0.238,0.633,0.064,0.633-0.262v-2.634c0.105-0.007,0.212-0.011,0.321-0.011c2.373,0,4.302,1.91,4.302,4.258c0,0.957-0.33,1.809-1.008,2.602c-0.259,0.307,0.084,0.762,0.451,0.572c2.336-1.195,3.73-3.408,3.73-5.924c0-3.741-3.103-6.783-6.916-6.783c-0.307,0-0.615,0.028-0.881,0.063V2.575c0-0.327-0.398-0.5-0.633-0.261L3.24,7.51 M4.027,7.771l4.301-4.3v2.073c0,0.232,0.21,0.409,0.441,0.366c0.298-0.056,0.746-0.123,1.184-0.123c3.402,0,6.172,2.709,6.172,6.041c0,1.695-0.718,3.24-1.979,4.352c0.193-0.51,0.293-1.045,0.293-1.602c0-2.76-2.266-5-5.046-5c-0.256,0-0.528,0.018-0.747,0.05C8.465,9.653,8.328,9.81,8.328,9.995v2.074L4.027,7.771z" Fill="#22B14C"
                       Height="16" Width="16"  Stretch="Fill" />
-              </MenuItem.Icon>
-            </MenuItem>
-          </ContextMenu>
-        </controls:ExtendedListBox.ContextMenu>
-        <controls:ExtendedListBox.ItemTemplate>
-          <DataTemplate>
-            <Grid>
-              <Expander Name="coinExpander" ExpandDirection="Down" Classes="coloredExpander"  Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
-                <Grid HorizontalAlignment="Left" ColumnDefinitions="150, *" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" MaxWidth="800" Margin="35 10 0 25">
+                </MenuItem.Icon>
+              </MenuItem>
+            </ContextMenu>
+          </controls:ExtendedListBox.ContextMenu>
+          <controls:ExtendedListBox.ItemTemplate>
+            <DataTemplate>
+              <Grid>
+                <Expander Name="coinExpander" ExpandDirection="Down" Classes="coloredExpander"  Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
+                  <Grid HorizontalAlignment="Left" ColumnDefinitions="150, *" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" MaxWidth="800" Margin="35 10 0 25">
                     <TextBlock Text="Transaction Id:" Grid.Row="0" />
                     <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding TransactionId}" Background="Transparent" Grid.Column="1" Grid.Row="0" />
 
@@ -111,39 +113,40 @@
                     <TextBlock Text="Public Key:" Grid.Row="7" />
                     <controls:ExtendedTextBox Classes="selectableTextBlock Transaparent" Text="{Binding PubKey}"  Grid.Column="1" Grid.Row="7" />
                   </Grid>
-              </Expander>
+                </Expander>
 
-              <Grid Margin="30 0 0 0" VerticalAlignment="Top">
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="30" />
-                  <ColumnDefinition Width="30" />
-                  <ColumnDefinition SharedSizeGroup="A" />
-                  <ColumnDefinition Width="123" />
-                  <ColumnDefinition Width="100" />
-                  <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+                <Grid Margin="30 0 0 0" VerticalAlignment="Top">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="30" />
+                    <ColumnDefinition Width="30" />
+                    <ColumnDefinition SharedSizeGroup="A" />
+                    <ColumnDefinition Width="123" />
+                    <ColumnDefinition Width="100" />
+                    <ColumnDefinition Width="Auto" />
+                  </Grid.ColumnDefinitions>
 
-                <CheckBox HorizontalContentAlignment="Left" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />
-                <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="1" ToolTip.Tip="Confirmed">
-                  <Path HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16"  Stretch="Fill" />
-                </Border>
+                  <CheckBox HorizontalContentAlignment="Left" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />
+                  <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="1" ToolTip.Tip="Confirmed">
+                    <Path HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16"  Stretch="Fill" />
+                  </Border>
 
-                <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left"  BorderThickness="1" CornerRadius="0,6,6,0">
-                  <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
-                </Border>
-                <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
-                <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent"
+                  <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left"  BorderThickness="1" CornerRadius="0,6,6,0">
+                    <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
+                  </Border>
+                  <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+                  <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent"
                     DataContext="{Binding AnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}"
                     ToolTip.Tip="{Binding ToolTip}">
-                  <DrawingPresenter Drawing="{Binding Icon}" Margin="0 0 25 0" />
-                </Panel>
-                <controls:ExtendedTextBox Classes="selectableTextBlock" Background="Transparent" Grid.Column="5" Text="{Binding Clusters, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
-                <TextBlock Text="" Grid.Column="6" />
+                    <DrawingPresenter Drawing="{Binding Icon}" Margin="0 0 25 0" />
+                  </Panel>
+                  <controls:ExtendedTextBox Classes="selectableTextBlock" Background="Transparent" Grid.Column="5" Text="{Binding Clusters, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+                  <TextBlock Text="" Grid.Column="6" />
+                </Grid>
               </Grid>
-            </Grid>
-          </DataTemplate>
-        </controls:ExtendedListBox.ItemTemplate>
-      </controls:ExtendedListBox>
+            </DataTemplate>
+          </controls:ExtendedListBox.ItemTemplate>
+        </controls:ExtendedListBox>
+      </controls:BusyIndicator>
     </DockPanel>
   </Grid>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -399,7 +399,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					IsCoinListLoading = false;
 				}
-			});
+			}, outputScheduler: RxApp.MainThreadScheduler);
 
 			InitList.ThrownExceptions.Subscribe(ex => Logging.Logger.LogError<CoinListViewModel>(ex));
 		}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using WalletWasabi.Gui.Models;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Models;
@@ -37,6 +38,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private SortOrder _clustersSortDirection;
 		private decimal _totalAmount;
 		private bool _isAnyCoinSelected;
+		private bool _isCoinListLoading;
 		public Global Global { get; }
 
 		public ReactiveCommand<Unit, Unit> EnqueueCoin { get; }
@@ -45,6 +47,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public ReactiveCommand<Unit, Unit> SelectPrivateCheckBoxCommand { get; }
 		public ReactiveCommand<Unit, Unit> SelectNonPrivateCheckBoxCommand { get; }
 		public ReactiveCommand<Unit, Unit> SortCommand { get; }
+		public ReactiveCommand<Unit, Unit> InitList { get; }
 
 		public event EventHandler DequeueCoinsPressed;
 
@@ -80,6 +83,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			get => _selectPrivateCheckBoxState;
 			set => this.RaiseAndSetIfChanged(ref _selectPrivateCheckBoxState, value);
+		}
+
+		public bool IsCoinListLoading
+		{
+			get => _isCoinListLoading;
+			set => this.RaiseAndSetIfChanged(ref _isCoinListLoading, value);
 		}
 
 		public SortOrder StatusSortDirection
@@ -227,6 +236,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			Global = global;
 			AmountSortDirection = SortOrder.Decreasing;
+			IsCoinListLoading = true;
 			RefreshOrdering();
 
 			var sortChanged = this.WhenValueChanged(@this => MyComparer)
@@ -367,10 +377,32 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						break;
 				}
 			});
+
+			InitList = ReactiveCommand.CreateFromTask(async () =>
+			{
+				try
+				{
+					IsCoinListLoading = true;
+					// We have to wait for the UI to became visible to the user.
+					await Task.Delay(800); // Let other tasks run to display the gui.
+					OnOpen();
+				}
+				finally
+				{
+					IsCoinListLoading = false;
+				}
+			});
+
+			InitList.ThrownExceptions.Subscribe(ex => Logging.Logger.LogError<CoinListViewModel>(ex));
 		}
 
-		public void OnOpen()
+		private void OnOpen()
 		{
+			if (Disposables != null)
+			{
+				throw new Exception("CoinList opened before previous closed.");
+			}
+
 			Disposables = new CompositeDisposable();
 
 			foreach (var sc in Global.WalletService.Coins.Where(sc => sc.Unspent))

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -22,36 +22,38 @@
             <controls:SortingArrow Grid.Column="2" Command="{Binding SortCommand}" Text="Amount (BTC)" SortDirection="{Binding AmountSortDirection}" />
             <controls:SortingArrow Grid.Column="3" Command="{Binding SortCommand}" Text="Transaction ID" SortDirection="{Binding TransactionSortDirection}" />
           </Grid>
-          <controls:ExtendedListBox Items="{Binding Transactions}" SelectedItem="{Binding SelectedTransaction, Mode=TwoWay}">
-            <controls:ExtendedListBox.ItemTemplate>
-              <DataTemplate>
-                <Grid ColumnDefinitions="40, 160, 150, *">
-                  <Grid.Styles>
-                    <Style Selector="TextBlock">
-                      <Setter Property="VerticalAlignment" Value="Center" />
-                    </Style>
-                  </Grid.Styles>
-                  <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="0" ToolTip.Tip="Confirmed">
-                    <Path HorizontalAlignment="Center" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
-                  </Border>
-                  <TextBlock Text="{Binding DateTime, ConverterParameter=11, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="1" />
-                  <TextBlock Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="2" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
-                  <TextBlock IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding TransactionId, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="3" />
+          <controls:BusyIndicator Text="Loading..." IsBusy="{Binding IsFirstLoading}">
+            <controls:ExtendedListBox Items="{Binding Transactions}" SelectedItem="{Binding SelectedTransaction, Mode=TwoWay}">
+              <controls:ExtendedListBox.ItemTemplate>
+                <DataTemplate>
+                  <Grid ColumnDefinitions="40, 160, 150, *">
+                    <Grid.Styles>
+                      <Style Selector="TextBlock">
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                      </Style>
+                    </Grid.Styles>
+                    <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="0" ToolTip.Tip="Confirmed">
+                      <Path HorizontalAlignment="Center" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
+                    </Border>
+                    <TextBlock Text="{Binding DateTime, ConverterParameter=11, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="1" />
+                    <TextBlock Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="2" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
+                    <TextBlock IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding TransactionId, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="3" />
 
-                  <Grid IsVisible="{Binding ClipboardNotificationVisible}" Grid.Column="3">
-                    <Grid Opacity="{Binding ClipboardNotificationOpacity}">
-                      <Grid.Transitions>
-                        <DoubleTransition Property="Opacity"
+                    <Grid IsVisible="{Binding ClipboardNotificationVisible}" Grid.Column="3">
+                      <Grid Opacity="{Binding ClipboardNotificationOpacity}">
+                        <Grid.Transitions>
+                          <DoubleTransition Property="Opacity"
                               Easing="CircularEaseIn"
                               Duration="0:0:0.5" />
-                      </Grid.Transitions>
-                      <TextBlock Text="Copied" Foreground="White" FontWeight="Bold" />
+                        </Grid.Transitions>
+                        <TextBlock Text="Copied" Foreground="White" FontWeight="Bold" />
+                      </Grid>
                     </Grid>
                   </Grid>
-                </Grid>
-              </DataTemplate>
-            </controls:ExtendedListBox.ItemTemplate>
-          </controls:ExtendedListBox>
+                </DataTemplate>
+              </controls:ExtendedListBox.ItemTemplate>
+            </controls:ExtendedListBox>
+          </controls:BusyIndicator>
         </DockPanel>
       </DockPanel>
     </Grid>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -22,12 +22,21 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private SortOrder _dateSortDirection;
 		private SortOrder _amountSortDirection;
 		private SortOrder _transactionSortDirection;
+		private bool _isFirstLoading;
+
+		public bool IsFirstLoading
+		{
+			get => _isFirstLoading;
+			set => this.RaiseAndSetIfChanged(ref _isFirstLoading, value);
+		}
 
 		public ReactiveCommand<Unit, Unit> SortCommand { get; }
 
 		public HistoryTabViewModel(WalletViewModel walletViewModel)
 			: base("History", walletViewModel)
 		{
+			IsFirstLoading = true;
+
 			Transactions = new ObservableCollection<TransactionViewModel>();
 
 			this.WhenAnyValue(x => x.SelectedTransaction).Subscribe(async transaction =>
@@ -53,7 +62,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			if (Disposables != null)
 			{
-				throw new Exception("Histroy Tab was opened before it was closed.");
+				throw new Exception("History Tab was opened before it was closed.");
 			}
 
 			Disposables = new CompositeDisposable();
@@ -118,6 +127,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			catch (Exception ex)
 			{
 				Logger.LogError<HistoryTabViewModel>($"Error while RewriteTable on HistoryTab:  {ex}.");
+			}
+			finally
+			{
+				IsFirstLoading = false;
 			}
 		}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -1064,8 +1064,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				SetFeesAndTexts();
 			}).DisposeWith(Disposables);
 
-			CoinList.OnOpen();
-
 			base.OnOpen();
 		}
 


### PR DESCRIPTION
Binding the list items to the Visual component (ExtendedListBox) can take several seconds. The Tab control loads the items before the Tab actually displayed. As a result when the user clicks to the Send/CoinJoin/History Tab for the first time it is not displayed immediately but seconds later. 

With the PR the Tab is displayed immediately and then start the loading. I also added a Loading animation too.