### PR TITLE
Fix the freeze on OSX related to CJ countdown

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -129,20 +129,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					TimeSpan left = x - DateTimeOffset.UtcNow;
 					TimeLeftTillRoundTimeout = left > TimeSpan.Zero ? left : TimeSpan.Zero; // Make sure cannot be less than zero.
-				});
-
-			this.WhenAnyValue(x => x.TimeLeftTillRoundTimeout)
-				.Throttle(TimeSpan.FromSeconds(1))
-				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(x =>
-				{
-					var next = TimeLeftTillRoundTimeout - TimeSpan.FromSeconds(1);
-					TimeLeftTillRoundTimeout = next > TimeSpan.Zero ? next : TimeSpan.Zero; // Make sure cannot be less than zero.
-				});
+				});				
+				
 		}
 
 		public override void OnOpen()
 		{
+			base.OnOpen();
+
 			if (Disposables != null)
 			{
 				throw new Exception("CoinJoin tab opened before previous closed.");
@@ -190,7 +184,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				this.RaisePropertyChanged(nameof(IsLurkingWifeMode));
 			}).DisposeWith(Disposables);
 
-			base.OnOpen();
+			Observable.Interval(TimeSpan.FromSeconds(1))
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ =>
+				{
+					TimeSpan left = RoundTimesout - DateTimeOffset.UtcNow;
+					TimeLeftTillRoundTimeout = left > TimeSpan.Zero ? left : TimeSpan.Zero; // Make sure cannot be less than zero.
+				}).DisposeWith(Disposables);
+
 		}
 
 		public override bool OnClose()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -129,8 +129,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					TimeSpan left = x - DateTimeOffset.UtcNow;
 					TimeLeftTillRoundTimeout = left > TimeSpan.Zero ? left : TimeSpan.Zero; // Make sure cannot be less than zero.
-				});				
-				
+				});
 		}
 
 		public override void OnOpen()
@@ -191,7 +190,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					TimeSpan left = RoundTimesout - DateTimeOffset.UtcNow;
 					TimeLeftTillRoundTimeout = left > TimeSpan.Zero ? left : TimeSpan.Zero; // Make sure cannot be less than zero.
 				}).DisposeWith(Disposables);
-
 		}
 
 		public override bool OnClose()


### PR DESCRIPTION
There is a recursive-ish RX call. Works on every OP system but on OSX it freezes the UI after a few minutes at this line:
https://github.com/zkSNACKs/WalletWasabi/blob/80acd15e13696b431ea722badb88f9f3e8a2cc16/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs#L140