### PR TITLE
Sort coinjoin outputs by amount.

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -258,5 +258,10 @@ namespace NBitcoin
 			var extractedTx = psbt.ExtractTransaction();
 			return new SmartTransaction(extractedTx, height, blockHash, blockIndex, label, firstSeenIfMemPoolTime, isReplacement);
 		}
+
+		public static void SortByAmount(this TxOutList list)
+		{
+			list.Sort((x, y) => x.Value.CompareTo(y.Value));
+		}
 	}
 }

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -401,6 +401,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						// 7. Shuffle. NBitcoin's shuffle doesn't work: https://github.com/MetacoSA/NBitcoin/issues/713
 						transaction.Inputs.Shuffle();
 						transaction.Outputs.Shuffle();
+						transaction.Outputs.SortByAmount(); // So the coinjoin looks better in block explorer.
 
 						// 8. Create the unsigned transaction.
 						var builder = Network.CreateTransactionBuilder();


### PR DESCRIPTION
This PR sorts the coinjoin outputs by amount (after shuffling). So it'll look better in a block explorer. This partly addresses what Aviv said about "it's nice to show people how coinjoins work in the CJ transaction" but it does not ruin the shuffling.