### PR TITLE
[Tests] Create a GuiTester to dramatically increase code coverage

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Gui
 
 		[DefaultValue("http://localhost:37127/")]
 		[JsonProperty(PropertyName = "RegTestBackendUriV3", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public string RegTestBackendUriV3 { get; private set; }
+		public string RegTestBackendUriV3 { get; internal set; }
 
 		[DefaultValue(true)]
 		[JsonProperty(PropertyName = "UseTor", DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -247,10 +247,10 @@ namespace WalletWasabi.Gui
 				Nodes = new NodesGroup(Network, requirements: Constants.NodeRequirements);
 				try
 				{
-					Node node = await Node.ConnectAsync(Network.RegTest, Config.GetBitcoinCoreEndPoint());
+					Node node = await Node.ConnectAsync(Network.RegTest, Config.GetBitcoinP2pEndPoint());
 					Nodes.ConnectedNodes.Add(node);
 
-					RegTestMemPoolServingNode = await Node.ConnectAsync(Network.RegTest, Config.GetBitcoinCoreEndPoint());
+					RegTestMempoolServingNode = await Node.ConnectAsync(Network.RegTest, Config.GetBitcoinP2pEndPoint());
 
 					RegTestMempoolServingNode.Behaviors.Add(new MempoolBehavior(MempoolService));
 				}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -66,9 +66,12 @@ namespace WalletWasabi.Gui
 
 		public Network Network => Config.Network;
 
-		public Global()
+		public Global(): this(EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client")))
 		{
-			DataDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client"));
+		}
+		public Global(string datadir)
+		{
+			DataDir = datadir ?? throw new ArgumentNullException(nameof(datadir));
 			TorLogsFile = Path.Combine(DataDir, "TorLogs.txt");
 			WalletsDir = Path.Combine(DataDir, "Wallets");
 			WalletBackupsDir = Path.Combine(DataDir, "WalletBackups");
@@ -244,10 +247,10 @@ namespace WalletWasabi.Gui
 				Nodes = new NodesGroup(Network, requirements: Constants.NodeRequirements);
 				try
 				{
-					Node node = await Node.ConnectAsync(Network.RegTest, new IPEndPoint(IPAddress.Loopback, 18444));
+					Node node = await Node.ConnectAsync(Network.RegTest, Config.GetBitcoinCoreEndPoint());
 					Nodes.ConnectedNodes.Add(node);
 
-					RegTestMempoolServingNode = await Node.ConnectAsync(Network.RegTest, new IPEndPoint(IPAddress.Loopback, 18444));
+					RegTestMemPoolServingNode = await Node.ConnectAsync(Network.RegTest, Config.GetBitcoinCoreEndPoint());
 
 					RegTestMempoolServingNode.Behaviors.Add(new MempoolBehavior(MempoolService));
 				}

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -6,6 +6,7 @@ using AvalonStudio.Shell.Extensibility.Platforms;
 using NBitcoin;
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using WalletWasabi.Gui.CommandLine;
@@ -13,6 +14,7 @@ using WalletWasabi.Gui.Controls.LockScreen;
 using WalletWasabi.Gui.ManagedDialogs;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Logging;
+[assembly:InternalsVisibleTo("WalletWasabi.Tests")]
 
 namespace WalletWasabi.Gui
 {
@@ -46,7 +48,7 @@ namespace WalletWasabi.Gui
 					.BeforeStarting(async builder =>
 					{
 						MainWindowViewModel.Instance = new MainWindowViewModel { Global = Global };
-						statusBar = new StatusBarViewModel(Global);
+						statusBar = new StatusBarViewModel(Global, MainWindowViewModel.Instance);
 						MainWindowViewModel.Instance.StatusBar = statusBar;
 						MainWindowViewModel.Instance.LockScreen = new LockScreenViewModel(Global);
 

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -55,9 +55,10 @@ namespace WalletWasabi.Gui.ViewModels
 		public Global Global { get; }
 		private StatusBarStatusSet ActiveStatuses { get; }
 
-		public StatusBarViewModel(Global global)
+		public StatusBarViewModel(Global global, MainWindowViewModel mainWindowViewModel)
 		{
 			Global = global;
+			_mainWindowViewModel = mainWindowViewModel;
 			UpdateStatus = UpdateStatus.Latest;
 			UpdateAvailable = false;
 			CriticalUpdateAvailable = false;
@@ -294,7 +295,7 @@ namespace WalletWasabi.Gui.ViewModels
 			if (isGenSocksServFail)
 			{
 				// Is close band present?
-				if (MainWindowViewModel.Instance.ModalDialog != null)
+				if (_mainWindowViewModel.ModalDialog != null)
 				{
 					// Do nothing.
 				}
@@ -305,19 +306,19 @@ namespace WalletWasabi.Gui.ViewModels
 					if (osDesc.Contains("16.04.1-Ubuntu", StringComparison.InvariantCultureIgnoreCase)
 						|| osDesc.Contains("16.04.0-Ubuntu", StringComparison.InvariantCultureIgnoreCase))
 					{
-						MainWindowViewModel.Instance.ShowDialogAsync(new GenSocksServFailDialogViewModel()).GetAwaiter().GetResult();
+						_mainWindowViewModel.ShowDialogAsync(new GenSocksServFailDialogViewModel()).GetAwaiter().GetResult();
 					}
 				}
 			}
 			else
 			{
 				// Is close band present?
-				if (MainWindowViewModel.Instance.ModalDialog != null)
+				if (_mainWindowViewModel.ModalDialog != null)
 				{
 					// Is it GenSocksServFail dialog?
-					if (MainWindowViewModel.Instance.ModalDialog is GenSocksServFailDialogViewModel)
+					if (_mainWindowViewModel.ModalDialog is GenSocksServFailDialogViewModel)
 					{
-						MainWindowViewModel.Instance.ModalDialog.Close(true);
+						_mainWindowViewModel.ModalDialog.Close(true);
 					}
 					else
 					{
@@ -369,6 +370,7 @@ namespace WalletWasabi.Gui.ViewModels
 		#region IDisposable Support
 
 		private volatile bool _disposedValue = false; // To detect redundant calls
+		private readonly MainWindowViewModel _mainWindowViewModel;
 
 		protected virtual void Dispose(bool disposing)
 		{

--- a/WalletWasabi.Tests/Extensions.cs
+++ b/WalletWasabi.Tests/Extensions.cs
@@ -16,8 +16,11 @@ namespace WalletWasabi.Tests
 
 			public void Dispose()
 			{
-				_coreNode.CreateRPCClient().Stop();
-				_coreNode.WaitForExit();
+				if (_coreNode.State == NBitcoin.Tests.CoreNodeState.Running)
+				{
+					_coreNode.CreateRPCClient().Stop();
+					_coreNode.WaitForExit();
+				}
 			}
 		}
 

--- a/WalletWasabi.Tests/Extensions.cs
+++ b/WalletWasabi.Tests/Extensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Tests
+{
+	public static class Extensions
+	{
+		class DisposableNode : IDisposable
+		{
+			private readonly NBitcoin.Tests.CoreNode _coreNode;
+			public DisposableNode(NBitcoin.Tests.CoreNode coreNode)
+			{
+				_coreNode = coreNode;
+			}
+
+			public void Dispose()
+			{
+				_coreNode.CreateRPCClient().Stop();
+				_coreNode.WaitForExit();
+			}
+		}
+
+		public static IDisposable AsDisposable(this NBitcoin.Tests.CoreNode coreNode)
+		{
+			return new DisposableNode(coreNode);
+		}
+	}
+}

--- a/WalletWasabi.Tests/GuiTester.cs
+++ b/WalletWasabi.Tests/GuiTester.cs
@@ -1,0 +1,154 @@
+using NBitcoin.Tests;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Gui.ViewModels;
+using WalletWasabi.Gui;
+
+namespace WalletWasabi.Tests
+{
+	public class GuiTester : IDisposable
+	{
+		List<GuiClientTester> _guiClients = new List<GuiClientTester>();
+		Stack<IDisposable> _resources = new Stack<IDisposable>();
+		private readonly NodeBuilder _nodeBuilder;
+		public NodeBuilder NodeBuilder
+		{
+			get
+			{
+				return _nodeBuilder;
+			}
+		}
+
+		private readonly string _testName;
+		public string TestName
+		{
+			get
+			{
+				return _testName;
+			}
+		}
+		public static GuiTester Create([CallerMemberName] string testName = null)
+		{
+			AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+			TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+			return new GuiTester(testName);
+		}
+
+		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+		{
+			e.Exception.ToString();
+		}
+
+		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+		{
+		}
+
+		private GuiTester(string testName)
+		{
+			_testName = testName;
+			IoHelpers.DeleteRecursivelyWithMagicDustAsync(_testName).GetAwaiter().GetResult();
+			_nodeBuilder = NBitcoin.Tests.NodeBuilder.Create(NodeDownloadData.Bitcoin.v0_18_0, NBitcoin.Network.RegTest, testName);
+			_resources.Push(_nodeBuilder);
+		}
+
+		public GuiClientTester CreateGuiClient()
+		{
+			string guiDatadir = Path.Combine(TestName, "GuiClients", _guiClients.Count.ToString());
+			var child = new GuiClientTester(this, guiDatadir);
+			_guiClients.Add(child);
+			_resources.Push(child);
+			return child;
+		}
+
+		public async Task StartAllAsync()
+		{
+			foreach (var gui in _guiClients.Select(g => g.StartAsync()).ToArray())
+			{
+				await gui;
+			}
+		}
+
+		public void Dispose()
+		{
+			while (_resources.TryPop(out var v))
+			{
+				v.Dispose();
+			}
+		}
+	}
+
+	public class GuiClientTester : IDisposable
+	{
+		private GuiTester _parent;
+		private string _dataDir;
+
+		public GuiClientTester(GuiTester parent, string datadir)
+		{
+			_parent = parent;
+			_dataDir = datadir;
+			_node = parent.NodeBuilder.CreateNode();
+			_GuiGlobal = new Gui.Global(datadir);
+		}
+
+
+		private readonly CoreNode _node;
+		public CoreNode Node
+		{
+			get
+			{
+				return _node;
+			}
+		}
+
+
+		private readonly WalletWasabi.Gui.Global _GuiGlobal;
+		public WalletWasabi.Gui.Global GuiGlobal
+		{
+			get
+			{
+				return _GuiGlobal;
+			}
+		}
+
+
+		private MainWindowViewModel _mainViewModel;
+		public MainWindowViewModel MainViewModel
+		{
+			get
+			{
+				return _mainViewModel;
+			}
+		}
+
+		public async Task StartAsync()
+		{
+			await Node.StartAsync();
+			_mainViewModel = new MainWindowViewModel { Global = GuiGlobal };
+
+			var config = new Config(Path.Combine(_dataDir, "Config.json"));
+			await config.LoadOrCreateDefaultFileAsync();
+			config.Network = _parent.NodeBuilder.Network;
+			config.RegTestBitcoinCorePort = _node.NodeEndpoint.Port;
+			config.RegTestBitcoinCoreHost = _node.NodeEndpoint.Address.ToString();
+			config.UseTor = false;
+			await config.ToFileAsync();
+
+			await GuiGlobal.InitializeNoWalletAsync();
+
+			var statusBar = new StatusBarViewModel(GuiGlobal, _mainViewModel);
+			statusBar.Initialize(GuiGlobal.Nodes.ConnectedNodes, GuiGlobal.Synchronizer, GuiGlobal.UpdateChecker);
+		}
+
+		public void Dispose()
+		{
+			GuiGlobal.DisposeAsync().GetAwaiter().GetResult();
+			_node.Kill();
+			_node.WaitForExit();
+		}
+	}
+}

--- a/WalletWasabi.Tests/GuiTester.cs
+++ b/WalletWasabi.Tests/GuiTester.cs
@@ -1,4 +1,5 @@
 using NBitcoin.Tests;
+using WalletWasabi.Logging;
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -55,11 +56,12 @@ namespace WalletWasabi.Tests
 
 		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
 		{
-			e.Exception.ToString();
+			Logger.LogWarning(e?.Exception, "UnobservedTaskException");
 		}
 
 		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
 		{
+			Logger.LogWarning(e?.ExceptionObject as Exception, "UnhandledException");
 		}
 
 		private GuiTester(string testName)

--- a/WalletWasabi.Tests/GuiTester.cs
+++ b/WalletWasabi.Tests/GuiTester.cs
@@ -92,7 +92,7 @@ namespace WalletWasabi.Tests
 				return;
 			}
 
-			var BackendNode = _nodeBuilder.CreateNode();
+			BackendNode = _nodeBuilder.CreateNode();
 			BackendNode.WhiteBind = true;
 			await BackendNode.StartAsync();
 			_resources.Push(BackendNode.AsDisposable());
@@ -201,6 +201,7 @@ namespace WalletWasabi.Tests
 				throw new InvalidOperationException("The coinjoin node should start before the client nodes");
 			}
 			Node.ConfigParameters.Add("connect", $"{_parent.BackendNode.Endpoint.Address}:{_parent.BackendNode.Endpoint.Port}");
+			Node.ConfigParameters.Add("listen", "1");
 			await Node.StartAsync();
 			_mainViewModel = new MainWindowViewModel { Global = GuiGlobal };
 

--- a/WalletWasabi.Tests/GuiTests.cs
+++ b/WalletWasabi.Tests/GuiTests.cs
@@ -24,14 +24,13 @@ namespace WalletWasabi.Tests
 		}
 
 		[Fact]
-		public async Task CanLoadCoinsAsync()
+		public async Task CanInitializeWalletGUIAsync()
 		{
 			using (var tester = GuiTester.Create())
 			{
 				var client1 = tester.CreateGuiClient();
-				//var client2 = tester.CreateGuiClient();
+				var client2 = tester.CreateGuiClient();
 				await tester.StartAllAsync();
-				await Task.Delay(10000);
 			}
 		}
 	}

--- a/WalletWasabi.Tests/GuiTests.cs
+++ b/WalletWasabi.Tests/GuiTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WalletWasabi.Tests
+{
+	public class GuiTests
+	{
+		public GuiTests(ITestOutputHelper helper)
+		{
+			var logsPath = Path.Combine(".", "Logs.txt");
+			if (File.Exists(logsPath))
+			{
+				File.Delete(logsPath);
+			}
+			Logger.SetFilePath(logsPath);
+			Logger.SetMinimumLevel(LogLevel.Info);
+			Logger.SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
+		}
+
+		[Fact]
+		public async Task CanLoadCoinsAsync()
+		{
+			using (var tester = GuiTester.Create())
+			{
+				var client1 = tester.CreateGuiClient();
+				//var client2 = tester.CreateGuiClient();
+				await tester.StartAllAsync();
+				await Task.Delay(10000);
+			}
+		}
+	}
+}

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AltCover" Version="5.3.675" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NBitcoin.TestFramework" Version="1.7.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -26,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WalletWasabi.Backend\WalletWasabi.Backend.csproj" />
+    <ProjectReference Include="..\WalletWasabi.Gui\WalletWasabi.Gui.csproj" />
     <ProjectReference Include="..\WalletWasabi\WalletWasabi.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
My refactoring on removing global state has been done to be able to easily create unit tests which setup a full wasabi wallet environment.

Example:
```csharp
		[Fact]
		public async Task CanLoadCoinsAsync()
		{
			using (var tester = GuiTester.Create())
			{

 				var client1 = tester.CreateGuiClient();
				var client2 = tester.CreateGuiClient();
				await tester.StartAllAsync();
				await Task.Delay(10000);
			}
		}
```

Via client1 and 2, you can access the mainviewmodel and global GUI.

This is far from being ready to merge, my goal is to reach the state where some basic operations are tested like: 
* If client1 and client2 receives coins, does it appears correctly in history and coin list?
* Can client1 properly send money to client2 via the view models?

The two clients have their own independant datadir, with their own full nodes.

I will then do tests on simple mixing and test how the viewmodels behave.

With such framework, it will become very easy to create 10 clients mixing together while reaching very high code coverage.

I need to use NBitcoin.Testframework, because of the reliance of Wasabi one on singletons which would prevent me to do such features easily.