### PR TITLE
Fix message

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -56,7 +56,7 @@
           <TextBlock Text = "Selected Amount:" />
           <TextBlock Foreground="YellowGreen" Text = "{Binding TotalAmount, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}}" />
           <TextBlock Text = "BTC" />
-          <TextBlock Text ="Merging red coins with non-red coins deanonymizes your non-red coins." Classes="warningMessage" IsVisible="{Binding LabelExposeCommonOwnershipWarning}" />
+          <TextBlock Text ="Merging unmixed coins with mixed ones undo those mixes." Classes="warningMessage" IsVisible="{Binding LabelExposeCommonOwnershipWarning}" />
         </StackPanel>
       </StackPanel>
       <controls:BusyIndicator IsBusy ="{Binding IsCoinListLoading}" Text="Loading...">


### PR DESCRIPTION
@benthecarman Good catch, but PR https://github.com/zkSNACKs/WalletWasabi/pull/1828/ is not good. Only if anonset 1 is when the warning should be shown. If anonset 2, then the heuristic is only 50% accurate, so warning message should not be shown. What can be improved is the message itself.

Closes https://github.com/zkSNACKs/WalletWasabi/issues/1826
Closes https://github.com/zkSNACKs/WalletWasabi/pull/1828/