### PR TITLE
Warning that while downloading filters, wallet history may be incorrect

### DIFF
--- a/WalletWasabi.Gui/Converters/FilterLeftStatusConverter.cs
+++ b/WalletWasabi.Gui/Converters/FilterLeftStatusConverter.cs
@@ -18,11 +18,11 @@ namespace WalletWasabi.Gui.Converters
 				}
 				else if (integer == 1)
 				{
-					return "Downloading a filter...";
+					return "Downloading a filter, your wallet history may be incorrect...";
 				}
 				else
 				{
-					return $"Downloading {value} filters...";
+					return $"Downloading {value} filters, your wallet history may be incorrect...";
 				}
 			}
 			else


### PR DESCRIPTION
Today, I temporarily thought I lost all my coins after sending them to a new wallet, turns out I just needed to download the block filters.  

Current implementation:

![](https://user-images.githubusercontent.com/15256660/61651721-1df49080-ac7c-11e9-80cd-54a1c6c572b8.png)
