### PR TITLE
Update InstallInstructions.md

### DIFF
--- a/WalletWasabi.Documentation/Guides/InstallInstructions.md
+++ b/WalletWasabi.Documentation/Guides/InstallInstructions.md
@@ -12,7 +12,7 @@ Check out [this](https://www.youtube.com/watch?v=tkaaC8yET1o) or [this](https://
 ![](https://imgur.com/K2J1WWG.png)
 
 Download the Windows installer (.msi) and follow the instructions.
-Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder. You will also have an icon in your Start Menu and on your Desktop.  
+Wasabi will be installed to your `C:\Program Files\WasabiWallet\` folder. You will also have an icon in your Start Menu and on your Desktop.
 
 After the first run, a working directory will be created: `%appdata%\WalletWasabi\`. Among others, here is where your wallet files and your logs reside.
 
@@ -20,13 +20,13 @@ After the first run, a working directory will be created: `%appdata%\WalletWasab
 
 Check out [Max's video tutorial](https://www.youtube.com/watch?v=DUc9A76rwX4) or follow the instructions below:
 
-After downloading the `.deb` package install it by double clicking on it or running `sudo dpkg -i Wasabi-1.1.6.deb`.
+After downloading the `.deb` package, install it by double clicking on it or running `sudo dpkg -i Wasabi-1.1.6.deb`.
 
 After the first run, a working directory will be created: `~/.walletwasabi/`. Among others, here is where your wallet files and your logs reside.
 
 # Linux
 
-Check out this short, to-the-point [video guide](https://www.youtube.com/watch?v=qFbv_b-bju4), or [this other funnier one](https://www.youtube.com/watch?time_continue=4&v=zPKpC9cRcZo) with more explanation, or take a look at the instructions below. Note that, the first video was created on OSX, but the steps are the same for Linux.
+Check out this short, to-the-point [video guide](https://www.youtube.com/watch?v=qFbv_b-bju4), or [this other funnier one](https://www.youtube.com/watch?time_continue=4&v=zPKpC9cRcZo) with more explanations, or take a look at the instructions below. Note that the first video was created on OSX, but the steps are the same for Linux.
 
 ![](https://imgur.com/wsJ66Qt.png)
 
@@ -49,6 +49,8 @@ After opening Wasabi, you may encounter a security popup. You can bypass it in m
 
 ![](https://imgur.com/dy1zfJG.png)
 
+Another way is to go to System Preferences / Security & Privacy, where you should find a message `"Wasabi Wallet" was blocked from opening because it is not from an identified developer` and an `open anyway` button. Click the button and confirm by entering your Mac user password.
+
 # GPG Verification
 
 [Get GnuPG](https://www.gnupg.org/download/index.html), then save [nopara73's PGP](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt).
@@ -67,7 +69,48 @@ gpg --verify {path to downloaded signature}.asc {path to binary}
 
 Example: `gpg --verify WasabiInstaller.msi.asc WasabiInstaller.msi`.
  
-If the message returned says Good signature and that it was signed by `Ficsór Ádám` with a Primary key fingerprint: `21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
+If the message returned says `Good signature` and that it was signed by `Ficsór Ádám` with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
+ 
+Remember to check again the PGP signature every time you make a new download.
+
+If you trust nopara73's key and you are familiar with the [Web Of Trust](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature), please consider also [validating it](https://www.gnupg.org/gph/en/manual/x334.html).
+
+## GPG Verification on OSX
+
+[Get GnuPG](https://www.gnupg.org/download/index.html), then save [nopara73's PGP](https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt). You can do so by copypasting it into a new TextEdit document and saving it as `PGP.txt`. Before saving, you need to go to Format / Make Plain Text (otherwise TextEdit will not be able to save it as a .txt file).
+
+Open Terminal and go to the folder in which you saved the `PGP.txt` file. In this case, it is on the desktop (substitute `desktop` with the actual folder): 
+
+```sh
+cd desktop
+``` 
+
+Import nopara73's PGP key (you might be asked to enter your Mac user password to confirm the command): 
+
+```sh
+sudo gpg2 --import PGP.txt
+``` 
+
+
+This should return the output: 
+
+`key B4B72266C47E075E: public key "nopara73 (GitHub key) <nopara73@github.com>" imported` 
+
+From now on, with this public key you will be able to make sure the Wasabi software you download (the `.dmg` file) was not tampered with by checking against the corresponding `.asc` file. Navigate to the location where the `.dmg` and the `.asc` files are saved. In this case, it is in the Downloads folder (substitute accordingly, if necessary): 
+
+```sh
+cd downloads
+```
+
+Check the signature (you might be asked for the Mac user password again):
+
+```sh
+sudo gpg2 --verify {file name}.asc {file name}.dmg
+```
+
+Example: `gpg2 --verify Wasabi-1.1.6.dmg.asc Wasabi-1.1.6.dmg`.
+
+If the message returned says `Good signature from nopara73 aka Ficsór Ádám` and that it was signed with `Primary key fingerprint: 21D7 CA45 565D BCCE BE45  115D B4B7 2266 C47E 075E`, then the software was not tampered with since the developer signed it.
  
 Remember to check again the PGP signature every time you make a new download.
 
@@ -75,7 +118,7 @@ If you trust nopara73's key and you are familiar with the [Web Of Trust](https:/
 
 ## GPG Verification with GUI
 
-If you prefer the Graphical User Interface this guide is yours. There is also a nice video guide [here](https://youtu.be/D8U53PFEsVk?t=45). 
+If you prefer the Graphical User Interface, this guide is yours. There is also a nice video guide [here](https://youtu.be/D8U53PFEsVk?t=45). 
 
 1. Download Gpg4win from https://www.gnupg.org/download/index.html
 2. Install Gpg4win 
@@ -84,7 +127,7 @@ If you prefer the Graphical User Interface this guide is yours. There is also a 
 
 3. Download Wasabi latest __release__ and the corresponding __.asc__ file.
 
-4. Double click on .asc file or right click More GpgEX options / Verify. (If the context menu is missing restart the computer).
+4. Double click on .asc file or right click More GpgEX options / Verify. If the context menu is missing - restart the computer.
 
 ![](https://i.imgur.com/fJME8Yh.png)
 
@@ -104,7 +147,7 @@ If you prefer the Graphical User Interface this guide is yours. There is also a 
 
 ![](https://i.imgur.com/PfdbegY.png)
 
-9. Press next, next, next. If there is an error you can try to import the key manually, navigate to section: [Import key manually](https://github.com/molnard/WalletWasabi/blob/patch-3/WalletWasabi.Documentation/Guides/InstallInstructions.md#import-key-manually)
+9. Press next, next, next. If there is an error, you can try to import the key manually, navigate to section: [Import key manually](https://github.com/molnard/WalletWasabi/blob/patch-3/WalletWasabi.Documentation/Guides/InstallInstructions.md#import-key-manually)
 
 9. Successful validation. The file was signed by the developer.
 
@@ -128,7 +171,7 @@ If you prefer the Graphical User Interface this guide is yours. There is also a 
 
 4. Save the file and close.
 
-5. Right click on pgp.txt. In the context menu navigate to More GpgEx options/Import keys. (If the context menu is missing restart the computer).
+5. Right click on pgp.txt. In the context menu navigate to More GpgEx options/Import keys. If the context menu is missing -  restart the computer.
 
 ![Imgur](https://i.imgur.com/qmuF3Hx.png)
 


### PR DESCRIPTION
As discussed in https://github.com/zkSNACKs/WalletWasabi/issues/1912, this PR: 

- adds an alternative way for macOS users to solve “unidentified developer” security pop up during Wasabi installation (line 52)
- adds a new section for macOS users how to verify GPG keys (line 78+)
- closes https://github.com/zkSNACKs/WalletWasabi/issues/1912 
- closes https://github.com/zkSNACKs/WalletWasabi/issues/1375 (both related to the GPG verification)
- fixes some punctuation and grammar