### PR TITLE
Remove readonly fields naming rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -119,14 +119,6 @@ dotnet_naming_rule.static_fields_should_be_pascal_case.style    = pascal_case_st
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 
-# name all readonly fields using PascalCase
-dotnet_naming_rule.readonly_fields_should_be_pascal_case.severity = error
-dotnet_naming_rule.readonly_fields_should_be_pascal_case.symbols  = readonly_fields
-dotnet_naming_rule.readonly_fields_should_be_pascal_case.style    = pascal_case_style
-
-dotnet_naming_symbols.readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.readonly_fields.required_modifiers = readonly
-
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = error
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields

--- a/WalletWasabi.Backend/Middlewares/HeadMethodMiddleware.cs
+++ b/WalletWasabi.Backend/Middlewares/HeadMethodMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -13,7 +13,7 @@ namespace WalletWasabi.Backend.Middlewares
 	{
 		#region Fields
 
-		private readonly RequestDelegate Next;
+		private readonly RequestDelegate _next;
 
 		#endregion Fields
 
@@ -21,7 +21,7 @@ namespace WalletWasabi.Backend.Middlewares
 
 		public HeadMethodMiddleware(RequestDelegate next)
 		{
-			Next = next ?? throw new ArgumentNullException(nameof(next));
+			_next = next ?? throw new ArgumentNullException(nameof(next));
 		}
 
 		#endregion Constructor
@@ -40,7 +40,7 @@ namespace WalletWasabi.Backend.Middlewares
 				context.Response.Body = Stream.Null;
 			}
 
-			await Next(context);
+			await _next(context);
 
 			if (methodSwitched)
 			{

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Gui.Dialogs
 			set => this.RaiseAndSetIfChanged(ref _warningMessage, value);
 		}
 
-		private readonly Global Global;
+		private readonly Global _global;
 
 		public string OperationMessage
 		{
@@ -49,7 +49,7 @@ namespace WalletWasabi.Gui.Dialogs
 
 		public CannotCloseDialogViewModel(Global global) : base("", false, false)
 		{
-			Global = global;
+			_global = global;
 			OperationMessage = "Dequeuing coins...Please wait";
 			var canCancel = this.WhenAnyValue(x => x.IsBusy);
 			var canOk = this.WhenAnyValue(x => x.IsBusy, (isbusy) => !isbusy);
@@ -134,12 +134,12 @@ namespace WalletWasabi.Gui.Dialogs
 
 					try
 					{
-						if (Global.WalletService is null || Global.ChaumianClient is null)
+						if (_global.WalletService is null || _global.ChaumianClient is null)
 						{
 							return;
 						}
 
-						SmartCoin[] enqueuedCoins = Global.WalletService.Coins.Where(x => x.CoinJoinInProgress).ToArray();
+						SmartCoin[] enqueuedCoins = _global.WalletService.Coins.Where(x => x.CoinJoinInProgress).ToArray();
 						Exception latestException = null;
 						foreach (var coin in enqueuedCoins)
 						{
@@ -150,7 +150,7 @@ namespace WalletWasabi.Gui.Dialogs
 									break;
 								}
 
-								await Global.ChaumianClient.DequeueCoinsFromMixAsync(new SmartCoin[] { coin }, "Closing Wasabi."); // Dequeue coins one-by-one to check cancel flag more frequently.
+								await _global.ChaumianClient.DequeueCoinsFromMixAsync(new SmartCoin[] { coin }, "Closing Wasabi."); // Dequeue coins one-by-one to check cancel flag more frequently.
 							}
 							catch (Exception ex)
 							{

--- a/WalletWasabi.Gui/Shell/Commands/DiskCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/DiskCommands.cs
@@ -9,12 +9,12 @@ namespace WalletWasabi.Gui.Shell.Commands
 {
 	internal class DiskCommands
 	{
-		private readonly Global Global;
+		private readonly Global _global;
 
 		[ImportingConstructor]
 		public DiskCommands(CommandIconService commandIconService, AvaloniaGlobalComponent global)
 		{
-			Global = global.Global;
+			_global = global.Global;
 			var onOpenDataFolder = ReactiveCommand.Create(OnOpenDataFolder);
 			var onOpenWalletsFolder = ReactiveCommand.Create(OnOpenWalletsFolder);
 			var onOpenLogFile = ReactiveCommand.Create(OnOpenLogFile);
@@ -57,12 +57,12 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnOpenDataFolder()
 		{
-			IoHelpers.OpenFolderInFileExplorer(Global.DataDir);
+			IoHelpers.OpenFolderInFileExplorer(_global.DataDir);
 		}
 
 		private void OnOpenWalletsFolder()
 		{
-			IoHelpers.OpenFolderInFileExplorer(Global.WalletsDir);
+			IoHelpers.OpenFolderInFileExplorer(_global.WalletsDir);
 		}
 
 		private void OnOpenLogFile()
@@ -72,12 +72,12 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnOpenTorLogFile()
 		{
-			IoHelpers.OpenFileInTextEditor(Global.TorLogsFile);
+			IoHelpers.OpenFileInTextEditor(_global.TorLogsFile);
 		}
 
 		private void OnOpenConfigFile()
 		{
-			IoHelpers.OpenFileInTextEditor(Global.Config.FilePath);
+			IoHelpers.OpenFileInTextEditor(_global.Config.FilePath);
 		}
 
 		private void OnFileOpenException(Exception ex)

--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			DataDir = Path.Combine(folder, "data");
 			Directory.CreateDirectory(DataDir);
 			var pass = Encoders.Hex.EncodeData(RandomUtils.GetBytes(20));
-			Creds = new NetworkCredential(pass, pass);
+			_creds = new NetworkCredential(pass, pass);
 			Config = Path.Combine(DataDir, "bitcoin.conf");
 			ConfigParameters.Import(builder.ConfigParameters);
 			Ports = new int[2];
@@ -62,11 +62,11 @@ namespace WalletWasabi.Tests.NodeBuilding
 
 		private int[] Ports { get; }
 
-		private readonly NetworkCredential Creds;
+		private readonly NetworkCredential _creds;
 
 		public RPCClient CreateRpcClient()
 		{
-			return new RPCClient(Creds, new Uri("http://127.0.0.1:" + Ports[1] + "/"), Network.RegTest);
+			return new RPCClient(_creds, new Uri("http://127.0.0.1:" + Ports[1] + "/"), Network.RegTest);
 		}
 
 		public async Task<Node> CreateNodeClientAsync()
@@ -88,8 +88,8 @@ namespace WalletWasabi.Tests.NodeBuilding
 				{"regtest.listenonion", "0"},
 				{"regtest.server", "1"},
 				{"regtest.txindex", "1"},
-				{"regtest.rpcuser", Creds.UserName},
-				{"regtest.rpcpassword", Creds.Password},
+				{"regtest.rpcuser", _creds.UserName},
+				{"regtest.rpcpassword", _creds.Password},
 				{"regtest.whitebind", "127.0.0.1:" + Ports[0].ToString()},
 				{"regtest.rpcport", Ports[1].ToString()},
 				{"regtest.printtoconsole", "0"}, // Set it to one if do not mind loud debug logs
@@ -98,7 +98,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			};
 			config.Import(ConfigParameters);
 			File.WriteAllText(Config, config.ToString());
-			using (await KillerLock.LockAsync())
+			using (await _killerLock.LockAsync())
 			{
 				Process = Process.Start(new FileInfo(Builder.BitcoinD).FullName, "-conf=bitcoin.conf" + " -datadir=" + DataDir + " -debug=1");
 				State = CoreNodeState.Starting;
@@ -156,13 +156,13 @@ namespace WalletWasabi.Tests.NodeBuilding
 			}
 		}
 
-		private readonly AsyncLock KillerLock = new AsyncLock();
+		private readonly AsyncLock _killerLock = new AsyncLock();
 
 		public async Task TryKillAsync(bool cleanFolder = true)
 		{
 			try
 			{
-				using (await KillerLock.LockAsync())
+				using (await _killerLock.LockAsync())
 				{
 					try
 					{

--- a/WalletWasabi/Mono/OptionSet.cs
+++ b/WalletWasabi/Mono/OptionSet.cs
@@ -556,7 +556,7 @@ namespace Mono.Options
 			return false;
 		}
 
-		private readonly Regex ValueOption = new Regex(
+		private readonly Regex _valueOption = new Regex(
 			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
 		protected bool GetOptionParts(string argument, out string flag, out string name, out string sep, out string value)
@@ -567,7 +567,7 @@ namespace Mono.Options
 			}
 
 			flag = name = sep = value = null;
-			Match m = ValueOption.Match(argument);
+			Match m = _valueOption.Match(argument);
 			if (!m.Success)
 			{
 				return false;

--- a/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
@@ -55,7 +55,7 @@ namespace Nito.AsyncEx
 		/// <summary>
 		/// The queue of TCSs that other tasks are awaiting to acquire the lock.
 		/// </summary>
-		private readonly IAsyncWaitQueue<IDisposable> Queue;
+		private readonly IAsyncWaitQueue<IDisposable> _queue;
 
 		/// <summary>
 		/// The semi-unique identifier for this instance. This is 0 if the id has not yet been created.
@@ -65,7 +65,7 @@ namespace Nito.AsyncEx
 		/// <summary>
 		/// The object used for mutual exclusion.
 		/// </summary>
-		private readonly object Mutex;
+		private readonly object _mutex;
 
 		/// <summary>
 		/// Creates a new async-compatible mutual exclusion lock.
@@ -81,8 +81,8 @@ namespace Nito.AsyncEx
 		/// <param name="queue">The wait queue used to manage waiters. This may be <c>null</c> to use a default (FIFO) queue.</param>
 		public AsyncLock(IAsyncWaitQueue<IDisposable> queue)
 		{
-			Queue = queue ?? new DefaultAsyncWaitQueue<IDisposable>();
-			Mutex = new object();
+			_queue = queue ?? new DefaultAsyncWaitQueue<IDisposable>();
+			_mutex = new object();
 		}
 
 		/// <summary>
@@ -97,7 +97,7 @@ namespace Nito.AsyncEx
 		/// <returns>A disposable that releases the lock when disposed.</returns>
 		private Task<IDisposable> RequestLockAsync(CancellationToken cancellationToken)
 		{
-			lock (Mutex)
+			lock (_mutex)
 			{
 				if (!_taken)
 				{
@@ -108,7 +108,7 @@ namespace Nito.AsyncEx
 				else
 				{
 					// Wait for the lock to become available or cancellation.
-					return Queue.Enqueue(Mutex, cancellationToken);
+					return _queue.Enqueue(_mutex, cancellationToken);
 				}
 			}
 		}
@@ -154,15 +154,15 @@ namespace Nito.AsyncEx
 		/// </summary>
 		internal void ReleaseLock()
 		{
-			lock (Mutex)
+			lock (_mutex)
 			{
-				if (Queue.IsEmpty)
+				if (_queue.IsEmpty)
 				{
 					_taken = false;
 				}
 				else
 				{
-					Queue.Dequeue(new Key(this));
+					_queue.Dequeue(new Key(this));
 				}
 			}
 		}
@@ -191,18 +191,18 @@ namespace Nito.AsyncEx
 		[DebuggerNonUserCode]
 		private sealed class DebugView
 		{
-			private readonly AsyncLock Mutex;
+			private readonly AsyncLock _mutex;
 
 			public DebugView(AsyncLock mutex)
 			{
-				Mutex = mutex;
+				_mutex = mutex;
 			}
 
-			public int Id => Mutex.Id;
+			public int Id => _mutex.Id;
 
-			public bool Taken => Mutex._taken;
+			public bool Taken => _mutex._taken;
 
-			public IAsyncWaitQueue<IDisposable> WaitQueue => Mutex.Queue;
+			public IAsyncWaitQueue<IDisposable> WaitQueue => _mutex._queue;
 		}
 
 		// ReSharper restore UnusedMember.Local

--- a/WalletWasabi/Nito/AsyncEx/AwaitableDisposable.cs
+++ b/WalletWasabi/Nito/AsyncEx/AwaitableDisposable.cs
@@ -13,7 +13,7 @@ namespace Nito.AsyncEx
 		/// <summary>
 		/// The underlying task.
 		/// </summary>
-		private readonly Task<T> Task;
+		private readonly Task<T> _task;
 
 		/// <summary>
 		/// Initializes a new awaitable wrapper around the specified task.
@@ -21,7 +21,7 @@ namespace Nito.AsyncEx
 		/// <param name="task">The underlying task to wrap. This may not be <c>null</c>.</param>
 		public AwaitableDisposable(Task<T> task)
 		{
-			Task = task ?? throw new ArgumentNullException(nameof(task));
+			_task = task ?? throw new ArgumentNullException(nameof(task));
 		}
 
 		/// <summary>
@@ -29,7 +29,7 @@ namespace Nito.AsyncEx
 		/// </summary>
 		public Task<T> AsTask()
 		{
-			return Task;
+			return _task;
 		}
 
 		/// <summary>
@@ -43,7 +43,7 @@ namespace Nito.AsyncEx
 		/// </summary>
 		public TaskAwaiter<T> GetAwaiter()
 		{
-			return Task.GetAwaiter();
+			return _task.GetAwaiter();
 		}
 
 		/// <summary>
@@ -52,7 +52,7 @@ namespace Nito.AsyncEx
 		/// <param name="continueOnCapturedContext">Whether to attempt to marshal the continuation back to the captured context.</param>
 		public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext)
 		{
-			return Task.ConfigureAwait(continueOnCapturedContext);
+			return _task.ConfigureAwait(continueOnCapturedContext);
 		}
 	}
 }

--- a/WalletWasabi/Nito/AsyncEx/DefaultAsyncWaitQueue.cs
+++ b/WalletWasabi/Nito/AsyncEx/DefaultAsyncWaitQueue.cs
@@ -17,42 +17,42 @@ namespace Nito.AsyncEx
 	[DebuggerTypeProxy(typeof(DefaultAsyncWaitQueue<>.DebugView))]
 	public sealed class DefaultAsyncWaitQueue<T> : IAsyncWaitQueue<T>
 	{
-		private readonly Deque<TaskCompletionSource<T>> Queue = new Deque<TaskCompletionSource<T>>();
+		private readonly Deque<TaskCompletionSource<T>> _queue = new Deque<TaskCompletionSource<T>>();
 
-		private int Count => Queue.Count;
+		private int Count => _queue.Count;
 
 		bool IAsyncWaitQueue<T>.IsEmpty => Count == 0;
 
 		Task<T> IAsyncWaitQueue<T>.Enqueue()
 		{
 			var tcs = TaskCompletionSourceExtensions.CreateAsyncTaskSource<T>();
-			Queue.AddToBack(tcs);
+			_queue.AddToBack(tcs);
 			return tcs.Task;
 		}
 
 		void IAsyncWaitQueue<T>.Dequeue(T result)
 		{
-			Queue.RemoveFromFront().TrySetResult(result);
+			_queue.RemoveFromFront().TrySetResult(result);
 		}
 
 		void IAsyncWaitQueue<T>.DequeueAll(T result)
 		{
-			foreach (var source in Queue)
+			foreach (var source in _queue)
 			{
 				source.TrySetResult(result);
 			}
 
-			Queue.Clear();
+			_queue.Clear();
 		}
 
 		bool IAsyncWaitQueue<T>.TryCancel(Task task, CancellationToken cancellationToken)
 		{
-			for (int i = 0; i != Queue.Count; ++i)
+			for (int i = 0; i != _queue.Count; ++i)
 			{
-				if (Queue[i].Task == task)
+				if (_queue[i].Task == task)
 				{
-					Queue[i].TrySetCanceled(cancellationToken);
-					Queue.RemoveAt(i);
+					_queue[i].TrySetCanceled(cancellationToken);
+					_queue.RemoveAt(i);
 					return true;
 				}
 			}
@@ -61,22 +61,22 @@ namespace Nito.AsyncEx
 
 		void IAsyncWaitQueue<T>.CancelAll(CancellationToken cancellationToken)
 		{
-			foreach (var source in Queue)
+			foreach (var source in _queue)
 			{
 				source.TrySetCanceled(cancellationToken);
 			}
 
-			Queue.Clear();
+			_queue.Clear();
 		}
 
 		[DebuggerNonUserCode]
 		internal sealed class DebugView
 		{
-			private readonly DefaultAsyncWaitQueue<T> Queue;
+			private readonly DefaultAsyncWaitQueue<T> _queue;
 
 			public DebugView(DefaultAsyncWaitQueue<T> queue)
 			{
-				Queue = queue;
+				_queue = queue;
 			}
 
 			[DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
@@ -84,8 +84,8 @@ namespace Nito.AsyncEx
 			{
 				get
 				{
-					var result = new List<Task<T>>(Queue.Queue.Count);
-					foreach (var entry in Queue.Queue)
+					var result = new List<Task<T>>(_queue._queue.Count);
+					foreach (var entry in _queue._queue)
 					{
 						result.Add(entry.Task);
 					}

--- a/WalletWasabi/Nito/Collections/CollectionHelpers.cs
+++ b/WalletWasabi/Nito/Collections/CollectionHelpers.cs
@@ -33,18 +33,18 @@ namespace Nito.Collections
 
 		private sealed class NongenericCollectionWrapper<T> : IReadOnlyCollection<T>
 		{
-			private readonly ICollection Collection;
+			private readonly ICollection _collection;
 
 			public NongenericCollectionWrapper(ICollection collection)
 			{
-				Collection = collection ?? throw new ArgumentNullException(nameof(collection));
+				_collection = collection ?? throw new ArgumentNullException(nameof(collection));
 			}
 
-			public int Count => Collection.Count;
+			public int Count => _collection.Count;
 
 			public IEnumerator<T> GetEnumerator()
 			{
-				foreach (T item in Collection)
+				foreach (T item in _collection)
 				{
 					yield return item;
 				}
@@ -52,29 +52,29 @@ namespace Nito.Collections
 
 			IEnumerator IEnumerable.GetEnumerator()
 			{
-				return Collection.GetEnumerator();
+				return _collection.GetEnumerator();
 			}
 		}
 
 		private sealed class CollectionWrapper<T> : IReadOnlyCollection<T>
 		{
-			private readonly ICollection<T> Collection;
+			private readonly ICollection<T> _collection;
 
 			public CollectionWrapper(ICollection<T> collection)
 			{
-				Collection = collection ?? throw new ArgumentNullException(nameof(collection));
+				_collection = collection ?? throw new ArgumentNullException(nameof(collection));
 			}
 
-			public int Count => Collection.Count;
+			public int Count => _collection.Count;
 
 			public IEnumerator<T> GetEnumerator()
 			{
-				return Collection.GetEnumerator();
+				return _collection.GetEnumerator();
 			}
 
 			IEnumerator IEnumerable.GetEnumerator()
 			{
-				return Collection.GetEnumerator();
+				return _collection.GetEnumerator();
 			}
 		}
 	}

--- a/WalletWasabi/Nito/Collections/Deque.cs
+++ b/WalletWasabi/Nito/Collections/Deque.cs
@@ -898,15 +898,15 @@ namespace Nito.Collections
 		[DebuggerNonUserCode]
 		private sealed class DebugView
 		{
-			private readonly Deque<T> Deque;
+			private readonly Deque<T> _deque;
 
 			public DebugView(Deque<T> deque)
 			{
-				Deque = deque;
+				_deque = deque;
 			}
 
 			[DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-			public T[] Items => Deque.ToArray();
+			public T[] Items => _deque.ToArray();
 		}
 	}
 }

--- a/WalletWasabi/Nito/Disposables/Internals/BoundAction.cs
+++ b/WalletWasabi/Nito/Disposables/Internals/BoundAction.cs
@@ -70,22 +70,22 @@ namespace Nito.Disposables.Internals
 
 		private sealed class BoundAction : IBoundAction
 		{
-			private readonly Action<T> Action;
-			private readonly T Context;
+			private readonly Action<T> _action;
+			private readonly T _context;
 
 			public BoundAction(Action<T> action, T context)
 			{
-				Action = action;
-				Context = context;
+				_action = action;
+				_context = context;
 			}
 
 			public BoundAction(BoundAction originalBoundAction, Func<T, T> contextUpdater)
 			{
-				Action = originalBoundAction.Action;
-				Context = contextUpdater(originalBoundAction.Context);
+				_action = originalBoundAction._action;
+				_context = contextUpdater(originalBoundAction._context);
 			}
 
-			public void Invoke() => Action?.Invoke(Context);
+			public void Invoke() => _action?.Invoke(_context);
 		}
 	}
 }

--- a/WalletWasabi/Nito/Disposables/SingleDisposable.cs
+++ b/WalletWasabi/Nito/Disposables/SingleDisposable.cs
@@ -16,9 +16,9 @@ namespace Nito.Disposables
 		/// <summary>
 		/// The context. This is never <c>null</c>. This is empty if this instance has already been disposed (or is being disposed).
 		/// </summary>
-		private readonly BoundActionField<T> Context;
+		private readonly BoundActionField<T> _context;
 
-		private readonly ManualResetEventSlim Mre = new ManualResetEventSlim();
+		private readonly ManualResetEventSlim _mre = new ManualResetEventSlim();
 
 		/// <summary>
 		/// Creates a disposable for the specified context.
@@ -26,18 +26,18 @@ namespace Nito.Disposables
 		/// <param name="context">The context passed to <see cref="Dispose(T)"/>.</param>
 		protected SingleDisposable(T context)
 		{
-			Context = new BoundActionField<T>(Dispose, context);
+			_context = new BoundActionField<T>(Dispose, context);
 		}
 
 		/// <summary>
 		/// Whether this instance is currently disposing or has been disposed.
 		/// </summary>
-		public bool IsDisposeStarted => Context.IsEmpty;
+		public bool IsDisposeStarted => _context.IsEmpty;
 
 		/// <summary>
 		/// Whether this instance is disposed (finished disposing).
 		/// </summary>
-		public bool IsDisposed => Mre.IsSet;
+		public bool IsDisposed => _mre.IsSet;
 
 		/// <summary>
 		/// Whether this instance is currently disposing, but not finished yet.
@@ -58,10 +58,10 @@ namespace Nito.Disposables
 		/// </remarks>
 		public void Dispose()
 		{
-			var context = Context.TryGetAndUnset();
+			var context = _context.TryGetAndUnset();
 			if (context is null)
 			{
-				Mre.Wait();
+				_mre.Wait();
 				return;
 			}
 			try
@@ -70,7 +70,7 @@ namespace Nito.Disposables
 			}
 			finally
 			{
-				Mre.Set();
+				_mre.Set();
 			}
 		}
 
@@ -78,6 +78,6 @@ namespace Nito.Disposables
 		/// Attempts to update the stored context. This method returns <c>false</c> if this instance has already been disposed (or is being disposed).
 		/// </summary>
 		/// <param name="contextUpdater">The function used to update an existing context. This may be called more than once if more than one thread attempts to simultanously update the context.</param>
-		protected bool TryUpdateContext(Func<T, T> contextUpdater) => Context.TryUpdateContext(contextUpdater);
+		protected bool TryUpdateContext(Func<T, T> contextUpdater) => _context.TryUpdateContext(contextUpdater);
 	}
 }

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.WebClients
 {
 	public class ExchangeRateProvider : IExchangeRateProvider
 	{
-		private readonly IExchangeRateProvider[] ExchangeRateProviders = {
+		private readonly IExchangeRateProvider[] _exchangeRateProviders = {
 			new BitcoinAverageExchangeRateProvider(),
 			new SmartBitExchangeRateProvider(new SmartBitClient(Network.Main, disposeHandler: true)),
 			new BlockchainInfoExchangeRateProvider(),
@@ -29,7 +29,7 @@ namespace WalletWasabi.WebClients
 		{
 			List<ExchangeRate> exchangeRates = null;
 
-			foreach (var provider in ExchangeRateProviders)
+			foreach (var provider in _exchangeRateProviders)
 			{
 				try
 				{


### PR DESCRIPTION
I think not all `readonly fields` should be `PascalCase`, only `static readonly fields` should (there is already a rule for `static fields`). `private readonly fields` should be `_camelCase`.