### PR TITLE
Features/fetch blocks local node only

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -67,6 +67,15 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
 		public int? RegTestBitcoinCorePort { get; internal set; }
 
+		[JsonProperty(PropertyName = "MainNetFetchFromLocalOnly")]
+		public bool MainNetFetchFromLocalOnly { get; internal set; }
+
+		[JsonProperty(PropertyName = "TestNetFetchFromLocalOnly")]
+		public bool TestNetFetchFromLocalOnly { get; internal set; }
+
+		[JsonProperty(PropertyName = "RegTestFetchFromLocalOnly")]
+		public bool RegTestFetchFromLocalOnly { get; internal set; }
+
 		[JsonProperty(PropertyName = "MixUntilAnonymitySet")]
 		public int? MixUntilAnonymitySet
 		{
@@ -349,6 +358,9 @@ namespace WalletWasabi.Gui
 			MainNetBitcoinCorePort = Network.Main.DefaultPort;
 			TestNetBitcoinCorePort = Network.TestNet.DefaultPort;
 			RegTestBitcoinCorePort = Network.RegTest.DefaultPort;
+			MainNetFetchFromLocalOnly = false;
+			TestNetFetchFromLocalOnly = false;
+			RegTestFetchFromLocalOnly = false;
 
 			MixUntilAnonymitySet = 50;
 			PrivacyLevelSome = 2;
@@ -396,6 +408,9 @@ namespace WalletWasabi.Gui
 			MainNetBitcoinCorePort = config.MainNetBitcoinCorePort ?? MainNetBitcoinCorePort;
 			TestNetBitcoinCorePort = config.TestNetBitcoinCorePort ?? TestNetBitcoinCorePort;
 			RegTestBitcoinCorePort = config.RegTestBitcoinCorePort ?? RegTestBitcoinCorePort;
+			MainNetFetchFromLocalOnly = config.MainNetFetchFromLocalOnly;
+			TestNetFetchFromLocalOnly = config.TestNetFetchFromLocalOnly;
+			RegTestFetchFromLocalOnly = config.RegTestFetchFromLocalOnly;
 
 			MixUntilAnonymitySet = config.MixUntilAnonymitySet ?? MixUntilAnonymitySet;
 			PrivacyLevelSome = config.PrivacyLevelSome ?? PrivacyLevelSome;
@@ -447,6 +462,18 @@ namespace WalletWasabi.Gui
 			if (!RegTestBackendUriV3.Equals(config.RegTestBackendUriV3, StringComparison.OrdinalIgnoreCase))
 			{
 				return true;
+			}
+			if (MainNetFetchFromLocalOnly != config.MainNetFetchFromLocalOnly)
+			{
+					return true;
+			}
+			if (TestNetFetchFromLocalOnly != config.TestNetFetchFromLocalOnly)
+			{
+					return true;
+			}
+			if (RegTestFetchFromLocalOnly != config.RegTestFetchFromLocalOnly)
+			{
+					return true;
 			}
 			if (UseTor != config.UseTor)
 			{

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -262,7 +262,6 @@ namespace WalletWasabi.Gui
 			return (bitcoinCoreEndPoint, fetchFromLocalOnly);
 		}
 
-
 		public Config()
 		{
 			_backendUri = null;

--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -47,6 +47,14 @@
           </StackPanel>
         </Panel>
 
+        <Panel IsVisible="{Binding BlockDownloadedLocally}">
+          <StackPanel Orientation="Horizontal">
+            <Canvas Width="10" Height="10">
+              <Ellipse Fill="Green" Width="10" Height="10" ToolTip.Tip="Latest block was fetched from local node." ToolTip.Placement="Right"  ToolTip.VerticalOffset="-30"/>
+            </Canvas>
+          </StackPanel>
+        </Panel>
+
         <Panel IsVisible="{Binding FiltersLeft, Converter={StaticResource ShouldDisplayValueConverter}}">
           <StackPanel Orientation="Horizontal" Spacing="4" IsVisible="{Binding !CriticalUpdateAvailable}">
             <Grid Height="10" Width="10">

--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -12,6 +12,8 @@
     <converters:ShouldDisplayValueConverter x:Key="ShouldDisplayValueConverter" />
     <converters:PascalToPhraseConverter x:Key="PascalToPhraseConverter" />
     <converters:StatusBarStatusStringConverter x:Key="StatusBarStatusStringConverter" />
+    <converters:BlockDownloadingStatusColorConverter x:Key="BlockDownloadingStatusColorConverter" />
+    <converters:BlockDownloadingStatusTipConverter x:Key="BlockDownloadingStatusTipConverter" />
   </UserControl.Resources>
 
   <Grid Cursor="{Binding UpdateAvailable, Converter={StaticResource ShowCursorConverter}}" Background="{Binding UpdateStatus, Converter={StaticResource UpdateStatusBrushConverter}}">
@@ -47,10 +49,11 @@
           </StackPanel>
         </Panel>
 
-        <Panel IsVisible="{Binding BlockDownloadedLocally}">
+        <Panel>
           <StackPanel Orientation="Horizontal">
             <Canvas Width="10" Height="10">
-              <Ellipse Fill="Green" Width="10" Height="10" ToolTip.Tip="Latest block was fetched from local node." ToolTip.Placement="Right"  ToolTip.VerticalOffset="-30"/>
+              <Ellipse Fill="{Binding BlockDownloadingStatus, Converter={StaticResource BlockDownloadingStatusColorConverter}}" Width="10" Height="10" 
+                       ToolTip.Tip="{Binding BlockDownloadingStatus, Converter={StaticResource BlockDownloadingStatusTipConverter}}" ToolTip.Placement="Right"  ToolTip.VerticalOffset="-30"/>
             </Canvas>
           </StackPanel>
         </Panel>

--- a/WalletWasabi.Gui/Converters/BlockDownloadingStatusColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/BlockDownloadingStatusColorConverter.cs
@@ -1,0 +1,65 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using AvalonStudio.Extensibility.Theme;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using WalletWasabi.Models;
+using WalletWasabi.Services;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class BlockDownloadingStatusColorConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var status = (BlockDownloadingStatus)value;
+			switch (status)
+			{
+				case BlockDownloadingStatus.None: 
+					return Brushes.Gray;
+				case BlockDownloadingStatus.DownloadedFromLocal:
+					return Brushes.Green;
+				case BlockDownloadingStatus.DownloadedFromRemote:
+					return Brushes.GreenYellow;
+				case BlockDownloadingStatus.NoDownloadedRestricted:
+					return Brushes.Red;
+				default:
+					return Brushes.Black;
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+
+	public class BlockDownloadingStatusTipConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var status = (BlockDownloadingStatus)value;
+			switch (status)
+			{
+				case BlockDownloadingStatus.None: 
+					return "No block was requested yet.";
+				case BlockDownloadingStatus.DownloadedFromLocal:
+					return "Latest block was downloaded from local node.";
+				case BlockDownloadingStatus.DownloadedFromRemote:
+					return "Latest block was downloaded from a remote node.";
+				case BlockDownloadingStatus.NoDownloadedRestricted:
+					return "No block downloaded. Cannot connect to local node.";
+				default:
+					return "";
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+
+}

--- a/WalletWasabi.Gui/Converters/BlockDownloadingStatusTipConverter.cs
+++ b/WalletWasabi.Gui/Converters/BlockDownloadingStatusTipConverter.cs
@@ -1,16 +1,11 @@
 using Avalonia.Data.Converters;
-using Avalonia.Media;
-using AvalonStudio.Extensibility.Theme;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
-using WalletWasabi.Models;
 using WalletWasabi.Services;
 
 namespace WalletWasabi.Gui.Converters
 {
-    public class BlockDownloadingStatusColorConverter : IValueConverter
+    public class BlockDownloadingStatusTipConverter : IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
@@ -18,15 +13,15 @@ namespace WalletWasabi.Gui.Converters
 			switch (status)
 			{
 				case BlockDownloadingStatus.None: 
-					return Brushes.Gray;
+					return "No block was requested yet.";
 				case BlockDownloadingStatus.DownloadedFromLocal:
-					return Brushes.Green;
+					return "Latest block was downloaded from local node.";
 				case BlockDownloadingStatus.DownloadedFromRemote:
-					return Brushes.GreenYellow;
+					return "Latest block was downloaded from a remote node.";
 				case BlockDownloadingStatus.NoDownloadedRestricted:
-					return Brushes.Red;
+					return "No block downloaded. Cannot connect to local node.";
 				default:
-					return Brushes.Black;
+					return "";
 			}
 		}
 

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -24,6 +24,10 @@
 
               <controls:GroupBox Title="{Binding Network, StringFormat=My Node for \{0\} }" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
                 <StackPanel Orientation="Vertical" Spacing="5">
+                  <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
+                    <ToggleButton IsChecked="{Binding FetchBlocksFromMyNodeOnly}" Content="{Binding FetchBlocksFromMyNodeOnly, Converter={StaticResource BooleanOnOffConverter}}" Margin="0 0 10 0" />
+                    <TextBlock VerticalAlignment="Center">Only fetch blocks from my node.</TextBlock>
+                  </StackPanel>
                   <StackPanel Margin="0 10" Spacing="5">
                     <TextBlock>Host</TextBlock>
                     <TextBox Text="{Binding LocalNodeHost}" />

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -52,6 +52,7 @@ namespace WalletWasabi.Gui.ViewModels
 		private string _btcPrice;
 		private ObservableAsPropertyHelper<StatusBarStatus> _status;
 		private bool _downloadingBlock;
+		private bool _blockDownloadedLocally;
 		public Global Global { get; }
 		private StatusBarStatusSet ActiveStatuses { get; }
 
@@ -100,6 +101,11 @@ namespace WalletWasabi.Gui.ViewModels
 			Observable.FromEventPattern<bool>(typeof(WalletService), nameof(WalletService.DownloadingBlockChanged))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x => DownloadingBlock = x.EventArgs)
+				.DisposeWith(Disposables);
+
+			Observable.FromEventPattern<bool>(typeof(WalletService), nameof(WalletService.BlockDownloaded))
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(x => BlockDownloadedLocally = x.EventArgs)
 				.DisposeWith(Disposables);
 
 			Synchronizer.WhenAnyValue(x => x.TorStatus)
@@ -287,6 +293,12 @@ namespace WalletWasabi.Gui.ViewModels
 		{
 			get => _downloadingBlock;
 			set => this.RaiseAndSetIfChanged(ref _downloadingBlock, value);
+		}
+
+		public bool BlockDownloadedLocally
+		{
+			get => _blockDownloadedLocally;
+			set => this.RaiseAndSetIfChanged(ref _blockDownloadedLocally, value);
 		}
 
 		private void OnResponseArrivedIsGenSocksServFail(bool isGenSocksServFail)

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Gui.ViewModels
 		private string _btcPrice;
 		private ObservableAsPropertyHelper<StatusBarStatus> _status;
 		private bool _downloadingBlock;
-		private bool _blockDownloadedLocally;
+		private BlockDownloadingStatus _blockDownloadingStatus;
 		public Global Global { get; }
 		private StatusBarStatusSet ActiveStatuses { get; }
 
@@ -103,9 +103,9 @@ namespace WalletWasabi.Gui.ViewModels
 				.Subscribe(x => DownloadingBlock = x.EventArgs)
 				.DisposeWith(Disposables);
 
-			Observable.FromEventPattern<bool>(typeof(WalletService), nameof(WalletService.BlockDownloaded))
+			Observable.FromEventPattern<BlockDownloadingStatus>(typeof(WalletService), nameof(WalletService.BlockDownloading))
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(x => BlockDownloadedLocally = x.EventArgs)
+				.Subscribe(x => BlockDownloadingStatus = x.EventArgs)
 				.DisposeWith(Disposables);
 
 			Synchronizer.WhenAnyValue(x => x.TorStatus)
@@ -295,10 +295,10 @@ namespace WalletWasabi.Gui.ViewModels
 			set => this.RaiseAndSetIfChanged(ref _downloadingBlock, value);
 		}
 
-		public bool BlockDownloadedLocally
+		public BlockDownloadingStatus BlockDownloadingStatus
 		{
-			get => _blockDownloadedLocally;
-			set => this.RaiseAndSetIfChanged(ref _blockDownloadedLocally, value);
+			get => _blockDownloadingStatus;
+			set => this.RaiseAndSetIfChanged(ref _blockDownloadingStatus, value);
 		}
 
 		private void OnResponseArrivedIsGenSocksServFail(bool isGenSocksServFail)

--- a/WalletWasabi.Tests/P2pTests.cs
+++ b/WalletWasabi.Tests/P2pTests.cs
@@ -91,7 +91,7 @@ namespace WalletWasabi.Tests
 			   memPoolService,
 			   nodes,
 			   Global.Instance.DataDir,
-			   new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(0.0001m)));
+			   new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), false, Money.Coins(0.0001m)));
 			Assert.True(Directory.Exists(blocksFolderPath));
 
 			try

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Tests
 			Backend.Global.Instance.Coordinator.UtxoReferee.Clear();
 
 			var network = Backend.Global.Instance.RpcClient.Network;
-			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, Money.Coins(0.0001m));
+			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, false, Money.Coins(0.0001m));
 			var bitcoinStore = new BitcoinStore();
 			var dir = Path.Combine(Global.Instance.DataDir, caller);
 			await bitcoinStore.InitializeAsync(dir, network);

--- a/WalletWasabi/Models/ServiceConfiguration.cs
+++ b/WalletWasabi/Models/ServiceConfiguration.cs
@@ -14,6 +14,7 @@ namespace WalletWasabi.Models
 		public int PrivacyLevelFine { get; set; }
 		public int PrivacyLevelStrong { get; set; }
 		public EndPoint BitcoinCoreEndPoint { get; set; }
+		public bool FetchFromLocalOnly { get; set; }
 		public Money DustThreshold { get; set; }
 
 		public ServiceConfiguration(
@@ -22,6 +23,7 @@ namespace WalletWasabi.Models
 			int privacyLevelFine,
 			int privacyLevelStrong,
 			EndPoint bitcoinCoreEndPoint,
+			bool fetchFromLocalOnly,
 			Money dustThreshold)
 		{
 			MixUntilAnonymitySet = Guard.NotNull(nameof(mixUntilAnonymitySet), mixUntilAnonymitySet);
@@ -29,6 +31,7 @@ namespace WalletWasabi.Models
 			PrivacyLevelFine = Guard.NotNull(nameof(privacyLevelFine), privacyLevelFine);
 			PrivacyLevelStrong = Guard.NotNull(nameof(privacyLevelStrong), privacyLevelStrong);
 			BitcoinCoreEndPoint = Guard.NotNull(nameof(bitcoinCoreEndPoint), bitcoinCoreEndPoint);
+			FetchFromLocalOnly = fetchFromLocalOnly;
 			DustThreshold = Guard.NotNull(nameof(dustThreshold), dustThreshold);
 		}
 	}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -51,6 +51,23 @@ namespace WalletWasabi.Services
 			}
 		}
 
+		public static event EventHandler<bool> BlockDownloaded;
+
+		private static bool BlockDownloadedLocallyBacking;
+
+		public static bool BlockDownloadedLocally
+		{
+			get => BlockDownloadedLocallyBacking;
+			set
+			{
+				if (value != BlockDownloadedLocallyBacking)
+				{
+					BlockDownloadedLocallyBacking = value;
+					BlockDownloaded?.Invoke(null, value);
+				}
+			}
+		}
+
 		public BitcoinStore BitcoinStore { get; }
 		public KeyManager KeyManager { get; }
 		public WasabiSynchronizer Synchronizer { get; }
@@ -843,7 +860,9 @@ namespace WalletWasabi.Services
 								throw new InvalidOperationException($"Disconnected node, because block invalid block received!");
 							}
 
+
 							block = blockFromLocalNode;
+							BlockDownloadedLocally = true;
 							Logger.LogInfo<WalletService>($"Block acquired from local P2P connection: {hash}");
 							break;
 						}
@@ -896,6 +915,7 @@ namespace WalletWasabi.Services
 								continue;
 							}
 
+							BlockDownloadedLocally = false;
 							if (Nodes.ConnectedNodes.Count > 1) // So to minimize risking missing unconfirmed transactions.
 							{
 								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}");


### PR DESCRIPTION
This PR contains the following two part:

### Fetch blocks from local node only switch

Several advanced users asked for a way to configure their local nodes and make sure Wasabi does not connect with any other node. Users now can opt-in for that if they want to. By default Wasabi behaves exactly as before.

![image](https://user-images.githubusercontent.com/127973/60536993-d9f61780-9cdd-11e9-8f81-3594de8bf65a.png)

### Block source visual indicator

Most advanced users asked many times for a way to know whether Wasabi is fetching blocks from local node or remote nodes. This PR adds a small bullet in the status bar with the following colors:
* Gray: No block has been requested yet.
* Lime Green: Latest block was downloaded from a remote peer.
* Green: Latest block was downloaded from local node.
* Red: No block was downloaded because FetchFromLocalOnly is on and cannot connect to local node.
 

![image](https://user-images.githubusercontent.com/127973/60537238-6dc7e380-9cde-11e9-89c5-6f0ca397f438.png)
 

  