### PR TITLE
Add local variables and parameters naming rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -148,6 +148,15 @@ dotnet_naming_symbols.any_async_methods.required_modifiers         = async
 dotnet_naming_style.end_with_async.required_suffix = Async
 dotnet_naming_style.end_with_async.capitalization  = pascal_case
 
+# name Local variables & parameters using camelCase
+dotnet_naming_rule.local_variables_and_parameters_camel_case.severity = error
+dotnet_naming_rule.local_variables_and_parameters_camel_case.symbols  = local_variables_and_parameters_symbols
+dotnet_naming_rule.local_variables_and_parameters_camel_case.style    = camel_case_style
+
+dotnet_naming_symbols.local_variables_and_parameters_symbols.applicable_kinds = local,parameter
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
 [*.xaml]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Local variables and parameters should be `camelCase`.