### PR TITLE
Moved null check to getter

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -474,7 +474,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _targetPrivacy, value);
 		}
 
-		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode;
 
 		public ReactiveCommand<Unit, Unit> EnqueueCommand { get; }
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private byte[] _psbtBytes;
 		public ReactiveCommand<Unit, Unit> ExportBinaryPsbtCommand { get; set; }
 
-		public bool? IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode;
+		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode;
 
 		public string TxId
 		{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -135,7 +135,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
 
-			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode.Value ? "#########" : balance.ToString(false, true))} BTC)";
+			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode ? "#########" : balance.ToString(false, true))} BTC)";
 		}
 	}
 }

--- a/WalletWasabi.Gui/Converters/LurkingWifeModeStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/LurkingWifeModeStringConverter.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Gui.Converters
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
 			var uiConfig = Application.Current.Resources[Global.UiConfigResourceKey] as UiConfig;
-			if (uiConfig.LurkingWifeMode is true)
+			if (uiConfig.LurkingWifeMode)
 			{
 				int len = 10;
 				if (int.TryParse(parameter.ToString(), out int newLength))

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -505,7 +505,7 @@ namespace WalletWasabi.Gui
 		{
 			try
 			{
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || UiConfig != null && UiConfig.LurkingWifeMode)
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (UiConfig != null && UiConfig.LurkingWifeMode))
 				{
 					return;
 				}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -505,7 +505,7 @@ namespace WalletWasabi.Gui
 		{
 			try
 			{
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || UiConfig?.LurkingWifeMode.Value is true)
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || UiConfig != null && UiConfig.LurkingWifeMode)
 				{
 					return;
 				}

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -216,7 +216,7 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _dustThreshold, value);
 		}
 
-		public bool LurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool LurkingWifeMode => Global.UiConfig.LurkingWifeMode;
 
 		private void Save()
 		{

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Newtonsoft.Json;
 using ReactiveUI;
 using System;
@@ -44,10 +44,11 @@ namespace WalletWasabi.Gui
 		public bool? Autocopy { get; internal set; }
 
 		[JsonProperty(PropertyName = "LurkingWifeMode")]
-		public bool? LurkingWifeMode
+		public bool LurkingWifeMode
 		{
-			get => _lurkingWifeMode;
-			set => this.RaiseAndSetIfChanged(ref _lurkingWifeMode, value);
+
+				get => _lurkingWifeMode ?? false;
+				set => this.RaiseAndSetIfChanged(ref _lurkingWifeMode, value);
 		}
 
 		public UiConfig()
@@ -117,7 +118,7 @@ namespace WalletWasabi.Gui
 			FeeTarget = config.FeeTarget ?? FeeTarget;
 			FeeDisplayFormat = config.FeeDisplayFormat ?? FeeDisplayFormat;
 			Autocopy = config.Autocopy ?? Autocopy;
-			LurkingWifeMode = config.LurkingWifeMode ?? LurkingWifeMode;
+			LurkingWifeMode = config.LurkingWifeMode;
 		}
 
 		/// <inheritdoc />

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -46,7 +46,6 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "LurkingWifeMode")]
 		public bool LurkingWifeMode
 		{
-
 				get => _lurkingWifeMode ?? false;
 				set => this.RaiseAndSetIfChanged(ref _lurkingWifeMode, value);
 		}

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -76,7 +76,7 @@ namespace WalletWasabi.Gui.ViewModels
 				});
 		}
 
-		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode;
 
 		public bool ClipboardNotificationVisible
 		{


### PR DESCRIPTION
Whenever the wallet needs to check the lurking wife mode state it has to also check that it is not null. This PR moves that null check to the getter and removes having to do that everywhere else.

I will also create separate PRs for other members of the UIConfig class if this PR/those changes are approved.