### PR TITLE
Toggle sensitive data on advanced wallet info

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
@@ -6,6 +6,7 @@
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui">
   <UserControl.Resources>
     <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShowHideSensitiveKeysBoolConverter x:Key="ShowHideSensitiveKeysBoolConverter" />
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
     <StackPanel>
@@ -55,13 +56,11 @@
             <StackPanel IsVisible="{Binding !IsWatchOnly}" Margin="0 10 0 0" Spacing="10" Orientation="Horizontal">
               <controls:NoparaPasswordBox Password="{Binding Password}" Watermark="Password" UseFloatingWatermark="True" MinWidth="173" MaxWidth="173">
                 <i:Interaction.Behaviors>
-                  <behaviors:CommandOnEnterBehavior Command="{Binding ShowSensitiveKeysCommand}" />
+                  <behaviors:CommandOnEnterBehavior Command="{Binding ToggleSensitiveKeysCommand}" />
                 </i:Interaction.Behaviors>
               </controls:NoparaPasswordBox>
               <DockPanel VerticalAlignment="Top" LastChildFill="True">
-                <Button Command="{Binding ShowSensitiveKeysCommand}" DockPanel.Dock="Right">
-                  Show Sensitive Keys
-                </Button>
+                <Button Content="{Binding IsShow, Converter={StaticResource ShowHideSensitiveKeysBoolConverter}}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right"/>
                 <Grid></Grid>
               </DockPanel>
               <TextBlock Text="{Binding WarningMessage}" Classes="warningMessage" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
@@ -60,7 +60,7 @@
                 </i:Interaction.Behaviors>
               </controls:NoparaPasswordBox>
               <DockPanel VerticalAlignment="Top" LastChildFill="True">
-                <Button Content="{Binding IsShow, Converter={StaticResource ShowHideSensitiveKeysBoolConverter}}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right" />
+                <Button Content="{Binding ShowSensitiveKeys, Converter={StaticResource ShowHideSensitiveKeysBoolConverter}}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right" />
                 <Grid></Grid>
               </DockPanel>
               <TextBlock Text="{Binding WarningMessage}" Classes="warningMessage" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
@@ -60,7 +60,7 @@
                 </i:Interaction.Behaviors>
               </controls:NoparaPasswordBox>
               <DockPanel VerticalAlignment="Top" LastChildFill="True">
-                <Button Content="{Binding IsShow, Converter={StaticResource ShowHideSensitiveKeysBoolConverter}}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right"/>
+                <Button Content="{Binding IsShow, Converter={StaticResource ShowHideSensitiveKeysBoolConverter}}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right" />
                 <Grid></Grid>
               </DockPanel>
               <TextBlock Text="{Binding WarningMessage}" Classes="warningMessage" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			{
 				try
 				{
-					if (IsShow)
+					if (ShowSensitiveKeys)
 					{
 						ClearSensitiveData(true);
 					}
@@ -82,7 +82,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			ExtendedMasterZprv = "";
 			ExtendedAccountPrivateKey = "";
 			ExtendedAccountZprv = "";
-			IsShow = false;
+			ShowSensitiveKeys = false;
 
 			if (passwordToo)
 			{
@@ -98,7 +98,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public string MasterKeyFingerprint => KeyManager.MasterFingerprint.ToString();
 		public ReactiveCommand<Unit, Unit> ToggleSensitiveKeysCommand { get; }
 
-		public bool IsShow
+		public bool ShowSensitiveKeys
 		{
 			get => _showSensitiveKeys;
 			set => this.RaiseAndSetIfChanged(ref _showSensitiveKeys, value);
@@ -140,7 +140,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			ExtendedAccountPrivateKey = extendedAccountPrivateKey;
 			ExtendedMasterZprv = extendedMasterZprv;
 			ExtendedAccountZprv = extendedAccountZprv;
-			IsShow = true;
+			ShowSensitiveKeys = true;
 
 			Dispatcher.UIThread.PostLogException(async () =>
 			{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -17,6 +17,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 	{
 		private CompositeDisposable Disposables { get; set; }
 
+		private bool _showSensitiveKeys;
 		private string _password;
 		private string _extendedMasterPrivateKey;
 		private string _extendedMasterZprv;
@@ -47,19 +48,26 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 			});
 
-			ShowSensitiveKeysCommand = ReactiveCommand.Create(() =>
+			ToggleSensitiveKeysCommand = ReactiveCommand.Create(() =>
 			{
 				try
 				{
-					Password = Guard.Correct(Password);
-					var secret = KeyManager.GetMasterExtKey(Password);
-					Password = "";
+					if (IsShow)
+					{
+						ClearSensitiveData(true);
+					}
+					else
+					{
+						Password = Guard.Correct(Password);
+						var secret = KeyManager.GetMasterExtKey(Password);
+						Password = "";
 
-					string master = secret.GetWif(Global.Network).ToWif();
-					string account = secret.Derive(KeyManager.AccountKeyPath).GetWif(Global.Network).ToWif();
-					string masterZ = secret.ToZPrv(Global.Network);
-					string accountZ = secret.Derive(KeyManager.AccountKeyPath).ToZPrv(Global.Network);
-					SetSensitiveData(master, account, masterZ, accountZ);
+						string master = secret.GetWif(Global.Network).ToWif();
+						string account = secret.Derive(KeyManager.AccountKeyPath).GetWif(Global.Network).ToWif();
+						string masterZ = secret.ToZPrv(Global.Network);
+						string accountZ = secret.Derive(KeyManager.AccountKeyPath).ToZPrv(Global.Network);
+						SetSensitiveData(master, account, masterZ, accountZ);
+					}
 				}
 				catch (Exception ex)
 				{
@@ -74,6 +82,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			ExtendedMasterZprv = "";
 			ExtendedAccountPrivateKey = "";
 			ExtendedAccountZprv = "";
+			IsShow = false;
 
 			if (passwordToo)
 			{
@@ -87,7 +96,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public string ExtendedAccountZpub => KeyManager.ExtPubKey.ToZpub(Global.Network);
 		public string AccountKeyPath => $"m/{KeyManager.AccountKeyPath.ToString()}";
 		public string MasterKeyFingerprint => KeyManager.MasterFingerprint.ToString();
-		public ReactiveCommand<Unit, Unit> ShowSensitiveKeysCommand { get; }
+		public ReactiveCommand<Unit, Unit> ToggleSensitiveKeysCommand { get; }
+
+		public bool IsShow
+		{
+			get => _showSensitiveKeys;
+			set => this.RaiseAndSetIfChanged(ref _showSensitiveKeys, value);
+		}
 
 		public string Password
 		{
@@ -125,6 +140,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			ExtendedAccountPrivateKey = extendedAccountPrivateKey;
 			ExtendedMasterZprv = extendedMasterZprv;
 			ExtendedAccountZprv = extendedAccountZprv;
+			IsShow = true;
 
 			Dispatcher.UIThread.PostLogException(async () =>
 			{

--- a/WalletWasabi.Gui/Converters/ShowHideSensitiveKeysBoolConverter.cs
+++ b/WalletWasabi.Gui/Converters/ShowHideSensitiveKeysBoolConverter.cs
@@ -1,0 +1,26 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class ShowHideSensitiveKeysBoolConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool isShow)
+			{
+				return isShow ? "Hide Sensitive Keys" : "Show Sensitive Keys";
+			}
+			else
+			{
+				throw new TypeArgumentException(value, typeof(bool), nameof(value));
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}


### PR DESCRIPTION
Added the ability to hide the sensitive keys after unlocking them. Prior to this PR you would need to close the advanced wallet info tab and re open it for you to hide the keys