### PR TITLE
Confirmation target setting

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -140,6 +140,9 @@ namespace WalletWasabi.Gui
 		[JsonConverter(typeof(MoneyBtcJsonConverter))]
 		public Money DustThreshold { get; internal set; }
 
+		[JsonProperty(PropertyName = "ConfirmationTarget")]
+		public int? ConfirmationTarget { get; internal set; }
+
 		private Uri _backendUri;
 		private Uri _fallbackBackendUri;
 
@@ -304,6 +307,7 @@ namespace WalletWasabi.Gui
 			PrivacyLevelFine = 21;
 			PrivacyLevelStrong = 50;
 			DustThreshold = Money.Coins(0.0001m);
+			ConfirmationTarget = 6;
 
 			if (!File.Exists(FilePath))
 			{
@@ -314,7 +318,7 @@ namespace WalletWasabi.Gui
 				await LoadFileAsync();
 			}
 
-			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, GetBitcoinCoreEndPoint(), DustThreshold);
+			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, GetBitcoinCoreEndPoint(), DustThreshold, ConfirmationTarget.Value);
 
 			// Just debug convenience.
 			_backendUri = GetCurrentBackendUri();
@@ -352,6 +356,8 @@ namespace WalletWasabi.Gui
 			PrivacyLevelStrong = config.PrivacyLevelStrong ?? PrivacyLevelStrong;
 
 			DustThreshold = config.DustThreshold ?? DustThreshold;
+
+			ConfirmationTarget = config.ConfirmationTarget ?? ConfirmationTarget;
 
 			ServiceConfiguration = config.ServiceConfiguration ?? ServiceConfiguration;
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -11,6 +11,7 @@
     <converters:CoinStatusBorderBrushConverter x:Key="CoinStatusBorderBrushConverter" />
     <converters:CoinStatusForegroundConverter x:Key="CoinStatusForegroundConverter" />
     <converters:CoinItemExpanderColorConverter x:Key="CoinItemExpanderColorConverter" />
+    <converters:ConfirmationTargetConverter x:Key="ConfirmationTargetConverter" />
     <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
   </UserControl.Resources>
   <UserControl.Styles>
@@ -127,9 +128,12 @@
                   </Grid.ColumnDefinitions>
 
                   <CheckBox HorizontalContentAlignment="Left" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />
-                  <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="1" ToolTip.Tip="{Binding Confirmations, StringFormat=\{0\} Confirmations}">
-                    <Path HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16"  Stretch="Fill" />
-                  </Border>
+
+                  <Panel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent"
+                    DataContext="{Binding Confirmations, Converter={StaticResource ConfirmationTargetConverter}}"
+                    ToolTip.Tip="{Binding ToolTip}">
+                    <DrawingPresenter Drawing="{Binding Icon}" Stretch="Fill" Height="16" Width="16" Margin="0 0 25 0" />
+                  </Panel>
 
                   <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left"  BorderThickness="1" CornerRadius="0,6,6,0">
                     <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -18,6 +18,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private bool _isSelected;
 		private SmartCoinStatus _status;
+		private int _confirmations;
 		private ObservableAsPropertyHelper<bool> _coinJoinInProgress;
 		private ObservableAsPropertyHelper<bool> _unspent;
 		private ObservableAsPropertyHelper<bool> _confirmed;
@@ -124,9 +125,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string Address => Model.ScriptPubKey.GetDestinationAddress(Global.Network).ToString();
 
-		public int Confirmations => Model.Height.Type == HeightType.Chain
-			? Global.BitcoinStore.HashChain.TipHeight - Model.Height.Value + 1
-			: 0;
+		public int Confirmations
+		{
+			get => _confirmations;
+			set => this.RaiseAndSetIfChanged(ref _confirmations, value);
+		}
 
 		public bool IsSelected
 		{
@@ -186,6 +189,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private void RefreshSmartCoinStatus()
 		{
 			Status = GetSmartCoinStatus();
+			Confirmations = Model.Height.Type == HeightType.Chain ? Global.BitcoinStore.HashChain.TipHeight - Model.Height.Value + 1 : 0;
 		}
 
 		private SmartCoinStatus GetSmartCoinStatus()

--- a/WalletWasabi.Gui/Converters/ConfirmationTargetConverter.cs
+++ b/WalletWasabi.Gui/Converters/ConfirmationTargetConverter.cs
@@ -1,0 +1,67 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class ConfirmationTargetConverter : IValueConverter
+	{
+		private static readonly Dictionary<string, DrawingGroup> Cache = new Dictionary<string, DrawingGroup>();
+
+		public DrawingGroup GetIconByName(string icon)
+		{
+			if (!Cache.TryGetValue(icon, out var image))
+			{
+				if (Application.Current.Styles.TryGetResource(icon, out object resource))
+				{
+					image = resource as DrawingGroup;
+					Cache.Add(icon, image);
+				}
+				else
+				{
+					throw new InvalidOperationException($"Icon {icon} not found");
+				}
+			}
+
+			return image;
+		}
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is int integer)
+			{
+				var config = Application.Current.Resources[Global.ConfigResourceKey] as Config;
+				string iconName;
+				string toolTip = $"{integer} Confirmations";
+
+				if (integer >= config.ConfirmationTarget)
+				{
+					iconName = "ConfTargetConfirmed";
+				}
+				else if (integer > 0)
+				{
+					iconName = "ConfTargetWaiting";
+				}
+				else
+				{
+					iconName = "ConfTargetUnconfirmed";
+					toolTip = "Unconfirmed";
+				}
+				
+				return new {Icon = GetIconByName(iconName), ToolTip = toolTip};
+			}
+			else
+			{
+				throw new TypeArgumentException(value, typeof(int), nameof(value));
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Icons/Icons.xaml
+++ b/WalletWasabi.Gui/Icons/Icons.xaml
@@ -185,6 +185,24 @@
         </DrawingGroup.Children>
       </DrawingGroup>
 
+      <DrawingGroup x:Key="ConfTargetConfirmed">
+        <DrawingGroup.Children>
+          <GeometryDrawing Brush="#FF22B14C" Geometry="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" />
+        </DrawingGroup.Children>
+      </DrawingGroup>
+
+      <DrawingGroup x:Key="ConfTargetWaiting">
+        <DrawingGroup.Children>
+          <GeometryDrawing Brush="#FFFFCC00" Geometry="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z" />
+        </DrawingGroup.Children>
+      </DrawingGroup>
+
+      <DrawingGroup x:Key="ConfTargetUnconfirmed">
+        <DrawingGroup.Children>
+          <GeometryDrawing Brush="#FFE41400" Geometry="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z" />
+        </DrawingGroup.Children>
+      </DrawingGroup>
+
       <DrawingGroup x:Key="TransactionBroadcaster">
         <DrawingGroup.Children>
           <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -100,6 +100,10 @@
                 <TextBlock ToolTip.Tip="Under the dust threshold coins are not appearing in the coin lists.">Dust Threshold (BTC)</TextBlock>
                 <TextBox Text="{Binding DustThreshold}" />
               </StackPanel>
+              <StackPanel Margin="0 10" Spacing="5">
+                <TextBlock ToolTip.Tip="How many blocks until a transaction is considered confirmed.">Confirmation Target</TextBlock>
+                <TextBox Text="{Binding ConfirmationTarget}" />
+              </StackPanel>
             </StackPanel>
           </controls:GroupBox>
 

--- a/WalletWasabi.Tests/P2pTests.cs
+++ b/WalletWasabi.Tests/P2pTests.cs
@@ -97,7 +97,7 @@ namespace WalletWasabi.Tests
 			   mempoolService,
 			   nodes,
 			   Global.Instance.DataDir,
-			   new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(0.0001m)));
+			   new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(0.0001m), 6));
 			Assert.True(Directory.Exists(blocksFolderPath));
 
 			try

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Tests
 			Backend.Global.Instance.Coordinator.UtxoReferee.Clear();
 
 			var network = Backend.Global.Instance.RpcClient.Network;
-			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, Money.Coins(0.0001m));
+			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, Money.Coins(0.0001m), 6);
 			var bitcoinStore = new BitcoinStore();
 			var dir = Path.Combine(Global.Instance.DataDir, caller);
 			await bitcoinStore.InitializeAsync(dir, network);

--- a/WalletWasabi/Models/ServiceConfiguration.cs
+++ b/WalletWasabi/Models/ServiceConfiguration.cs
@@ -15,6 +15,7 @@ namespace WalletWasabi.Models
 		public int PrivacyLevelStrong { get; set; }
 		public EndPoint BitcoinCoreEndPoint { get; set; }
 		public Money DustThreshold { get; set; }
+		public int ConfirmationTarget { get; set; }
 
 		public ServiceConfiguration(
 			int mixUntilAnonymitySet,
@@ -22,7 +23,8 @@ namespace WalletWasabi.Models
 			int privacyLevelFine,
 			int privacyLevelStrong,
 			EndPoint bitcoinCoreEndPoint,
-			Money dustThreshold)
+			Money dustThreshold,
+			int confirmationTarget)
 		{
 			MixUntilAnonymitySet = Guard.NotNull(nameof(mixUntilAnonymitySet), mixUntilAnonymitySet);
 			PrivacyLevelSome = Guard.NotNull(nameof(privacyLevelSome), privacyLevelSome);
@@ -30,6 +32,7 @@ namespace WalletWasabi.Models
 			PrivacyLevelStrong = Guard.NotNull(nameof(privacyLevelStrong), privacyLevelStrong);
 			BitcoinCoreEndPoint = Guard.NotNull(nameof(bitcoinCoreEndPoint), bitcoinCoreEndPoint);
 			DustThreshold = Guard.NotNull(nameof(dustThreshold), dustThreshold);
+			ConfirmationTarget = Guard.NotNull(nameof(confirmationTarget), confirmationTarget);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds an option for the user to set a confirmation target.  This allows the user to be able to check if their payment has reached enough confirmations for the user to consider it confirmed.  The UI also reflects it as:
Green Check: Confirmations > confirmation target
Yellow Clock: Confirmed but not yet Confirmation target
Red X: Not Confirmed 

![Screenshot_1](https://user-images.githubusercontent.com/15256660/61086516-a95a6000-a3f8-11e9-9f21-77682237e0b1.png)

Note: this currently doesn't work on the history tab, it is possible to add it to there but would require changes to `SmartCoin.cs`