### PR TITLE
Grammatical error fix

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletView.xaml
@@ -24,7 +24,7 @@
             </StackPanel>
             <StackPanel>
               <TextBlock Text="Which hardware wallets are currently supported?" FontWeight="Bold" />
-              <TextBlock Text="- Coldcard Mk1, Mk2, Ledger Nano S, Trezor One and Trezor T." TextWrapping="Wrap" />
+              <TextBlock Text="- Coldcard Mk1, Mk2, Ledger Nano S, Trezor One, and Trezor T." TextWrapping="Wrap" />
               <TextBlock Text="- While other hardware wallets may also work, they were not tested by Wasabi developers." TextWrapping="Wrap" />
             </StackPanel>
           </StackPanel>


### PR DESCRIPTION
The current line signifies that the Terzor One and the Terzor T are 1 item, by adding the comma after Tezor One it signifies that the two are separate.