### PR TITLE
No notification of ZeroLink coins

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -519,7 +519,10 @@ namespace WalletWasabi.Gui
 						//	// It's harder than you'd think. Maybe the best would be to wait for .NET Core 3 for WPF things on Windows?
 						//}
 						// else
-
+						if (coin.HdPubKey.IsInternal)
+						{
+							continue;
+						}
 						string amountString = coin.Amount.ToString(false, true);
 						using (var process = Process.Start(new ProcessStartInfo {
 							FileName = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osascript" : "notify-send",


### PR DESCRIPTION
People get confused when they see notifications saying they received xxx.yyyBTC after a successful coinjoin participation. This PR do not display those notifications when the received coin is a ZeroLink coin. 