### PR TITLE
Make P2P and Tor configurations oneliners

### DIFF
--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -28,15 +28,15 @@ namespace WalletWasabi.Backend
 		public string BitcoinRpcConnectionString { get; private set; }
 
 		[JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBitcoinP2pPort)]
 		public EndPoint MainNetBitcoinP2pEndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBitcoinP2pPort)]
 		public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinP2pPort)]
 		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
 
 		private EndPoint _bitcoinP2pEndPoint;
@@ -108,9 +108,9 @@ namespace WalletWasabi.Backend
 			Network = Network.Main;
 			BitcoinRpcConnectionString = "user:password";
 
-			MainNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBintcoinP2pPort);
-			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBintcoinP2pPort);
-			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBintcoinP2pPort);
+			MainNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinP2pPort);
+			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort);
+			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort);
 
 			if (!File.Exists(FilePath))
 			{
@@ -175,7 +175,7 @@ namespace WalletWasabi.Backend
 
 			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
 			{
-				int port = Constants.DefaultMainNetBintcoinP2pPort;
+				int port = Constants.DefaultMainNetBitcoinP2pPort;
 				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort) && int.TryParse(jMainNetBitcoinCorePort.ToString(), out int p))
 				{
 					port = p;
@@ -190,7 +190,7 @@ namespace WalletWasabi.Backend
 
 			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
 			{
-				int port = Constants.DefaultTestNetBintcoinP2pPort;
+				int port = Constants.DefaultTestNetBitcoinP2pPort;
 				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort) && int.TryParse(jTestNetBitcoinCorePort.ToString(), out int p))
 				{
 					port = p;
@@ -205,7 +205,7 @@ namespace WalletWasabi.Backend
 
 			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
 			{
-				int port = Constants.DefaultRegTestBintcoinP2pPort;
+				int port = Constants.DefaultRegTestBitcoinP2pPort;
 				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort) && int.TryParse(jRegTestBitcoinCorePort.ToString(), out int p))
 				{
 					port = p;

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -39,23 +39,23 @@ namespace WalletWasabi.Backend
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
 		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
 
-		private EndPoint _bitcoinCoreEndPoint;
+		private EndPoint _bitcoinP2pEndPoint;
 
 		public EndPoint GetBitcoinP2pEndPoint()
 		{
-			if (_bitcoinCoreEndPoint is null)
+			if (_bitcoinP2pEndPoint is null)
 			{
 				if (Network == Network.Main)
 				{
-					_bitcoinCoreEndPoint = MainNetBitcoinP2pEndPoint;
+					_bitcoinP2pEndPoint = MainNetBitcoinP2pEndPoint;
 				}
 				else if (Network == Network.TestNet)
 				{
-					_bitcoinCoreEndPoint = TestNetBitcoinP2pEndPoint;
+					_bitcoinP2pEndPoint = TestNetBitcoinP2pEndPoint;
 				}
 				else if (Network == Network.RegTest)
 				{
-					_bitcoinCoreEndPoint = RegTestBitcoinP2pEndPoint;
+					_bitcoinP2pEndPoint = RegTestBitcoinP2pEndPoint;
 				}
 				else
 				{
@@ -63,7 +63,7 @@ namespace WalletWasabi.Backend
 				}
 			}
 
-			return _bitcoinCoreEndPoint;
+			return _bitcoinP2pEndPoint;
 		}
 
 		public Config()

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using NBitcoin.RPC;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -39,6 +40,18 @@ namespace WalletWasabi.Backend
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinP2pPort)]
 		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
 
+		[JsonProperty(PropertyName = "MainNetBitcoinCoreRpcEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBitcoinCoreRpcPort)]
+		public EndPoint MainNetBitcoinCoreRpcEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "TestNetBitcoinCoreRpcEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBitcoinCoreRpcPort)]
+		public EndPoint TestNetBitcoinCoreRpcEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "RegTestBitcoinCoreRpcEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinCoreRpcPort)]
+		public EndPoint RegTestBitcoinCoreRpcEndPoint { get; internal set; }
+
 		public EndPoint GetBitcoinP2pEndPoint()
 		{
 			if (Network == Network.Main)
@@ -59,6 +72,26 @@ namespace WalletWasabi.Backend
 			}
 		}
 
+		public EndPoint GetBitcoinCoreRpcEndPoint()
+		{
+			if (Network == Network.Main)
+			{
+				return MainNetBitcoinCoreRpcEndPoint;
+			}
+			else if (Network == Network.TestNet)
+			{
+				return TestNetBitcoinCoreRpcEndPoint;
+			}
+			else if (Network == Network.RegTest)
+			{
+				return RegTestBitcoinCoreRpcEndPoint;
+			}
+			else
+			{
+				throw new NotSupportedException($"{nameof(Network)} not supported: {Network}.");
+			}
+		}
+
 		public Config()
 		{
 		}
@@ -72,7 +105,10 @@ namespace WalletWasabi.Backend
 			string bitcoinRpcConnectionString,
 			EndPoint mainNetBitcoinP2pEndPoint,
 			EndPoint testNetBitcoinP2pEndPoint,
-			EndPoint regTestBitcoinP2pEndPoint)
+			EndPoint regTestBitcoinP2pEndPoint,
+			EndPoint mainNetBitcoinCoreRpcEndPoint,
+			EndPoint testNetBitcoinCoreRpcEndPoint,
+			EndPoint regTestBitcoinCoreRpcEndPoint)
 		{
 			Network = Guard.NotNull(nameof(network), network);
 			BitcoinRpcConnectionString = Guard.NotNullOrEmptyOrWhitespace(nameof(bitcoinRpcConnectionString), bitcoinRpcConnectionString);
@@ -80,6 +116,10 @@ namespace WalletWasabi.Backend
 			MainNetBitcoinP2pEndPoint = Guard.NotNull(nameof(mainNetBitcoinP2pEndPoint), mainNetBitcoinP2pEndPoint);
 			TestNetBitcoinP2pEndPoint = Guard.NotNull(nameof(testNetBitcoinP2pEndPoint), testNetBitcoinP2pEndPoint);
 			RegTestBitcoinP2pEndPoint = Guard.NotNull(nameof(regTestBitcoinP2pEndPoint), regTestBitcoinP2pEndPoint);
+
+			MainNetBitcoinCoreRpcEndPoint = Guard.NotNull(nameof(mainNetBitcoinCoreRpcEndPoint), mainNetBitcoinCoreRpcEndPoint);
+			TestNetBitcoinCoreRpcEndPoint = Guard.NotNull(nameof(testNetBitcoinCoreRpcEndPoint), testNetBitcoinCoreRpcEndPoint);
+			RegTestBitcoinCoreRpcEndPoint = Guard.NotNull(nameof(regTestBitcoinCoreRpcEndPoint), regTestBitcoinCoreRpcEndPoint);
 		}
 
 		/// <inheritdoc />
@@ -105,6 +145,10 @@ namespace WalletWasabi.Backend
 			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort);
 			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort);
 
+			MainNetBitcoinCoreRpcEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinCoreRpcPort);
+			TestNetBitcoinCoreRpcEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinCoreRpcPort);
+			RegTestBitcoinCoreRpcEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinCoreRpcPort);
+
 			if (!File.Exists(FilePath))
 			{
 				Logger.LogInfo<Config>($"{nameof(Config)} file did not exist. Created at path: `{FilePath}`.");
@@ -120,6 +164,10 @@ namespace WalletWasabi.Backend
 				MainNetBitcoinP2pEndPoint = config.MainNetBitcoinP2pEndPoint ?? MainNetBitcoinP2pEndPoint;
 				TestNetBitcoinP2pEndPoint = config.TestNetBitcoinP2pEndPoint ?? TestNetBitcoinP2pEndPoint;
 				RegTestBitcoinP2pEndPoint = config.RegTestBitcoinP2pEndPoint ?? RegTestBitcoinP2pEndPoint;
+
+				MainNetBitcoinCoreRpcEndPoint = config.MainNetBitcoinCoreRpcEndPoint ?? MainNetBitcoinCoreRpcEndPoint;
+				TestNetBitcoinCoreRpcEndPoint = config.TestNetBitcoinCoreRpcEndPoint ?? TestNetBitcoinCoreRpcEndPoint;
+				RegTestBitcoinCoreRpcEndPoint = config.RegTestBitcoinCoreRpcEndPoint ?? RegTestBitcoinCoreRpcEndPoint;
 
 				if (TryEnsureBackwardsCompatibility(jsonString))
 				{

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -39,31 +39,24 @@ namespace WalletWasabi.Backend
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinP2pPort)]
 		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
 
-		private EndPoint _bitcoinP2pEndPoint;
-
 		public EndPoint GetBitcoinP2pEndPoint()
 		{
-			if (_bitcoinP2pEndPoint is null)
+			if (Network == Network.Main)
 			{
-				if (Network == Network.Main)
-				{
-					_bitcoinP2pEndPoint = MainNetBitcoinP2pEndPoint;
-				}
-				else if (Network == Network.TestNet)
-				{
-					_bitcoinP2pEndPoint = TestNetBitcoinP2pEndPoint;
-				}
-				else if (Network == Network.RegTest)
-				{
-					_bitcoinP2pEndPoint = RegTestBitcoinP2pEndPoint;
-				}
-				else
-				{
-					throw new NotSupportedException("Network not supported.");
-				}
+				return MainNetBitcoinP2pEndPoint;
 			}
-
-			return _bitcoinP2pEndPoint;
+			else if (Network == Network.TestNet)
+			{
+				return TestNetBitcoinP2pEndPoint;
+			}
+			else if (Network == Network.RegTest)
+			{
+				return RegTestBitcoinP2pEndPoint;
+			}
+			else
+			{
+				throw new NotSupportedException($"{nameof(Network)} not supported: {Network}.");
+			}
 		}
 
 		public Config()

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -170,51 +170,52 @@ namespace WalletWasabi.Backend
 
 		private bool TryEnsureBackwardsCompatibility(string jsonString)
 		{
-			// Before Wasabi 1.1.7
-			EndPoint obsoleteStringToEndPoint(string endPointString, int port = 0)
-			{
-				if (IPAddress.TryParse(endPointString, out IPAddress ipAddress))
-				{
-					return new IPEndPoint(ipAddress, port);
-				}
-
-				return new DnsEndPoint(endPointString, port);
-			};
-
 			var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
 			bool saveIt = false;
 
 			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
 			{
 				int port = Constants.DefaultMainNetBintcoinP2pPort;
-				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort))
+				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort) && int.TryParse(jMainNetBitcoinCorePort.ToString(), out int p))
 				{
-					port = int.Parse(jMainNetBitcoinCorePort.ToString());
+					port = p;
 				}
-				MainNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jMainNetBitcoinCoreHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jMainNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				{
+					MainNetBitcoinP2pEndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
 			{
 				int port = Constants.DefaultTestNetBintcoinP2pPort;
-				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort))
+				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort) && int.TryParse(jTestNetBitcoinCorePort.ToString(), out int p))
 				{
-					port = int.Parse(jTestNetBitcoinCorePort.ToString());
+					port = p;
 				}
-				TestNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jTestNetBitcoinCoreHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jTestNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				{
+					TestNetBitcoinP2pEndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
 			{
 				int port = Constants.DefaultRegTestBintcoinP2pPort;
-				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort))
+				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort) && int.TryParse(jRegTestBitcoinCorePort.ToString(), out int p))
 				{
-					port = int.Parse(jRegTestBitcoinCorePort.ToString());
+					port = p;
 				}
-				RegTestBitcoinP2pEndPoint = obsoleteStringToEndPoint(jRegTestBitcoinCoreHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jRegTestBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				{
+					RegTestBitcoinP2pEndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			return saveIt;

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -163,55 +163,59 @@ namespace WalletWasabi.Backend
 
 		private bool TryEnsureBackwardsCompatibility(string jsonString)
 		{
-			var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
-			bool saveIt = false;
-
-			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
+			try
 			{
-				int port = Constants.DefaultMainNetBitcoinP2pPort;
-				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort) && int.TryParse(jMainNetBitcoinCorePort.ToString(), out int p))
+				var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
+				bool saveIt = false;
+
+				var mainNetBitcoinCoreHost = jsObject.Value<string>("MainNetBitcoinCoreHost");
+				var mainNetBitcoinCorePort = jsObject.Value<int?>("MainNetBitcoinCorePort");
+				var testNetBitcoinCoreHost = jsObject.Value<string>("TestNetBitcoinCoreHost");
+				var testNetBitcoinCorePort = jsObject.Value<int?>("TestNetBitcoinCorePort");
+				var regTestBitcoinCoreHost = jsObject.Value<string>("RegTestBitcoinCoreHost");
+				var regTestBitcoinCorePort = jsObject.Value<int?>("RegTestBitcoinCorePort");
+
+				if (mainNetBitcoinCoreHost != null)
 				{
-					port = p;
+					int port = mainNetBitcoinCorePort ?? Constants.DefaultMainNetBitcoinP2pPort;
+
+					if (EndPointParser.TryParse(mainNetBitcoinCoreHost, port, out EndPoint ep))
+					{
+						MainNetBitcoinP2pEndPoint = ep;
+						saveIt = true;
+					}
 				}
 
-				if (EndPointParser.TryParse(jMainNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				if (testNetBitcoinCoreHost != null)
 				{
-					MainNetBitcoinP2pEndPoint = ep;
-					saveIt = true;
+					int port = testNetBitcoinCorePort ?? Constants.DefaultTestNetBitcoinP2pPort;
+
+					if (EndPointParser.TryParse(testNetBitcoinCoreHost, port, out EndPoint ep))
+					{
+						TestNetBitcoinP2pEndPoint = ep;
+						saveIt = true;
+					}
 				}
+
+				if (regTestBitcoinCoreHost != null)
+				{
+					int port = regTestBitcoinCorePort ?? Constants.DefaultRegTestBitcoinP2pPort;
+
+					if (EndPointParser.TryParse(regTestBitcoinCoreHost, port, out EndPoint ep))
+					{
+						RegTestBitcoinP2pEndPoint = ep;
+						saveIt = true;
+					}
+				}
+
+				return saveIt;
 			}
-
-			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
+			catch (Exception ex)
 			{
-				int port = Constants.DefaultTestNetBitcoinP2pPort;
-				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort) && int.TryParse(jTestNetBitcoinCorePort.ToString(), out int p))
-				{
-					port = p;
-				}
-
-				if (EndPointParser.TryParse(jTestNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
-				{
-					TestNetBitcoinP2pEndPoint = ep;
-					saveIt = true;
-				}
+				Logger.LogWarning<Config>("Backwards compatibility couldn't be ensured.");
+				Logger.LogInfo<Config>(ex);
+				return false;
 			}
-
-			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
-			{
-				int port = Constants.DefaultRegTestBitcoinP2pPort;
-				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort) && int.TryParse(jRegTestBitcoinCorePort.ToString(), out int p))
-				{
-					port = p;
-				}
-
-				if (EndPointParser.TryParse(jRegTestBitcoinCoreHost.ToString(), port, out EndPoint ep))
-				{
-					RegTestBitcoinP2pEndPoint = ep;
-					saveIt = true;
-				}
-			}
-
-			return saveIt;
 		}
 	}
 }

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -27,6 +27,32 @@ namespace WalletWasabi.Backend
 		[JsonProperty(PropertyName = "BitcoinRpcConnectionString")]
 		public string BitcoinRpcConnectionString { get; private set; }
 
+		[JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
+		public EndPoint MainNetBitcoinP2PEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
+		public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
+		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "MainNetBitcoinCoreRpcEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinCoreRpcPort)]
+		public EndPoint MainNetBitcoinCoreRpcEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "TestNetBitcoinCoreRpcEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinCoreRpcPort)]
+		public EndPoint TestNetBitcoinCoreRpcEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "RegTestBitcoinCoreRpcEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinCoreRpcPort)]
+		public EndPoint RegTestBitcoinCoreRpcEndPoint { get; internal set; }
+
+		#region Deleteme
+
 		[JsonProperty(PropertyName = "MainNetBitcoinCoreHost")]
 		public string MainNetBitcoinCoreHost { get; internal set; }
 
@@ -44,6 +70,8 @@ namespace WalletWasabi.Backend
 
 		[JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
 		public int? RegTestBitcoinCorePort { get; internal set; }
+
+		#endregion Deleteme
 
 		private EndPoint _bitcoinCoreEndPoint;
 

--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.Backend
 
 		[JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
-		public EndPoint MainNetBitcoinP2PEndPoint { get; internal set; }
+		public EndPoint MainNetBitcoinP2pEndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
@@ -39,75 +39,27 @@ namespace WalletWasabi.Backend
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
 		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
 
-		[JsonProperty(PropertyName = "MainNetBitcoinCoreRpcEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinCoreRpcPort)]
-		public EndPoint MainNetBitcoinCoreRpcEndPoint { get; internal set; }
-
-		[JsonProperty(PropertyName = "TestNetBitcoinCoreRpcEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinCoreRpcPort)]
-		public EndPoint TestNetBitcoinCoreRpcEndPoint { get; internal set; }
-
-		[JsonProperty(PropertyName = "RegTestBitcoinCoreRpcEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinCoreRpcPort)]
-		public EndPoint RegTestBitcoinCoreRpcEndPoint { get; internal set; }
-
-		#region Deleteme
-
-		[JsonProperty(PropertyName = "MainNetBitcoinCoreHost")]
-		public string MainNetBitcoinCoreHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "TestNetBitcoinCoreHost")]
-		public string TestNetBitcoinCoreHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "RegTestBitcoinCoreHost")]
-		public string RegTestBitcoinCoreHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "MainNetBitcoinCorePort")]
-		public int? MainNetBitcoinCorePort { get; internal set; }
-
-		[JsonProperty(PropertyName = "TestNetBitcoinCorePort")]
-		public int? TestNetBitcoinCorePort { get; internal set; }
-
-		[JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
-		public int? RegTestBitcoinCorePort { get; internal set; }
-
-		#endregion Deleteme
-
 		private EndPoint _bitcoinCoreEndPoint;
 
-		public EndPoint GetBitcoinCoreEndPoint()
+		public EndPoint GetBitcoinP2pEndPoint()
 		{
 			if (_bitcoinCoreEndPoint is null)
 			{
-				IPAddress ipHost;
-				string dnsHost = null;
-				int? port = null;
-				try
+				if (Network == Network.Main)
 				{
-					if (Network == Network.Main)
-					{
-						port = MainNetBitcoinCorePort;
-						dnsHost = MainNetBitcoinCoreHost;
-						ipHost = IPAddress.Parse(MainNetBitcoinCoreHost);
-					}
-					else if (Network == Network.TestNet)
-					{
-						port = TestNetBitcoinCorePort;
-						dnsHost = TestNetBitcoinCoreHost;
-						ipHost = IPAddress.Parse(TestNetBitcoinCoreHost);
-					}
-					else // if (Network == Network.RegTest)
-					{
-						port = RegTestBitcoinCorePort;
-						dnsHost = RegTestBitcoinCoreHost;
-						ipHost = IPAddress.Parse(RegTestBitcoinCoreHost);
-					}
-
-					_bitcoinCoreEndPoint = new IPEndPoint(ipHost, port ?? Network.DefaultPort);
+					_bitcoinCoreEndPoint = MainNetBitcoinP2pEndPoint;
 				}
-				catch
+				else if (Network == Network.TestNet)
 				{
-					_bitcoinCoreEndPoint = new DnsEndPoint(dnsHost, port ?? Network.DefaultPort);
+					_bitcoinCoreEndPoint = TestNetBitcoinP2pEndPoint;
+				}
+				else if (Network == Network.RegTest)
+				{
+					_bitcoinCoreEndPoint = RegTestBitcoinP2pEndPoint;
+				}
+				else
+				{
+					throw new NotSupportedException("Network not supported.");
 				}
 			}
 
@@ -125,22 +77,16 @@ namespace WalletWasabi.Backend
 
 		public Config(Network network,
 			string bitcoinRpcConnectionString,
-			string mainNetBitcoinCoreHost,
-			string testNetBitcoinCoreHost,
-			string regTestBitcoinCoreHost,
-			int? mainNetBitcoinCorePort,
-			int? testNetBitcoinCorePort,
-			int? regTestBitcoinCorePort)
+			EndPoint mainNetBitcoinP2pEndPoint,
+			EndPoint testNetBitcoinP2pEndPoint,
+			EndPoint regTestBitcoinP2pEndPoint)
 		{
 			Network = Guard.NotNull(nameof(network), network);
 			BitcoinRpcConnectionString = Guard.NotNullOrEmptyOrWhitespace(nameof(bitcoinRpcConnectionString), bitcoinRpcConnectionString);
 
-			MainNetBitcoinCoreHost = Guard.NotNullOrEmptyOrWhitespace(nameof(mainNetBitcoinCoreHost), mainNetBitcoinCoreHost);
-			TestNetBitcoinCoreHost = Guard.NotNullOrEmptyOrWhitespace(nameof(testNetBitcoinCoreHost), testNetBitcoinCoreHost);
-			RegTestBitcoinCoreHost = Guard.NotNullOrEmptyOrWhitespace(nameof(regTestBitcoinCoreHost), regTestBitcoinCoreHost);
-			MainNetBitcoinCorePort = Guard.NotNull(nameof(mainNetBitcoinCorePort), mainNetBitcoinCorePort);
-			TestNetBitcoinCorePort = Guard.NotNull(nameof(testNetBitcoinCorePort), testNetBitcoinCorePort);
-			RegTestBitcoinCorePort = Guard.NotNull(nameof(regTestBitcoinCorePort), regTestBitcoinCorePort);
+			MainNetBitcoinP2pEndPoint = Guard.NotNull(nameof(mainNetBitcoinP2pEndPoint), mainNetBitcoinP2pEndPoint);
+			TestNetBitcoinP2pEndPoint = Guard.NotNull(nameof(testNetBitcoinP2pEndPoint), testNetBitcoinP2pEndPoint);
+			RegTestBitcoinP2pEndPoint = Guard.NotNull(nameof(regTestBitcoinP2pEndPoint), regTestBitcoinP2pEndPoint);
 		}
 
 		/// <inheritdoc />
@@ -162,12 +108,10 @@ namespace WalletWasabi.Backend
 			Network = Network.Main;
 			BitcoinRpcConnectionString = "user:password";
 
-			MainNetBitcoinCoreHost = IPAddress.Loopback.ToString();
-			TestNetBitcoinCoreHost = IPAddress.Loopback.ToString();
-			RegTestBitcoinCoreHost = IPAddress.Loopback.ToString();
-			MainNetBitcoinCorePort = Network.Main.DefaultPort;
-			TestNetBitcoinCorePort = Network.TestNet.DefaultPort;
-			RegTestBitcoinCorePort = Network.RegTest.DefaultPort;
+			MainNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBintcoinP2pPort);
+			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBintcoinP2pPort);
+			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBintcoinP2pPort);
+
 			if (!File.Exists(FilePath))
 			{
 				Logger.LogInfo<Config>($"{nameof(Config)} file did not exist. Created at path: `{FilePath}`.");
@@ -180,12 +124,14 @@ namespace WalletWasabi.Backend
 				Network = config.Network ?? Network;
 				BitcoinRpcConnectionString = config.BitcoinRpcConnectionString ?? BitcoinRpcConnectionString;
 
-				MainNetBitcoinCoreHost = config.MainNetBitcoinCoreHost ?? MainNetBitcoinCoreHost;
-				TestNetBitcoinCoreHost = config.TestNetBitcoinCoreHost ?? TestNetBitcoinCoreHost;
-				RegTestBitcoinCoreHost = config.RegTestBitcoinCoreHost ?? RegTestBitcoinCoreHost;
-				MainNetBitcoinCorePort = config.MainNetBitcoinCorePort ?? MainNetBitcoinCorePort;
-				TestNetBitcoinCorePort = config.TestNetBitcoinCorePort ?? TestNetBitcoinCorePort;
-				RegTestBitcoinCorePort = config.RegTestBitcoinCorePort ?? RegTestBitcoinCorePort;
+				MainNetBitcoinP2pEndPoint = config.MainNetBitcoinP2pEndPoint ?? MainNetBitcoinP2pEndPoint;
+				TestNetBitcoinP2pEndPoint = config.TestNetBitcoinP2pEndPoint ?? TestNetBitcoinP2pEndPoint;
+				RegTestBitcoinP2pEndPoint = config.RegTestBitcoinP2pEndPoint ?? RegTestBitcoinP2pEndPoint;
+
+				if (TryEnsureBackwardsCompatibility(jsonString))
+				{
+					await ToFileAsync();
+				}
 			}
 
 			await ToFileAsync();
@@ -220,6 +166,58 @@ namespace WalletWasabi.Backend
 			{
 				throw new NotSupportedException($"{nameof(FilePath)} is not set. Use {nameof(SetFilePath)} to set it.");
 			}
+		}
+
+		private bool TryEnsureBackwardsCompatibility(string jsonString)
+		{
+			// Before Wasabi 1.1.7
+			EndPoint obsoleteStringToEndPoint(string endPointString, int port = 0)
+			{
+				if (IPAddress.TryParse(endPointString, out IPAddress ipAddress))
+				{
+					return new IPEndPoint(ipAddress, port);
+				}
+
+				return new DnsEndPoint(endPointString, port);
+			};
+
+			var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
+			bool saveIt = false;
+
+			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
+			{
+				int port = Constants.DefaultMainNetBintcoinP2pPort;
+				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort))
+				{
+					port = int.Parse(jMainNetBitcoinCorePort.ToString());
+				}
+				MainNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jMainNetBitcoinCoreHost.ToString(), port);
+				saveIt = true;
+			}
+
+			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
+			{
+				int port = Constants.DefaultTestNetBintcoinP2pPort;
+				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort))
+				{
+					port = int.Parse(jTestNetBitcoinCorePort.ToString());
+				}
+				TestNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jTestNetBitcoinCoreHost.ToString(), port);
+				saveIt = true;
+			}
+
+			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
+			{
+				int port = Constants.DefaultRegTestBintcoinP2pPort;
+				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort))
+				{
+					port = int.Parse(jRegTestBitcoinCorePort.ToString());
+				}
+				RegTestBitcoinP2pEndPoint = obsoleteStringToEndPoint(jRegTestBitcoinCoreHost.ToString(), port);
+				saveIt = true;
+			}
+
+			return saveIt;
 		}
 	}
 }

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Backend
 			await AssertRpcNodeFullyInitializedAsync();
 
 			// Make sure P2P works.
-			await InitializeP2pAsync(config.Network, config.GetBitcoinCoreEndPoint());
+			await InitializeP2pAsync(config.Network, config.GetBitcoinP2pEndPoint());
 
 			// Initialize index building
 			var indexBuilderServiceDir = Path.Combine(DataDir, nameof(IndexBuilderService));

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
@@ -43,8 +44,10 @@ namespace WalletWasabi.Backend
 			await roundConfig.LoadOrCreateDefaultFileAsync();
 			Logger.LogInfo<CcjRoundConfig>("RoundConfig is successfully initialized.");
 
+			string host = config.GetBitcoinCoreRpcEndPoint().ToString(config.Network.RPCPort);
 			var rpc = new RPCClient(
-					credentials: RPCCredentialString.Parse(config.BitcoinRpcConnectionString),
+					authenticationString: config.BitcoinRpcConnectionString,
+					hostOrUri: host,
 					network: config.Network);
 
 			await Global.InitializeAsync(config, roundConfig, rpc);

--- a/WalletWasabi.Gui/Behaviors/CommandOnLostFocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnLostFocusBehavior.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Text;
+
+namespace WalletWasabi.Gui.Behaviors
+{
+	internal class CommandOnLostFocusBehavior : CommandBasedBehavior<Control>
+	{
+		private CompositeDisposable Disposables { get; set; }
+
+		protected override void OnAttached()
+		{
+			Disposables = new CompositeDisposable();
+
+			base.OnAttached();
+
+			Disposables.Add(AssociatedObject.AddHandler(InputElement.LostFocusEvent, (sender, e) =>
+			{
+				e.Handled = ExecuteCommand();
+			}));
+		}
+
+		protected override void OnDetaching()
+		{
+			base.OnDetaching();
+
+			Disposables?.Dispose();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -49,15 +49,15 @@ namespace WalletWasabi.Gui
 		public EndPoint TorSocks5EndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBitcoinP2pPort)]
 		public EndPoint MainNetBitcoinP2pEndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBitcoinP2pPort)]
 		public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
-		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinP2pPort)]
 		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
 
 		[JsonProperty(PropertyName = "MixUntilAnonymitySet")]
@@ -268,9 +268,9 @@ namespace WalletWasabi.Gui
 			UseTor = true;
 			TorSocks5EndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTorSocksPort);
 
-			MainNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBintcoinP2pPort);
-			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBintcoinP2pPort);
-			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBintcoinP2pPort);
+			MainNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinP2pPort);
+			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort);
+			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort);
 
 			MixUntilAnonymitySet = 50;
 			PrivacyLevelSome = 2;
@@ -447,7 +447,7 @@ namespace WalletWasabi.Gui
 
 			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
 			{
-				int port = Constants.DefaultMainNetBintcoinP2pPort;
+				int port = Constants.DefaultMainNetBitcoinP2pPort;
 				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort) && int.TryParse(jMainNetBitcoinCorePort.ToString(), out int p))
 				{
 					port = p;
@@ -462,7 +462,7 @@ namespace WalletWasabi.Gui
 
 			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
 			{
-				int port = Constants.DefaultTestNetBintcoinP2pPort;
+				int port = Constants.DefaultTestNetBitcoinP2pPort;
 				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort) && int.TryParse(jTestNetBitcoinCorePort.ToString(), out int p))
 				{
 					port = p;
@@ -477,7 +477,7 @@ namespace WalletWasabi.Gui
 
 			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
 			{
-				int port = Constants.DefaultRegTestBintcoinP2pPort;
+				int port = Constants.DefaultRegTestBitcoinP2pPort;
 				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort) && int.TryParse(jRegTestBitcoinCorePort.ToString(), out int p))
 				{
 					port = p;

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -16,438 +16,459 @@ using WalletWasabi.TorSocks5;
 
 namespace WalletWasabi.Gui
 {
-	[JsonObject(MemberSerialization.OptIn)]
-	public class Config : IConfig
-	{
-		/// <inheritdoc />
-		public string FilePath { get; private set; }
-
-		[JsonProperty(PropertyName = "Network")]
-		[JsonConverter(typeof(NetworkJsonConverter))]
-		public Network Network { get; internal set; }
-
-		[JsonProperty(PropertyName = "MainNetBackendUriV3")]
-		public string MainNetBackendUriV3 { get; private set; }
-
-		[JsonProperty(PropertyName = "TestNetBackendUriV3")]
-		public string TestNetBackendUriV3 { get; private set; }
-
-		[JsonProperty(PropertyName = "MainNetFallbackBackendUri")]
-		public string MainNetFallbackBackendUri { get; private set; }
-
-		[JsonProperty(PropertyName = "TestNetFallbackBackendUri")]
-		public string TestNetFallbackBackendUri { get; private set; }
-
-		[JsonProperty(PropertyName = "RegTestBackendUriV3")]
-		public string RegTestBackendUriV3 { get; private set; }
-
-		[JsonProperty(PropertyName = "UseTor")]
-		public bool? UseTor { get; internal set; }
-
-		[JsonProperty(PropertyName = "TorHost")]
-		public string TorHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "TorSocks5Port")]
-		public int? TorSocks5Port { get; internal set; }
-
-		[JsonProperty(PropertyName = "MainNetBitcoinCoreHost")]
-		public string MainNetBitcoinCoreHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "TestNetBitcoinCoreHost")]
-		public string TestNetBitcoinCoreHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "RegTestBitcoinCoreHost")]
-		public string RegTestBitcoinCoreHost { get; internal set; }
-
-		[JsonProperty(PropertyName = "MainNetBitcoinCorePort")]
-		public int? MainNetBitcoinCorePort { get; internal set; }
-
-		[JsonProperty(PropertyName = "TestNetBitcoinCorePort")]
-		public int? TestNetBitcoinCorePort { get; internal set; }
-
-		[JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
-		public int? RegTestBitcoinCorePort { get; internal set; }
-
-		[JsonProperty(PropertyName = "MixUntilAnonymitySet")]
-		public int? MixUntilAnonymitySet
-		{
-			get => _mixUntilAnonymitySet;
-			internal set
-			{
-				if (_mixUntilAnonymitySet != value)
-				{
-					_mixUntilAnonymitySet = value;
-					if (value.HasValue && ServiceConfiguration != default)
-					{
-						ServiceConfiguration.MixUntilAnonymitySet = value.Value;
-					}
-				}
-			}
-		}
-
-		[JsonProperty(PropertyName = "PrivacyLevelSome")]
-		public int? PrivacyLevelSome
-		{
-			get => _privacyLevelSome;
-			internal set
-			{
-				if (_privacyLevelSome != value)
-				{
-					_privacyLevelSome = value;
-					if (value.HasValue && ServiceConfiguration != default)
-					{
-						ServiceConfiguration.PrivacyLevelSome = value.Value;
-					}
-				}
-			}
-		}
-
-		[JsonProperty(PropertyName = "PrivacyLevelFine")]
-		public int? PrivacyLevelFine
-		{
-			get => _privacyLevelFine;
-			internal set
-			{
-				if (_privacyLevelFine != value)
-				{
-					_privacyLevelFine = value;
-					if (value.HasValue && ServiceConfiguration != default)
-					{
-						ServiceConfiguration.PrivacyLevelFine = value.Value;
-					}
-				}
-			}
-		}
-
-		[JsonProperty(PropertyName = "PrivacyLevelStrong")]
-		public int? PrivacyLevelStrong
-		{
-			get => _privacyLevelStrong;
-			internal set
-			{
-				if (_privacyLevelStrong != value)
-				{
-					_privacyLevelStrong = value;
-					if (value.HasValue && ServiceConfiguration != default)
-					{
-						ServiceConfiguration.PrivacyLevelStrong = value.Value;
-					}
-				}
-			}
-		}
-
-		[JsonProperty(PropertyName = "DustThreshold")]
-		[JsonConverter(typeof(MoneyBtcJsonConverter))]
-		public Money DustThreshold { get; internal set; }
-
-		private Uri _backendUri;
-		private Uri _fallbackBackendUri;
-
-		public ServiceConfiguration ServiceConfiguration { get; private set; }
-
-		public Uri GetCurrentBackendUri()
-		{
-			if (TorProcessManager.RequestFallbackAddressUsage)
-			{
-				return GetFallbackBackendUri();
-			}
-
-			if (_backendUri != null)
-			{
-				return _backendUri;
-			}
-
-			if (Network == Network.Main)
-			{
-				_backendUri = new Uri(MainNetBackendUriV3);
-			}
-			else if (Network == Network.TestNet)
-			{
-				_backendUri = new Uri(TestNetBackendUriV3);
-			}
-			else // RegTest
-			{
-				_backendUri = new Uri(RegTestBackendUriV3);
-			}
-
-			return _backendUri;
-		}
-
-		public Uri GetFallbackBackendUri()
-		{
-			if (_fallbackBackendUri != null)
-			{
-				return _fallbackBackendUri;
-			}
-
-			if (Network == Network.Main)
-			{
-				_fallbackBackendUri = new Uri(MainNetFallbackBackendUri);
-			}
-			else if (Network == Network.TestNet)
-			{
-				_fallbackBackendUri = new Uri(TestNetFallbackBackendUri);
-			}
-			else // RegTest
-			{
-				_fallbackBackendUri = new Uri(RegTestBackendUriV3);
-			}
-
-			return _fallbackBackendUri;
-		}
-
-		private IPEndPoint _torSocks5EndPoint;
-		private int? _mixUntilAnonymitySet;
-		private int? _privacyLevelSome;
-		private int? _privacyLevelFine;
-		private int? _privacyLevelStrong;
-		private EndPoint _bitcoinCoreEndPoint;
-
-		public IPEndPoint GetTorSocks5EndPoint()
-		{
-			if (_torSocks5EndPoint is null)
-			{
-				var host = IPAddress.Parse(TorHost);
-				_torSocks5EndPoint = new IPEndPoint(host, (int)TorSocks5Port);
-			}
-
-			return _torSocks5EndPoint;
-		}
-
-		public EndPoint GetBitcoinCoreEndPoint()
-		{
-			if (_bitcoinCoreEndPoint is null)
-			{
-				IPAddress ipHost;
-				string dnsHost = null;
-				int? port = null;
-				try
-				{
-					if (Network == Network.Main)
-					{
-						port = MainNetBitcoinCorePort;
-						dnsHost = MainNetBitcoinCoreHost;
-						ipHost = IPAddress.Parse(MainNetBitcoinCoreHost);
-					}
-					else if (Network == Network.TestNet)
-					{
-						port = TestNetBitcoinCorePort;
-						dnsHost = TestNetBitcoinCoreHost;
-						ipHost = IPAddress.Parse(TestNetBitcoinCoreHost);
-					}
-					else // if (Network == Network.RegTest)
-					{
-						port = RegTestBitcoinCorePort;
-						dnsHost = RegTestBitcoinCoreHost;
-						ipHost = IPAddress.Parse(RegTestBitcoinCoreHost);
-					}
-
-					_bitcoinCoreEndPoint = new IPEndPoint(ipHost, port ?? Network.DefaultPort);
-				}
-				catch
-				{
-					_bitcoinCoreEndPoint = new DnsEndPoint(dnsHost, port ?? Network.DefaultPort);
-				}
-			}
-
-			return _bitcoinCoreEndPoint;
-		}
-
-		public Config()
-		{
-			_backendUri = null;
-		}
-
-		public Config(string filePath)
-		{
-			_backendUri = null;
-			SetFilePath(filePath);
-		}
-
-		/// <inheritdoc />
-		public async Task ToFileAsync()
-		{
-			AssertFilePathSet();
-
-			string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
-			await File.WriteAllTextAsync(FilePath,
-			jsonString,
-			Encoding.UTF8);
-		}
-
-		/// <inheritdoc />
-		public async Task LoadOrCreateDefaultFileAsync()
-		{
-			AssertFilePathSet();
-
-			Network = Network.Main;
-
-			MainNetBackendUriV3 = "http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/";
-			TestNetBackendUriV3 = "http://testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion/";
-			MainNetFallbackBackendUri = "https://wasabiwallet.io/";
-			TestNetFallbackBackendUri = "https://wasabiwallet.co/";
-			RegTestBackendUriV3 = "http://localhost:37127/";
-
-			UseTor = true;
-			TorHost = IPAddress.Loopback.ToString();
-			TorSocks5Port = 9050;
-
-			MainNetBitcoinCoreHost = IPAddress.Loopback.ToString();
-			TestNetBitcoinCoreHost = IPAddress.Loopback.ToString();
-			RegTestBitcoinCoreHost = IPAddress.Loopback.ToString();
-			MainNetBitcoinCorePort = Network.Main.DefaultPort;
-			TestNetBitcoinCorePort = Network.TestNet.DefaultPort;
-			RegTestBitcoinCorePort = Network.RegTest.DefaultPort;
-
-			MixUntilAnonymitySet = 50;
-			PrivacyLevelSome = 2;
-			PrivacyLevelFine = 21;
-			PrivacyLevelStrong = 50;
-			DustThreshold = Money.Coins(0.0001m);
-
-			if (!File.Exists(FilePath))
-			{
-				Logger.LogInfo<Config>($"{nameof(Config)} file did not exist. Created at path: `{FilePath}`.");
-			}
-			else
-			{
-				await LoadFileAsync();
-			}
-
-			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, GetBitcoinCoreEndPoint(), DustThreshold);
-
-			// Just debug convenience.
-			_backendUri = GetCurrentBackendUri();
-
-			await ToFileAsync();
-		}
-
-		public async Task LoadFileAsync()
-		{
-			string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
-			var config = JsonConvert.DeserializeObject<Config>(jsonString);
-
-			Network = config.Network ?? Network;
-
-			MainNetBackendUriV3 = config.MainNetBackendUriV3 ?? MainNetBackendUriV3;
-			TestNetBackendUriV3 = config.TestNetBackendUriV3 ?? TestNetBackendUriV3;
-			MainNetFallbackBackendUri = config.MainNetFallbackBackendUri ?? MainNetFallbackBackendUri;
-			TestNetFallbackBackendUri = config.TestNetFallbackBackendUri ?? TestNetFallbackBackendUri;
-			RegTestBackendUriV3 = config.RegTestBackendUriV3 ?? RegTestBackendUriV3;
-
-			UseTor = config.UseTor ?? UseTor;
-			TorHost = config.TorHost ?? TorHost;
-			TorSocks5Port = config.TorSocks5Port ?? TorSocks5Port;
-
-			MainNetBitcoinCoreHost = config.MainNetBitcoinCoreHost ?? MainNetBitcoinCoreHost;
-			TestNetBitcoinCoreHost = config.TestNetBitcoinCoreHost ?? TestNetBitcoinCoreHost;
-			RegTestBitcoinCoreHost = config.RegTestBitcoinCoreHost ?? RegTestBitcoinCoreHost;
-			MainNetBitcoinCorePort = config.MainNetBitcoinCorePort ?? MainNetBitcoinCorePort;
-			TestNetBitcoinCorePort = config.TestNetBitcoinCorePort ?? TestNetBitcoinCorePort;
-			RegTestBitcoinCorePort = config.RegTestBitcoinCorePort ?? RegTestBitcoinCorePort;
-
-			MixUntilAnonymitySet = config.MixUntilAnonymitySet ?? MixUntilAnonymitySet;
-			PrivacyLevelSome = config.PrivacyLevelSome ?? PrivacyLevelSome;
-			PrivacyLevelFine = config.PrivacyLevelFine ?? PrivacyLevelFine;
-			PrivacyLevelStrong = config.PrivacyLevelStrong ?? PrivacyLevelStrong;
-
-			DustThreshold = config.DustThreshold ?? DustThreshold;
-
-			ServiceConfiguration = config.ServiceConfiguration ?? ServiceConfiguration;
-
-			// Just debug convenience.
-			_backendUri = GetCurrentBackendUri();
-		}
-
-		/// <inheritdoc />
-		public async Task<bool> CheckFileChangeAsync()
-		{
-			AssertFilePathSet();
-
-			if (!File.Exists(FilePath))
-			{
-				throw new FileNotFoundException($"{nameof(Config)} file did not exist at path: `{FilePath}`.");
-			}
-
-			string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
-			var newConfig = JsonConvert.DeserializeObject<JObject>(jsonString);
-			var currentConfig = JObject.FromObject(this);
-
-			return !JToken.DeepEquals(newConfig, currentConfig);
-		}
-
-		/// <inheritdoc />
-		public void SetFilePath(string path)
-		{
-			FilePath = Guard.NotNullOrEmptyOrWhitespace(nameof(path), path, trim: true);
-		}
-
-		/// <inheritdoc />
-		public void AssertFilePathSet()
-		{
-			if (FilePath is null)
-			{
-				throw new NotSupportedException($"{nameof(FilePath)} is not set. Use {nameof(SetFilePath)} to set it.");
-			}
-		}
-
-		public TargetPrivacy GetTargetPrivacy()
-		{
-			if (MixUntilAnonymitySet == PrivacyLevelSome)
-			{
-				return TargetPrivacy.Some;
-			}
-
-			if (MixUntilAnonymitySet == PrivacyLevelFine)
-			{
-				return TargetPrivacy.Fine;
-			}
-
-			if (MixUntilAnonymitySet == PrivacyLevelStrong)
-			{
-				return TargetPrivacy.Strong;
-			}
-			//the levels changed in the config file, adjust
-			if (MixUntilAnonymitySet < PrivacyLevelSome)
-			{
-				return TargetPrivacy.None; //choose the lower
-			}
-
-			if (MixUntilAnonymitySet < PrivacyLevelFine)
-			{
-				return TargetPrivacy.Some;
-			}
-
-			if (MixUntilAnonymitySet < PrivacyLevelStrong)
-			{
-				return TargetPrivacy.Fine;
-			}
-
-			if (MixUntilAnonymitySet > PrivacyLevelFine)
-			{
-				return TargetPrivacy.Strong;
-			}
-
-			return TargetPrivacy.None;
-		}
-
-		public int GetTargetLevel(TargetPrivacy target)
-		{
-			switch (target)
-			{
-				case TargetPrivacy.None:
-					return 0;
-
-				case TargetPrivacy.Some:
-					return PrivacyLevelSome.Value;
-
-				case TargetPrivacy.Fine:
-					return PrivacyLevelFine.Value;
-
-				case TargetPrivacy.Strong:
-					return PrivacyLevelStrong.Value;
-			}
-			return 0;
-		}
-	}
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Config : IConfig
+    {
+        /// <inheritdoc />
+        public string FilePath { get; private set; }
+
+        [JsonProperty(PropertyName = "Network")]
+        [JsonConverter(typeof(NetworkJsonConverter))]
+        public Network Network { get; internal set; }
+
+        [JsonProperty(PropertyName = "MainNetBackendUriV3")]
+        public string MainNetBackendUriV3 { get; private set; }
+
+        [JsonProperty(PropertyName = "TestNetBackendUriV3")]
+        public string TestNetBackendUriV3 { get; private set; }
+
+        [JsonProperty(PropertyName = "MainNetFallbackBackendUri")]
+        public string MainNetFallbackBackendUri { get; private set; }
+
+        [JsonProperty(PropertyName = "TestNetFallbackBackendUri")]
+        public string TestNetFallbackBackendUri { get; private set; }
+
+        [JsonProperty(PropertyName = "RegTestBackendUriV3")]
+        public string RegTestBackendUriV3 { get; private set; }
+
+        [JsonProperty(PropertyName = "UseTor")]
+        public bool? UseTor { get; internal set; }
+
+        [JsonProperty(PropertyName = "TorSocks5EndPoint")]
+        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTorSocksPort)]
+        public EndPoint TorSocks5EndPoint { get; internal set; }
+
+        [JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
+        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
+        public EndPoint MainNetBitcoinP2PEndPoint { get; internal set; }
+
+        [JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
+        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
+        public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; }
+
+        [JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
+        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
+        public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
+
+        #region Deleteme
+
+        [JsonProperty(PropertyName = "TorHost")]
+        public string TorHost { get; internal set; }
+
+        [JsonProperty(PropertyName = "TorSocks5Port")]
+        public int? TorSocks5Port { get; internal set; }
+
+        [JsonProperty(PropertyName = "MainNetBitcoinCoreHost")]
+        public string MainNetBitcoinCoreHost { get; internal set; }
+
+        [JsonProperty(PropertyName = "TestNetBitcoinCoreHost")]
+        public string TestNetBitcoinCoreHost { get; internal set; }
+
+        [JsonProperty(PropertyName = "RegTestBitcoinCoreHost")]
+        public string RegTestBitcoinCoreHost { get; internal set; }
+
+        [JsonProperty(PropertyName = "MainNetBitcoinCorePort")]
+        public int? MainNetBitcoinCorePort { get; internal set; }
+
+        [JsonProperty(PropertyName = "TestNetBitcoinCorePort")]
+        public int? TestNetBitcoinCorePort { get; internal set; }
+
+        [JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
+        public int? RegTestBitcoinCorePort { get; internal set; }
+
+        #endregion Deleteme
+
+        [JsonProperty(PropertyName = "MixUntilAnonymitySet")]
+        public int? MixUntilAnonymitySet
+        {
+            get => _mixUntilAnonymitySet;
+            internal set
+            {
+                if (_mixUntilAnonymitySet != value)
+                {
+                    _mixUntilAnonymitySet = value;
+                    if (value.HasValue && ServiceConfiguration != default)
+                    {
+                        ServiceConfiguration.MixUntilAnonymitySet = value.Value;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty(PropertyName = "PrivacyLevelSome")]
+        public int? PrivacyLevelSome
+        {
+            get => _privacyLevelSome;
+            internal set
+            {
+                if (_privacyLevelSome != value)
+                {
+                    _privacyLevelSome = value;
+                    if (value.HasValue && ServiceConfiguration != default)
+                    {
+                        ServiceConfiguration.PrivacyLevelSome = value.Value;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty(PropertyName = "PrivacyLevelFine")]
+        public int? PrivacyLevelFine
+        {
+            get => _privacyLevelFine;
+            internal set
+            {
+                if (_privacyLevelFine != value)
+                {
+                    _privacyLevelFine = value;
+                    if (value.HasValue && ServiceConfiguration != default)
+                    {
+                        ServiceConfiguration.PrivacyLevelFine = value.Value;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty(PropertyName = "PrivacyLevelStrong")]
+        public int? PrivacyLevelStrong
+        {
+            get => _privacyLevelStrong;
+            internal set
+            {
+                if (_privacyLevelStrong != value)
+                {
+                    _privacyLevelStrong = value;
+                    if (value.HasValue && ServiceConfiguration != default)
+                    {
+                        ServiceConfiguration.PrivacyLevelStrong = value.Value;
+                    }
+                }
+            }
+        }
+
+        [JsonProperty(PropertyName = "DustThreshold")]
+        [JsonConverter(typeof(MoneyBtcJsonConverter))]
+        public Money DustThreshold { get; internal set; }
+
+        private Uri _backendUri;
+        private Uri _fallbackBackendUri;
+
+        public ServiceConfiguration ServiceConfiguration { get; private set; }
+
+        public Uri GetCurrentBackendUri()
+        {
+            if (TorProcessManager.RequestFallbackAddressUsage)
+            {
+                return GetFallbackBackendUri();
+            }
+
+            if (_backendUri != null)
+            {
+                return _backendUri;
+            }
+
+            if (Network == Network.Main)
+            {
+                _backendUri = new Uri(MainNetBackendUriV3);
+            }
+            else if (Network == Network.TestNet)
+            {
+                _backendUri = new Uri(TestNetBackendUriV3);
+            }
+            else // RegTest
+            {
+                _backendUri = new Uri(RegTestBackendUriV3);
+            }
+
+            return _backendUri;
+        }
+
+        public Uri GetFallbackBackendUri()
+        {
+            if (_fallbackBackendUri != null)
+            {
+                return _fallbackBackendUri;
+            }
+
+            if (Network == Network.Main)
+            {
+                _fallbackBackendUri = new Uri(MainNetFallbackBackendUri);
+            }
+            else if (Network == Network.TestNet)
+            {
+                _fallbackBackendUri = new Uri(TestNetFallbackBackendUri);
+            }
+            else // RegTest
+            {
+                _fallbackBackendUri = new Uri(RegTestBackendUriV3);
+            }
+
+            return _fallbackBackendUri;
+        }
+
+        private IPEndPoint _torSocks5EndPoint;
+        private int? _mixUntilAnonymitySet;
+        private int? _privacyLevelSome;
+        private int? _privacyLevelFine;
+        private int? _privacyLevelStrong;
+        private EndPoint _bitcoinCoreEndPoint;
+
+        public IPEndPoint GetTorSocks5EndPoint()
+        {
+            if (_torSocks5EndPoint is null)
+            {
+                var host = IPAddress.Parse(TorHost);
+                _torSocks5EndPoint = new IPEndPoint(host, (int)TorSocks5Port);
+            }
+
+            return _torSocks5EndPoint;
+        }
+
+        public EndPoint GetBitcoinCoreEndPoint()
+        {
+            if (_bitcoinCoreEndPoint is null)
+            {
+                IPAddress ipHost;
+                string dnsHost = null;
+                int? port = null;
+                try
+                {
+                    if (Network == Network.Main)
+                    {
+                        port = MainNetBitcoinCorePort;
+                        dnsHost = MainNetBitcoinCoreHost;
+                        ipHost = IPAddress.Parse(MainNetBitcoinCoreHost);
+                    }
+                    else if (Network == Network.TestNet)
+                    {
+                        port = TestNetBitcoinCorePort;
+                        dnsHost = TestNetBitcoinCoreHost;
+                        ipHost = IPAddress.Parse(TestNetBitcoinCoreHost);
+                    }
+                    else // if (Network == Network.RegTest)
+                    {
+                        port = RegTestBitcoinCorePort;
+                        dnsHost = RegTestBitcoinCoreHost;
+                        ipHost = IPAddress.Parse(RegTestBitcoinCoreHost);
+                    }
+
+                    _bitcoinCoreEndPoint = new IPEndPoint(ipHost, port ?? Network.DefaultPort);
+                }
+                catch
+                {
+                    _bitcoinCoreEndPoint = new DnsEndPoint(dnsHost, port ?? Network.DefaultPort);
+                }
+            }
+
+            return _bitcoinCoreEndPoint;
+        }
+
+        public Config()
+        {
+            _backendUri = null;
+        }
+
+        public Config(string filePath)
+        {
+            _backendUri = null;
+            SetFilePath(filePath);
+        }
+
+        /// <inheritdoc />
+        public async Task ToFileAsync()
+        {
+            AssertFilePathSet();
+
+            string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
+            await File.WriteAllTextAsync(FilePath,
+            jsonString,
+            Encoding.UTF8);
+        }
+
+        /// <inheritdoc />
+        public async Task LoadOrCreateDefaultFileAsync()
+        {
+            AssertFilePathSet();
+
+            Network = Network.Main;
+
+            MainNetBackendUriV3 = "http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/";
+            TestNetBackendUriV3 = "http://testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion/";
+            MainNetFallbackBackendUri = "https://wasabiwallet.io/";
+            TestNetFallbackBackendUri = "https://wasabiwallet.co/";
+            RegTestBackendUriV3 = "http://localhost:37127/";
+
+            UseTor = true;
+            TorHost = IPAddress.Loopback.ToString();
+            TorSocks5Port = 9050;
+
+            MainNetBitcoinCoreHost = IPAddress.Loopback.ToString();
+            TestNetBitcoinCoreHost = IPAddress.Loopback.ToString();
+            RegTestBitcoinCoreHost = IPAddress.Loopback.ToString();
+            MainNetBitcoinCorePort = Network.Main.DefaultPort;
+            TestNetBitcoinCorePort = Network.TestNet.DefaultPort;
+            RegTestBitcoinCorePort = Network.RegTest.DefaultPort;
+
+            MixUntilAnonymitySet = 50;
+            PrivacyLevelSome = 2;
+            PrivacyLevelFine = 21;
+            PrivacyLevelStrong = 50;
+            DustThreshold = Money.Coins(0.0001m);
+
+            if (!File.Exists(FilePath))
+            {
+                Logger.LogInfo<Config>($"{nameof(Config)} file did not exist. Created at path: `{FilePath}`.");
+            }
+            else
+            {
+                await LoadFileAsync();
+            }
+
+            ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, GetBitcoinCoreEndPoint(), DustThreshold);
+
+            // Just debug convenience.
+            _backendUri = GetCurrentBackendUri();
+
+            await ToFileAsync();
+        }
+
+        public async Task LoadFileAsync()
+        {
+            string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+
+            var config = JsonConvert.DeserializeObject<Config>(jsonString);
+
+            Network = config.Network ?? Network;
+
+            MainNetBackendUriV3 = config.MainNetBackendUriV3 ?? MainNetBackendUriV3;
+            TestNetBackendUriV3 = config.TestNetBackendUriV3 ?? TestNetBackendUriV3;
+            MainNetFallbackBackendUri = config.MainNetFallbackBackendUri ?? MainNetFallbackBackendUri;
+            TestNetFallbackBackendUri = config.TestNetFallbackBackendUri ?? TestNetFallbackBackendUri;
+            RegTestBackendUriV3 = config.RegTestBackendUriV3 ?? RegTestBackendUriV3;
+
+            UseTor = config.UseTor ?? UseTor;
+            TorHost = config.TorHost ?? TorHost;
+            TorSocks5Port = config.TorSocks5Port ?? TorSocks5Port;
+
+            MainNetBitcoinCoreHost = config.MainNetBitcoinCoreHost ?? MainNetBitcoinCoreHost;
+            TestNetBitcoinCoreHost = config.TestNetBitcoinCoreHost ?? TestNetBitcoinCoreHost;
+            RegTestBitcoinCoreHost = config.RegTestBitcoinCoreHost ?? RegTestBitcoinCoreHost;
+            MainNetBitcoinCorePort = config.MainNetBitcoinCorePort ?? MainNetBitcoinCorePort;
+            TestNetBitcoinCorePort = config.TestNetBitcoinCorePort ?? TestNetBitcoinCorePort;
+            RegTestBitcoinCorePort = config.RegTestBitcoinCorePort ?? RegTestBitcoinCorePort;
+
+            MixUntilAnonymitySet = config.MixUntilAnonymitySet ?? MixUntilAnonymitySet;
+            PrivacyLevelSome = config.PrivacyLevelSome ?? PrivacyLevelSome;
+            PrivacyLevelFine = config.PrivacyLevelFine ?? PrivacyLevelFine;
+            PrivacyLevelStrong = config.PrivacyLevelStrong ?? PrivacyLevelStrong;
+
+            DustThreshold = config.DustThreshold ?? DustThreshold;
+
+            ServiceConfiguration = config.ServiceConfiguration ?? ServiceConfiguration;
+
+            // Just debug convenience.
+            _backendUri = GetCurrentBackendUri();
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> CheckFileChangeAsync()
+        {
+            AssertFilePathSet();
+
+            if (!File.Exists(FilePath))
+            {
+                throw new FileNotFoundException($"{nameof(Config)} file did not exist at path: `{FilePath}`.");
+            }
+
+            string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+            var newConfig = JsonConvert.DeserializeObject<JObject>(jsonString);
+            var currentConfig = JObject.FromObject(this);
+
+            return !JToken.DeepEquals(newConfig, currentConfig);
+        }
+
+        /// <inheritdoc />
+        public void SetFilePath(string path)
+        {
+            FilePath = Guard.NotNullOrEmptyOrWhitespace(nameof(path), path, trim: true);
+        }
+
+        /// <inheritdoc />
+        public void AssertFilePathSet()
+        {
+            if (FilePath is null)
+            {
+                throw new NotSupportedException($"{nameof(FilePath)} is not set. Use {nameof(SetFilePath)} to set it.");
+            }
+        }
+
+        public TargetPrivacy GetTargetPrivacy()
+        {
+            if (MixUntilAnonymitySet == PrivacyLevelSome)
+            {
+                return TargetPrivacy.Some;
+            }
+
+            if (MixUntilAnonymitySet == PrivacyLevelFine)
+            {
+                return TargetPrivacy.Fine;
+            }
+
+            if (MixUntilAnonymitySet == PrivacyLevelStrong)
+            {
+                return TargetPrivacy.Strong;
+            }
+            //the levels changed in the config file, adjust
+            if (MixUntilAnonymitySet < PrivacyLevelSome)
+            {
+                return TargetPrivacy.None; //choose the lower
+            }
+
+            if (MixUntilAnonymitySet < PrivacyLevelFine)
+            {
+                return TargetPrivacy.Some;
+            }
+
+            if (MixUntilAnonymitySet < PrivacyLevelStrong)
+            {
+                return TargetPrivacy.Fine;
+            }
+
+            if (MixUntilAnonymitySet > PrivacyLevelFine)
+            {
+                return TargetPrivacy.Strong;
+            }
+
+            return TargetPrivacy.None;
+        }
+
+        public int GetTargetLevel(TargetPrivacy target)
+        {
+            switch (target)
+            {
+                case TargetPrivacy.None:
+                    return 0;
+
+                case TargetPrivacy.Some:
+                    return PrivacyLevelSome.Value;
+
+                case TargetPrivacy.Fine:
+                    return PrivacyLevelFine.Value;
+
+                case TargetPrivacy.Strong:
+                    return PrivacyLevelStrong.Value;
+            }
+            return 0;
+        }
+    }
 }

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -16,459 +16,475 @@ using WalletWasabi.TorSocks5;
 
 namespace WalletWasabi.Gui
 {
-    [JsonObject(MemberSerialization.OptIn)]
-    public class Config : IConfig
-    {
-        /// <inheritdoc />
-        public string FilePath { get; private set; }
-
-        [JsonProperty(PropertyName = "Network")]
-        [JsonConverter(typeof(NetworkJsonConverter))]
-        public Network Network { get; internal set; }
-
-        [JsonProperty(PropertyName = "MainNetBackendUriV3")]
-        public string MainNetBackendUriV3 { get; private set; }
-
-        [JsonProperty(PropertyName = "TestNetBackendUriV3")]
-        public string TestNetBackendUriV3 { get; private set; }
-
-        [JsonProperty(PropertyName = "MainNetFallbackBackendUri")]
-        public string MainNetFallbackBackendUri { get; private set; }
-
-        [JsonProperty(PropertyName = "TestNetFallbackBackendUri")]
-        public string TestNetFallbackBackendUri { get; private set; }
-
-        [JsonProperty(PropertyName = "RegTestBackendUriV3")]
-        public string RegTestBackendUriV3 { get; private set; }
-
-        [JsonProperty(PropertyName = "UseTor")]
-        public bool? UseTor { get; internal set; }
-
-        [JsonProperty(PropertyName = "TorSocks5EndPoint")]
-        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTorSocksPort)]
-        public EndPoint TorSocks5EndPoint { get; internal set; }
-
-        [JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
-        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
-        public EndPoint MainNetBitcoinP2PEndPoint { get; internal set; }
-
-        [JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
-        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
-        public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; }
-
-        [JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
-        [JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
-        public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
-
-        #region Deleteme
-
-        [JsonProperty(PropertyName = "TorHost")]
-        public string TorHost { get; internal set; }
-
-        [JsonProperty(PropertyName = "TorSocks5Port")]
-        public int? TorSocks5Port { get; internal set; }
-
-        [JsonProperty(PropertyName = "MainNetBitcoinCoreHost")]
-        public string MainNetBitcoinCoreHost { get; internal set; }
-
-        [JsonProperty(PropertyName = "TestNetBitcoinCoreHost")]
-        public string TestNetBitcoinCoreHost { get; internal set; }
-
-        [JsonProperty(PropertyName = "RegTestBitcoinCoreHost")]
-        public string RegTestBitcoinCoreHost { get; internal set; }
-
-        [JsonProperty(PropertyName = "MainNetBitcoinCorePort")]
-        public int? MainNetBitcoinCorePort { get; internal set; }
-
-        [JsonProperty(PropertyName = "TestNetBitcoinCorePort")]
-        public int? TestNetBitcoinCorePort { get; internal set; }
-
-        [JsonProperty(PropertyName = "RegTestBitcoinCorePort")]
-        public int? RegTestBitcoinCorePort { get; internal set; }
-
-        #endregion Deleteme
-
-        [JsonProperty(PropertyName = "MixUntilAnonymitySet")]
-        public int? MixUntilAnonymitySet
-        {
-            get => _mixUntilAnonymitySet;
-            internal set
-            {
-                if (_mixUntilAnonymitySet != value)
-                {
-                    _mixUntilAnonymitySet = value;
-                    if (value.HasValue && ServiceConfiguration != default)
-                    {
-                        ServiceConfiguration.MixUntilAnonymitySet = value.Value;
-                    }
-                }
-            }
-        }
-
-        [JsonProperty(PropertyName = "PrivacyLevelSome")]
-        public int? PrivacyLevelSome
-        {
-            get => _privacyLevelSome;
-            internal set
-            {
-                if (_privacyLevelSome != value)
-                {
-                    _privacyLevelSome = value;
-                    if (value.HasValue && ServiceConfiguration != default)
-                    {
-                        ServiceConfiguration.PrivacyLevelSome = value.Value;
-                    }
-                }
-            }
-        }
-
-        [JsonProperty(PropertyName = "PrivacyLevelFine")]
-        public int? PrivacyLevelFine
-        {
-            get => _privacyLevelFine;
-            internal set
-            {
-                if (_privacyLevelFine != value)
-                {
-                    _privacyLevelFine = value;
-                    if (value.HasValue && ServiceConfiguration != default)
-                    {
-                        ServiceConfiguration.PrivacyLevelFine = value.Value;
-                    }
-                }
-            }
-        }
-
-        [JsonProperty(PropertyName = "PrivacyLevelStrong")]
-        public int? PrivacyLevelStrong
-        {
-            get => _privacyLevelStrong;
-            internal set
-            {
-                if (_privacyLevelStrong != value)
-                {
-                    _privacyLevelStrong = value;
-                    if (value.HasValue && ServiceConfiguration != default)
-                    {
-                        ServiceConfiguration.PrivacyLevelStrong = value.Value;
-                    }
-                }
-            }
-        }
-
-        [JsonProperty(PropertyName = "DustThreshold")]
-        [JsonConverter(typeof(MoneyBtcJsonConverter))]
-        public Money DustThreshold { get; internal set; }
-
-        private Uri _backendUri;
-        private Uri _fallbackBackendUri;
-
-        public ServiceConfiguration ServiceConfiguration { get; private set; }
-
-        public Uri GetCurrentBackendUri()
-        {
-            if (TorProcessManager.RequestFallbackAddressUsage)
-            {
-                return GetFallbackBackendUri();
-            }
-
-            if (_backendUri != null)
-            {
-                return _backendUri;
-            }
-
-            if (Network == Network.Main)
-            {
-                _backendUri = new Uri(MainNetBackendUriV3);
-            }
-            else if (Network == Network.TestNet)
-            {
-                _backendUri = new Uri(TestNetBackendUriV3);
-            }
-            else // RegTest
-            {
-                _backendUri = new Uri(RegTestBackendUriV3);
-            }
-
-            return _backendUri;
-        }
-
-        public Uri GetFallbackBackendUri()
-        {
-            if (_fallbackBackendUri != null)
-            {
-                return _fallbackBackendUri;
-            }
-
-            if (Network == Network.Main)
-            {
-                _fallbackBackendUri = new Uri(MainNetFallbackBackendUri);
-            }
-            else if (Network == Network.TestNet)
-            {
-                _fallbackBackendUri = new Uri(TestNetFallbackBackendUri);
-            }
-            else // RegTest
-            {
-                _fallbackBackendUri = new Uri(RegTestBackendUriV3);
-            }
-
-            return _fallbackBackendUri;
-        }
-
-        private IPEndPoint _torSocks5EndPoint;
-        private int? _mixUntilAnonymitySet;
-        private int? _privacyLevelSome;
-        private int? _privacyLevelFine;
-        private int? _privacyLevelStrong;
-        private EndPoint _bitcoinCoreEndPoint;
-
-        public IPEndPoint GetTorSocks5EndPoint()
-        {
-            if (_torSocks5EndPoint is null)
-            {
-                var host = IPAddress.Parse(TorHost);
-                _torSocks5EndPoint = new IPEndPoint(host, (int)TorSocks5Port);
-            }
-
-            return _torSocks5EndPoint;
-        }
-
-        public EndPoint GetBitcoinCoreEndPoint()
-        {
-            if (_bitcoinCoreEndPoint is null)
-            {
-                IPAddress ipHost;
-                string dnsHost = null;
-                int? port = null;
-                try
-                {
-                    if (Network == Network.Main)
-                    {
-                        port = MainNetBitcoinCorePort;
-                        dnsHost = MainNetBitcoinCoreHost;
-                        ipHost = IPAddress.Parse(MainNetBitcoinCoreHost);
-                    }
-                    else if (Network == Network.TestNet)
-                    {
-                        port = TestNetBitcoinCorePort;
-                        dnsHost = TestNetBitcoinCoreHost;
-                        ipHost = IPAddress.Parse(TestNetBitcoinCoreHost);
-                    }
-                    else // if (Network == Network.RegTest)
-                    {
-                        port = RegTestBitcoinCorePort;
-                        dnsHost = RegTestBitcoinCoreHost;
-                        ipHost = IPAddress.Parse(RegTestBitcoinCoreHost);
-                    }
-
-                    _bitcoinCoreEndPoint = new IPEndPoint(ipHost, port ?? Network.DefaultPort);
-                }
-                catch
-                {
-                    _bitcoinCoreEndPoint = new DnsEndPoint(dnsHost, port ?? Network.DefaultPort);
-                }
-            }
-
-            return _bitcoinCoreEndPoint;
-        }
-
-        public Config()
-        {
-            _backendUri = null;
-        }
-
-        public Config(string filePath)
-        {
-            _backendUri = null;
-            SetFilePath(filePath);
-        }
-
-        /// <inheritdoc />
-        public async Task ToFileAsync()
-        {
-            AssertFilePathSet();
-
-            string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
-            await File.WriteAllTextAsync(FilePath,
-            jsonString,
-            Encoding.UTF8);
-        }
-
-        /// <inheritdoc />
-        public async Task LoadOrCreateDefaultFileAsync()
-        {
-            AssertFilePathSet();
-
-            Network = Network.Main;
-
-            MainNetBackendUriV3 = "http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/";
-            TestNetBackendUriV3 = "http://testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion/";
-            MainNetFallbackBackendUri = "https://wasabiwallet.io/";
-            TestNetFallbackBackendUri = "https://wasabiwallet.co/";
-            RegTestBackendUriV3 = "http://localhost:37127/";
-
-            UseTor = true;
-            TorHost = IPAddress.Loopback.ToString();
-            TorSocks5Port = 9050;
-
-            MainNetBitcoinCoreHost = IPAddress.Loopback.ToString();
-            TestNetBitcoinCoreHost = IPAddress.Loopback.ToString();
-            RegTestBitcoinCoreHost = IPAddress.Loopback.ToString();
-            MainNetBitcoinCorePort = Network.Main.DefaultPort;
-            TestNetBitcoinCorePort = Network.TestNet.DefaultPort;
-            RegTestBitcoinCorePort = Network.RegTest.DefaultPort;
-
-            MixUntilAnonymitySet = 50;
-            PrivacyLevelSome = 2;
-            PrivacyLevelFine = 21;
-            PrivacyLevelStrong = 50;
-            DustThreshold = Money.Coins(0.0001m);
-
-            if (!File.Exists(FilePath))
-            {
-                Logger.LogInfo<Config>($"{nameof(Config)} file did not exist. Created at path: `{FilePath}`.");
-            }
-            else
-            {
-                await LoadFileAsync();
-            }
-
-            ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, GetBitcoinCoreEndPoint(), DustThreshold);
-
-            // Just debug convenience.
-            _backendUri = GetCurrentBackendUri();
-
-            await ToFileAsync();
-        }
-
-        public async Task LoadFileAsync()
-        {
-            string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
-
-            var config = JsonConvert.DeserializeObject<Config>(jsonString);
-
-            Network = config.Network ?? Network;
-
-            MainNetBackendUriV3 = config.MainNetBackendUriV3 ?? MainNetBackendUriV3;
-            TestNetBackendUriV3 = config.TestNetBackendUriV3 ?? TestNetBackendUriV3;
-            MainNetFallbackBackendUri = config.MainNetFallbackBackendUri ?? MainNetFallbackBackendUri;
-            TestNetFallbackBackendUri = config.TestNetFallbackBackendUri ?? TestNetFallbackBackendUri;
-            RegTestBackendUriV3 = config.RegTestBackendUriV3 ?? RegTestBackendUriV3;
-
-            UseTor = config.UseTor ?? UseTor;
-            TorHost = config.TorHost ?? TorHost;
-            TorSocks5Port = config.TorSocks5Port ?? TorSocks5Port;
-
-            MainNetBitcoinCoreHost = config.MainNetBitcoinCoreHost ?? MainNetBitcoinCoreHost;
-            TestNetBitcoinCoreHost = config.TestNetBitcoinCoreHost ?? TestNetBitcoinCoreHost;
-            RegTestBitcoinCoreHost = config.RegTestBitcoinCoreHost ?? RegTestBitcoinCoreHost;
-            MainNetBitcoinCorePort = config.MainNetBitcoinCorePort ?? MainNetBitcoinCorePort;
-            TestNetBitcoinCorePort = config.TestNetBitcoinCorePort ?? TestNetBitcoinCorePort;
-            RegTestBitcoinCorePort = config.RegTestBitcoinCorePort ?? RegTestBitcoinCorePort;
-
-            MixUntilAnonymitySet = config.MixUntilAnonymitySet ?? MixUntilAnonymitySet;
-            PrivacyLevelSome = config.PrivacyLevelSome ?? PrivacyLevelSome;
-            PrivacyLevelFine = config.PrivacyLevelFine ?? PrivacyLevelFine;
-            PrivacyLevelStrong = config.PrivacyLevelStrong ?? PrivacyLevelStrong;
-
-            DustThreshold = config.DustThreshold ?? DustThreshold;
-
-            ServiceConfiguration = config.ServiceConfiguration ?? ServiceConfiguration;
-
-            // Just debug convenience.
-            _backendUri = GetCurrentBackendUri();
-        }
-
-        /// <inheritdoc />
-        public async Task<bool> CheckFileChangeAsync()
-        {
-            AssertFilePathSet();
-
-            if (!File.Exists(FilePath))
-            {
-                throw new FileNotFoundException($"{nameof(Config)} file did not exist at path: `{FilePath}`.");
-            }
-
-            string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
-            var newConfig = JsonConvert.DeserializeObject<JObject>(jsonString);
-            var currentConfig = JObject.FromObject(this);
-
-            return !JToken.DeepEquals(newConfig, currentConfig);
-        }
-
-        /// <inheritdoc />
-        public void SetFilePath(string path)
-        {
-            FilePath = Guard.NotNullOrEmptyOrWhitespace(nameof(path), path, trim: true);
-        }
-
-        /// <inheritdoc />
-        public void AssertFilePathSet()
-        {
-            if (FilePath is null)
-            {
-                throw new NotSupportedException($"{nameof(FilePath)} is not set. Use {nameof(SetFilePath)} to set it.");
-            }
-        }
-
-        public TargetPrivacy GetTargetPrivacy()
-        {
-            if (MixUntilAnonymitySet == PrivacyLevelSome)
-            {
-                return TargetPrivacy.Some;
-            }
-
-            if (MixUntilAnonymitySet == PrivacyLevelFine)
-            {
-                return TargetPrivacy.Fine;
-            }
-
-            if (MixUntilAnonymitySet == PrivacyLevelStrong)
-            {
-                return TargetPrivacy.Strong;
-            }
-            //the levels changed in the config file, adjust
-            if (MixUntilAnonymitySet < PrivacyLevelSome)
-            {
-                return TargetPrivacy.None; //choose the lower
-            }
-
-            if (MixUntilAnonymitySet < PrivacyLevelFine)
-            {
-                return TargetPrivacy.Some;
-            }
-
-            if (MixUntilAnonymitySet < PrivacyLevelStrong)
-            {
-                return TargetPrivacy.Fine;
-            }
-
-            if (MixUntilAnonymitySet > PrivacyLevelFine)
-            {
-                return TargetPrivacy.Strong;
-            }
-
-            return TargetPrivacy.None;
-        }
-
-        public int GetTargetLevel(TargetPrivacy target)
-        {
-            switch (target)
-            {
-                case TargetPrivacy.None:
-                    return 0;
-
-                case TargetPrivacy.Some:
-                    return PrivacyLevelSome.Value;
-
-                case TargetPrivacy.Fine:
-                    return PrivacyLevelFine.Value;
-
-                case TargetPrivacy.Strong:
-                    return PrivacyLevelStrong.Value;
-            }
-            return 0;
-        }
-    }
+	[JsonObject(MemberSerialization.OptIn)]
+	public class Config : IConfig
+	{
+		/// <inheritdoc />
+		public string FilePath { get; private set; }
+
+		[JsonProperty(PropertyName = "Network")]
+		[JsonConverter(typeof(NetworkJsonConverter))]
+		public Network Network { get; internal set; }
+
+		[JsonProperty(PropertyName = "MainNetBackendUriV3")]
+		public string MainNetBackendUriV3 { get; private set; }
+
+		[JsonProperty(PropertyName = "TestNetBackendUriV3")]
+		public string TestNetBackendUriV3 { get; private set; }
+
+		[JsonProperty(PropertyName = "MainNetFallbackBackendUri")]
+		public string MainNetFallbackBackendUri { get; private set; }
+
+		[JsonProperty(PropertyName = "TestNetFallbackBackendUri")]
+		public string TestNetFallbackBackendUri { get; private set; }
+
+		[JsonProperty(PropertyName = "RegTestBackendUriV3")]
+		public string RegTestBackendUriV3 { get; private set; }
+
+		[JsonProperty(PropertyName = "UseTor")]
+		public bool? UseTor { get; internal set; }
+
+		[JsonProperty(PropertyName = "TorSocks5EndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTorSocksPort)]
+		public EndPoint TorSocks5EndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBintcoinP2pPort)]
+		public EndPoint MainNetBitcoinP2pEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBintcoinP2pPort)]
+		public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
+		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBintcoinP2pPort)]
+		public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; }
+
+		[JsonProperty(PropertyName = "MixUntilAnonymitySet")]
+		public int? MixUntilAnonymitySet
+		{
+			get => _mixUntilAnonymitySet;
+			internal set
+			{
+				if (_mixUntilAnonymitySet != value)
+				{
+					_mixUntilAnonymitySet = value;
+					if (value.HasValue && ServiceConfiguration != default)
+					{
+						ServiceConfiguration.MixUntilAnonymitySet = value.Value;
+					}
+				}
+			}
+		}
+
+		[JsonProperty(PropertyName = "PrivacyLevelSome")]
+		public int? PrivacyLevelSome
+		{
+			get => _privacyLevelSome;
+			internal set
+			{
+				if (_privacyLevelSome != value)
+				{
+					_privacyLevelSome = value;
+					if (value.HasValue && ServiceConfiguration != default)
+					{
+						ServiceConfiguration.PrivacyLevelSome = value.Value;
+					}
+				}
+			}
+		}
+
+		[JsonProperty(PropertyName = "PrivacyLevelFine")]
+		public int? PrivacyLevelFine
+		{
+			get => _privacyLevelFine;
+			internal set
+			{
+				if (_privacyLevelFine != value)
+				{
+					_privacyLevelFine = value;
+					if (value.HasValue && ServiceConfiguration != default)
+					{
+						ServiceConfiguration.PrivacyLevelFine = value.Value;
+					}
+				}
+			}
+		}
+
+		[JsonProperty(PropertyName = "PrivacyLevelStrong")]
+		public int? PrivacyLevelStrong
+		{
+			get => _privacyLevelStrong;
+			internal set
+			{
+				if (_privacyLevelStrong != value)
+				{
+					_privacyLevelStrong = value;
+					if (value.HasValue && ServiceConfiguration != default)
+					{
+						ServiceConfiguration.PrivacyLevelStrong = value.Value;
+					}
+				}
+			}
+		}
+
+		[JsonProperty(PropertyName = "DustThreshold")]
+		[JsonConverter(typeof(MoneyBtcJsonConverter))]
+		public Money DustThreshold { get; internal set; }
+
+		private Uri _backendUri;
+		private Uri _fallbackBackendUri;
+
+		public ServiceConfiguration ServiceConfiguration { get; private set; }
+
+		public Uri GetCurrentBackendUri()
+		{
+			if (TorProcessManager.RequestFallbackAddressUsage)
+			{
+				return GetFallbackBackendUri();
+			}
+
+			if (_backendUri != null)
+			{
+				return _backendUri;
+			}
+
+			if (Network == Network.Main)
+			{
+				_backendUri = new Uri(MainNetBackendUriV3);
+			}
+			else if (Network == Network.TestNet)
+			{
+				_backendUri = new Uri(TestNetBackendUriV3);
+			}
+			else // RegTest
+			{
+				_backendUri = new Uri(RegTestBackendUriV3);
+			}
+
+			return _backendUri;
+		}
+
+		public Uri GetFallbackBackendUri()
+		{
+			if (_fallbackBackendUri != null)
+			{
+				return _fallbackBackendUri;
+			}
+
+			if (Network == Network.Main)
+			{
+				_fallbackBackendUri = new Uri(MainNetFallbackBackendUri);
+			}
+			else if (Network == Network.TestNet)
+			{
+				_fallbackBackendUri = new Uri(TestNetFallbackBackendUri);
+			}
+			else // RegTest
+			{
+				_fallbackBackendUri = new Uri(RegTestBackendUriV3);
+			}
+
+			return _fallbackBackendUri;
+		}
+
+		private IPEndPoint _torSocks5EndPoint;
+		private int? _mixUntilAnonymitySet;
+		private int? _privacyLevelSome;
+		private int? _privacyLevelFine;
+		private int? _privacyLevelStrong;
+		private EndPoint _bitcoinCoreEndPoint;
+
+		public IPEndPoint GetTorSocks5EndPoint()
+		{
+			if (_torSocks5EndPoint is null)
+			{
+				_torSocks5EndPoint = TorSocks5EndPoint as IPEndPoint;
+			}
+
+			return _torSocks5EndPoint;
+		}
+
+		public EndPoint GetBitcoinP2pEndPoint()
+		{
+			if (_bitcoinCoreEndPoint is null)
+			{
+				if (Network == Network.Main)
+				{
+					_bitcoinCoreEndPoint = MainNetBitcoinP2pEndPoint;
+				}
+				else if (Network == Network.TestNet)
+				{
+					_bitcoinCoreEndPoint = TestNetBitcoinP2pEndPoint;
+				}
+				else if (Network == Network.RegTest)
+				{
+					_bitcoinCoreEndPoint = RegTestBitcoinP2pEndPoint;
+				}
+				else
+				{
+					throw new NotSupportedException("Network not supported.");
+				}
+			}
+
+			return _bitcoinCoreEndPoint;
+		}
+
+		public Config()
+		{
+			_backendUri = null;
+		}
+
+		public Config(string filePath)
+		{
+			_backendUri = null;
+			SetFilePath(filePath);
+		}
+
+		/// <inheritdoc />
+		public async Task ToFileAsync()
+		{
+			AssertFilePathSet();
+
+			string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
+			await File.WriteAllTextAsync(FilePath,
+			jsonString,
+			Encoding.UTF8);
+		}
+
+		/// <inheritdoc />
+		public async Task LoadOrCreateDefaultFileAsync()
+		{
+			AssertFilePathSet();
+
+			Network = Network.Main;
+
+			MainNetBackendUriV3 = "http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/";
+			TestNetBackendUriV3 = "http://testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion/";
+			MainNetFallbackBackendUri = "https://wasabiwallet.io/";
+			TestNetFallbackBackendUri = "https://wasabiwallet.co/";
+			RegTestBackendUriV3 = "http://localhost:37127/";
+
+			UseTor = true;
+			TorSocks5EndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTorSocksPort);
+
+			MainNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBintcoinP2pPort);
+			TestNetBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBintcoinP2pPort);
+			RegTestBitcoinP2pEndPoint = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBintcoinP2pPort);
+
+			MixUntilAnonymitySet = 50;
+			PrivacyLevelSome = 2;
+			PrivacyLevelFine = 21;
+			PrivacyLevelStrong = 50;
+			DustThreshold = Money.Coins(0.0001m);
+
+			if (!File.Exists(FilePath))
+			{
+				Logger.LogInfo<Config>($"{nameof(Config)} file did not exist. Created at path: `{FilePath}`.");
+			}
+			else
+			{
+				await LoadFileAsync();
+			}
+
+			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.Value, PrivacyLevelSome.Value, PrivacyLevelFine.Value, PrivacyLevelStrong.Value, GetBitcoinP2pEndPoint(), DustThreshold);
+
+			// Just debug convenience.
+			_backendUri = GetCurrentBackendUri();
+
+			await ToFileAsync();
+		}
+
+		public async Task LoadFileAsync()
+		{
+			string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+
+			var config = JsonConvert.DeserializeObject<Config>(jsonString);
+
+			Network = config.Network ?? Network;
+
+			MainNetBackendUriV3 = config.MainNetBackendUriV3 ?? MainNetBackendUriV3;
+			TestNetBackendUriV3 = config.TestNetBackendUriV3 ?? TestNetBackendUriV3;
+			MainNetFallbackBackendUri = config.MainNetFallbackBackendUri ?? MainNetFallbackBackendUri;
+			TestNetFallbackBackendUri = config.TestNetFallbackBackendUri ?? TestNetFallbackBackendUri;
+			RegTestBackendUriV3 = config.RegTestBackendUriV3 ?? RegTestBackendUriV3;
+
+			UseTor = config.UseTor ?? UseTor;
+			TorSocks5EndPoint = config.TorSocks5EndPoint ?? TorSocks5EndPoint;
+
+			MainNetBitcoinP2pEndPoint = config.MainNetBitcoinP2pEndPoint ?? MainNetBitcoinP2pEndPoint;
+			TestNetBitcoinP2pEndPoint = config.TestNetBitcoinP2pEndPoint ?? TestNetBitcoinP2pEndPoint;
+			RegTestBitcoinP2pEndPoint = config.RegTestBitcoinP2pEndPoint ?? RegTestBitcoinP2pEndPoint;
+
+			MixUntilAnonymitySet = config.MixUntilAnonymitySet ?? MixUntilAnonymitySet;
+			PrivacyLevelSome = config.PrivacyLevelSome ?? PrivacyLevelSome;
+			PrivacyLevelFine = config.PrivacyLevelFine ?? PrivacyLevelFine;
+			PrivacyLevelStrong = config.PrivacyLevelStrong ?? PrivacyLevelStrong;
+
+			DustThreshold = config.DustThreshold ?? DustThreshold;
+
+			ServiceConfiguration = config.ServiceConfiguration ?? ServiceConfiguration;
+
+			// Just debug convenience.
+			_backendUri = GetCurrentBackendUri();
+
+			if (TryEnsureBackwardsCompatibility(jsonString))
+			{
+				await ToFileAsync();
+			}
+		}
+
+		/// <inheritdoc />
+		public async Task<bool> CheckFileChangeAsync()
+		{
+			AssertFilePathSet();
+
+			if (!File.Exists(FilePath))
+			{
+				throw new FileNotFoundException($"{nameof(Config)} file did not exist at path: `{FilePath}`.");
+			}
+
+			string jsonString = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
+			var newConfig = JsonConvert.DeserializeObject<JObject>(jsonString);
+			var currentConfig = JObject.FromObject(this);
+
+			return !JToken.DeepEquals(newConfig, currentConfig);
+		}
+
+		/// <inheritdoc />
+		public void SetFilePath(string path)
+		{
+			FilePath = Guard.NotNullOrEmptyOrWhitespace(nameof(path), path, trim: true);
+		}
+
+		/// <inheritdoc />
+		public void AssertFilePathSet()
+		{
+			if (FilePath is null)
+			{
+				throw new NotSupportedException($"{nameof(FilePath)} is not set. Use {nameof(SetFilePath)} to set it.");
+			}
+		}
+
+		public TargetPrivacy GetTargetPrivacy()
+		{
+			if (MixUntilAnonymitySet == PrivacyLevelSome)
+			{
+				return TargetPrivacy.Some;
+			}
+
+			if (MixUntilAnonymitySet == PrivacyLevelFine)
+			{
+				return TargetPrivacy.Fine;
+			}
+
+			if (MixUntilAnonymitySet == PrivacyLevelStrong)
+			{
+				return TargetPrivacy.Strong;
+			}
+			//the levels changed in the config file, adjust
+			if (MixUntilAnonymitySet < PrivacyLevelSome)
+			{
+				return TargetPrivacy.None; //choose the lower
+			}
+
+			if (MixUntilAnonymitySet < PrivacyLevelFine)
+			{
+				return TargetPrivacy.Some;
+			}
+
+			if (MixUntilAnonymitySet < PrivacyLevelStrong)
+			{
+				return TargetPrivacy.Fine;
+			}
+
+			if (MixUntilAnonymitySet > PrivacyLevelFine)
+			{
+				return TargetPrivacy.Strong;
+			}
+
+			return TargetPrivacy.None;
+		}
+
+		public int GetTargetLevel(TargetPrivacy target)
+		{
+			switch (target)
+			{
+				case TargetPrivacy.None:
+					return 0;
+
+				case TargetPrivacy.Some:
+					return PrivacyLevelSome.Value;
+
+				case TargetPrivacy.Fine:
+					return PrivacyLevelFine.Value;
+
+				case TargetPrivacy.Strong:
+					return PrivacyLevelStrong.Value;
+			}
+			return 0;
+		}
+
+		private bool TryEnsureBackwardsCompatibility(string jsonString)
+		{
+			// Before Wasabi 1.1.7
+			EndPoint obsoleteStringToEndPoint(string endPointString, int port = 0)
+			{
+				if (IPAddress.TryParse(endPointString, out IPAddress ipAddress))
+				{
+					return new IPEndPoint(ipAddress, port);
+				}
+
+				return new DnsEndPoint(endPointString, port);
+			};
+
+			var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
+			bool saveIt = false;
+			if (jsObject.TryGetValue("TorHost", out JToken jTorHost))
+			{
+				int port = Constants.DefaultTorSocksPort;
+				if (jsObject.TryGetValue("TorSocks5Port", out JToken jTorSocks5Port))
+				{
+					port = int.Parse(jTorSocks5Port.ToString());
+				}
+				TorSocks5EndPoint = obsoleteStringToEndPoint(jTorHost.ToString(), port);
+				saveIt = true;
+			}
+
+			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
+			{
+				int port = Constants.DefaultMainNetBintcoinP2pPort;
+				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort))
+				{
+					port = int.Parse(jMainNetBitcoinCorePort.ToString());
+				}
+				MainNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jMainNetBitcoinCoreHost.ToString(), port);
+				saveIt = true;
+			}
+
+			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
+			{
+				int port = Constants.DefaultTestNetBintcoinP2pPort;
+				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort))
+				{
+					port = int.Parse(jTestNetBitcoinCorePort.ToString());
+				}
+				TestNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jTestNetBitcoinCoreHost.ToString(), port);
+				saveIt = true;
+			}
+
+			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
+			{
+				int port = Constants.DefaultRegTestBintcoinP2pPort;
+				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort))
+				{
+					port = int.Parse(jRegTestBitcoinCorePort.ToString());
+				}
+				RegTestBitcoinP2pEndPoint = obsoleteStringToEndPoint(jRegTestBitcoinCoreHost.ToString(), port);
+				saveIt = true;
+			}
+
+			return saveIt;
+		}
+	}
 }

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -427,61 +427,67 @@ namespace WalletWasabi.Gui
 
 		private bool TryEnsureBackwardsCompatibility(string jsonString)
 		{
-			// Before Wasabi 1.1.7
-			EndPoint obsoleteStringToEndPoint(string endPointString, int port = 0)
-			{
-				if (IPAddress.TryParse(endPointString, out IPAddress ipAddress))
-				{
-					return new IPEndPoint(ipAddress, port);
-				}
-
-				return new DnsEndPoint(endPointString, port);
-			};
-
 			var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
 			bool saveIt = false;
+
 			if (jsObject.TryGetValue("TorHost", out JToken jTorHost))
 			{
 				int port = Constants.DefaultTorSocksPort;
-				if (jsObject.TryGetValue("TorSocks5Port", out JToken jTorSocks5Port))
+				if (jsObject.TryGetValue("TorSocks5Port", out JToken jTorSocks5Port) && int.TryParse(jTorSocks5Port.ToString(), out int p))
 				{
-					port = int.Parse(jTorSocks5Port.ToString());
+					port = p;
 				}
-				TorSocks5EndPoint = obsoleteStringToEndPoint(jTorHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jTorHost.ToString(), port, out EndPoint ep))
+				{
+					TorSocks5EndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
 			{
 				int port = Constants.DefaultMainNetBintcoinP2pPort;
-				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort))
+				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort) && int.TryParse(jMainNetBitcoinCorePort.ToString(), out int p))
 				{
-					port = int.Parse(jMainNetBitcoinCorePort.ToString());
+					port = p;
 				}
-				MainNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jMainNetBitcoinCoreHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jMainNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				{
+					MainNetBitcoinP2pEndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
 			{
 				int port = Constants.DefaultTestNetBintcoinP2pPort;
-				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort))
+				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort) && int.TryParse(jTestNetBitcoinCorePort.ToString(), out int p))
 				{
-					port = int.Parse(jTestNetBitcoinCorePort.ToString());
+					port = p;
 				}
-				TestNetBitcoinP2pEndPoint = obsoleteStringToEndPoint(jTestNetBitcoinCoreHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jTestNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				{
+					TestNetBitcoinP2pEndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
 			{
 				int port = Constants.DefaultRegTestBintcoinP2pPort;
-				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort))
+				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort) && int.TryParse(jRegTestBitcoinCorePort.ToString(), out int p))
 				{
-					port = int.Parse(jRegTestBitcoinCorePort.ToString());
+					port = p;
 				}
-				RegTestBitcoinP2pEndPoint = obsoleteStringToEndPoint(jRegTestBitcoinCoreHost.ToString(), port);
-				saveIt = true;
+
+				if (EndPointParser.TryParse(jRegTestBitcoinCoreHost.ToString(), port, out EndPoint ep))
+				{
+					RegTestBitcoinP2pEndPoint = ep;
+					saveIt = true;
+				}
 			}
 
 			return saveIt;

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -421,70 +421,72 @@ namespace WalletWasabi.Gui
 
 		private bool TryEnsureBackwardsCompatibility(string jsonString)
 		{
-			var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
-			bool saveIt = false;
-
-			if (jsObject.TryGetValue("TorHost", out JToken jTorHost))
+			try
 			{
-				int port = Constants.DefaultTorSocksPort;
-				if (jsObject.TryGetValue("TorSocks5Port", out JToken jTorSocks5Port) && int.TryParse(jTorSocks5Port.ToString(), out int p))
+				var jsObject = JsonConvert.DeserializeObject<JObject>(jsonString);
+				bool saveIt = false;
+
+				var torHost = jsObject.Value<string>("TorHost");
+				var torSocks5Port = jsObject.Value<int?>("TorSocks5Port");
+				var mainNetBitcoinCoreHost = jsObject.Value<string>("MainNetBitcoinCoreHost");
+				var mainNetBitcoinCorePort = jsObject.Value<int?>("MainNetBitcoinCorePort");
+				var testNetBitcoinCoreHost = jsObject.Value<string>("TestNetBitcoinCoreHost");
+				var testNetBitcoinCorePort = jsObject.Value<int?>("TestNetBitcoinCorePort");
+				var regTestBitcoinCoreHost = jsObject.Value<string>("RegTestBitcoinCoreHost");
+				var regTestBitcoinCorePort = jsObject.Value<int?>("RegTestBitcoinCorePort");
+
+				if (torHost != null)
 				{
-					port = p;
+					int port = torSocks5Port ?? Constants.DefaultTorSocksPort;
+
+					if (EndPointParser.TryParse(torHost, port, out EndPoint ep))
+					{
+						TorSocks5EndPoint = ep;
+						saveIt = true;
+					}
 				}
 
-				if (EndPointParser.TryParse(jTorHost.ToString(), port, out EndPoint ep))
+				if (mainNetBitcoinCoreHost != null)
 				{
-					TorSocks5EndPoint = ep;
-					saveIt = true;
+					int port = mainNetBitcoinCorePort ?? Constants.DefaultMainNetBitcoinP2pPort;
+
+					if (EndPointParser.TryParse(mainNetBitcoinCoreHost, port, out EndPoint ep))
+					{
+						MainNetBitcoinP2pEndPoint = ep;
+						saveIt = true;
+					}
 				}
+
+				if (testNetBitcoinCoreHost != null)
+				{
+					int port = testNetBitcoinCorePort ?? Constants.DefaultTestNetBitcoinP2pPort;
+
+					if (EndPointParser.TryParse(testNetBitcoinCoreHost, port, out EndPoint ep))
+					{
+						TestNetBitcoinP2pEndPoint = ep;
+						saveIt = true;
+					}
+				}
+
+				if (regTestBitcoinCoreHost != null)
+				{
+					int port = regTestBitcoinCorePort ?? Constants.DefaultRegTestBitcoinP2pPort;
+
+					if (EndPointParser.TryParse(regTestBitcoinCoreHost, port, out EndPoint ep))
+					{
+						RegTestBitcoinP2pEndPoint = ep;
+						saveIt = true;
+					}
+				}
+
+				return saveIt;
 			}
-
-			if (jsObject.TryGetValue("MainNetBitcoinCoreHost", out JToken jMainNetBitcoinCoreHost))
+			catch (Exception ex)
 			{
-				int port = Constants.DefaultMainNetBitcoinP2pPort;
-				if (jsObject.TryGetValue("MainNetBitcoinCorePort", out JToken jMainNetBitcoinCorePort) && int.TryParse(jMainNetBitcoinCorePort.ToString(), out int p))
-				{
-					port = p;
-				}
-
-				if (EndPointParser.TryParse(jMainNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
-				{
-					MainNetBitcoinP2pEndPoint = ep;
-					saveIt = true;
-				}
+				Logger.LogWarning<Config>("Backwards compatibility couldn't be ensured.");
+				Logger.LogInfo<Config>(ex);
+				return false;
 			}
-
-			if (jsObject.TryGetValue("TestNetBitcoinCoreHost", out JToken jTestNetBitcoinCoreHost))
-			{
-				int port = Constants.DefaultTestNetBitcoinP2pPort;
-				if (jsObject.TryGetValue("TestNetBitcoinCorePort", out JToken jTestNetBitcoinCorePort) && int.TryParse(jTestNetBitcoinCorePort.ToString(), out int p))
-				{
-					port = p;
-				}
-
-				if (EndPointParser.TryParse(jTestNetBitcoinCoreHost.ToString(), port, out EndPoint ep))
-				{
-					TestNetBitcoinP2pEndPoint = ep;
-					saveIt = true;
-				}
-			}
-
-			if (jsObject.TryGetValue("RegTestBitcoinCoreHost", out JToken jRegTestBitcoinCoreHost))
-			{
-				int port = Constants.DefaultRegTestBitcoinP2pPort;
-				if (jsObject.TryGetValue("RegTestBitcoinCorePort", out JToken jRegTestBitcoinCorePort) && int.TryParse(jRegTestBitcoinCorePort.ToString(), out int p))
-				{
-					port = p;
-				}
-
-				if (EndPointParser.TryParse(jRegTestBitcoinCoreHost.ToString(), port, out EndPoint ep))
-				{
-					RegTestBitcoinP2pEndPoint = ep;
-					saveIt = true;
-				}
-			}
-
-			return saveIt;
 		}
 	}
 }

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -193,7 +193,6 @@ namespace WalletWasabi.Gui
 		private int? _privacyLevelSome;
 		private int? _privacyLevelFine;
 		private int? _privacyLevelStrong;
-		private EndPoint _bitcoinP2pEndPoint;
 
 		public IPEndPoint GetTorSocks5EndPoint()
 		{
@@ -207,27 +206,22 @@ namespace WalletWasabi.Gui
 
 		public EndPoint GetBitcoinP2pEndPoint()
 		{
-			if (_bitcoinP2pEndPoint is null)
+			if (Network == Network.Main)
 			{
-				if (Network == Network.Main)
-				{
-					_bitcoinP2pEndPoint = MainNetBitcoinP2pEndPoint;
-				}
-				else if (Network == Network.TestNet)
-				{
-					_bitcoinP2pEndPoint = TestNetBitcoinP2pEndPoint;
-				}
-				else if (Network == Network.RegTest)
-				{
-					_bitcoinP2pEndPoint = RegTestBitcoinP2pEndPoint;
-				}
-				else
-				{
-					throw new NotSupportedException("Network not supported.");
-				}
+				return MainNetBitcoinP2pEndPoint;
 			}
-
-			return _bitcoinP2pEndPoint;
+			else if (Network == Network.TestNet)
+			{
+				return TestNetBitcoinP2pEndPoint;
+			}
+			else if (Network == Network.RegTest)
+			{
+				return RegTestBitcoinP2pEndPoint;
+			}
+			else
+			{
+				throw new NotSupportedException($"{nameof(Network)} not supported: {Network}.");
+			}
 		}
 
 		public Config()

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -188,21 +188,10 @@ namespace WalletWasabi.Gui
 			return _fallbackBackendUri;
 		}
 
-		private IPEndPoint _torSocks5EndPoint;
 		private int? _mixUntilAnonymitySet;
 		private int? _privacyLevelSome;
 		private int? _privacyLevelFine;
 		private int? _privacyLevelStrong;
-
-		public IPEndPoint GetTorSocks5EndPoint()
-		{
-			if (_torSocks5EndPoint is null)
-			{
-				_torSocks5EndPoint = TorSocks5EndPoint as IPEndPoint;
-			}
-
-			return _torSocks5EndPoint;
-		}
 
 		public EndPoint GetBitcoinP2pEndPoint()
 		{

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -193,7 +193,7 @@ namespace WalletWasabi.Gui
 		private int? _privacyLevelSome;
 		private int? _privacyLevelFine;
 		private int? _privacyLevelStrong;
-		private EndPoint _bitcoinCoreEndPoint;
+		private EndPoint _bitcoinP2pEndPoint;
 
 		public IPEndPoint GetTorSocks5EndPoint()
 		{
@@ -207,19 +207,19 @@ namespace WalletWasabi.Gui
 
 		public EndPoint GetBitcoinP2pEndPoint()
 		{
-			if (_bitcoinCoreEndPoint is null)
+			if (_bitcoinP2pEndPoint is null)
 			{
 				if (Network == Network.Main)
 				{
-					_bitcoinCoreEndPoint = MainNetBitcoinP2pEndPoint;
+					_bitcoinP2pEndPoint = MainNetBitcoinP2pEndPoint;
 				}
 				else if (Network == Network.TestNet)
 				{
-					_bitcoinCoreEndPoint = TestNetBitcoinP2pEndPoint;
+					_bitcoinP2pEndPoint = TestNetBitcoinP2pEndPoint;
 				}
 				else if (Network == Network.RegTest)
 				{
-					_bitcoinCoreEndPoint = RegTestBitcoinP2pEndPoint;
+					_bitcoinP2pEndPoint = RegTestBitcoinP2pEndPoint;
 				}
 				else
 				{
@@ -227,7 +227,7 @@ namespace WalletWasabi.Gui
 				}
 			}
 
-			return _bitcoinCoreEndPoint;
+			return _bitcoinP2pEndPoint;
 		}
 
 		public Config()

--- a/WalletWasabi.Gui/Converters/NetworkStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/NetworkStringConverter.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Data.Converters;
+using Avalonia.Data.Converters;
 using NBitcoin;
 using System;
 using System.Collections.Generic;

--- a/WalletWasabi.Gui/Converters/NetworkStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/NetworkStringConverter.cs
@@ -1,0 +1,31 @@
+﻿using Avalonia.Data.Converters;
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class NetworkStringConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is Network network)
+			{
+				return network.ToString();
+			}
+			else
+			{
+				throw new TypeArgumentException(value, typeof(Network), nameof(value));
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var networkString = value as string;
+
+			return Network.GetNetwork(networkString);
+		}
+	}
+}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -155,7 +155,7 @@ namespace WalletWasabi.Gui
 
 			if (Config.UseTor.Value)
 			{
-				Synchronizer = new WasabiSynchronizer(Network, BitcoinStore, () => Config.GetCurrentBackendUri(), Config.GetTorSocks5EndPoint());
+				Synchronizer = new WasabiSynchronizer(Network, BitcoinStore, () => Config.GetCurrentBackendUri(), Config.TorSocks5EndPoint);
 			}
 			else
 			{
@@ -189,7 +189,7 @@ namespace WalletWasabi.Gui
 
 			if (Config.UseTor.Value)
 			{
-				TorManager = new TorProcessManager(Config.GetTorSocks5EndPoint(), TorLogsFile);
+				TorManager = new TorProcessManager(Config.TorSocks5EndPoint, TorLogsFile);
 			}
 			else
 			{
@@ -261,7 +261,7 @@ namespace WalletWasabi.Gui
 				if (Config.UseTor is true)
 				{
 					// onlyForOnionHosts: false - Connect to clearnet IPs through Tor, too.
-					connectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Config.GetTorSocks5EndPoint(), onlyForOnionHosts: false, networkCredential: null, streamIsolation: true));
+					connectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Config.TorSocks5EndPoint, onlyForOnionHosts: false, networkCredential: null, streamIsolation: true));
 					// allowOnlyTorEndpoints: true - Connect only to onions and do not connect to clearnet IPs at all.
 					// This of course makes the first setting unnecessary, but it's better if that's around, in case someone wants to tinker here.
 					connectionParameters.EndpointConnector = new DefaultEndpointConnector(allowOnlyTorEndpoints: Network == Network.Main);
@@ -410,7 +410,7 @@ namespace WalletWasabi.Gui
 
 				if (Config.UseTor.Value)
 				{
-					ChaumianClient = new CcjClient(Synchronizer, Network, keyManager, () => Config.GetCurrentBackendUri(), Config.GetTorSocks5EndPoint());
+					ChaumianClient = new CcjClient(Synchronizer, Network, keyManager, () => Config.GetCurrentBackendUri(), Config.TorSocks5EndPoint);
 				}
 				else
 				{

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -20,7 +20,13 @@
             <StackPanel Orientation="Vertical" Spacing="5">
               <StackPanel Margin="0 10" Spacing="5">
                 <TextBlock>Network</TextBlock>
-                <DropDown Items="{Binding Networks}" SelectedItem="{Binding Network, Converter={StaticResource NetworkStringConverter}}" />
+                <DropDown Items="{Binding Networks}" SelectedItem="{Binding Network}">
+                  <DropDown.ItemTemplate>
+                    <DataTemplate>
+                      <TextBlock Text="{Binding Converter={StaticResource NetworkStringConverter}}" />
+                    </DataTemplate>
+                  </DropDown.ItemTemplate>
+                </DropDown>
               </StackPanel>
 
               <controls:GroupBox Title="{Binding Network, StringFormat=My Node for \{0\}, Converter={StaticResource NetworkStringConverter}}" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -4,6 +4,7 @@
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui">
   <UserControl.Resources>
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
+    <converters:NetworkStringConverter x:Key="NetworkStringConverter" />
   </UserControl.Resources>
 
   <ScrollViewer>
@@ -19,10 +20,10 @@
             <StackPanel Orientation="Vertical" Spacing="5">
               <StackPanel Margin="0 10" Spacing="5">
                 <TextBlock>Network</TextBlock>
-                <DropDown Items="{Binding Networks}" SelectedItem="{Binding Network}" />
+                <DropDown Items="{Binding Networks}" SelectedItem="{Binding Network, Converter={StaticResource NetworkStringConverter}}" />
               </StackPanel>
 
-              <controls:GroupBox Title="{Binding Network, StringFormat=My Node for \{0\} }" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
+              <controls:GroupBox Title="{Binding Network, StringFormat=My Node for \{0\}, Converter={StaticResource NetworkStringConverter}}" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
                 <StackPanel Orientation="Vertical" Spacing="5">
                   <StackPanel Margin="0 10" Spacing="5">
                     <TextBlock>Bitcoin P2P Endpoint</TextBlock>

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -25,13 +25,8 @@
               <controls:GroupBox Title="{Binding Network, StringFormat=My Node for \{0\} }" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
                 <StackPanel Orientation="Vertical" Spacing="5">
                   <StackPanel Margin="0 10" Spacing="5">
-                    <TextBlock>Host</TextBlock>
-                    <TextBox Text="{Binding LocalNodeHost}" />
-                  </StackPanel>
-                  <Separator />
-                  <StackPanel Spacing="5">
-                    <TextBlock>Port</TextBlock>
-                    <TextBox Text="{Binding LocalNodePort}" />
+                    <TextBlock>Bitcoin P2P Endpoint</TextBlock>
+                    <TextBox Text="{Binding BitcoinP2pEndPoint}" />
                   </StackPanel>
                 </StackPanel>
               </controls:GroupBox>
@@ -45,12 +40,8 @@
                 <TextBlock VerticalAlignment="Center">Tor can be turned off for debugging.</TextBlock>
               </StackPanel>
               <StackPanel Margin="0 10" Spacing="5">
-                <TextBlock>Host</TextBlock>
-                <TextBox Text="{Binding TorHost}" />
-              </StackPanel>
-              <StackPanel Spacing="5">
-                <TextBlock>Port</TextBlock>
-                <TextBox Text="{Binding TorPort}" />
+                <TextBlock>Tor SOCKS5 Endpoint</TextBlock>
+                <TextBox Text="{Binding TorSocks5EndPoint}" />
               </StackPanel>
             </StackPanel>
           </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -1,7 +1,9 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui">
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui">
   <UserControl.Resources>
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
     <converters:NetworkStringConverter x:Key="NetworkStringConverter" />
@@ -33,7 +35,11 @@
                 <StackPanel Orientation="Vertical" Spacing="5">
                   <StackPanel Margin="0 10" Spacing="5">
                     <TextBlock>Bitcoin P2P Endpoint</TextBlock>
-                    <TextBox Text="{Binding BitcoinP2pEndPoint}" />
+                    <TextBox Text="{Binding BitcoinP2pEndPoint}">
+                      <i:Interaction.Behaviors>
+                        <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />
+                      </i:Interaction.Behaviors>
+                    </TextBox>
                   </StackPanel>
                 </StackPanel>
               </controls:GroupBox>
@@ -48,7 +54,11 @@
               </StackPanel>
               <StackPanel Margin="0 10" Spacing="5">
                 <TextBlock>Tor SOCKS5 Endpoint</TextBlock>
-                <TextBox Text="{Binding TorSocks5EndPoint}" />
+                <TextBox Text="{Binding TorSocks5EndPoint}">
+                  <i:Interaction.Behaviors>
+                    <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />
+                  </i:Interaction.Behaviors>
+                </TextBox>
               </StackPanel>
             </StackPanel>
           </controls:GroupBox>
@@ -73,21 +83,33 @@
                     Margin="0 0 10 10"
                     VerticalAlignment="Center" HorizontalAlignment="Center"
                     Drawing="{DynamicResource PrivacySome}" />
-                <TextBox Text="{Binding SomePrivacyLevel}" Grid.Column="1" />
+                <TextBox Text="{Binding SomePrivacyLevel}" Grid.Column="1">
+                  <i:Interaction.Behaviors>
+                    <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />
+                  </i:Interaction.Behaviors>
+                </TextBox>
               </Grid>
               <Grid Margin="0 10" ColumnDefinitions="30, *">
                 <DrawingPresenter Height="24" Width="24" Grid.Column="0"
                     Margin="0 0 10 10"
                     VerticalAlignment="Center" HorizontalAlignment="Center"
                     Drawing="{DynamicResource PrivacyFine}" />
-                <TextBox Text="{Binding FinePrivacyLevel}" Grid.Column="1" />
+                <TextBox Text="{Binding FinePrivacyLevel}" Grid.Column="1">
+                  <i:Interaction.Behaviors>
+                    <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />
+                  </i:Interaction.Behaviors>
+                </TextBox>
               </Grid>
               <Grid Margin="0 10" ColumnDefinitions="30, *">
                 <DrawingPresenter Height="24" Width="24" Grid.Column="0"
                     Margin="0 0 10 10"
                     VerticalAlignment="Center" HorizontalAlignment="Center"
                     Drawing="{DynamicResource PrivacyStrong}" />
-                <TextBox Text="{Binding StrongPrivacyLevel}" Grid.Column="1" />
+                <TextBox Text="{Binding StrongPrivacyLevel}" Grid.Column="1">
+                  <i:Interaction.Behaviors>
+                    <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />
+                  </i:Interaction.Behaviors>
+                </TextBox>
               </Grid>
             </StackPanel>
           </controls:GroupBox>
@@ -96,7 +118,11 @@
             <StackPanel Orientation="Vertical" Spacing="5">
               <StackPanel Margin="0 10" Spacing="5">
                 <TextBlock ToolTip.Tip="Under the dust threshold coins are not appearing in the coin lists.">Dust Threshold (BTC)</TextBlock>
-                <TextBox Text="{Binding DustThreshold}" />
+                <TextBox Text="{Binding DustThreshold}">
+                  <i:Interaction.Behaviors>
+                    <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />
+                  </i:Interaction.Behaviors>
+                </TextBox>
               </StackPanel>
             </StackPanel>
           </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -12,6 +12,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Gui.ViewModels.Validation;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Gui.Tabs
 {
@@ -237,8 +238,8 @@ namespace WalletWasabi.Gui.Tabs
 					await config.LoadFileAsync();
 
 					var network = NBitcoin.Network.GetNetwork(Network);
-					var torSocks5EndPoint = EndPointParser.TryParse(TorSocks5EndPoint, -1, out EndPoint torEp) ? torEp : null;
-					var bitcoinP2pEndPoint = EndPointParser.TryParse(BitcoinP2pEndPoint, -1, out EndPoint p2pEp) ? p2pEp : null;
+					var torSocks5EndPoint = EndPointParser.TryParse(TorSocks5EndPoint, Constants.DefaultTorSocksPort, out EndPoint torEp) ? torEp : null;
+					var bitcoinP2pEndPoint = EndPointParser.TryParse(BitcoinP2pEndPoint, network.DefaultPort, out EndPoint p2pEp) ? p2pEp : null;
 					var useTor = UseTor;
 					var somePrivacyLevel = int.TryParse(SomePrivacyLevel, out int level) ? (int?)level : null;
 					var finePrivacyLevel = int.TryParse(FinePrivacyLevel, out level) ? (int?)level : null;
@@ -347,7 +348,7 @@ namespace WalletWasabi.Gui.Tabs
 				return string.Empty;
 			}
 
-			if (EndPointParser.TryParse(endPoint, -1, out _))
+			if (EndPointParser.TryParse(endPoint, 0, out _))
 			{
 				return string.Empty;
 			}

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -34,6 +34,7 @@ namespace WalletWasabi.Gui.Tabs
 
 		public ReactiveCommand<Unit, Unit> OpenConfigFileCommand { get; }
 		public ReactiveCommand<Unit, Unit> LurkingWifeModeCommand { get; }
+		public ReactiveCommand<Unit, Unit> TextBoxLostFocusCommand { get; }
 
 		public SettingsViewModel(Global global) : base(global, "Settings")
 		{
@@ -57,22 +58,7 @@ namespace WalletWasabi.Gui.Tabs
 
 			this.WhenAnyValue(
 				x => x.Network,
-				x => x.BitcoinP2pEndPoint,
-				x => x.DustThreshold)
-				.ObserveOn(RxApp.TaskpoolScheduler)
-				.Subscribe(x => Save());
-
-			this.WhenAnyValue(
-				x => x.UseTor,
-				x => x.TorSocks5EndPoint)
-				.ObserveOn(RxApp.TaskpoolScheduler)
-				.Subscribe(x => Save());
-
-			this.WhenAnyValue(
-				x => x.SomePrivacyLevel,
-				x => x.FinePrivacyLevel,
-				x => x.StrongPrivacyLevel,
-				x => x.DustThreshold)
+				x => x.UseTor)
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(x => Save());
 
@@ -107,6 +93,8 @@ namespace WalletWasabi.Gui.Tabs
 				Global.UiConfig.LurkingWifeMode = !LurkingWifeMode;
 				await Global.UiConfig.ToFileAsync();
 			});
+
+			TextBoxLostFocusCommand = ReactiveCommand.Create(Save);
 		}
 
 		public override void OnOpen()

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -211,7 +211,13 @@ namespace WalletWasabi.Gui.Tabs
 
 		private void Save()
 		{
+			if (string.IsNullOrWhiteSpace(Network))
+			{
+				return;
+			}
+
 			var network = NBitcoin.Network.GetNetwork(Network);
+
 			var isValid =
 				string.IsNullOrEmpty(ValidatePrivacyLevel(SomePrivacyLevel, whiteSpaceOk: false))
 				&& string.IsNullOrEmpty(ValidatePrivacyLevel(FinePrivacyLevel, whiteSpaceOk: false))
@@ -221,11 +227,6 @@ namespace WalletWasabi.Gui.Tabs
 				&& string.IsNullOrEmpty(ValidateEndPoint(BitcoinP2pEndPoint, network.DefaultPort, whiteSpaceOk: false));
 
 			if (!isValid)
-			{
-				return;
-			}
-
-			if (string.IsNullOrWhiteSpace(Network))
 			{
 				return;
 			}

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -21,9 +21,7 @@ namespace WalletWasabi.Gui.Tabs
 
 		private string _network;
 		private string _torHost;
-		private string _torPort;
 		private string _localNodeHost;
-		private string _localNodePort;
 		private bool _autocopy;
 		private bool _useTor;
 		private bool _isModified;
@@ -149,25 +147,11 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _torHost, value);
 		}
 
-		[ValidateMethod(nameof(ValidateTorPort))]
-		public string TorPort
-		{
-			get => _torPort;
-			set => this.RaiseAndSetIfChanged(ref _torPort, value);
-		}
-
 		[ValidateMethod(nameof(ValidateLocalNodeHost))]
 		public string LocalNodeHost
 		{
 			get => _localNodeHost;
 			set => this.RaiseAndSetIfChanged(ref _localNodeHost, value);
-		}
-
-		[ValidateMethod(nameof(ValidateLocalNodePort))]
-		public string LocalNodePort
-		{
-			get => _localNodePort;
-			set => this.RaiseAndSetIfChanged(ref _localNodePort, value);
 		}
 
 		public bool IsModified
@@ -316,12 +300,6 @@ namespace WalletWasabi.Gui.Tabs
 		public string ValidateLocalNodeHost()
 			=> ValidateHost(LocalNodeHost);
 
-		public string ValidateTorPort()
-			=> ValidatePort(TorPort);
-
-		public string ValidateLocalNodePort()
-			=> ValidatePort(LocalNodePort);
-
 		public string ValidateSomePrivacyLevel()
 			=> ValidatePrivacyLevel(SomePrivacyLevel);
 
@@ -383,22 +361,6 @@ namespace WalletWasabi.Gui.Tabs
 			}
 
 			return "Invalid host.";
-		}
-
-		public string ValidatePort(string port)
-		{
-			if (string.IsNullOrEmpty(port))
-			{
-				return string.Empty;
-			}
-
-			var thePort = port.Trim();
-			if (ushort.TryParse(thePort, out var p) && p > 1024)
-			{
-				return string.Empty;
-			}
-
-			return "Invalid port.";
 		}
 
 		private void OpenConfigFile()

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Gui.Tabs
 	{
 		private CompositeDisposable Disposables { get; set; }
 
-		private string _network;
+		private Network _network;
 		private string _torSocks5EndPoint;
 		private string _bitcoinP2pEndPoint;
 		private bool _autocopy;
@@ -46,9 +46,9 @@ namespace WalletWasabi.Gui.Tabs
 				{
 					await config.LoadFileAsync();
 
-					var configBitcoinP2pEndPoint = Network == NBitcoin.Network.Main.Name
+					var configBitcoinP2pEndPoint = Network == Network.Main
 						? config.MainNetBitcoinP2pEndPoint
-						: (Network == NBitcoin.Network.TestNet.Name
+						: (Network == Network.TestNet
 							? config.TestNetBitcoinP2pEndPoint
 							: config.RegTestBitcoinP2pEndPoint);
 
@@ -87,7 +87,7 @@ namespace WalletWasabi.Gui.Tabs
 			{
 				await config.LoadFileAsync();
 
-				Network = config.Network.ToString();
+				Network = config.Network;
 				TorSocks5EndPoint = config.TorSocks5EndPoint.ToString(-1);
 				UseTor = config.UseTor.Value;
 
@@ -141,7 +141,7 @@ namespace WalletWasabi.Gui.Tabs
 			"RegTest"
 		};
 
-		public string Network
+		public Network Network
 		{
 			get => _network;
 			set => this.RaiseAndSetIfChanged(ref _network, value);
@@ -211,12 +211,11 @@ namespace WalletWasabi.Gui.Tabs
 
 		private void Save()
 		{
-			if (string.IsNullOrWhiteSpace(Network))
+			var network = Network;
+			if (network is null)
 			{
 				return;
 			}
-
-			var network = NBitcoin.Network.GetNetwork(Network);
 
 			var isValid =
 				string.IsNullOrEmpty(ValidatePrivacyLevel(SomePrivacyLevel, whiteSpaceOk: false))
@@ -310,7 +309,7 @@ namespace WalletWasabi.Gui.Tabs
 			=> ValidateEndPoint(TorSocks5EndPoint, Constants.DefaultTorSocksPort, whiteSpaceOk: true);
 
 		public string ValidateBitcoinP2pEndPoint()
-			=> ValidateEndPoint(BitcoinP2pEndPoint, NBitcoin.Network.GetNetwork(Network).DefaultPort, whiteSpaceOk: true);
+			=> ValidateEndPoint(BitcoinP2pEndPoint, Network.DefaultPort, whiteSpaceOk: true);
 
 		public string ValidatePrivacyLevel(string value, bool whiteSpaceOk)
 		{

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -211,13 +211,14 @@ namespace WalletWasabi.Gui.Tabs
 
 		private void Save()
 		{
+			var network = NBitcoin.Network.GetNetwork(Network);
 			var isValid =
 				string.IsNullOrEmpty(ValidatePrivacyLevel(SomePrivacyLevel, whiteSpaceOk: false))
 				&& string.IsNullOrEmpty(ValidatePrivacyLevel(FinePrivacyLevel, whiteSpaceOk: false))
 				&& string.IsNullOrEmpty(ValidatePrivacyLevel(StrongPrivacyLevel, whiteSpaceOk: false))
 				&& string.IsNullOrEmpty(ValidateDustThreshold(DustThreshold, whiteSpaceOk: false))
-				&& string.IsNullOrEmpty(ValidateEndPoint(TorSocks5EndPoint, whiteSpaceOk: false))
-				&& string.IsNullOrEmpty(ValidateEndPoint(BitcoinP2pEndPoint, whiteSpaceOk: false));
+				&& string.IsNullOrEmpty(ValidateEndPoint(TorSocks5EndPoint, Constants.DefaultTorSocksPort, whiteSpaceOk: false))
+				&& string.IsNullOrEmpty(ValidateEndPoint(BitcoinP2pEndPoint, network.DefaultPort, whiteSpaceOk: false));
 
 			if (!isValid)
 			{
@@ -237,7 +238,6 @@ namespace WalletWasabi.Gui.Tabs
 				{
 					await config.LoadFileAsync();
 
-					var network = NBitcoin.Network.GetNetwork(Network);
 					var torSocks5EndPoint = EndPointParser.TryParse(TorSocks5EndPoint, Constants.DefaultTorSocksPort, out EndPoint torEp) ? torEp : null;
 					var bitcoinP2pEndPoint = EndPointParser.TryParse(BitcoinP2pEndPoint, network.DefaultPort, out EndPoint p2pEp) ? p2pEp : null;
 					var useTor = UseTor;
@@ -306,10 +306,10 @@ namespace WalletWasabi.Gui.Tabs
 			=> ValidateDustThreshold(DustThreshold, whiteSpaceOk: true);
 
 		public string ValidateTorSocks5EndPoint()
-			=> ValidateEndPoint(TorSocks5EndPoint, whiteSpaceOk: true);
+			=> ValidateEndPoint(TorSocks5EndPoint, Constants.DefaultTorSocksPort, whiteSpaceOk: true);
 
 		public string ValidateBitcoinP2pEndPoint()
-			=> ValidateEndPoint(BitcoinP2pEndPoint, whiteSpaceOk: true);
+			=> ValidateEndPoint(BitcoinP2pEndPoint, NBitcoin.Network.GetNetwork(Network).DefaultPort, whiteSpaceOk: true);
 
 		public string ValidatePrivacyLevel(string value, bool whiteSpaceOk)
 		{
@@ -341,14 +341,14 @@ namespace WalletWasabi.Gui.Tabs
 			return "Invalid dust threshold.";
 		}
 
-		public string ValidateEndPoint(string endPoint, bool whiteSpaceOk)
+		public string ValidateEndPoint(string endPoint, int defaultPort, bool whiteSpaceOk)
 		{
 			if (whiteSpaceOk && string.IsNullOrWhiteSpace(endPoint))
 			{
 				return string.Empty;
 			}
 
-			if (EndPointParser.TryParse(endPoint, 0, out _))
+			if (EndPointParser.TryParse(endPoint, defaultPort, out _))
 			{
 				return string.Empty;
 			}

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -134,11 +134,11 @@ namespace WalletWasabi.Gui.Tabs
 			return base.OnClose();
 		}
 
-		public IEnumerable<string> Networks => new[]
+		public IEnumerable<Network> Networks => new[]
 		{
-			"Main",
-			"TestNet",
-			"RegTest"
+			Network.Main,
+			Network.TestNet,
+			Network.RegTest
 		};
 
 		public Network Network

--- a/WalletWasabi.Tests/Global.cs
+++ b/WalletWasabi.Tests/Global.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Tests
 	{
 		public static Global Instance { get; } = new Global();
 
-		public IPEndPoint TorSocks5Endpoint { get; }
+		public EndPoint TorSocks5Endpoint { get; }
 
 		public string DataDir { get; }
 

--- a/WalletWasabi.Tests/NBitcoinTests.cs
+++ b/WalletWasabi.Tests/NBitcoinTests.cs
@@ -6,17 +6,17 @@ using Xunit;
 
 namespace WalletWasabi.Tests
 {
-    public class NBitcoinTests
-    {
-        [Fact]
-        public void DefaultPortsMatch()
-        {
-            Assert.Equal(Helpers.Constants.DefaultMainNetBitcoinCoreRpcPort, Network.Main.RPCPort);
-            Assert.Equal(Helpers.Constants.DefaultTestNetBitcoinCoreRpcPort, Network.TestNet.RPCPort);
-            Assert.Equal(Helpers.Constants.DefaultRegTestBitcoinCoreRpcPort, Network.RegTest.RPCPort);
-            Assert.Equal(Helpers.Constants.DefaultMainNetBitcoinP2pPort, Network.Main.DefaultPort);
-            Assert.Equal(Helpers.Constants.DefaultTestNetBitcoinP2pPort, Network.TestNet.DefaultPort);
-            Assert.Equal(Helpers.Constants.DefaultRegTestBitcoinP2pPort, Network.RegTest.DefaultPort);
-        }
-    }
+	public class NBitcoinTests
+	{
+		[Fact]
+		public void DefaultPortsMatch()
+		{
+			Assert.Equal(Helpers.Constants.DefaultMainNetBitcoinCoreRpcPort, Network.Main.RPCPort);
+			Assert.Equal(Helpers.Constants.DefaultTestNetBitcoinCoreRpcPort, Network.TestNet.RPCPort);
+			Assert.Equal(Helpers.Constants.DefaultRegTestBitcoinCoreRpcPort, Network.RegTest.RPCPort);
+			Assert.Equal(Helpers.Constants.DefaultMainNetBitcoinP2pPort, Network.Main.DefaultPort);
+			Assert.Equal(Helpers.Constants.DefaultTestNetBitcoinP2pPort, Network.TestNet.DefaultPort);
+			Assert.Equal(Helpers.Constants.DefaultRegTestBitcoinP2pPort, Network.RegTest.DefaultPort);
+		}
+	}
 }

--- a/WalletWasabi.Tests/NBitcoinTests.cs
+++ b/WalletWasabi.Tests/NBitcoinTests.cs
@@ -1,0 +1,22 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace WalletWasabi.Tests
+{
+    public class NBitcoinTests
+    {
+        [Fact]
+        public void DefaultPortsMatch()
+        {
+            Assert.Equal(Helpers.Constants.DefaultMainNetBitcoinCoreRpcPort, Network.Main.RPCPort);
+            Assert.Equal(Helpers.Constants.DefaultTestNetBitcoinCoreRpcPort, Network.TestNet.RPCPort);
+            Assert.Equal(Helpers.Constants.DefaultRegTestBitcoinCoreRpcPort, Network.RegTest.RPCPort);
+            Assert.Equal(Helpers.Constants.DefaultMainNetBitcoinP2pPort, Network.Main.DefaultPort);
+            Assert.Equal(Helpers.Constants.DefaultTestNetBitcoinP2pPort, Network.TestNet.DefaultPort);
+            Assert.Equal(Helpers.Constants.DefaultRegTestBitcoinP2pPort, Network.RegTest.DefaultPort);
+        }
+    }
+}

--- a/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
+++ b/WalletWasabi.Tests/NodeBuilding/CoreNode.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 		private NodeBuilder Builder { get; }
 		public string Folder { get; }
 
-		public IPEndPoint Endpoint => new IPEndPoint(IPAddress.Parse("127.0.0.1"), Ports[0]);
+		public EndPoint Endpoint => new IPEndPoint(IPAddress.Loopback, Ports[0]);
 
 		public string Config { get; }
 

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -21,6 +21,10 @@ namespace WalletWasabi.Tests
 			{
 				host,
 				$"{host} ",
+				$"bitcoin-p2p://{host}",
+				$"Bitcoin-P2P://{host}",
+				$"tcp://{host}",
+				$"TCP://{host}",
 				$" {host}",
 				$" {host} ",
 				$"{host}:",
@@ -36,6 +40,10 @@ namespace WalletWasabi.Tests
 			var inputsWithtPorts = new[]
 			{
 				$"{host}:5000",
+				$"bitcoin-p2p://{host}:5000",
+				$"BITCOIN-P2P://{host}:5000",
+				$"tcp://{host}:5000",
+				$"TCP://{host}:5000",
 				$" {host}:5000",
 				$"{host} :5000",
 				$" {host}:5000",

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 using Xunit;
@@ -16,7 +17,7 @@ namespace WalletWasabi.Tests
         [InlineData("foo.onion")]
         public void EndPointParserTests(string host)
         {
-            var inputs = new[]
+            var inputsWithoutPorts = new[]
             {
                 host,
                 $"{host} ",
@@ -27,15 +28,19 @@ namespace WalletWasabi.Tests
                 $"{host} :",
                 $"{host} : ",
                 $" {host} : ",
+                $"{host}/",
+                $"{host}/ ",
+                $" {host}/ ",
+            };
+
+            var inputsWithtPorts = new[]
+            {
                 $"{host}:5000",
                 $" {host}:5000",
                 $"{host} :5000",
                 $" {host}:5000",
                 $"{host}: 5000",
                 $" {host} : 5000 ",
-                $"{host}/",
-                $"{host}/ ",
-                $" {host}/ ",
                 $"{host}/:5000",
                 $"{host}/:5000/",
                 $"{host}/:5000/ ",
@@ -46,21 +51,46 @@ namespace WalletWasabi.Tests
                 $"         {host}/              :             5000/           "
             };
 
-            foreach (var inputString in inputs)
+            // Default port is used.
+            foreach (var inputString in inputsWithoutPorts)
             {
                 var success = EndPointParser.TryParse(inputString, 5000, out EndPoint ep);
-                Assert.True(success);
-                var actualPort = ep.GetPortOrDefault();
-                Assert.Equal(5000, actualPort);
-                var actualHost = ep.GetHostOrDefault();
-                var expectedHost = host;
-                if (host == "localhost")
-                {
-                    expectedHost = "127.0.0.1";
-                }
-                Assert.Equal(expectedHost, actualHost);
-                Assert.Equal($"{actualHost}:{actualPort}", ep.ToString(5000));
+                AssertEndPointParserOutputs(success, ep, host, 5000);
             }
+
+            // Default port is not used.
+            foreach (var inputString in inputsWithtPorts)
+            {
+                var success = EndPointParser.TryParse(inputString, 12345, out EndPoint ep);
+                AssertEndPointParserOutputs(success, ep, host, 5000);
+            }
+
+            // Zero can be used as a discarded port.
+            foreach (var inputString in inputsWithoutPorts)
+            {
+                var success = EndPointParser.TryParse(inputString, 0, out EndPoint ep);
+                AssertEndPointParserOutputs(success, ep, host, 0);
+            }
+
+            // -1 means default port is not accepted.
+            foreach (var inputString in inputsWithoutPorts)
+            {
+                Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
+            }
+        }
+
+        private static void AssertEndPointParserOutputs(bool isSuccess, EndPoint endPoint, string expectedHost, int expectedPort)
+        {
+            Assert.True(isSuccess);
+            var actualPort = endPoint.GetPortOrDefault();
+            Assert.Equal(expectedPort, actualPort);
+            var actualHost = endPoint.GetHostOrDefault();
+            if (expectedHost == "localhost")
+            {
+                expectedHost = "127.0.0.1";
+            }
+            Assert.Equal((string)expectedHost, actualHost);
+            Assert.Equal($"{actualHost}:{actualPort}", endPoint.ToString(expectedPort));
         }
     }
 }

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -51,6 +51,19 @@ namespace WalletWasabi.Tests
                 $"         {host}/              :             5000/           "
             };
 
+            var inputsWithInvalidPorts = new[]
+                        {
+                $"{host}:-1",
+                $"{host}:999999999999999999999",
+                $"{host}:-999999999999999999999",
+                $"{host}:{int.MaxValue}",
+                $"{host}:{uint.MaxValue}",
+                $"{host}:{long.MaxValue}",
+                $"{host}:0.1",
+                $"{host}:{int.MinValue}",
+                $"{host}:{long.MinValue}",
+            };
+
             // Default port is used.
             foreach (var inputString in inputsWithoutPorts)
             {
@@ -74,6 +87,18 @@ namespace WalletWasabi.Tests
 
             // -1 means default port is not accepted.
             foreach (var inputString in inputsWithoutPorts)
+            {
+                Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
+            }
+
+            // Defaultport corrects invalid inputs.
+            foreach (var inputString in inputsWithInvalidPorts)
+            {
+                Assert.True(EndPointParser.TryParse(inputString, 5000, out EndPoint ep));
+            }
+
+            // Invalid ports -1 default.
+            foreach (var inputString in inputsWithInvalidPorts)
             {
                 Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
             }

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -6,48 +6,61 @@ using Xunit;
 
 namespace WalletWasabi.Tests
 {
-	public class ParserTests
-	{
-		[Theory]
-		[InlineData("localhost")]
-		//[InlineData("127.0.0.1")]
-		//[InlineData("192.168.56.1")]
-		//[InlineData("foo.com")]
-		//[InlineData("foo.onion")]
-		public void EndPointParserTests(string host)
-		{
-			var inputs = new[]
-			{
-				host,
-				$"{host} ",
-				$" {host}",
-				$" {host} ",
-				$"{host}:",
-				$"{host}: ",
-				$"{host} :",
-				$"{host} : ",
-				$" {host} : ",
-				$"{host}:5000",
-				$" {host}:5000",
-				$"{host} :5000",
-				$" {host}:5000",
-				$"{host}: 5000",
-				$" {host} : 5000 "
-			};
+    public class ParserTests
+    {
+        [Theory]
+        [InlineData("localhost")]
+        [InlineData("127.0.0.1")]
+        [InlineData("192.168.56.1")]
+        [InlineData("foo.com")]
+        [InlineData("foo.onion")]
+        public void EndPointParserTests(string host)
+        {
+            var inputs = new[]
+            {
+                host,
+                $"{host} ",
+                $" {host}",
+                $" {host} ",
+                $"{host}:",
+                $"{host}: ",
+                $"{host} :",
+                $"{host} : ",
+                $" {host} : ",
+                $"{host}:5000",
+                $" {host}:5000",
+                $"{host} :5000",
+                $" {host}:5000",
+                $"{host}: 5000",
+                $" {host} : 5000 ",
+                $"{host}/",
+                $"{host}/ ",
+                $" {host}/ ",
+                $"{host}/:5000",
+                $"{host}/:5000/",
+                $"{host}/:5000/ ",
+                $"{host}/: 5000/",
+                $"{host}/ :5000/ ",
+                $"{host}/ : 5000/",
+                $"{host}/ : 5000/ ",
+                $"         {host}/              :             5000/           "
+            };
 
-			foreach (var inputString in inputs)
-			{
-				var success = EndPointParser.TryParse(inputString, 5000, out EndPoint ep);
-				Assert.True(success);
-				Assert.Equal(5000, ep.GetPortOrDefault());
-				var actualHost = ep.GetHostOrDefault();
-				var expectedHost = host;
-				if (host == "localhost")
-				{
-					expectedHost = "127.0.0.1";
-				}
-				Assert.Equal(expectedHost, actualHost);
-			}
-		}
-	}
+            foreach (var inputString in inputs)
+            {
+                var success = EndPointParser.TryParse(inputString, 5000, out EndPoint ep);
+                Assert.True(success);
+                var actualPort = ep.GetPortOrDefault();
+                Assert.Equal(5000, actualPort);
+                var actualHost = ep.GetHostOrDefault();
+                var expectedHost = host;
+                if (host == "localhost")
+                {
+                    expectedHost = "127.0.0.1";
+                }
+                Assert.Equal(expectedHost, actualHost);
+                Assert.Equal($"{actualHost}:{actualPort}", ep.ToString(5000));
+            }
+        }
+    }
 }

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -51,18 +51,33 @@ namespace WalletWasabi.Tests
                 $"         {host}/              :             5000/           "
             };
 
-            var inputsWithInvalidPorts = new[]
-                        {
-                $"{host}:-1",
-                $"{host}:999999999999999999999",
-                $"{host}:-999999999999999999999",
-                $"{host}:{int.MaxValue}",
-                $"{host}:{uint.MaxValue}",
-                $"{host}:{long.MaxValue}",
-                $"{host}:0.1",
-                $"{host}:{int.MinValue}",
-                $"{host}:{long.MinValue}",
+            var invalidPortStrings = new[]
+            {
+                "-1",
+                "-5000",
+                "999999999999999999999",
+                "foo",
+                "-999999999999999999999",
+                int.MaxValue.ToString(),
+                uint.MaxValue.ToString(),
+                long.MaxValue.ToString(),
+                "0.1",
+                int.MinValue.ToString(),
+                long.MinValue.ToString(),
+                (ushort.MinValue - 1).ToString(),
+                (ushort.MaxValue + 1).ToString()
             };
+
+            var validPorts = new[]
+            {
+                0,
+                5000,
+                9999,
+                ushort.MinValue,
+                ushort.MaxValue
+            };
+
+            var inputsWithInvalidPorts = invalidPortStrings.Select(x => $"{host}:{x}").ToArray();
 
             // Default port is used.
             foreach (var inputString in inputsWithoutPorts)
@@ -78,7 +93,7 @@ namespace WalletWasabi.Tests
                 AssertEndPointParserOutputs(success, ep, host, 5000);
             }
 
-            // -1 means default port is not accepted.
+            // Default port is invalid, string port is not provided.
             foreach (var inputString in inputsWithoutPorts)
             {
                 Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
@@ -87,10 +102,13 @@ namespace WalletWasabi.Tests
             // Defaultport corrects invalid inputs.
             foreach (var inputString in inputsWithInvalidPorts)
             {
-                Assert.True(EndPointParser.TryParse(inputString, 5000, out EndPoint ep));
+                foreach (var defaultPort in validPorts)
+                {
+                    Assert.True(EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep));
+                }
             }
 
-            // Invalid ports -1 default.
+            // Both default and string ports are invalid.
             foreach (var inputString in inputsWithInvalidPorts)
             {
                 Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using Xunit;
+
+namespace WalletWasabi.Tests
+{
+	public class ParserTests
+	{
+		[Theory]
+		[InlineData("localhost")]
+		//[InlineData("127.0.0.1")]
+		//[InlineData("192.168.56.1")]
+		//[InlineData("foo.com")]
+		//[InlineData("foo.onion")]
+		public void EndPointParserTests(string host)
+		{
+			var inputs = new[]
+			{
+				host,
+				$"{host} ",
+				$" {host}",
+				$" {host} ",
+				$"{host}:",
+				$"{host}: ",
+				$"{host} :",
+				$"{host} : ",
+				$" {host} : ",
+				$"{host}:5000",
+				$" {host}:5000",
+				$"{host} :5000",
+				$" {host}:5000",
+				$"{host}: 5000",
+				$" {host} : 5000 "
+			};
+
+			foreach (var inputString in inputs)
+			{
+				var success = EndPointParser.TryParse(inputString, 5000, out EndPoint ep);
+				Assert.True(success);
+				Assert.Equal(5000, ep.GetPortOrDefault());
+				var actualHost = ep.GetHostOrDefault();
+				var expectedHost = host;
+				if (host == "localhost")
+				{
+					expectedHost = "127.0.0.1";
+				}
+				Assert.Equal(expectedHost, actualHost);
+			}
+		}
+	}
+}

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -7,129 +7,129 @@ using Xunit;
 
 namespace WalletWasabi.Tests
 {
-    public class ParserTests
-    {
-        [Theory]
-        [InlineData("localhost")]
-        [InlineData("127.0.0.1")]
-        [InlineData("192.168.56.1")]
-        [InlineData("foo.com")]
-        [InlineData("foo.onion")]
-        public void EndPointParserTests(string host)
-        {
-            var inputsWithoutPorts = new[]
-            {
-                host,
-                $"{host} ",
-                $" {host}",
-                $" {host} ",
-                $"{host}:",
-                $"{host}: ",
-                $"{host} :",
-                $"{host} : ",
-                $" {host} : ",
-                $"{host}/",
-                $"{host}/ ",
-                $" {host}/ ",
-            };
+	public class ParserTests
+	{
+		[Theory]
+		[InlineData("localhost")]
+		[InlineData("127.0.0.1")]
+		[InlineData("192.168.56.1")]
+		[InlineData("foo.com")]
+		[InlineData("foo.onion")]
+		public void EndPointParserTests(string host)
+		{
+			var inputsWithoutPorts = new[]
+			{
+				host,
+				$"{host} ",
+				$" {host}",
+				$" {host} ",
+				$"{host}:",
+				$"{host}: ",
+				$"{host} :",
+				$"{host} : ",
+				$" {host} : ",
+				$"{host}/",
+				$"{host}/ ",
+				$" {host}/ ",
+			};
 
-            var inputsWithtPorts = new[]
-            {
-                $"{host}:5000",
-                $" {host}:5000",
-                $"{host} :5000",
-                $" {host}:5000",
-                $"{host}: 5000",
-                $" {host} : 5000 ",
-                $"{host}/:5000",
-                $"{host}/:5000/",
-                $"{host}/:5000/ ",
-                $"{host}/: 5000/",
-                $"{host}/ :5000/ ",
-                $"{host}/ : 5000/",
-                $"{host}/ : 5000/ ",
-                $"         {host}/              :             5000/           "
-            };
+			var inputsWithtPorts = new[]
+			{
+				$"{host}:5000",
+				$" {host}:5000",
+				$"{host} :5000",
+				$" {host}:5000",
+				$"{host}: 5000",
+				$" {host} : 5000 ",
+				$"{host}/:5000",
+				$"{host}/:5000/",
+				$"{host}/:5000/ ",
+				$"{host}/: 5000/",
+				$"{host}/ :5000/ ",
+				$"{host}/ : 5000/",
+				$"{host}/ : 5000/ ",
+				$"         {host}/              :             5000/           "
+			};
 
-            var invalidPortStrings = new[]
-            {
-                "-1",
-                "-5000",
-                "999999999999999999999",
-                "foo",
-                "-999999999999999999999",
-                int.MaxValue.ToString(),
-                uint.MaxValue.ToString(),
-                long.MaxValue.ToString(),
-                "0.1",
-                int.MinValue.ToString(),
-                long.MinValue.ToString(),
-                (ushort.MinValue - 1).ToString(),
-                (ushort.MaxValue + 1).ToString()
-            };
+			var invalidPortStrings = new[]
+			{
+				"-1",
+				"-5000",
+				"999999999999999999999",
+				"foo",
+				"-999999999999999999999",
+				int.MaxValue.ToString(),
+				uint.MaxValue.ToString(),
+				long.MaxValue.ToString(),
+				"0.1",
+				int.MinValue.ToString(),
+				long.MinValue.ToString(),
+				(ushort.MinValue - 1).ToString(),
+				(ushort.MaxValue + 1).ToString()
+			};
 
-            var validPorts = new[]
-            {
-                0,
-                5000,
-                9999,
-                ushort.MinValue,
-                ushort.MaxValue
-            };
+			var validPorts = new[]
+			{
+				0,
+				5000,
+				9999,
+				ushort.MinValue,
+				ushort.MaxValue
+			};
 
-            var inputsWithInvalidPorts = invalidPortStrings.Select(x => $"{host}:{x}").ToArray();
+			var inputsWithInvalidPorts = invalidPortStrings.Select(x => $"{host}:{x}").ToArray();
 
-            // Default port is used.
-            foreach (var inputString in inputsWithoutPorts)
-            {
-                foreach (var defaultPort in validPorts)
-                {
-                    var success = EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep);
-                    AssertEndPointParserOutputs(success, ep, host, defaultPort);
-                }
-            }
+			// Default port is used.
+			foreach (var inputString in inputsWithoutPorts)
+			{
+				foreach (var defaultPort in validPorts)
+				{
+					var success = EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep);
+					AssertEndPointParserOutputs(success, ep, host, defaultPort);
+				}
+			}
 
-            // Default port is not used.
-            foreach (var inputString in inputsWithtPorts)
-            {
-                var success = EndPointParser.TryParse(inputString, 12345, out EndPoint ep);
-                AssertEndPointParserOutputs(success, ep, host, 5000);
-            }
+			// Default port is not used.
+			foreach (var inputString in inputsWithtPorts)
+			{
+				var success = EndPointParser.TryParse(inputString, 12345, out EndPoint ep);
+				AssertEndPointParserOutputs(success, ep, host, 5000);
+			}
 
-            // Default port is invalid, string port is not provided.
-            foreach (var inputString in inputsWithoutPorts)
-            {
-                Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
-            }
+			// Default port is invalid, string port is not provided.
+			foreach (var inputString in inputsWithoutPorts)
+			{
+				Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
+			}
 
-            // Defaultport doesn't correct invalid port input.
-            foreach (var inputString in inputsWithInvalidPorts)
-            {
-                foreach (var defaultPort in validPorts)
-                {
-                    Assert.False(EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep));
-                }
-            }
+			// Defaultport doesn't correct invalid port input.
+			foreach (var inputString in inputsWithInvalidPorts)
+			{
+				foreach (var defaultPort in validPorts)
+				{
+					Assert.False(EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep));
+				}
+			}
 
-            // Both default and string ports are invalid.
-            foreach (var inputString in inputsWithInvalidPorts)
-            {
-                Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
-            }
-        }
+			// Both default and string ports are invalid.
+			foreach (var inputString in inputsWithInvalidPorts)
+			{
+				Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
+			}
+		}
 
-        private static void AssertEndPointParserOutputs(bool isSuccess, EndPoint endPoint, string expectedHost, int expectedPort)
-        {
-            Assert.True(isSuccess);
-            var actualPort = endPoint.GetPortOrDefault();
-            Assert.Equal(expectedPort, actualPort);
-            var actualHost = endPoint.GetHostOrDefault();
-            if (expectedHost == "localhost")
-            {
-                expectedHost = "127.0.0.1";
-            }
-            Assert.Equal((string)expectedHost, actualHost);
-            Assert.Equal($"{actualHost}:{actualPort}", endPoint.ToString(expectedPort));
-        }
-    }
+		private static void AssertEndPointParserOutputs(bool isSuccess, EndPoint endPoint, string expectedHost, int expectedPort)
+		{
+			Assert.True(isSuccess);
+			var actualPort = endPoint.GetPortOrDefault();
+			Assert.Equal(expectedPort, actualPort);
+			var actualHost = endPoint.GetHostOrDefault();
+			if (expectedHost == "localhost")
+			{
+				expectedHost = "127.0.0.1";
+			}
+			Assert.Equal((string)expectedHost, actualHost);
+			Assert.Equal($"{actualHost}:{actualPort}", endPoint.ToString(expectedPort));
+		}
+	}
 }

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -82,8 +82,11 @@ namespace WalletWasabi.Tests
             // Default port is used.
             foreach (var inputString in inputsWithoutPorts)
             {
-                var success = EndPointParser.TryParse(inputString, 5000, out EndPoint ep);
-                AssertEndPointParserOutputs(success, ep, host, 5000);
+                foreach (var defaultPort in validPorts)
+                {
+                    var success = EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep);
+                    AssertEndPointParserOutputs(success, ep, host, defaultPort);
+                }
             }
 
             // Default port is not used.
@@ -99,12 +102,12 @@ namespace WalletWasabi.Tests
                 Assert.False(EndPointParser.TryParse(inputString, -1, out EndPoint ep));
             }
 
-            // Defaultport corrects invalid inputs.
+            // Defaultport doesn't correct invalid port input.
             foreach (var inputString in inputsWithInvalidPorts)
             {
                 foreach (var defaultPort in validPorts)
                 {
-                    Assert.True(EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep));
+                    Assert.False(EndPointParser.TryParse(inputString, defaultPort, out EndPoint ep));
                 }
             }
 

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -78,13 +78,6 @@ namespace WalletWasabi.Tests
                 AssertEndPointParserOutputs(success, ep, host, 5000);
             }
 
-            // Zero can be used as a discarded port.
-            foreach (var inputString in inputsWithoutPorts)
-            {
-                var success = EndPointParser.TryParse(inputString, 0, out EndPoint ep);
-                AssertEndPointParserOutputs(success, ep, host, 0);
-            }
-
             // -1 means default port is not accepted.
             foreach (var inputString in inputsWithoutPorts)
             {

--- a/WalletWasabi.Tests/RegTests.cs
+++ b/WalletWasabi.Tests/RegTests.cs
@@ -83,7 +83,7 @@ namespace WalletWasabi.Tests
 			global.Coordinator.UtxoReferee.Clear();
 
 			var network = global.RpcClient.Network;
-			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.Endpoint, Money.Coins(0.0001m));
+			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.P2pEndPoint, Money.Coins(0.0001m));
 			var bitcoinStore = new BitcoinStore();
 			var dir = Path.Combine(Global.Instance.DataDir, caller);
 			await bitcoinStore.InitializeAsync(dir, network);

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -33,18 +33,21 @@ namespace WalletWasabi.Tests.XunitConfiguration
 			BackendRegTestNode = BackendNodeBuilder.Nodes[0];
 
 			var rpc = BackendRegTestNode.CreateRpcClient();
-			var connectionString = new RPCCredentialString()
-			{
-				Server = rpc.Address.AbsoluteUri,
-				UserPassword = BackendRegTestNode.Creds
-			}.ToString();
+			var connectionString = $"{BackendRegTestNode.Creds.UserName}:{BackendRegTestNode.Creds.Password}";
 
 			var testnetBackendDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Tests", "Backend"));
 			IoHelpers.DeleteRecursivelyWithMagicDustAsync(testnetBackendDir).GetAwaiter().GetResult();
 			Thread.Sleep(100);
 			Directory.CreateDirectory(testnetBackendDir);
 			Thread.Sleep(100);
-			var config = new Config(BackendNodeBuilder.Network, connectionString, new IPEndPoint(IPAddress.Loopback, Network.Main.DefaultPort), new IPEndPoint(IPAddress.Loopback, Network.TestNet.DefaultPort), BackendRegTestNode.Endpoint);
+			var config = new Config(
+				BackendNodeBuilder.Network, connectionString,
+				new IPEndPoint(IPAddress.Loopback, Network.Main.DefaultPort),
+				new IPEndPoint(IPAddress.Loopback, Network.TestNet.DefaultPort),
+				BackendRegTestNode.Endpoint,
+				new IPEndPoint(IPAddress.Loopback, Network.Main.RPCPort),
+				new IPEndPoint(IPAddress.Loopback, Network.TestNet.RPCPort),
+				EndPointParser.TryParse(rpc.Address.DnsSafeHost, rpc.Address.Port, out EndPoint rep) ? rep : throw new NotSupportedException());
 			var configFilePath = Path.Combine(testnetBackendDir, "Config.json");
 			config.SetFilePath(configFilePath);
 			config.ToFileAsync().GetAwaiter().GetResult();

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -32,7 +32,6 @@ namespace WalletWasabi.Tests.XunitConfiguration
 			BackendNodeBuilder.StartAllAsync().GetAwaiter().GetResult();
 			BackendRegTestNode = BackendNodeBuilder.Nodes[0];
 
-			var rpc = BackendRegTestNode.CreateRpcClient();
 			var connectionString = $"{BackendRegTestNode.Creds.UserName}:{BackendRegTestNode.Creds.Password}";
 
 			var testnetBackendDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Tests", "Backend"));
@@ -44,10 +43,10 @@ namespace WalletWasabi.Tests.XunitConfiguration
 				BackendNodeBuilder.Network, connectionString,
 				new IPEndPoint(IPAddress.Loopback, Network.Main.DefaultPort),
 				new IPEndPoint(IPAddress.Loopback, Network.TestNet.DefaultPort),
-				BackendRegTestNode.Endpoint,
+				BackendRegTestNode.P2pEndPoint,
 				new IPEndPoint(IPAddress.Loopback, Network.Main.RPCPort),
 				new IPEndPoint(IPAddress.Loopback, Network.TestNet.RPCPort),
-				EndPointParser.TryParse(rpc.Address.DnsSafeHost, rpc.Address.Port, out EndPoint rep) ? rep : throw new NotSupportedException());
+				BackendRegTestNode.RpcEndPoint);
 			var configFilePath = Path.Combine(testnetBackendDir, "Config.json");
 			config.SetFilePath(configFilePath);
 			config.ToFileAsync().GetAwaiter().GetResult();

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 			Thread.Sleep(100);
 			Directory.CreateDirectory(testnetBackendDir);
 			Thread.Sleep(100);
-			var config = new Config(BackendNodeBuilder.Network, connectionString, new IPEndPoint(IPAddress.Loopback, Network.Main.DefaultPort), new IPEndPoint(IPAddress.Loopback, Network.TestNet.DefaultPort), new IPEndPoint(IPAddress.Loopback, Network.RegTest.DefaultPort));
+			var config = new Config(BackendNodeBuilder.Network, connectionString, new IPEndPoint(IPAddress.Loopback, Network.Main.DefaultPort), new IPEndPoint(IPAddress.Loopback, Network.TestNet.DefaultPort), BackendRegTestNode.Endpoint);
 			var configFilePath = Path.Combine(testnetBackendDir, "Config.json");
 			config.SetFilePath(configFilePath);
 			config.ToFileAsync().GetAwaiter().GetResult();

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 			Thread.Sleep(100);
 			Directory.CreateDirectory(testnetBackendDir);
 			Thread.Sleep(100);
-			var config = new Config(BackendNodeBuilder.Network, connectionString, IPAddress.Loopback.ToString(), IPAddress.Loopback.ToString(), BackendRegTestNode.Endpoint.Address.ToString(), Network.Main.DefaultPort, Network.TestNet.DefaultPort, BackendRegTestNode.Endpoint.Port);
+			var config = new Config(BackendNodeBuilder.Network, connectionString, new IPEndPoint(IPAddress.Loopback, Network.Main.DefaultPort), new IPEndPoint(IPAddress.Loopback, Network.TestNet.DefaultPort), new IPEndPoint(IPAddress.Loopback, Network.RegTest.DefaultPort));
 			var configFilePath = Path.Combine(testnetBackendDir, "Config.json");
 			config.SetFilePath(configFilePath);
 			config.ToFileAsync().GetAwaiter().GetResult();

--- a/WalletWasabi/Bases/TorDisposableBase.cs
+++ b/WalletWasabi/Bases/TorDisposableBase.cs
@@ -4,46 +4,46 @@ using WalletWasabi.TorSocks5;
 
 namespace WalletWasabi.Bases
 {
-    public abstract class TorDisposableBase : IDisposable
-    {
-        public TorHttpClient TorClient { get; }
+	public abstract class TorDisposableBase : IDisposable
+	{
+		public TorHttpClient TorClient { get; }
 
-        /// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
-        protected TorDisposableBase(Uri baseUri, EndPoint torSocks5EndPoint)
-        {
-            TorClient = new TorHttpClient(baseUri, torSocks5EndPoint, isolateStream: true);
-        }
+		/// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
+		protected TorDisposableBase(Uri baseUri, EndPoint torSocks5EndPoint)
+		{
+			TorClient = new TorHttpClient(baseUri, torSocks5EndPoint, isolateStream: true);
+		}
 
-        /// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
-        protected TorDisposableBase(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
-        {
-            TorClient = new TorHttpClient(baseUriAction, torSocks5EndPoint, isolateStream: true);
-        }
+		/// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
+		protected TorDisposableBase(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
+		{
+			TorClient = new TorHttpClient(baseUriAction, torSocks5EndPoint, isolateStream: true);
+		}
 
-        #region IDisposable Support
+		#region IDisposable Support
 
-        private volatile bool _disposedValue = false; // To detect redundant calls
+		private volatile bool _disposedValue = false; // To detect redundant calls
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    TorClient?.Dispose();
-                }
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					TorClient?.Dispose();
+				}
 
-                _disposedValue = true;
-            }
-        }
+				_disposedValue = true;
+			}
+		}
 
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-        }
+		// This code added to correctly implement the disposable pattern.
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+			Dispose(true);
+		}
 
-        #endregion IDisposable Support
-    }
+		#endregion IDisposable Support
+	}
 }

--- a/WalletWasabi/Bases/TorDisposableBase.cs
+++ b/WalletWasabi/Bases/TorDisposableBase.cs
@@ -1,49 +1,49 @@
-﻿using System;
+using System;
 using System.Net;
 using WalletWasabi.TorSocks5;
 
 namespace WalletWasabi.Bases
 {
-	public abstract class TorDisposableBase : IDisposable
-	{
-		public TorHttpClient TorClient { get; }
+    public abstract class TorDisposableBase : IDisposable
+    {
+        public TorHttpClient TorClient { get; }
 
-		/// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
-		protected TorDisposableBase(Uri baseUri, IPEndPoint torSocks5EndPoint)
-		{
-			TorClient = new TorHttpClient(baseUri, torSocks5EndPoint, isolateStream: true);
-		}
+        /// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
+        protected TorDisposableBase(Uri baseUri, EndPoint torSocks5EndPoint)
+        {
+            TorClient = new TorHttpClient(baseUri, torSocks5EndPoint, isolateStream: true);
+        }
 
-		/// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
-		protected TorDisposableBase(Func<Uri> baseUriAction, IPEndPoint torSocks5EndPoint)
-		{
-			TorClient = new TorHttpClient(baseUriAction, torSocks5EndPoint, isolateStream: true);
-		}
+        /// <param name="torSocks5EndPoint">if null, then localhost:9050</param>
+        protected TorDisposableBase(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
+        {
+            TorClient = new TorHttpClient(baseUriAction, torSocks5EndPoint, isolateStream: true);
+        }
 
-		#region IDisposable Support
+        #region IDisposable Support
 
-		private volatile bool _disposedValue = false; // To detect redundant calls
+        private volatile bool _disposedValue = false; // To detect redundant calls
 
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!_disposedValue)
-			{
-				if (disposing)
-				{
-					TorClient?.Dispose();
-				}
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    TorClient?.Dispose();
+                }
 
-				_disposedValue = true;
-			}
-		}
+                _disposedValue = true;
+            }
+        }
 
-		// This code added to correctly implement the disposable pattern.
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(true);
-		}
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
 
-		#endregion IDisposable Support
-	}
+        #endregion IDisposable Support
+    }
 }

--- a/WalletWasabi/Extensions/SystemNetExtensions.cs
+++ b/WalletWasabi/Extensions/SystemNetExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Net
+{
+	public static class SystemNetExtensions
+	{
+		public static int? GetPortOrDefault(this EndPoint me)
+		{
+			int port;
+			if (me is DnsEndPoint dnsEndPoint)
+			{
+				port = dnsEndPoint.Port;
+			}
+			else if (me is IPEndPoint ipEndPoint)
+			{
+				port = ipEndPoint.Port;
+			}
+			else
+			{
+				return null;
+			}
+
+			return port;
+		}
+
+		public static string GetHostOrDefault(this EndPoint me)
+		{
+			string host;
+			if (me is DnsEndPoint dnsEndPoint)
+			{
+				host = dnsEndPoint.Host;
+			}
+			else if (me is IPEndPoint ipEndPoint)
+			{
+				host = ipEndPoint.Address.ToString();
+			}
+			else
+			{
+				return null;
+			}
+
+			return host;
+		}
+	}
+}

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -5,93 +5,93 @@ using WalletWasabi.Backend.Models.Responses;
 
 namespace WalletWasabi.Helpers
 {
-    public static class Constants
-    {
-        public static readonly Version ClientVersion = new Version(1, 1, 6);
-        public const string BackendMajorVersion = "3";
-        public static readonly VersionsResponse VersionsResponse = new VersionsResponse { ClientVersion = ClientVersion.ToString(), BackendMajorVersion = BackendMajorVersion };
+	public static class Constants
+	{
+		public static readonly Version ClientVersion = new Version(1, 1, 6);
+		public const string BackendMajorVersion = "3";
+		public static readonly VersionsResponse VersionsResponse = new VersionsResponse { ClientVersion = ClientVersion.ToString(), BackendMajorVersion = BackendMajorVersion };
 
-        public const uint ProtocolVersion_WITNESS_VERSION = 70012;
+		public const uint ProtocolVersion_WITNESS_VERSION = 70012;
 
-        public const int MaxPasswordLength = 150;
+		public const int MaxPasswordLength = 150;
 
-        public static readonly NodeRequirement NodeRequirements = new NodeRequirement
-        {
-            RequiredServices = NodeServices.NODE_WITNESS,
-            MinVersion = ProtocolVersion_WITNESS_VERSION,
-            MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true, SupportMempoolQuery = true }
-        };
+		public static readonly NodeRequirement NodeRequirements = new NodeRequirement
+		{
+			RequiredServices = NodeServices.NODE_WITNESS,
+			MinVersion = ProtocolVersion_WITNESS_VERSION,
+			MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true, SupportMempoolQuery = true }
+		};
 
-        public static readonly NodeRequirement LocalNodeRequirements = new NodeRequirement
-        {
-            RequiredServices = NodeServices.NODE_WITNESS,
-            MinVersion = ProtocolVersion_WITNESS_VERSION,
-            MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true }
-        };
+		public static readonly NodeRequirement LocalNodeRequirements = new NodeRequirement
+		{
+			RequiredServices = NodeServices.NODE_WITNESS,
+			MinVersion = ProtocolVersion_WITNESS_VERSION,
+			MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true }
+		};
 
-        public static readonly NodeRequirement LocalBackendNodeRequirements = new NodeRequirement
-        {
-            RequiredServices = NodeServices.NODE_WITNESS,
-            MinVersion = ProtocolVersion_WITNESS_VERSION,
-            MinProtocolCapabilities = new ProtocolCapabilities
-            {
-                SupportGetBlock = true,
-                SupportWitness = true,
-                SupportMempoolQuery = true,
-                SupportSendHeaders = true,
-                SupportPingPong = true,
-                PeerTooOld = true
-            }
-        };
+		public static readonly NodeRequirement LocalBackendNodeRequirements = new NodeRequirement
+		{
+			RequiredServices = NodeServices.NODE_WITNESS,
+			MinVersion = ProtocolVersion_WITNESS_VERSION,
+			MinProtocolCapabilities = new ProtocolCapabilities
+			{
+				SupportGetBlock = true,
+				SupportWitness = true,
+				SupportMempoolQuery = true,
+				SupportSendHeaders = true,
+				SupportPingPong = true,
+				PeerTooOld = true
+			}
+		};
 
-        public const int P2wpkhInputSizeInBytes = 41;
-        public const int P2pkhInputSizeInBytes = 145;
-        public const int OutputSizeInBytes = 33;
+		public const int P2wpkhInputSizeInBytes = 41;
+		public const int P2pkhInputSizeInBytes = 145;
+		public const int OutputSizeInBytes = 33;
 
-        // https://en.bitcoin.it/wiki/Bitcoin
-        // There are a maximum of 2,099,999,997,690,000 Bitcoin elements (called satoshis), which are currently most commonly measured in units of 100,000,000 known as BTC. Stated another way, no more than 21 million BTC can ever be created.
-        public const long MaximumNumberOfSatoshis = 2099999997690000;
+		// https://en.bitcoin.it/wiki/Bitcoin
+		// There are a maximum of 2,099,999,997,690,000 Bitcoin elements (called satoshis), which are currently most commonly measured in units of 100,000,000 known as BTC. Stated another way, no more than 21 million BTC can ever be created.
+		public const long MaximumNumberOfSatoshis = 2099999997690000;
 
-        private static readonly BitcoinWitPubKeyAddress MainNetCoordinatorAddress = new BitcoinWitPubKeyAddress("bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew", Network.Main);
-        private static readonly BitcoinWitPubKeyAddress TestNetCoordinatorAddress = new BitcoinWitPubKeyAddress("tb1qecaheev3hjzs9a3w9x33wr8n0ptu7txp359exs", Network.TestNet);
-        private static readonly BitcoinWitPubKeyAddress RegTestCoordinatorAddress = new BitcoinWitPubKeyAddress("bcrt1qangxrwyej05x9mnztkakk29s4yfdv4n586gs8l", Network.RegTest);
+		private static readonly BitcoinWitPubKeyAddress MainNetCoordinatorAddress = new BitcoinWitPubKeyAddress("bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew", Network.Main);
+		private static readonly BitcoinWitPubKeyAddress TestNetCoordinatorAddress = new BitcoinWitPubKeyAddress("tb1qecaheev3hjzs9a3w9x33wr8n0ptu7txp359exs", Network.TestNet);
+		private static readonly BitcoinWitPubKeyAddress RegTestCoordinatorAddress = new BitcoinWitPubKeyAddress("bcrt1qangxrwyej05x9mnztkakk29s4yfdv4n586gs8l", Network.RegTest);
 
-        public static BitcoinWitPubKeyAddress GetCoordinatorAddress(Network network)
-        {
-            Guard.NotNull(nameof(network), network);
+		public static BitcoinWitPubKeyAddress GetCoordinatorAddress(Network network)
+		{
+			Guard.NotNull(nameof(network), network);
 
-            if (network == Network.Main)
-            {
-                return MainNetCoordinatorAddress;
-            }
+			if (network == Network.Main)
+			{
+				return MainNetCoordinatorAddress;
+			}
 
-            if (network == Network.TestNet)
-            {
-                return TestNetCoordinatorAddress;
-            }
+			if (network == Network.TestNet)
+			{
+				return TestNetCoordinatorAddress;
+			}
 
-            // else regtest
-            return RegTestCoordinatorAddress;
-        }
+			// else regtest
+			return RegTestCoordinatorAddress;
+		}
 
-        public const string ChangeOfSpecialLabelStart = "change of (";
-        public const string ChangeOfSpecialLabelEnd = ")";
-        public const int BigFileReadWriteBufferSize = 1 * 1024 * 1024;
+		public const string ChangeOfSpecialLabelStart = "change of (";
+		public const string ChangeOfSpecialLabelEnd = ")";
+		public const int BigFileReadWriteBufferSize = 1 * 1024 * 1024;
 
-        public const int OneDayConfirmationTarget = 144;
-        public const int SevenDaysConfirmationTarget = 1008;
+		public const int OneDayConfirmationTarget = 144;
+		public const int SevenDaysConfirmationTarget = 1008;
 
-        public const int DefaultTorSocksPort = 9050;
-        public const int DefaultTorBrowserSocksPort = 9150;
-        public const int DefaultTorControlPort = 9051;
-        public const int DefaultTorBrowserControlPort = 9151;
+		public const int DefaultTorSocksPort = 9050;
+		public const int DefaultTorBrowserSocksPort = 9150;
+		public const int DefaultTorControlPort = 9051;
+		public const int DefaultTorBrowserControlPort = 9151;
 
-        public const int DefaultMainNetBitcoinP2pPort = 8333;
-        public const int DefaultTestNetBitcoinP2pPort = 18333;
-        public const int DefaultRegTestBitcoinP2pPort = 18444;
+		public const int DefaultMainNetBitcoinP2pPort = 8333;
+		public const int DefaultTestNetBitcoinP2pPort = 18333;
+		public const int DefaultRegTestBitcoinP2pPort = 18444;
 
-        public const int DefaultMainNetBitcoinCoreRpcPort = 8332;
-        public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
-        public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
-    }
+		public const int DefaultMainNetBitcoinCoreRpcPort = 8332;
+		public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
+		public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
+	}
 }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -5,93 +5,93 @@ using WalletWasabi.Backend.Models.Responses;
 
 namespace WalletWasabi.Helpers
 {
-	public static class Constants
-	{
-		public static readonly Version ClientVersion = new Version(1, 1, 6);
-		public const string BackendMajorVersion = "3";
-		public static readonly VersionsResponse VersionsResponse = new VersionsResponse { ClientVersion = ClientVersion.ToString(), BackendMajorVersion = BackendMajorVersion };
+    public static class Constants
+    {
+        public static readonly Version ClientVersion = new Version(1, 1, 6);
+        public const string BackendMajorVersion = "3";
+        public static readonly VersionsResponse VersionsResponse = new VersionsResponse { ClientVersion = ClientVersion.ToString(), BackendMajorVersion = BackendMajorVersion };
 
-		public const uint ProtocolVersion_WITNESS_VERSION = 70012;
+        public const uint ProtocolVersion_WITNESS_VERSION = 70012;
 
-		public const int MaxPasswordLength = 150;
+        public const int MaxPasswordLength = 150;
 
-		public static readonly NodeRequirement NodeRequirements = new NodeRequirement
-		{
-			RequiredServices = NodeServices.NODE_WITNESS,
-			MinVersion = ProtocolVersion_WITNESS_VERSION,
-			MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true, SupportMempoolQuery = true }
-		};
+        public static readonly NodeRequirement NodeRequirements = new NodeRequirement
+        {
+            RequiredServices = NodeServices.NODE_WITNESS,
+            MinVersion = ProtocolVersion_WITNESS_VERSION,
+            MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true, SupportMempoolQuery = true }
+        };
 
-		public static readonly NodeRequirement LocalNodeRequirements = new NodeRequirement
-		{
-			RequiredServices = NodeServices.NODE_WITNESS,
-			MinVersion = ProtocolVersion_WITNESS_VERSION,
-			MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true }
-		};
+        public static readonly NodeRequirement LocalNodeRequirements = new NodeRequirement
+        {
+            RequiredServices = NodeServices.NODE_WITNESS,
+            MinVersion = ProtocolVersion_WITNESS_VERSION,
+            MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true }
+        };
 
-		public static readonly NodeRequirement LocalBackendNodeRequirements = new NodeRequirement
-		{
-			RequiredServices = NodeServices.NODE_WITNESS,
-			MinVersion = ProtocolVersion_WITNESS_VERSION,
-			MinProtocolCapabilities = new ProtocolCapabilities
-			{
-				SupportGetBlock = true,
-				SupportWitness = true,
-				SupportMempoolQuery = true,
-				SupportSendHeaders = true,
-				SupportPingPong = true,
-				PeerTooOld = true
-			}
-		};
+        public static readonly NodeRequirement LocalBackendNodeRequirements = new NodeRequirement
+        {
+            RequiredServices = NodeServices.NODE_WITNESS,
+            MinVersion = ProtocolVersion_WITNESS_VERSION,
+            MinProtocolCapabilities = new ProtocolCapabilities
+            {
+                SupportGetBlock = true,
+                SupportWitness = true,
+                SupportMempoolQuery = true,
+                SupportSendHeaders = true,
+                SupportPingPong = true,
+                PeerTooOld = true
+            }
+        };
 
-		public const int P2wpkhInputSizeInBytes = 41;
-		public const int P2pkhInputSizeInBytes = 145;
-		public const int OutputSizeInBytes = 33;
+        public const int P2wpkhInputSizeInBytes = 41;
+        public const int P2pkhInputSizeInBytes = 145;
+        public const int OutputSizeInBytes = 33;
 
-		// https://en.bitcoin.it/wiki/Bitcoin
-		// There are a maximum of 2,099,999,997,690,000 Bitcoin elements (called satoshis), which are currently most commonly measured in units of 100,000,000 known as BTC. Stated another way, no more than 21 million BTC can ever be created.
-		public const long MaximumNumberOfSatoshis = 2099999997690000;
+        // https://en.bitcoin.it/wiki/Bitcoin
+        // There are a maximum of 2,099,999,997,690,000 Bitcoin elements (called satoshis), which are currently most commonly measured in units of 100,000,000 known as BTC. Stated another way, no more than 21 million BTC can ever be created.
+        public const long MaximumNumberOfSatoshis = 2099999997690000;
 
-		private static readonly BitcoinWitPubKeyAddress MainNetCoordinatorAddress = new BitcoinWitPubKeyAddress("bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew", Network.Main);
-		private static readonly BitcoinWitPubKeyAddress TestNetCoordinatorAddress = new BitcoinWitPubKeyAddress("tb1qecaheev3hjzs9a3w9x33wr8n0ptu7txp359exs", Network.TestNet);
-		private static readonly BitcoinWitPubKeyAddress RegTestCoordinatorAddress = new BitcoinWitPubKeyAddress("bcrt1qangxrwyej05x9mnztkakk29s4yfdv4n586gs8l", Network.RegTest);
+        private static readonly BitcoinWitPubKeyAddress MainNetCoordinatorAddress = new BitcoinWitPubKeyAddress("bc1qs604c7jv6amk4cxqlnvuxv26hv3e48cds4m0ew", Network.Main);
+        private static readonly BitcoinWitPubKeyAddress TestNetCoordinatorAddress = new BitcoinWitPubKeyAddress("tb1qecaheev3hjzs9a3w9x33wr8n0ptu7txp359exs", Network.TestNet);
+        private static readonly BitcoinWitPubKeyAddress RegTestCoordinatorAddress = new BitcoinWitPubKeyAddress("bcrt1qangxrwyej05x9mnztkakk29s4yfdv4n586gs8l", Network.RegTest);
 
-		public static BitcoinWitPubKeyAddress GetCoordinatorAddress(Network network)
-		{
-			Guard.NotNull(nameof(network), network);
+        public static BitcoinWitPubKeyAddress GetCoordinatorAddress(Network network)
+        {
+            Guard.NotNull(nameof(network), network);
 
-			if (network == Network.Main)
-			{
-				return MainNetCoordinatorAddress;
-			}
+            if (network == Network.Main)
+            {
+                return MainNetCoordinatorAddress;
+            }
 
-			if (network == Network.TestNet)
-			{
-				return TestNetCoordinatorAddress;
-			}
+            if (network == Network.TestNet)
+            {
+                return TestNetCoordinatorAddress;
+            }
 
-			// else regtest
-			return RegTestCoordinatorAddress;
-		}
+            // else regtest
+            return RegTestCoordinatorAddress;
+        }
 
-		public const string ChangeOfSpecialLabelStart = "change of (";
-		public const string ChangeOfSpecialLabelEnd = ")";
-		public const int BigFileReadWriteBufferSize = 1 * 1024 * 1024;
+        public const string ChangeOfSpecialLabelStart = "change of (";
+        public const string ChangeOfSpecialLabelEnd = ")";
+        public const int BigFileReadWriteBufferSize = 1 * 1024 * 1024;
 
-		public const int OneDayConfirmationTarget = 144;
-		public const int SevenDaysConfirmationTarget = 1008;
+        public const int OneDayConfirmationTarget = 144;
+        public const int SevenDaysConfirmationTarget = 1008;
 
-		public const int DefaultTorSocksPort = 9050;
-		public const int DefaultTorBrowserSocksPort = 9150;
-		public const int DefaultTorControlPort = 9051;
-		public const int DefaultTorBrowserControlPort = 9151;
+        public const int DefaultTorSocksPort = 9050;
+        public const int DefaultTorBrowserSocksPort = 9150;
+        public const int DefaultTorControlPort = 9051;
+        public const int DefaultTorBrowserControlPort = 9151;
 
-		public const int DefaultMainNetBitcoinP2pPort = 8333;
-		public const int DefaultTestNetBitcoinP2pPort = 18333;
-		public const int DefaultRegTestBitcoinP2pPort = 18444;
+        public const int DefaultMainNetBitcoinP2pPort = 8333;
+        public const int DefaultTestNetBitcoinP2pPort = 18333;
+        public const int DefaultRegTestBitcoinP2pPort = 18444;
 
-		public const int DefaultMainNetBitcoinCoreRpcPort = 8332;
-		public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
-		public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
-	}
+        public const int DefaultMainNetBitcoinCoreRpcPort = 8332;
+        public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
+        public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
+    }
 }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -80,5 +80,18 @@ namespace WalletWasabi.Helpers
 
 		public const int OneDayConfirmationTarget = 144;
 		public const int SevenDaysConfirmationTarget = 1008;
+
+		public const int DefaultTorSocksPort = 9050;
+		public const int DefaultTorBrowserSocksPort = 9150;
+		public const int DefaultTorControlPort = 9051;
+		public const int DefaultTorBrowserControlPort = 9151;
+
+		public const int DefaultMainNetBintcoinP2pPort = 8333;
+		public const int DefaultTestNetBintcoinP2pPort = 18333;
+		public const int DefaultRegTestBintcoinP2pPort = 18444;
+
+		public const int DefaultMainNetBintcoinCoreRpcPort = 8332;
+		public const int DefaultTestNetBintcoinCoreRpcPort = 18332;
+		public const int DefaultRegTestBintcoinCoreRpcPort = 18443;
 	}
 }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -86,12 +86,12 @@ namespace WalletWasabi.Helpers
 		public const int DefaultTorControlPort = 9051;
 		public const int DefaultTorBrowserControlPort = 9151;
 
-		public const int DefaultMainNetBintcoinP2pPort = 8333;
-		public const int DefaultTestNetBintcoinP2pPort = 18333;
-		public const int DefaultRegTestBintcoinP2pPort = 18444;
+		public const int DefaultMainNetBitcoinP2pPort = 8333;
+		public const int DefaultTestNetBitcoinP2pPort = 18333;
+		public const int DefaultRegTestBitcoinP2pPort = 18444;
 
-		public const int DefaultMainNetBintcoinCoreRpcPort = 8332;
-		public const int DefaultTestNetBintcoinCoreRpcPort = 18332;
-		public const int DefaultRegTestBintcoinCoreRpcPort = 18443;
+		public const int DefaultMainNetBitcoinCoreRpcPort = 8332;
+		public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
+		public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
 	}
 }

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -37,7 +37,7 @@ namespace System.Net
             return endPointString;
         }
 
-        /// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false. Use 0 if you want to just discard the port.</param>
+        /// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false.</param>
         public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
         {
             endPoint = null;

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -37,7 +37,7 @@ namespace System.Net
             return endPointString;
         }
 
-        /// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false.</param>
+        /// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false. Use 0 if you want to just discard the port.</param>
         public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
         {
             endPoint = null;

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -47,7 +47,7 @@ namespace System.Net
 
 			var lastIndex = endPointString.LastIndexOf(':');
 
-			string portString = null;
+			string portString = "";
 			if (lastIndex != -1)
 			{
 				portString = endPointString.Substring(endPointString.LastIndexOf(':') + 1);
@@ -63,15 +63,15 @@ namespace System.Net
 				port = defaultPort;
 			}
 
-			string host = "";
-			if (portString != null)
-			{
-				host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase);
-			}
+			var host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase);
 
 			host = host.TrimEnd(':');
 
-			if (IPAddress.TryParse(host, out IPAddress addr))
+			if (host == "localhost")
+			{
+				endPoint = new IPEndPoint(IPAddress.Loopback, port);
+			}
+			else if (IPAddress.TryParse(host, out IPAddress addr))
 			{
 				endPoint = new IPEndPoint(addr, port);
 			}

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -92,9 +92,23 @@ namespace System.Net
             string host = parts[0];
             if (host == "localhost")
             {
-                endPoint = new IPEndPoint(IPAddress.Loopback, port);
+                host = IPAddress.Loopback.ToString();
             }
-            else if (IPAddress.TryParse(host, out IPAddress addr))
+
+            bool isPortInValidRange = port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort;
+            if (isPortInValidRange)
+            {
+                if (defaultPort == -1)
+                {
+                    return false;
+                }
+                else
+                {
+                    port = defaultPort;
+                }
+            }
+
+            if (IPAddress.TryParse(host, out IPAddress addr))
             {
                 endPoint = new IPEndPoint(addr, port);
             }

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -95,8 +95,8 @@ namespace System.Net
                 host = IPAddress.Loopback.ToString();
             }
 
-            bool isPortInValidRange = port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort;
-            if (isPortInValidRange)
+            bool isPortInvalid = port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort;
+            if (isPortInvalid)
             {
                 if (defaultPort == -1)
                 {

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -1,93 +1,116 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using WalletWasabi.Helpers;
 
 namespace System.Net
 {
-	public static class EndPointParser
-	{
-		public static string ToString(this EndPoint me, int defaultPort)
-		{
-			string host;
-			int port;
-			if (me is DnsEndPoint dnsEndPoint)
-			{
-				host = dnsEndPoint.Host;
-				port = dnsEndPoint.Port;
-			}
-			else if (me is IPEndPoint ipEndPoint)
-			{
-				host = ipEndPoint.Address.ToString();
-				port = ipEndPoint.Port;
-			}
-			else
-			{
-				throw new FormatException($"Invalid endpoint: {me.ToString()}");
-			}
+    public static class EndPointParser
+    {
+        public static string ToString(this EndPoint me, int defaultPort)
+        {
+            string host;
+            int port;
+            if (me is DnsEndPoint dnsEndPoint)
+            {
+                host = dnsEndPoint.Host;
+                port = dnsEndPoint.Port;
+            }
+            else if (me is IPEndPoint ipEndPoint)
+            {
+                host = ipEndPoint.Address.ToString();
+                port = ipEndPoint.Port;
+            }
+            else
+            {
+                throw new FormatException($"Invalid endpoint: {me.ToString()}");
+            }
 
-			if (port == 0)
-			{
-				port = defaultPort;
-			}
+            if (port == 0)
+            {
+                port = defaultPort;
+            }
 
-			var endPointString = $"{host}:{port}";
+            var endPointString = $"{host}:{port}";
 
-			return endPointString;
-		}
+            return endPointString;
+        }
 
-		/// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false.</param>
-		public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
-		{
-			endPoint = null;
+        /// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false.</param>
+        public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
+        {
+            endPoint = null;
 
-			endPointString = Guard.Correct(endPointString);
-			endPointString = endPointString.TrimEnd('/');
-			endPointString = endPointString.TrimEnd(':');
+            if (string.IsNullOrWhiteSpace(endPointString))
+            {
+                return false;
+            }
 
-			var lastIndex = endPointString.LastIndexOf(':');
+            endPointString = Guard.Correct(endPointString);
+            endPointString = endPointString.TrimEnd(':', '/');
+            var parts = endPointString.Split(':', StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().TrimEnd('/').TrimEnd()).ToArray();
 
-			string portString = "";
-			if (lastIndex != -1)
-			{
-				portString = endPointString.Substring(endPointString.LastIndexOf(':') + 1);
-			}
+            int port;
+            if (parts.Length == 0)
+            {
+                return false;
+            }
+            else if (parts.Length == 1)
+            {
+                if (defaultPort == -1)
+                {
+                    return false;
+                }
+                else
+                {
+                    port = defaultPort;
+                }
+            }
+            else if (parts.Length == 2)
+            {
+                var portString = parts[1];
+                if (int.TryParse(portString, out int p))
+                {
+                    port = p;
+                }
+                else
+                {
+                    if (defaultPort == -1)
+                    {
+                        return false;
+                    }
 
-			if (portString is null || !int.TryParse(portString, out int port))
-			{
-				if (defaultPort == -1)
-				{
-					return false;
-				}
+                    port = defaultPort;
+                }
+            }
+            else
+            {
+                return false;
+            }
 
-				port = defaultPort;
-			}
+            string host = parts[0];
+            if (host == "localhost")
+            {
+                endPoint = new IPEndPoint(IPAddress.Loopback, port);
+            }
+            else if (IPAddress.TryParse(host, out IPAddress addr))
+            {
+                endPoint = new IPEndPoint(addr, port);
+            }
+            else
+            {
+                try
+                {
+                    endPoint = new DnsEndPoint(host, port);
+                }
+                catch
+                {
+                    return false;
+                }
+            }
 
-			var host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase);
-
-			host = host.TrimEnd(':');
-
-			if (host == "localhost")
-			{
-				endPoint = new IPEndPoint(IPAddress.Loopback, port);
-			}
-			else if (IPAddress.TryParse(host, out IPAddress addr))
-			{
-				endPoint = new IPEndPoint(addr, port);
-			}
-			else
-			{
-				try
-				{
-					endPoint = new DnsEndPoint(host, port);
-				}
-				catch
-				{
-					return false;
-				}
-			}
-
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 }

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -36,6 +36,7 @@ namespace System.Net
 			return endPointString;
 		}
 
+		/// <param name="defaultPort">If set to -1 and it's needed to use, then this function returns false.</param>
 		public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
 		{
 			endPoint = null;
@@ -54,10 +55,21 @@ namespace System.Net
 
 			if (portString is null || !int.TryParse(portString, out int port))
 			{
+				if (defaultPort == -1)
+				{
+					return false;
+				}
+
 				port = defaultPort;
 			}
 
-			string host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase).TrimEnd(':');
+			string host = "";
+			if (portString != null)
+			{
+				host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase);
+			}
+
+			host = host.TrimEnd(':');
 
 			if (IPAddress.TryParse(host, out IPAddress addr))
 			{

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -6,108 +6,108 @@ using WalletWasabi.Helpers;
 
 namespace System.Net
 {
-    public static class EndPointParser
-    {
-        public static string ToString(this EndPoint me, int defaultPort)
-        {
-            string host;
-            int port;
-            if (me is DnsEndPoint dnsEndPoint)
-            {
-                host = dnsEndPoint.Host;
-                port = dnsEndPoint.Port;
-            }
-            else if (me is IPEndPoint ipEndPoint)
-            {
-                host = ipEndPoint.Address.ToString();
-                port = ipEndPoint.Port;
-            }
-            else
-            {
-                throw new FormatException($"Invalid endpoint: {me.ToString()}");
-            }
+	public static class EndPointParser
+	{
+		public static string ToString(this EndPoint me, int defaultPort)
+		{
+			string host;
+			int port;
+			if (me is DnsEndPoint dnsEndPoint)
+			{
+				host = dnsEndPoint.Host;
+				port = dnsEndPoint.Port;
+			}
+			else if (me is IPEndPoint ipEndPoint)
+			{
+				host = ipEndPoint.Address.ToString();
+				port = ipEndPoint.Port;
+			}
+			else
+			{
+				throw new FormatException($"Invalid endpoint: {me.ToString()}");
+			}
 
-            if (port == 0)
-            {
-                port = defaultPort;
-            }
+			if (port == 0)
+			{
+				port = defaultPort;
+			}
 
-            var endPointString = $"{host}:{port}";
+			var endPointString = $"{host}:{port}";
 
-            return endPointString;
-        }
+			return endPointString;
+		}
 
-        /// <param name="defaultPort">If invalid and it's needed to use, then this function returns false.</param>
-        public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
-        {
-            endPoint = null;
+		/// <param name="defaultPort">If invalid and it's needed to use, then this function returns false.</param>
+		public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
+		{
+			endPoint = null;
 
-            try
-            {
-                if (string.IsNullOrWhiteSpace(endPointString))
-                {
-                    return false;
-                }
+			try
+			{
+				if (string.IsNullOrWhiteSpace(endPointString))
+				{
+					return false;
+				}
 
-                endPointString = Guard.Correct(endPointString);
-                endPointString = endPointString.TrimEnd(':', '/');
-                var parts = endPointString.Split(':', StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().TrimEnd('/').TrimEnd()).ToArray();
+				endPointString = Guard.Correct(endPointString);
+				endPointString = endPointString.TrimEnd(':', '/');
+				var parts = endPointString.Split(':', StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().TrimEnd('/').TrimEnd()).ToArray();
 
-                var isDefaultPortInvalid = !ushort.TryParse(defaultPort.ToString(), out ushort dp) || dp < IPEndPoint.MinPort || dp > IPEndPoint.MaxPort;
-                int port;
-                if (parts.Length == 0)
-                {
-                    return false;
-                }
-                else if (parts.Length == 1)
-                {
-                    if (isDefaultPortInvalid)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        port = defaultPort;
-                    }
-                }
-                else if (parts.Length == 2)
-                {
-                    var portString = parts[1];
-                    if (ushort.TryParse(portString, out ushort p) && p >= IPEndPoint.MinPort && p <= IPEndPoint.MaxPort)
-                    {
-                        port = p;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    return false;
-                }
+				var isDefaultPortInvalid = !ushort.TryParse(defaultPort.ToString(), out ushort dp) || dp < IPEndPoint.MinPort || dp > IPEndPoint.MaxPort;
+				int port;
+				if (parts.Length == 0)
+				{
+					return false;
+				}
+				else if (parts.Length == 1)
+				{
+					if (isDefaultPortInvalid)
+					{
+						return false;
+					}
+					else
+					{
+						port = defaultPort;
+					}
+				}
+				else if (parts.Length == 2)
+				{
+					var portString = parts[1];
+					if (ushort.TryParse(portString, out ushort p) && p >= IPEndPoint.MinPort && p <= IPEndPoint.MaxPort)
+					{
+						port = p;
+					}
+					else
+					{
+						return false;
+					}
+				}
+				else
+				{
+					return false;
+				}
 
-                string host = parts[0];
-                if (host == "localhost")
-                {
-                    host = IPAddress.Loopback.ToString();
-                }
+				string host = parts[0];
+				if (host == "localhost")
+				{
+					host = IPAddress.Loopback.ToString();
+				}
 
-                if (IPAddress.TryParse(host, out IPAddress addr))
-                {
-                    endPoint = new IPEndPoint(addr, port);
-                }
-                else
-                {
-                    endPoint = new DnsEndPoint(host, port);
-                }
+				if (IPAddress.TryParse(host, out IPAddress addr))
+				{
+					endPoint = new IPEndPoint(addr, port);
+				}
+				else
+				{
+					endPoint = new DnsEndPoint(host, port);
+				}
 
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-    }
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+	}
 }

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace System.Net
+{
+	public static class EndPointParser
+	{
+		public static string ToString(this EndPoint me, int defaultPort)
+		{
+			string host;
+			int port;
+			if (me is DnsEndPoint dnsEndPoint)
+			{
+				host = dnsEndPoint.Host;
+				port = dnsEndPoint.Port;
+			}
+			else if (me is IPEndPoint ipEndPoint)
+			{
+				host = ipEndPoint.Address.ToString();
+				port = ipEndPoint.Port;
+			}
+			else
+			{
+				throw new FormatException($"Invalid endpoint: {me.ToString()}");
+			}
+
+			if (port == 0)
+			{
+				port = defaultPort;
+			}
+
+			var endPointString = $"{host}:{port}";
+
+			return endPointString;
+		}
+
+		public static bool TryParse(string endPointString, int defaultPort, out EndPoint endPoint)
+		{
+			endPoint = null;
+
+			endPointString = Guard.Correct(endPointString);
+			endPointString = endPointString.TrimEnd('/');
+			endPointString = endPointString.TrimEnd(':');
+
+			var lastIndex = endPointString.LastIndexOf(':');
+
+			string portString = null;
+			if (lastIndex != -1)
+			{
+				portString = endPointString.Substring(endPointString.LastIndexOf(':') + 1);
+			}
+
+			if (portString is null || !int.TryParse(portString, out int port))
+			{
+				port = defaultPort;
+			}
+
+			string host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase).TrimEnd(':');
+
+			if (IPAddress.TryParse(host, out IPAddress addr))
+			{
+				endPoint = new IPEndPoint(addr, port);
+			}
+			else
+			{
+				try
+				{
+					endPoint = new DnsEndPoint(host, port);
+				}
+				catch
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+}

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -53,7 +53,7 @@ namespace System.Net
                 endPointString = endPointString.TrimEnd(':', '/');
                 var parts = endPointString.Split(':', StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().TrimEnd('/').TrimEnd()).ToArray();
 
-                var isDefaultPortInvalid = !ushort.TryParse(defaultPort.ToString(), out _);
+                var isDefaultPortInvalid = !ushort.TryParse(defaultPort.ToString(), out ushort dp) || dp < IPEndPoint.MinPort || dp > IPEndPoint.MaxPort;
                 int port;
                 if (parts.Length == 0)
                 {
@@ -73,20 +73,13 @@ namespace System.Net
                 else if (parts.Length == 2)
                 {
                     var portString = parts[1];
-                    if (ushort.TryParse(portString, out ushort p))
+                    if (ushort.TryParse(portString, out ushort p) && p >= IPEndPoint.MinPort && p <= IPEndPoint.MaxPort)
                     {
                         port = p;
                     }
                     else
                     {
-                        if (isDefaultPortInvalid)
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            port = defaultPort;
-                        }
+                        return false;
                     }
                 }
                 else
@@ -100,33 +93,13 @@ namespace System.Net
                     host = IPAddress.Loopback.ToString();
                 }
 
-                bool isPortInvalid = port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort || !ushort.TryParse(port.ToString(), out _);
-                if (isPortInvalid)
-                {
-                    if (isDefaultPortInvalid)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        port = defaultPort;
-                    }
-                }
-
                 if (IPAddress.TryParse(host, out IPAddress addr))
                 {
                     endPoint = new IPEndPoint(addr, port);
                 }
                 else
                 {
-                    try
-                    {
-                        endPoint = new DnsEndPoint(host, port);
-                    }
-                    catch
-                    {
-                        return false;
-                    }
+                    endPoint = new DnsEndPoint(host, port);
                 }
 
                 return true;

--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -51,6 +51,9 @@ namespace System.Net
 
 				endPointString = Guard.Correct(endPointString);
 				endPointString = endPointString.TrimEnd(':', '/');
+				endPointString = endPointString.TrimStart("bitcoin-p2p://", StringComparison.OrdinalIgnoreCase);
+				endPointString = endPointString.TrimStart("tcp://", StringComparison.OrdinalIgnoreCase);
+
 				var parts = endPointString.Split(':', StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().TrimEnd('/').TrimEnd()).ToArray();
 
 				var isDefaultPortInvalid = !ushort.TryParse(defaultPort.ToString(), out ushort dp) || dp < IPEndPoint.MinPort || dp > IPEndPoint.MaxPort;

--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -17,9 +17,9 @@ namespace WalletWasabi.JsonConverters
 
 		public EndPointJsonConverter(int defaultPort)
 		{
-			if (DefaultPort == 0)
+			if (defaultPort == 0)
 			{
-				throw new ArgumentException("Default port not specified.", nameof(DefaultPort));
+				throw new ArgumentException("Default port not specified.", nameof(defaultPort));
 			}
 
 			DefaultPort = defaultPort;

--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -1,0 +1,99 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.JsonConverters
+{
+	public class EndPointJsonConverter : JsonConverter
+	{
+		public int DefaultPort { get; }
+
+		private EndPointJsonConverter()
+		{
+		}
+
+		public EndPointJsonConverter(int defaultPort)
+		{
+			if (DefaultPort == 0)
+			{
+				throw new ArgumentException("Default port not specified.", nameof(DefaultPort));
+			}
+
+			DefaultPort = defaultPort;
+		}
+
+		/// <inheritdoc />
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(EndPoint);
+		}
+
+		/// <inheritdoc />
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			string endPointString = Guard.Correct(reader.Value as string);
+			endPointString = endPointString.TrimEnd('/');
+			endPointString = endPointString.TrimEnd(':');
+
+			var lastIndex = endPointString.LastIndexOf(':');
+
+			string portString = null;
+			if (lastIndex != -1)
+			{
+				portString = endPointString.Substring(endPointString.LastIndexOf(':') + 1);
+			}
+
+			if (portString is null || !int.TryParse(portString, out int port))
+			{
+				port = DefaultPort;
+			}
+
+			string host = endPointString.TrimEnd(portString, StringComparison.OrdinalIgnoreCase).TrimEnd(':');
+
+			EndPoint endPoint;
+			if (IPAddress.TryParse(host, out IPAddress addr))
+			{
+				endPoint = new IPEndPoint(addr, port);
+			}
+			else
+			{
+				endPoint = new DnsEndPoint(host, port);
+			}
+
+			return endPoint;
+		}
+
+		/// <inheritdoc />
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			string host;
+			int port;
+			if (value is DnsEndPoint dnsEndPoint)
+			{
+				host = dnsEndPoint.Host;
+				port = dnsEndPoint.Port;
+			}
+			else if (value is IPEndPoint ipEndPoint)
+			{
+				host = ipEndPoint.Address.ToString();
+				port = ipEndPoint.Port;
+			}
+			else
+			{
+				throw new FormatException($"Invalid endpoint: {value.ToString()}");
+			}
+
+			if (port == 0)
+			{
+				port = DefaultPort;
+			}
+
+			var endPointString = $"{host}:{port}";
+
+			writer.WriteValue(endPointString);
+		}
+	}
+}

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -24,1078 +24,1078 @@ using static NBitcoin.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.Services
 {
-	public class CcjClient
-	{
-		public Network Network { get; private set; }
-		public KeyManager KeyManager { get; private set; }
-		public bool IsQuitPending { get; set; }
-
-		private ClientRoundRegistration DelayedRoundRegistration { get; set; }
-
-		public Func<Uri> CcjHostUriAction { get; private set; }
-		public WasabiSynchronizer Synchronizer { get; private set; }
-		private IPEndPoint TorSocks5EndPoint { get; set; }
-
-		private decimal? CoordinatorFeepercentToCheck { get; set; }
-
-		public ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>> ExposedLinks { get; set; }
-
-		private AsyncLock MixLock { get; set; }
-
-		public CcjClientState State { get; private set; }
-
-		public event EventHandler StateUpdated;
-
-		public event EventHandler<SmartCoin> CoinQueued;
-
-		public event EventHandler<SmartCoin> CoinDequeued;
-
-		private long _frequentStatusProcessingIfNotMixing;
-
-		/// <summary>
-		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
-		/// </summary>
-		private long _running;
-
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
-
-		private long _statusProcessing;
-
-		private CancellationTokenSource Cancel { get; set; }
-
-		public CcjClient(
-			WasabiSynchronizer synchronizer,
-			Network network,
-			KeyManager keyManager,
-			Func<Uri> ccjHostUriAction,
-			IPEndPoint torSocks5EndPoint)
-		{
-			Create(synchronizer, network, keyManager, ccjHostUriAction, torSocks5EndPoint);
-		}
-
-		public CcjClient(
-			WasabiSynchronizer synchronizer,
-			Network network,
-			KeyManager keyManager,
-			Uri ccjHostUri,
-			IPEndPoint torSocks5EndPoint)
-		{
-			Create(synchronizer, network, keyManager, () => ccjHostUri, torSocks5EndPoint);
-		}
-
-		private void Create(WasabiSynchronizer synchronizer, Network network, KeyManager keyManager, Func<Uri> ccjHostUriAction, IPEndPoint torSocks5EndPoint)
-		{
-			Network = Guard.NotNull(nameof(network), network);
-			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-			CcjHostUriAction = Guard.NotNull(nameof(ccjHostUriAction), ccjHostUriAction);
-			Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
-			TorSocks5EndPoint = torSocks5EndPoint;
-			CoordinatorFeepercentToCheck = null;
-
-			ExposedLinks = new ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>>();
-			_running = 0;
-			Cancel = new CancellationTokenSource();
-			_frequentStatusProcessingIfNotMixing = 0;
-			State = new CcjClientState();
-			MixLock = new AsyncLock();
-			_statusProcessing = 0;
-			DelayedRoundRegistration = null;
-
-			Synchronizer.ResponseArrived += Synchronizer_ResponseArrivedAsync;
-
-			var lastResponse = Synchronizer.LastResponse;
-			if (lastResponse != null)
-			{
-				_ = TryProcessStatusAsync(Synchronizer.LastResponse.CcjRoundStates);
-			}
-		}
-
-		private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse e)
-		{
-			await TryProcessStatusAsync(e?.CcjRoundStates);
-		}
-
-		public void Start()
-		{
-			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
-			{
-				return;
-			}
-
-			// The client is asking for status periodically, randomly between every 0.2 * connConfTimeout and 0.7 * connConfTimeout.
-			// - if the GUI is at the mixer tab -Activate(), DeactivateIfNotMixing().
-			// - if coins are queued to mix.
-			// The client is asking for status periodically, randomly between every 2 to 7 seconds.
-			// - if it is participating in a mix thats status >= connConf.
-
-			// The client is triggered only when a status response arrives. The answer to the server is delayed randomly from 0 to 7 seconds.
-
-			Task.Run(async () =>
-			{
-				try
-				{
-					Logger.LogInfo<CcjClient>("CcjClient is successfully initialized.");
-
-					while (IsRunning)
-					{
-						try
-						{
-							using (await MixLock.LockAsync())
-							{
-								await DequeueSpentCoinsFromMixNoLockAsync();
-
-								// If stop was requested return.
-								if (!IsRunning)
-								{
-									return;
-								}
-
-								// if mixing >= connConf
-								if (State.GetActivelyMixingRounds().Any())
-								{
-									int delaySeconds = new Random().Next(2, 7);
-									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
-								}
-								else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Any() || State.GetWaitingListCount() > 0)
-								{
-									double rand = double.Parse($"0.{new Random().Next(2, 6)}"); // randomly between every 0.2 * connConfTimeout - 7 and 0.6 * connConfTimeout
-									int delaySeconds = Math.Max(0, (int)(rand * State.GetSmallestRegistrationTimeout() - 7));
-
-									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
-								}
-								else // dormant
-								{
-									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromMinutes(3);
-								}
-							}
-						}
-						catch (Exception ex)
-						{
-							Logger.LogError<CcjClient>(ex);
-						}
-						finally
-						{
-							try
-							{
-								await Task.Delay(1000, Cancel.Token);
-							}
-							catch (TaskCanceledException ex)
-							{
-								Logger.LogTrace<CcjClient>(ex);
-							}
-						}
-					}
-				}
-				finally
-				{
-					Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
-				}
-			});
-		}
-
-		private async Task TryProcessStatusAsync(IEnumerable<CcjRunningRoundState> states)
-		{
-			states = states ?? Enumerable.Empty<CcjRunningRoundState>();
-
-			if (Interlocked.Read(ref _statusProcessing) == 1) // It's ok to wait for status processing next time.
-			{
-				return;
-			}
-
-			try
-			{
-				Synchronizer.BlockRequests();
-
-				Interlocked.Exchange(ref _statusProcessing, 1);
-				using (await MixLock.LockAsync())
-				{
-					// First, if there's delayed round registration update based on the state.
-					if (DelayedRoundRegistration != null)
-					{
-						CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(DelayedRoundRegistration.AliceClient.RoundId);
-						roundRegistered.Registration = DelayedRoundRegistration;
-						DelayedRoundRegistration = null; // Do not dispose.
-					}
-
-					await DequeueSpentCoinsFromMixNoLockAsync();
-
-					State.UpdateRoundsByStates(ExposedLinks, states.ToArray());
-
-					// If we do not have enough coin queued to register a round, then dequeue all.
-					CcjClientRound registrableRound = State.GetRegistrableRoundOrDefault();
-					if (registrableRound != default)
-					{
-						// If the coordinator increases fees, do not register. Let the users register manually again.
-						bool dequeueBecauseCoordinatorFeeChanged = false;
-						if (CoordinatorFeepercentToCheck != default)
-						{
-							dequeueBecauseCoordinatorFeeChanged = registrableRound.State.CoordinatorFeePercent > CoordinatorFeepercentToCheck;
-						}
-
-						if (!registrableRound.State.HaveEnoughQueued(State.GetAllQueuedCoinAmounts().ToArray())
-							|| dequeueBecauseCoordinatorFeeChanged)
-						{
-							await DequeueAllCoinsFromMixNoLockAsync("The total value of the registered coins is not enough or the coordinator's fee changed.");
-						}
-					}
-				}
-				StateUpdated?.Invoke(this, null);
-
-				int delaySeconds = new Random().Next(0, 7); // delay the response to defend timing attack privacy.
-
-				if (Network == Network.RegTest)
-				{
-					delaySeconds = 0;
-				}
-
-				await Task.Delay(TimeSpan.FromSeconds(delaySeconds), Cancel.Token);
-
-				using (await MixLock.LockAsync())
-				{
-					foreach (long ongoingRoundId in State.GetActivelyMixingRounds())
-					{
-						await TryProcessRoundStateAsync(ongoingRoundId);
-					}
-
-					await DequeueSpentCoinsFromMixNoLockAsync();
-					CcjClientRound inputRegistrableRound = State.GetRegistrableRoundOrDefault();
-					if (inputRegistrableRound != null)
-					{
-						if (inputRegistrableRound.Registration is null) // If did not register already, check what can we register.
-						{
-							await TryRegisterCoinsAsync(inputRegistrableRound);
-						}
-						else // We registered, let's confirm we're online.
-						{
-							await TryConfirmConnectionAsync(inputRegistrableRound);
-						}
-					}
-				}
-			}
-			catch (TaskCanceledException ex)
-			{
-				Logger.LogTrace<CcjClient>(ex);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError<CcjClient>(ex);
-			}
-			finally
-			{
-				Interlocked.Exchange(ref _statusProcessing, 0);
-				Synchronizer.EnableRequests();
-			}
-		}
-
-		private async Task TryProcessRoundStateAsync(long ongoingRoundId)
-		{
-			try
-			{
-				var ongoingRound = State.GetSingleOrDefaultRound(ongoingRoundId);
-				if (ongoingRound is null)
-				{
-					throw new NotSupportedException("This is impossible.");
-				}
-
-				if (ongoingRound.State.Phase == CcjRoundPhase.ConnectionConfirmation)
-				{
-					if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.ConnectionConfirmation)) // If we did not already confirm connection in connection confirmation phase confirm it.
-					{
-						var res = await ongoingRound.Registration.AliceClient.PostConfirmationAsync();
-						if (res.activeOutputs.Any())
-						{
-							ongoingRound.Registration.ActiveOutputs = res.activeOutputs;
-						}
-						ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
-					}
-				}
-				else if (ongoingRound.State.Phase == CcjRoundPhase.OutputRegistration)
-				{
-					if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.OutputRegistration))
-					{
-						await RegisterOutputAsync(ongoingRound);
-					}
-				}
-				else if (ongoingRound.State.Phase == CcjRoundPhase.Signing)
-				{
-					if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.Signing))
-					{
-						Transaction unsignedCoinJoin = await ongoingRound.Registration.AliceClient.GetUnsignedCoinJoinAsync();
-						Dictionary<int, WitScript> myDic = SignCoinJoin(ongoingRound, unsignedCoinJoin);
-
-						await ongoingRound.Registration.AliceClient.PostSignaturesAsync(myDic);
-						ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.Signing);
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError<CcjClient>(ex); // Keep this in front of the logic (Logs will make more sense.)
-				if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
-				{
-					State.ClearRoundRegistration(ongoingRoundId);
-				}
-			}
-		}
-
-		private Dictionary<int, WitScript> SignCoinJoin(CcjClientRound ongoingRound, Transaction unsignedCoinJoin)
-		{
-			TxOut[] myOutputs = unsignedCoinJoin.Outputs
-				.Where(x => x.ScriptPubKey == ongoingRound.Registration.ChangeAddress.ScriptPubKey
-					|| ongoingRound.Registration.ActiveOutputs.Select(y => y.Address.ScriptPubKey).Contains(x.ScriptPubKey))
-					.ToArray();
-			Money amountBack = myOutputs.Sum(y => y.Value);
-
-			// Make sure change is counted.
-			Money minAmountBack = ongoingRound.CoinsRegistered.Sum(x => x.Amount); // Start with input sum.
-																				   // Do outputs.lenght + 1 in case the server estimated the network fees wrongly due to insufficient data in an edge case.
-			Money networkFeesAfterOutputs = ongoingRound.State.FeePerOutputs * (ongoingRound.Registration.AliceClient.RegisteredAddresses.Length + 1); // Use registered addresses here, because network fees are decided at inputregistration.
-			Money networkFeesAfterInputs = ongoingRound.State.FeePerInputs * ongoingRound.Registration.CoinsRegistered.Count();
-			Money networkFees = networkFeesAfterOutputs + networkFeesAfterInputs;
-			minAmountBack -= networkFees; // Minus miner fee.
-
-			IOrderedEnumerable<(Money value, int count)> indistinguishableOutputs = unsignedCoinJoin.GetIndistinguishableOutputs(includeSingle: false).OrderByDescending(x => x.count);
-			foreach ((Money value, int count) denomPair in indistinguishableOutputs)
-			{
-				var mineCount = myOutputs.Count(x => x.Value == denomPair.value);
-
-				Money denomination = denomPair.value;
-				int anonset = Math.Min(110, denomPair.count); // https://github.com/zkSNACKs/WalletWasabi/issues/1379
-				Money expectedCoordinatorFee = denomination.Percentage(ongoingRound.State.CoordinatorFeePercent * anonset);
-				for (int i = 0; i < mineCount; i++)
-				{
-					minAmountBack -= expectedCoordinatorFee; // Minus expected coordinator fee.
-				}
-			}
-
-			// If there's no change output then coordinator protection may happened:
-			bool gotChange = myOutputs.Select(x => x.ScriptPubKey).Contains(ongoingRound.Registration.ChangeAddress.ScriptPubKey);
-			if (!gotChange)
-			{
-				Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
-				Money baseDenomination = indistinguishableOutputs.First().value;
-				Money onePercentOfDenomination = baseDenomination.Percentage(1m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
-				Money minimumChangeAmount = Math.Max(minimumOutputAmount, onePercentOfDenomination);
-
-				minAmountBack -= minimumChangeAmount; // Minus coordinator protections (so it won't create bad coinjoins.)
-			}
-
-			if (amountBack < minAmountBack && !amountBack.Almost(minAmountBack, Money.Satoshis(1000))) // Just in case. Rounding error maybe?
-			{
-				Money diff = minAmountBack - amountBack;
-				throw new NotSupportedException($"Coordinator did not add enough value to our outputs in the coinjoin. Missing: {diff.Satoshi} satoshis.");
-			}
-
-			var signedCoinJoin = unsignedCoinJoin.Clone();
-			signedCoinJoin.Sign(ongoingRound.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(SaltSoup(), x.ScriptPubKey).Single()).ToArray(), ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()).ToArray());
-
-			// Old way of signing, which randomly fails! https://github.com/zkSNACKs/WalletWasabi/issues/716#issuecomment-435498906
-			// Must be fixed in NBitcoin.
-			//var builder = Network.CreateTransactionBuilder();
-			//var signedCoinJoin = builder
-			//	.ContinueToBuild(unsignedCoinJoin)
-			//	.AddKeys(ongoingRound.Registration.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(OnePiece, x.ScriptPubKey).Single()).ToArray())
-			//	.AddCoins(ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()))
-			//	.BuildTransaction(true);
-
-			var myDic = new Dictionary<int, WitScript>();
-
-			for (int i = 0; i < signedCoinJoin.Inputs.Count; i++)
-			{
-				var input = signedCoinJoin.Inputs[i];
-				if (ongoingRound.CoinsRegistered.Select(x => x.GetOutPoint()).Contains(input.PrevOut))
-				{
-					myDic.Add(i, signedCoinJoin.Inputs[i].WitScript);
-				}
-			}
-
-			return myDic;
-		}
-
-		private async Task RegisterOutputAsync(CcjClientRound ongoingRound)
-		{
-			IEnumerable<TxoRef> registeredInputs = ongoingRound.Registration.CoinsRegistered.Select(x => x.GetTxoRef());
-
-			var shuffledOutputs = ongoingRound.Registration.ActiveOutputs.ToList();
-			shuffledOutputs.Shuffle();
-			foreach (var activeOutput in shuffledOutputs)
-			{
-				using (var bobClient = new BobClient(CcjHostUriAction, TorSocks5EndPoint))
-				{
-					if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput))
-					{
-						Logger.LogWarning<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.)");
-						break;
-					}
-
-					// Unblind our exposed links.
-					foreach (TxoRef input in registeredInputs)
-					{
-						if (ExposedLinks.ContainsKey(input)) // Should never not contain, but oh well, let's not disrupt the round for this.
-						{
-							var found = ExposedLinks[input].FirstOrDefault(x => x.Key.GetP2wpkhAddress(Network) == activeOutput.Address);
-							if (found != default)
-							{
-								found.IsBlinded = false;
-							}
-							else
-							{
-								// Should never happen, but oh well we can autocorrect it so why not.
-								ExposedLinks[input] = ExposedLinks[input].Append(new HdPubKeyBlindedPair(KeyManager.GetKeyForScriptPubKey(activeOutput.Address.ScriptPubKey), false));
-							}
-						}
-					}
-				}
-			}
-
-			ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.OutputRegistration);
-			Logger.LogInfo<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bob Posted outputs: {ongoingRound.Registration.ActiveOutputs.Count()}.");
-		}
-
-		private async Task TryConfirmConnectionAsync(CcjClientRound inputRegistrableRound)
-		{
-			try
-			{
-				var res = await inputRegistrableRound.Registration.AliceClient.PostConfirmationAsync();
-
-				if (res.activeOutputs.Any())
-				{
-					inputRegistrableRound.Registration.ActiveOutputs = res.activeOutputs;
-				}
-
-				if (res.currentPhase > CcjRoundPhase.InputRegistration) // Then the phase went to connection confirmation (probably).
-				{
-					inputRegistrableRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
-					inputRegistrableRound.State.Phase = res.currentPhase;
-				}
-			}
-			catch (Exception ex)
-			{
-				if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
-				{
-					State.ClearRoundRegistration(inputRegistrableRound.State.RoundId);
-				}
-				Logger.LogError<CcjClient>(ex);
-			}
-		}
-
-		private async Task TryRegisterCoinsAsync(CcjClientRound inputRegistrableRound)
-		{
-			try
-			{
-				// Select the most suitable coins to regiter.
-				List<TxoRef> registrableCoins = State.GetRegistrableCoins(
-					inputRegistrableRound.State.MaximumInputCountPerPeer,
-					inputRegistrableRound.State.Denomination,
-					inputRegistrableRound.State.FeePerInputs,
-					inputRegistrableRound.State.FeePerOutputs).ToList();
-
-				// If there are no suitable coins to register return.
-				if (!registrableCoins.Any())
-				{
-					return;
-				}
-
-				(HdPubKey change, IEnumerable<HdPubKey> actives) outputAddresses = GetOutputsToRegister(inputRegistrableRound.State.Denomination, inputRegistrableRound.State.SchnorrPubKeys.Count(), registrableCoins);
-
-				SchnorrPubKey[] schnorrPubKeys = inputRegistrableRound.State.SchnorrPubKeys.ToArray();
-				List<Requester> requesters = new List<Requester>();
-				var blindedOutputScriptHashes = new List<uint256>();
-
-				var registeredAddresses = new List<BitcoinAddress>();
-				for (int i = 0; i < schnorrPubKeys.Length; i++)
-				{
-					if (outputAddresses.actives.Count() <= i)
-					{
-						break;
-					}
-
-					BitcoinAddress address = outputAddresses.actives.Select(x => x.GetP2wpkhAddress(Network)).ElementAt(i);
-
-					SchnorrPubKey schnorrPubKey = schnorrPubKeys[i];
-					var outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
-					var requester = new Requester();
-					uint256 blindedOutputScriptHash = requester.BlindMessage(outputScriptHash, schnorrPubKey);
-					requesters.Add(requester);
-					blindedOutputScriptHashes.Add(blindedOutputScriptHash);
-					registeredAddresses.Add(address);
-				}
-
-				byte[] blindedOutputScriptHashesByte = ByteHelpers.Combine(blindedOutputScriptHashes.Select(x => x.ToBytes()));
-				uint256 blindedOutputScriptsHash = new uint256(Hashes.SHA256(blindedOutputScriptHashesByte));
-
-				var inputProofs = new List<InputProofModel>();
-				foreach (TxoRef coinReference in registrableCoins)
-				{
-					SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-					if (coin is null)
-					{
-						throw new NotSupportedException("This is impossible.");
-					}
-
-					coin.Secret = coin.Secret ?? KeyManager.GetSecrets(SaltSoup(), coin.ScriptPubKey).Single();
-					var inputProof = new InputProofModel
-					{
-						Input = coin.GetTxoRef(),
-						Proof = coin.Secret.PrivateKey.SignCompact(blindedOutputScriptsHash)
-					};
-					inputProofs.Add(inputProof);
-				}
-
-				AliceClient aliceClient = null;
-				try
-				{
-					aliceClient = await AliceClient.CreateNewAsync(inputRegistrableRound.RoundId, registeredAddresses, schnorrPubKeys, requesters, Network, outputAddresses.change.GetP2wpkhAddress(Network), blindedOutputScriptHashes, inputProofs, CcjHostUriAction, TorSocks5EndPoint);
-				}
-				catch (HttpRequestException ex) when (ex.Message.Contains("Input is banned", StringComparison.InvariantCultureIgnoreCase))
-				{
-					string[] parts = ex.Message.Split(new[] { "Input is banned from participation for ", " minutes: " }, StringSplitOptions.RemoveEmptyEntries);
-					string minutesString = parts[1];
-					int minuteInt = int.Parse(minutesString);
-					string bannedInputString = parts[2].TrimEnd('.');
-					string[] bannedInputStringParts = bannedInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
-					TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
-					SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-					if (coin is null)
-					{
-						throw new NotSupportedException("This is impossible.");
-					}
-
-					coin.BannedUntilUtc = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(minuteInt);
-
-					Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
-
-					await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator.");
-					aliceClient?.Dispose();
-					return;
-				}
-				catch (HttpRequestException ex) when (ex.Message.Contains("Provided input is not unspent", StringComparison.InvariantCultureIgnoreCase))
-				{
-					string[] parts = ex.Message.Split(new[] { "Provided input is not unspent: " }, StringSplitOptions.RemoveEmptyEntries);
-					string spentInputString = parts[1].TrimEnd('.');
-					string[] bannedInputStringParts = spentInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
-					TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
-					SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-					if (coin is null)
-					{
-						throw new NotSupportedException("This is impossible.");
-					}
-
-					coin.SpentAccordingToBackend = true;
-
-					Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
-
-					await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator. The coin is already spent.");
-					aliceClient?.Dispose();
-					return;
-				}
-				catch (HttpRequestException ex) when (ex.Message.Contains("No such running round in InputRegistration.", StringComparison.InvariantCultureIgnoreCase))
-				{
-					Logger.LogInfo<CcjClient>("Client tried to register a round that is not in InputRegistration anymore. Trying again later.");
-					aliceClient?.Dispose();
-					return;
-				}
-				catch (HttpRequestException ex) when (ex.Message.Contains("too-long-mempool-chain", StringComparison.InvariantCultureIgnoreCase))
-				{
-					Logger.LogInfo<CcjClient>("Coordinator failed because too much unconfirmed parent transactions. Trying again later.");
-					aliceClient?.Dispose();
-					return;
-				}
-
-				var coinsRegistered = new List<SmartCoin>();
-				foreach (TxoRef coinReference in registrableCoins)
-				{
-					var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-					if (coin is null)
-					{
-						throw new NotSupportedException("This is impossible.");
-					}
-
-					coinsRegistered.Add(coin);
-					State.RemoveCoinFromWaitingList(coin);
-				}
-
-				var registration = new ClientRoundRegistration(aliceClient, coinsRegistered, outputAddresses.change.GetP2wpkhAddress(Network));
-
-				CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(aliceClient.RoundId);
-				if (roundRegistered is null)
-				{
-					// If our SatoshiClient does not yet know about the round, because of delay, then delay the round registration.
-					DelayedRoundRegistration?.Dispose();
-					DelayedRoundRegistration = registration;
-				}
-
-				roundRegistered.Registration = registration;
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError<CcjClient>(ex);
-			}
-		}
-
-		private (HdPubKey change, IEnumerable<HdPubKey> active) GetOutputsToRegister(Money baseDenomination, int mixingLevelCount, IEnumerable<TxoRef> coinsToRegister)
-		{
-			// Figure out how many mixing level we need to register active outputs.
-			Money inputSum = Money.Zero;
-			foreach (TxoRef coinReference in coinsToRegister)
-			{
-				SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-				inputSum += coin.Amount;
-			}
-
-			int maximumMixingLevelCount = 1;
-			var denominations = new List<Money>
-					{
-						baseDenomination
-					};
-			for (int i = 1; i < mixingLevelCount; i++)
-			{
-				Money denom = denominations.Last() * 2;
-				denominations.Add(denom);
-				if (inputSum > denom)
-				{
-					maximumMixingLevelCount = i + 1;
-				}
-			}
-
-			string changeLabel = "ZeroLink Change";
-			string activeLabel = "ZeroLink Mixed Coin";
-
-			var keysToSurelyRegister = ExposedLinks.Where(x => coinsToRegister.Contains(x.Key)).SelectMany(x => x.Value).Select(x => x.Key).ToArray();
-			var keysTryNotToRegister = ExposedLinks.SelectMany(x => x.Value).Select(x => x.Key).Except(keysToSurelyRegister).ToArray();
-
-			// Get all locked internal keys we have and assert we have enough.
-			KeyManager.AssertLockedInternalKeysIndexed(howMany: maximumMixingLevelCount + 1);
-			IEnumerable<HdPubKey> allLockedInternalKeys = KeyManager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked && !keysTryNotToRegister.Contains(x));
-
-			// If any of our inputs have exposed address relationship then prefer that.
-			allLockedInternalKeys = keysToSurelyRegister.Concat(allLockedInternalKeys).Distinct();
-
-			// Prefer not to bloat the wallet:
-			if (allLockedInternalKeys.Count() <= maximumMixingLevelCount)
-			{
-				allLockedInternalKeys = allLockedInternalKeys.Concat(keysTryNotToRegister).Distinct();
-			}
-
-			var newKeys = new List<HdPubKey>();
-			for (int i = allLockedInternalKeys.Count(); i <= maximumMixingLevelCount + 1; i++)
-			{
-				HdPubKey k = KeyManager.GenerateNewKey("", KeyState.Locked, isInternal: true, toFile: false);
-				newKeys.Add(k);
-			}
-			allLockedInternalKeys = allLockedInternalKeys.Concat(newKeys);
-
-			// Select the change and active keys to register and label them accordingly.
-			HdPubKey change = allLockedInternalKeys.First();
-			change.SetLabel(changeLabel);
-
-			var actives = new List<HdPubKey>();
-			foreach (HdPubKey active in allLockedInternalKeys.Skip(1).Take(maximumMixingLevelCount))
-			{
-				actives.Add(active);
-				active.SetLabel(activeLabel);
-			}
-
-			// Remember which links we are exposing.
-			var outLinks = new List<HdPubKeyBlindedPair>
-			{
-				new HdPubKeyBlindedPair(change, isBlinded: false)
-			};
-			foreach (var active in actives)
-			{
-				outLinks.Add(new HdPubKeyBlindedPair(active, isBlinded: true));
-			}
-			foreach (TxoRef coin in coinsToRegister)
-			{
-				if (!ExposedLinks.TryAdd(coin, outLinks))
-				{
-					var newOutLinks = new List<HdPubKeyBlindedPair>();
-					foreach (HdPubKeyBlindedPair link in ExposedLinks[coin])
-					{
-						newOutLinks.Add(link);
-					}
-					foreach (HdPubKeyBlindedPair link in outLinks)
-					{
-						HdPubKeyBlindedPair found = newOutLinks.FirstOrDefault(x => x == link);
-
-						if (found == default)
-						{
-							newOutLinks.Add(link);
-						}
-						else // If already in it then update the blinded value if it's getting exposed just now. (eg. the change)
-						{
-							if (found.IsBlinded)
-							{
-								found.IsBlinded = link.IsBlinded;
-							}
-						}
-					}
-
-					ExposedLinks[coin] = newOutLinks;
-				}
-			}
-
-			// Save our modifications in the keymanager before we give back the selected keys.
-			KeyManager.ToFile();
-			return (change, actives);
-		}
-
-		public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)
-		{
-			await QueueCoinsToMixAsync(SaltSoup(), coins);
-		}
-
-		public void ActivateFrequentStatusProcessing()
-		{
-			Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 1);
-		}
-
-		public void DeactivateFrequentStatusProcessingIfNotMixing()
-		{
-			Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 0);
-		}
-
-		private string Salt { get; set; } = null;
-		private string Soup { get; set; } = null;
-		private object RefrigeratorLock { get; } = new object();
-
-		public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, params SmartCoin[] coins)
-		{
-			if (coins is null || !coins.Any() || IsQuitPending)
-			{
-				return Enumerable.Empty<SmartCoin>();
-			}
-
-			var successful = new List<SmartCoin>();
-			using (await MixLock.LockAsync())
-			{
-				await DequeueSpentCoinsFromMixNoLockAsync();
-
-				// Every time the user enqueues (intentionally writes in password) then the coordinator fee percent must be noted and dequeue later if changes.
-				CcjClientRound latestRound = State.GetLatestRoundOrDefault();
-				CoordinatorFeepercentToCheck = latestRound?.State?.CoordinatorFeePercent;
-
-				var except = new List<SmartCoin>();
-
-				foreach (SmartCoin coin in coins)
-				{
-					if (State.Contains(coin))
-					{
-						successful.Add(coin);
-						except.Add(coin);
-						continue;
-					}
-
-					if (coin.Unavailable)
-					{
-						except.Add(coin);
-						continue;
-					}
-				}
-
-				var coinsExcept = coins.Except(except);
-				var secPubs = KeyManager.GetSecretsAndPubKeyPairs(password, coinsExcept.Select(x => x.ScriptPubKey).ToArray());
-
-				Cook(password);
-
-				foreach (SmartCoin coin in coinsExcept)
-				{
-					coin.Secret = secPubs.Single(x => x.pubKey.P2wpkhScript == coin.ScriptPubKey).secret;
-
-					coin.CoinJoinInProgress = true;
-
-					State.AddCoinToWaitingList(coin);
-					successful.Add(coin);
-					Logger.LogInfo<CcjClient>($"Coin queued: {coin.Index}:{coin.TransactionId}.");
-				}
-			}
-
-			foreach (var coin in successful)
-			{
-				CoinQueued?.Invoke(this, coin);
-			}
-			return successful;
-		}
-
-		public async Task DequeueCoinsFromMixAsync(SmartCoin coin, string reason)
-		{
-			await DequeueCoinsFromMixAsync(new[] { coin }, reason);
-		}
-
-		public async Task DequeueCoinsFromMixAsync(IEnumerable<SmartCoin> coins, string reason)
-		{
-			if (coins is null || !coins.Any())
-			{
-				return;
-			}
-
-			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-			{
-				try
-				{
-					using (await MixLock.LockAsync(cts.Token))
-					{
-						await DequeueSpentCoinsFromMixNoLockAsync();
-
-						await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
-					}
-				}
-				catch (TaskCanceledException)
-				{
-					await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray(), reason);
-
-					await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
-				}
-			}
-		}
-
-		public bool HasIngredients => Salt != null && Soup != null;
-
-		private string SaltSoup()
-		{
-			if (!HasIngredients)
-			{
-				return null;
-			}
-
-			string res;
-			lock (RefrigeratorLock)
-			{
-				res = StringCipher.Decrypt(Soup, Salt);
-			}
-
-			Cook(res);
-
-			return res;
-		}
-
-		private void Cook(string ingredients)
-		{
-			lock (RefrigeratorLock)
-			{
-				ingredients = ingredients ?? "";
-
-				Salt = TokenGenerator.GetUniqueKey(21);
-				Soup = StringCipher.Encrypt(ingredients, Salt);
-			}
-		}
-
-		public async Task DequeueCoinsFromMixAsync(TxoRef coin, string reason)
-		{
-			await DequeueCoinsFromMixAsync(new[] { coin }, reason);
-		}
-
-		public async Task DequeueCoinsFromMixAsync(TxoRef[] coins, string reason)
-		{
-			if (coins is null || !coins.Any())
-			{
-				return;
-			}
-
-			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-			{
-				try
-				{
-					using (await MixLock.LockAsync(cts.Token))
-					{
-						await DequeueSpentCoinsFromMixNoLockAsync();
-
-						await DequeueCoinsFromMixNoLockAsync(coins, reason);
-					}
-				}
-				catch (TaskCanceledException)
-				{
-					await DequeueSpentCoinsFromMixNoLockAsync();
-
-					await DequeueCoinsFromMixNoLockAsync(coins, reason);
-				}
-			}
-		}
-
-		public async Task DequeueAllCoinsFromMixAsync(string reason)
-		{
-			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-			{
-				try
-				{
-					using (await MixLock.LockAsync(cts.Token))
-					{
-						await DequeueAllCoinsFromMixNoLockAsync(reason);
-					}
-				}
-				catch (TaskCanceledException)
-				{
-					await DequeueAllCoinsFromMixNoLockAsync(reason);
-				}
-			}
-		}
-
-		private async Task DequeueAllCoinsFromMixNoLockAsync(string reason)
-		{
-			await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray(), reason);
-		}
-
-		private async Task DequeueSpentCoinsFromMixNoLockAsync()
-		{
-			await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
-		}
-
-		private async Task DequeueCoinsFromMixNoLockAsync(TxoRef coin, string reason = null)
-		{
-			await DequeueCoinsFromMixNoLockAsync(new[] { coin }, reason);
-		}
-
-		private async Task DequeueCoinsFromMixNoLockAsync(TxoRef[] coins, string reason = null)
-		{
-			if (coins is null || !coins.Any())
-			{
-				return;
-			}
-
-			List<Exception> exceptions = new List<Exception>();
-
-			foreach (var coinReference in coins)
-			{
-				var coinToDequeue = State.GetSingleOrDefaultCoin(coinReference);
-				if (coinToDequeue is null)
-				{
-					continue;
-				}
-
-				foreach (long roundId in State.GetPassivelyMixingRounds())
-				{
-					var round = State.GetSingleOrDefaultRound(roundId);
-					if (round is null)
-					{
-						throw new NotSupportedException("This is impossible.");
-					}
-
-					if (round.CoinsRegistered.Contains(coinToDequeue))
-					{
-						try
-						{
-							await round.Registration.AliceClient.PostUnConfirmationAsync(); // AliceUniqueId must be there.
-							State.ClearRoundRegistration(round.State.RoundId);
-						}
-						catch (Exception ex)
-						{
-							if (coinToDequeue.Unspent)
-							{
-								exceptions.Add(ex);
-							}
-						}
-					}
-				}
-
-				foreach (long roundId in State.GetActivelyMixingRounds())
-				{
-					var round = State.GetSingleOrDefaultRound(roundId);
-					if (round is null)
-					{
-						continue;
-					}
-
-					if (round.CoinsRegistered.Contains(coinToDequeue))
-					{
-						if (!coinToDequeue.Unspent) // If coin was spent, well that sucks, except if it was spent by the tumbler in signing phase.
-						{
-							State.ClearRoundRegistration(round.State.RoundId);
-							continue;
-						}
-						else
-						{
-							exceptions.Add(new NotSupportedException($"Cannot deque coin in {round.State.Phase} phase. Coin: {coinToDequeue.Index}:{coinToDequeue.TransactionId}."));
-						}
-					}
-				}
-
-				SmartCoin coinWaitingForMix = State.GetSingleOrDefaultFromWaitingList(coinToDequeue);
-				if (coinWaitingForMix != null) // If it is not being mixed, we can just remove it.
-				{
-					RemoveCoin(coinWaitingForMix, reason);
-				}
-			}
-
-			if (exceptions.Count == 1)
-			{
-				throw exceptions.Single();
-			}
-
-			if (exceptions.Count > 0)
-			{
-				throw new AggregateException(exceptions);
-			}
-		}
-
-		private void RemoveCoin(SmartCoin coinWaitingForMix, string reason = null)
-		{
-			State.RemoveCoinFromWaitingList(coinWaitingForMix);
-			coinWaitingForMix.CoinJoinInProgress = false;
-			coinWaitingForMix.Secret = null;
-			if (coinWaitingForMix.Label == "ZeroLink Change" && coinWaitingForMix.Unspent)
-			{
-				coinWaitingForMix.Label = "ZeroLink Dequeued Change";
-				var key = KeyManager.GetKeys(x => x.P2wpkhScript == coinWaitingForMix.ScriptPubKey).SingleOrDefault();
-				if (key != null)
-				{
-					key.SetLabel(coinWaitingForMix.Label, KeyManager);
-				}
-			}
-			CoinDequeued?.Invoke(this, coinWaitingForMix);
-			var correctReason = Guard.Correct(reason);
-			var reasonText = correctReason != "" ? $" Reason: {correctReason}" : "";
-			Logger.LogInfo<CcjClient>($"Coin dequeued: {coinWaitingForMix.Index}:{coinWaitingForMix.TransactionId}.{reasonText}");
-		}
-
-		public async Task StopAsync()
-		{
-			Synchronizer.ResponseArrived -= Synchronizer_ResponseArrivedAsync;
-
-			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
-			Cancel?.Cancel();
-			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
-			{
-				await Task.Delay(50);
-			}
-
-			Cancel?.Dispose();
-			Cancel = null;
-
-			using (await MixLock.LockAsync())
-			{
-				await DequeueSpentCoinsFromMixNoLockAsync();
-
-				State.DisposeAllAliceClients();
-
-				IEnumerable<TxoRef> allCoins = State.GetAllQueuedCoins();
-				foreach (var coinReference in allCoins)
-				{
-					try
-					{
-						var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-						if (coin is null)
-						{
-							continue; // The coin is not present anymore. Good. This should never happen though.
-						}
-						await DequeueCoinsFromMixNoLockAsync(coin.GetTxoRef(), "Stopping Wasabi.");
-					}
-					catch (Exception ex)
-					{
-						Logger.LogError<CcjClient>("Could not dequeue all coins. Some coins will likely be banned from mixing.");
-						if (ex is AggregateException aggrEx)
-						{
-							foreach (var innerEx in aggrEx.InnerExceptions)
-							{
-								Logger.LogError<CcjClient>(innerEx);
-							}
-						}
-						else
-						{
-							Logger.LogError<CcjClient>(ex);
-						}
-					}
-				}
-			}
-		}
-	}
+    public class CcjClient
+    {
+        public Network Network { get; private set; }
+        public KeyManager KeyManager { get; private set; }
+        public bool IsQuitPending { get; set; }
+
+        private ClientRoundRegistration DelayedRoundRegistration { get; set; }
+
+        public Func<Uri> CcjHostUriAction { get; private set; }
+        public WasabiSynchronizer Synchronizer { get; private set; }
+        private EndPoint TorSocks5EndPoint { get; set; }
+
+        private decimal? CoordinatorFeepercentToCheck { get; set; }
+
+        public ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>> ExposedLinks { get; set; }
+
+        private AsyncLock MixLock { get; set; }
+
+        public CcjClientState State { get; private set; }
+
+        public event EventHandler StateUpdated;
+
+        public event EventHandler<SmartCoin> CoinQueued;
+
+        public event EventHandler<SmartCoin> CoinDequeued;
+
+        private long _frequentStatusProcessingIfNotMixing;
+
+        /// <summary>
+        /// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
+        /// </summary>
+        private long _running;
+
+        public bool IsRunning => Interlocked.Read(ref _running) == 1;
+
+        private long _statusProcessing;
+
+        private CancellationTokenSource Cancel { get; set; }
+
+        public CcjClient(
+            WasabiSynchronizer synchronizer,
+            Network network,
+            KeyManager keyManager,
+            Func<Uri> ccjHostUriAction,
+            EndPoint torSocks5EndPoint)
+        {
+            Create(synchronizer, network, keyManager, ccjHostUriAction, torSocks5EndPoint);
+        }
+
+        public CcjClient(
+            WasabiSynchronizer synchronizer,
+            Network network,
+            KeyManager keyManager,
+            Uri ccjHostUri,
+            EndPoint torSocks5EndPoint)
+        {
+            Create(synchronizer, network, keyManager, () => ccjHostUri, torSocks5EndPoint);
+        }
+
+        private void Create(WasabiSynchronizer synchronizer, Network network, KeyManager keyManager, Func<Uri> ccjHostUriAction, EndPoint torSocks5EndPoint)
+        {
+            Network = Guard.NotNull(nameof(network), network);
+            KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+            CcjHostUriAction = Guard.NotNull(nameof(ccjHostUriAction), ccjHostUriAction);
+            Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
+            TorSocks5EndPoint = torSocks5EndPoint;
+            CoordinatorFeepercentToCheck = null;
+
+            ExposedLinks = new ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>>();
+            _running = 0;
+            Cancel = new CancellationTokenSource();
+            _frequentStatusProcessingIfNotMixing = 0;
+            State = new CcjClientState();
+            MixLock = new AsyncLock();
+            _statusProcessing = 0;
+            DelayedRoundRegistration = null;
+
+            Synchronizer.ResponseArrived += Synchronizer_ResponseArrivedAsync;
+
+            var lastResponse = Synchronizer.LastResponse;
+            if (lastResponse != null)
+            {
+                _ = TryProcessStatusAsync(Synchronizer.LastResponse.CcjRoundStates);
+            }
+        }
+
+        private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse e)
+        {
+            await TryProcessStatusAsync(e?.CcjRoundStates);
+        }
+
+        public void Start()
+        {
+            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+            {
+                return;
+            }
+
+            // The client is asking for status periodically, randomly between every 0.2 * connConfTimeout and 0.7 * connConfTimeout.
+            // - if the GUI is at the mixer tab -Activate(), DeactivateIfNotMixing().
+            // - if coins are queued to mix.
+            // The client is asking for status periodically, randomly between every 2 to 7 seconds.
+            // - if it is participating in a mix thats status >= connConf.
+
+            // The client is triggered only when a status response arrives. The answer to the server is delayed randomly from 0 to 7 seconds.
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    Logger.LogInfo<CcjClient>("CcjClient is successfully initialized.");
+
+                    while (IsRunning)
+                    {
+                        try
+                        {
+                            using (await MixLock.LockAsync())
+                            {
+                                await DequeueSpentCoinsFromMixNoLockAsync();
+
+                                // If stop was requested return.
+                                if (!IsRunning)
+                                {
+                                    return;
+                                }
+
+                                // if mixing >= connConf
+                                if (State.GetActivelyMixingRounds().Any())
+                                {
+                                    int delaySeconds = new Random().Next(2, 7);
+                                    Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
+                                }
+                                else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Any() || State.GetWaitingListCount() > 0)
+                                {
+                                    double rand = double.Parse($"0.{new Random().Next(2, 6)}"); // randomly between every 0.2 * connConfTimeout - 7 and 0.6 * connConfTimeout
+                                    int delaySeconds = Math.Max(0, (int)(rand * State.GetSmallestRegistrationTimeout() - 7));
+
+                                    Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
+                                }
+                                else // dormant
+                                {
+                                    Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromMinutes(3);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogError<CcjClient>(ex);
+                        }
+                        finally
+                        {
+                            try
+                            {
+                                await Task.Delay(1000, Cancel.Token);
+                            }
+                            catch (TaskCanceledException ex)
+                            {
+                                Logger.LogTrace<CcjClient>(ex);
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
+                }
+            });
+        }
+
+        private async Task TryProcessStatusAsync(IEnumerable<CcjRunningRoundState> states)
+        {
+            states = states ?? Enumerable.Empty<CcjRunningRoundState>();
+
+            if (Interlocked.Read(ref _statusProcessing) == 1) // It's ok to wait for status processing next time.
+            {
+                return;
+            }
+
+            try
+            {
+                Synchronizer.BlockRequests();
+
+                Interlocked.Exchange(ref _statusProcessing, 1);
+                using (await MixLock.LockAsync())
+                {
+                    // First, if there's delayed round registration update based on the state.
+                    if (DelayedRoundRegistration != null)
+                    {
+                        CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(DelayedRoundRegistration.AliceClient.RoundId);
+                        roundRegistered.Registration = DelayedRoundRegistration;
+                        DelayedRoundRegistration = null; // Do not dispose.
+                    }
+
+                    await DequeueSpentCoinsFromMixNoLockAsync();
+
+                    State.UpdateRoundsByStates(ExposedLinks, states.ToArray());
+
+                    // If we do not have enough coin queued to register a round, then dequeue all.
+                    CcjClientRound registrableRound = State.GetRegistrableRoundOrDefault();
+                    if (registrableRound != default)
+                    {
+                        // If the coordinator increases fees, do not register. Let the users register manually again.
+                        bool dequeueBecauseCoordinatorFeeChanged = false;
+                        if (CoordinatorFeepercentToCheck != default)
+                        {
+                            dequeueBecauseCoordinatorFeeChanged = registrableRound.State.CoordinatorFeePercent > CoordinatorFeepercentToCheck;
+                        }
+
+                        if (!registrableRound.State.HaveEnoughQueued(State.GetAllQueuedCoinAmounts().ToArray())
+                            || dequeueBecauseCoordinatorFeeChanged)
+                        {
+                            await DequeueAllCoinsFromMixNoLockAsync("The total value of the registered coins is not enough or the coordinator's fee changed.");
+                        }
+                    }
+                }
+                StateUpdated?.Invoke(this, null);
+
+                int delaySeconds = new Random().Next(0, 7); // delay the response to defend timing attack privacy.
+
+                if (Network == Network.RegTest)
+                {
+                    delaySeconds = 0;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(delaySeconds), Cancel.Token);
+
+                using (await MixLock.LockAsync())
+                {
+                    foreach (long ongoingRoundId in State.GetActivelyMixingRounds())
+                    {
+                        await TryProcessRoundStateAsync(ongoingRoundId);
+                    }
+
+                    await DequeueSpentCoinsFromMixNoLockAsync();
+                    CcjClientRound inputRegistrableRound = State.GetRegistrableRoundOrDefault();
+                    if (inputRegistrableRound != null)
+                    {
+                        if (inputRegistrableRound.Registration is null) // If did not register already, check what can we register.
+                        {
+                            await TryRegisterCoinsAsync(inputRegistrableRound);
+                        }
+                        else // We registered, let's confirm we're online.
+                        {
+                            await TryConfirmConnectionAsync(inputRegistrableRound);
+                        }
+                    }
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                Logger.LogTrace<CcjClient>(ex);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError<CcjClient>(ex);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _statusProcessing, 0);
+                Synchronizer.EnableRequests();
+            }
+        }
+
+        private async Task TryProcessRoundStateAsync(long ongoingRoundId)
+        {
+            try
+            {
+                var ongoingRound = State.GetSingleOrDefaultRound(ongoingRoundId);
+                if (ongoingRound is null)
+                {
+                    throw new NotSupportedException("This is impossible.");
+                }
+
+                if (ongoingRound.State.Phase == CcjRoundPhase.ConnectionConfirmation)
+                {
+                    if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.ConnectionConfirmation)) // If we did not already confirm connection in connection confirmation phase confirm it.
+                    {
+                        var res = await ongoingRound.Registration.AliceClient.PostConfirmationAsync();
+                        if (res.activeOutputs.Any())
+                        {
+                            ongoingRound.Registration.ActiveOutputs = res.activeOutputs;
+                        }
+                        ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
+                    }
+                }
+                else if (ongoingRound.State.Phase == CcjRoundPhase.OutputRegistration)
+                {
+                    if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.OutputRegistration))
+                    {
+                        await RegisterOutputAsync(ongoingRound);
+                    }
+                }
+                else if (ongoingRound.State.Phase == CcjRoundPhase.Signing)
+                {
+                    if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.Signing))
+                    {
+                        Transaction unsignedCoinJoin = await ongoingRound.Registration.AliceClient.GetUnsignedCoinJoinAsync();
+                        Dictionary<int, WitScript> myDic = SignCoinJoin(ongoingRound, unsignedCoinJoin);
+
+                        await ongoingRound.Registration.AliceClient.PostSignaturesAsync(myDic);
+                        ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.Signing);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError<CcjClient>(ex); // Keep this in front of the logic (Logs will make more sense.)
+                if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
+                {
+                    State.ClearRoundRegistration(ongoingRoundId);
+                }
+            }
+        }
+
+        private Dictionary<int, WitScript> SignCoinJoin(CcjClientRound ongoingRound, Transaction unsignedCoinJoin)
+        {
+            TxOut[] myOutputs = unsignedCoinJoin.Outputs
+                .Where(x => x.ScriptPubKey == ongoingRound.Registration.ChangeAddress.ScriptPubKey
+                    || ongoingRound.Registration.ActiveOutputs.Select(y => y.Address.ScriptPubKey).Contains(x.ScriptPubKey))
+                    .ToArray();
+            Money amountBack = myOutputs.Sum(y => y.Value);
+
+            // Make sure change is counted.
+            Money minAmountBack = ongoingRound.CoinsRegistered.Sum(x => x.Amount); // Start with input sum.
+                                                                                   // Do outputs.lenght + 1 in case the server estimated the network fees wrongly due to insufficient data in an edge case.
+            Money networkFeesAfterOutputs = ongoingRound.State.FeePerOutputs * (ongoingRound.Registration.AliceClient.RegisteredAddresses.Length + 1); // Use registered addresses here, because network fees are decided at inputregistration.
+            Money networkFeesAfterInputs = ongoingRound.State.FeePerInputs * ongoingRound.Registration.CoinsRegistered.Count();
+            Money networkFees = networkFeesAfterOutputs + networkFeesAfterInputs;
+            minAmountBack -= networkFees; // Minus miner fee.
+
+            IOrderedEnumerable<(Money value, int count)> indistinguishableOutputs = unsignedCoinJoin.GetIndistinguishableOutputs(includeSingle: false).OrderByDescending(x => x.count);
+            foreach ((Money value, int count) denomPair in indistinguishableOutputs)
+            {
+                var mineCount = myOutputs.Count(x => x.Value == denomPair.value);
+
+                Money denomination = denomPair.value;
+                int anonset = Math.Min(110, denomPair.count); // https://github.com/zkSNACKs/WalletWasabi/issues/1379
+                Money expectedCoordinatorFee = denomination.Percentage(ongoingRound.State.CoordinatorFeePercent * anonset);
+                for (int i = 0; i < mineCount; i++)
+                {
+                    minAmountBack -= expectedCoordinatorFee; // Minus expected coordinator fee.
+                }
+            }
+
+            // If there's no change output then coordinator protection may happened:
+            bool gotChange = myOutputs.Select(x => x.ScriptPubKey).Contains(ongoingRound.Registration.ChangeAddress.ScriptPubKey);
+            if (!gotChange)
+            {
+                Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
+                Money baseDenomination = indistinguishableOutputs.First().value;
+                Money onePercentOfDenomination = baseDenomination.Percentage(1m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
+                Money minimumChangeAmount = Math.Max(minimumOutputAmount, onePercentOfDenomination);
+
+                minAmountBack -= minimumChangeAmount; // Minus coordinator protections (so it won't create bad coinjoins.)
+            }
+
+            if (amountBack < minAmountBack && !amountBack.Almost(minAmountBack, Money.Satoshis(1000))) // Just in case. Rounding error maybe?
+            {
+                Money diff = minAmountBack - amountBack;
+                throw new NotSupportedException($"Coordinator did not add enough value to our outputs in the coinjoin. Missing: {diff.Satoshi} satoshis.");
+            }
+
+            var signedCoinJoin = unsignedCoinJoin.Clone();
+            signedCoinJoin.Sign(ongoingRound.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(SaltSoup(), x.ScriptPubKey).Single()).ToArray(), ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()).ToArray());
+
+            // Old way of signing, which randomly fails! https://github.com/zkSNACKs/WalletWasabi/issues/716#issuecomment-435498906
+            // Must be fixed in NBitcoin.
+            //var builder = Network.CreateTransactionBuilder();
+            //var signedCoinJoin = builder
+            //	.ContinueToBuild(unsignedCoinJoin)
+            //	.AddKeys(ongoingRound.Registration.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(OnePiece, x.ScriptPubKey).Single()).ToArray())
+            //	.AddCoins(ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()))
+            //	.BuildTransaction(true);
+
+            var myDic = new Dictionary<int, WitScript>();
+
+            for (int i = 0; i < signedCoinJoin.Inputs.Count; i++)
+            {
+                var input = signedCoinJoin.Inputs[i];
+                if (ongoingRound.CoinsRegistered.Select(x => x.GetOutPoint()).Contains(input.PrevOut))
+                {
+                    myDic.Add(i, signedCoinJoin.Inputs[i].WitScript);
+                }
+            }
+
+            return myDic;
+        }
+
+        private async Task RegisterOutputAsync(CcjClientRound ongoingRound)
+        {
+            IEnumerable<TxoRef> registeredInputs = ongoingRound.Registration.CoinsRegistered.Select(x => x.GetTxoRef());
+
+            var shuffledOutputs = ongoingRound.Registration.ActiveOutputs.ToList();
+            shuffledOutputs.Shuffle();
+            foreach (var activeOutput in shuffledOutputs)
+            {
+                using (var bobClient = new BobClient(CcjHostUriAction, TorSocks5EndPoint))
+                {
+                    if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput))
+                    {
+                        Logger.LogWarning<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.)");
+                        break;
+                    }
+
+                    // Unblind our exposed links.
+                    foreach (TxoRef input in registeredInputs)
+                    {
+                        if (ExposedLinks.ContainsKey(input)) // Should never not contain, but oh well, let's not disrupt the round for this.
+                        {
+                            var found = ExposedLinks[input].FirstOrDefault(x => x.Key.GetP2wpkhAddress(Network) == activeOutput.Address);
+                            if (found != default)
+                            {
+                                found.IsBlinded = false;
+                            }
+                            else
+                            {
+                                // Should never happen, but oh well we can autocorrect it so why not.
+                                ExposedLinks[input] = ExposedLinks[input].Append(new HdPubKeyBlindedPair(KeyManager.GetKeyForScriptPubKey(activeOutput.Address.ScriptPubKey), false));
+                            }
+                        }
+                    }
+                }
+            }
+
+            ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.OutputRegistration);
+            Logger.LogInfo<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bob Posted outputs: {ongoingRound.Registration.ActiveOutputs.Count()}.");
+        }
+
+        private async Task TryConfirmConnectionAsync(CcjClientRound inputRegistrableRound)
+        {
+            try
+            {
+                var res = await inputRegistrableRound.Registration.AliceClient.PostConfirmationAsync();
+
+                if (res.activeOutputs.Any())
+                {
+                    inputRegistrableRound.Registration.ActiveOutputs = res.activeOutputs;
+                }
+
+                if (res.currentPhase > CcjRoundPhase.InputRegistration) // Then the phase went to connection confirmation (probably).
+                {
+                    inputRegistrableRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
+                    inputRegistrableRound.State.Phase = res.currentPhase;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
+                {
+                    State.ClearRoundRegistration(inputRegistrableRound.State.RoundId);
+                }
+                Logger.LogError<CcjClient>(ex);
+            }
+        }
+
+        private async Task TryRegisterCoinsAsync(CcjClientRound inputRegistrableRound)
+        {
+            try
+            {
+                // Select the most suitable coins to regiter.
+                List<TxoRef> registrableCoins = State.GetRegistrableCoins(
+                    inputRegistrableRound.State.MaximumInputCountPerPeer,
+                    inputRegistrableRound.State.Denomination,
+                    inputRegistrableRound.State.FeePerInputs,
+                    inputRegistrableRound.State.FeePerOutputs).ToList();
+
+                // If there are no suitable coins to register return.
+                if (!registrableCoins.Any())
+                {
+                    return;
+                }
+
+                (HdPubKey change, IEnumerable<HdPubKey> actives) outputAddresses = GetOutputsToRegister(inputRegistrableRound.State.Denomination, inputRegistrableRound.State.SchnorrPubKeys.Count(), registrableCoins);
+
+                SchnorrPubKey[] schnorrPubKeys = inputRegistrableRound.State.SchnorrPubKeys.ToArray();
+                List<Requester> requesters = new List<Requester>();
+                var blindedOutputScriptHashes = new List<uint256>();
+
+                var registeredAddresses = new List<BitcoinAddress>();
+                for (int i = 0; i < schnorrPubKeys.Length; i++)
+                {
+                    if (outputAddresses.actives.Count() <= i)
+                    {
+                        break;
+                    }
+
+                    BitcoinAddress address = outputAddresses.actives.Select(x => x.GetP2wpkhAddress(Network)).ElementAt(i);
+
+                    SchnorrPubKey schnorrPubKey = schnorrPubKeys[i];
+                    var outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
+                    var requester = new Requester();
+                    uint256 blindedOutputScriptHash = requester.BlindMessage(outputScriptHash, schnorrPubKey);
+                    requesters.Add(requester);
+                    blindedOutputScriptHashes.Add(blindedOutputScriptHash);
+                    registeredAddresses.Add(address);
+                }
+
+                byte[] blindedOutputScriptHashesByte = ByteHelpers.Combine(blindedOutputScriptHashes.Select(x => x.ToBytes()));
+                uint256 blindedOutputScriptsHash = new uint256(Hashes.SHA256(blindedOutputScriptHashesByte));
+
+                var inputProofs = new List<InputProofModel>();
+                foreach (TxoRef coinReference in registrableCoins)
+                {
+                    SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+                    if (coin is null)
+                    {
+                        throw new NotSupportedException("This is impossible.");
+                    }
+
+                    coin.Secret = coin.Secret ?? KeyManager.GetSecrets(SaltSoup(), coin.ScriptPubKey).Single();
+                    var inputProof = new InputProofModel
+                    {
+                        Input = coin.GetTxoRef(),
+                        Proof = coin.Secret.PrivateKey.SignCompact(blindedOutputScriptsHash)
+                    };
+                    inputProofs.Add(inputProof);
+                }
+
+                AliceClient aliceClient = null;
+                try
+                {
+                    aliceClient = await AliceClient.CreateNewAsync(inputRegistrableRound.RoundId, registeredAddresses, schnorrPubKeys, requesters, Network, outputAddresses.change.GetP2wpkhAddress(Network), blindedOutputScriptHashes, inputProofs, CcjHostUriAction, TorSocks5EndPoint);
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("Input is banned", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    string[] parts = ex.Message.Split(new[] { "Input is banned from participation for ", " minutes: " }, StringSplitOptions.RemoveEmptyEntries);
+                    string minutesString = parts[1];
+                    int minuteInt = int.Parse(minutesString);
+                    string bannedInputString = parts[2].TrimEnd('.');
+                    string[] bannedInputStringParts = bannedInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                    TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
+                    SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+                    if (coin is null)
+                    {
+                        throw new NotSupportedException("This is impossible.");
+                    }
+
+                    coin.BannedUntilUtc = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(minuteInt);
+
+                    Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
+
+                    await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator.");
+                    aliceClient?.Dispose();
+                    return;
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("Provided input is not unspent", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    string[] parts = ex.Message.Split(new[] { "Provided input is not unspent: " }, StringSplitOptions.RemoveEmptyEntries);
+                    string spentInputString = parts[1].TrimEnd('.');
+                    string[] bannedInputStringParts = spentInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                    TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
+                    SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+                    if (coin is null)
+                    {
+                        throw new NotSupportedException("This is impossible.");
+                    }
+
+                    coin.SpentAccordingToBackend = true;
+
+                    Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
+
+                    await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator. The coin is already spent.");
+                    aliceClient?.Dispose();
+                    return;
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("No such running round in InputRegistration.", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    Logger.LogInfo<CcjClient>("Client tried to register a round that is not in InputRegistration anymore. Trying again later.");
+                    aliceClient?.Dispose();
+                    return;
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("too-long-mempool-chain", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    Logger.LogInfo<CcjClient>("Coordinator failed because too much unconfirmed parent transactions. Trying again later.");
+                    aliceClient?.Dispose();
+                    return;
+                }
+
+                var coinsRegistered = new List<SmartCoin>();
+                foreach (TxoRef coinReference in registrableCoins)
+                {
+                    var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+                    if (coin is null)
+                    {
+                        throw new NotSupportedException("This is impossible.");
+                    }
+
+                    coinsRegistered.Add(coin);
+                    State.RemoveCoinFromWaitingList(coin);
+                }
+
+                var registration = new ClientRoundRegistration(aliceClient, coinsRegistered, outputAddresses.change.GetP2wpkhAddress(Network));
+
+                CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(aliceClient.RoundId);
+                if (roundRegistered is null)
+                {
+                    // If our SatoshiClient does not yet know about the round, because of delay, then delay the round registration.
+                    DelayedRoundRegistration?.Dispose();
+                    DelayedRoundRegistration = registration;
+                }
+
+                roundRegistered.Registration = registration;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError<CcjClient>(ex);
+            }
+        }
+
+        private (HdPubKey change, IEnumerable<HdPubKey> active) GetOutputsToRegister(Money baseDenomination, int mixingLevelCount, IEnumerable<TxoRef> coinsToRegister)
+        {
+            // Figure out how many mixing level we need to register active outputs.
+            Money inputSum = Money.Zero;
+            foreach (TxoRef coinReference in coinsToRegister)
+            {
+                SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+                inputSum += coin.Amount;
+            }
+
+            int maximumMixingLevelCount = 1;
+            var denominations = new List<Money>
+                    {
+                        baseDenomination
+                    };
+            for (int i = 1; i < mixingLevelCount; i++)
+            {
+                Money denom = denominations.Last() * 2;
+                denominations.Add(denom);
+                if (inputSum > denom)
+                {
+                    maximumMixingLevelCount = i + 1;
+                }
+            }
+
+            string changeLabel = "ZeroLink Change";
+            string activeLabel = "ZeroLink Mixed Coin";
+
+            var keysToSurelyRegister = ExposedLinks.Where(x => coinsToRegister.Contains(x.Key)).SelectMany(x => x.Value).Select(x => x.Key).ToArray();
+            var keysTryNotToRegister = ExposedLinks.SelectMany(x => x.Value).Select(x => x.Key).Except(keysToSurelyRegister).ToArray();
+
+            // Get all locked internal keys we have and assert we have enough.
+            KeyManager.AssertLockedInternalKeysIndexed(howMany: maximumMixingLevelCount + 1);
+            IEnumerable<HdPubKey> allLockedInternalKeys = KeyManager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked && !keysTryNotToRegister.Contains(x));
+
+            // If any of our inputs have exposed address relationship then prefer that.
+            allLockedInternalKeys = keysToSurelyRegister.Concat(allLockedInternalKeys).Distinct();
+
+            // Prefer not to bloat the wallet:
+            if (allLockedInternalKeys.Count() <= maximumMixingLevelCount)
+            {
+                allLockedInternalKeys = allLockedInternalKeys.Concat(keysTryNotToRegister).Distinct();
+            }
+
+            var newKeys = new List<HdPubKey>();
+            for (int i = allLockedInternalKeys.Count(); i <= maximumMixingLevelCount + 1; i++)
+            {
+                HdPubKey k = KeyManager.GenerateNewKey("", KeyState.Locked, isInternal: true, toFile: false);
+                newKeys.Add(k);
+            }
+            allLockedInternalKeys = allLockedInternalKeys.Concat(newKeys);
+
+            // Select the change and active keys to register and label them accordingly.
+            HdPubKey change = allLockedInternalKeys.First();
+            change.SetLabel(changeLabel);
+
+            var actives = new List<HdPubKey>();
+            foreach (HdPubKey active in allLockedInternalKeys.Skip(1).Take(maximumMixingLevelCount))
+            {
+                actives.Add(active);
+                active.SetLabel(activeLabel);
+            }
+
+            // Remember which links we are exposing.
+            var outLinks = new List<HdPubKeyBlindedPair>
+            {
+                new HdPubKeyBlindedPair(change, isBlinded: false)
+            };
+            foreach (var active in actives)
+            {
+                outLinks.Add(new HdPubKeyBlindedPair(active, isBlinded: true));
+            }
+            foreach (TxoRef coin in coinsToRegister)
+            {
+                if (!ExposedLinks.TryAdd(coin, outLinks))
+                {
+                    var newOutLinks = new List<HdPubKeyBlindedPair>();
+                    foreach (HdPubKeyBlindedPair link in ExposedLinks[coin])
+                    {
+                        newOutLinks.Add(link);
+                    }
+                    foreach (HdPubKeyBlindedPair link in outLinks)
+                    {
+                        HdPubKeyBlindedPair found = newOutLinks.FirstOrDefault(x => x == link);
+
+                        if (found == default)
+                        {
+                            newOutLinks.Add(link);
+                        }
+                        else // If already in it then update the blinded value if it's getting exposed just now. (eg. the change)
+                        {
+                            if (found.IsBlinded)
+                            {
+                                found.IsBlinded = link.IsBlinded;
+                            }
+                        }
+                    }
+
+                    ExposedLinks[coin] = newOutLinks;
+                }
+            }
+
+            // Save our modifications in the keymanager before we give back the selected keys.
+            KeyManager.ToFile();
+            return (change, actives);
+        }
+
+        public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)
+        {
+            await QueueCoinsToMixAsync(SaltSoup(), coins);
+        }
+
+        public void ActivateFrequentStatusProcessing()
+        {
+            Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 1);
+        }
+
+        public void DeactivateFrequentStatusProcessingIfNotMixing()
+        {
+            Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 0);
+        }
+
+        private string Salt { get; set; } = null;
+        private string Soup { get; set; } = null;
+        private object RefrigeratorLock { get; } = new object();
+
+        public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, params SmartCoin[] coins)
+        {
+            if (coins is null || !coins.Any() || IsQuitPending)
+            {
+                return Enumerable.Empty<SmartCoin>();
+            }
+
+            var successful = new List<SmartCoin>();
+            using (await MixLock.LockAsync())
+            {
+                await DequeueSpentCoinsFromMixNoLockAsync();
+
+                // Every time the user enqueues (intentionally writes in password) then the coordinator fee percent must be noted and dequeue later if changes.
+                CcjClientRound latestRound = State.GetLatestRoundOrDefault();
+                CoordinatorFeepercentToCheck = latestRound?.State?.CoordinatorFeePercent;
+
+                var except = new List<SmartCoin>();
+
+                foreach (SmartCoin coin in coins)
+                {
+                    if (State.Contains(coin))
+                    {
+                        successful.Add(coin);
+                        except.Add(coin);
+                        continue;
+                    }
+
+                    if (coin.Unavailable)
+                    {
+                        except.Add(coin);
+                        continue;
+                    }
+                }
+
+                var coinsExcept = coins.Except(except);
+                var secPubs = KeyManager.GetSecretsAndPubKeyPairs(password, coinsExcept.Select(x => x.ScriptPubKey).ToArray());
+
+                Cook(password);
+
+                foreach (SmartCoin coin in coinsExcept)
+                {
+                    coin.Secret = secPubs.Single(x => x.pubKey.P2wpkhScript == coin.ScriptPubKey).secret;
+
+                    coin.CoinJoinInProgress = true;
+
+                    State.AddCoinToWaitingList(coin);
+                    successful.Add(coin);
+                    Logger.LogInfo<CcjClient>($"Coin queued: {coin.Index}:{coin.TransactionId}.");
+                }
+            }
+
+            foreach (var coin in successful)
+            {
+                CoinQueued?.Invoke(this, coin);
+            }
+            return successful;
+        }
+
+        public async Task DequeueCoinsFromMixAsync(SmartCoin coin, string reason)
+        {
+            await DequeueCoinsFromMixAsync(new[] { coin }, reason);
+        }
+
+        public async Task DequeueCoinsFromMixAsync(IEnumerable<SmartCoin> coins, string reason)
+        {
+            if (coins is null || !coins.Any())
+            {
+                return;
+            }
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+            {
+                try
+                {
+                    using (await MixLock.LockAsync(cts.Token))
+                    {
+                        await DequeueSpentCoinsFromMixNoLockAsync();
+
+                        await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray(), reason);
+
+                    await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
+                }
+            }
+        }
+
+        public bool HasIngredients => Salt != null && Soup != null;
+
+        private string SaltSoup()
+        {
+            if (!HasIngredients)
+            {
+                return null;
+            }
+
+            string res;
+            lock (RefrigeratorLock)
+            {
+                res = StringCipher.Decrypt(Soup, Salt);
+            }
+
+            Cook(res);
+
+            return res;
+        }
+
+        private void Cook(string ingredients)
+        {
+            lock (RefrigeratorLock)
+            {
+                ingredients = ingredients ?? "";
+
+                Salt = TokenGenerator.GetUniqueKey(21);
+                Soup = StringCipher.Encrypt(ingredients, Salt);
+            }
+        }
+
+        public async Task DequeueCoinsFromMixAsync(TxoRef coin, string reason)
+        {
+            await DequeueCoinsFromMixAsync(new[] { coin }, reason);
+        }
+
+        public async Task DequeueCoinsFromMixAsync(TxoRef[] coins, string reason)
+        {
+            if (coins is null || !coins.Any())
+            {
+                return;
+            }
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+            {
+                try
+                {
+                    using (await MixLock.LockAsync(cts.Token))
+                    {
+                        await DequeueSpentCoinsFromMixNoLockAsync();
+
+                        await DequeueCoinsFromMixNoLockAsync(coins, reason);
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    await DequeueSpentCoinsFromMixNoLockAsync();
+
+                    await DequeueCoinsFromMixNoLockAsync(coins, reason);
+                }
+            }
+        }
+
+        public async Task DequeueAllCoinsFromMixAsync(string reason)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+            {
+                try
+                {
+                    using (await MixLock.LockAsync(cts.Token))
+                    {
+                        await DequeueAllCoinsFromMixNoLockAsync(reason);
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    await DequeueAllCoinsFromMixNoLockAsync(reason);
+                }
+            }
+        }
+
+        private async Task DequeueAllCoinsFromMixNoLockAsync(string reason)
+        {
+            await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray(), reason);
+        }
+
+        private async Task DequeueSpentCoinsFromMixNoLockAsync()
+        {
+            await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+        }
+
+        private async Task DequeueCoinsFromMixNoLockAsync(TxoRef coin, string reason = null)
+        {
+            await DequeueCoinsFromMixNoLockAsync(new[] { coin }, reason);
+        }
+
+        private async Task DequeueCoinsFromMixNoLockAsync(TxoRef[] coins, string reason = null)
+        {
+            if (coins is null || !coins.Any())
+            {
+                return;
+            }
+
+            List<Exception> exceptions = new List<Exception>();
+
+            foreach (var coinReference in coins)
+            {
+                var coinToDequeue = State.GetSingleOrDefaultCoin(coinReference);
+                if (coinToDequeue is null)
+                {
+                    continue;
+                }
+
+                foreach (long roundId in State.GetPassivelyMixingRounds())
+                {
+                    var round = State.GetSingleOrDefaultRound(roundId);
+                    if (round is null)
+                    {
+                        throw new NotSupportedException("This is impossible.");
+                    }
+
+                    if (round.CoinsRegistered.Contains(coinToDequeue))
+                    {
+                        try
+                        {
+                            await round.Registration.AliceClient.PostUnConfirmationAsync(); // AliceUniqueId must be there.
+                            State.ClearRoundRegistration(round.State.RoundId);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (coinToDequeue.Unspent)
+                            {
+                                exceptions.Add(ex);
+                            }
+                        }
+                    }
+                }
+
+                foreach (long roundId in State.GetActivelyMixingRounds())
+                {
+                    var round = State.GetSingleOrDefaultRound(roundId);
+                    if (round is null)
+                    {
+                        continue;
+                    }
+
+                    if (round.CoinsRegistered.Contains(coinToDequeue))
+                    {
+                        if (!coinToDequeue.Unspent) // If coin was spent, well that sucks, except if it was spent by the tumbler in signing phase.
+                        {
+                            State.ClearRoundRegistration(round.State.RoundId);
+                            continue;
+                        }
+                        else
+                        {
+                            exceptions.Add(new NotSupportedException($"Cannot deque coin in {round.State.Phase} phase. Coin: {coinToDequeue.Index}:{coinToDequeue.TransactionId}."));
+                        }
+                    }
+                }
+
+                SmartCoin coinWaitingForMix = State.GetSingleOrDefaultFromWaitingList(coinToDequeue);
+                if (coinWaitingForMix != null) // If it is not being mixed, we can just remove it.
+                {
+                    RemoveCoin(coinWaitingForMix, reason);
+                }
+            }
+
+            if (exceptions.Count == 1)
+            {
+                throw exceptions.Single();
+            }
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        private void RemoveCoin(SmartCoin coinWaitingForMix, string reason = null)
+        {
+            State.RemoveCoinFromWaitingList(coinWaitingForMix);
+            coinWaitingForMix.CoinJoinInProgress = false;
+            coinWaitingForMix.Secret = null;
+            if (coinWaitingForMix.Label == "ZeroLink Change" && coinWaitingForMix.Unspent)
+            {
+                coinWaitingForMix.Label = "ZeroLink Dequeued Change";
+                var key = KeyManager.GetKeys(x => x.P2wpkhScript == coinWaitingForMix.ScriptPubKey).SingleOrDefault();
+                if (key != null)
+                {
+                    key.SetLabel(coinWaitingForMix.Label, KeyManager);
+                }
+            }
+            CoinDequeued?.Invoke(this, coinWaitingForMix);
+            var correctReason = Guard.Correct(reason);
+            var reasonText = correctReason != "" ? $" Reason: {correctReason}" : "";
+            Logger.LogInfo<CcjClient>($"Coin dequeued: {coinWaitingForMix.Index}:{coinWaitingForMix.TransactionId}.{reasonText}");
+        }
+
+        public async Task StopAsync()
+        {
+            Synchronizer.ResponseArrived -= Synchronizer_ResponseArrivedAsync;
+
+            Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+            Cancel?.Cancel();
+            while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+            {
+                await Task.Delay(50);
+            }
+
+            Cancel?.Dispose();
+            Cancel = null;
+
+            using (await MixLock.LockAsync())
+            {
+                await DequeueSpentCoinsFromMixNoLockAsync();
+
+                State.DisposeAllAliceClients();
+
+                IEnumerable<TxoRef> allCoins = State.GetAllQueuedCoins();
+                foreach (var coinReference in allCoins)
+                {
+                    try
+                    {
+                        var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+                        if (coin is null)
+                        {
+                            continue; // The coin is not present anymore. Good. This should never happen though.
+                        }
+                        await DequeueCoinsFromMixNoLockAsync(coin.GetTxoRef(), "Stopping Wasabi.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError<CcjClient>("Could not dequeue all coins. Some coins will likely be banned from mixing.");
+                        if (ex is AggregateException aggrEx)
+                        {
+                            foreach (var innerEx in aggrEx.InnerExceptions)
+                            {
+                                Logger.LogError<CcjClient>(innerEx);
+                            }
+                        }
+                        else
+                        {
+                            Logger.LogError<CcjClient>(ex);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -24,1078 +24,1078 @@ using static NBitcoin.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.Services
 {
-    public class CcjClient
-    {
-        public Network Network { get; private set; }
-        public KeyManager KeyManager { get; private set; }
-        public bool IsQuitPending { get; set; }
-
-        private ClientRoundRegistration DelayedRoundRegistration { get; set; }
-
-        public Func<Uri> CcjHostUriAction { get; private set; }
-        public WasabiSynchronizer Synchronizer { get; private set; }
-        private EndPoint TorSocks5EndPoint { get; set; }
-
-        private decimal? CoordinatorFeepercentToCheck { get; set; }
-
-        public ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>> ExposedLinks { get; set; }
-
-        private AsyncLock MixLock { get; set; }
-
-        public CcjClientState State { get; private set; }
-
-        public event EventHandler StateUpdated;
-
-        public event EventHandler<SmartCoin> CoinQueued;
-
-        public event EventHandler<SmartCoin> CoinDequeued;
-
-        private long _frequentStatusProcessingIfNotMixing;
-
-        /// <summary>
-        /// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
-        /// </summary>
-        private long _running;
-
-        public bool IsRunning => Interlocked.Read(ref _running) == 1;
-
-        private long _statusProcessing;
-
-        private CancellationTokenSource Cancel { get; set; }
-
-        public CcjClient(
-            WasabiSynchronizer synchronizer,
-            Network network,
-            KeyManager keyManager,
-            Func<Uri> ccjHostUriAction,
-            EndPoint torSocks5EndPoint)
-        {
-            Create(synchronizer, network, keyManager, ccjHostUriAction, torSocks5EndPoint);
-        }
-
-        public CcjClient(
-            WasabiSynchronizer synchronizer,
-            Network network,
-            KeyManager keyManager,
-            Uri ccjHostUri,
-            EndPoint torSocks5EndPoint)
-        {
-            Create(synchronizer, network, keyManager, () => ccjHostUri, torSocks5EndPoint);
-        }
-
-        private void Create(WasabiSynchronizer synchronizer, Network network, KeyManager keyManager, Func<Uri> ccjHostUriAction, EndPoint torSocks5EndPoint)
-        {
-            Network = Guard.NotNull(nameof(network), network);
-            KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-            CcjHostUriAction = Guard.NotNull(nameof(ccjHostUriAction), ccjHostUriAction);
-            Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
-            TorSocks5EndPoint = torSocks5EndPoint;
-            CoordinatorFeepercentToCheck = null;
-
-            ExposedLinks = new ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>>();
-            _running = 0;
-            Cancel = new CancellationTokenSource();
-            _frequentStatusProcessingIfNotMixing = 0;
-            State = new CcjClientState();
-            MixLock = new AsyncLock();
-            _statusProcessing = 0;
-            DelayedRoundRegistration = null;
-
-            Synchronizer.ResponseArrived += Synchronizer_ResponseArrivedAsync;
-
-            var lastResponse = Synchronizer.LastResponse;
-            if (lastResponse != null)
-            {
-                _ = TryProcessStatusAsync(Synchronizer.LastResponse.CcjRoundStates);
-            }
-        }
-
-        private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse e)
-        {
-            await TryProcessStatusAsync(e?.CcjRoundStates);
-        }
-
-        public void Start()
-        {
-            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
-            {
-                return;
-            }
-
-            // The client is asking for status periodically, randomly between every 0.2 * connConfTimeout and 0.7 * connConfTimeout.
-            // - if the GUI is at the mixer tab -Activate(), DeactivateIfNotMixing().
-            // - if coins are queued to mix.
-            // The client is asking for status periodically, randomly between every 2 to 7 seconds.
-            // - if it is participating in a mix thats status >= connConf.
-
-            // The client is triggered only when a status response arrives. The answer to the server is delayed randomly from 0 to 7 seconds.
-
-            Task.Run(async () =>
-            {
-                try
-                {
-                    Logger.LogInfo<CcjClient>("CcjClient is successfully initialized.");
-
-                    while (IsRunning)
-                    {
-                        try
-                        {
-                            using (await MixLock.LockAsync())
-                            {
-                                await DequeueSpentCoinsFromMixNoLockAsync();
-
-                                // If stop was requested return.
-                                if (!IsRunning)
-                                {
-                                    return;
-                                }
-
-                                // if mixing >= connConf
-                                if (State.GetActivelyMixingRounds().Any())
-                                {
-                                    int delaySeconds = new Random().Next(2, 7);
-                                    Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
-                                }
-                                else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Any() || State.GetWaitingListCount() > 0)
-                                {
-                                    double rand = double.Parse($"0.{new Random().Next(2, 6)}"); // randomly between every 0.2 * connConfTimeout - 7 and 0.6 * connConfTimeout
-                                    int delaySeconds = Math.Max(0, (int)(rand * State.GetSmallestRegistrationTimeout() - 7));
-
-                                    Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
-                                }
-                                else // dormant
-                                {
-                                    Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromMinutes(3);
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogError<CcjClient>(ex);
-                        }
-                        finally
-                        {
-                            try
-                            {
-                                await Task.Delay(1000, Cancel.Token);
-                            }
-                            catch (TaskCanceledException ex)
-                            {
-                                Logger.LogTrace<CcjClient>(ex);
-                            }
-                        }
-                    }
-                }
-                finally
-                {
-                    Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
-                }
-            });
-        }
-
-        private async Task TryProcessStatusAsync(IEnumerable<CcjRunningRoundState> states)
-        {
-            states = states ?? Enumerable.Empty<CcjRunningRoundState>();
-
-            if (Interlocked.Read(ref _statusProcessing) == 1) // It's ok to wait for status processing next time.
-            {
-                return;
-            }
-
-            try
-            {
-                Synchronizer.BlockRequests();
-
-                Interlocked.Exchange(ref _statusProcessing, 1);
-                using (await MixLock.LockAsync())
-                {
-                    // First, if there's delayed round registration update based on the state.
-                    if (DelayedRoundRegistration != null)
-                    {
-                        CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(DelayedRoundRegistration.AliceClient.RoundId);
-                        roundRegistered.Registration = DelayedRoundRegistration;
-                        DelayedRoundRegistration = null; // Do not dispose.
-                    }
-
-                    await DequeueSpentCoinsFromMixNoLockAsync();
-
-                    State.UpdateRoundsByStates(ExposedLinks, states.ToArray());
-
-                    // If we do not have enough coin queued to register a round, then dequeue all.
-                    CcjClientRound registrableRound = State.GetRegistrableRoundOrDefault();
-                    if (registrableRound != default)
-                    {
-                        // If the coordinator increases fees, do not register. Let the users register manually again.
-                        bool dequeueBecauseCoordinatorFeeChanged = false;
-                        if (CoordinatorFeepercentToCheck != default)
-                        {
-                            dequeueBecauseCoordinatorFeeChanged = registrableRound.State.CoordinatorFeePercent > CoordinatorFeepercentToCheck;
-                        }
-
-                        if (!registrableRound.State.HaveEnoughQueued(State.GetAllQueuedCoinAmounts().ToArray())
-                            || dequeueBecauseCoordinatorFeeChanged)
-                        {
-                            await DequeueAllCoinsFromMixNoLockAsync("The total value of the registered coins is not enough or the coordinator's fee changed.");
-                        }
-                    }
-                }
-                StateUpdated?.Invoke(this, null);
-
-                int delaySeconds = new Random().Next(0, 7); // delay the response to defend timing attack privacy.
-
-                if (Network == Network.RegTest)
-                {
-                    delaySeconds = 0;
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(delaySeconds), Cancel.Token);
-
-                using (await MixLock.LockAsync())
-                {
-                    foreach (long ongoingRoundId in State.GetActivelyMixingRounds())
-                    {
-                        await TryProcessRoundStateAsync(ongoingRoundId);
-                    }
-
-                    await DequeueSpentCoinsFromMixNoLockAsync();
-                    CcjClientRound inputRegistrableRound = State.GetRegistrableRoundOrDefault();
-                    if (inputRegistrableRound != null)
-                    {
-                        if (inputRegistrableRound.Registration is null) // If did not register already, check what can we register.
-                        {
-                            await TryRegisterCoinsAsync(inputRegistrableRound);
-                        }
-                        else // We registered, let's confirm we're online.
-                        {
-                            await TryConfirmConnectionAsync(inputRegistrableRound);
-                        }
-                    }
-                }
-            }
-            catch (TaskCanceledException ex)
-            {
-                Logger.LogTrace<CcjClient>(ex);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError<CcjClient>(ex);
-            }
-            finally
-            {
-                Interlocked.Exchange(ref _statusProcessing, 0);
-                Synchronizer.EnableRequests();
-            }
-        }
-
-        private async Task TryProcessRoundStateAsync(long ongoingRoundId)
-        {
-            try
-            {
-                var ongoingRound = State.GetSingleOrDefaultRound(ongoingRoundId);
-                if (ongoingRound is null)
-                {
-                    throw new NotSupportedException("This is impossible.");
-                }
-
-                if (ongoingRound.State.Phase == CcjRoundPhase.ConnectionConfirmation)
-                {
-                    if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.ConnectionConfirmation)) // If we did not already confirm connection in connection confirmation phase confirm it.
-                    {
-                        var res = await ongoingRound.Registration.AliceClient.PostConfirmationAsync();
-                        if (res.activeOutputs.Any())
-                        {
-                            ongoingRound.Registration.ActiveOutputs = res.activeOutputs;
-                        }
-                        ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
-                    }
-                }
-                else if (ongoingRound.State.Phase == CcjRoundPhase.OutputRegistration)
-                {
-                    if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.OutputRegistration))
-                    {
-                        await RegisterOutputAsync(ongoingRound);
-                    }
-                }
-                else if (ongoingRound.State.Phase == CcjRoundPhase.Signing)
-                {
-                    if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.Signing))
-                    {
-                        Transaction unsignedCoinJoin = await ongoingRound.Registration.AliceClient.GetUnsignedCoinJoinAsync();
-                        Dictionary<int, WitScript> myDic = SignCoinJoin(ongoingRound, unsignedCoinJoin);
-
-                        await ongoingRound.Registration.AliceClient.PostSignaturesAsync(myDic);
-                        ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.Signing);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError<CcjClient>(ex); // Keep this in front of the logic (Logs will make more sense.)
-                if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
-                {
-                    State.ClearRoundRegistration(ongoingRoundId);
-                }
-            }
-        }
-
-        private Dictionary<int, WitScript> SignCoinJoin(CcjClientRound ongoingRound, Transaction unsignedCoinJoin)
-        {
-            TxOut[] myOutputs = unsignedCoinJoin.Outputs
-                .Where(x => x.ScriptPubKey == ongoingRound.Registration.ChangeAddress.ScriptPubKey
-                    || ongoingRound.Registration.ActiveOutputs.Select(y => y.Address.ScriptPubKey).Contains(x.ScriptPubKey))
-                    .ToArray();
-            Money amountBack = myOutputs.Sum(y => y.Value);
-
-            // Make sure change is counted.
-            Money minAmountBack = ongoingRound.CoinsRegistered.Sum(x => x.Amount); // Start with input sum.
-                                                                                   // Do outputs.lenght + 1 in case the server estimated the network fees wrongly due to insufficient data in an edge case.
-            Money networkFeesAfterOutputs = ongoingRound.State.FeePerOutputs * (ongoingRound.Registration.AliceClient.RegisteredAddresses.Length + 1); // Use registered addresses here, because network fees are decided at inputregistration.
-            Money networkFeesAfterInputs = ongoingRound.State.FeePerInputs * ongoingRound.Registration.CoinsRegistered.Count();
-            Money networkFees = networkFeesAfterOutputs + networkFeesAfterInputs;
-            minAmountBack -= networkFees; // Minus miner fee.
-
-            IOrderedEnumerable<(Money value, int count)> indistinguishableOutputs = unsignedCoinJoin.GetIndistinguishableOutputs(includeSingle: false).OrderByDescending(x => x.count);
-            foreach ((Money value, int count) denomPair in indistinguishableOutputs)
-            {
-                var mineCount = myOutputs.Count(x => x.Value == denomPair.value);
-
-                Money denomination = denomPair.value;
-                int anonset = Math.Min(110, denomPair.count); // https://github.com/zkSNACKs/WalletWasabi/issues/1379
-                Money expectedCoordinatorFee = denomination.Percentage(ongoingRound.State.CoordinatorFeePercent * anonset);
-                for (int i = 0; i < mineCount; i++)
-                {
-                    minAmountBack -= expectedCoordinatorFee; // Minus expected coordinator fee.
-                }
-            }
-
-            // If there's no change output then coordinator protection may happened:
-            bool gotChange = myOutputs.Select(x => x.ScriptPubKey).Contains(ongoingRound.Registration.ChangeAddress.ScriptPubKey);
-            if (!gotChange)
-            {
-                Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
-                Money baseDenomination = indistinguishableOutputs.First().value;
-                Money onePercentOfDenomination = baseDenomination.Percentage(1m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
-                Money minimumChangeAmount = Math.Max(minimumOutputAmount, onePercentOfDenomination);
-
-                minAmountBack -= minimumChangeAmount; // Minus coordinator protections (so it won't create bad coinjoins.)
-            }
-
-            if (amountBack < minAmountBack && !amountBack.Almost(minAmountBack, Money.Satoshis(1000))) // Just in case. Rounding error maybe?
-            {
-                Money diff = minAmountBack - amountBack;
-                throw new NotSupportedException($"Coordinator did not add enough value to our outputs in the coinjoin. Missing: {diff.Satoshi} satoshis.");
-            }
-
-            var signedCoinJoin = unsignedCoinJoin.Clone();
-            signedCoinJoin.Sign(ongoingRound.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(SaltSoup(), x.ScriptPubKey).Single()).ToArray(), ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()).ToArray());
-
-            // Old way of signing, which randomly fails! https://github.com/zkSNACKs/WalletWasabi/issues/716#issuecomment-435498906
-            // Must be fixed in NBitcoin.
-            //var builder = Network.CreateTransactionBuilder();
-            //var signedCoinJoin = builder
-            //	.ContinueToBuild(unsignedCoinJoin)
-            //	.AddKeys(ongoingRound.Registration.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(OnePiece, x.ScriptPubKey).Single()).ToArray())
-            //	.AddCoins(ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()))
-            //	.BuildTransaction(true);
-
-            var myDic = new Dictionary<int, WitScript>();
-
-            for (int i = 0; i < signedCoinJoin.Inputs.Count; i++)
-            {
-                var input = signedCoinJoin.Inputs[i];
-                if (ongoingRound.CoinsRegistered.Select(x => x.GetOutPoint()).Contains(input.PrevOut))
-                {
-                    myDic.Add(i, signedCoinJoin.Inputs[i].WitScript);
-                }
-            }
-
-            return myDic;
-        }
-
-        private async Task RegisterOutputAsync(CcjClientRound ongoingRound)
-        {
-            IEnumerable<TxoRef> registeredInputs = ongoingRound.Registration.CoinsRegistered.Select(x => x.GetTxoRef());
-
-            var shuffledOutputs = ongoingRound.Registration.ActiveOutputs.ToList();
-            shuffledOutputs.Shuffle();
-            foreach (var activeOutput in shuffledOutputs)
-            {
-                using (var bobClient = new BobClient(CcjHostUriAction, TorSocks5EndPoint))
-                {
-                    if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput))
-                    {
-                        Logger.LogWarning<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.)");
-                        break;
-                    }
-
-                    // Unblind our exposed links.
-                    foreach (TxoRef input in registeredInputs)
-                    {
-                        if (ExposedLinks.ContainsKey(input)) // Should never not contain, but oh well, let's not disrupt the round for this.
-                        {
-                            var found = ExposedLinks[input].FirstOrDefault(x => x.Key.GetP2wpkhAddress(Network) == activeOutput.Address);
-                            if (found != default)
-                            {
-                                found.IsBlinded = false;
-                            }
-                            else
-                            {
-                                // Should never happen, but oh well we can autocorrect it so why not.
-                                ExposedLinks[input] = ExposedLinks[input].Append(new HdPubKeyBlindedPair(KeyManager.GetKeyForScriptPubKey(activeOutput.Address.ScriptPubKey), false));
-                            }
-                        }
-                    }
-                }
-            }
-
-            ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.OutputRegistration);
-            Logger.LogInfo<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bob Posted outputs: {ongoingRound.Registration.ActiveOutputs.Count()}.");
-        }
-
-        private async Task TryConfirmConnectionAsync(CcjClientRound inputRegistrableRound)
-        {
-            try
-            {
-                var res = await inputRegistrableRound.Registration.AliceClient.PostConfirmationAsync();
-
-                if (res.activeOutputs.Any())
-                {
-                    inputRegistrableRound.Registration.ActiveOutputs = res.activeOutputs;
-                }
-
-                if (res.currentPhase > CcjRoundPhase.InputRegistration) // Then the phase went to connection confirmation (probably).
-                {
-                    inputRegistrableRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
-                    inputRegistrableRound.State.Phase = res.currentPhase;
-                }
-            }
-            catch (Exception ex)
-            {
-                if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
-                {
-                    State.ClearRoundRegistration(inputRegistrableRound.State.RoundId);
-                }
-                Logger.LogError<CcjClient>(ex);
-            }
-        }
-
-        private async Task TryRegisterCoinsAsync(CcjClientRound inputRegistrableRound)
-        {
-            try
-            {
-                // Select the most suitable coins to regiter.
-                List<TxoRef> registrableCoins = State.GetRegistrableCoins(
-                    inputRegistrableRound.State.MaximumInputCountPerPeer,
-                    inputRegistrableRound.State.Denomination,
-                    inputRegistrableRound.State.FeePerInputs,
-                    inputRegistrableRound.State.FeePerOutputs).ToList();
-
-                // If there are no suitable coins to register return.
-                if (!registrableCoins.Any())
-                {
-                    return;
-                }
-
-                (HdPubKey change, IEnumerable<HdPubKey> actives) outputAddresses = GetOutputsToRegister(inputRegistrableRound.State.Denomination, inputRegistrableRound.State.SchnorrPubKeys.Count(), registrableCoins);
-
-                SchnorrPubKey[] schnorrPubKeys = inputRegistrableRound.State.SchnorrPubKeys.ToArray();
-                List<Requester> requesters = new List<Requester>();
-                var blindedOutputScriptHashes = new List<uint256>();
-
-                var registeredAddresses = new List<BitcoinAddress>();
-                for (int i = 0; i < schnorrPubKeys.Length; i++)
-                {
-                    if (outputAddresses.actives.Count() <= i)
-                    {
-                        break;
-                    }
-
-                    BitcoinAddress address = outputAddresses.actives.Select(x => x.GetP2wpkhAddress(Network)).ElementAt(i);
-
-                    SchnorrPubKey schnorrPubKey = schnorrPubKeys[i];
-                    var outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
-                    var requester = new Requester();
-                    uint256 blindedOutputScriptHash = requester.BlindMessage(outputScriptHash, schnorrPubKey);
-                    requesters.Add(requester);
-                    blindedOutputScriptHashes.Add(blindedOutputScriptHash);
-                    registeredAddresses.Add(address);
-                }
-
-                byte[] blindedOutputScriptHashesByte = ByteHelpers.Combine(blindedOutputScriptHashes.Select(x => x.ToBytes()));
-                uint256 blindedOutputScriptsHash = new uint256(Hashes.SHA256(blindedOutputScriptHashesByte));
-
-                var inputProofs = new List<InputProofModel>();
-                foreach (TxoRef coinReference in registrableCoins)
-                {
-                    SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-                    if (coin is null)
-                    {
-                        throw new NotSupportedException("This is impossible.");
-                    }
-
-                    coin.Secret = coin.Secret ?? KeyManager.GetSecrets(SaltSoup(), coin.ScriptPubKey).Single();
-                    var inputProof = new InputProofModel
-                    {
-                        Input = coin.GetTxoRef(),
-                        Proof = coin.Secret.PrivateKey.SignCompact(blindedOutputScriptsHash)
-                    };
-                    inputProofs.Add(inputProof);
-                }
-
-                AliceClient aliceClient = null;
-                try
-                {
-                    aliceClient = await AliceClient.CreateNewAsync(inputRegistrableRound.RoundId, registeredAddresses, schnorrPubKeys, requesters, Network, outputAddresses.change.GetP2wpkhAddress(Network), blindedOutputScriptHashes, inputProofs, CcjHostUriAction, TorSocks5EndPoint);
-                }
-                catch (HttpRequestException ex) when (ex.Message.Contains("Input is banned", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    string[] parts = ex.Message.Split(new[] { "Input is banned from participation for ", " minutes: " }, StringSplitOptions.RemoveEmptyEntries);
-                    string minutesString = parts[1];
-                    int minuteInt = int.Parse(minutesString);
-                    string bannedInputString = parts[2].TrimEnd('.');
-                    string[] bannedInputStringParts = bannedInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
-                    TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
-                    SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-                    if (coin is null)
-                    {
-                        throw new NotSupportedException("This is impossible.");
-                    }
-
-                    coin.BannedUntilUtc = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(minuteInt);
-
-                    Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
-
-                    await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator.");
-                    aliceClient?.Dispose();
-                    return;
-                }
-                catch (HttpRequestException ex) when (ex.Message.Contains("Provided input is not unspent", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    string[] parts = ex.Message.Split(new[] { "Provided input is not unspent: " }, StringSplitOptions.RemoveEmptyEntries);
-                    string spentInputString = parts[1].TrimEnd('.');
-                    string[] bannedInputStringParts = spentInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
-                    TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
-                    SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-                    if (coin is null)
-                    {
-                        throw new NotSupportedException("This is impossible.");
-                    }
-
-                    coin.SpentAccordingToBackend = true;
-
-                    Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
-
-                    await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator. The coin is already spent.");
-                    aliceClient?.Dispose();
-                    return;
-                }
-                catch (HttpRequestException ex) when (ex.Message.Contains("No such running round in InputRegistration.", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    Logger.LogInfo<CcjClient>("Client tried to register a round that is not in InputRegistration anymore. Trying again later.");
-                    aliceClient?.Dispose();
-                    return;
-                }
-                catch (HttpRequestException ex) when (ex.Message.Contains("too-long-mempool-chain", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    Logger.LogInfo<CcjClient>("Coordinator failed because too much unconfirmed parent transactions. Trying again later.");
-                    aliceClient?.Dispose();
-                    return;
-                }
-
-                var coinsRegistered = new List<SmartCoin>();
-                foreach (TxoRef coinReference in registrableCoins)
-                {
-                    var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-                    if (coin is null)
-                    {
-                        throw new NotSupportedException("This is impossible.");
-                    }
-
-                    coinsRegistered.Add(coin);
-                    State.RemoveCoinFromWaitingList(coin);
-                }
-
-                var registration = new ClientRoundRegistration(aliceClient, coinsRegistered, outputAddresses.change.GetP2wpkhAddress(Network));
-
-                CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(aliceClient.RoundId);
-                if (roundRegistered is null)
-                {
-                    // If our SatoshiClient does not yet know about the round, because of delay, then delay the round registration.
-                    DelayedRoundRegistration?.Dispose();
-                    DelayedRoundRegistration = registration;
-                }
-
-                roundRegistered.Registration = registration;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError<CcjClient>(ex);
-            }
-        }
-
-        private (HdPubKey change, IEnumerable<HdPubKey> active) GetOutputsToRegister(Money baseDenomination, int mixingLevelCount, IEnumerable<TxoRef> coinsToRegister)
-        {
-            // Figure out how many mixing level we need to register active outputs.
-            Money inputSum = Money.Zero;
-            foreach (TxoRef coinReference in coinsToRegister)
-            {
-                SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-                inputSum += coin.Amount;
-            }
-
-            int maximumMixingLevelCount = 1;
-            var denominations = new List<Money>
-                    {
-                        baseDenomination
-                    };
-            for (int i = 1; i < mixingLevelCount; i++)
-            {
-                Money denom = denominations.Last() * 2;
-                denominations.Add(denom);
-                if (inputSum > denom)
-                {
-                    maximumMixingLevelCount = i + 1;
-                }
-            }
-
-            string changeLabel = "ZeroLink Change";
-            string activeLabel = "ZeroLink Mixed Coin";
-
-            var keysToSurelyRegister = ExposedLinks.Where(x => coinsToRegister.Contains(x.Key)).SelectMany(x => x.Value).Select(x => x.Key).ToArray();
-            var keysTryNotToRegister = ExposedLinks.SelectMany(x => x.Value).Select(x => x.Key).Except(keysToSurelyRegister).ToArray();
-
-            // Get all locked internal keys we have and assert we have enough.
-            KeyManager.AssertLockedInternalKeysIndexed(howMany: maximumMixingLevelCount + 1);
-            IEnumerable<HdPubKey> allLockedInternalKeys = KeyManager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked && !keysTryNotToRegister.Contains(x));
-
-            // If any of our inputs have exposed address relationship then prefer that.
-            allLockedInternalKeys = keysToSurelyRegister.Concat(allLockedInternalKeys).Distinct();
-
-            // Prefer not to bloat the wallet:
-            if (allLockedInternalKeys.Count() <= maximumMixingLevelCount)
-            {
-                allLockedInternalKeys = allLockedInternalKeys.Concat(keysTryNotToRegister).Distinct();
-            }
-
-            var newKeys = new List<HdPubKey>();
-            for (int i = allLockedInternalKeys.Count(); i <= maximumMixingLevelCount + 1; i++)
-            {
-                HdPubKey k = KeyManager.GenerateNewKey("", KeyState.Locked, isInternal: true, toFile: false);
-                newKeys.Add(k);
-            }
-            allLockedInternalKeys = allLockedInternalKeys.Concat(newKeys);
-
-            // Select the change and active keys to register and label them accordingly.
-            HdPubKey change = allLockedInternalKeys.First();
-            change.SetLabel(changeLabel);
-
-            var actives = new List<HdPubKey>();
-            foreach (HdPubKey active in allLockedInternalKeys.Skip(1).Take(maximumMixingLevelCount))
-            {
-                actives.Add(active);
-                active.SetLabel(activeLabel);
-            }
-
-            // Remember which links we are exposing.
-            var outLinks = new List<HdPubKeyBlindedPair>
-            {
-                new HdPubKeyBlindedPair(change, isBlinded: false)
-            };
-            foreach (var active in actives)
-            {
-                outLinks.Add(new HdPubKeyBlindedPair(active, isBlinded: true));
-            }
-            foreach (TxoRef coin in coinsToRegister)
-            {
-                if (!ExposedLinks.TryAdd(coin, outLinks))
-                {
-                    var newOutLinks = new List<HdPubKeyBlindedPair>();
-                    foreach (HdPubKeyBlindedPair link in ExposedLinks[coin])
-                    {
-                        newOutLinks.Add(link);
-                    }
-                    foreach (HdPubKeyBlindedPair link in outLinks)
-                    {
-                        HdPubKeyBlindedPair found = newOutLinks.FirstOrDefault(x => x == link);
-
-                        if (found == default)
-                        {
-                            newOutLinks.Add(link);
-                        }
-                        else // If already in it then update the blinded value if it's getting exposed just now. (eg. the change)
-                        {
-                            if (found.IsBlinded)
-                            {
-                                found.IsBlinded = link.IsBlinded;
-                            }
-                        }
-                    }
-
-                    ExposedLinks[coin] = newOutLinks;
-                }
-            }
-
-            // Save our modifications in the keymanager before we give back the selected keys.
-            KeyManager.ToFile();
-            return (change, actives);
-        }
-
-        public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)
-        {
-            await QueueCoinsToMixAsync(SaltSoup(), coins);
-        }
-
-        public void ActivateFrequentStatusProcessing()
-        {
-            Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 1);
-        }
-
-        public void DeactivateFrequentStatusProcessingIfNotMixing()
-        {
-            Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 0);
-        }
-
-        private string Salt { get; set; } = null;
-        private string Soup { get; set; } = null;
-        private object RefrigeratorLock { get; } = new object();
-
-        public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, params SmartCoin[] coins)
-        {
-            if (coins is null || !coins.Any() || IsQuitPending)
-            {
-                return Enumerable.Empty<SmartCoin>();
-            }
-
-            var successful = new List<SmartCoin>();
-            using (await MixLock.LockAsync())
-            {
-                await DequeueSpentCoinsFromMixNoLockAsync();
-
-                // Every time the user enqueues (intentionally writes in password) then the coordinator fee percent must be noted and dequeue later if changes.
-                CcjClientRound latestRound = State.GetLatestRoundOrDefault();
-                CoordinatorFeepercentToCheck = latestRound?.State?.CoordinatorFeePercent;
-
-                var except = new List<SmartCoin>();
-
-                foreach (SmartCoin coin in coins)
-                {
-                    if (State.Contains(coin))
-                    {
-                        successful.Add(coin);
-                        except.Add(coin);
-                        continue;
-                    }
-
-                    if (coin.Unavailable)
-                    {
-                        except.Add(coin);
-                        continue;
-                    }
-                }
-
-                var coinsExcept = coins.Except(except);
-                var secPubs = KeyManager.GetSecretsAndPubKeyPairs(password, coinsExcept.Select(x => x.ScriptPubKey).ToArray());
-
-                Cook(password);
-
-                foreach (SmartCoin coin in coinsExcept)
-                {
-                    coin.Secret = secPubs.Single(x => x.pubKey.P2wpkhScript == coin.ScriptPubKey).secret;
-
-                    coin.CoinJoinInProgress = true;
-
-                    State.AddCoinToWaitingList(coin);
-                    successful.Add(coin);
-                    Logger.LogInfo<CcjClient>($"Coin queued: {coin.Index}:{coin.TransactionId}.");
-                }
-            }
-
-            foreach (var coin in successful)
-            {
-                CoinQueued?.Invoke(this, coin);
-            }
-            return successful;
-        }
-
-        public async Task DequeueCoinsFromMixAsync(SmartCoin coin, string reason)
-        {
-            await DequeueCoinsFromMixAsync(new[] { coin }, reason);
-        }
-
-        public async Task DequeueCoinsFromMixAsync(IEnumerable<SmartCoin> coins, string reason)
-        {
-            if (coins is null || !coins.Any())
-            {
-                return;
-            }
-
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-            {
-                try
-                {
-                    using (await MixLock.LockAsync(cts.Token))
-                    {
-                        await DequeueSpentCoinsFromMixNoLockAsync();
-
-                        await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
-                    }
-                }
-                catch (TaskCanceledException)
-                {
-                    await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray(), reason);
-
-                    await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
-                }
-            }
-        }
-
-        public bool HasIngredients => Salt != null && Soup != null;
-
-        private string SaltSoup()
-        {
-            if (!HasIngredients)
-            {
-                return null;
-            }
-
-            string res;
-            lock (RefrigeratorLock)
-            {
-                res = StringCipher.Decrypt(Soup, Salt);
-            }
-
-            Cook(res);
-
-            return res;
-        }
-
-        private void Cook(string ingredients)
-        {
-            lock (RefrigeratorLock)
-            {
-                ingredients = ingredients ?? "";
-
-                Salt = TokenGenerator.GetUniqueKey(21);
-                Soup = StringCipher.Encrypt(ingredients, Salt);
-            }
-        }
-
-        public async Task DequeueCoinsFromMixAsync(TxoRef coin, string reason)
-        {
-            await DequeueCoinsFromMixAsync(new[] { coin }, reason);
-        }
-
-        public async Task DequeueCoinsFromMixAsync(TxoRef[] coins, string reason)
-        {
-            if (coins is null || !coins.Any())
-            {
-                return;
-            }
-
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-            {
-                try
-                {
-                    using (await MixLock.LockAsync(cts.Token))
-                    {
-                        await DequeueSpentCoinsFromMixNoLockAsync();
-
-                        await DequeueCoinsFromMixNoLockAsync(coins, reason);
-                    }
-                }
-                catch (TaskCanceledException)
-                {
-                    await DequeueSpentCoinsFromMixNoLockAsync();
-
-                    await DequeueCoinsFromMixNoLockAsync(coins, reason);
-                }
-            }
-        }
-
-        public async Task DequeueAllCoinsFromMixAsync(string reason)
-        {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-            {
-                try
-                {
-                    using (await MixLock.LockAsync(cts.Token))
-                    {
-                        await DequeueAllCoinsFromMixNoLockAsync(reason);
-                    }
-                }
-                catch (TaskCanceledException)
-                {
-                    await DequeueAllCoinsFromMixNoLockAsync(reason);
-                }
-            }
-        }
-
-        private async Task DequeueAllCoinsFromMixNoLockAsync(string reason)
-        {
-            await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray(), reason);
-        }
-
-        private async Task DequeueSpentCoinsFromMixNoLockAsync()
-        {
-            await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
-        }
-
-        private async Task DequeueCoinsFromMixNoLockAsync(TxoRef coin, string reason = null)
-        {
-            await DequeueCoinsFromMixNoLockAsync(new[] { coin }, reason);
-        }
-
-        private async Task DequeueCoinsFromMixNoLockAsync(TxoRef[] coins, string reason = null)
-        {
-            if (coins is null || !coins.Any())
-            {
-                return;
-            }
-
-            List<Exception> exceptions = new List<Exception>();
-
-            foreach (var coinReference in coins)
-            {
-                var coinToDequeue = State.GetSingleOrDefaultCoin(coinReference);
-                if (coinToDequeue is null)
-                {
-                    continue;
-                }
-
-                foreach (long roundId in State.GetPassivelyMixingRounds())
-                {
-                    var round = State.GetSingleOrDefaultRound(roundId);
-                    if (round is null)
-                    {
-                        throw new NotSupportedException("This is impossible.");
-                    }
-
-                    if (round.CoinsRegistered.Contains(coinToDequeue))
-                    {
-                        try
-                        {
-                            await round.Registration.AliceClient.PostUnConfirmationAsync(); // AliceUniqueId must be there.
-                            State.ClearRoundRegistration(round.State.RoundId);
-                        }
-                        catch (Exception ex)
-                        {
-                            if (coinToDequeue.Unspent)
-                            {
-                                exceptions.Add(ex);
-                            }
-                        }
-                    }
-                }
-
-                foreach (long roundId in State.GetActivelyMixingRounds())
-                {
-                    var round = State.GetSingleOrDefaultRound(roundId);
-                    if (round is null)
-                    {
-                        continue;
-                    }
-
-                    if (round.CoinsRegistered.Contains(coinToDequeue))
-                    {
-                        if (!coinToDequeue.Unspent) // If coin was spent, well that sucks, except if it was spent by the tumbler in signing phase.
-                        {
-                            State.ClearRoundRegistration(round.State.RoundId);
-                            continue;
-                        }
-                        else
-                        {
-                            exceptions.Add(new NotSupportedException($"Cannot deque coin in {round.State.Phase} phase. Coin: {coinToDequeue.Index}:{coinToDequeue.TransactionId}."));
-                        }
-                    }
-                }
-
-                SmartCoin coinWaitingForMix = State.GetSingleOrDefaultFromWaitingList(coinToDequeue);
-                if (coinWaitingForMix != null) // If it is not being mixed, we can just remove it.
-                {
-                    RemoveCoin(coinWaitingForMix, reason);
-                }
-            }
-
-            if (exceptions.Count == 1)
-            {
-                throw exceptions.Single();
-            }
-
-            if (exceptions.Count > 0)
-            {
-                throw new AggregateException(exceptions);
-            }
-        }
-
-        private void RemoveCoin(SmartCoin coinWaitingForMix, string reason = null)
-        {
-            State.RemoveCoinFromWaitingList(coinWaitingForMix);
-            coinWaitingForMix.CoinJoinInProgress = false;
-            coinWaitingForMix.Secret = null;
-            if (coinWaitingForMix.Label == "ZeroLink Change" && coinWaitingForMix.Unspent)
-            {
-                coinWaitingForMix.Label = "ZeroLink Dequeued Change";
-                var key = KeyManager.GetKeys(x => x.P2wpkhScript == coinWaitingForMix.ScriptPubKey).SingleOrDefault();
-                if (key != null)
-                {
-                    key.SetLabel(coinWaitingForMix.Label, KeyManager);
-                }
-            }
-            CoinDequeued?.Invoke(this, coinWaitingForMix);
-            var correctReason = Guard.Correct(reason);
-            var reasonText = correctReason != "" ? $" Reason: {correctReason}" : "";
-            Logger.LogInfo<CcjClient>($"Coin dequeued: {coinWaitingForMix.Index}:{coinWaitingForMix.TransactionId}.{reasonText}");
-        }
-
-        public async Task StopAsync()
-        {
-            Synchronizer.ResponseArrived -= Synchronizer_ResponseArrivedAsync;
-
-            Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
-            Cancel?.Cancel();
-            while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
-            {
-                await Task.Delay(50);
-            }
-
-            Cancel?.Dispose();
-            Cancel = null;
-
-            using (await MixLock.LockAsync())
-            {
-                await DequeueSpentCoinsFromMixNoLockAsync();
-
-                State.DisposeAllAliceClients();
-
-                IEnumerable<TxoRef> allCoins = State.GetAllQueuedCoins();
-                foreach (var coinReference in allCoins)
-                {
-                    try
-                    {
-                        var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
-                        if (coin is null)
-                        {
-                            continue; // The coin is not present anymore. Good. This should never happen though.
-                        }
-                        await DequeueCoinsFromMixNoLockAsync(coin.GetTxoRef(), "Stopping Wasabi.");
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogError<CcjClient>("Could not dequeue all coins. Some coins will likely be banned from mixing.");
-                        if (ex is AggregateException aggrEx)
-                        {
-                            foreach (var innerEx in aggrEx.InnerExceptions)
-                            {
-                                Logger.LogError<CcjClient>(innerEx);
-                            }
-                        }
-                        else
-                        {
-                            Logger.LogError<CcjClient>(ex);
-                        }
-                    }
-                }
-            }
-        }
-    }
+	public class CcjClient
+	{
+		public Network Network { get; private set; }
+		public KeyManager KeyManager { get; private set; }
+		public bool IsQuitPending { get; set; }
+
+		private ClientRoundRegistration DelayedRoundRegistration { get; set; }
+
+		public Func<Uri> CcjHostUriAction { get; private set; }
+		public WasabiSynchronizer Synchronizer { get; private set; }
+		private EndPoint TorSocks5EndPoint { get; set; }
+
+		private decimal? CoordinatorFeepercentToCheck { get; set; }
+
+		public ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>> ExposedLinks { get; set; }
+
+		private AsyncLock MixLock { get; set; }
+
+		public CcjClientState State { get; private set; }
+
+		public event EventHandler StateUpdated;
+
+		public event EventHandler<SmartCoin> CoinQueued;
+
+		public event EventHandler<SmartCoin> CoinDequeued;
+
+		private long _frequentStatusProcessingIfNotMixing;
+
+		/// <summary>
+		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
+		/// </summary>
+		private long _running;
+
+		public bool IsRunning => Interlocked.Read(ref _running) == 1;
+
+		private long _statusProcessing;
+
+		private CancellationTokenSource Cancel { get; set; }
+
+		public CcjClient(
+			WasabiSynchronizer synchronizer,
+			Network network,
+			KeyManager keyManager,
+			Func<Uri> ccjHostUriAction,
+			EndPoint torSocks5EndPoint)
+		{
+			Create(synchronizer, network, keyManager, ccjHostUriAction, torSocks5EndPoint);
+		}
+
+		public CcjClient(
+			WasabiSynchronizer synchronizer,
+			Network network,
+			KeyManager keyManager,
+			Uri ccjHostUri,
+			EndPoint torSocks5EndPoint)
+		{
+			Create(synchronizer, network, keyManager, () => ccjHostUri, torSocks5EndPoint);
+		}
+
+		private void Create(WasabiSynchronizer synchronizer, Network network, KeyManager keyManager, Func<Uri> ccjHostUriAction, EndPoint torSocks5EndPoint)
+		{
+			Network = Guard.NotNull(nameof(network), network);
+			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+			CcjHostUriAction = Guard.NotNull(nameof(ccjHostUriAction), ccjHostUriAction);
+			Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
+			TorSocks5EndPoint = torSocks5EndPoint;
+			CoordinatorFeepercentToCheck = null;
+
+			ExposedLinks = new ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>>();
+			_running = 0;
+			Cancel = new CancellationTokenSource();
+			_frequentStatusProcessingIfNotMixing = 0;
+			State = new CcjClientState();
+			MixLock = new AsyncLock();
+			_statusProcessing = 0;
+			DelayedRoundRegistration = null;
+
+			Synchronizer.ResponseArrived += Synchronizer_ResponseArrivedAsync;
+
+			var lastResponse = Synchronizer.LastResponse;
+			if (lastResponse != null)
+			{
+				_ = TryProcessStatusAsync(Synchronizer.LastResponse.CcjRoundStates);
+			}
+		}
+
+		private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse e)
+		{
+			await TryProcessStatusAsync(e?.CcjRoundStates);
+		}
+
+		public void Start()
+		{
+			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+			{
+				return;
+			}
+
+			// The client is asking for status periodically, randomly between every 0.2 * connConfTimeout and 0.7 * connConfTimeout.
+			// - if the GUI is at the mixer tab -Activate(), DeactivateIfNotMixing().
+			// - if coins are queued to mix.
+			// The client is asking for status periodically, randomly between every 2 to 7 seconds.
+			// - if it is participating in a mix thats status >= connConf.
+
+			// The client is triggered only when a status response arrives. The answer to the server is delayed randomly from 0 to 7 seconds.
+
+			Task.Run(async () =>
+			{
+				try
+				{
+					Logger.LogInfo<CcjClient>("CcjClient is successfully initialized.");
+
+					while (IsRunning)
+					{
+						try
+						{
+							using (await MixLock.LockAsync())
+							{
+								await DequeueSpentCoinsFromMixNoLockAsync();
+
+								// If stop was requested return.
+								if (!IsRunning)
+								{
+									return;
+								}
+
+								// if mixing >= connConf
+								if (State.GetActivelyMixingRounds().Any())
+								{
+									int delaySeconds = new Random().Next(2, 7);
+									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
+								}
+								else if (Interlocked.Read(ref _frequentStatusProcessingIfNotMixing) == 1 || State.GetPassivelyMixingRounds().Any() || State.GetWaitingListCount() > 0)
+								{
+									double rand = double.Parse($"0.{new Random().Next(2, 6)}"); // randomly between every 0.2 * connConfTimeout - 7 and 0.6 * connConfTimeout
+									int delaySeconds = Math.Max(0, (int)(rand * State.GetSmallestRegistrationTimeout() - 7));
+
+									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromSeconds(delaySeconds);
+								}
+								else // dormant
+								{
+									Synchronizer.MaxRequestIntervalForMixing = TimeSpan.FromMinutes(3);
+								}
+							}
+						}
+						catch (Exception ex)
+						{
+							Logger.LogError<CcjClient>(ex);
+						}
+						finally
+						{
+							try
+							{
+								await Task.Delay(1000, Cancel.Token);
+							}
+							catch (TaskCanceledException ex)
+							{
+								Logger.LogTrace<CcjClient>(ex);
+							}
+						}
+					}
+				}
+				finally
+				{
+					Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
+				}
+			});
+		}
+
+		private async Task TryProcessStatusAsync(IEnumerable<CcjRunningRoundState> states)
+		{
+			states = states ?? Enumerable.Empty<CcjRunningRoundState>();
+
+			if (Interlocked.Read(ref _statusProcessing) == 1) // It's ok to wait for status processing next time.
+			{
+				return;
+			}
+
+			try
+			{
+				Synchronizer.BlockRequests();
+
+				Interlocked.Exchange(ref _statusProcessing, 1);
+				using (await MixLock.LockAsync())
+				{
+					// First, if there's delayed round registration update based on the state.
+					if (DelayedRoundRegistration != null)
+					{
+						CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(DelayedRoundRegistration.AliceClient.RoundId);
+						roundRegistered.Registration = DelayedRoundRegistration;
+						DelayedRoundRegistration = null; // Do not dispose.
+					}
+
+					await DequeueSpentCoinsFromMixNoLockAsync();
+
+					State.UpdateRoundsByStates(ExposedLinks, states.ToArray());
+
+					// If we do not have enough coin queued to register a round, then dequeue all.
+					CcjClientRound registrableRound = State.GetRegistrableRoundOrDefault();
+					if (registrableRound != default)
+					{
+						// If the coordinator increases fees, do not register. Let the users register manually again.
+						bool dequeueBecauseCoordinatorFeeChanged = false;
+						if (CoordinatorFeepercentToCheck != default)
+						{
+							dequeueBecauseCoordinatorFeeChanged = registrableRound.State.CoordinatorFeePercent > CoordinatorFeepercentToCheck;
+						}
+
+						if (!registrableRound.State.HaveEnoughQueued(State.GetAllQueuedCoinAmounts().ToArray())
+							|| dequeueBecauseCoordinatorFeeChanged)
+						{
+							await DequeueAllCoinsFromMixNoLockAsync("The total value of the registered coins is not enough or the coordinator's fee changed.");
+						}
+					}
+				}
+				StateUpdated?.Invoke(this, null);
+
+				int delaySeconds = new Random().Next(0, 7); // delay the response to defend timing attack privacy.
+
+				if (Network == Network.RegTest)
+				{
+					delaySeconds = 0;
+				}
+
+				await Task.Delay(TimeSpan.FromSeconds(delaySeconds), Cancel.Token);
+
+				using (await MixLock.LockAsync())
+				{
+					foreach (long ongoingRoundId in State.GetActivelyMixingRounds())
+					{
+						await TryProcessRoundStateAsync(ongoingRoundId);
+					}
+
+					await DequeueSpentCoinsFromMixNoLockAsync();
+					CcjClientRound inputRegistrableRound = State.GetRegistrableRoundOrDefault();
+					if (inputRegistrableRound != null)
+					{
+						if (inputRegistrableRound.Registration is null) // If did not register already, check what can we register.
+						{
+							await TryRegisterCoinsAsync(inputRegistrableRound);
+						}
+						else // We registered, let's confirm we're online.
+						{
+							await TryConfirmConnectionAsync(inputRegistrableRound);
+						}
+					}
+				}
+			}
+			catch (TaskCanceledException ex)
+			{
+				Logger.LogTrace<CcjClient>(ex);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError<CcjClient>(ex);
+			}
+			finally
+			{
+				Interlocked.Exchange(ref _statusProcessing, 0);
+				Synchronizer.EnableRequests();
+			}
+		}
+
+		private async Task TryProcessRoundStateAsync(long ongoingRoundId)
+		{
+			try
+			{
+				var ongoingRound = State.GetSingleOrDefaultRound(ongoingRoundId);
+				if (ongoingRound is null)
+				{
+					throw new NotSupportedException("This is impossible.");
+				}
+
+				if (ongoingRound.State.Phase == CcjRoundPhase.ConnectionConfirmation)
+				{
+					if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.ConnectionConfirmation)) // If we did not already confirm connection in connection confirmation phase confirm it.
+					{
+						var res = await ongoingRound.Registration.AliceClient.PostConfirmationAsync();
+						if (res.activeOutputs.Any())
+						{
+							ongoingRound.Registration.ActiveOutputs = res.activeOutputs;
+						}
+						ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
+					}
+				}
+				else if (ongoingRound.State.Phase == CcjRoundPhase.OutputRegistration)
+				{
+					if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.OutputRegistration))
+					{
+						await RegisterOutputAsync(ongoingRound);
+					}
+				}
+				else if (ongoingRound.State.Phase == CcjRoundPhase.Signing)
+				{
+					if (!ongoingRound.Registration.IsPhaseActionsComleted(CcjRoundPhase.Signing))
+					{
+						Transaction unsignedCoinJoin = await ongoingRound.Registration.AliceClient.GetUnsignedCoinJoinAsync();
+						Dictionary<int, WitScript> myDic = SignCoinJoin(ongoingRound, unsignedCoinJoin);
+
+						await ongoingRound.Registration.AliceClient.PostSignaturesAsync(myDic);
+						ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.Signing);
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError<CcjClient>(ex); // Keep this in front of the logic (Logs will make more sense.)
+				if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
+				{
+					State.ClearRoundRegistration(ongoingRoundId);
+				}
+			}
+		}
+
+		private Dictionary<int, WitScript> SignCoinJoin(CcjClientRound ongoingRound, Transaction unsignedCoinJoin)
+		{
+			TxOut[] myOutputs = unsignedCoinJoin.Outputs
+				.Where(x => x.ScriptPubKey == ongoingRound.Registration.ChangeAddress.ScriptPubKey
+					|| ongoingRound.Registration.ActiveOutputs.Select(y => y.Address.ScriptPubKey).Contains(x.ScriptPubKey))
+					.ToArray();
+			Money amountBack = myOutputs.Sum(y => y.Value);
+
+			// Make sure change is counted.
+			Money minAmountBack = ongoingRound.CoinsRegistered.Sum(x => x.Amount); // Start with input sum.
+																				   // Do outputs.lenght + 1 in case the server estimated the network fees wrongly due to insufficient data in an edge case.
+			Money networkFeesAfterOutputs = ongoingRound.State.FeePerOutputs * (ongoingRound.Registration.AliceClient.RegisteredAddresses.Length + 1); // Use registered addresses here, because network fees are decided at inputregistration.
+			Money networkFeesAfterInputs = ongoingRound.State.FeePerInputs * ongoingRound.Registration.CoinsRegistered.Count();
+			Money networkFees = networkFeesAfterOutputs + networkFeesAfterInputs;
+			minAmountBack -= networkFees; // Minus miner fee.
+
+			IOrderedEnumerable<(Money value, int count)> indistinguishableOutputs = unsignedCoinJoin.GetIndistinguishableOutputs(includeSingle: false).OrderByDescending(x => x.count);
+			foreach ((Money value, int count) denomPair in indistinguishableOutputs)
+			{
+				var mineCount = myOutputs.Count(x => x.Value == denomPair.value);
+
+				Money denomination = denomPair.value;
+				int anonset = Math.Min(110, denomPair.count); // https://github.com/zkSNACKs/WalletWasabi/issues/1379
+				Money expectedCoordinatorFee = denomination.Percentage(ongoingRound.State.CoordinatorFeePercent * anonset);
+				for (int i = 0; i < mineCount; i++)
+				{
+					minAmountBack -= expectedCoordinatorFee; // Minus expected coordinator fee.
+				}
+			}
+
+			// If there's no change output then coordinator protection may happened:
+			bool gotChange = myOutputs.Select(x => x.ScriptPubKey).Contains(ongoingRound.Registration.ChangeAddress.ScriptPubKey);
+			if (!gotChange)
+			{
+				Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
+				Money baseDenomination = indistinguishableOutputs.First().value;
+				Money onePercentOfDenomination = baseDenomination.Percentage(1m); // If the change is less than about 1% of the newDenomination then add it to the coordinator fee.
+				Money minimumChangeAmount = Math.Max(minimumOutputAmount, onePercentOfDenomination);
+
+				minAmountBack -= minimumChangeAmount; // Minus coordinator protections (so it won't create bad coinjoins.)
+			}
+
+			if (amountBack < minAmountBack && !amountBack.Almost(minAmountBack, Money.Satoshis(1000))) // Just in case. Rounding error maybe?
+			{
+				Money diff = minAmountBack - amountBack;
+				throw new NotSupportedException($"Coordinator did not add enough value to our outputs in the coinjoin. Missing: {diff.Satoshi} satoshis.");
+			}
+
+			var signedCoinJoin = unsignedCoinJoin.Clone();
+			signedCoinJoin.Sign(ongoingRound.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(SaltSoup(), x.ScriptPubKey).Single()).ToArray(), ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()).ToArray());
+
+			// Old way of signing, which randomly fails! https://github.com/zkSNACKs/WalletWasabi/issues/716#issuecomment-435498906
+			// Must be fixed in NBitcoin.
+			//var builder = Network.CreateTransactionBuilder();
+			//var signedCoinJoin = builder
+			//	.ContinueToBuild(unsignedCoinJoin)
+			//	.AddKeys(ongoingRound.Registration.CoinsRegistered.Select(x => x.Secret = x.Secret ?? KeyManager.GetSecrets(OnePiece, x.ScriptPubKey).Single()).ToArray())
+			//	.AddCoins(ongoingRound.Registration.CoinsRegistered.Select(x => x.GetCoin()))
+			//	.BuildTransaction(true);
+
+			var myDic = new Dictionary<int, WitScript>();
+
+			for (int i = 0; i < signedCoinJoin.Inputs.Count; i++)
+			{
+				var input = signedCoinJoin.Inputs[i];
+				if (ongoingRound.CoinsRegistered.Select(x => x.GetOutPoint()).Contains(input.PrevOut))
+				{
+					myDic.Add(i, signedCoinJoin.Inputs[i].WitScript);
+				}
+			}
+
+			return myDic;
+		}
+
+		private async Task RegisterOutputAsync(CcjClientRound ongoingRound)
+		{
+			IEnumerable<TxoRef> registeredInputs = ongoingRound.Registration.CoinsRegistered.Select(x => x.GetTxoRef());
+
+			var shuffledOutputs = ongoingRound.Registration.ActiveOutputs.ToList();
+			shuffledOutputs.Shuffle();
+			foreach (var activeOutput in shuffledOutputs)
+			{
+				using (var bobClient = new BobClient(CcjHostUriAction, TorSocks5EndPoint))
+				{
+					if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput))
+					{
+						Logger.LogWarning<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.)");
+						break;
+					}
+
+					// Unblind our exposed links.
+					foreach (TxoRef input in registeredInputs)
+					{
+						if (ExposedLinks.ContainsKey(input)) // Should never not contain, but oh well, let's not disrupt the round for this.
+						{
+							var found = ExposedLinks[input].FirstOrDefault(x => x.Key.GetP2wpkhAddress(Network) == activeOutput.Address);
+							if (found != default)
+							{
+								found.IsBlinded = false;
+							}
+							else
+							{
+								// Should never happen, but oh well we can autocorrect it so why not.
+								ExposedLinks[input] = ExposedLinks[input].Append(new HdPubKeyBlindedPair(KeyManager.GetKeyForScriptPubKey(activeOutput.Address.ScriptPubKey), false));
+							}
+						}
+					}
+				}
+			}
+
+			ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.OutputRegistration);
+			Logger.LogInfo<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bob Posted outputs: {ongoingRound.Registration.ActiveOutputs.Count()}.");
+		}
+
+		private async Task TryConfirmConnectionAsync(CcjClientRound inputRegistrableRound)
+		{
+			try
+			{
+				var res = await inputRegistrableRound.Registration.AliceClient.PostConfirmationAsync();
+
+				if (res.activeOutputs.Any())
+				{
+					inputRegistrableRound.Registration.ActiveOutputs = res.activeOutputs;
+				}
+
+				if (res.currentPhase > CcjRoundPhase.InputRegistration) // Then the phase went to connection confirmation (probably).
+				{
+					inputRegistrableRound.Registration.SetPhaseCompleted(CcjRoundPhase.ConnectionConfirmation);
+					inputRegistrableRound.State.Phase = res.currentPhase;
+				}
+			}
+			catch (Exception ex)
+			{
+				if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
+				{
+					State.ClearRoundRegistration(inputRegistrableRound.State.RoundId);
+				}
+				Logger.LogError<CcjClient>(ex);
+			}
+		}
+
+		private async Task TryRegisterCoinsAsync(CcjClientRound inputRegistrableRound)
+		{
+			try
+			{
+				// Select the most suitable coins to regiter.
+				List<TxoRef> registrableCoins = State.GetRegistrableCoins(
+					inputRegistrableRound.State.MaximumInputCountPerPeer,
+					inputRegistrableRound.State.Denomination,
+					inputRegistrableRound.State.FeePerInputs,
+					inputRegistrableRound.State.FeePerOutputs).ToList();
+
+				// If there are no suitable coins to register return.
+				if (!registrableCoins.Any())
+				{
+					return;
+				}
+
+				(HdPubKey change, IEnumerable<HdPubKey> actives) outputAddresses = GetOutputsToRegister(inputRegistrableRound.State.Denomination, inputRegistrableRound.State.SchnorrPubKeys.Count(), registrableCoins);
+
+				SchnorrPubKey[] schnorrPubKeys = inputRegistrableRound.State.SchnorrPubKeys.ToArray();
+				List<Requester> requesters = new List<Requester>();
+				var blindedOutputScriptHashes = new List<uint256>();
+
+				var registeredAddresses = new List<BitcoinAddress>();
+				for (int i = 0; i < schnorrPubKeys.Length; i++)
+				{
+					if (outputAddresses.actives.Count() <= i)
+					{
+						break;
+					}
+
+					BitcoinAddress address = outputAddresses.actives.Select(x => x.GetP2wpkhAddress(Network)).ElementAt(i);
+
+					SchnorrPubKey schnorrPubKey = schnorrPubKeys[i];
+					var outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
+					var requester = new Requester();
+					uint256 blindedOutputScriptHash = requester.BlindMessage(outputScriptHash, schnorrPubKey);
+					requesters.Add(requester);
+					blindedOutputScriptHashes.Add(blindedOutputScriptHash);
+					registeredAddresses.Add(address);
+				}
+
+				byte[] blindedOutputScriptHashesByte = ByteHelpers.Combine(blindedOutputScriptHashes.Select(x => x.ToBytes()));
+				uint256 blindedOutputScriptsHash = new uint256(Hashes.SHA256(blindedOutputScriptHashesByte));
+
+				var inputProofs = new List<InputProofModel>();
+				foreach (TxoRef coinReference in registrableCoins)
+				{
+					SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+					if (coin is null)
+					{
+						throw new NotSupportedException("This is impossible.");
+					}
+
+					coin.Secret = coin.Secret ?? KeyManager.GetSecrets(SaltSoup(), coin.ScriptPubKey).Single();
+					var inputProof = new InputProofModel
+					{
+						Input = coin.GetTxoRef(),
+						Proof = coin.Secret.PrivateKey.SignCompact(blindedOutputScriptsHash)
+					};
+					inputProofs.Add(inputProof);
+				}
+
+				AliceClient aliceClient = null;
+				try
+				{
+					aliceClient = await AliceClient.CreateNewAsync(inputRegistrableRound.RoundId, registeredAddresses, schnorrPubKeys, requesters, Network, outputAddresses.change.GetP2wpkhAddress(Network), blindedOutputScriptHashes, inputProofs, CcjHostUriAction, TorSocks5EndPoint);
+				}
+				catch (HttpRequestException ex) when (ex.Message.Contains("Input is banned", StringComparison.InvariantCultureIgnoreCase))
+				{
+					string[] parts = ex.Message.Split(new[] { "Input is banned from participation for ", " minutes: " }, StringSplitOptions.RemoveEmptyEntries);
+					string minutesString = parts[1];
+					int minuteInt = int.Parse(minutesString);
+					string bannedInputString = parts[2].TrimEnd('.');
+					string[] bannedInputStringParts = bannedInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
+					TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
+					SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+					if (coin is null)
+					{
+						throw new NotSupportedException("This is impossible.");
+					}
+
+					coin.BannedUntilUtc = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(minuteInt);
+
+					Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
+
+					await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator.");
+					aliceClient?.Dispose();
+					return;
+				}
+				catch (HttpRequestException ex) when (ex.Message.Contains("Provided input is not unspent", StringComparison.InvariantCultureIgnoreCase))
+				{
+					string[] parts = ex.Message.Split(new[] { "Provided input is not unspent: " }, StringSplitOptions.RemoveEmptyEntries);
+					string spentInputString = parts[1].TrimEnd('.');
+					string[] bannedInputStringParts = spentInputString.Split(':', StringSplitOptions.RemoveEmptyEntries);
+					TxoRef coinReference = new TxoRef(new uint256(bannedInputStringParts[1]), uint.Parse(bannedInputStringParts[0]));
+					SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+					if (coin is null)
+					{
+						throw new NotSupportedException("This is impossible.");
+					}
+
+					coin.SpentAccordingToBackend = true;
+
+					Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
+
+					await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator. The coin is already spent.");
+					aliceClient?.Dispose();
+					return;
+				}
+				catch (HttpRequestException ex) when (ex.Message.Contains("No such running round in InputRegistration.", StringComparison.InvariantCultureIgnoreCase))
+				{
+					Logger.LogInfo<CcjClient>("Client tried to register a round that is not in InputRegistration anymore. Trying again later.");
+					aliceClient?.Dispose();
+					return;
+				}
+				catch (HttpRequestException ex) when (ex.Message.Contains("too-long-mempool-chain", StringComparison.InvariantCultureIgnoreCase))
+				{
+					Logger.LogInfo<CcjClient>("Coordinator failed because too much unconfirmed parent transactions. Trying again later.");
+					aliceClient?.Dispose();
+					return;
+				}
+
+				var coinsRegistered = new List<SmartCoin>();
+				foreach (TxoRef coinReference in registrableCoins)
+				{
+					var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+					if (coin is null)
+					{
+						throw new NotSupportedException("This is impossible.");
+					}
+
+					coinsRegistered.Add(coin);
+					State.RemoveCoinFromWaitingList(coin);
+				}
+
+				var registration = new ClientRoundRegistration(aliceClient, coinsRegistered, outputAddresses.change.GetP2wpkhAddress(Network));
+
+				CcjClientRound roundRegistered = State.GetSingleOrDefaultRound(aliceClient.RoundId);
+				if (roundRegistered is null)
+				{
+					// If our SatoshiClient does not yet know about the round, because of delay, then delay the round registration.
+					DelayedRoundRegistration?.Dispose();
+					DelayedRoundRegistration = registration;
+				}
+
+				roundRegistered.Registration = registration;
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError<CcjClient>(ex);
+			}
+		}
+
+		private (HdPubKey change, IEnumerable<HdPubKey> active) GetOutputsToRegister(Money baseDenomination, int mixingLevelCount, IEnumerable<TxoRef> coinsToRegister)
+		{
+			// Figure out how many mixing level we need to register active outputs.
+			Money inputSum = Money.Zero;
+			foreach (TxoRef coinReference in coinsToRegister)
+			{
+				SmartCoin coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+				inputSum += coin.Amount;
+			}
+
+			int maximumMixingLevelCount = 1;
+			var denominations = new List<Money>
+					{
+						baseDenomination
+					};
+			for (int i = 1; i < mixingLevelCount; i++)
+			{
+				Money denom = denominations.Last() * 2;
+				denominations.Add(denom);
+				if (inputSum > denom)
+				{
+					maximumMixingLevelCount = i + 1;
+				}
+			}
+
+			string changeLabel = "ZeroLink Change";
+			string activeLabel = "ZeroLink Mixed Coin";
+
+			var keysToSurelyRegister = ExposedLinks.Where(x => coinsToRegister.Contains(x.Key)).SelectMany(x => x.Value).Select(x => x.Key).ToArray();
+			var keysTryNotToRegister = ExposedLinks.SelectMany(x => x.Value).Select(x => x.Key).Except(keysToSurelyRegister).ToArray();
+
+			// Get all locked internal keys we have and assert we have enough.
+			KeyManager.AssertLockedInternalKeysIndexed(howMany: maximumMixingLevelCount + 1);
+			IEnumerable<HdPubKey> allLockedInternalKeys = KeyManager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked && !keysTryNotToRegister.Contains(x));
+
+			// If any of our inputs have exposed address relationship then prefer that.
+			allLockedInternalKeys = keysToSurelyRegister.Concat(allLockedInternalKeys).Distinct();
+
+			// Prefer not to bloat the wallet:
+			if (allLockedInternalKeys.Count() <= maximumMixingLevelCount)
+			{
+				allLockedInternalKeys = allLockedInternalKeys.Concat(keysTryNotToRegister).Distinct();
+			}
+
+			var newKeys = new List<HdPubKey>();
+			for (int i = allLockedInternalKeys.Count(); i <= maximumMixingLevelCount + 1; i++)
+			{
+				HdPubKey k = KeyManager.GenerateNewKey("", KeyState.Locked, isInternal: true, toFile: false);
+				newKeys.Add(k);
+			}
+			allLockedInternalKeys = allLockedInternalKeys.Concat(newKeys);
+
+			// Select the change and active keys to register and label them accordingly.
+			HdPubKey change = allLockedInternalKeys.First();
+			change.SetLabel(changeLabel);
+
+			var actives = new List<HdPubKey>();
+			foreach (HdPubKey active in allLockedInternalKeys.Skip(1).Take(maximumMixingLevelCount))
+			{
+				actives.Add(active);
+				active.SetLabel(activeLabel);
+			}
+
+			// Remember which links we are exposing.
+			var outLinks = new List<HdPubKeyBlindedPair>
+			{
+				new HdPubKeyBlindedPair(change, isBlinded: false)
+			};
+			foreach (var active in actives)
+			{
+				outLinks.Add(new HdPubKeyBlindedPair(active, isBlinded: true));
+			}
+			foreach (TxoRef coin in coinsToRegister)
+			{
+				if (!ExposedLinks.TryAdd(coin, outLinks))
+				{
+					var newOutLinks = new List<HdPubKeyBlindedPair>();
+					foreach (HdPubKeyBlindedPair link in ExposedLinks[coin])
+					{
+						newOutLinks.Add(link);
+					}
+					foreach (HdPubKeyBlindedPair link in outLinks)
+					{
+						HdPubKeyBlindedPair found = newOutLinks.FirstOrDefault(x => x == link);
+
+						if (found == default)
+						{
+							newOutLinks.Add(link);
+						}
+						else // If already in it then update the blinded value if it's getting exposed just now. (eg. the change)
+						{
+							if (found.IsBlinded)
+							{
+								found.IsBlinded = link.IsBlinded;
+							}
+						}
+					}
+
+					ExposedLinks[coin] = newOutLinks;
+				}
+			}
+
+			// Save our modifications in the keymanager before we give back the selected keys.
+			KeyManager.ToFile();
+			return (change, actives);
+		}
+
+		public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)
+		{
+			await QueueCoinsToMixAsync(SaltSoup(), coins);
+		}
+
+		public void ActivateFrequentStatusProcessing()
+		{
+			Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 1);
+		}
+
+		public void DeactivateFrequentStatusProcessingIfNotMixing()
+		{
+			Interlocked.Exchange(ref _frequentStatusProcessingIfNotMixing, 0);
+		}
+
+		private string Salt { get; set; } = null;
+		private string Soup { get; set; } = null;
+		private object RefrigeratorLock { get; } = new object();
+
+		public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, params SmartCoin[] coins)
+		{
+			if (coins is null || !coins.Any() || IsQuitPending)
+			{
+				return Enumerable.Empty<SmartCoin>();
+			}
+
+			var successful = new List<SmartCoin>();
+			using (await MixLock.LockAsync())
+			{
+				await DequeueSpentCoinsFromMixNoLockAsync();
+
+				// Every time the user enqueues (intentionally writes in password) then the coordinator fee percent must be noted and dequeue later if changes.
+				CcjClientRound latestRound = State.GetLatestRoundOrDefault();
+				CoordinatorFeepercentToCheck = latestRound?.State?.CoordinatorFeePercent;
+
+				var except = new List<SmartCoin>();
+
+				foreach (SmartCoin coin in coins)
+				{
+					if (State.Contains(coin))
+					{
+						successful.Add(coin);
+						except.Add(coin);
+						continue;
+					}
+
+					if (coin.Unavailable)
+					{
+						except.Add(coin);
+						continue;
+					}
+				}
+
+				var coinsExcept = coins.Except(except);
+				var secPubs = KeyManager.GetSecretsAndPubKeyPairs(password, coinsExcept.Select(x => x.ScriptPubKey).ToArray());
+
+				Cook(password);
+
+				foreach (SmartCoin coin in coinsExcept)
+				{
+					coin.Secret = secPubs.Single(x => x.pubKey.P2wpkhScript == coin.ScriptPubKey).secret;
+
+					coin.CoinJoinInProgress = true;
+
+					State.AddCoinToWaitingList(coin);
+					successful.Add(coin);
+					Logger.LogInfo<CcjClient>($"Coin queued: {coin.Index}:{coin.TransactionId}.");
+				}
+			}
+
+			foreach (var coin in successful)
+			{
+				CoinQueued?.Invoke(this, coin);
+			}
+			return successful;
+		}
+
+		public async Task DequeueCoinsFromMixAsync(SmartCoin coin, string reason)
+		{
+			await DequeueCoinsFromMixAsync(new[] { coin }, reason);
+		}
+
+		public async Task DequeueCoinsFromMixAsync(IEnumerable<SmartCoin> coins, string reason)
+		{
+			if (coins is null || !coins.Any())
+			{
+				return;
+			}
+
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+			{
+				try
+				{
+					using (await MixLock.LockAsync(cts.Token))
+					{
+						await DequeueSpentCoinsFromMixNoLockAsync();
+
+						await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
+					}
+				}
+				catch (TaskCanceledException)
+				{
+					await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray(), reason);
+
+					await DequeueCoinsFromMixNoLockAsync(coins.Select(x => x.GetTxoRef()).ToArray(), reason);
+				}
+			}
+		}
+
+		public bool HasIngredients => Salt != null && Soup != null;
+
+		private string SaltSoup()
+		{
+			if (!HasIngredients)
+			{
+				return null;
+			}
+
+			string res;
+			lock (RefrigeratorLock)
+			{
+				res = StringCipher.Decrypt(Soup, Salt);
+			}
+
+			Cook(res);
+
+			return res;
+		}
+
+		private void Cook(string ingredients)
+		{
+			lock (RefrigeratorLock)
+			{
+				ingredients = ingredients ?? "";
+
+				Salt = TokenGenerator.GetUniqueKey(21);
+				Soup = StringCipher.Encrypt(ingredients, Salt);
+			}
+		}
+
+		public async Task DequeueCoinsFromMixAsync(TxoRef coin, string reason)
+		{
+			await DequeueCoinsFromMixAsync(new[] { coin }, reason);
+		}
+
+		public async Task DequeueCoinsFromMixAsync(TxoRef[] coins, string reason)
+		{
+			if (coins is null || !coins.Any())
+			{
+				return;
+			}
+
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+			{
+				try
+				{
+					using (await MixLock.LockAsync(cts.Token))
+					{
+						await DequeueSpentCoinsFromMixNoLockAsync();
+
+						await DequeueCoinsFromMixNoLockAsync(coins, reason);
+					}
+				}
+				catch (TaskCanceledException)
+				{
+					await DequeueSpentCoinsFromMixNoLockAsync();
+
+					await DequeueCoinsFromMixNoLockAsync(coins, reason);
+				}
+			}
+		}
+
+		public async Task DequeueAllCoinsFromMixAsync(string reason)
+		{
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+			{
+				try
+				{
+					using (await MixLock.LockAsync(cts.Token))
+					{
+						await DequeueAllCoinsFromMixNoLockAsync(reason);
+					}
+				}
+				catch (TaskCanceledException)
+				{
+					await DequeueAllCoinsFromMixNoLockAsync(reason);
+				}
+			}
+		}
+
+		private async Task DequeueAllCoinsFromMixNoLockAsync(string reason)
+		{
+			await DequeueCoinsFromMixNoLockAsync(State.GetAllQueuedCoins().ToArray(), reason);
+		}
+
+		private async Task DequeueSpentCoinsFromMixNoLockAsync()
+		{
+			await DequeueCoinsFromMixNoLockAsync(State.GetSpentCoins().ToArray());
+		}
+
+		private async Task DequeueCoinsFromMixNoLockAsync(TxoRef coin, string reason = null)
+		{
+			await DequeueCoinsFromMixNoLockAsync(new[] { coin }, reason);
+		}
+
+		private async Task DequeueCoinsFromMixNoLockAsync(TxoRef[] coins, string reason = null)
+		{
+			if (coins is null || !coins.Any())
+			{
+				return;
+			}
+
+			List<Exception> exceptions = new List<Exception>();
+
+			foreach (var coinReference in coins)
+			{
+				var coinToDequeue = State.GetSingleOrDefaultCoin(coinReference);
+				if (coinToDequeue is null)
+				{
+					continue;
+				}
+
+				foreach (long roundId in State.GetPassivelyMixingRounds())
+				{
+					var round = State.GetSingleOrDefaultRound(roundId);
+					if (round is null)
+					{
+						throw new NotSupportedException("This is impossible.");
+					}
+
+					if (round.CoinsRegistered.Contains(coinToDequeue))
+					{
+						try
+						{
+							await round.Registration.AliceClient.PostUnConfirmationAsync(); // AliceUniqueId must be there.
+							State.ClearRoundRegistration(round.State.RoundId);
+						}
+						catch (Exception ex)
+						{
+							if (coinToDequeue.Unspent)
+							{
+								exceptions.Add(ex);
+							}
+						}
+					}
+				}
+
+				foreach (long roundId in State.GetActivelyMixingRounds())
+				{
+					var round = State.GetSingleOrDefaultRound(roundId);
+					if (round is null)
+					{
+						continue;
+					}
+
+					if (round.CoinsRegistered.Contains(coinToDequeue))
+					{
+						if (!coinToDequeue.Unspent) // If coin was spent, well that sucks, except if it was spent by the tumbler in signing phase.
+						{
+							State.ClearRoundRegistration(round.State.RoundId);
+							continue;
+						}
+						else
+						{
+							exceptions.Add(new NotSupportedException($"Cannot deque coin in {round.State.Phase} phase. Coin: {coinToDequeue.Index}:{coinToDequeue.TransactionId}."));
+						}
+					}
+				}
+
+				SmartCoin coinWaitingForMix = State.GetSingleOrDefaultFromWaitingList(coinToDequeue);
+				if (coinWaitingForMix != null) // If it is not being mixed, we can just remove it.
+				{
+					RemoveCoin(coinWaitingForMix, reason);
+				}
+			}
+
+			if (exceptions.Count == 1)
+			{
+				throw exceptions.Single();
+			}
+
+			if (exceptions.Count > 0)
+			{
+				throw new AggregateException(exceptions);
+			}
+		}
+
+		private void RemoveCoin(SmartCoin coinWaitingForMix, string reason = null)
+		{
+			State.RemoveCoinFromWaitingList(coinWaitingForMix);
+			coinWaitingForMix.CoinJoinInProgress = false;
+			coinWaitingForMix.Secret = null;
+			if (coinWaitingForMix.Label == "ZeroLink Change" && coinWaitingForMix.Unspent)
+			{
+				coinWaitingForMix.Label = "ZeroLink Dequeued Change";
+				var key = KeyManager.GetKeys(x => x.P2wpkhScript == coinWaitingForMix.ScriptPubKey).SingleOrDefault();
+				if (key != null)
+				{
+					key.SetLabel(coinWaitingForMix.Label, KeyManager);
+				}
+			}
+			CoinDequeued?.Invoke(this, coinWaitingForMix);
+			var correctReason = Guard.Correct(reason);
+			var reasonText = correctReason != "" ? $" Reason: {correctReason}" : "";
+			Logger.LogInfo<CcjClient>($"Coin dequeued: {coinWaitingForMix.Index}:{coinWaitingForMix.TransactionId}.{reasonText}");
+		}
+
+		public async Task StopAsync()
+		{
+			Synchronizer.ResponseArrived -= Synchronizer_ResponseArrivedAsync;
+
+			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+			Cancel?.Cancel();
+			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+			{
+				await Task.Delay(50);
+			}
+
+			Cancel?.Dispose();
+			Cancel = null;
+
+			using (await MixLock.LockAsync())
+			{
+				await DequeueSpentCoinsFromMixNoLockAsync();
+
+				State.DisposeAllAliceClients();
+
+				IEnumerable<TxoRef> allCoins = State.GetAllQueuedCoins();
+				foreach (var coinReference in allCoins)
+				{
+					try
+					{
+						var coin = State.GetSingleOrDefaultFromWaitingList(coinReference);
+						if (coin is null)
+						{
+							continue; // The coin is not present anymore. Good. This should never happen though.
+						}
+						await DequeueCoinsFromMixNoLockAsync(coin.GetTxoRef(), "Stopping Wasabi.");
+					}
+					catch (Exception ex)
+					{
+						Logger.LogError<CcjClient>("Could not dequeue all coins. Some coins will likely be banned from mixing.");
+						if (ex is AggregateException aggrEx)
+						{
+							foreach (var innerEx in aggrEx.InnerExceptions)
+							{
+								Logger.LogError<CcjClient>(innerEx);
+							}
+						}
+						else
+						{
+							Logger.LogError<CcjClient>(ex);
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/WalletWasabi/Services/MempoolService.cs
+++ b/WalletWasabi/Services/MempoolService.cs
@@ -12,137 +12,137 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-    public class MempoolService
-    {
-        public ConcurrentHashSet<uint256> TransactionHashes { get; }
+	public class MempoolService
+	{
+		public ConcurrentHashSet<uint256> TransactionHashes { get; }
 
-        // Transactions those we would reply to INV messages.
-        private List<TransactionBroadcastEntry> BroadcastStore { get; }
+		// Transactions those we would reply to INV messages.
+		private List<TransactionBroadcastEntry> BroadcastStore { get; }
 
-        private object BroadcastStoreLock { get; }
+		private object BroadcastStoreLock { get; }
 
-        public event EventHandler<SmartTransaction> TransactionReceived;
+		public event EventHandler<SmartTransaction> TransactionReceived;
 
-        internal void OnTransactionReceived(SmartTransaction transaction) => TransactionReceived?.Invoke(this, transaction);
+		internal void OnTransactionReceived(SmartTransaction transaction) => TransactionReceived?.Invoke(this, transaction);
 
-        public MempoolService()
-        {
-            TransactionHashes = new ConcurrentHashSet<uint256>();
-            BroadcastStore = new List<TransactionBroadcastEntry>();
-            BroadcastStoreLock = new object();
-            _cleanupInProcess = 0;
-        }
+		public MempoolService()
+		{
+			TransactionHashes = new ConcurrentHashSet<uint256>();
+			BroadcastStore = new List<TransactionBroadcastEntry>();
+			BroadcastStoreLock = new object();
+			_cleanupInProcess = 0;
+		}
 
-        public bool TryAddToBroadcastStore(Transaction transaction, string nodeRemoteSocketEndpoint)
-        {
-            lock (BroadcastStoreLock)
-            {
-                if (BroadcastStore.Any(x => x.TransactionId == transaction.GetHash()))
-                {
-                    return false;
-                }
-                else
-                {
-                    var entry = new TransactionBroadcastEntry(transaction, nodeRemoteSocketEndpoint);
-                    BroadcastStore.Add(entry);
-                    return true;
-                }
-            }
-        }
+		public bool TryAddToBroadcastStore(Transaction transaction, string nodeRemoteSocketEndpoint)
+		{
+			lock (BroadcastStoreLock)
+			{
+				if (BroadcastStore.Any(x => x.TransactionId == transaction.GetHash()))
+				{
+					return false;
+				}
+				else
+				{
+					var entry = new TransactionBroadcastEntry(transaction, nodeRemoteSocketEndpoint);
+					BroadcastStore.Add(entry);
+					return true;
+				}
+			}
+		}
 
-        public bool TryRemoveFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
-        {
-            lock (BroadcastStoreLock)
-            {
-                var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
-                entry = found;
+		public bool TryRemoveFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
+		{
+			lock (BroadcastStoreLock)
+			{
+				var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
+				entry = found;
 
-                if (found is null)
-                {
-                    return false;
-                }
-                else
-                {
-                    BroadcastStore.RemoveAll(x => x.TransactionId == transactionHash);
-                    return true;
-                }
-            }
-        }
+				if (found is null)
+				{
+					return false;
+				}
+				else
+				{
+					BroadcastStore.RemoveAll(x => x.TransactionId == transactionHash);
+					return true;
+				}
+			}
+		}
 
-        public bool TryGetFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
-        {
-            lock (BroadcastStoreLock)
-            {
-                var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
-                entry = found;
+		public bool TryGetFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
+		{
+			lock (BroadcastStoreLock)
+			{
+				var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
+				entry = found;
 
-                return found is null
-                    ? false
-                    : true;
-            }
-        }
+				return found is null
+					? false
+					: true;
+			}
+		}
 
-        public IEnumerable<TransactionBroadcastEntry> GetBroadcastStore()
-        {
-            lock (BroadcastStoreLock)
-            {
-                return BroadcastStore.ToList();
-            }
-        }
+		public IEnumerable<TransactionBroadcastEntry> GetBroadcastStore()
+		{
+			lock (BroadcastStoreLock)
+			{
+				return BroadcastStore.ToList();
+			}
+		}
 
-        private int _cleanupInProcess;
+		private int _cleanupInProcess;
 
-        /// <summary>
-        /// Tries to perform mempool cleanup with the help of the backend.
-        /// </summary>
-        public async Task<bool> TryPerformMempoolCleanupAsync(Func<Uri> destAction, EndPoint torSocks)
-        {
-            // If already cleaning, then no need to run it that often.
-            if (Interlocked.CompareExchange(ref _cleanupInProcess, 1, 0) == 1)
-            {
-                return false;
-            }
+		/// <summary>
+		/// Tries to perform mempool cleanup with the help of the backend.
+		/// </summary>
+		public async Task<bool> TryPerformMempoolCleanupAsync(Func<Uri> destAction, EndPoint torSocks)
+		{
+			// If already cleaning, then no need to run it that often.
+			if (Interlocked.CompareExchange(ref _cleanupInProcess, 1, 0) == 1)
+			{
+				return false;
+			}
 
-            // This function is designed to prevent forever growing mempool.
-            try
-            {
-                if (!TransactionHashes.Any())
-                {
-                    return true; // There's nothing to cleanup.
-                }
+			// This function is designed to prevent forever growing mempool.
+			try
+			{
+				if (!TransactionHashes.Any())
+				{
+					return true; // There's nothing to cleanup.
+				}
 
-                Logger.LogInfo<MempoolService>("Start cleaning out mempool...");
-                using (var client = new WasabiClient(destAction, torSocks))
-                {
-                    var compactness = 10;
-                    var allMempoolHashes = await client.GetMempoolHashesAsync(compactness);
+				Logger.LogInfo<MempoolService>("Start cleaning out mempool...");
+				using (var client = new WasabiClient(destAction, torSocks))
+				{
+					var compactness = 10;
+					var allMempoolHashes = await client.GetMempoolHashesAsync(compactness);
 
-                    var toRemove = TransactionHashes.Where(x => !allMempoolHashes.Contains(x.ToString().Substring(0, compactness)));
+					var toRemove = TransactionHashes.Where(x => !allMempoolHashes.Contains(x.ToString().Substring(0, compactness)));
 
-                    int removedTxCount = 0;
-                    foreach (uint256 tx in toRemove)
-                    {
-                        if (TransactionHashes.TryRemove(tx))
-                        {
-                            removedTxCount++;
-                        }
-                    }
+					int removedTxCount = 0;
+					foreach (uint256 tx in toRemove)
+					{
+						if (TransactionHashes.TryRemove(tx))
+						{
+							removedTxCount++;
+						}
+					}
 
-                    Logger.LogInfo<MempoolService>($"{removedTxCount} transactions were cleaned from mempool.");
-                }
+					Logger.LogInfo<MempoolService>($"{removedTxCount} transactions were cleaned from mempool.");
+				}
 
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning<MempoolService>(ex);
-            }
-            finally
-            {
-                Interlocked.Exchange(ref _cleanupInProcess, 0);
-            }
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<MempoolService>(ex);
+			}
+			finally
+			{
+				Interlocked.Exchange(ref _cleanupInProcess, 0);
+			}
 
-            return false;
-        }
-    }
+			return false;
+		}
+	}
 }

--- a/WalletWasabi/Services/MempoolService.cs
+++ b/WalletWasabi/Services/MempoolService.cs
@@ -12,137 +12,137 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-	public class MempoolService
-	{
-		public ConcurrentHashSet<uint256> TransactionHashes { get; }
+    public class MempoolService
+    {
+        public ConcurrentHashSet<uint256> TransactionHashes { get; }
 
-		// Transactions those we would reply to INV messages.
-		private List<TransactionBroadcastEntry> BroadcastStore { get; }
+        // Transactions those we would reply to INV messages.
+        private List<TransactionBroadcastEntry> BroadcastStore { get; }
 
-		private object BroadcastStoreLock { get; }
+        private object BroadcastStoreLock { get; }
 
-		public event EventHandler<SmartTransaction> TransactionReceived;
+        public event EventHandler<SmartTransaction> TransactionReceived;
 
-		internal void OnTransactionReceived(SmartTransaction transaction) => TransactionReceived?.Invoke(this, transaction);
+        internal void OnTransactionReceived(SmartTransaction transaction) => TransactionReceived?.Invoke(this, transaction);
 
-		public MempoolService()
-		{
-			TransactionHashes = new ConcurrentHashSet<uint256>();
-			BroadcastStore = new List<TransactionBroadcastEntry>();
-			BroadcastStoreLock = new object();
-			_cleanupInProcess = 0;
-		}
+        public MempoolService()
+        {
+            TransactionHashes = new ConcurrentHashSet<uint256>();
+            BroadcastStore = new List<TransactionBroadcastEntry>();
+            BroadcastStoreLock = new object();
+            _cleanupInProcess = 0;
+        }
 
-		public bool TryAddToBroadcastStore(Transaction transaction, string nodeRemoteSocketEndpoint)
-		{
-			lock (BroadcastStoreLock)
-			{
-				if (BroadcastStore.Any(x => x.TransactionId == transaction.GetHash()))
-				{
-					return false;
-				}
-				else
-				{
-					var entry = new TransactionBroadcastEntry(transaction, nodeRemoteSocketEndpoint);
-					BroadcastStore.Add(entry);
-					return true;
-				}
-			}
-		}
+        public bool TryAddToBroadcastStore(Transaction transaction, string nodeRemoteSocketEndpoint)
+        {
+            lock (BroadcastStoreLock)
+            {
+                if (BroadcastStore.Any(x => x.TransactionId == transaction.GetHash()))
+                {
+                    return false;
+                }
+                else
+                {
+                    var entry = new TransactionBroadcastEntry(transaction, nodeRemoteSocketEndpoint);
+                    BroadcastStore.Add(entry);
+                    return true;
+                }
+            }
+        }
 
-		public bool TryRemoveFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
-		{
-			lock (BroadcastStoreLock)
-			{
-				var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
-				entry = found;
+        public bool TryRemoveFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
+        {
+            lock (BroadcastStoreLock)
+            {
+                var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
+                entry = found;
 
-				if (found is null)
-				{
-					return false;
-				}
-				else
-				{
-					BroadcastStore.RemoveAll(x => x.TransactionId == transactionHash);
-					return true;
-				}
-			}
-		}
+                if (found is null)
+                {
+                    return false;
+                }
+                else
+                {
+                    BroadcastStore.RemoveAll(x => x.TransactionId == transactionHash);
+                    return true;
+                }
+            }
+        }
 
-		public bool TryGetFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
-		{
-			lock (BroadcastStoreLock)
-			{
-				var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
-				entry = found;
+        public bool TryGetFromBroadcastStore(uint256 transactionHash, out TransactionBroadcastEntry entry)
+        {
+            lock (BroadcastStoreLock)
+            {
+                var found = BroadcastStore.FirstOrDefault(x => x.TransactionId == transactionHash);
+                entry = found;
 
-				return found is null
-					? false
-					: true;
-			}
-		}
+                return found is null
+                    ? false
+                    : true;
+            }
+        }
 
-		public IEnumerable<TransactionBroadcastEntry> GetBroadcastStore()
-		{
-			lock (BroadcastStoreLock)
-			{
-				return BroadcastStore.ToList();
-			}
-		}
+        public IEnumerable<TransactionBroadcastEntry> GetBroadcastStore()
+        {
+            lock (BroadcastStoreLock)
+            {
+                return BroadcastStore.ToList();
+            }
+        }
 
-		private int _cleanupInProcess;
+        private int _cleanupInProcess;
 
-		/// <summary>
-		/// Tries to perform mempool cleanup with the help of the backend.
-		/// </summary>
-		public async Task<bool> TryPerformMempoolCleanupAsync(Func<Uri> destAction, IPEndPoint torSocks)
-		{
-			// If already cleaning, then no need to run it that often.
-			if (Interlocked.CompareExchange(ref _cleanupInProcess, 1, 0) == 1)
-			{
-				return false;
-			}
+        /// <summary>
+        /// Tries to perform mempool cleanup with the help of the backend.
+        /// </summary>
+        public async Task<bool> TryPerformMempoolCleanupAsync(Func<Uri> destAction, EndPoint torSocks)
+        {
+            // If already cleaning, then no need to run it that often.
+            if (Interlocked.CompareExchange(ref _cleanupInProcess, 1, 0) == 1)
+            {
+                return false;
+            }
 
-			// This function is designed to prevent forever growing mempool.
-			try
-			{
-				if (!TransactionHashes.Any())
-				{
-					return true; // There's nothing to cleanup.
-				}
+            // This function is designed to prevent forever growing mempool.
+            try
+            {
+                if (!TransactionHashes.Any())
+                {
+                    return true; // There's nothing to cleanup.
+                }
 
-				Logger.LogInfo<MempoolService>("Start cleaning out mempool...");
-				using (var client = new WasabiClient(destAction, torSocks))
-				{
-					var compactness = 10;
-					var allMempoolHashes = await client.GetMempoolHashesAsync(compactness);
+                Logger.LogInfo<MempoolService>("Start cleaning out mempool...");
+                using (var client = new WasabiClient(destAction, torSocks))
+                {
+                    var compactness = 10;
+                    var allMempoolHashes = await client.GetMempoolHashesAsync(compactness);
 
-					var toRemove = TransactionHashes.Where(x => !allMempoolHashes.Contains(x.ToString().Substring(0, compactness)));
+                    var toRemove = TransactionHashes.Where(x => !allMempoolHashes.Contains(x.ToString().Substring(0, compactness)));
 
-					int removedTxCount = 0;
-					foreach (uint256 tx in toRemove)
-					{
-						if (TransactionHashes.TryRemove(tx))
-						{
-							removedTxCount++;
-						}
-					}
+                    int removedTxCount = 0;
+                    foreach (uint256 tx in toRemove)
+                    {
+                        if (TransactionHashes.TryRemove(tx))
+                        {
+                            removedTxCount++;
+                        }
+                    }
 
-					Logger.LogInfo<MempoolService>($"{removedTxCount} transactions were cleaned from mempool.");
-				}
+                    Logger.LogInfo<MempoolService>($"{removedTxCount} transactions were cleaned from mempool.");
+                }
 
-				return true;
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning<MempoolService>(ex);
-			}
-			finally
-			{
-				Interlocked.Exchange(ref _cleanupInProcess, 0);
-			}
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning<MempoolService>(ex);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _cleanupInProcess, 0);
+            }
 
-			return false;
-		}
-	}
+            return false;
+        }
+    }
 }

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -29,1654 +29,1654 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-    public class WalletService
-    {
-        public static event EventHandler<bool> DownloadingBlockChanged;
-
-        // So we will make sure when blocks are downloading with multiple wallet services, they do not conflict.
-        private static AsyncLock BlockDownloadLock { get; } = new AsyncLock();
-
-        private static bool DownloadingBlockBacking;
-
-        public static bool DownloadingBlock
-        {
-            get => DownloadingBlockBacking;
-            set
-            {
-                if (value != DownloadingBlockBacking)
-                {
-                    DownloadingBlockBacking = value;
-                    DownloadingBlockChanged?.Invoke(null, value);
-                }
-            }
-        }
-
-        public BitcoinStore BitcoinStore { get; }
-        public KeyManager KeyManager { get; }
-        public WasabiSynchronizer Synchronizer { get; }
-        public CcjClient ChaumianClient { get; }
-        public MempoolService Mempool { get; }
-
-        public NodesGroup Nodes { get; }
-        public string BlocksFolderPath { get; }
-        public string TransactionsFolderPath { get; }
-        public string TransactionsFilePath { get; }
-
-        private AsyncLock HandleFiltersLock { get; }
-
-        private AsyncLock BlockFolderLock { get; }
-
-        private int NodeTimeouts { get; set; }
-
-        public ServiceConfiguration ServiceConfiguration { get; }
-
-        public ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)> ProcessedBlocks { get; }
-
-        public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
-
-        public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
-
-        public event EventHandler<FilterModel> NewFilterProcessed;
-
-        public event EventHandler<SmartCoin> CoinSpentOrSpenderConfirmed;
-
-        public event EventHandler<Block> NewBlockProcessed;
-
-        public Network Network => Synchronizer.Network;
-
-        public WalletService(
-            BitcoinStore bitcoinStore,
-            KeyManager keyManager,
-            WasabiSynchronizer syncer,
-            CcjClient chaumianClient,
-            MempoolService mempool,
-            NodesGroup nodes,
-            string workFolderDir,
-            ServiceConfiguration serviceConfiguration)
-        {
-            BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
-            KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-            Nodes = Guard.NotNull(nameof(nodes), nodes);
-            Synchronizer = Guard.NotNull(nameof(syncer), syncer);
-            ChaumianClient = Guard.NotNull(nameof(chaumianClient), chaumianClient);
-            Mempool = Guard.NotNull(nameof(mempool), mempool);
-            ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
-
-            ProcessedBlocks = new ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)>();
-            HandleFiltersLock = new AsyncLock();
-
-            Coins = new ObservableConcurrentHashSet<SmartCoin>();
-            TransactionCache = new ConcurrentHashSet<SmartTransaction>();
-
-            BlocksFolderPath = Path.Combine(workFolderDir, "Blocks", Network.ToString());
-            TransactionsFolderPath = Path.Combine(workFolderDir, "Transactions", Network.ToString());
-            RuntimeParams.SetDataDir(workFolderDir);
-
-            BlockFolderLock = new AsyncLock();
-
-            KeyManager.AssertCleanKeysIndexed();
-            KeyManager.AssertLockedInternalKeysIndexed(14);
-
-            if (Directory.Exists(BlocksFolderPath))
-            {
-                if (Synchronizer.Network == Network.RegTest)
-                {
-                    Directory.Delete(BlocksFolderPath, true);
-                    Directory.CreateDirectory(BlocksFolderPath);
-                }
-            }
-            else
-            {
-                Directory.CreateDirectory(BlocksFolderPath);
-            }
-            if (Directory.Exists(TransactionsFolderPath))
-            {
-                if (Synchronizer.Network == Network.RegTest)
-                {
-                    Directory.Delete(TransactionsFolderPath, true);
-                    Directory.CreateDirectory(TransactionsFolderPath);
-                }
-            }
-            else
-            {
-                Directory.CreateDirectory(TransactionsFolderPath);
-            }
-
-            var walletName = "UnnamedWallet";
-            if (!string.IsNullOrWhiteSpace(KeyManager.FilePath))
-            {
-                walletName = Path.GetFileNameWithoutExtension(KeyManager.FilePath);
-            }
-            TransactionsFilePath = Path.Combine(TransactionsFolderPath, $"{walletName}Transactions.json");
-
-            BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
-            BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
-            Mempool.TransactionReceived += Mempool_TransactionReceivedAsync;
-        }
-
-        private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            RefreshCoinHistories();
-        }
-
-        private static AsyncLock TransactionProcessingLock { get; } = new AsyncLock();
-
-        private async void Mempool_TransactionReceivedAsync(object sender, SmartTransaction tx)
-        {
-            try
-            {
-                using (await TransactionProcessingLock.LockAsync())
-                {
-                    if (await ProcessTransactionAsync(tx))
-                    {
-                        SerializeTransactionCache();
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning<WalletService>(ex);
-            }
-        }
-
-        private async void IndexDownloader_ReorgedAsync(object sender, FilterModel invalidFilter)
-        {
-            try
-            {
-                using (await HandleFiltersLock.LockAsync())
-                {
-                    uint256 invalidBlockHash = invalidFilter.BlockHash;
-                    await DeleteBlockAsync(invalidBlockHash);
-                    var blockState = KeyManager.TryRemoveBlockState(invalidBlockHash);
-                    ProcessedBlocks.TryRemove(invalidBlockHash, out _);
-                    if (blockState != null && blockState.BlockHeight != default(Height))
-                    {
-                        foreach (var toRemove in Coins.Where(x => x.Height == blockState.BlockHeight).Distinct().ToList())
-                        {
-                            RemoveCoinRecursively(toRemove);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning<WalletService>(ex);
-            }
-        }
-
-        private void RemoveCoinRecursively(SmartCoin toRemove)
-        {
-            if (toRemove.SpenderTransactionId != null)
-            {
-                foreach (var toAlsoRemove in Coins.Where(x => x.TransactionId == toRemove.SpenderTransactionId).Distinct().ToList())
-                {
-                    RemoveCoinRecursively(toAlsoRemove);
-                }
-            }
-
-            Coins.TryRemove(toRemove);
-            Mempool.TransactionHashes.TryRemove(toRemove.SpenderTransactionId);
-        }
-
-        private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)
-        {
-            try
-            {
-                using (await HandleFiltersLock.LockAsync())
-                {
-                    if (filterModel.Filter != null && !KeyManager.CointainsBlockState(filterModel.BlockHash))
-                    {
-                        await ProcessFilterModelAsync(filterModel, CancellationToken.None);
-                    }
-                }
-                NewFilterProcessed?.Invoke(this, filterModel);
-
-                do
-                {
-                    await Task.Delay(100);
-                    if (Synchronizer is null || BitcoinStore?.HashChain is null)
-                    {
-                        return;
-                    }
-                    // Make sure fully synced and this filter is the lastest filter.
-                    if (BitcoinStore.HashChain.HashesLeft != 0 || BitcoinStore.HashChain.TipHash != filterModel.BlockHash)
-                    {
-                        return;
-                    }
-                } while (Synchronizer.AreRequestsBlocked()); // If requests are blocked, delay mempool cleanup, because coinjoin answers are always priority.
-
-                await Mempool?.TryPerformMempoolCleanupAsync(Synchronizer?.WasabiClient?.TorClient?.DestinationUriAction, Synchronizer?.WasabiClient?.TorClient?.TorSocks5EndPoint);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning<WalletService>(ex);
-            }
-        }
-
-        public async Task InitializeAsync(CancellationToken cancel)
-        {
-            if (!Synchronizer.IsRunning)
-            {
-                throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
-            }
-
-            await RuntimeParams.LoadAsync();
-
-            using (await HandleFiltersLock.LockAsync())
-            {
-                var unconfirmedTransactions = new SmartTransaction[0];
-                var confirmedTransactions = new SmartTransaction[0];
-
-                if (File.Exists(TransactionsFilePath))
-                {
-                    try
-                    {
-                        IEnumerable<SmartTransaction> transactions = null;
-                        string jsonString = File.ReadAllText(TransactionsFilePath, Encoding.UTF8);
-                        transactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?
-                            .OrderByBlockchain();
-
-                        confirmedTransactions = transactions?
-                            .Where(x => x.Confirmed)?
-                            .ToArray() ?? new SmartTransaction[0];
-
-                        unconfirmedTransactions = transactions?
-                            .Where(x => !x.Confirmed)?
-                            .ToArray() ?? new SmartTransaction[0];
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogWarning<WalletService>(ex);
-                        Logger.LogWarning<WalletService>($"Transaction cache got corrupted. Deleting {TransactionsFilePath}.");
-                        File.Delete(TransactionsFilePath);
-                    }
-                }
-
-                // Go through the keymanager's index.
-                KeyManager.AssertNetworkOrClearBlockState(Network);
-                Height bestKeyManagerHeight = KeyManager.GetBestHeight();
-
-                foreach (BlockState blockState in KeyManager.GetTransactionIndex())
-                {
-                    var relevantTransactions = confirmedTransactions.Where(x => x.BlockHash == blockState.BlockHash).ToArray();
-                    var block = await GetOrDownloadBlockAsync(blockState.BlockHash, cancel);
-                    await ProcessBlockAsync(blockState.BlockHeight, block, blockState.TransactionIndices, relevantTransactions);
-                }
-
-                // Go through the filters and que to download the matches.
-                await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>
-                {
-                    if (filterModel.Filter != null) // Filter can be null if there is no bech32 tx.
-                    {
-                        await ProcessFilterModelAsync(filterModel, cancel);
-                    }
-                }, new Height(bestKeyManagerHeight.Value + 1));
-
-                // Load in dummy mempool
-                try
-                {
-                    if (unconfirmedTransactions != null && unconfirmedTransactions.Any())
-                    {
-                        try
-                        {
-                            using (await TransactionProcessingLock.LockAsync())
-                            using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
-                            {
-                                var compactness = 10;
-
-                                var mempoolHashes = await client.GetMempoolHashesAsync(compactness);
-
-                                var cnt = 0;
-                                foreach (var tx in unconfirmedTransactions)
-                                {
-                                    if (mempoolHashes.Contains(tx.GetHash().ToString().Substring(0, compactness)))
-                                    {
-                                        tx.SetHeight(Height.Mempool);
-                                        await ProcessTransactionAsync(tx);
-                                        Mempool.TransactionHashes.TryAdd(tx.GetHash());
-
-                                        Logger.LogInfo<WalletService>($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
-                                        cnt++;
-                                    }
-                                }
-
-                                if (cnt != unconfirmedTransactions.Length)
-                                {
-                                    SerializeTransactionCache();
-                                }
-                            }
-                        }
-                        catch
-                        {
-                            // When there's a connection failure do not clean the transactions, add it to processing.
-                            foreach (var tx in unconfirmedTransactions)
-                            {
-                                tx.SetHeight(Height.Mempool);
-                                await ProcessTransactionAsync(tx);
-                                Mempool.TransactionHashes.TryAdd(tx.GetHash());
-                            }
-
-                            throw;
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogWarning<WalletService>(ex);
-                }
-                finally
-                {
-                    UnconfirmedTransactionsInitialized = true;
-                }
-            }
-            Coins.CollectionChanged += Coins_CollectionChanged;
-            RefreshCoinHistories();
-        }
-
-        private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
-        {
-            if (ProcessedBlocks.ContainsKey(filterModel.BlockHash))
-            {
-                return;
-            }
-
-            var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
-            if (!matchFound)
-            {
-                return;
-            }
-
-            Block currentBlock = await GetOrDownloadBlockAsync(filterModel.BlockHash, cancel); // Wait until not downloaded.
-
-            if (await ProcessBlockAsync(filterModel.BlockHeight, currentBlock))
-            {
-                SerializeTransactionCache();
-            }
-        }
-
-        public HdPubKey GetReceiveKey(string label, IEnumerable<HdPubKey> dontTouch = null)
-        {
-            label = Guard.Correct(label);
-
-            // Make sure there's always 21 clean keys generated and indexed.
-            KeyManager.AssertCleanKeysIndexed(isInternal: false);
-
-            IEnumerable<HdPubKey> keys = KeyManager.GetKeys(KeyState.Clean, isInternal: false);
-            if (dontTouch != null)
-            {
-                keys = keys.Except(dontTouch);
-                if (!keys.Any())
-                {
-                    throw new InvalidOperationException($"{nameof(dontTouch)} covers all the possible keys.");
-                }
-            }
-
-            var foundLabelless = keys.FirstOrDefault(x => !x.HasLabel); // Return the first labelless.
-            HdPubKey ret = foundLabelless ?? keys.RandomElement(); // Return the first, because that's the oldest.
-
-            ret.SetLabel(label, KeyManager);
-
-            return ret;
-        }
-
-        public List<SmartCoin> GetClusters(SmartCoin coin, List<SmartCoin> current, ILookup<Script, SmartCoin> lookupScriptPubKey, ILookup<uint256, SmartCoin> lookupSpenderTransactionId, ILookup<uint256, SmartCoin> lookupTransactionId)
-        {
-            Guard.NotNull(nameof(coin), coin);
-            if (current.Contains(coin))
-            {
-                return current;
-            }
-
-            var clusters = current.Concat(new List<SmartCoin> { coin }).ToList(); // The coin is the first elem in its cluster.
-
-            // If the script is the same then we have a match, no matter of the anonymity set.
-            foreach (var c in lookupScriptPubKey[coin.ScriptPubKey])
-            {
-                if (!clusters.Contains(c))
-                {
-                    var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
-                    foreach (var hr in h)
-                    {
-                        if (!clusters.Contains(hr))
-                        {
-                            clusters.Add(hr);
-                        }
-                    }
-                }
-            }
-
-            // If it spends someone and has not been sufficiently anonymized.
-            if (coin.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
-            {
-                var c = lookupSpenderTransactionId[coin.TransactionId].FirstOrDefault(x => !clusters.Contains(x));
-                if (c != default)
-                {
-                    var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
-                    foreach (var hr in h)
-                    {
-                        if (!clusters.Contains(hr))
-                        {
-                            clusters.Add(hr);
-                        }
-                    }
-                }
-            }
-
-            // If it's being spent by someone and that someone has not been sufficiently anonymized.
-            if (!coin.Unspent)
-            {
-                var c = lookupTransactionId[coin.SpenderTransactionId].FirstOrDefault(x => !clusters.Contains(x));
-                if (c != default)
-                {
-                    if (c.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
-                    {
-                        if (c != default)
-                        {
-                            var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
-                            foreach (var hr in h)
-                            {
-                                if (!clusters.Contains(hr))
-                                {
-                                    clusters.Add(hr);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            return clusters;
-        }
-
-        private async Task<bool> ProcessBlockAsync(Height height, Block block, IEnumerable<int> filterByTxIds = null, IEnumerable<SmartTransaction> skeletonBlock = null)
-        {
-            var ret = false;
-            using (await TransactionProcessingLock.LockAsync())
-            {
-                if (filterByTxIds is null)
-                {
-                    var relevantIndicies = new List<int>();
-                    for (int i = 0; i < block.Transactions.Count; i++)
-                    {
-                        Transaction tx = block.Transactions[i];
-                        if (await ProcessTransactionAsync(new SmartTransaction(tx, height, block.GetHash(), i)))
-                        {
-                            relevantIndicies.Add(i);
-                            ret = true;
-                        }
-                    }
-
-                    if (relevantIndicies.Any())
-                    {
-                        var blockState = new BlockState(block.GetHash(), height, relevantIndicies);
-                        KeyManager.AddBlockState(blockState, setItsHeightToBest: true); // Set the heigh here (so less toFile and lock.)
-                    }
-                    else
-                    {
-                        KeyManager.SetBestHeight(height);
-                    }
-                }
-                else
-                {
-                    foreach (var i in filterByTxIds.OrderBy(x => x))
-                    {
-                        var tx = skeletonBlock?.FirstOrDefault(x => x.BlockIndex == i) ?? new SmartTransaction(block.Transactions[i], height, block.GetHash(), i);
-                        if (await ProcessTransactionAsync(tx))
-                        {
-                            ret = true;
-                        }
-                    }
-                }
-            }
-
-            ProcessedBlocks.TryAdd(block.GetHash(), (height, block.Header.BlockTime));
-
-            NewBlockProcessed?.Invoke(this, block);
-
-            return ret;
-        }
-
-        private async Task<bool> ProcessTransactionAsync(SmartTransaction tx)
-        {
-            uint256 txId = tx.GetHash();
-            var walletRelevant = false;
-
-            bool justUpdate = false;
-            if (tx.Confirmed)
-            {
-                Mempool.TransactionHashes.TryRemove(txId); // If we have in mempool, remove.
-                if (!tx.Transaction.PossiblyP2WPKHInvolved())
-                {
-                    return false; // We do not care about non-witness transactions for other than mempool cleanup.
-                }
-
-                bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
-                if (isFoundTx)
-                {
-                    SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
-                    if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
-                    {
-                        foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
-                        walletRelevant = true;
-                        justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
-                    }
-                }
-            }
-            else if (!tx.Transaction.PossiblyP2WPKHInvolved())
-            {
-                return false; // We do not care about non-witness transactions for other than mempool cleanup.
-            }
-
-            if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
-            {
-                var doubleSpends = new List<SmartCoin>();
-                foreach (SmartCoin coin in Coins)
-                {
-                    var spent = false;
-                    foreach (TxoRef spentOutput in coin.SpentOutputs)
-                    {
-                        foreach (TxIn txIn in tx.Transaction.Inputs)
-                        {
-                            if (spentOutput.TransactionId == txIn.PrevOut.Hash && spentOutput.Index == txIn.PrevOut.N) // Do not do (spentOutput == txIn.PrevOut), it's faster this way, because it won't check for null.
-                            {
-                                doubleSpends.Add(coin);
-                                spent = true;
-                                walletRelevant = true;
-                                break;
-                            }
-                        }
-                        if (spent)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (doubleSpends.Any())
-                {
-                    if (tx.Height == Height.Mempool)
-                    {
-                        // if the received transaction is spending at least one input already
-                        // spent by a previous unconfirmed transaction signaling RBF then it is not a double
-                        // spanding transaction but a replacement transaction.
-                        if (doubleSpends.Any(x => x.IsReplaceable))
-                        {
-                            // remove double spent coins (if other coin spends it, remove that too and so on)
-                            // will add later if they came to our keys
-                            foreach (SmartCoin doubleSpentCoin in doubleSpends.Where(x => !x.Confirmed))
-                            {
-                                RemoveCoinRecursively(doubleSpentCoin);
-                            }
-                            tx.SetReplacement();
-                            walletRelevant = true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-                    else // new confirmation always enjoys priority
-                    {
-                        // remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
-                        foreach (SmartCoin doubleSpentCoin in doubleSpends)
-                        {
-                            RemoveCoinRecursively(doubleSpentCoin);
-                        }
-                        walletRelevant = true;
-                    }
-                }
-            }
-
-            for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
-            {
-                // If transaction received to any of the wallet keys:
-                var output = tx.Transaction.Outputs[i];
-                HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
-                if (foundKey != default)
-                {
-                    walletRelevant = true;
-
-                    foundKey.SetKeyState(KeyState.Used, KeyManager);
-                    List<SmartCoin> spentOwnCoins = Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
-                    var anonset = tx.Transaction.GetAnonymitySet(i);
-                    if (spentOwnCoins.Count != 0)
-                    {
-                        anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
-
-                        // Cleanup exposed links where the txo has been spent.
-                        foreach (var input in spentOwnCoins.Select(x => x.GetTxoRef()))
-                        {
-                            ChaumianClient.ExposedLinks.TryRemove(input, out _);
-                        }
-                    }
-
-                    if (output.Value <= ServiceConfiguration.DustThreshold)
-                    {
-                        continue;
-                    }
-
-                    SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
-                                                                                                                                                                                                                                                   // If we did not have it.
-                    if (Coins.TryAdd(newCoin))
-                    {
-                        TransactionCache.TryAdd(tx);
-
-                        // If it's being mixed and anonset is not sufficient, then queue it.
-                        if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && ChaumianClient.State.Contains(newCoin.SpentOutputs))
-                        {
-                            try
-                            {
-                                await ChaumianClient.QueueCoinsToMixAsync(newCoin);
-                            }
-                            catch (Exception ex)
-                            {
-                                Logger.LogError<WalletService>(ex);
-                            }
-                        }
-
-                        // Make sure there's always 21 clean keys generated and indexed.
-                        KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
-
-                        if (foundKey.IsInternal)
-                        {
-                            // Make sure there's always 14 internal locked keys generated and indexed.
-                            KeyManager.AssertLockedInternalKeysIndexed(14);
-                        }
-                    }
-                    else // If we had this coin already.
-                    {
-                        if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
-                        {
-                            SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
-                            if (oldCoin != null) // Just to be sure, it is a concurrent collection.
-                            {
-                                oldCoin.Height = newCoin.Height;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // If spends any of our coin
-            for (var i = 0; i < tx.Transaction.Inputs.Count; i++)
-            {
-                var input = tx.Transaction.Inputs[i];
-
-                var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
-                if (foundCoin != null)
-                {
-                    walletRelevant = true;
-
-                    foundCoin.SpenderTransactionId = txId;
-                    TransactionCache.TryAdd(tx);
-                    CoinSpentOrSpenderConfirmed?.Invoke(this, foundCoin);
-                }
-            }
-
-            return walletRelevant;
-        }
-
-        private Node _localBitcoinCoreNode = null;
-
-        public Node LocalBitcoinCoreNode
-        {
-            get
-            {
-                if (Network == Network.RegTest)
-                {
-                    return Nodes.ConnectedNodes.First();
-                }
-
-                return _localBitcoinCoreNode;
-            }
-            private set => _localBitcoinCoreNode = value;
-        }
-
-        /// <exception cref="OperationCanceledException"></exception>
-        public async Task<Block> GetOrDownloadBlockAsync(uint256 hash, CancellationToken cancel)
-        {
-            // Try get the block
-            using (await BlockFolderLock.LockAsync())
-            {
-                var encoder = new HexEncoder();
-                foreach (var filePath in Directory.EnumerateFiles(BlocksFolderPath))
-                {
-                    var fileName = Path.GetFileName(filePath);
-                    if (!encoder.IsValid(fileName))
-                    {
-                        Logger.LogTrace<WalletService>($"Filename is not a hash: {fileName}.");
-                        continue;
-                    }
-
-                    if (hash == new uint256(fileName))
-                    {
-                        var blockBytes = await File.ReadAllBytesAsync(filePath);
-                        try
-                        {
-                            return Block.Load(blockBytes, Synchronizer.Network);
-                        }
-                        catch (Exception)
-                        {
-                            // In case the block file is corrupted we get an EndOfStreamException exception
-                            // Ignore any error and continue by re-downloading the block.
-                            break;
-                        }
-                    }
-                }
-            }
-            cancel.ThrowIfCancellationRequested();
-
-            // Download the block
-            Block block = null;
-            try
-            {
-                await BlockDownloadLock.LockAsync();
-                DownloadingBlock = true;
-
-                while (true)
-                {
-                    cancel.ThrowIfCancellationRequested();
-                    try
-                    {
-                        // Try to get block information from local running Core node first.
-                        try
-                        {
-                            if (LocalBitcoinCoreNode is null || !LocalBitcoinCoreNode.IsConnected && Network != Network.RegTest) // If RegTest then we're already connected do not try again.
-                            {
-                                DisconnectDisposeNullLocalBitcoinCoreNode();
-                                using (var handshakeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancel))
-                                {
-                                    handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
-                                    var nodeConnectionParameters = new NodeConnectionParameters()
-                                    {
-                                        ConnectCancellation = handshakeTimeout.Token,
-                                        IsRelay = false,
-                                        UserAgent = $"/Wasabi:{Constants.ClientVersion}/"
-                                    };
-
-                                    // If an onion was added must try to use Tor.
-                                    // onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
-                                    if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
-                                    {
-                                        nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
-                                    }
-
-                                    var localEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;
-                                    var localNode = await Node.ConnectAsync(Network, localEndPoint, nodeConnectionParameters);
-                                    try
-                                    {
-                                        Logger.LogInfo<WalletService>($"TCP Connection succeeded, handshaking...");
-                                        localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
-                                        var peerServices = localNode.PeerVersion.Services;
-
-                                        //if(!peerServices.HasFlag(NodeServices.Network) && !peerServices.HasFlag(NodeServices.NODE_NETWORK_LIMITED))
-                                        //{
-                                        //	throw new InvalidOperationException($"Wasabi cannot use the local node because it does not provide blocks.");
-                                        //}
-
-                                        Logger.LogInfo<WalletService>($"Handshake completed successfully.");
-
-                                        if (!localNode.IsConnected)
-                                        {
-                                            throw new InvalidOperationException($"Wasabi could not complete the handshake with the local node and dropped the connection.{Environment.NewLine}" +
-                                                $"Probably this is because the node does not support retrieving full blocks or segwit serialization.");
-                                        }
-                                        LocalBitcoinCoreNode = localNode;
-                                    }
-                                    catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
-                                    {
-                                        Logger.LogWarning<Node>($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
-                                            $"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
-                                        throw;
-                                    }
-                                }
-                            }
-
-                            Block blockFromLocalNode = null;
-                            // Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
-                            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
-                            {
-                                blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
-                            }
-
-                            if (!blockFromLocalNode.Check())
-                            {
-                                throw new InvalidOperationException($"Disconnected node, because invalid block received!");
-                            }
-
-                            block = blockFromLocalNode;
-                            Logger.LogInfo<WalletService>($"Block acquired from local P2P connection: {hash}");
-                            break;
-                        }
-                        catch (Exception ex)
-                        {
-                            block = null;
-                            DisconnectDisposeNullLocalBitcoinCoreNode();
-
-                            if (ex is SocketException)
-                            {
-                                Logger.LogTrace<WalletService>("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
-                            }
-                            else
-                            {
-                                Logger.LogWarning<WalletService>(ex);
-                            }
-                        }
-                        cancel.ThrowIfCancellationRequested();
-
-                        // If no connection, wait then continue.
-                        while (Nodes.ConnectedNodes.Count == 0)
-                        {
-                            await Task.Delay(100);
-                        }
-
-                        Node node = Nodes.ConnectedNodes.RandomElement();
-                        if (node == default(Node))
-                        {
-                            await Task.Delay(100);
-                            continue;
-                        }
-
-                        if (!node.IsConnected && !(Synchronizer.Network != Network.RegTest))
-                        {
-                            await Task.Delay(100);
-                            continue;
-                        }
-
-                        try
-                        {
-                            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
-                            {
-                                block = await node.DownloadBlockAsync(hash, cts.Token);
-                            }
-
-                            if (!block.Check())
-                            {
-                                Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
-                                node.DisconnectAsync("Invalid block received.");
-                                continue;
-                            }
-
-                            if (Nodes.ConnectedNodes.Count > 1) // So to minimize risking missing unconfirmed transactions.
-                            {
-                                Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}");
-                                node.DisconnectAsync("Thank you!");
-                            }
-
-                            await NodeTimeoutsAsync(false);
-                        }
-                        catch (Exception ex) when (ex is OperationCanceledException
-                                                || ex is TaskCanceledException
-                                                || ex is TimeoutException)
-                        {
-                            Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
-
-                            await NodeTimeoutsAsync(true);
-
-                            node.DisconnectAsync("Block download took too long.");
-                            continue;
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogDebug<WalletService>(ex);
-                            Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}");
-                            node.DisconnectAsync("Block download failed.");
-                            continue;
-                        }
-
-                        break; // If got this far break, then we have the block, it's valid. Break.
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogDebug<WalletService>(ex);
-                    }
-                }
-
-                // Save the block
-                using (await BlockFolderLock.LockAsync())
-                {
-                    var path = Path.Combine(BlocksFolderPath, hash.ToString());
-                    await File.WriteAllBytesAsync(path, block.ToBytes());
-                }
-            }
-            finally
-            {
-                DownloadingBlock = false;
-                BlockDownloadLock.ReleaseLock();
-            }
-
-            return block;
-        }
-
-        private void DisconnectDisposeNullLocalBitcoinCoreNode()
-        {
-            if (LocalBitcoinCoreNode != null)
-            {
-                try
-                {
-                    LocalBitcoinCoreNode?.Disconnect();
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogDebug<WalletService>(ex);
-                }
-                finally
-                {
-                    try
-                    {
-                        LocalBitcoinCoreNode?.Dispose();
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogDebug<WalletService>(ex);
-                    }
-                    finally
-                    {
-                        LocalBitcoinCoreNode = null;
-                        Logger.LogInfo<WalletService>("Local Bitcoin Core node disconnected.");
-                    }
-                }
-            }
-        }
-
-        /// <remarks>
-        /// Use it at reorgs.
-        /// </remarks>
-        public async Task DeleteBlockAsync(uint256 hash)
-        {
-            try
-            {
-                using (await BlockFolderLock.LockAsync())
-                {
-                    var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
-                    var fileNames = filePaths.Select(Path.GetFileName);
-                    var hashes = fileNames.Select(x => new uint256(x));
-
-                    if (hashes.Contains(hash))
-                    {
-                        File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning<WalletService>(ex);
-            }
-        }
-
-        public async Task<int> CountBlocksAsync()
-        {
-            using (await BlockFolderLock.LockAsync())
-            {
-                return Directory.EnumerateFiles(BlocksFolderPath).Count();
-            }
-        }
-
-        public class Operation
-        {
-            public Script Script { get; }
-            public Money Amount { get; }
-            public string Label { get; }
-
-            public Operation(Script script, Money amount, string label)
-            {
-                Script = Guard.NotNull(nameof(script), script);
-                Amount = Guard.NotNull(nameof(amount), amount);
-                Label = label ?? "";
-            }
-        }
-
-        /// <param name="toSend">If Money.Zero then spends all available amount. Does not generate change.</param>
-        /// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
-        /// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
-        /// <param name="subtractFeeFromAmountIndex">If null, fee is substracted from the change. Otherwise it denotes the index in the toSend array.</param>
-        /// <exception cref="ArgumentException"></exception>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public BuildTransactionResult BuildTransaction(string password,
-                                                        Operation[] toSend,
-                                                        int feeTarget,
-                                                        bool allowUnconfirmed = false,
-                                                        int? subtractFeeFromAmountIndex = null,
-                                                        Script customChange = null,
-                                                        IEnumerable<TxoRef> allowedInputs = null)
-        {
-            password = password ?? ""; // Correction.
-            toSend = Guard.NotNullOrEmpty(nameof(toSend), toSend);
-            if (toSend.Any(x => x is null))
-            {
-                throw new ArgumentNullException($"{nameof(toSend)} cannot contain null element.");
-            }
-            if (toSend.Any(x => x.Amount < Money.Zero))
-            {
-                throw new ArgumentException($"{nameof(toSend)} cannot contain negative element.");
-            }
-
-            long sum = toSend.Select(x => x.Amount).Sum().Satoshi;
-            if (sum < 0 || sum > Constants.MaximumNumberOfSatoshis)
-            {
-                throw new ArgumentOutOfRangeException($"{nameof(toSend)} sum cannot be smaller than 0 or greater than {Constants.MaximumNumberOfSatoshis}.");
-            }
-
-            int spendAllCount = toSend.Count(x => x.Amount == Money.Zero);
-            if (spendAllCount > 1)
-            {
-                throw new ArgumentException($"Only one {nameof(toSend)} element can contain Money.Zero. Money.Zero means add the change to the value of this output.");
-            }
-            if (spendAllCount == 1 && !(customChange is null))
-            {
-                throw new ArgumentException($"{nameof(customChange)} and send all to destination cannot be specified at the same time.");
-            }
-            Guard.InRangeAndNotNull(nameof(feeTarget), feeTarget, 0, Constants.SevenDaysConfirmationTarget); // Allow 0 and 1, and correct later.
-            if (feeTarget < 2) // Correct 0 and 1 to 2.
-            {
-                feeTarget = 2;
-            }
-            if (subtractFeeFromAmountIndex != null) // If not null, make sure not out of range. If null fee is substracted from the change.
-            {
-                if (subtractFeeFromAmountIndex < 0)
-                {
-                    throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} cannot be smaller than 0.");
-                }
-                if (subtractFeeFromAmountIndex > toSend.Length - 1)
-                {
-                    throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} can be maximum {nameof(toSend)}.Length - 1. {nameof(subtractFeeFromAmountIndex)}: {subtractFeeFromAmountIndex}, {nameof(toSend)}.Length - 1: {toSend.Length - 1}.");
-                }
-            }
-
-            // Get allowed coins to spend.
-            List<SmartCoin> allowedSmartCoinInputs; // Inputs those can be used to build the transaction.
-            if (allowedInputs != null) // If allowedInputs are specified then select the coins from them.
-            {
-                if (!allowedInputs.Any())
-                {
-                    throw new ArgumentException($"{nameof(allowedInputs)} is not null, but empty.");
-                }
-
-                if (allowUnconfirmed)
-                {
-                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
-                }
-                else
-                {
-                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
-                }
-            }
-            else
-            {
-                if (allowUnconfirmed)
-                {
-                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable).ToList();
-                }
-                else
-                {
-                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed).ToList();
-                }
-            }
-
-            // 4. Get and calculate fee
-            Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
-
-            Money feePerBytes = null;
-            using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
-            {
-                Money feeRate = Synchronizer.GetFeeRate(feeTarget);
-                Money sanityCheckedFeeRate = Math.Max(feeRate, 2); // Use the sanity check that under 2 satoshi per bytes should not be displayed. To correct possible rounding errors.
-                feePerBytes = new Money(sanityCheckedFeeRate);
-            }
-
-            bool spendAll = spendAllCount == 1;
-            int inNum;
-            if (spendAll)
-            {
-                inNum = allowedSmartCoinInputs.Count;
-            }
-            else
-            {
-                int expectedMinTxSize = 1 * Constants.P2wpkhInputSizeInBytes + 1 * Constants.OutputSizeInBytes + 10;
-                inNum = SelectCoinsToSpend(allowedSmartCoinInputs, toSend.Select(x => x.Amount).Sum() + feePerBytes * expectedMinTxSize).Count();
-            }
-
-            // https://bitcoincore.org/en/segwit_wallet_dev/#transaction-fee-estimation
-            // https://bitcoin.stackexchange.com/a/46379/26859
-            int outNum = spendAll ? toSend.Length : toSend.Length + 1; // number of addresses to send + 1 for change
-            int vSize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(inNum, outNum);
-            Logger.LogInfo<WalletService>($"Estimated tx size: {vSize} vbytes.");
-            Money fee = feePerBytes * vSize;
-            Logger.LogInfo<WalletService>($"Fee: {fee.Satoshi} Satoshi.");
-
-            // 5. How much to spend?
-            long toSendAmountSumInSatoshis = toSend.Select(x => x.Amount).Sum(); // Does it work if I simply go with Money class here? Is that copied by reference of value?
-            var realToSend = new (Script script, Money amount, string label)[toSend.Length];
-            for (int i = 0; i < toSend.Length; i++) // clone
-            {
-                realToSend[i] = (
-                    new Script(toSend[i].Script.ToString()),
-                    new Money(toSend[i].Amount.Satoshi),
-                    toSend[i].Label);
-            }
-            for (int i = 0; i < realToSend.Length; i++)
-            {
-                if (realToSend[i].amount == Money.Zero) // means spend all
-                {
-                    realToSend[i].amount = allowedSmartCoinInputs.Select(x => x.Amount).Sum();
-
-                    realToSend[i].amount -= new Money(toSendAmountSumInSatoshis);
-
-                    if (subtractFeeFromAmountIndex is null)
-                    {
-                        realToSend[i].amount -= fee;
-                    }
-                }
-
-                if (subtractFeeFromAmountIndex == i)
-                {
-                    realToSend[i].amount -= fee;
-                }
-
-                if (realToSend[i].amount < Money.Zero)
-                {
-                    throw new InsufficientBalanceException(fee + Money.Satoshis(1), realToSend[i].amount + fee);
-                }
-            }
-
-            var toRemoveList = new List<(Script script, Money money, string label)>(realToSend);
-            toRemoveList.RemoveAll(x => x.money == Money.Zero);
-            realToSend = toRemoveList.ToArray();
-
-            // 1. Get the possible changes.
-            Script changeScriptPubKey;
-            var sb = new StringBuilder();
-            foreach (var item in realToSend)
-            {
-                sb.Append(item.label ?? "?");
-                sb.Append(", ");
-            }
-            var changeLabel = $"{Constants.ChangeOfSpecialLabelStart}{sb.ToString().TrimEnd(',', ' ')}{Constants.ChangeOfSpecialLabelEnd}";
-
-            if (customChange is null)
-            {
-                KeyManager.AssertCleanKeysIndexed(isInternal: true);
-                KeyManager.AssertLockedInternalKeysIndexed(14);
-                var changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
-
-                changeHdPubKey.SetLabel(changeLabel, KeyManager);
-                changeScriptPubKey = changeHdPubKey.P2wpkhScript;
-            }
-            else
-            {
-                changeScriptPubKey = customChange;
-            }
-
-            // 6. Do some checks
-            Money totalOutgoingAmountNoFee = realToSend.Select(x => x.amount).Sum();
-            Money totalOutgoingAmount = totalOutgoingAmountNoFee + fee;
-            decimal feePc = (100 * fee.ToDecimal(MoneyUnit.BTC)) / totalOutgoingAmountNoFee.ToDecimal(MoneyUnit.BTC);
-
-            if (feePc > 1)
-            {
-                Logger.LogInfo<WalletService>($"The transaction fee is {feePc:0.#}% of your transaction amount."
-                    + Environment.NewLine + $"Sending:\t {totalOutgoingAmount.ToString(fplus: false, trimExcessZero: true)} BTC."
-                    + Environment.NewLine + $"Fee:\t\t {fee.Satoshi} Satoshi.");
-            }
-            if (feePc > 100)
-            {
-                throw new InvalidOperationException($"The transaction fee is more than twice as much as your transaction amount: {feePc:0.#}%.");
-            }
-
-            var confirmedAvailableAmount = allowedSmartCoinInputs.Where(x => x.Confirmed).Select(x => x.Amount).Sum();
-            var spendsUnconfirmed = false;
-            if (confirmedAvailableAmount < totalOutgoingAmount)
-            {
-                spendsUnconfirmed = true;
-                Logger.LogInfo<WalletService>("Unconfirmed transaction are being spent.");
-            }
-
-            // 7. Select coins
-            Logger.LogInfo<WalletService>("Selecting coins...");
-            IEnumerable<SmartCoin> coinsToSpend = SelectCoinsToSpend(allowedSmartCoinInputs, totalOutgoingAmount);
-
-            // 9. Build the transaction
-            Logger.LogInfo<WalletService>("Signing transaction...");
-            TransactionBuilder builder = Network.CreateTransactionBuilder();
-            // It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
-            bool sign = !KeyManager.IsWatchOnly;
-            if (sign)
-            {
-                // 8. Get signing keys
-                IEnumerable<ExtKey> signingKeys = KeyManager.GetSecrets(password, coinsToSpend.Select(x => x.ScriptPubKey).ToArray());
-
-                builder = builder
-                    .AddCoins(coinsToSpend.Select(x => x.GetCoin()))
-                    .AddKeys(signingKeys.ToArray());
-            }
-            else
-            {
-                builder = builder
-                    .AddCoins(coinsToSpend.Select(x => x.GetCoin()));
-            }
-
-            foreach ((Script scriptPubKey, Money amount, string label) output in realToSend)
-            {
-                builder = builder.Send(output.scriptPubKey, output.amount);
-            }
-
-            Transaction tx = builder
-                .SetChange(changeScriptPubKey)
-                .SendFees(fee)
-                .BuildTransaction(sign);
-
-            if (sign)
-            {
-                TransactionPolicyError[] checkResults = builder.Check(tx, fee);
-                if (checkResults.Length > 0)
-                {
-                    throw new InvalidTxException(tx, checkResults);
-                }
-            }
-
-            List<SmartCoin> spentCoins = Coins.Where(x => tx.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
-
-            var outerWalletOutputs = new List<SmartCoin>();
-            var innerWalletOutputs = new List<SmartCoin>();
-            for (var i = 0U; i < tx.Outputs.Count; i++)
-            {
-                TxOut output = tx.Outputs[i];
-                var anonset = (tx.GetAnonymitySet(i) + spentCoins.Min(x => x.AnonymitySet)) - 1; // Minus 1, because count own only once.
-                var foundKey = KeyManager.GetKeys(KeyState.Clean).FirstOrDefault(x => output.ScriptPubKey == x.P2wpkhScript);
-                var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Inputs.ToTxoRefs().ToArray(), Height.Unknown, tx.RBF, anonset, pubKey: foundKey);
-
-                if (foundKey != null)
-                {
-                    coin.Label = changeLabel;
-                    innerWalletOutputs.Add(coin);
-                }
-                else
-                {
-                    outerWalletOutputs.Add(coin);
-                }
-            }
-
-            PSBT psbt = builder.BuildPSBT(sign);
-            HashSet<SmartCoin> allTxCoins = spentCoins.Concat(innerWalletOutputs).Concat(outerWalletOutputs).ToHashSet();
-            foreach (var coin in allTxCoins)
-            {
-                if (coin.HdPubKey != null)
-                {
-                    var index = -1;
-                    var isInput = false;
-                    for (int i = 0; i < tx.Inputs.Count; i++)
-                    {
-                        var input = tx.Inputs[i];
-                        if (input.PrevOut == coin.GetOutPoint())
-                        {
-                            index = i;
-                            isInput = true;
-                            break;
-                        }
-                    }
-                    if (!isInput)
-                    {
-                        index = (int)coin.Index;
-                    }
-
-                    if (KeyManager.MasterFingerprint.HasValue)
-                    {
-                        var rootKeyPath = new RootedKeyPath(KeyManager.MasterFingerprint.Value, coin.HdPubKey.FullKeyPath);
-                        psbt.AddKeyPath(coin.HdPubKey.PubKey, rootKeyPath, coin.ScriptPubKey);
-                    }
-                }
-            }
-
-            Logger.LogInfo<WalletService>($"Transaction is successfully built: {tx.GetHash()}.");
-
-            return new BuildTransactionResult(new SmartTransaction(tx, Height.Unknown), psbt, spendsUnconfirmed, sign, fee, feePc, outerWalletOutputs, innerWalletOutputs, spentCoins);
-        }
-
-        private IEnumerable<SmartCoin> SelectCoinsToSpend(IEnumerable<SmartCoin> unspentCoins, Money totalOutAmount)
-        {
-            var coinsToSpend = new HashSet<SmartCoin>();
-            var unspentConfirmedCoins = new List<SmartCoin>();
-            var unspentUnconfirmedCoins = new List<SmartCoin>();
-            foreach (SmartCoin coin in unspentCoins)
-            {
-                if (coin.Confirmed)
-                {
-                    unspentConfirmedCoins.Add(coin);
-                }
-                else
-                {
-                    unspentUnconfirmedCoins.Add(coin);
-                }
-            }
-
-            bool haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentConfirmedCoins);
-            if (!haveEnough)
-            {
-                haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentUnconfirmedCoins);
-            }
-
-            if (!haveEnough)
-            {
-                throw new InsufficientBalanceException(totalOutAmount, unspentConfirmedCoins.Select(x => x.Amount).Sum() + unspentUnconfirmedCoins.Select(x => x.Amount).Sum());
-            }
-
-            return coinsToSpend;
-        }
-
-        /// <returns>If the selection was successful. If there's enough coins to spend from.</returns>
-        private bool TrySelectCoins(ref HashSet<SmartCoin> coinsToSpend, Money totalOutAmount, IEnumerable<SmartCoin> unspentCoins)
-        {
-            // If there's no need for input merging, then use the largest selected.
-            // Do not prefer anonymity set. You can assume the user prefers anonymity set manually through the GUI.
-            SmartCoin largestCoin = unspentCoins.OrderByDescending(x => x.Amount).FirstOrDefault();
-            if (largestCoin == default)
-            {
-                return false; // If there's no coin then unsuccessful selection.
-            }
-            else // Check if we can do without input merging.
-            {
-                if (largestCoin.Amount >= totalOutAmount)
-                {
-                    coinsToSpend.Add(largestCoin);
-                    return true;
-                }
-            }
-
-            // If there's a need for input merging.
-            foreach (var coin in unspentCoins
-                .OrderByDescending(x => x.AnonymitySet) // Always try to spend/merge the largest anonset coins first.
-                .ThenByDescending(x => x.Amount)) // Then always try to spend by amount.
-            {
-                coinsToSpend.Add(coin);
-                // If reaches the amount, then return true, else just go with the largest coin.
-                if (coinsToSpend.Select(x => x.Amount).Sum() >= totalOutAmount)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public void RenameLabel(SmartCoin coin, string newLabel)
-        {
-            newLabel = Guard.Correct(newLabel);
-            coin.Label = newLabel;
-            var key = KeyManager.GetKeys(x => x.P2wpkhScript == coin.ScriptPubKey).SingleOrDefault();
-            if (key != null)
-            {
-                key.SetLabel(newLabel, KeyManager);
-            }
-        }
-
-        private static long SendCount = 0;
-
-        public async Task SendTransactionAsync(SmartTransaction transaction)
-        {
-            try
-            {
-                Interlocked.Increment(ref SendCount);
-                // Broadcast to a random node.
-                // Wait until it arrives to at least two other nodes.
-                // If something's wrong, fall back broadcasting with backend.
-
-                if (Network == Network.RegTest)
-                {
-                    throw new InvalidOperationException("Transaction broadcasting to nodes does not work in RegTest.");
-                }
-
-                while (true)
-                {
-                    // As long as we are connected to at least 4 nodes, we can always try again.
-                    // 3 should be enough, but make it 5 so 2 nodes could disconnect the meantime.
-                    if (Nodes.ConnectedNodes.Count < 5)
-                    {
-                        throw new InvalidOperationException("We are not connected to enough nodes.");
-                    }
-
-                    Node node = Nodes.ConnectedNodes.RandomElement();
-                    if (node == default(Node))
-                    {
-                        await Task.Delay(100);
-                        continue;
-                    }
-
-                    if (!node.IsConnected)
-                    {
-                        await Task.Delay(100);
-                        continue;
-                    }
-
-                    Logger.LogInfo<WalletService>($"Trying to broadcast transaction with random node ({node.RemoteSocketAddress}):{transaction.GetHash()}");
-                    var addedToBroadcastStore = Mempool.TryAddToBroadcastStore(transaction.Transaction, node.RemoteSocketEndpoint.ToString()); // So we'll reply to INV with this transaction.
-                    if (!addedToBroadcastStore)
-                    {
-                        Logger.LogWarning<WalletService>($"Transaction {transaction.GetHash()} was already present in the broadcast store.");
-                    }
-                    var invPayload = new InvPayload(transaction.Transaction);
-                    // Give 7 seconds to send the inv payload.
-                    using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7)))
-                    {
-                        await node.SendMessageAsync(invPayload).WithCancellation(cts.Token); // ToDo: It's dangerous way to cancel. Implement proper cancellation to NBitcoin!
-                    }
-
-                    if (Mempool.TryGetFromBroadcastStore(transaction.GetHash(), out TransactionBroadcastEntry entry))
-                    {
-                        // Give 7 seconds for serving.
-                        var timeout = 0;
-                        while (!entry.IsBroadcasted())
-                        {
-                            if (timeout > 7)
-                            {
-                                throw new TimeoutException("Did not serve the transaction.");
-                            }
-                            await Task.Delay(1_000);
-                            timeout++;
-                        }
-                        node.DisconnectAsync("Thank you!");
-                        Logger.LogInfo<MempoolBehavior>($"Disconnected node: {node.RemoteSocketAddress}. Successfully broadcasted transaction: {transaction.GetHash()}.");
-
-                        // Give 21 seconds for propagation.
-                        timeout = 0;
-                        while (entry.GetPropagationConfirmations() < 2)
-                        {
-                            if (timeout > 21)
-                            {
-                                throw new TimeoutException("Did not serve the transaction.");
-                            }
-                            await Task.Delay(1_000);
-                            timeout++;
-                        }
-                        Logger.LogInfo<MempoolBehavior>($"Transaction is successfully propagated: {transaction.GetHash()}.");
-                    }
-                    else
-                    {
-                        Logger.LogWarning<WalletService>($"Expected transaction {transaction.GetHash()} was not found in the broadcast store.");
-                    }
-                    break;
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogInfo<WalletService>($"Random node could not broadcast transaction. Broadcasting with backend... Reason: {ex.Message}");
-                Logger.LogDebug<WalletService>(ex);
-
-                using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
-                {
-                    try
-                    {
-                        await client.BroadcastAsync(transaction);
-                    }
-                    catch (HttpRequestException ex2) when (
-                        ex2.Message.Contains("bad-txns-inputs-missingorspent", StringComparison.InvariantCultureIgnoreCase)
-                        || ex2.Message.Contains("missing-inputs", StringComparison.InvariantCultureIgnoreCase)
-                        || ex2.Message.Contains("txn-mempool-conflict", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        if (transaction.Transaction.Inputs.Count == 1) // If we tried to only spend one coin, then we can mark it as spent. If there were more coins, then we do not know.
-                        {
-                            OutPoint input = transaction.Transaction.Inputs.First().PrevOut;
-                            SmartCoin coin = Coins.FirstOrDefault(x => x.TransactionId == input.Hash && x.Index == input.N);
-                            if (coin != default)
-                            {
-                                coin.SpentAccordingToBackend = true;
-                            }
-                        }
-                    }
-                }
-
-                using (await TransactionProcessingLock.LockAsync())
-                {
-                    if (await ProcessTransactionAsync(new SmartTransaction(transaction.Transaction, Height.Mempool)))
-                    {
-                        SerializeTransactionCache();
-                    }
-
-                    Mempool.TransactionHashes.TryAdd(transaction.GetHash());
-                }
-
-                Logger.LogInfo<WalletService>($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
-            }
-            finally
-            {
-                Mempool.TryRemoveFromBroadcastStore(transaction.GetHash(), out _); // Remove it just to be sure. Probably has been removed previously.
-                Interlocked.Decrement(ref SendCount);
-            }
-        }
-
-        public IEnumerable<string> GetNonSpecialLabels()
-        {
-            return Coins.Where(x => !x.Label.StartsWith("ZeroLink", StringComparison.Ordinal))
-                .SelectMany(x => x.Label.Split(new string[] { Constants.ChangeOfSpecialLabelStart, Constants.ChangeOfSpecialLabelEnd, "(", "," }, StringSplitOptions.RemoveEmptyEntries))
-                .Select(x => x.Trim())
-                .Distinct();
-        }
-
-        private int _refreshCoinHistoriesRerunRequested = 0;
-        private int _refreshCoinHistoriesRunning = 0;
-
-        public void RefreshCoinHistories()
-        {
-            // If already running, then make sure another run is requested, else do the work.
-            if (Interlocked.CompareExchange(ref _refreshCoinHistoriesRunning, 1, 0) == 1)
-            {
-                Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 1);
-                return;
-            }
-
-            try
-            {
-                var unspentCoins = Coins.Where(c => c.Unspent); //refreshing unspent coins clusters only
-                if (unspentCoins.Any())
-                {
-                    ILookup<Script, SmartCoin> lookupScriptPubKey = Coins.ToLookup(c => c.ScriptPubKey, c => c);
-                    ILookup<uint256, SmartCoin> lookupSpenderTransactionId = Coins.ToLookup(c => c.SpenderTransactionId, c => c);
-                    ILookup<uint256, SmartCoin> lookupTransactionId = Coins.ToLookup(c => c.TransactionId, c => c);
-
-                    const int simultaneousThread = 2; //threads allowed to run simultaneously in threadpool
-
-                    Parallel.ForEach(unspentCoins, new ParallelOptions { MaxDegreeOfParallelism = simultaneousThread }, coin =>
-                    {
-                        var result = string.Join(", ", GetClusters(coin, new List<SmartCoin>(), lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId).Select(x => x.Label).Distinct());
-                        coin.SetClusters(result);
-                    });
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError<WalletService>($"Refreshing coin clusters failed: {ex}");
-            }
-            finally
-            {
-                // It's not running anymore, but someone may requested another run.
-                Interlocked.Exchange(ref _refreshCoinHistoriesRunning, 0);
-
-                // Clear the rerun request, too and if it was requested, then rerun.
-                if (Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 0) == 1)
-                {
-                    RefreshCoinHistories();
-                }
-            }
-        }
-
-        public bool UnconfirmedTransactionsInitialized { get; private set; } = false;
-
-        private void SerializeTransactionCache()
-        {
-            if (!UnconfirmedTransactionsInitialized) // If unconfirmed ones are not yet initialized, then do not serialize because unconfirmed are going to be lost.
-            {
-                return;
-            }
-
-            IoHelpers.EnsureContainingDirectoryExists(TransactionsFilePath);
-            string jsonString = JsonConvert.SerializeObject(TransactionCache.OrderByBlockchain(), Formatting.Indented);
-            File.WriteAllText(TransactionsFilePath,
-                jsonString,
-                Encoding.UTF8);
-        }
-
-        /// <summary>
-        /// Current timeout used when downloading a block from the remote node. It is defined in seconds.
-        /// </summary>
-        private async Task NodeTimeoutsAsync(bool increaseDecrease)
-        {
-            if (increaseDecrease)
-            {
-                NodeTimeouts++;
-            }
-            else
-            {
-                NodeTimeouts--;
-            }
-
-            var timeout = RuntimeParams.Instance.NetworkNodeTimeout;
-
-            // If it times out 2 times in a row then increase the timeout.
-            if (NodeTimeouts >= 2)
-            {
-                NodeTimeouts = 0;
-                timeout *= 2;
-            }
-            else if (NodeTimeouts <= -3) // If it does not time out 3 times in a row, lower the timeout.
-            {
-                NodeTimeouts = 0;
-                timeout = (int)Math.Round(timeout * 0.7);
-            }
-
-            // Sanity check
-            if (timeout < 32)
-            {
-                timeout = 32;
-            }
-            else if (timeout > 600)
-            {
-                timeout = 600;
-            }
-
-            if (timeout == RuntimeParams.Instance.NetworkNodeTimeout)
-            {
-                return;
-            }
-
-            RuntimeParams.Instance.NetworkNodeTimeout = timeout;
-            await RuntimeParams.Instance.SaveAsync();
-
-            Logger.LogInfo<WalletService>($"Current timeout value used on block download is: {timeout} seconds.");
-        }
-
-        public async Task StopAsync()
-        {
-            while (Interlocked.Read(ref SendCount) != 0) // Make sure to wait for send to finish.
-            {
-                await Task.Delay(50);
-            }
-
-            BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
-            BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
-            Mempool.TransactionReceived -= Mempool_TransactionReceivedAsync;
-            Coins.CollectionChanged -= Coins_CollectionChanged;
-
-            DisconnectDisposeNullLocalBitcoinCoreNode();
-        }
-    }
+	public class WalletService
+	{
+		public static event EventHandler<bool> DownloadingBlockChanged;
+
+		// So we will make sure when blocks are downloading with multiple wallet services, they do not conflict.
+		private static AsyncLock BlockDownloadLock { get; } = new AsyncLock();
+
+		private static bool DownloadingBlockBacking;
+
+		public static bool DownloadingBlock
+		{
+			get => DownloadingBlockBacking;
+			set
+			{
+				if (value != DownloadingBlockBacking)
+				{
+					DownloadingBlockBacking = value;
+					DownloadingBlockChanged?.Invoke(null, value);
+				}
+			}
+		}
+
+		public BitcoinStore BitcoinStore { get; }
+		public KeyManager KeyManager { get; }
+		public WasabiSynchronizer Synchronizer { get; }
+		public CcjClient ChaumianClient { get; }
+		public MempoolService Mempool { get; }
+
+		public NodesGroup Nodes { get; }
+		public string BlocksFolderPath { get; }
+		public string TransactionsFolderPath { get; }
+		public string TransactionsFilePath { get; }
+
+		private AsyncLock HandleFiltersLock { get; }
+
+		private AsyncLock BlockFolderLock { get; }
+
+		private int NodeTimeouts { get; set; }
+
+		public ServiceConfiguration ServiceConfiguration { get; }
+
+		public ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)> ProcessedBlocks { get; }
+
+		public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
+
+		public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
+
+		public event EventHandler<FilterModel> NewFilterProcessed;
+
+		public event EventHandler<SmartCoin> CoinSpentOrSpenderConfirmed;
+
+		public event EventHandler<Block> NewBlockProcessed;
+
+		public Network Network => Synchronizer.Network;
+
+		public WalletService(
+			BitcoinStore bitcoinStore,
+			KeyManager keyManager,
+			WasabiSynchronizer syncer,
+			CcjClient chaumianClient,
+			MempoolService mempool,
+			NodesGroup nodes,
+			string workFolderDir,
+			ServiceConfiguration serviceConfiguration)
+		{
+			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+			Nodes = Guard.NotNull(nameof(nodes), nodes);
+			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
+			ChaumianClient = Guard.NotNull(nameof(chaumianClient), chaumianClient);
+			Mempool = Guard.NotNull(nameof(mempool), mempool);
+			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
+
+			ProcessedBlocks = new ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)>();
+			HandleFiltersLock = new AsyncLock();
+
+			Coins = new ObservableConcurrentHashSet<SmartCoin>();
+			TransactionCache = new ConcurrentHashSet<SmartTransaction>();
+
+			BlocksFolderPath = Path.Combine(workFolderDir, "Blocks", Network.ToString());
+			TransactionsFolderPath = Path.Combine(workFolderDir, "Transactions", Network.ToString());
+			RuntimeParams.SetDataDir(workFolderDir);
+
+			BlockFolderLock = new AsyncLock();
+
+			KeyManager.AssertCleanKeysIndexed();
+			KeyManager.AssertLockedInternalKeysIndexed(14);
+
+			if (Directory.Exists(BlocksFolderPath))
+			{
+				if (Synchronizer.Network == Network.RegTest)
+				{
+					Directory.Delete(BlocksFolderPath, true);
+					Directory.CreateDirectory(BlocksFolderPath);
+				}
+			}
+			else
+			{
+				Directory.CreateDirectory(BlocksFolderPath);
+			}
+			if (Directory.Exists(TransactionsFolderPath))
+			{
+				if (Synchronizer.Network == Network.RegTest)
+				{
+					Directory.Delete(TransactionsFolderPath, true);
+					Directory.CreateDirectory(TransactionsFolderPath);
+				}
+			}
+			else
+			{
+				Directory.CreateDirectory(TransactionsFolderPath);
+			}
+
+			var walletName = "UnnamedWallet";
+			if (!string.IsNullOrWhiteSpace(KeyManager.FilePath))
+			{
+				walletName = Path.GetFileNameWithoutExtension(KeyManager.FilePath);
+			}
+			TransactionsFilePath = Path.Combine(TransactionsFolderPath, $"{walletName}Transactions.json");
+
+			BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
+			BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
+			Mempool.TransactionReceived += Mempool_TransactionReceivedAsync;
+		}
+
+		private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			RefreshCoinHistories();
+		}
+
+		private static AsyncLock TransactionProcessingLock { get; } = new AsyncLock();
+
+		private async void Mempool_TransactionReceivedAsync(object sender, SmartTransaction tx)
+		{
+			try
+			{
+				using (await TransactionProcessingLock.LockAsync())
+				{
+					if (await ProcessTransactionAsync(tx))
+					{
+						SerializeTransactionCache();
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<WalletService>(ex);
+			}
+		}
+
+		private async void IndexDownloader_ReorgedAsync(object sender, FilterModel invalidFilter)
+		{
+			try
+			{
+				using (await HandleFiltersLock.LockAsync())
+				{
+					uint256 invalidBlockHash = invalidFilter.BlockHash;
+					await DeleteBlockAsync(invalidBlockHash);
+					var blockState = KeyManager.TryRemoveBlockState(invalidBlockHash);
+					ProcessedBlocks.TryRemove(invalidBlockHash, out _);
+					if (blockState != null && blockState.BlockHeight != default(Height))
+					{
+						foreach (var toRemove in Coins.Where(x => x.Height == blockState.BlockHeight).Distinct().ToList())
+						{
+							RemoveCoinRecursively(toRemove);
+						}
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<WalletService>(ex);
+			}
+		}
+
+		private void RemoveCoinRecursively(SmartCoin toRemove)
+		{
+			if (toRemove.SpenderTransactionId != null)
+			{
+				foreach (var toAlsoRemove in Coins.Where(x => x.TransactionId == toRemove.SpenderTransactionId).Distinct().ToList())
+				{
+					RemoveCoinRecursively(toAlsoRemove);
+				}
+			}
+
+			Coins.TryRemove(toRemove);
+			Mempool.TransactionHashes.TryRemove(toRemove.SpenderTransactionId);
+		}
+
+		private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)
+		{
+			try
+			{
+				using (await HandleFiltersLock.LockAsync())
+				{
+					if (filterModel.Filter != null && !KeyManager.CointainsBlockState(filterModel.BlockHash))
+					{
+						await ProcessFilterModelAsync(filterModel, CancellationToken.None);
+					}
+				}
+				NewFilterProcessed?.Invoke(this, filterModel);
+
+				do
+				{
+					await Task.Delay(100);
+					if (Synchronizer is null || BitcoinStore?.HashChain is null)
+					{
+						return;
+					}
+					// Make sure fully synced and this filter is the lastest filter.
+					if (BitcoinStore.HashChain.HashesLeft != 0 || BitcoinStore.HashChain.TipHash != filterModel.BlockHash)
+					{
+						return;
+					}
+				} while (Synchronizer.AreRequestsBlocked()); // If requests are blocked, delay mempool cleanup, because coinjoin answers are always priority.
+
+				await Mempool?.TryPerformMempoolCleanupAsync(Synchronizer?.WasabiClient?.TorClient?.DestinationUriAction, Synchronizer?.WasabiClient?.TorClient?.TorSocks5EndPoint);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<WalletService>(ex);
+			}
+		}
+
+		public async Task InitializeAsync(CancellationToken cancel)
+		{
+			if (!Synchronizer.IsRunning)
+			{
+				throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
+			}
+
+			await RuntimeParams.LoadAsync();
+
+			using (await HandleFiltersLock.LockAsync())
+			{
+				var unconfirmedTransactions = new SmartTransaction[0];
+				var confirmedTransactions = new SmartTransaction[0];
+
+				if (File.Exists(TransactionsFilePath))
+				{
+					try
+					{
+						IEnumerable<SmartTransaction> transactions = null;
+						string jsonString = File.ReadAllText(TransactionsFilePath, Encoding.UTF8);
+						transactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?
+							.OrderByBlockchain();
+
+						confirmedTransactions = transactions?
+							.Where(x => x.Confirmed)?
+							.ToArray() ?? new SmartTransaction[0];
+
+						unconfirmedTransactions = transactions?
+							.Where(x => !x.Confirmed)?
+							.ToArray() ?? new SmartTransaction[0];
+					}
+					catch (Exception ex)
+					{
+						Logger.LogWarning<WalletService>(ex);
+						Logger.LogWarning<WalletService>($"Transaction cache got corrupted. Deleting {TransactionsFilePath}.");
+						File.Delete(TransactionsFilePath);
+					}
+				}
+
+				// Go through the keymanager's index.
+				KeyManager.AssertNetworkOrClearBlockState(Network);
+				Height bestKeyManagerHeight = KeyManager.GetBestHeight();
+
+				foreach (BlockState blockState in KeyManager.GetTransactionIndex())
+				{
+					var relevantTransactions = confirmedTransactions.Where(x => x.BlockHash == blockState.BlockHash).ToArray();
+					var block = await GetOrDownloadBlockAsync(blockState.BlockHash, cancel);
+					await ProcessBlockAsync(blockState.BlockHeight, block, blockState.TransactionIndices, relevantTransactions);
+				}
+
+				// Go through the filters and que to download the matches.
+				await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>
+				{
+					if (filterModel.Filter != null) // Filter can be null if there is no bech32 tx.
+					{
+						await ProcessFilterModelAsync(filterModel, cancel);
+					}
+				}, new Height(bestKeyManagerHeight.Value + 1));
+
+				// Load in dummy mempool
+				try
+				{
+					if (unconfirmedTransactions != null && unconfirmedTransactions.Any())
+					{
+						try
+						{
+							using (await TransactionProcessingLock.LockAsync())
+							using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+							{
+								var compactness = 10;
+
+								var mempoolHashes = await client.GetMempoolHashesAsync(compactness);
+
+								var cnt = 0;
+								foreach (var tx in unconfirmedTransactions)
+								{
+									if (mempoolHashes.Contains(tx.GetHash().ToString().Substring(0, compactness)))
+									{
+										tx.SetHeight(Height.Mempool);
+										await ProcessTransactionAsync(tx);
+										Mempool.TransactionHashes.TryAdd(tx.GetHash());
+
+										Logger.LogInfo<WalletService>($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
+										cnt++;
+									}
+								}
+
+								if (cnt != unconfirmedTransactions.Length)
+								{
+									SerializeTransactionCache();
+								}
+							}
+						}
+						catch
+						{
+							// When there's a connection failure do not clean the transactions, add it to processing.
+							foreach (var tx in unconfirmedTransactions)
+							{
+								tx.SetHeight(Height.Mempool);
+								await ProcessTransactionAsync(tx);
+								Mempool.TransactionHashes.TryAdd(tx.GetHash());
+							}
+
+							throw;
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					Logger.LogWarning<WalletService>(ex);
+				}
+				finally
+				{
+					UnconfirmedTransactionsInitialized = true;
+				}
+			}
+			Coins.CollectionChanged += Coins_CollectionChanged;
+			RefreshCoinHistories();
+		}
+
+		private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
+		{
+			if (ProcessedBlocks.ContainsKey(filterModel.BlockHash))
+			{
+				return;
+			}
+
+			var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
+			if (!matchFound)
+			{
+				return;
+			}
+
+			Block currentBlock = await GetOrDownloadBlockAsync(filterModel.BlockHash, cancel); // Wait until not downloaded.
+
+			if (await ProcessBlockAsync(filterModel.BlockHeight, currentBlock))
+			{
+				SerializeTransactionCache();
+			}
+		}
+
+		public HdPubKey GetReceiveKey(string label, IEnumerable<HdPubKey> dontTouch = null)
+		{
+			label = Guard.Correct(label);
+
+			// Make sure there's always 21 clean keys generated and indexed.
+			KeyManager.AssertCleanKeysIndexed(isInternal: false);
+
+			IEnumerable<HdPubKey> keys = KeyManager.GetKeys(KeyState.Clean, isInternal: false);
+			if (dontTouch != null)
+			{
+				keys = keys.Except(dontTouch);
+				if (!keys.Any())
+				{
+					throw new InvalidOperationException($"{nameof(dontTouch)} covers all the possible keys.");
+				}
+			}
+
+			var foundLabelless = keys.FirstOrDefault(x => !x.HasLabel); // Return the first labelless.
+			HdPubKey ret = foundLabelless ?? keys.RandomElement(); // Return the first, because that's the oldest.
+
+			ret.SetLabel(label, KeyManager);
+
+			return ret;
+		}
+
+		public List<SmartCoin> GetClusters(SmartCoin coin, List<SmartCoin> current, ILookup<Script, SmartCoin> lookupScriptPubKey, ILookup<uint256, SmartCoin> lookupSpenderTransactionId, ILookup<uint256, SmartCoin> lookupTransactionId)
+		{
+			Guard.NotNull(nameof(coin), coin);
+			if (current.Contains(coin))
+			{
+				return current;
+			}
+
+			var clusters = current.Concat(new List<SmartCoin> { coin }).ToList(); // The coin is the first elem in its cluster.
+
+			// If the script is the same then we have a match, no matter of the anonymity set.
+			foreach (var c in lookupScriptPubKey[coin.ScriptPubKey])
+			{
+				if (!clusters.Contains(c))
+				{
+					var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
+					foreach (var hr in h)
+					{
+						if (!clusters.Contains(hr))
+						{
+							clusters.Add(hr);
+						}
+					}
+				}
+			}
+
+			// If it spends someone and has not been sufficiently anonymized.
+			if (coin.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
+			{
+				var c = lookupSpenderTransactionId[coin.TransactionId].FirstOrDefault(x => !clusters.Contains(x));
+				if (c != default)
+				{
+					var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
+					foreach (var hr in h)
+					{
+						if (!clusters.Contains(hr))
+						{
+							clusters.Add(hr);
+						}
+					}
+				}
+			}
+
+			// If it's being spent by someone and that someone has not been sufficiently anonymized.
+			if (!coin.Unspent)
+			{
+				var c = lookupTransactionId[coin.SpenderTransactionId].FirstOrDefault(x => !clusters.Contains(x));
+				if (c != default)
+				{
+					if (c.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
+					{
+						if (c != default)
+						{
+							var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
+							foreach (var hr in h)
+							{
+								if (!clusters.Contains(hr))
+								{
+									clusters.Add(hr);
+								}
+							}
+						}
+					}
+				}
+			}
+
+			return clusters;
+		}
+
+		private async Task<bool> ProcessBlockAsync(Height height, Block block, IEnumerable<int> filterByTxIds = null, IEnumerable<SmartTransaction> skeletonBlock = null)
+		{
+			var ret = false;
+			using (await TransactionProcessingLock.LockAsync())
+			{
+				if (filterByTxIds is null)
+				{
+					var relevantIndicies = new List<int>();
+					for (int i = 0; i < block.Transactions.Count; i++)
+					{
+						Transaction tx = block.Transactions[i];
+						if (await ProcessTransactionAsync(new SmartTransaction(tx, height, block.GetHash(), i)))
+						{
+							relevantIndicies.Add(i);
+							ret = true;
+						}
+					}
+
+					if (relevantIndicies.Any())
+					{
+						var blockState = new BlockState(block.GetHash(), height, relevantIndicies);
+						KeyManager.AddBlockState(blockState, setItsHeightToBest: true); // Set the heigh here (so less toFile and lock.)
+					}
+					else
+					{
+						KeyManager.SetBestHeight(height);
+					}
+				}
+				else
+				{
+					foreach (var i in filterByTxIds.OrderBy(x => x))
+					{
+						var tx = skeletonBlock?.FirstOrDefault(x => x.BlockIndex == i) ?? new SmartTransaction(block.Transactions[i], height, block.GetHash(), i);
+						if (await ProcessTransactionAsync(tx))
+						{
+							ret = true;
+						}
+					}
+				}
+			}
+
+			ProcessedBlocks.TryAdd(block.GetHash(), (height, block.Header.BlockTime));
+
+			NewBlockProcessed?.Invoke(this, block);
+
+			return ret;
+		}
+
+		private async Task<bool> ProcessTransactionAsync(SmartTransaction tx)
+		{
+			uint256 txId = tx.GetHash();
+			var walletRelevant = false;
+
+			bool justUpdate = false;
+			if (tx.Confirmed)
+			{
+				Mempool.TransactionHashes.TryRemove(txId); // If we have in mempool, remove.
+				if (!tx.Transaction.PossiblyP2WPKHInvolved())
+				{
+					return false; // We do not care about non-witness transactions for other than mempool cleanup.
+				}
+
+				bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
+				if (isFoundTx)
+				{
+					SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
+					if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
+					{
+						foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
+						walletRelevant = true;
+						justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
+					}
+				}
+			}
+			else if (!tx.Transaction.PossiblyP2WPKHInvolved())
+			{
+				return false; // We do not care about non-witness transactions for other than mempool cleanup.
+			}
+
+			if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
+			{
+				var doubleSpends = new List<SmartCoin>();
+				foreach (SmartCoin coin in Coins)
+				{
+					var spent = false;
+					foreach (TxoRef spentOutput in coin.SpentOutputs)
+					{
+						foreach (TxIn txIn in tx.Transaction.Inputs)
+						{
+							if (spentOutput.TransactionId == txIn.PrevOut.Hash && spentOutput.Index == txIn.PrevOut.N) // Do not do (spentOutput == txIn.PrevOut), it's faster this way, because it won't check for null.
+							{
+								doubleSpends.Add(coin);
+								spent = true;
+								walletRelevant = true;
+								break;
+							}
+						}
+						if (spent)
+						{
+							break;
+						}
+					}
+				}
+
+				if (doubleSpends.Any())
+				{
+					if (tx.Height == Height.Mempool)
+					{
+						// if the received transaction is spending at least one input already
+						// spent by a previous unconfirmed transaction signaling RBF then it is not a double
+						// spanding transaction but a replacement transaction.
+						if (doubleSpends.Any(x => x.IsReplaceable))
+						{
+							// remove double spent coins (if other coin spends it, remove that too and so on)
+							// will add later if they came to our keys
+							foreach (SmartCoin doubleSpentCoin in doubleSpends.Where(x => !x.Confirmed))
+							{
+								RemoveCoinRecursively(doubleSpentCoin);
+							}
+							tx.SetReplacement();
+							walletRelevant = true;
+						}
+						else
+						{
+							return false;
+						}
+					}
+					else // new confirmation always enjoys priority
+					{
+						// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
+						foreach (SmartCoin doubleSpentCoin in doubleSpends)
+						{
+							RemoveCoinRecursively(doubleSpentCoin);
+						}
+						walletRelevant = true;
+					}
+				}
+			}
+
+			for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
+			{
+				// If transaction received to any of the wallet keys:
+				var output = tx.Transaction.Outputs[i];
+				HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
+				if (foundKey != default)
+				{
+					walletRelevant = true;
+
+					foundKey.SetKeyState(KeyState.Used, KeyManager);
+					List<SmartCoin> spentOwnCoins = Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
+					var anonset = tx.Transaction.GetAnonymitySet(i);
+					if (spentOwnCoins.Count != 0)
+					{
+						anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
+
+						// Cleanup exposed links where the txo has been spent.
+						foreach (var input in spentOwnCoins.Select(x => x.GetTxoRef()))
+						{
+							ChaumianClient.ExposedLinks.TryRemove(input, out _);
+						}
+					}
+
+					if (output.Value <= ServiceConfiguration.DustThreshold)
+					{
+						continue;
+					}
+
+					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
+																																																												   // If we did not have it.
+					if (Coins.TryAdd(newCoin))
+					{
+						TransactionCache.TryAdd(tx);
+
+						// If it's being mixed and anonset is not sufficient, then queue it.
+						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && ChaumianClient.State.Contains(newCoin.SpentOutputs))
+						{
+							try
+							{
+								await ChaumianClient.QueueCoinsToMixAsync(newCoin);
+							}
+							catch (Exception ex)
+							{
+								Logger.LogError<WalletService>(ex);
+							}
+						}
+
+						// Make sure there's always 21 clean keys generated and indexed.
+						KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
+
+						if (foundKey.IsInternal)
+						{
+							// Make sure there's always 14 internal locked keys generated and indexed.
+							KeyManager.AssertLockedInternalKeysIndexed(14);
+						}
+					}
+					else // If we had this coin already.
+					{
+						if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
+						{
+							SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
+							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
+							{
+								oldCoin.Height = newCoin.Height;
+							}
+						}
+					}
+				}
+			}
+
+			// If spends any of our coin
+			for (var i = 0; i < tx.Transaction.Inputs.Count; i++)
+			{
+				var input = tx.Transaction.Inputs[i];
+
+				var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
+				if (foundCoin != null)
+				{
+					walletRelevant = true;
+
+					foundCoin.SpenderTransactionId = txId;
+					TransactionCache.TryAdd(tx);
+					CoinSpentOrSpenderConfirmed?.Invoke(this, foundCoin);
+				}
+			}
+
+			return walletRelevant;
+		}
+
+		private Node _localBitcoinCoreNode = null;
+
+		public Node LocalBitcoinCoreNode
+		{
+			get
+			{
+				if (Network == Network.RegTest)
+				{
+					return Nodes.ConnectedNodes.First();
+				}
+
+				return _localBitcoinCoreNode;
+			}
+			private set => _localBitcoinCoreNode = value;
+		}
+
+		/// <exception cref="OperationCanceledException"></exception>
+		public async Task<Block> GetOrDownloadBlockAsync(uint256 hash, CancellationToken cancel)
+		{
+			// Try get the block
+			using (await BlockFolderLock.LockAsync())
+			{
+				var encoder = new HexEncoder();
+				foreach (var filePath in Directory.EnumerateFiles(BlocksFolderPath))
+				{
+					var fileName = Path.GetFileName(filePath);
+					if (!encoder.IsValid(fileName))
+					{
+						Logger.LogTrace<WalletService>($"Filename is not a hash: {fileName}.");
+						continue;
+					}
+
+					if (hash == new uint256(fileName))
+					{
+						var blockBytes = await File.ReadAllBytesAsync(filePath);
+						try
+						{
+							return Block.Load(blockBytes, Synchronizer.Network);
+						}
+						catch (Exception)
+						{
+							// In case the block file is corrupted we get an EndOfStreamException exception
+							// Ignore any error and continue by re-downloading the block.
+							break;
+						}
+					}
+				}
+			}
+			cancel.ThrowIfCancellationRequested();
+
+			// Download the block
+			Block block = null;
+			try
+			{
+				await BlockDownloadLock.LockAsync();
+				DownloadingBlock = true;
+
+				while (true)
+				{
+					cancel.ThrowIfCancellationRequested();
+					try
+					{
+						// Try to get block information from local running Core node first.
+						try
+						{
+							if (LocalBitcoinCoreNode is null || !LocalBitcoinCoreNode.IsConnected && Network != Network.RegTest) // If RegTest then we're already connected do not try again.
+							{
+								DisconnectDisposeNullLocalBitcoinCoreNode();
+								using (var handshakeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancel))
+								{
+									handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
+									var nodeConnectionParameters = new NodeConnectionParameters()
+									{
+										ConnectCancellation = handshakeTimeout.Token,
+										IsRelay = false,
+										UserAgent = $"/Wasabi:{Constants.ClientVersion}/"
+									};
+
+									// If an onion was added must try to use Tor.
+									// onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
+									if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
+									{
+										nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
+									}
+
+									var localEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;
+									var localNode = await Node.ConnectAsync(Network, localEndPoint, nodeConnectionParameters);
+									try
+									{
+										Logger.LogInfo<WalletService>($"TCP Connection succeeded, handshaking...");
+										localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
+										var peerServices = localNode.PeerVersion.Services;
+
+										//if(!peerServices.HasFlag(NodeServices.Network) && !peerServices.HasFlag(NodeServices.NODE_NETWORK_LIMITED))
+										//{
+										//	throw new InvalidOperationException($"Wasabi cannot use the local node because it does not provide blocks.");
+										//}
+
+										Logger.LogInfo<WalletService>($"Handshake completed successfully.");
+
+										if (!localNode.IsConnected)
+										{
+											throw new InvalidOperationException($"Wasabi could not complete the handshake with the local node and dropped the connection.{Environment.NewLine}" +
+												$"Probably this is because the node does not support retrieving full blocks or segwit serialization.");
+										}
+										LocalBitcoinCoreNode = localNode;
+									}
+									catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
+									{
+										Logger.LogWarning<Node>($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
+											$"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
+										throw;
+									}
+								}
+							}
+
+							Block blockFromLocalNode = null;
+							// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
+							{
+								blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
+							}
+
+							if (!blockFromLocalNode.Check())
+							{
+								throw new InvalidOperationException($"Disconnected node, because invalid block received!");
+							}
+
+							block = blockFromLocalNode;
+							Logger.LogInfo<WalletService>($"Block acquired from local P2P connection: {hash}");
+							break;
+						}
+						catch (Exception ex)
+						{
+							block = null;
+							DisconnectDisposeNullLocalBitcoinCoreNode();
+
+							if (ex is SocketException)
+							{
+								Logger.LogTrace<WalletService>("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
+							}
+							else
+							{
+								Logger.LogWarning<WalletService>(ex);
+							}
+						}
+						cancel.ThrowIfCancellationRequested();
+
+						// If no connection, wait then continue.
+						while (Nodes.ConnectedNodes.Count == 0)
+						{
+							await Task.Delay(100);
+						}
+
+						Node node = Nodes.ConnectedNodes.RandomElement();
+						if (node == default(Node))
+						{
+							await Task.Delay(100);
+							continue;
+						}
+
+						if (!node.IsConnected && !(Synchronizer.Network != Network.RegTest))
+						{
+							await Task.Delay(100);
+							continue;
+						}
+
+						try
+						{
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
+							{
+								block = await node.DownloadBlockAsync(hash, cts.Token);
+							}
+
+							if (!block.Check())
+							{
+								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
+								node.DisconnectAsync("Invalid block received.");
+								continue;
+							}
+
+							if (Nodes.ConnectedNodes.Count > 1) // So to minimize risking missing unconfirmed transactions.
+							{
+								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}");
+								node.DisconnectAsync("Thank you!");
+							}
+
+							await NodeTimeoutsAsync(false);
+						}
+						catch (Exception ex) when (ex is OperationCanceledException
+												|| ex is TaskCanceledException
+												|| ex is TimeoutException)
+						{
+							Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
+
+							await NodeTimeoutsAsync(true);
+
+							node.DisconnectAsync("Block download took too long.");
+							continue;
+						}
+						catch (Exception ex)
+						{
+							Logger.LogDebug<WalletService>(ex);
+							Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}");
+							node.DisconnectAsync("Block download failed.");
+							continue;
+						}
+
+						break; // If got this far break, then we have the block, it's valid. Break.
+					}
+					catch (Exception ex)
+					{
+						Logger.LogDebug<WalletService>(ex);
+					}
+				}
+
+				// Save the block
+				using (await BlockFolderLock.LockAsync())
+				{
+					var path = Path.Combine(BlocksFolderPath, hash.ToString());
+					await File.WriteAllBytesAsync(path, block.ToBytes());
+				}
+			}
+			finally
+			{
+				DownloadingBlock = false;
+				BlockDownloadLock.ReleaseLock();
+			}
+
+			return block;
+		}
+
+		private void DisconnectDisposeNullLocalBitcoinCoreNode()
+		{
+			if (LocalBitcoinCoreNode != null)
+			{
+				try
+				{
+					LocalBitcoinCoreNode?.Disconnect();
+				}
+				catch (Exception ex)
+				{
+					Logger.LogDebug<WalletService>(ex);
+				}
+				finally
+				{
+					try
+					{
+						LocalBitcoinCoreNode?.Dispose();
+					}
+					catch (Exception ex)
+					{
+						Logger.LogDebug<WalletService>(ex);
+					}
+					finally
+					{
+						LocalBitcoinCoreNode = null;
+						Logger.LogInfo<WalletService>("Local Bitcoin Core node disconnected.");
+					}
+				}
+			}
+		}
+
+		/// <remarks>
+		/// Use it at reorgs.
+		/// </remarks>
+		public async Task DeleteBlockAsync(uint256 hash)
+		{
+			try
+			{
+				using (await BlockFolderLock.LockAsync())
+				{
+					var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
+					var fileNames = filePaths.Select(Path.GetFileName);
+					var hashes = fileNames.Select(x => new uint256(x));
+
+					if (hashes.Contains(hash))
+					{
+						File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<WalletService>(ex);
+			}
+		}
+
+		public async Task<int> CountBlocksAsync()
+		{
+			using (await BlockFolderLock.LockAsync())
+			{
+				return Directory.EnumerateFiles(BlocksFolderPath).Count();
+			}
+		}
+
+		public class Operation
+		{
+			public Script Script { get; }
+			public Money Amount { get; }
+			public string Label { get; }
+
+			public Operation(Script script, Money amount, string label)
+			{
+				Script = Guard.NotNull(nameof(script), script);
+				Amount = Guard.NotNull(nameof(amount), amount);
+				Label = label ?? "";
+			}
+		}
+
+		/// <param name="toSend">If Money.Zero then spends all available amount. Does not generate change.</param>
+		/// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
+		/// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
+		/// <param name="subtractFeeFromAmountIndex">If null, fee is substracted from the change. Otherwise it denotes the index in the toSend array.</param>
+		/// <exception cref="ArgumentException"></exception>
+		/// <exception cref="ArgumentNullException"></exception>
+		/// <exception cref="ArgumentOutOfRangeException"></exception>
+		public BuildTransactionResult BuildTransaction(string password,
+														Operation[] toSend,
+														int feeTarget,
+														bool allowUnconfirmed = false,
+														int? subtractFeeFromAmountIndex = null,
+														Script customChange = null,
+														IEnumerable<TxoRef> allowedInputs = null)
+		{
+			password = password ?? ""; // Correction.
+			toSend = Guard.NotNullOrEmpty(nameof(toSend), toSend);
+			if (toSend.Any(x => x is null))
+			{
+				throw new ArgumentNullException($"{nameof(toSend)} cannot contain null element.");
+			}
+			if (toSend.Any(x => x.Amount < Money.Zero))
+			{
+				throw new ArgumentException($"{nameof(toSend)} cannot contain negative element.");
+			}
+
+			long sum = toSend.Select(x => x.Amount).Sum().Satoshi;
+			if (sum < 0 || sum > Constants.MaximumNumberOfSatoshis)
+			{
+				throw new ArgumentOutOfRangeException($"{nameof(toSend)} sum cannot be smaller than 0 or greater than {Constants.MaximumNumberOfSatoshis}.");
+			}
+
+			int spendAllCount = toSend.Count(x => x.Amount == Money.Zero);
+			if (spendAllCount > 1)
+			{
+				throw new ArgumentException($"Only one {nameof(toSend)} element can contain Money.Zero. Money.Zero means add the change to the value of this output.");
+			}
+			if (spendAllCount == 1 && !(customChange is null))
+			{
+				throw new ArgumentException($"{nameof(customChange)} and send all to destination cannot be specified at the same time.");
+			}
+			Guard.InRangeAndNotNull(nameof(feeTarget), feeTarget, 0, Constants.SevenDaysConfirmationTarget); // Allow 0 and 1, and correct later.
+			if (feeTarget < 2) // Correct 0 and 1 to 2.
+			{
+				feeTarget = 2;
+			}
+			if (subtractFeeFromAmountIndex != null) // If not null, make sure not out of range. If null fee is substracted from the change.
+			{
+				if (subtractFeeFromAmountIndex < 0)
+				{
+					throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} cannot be smaller than 0.");
+				}
+				if (subtractFeeFromAmountIndex > toSend.Length - 1)
+				{
+					throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} can be maximum {nameof(toSend)}.Length - 1. {nameof(subtractFeeFromAmountIndex)}: {subtractFeeFromAmountIndex}, {nameof(toSend)}.Length - 1: {toSend.Length - 1}.");
+				}
+			}
+
+			// Get allowed coins to spend.
+			List<SmartCoin> allowedSmartCoinInputs; // Inputs those can be used to build the transaction.
+			if (allowedInputs != null) // If allowedInputs are specified then select the coins from them.
+			{
+				if (!allowedInputs.Any())
+				{
+					throw new ArgumentException($"{nameof(allowedInputs)} is not null, but empty.");
+				}
+
+				if (allowUnconfirmed)
+				{
+					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
+				}
+				else
+				{
+					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
+				}
+			}
+			else
+			{
+				if (allowUnconfirmed)
+				{
+					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable).ToList();
+				}
+				else
+				{
+					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed).ToList();
+				}
+			}
+
+			// 4. Get and calculate fee
+			Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
+
+			Money feePerBytes = null;
+			using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+			{
+				Money feeRate = Synchronizer.GetFeeRate(feeTarget);
+				Money sanityCheckedFeeRate = Math.Max(feeRate, 2); // Use the sanity check that under 2 satoshi per bytes should not be displayed. To correct possible rounding errors.
+				feePerBytes = new Money(sanityCheckedFeeRate);
+			}
+
+			bool spendAll = spendAllCount == 1;
+			int inNum;
+			if (spendAll)
+			{
+				inNum = allowedSmartCoinInputs.Count;
+			}
+			else
+			{
+				int expectedMinTxSize = 1 * Constants.P2wpkhInputSizeInBytes + 1 * Constants.OutputSizeInBytes + 10;
+				inNum = SelectCoinsToSpend(allowedSmartCoinInputs, toSend.Select(x => x.Amount).Sum() + feePerBytes * expectedMinTxSize).Count();
+			}
+
+			// https://bitcoincore.org/en/segwit_wallet_dev/#transaction-fee-estimation
+			// https://bitcoin.stackexchange.com/a/46379/26859
+			int outNum = spendAll ? toSend.Length : toSend.Length + 1; // number of addresses to send + 1 for change
+			int vSize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(inNum, outNum);
+			Logger.LogInfo<WalletService>($"Estimated tx size: {vSize} vbytes.");
+			Money fee = feePerBytes * vSize;
+			Logger.LogInfo<WalletService>($"Fee: {fee.Satoshi} Satoshi.");
+
+			// 5. How much to spend?
+			long toSendAmountSumInSatoshis = toSend.Select(x => x.Amount).Sum(); // Does it work if I simply go with Money class here? Is that copied by reference of value?
+			var realToSend = new (Script script, Money amount, string label)[toSend.Length];
+			for (int i = 0; i < toSend.Length; i++) // clone
+			{
+				realToSend[i] = (
+					new Script(toSend[i].Script.ToString()),
+					new Money(toSend[i].Amount.Satoshi),
+					toSend[i].Label);
+			}
+			for (int i = 0; i < realToSend.Length; i++)
+			{
+				if (realToSend[i].amount == Money.Zero) // means spend all
+				{
+					realToSend[i].amount = allowedSmartCoinInputs.Select(x => x.Amount).Sum();
+
+					realToSend[i].amount -= new Money(toSendAmountSumInSatoshis);
+
+					if (subtractFeeFromAmountIndex is null)
+					{
+						realToSend[i].amount -= fee;
+					}
+				}
+
+				if (subtractFeeFromAmountIndex == i)
+				{
+					realToSend[i].amount -= fee;
+				}
+
+				if (realToSend[i].amount < Money.Zero)
+				{
+					throw new InsufficientBalanceException(fee + Money.Satoshis(1), realToSend[i].amount + fee);
+				}
+			}
+
+			var toRemoveList = new List<(Script script, Money money, string label)>(realToSend);
+			toRemoveList.RemoveAll(x => x.money == Money.Zero);
+			realToSend = toRemoveList.ToArray();
+
+			// 1. Get the possible changes.
+			Script changeScriptPubKey;
+			var sb = new StringBuilder();
+			foreach (var item in realToSend)
+			{
+				sb.Append(item.label ?? "?");
+				sb.Append(", ");
+			}
+			var changeLabel = $"{Constants.ChangeOfSpecialLabelStart}{sb.ToString().TrimEnd(',', ' ')}{Constants.ChangeOfSpecialLabelEnd}";
+
+			if (customChange is null)
+			{
+				KeyManager.AssertCleanKeysIndexed(isInternal: true);
+				KeyManager.AssertLockedInternalKeysIndexed(14);
+				var changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
+
+				changeHdPubKey.SetLabel(changeLabel, KeyManager);
+				changeScriptPubKey = changeHdPubKey.P2wpkhScript;
+			}
+			else
+			{
+				changeScriptPubKey = customChange;
+			}
+
+			// 6. Do some checks
+			Money totalOutgoingAmountNoFee = realToSend.Select(x => x.amount).Sum();
+			Money totalOutgoingAmount = totalOutgoingAmountNoFee + fee;
+			decimal feePc = (100 * fee.ToDecimal(MoneyUnit.BTC)) / totalOutgoingAmountNoFee.ToDecimal(MoneyUnit.BTC);
+
+			if (feePc > 1)
+			{
+				Logger.LogInfo<WalletService>($"The transaction fee is {feePc:0.#}% of your transaction amount."
+					+ Environment.NewLine + $"Sending:\t {totalOutgoingAmount.ToString(fplus: false, trimExcessZero: true)} BTC."
+					+ Environment.NewLine + $"Fee:\t\t {fee.Satoshi} Satoshi.");
+			}
+			if (feePc > 100)
+			{
+				throw new InvalidOperationException($"The transaction fee is more than twice as much as your transaction amount: {feePc:0.#}%.");
+			}
+
+			var confirmedAvailableAmount = allowedSmartCoinInputs.Where(x => x.Confirmed).Select(x => x.Amount).Sum();
+			var spendsUnconfirmed = false;
+			if (confirmedAvailableAmount < totalOutgoingAmount)
+			{
+				spendsUnconfirmed = true;
+				Logger.LogInfo<WalletService>("Unconfirmed transaction are being spent.");
+			}
+
+			// 7. Select coins
+			Logger.LogInfo<WalletService>("Selecting coins...");
+			IEnumerable<SmartCoin> coinsToSpend = SelectCoinsToSpend(allowedSmartCoinInputs, totalOutgoingAmount);
+
+			// 9. Build the transaction
+			Logger.LogInfo<WalletService>("Signing transaction...");
+			TransactionBuilder builder = Network.CreateTransactionBuilder();
+			// It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
+			bool sign = !KeyManager.IsWatchOnly;
+			if (sign)
+			{
+				// 8. Get signing keys
+				IEnumerable<ExtKey> signingKeys = KeyManager.GetSecrets(password, coinsToSpend.Select(x => x.ScriptPubKey).ToArray());
+
+				builder = builder
+					.AddCoins(coinsToSpend.Select(x => x.GetCoin()))
+					.AddKeys(signingKeys.ToArray());
+			}
+			else
+			{
+				builder = builder
+					.AddCoins(coinsToSpend.Select(x => x.GetCoin()));
+			}
+
+			foreach ((Script scriptPubKey, Money amount, string label) output in realToSend)
+			{
+				builder = builder.Send(output.scriptPubKey, output.amount);
+			}
+
+			Transaction tx = builder
+				.SetChange(changeScriptPubKey)
+				.SendFees(fee)
+				.BuildTransaction(sign);
+
+			if (sign)
+			{
+				TransactionPolicyError[] checkResults = builder.Check(tx, fee);
+				if (checkResults.Length > 0)
+				{
+					throw new InvalidTxException(tx, checkResults);
+				}
+			}
+
+			List<SmartCoin> spentCoins = Coins.Where(x => tx.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
+
+			var outerWalletOutputs = new List<SmartCoin>();
+			var innerWalletOutputs = new List<SmartCoin>();
+			for (var i = 0U; i < tx.Outputs.Count; i++)
+			{
+				TxOut output = tx.Outputs[i];
+				var anonset = (tx.GetAnonymitySet(i) + spentCoins.Min(x => x.AnonymitySet)) - 1; // Minus 1, because count own only once.
+				var foundKey = KeyManager.GetKeys(KeyState.Clean).FirstOrDefault(x => output.ScriptPubKey == x.P2wpkhScript);
+				var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Inputs.ToTxoRefs().ToArray(), Height.Unknown, tx.RBF, anonset, pubKey: foundKey);
+
+				if (foundKey != null)
+				{
+					coin.Label = changeLabel;
+					innerWalletOutputs.Add(coin);
+				}
+				else
+				{
+					outerWalletOutputs.Add(coin);
+				}
+			}
+
+			PSBT psbt = builder.BuildPSBT(sign);
+			HashSet<SmartCoin> allTxCoins = spentCoins.Concat(innerWalletOutputs).Concat(outerWalletOutputs).ToHashSet();
+			foreach (var coin in allTxCoins)
+			{
+				if (coin.HdPubKey != null)
+				{
+					var index = -1;
+					var isInput = false;
+					for (int i = 0; i < tx.Inputs.Count; i++)
+					{
+						var input = tx.Inputs[i];
+						if (input.PrevOut == coin.GetOutPoint())
+						{
+							index = i;
+							isInput = true;
+							break;
+						}
+					}
+					if (!isInput)
+					{
+						index = (int)coin.Index;
+					}
+
+					if (KeyManager.MasterFingerprint.HasValue)
+					{
+						var rootKeyPath = new RootedKeyPath(KeyManager.MasterFingerprint.Value, coin.HdPubKey.FullKeyPath);
+						psbt.AddKeyPath(coin.HdPubKey.PubKey, rootKeyPath, coin.ScriptPubKey);
+					}
+				}
+			}
+
+			Logger.LogInfo<WalletService>($"Transaction is successfully built: {tx.GetHash()}.");
+
+			return new BuildTransactionResult(new SmartTransaction(tx, Height.Unknown), psbt, spendsUnconfirmed, sign, fee, feePc, outerWalletOutputs, innerWalletOutputs, spentCoins);
+		}
+
+		private IEnumerable<SmartCoin> SelectCoinsToSpend(IEnumerable<SmartCoin> unspentCoins, Money totalOutAmount)
+		{
+			var coinsToSpend = new HashSet<SmartCoin>();
+			var unspentConfirmedCoins = new List<SmartCoin>();
+			var unspentUnconfirmedCoins = new List<SmartCoin>();
+			foreach (SmartCoin coin in unspentCoins)
+			{
+				if (coin.Confirmed)
+				{
+					unspentConfirmedCoins.Add(coin);
+				}
+				else
+				{
+					unspentUnconfirmedCoins.Add(coin);
+				}
+			}
+
+			bool haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentConfirmedCoins);
+			if (!haveEnough)
+			{
+				haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentUnconfirmedCoins);
+			}
+
+			if (!haveEnough)
+			{
+				throw new InsufficientBalanceException(totalOutAmount, unspentConfirmedCoins.Select(x => x.Amount).Sum() + unspentUnconfirmedCoins.Select(x => x.Amount).Sum());
+			}
+
+			return coinsToSpend;
+		}
+
+		/// <returns>If the selection was successful. If there's enough coins to spend from.</returns>
+		private bool TrySelectCoins(ref HashSet<SmartCoin> coinsToSpend, Money totalOutAmount, IEnumerable<SmartCoin> unspentCoins)
+		{
+			// If there's no need for input merging, then use the largest selected.
+			// Do not prefer anonymity set. You can assume the user prefers anonymity set manually through the GUI.
+			SmartCoin largestCoin = unspentCoins.OrderByDescending(x => x.Amount).FirstOrDefault();
+			if (largestCoin == default)
+			{
+				return false; // If there's no coin then unsuccessful selection.
+			}
+			else // Check if we can do without input merging.
+			{
+				if (largestCoin.Amount >= totalOutAmount)
+				{
+					coinsToSpend.Add(largestCoin);
+					return true;
+				}
+			}
+
+			// If there's a need for input merging.
+			foreach (var coin in unspentCoins
+				.OrderByDescending(x => x.AnonymitySet) // Always try to spend/merge the largest anonset coins first.
+				.ThenByDescending(x => x.Amount)) // Then always try to spend by amount.
+			{
+				coinsToSpend.Add(coin);
+				// If reaches the amount, then return true, else just go with the largest coin.
+				if (coinsToSpend.Select(x => x.Amount).Sum() >= totalOutAmount)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public void RenameLabel(SmartCoin coin, string newLabel)
+		{
+			newLabel = Guard.Correct(newLabel);
+			coin.Label = newLabel;
+			var key = KeyManager.GetKeys(x => x.P2wpkhScript == coin.ScriptPubKey).SingleOrDefault();
+			if (key != null)
+			{
+				key.SetLabel(newLabel, KeyManager);
+			}
+		}
+
+		private static long SendCount = 0;
+
+		public async Task SendTransactionAsync(SmartTransaction transaction)
+		{
+			try
+			{
+				Interlocked.Increment(ref SendCount);
+				// Broadcast to a random node.
+				// Wait until it arrives to at least two other nodes.
+				// If something's wrong, fall back broadcasting with backend.
+
+				if (Network == Network.RegTest)
+				{
+					throw new InvalidOperationException("Transaction broadcasting to nodes does not work in RegTest.");
+				}
+
+				while (true)
+				{
+					// As long as we are connected to at least 4 nodes, we can always try again.
+					// 3 should be enough, but make it 5 so 2 nodes could disconnect the meantime.
+					if (Nodes.ConnectedNodes.Count < 5)
+					{
+						throw new InvalidOperationException("We are not connected to enough nodes.");
+					}
+
+					Node node = Nodes.ConnectedNodes.RandomElement();
+					if (node == default(Node))
+					{
+						await Task.Delay(100);
+						continue;
+					}
+
+					if (!node.IsConnected)
+					{
+						await Task.Delay(100);
+						continue;
+					}
+
+					Logger.LogInfo<WalletService>($"Trying to broadcast transaction with random node ({node.RemoteSocketAddress}):{transaction.GetHash()}");
+					var addedToBroadcastStore = Mempool.TryAddToBroadcastStore(transaction.Transaction, node.RemoteSocketEndpoint.ToString()); // So we'll reply to INV with this transaction.
+					if (!addedToBroadcastStore)
+					{
+						Logger.LogWarning<WalletService>($"Transaction {transaction.GetHash()} was already present in the broadcast store.");
+					}
+					var invPayload = new InvPayload(transaction.Transaction);
+					// Give 7 seconds to send the inv payload.
+					using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7)))
+					{
+						await node.SendMessageAsync(invPayload).WithCancellation(cts.Token); // ToDo: It's dangerous way to cancel. Implement proper cancellation to NBitcoin!
+					}
+
+					if (Mempool.TryGetFromBroadcastStore(transaction.GetHash(), out TransactionBroadcastEntry entry))
+					{
+						// Give 7 seconds for serving.
+						var timeout = 0;
+						while (!entry.IsBroadcasted())
+						{
+							if (timeout > 7)
+							{
+								throw new TimeoutException("Did not serve the transaction.");
+							}
+							await Task.Delay(1_000);
+							timeout++;
+						}
+						node.DisconnectAsync("Thank you!");
+						Logger.LogInfo<MempoolBehavior>($"Disconnected node: {node.RemoteSocketAddress}. Successfully broadcasted transaction: {transaction.GetHash()}.");
+
+						// Give 21 seconds for propagation.
+						timeout = 0;
+						while (entry.GetPropagationConfirmations() < 2)
+						{
+							if (timeout > 21)
+							{
+								throw new TimeoutException("Did not serve the transaction.");
+							}
+							await Task.Delay(1_000);
+							timeout++;
+						}
+						Logger.LogInfo<MempoolBehavior>($"Transaction is successfully propagated: {transaction.GetHash()}.");
+					}
+					else
+					{
+						Logger.LogWarning<WalletService>($"Expected transaction {transaction.GetHash()} was not found in the broadcast store.");
+					}
+					break;
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogInfo<WalletService>($"Random node could not broadcast transaction. Broadcasting with backend... Reason: {ex.Message}");
+				Logger.LogDebug<WalletService>(ex);
+
+				using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+				{
+					try
+					{
+						await client.BroadcastAsync(transaction);
+					}
+					catch (HttpRequestException ex2) when (
+						ex2.Message.Contains("bad-txns-inputs-missingorspent", StringComparison.InvariantCultureIgnoreCase)
+						|| ex2.Message.Contains("missing-inputs", StringComparison.InvariantCultureIgnoreCase)
+						|| ex2.Message.Contains("txn-mempool-conflict", StringComparison.InvariantCultureIgnoreCase))
+					{
+						if (transaction.Transaction.Inputs.Count == 1) // If we tried to only spend one coin, then we can mark it as spent. If there were more coins, then we do not know.
+						{
+							OutPoint input = transaction.Transaction.Inputs.First().PrevOut;
+							SmartCoin coin = Coins.FirstOrDefault(x => x.TransactionId == input.Hash && x.Index == input.N);
+							if (coin != default)
+							{
+								coin.SpentAccordingToBackend = true;
+							}
+						}
+					}
+				}
+
+				using (await TransactionProcessingLock.LockAsync())
+				{
+					if (await ProcessTransactionAsync(new SmartTransaction(transaction.Transaction, Height.Mempool)))
+					{
+						SerializeTransactionCache();
+					}
+
+					Mempool.TransactionHashes.TryAdd(transaction.GetHash());
+				}
+
+				Logger.LogInfo<WalletService>($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
+			}
+			finally
+			{
+				Mempool.TryRemoveFromBroadcastStore(transaction.GetHash(), out _); // Remove it just to be sure. Probably has been removed previously.
+				Interlocked.Decrement(ref SendCount);
+			}
+		}
+
+		public IEnumerable<string> GetNonSpecialLabels()
+		{
+			return Coins.Where(x => !x.Label.StartsWith("ZeroLink", StringComparison.Ordinal))
+				.SelectMany(x => x.Label.Split(new string[] { Constants.ChangeOfSpecialLabelStart, Constants.ChangeOfSpecialLabelEnd, "(", "," }, StringSplitOptions.RemoveEmptyEntries))
+				.Select(x => x.Trim())
+				.Distinct();
+		}
+
+		private int _refreshCoinHistoriesRerunRequested = 0;
+		private int _refreshCoinHistoriesRunning = 0;
+
+		public void RefreshCoinHistories()
+		{
+			// If already running, then make sure another run is requested, else do the work.
+			if (Interlocked.CompareExchange(ref _refreshCoinHistoriesRunning, 1, 0) == 1)
+			{
+				Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 1);
+				return;
+			}
+
+			try
+			{
+				var unspentCoins = Coins.Where(c => c.Unspent); //refreshing unspent coins clusters only
+				if (unspentCoins.Any())
+				{
+					ILookup<Script, SmartCoin> lookupScriptPubKey = Coins.ToLookup(c => c.ScriptPubKey, c => c);
+					ILookup<uint256, SmartCoin> lookupSpenderTransactionId = Coins.ToLookup(c => c.SpenderTransactionId, c => c);
+					ILookup<uint256, SmartCoin> lookupTransactionId = Coins.ToLookup(c => c.TransactionId, c => c);
+
+					const int simultaneousThread = 2; //threads allowed to run simultaneously in threadpool
+
+					Parallel.ForEach(unspentCoins, new ParallelOptions { MaxDegreeOfParallelism = simultaneousThread }, coin =>
+					{
+						var result = string.Join(", ", GetClusters(coin, new List<SmartCoin>(), lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId).Select(x => x.Label).Distinct());
+						coin.SetClusters(result);
+					});
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError<WalletService>($"Refreshing coin clusters failed: {ex}");
+			}
+			finally
+			{
+				// It's not running anymore, but someone may requested another run.
+				Interlocked.Exchange(ref _refreshCoinHistoriesRunning, 0);
+
+				// Clear the rerun request, too and if it was requested, then rerun.
+				if (Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 0) == 1)
+				{
+					RefreshCoinHistories();
+				}
+			}
+		}
+
+		public bool UnconfirmedTransactionsInitialized { get; private set; } = false;
+
+		private void SerializeTransactionCache()
+		{
+			if (!UnconfirmedTransactionsInitialized) // If unconfirmed ones are not yet initialized, then do not serialize because unconfirmed are going to be lost.
+			{
+				return;
+			}
+
+			IoHelpers.EnsureContainingDirectoryExists(TransactionsFilePath);
+			string jsonString = JsonConvert.SerializeObject(TransactionCache.OrderByBlockchain(), Formatting.Indented);
+			File.WriteAllText(TransactionsFilePath,
+				jsonString,
+				Encoding.UTF8);
+		}
+
+		/// <summary>
+		/// Current timeout used when downloading a block from the remote node. It is defined in seconds.
+		/// </summary>
+		private async Task NodeTimeoutsAsync(bool increaseDecrease)
+		{
+			if (increaseDecrease)
+			{
+				NodeTimeouts++;
+			}
+			else
+			{
+				NodeTimeouts--;
+			}
+
+			var timeout = RuntimeParams.Instance.NetworkNodeTimeout;
+
+			// If it times out 2 times in a row then increase the timeout.
+			if (NodeTimeouts >= 2)
+			{
+				NodeTimeouts = 0;
+				timeout *= 2;
+			}
+			else if (NodeTimeouts <= -3) // If it does not time out 3 times in a row, lower the timeout.
+			{
+				NodeTimeouts = 0;
+				timeout = (int)Math.Round(timeout * 0.7);
+			}
+
+			// Sanity check
+			if (timeout < 32)
+			{
+				timeout = 32;
+			}
+			else if (timeout > 600)
+			{
+				timeout = 600;
+			}
+
+			if (timeout == RuntimeParams.Instance.NetworkNodeTimeout)
+			{
+				return;
+			}
+
+			RuntimeParams.Instance.NetworkNodeTimeout = timeout;
+			await RuntimeParams.Instance.SaveAsync();
+
+			Logger.LogInfo<WalletService>($"Current timeout value used on block download is: {timeout} seconds.");
+		}
+
+		public async Task StopAsync()
+		{
+			while (Interlocked.Read(ref SendCount) != 0) // Make sure to wait for send to finish.
+			{
+				await Task.Delay(50);
+			}
+
+			BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
+			BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
+			Mempool.TransactionReceived -= Mempool_TransactionReceivedAsync;
+			Coins.CollectionChanged -= Coins_CollectionChanged;
+
+			DisconnectDisposeNullLocalBitcoinCoreNode();
+		}
+	}
 }

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -29,1654 +29,1654 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-	public class WalletService
-	{
-		public static event EventHandler<bool> DownloadingBlockChanged;
-
-		// So we will make sure when blocks are downloading with multiple wallet services, they do not conflict.
-		private static AsyncLock BlockDownloadLock { get; } = new AsyncLock();
-
-		private static bool DownloadingBlockBacking;
-
-		public static bool DownloadingBlock
-		{
-			get => DownloadingBlockBacking;
-			set
-			{
-				if (value != DownloadingBlockBacking)
-				{
-					DownloadingBlockBacking = value;
-					DownloadingBlockChanged?.Invoke(null, value);
-				}
-			}
-		}
-
-		public BitcoinStore BitcoinStore { get; }
-		public KeyManager KeyManager { get; }
-		public WasabiSynchronizer Synchronizer { get; }
-		public CcjClient ChaumianClient { get; }
-		public MempoolService Mempool { get; }
-
-		public NodesGroup Nodes { get; }
-		public string BlocksFolderPath { get; }
-		public string TransactionsFolderPath { get; }
-		public string TransactionsFilePath { get; }
-
-		private AsyncLock HandleFiltersLock { get; }
-
-		private AsyncLock BlockFolderLock { get; }
-
-		private int NodeTimeouts { get; set; }
-
-		public ServiceConfiguration ServiceConfiguration { get; }
-
-		public ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)> ProcessedBlocks { get; }
-
-		public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
-
-		public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
-
-		public event EventHandler<FilterModel> NewFilterProcessed;
-
-		public event EventHandler<SmartCoin> CoinSpentOrSpenderConfirmed;
-
-		public event EventHandler<Block> NewBlockProcessed;
-
-		public Network Network => Synchronizer.Network;
-
-		public WalletService(
-			BitcoinStore bitcoinStore,
-			KeyManager keyManager,
-			WasabiSynchronizer syncer,
-			CcjClient chaumianClient,
-			MempoolService mempool,
-			NodesGroup nodes,
-			string workFolderDir,
-			ServiceConfiguration serviceConfiguration)
-		{
-			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
-			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-			Nodes = Guard.NotNull(nameof(nodes), nodes);
-			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
-			ChaumianClient = Guard.NotNull(nameof(chaumianClient), chaumianClient);
-			Mempool = Guard.NotNull(nameof(mempool), mempool);
-			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
-
-			ProcessedBlocks = new ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)>();
-			HandleFiltersLock = new AsyncLock();
-
-			Coins = new ObservableConcurrentHashSet<SmartCoin>();
-			TransactionCache = new ConcurrentHashSet<SmartTransaction>();
-
-			BlocksFolderPath = Path.Combine(workFolderDir, "Blocks", Network.ToString());
-			TransactionsFolderPath = Path.Combine(workFolderDir, "Transactions", Network.ToString());
-			RuntimeParams.SetDataDir(workFolderDir);
-
-			BlockFolderLock = new AsyncLock();
-
-			KeyManager.AssertCleanKeysIndexed();
-			KeyManager.AssertLockedInternalKeysIndexed(14);
-
-			if (Directory.Exists(BlocksFolderPath))
-			{
-				if (Synchronizer.Network == Network.RegTest)
-				{
-					Directory.Delete(BlocksFolderPath, true);
-					Directory.CreateDirectory(BlocksFolderPath);
-				}
-			}
-			else
-			{
-				Directory.CreateDirectory(BlocksFolderPath);
-			}
-			if (Directory.Exists(TransactionsFolderPath))
-			{
-				if (Synchronizer.Network == Network.RegTest)
-				{
-					Directory.Delete(TransactionsFolderPath, true);
-					Directory.CreateDirectory(TransactionsFolderPath);
-				}
-			}
-			else
-			{
-				Directory.CreateDirectory(TransactionsFolderPath);
-			}
-
-			var walletName = "UnnamedWallet";
-			if (!string.IsNullOrWhiteSpace(KeyManager.FilePath))
-			{
-				walletName = Path.GetFileNameWithoutExtension(KeyManager.FilePath);
-			}
-			TransactionsFilePath = Path.Combine(TransactionsFolderPath, $"{walletName}Transactions.json");
-
-			BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
-			BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
-			Mempool.TransactionReceived += Mempool_TransactionReceivedAsync;
-		}
-
-		private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
-			RefreshCoinHistories();
-		}
-
-		private static AsyncLock TransactionProcessingLock { get; } = new AsyncLock();
-
-		private async void Mempool_TransactionReceivedAsync(object sender, SmartTransaction tx)
-		{
-			try
-			{
-				using (await TransactionProcessingLock.LockAsync())
-				{
-					if (await ProcessTransactionAsync(tx))
-					{
-						SerializeTransactionCache();
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning<WalletService>(ex);
-			}
-		}
-
-		private async void IndexDownloader_ReorgedAsync(object sender, FilterModel invalidFilter)
-		{
-			try
-			{
-				using (await HandleFiltersLock.LockAsync())
-				{
-					uint256 invalidBlockHash = invalidFilter.BlockHash;
-					await DeleteBlockAsync(invalidBlockHash);
-					var blockState = KeyManager.TryRemoveBlockState(invalidBlockHash);
-					ProcessedBlocks.TryRemove(invalidBlockHash, out _);
-					if (blockState != null && blockState.BlockHeight != default(Height))
-					{
-						foreach (var toRemove in Coins.Where(x => x.Height == blockState.BlockHeight).Distinct().ToList())
-						{
-							RemoveCoinRecursively(toRemove);
-						}
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning<WalletService>(ex);
-			}
-		}
-
-		private void RemoveCoinRecursively(SmartCoin toRemove)
-		{
-			if (toRemove.SpenderTransactionId != null)
-			{
-				foreach (var toAlsoRemove in Coins.Where(x => x.TransactionId == toRemove.SpenderTransactionId).Distinct().ToList())
-				{
-					RemoveCoinRecursively(toAlsoRemove);
-				}
-			}
-
-			Coins.TryRemove(toRemove);
-			Mempool.TransactionHashes.TryRemove(toRemove.SpenderTransactionId);
-		}
-
-		private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)
-		{
-			try
-			{
-				using (await HandleFiltersLock.LockAsync())
-				{
-					if (filterModel.Filter != null && !KeyManager.CointainsBlockState(filterModel.BlockHash))
-					{
-						await ProcessFilterModelAsync(filterModel, CancellationToken.None);
-					}
-				}
-				NewFilterProcessed?.Invoke(this, filterModel);
-
-				do
-				{
-					await Task.Delay(100);
-					if (Synchronizer is null || BitcoinStore?.HashChain is null)
-					{
-						return;
-					}
-					// Make sure fully synced and this filter is the lastest filter.
-					if (BitcoinStore.HashChain.HashesLeft != 0 || BitcoinStore.HashChain.TipHash != filterModel.BlockHash)
-					{
-						return;
-					}
-				} while (Synchronizer.AreRequestsBlocked()); // If requests are blocked, delay mempool cleanup, because coinjoin answers are always priority.
-
-				await Mempool?.TryPerformMempoolCleanupAsync(Synchronizer?.WasabiClient?.TorClient?.DestinationUriAction, Synchronizer?.WasabiClient?.TorClient?.TorSocks5EndPoint);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning<WalletService>(ex);
-			}
-		}
-
-		public async Task InitializeAsync(CancellationToken cancel)
-		{
-			if (!Synchronizer.IsRunning)
-			{
-				throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
-			}
-
-			await RuntimeParams.LoadAsync();
-
-			using (await HandleFiltersLock.LockAsync())
-			{
-				var unconfirmedTransactions = new SmartTransaction[0];
-				var confirmedTransactions = new SmartTransaction[0];
-
-				if (File.Exists(TransactionsFilePath))
-				{
-					try
-					{
-						IEnumerable<SmartTransaction> transactions = null;
-						string jsonString = File.ReadAllText(TransactionsFilePath, Encoding.UTF8);
-						transactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?
-							.OrderByBlockchain();
-
-						confirmedTransactions = transactions?
-							.Where(x => x.Confirmed)?
-							.ToArray() ?? new SmartTransaction[0];
-
-						unconfirmedTransactions = transactions?
-							.Where(x => !x.Confirmed)?
-							.ToArray() ?? new SmartTransaction[0];
-					}
-					catch (Exception ex)
-					{
-						Logger.LogWarning<WalletService>(ex);
-						Logger.LogWarning<WalletService>($"Transaction cache got corrupted. Deleting {TransactionsFilePath}.");
-						File.Delete(TransactionsFilePath);
-					}
-				}
-
-				// Go through the keymanager's index.
-				KeyManager.AssertNetworkOrClearBlockState(Network);
-				Height bestKeyManagerHeight = KeyManager.GetBestHeight();
-
-				foreach (BlockState blockState in KeyManager.GetTransactionIndex())
-				{
-					var relevantTransactions = confirmedTransactions.Where(x => x.BlockHash == blockState.BlockHash).ToArray();
-					var block = await GetOrDownloadBlockAsync(blockState.BlockHash, cancel);
-					await ProcessBlockAsync(blockState.BlockHeight, block, blockState.TransactionIndices, relevantTransactions);
-				}
-
-				// Go through the filters and que to download the matches.
-				await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>
-				{
-					if (filterModel.Filter != null) // Filter can be null if there is no bech32 tx.
-					{
-						await ProcessFilterModelAsync(filterModel, cancel);
-					}
-				}, new Height(bestKeyManagerHeight.Value + 1));
-
-				// Load in dummy mempool
-				try
-				{
-					if (unconfirmedTransactions != null && unconfirmedTransactions.Any())
-					{
-						try
-						{
-							using (await TransactionProcessingLock.LockAsync())
-							using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
-							{
-								var compactness = 10;
-
-								var mempoolHashes = await client.GetMempoolHashesAsync(compactness);
-
-								var cnt = 0;
-								foreach (var tx in unconfirmedTransactions)
-								{
-									if (mempoolHashes.Contains(tx.GetHash().ToString().Substring(0, compactness)))
-									{
-										tx.SetHeight(Height.Mempool);
-										await ProcessTransactionAsync(tx);
-										Mempool.TransactionHashes.TryAdd(tx.GetHash());
-
-										Logger.LogInfo<WalletService>($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
-										cnt++;
-									}
-								}
-
-								if (cnt != unconfirmedTransactions.Length)
-								{
-									SerializeTransactionCache();
-								}
-							}
-						}
-						catch
-						{
-							// When there's a connection failure do not clean the transactions, add it to processing.
-							foreach (var tx in unconfirmedTransactions)
-							{
-								tx.SetHeight(Height.Mempool);
-								await ProcessTransactionAsync(tx);
-								Mempool.TransactionHashes.TryAdd(tx.GetHash());
-							}
-
-							throw;
-						}
-					}
-				}
-				catch (Exception ex)
-				{
-					Logger.LogWarning<WalletService>(ex);
-				}
-				finally
-				{
-					UnconfirmedTransactionsInitialized = true;
-				}
-			}
-			Coins.CollectionChanged += Coins_CollectionChanged;
-			RefreshCoinHistories();
-		}
-
-		private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
-		{
-			if (ProcessedBlocks.ContainsKey(filterModel.BlockHash))
-			{
-				return;
-			}
-
-			var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
-			if (!matchFound)
-			{
-				return;
-			}
-
-			Block currentBlock = await GetOrDownloadBlockAsync(filterModel.BlockHash, cancel); // Wait until not downloaded.
-
-			if (await ProcessBlockAsync(filterModel.BlockHeight, currentBlock))
-			{
-				SerializeTransactionCache();
-			}
-		}
-
-		public HdPubKey GetReceiveKey(string label, IEnumerable<HdPubKey> dontTouch = null)
-		{
-			label = Guard.Correct(label);
-
-			// Make sure there's always 21 clean keys generated and indexed.
-			KeyManager.AssertCleanKeysIndexed(isInternal: false);
-
-			IEnumerable<HdPubKey> keys = KeyManager.GetKeys(KeyState.Clean, isInternal: false);
-			if (dontTouch != null)
-			{
-				keys = keys.Except(dontTouch);
-				if (!keys.Any())
-				{
-					throw new InvalidOperationException($"{nameof(dontTouch)} covers all the possible keys.");
-				}
-			}
-
-			var foundLabelless = keys.FirstOrDefault(x => !x.HasLabel); // Return the first labelless.
-			HdPubKey ret = foundLabelless ?? keys.RandomElement(); // Return the first, because that's the oldest.
-
-			ret.SetLabel(label, KeyManager);
-
-			return ret;
-		}
-
-		public List<SmartCoin> GetClusters(SmartCoin coin, List<SmartCoin> current, ILookup<Script, SmartCoin> lookupScriptPubKey, ILookup<uint256, SmartCoin> lookupSpenderTransactionId, ILookup<uint256, SmartCoin> lookupTransactionId)
-		{
-			Guard.NotNull(nameof(coin), coin);
-			if (current.Contains(coin))
-			{
-				return current;
-			}
-
-			var clusters = current.Concat(new List<SmartCoin> { coin }).ToList(); // The coin is the first elem in its cluster.
-
-			// If the script is the same then we have a match, no matter of the anonymity set.
-			foreach (var c in lookupScriptPubKey[coin.ScriptPubKey])
-			{
-				if (!clusters.Contains(c))
-				{
-					var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
-					foreach (var hr in h)
-					{
-						if (!clusters.Contains(hr))
-						{
-							clusters.Add(hr);
-						}
-					}
-				}
-			}
-
-			// If it spends someone and has not been sufficiently anonymized.
-			if (coin.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
-			{
-				var c = lookupSpenderTransactionId[coin.TransactionId].FirstOrDefault(x => !clusters.Contains(x));
-				if (c != default)
-				{
-					var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
-					foreach (var hr in h)
-					{
-						if (!clusters.Contains(hr))
-						{
-							clusters.Add(hr);
-						}
-					}
-				}
-			}
-
-			// If it's being spent by someone and that someone has not been sufficiently anonymized.
-			if (!coin.Unspent)
-			{
-				var c = lookupTransactionId[coin.SpenderTransactionId].FirstOrDefault(x => !clusters.Contains(x));
-				if (c != default)
-				{
-					if (c.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
-					{
-						if (c != default)
-						{
-							var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
-							foreach (var hr in h)
-							{
-								if (!clusters.Contains(hr))
-								{
-									clusters.Add(hr);
-								}
-							}
-						}
-					}
-				}
-			}
-
-			return clusters;
-		}
-
-		private async Task<bool> ProcessBlockAsync(Height height, Block block, IEnumerable<int> filterByTxIds = null, IEnumerable<SmartTransaction> skeletonBlock = null)
-		{
-			var ret = false;
-			using (await TransactionProcessingLock.LockAsync())
-			{
-				if (filterByTxIds is null)
-				{
-					var relevantIndicies = new List<int>();
-					for (int i = 0; i < block.Transactions.Count; i++)
-					{
-						Transaction tx = block.Transactions[i];
-						if (await ProcessTransactionAsync(new SmartTransaction(tx, height, block.GetHash(), i)))
-						{
-							relevantIndicies.Add(i);
-							ret = true;
-						}
-					}
-
-					if (relevantIndicies.Any())
-					{
-						var blockState = new BlockState(block.GetHash(), height, relevantIndicies);
-						KeyManager.AddBlockState(blockState, setItsHeightToBest: true); // Set the heigh here (so less toFile and lock.)
-					}
-					else
-					{
-						KeyManager.SetBestHeight(height);
-					}
-				}
-				else
-				{
-					foreach (var i in filterByTxIds.OrderBy(x => x))
-					{
-						var tx = skeletonBlock?.FirstOrDefault(x => x.BlockIndex == i) ?? new SmartTransaction(block.Transactions[i], height, block.GetHash(), i);
-						if (await ProcessTransactionAsync(tx))
-						{
-							ret = true;
-						}
-					}
-				}
-			}
-
-			ProcessedBlocks.TryAdd(block.GetHash(), (height, block.Header.BlockTime));
-
-			NewBlockProcessed?.Invoke(this, block);
-
-			return ret;
-		}
-
-		private async Task<bool> ProcessTransactionAsync(SmartTransaction tx)
-		{
-			uint256 txId = tx.GetHash();
-			var walletRelevant = false;
-
-			bool justUpdate = false;
-			if (tx.Confirmed)
-			{
-				Mempool.TransactionHashes.TryRemove(txId); // If we have in mempool, remove.
-				if (!tx.Transaction.PossiblyP2WPKHInvolved())
-				{
-					return false; // We do not care about non-witness transactions for other than mempool cleanup.
-				}
-
-				bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
-				if (isFoundTx)
-				{
-					SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
-					if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
-					{
-						foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
-						walletRelevant = true;
-						justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
-					}
-				}
-			}
-			else if (!tx.Transaction.PossiblyP2WPKHInvolved())
-			{
-				return false; // We do not care about non-witness transactions for other than mempool cleanup.
-			}
-
-			if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
-			{
-				var doubleSpends = new List<SmartCoin>();
-				foreach (SmartCoin coin in Coins)
-				{
-					var spent = false;
-					foreach (TxoRef spentOutput in coin.SpentOutputs)
-					{
-						foreach (TxIn txIn in tx.Transaction.Inputs)
-						{
-							if (spentOutput.TransactionId == txIn.PrevOut.Hash && spentOutput.Index == txIn.PrevOut.N) // Do not do (spentOutput == txIn.PrevOut), it's faster this way, because it won't check for null.
-							{
-								doubleSpends.Add(coin);
-								spent = true;
-								walletRelevant = true;
-								break;
-							}
-						}
-						if (spent)
-						{
-							break;
-						}
-					}
-				}
-
-				if (doubleSpends.Any())
-				{
-					if (tx.Height == Height.Mempool)
-					{
-						// if the received transaction is spending at least one input already
-						// spent by a previous unconfirmed transaction signaling RBF then it is not a double
-						// spanding transaction but a replacement transaction.
-						if (doubleSpends.Any(x => x.IsReplaceable))
-						{
-							// remove double spent coins (if other coin spends it, remove that too and so on)
-							// will add later if they came to our keys
-							foreach (SmartCoin doubleSpentCoin in doubleSpends.Where(x => !x.Confirmed))
-							{
-								RemoveCoinRecursively(doubleSpentCoin);
-							}
-							tx.SetReplacement();
-							walletRelevant = true;
-						}
-						else
-						{
-							return false;
-						}
-					}
-					else // new confirmation always enjoys priority
-					{
-						// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
-						foreach (SmartCoin doubleSpentCoin in doubleSpends)
-						{
-							RemoveCoinRecursively(doubleSpentCoin);
-						}
-						walletRelevant = true;
-					}
-				}
-			}
-
-			for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
-			{
-				// If transaction received to any of the wallet keys:
-				var output = tx.Transaction.Outputs[i];
-				HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
-				if (foundKey != default)
-				{
-					walletRelevant = true;
-
-					foundKey.SetKeyState(KeyState.Used, KeyManager);
-					List<SmartCoin> spentOwnCoins = Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
-					var anonset = tx.Transaction.GetAnonymitySet(i);
-					if (spentOwnCoins.Count != 0)
-					{
-						anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
-
-						// Cleanup exposed links where the txo has been spent.
-						foreach (var input in spentOwnCoins.Select(x => x.GetTxoRef()))
-						{
-							ChaumianClient.ExposedLinks.TryRemove(input, out _);
-						}
-					}
-
-					if (output.Value <= ServiceConfiguration.DustThreshold)
-					{
-						continue;
-					}
-
-					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
-																																																												   // If we did not have it.
-					if (Coins.TryAdd(newCoin))
-					{
-						TransactionCache.TryAdd(tx);
-
-						// If it's being mixed and anonset is not sufficient, then queue it.
-						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && ChaumianClient.State.Contains(newCoin.SpentOutputs))
-						{
-							try
-							{
-								await ChaumianClient.QueueCoinsToMixAsync(newCoin);
-							}
-							catch (Exception ex)
-							{
-								Logger.LogError<WalletService>(ex);
-							}
-						}
-
-						// Make sure there's always 21 clean keys generated and indexed.
-						KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
-
-						if (foundKey.IsInternal)
-						{
-							// Make sure there's always 14 internal locked keys generated and indexed.
-							KeyManager.AssertLockedInternalKeysIndexed(14);
-						}
-					}
-					else // If we had this coin already.
-					{
-						if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
-						{
-							SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
-							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
-							{
-								oldCoin.Height = newCoin.Height;
-							}
-						}
-					}
-				}
-			}
-
-			// If spends any of our coin
-			for (var i = 0; i < tx.Transaction.Inputs.Count; i++)
-			{
-				var input = tx.Transaction.Inputs[i];
-
-				var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
-				if (foundCoin != null)
-				{
-					walletRelevant = true;
-
-					foundCoin.SpenderTransactionId = txId;
-					TransactionCache.TryAdd(tx);
-					CoinSpentOrSpenderConfirmed?.Invoke(this, foundCoin);
-				}
-			}
-
-			return walletRelevant;
-		}
-
-		private Node _localBitcoinCoreNode = null;
-
-		public Node LocalBitcoinCoreNode
-		{
-			get
-			{
-				if (Network == Network.RegTest)
-				{
-					return Nodes.ConnectedNodes.First();
-				}
-
-				return _localBitcoinCoreNode;
-			}
-			private set => _localBitcoinCoreNode = value;
-		}
-
-		/// <exception cref="OperationCanceledException"></exception>
-		public async Task<Block> GetOrDownloadBlockAsync(uint256 hash, CancellationToken cancel)
-		{
-			// Try get the block
-			using (await BlockFolderLock.LockAsync())
-			{
-				var encoder = new HexEncoder();
-				foreach (var filePath in Directory.EnumerateFiles(BlocksFolderPath))
-				{
-					var fileName = Path.GetFileName(filePath);
-					if (!encoder.IsValid(fileName))
-					{
-						Logger.LogTrace<WalletService>($"Filename is not a hash: {fileName}.");
-						continue;
-					}
-
-					if (hash == new uint256(fileName))
-					{
-						var blockBytes = await File.ReadAllBytesAsync(filePath);
-						try
-						{
-							return Block.Load(blockBytes, Synchronizer.Network);
-						}
-						catch (Exception)
-						{
-							// In case the block file is corrupted we get an EndOfStreamException exception
-							// Ignore any error and continue by re-downloading the block.
-							break;
-						}
-					}
-				}
-			}
-			cancel.ThrowIfCancellationRequested();
-
-			// Download the block
-			Block block = null;
-			try
-			{
-				await BlockDownloadLock.LockAsync();
-				DownloadingBlock = true;
-
-				while (true)
-				{
-					cancel.ThrowIfCancellationRequested();
-					try
-					{
-						// Try to get block information from local running Core node first.
-						try
-						{
-							if (LocalBitcoinCoreNode is null || !LocalBitcoinCoreNode.IsConnected && Network != Network.RegTest) // If RegTest then we're already connected do not try again.
-							{
-								DisconnectDisposeNullLocalBitcoinCoreNode();
-								using (var handshakeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancel))
-								{
-									handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
-									var nodeConnectionParameters = new NodeConnectionParameters()
-									{
-										ConnectCancellation = handshakeTimeout.Token,
-										IsRelay = false,
-										UserAgent = $"/Wasabi:{Constants.ClientVersion}/"
-									};
-
-									// If an onion was added must try to use Tor.
-									// onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
-									if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
-									{
-										nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
-									}
-
-									var localIpEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;
-									var localNode = await Node.ConnectAsync(Network, localIpEndPoint, nodeConnectionParameters);
-									try
-									{
-										Logger.LogInfo<WalletService>($"TCP Connection succeeded, handshaking...");
-										localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
-										var peerServices = localNode.PeerVersion.Services;
-
-										//if(!peerServices.HasFlag(NodeServices.Network) && !peerServices.HasFlag(NodeServices.NODE_NETWORK_LIMITED))
-										//{
-										//	throw new InvalidOperationException($"Wasabi cannot use the local node because it does not provide blocks.");
-										//}
-
-										Logger.LogInfo<WalletService>($"Handshake completed successfully.");
-
-										if (!localNode.IsConnected)
-										{
-											throw new InvalidOperationException($"Wasabi could not complete the handshake with the local node and dropped the connection.{Environment.NewLine}" +
-												$"Probably this is because the node does not support retrieving full blocks or segwit serialization.");
-										}
-										LocalBitcoinCoreNode = localNode;
-									}
-									catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
-									{
-										Logger.LogWarning<Node>($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
-											$"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
-										throw;
-									}
-								}
-							}
-
-							Block blockFromLocalNode = null;
-							// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
-							{
-								blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
-							}
-
-							if (!blockFromLocalNode.Check())
-							{
-								throw new InvalidOperationException($"Disconnected node, because invalid block received!");
-							}
-
-							block = blockFromLocalNode;
-							Logger.LogInfo<WalletService>($"Block acquired from local P2P connection: {hash}");
-							break;
-						}
-						catch (Exception ex)
-						{
-							block = null;
-							DisconnectDisposeNullLocalBitcoinCoreNode();
-
-							if (ex is SocketException)
-							{
-								Logger.LogTrace<WalletService>("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
-							}
-							else
-							{
-								Logger.LogWarning<WalletService>(ex);
-							}
-						}
-						cancel.ThrowIfCancellationRequested();
-
-						// If no connection, wait then continue.
-						while (Nodes.ConnectedNodes.Count == 0)
-						{
-							await Task.Delay(100);
-						}
-
-						Node node = Nodes.ConnectedNodes.RandomElement();
-						if (node == default(Node))
-						{
-							await Task.Delay(100);
-							continue;
-						}
-
-						if (!node.IsConnected && !(Synchronizer.Network != Network.RegTest))
-						{
-							await Task.Delay(100);
-							continue;
-						}
-
-						try
-						{
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
-							{
-								block = await node.DownloadBlockAsync(hash, cts.Token);
-							}
-
-							if (!block.Check())
-							{
-								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
-								node.DisconnectAsync("Invalid block received.");
-								continue;
-							}
-
-							if (Nodes.ConnectedNodes.Count > 1) // So to minimize risking missing unconfirmed transactions.
-							{
-								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}");
-								node.DisconnectAsync("Thank you!");
-							}
-
-							await NodeTimeoutsAsync(false);
-						}
-						catch (Exception ex) when (ex is OperationCanceledException
-												|| ex is TaskCanceledException
-												|| ex is TimeoutException)
-						{
-							Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
-
-							await NodeTimeoutsAsync(true);
-
-							node.DisconnectAsync("Block download took too long.");
-							continue;
-						}
-						catch (Exception ex)
-						{
-							Logger.LogDebug<WalletService>(ex);
-							Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}");
-							node.DisconnectAsync("Block download failed.");
-							continue;
-						}
-
-						break; // If got this far break, then we have the block, it's valid. Break.
-					}
-					catch (Exception ex)
-					{
-						Logger.LogDebug<WalletService>(ex);
-					}
-				}
-
-				// Save the block
-				using (await BlockFolderLock.LockAsync())
-				{
-					var path = Path.Combine(BlocksFolderPath, hash.ToString());
-					await File.WriteAllBytesAsync(path, block.ToBytes());
-				}
-			}
-			finally
-			{
-				DownloadingBlock = false;
-				BlockDownloadLock.ReleaseLock();
-			}
-
-			return block;
-		}
-
-		private void DisconnectDisposeNullLocalBitcoinCoreNode()
-		{
-			if (LocalBitcoinCoreNode != null)
-			{
-				try
-				{
-					LocalBitcoinCoreNode?.Disconnect();
-				}
-				catch (Exception ex)
-				{
-					Logger.LogDebug<WalletService>(ex);
-				}
-				finally
-				{
-					try
-					{
-						LocalBitcoinCoreNode?.Dispose();
-					}
-					catch (Exception ex)
-					{
-						Logger.LogDebug<WalletService>(ex);
-					}
-					finally
-					{
-						LocalBitcoinCoreNode = null;
-						Logger.LogInfo<WalletService>("Local Bitcoin Core node disconnected.");
-					}
-				}
-			}
-		}
-
-		/// <remarks>
-		/// Use it at reorgs.
-		/// </remarks>
-		public async Task DeleteBlockAsync(uint256 hash)
-		{
-			try
-			{
-				using (await BlockFolderLock.LockAsync())
-				{
-					var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
-					var fileNames = filePaths.Select(Path.GetFileName);
-					var hashes = fileNames.Select(x => new uint256(x));
-
-					if (hashes.Contains(hash))
-					{
-						File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning<WalletService>(ex);
-			}
-		}
-
-		public async Task<int> CountBlocksAsync()
-		{
-			using (await BlockFolderLock.LockAsync())
-			{
-				return Directory.EnumerateFiles(BlocksFolderPath).Count();
-			}
-		}
-
-		public class Operation
-		{
-			public Script Script { get; }
-			public Money Amount { get; }
-			public string Label { get; }
-
-			public Operation(Script script, Money amount, string label)
-			{
-				Script = Guard.NotNull(nameof(script), script);
-				Amount = Guard.NotNull(nameof(amount), amount);
-				Label = label ?? "";
-			}
-		}
-
-		/// <param name="toSend">If Money.Zero then spends all available amount. Does not generate change.</param>
-		/// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
-		/// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
-		/// <param name="subtractFeeFromAmountIndex">If null, fee is substracted from the change. Otherwise it denotes the index in the toSend array.</param>
-		/// <exception cref="ArgumentException"></exception>
-		/// <exception cref="ArgumentNullException"></exception>
-		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public BuildTransactionResult BuildTransaction(string password,
-														Operation[] toSend,
-														int feeTarget,
-														bool allowUnconfirmed = false,
-														int? subtractFeeFromAmountIndex = null,
-														Script customChange = null,
-														IEnumerable<TxoRef> allowedInputs = null)
-		{
-			password = password ?? ""; // Correction.
-			toSend = Guard.NotNullOrEmpty(nameof(toSend), toSend);
-			if (toSend.Any(x => x is null))
-			{
-				throw new ArgumentNullException($"{nameof(toSend)} cannot contain null element.");
-			}
-			if (toSend.Any(x => x.Amount < Money.Zero))
-			{
-				throw new ArgumentException($"{nameof(toSend)} cannot contain negative element.");
-			}
-
-			long sum = toSend.Select(x => x.Amount).Sum().Satoshi;
-			if (sum < 0 || sum > Constants.MaximumNumberOfSatoshis)
-			{
-				throw new ArgumentOutOfRangeException($"{nameof(toSend)} sum cannot be smaller than 0 or greater than {Constants.MaximumNumberOfSatoshis}.");
-			}
-
-			int spendAllCount = toSend.Count(x => x.Amount == Money.Zero);
-			if (spendAllCount > 1)
-			{
-				throw new ArgumentException($"Only one {nameof(toSend)} element can contain Money.Zero. Money.Zero means add the change to the value of this output.");
-			}
-			if (spendAllCount == 1 && !(customChange is null))
-			{
-				throw new ArgumentException($"{nameof(customChange)} and send all to destination cannot be specified at the same time.");
-			}
-			Guard.InRangeAndNotNull(nameof(feeTarget), feeTarget, 0, Constants.SevenDaysConfirmationTarget); // Allow 0 and 1, and correct later.
-			if (feeTarget < 2) // Correct 0 and 1 to 2.
-			{
-				feeTarget = 2;
-			}
-			if (subtractFeeFromAmountIndex != null) // If not null, make sure not out of range. If null fee is substracted from the change.
-			{
-				if (subtractFeeFromAmountIndex < 0)
-				{
-					throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} cannot be smaller than 0.");
-				}
-				if (subtractFeeFromAmountIndex > toSend.Length - 1)
-				{
-					throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} can be maximum {nameof(toSend)}.Length - 1. {nameof(subtractFeeFromAmountIndex)}: {subtractFeeFromAmountIndex}, {nameof(toSend)}.Length - 1: {toSend.Length - 1}.");
-				}
-			}
-
-			// Get allowed coins to spend.
-			List<SmartCoin> allowedSmartCoinInputs; // Inputs those can be used to build the transaction.
-			if (allowedInputs != null) // If allowedInputs are specified then select the coins from them.
-			{
-				if (!allowedInputs.Any())
-				{
-					throw new ArgumentException($"{nameof(allowedInputs)} is not null, but empty.");
-				}
-
-				if (allowUnconfirmed)
-				{
-					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
-				}
-				else
-				{
-					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
-				}
-			}
-			else
-			{
-				if (allowUnconfirmed)
-				{
-					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable).ToList();
-				}
-				else
-				{
-					allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed).ToList();
-				}
-			}
-
-			// 4. Get and calculate fee
-			Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
-
-			Money feePerBytes = null;
-			using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
-			{
-				Money feeRate = Synchronizer.GetFeeRate(feeTarget);
-				Money sanityCheckedFeeRate = Math.Max(feeRate, 2); // Use the sanity check that under 2 satoshi per bytes should not be displayed. To correct possible rounding errors.
-				feePerBytes = new Money(sanityCheckedFeeRate);
-			}
-
-			bool spendAll = spendAllCount == 1;
-			int inNum;
-			if (spendAll)
-			{
-				inNum = allowedSmartCoinInputs.Count;
-			}
-			else
-			{
-				int expectedMinTxSize = 1 * Constants.P2wpkhInputSizeInBytes + 1 * Constants.OutputSizeInBytes + 10;
-				inNum = SelectCoinsToSpend(allowedSmartCoinInputs, toSend.Select(x => x.Amount).Sum() + feePerBytes * expectedMinTxSize).Count();
-			}
-
-			// https://bitcoincore.org/en/segwit_wallet_dev/#transaction-fee-estimation
-			// https://bitcoin.stackexchange.com/a/46379/26859
-			int outNum = spendAll ? toSend.Length : toSend.Length + 1; // number of addresses to send + 1 for change
-			int vSize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(inNum, outNum);
-			Logger.LogInfo<WalletService>($"Estimated tx size: {vSize} vbytes.");
-			Money fee = feePerBytes * vSize;
-			Logger.LogInfo<WalletService>($"Fee: {fee.Satoshi} Satoshi.");
-
-			// 5. How much to spend?
-			long toSendAmountSumInSatoshis = toSend.Select(x => x.Amount).Sum(); // Does it work if I simply go with Money class here? Is that copied by reference of value?
-			var realToSend = new (Script script, Money amount, string label)[toSend.Length];
-			for (int i = 0; i < toSend.Length; i++) // clone
-			{
-				realToSend[i] = (
-					new Script(toSend[i].Script.ToString()),
-					new Money(toSend[i].Amount.Satoshi),
-					toSend[i].Label);
-			}
-			for (int i = 0; i < realToSend.Length; i++)
-			{
-				if (realToSend[i].amount == Money.Zero) // means spend all
-				{
-					realToSend[i].amount = allowedSmartCoinInputs.Select(x => x.Amount).Sum();
-
-					realToSend[i].amount -= new Money(toSendAmountSumInSatoshis);
-
-					if (subtractFeeFromAmountIndex is null)
-					{
-						realToSend[i].amount -= fee;
-					}
-				}
-
-				if (subtractFeeFromAmountIndex == i)
-				{
-					realToSend[i].amount -= fee;
-				}
-
-				if (realToSend[i].amount < Money.Zero)
-				{
-					throw new InsufficientBalanceException(fee + Money.Satoshis(1), realToSend[i].amount + fee);
-				}
-			}
-
-			var toRemoveList = new List<(Script script, Money money, string label)>(realToSend);
-			toRemoveList.RemoveAll(x => x.money == Money.Zero);
-			realToSend = toRemoveList.ToArray();
-
-			// 1. Get the possible changes.
-			Script changeScriptPubKey;
-			var sb = new StringBuilder();
-			foreach (var item in realToSend)
-			{
-				sb.Append(item.label ?? "?");
-				sb.Append(", ");
-			}
-			var changeLabel = $"{Constants.ChangeOfSpecialLabelStart}{sb.ToString().TrimEnd(',', ' ')}{Constants.ChangeOfSpecialLabelEnd}";
-
-			if (customChange is null)
-			{
-				KeyManager.AssertCleanKeysIndexed(isInternal: true);
-				KeyManager.AssertLockedInternalKeysIndexed(14);
-				var changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
-
-				changeHdPubKey.SetLabel(changeLabel, KeyManager);
-				changeScriptPubKey = changeHdPubKey.P2wpkhScript;
-			}
-			else
-			{
-				changeScriptPubKey = customChange;
-			}
-
-			// 6. Do some checks
-			Money totalOutgoingAmountNoFee = realToSend.Select(x => x.amount).Sum();
-			Money totalOutgoingAmount = totalOutgoingAmountNoFee + fee;
-			decimal feePc = (100 * fee.ToDecimal(MoneyUnit.BTC)) / totalOutgoingAmountNoFee.ToDecimal(MoneyUnit.BTC);
-
-			if (feePc > 1)
-			{
-				Logger.LogInfo<WalletService>($"The transaction fee is {feePc:0.#}% of your transaction amount."
-					+ Environment.NewLine + $"Sending:\t {totalOutgoingAmount.ToString(fplus: false, trimExcessZero: true)} BTC."
-					+ Environment.NewLine + $"Fee:\t\t {fee.Satoshi} Satoshi.");
-			}
-			if (feePc > 100)
-			{
-				throw new InvalidOperationException($"The transaction fee is more than twice as much as your transaction amount: {feePc:0.#}%.");
-			}
-
-			var confirmedAvailableAmount = allowedSmartCoinInputs.Where(x => x.Confirmed).Select(x => x.Amount).Sum();
-			var spendsUnconfirmed = false;
-			if (confirmedAvailableAmount < totalOutgoingAmount)
-			{
-				spendsUnconfirmed = true;
-				Logger.LogInfo<WalletService>("Unconfirmed transaction are being spent.");
-			}
-
-			// 7. Select coins
-			Logger.LogInfo<WalletService>("Selecting coins...");
-			IEnumerable<SmartCoin> coinsToSpend = SelectCoinsToSpend(allowedSmartCoinInputs, totalOutgoingAmount);
-
-			// 9. Build the transaction
-			Logger.LogInfo<WalletService>("Signing transaction...");
-			TransactionBuilder builder = Network.CreateTransactionBuilder();
-			// It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
-			bool sign = !KeyManager.IsWatchOnly;
-			if (sign)
-			{
-				// 8. Get signing keys
-				IEnumerable<ExtKey> signingKeys = KeyManager.GetSecrets(password, coinsToSpend.Select(x => x.ScriptPubKey).ToArray());
-
-				builder = builder
-					.AddCoins(coinsToSpend.Select(x => x.GetCoin()))
-					.AddKeys(signingKeys.ToArray());
-			}
-			else
-			{
-				builder = builder
-					.AddCoins(coinsToSpend.Select(x => x.GetCoin()));
-			}
-
-			foreach ((Script scriptPubKey, Money amount, string label) output in realToSend)
-			{
-				builder = builder.Send(output.scriptPubKey, output.amount);
-			}
-
-			Transaction tx = builder
-				.SetChange(changeScriptPubKey)
-				.SendFees(fee)
-				.BuildTransaction(sign);
-
-			if (sign)
-			{
-				TransactionPolicyError[] checkResults = builder.Check(tx, fee);
-				if (checkResults.Length > 0)
-				{
-					throw new InvalidTxException(tx, checkResults);
-				}
-			}
-
-			List<SmartCoin> spentCoins = Coins.Where(x => tx.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
-
-			var outerWalletOutputs = new List<SmartCoin>();
-			var innerWalletOutputs = new List<SmartCoin>();
-			for (var i = 0U; i < tx.Outputs.Count; i++)
-			{
-				TxOut output = tx.Outputs[i];
-				var anonset = (tx.GetAnonymitySet(i) + spentCoins.Min(x => x.AnonymitySet)) - 1; // Minus 1, because count own only once.
-				var foundKey = KeyManager.GetKeys(KeyState.Clean).FirstOrDefault(x => output.ScriptPubKey == x.P2wpkhScript);
-				var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Inputs.ToTxoRefs().ToArray(), Height.Unknown, tx.RBF, anonset, pubKey: foundKey);
-
-				if (foundKey != null)
-				{
-					coin.Label = changeLabel;
-					innerWalletOutputs.Add(coin);
-				}
-				else
-				{
-					outerWalletOutputs.Add(coin);
-				}
-			}
-
-			PSBT psbt = builder.BuildPSBT(sign);
-			HashSet<SmartCoin> allTxCoins = spentCoins.Concat(innerWalletOutputs).Concat(outerWalletOutputs).ToHashSet();
-			foreach (var coin in allTxCoins)
-			{
-				if (coin.HdPubKey != null)
-				{
-					var index = -1;
-					var isInput = false;
-					for (int i = 0; i < tx.Inputs.Count; i++)
-					{
-						var input = tx.Inputs[i];
-						if (input.PrevOut == coin.GetOutPoint())
-						{
-							index = i;
-							isInput = true;
-							break;
-						}
-					}
-					if (!isInput)
-					{
-						index = (int)coin.Index;
-					}
-
-					if (KeyManager.MasterFingerprint.HasValue)
-					{
-						var rootKeyPath = new RootedKeyPath(KeyManager.MasterFingerprint.Value, coin.HdPubKey.FullKeyPath);
-						psbt.AddKeyPath(coin.HdPubKey.PubKey, rootKeyPath, coin.ScriptPubKey);
-					}
-				}
-			}
-
-			Logger.LogInfo<WalletService>($"Transaction is successfully built: {tx.GetHash()}.");
-
-			return new BuildTransactionResult(new SmartTransaction(tx, Height.Unknown), psbt, spendsUnconfirmed, sign, fee, feePc, outerWalletOutputs, innerWalletOutputs, spentCoins);
-		}
-
-		private IEnumerable<SmartCoin> SelectCoinsToSpend(IEnumerable<SmartCoin> unspentCoins, Money totalOutAmount)
-		{
-			var coinsToSpend = new HashSet<SmartCoin>();
-			var unspentConfirmedCoins = new List<SmartCoin>();
-			var unspentUnconfirmedCoins = new List<SmartCoin>();
-			foreach (SmartCoin coin in unspentCoins)
-			{
-				if (coin.Confirmed)
-				{
-					unspentConfirmedCoins.Add(coin);
-				}
-				else
-				{
-					unspentUnconfirmedCoins.Add(coin);
-				}
-			}
-
-			bool haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentConfirmedCoins);
-			if (!haveEnough)
-			{
-				haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentUnconfirmedCoins);
-			}
-
-			if (!haveEnough)
-			{
-				throw new InsufficientBalanceException(totalOutAmount, unspentConfirmedCoins.Select(x => x.Amount).Sum() + unspentUnconfirmedCoins.Select(x => x.Amount).Sum());
-			}
-
-			return coinsToSpend;
-		}
-
-		/// <returns>If the selection was successful. If there's enough coins to spend from.</returns>
-		private bool TrySelectCoins(ref HashSet<SmartCoin> coinsToSpend, Money totalOutAmount, IEnumerable<SmartCoin> unspentCoins)
-		{
-			// If there's no need for input merging, then use the largest selected.
-			// Do not prefer anonymity set. You can assume the user prefers anonymity set manually through the GUI.
-			SmartCoin largestCoin = unspentCoins.OrderByDescending(x => x.Amount).FirstOrDefault();
-			if (largestCoin == default)
-			{
-				return false; // If there's no coin then unsuccessful selection.
-			}
-			else // Check if we can do without input merging.
-			{
-				if (largestCoin.Amount >= totalOutAmount)
-				{
-					coinsToSpend.Add(largestCoin);
-					return true;
-				}
-			}
-
-			// If there's a need for input merging.
-			foreach (var coin in unspentCoins
-				.OrderByDescending(x => x.AnonymitySet) // Always try to spend/merge the largest anonset coins first.
-				.ThenByDescending(x => x.Amount)) // Then always try to spend by amount.
-			{
-				coinsToSpend.Add(coin);
-				// If reaches the amount, then return true, else just go with the largest coin.
-				if (coinsToSpend.Select(x => x.Amount).Sum() >= totalOutAmount)
-				{
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		public void RenameLabel(SmartCoin coin, string newLabel)
-		{
-			newLabel = Guard.Correct(newLabel);
-			coin.Label = newLabel;
-			var key = KeyManager.GetKeys(x => x.P2wpkhScript == coin.ScriptPubKey).SingleOrDefault();
-			if (key != null)
-			{
-				key.SetLabel(newLabel, KeyManager);
-			}
-		}
-
-		private static long SendCount = 0;
-
-		public async Task SendTransactionAsync(SmartTransaction transaction)
-		{
-			try
-			{
-				Interlocked.Increment(ref SendCount);
-				// Broadcast to a random node.
-				// Wait until it arrives to at least two other nodes.
-				// If something's wrong, fall back broadcasting with backend.
-
-				if (Network == Network.RegTest)
-				{
-					throw new InvalidOperationException("Transaction broadcasting to nodes does not work in RegTest.");
-				}
-
-				while (true)
-				{
-					// As long as we are connected to at least 4 nodes, we can always try again.
-					// 3 should be enough, but make it 5 so 2 nodes could disconnect the meantime.
-					if (Nodes.ConnectedNodes.Count < 5)
-					{
-						throw new InvalidOperationException("We are not connected to enough nodes.");
-					}
-
-					Node node = Nodes.ConnectedNodes.RandomElement();
-					if (node == default(Node))
-					{
-						await Task.Delay(100);
-						continue;
-					}
-
-					if (!node.IsConnected)
-					{
-						await Task.Delay(100);
-						continue;
-					}
-
-					Logger.LogInfo<WalletService>($"Trying to broadcast transaction with random node ({node.RemoteSocketAddress}):{transaction.GetHash()}");
-					var addedToBroadcastStore = Mempool.TryAddToBroadcastStore(transaction.Transaction, node.RemoteSocketEndpoint.ToString()); // So we'll reply to INV with this transaction.
-					if(!addedToBroadcastStore)
-					{
-						Logger.LogWarning<WalletService>($"Transaction {transaction.GetHash()} was already present in the broadcast store.");
-					}
-					var invPayload = new InvPayload(transaction.Transaction);
-					// Give 7 seconds to send the inv payload.
-					using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7)))
-					{
-						await node.SendMessageAsync(invPayload).WithCancellation(cts.Token); // ToDo: It's dangerous way to cancel. Implement proper cancellation to NBitcoin!
-					}
-
-					if(Mempool.TryGetFromBroadcastStore(transaction.GetHash(), out TransactionBroadcastEntry entry))
-					{
-						// Give 7 seconds for serving.
-						var timeout = 0;
-						while (!entry.IsBroadcasted())
-						{
-							if (timeout > 7)
-							{
-								throw new TimeoutException("Did not serve the transaction.");
-							}
-							await Task.Delay(1_000);
-							timeout++;
-						}
-						node.DisconnectAsync("Thank you!");
-						Logger.LogInfo<MempoolBehavior>($"Disconnected node: {node.RemoteSocketAddress}. Successfully broadcasted transaction: {transaction.GetHash()}.");
-					
-						// Give 21 seconds for propagation.
-						timeout = 0;
-						while (entry.GetPropagationConfirmations() < 2)
-						{
-							if (timeout > 21)
-							{
-								throw new TimeoutException("Did not serve the transaction.");
-							}
-							await Task.Delay(1_000);
-							timeout++;
-						}
-						Logger.LogInfo<MempoolBehavior>($"Transaction is successfully propagated: {transaction.GetHash()}.");
-					}
-					else
-					{
-						Logger.LogWarning<WalletService>($"Expected transaction {transaction.GetHash()} was not found in the broadcast store.");
-					}
-					break;
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogInfo<WalletService>($"Random node could not broadcast transaction. Broadcasting with backend... Reason: {ex.Message}");
-				Logger.LogDebug<WalletService>(ex);
-
-				using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
-				{
-					try
-					{
-						await client.BroadcastAsync(transaction);
-					}
-					catch (HttpRequestException ex2) when (
-						ex2.Message.Contains("bad-txns-inputs-missingorspent", StringComparison.InvariantCultureIgnoreCase)
-						|| ex2.Message.Contains("missing-inputs", StringComparison.InvariantCultureIgnoreCase)
-						|| ex2.Message.Contains("txn-mempool-conflict", StringComparison.InvariantCultureIgnoreCase))
-					{
-						if (transaction.Transaction.Inputs.Count == 1) // If we tried to only spend one coin, then we can mark it as spent. If there were more coins, then we do not know.
-						{
-							OutPoint input = transaction.Transaction.Inputs.First().PrevOut;
-							SmartCoin coin = Coins.FirstOrDefault(x => x.TransactionId == input.Hash && x.Index == input.N);
-							if (coin != default)
-							{
-								coin.SpentAccordingToBackend = true;
-							}
-						}
-					}
-				}
-
-				using (await TransactionProcessingLock.LockAsync())
-				{
-					if (await ProcessTransactionAsync(new SmartTransaction(transaction.Transaction, Height.Mempool)))
-					{
-						SerializeTransactionCache();
-					}
-
-					Mempool.TransactionHashes.TryAdd(transaction.GetHash());
-				}
-
-				Logger.LogInfo<WalletService>($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
-			}
-			finally
-			{
-				Mempool.TryRemoveFromBroadcastStore(transaction.GetHash(), out _); // Remove it just to be sure. Probably has been removed previously.
-				Interlocked.Decrement(ref SendCount);
-			}
-		}
-
-		public IEnumerable<string> GetNonSpecialLabels()
-		{
-			return Coins.Where(x => !x.Label.StartsWith("ZeroLink", StringComparison.Ordinal))
-				.SelectMany(x => x.Label.Split(new string[] { Constants.ChangeOfSpecialLabelStart, Constants.ChangeOfSpecialLabelEnd, "(", "," }, StringSplitOptions.RemoveEmptyEntries))
-				.Select(x => x.Trim())
-				.Distinct();
-		}
-
-		private int _refreshCoinHistoriesRerunRequested = 0;
-		private int _refreshCoinHistoriesRunning = 0;
-
-		public void RefreshCoinHistories()
-		{
-			// If already running, then make sure another run is requested, else do the work.
-			if (Interlocked.CompareExchange(ref _refreshCoinHistoriesRunning, 1, 0) == 1)
-			{
-				Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 1);
-				return;
-			}
-
-			try
-			{
-				var unspentCoins = Coins.Where(c => c.Unspent); //refreshing unspent coins clusters only
-				if (unspentCoins.Any())
-				{
-					ILookup<Script, SmartCoin> lookupScriptPubKey = Coins.ToLookup(c => c.ScriptPubKey, c => c);
-					ILookup<uint256, SmartCoin> lookupSpenderTransactionId = Coins.ToLookup(c => c.SpenderTransactionId, c => c);
-					ILookup<uint256, SmartCoin> lookupTransactionId = Coins.ToLookup(c => c.TransactionId, c => c);
-
-					const int simultaneousThread = 2; //threads allowed to run simultaneously in threadpool
-
-					Parallel.ForEach(unspentCoins, new ParallelOptions { MaxDegreeOfParallelism = simultaneousThread }, coin =>
-					{
-						var result = string.Join(", ", GetClusters(coin, new List<SmartCoin>(), lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId).Select(x => x.Label).Distinct());
-						coin.SetClusters(result);
-					});
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError<WalletService>($"Refreshing coin clusters failed: {ex}");
-			}
-			finally
-			{
-				// It's not running anymore, but someone may requested another run.
-				Interlocked.Exchange(ref _refreshCoinHistoriesRunning, 0);
-
-				// Clear the rerun request, too and if it was requested, then rerun.
-				if (Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 0) == 1)
-				{
-					RefreshCoinHistories();
-				}
-			}
-		}
-
-		public bool UnconfirmedTransactionsInitialized { get; private set; } = false;
-
-		private void SerializeTransactionCache()
-		{
-			if (!UnconfirmedTransactionsInitialized) // If unconfirmed ones are not yet initialized, then do not serialize because unconfirmed are going to be lost.
-			{
-				return;
-			}
-
-			IoHelpers.EnsureContainingDirectoryExists(TransactionsFilePath);
-			string jsonString = JsonConvert.SerializeObject(TransactionCache.OrderByBlockchain(), Formatting.Indented);
-			File.WriteAllText(TransactionsFilePath,
-				jsonString,
-				Encoding.UTF8);
-		}
-
-		/// <summary>
-		/// Current timeout used when downloading a block from the remote node. It is defined in seconds.
-		/// </summary>
-		private async Task NodeTimeoutsAsync(bool increaseDecrease)
-		{
-			if (increaseDecrease)
-			{
-				NodeTimeouts++;
-			}
-			else
-			{
-				NodeTimeouts--;
-			}
-
-			var timeout = RuntimeParams.Instance.NetworkNodeTimeout;
-
-			// If it times out 2 times in a row then increase the timeout.
-			if (NodeTimeouts >= 2)
-			{
-				NodeTimeouts = 0;
-				timeout *= 2;
-			}
-			else if (NodeTimeouts <= -3) // If it does not time out 3 times in a row, lower the timeout.
-			{
-				NodeTimeouts = 0;
-				timeout = (int)Math.Round(timeout * 0.7);
-			}
-
-			// Sanity check
-			if (timeout < 32)
-			{
-				timeout = 32;
-			}
-			else if (timeout > 600)
-			{
-				timeout = 600;
-			}
-
-			if (timeout == RuntimeParams.Instance.NetworkNodeTimeout)
-			{
-				return;
-			}
-
-			RuntimeParams.Instance.NetworkNodeTimeout = timeout;
-			await RuntimeParams.Instance.SaveAsync();
-
-			Logger.LogInfo<WalletService>($"Current timeout value used on block download is: {timeout} seconds.");
-		}
-
-		public async Task StopAsync()
-		{
-			while (Interlocked.Read(ref SendCount) != 0) // Make sure to wait for send to finish.
-			{
-				await Task.Delay(50);
-			}
-
-			BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
-			BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
-			Mempool.TransactionReceived -= Mempool_TransactionReceivedAsync;
-			Coins.CollectionChanged -= Coins_CollectionChanged;
-
-			DisconnectDisposeNullLocalBitcoinCoreNode();
-		}
-	}
+    public class WalletService
+    {
+        public static event EventHandler<bool> DownloadingBlockChanged;
+
+        // So we will make sure when blocks are downloading with multiple wallet services, they do not conflict.
+        private static AsyncLock BlockDownloadLock { get; } = new AsyncLock();
+
+        private static bool DownloadingBlockBacking;
+
+        public static bool DownloadingBlock
+        {
+            get => DownloadingBlockBacking;
+            set
+            {
+                if (value != DownloadingBlockBacking)
+                {
+                    DownloadingBlockBacking = value;
+                    DownloadingBlockChanged?.Invoke(null, value);
+                }
+            }
+        }
+
+        public BitcoinStore BitcoinStore { get; }
+        public KeyManager KeyManager { get; }
+        public WasabiSynchronizer Synchronizer { get; }
+        public CcjClient ChaumianClient { get; }
+        public MempoolService Mempool { get; }
+
+        public NodesGroup Nodes { get; }
+        public string BlocksFolderPath { get; }
+        public string TransactionsFolderPath { get; }
+        public string TransactionsFilePath { get; }
+
+        private AsyncLock HandleFiltersLock { get; }
+
+        private AsyncLock BlockFolderLock { get; }
+
+        private int NodeTimeouts { get; set; }
+
+        public ServiceConfiguration ServiceConfiguration { get; }
+
+        public ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)> ProcessedBlocks { get; }
+
+        public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
+
+        public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
+
+        public event EventHandler<FilterModel> NewFilterProcessed;
+
+        public event EventHandler<SmartCoin> CoinSpentOrSpenderConfirmed;
+
+        public event EventHandler<Block> NewBlockProcessed;
+
+        public Network Network => Synchronizer.Network;
+
+        public WalletService(
+            BitcoinStore bitcoinStore,
+            KeyManager keyManager,
+            WasabiSynchronizer syncer,
+            CcjClient chaumianClient,
+            MempoolService mempool,
+            NodesGroup nodes,
+            string workFolderDir,
+            ServiceConfiguration serviceConfiguration)
+        {
+            BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+            KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+            Nodes = Guard.NotNull(nameof(nodes), nodes);
+            Synchronizer = Guard.NotNull(nameof(syncer), syncer);
+            ChaumianClient = Guard.NotNull(nameof(chaumianClient), chaumianClient);
+            Mempool = Guard.NotNull(nameof(mempool), mempool);
+            ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
+
+            ProcessedBlocks = new ConcurrentDictionary<uint256, (Height height, DateTimeOffset dateTime)>();
+            HandleFiltersLock = new AsyncLock();
+
+            Coins = new ObservableConcurrentHashSet<SmartCoin>();
+            TransactionCache = new ConcurrentHashSet<SmartTransaction>();
+
+            BlocksFolderPath = Path.Combine(workFolderDir, "Blocks", Network.ToString());
+            TransactionsFolderPath = Path.Combine(workFolderDir, "Transactions", Network.ToString());
+            RuntimeParams.SetDataDir(workFolderDir);
+
+            BlockFolderLock = new AsyncLock();
+
+            KeyManager.AssertCleanKeysIndexed();
+            KeyManager.AssertLockedInternalKeysIndexed(14);
+
+            if (Directory.Exists(BlocksFolderPath))
+            {
+                if (Synchronizer.Network == Network.RegTest)
+                {
+                    Directory.Delete(BlocksFolderPath, true);
+                    Directory.CreateDirectory(BlocksFolderPath);
+                }
+            }
+            else
+            {
+                Directory.CreateDirectory(BlocksFolderPath);
+            }
+            if (Directory.Exists(TransactionsFolderPath))
+            {
+                if (Synchronizer.Network == Network.RegTest)
+                {
+                    Directory.Delete(TransactionsFolderPath, true);
+                    Directory.CreateDirectory(TransactionsFolderPath);
+                }
+            }
+            else
+            {
+                Directory.CreateDirectory(TransactionsFolderPath);
+            }
+
+            var walletName = "UnnamedWallet";
+            if (!string.IsNullOrWhiteSpace(KeyManager.FilePath))
+            {
+                walletName = Path.GetFileNameWithoutExtension(KeyManager.FilePath);
+            }
+            TransactionsFilePath = Path.Combine(TransactionsFolderPath, $"{walletName}Transactions.json");
+
+            BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
+            BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
+            Mempool.TransactionReceived += Mempool_TransactionReceivedAsync;
+        }
+
+        private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            RefreshCoinHistories();
+        }
+
+        private static AsyncLock TransactionProcessingLock { get; } = new AsyncLock();
+
+        private async void Mempool_TransactionReceivedAsync(object sender, SmartTransaction tx)
+        {
+            try
+            {
+                using (await TransactionProcessingLock.LockAsync())
+                {
+                    if (await ProcessTransactionAsync(tx))
+                    {
+                        SerializeTransactionCache();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning<WalletService>(ex);
+            }
+        }
+
+        private async void IndexDownloader_ReorgedAsync(object sender, FilterModel invalidFilter)
+        {
+            try
+            {
+                using (await HandleFiltersLock.LockAsync())
+                {
+                    uint256 invalidBlockHash = invalidFilter.BlockHash;
+                    await DeleteBlockAsync(invalidBlockHash);
+                    var blockState = KeyManager.TryRemoveBlockState(invalidBlockHash);
+                    ProcessedBlocks.TryRemove(invalidBlockHash, out _);
+                    if (blockState != null && blockState.BlockHeight != default(Height))
+                    {
+                        foreach (var toRemove in Coins.Where(x => x.Height == blockState.BlockHeight).Distinct().ToList())
+                        {
+                            RemoveCoinRecursively(toRemove);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning<WalletService>(ex);
+            }
+        }
+
+        private void RemoveCoinRecursively(SmartCoin toRemove)
+        {
+            if (toRemove.SpenderTransactionId != null)
+            {
+                foreach (var toAlsoRemove in Coins.Where(x => x.TransactionId == toRemove.SpenderTransactionId).Distinct().ToList())
+                {
+                    RemoveCoinRecursively(toAlsoRemove);
+                }
+            }
+
+            Coins.TryRemove(toRemove);
+            Mempool.TransactionHashes.TryRemove(toRemove.SpenderTransactionId);
+        }
+
+        private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)
+        {
+            try
+            {
+                using (await HandleFiltersLock.LockAsync())
+                {
+                    if (filterModel.Filter != null && !KeyManager.CointainsBlockState(filterModel.BlockHash))
+                    {
+                        await ProcessFilterModelAsync(filterModel, CancellationToken.None);
+                    }
+                }
+                NewFilterProcessed?.Invoke(this, filterModel);
+
+                do
+                {
+                    await Task.Delay(100);
+                    if (Synchronizer is null || BitcoinStore?.HashChain is null)
+                    {
+                        return;
+                    }
+                    // Make sure fully synced and this filter is the lastest filter.
+                    if (BitcoinStore.HashChain.HashesLeft != 0 || BitcoinStore.HashChain.TipHash != filterModel.BlockHash)
+                    {
+                        return;
+                    }
+                } while (Synchronizer.AreRequestsBlocked()); // If requests are blocked, delay mempool cleanup, because coinjoin answers are always priority.
+
+                await Mempool?.TryPerformMempoolCleanupAsync(Synchronizer?.WasabiClient?.TorClient?.DestinationUriAction, Synchronizer?.WasabiClient?.TorClient?.TorSocks5EndPoint);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning<WalletService>(ex);
+            }
+        }
+
+        public async Task InitializeAsync(CancellationToken cancel)
+        {
+            if (!Synchronizer.IsRunning)
+            {
+                throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
+            }
+
+            await RuntimeParams.LoadAsync();
+
+            using (await HandleFiltersLock.LockAsync())
+            {
+                var unconfirmedTransactions = new SmartTransaction[0];
+                var confirmedTransactions = new SmartTransaction[0];
+
+                if (File.Exists(TransactionsFilePath))
+                {
+                    try
+                    {
+                        IEnumerable<SmartTransaction> transactions = null;
+                        string jsonString = File.ReadAllText(TransactionsFilePath, Encoding.UTF8);
+                        transactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?
+                            .OrderByBlockchain();
+
+                        confirmedTransactions = transactions?
+                            .Where(x => x.Confirmed)?
+                            .ToArray() ?? new SmartTransaction[0];
+
+                        unconfirmedTransactions = transactions?
+                            .Where(x => !x.Confirmed)?
+                            .ToArray() ?? new SmartTransaction[0];
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogWarning<WalletService>(ex);
+                        Logger.LogWarning<WalletService>($"Transaction cache got corrupted. Deleting {TransactionsFilePath}.");
+                        File.Delete(TransactionsFilePath);
+                    }
+                }
+
+                // Go through the keymanager's index.
+                KeyManager.AssertNetworkOrClearBlockState(Network);
+                Height bestKeyManagerHeight = KeyManager.GetBestHeight();
+
+                foreach (BlockState blockState in KeyManager.GetTransactionIndex())
+                {
+                    var relevantTransactions = confirmedTransactions.Where(x => x.BlockHash == blockState.BlockHash).ToArray();
+                    var block = await GetOrDownloadBlockAsync(blockState.BlockHash, cancel);
+                    await ProcessBlockAsync(blockState.BlockHeight, block, blockState.TransactionIndices, relevantTransactions);
+                }
+
+                // Go through the filters and que to download the matches.
+                await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>
+                {
+                    if (filterModel.Filter != null) // Filter can be null if there is no bech32 tx.
+                    {
+                        await ProcessFilterModelAsync(filterModel, cancel);
+                    }
+                }, new Height(bestKeyManagerHeight.Value + 1));
+
+                // Load in dummy mempool
+                try
+                {
+                    if (unconfirmedTransactions != null && unconfirmedTransactions.Any())
+                    {
+                        try
+                        {
+                            using (await TransactionProcessingLock.LockAsync())
+                            using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+                            {
+                                var compactness = 10;
+
+                                var mempoolHashes = await client.GetMempoolHashesAsync(compactness);
+
+                                var cnt = 0;
+                                foreach (var tx in unconfirmedTransactions)
+                                {
+                                    if (mempoolHashes.Contains(tx.GetHash().ToString().Substring(0, compactness)))
+                                    {
+                                        tx.SetHeight(Height.Mempool);
+                                        await ProcessTransactionAsync(tx);
+                                        Mempool.TransactionHashes.TryAdd(tx.GetHash());
+
+                                        Logger.LogInfo<WalletService>($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
+                                        cnt++;
+                                    }
+                                }
+
+                                if (cnt != unconfirmedTransactions.Length)
+                                {
+                                    SerializeTransactionCache();
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            // When there's a connection failure do not clean the transactions, add it to processing.
+                            foreach (var tx in unconfirmedTransactions)
+                            {
+                                tx.SetHeight(Height.Mempool);
+                                await ProcessTransactionAsync(tx);
+                                Mempool.TransactionHashes.TryAdd(tx.GetHash());
+                            }
+
+                            throw;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning<WalletService>(ex);
+                }
+                finally
+                {
+                    UnconfirmedTransactionsInitialized = true;
+                }
+            }
+            Coins.CollectionChanged += Coins_CollectionChanged;
+            RefreshCoinHistories();
+        }
+
+        private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
+        {
+            if (ProcessedBlocks.ContainsKey(filterModel.BlockHash))
+            {
+                return;
+            }
+
+            var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
+            if (!matchFound)
+            {
+                return;
+            }
+
+            Block currentBlock = await GetOrDownloadBlockAsync(filterModel.BlockHash, cancel); // Wait until not downloaded.
+
+            if (await ProcessBlockAsync(filterModel.BlockHeight, currentBlock))
+            {
+                SerializeTransactionCache();
+            }
+        }
+
+        public HdPubKey GetReceiveKey(string label, IEnumerable<HdPubKey> dontTouch = null)
+        {
+            label = Guard.Correct(label);
+
+            // Make sure there's always 21 clean keys generated and indexed.
+            KeyManager.AssertCleanKeysIndexed(isInternal: false);
+
+            IEnumerable<HdPubKey> keys = KeyManager.GetKeys(KeyState.Clean, isInternal: false);
+            if (dontTouch != null)
+            {
+                keys = keys.Except(dontTouch);
+                if (!keys.Any())
+                {
+                    throw new InvalidOperationException($"{nameof(dontTouch)} covers all the possible keys.");
+                }
+            }
+
+            var foundLabelless = keys.FirstOrDefault(x => !x.HasLabel); // Return the first labelless.
+            HdPubKey ret = foundLabelless ?? keys.RandomElement(); // Return the first, because that's the oldest.
+
+            ret.SetLabel(label, KeyManager);
+
+            return ret;
+        }
+
+        public List<SmartCoin> GetClusters(SmartCoin coin, List<SmartCoin> current, ILookup<Script, SmartCoin> lookupScriptPubKey, ILookup<uint256, SmartCoin> lookupSpenderTransactionId, ILookup<uint256, SmartCoin> lookupTransactionId)
+        {
+            Guard.NotNull(nameof(coin), coin);
+            if (current.Contains(coin))
+            {
+                return current;
+            }
+
+            var clusters = current.Concat(new List<SmartCoin> { coin }).ToList(); // The coin is the first elem in its cluster.
+
+            // If the script is the same then we have a match, no matter of the anonymity set.
+            foreach (var c in lookupScriptPubKey[coin.ScriptPubKey])
+            {
+                if (!clusters.Contains(c))
+                {
+                    var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
+                    foreach (var hr in h)
+                    {
+                        if (!clusters.Contains(hr))
+                        {
+                            clusters.Add(hr);
+                        }
+                    }
+                }
+            }
+
+            // If it spends someone and has not been sufficiently anonymized.
+            if (coin.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
+            {
+                var c = lookupSpenderTransactionId[coin.TransactionId].FirstOrDefault(x => !clusters.Contains(x));
+                if (c != default)
+                {
+                    var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
+                    foreach (var hr in h)
+                    {
+                        if (!clusters.Contains(hr))
+                        {
+                            clusters.Add(hr);
+                        }
+                    }
+                }
+            }
+
+            // If it's being spent by someone and that someone has not been sufficiently anonymized.
+            if (!coin.Unspent)
+            {
+                var c = lookupTransactionId[coin.SpenderTransactionId].FirstOrDefault(x => !clusters.Contains(x));
+                if (c != default)
+                {
+                    if (c.AnonymitySet < ServiceConfiguration.PrivacyLevelStrong)
+                    {
+                        if (c != default)
+                        {
+                            var h = GetClusters(c, clusters, lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId);
+                            foreach (var hr in h)
+                            {
+                                if (!clusters.Contains(hr))
+                                {
+                                    clusters.Add(hr);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return clusters;
+        }
+
+        private async Task<bool> ProcessBlockAsync(Height height, Block block, IEnumerable<int> filterByTxIds = null, IEnumerable<SmartTransaction> skeletonBlock = null)
+        {
+            var ret = false;
+            using (await TransactionProcessingLock.LockAsync())
+            {
+                if (filterByTxIds is null)
+                {
+                    var relevantIndicies = new List<int>();
+                    for (int i = 0; i < block.Transactions.Count; i++)
+                    {
+                        Transaction tx = block.Transactions[i];
+                        if (await ProcessTransactionAsync(new SmartTransaction(tx, height, block.GetHash(), i)))
+                        {
+                            relevantIndicies.Add(i);
+                            ret = true;
+                        }
+                    }
+
+                    if (relevantIndicies.Any())
+                    {
+                        var blockState = new BlockState(block.GetHash(), height, relevantIndicies);
+                        KeyManager.AddBlockState(blockState, setItsHeightToBest: true); // Set the heigh here (so less toFile and lock.)
+                    }
+                    else
+                    {
+                        KeyManager.SetBestHeight(height);
+                    }
+                }
+                else
+                {
+                    foreach (var i in filterByTxIds.OrderBy(x => x))
+                    {
+                        var tx = skeletonBlock?.FirstOrDefault(x => x.BlockIndex == i) ?? new SmartTransaction(block.Transactions[i], height, block.GetHash(), i);
+                        if (await ProcessTransactionAsync(tx))
+                        {
+                            ret = true;
+                        }
+                    }
+                }
+            }
+
+            ProcessedBlocks.TryAdd(block.GetHash(), (height, block.Header.BlockTime));
+
+            NewBlockProcessed?.Invoke(this, block);
+
+            return ret;
+        }
+
+        private async Task<bool> ProcessTransactionAsync(SmartTransaction tx)
+        {
+            uint256 txId = tx.GetHash();
+            var walletRelevant = false;
+
+            bool justUpdate = false;
+            if (tx.Confirmed)
+            {
+                Mempool.TransactionHashes.TryRemove(txId); // If we have in mempool, remove.
+                if (!tx.Transaction.PossiblyP2WPKHInvolved())
+                {
+                    return false; // We do not care about non-witness transactions for other than mempool cleanup.
+                }
+
+                bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
+                if (isFoundTx)
+                {
+                    SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
+                    if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
+                    {
+                        foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
+                        walletRelevant = true;
+                        justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
+                    }
+                }
+            }
+            else if (!tx.Transaction.PossiblyP2WPKHInvolved())
+            {
+                return false; // We do not care about non-witness transactions for other than mempool cleanup.
+            }
+
+            if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
+            {
+                var doubleSpends = new List<SmartCoin>();
+                foreach (SmartCoin coin in Coins)
+                {
+                    var spent = false;
+                    foreach (TxoRef spentOutput in coin.SpentOutputs)
+                    {
+                        foreach (TxIn txIn in tx.Transaction.Inputs)
+                        {
+                            if (spentOutput.TransactionId == txIn.PrevOut.Hash && spentOutput.Index == txIn.PrevOut.N) // Do not do (spentOutput == txIn.PrevOut), it's faster this way, because it won't check for null.
+                            {
+                                doubleSpends.Add(coin);
+                                spent = true;
+                                walletRelevant = true;
+                                break;
+                            }
+                        }
+                        if (spent)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (doubleSpends.Any())
+                {
+                    if (tx.Height == Height.Mempool)
+                    {
+                        // if the received transaction is spending at least one input already
+                        // spent by a previous unconfirmed transaction signaling RBF then it is not a double
+                        // spanding transaction but a replacement transaction.
+                        if (doubleSpends.Any(x => x.IsReplaceable))
+                        {
+                            // remove double spent coins (if other coin spends it, remove that too and so on)
+                            // will add later if they came to our keys
+                            foreach (SmartCoin doubleSpentCoin in doubleSpends.Where(x => !x.Confirmed))
+                            {
+                                RemoveCoinRecursively(doubleSpentCoin);
+                            }
+                            tx.SetReplacement();
+                            walletRelevant = true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    else // new confirmation always enjoys priority
+                    {
+                        // remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
+                        foreach (SmartCoin doubleSpentCoin in doubleSpends)
+                        {
+                            RemoveCoinRecursively(doubleSpentCoin);
+                        }
+                        walletRelevant = true;
+                    }
+                }
+            }
+
+            for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
+            {
+                // If transaction received to any of the wallet keys:
+                var output = tx.Transaction.Outputs[i];
+                HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
+                if (foundKey != default)
+                {
+                    walletRelevant = true;
+
+                    foundKey.SetKeyState(KeyState.Used, KeyManager);
+                    List<SmartCoin> spentOwnCoins = Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
+                    var anonset = tx.Transaction.GetAnonymitySet(i);
+                    if (spentOwnCoins.Count != 0)
+                    {
+                        anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
+
+                        // Cleanup exposed links where the txo has been spent.
+                        foreach (var input in spentOwnCoins.Select(x => x.GetTxoRef()))
+                        {
+                            ChaumianClient.ExposedLinks.TryRemove(input, out _);
+                        }
+                    }
+
+                    if (output.Value <= ServiceConfiguration.DustThreshold)
+                    {
+                        continue;
+                    }
+
+                    SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
+                                                                                                                                                                                                                                                   // If we did not have it.
+                    if (Coins.TryAdd(newCoin))
+                    {
+                        TransactionCache.TryAdd(tx);
+
+                        // If it's being mixed and anonset is not sufficient, then queue it.
+                        if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && ChaumianClient.State.Contains(newCoin.SpentOutputs))
+                        {
+                            try
+                            {
+                                await ChaumianClient.QueueCoinsToMixAsync(newCoin);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.LogError<WalletService>(ex);
+                            }
+                        }
+
+                        // Make sure there's always 21 clean keys generated and indexed.
+                        KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
+
+                        if (foundKey.IsInternal)
+                        {
+                            // Make sure there's always 14 internal locked keys generated and indexed.
+                            KeyManager.AssertLockedInternalKeysIndexed(14);
+                        }
+                    }
+                    else // If we had this coin already.
+                    {
+                        if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
+                        {
+                            SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
+                            if (oldCoin != null) // Just to be sure, it is a concurrent collection.
+                            {
+                                oldCoin.Height = newCoin.Height;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // If spends any of our coin
+            for (var i = 0; i < tx.Transaction.Inputs.Count; i++)
+            {
+                var input = tx.Transaction.Inputs[i];
+
+                var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
+                if (foundCoin != null)
+                {
+                    walletRelevant = true;
+
+                    foundCoin.SpenderTransactionId = txId;
+                    TransactionCache.TryAdd(tx);
+                    CoinSpentOrSpenderConfirmed?.Invoke(this, foundCoin);
+                }
+            }
+
+            return walletRelevant;
+        }
+
+        private Node _localBitcoinCoreNode = null;
+
+        public Node LocalBitcoinCoreNode
+        {
+            get
+            {
+                if (Network == Network.RegTest)
+                {
+                    return Nodes.ConnectedNodes.First();
+                }
+
+                return _localBitcoinCoreNode;
+            }
+            private set => _localBitcoinCoreNode = value;
+        }
+
+        /// <exception cref="OperationCanceledException"></exception>
+        public async Task<Block> GetOrDownloadBlockAsync(uint256 hash, CancellationToken cancel)
+        {
+            // Try get the block
+            using (await BlockFolderLock.LockAsync())
+            {
+                var encoder = new HexEncoder();
+                foreach (var filePath in Directory.EnumerateFiles(BlocksFolderPath))
+                {
+                    var fileName = Path.GetFileName(filePath);
+                    if (!encoder.IsValid(fileName))
+                    {
+                        Logger.LogTrace<WalletService>($"Filename is not a hash: {fileName}.");
+                        continue;
+                    }
+
+                    if (hash == new uint256(fileName))
+                    {
+                        var blockBytes = await File.ReadAllBytesAsync(filePath);
+                        try
+                        {
+                            return Block.Load(blockBytes, Synchronizer.Network);
+                        }
+                        catch (Exception)
+                        {
+                            // In case the block file is corrupted we get an EndOfStreamException exception
+                            // Ignore any error and continue by re-downloading the block.
+                            break;
+                        }
+                    }
+                }
+            }
+            cancel.ThrowIfCancellationRequested();
+
+            // Download the block
+            Block block = null;
+            try
+            {
+                await BlockDownloadLock.LockAsync();
+                DownloadingBlock = true;
+
+                while (true)
+                {
+                    cancel.ThrowIfCancellationRequested();
+                    try
+                    {
+                        // Try to get block information from local running Core node first.
+                        try
+                        {
+                            if (LocalBitcoinCoreNode is null || !LocalBitcoinCoreNode.IsConnected && Network != Network.RegTest) // If RegTest then we're already connected do not try again.
+                            {
+                                DisconnectDisposeNullLocalBitcoinCoreNode();
+                                using (var handshakeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancel))
+                                {
+                                    handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
+                                    var nodeConnectionParameters = new NodeConnectionParameters()
+                                    {
+                                        ConnectCancellation = handshakeTimeout.Token,
+                                        IsRelay = false,
+                                        UserAgent = $"/Wasabi:{Constants.ClientVersion}/"
+                                    };
+
+                                    // If an onion was added must try to use Tor.
+                                    // onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
+                                    if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
+                                    {
+                                        nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
+                                    }
+
+                                    var localEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;
+                                    var localNode = await Node.ConnectAsync(Network, localEndPoint, nodeConnectionParameters);
+                                    try
+                                    {
+                                        Logger.LogInfo<WalletService>($"TCP Connection succeeded, handshaking...");
+                                        localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
+                                        var peerServices = localNode.PeerVersion.Services;
+
+                                        //if(!peerServices.HasFlag(NodeServices.Network) && !peerServices.HasFlag(NodeServices.NODE_NETWORK_LIMITED))
+                                        //{
+                                        //	throw new InvalidOperationException($"Wasabi cannot use the local node because it does not provide blocks.");
+                                        //}
+
+                                        Logger.LogInfo<WalletService>($"Handshake completed successfully.");
+
+                                        if (!localNode.IsConnected)
+                                        {
+                                            throw new InvalidOperationException($"Wasabi could not complete the handshake with the local node and dropped the connection.{Environment.NewLine}" +
+                                                $"Probably this is because the node does not support retrieving full blocks or segwit serialization.");
+                                        }
+                                        LocalBitcoinCoreNode = localNode;
+                                    }
+                                    catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
+                                    {
+                                        Logger.LogWarning<Node>($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
+                                            $"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
+                                        throw;
+                                    }
+                                }
+                            }
+
+                            Block blockFromLocalNode = null;
+                            // Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
+                            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
+                            {
+                                blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
+                            }
+
+                            if (!blockFromLocalNode.Check())
+                            {
+                                throw new InvalidOperationException($"Disconnected node, because invalid block received!");
+                            }
+
+                            block = blockFromLocalNode;
+                            Logger.LogInfo<WalletService>($"Block acquired from local P2P connection: {hash}");
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            block = null;
+                            DisconnectDisposeNullLocalBitcoinCoreNode();
+
+                            if (ex is SocketException)
+                            {
+                                Logger.LogTrace<WalletService>("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
+                            }
+                            else
+                            {
+                                Logger.LogWarning<WalletService>(ex);
+                            }
+                        }
+                        cancel.ThrowIfCancellationRequested();
+
+                        // If no connection, wait then continue.
+                        while (Nodes.ConnectedNodes.Count == 0)
+                        {
+                            await Task.Delay(100);
+                        }
+
+                        Node node = Nodes.ConnectedNodes.RandomElement();
+                        if (node == default(Node))
+                        {
+                            await Task.Delay(100);
+                            continue;
+                        }
+
+                        if (!node.IsConnected && !(Synchronizer.Network != Network.RegTest))
+                        {
+                            await Task.Delay(100);
+                            continue;
+                        }
+
+                        try
+                        {
+                            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
+                            {
+                                block = await node.DownloadBlockAsync(hash, cts.Token);
+                            }
+
+                            if (!block.Check())
+                            {
+                                Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
+                                node.DisconnectAsync("Invalid block received.");
+                                continue;
+                            }
+
+                            if (Nodes.ConnectedNodes.Count > 1) // So to minimize risking missing unconfirmed transactions.
+                            {
+                                Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}");
+                                node.DisconnectAsync("Thank you!");
+                            }
+
+                            await NodeTimeoutsAsync(false);
+                        }
+                        catch (Exception ex) when (ex is OperationCanceledException
+                                                || ex is TaskCanceledException
+                                                || ex is TimeoutException)
+                        {
+                            Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
+
+                            await NodeTimeoutsAsync(true);
+
+                            node.DisconnectAsync("Block download took too long.");
+                            continue;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogDebug<WalletService>(ex);
+                            Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}");
+                            node.DisconnectAsync("Block download failed.");
+                            continue;
+                        }
+
+                        break; // If got this far break, then we have the block, it's valid. Break.
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogDebug<WalletService>(ex);
+                    }
+                }
+
+                // Save the block
+                using (await BlockFolderLock.LockAsync())
+                {
+                    var path = Path.Combine(BlocksFolderPath, hash.ToString());
+                    await File.WriteAllBytesAsync(path, block.ToBytes());
+                }
+            }
+            finally
+            {
+                DownloadingBlock = false;
+                BlockDownloadLock.ReleaseLock();
+            }
+
+            return block;
+        }
+
+        private void DisconnectDisposeNullLocalBitcoinCoreNode()
+        {
+            if (LocalBitcoinCoreNode != null)
+            {
+                try
+                {
+                    LocalBitcoinCoreNode?.Disconnect();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug<WalletService>(ex);
+                }
+                finally
+                {
+                    try
+                    {
+                        LocalBitcoinCoreNode?.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogDebug<WalletService>(ex);
+                    }
+                    finally
+                    {
+                        LocalBitcoinCoreNode = null;
+                        Logger.LogInfo<WalletService>("Local Bitcoin Core node disconnected.");
+                    }
+                }
+            }
+        }
+
+        /// <remarks>
+        /// Use it at reorgs.
+        /// </remarks>
+        public async Task DeleteBlockAsync(uint256 hash)
+        {
+            try
+            {
+                using (await BlockFolderLock.LockAsync())
+                {
+                    var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
+                    var fileNames = filePaths.Select(Path.GetFileName);
+                    var hashes = fileNames.Select(x => new uint256(x));
+
+                    if (hashes.Contains(hash))
+                    {
+                        File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning<WalletService>(ex);
+            }
+        }
+
+        public async Task<int> CountBlocksAsync()
+        {
+            using (await BlockFolderLock.LockAsync())
+            {
+                return Directory.EnumerateFiles(BlocksFolderPath).Count();
+            }
+        }
+
+        public class Operation
+        {
+            public Script Script { get; }
+            public Money Amount { get; }
+            public string Label { get; }
+
+            public Operation(Script script, Money amount, string label)
+            {
+                Script = Guard.NotNull(nameof(script), script);
+                Amount = Guard.NotNull(nameof(amount), amount);
+                Label = label ?? "";
+            }
+        }
+
+        /// <param name="toSend">If Money.Zero then spends all available amount. Does not generate change.</param>
+        /// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
+        /// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
+        /// <param name="subtractFeeFromAmountIndex">If null, fee is substracted from the change. Otherwise it denotes the index in the toSend array.</param>
+        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public BuildTransactionResult BuildTransaction(string password,
+                                                        Operation[] toSend,
+                                                        int feeTarget,
+                                                        bool allowUnconfirmed = false,
+                                                        int? subtractFeeFromAmountIndex = null,
+                                                        Script customChange = null,
+                                                        IEnumerable<TxoRef> allowedInputs = null)
+        {
+            password = password ?? ""; // Correction.
+            toSend = Guard.NotNullOrEmpty(nameof(toSend), toSend);
+            if (toSend.Any(x => x is null))
+            {
+                throw new ArgumentNullException($"{nameof(toSend)} cannot contain null element.");
+            }
+            if (toSend.Any(x => x.Amount < Money.Zero))
+            {
+                throw new ArgumentException($"{nameof(toSend)} cannot contain negative element.");
+            }
+
+            long sum = toSend.Select(x => x.Amount).Sum().Satoshi;
+            if (sum < 0 || sum > Constants.MaximumNumberOfSatoshis)
+            {
+                throw new ArgumentOutOfRangeException($"{nameof(toSend)} sum cannot be smaller than 0 or greater than {Constants.MaximumNumberOfSatoshis}.");
+            }
+
+            int spendAllCount = toSend.Count(x => x.Amount == Money.Zero);
+            if (spendAllCount > 1)
+            {
+                throw new ArgumentException($"Only one {nameof(toSend)} element can contain Money.Zero. Money.Zero means add the change to the value of this output.");
+            }
+            if (spendAllCount == 1 && !(customChange is null))
+            {
+                throw new ArgumentException($"{nameof(customChange)} and send all to destination cannot be specified at the same time.");
+            }
+            Guard.InRangeAndNotNull(nameof(feeTarget), feeTarget, 0, Constants.SevenDaysConfirmationTarget); // Allow 0 and 1, and correct later.
+            if (feeTarget < 2) // Correct 0 and 1 to 2.
+            {
+                feeTarget = 2;
+            }
+            if (subtractFeeFromAmountIndex != null) // If not null, make sure not out of range. If null fee is substracted from the change.
+            {
+                if (subtractFeeFromAmountIndex < 0)
+                {
+                    throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} cannot be smaller than 0.");
+                }
+                if (subtractFeeFromAmountIndex > toSend.Length - 1)
+                {
+                    throw new ArgumentOutOfRangeException($"{nameof(subtractFeeFromAmountIndex)} can be maximum {nameof(toSend)}.Length - 1. {nameof(subtractFeeFromAmountIndex)}: {subtractFeeFromAmountIndex}, {nameof(toSend)}.Length - 1: {toSend.Length - 1}.");
+                }
+            }
+
+            // Get allowed coins to spend.
+            List<SmartCoin> allowedSmartCoinInputs; // Inputs those can be used to build the transaction.
+            if (allowedInputs != null) // If allowedInputs are specified then select the coins from them.
+            {
+                if (!allowedInputs.Any())
+                {
+                    throw new ArgumentException($"{nameof(allowedInputs)} is not null, but empty.");
+                }
+
+                if (allowUnconfirmed)
+                {
+                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
+                }
+                else
+                {
+                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed && allowedInputs.Any(y => y.TransactionId == x.TransactionId && y.Index == x.Index)).ToList();
+                }
+            }
+            else
+            {
+                if (allowUnconfirmed)
+                {
+                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable).ToList();
+                }
+                else
+                {
+                    allowedSmartCoinInputs = Coins.Where(x => !x.Unavailable && x.Confirmed).ToList();
+                }
+            }
+
+            // 4. Get and calculate fee
+            Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
+
+            Money feePerBytes = null;
+            using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+            {
+                Money feeRate = Synchronizer.GetFeeRate(feeTarget);
+                Money sanityCheckedFeeRate = Math.Max(feeRate, 2); // Use the sanity check that under 2 satoshi per bytes should not be displayed. To correct possible rounding errors.
+                feePerBytes = new Money(sanityCheckedFeeRate);
+            }
+
+            bool spendAll = spendAllCount == 1;
+            int inNum;
+            if (spendAll)
+            {
+                inNum = allowedSmartCoinInputs.Count;
+            }
+            else
+            {
+                int expectedMinTxSize = 1 * Constants.P2wpkhInputSizeInBytes + 1 * Constants.OutputSizeInBytes + 10;
+                inNum = SelectCoinsToSpend(allowedSmartCoinInputs, toSend.Select(x => x.Amount).Sum() + feePerBytes * expectedMinTxSize).Count();
+            }
+
+            // https://bitcoincore.org/en/segwit_wallet_dev/#transaction-fee-estimation
+            // https://bitcoin.stackexchange.com/a/46379/26859
+            int outNum = spendAll ? toSend.Length : toSend.Length + 1; // number of addresses to send + 1 for change
+            int vSize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(inNum, outNum);
+            Logger.LogInfo<WalletService>($"Estimated tx size: {vSize} vbytes.");
+            Money fee = feePerBytes * vSize;
+            Logger.LogInfo<WalletService>($"Fee: {fee.Satoshi} Satoshi.");
+
+            // 5. How much to spend?
+            long toSendAmountSumInSatoshis = toSend.Select(x => x.Amount).Sum(); // Does it work if I simply go with Money class here? Is that copied by reference of value?
+            var realToSend = new (Script script, Money amount, string label)[toSend.Length];
+            for (int i = 0; i < toSend.Length; i++) // clone
+            {
+                realToSend[i] = (
+                    new Script(toSend[i].Script.ToString()),
+                    new Money(toSend[i].Amount.Satoshi),
+                    toSend[i].Label);
+            }
+            for (int i = 0; i < realToSend.Length; i++)
+            {
+                if (realToSend[i].amount == Money.Zero) // means spend all
+                {
+                    realToSend[i].amount = allowedSmartCoinInputs.Select(x => x.Amount).Sum();
+
+                    realToSend[i].amount -= new Money(toSendAmountSumInSatoshis);
+
+                    if (subtractFeeFromAmountIndex is null)
+                    {
+                        realToSend[i].amount -= fee;
+                    }
+                }
+
+                if (subtractFeeFromAmountIndex == i)
+                {
+                    realToSend[i].amount -= fee;
+                }
+
+                if (realToSend[i].amount < Money.Zero)
+                {
+                    throw new InsufficientBalanceException(fee + Money.Satoshis(1), realToSend[i].amount + fee);
+                }
+            }
+
+            var toRemoveList = new List<(Script script, Money money, string label)>(realToSend);
+            toRemoveList.RemoveAll(x => x.money == Money.Zero);
+            realToSend = toRemoveList.ToArray();
+
+            // 1. Get the possible changes.
+            Script changeScriptPubKey;
+            var sb = new StringBuilder();
+            foreach (var item in realToSend)
+            {
+                sb.Append(item.label ?? "?");
+                sb.Append(", ");
+            }
+            var changeLabel = $"{Constants.ChangeOfSpecialLabelStart}{sb.ToString().TrimEnd(',', ' ')}{Constants.ChangeOfSpecialLabelEnd}";
+
+            if (customChange is null)
+            {
+                KeyManager.AssertCleanKeysIndexed(isInternal: true);
+                KeyManager.AssertLockedInternalKeysIndexed(14);
+                var changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
+
+                changeHdPubKey.SetLabel(changeLabel, KeyManager);
+                changeScriptPubKey = changeHdPubKey.P2wpkhScript;
+            }
+            else
+            {
+                changeScriptPubKey = customChange;
+            }
+
+            // 6. Do some checks
+            Money totalOutgoingAmountNoFee = realToSend.Select(x => x.amount).Sum();
+            Money totalOutgoingAmount = totalOutgoingAmountNoFee + fee;
+            decimal feePc = (100 * fee.ToDecimal(MoneyUnit.BTC)) / totalOutgoingAmountNoFee.ToDecimal(MoneyUnit.BTC);
+
+            if (feePc > 1)
+            {
+                Logger.LogInfo<WalletService>($"The transaction fee is {feePc:0.#}% of your transaction amount."
+                    + Environment.NewLine + $"Sending:\t {totalOutgoingAmount.ToString(fplus: false, trimExcessZero: true)} BTC."
+                    + Environment.NewLine + $"Fee:\t\t {fee.Satoshi} Satoshi.");
+            }
+            if (feePc > 100)
+            {
+                throw new InvalidOperationException($"The transaction fee is more than twice as much as your transaction amount: {feePc:0.#}%.");
+            }
+
+            var confirmedAvailableAmount = allowedSmartCoinInputs.Where(x => x.Confirmed).Select(x => x.Amount).Sum();
+            var spendsUnconfirmed = false;
+            if (confirmedAvailableAmount < totalOutgoingAmount)
+            {
+                spendsUnconfirmed = true;
+                Logger.LogInfo<WalletService>("Unconfirmed transaction are being spent.");
+            }
+
+            // 7. Select coins
+            Logger.LogInfo<WalletService>("Selecting coins...");
+            IEnumerable<SmartCoin> coinsToSpend = SelectCoinsToSpend(allowedSmartCoinInputs, totalOutgoingAmount);
+
+            // 9. Build the transaction
+            Logger.LogInfo<WalletService>("Signing transaction...");
+            TransactionBuilder builder = Network.CreateTransactionBuilder();
+            // It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
+            bool sign = !KeyManager.IsWatchOnly;
+            if (sign)
+            {
+                // 8. Get signing keys
+                IEnumerable<ExtKey> signingKeys = KeyManager.GetSecrets(password, coinsToSpend.Select(x => x.ScriptPubKey).ToArray());
+
+                builder = builder
+                    .AddCoins(coinsToSpend.Select(x => x.GetCoin()))
+                    .AddKeys(signingKeys.ToArray());
+            }
+            else
+            {
+                builder = builder
+                    .AddCoins(coinsToSpend.Select(x => x.GetCoin()));
+            }
+
+            foreach ((Script scriptPubKey, Money amount, string label) output in realToSend)
+            {
+                builder = builder.Send(output.scriptPubKey, output.amount);
+            }
+
+            Transaction tx = builder
+                .SetChange(changeScriptPubKey)
+                .SendFees(fee)
+                .BuildTransaction(sign);
+
+            if (sign)
+            {
+                TransactionPolicyError[] checkResults = builder.Check(tx, fee);
+                if (checkResults.Length > 0)
+                {
+                    throw new InvalidTxException(tx, checkResults);
+                }
+            }
+
+            List<SmartCoin> spentCoins = Coins.Where(x => tx.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
+
+            var outerWalletOutputs = new List<SmartCoin>();
+            var innerWalletOutputs = new List<SmartCoin>();
+            for (var i = 0U; i < tx.Outputs.Count; i++)
+            {
+                TxOut output = tx.Outputs[i];
+                var anonset = (tx.GetAnonymitySet(i) + spentCoins.Min(x => x.AnonymitySet)) - 1; // Minus 1, because count own only once.
+                var foundKey = KeyManager.GetKeys(KeyState.Clean).FirstOrDefault(x => output.ScriptPubKey == x.P2wpkhScript);
+                var coin = new SmartCoin(tx.GetHash(), i, output.ScriptPubKey, output.Value, tx.Inputs.ToTxoRefs().ToArray(), Height.Unknown, tx.RBF, anonset, pubKey: foundKey);
+
+                if (foundKey != null)
+                {
+                    coin.Label = changeLabel;
+                    innerWalletOutputs.Add(coin);
+                }
+                else
+                {
+                    outerWalletOutputs.Add(coin);
+                }
+            }
+
+            PSBT psbt = builder.BuildPSBT(sign);
+            HashSet<SmartCoin> allTxCoins = spentCoins.Concat(innerWalletOutputs).Concat(outerWalletOutputs).ToHashSet();
+            foreach (var coin in allTxCoins)
+            {
+                if (coin.HdPubKey != null)
+                {
+                    var index = -1;
+                    var isInput = false;
+                    for (int i = 0; i < tx.Inputs.Count; i++)
+                    {
+                        var input = tx.Inputs[i];
+                        if (input.PrevOut == coin.GetOutPoint())
+                        {
+                            index = i;
+                            isInput = true;
+                            break;
+                        }
+                    }
+                    if (!isInput)
+                    {
+                        index = (int)coin.Index;
+                    }
+
+                    if (KeyManager.MasterFingerprint.HasValue)
+                    {
+                        var rootKeyPath = new RootedKeyPath(KeyManager.MasterFingerprint.Value, coin.HdPubKey.FullKeyPath);
+                        psbt.AddKeyPath(coin.HdPubKey.PubKey, rootKeyPath, coin.ScriptPubKey);
+                    }
+                }
+            }
+
+            Logger.LogInfo<WalletService>($"Transaction is successfully built: {tx.GetHash()}.");
+
+            return new BuildTransactionResult(new SmartTransaction(tx, Height.Unknown), psbt, spendsUnconfirmed, sign, fee, feePc, outerWalletOutputs, innerWalletOutputs, spentCoins);
+        }
+
+        private IEnumerable<SmartCoin> SelectCoinsToSpend(IEnumerable<SmartCoin> unspentCoins, Money totalOutAmount)
+        {
+            var coinsToSpend = new HashSet<SmartCoin>();
+            var unspentConfirmedCoins = new List<SmartCoin>();
+            var unspentUnconfirmedCoins = new List<SmartCoin>();
+            foreach (SmartCoin coin in unspentCoins)
+            {
+                if (coin.Confirmed)
+                {
+                    unspentConfirmedCoins.Add(coin);
+                }
+                else
+                {
+                    unspentUnconfirmedCoins.Add(coin);
+                }
+            }
+
+            bool haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentConfirmedCoins);
+            if (!haveEnough)
+            {
+                haveEnough = TrySelectCoins(ref coinsToSpend, totalOutAmount, unspentUnconfirmedCoins);
+            }
+
+            if (!haveEnough)
+            {
+                throw new InsufficientBalanceException(totalOutAmount, unspentConfirmedCoins.Select(x => x.Amount).Sum() + unspentUnconfirmedCoins.Select(x => x.Amount).Sum());
+            }
+
+            return coinsToSpend;
+        }
+
+        /// <returns>If the selection was successful. If there's enough coins to spend from.</returns>
+        private bool TrySelectCoins(ref HashSet<SmartCoin> coinsToSpend, Money totalOutAmount, IEnumerable<SmartCoin> unspentCoins)
+        {
+            // If there's no need for input merging, then use the largest selected.
+            // Do not prefer anonymity set. You can assume the user prefers anonymity set manually through the GUI.
+            SmartCoin largestCoin = unspentCoins.OrderByDescending(x => x.Amount).FirstOrDefault();
+            if (largestCoin == default)
+            {
+                return false; // If there's no coin then unsuccessful selection.
+            }
+            else // Check if we can do without input merging.
+            {
+                if (largestCoin.Amount >= totalOutAmount)
+                {
+                    coinsToSpend.Add(largestCoin);
+                    return true;
+                }
+            }
+
+            // If there's a need for input merging.
+            foreach (var coin in unspentCoins
+                .OrderByDescending(x => x.AnonymitySet) // Always try to spend/merge the largest anonset coins first.
+                .ThenByDescending(x => x.Amount)) // Then always try to spend by amount.
+            {
+                coinsToSpend.Add(coin);
+                // If reaches the amount, then return true, else just go with the largest coin.
+                if (coinsToSpend.Select(x => x.Amount).Sum() >= totalOutAmount)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void RenameLabel(SmartCoin coin, string newLabel)
+        {
+            newLabel = Guard.Correct(newLabel);
+            coin.Label = newLabel;
+            var key = KeyManager.GetKeys(x => x.P2wpkhScript == coin.ScriptPubKey).SingleOrDefault();
+            if (key != null)
+            {
+                key.SetLabel(newLabel, KeyManager);
+            }
+        }
+
+        private static long SendCount = 0;
+
+        public async Task SendTransactionAsync(SmartTransaction transaction)
+        {
+            try
+            {
+                Interlocked.Increment(ref SendCount);
+                // Broadcast to a random node.
+                // Wait until it arrives to at least two other nodes.
+                // If something's wrong, fall back broadcasting with backend.
+
+                if (Network == Network.RegTest)
+                {
+                    throw new InvalidOperationException("Transaction broadcasting to nodes does not work in RegTest.");
+                }
+
+                while (true)
+                {
+                    // As long as we are connected to at least 4 nodes, we can always try again.
+                    // 3 should be enough, but make it 5 so 2 nodes could disconnect the meantime.
+                    if (Nodes.ConnectedNodes.Count < 5)
+                    {
+                        throw new InvalidOperationException("We are not connected to enough nodes.");
+                    }
+
+                    Node node = Nodes.ConnectedNodes.RandomElement();
+                    if (node == default(Node))
+                    {
+                        await Task.Delay(100);
+                        continue;
+                    }
+
+                    if (!node.IsConnected)
+                    {
+                        await Task.Delay(100);
+                        continue;
+                    }
+
+                    Logger.LogInfo<WalletService>($"Trying to broadcast transaction with random node ({node.RemoteSocketAddress}):{transaction.GetHash()}");
+                    var addedToBroadcastStore = Mempool.TryAddToBroadcastStore(transaction.Transaction, node.RemoteSocketEndpoint.ToString()); // So we'll reply to INV with this transaction.
+                    if (!addedToBroadcastStore)
+                    {
+                        Logger.LogWarning<WalletService>($"Transaction {transaction.GetHash()} was already present in the broadcast store.");
+                    }
+                    var invPayload = new InvPayload(transaction.Transaction);
+                    // Give 7 seconds to send the inv payload.
+                    using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7)))
+                    {
+                        await node.SendMessageAsync(invPayload).WithCancellation(cts.Token); // ToDo: It's dangerous way to cancel. Implement proper cancellation to NBitcoin!
+                    }
+
+                    if (Mempool.TryGetFromBroadcastStore(transaction.GetHash(), out TransactionBroadcastEntry entry))
+                    {
+                        // Give 7 seconds for serving.
+                        var timeout = 0;
+                        while (!entry.IsBroadcasted())
+                        {
+                            if (timeout > 7)
+                            {
+                                throw new TimeoutException("Did not serve the transaction.");
+                            }
+                            await Task.Delay(1_000);
+                            timeout++;
+                        }
+                        node.DisconnectAsync("Thank you!");
+                        Logger.LogInfo<MempoolBehavior>($"Disconnected node: {node.RemoteSocketAddress}. Successfully broadcasted transaction: {transaction.GetHash()}.");
+
+                        // Give 21 seconds for propagation.
+                        timeout = 0;
+                        while (entry.GetPropagationConfirmations() < 2)
+                        {
+                            if (timeout > 21)
+                            {
+                                throw new TimeoutException("Did not serve the transaction.");
+                            }
+                            await Task.Delay(1_000);
+                            timeout++;
+                        }
+                        Logger.LogInfo<MempoolBehavior>($"Transaction is successfully propagated: {transaction.GetHash()}.");
+                    }
+                    else
+                    {
+                        Logger.LogWarning<WalletService>($"Expected transaction {transaction.GetHash()} was not found in the broadcast store.");
+                    }
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogInfo<WalletService>($"Random node could not broadcast transaction. Broadcasting with backend... Reason: {ex.Message}");
+                Logger.LogDebug<WalletService>(ex);
+
+                using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+                {
+                    try
+                    {
+                        await client.BroadcastAsync(transaction);
+                    }
+                    catch (HttpRequestException ex2) when (
+                        ex2.Message.Contains("bad-txns-inputs-missingorspent", StringComparison.InvariantCultureIgnoreCase)
+                        || ex2.Message.Contains("missing-inputs", StringComparison.InvariantCultureIgnoreCase)
+                        || ex2.Message.Contains("txn-mempool-conflict", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        if (transaction.Transaction.Inputs.Count == 1) // If we tried to only spend one coin, then we can mark it as spent. If there were more coins, then we do not know.
+                        {
+                            OutPoint input = transaction.Transaction.Inputs.First().PrevOut;
+                            SmartCoin coin = Coins.FirstOrDefault(x => x.TransactionId == input.Hash && x.Index == input.N);
+                            if (coin != default)
+                            {
+                                coin.SpentAccordingToBackend = true;
+                            }
+                        }
+                    }
+                }
+
+                using (await TransactionProcessingLock.LockAsync())
+                {
+                    if (await ProcessTransactionAsync(new SmartTransaction(transaction.Transaction, Height.Mempool)))
+                    {
+                        SerializeTransactionCache();
+                    }
+
+                    Mempool.TransactionHashes.TryAdd(transaction.GetHash());
+                }
+
+                Logger.LogInfo<WalletService>($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
+            }
+            finally
+            {
+                Mempool.TryRemoveFromBroadcastStore(transaction.GetHash(), out _); // Remove it just to be sure. Probably has been removed previously.
+                Interlocked.Decrement(ref SendCount);
+            }
+        }
+
+        public IEnumerable<string> GetNonSpecialLabels()
+        {
+            return Coins.Where(x => !x.Label.StartsWith("ZeroLink", StringComparison.Ordinal))
+                .SelectMany(x => x.Label.Split(new string[] { Constants.ChangeOfSpecialLabelStart, Constants.ChangeOfSpecialLabelEnd, "(", "," }, StringSplitOptions.RemoveEmptyEntries))
+                .Select(x => x.Trim())
+                .Distinct();
+        }
+
+        private int _refreshCoinHistoriesRerunRequested = 0;
+        private int _refreshCoinHistoriesRunning = 0;
+
+        public void RefreshCoinHistories()
+        {
+            // If already running, then make sure another run is requested, else do the work.
+            if (Interlocked.CompareExchange(ref _refreshCoinHistoriesRunning, 1, 0) == 1)
+            {
+                Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 1);
+                return;
+            }
+
+            try
+            {
+                var unspentCoins = Coins.Where(c => c.Unspent); //refreshing unspent coins clusters only
+                if (unspentCoins.Any())
+                {
+                    ILookup<Script, SmartCoin> lookupScriptPubKey = Coins.ToLookup(c => c.ScriptPubKey, c => c);
+                    ILookup<uint256, SmartCoin> lookupSpenderTransactionId = Coins.ToLookup(c => c.SpenderTransactionId, c => c);
+                    ILookup<uint256, SmartCoin> lookupTransactionId = Coins.ToLookup(c => c.TransactionId, c => c);
+
+                    const int simultaneousThread = 2; //threads allowed to run simultaneously in threadpool
+
+                    Parallel.ForEach(unspentCoins, new ParallelOptions { MaxDegreeOfParallelism = simultaneousThread }, coin =>
+                    {
+                        var result = string.Join(", ", GetClusters(coin, new List<SmartCoin>(), lookupScriptPubKey, lookupSpenderTransactionId, lookupTransactionId).Select(x => x.Label).Distinct());
+                        coin.SetClusters(result);
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError<WalletService>($"Refreshing coin clusters failed: {ex}");
+            }
+            finally
+            {
+                // It's not running anymore, but someone may requested another run.
+                Interlocked.Exchange(ref _refreshCoinHistoriesRunning, 0);
+
+                // Clear the rerun request, too and if it was requested, then rerun.
+                if (Interlocked.Exchange(ref _refreshCoinHistoriesRerunRequested, 0) == 1)
+                {
+                    RefreshCoinHistories();
+                }
+            }
+        }
+
+        public bool UnconfirmedTransactionsInitialized { get; private set; } = false;
+
+        private void SerializeTransactionCache()
+        {
+            if (!UnconfirmedTransactionsInitialized) // If unconfirmed ones are not yet initialized, then do not serialize because unconfirmed are going to be lost.
+            {
+                return;
+            }
+
+            IoHelpers.EnsureContainingDirectoryExists(TransactionsFilePath);
+            string jsonString = JsonConvert.SerializeObject(TransactionCache.OrderByBlockchain(), Formatting.Indented);
+            File.WriteAllText(TransactionsFilePath,
+                jsonString,
+                Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Current timeout used when downloading a block from the remote node. It is defined in seconds.
+        /// </summary>
+        private async Task NodeTimeoutsAsync(bool increaseDecrease)
+        {
+            if (increaseDecrease)
+            {
+                NodeTimeouts++;
+            }
+            else
+            {
+                NodeTimeouts--;
+            }
+
+            var timeout = RuntimeParams.Instance.NetworkNodeTimeout;
+
+            // If it times out 2 times in a row then increase the timeout.
+            if (NodeTimeouts >= 2)
+            {
+                NodeTimeouts = 0;
+                timeout *= 2;
+            }
+            else if (NodeTimeouts <= -3) // If it does not time out 3 times in a row, lower the timeout.
+            {
+                NodeTimeouts = 0;
+                timeout = (int)Math.Round(timeout * 0.7);
+            }
+
+            // Sanity check
+            if (timeout < 32)
+            {
+                timeout = 32;
+            }
+            else if (timeout > 600)
+            {
+                timeout = 600;
+            }
+
+            if (timeout == RuntimeParams.Instance.NetworkNodeTimeout)
+            {
+                return;
+            }
+
+            RuntimeParams.Instance.NetworkNodeTimeout = timeout;
+            await RuntimeParams.Instance.SaveAsync();
+
+            Logger.LogInfo<WalletService>($"Current timeout value used on block download is: {timeout} seconds.");
+        }
+
+        public async Task StopAsync()
+        {
+            while (Interlocked.Read(ref SendCount) != 0) // Make sure to wait for send to finish.
+            {
+                await Task.Delay(50);
+            }
+
+            BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
+            BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
+            Mempool.TransactionReceived -= Mempool_TransactionReceivedAsync;
+            Coins.CollectionChanged -= Coins_CollectionChanged;
+
+            DisconnectDisposeNullLocalBitcoinCoreNode();
+        }
+    }
 }

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -22,393 +22,393 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-	public class WasabiSynchronizer : INotifyPropertyChanged
-	{
-		#region MembersPropertiesEvents
+    public class WasabiSynchronizer : INotifyPropertyChanged
+    {
+        #region MembersPropertiesEvents
 
-		public SynchronizeResponse LastResponse { get; private set; }
+        public SynchronizeResponse LastResponse { get; private set; }
 
-		public WasabiClient WasabiClient { get; private set; }
+        public WasabiClient WasabiClient { get; private set; }
 
-		public Network Network { get; private set; }
+        public Network Network { get; private set; }
 
-		private decimal _usdExchangeRate;
+        private decimal _usdExchangeRate;
 
-		/// <summary>
-		/// The Bitcoin price in USD.
-		/// </summary>
-		public decimal UsdExchangeRate
-		{
-			get => _usdExchangeRate;
+        /// <summary>
+        /// The Bitcoin price in USD.
+        /// </summary>
+        public decimal UsdExchangeRate
+        {
+            get => _usdExchangeRate;
 
-			private set
-			{
-				if (_usdExchangeRate != value)
-				{
-					_usdExchangeRate = value;
-					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UsdExchangeRate)));
-				}
-			}
-		}
+            private set
+            {
+                if (_usdExchangeRate != value)
+                {
+                    _usdExchangeRate = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UsdExchangeRate)));
+                }
+            }
+        }
 
-		private AllFeeEstimate _allFeeEstimate;
+        private AllFeeEstimate _allFeeEstimate;
 
-		public AllFeeEstimate AllFeeEstimate
-		{
-			get => _allFeeEstimate;
+        public AllFeeEstimate AllFeeEstimate
+        {
+            get => _allFeeEstimate;
 
-			private set
-			{
-				if (_allFeeEstimate != value)
-				{
-					_allFeeEstimate = value;
-					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AllFeeEstimate)));
-				}
-			}
-		}
+            private set
+            {
+                if (_allFeeEstimate != value)
+                {
+                    _allFeeEstimate = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AllFeeEstimate)));
+                }
+            }
+        }
 
-		private TorStatus _torStatus;
+        private TorStatus _torStatus;
 
-		public TorStatus TorStatus
-		{
-			get => _torStatus;
+        public TorStatus TorStatus
+        {
+            get => _torStatus;
 
-			private set
-			{
-				if (_torStatus != value)
-				{
-					_torStatus = value;
-					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TorStatus)));
-				}
-			}
-		}
+            private set
+            {
+                if (_torStatus != value)
+                {
+                    _torStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TorStatus)));
+                }
+            }
+        }
 
-		private BackendStatus _backendStatus;
+        private BackendStatus _backendStatus;
 
-		public BackendStatus BackendStatus
-		{
-			get => _backendStatus;
+        public BackendStatus BackendStatus
+        {
+            get => _backendStatus;
 
-			private set
-			{
-				if (_backendStatus != value)
-				{
-					_backendStatus = value;
-					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BackendStatus)));
-				}
-			}
-		}
+            private set
+            {
+                if (_backendStatus != value)
+                {
+                    _backendStatus = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BackendStatus)));
+                }
+            }
+        }
 
-		public TimeSpan MaxRequestIntervalForMixing { get; set; }
-		private long _blockRequests; // There are priority requests in queue.
+        public TimeSpan MaxRequestIntervalForMixing { get; set; }
+        private long _blockRequests; // There are priority requests in queue.
 
-		public bool AreRequestsBlocked() => Interlocked.Read(ref _blockRequests) == 1;
+        public bool AreRequestsBlocked() => Interlocked.Read(ref _blockRequests) == 1;
 
-		public void BlockRequests() => Interlocked.Exchange(ref _blockRequests, 1);
+        public void BlockRequests() => Interlocked.Exchange(ref _blockRequests, 1);
 
-		public void EnableRequests() => Interlocked.Exchange(ref _blockRequests, 0);
+        public void EnableRequests() => Interlocked.Exchange(ref _blockRequests, 0);
 
-		public BitcoinStore BitcoinStore { get; private set; }
+        public BitcoinStore BitcoinStore { get; private set; }
 
-		public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler PropertyChanged;
 
-		public event EventHandler<bool> ResponseArrivedIsGenSocksServFail;
+        public event EventHandler<bool> ResponseArrivedIsGenSocksServFail;
 
-		public event EventHandler<SynchronizeResponse> ResponseArrived;
+        public event EventHandler<SynchronizeResponse> ResponseArrived;
 
-		/// <summary>
-		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
-		/// </summary>
-		private long _running;
+        /// <summary>
+        /// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
+        /// </summary>
+        private long _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
+        public bool IsRunning => Interlocked.Read(ref _running) == 1;
 
-		private CancellationTokenSource Cancel { get; set; }
+        private CancellationTokenSource Cancel { get; set; }
 
-		#endregion MembersPropertiesEvents
+        #endregion MembersPropertiesEvents
 
-		#region ConstructorsAndInitializers
+        #region ConstructorsAndInitializers
 
-		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, WasabiClient client)
-		{
-			CreateNew(network, bitcoinStore, client);
-		}
+        public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, WasabiClient client)
+        {
+            CreateNew(network, bitcoinStore, client);
+        }
 
-		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Func<Uri> baseUriAction, IPEndPoint torSocks5EndPoint)
-		{
-			var client = new WasabiClient(baseUriAction, torSocks5EndPoint);
-			CreateNew(network, bitcoinStore, client);
-		}
+        public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
+        {
+            var client = new WasabiClient(baseUriAction, torSocks5EndPoint);
+            CreateNew(network, bitcoinStore, client);
+        }
 
-		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Uri baseUri, IPEndPoint torSocks5EndPoint)
-		{
-			var client = new WasabiClient(baseUri, torSocks5EndPoint);
-			CreateNew(network, bitcoinStore, client);
-		}
+        public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Uri baseUri, EndPoint torSocks5EndPoint)
+        {
+            var client = new WasabiClient(baseUri, torSocks5EndPoint);
+            CreateNew(network, bitcoinStore, client);
+        }
 
-		private void CreateNew(Network network, BitcoinStore bitcoinStore, WasabiClient client)
-		{
-			Network = Guard.NotNull(nameof(network), network);
-			WasabiClient = Guard.NotNull(nameof(client), client);
-			LastResponse = null;
-			_running = 0;
-			Cancel = new CancellationTokenSource();
-			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
-		}
+        private void CreateNew(Network network, BitcoinStore bitcoinStore, WasabiClient client)
+        {
+            Network = Guard.NotNull(nameof(network), network);
+            WasabiClient = Guard.NotNull(nameof(client), client);
+            LastResponse = null;
+            _running = 0;
+            Cancel = new CancellationTokenSource();
+            BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+        }
 
-		public void Start(TimeSpan requestInterval, TimeSpan feeQueryRequestInterval, int maxFiltersToSyncAtInitialization)
-		{
-			Guard.NotNull(nameof(requestInterval), requestInterval);
-			Guard.MinimumAndNotNull(nameof(feeQueryRequestInterval), feeQueryRequestInterval, requestInterval);
-			Guard.MinimumAndNotNull(nameof(maxFiltersToSyncAtInitialization), maxFiltersToSyncAtInitialization, 0);
+        public void Start(TimeSpan requestInterval, TimeSpan feeQueryRequestInterval, int maxFiltersToSyncAtInitialization)
+        {
+            Guard.NotNull(nameof(requestInterval), requestInterval);
+            Guard.MinimumAndNotNull(nameof(feeQueryRequestInterval), feeQueryRequestInterval, requestInterval);
+            Guard.MinimumAndNotNull(nameof(maxFiltersToSyncAtInitialization), maxFiltersToSyncAtInitialization, 0);
 
-			MaxRequestIntervalForMixing = requestInterval; // Let's start with this, it'll be modified from outside.
+            MaxRequestIntervalForMixing = requestInterval; // Let's start with this, it'll be modified from outside.
 
-			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
-			{
-				return;
-			}
+            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+            {
+                return;
+            }
 
-			Task.Run(async () =>
-			{
-				try
-				{
-					DateTimeOffset lastFeeQueried = DateTimeOffset.UtcNow - feeQueryRequestInterval;
-					bool ignoreRequestInterval = false;
-					var hashChain = BitcoinStore.HashChain;
-					EnableRequests();
-					while (IsRunning)
-					{
-						try
-						{
-							while (AreRequestsBlocked())
-							{
-								await Task.Delay(3000, Cancel.Token);
-							}
+            Task.Run(async () =>
+            {
+                try
+                {
+                    DateTimeOffset lastFeeQueried = DateTimeOffset.UtcNow - feeQueryRequestInterval;
+                    bool ignoreRequestInterval = false;
+                    var hashChain = BitcoinStore.HashChain;
+                    EnableRequests();
+                    while (IsRunning)
+                    {
+                        try
+                        {
+                            while (AreRequestsBlocked())
+                            {
+                                await Task.Delay(3000, Cancel.Token);
+                            }
 
-							EstimateSmartFeeMode? estimateMode = null;
-							TimeSpan elapsed = DateTimeOffset.UtcNow - lastFeeQueried;
-							if (elapsed >= feeQueryRequestInterval)
-							{
-								estimateMode = EstimateSmartFeeMode.Conservative;
-							}
+                            EstimateSmartFeeMode? estimateMode = null;
+                            TimeSpan elapsed = DateTimeOffset.UtcNow - lastFeeQueried;
+                            if (elapsed >= feeQueryRequestInterval)
+                            {
+                                estimateMode = EstimateSmartFeeMode.Conservative;
+                            }
 
-							SynchronizeResponse response;
-							try
-							{
-								if (!IsRunning)
-								{
-									return;
-								}
+                            SynchronizeResponse response;
+                            try
+                            {
+                                if (!IsRunning)
+                                {
+                                    return;
+                                }
 
-								response = await WasabiClient.GetSynchronizeAsync(hashChain.TipHash, maxFiltersToSyncAtInitialization, estimateMode, Cancel.Token).WithAwaitCancellationAsync(Cancel.Token, 300);
-								// NOT GenSocksServErr
-								BackendStatus = BackendStatus.Connected;
-								TorStatus = TorStatus.Running;
-								DoNotGenSocksServFail();
-							}
-							catch (ConnectionException ex)
-							{
-								TorStatus = TorStatus.NotRunning;
-								BackendStatus = BackendStatus.NotConnected;
-								HandleIfGenSocksServFail(ex);
-								throw;
-							}
-							catch (TorSocks5FailureResponseException ex)
-							{
-								TorStatus = TorStatus.Running;
-								BackendStatus = BackendStatus.NotConnected;
-								HandleIfGenSocksServFail(ex);
-								throw;
-							}
-							catch (Exception ex)
-							{
-								TorStatus = TorStatus.Running;
-								BackendStatus = BackendStatus.Connected;
-								HandleIfGenSocksServFail(ex);
-								throw;
-							}
+                                response = await WasabiClient.GetSynchronizeAsync(hashChain.TipHash, maxFiltersToSyncAtInitialization, estimateMode, Cancel.Token).WithAwaitCancellationAsync(Cancel.Token, 300);
+                                // NOT GenSocksServErr
+                                BackendStatus = BackendStatus.Connected;
+                                TorStatus = TorStatus.Running;
+                                DoNotGenSocksServFail();
+                            }
+                            catch (ConnectionException ex)
+                            {
+                                TorStatus = TorStatus.NotRunning;
+                                BackendStatus = BackendStatus.NotConnected;
+                                HandleIfGenSocksServFail(ex);
+                                throw;
+                            }
+                            catch (TorSocks5FailureResponseException ex)
+                            {
+                                TorStatus = TorStatus.Running;
+                                BackendStatus = BackendStatus.NotConnected;
+                                HandleIfGenSocksServFail(ex);
+                                throw;
+                            }
+                            catch (Exception ex)
+                            {
+                                TorStatus = TorStatus.Running;
+                                BackendStatus = BackendStatus.Connected;
+                                HandleIfGenSocksServFail(ex);
+                                throw;
+                            }
 
-							if (response.AllFeeEstimate != null && response.AllFeeEstimate.Estimations.Any())
-							{
-								lastFeeQueried = DateTimeOffset.UtcNow;
-								AllFeeEstimate = response.AllFeeEstimate;
-							}
+                            if (response.AllFeeEstimate != null && response.AllFeeEstimate.Estimations.Any())
+                            {
+                                lastFeeQueried = DateTimeOffset.UtcNow;
+                                AllFeeEstimate = response.AllFeeEstimate;
+                            }
 
-							if (response.Filters.Count() == maxFiltersToSyncAtInitialization)
-							{
-								ignoreRequestInterval = true;
-							}
-							else
-							{
-								ignoreRequestInterval = false;
-							}
+                            if (response.Filters.Count() == maxFiltersToSyncAtInitialization)
+                            {
+                                ignoreRequestInterval = true;
+                            }
+                            else
+                            {
+                                ignoreRequestInterval = false;
+                            }
 
-							hashChain.UpdateServerTipHeight(response.BestHeight);
-							ExchangeRate exchangeRate = response.ExchangeRates.FirstOrDefault();
-							if (exchangeRate != default && exchangeRate.Rate != 0)
-							{
-								UsdExchangeRate = exchangeRate.Rate;
-							}
+                            hashChain.UpdateServerTipHeight(response.BestHeight);
+                            ExchangeRate exchangeRate = response.ExchangeRates.FirstOrDefault();
+                            if (exchangeRate != default && exchangeRate.Rate != 0)
+                            {
+                                UsdExchangeRate = exchangeRate.Rate;
+                            }
 
-							if (response.FiltersResponseState == FiltersResponseState.NewFilters)
-							{
-								var filters = response.Filters;
+                            if (response.FiltersResponseState == FiltersResponseState.NewFilters)
+                            {
+                                var filters = response.Filters;
 
-								var firstFilter = filters.First();
-								if (hashChain.TipHeight + 1 != firstFilter.BlockHeight)
-								{
-									// We have a problem.
-									// We have wrong filters, the heights are not in sync with the server's.
-									Logger.LogError<WasabiSynchronizer>($"Inconsistent index state detected.{Environment.NewLine}" +
-										$"{nameof(hashChain)}.{nameof(hashChain.TipHeight)}:{hashChain.TipHeight}{Environment.NewLine}" +
-										$"{nameof(hashChain)}.{nameof(hashChain.HashesLeft)}:{hashChain.HashesLeft}{Environment.NewLine}" +
-										$"{nameof(hashChain)}.{nameof(hashChain.TipHash)}:{hashChain.TipHash}{Environment.NewLine}" +
-										$"{nameof(hashChain)}.{nameof(hashChain.HashCount)}:{hashChain.HashCount}{Environment.NewLine}" +
-										$"{nameof(hashChain)}.{nameof(hashChain.ServerTipHeight)}:{hashChain.ServerTipHeight}{Environment.NewLine}" +
-										$"{nameof(firstFilter)}.{nameof(firstFilter.BlockHash)}:{firstFilter.BlockHash}{Environment.NewLine}" +
-										$"{nameof(firstFilter)}.{nameof(firstFilter.BlockHeight)}:{firstFilter.BlockHeight}");
+                                var firstFilter = filters.First();
+                                if (hashChain.TipHeight + 1 != firstFilter.BlockHeight)
+                                {
+                                    // We have a problem.
+                                    // We have wrong filters, the heights are not in sync with the server's.
+                                    Logger.LogError<WasabiSynchronizer>($"Inconsistent index state detected.{Environment.NewLine}" +
+                                        $"{nameof(hashChain)}.{nameof(hashChain.TipHeight)}:{hashChain.TipHeight}{Environment.NewLine}" +
+                                        $"{nameof(hashChain)}.{nameof(hashChain.HashesLeft)}:{hashChain.HashesLeft}{Environment.NewLine}" +
+                                        $"{nameof(hashChain)}.{nameof(hashChain.TipHash)}:{hashChain.TipHash}{Environment.NewLine}" +
+                                        $"{nameof(hashChain)}.{nameof(hashChain.HashCount)}:{hashChain.HashCount}{Environment.NewLine}" +
+                                        $"{nameof(hashChain)}.{nameof(hashChain.ServerTipHeight)}:{hashChain.ServerTipHeight}{Environment.NewLine}" +
+                                        $"{nameof(firstFilter)}.{nameof(firstFilter.BlockHash)}:{firstFilter.BlockHash}{Environment.NewLine}" +
+                                        $"{nameof(firstFilter)}.{nameof(firstFilter.BlockHeight)}:{firstFilter.BlockHeight}");
 
-									await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
-								}
-								else
-								{
-									await BitcoinStore.IndexStore.AddNewFiltersAsync(filters, Cancel.Token);
+                                    await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
+                                }
+                                else
+                                {
+                                    await BitcoinStore.IndexStore.AddNewFiltersAsync(filters, Cancel.Token);
 
-									if (filters.Count() == 1)
-									{
-										Logger.LogInfo<WasabiSynchronizer>($"Downloaded filter for block {firstFilter.BlockHeight}.");
-									}
-									else
-									{
-										Logger.LogInfo<WasabiSynchronizer>($"Downloaded filters for blocks from {firstFilter.BlockHeight} to {filters.Last().BlockHeight}.");
-									}
-								}
-							}
-							else if (response.FiltersResponseState == FiltersResponseState.BestKnownHashNotFound)
-							{
-								// Reorg happened
-								// 1. Rollback index
-								FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token);
-								Logger.LogInfo<WasabiSynchronizer>($"REORG Invalid Block: {reorgedFilter.BlockHash}");
+                                    if (filters.Count() == 1)
+                                    {
+                                        Logger.LogInfo<WasabiSynchronizer>($"Downloaded filter for block {firstFilter.BlockHeight}.");
+                                    }
+                                    else
+                                    {
+                                        Logger.LogInfo<WasabiSynchronizer>($"Downloaded filters for blocks from {firstFilter.BlockHeight} to {filters.Last().BlockHeight}.");
+                                    }
+                                }
+                            }
+                            else if (response.FiltersResponseState == FiltersResponseState.BestKnownHashNotFound)
+                            {
+                                // Reorg happened
+                                // 1. Rollback index
+                                FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token);
+                                Logger.LogInfo<WasabiSynchronizer>($"REORG Invalid Block: {reorgedFilter.BlockHash}");
 
-								ignoreRequestInterval = true;
-							}
-							else if (response.FiltersResponseState == FiltersResponseState.NoNewFilter)
-							{
-								// We are synced.
-								// Assert index state.
-								if (response.BestHeight > hashChain.TipHeight) // If the server's tip height is larger than ours, we're missing a filter, our index got corrupted.
-								{
-									await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
-									// If still bad delete filters and crash the software?
-								}
-							}
+                                ignoreRequestInterval = true;
+                            }
+                            else if (response.FiltersResponseState == FiltersResponseState.NoNewFilter)
+                            {
+                                // We are synced.
+                                // Assert index state.
+                                if (response.BestHeight > hashChain.TipHeight) // If the server's tip height is larger than ours, we're missing a filter, our index got corrupted.
+                                {
+                                    await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
+                                    // If still bad delete filters and crash the software?
+                                }
+                            }
 
-							LastResponse = response;
-							ResponseArrived?.Invoke(this, response);
-						}
-						catch (ConnectionException ex)
-						{
-							Logger.LogError<CcjClient>(ex);
-							try
-							{
-								await Task.Delay(3000, Cancel.Token); // Give other threads time to do stuff.
-							}
-							catch (TaskCanceledException ex2)
-							{
-								Logger.LogTrace<CcjClient>(ex2);
-							}
-						}
-						catch (Exception ex) when (ex is OperationCanceledException
-												|| ex is TaskCanceledException
-												|| ex is TimeoutException)
-						{
-							Logger.LogTrace<WasabiSynchronizer>(ex);
-						}
-						catch (Exception ex)
-						{
-							Logger.LogError<WasabiSynchronizer>(ex);
-						}
-						finally
-						{
-							if (IsRunning && !ignoreRequestInterval)
-							{
-								try
-								{
-									int delay = (int)Math.Min(requestInterval.TotalMilliseconds, MaxRequestIntervalForMixing.TotalMilliseconds);
-									await Task.Delay(delay, Cancel.Token); // Ask for new index in every requestInterval.
-								}
-								catch (TaskCanceledException ex)
-								{
-									Logger.LogTrace<CcjClient>(ex);
-								}
-							}
-						}
-					}
-				}
-				finally
-				{
-					Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
-				}
-			});
-		}
+                            LastResponse = response;
+                            ResponseArrived?.Invoke(this, response);
+                        }
+                        catch (ConnectionException ex)
+                        {
+                            Logger.LogError<CcjClient>(ex);
+                            try
+                            {
+                                await Task.Delay(3000, Cancel.Token); // Give other threads time to do stuff.
+                            }
+                            catch (TaskCanceledException ex2)
+                            {
+                                Logger.LogTrace<CcjClient>(ex2);
+                            }
+                        }
+                        catch (Exception ex) when (ex is OperationCanceledException
+                                                || ex is TaskCanceledException
+                                                || ex is TimeoutException)
+                        {
+                            Logger.LogTrace<WasabiSynchronizer>(ex);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogError<WasabiSynchronizer>(ex);
+                        }
+                        finally
+                        {
+                            if (IsRunning && !ignoreRequestInterval)
+                            {
+                                try
+                                {
+                                    int delay = (int)Math.Min(requestInterval.TotalMilliseconds, MaxRequestIntervalForMixing.TotalMilliseconds);
+                                    await Task.Delay(delay, Cancel.Token); // Ask for new index in every requestInterval.
+                                }
+                                catch (TaskCanceledException ex)
+                                {
+                                    Logger.LogTrace<CcjClient>(ex);
+                                }
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
+                }
+            });
+        }
 
-		#endregion ConstructorsAndInitializers
+        #endregion ConstructorsAndInitializers
 
-		#region Methods
+        #region Methods
 
-		private void HandleIfGenSocksServFail(Exception ex)
-		{
-			// IS GenSocksServFail?
-			if (ex.ToString().Contains("GeneralSocksServerFailure", StringComparison.OrdinalIgnoreCase))
-			{
-				// IS GenSocksServFail
-				DoGenSocksServFail();
-			}
-			else
-			{
-				// NOT GenSocksServFail
-				DoNotGenSocksServFail();
-			}
-		}
+        private void HandleIfGenSocksServFail(Exception ex)
+        {
+            // IS GenSocksServFail?
+            if (ex.ToString().Contains("GeneralSocksServerFailure", StringComparison.OrdinalIgnoreCase))
+            {
+                // IS GenSocksServFail
+                DoGenSocksServFail();
+            }
+            else
+            {
+                // NOT GenSocksServFail
+                DoNotGenSocksServFail();
+            }
+        }
 
-		private void DoGenSocksServFail()
-		{
-			ResponseArrivedIsGenSocksServFail?.Invoke(this, true);
-		}
+        private void DoGenSocksServFail()
+        {
+            ResponseArrivedIsGenSocksServFail?.Invoke(this, true);
+        }
 
-		private void DoNotGenSocksServFail()
-		{
-			ResponseArrivedIsGenSocksServFail?.Invoke(this, false);
-		}
+        private void DoNotGenSocksServFail()
+        {
+            ResponseArrivedIsGenSocksServFail?.Invoke(this, false);
+        }
 
-		public Money GetFeeRate(int feeTarget)
-		{
-			if (AllFeeEstimate is null)
-			{
-				throw new InvalidOperationException("Cannot get fee estimations.");
-			}
-			return AllFeeEstimate.GetFeeRate(feeTarget);
-		}
+        public Money GetFeeRate(int feeTarget)
+        {
+            if (AllFeeEstimate is null)
+            {
+                throw new InvalidOperationException("Cannot get fee estimations.");
+            }
+            return AllFeeEstimate.GetFeeRate(feeTarget);
+        }
 
-		#endregion Methods
+        #endregion Methods
 
-		public async Task StopAsync()
-		{
-			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
-			Cancel?.Cancel();
-			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
-			{
-				await Task.Delay(50);
-			}
+        public async Task StopAsync()
+        {
+            Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+            Cancel?.Cancel();
+            while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+            {
+                await Task.Delay(50);
+            }
 
-			Cancel?.Dispose();
-			Cancel = null;
-			WasabiClient?.Dispose();
-			WasabiClient = null;
+            Cancel?.Dispose();
+            Cancel = null;
+            WasabiClient?.Dispose();
+            WasabiClient = null;
 
-			EnableRequests(); // Enable requests (it's possible something is being blocked outside the class by AreRequestsBlocked.
-		}
-	}
+            EnableRequests(); // Enable requests (it's possible something is being blocked outside the class by AreRequestsBlocked.
+        }
+    }
 }

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -22,393 +22,393 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-    public class WasabiSynchronizer : INotifyPropertyChanged
-    {
-        #region MembersPropertiesEvents
+	public class WasabiSynchronizer : INotifyPropertyChanged
+	{
+		#region MembersPropertiesEvents
 
-        public SynchronizeResponse LastResponse { get; private set; }
+		public SynchronizeResponse LastResponse { get; private set; }
 
-        public WasabiClient WasabiClient { get; private set; }
+		public WasabiClient WasabiClient { get; private set; }
 
-        public Network Network { get; private set; }
+		public Network Network { get; private set; }
 
-        private decimal _usdExchangeRate;
+		private decimal _usdExchangeRate;
 
-        /// <summary>
-        /// The Bitcoin price in USD.
-        /// </summary>
-        public decimal UsdExchangeRate
-        {
-            get => _usdExchangeRate;
+		/// <summary>
+		/// The Bitcoin price in USD.
+		/// </summary>
+		public decimal UsdExchangeRate
+		{
+			get => _usdExchangeRate;
 
-            private set
-            {
-                if (_usdExchangeRate != value)
-                {
-                    _usdExchangeRate = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UsdExchangeRate)));
-                }
-            }
-        }
+			private set
+			{
+				if (_usdExchangeRate != value)
+				{
+					_usdExchangeRate = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(UsdExchangeRate)));
+				}
+			}
+		}
 
-        private AllFeeEstimate _allFeeEstimate;
+		private AllFeeEstimate _allFeeEstimate;
 
-        public AllFeeEstimate AllFeeEstimate
-        {
-            get => _allFeeEstimate;
+		public AllFeeEstimate AllFeeEstimate
+		{
+			get => _allFeeEstimate;
 
-            private set
-            {
-                if (_allFeeEstimate != value)
-                {
-                    _allFeeEstimate = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AllFeeEstimate)));
-                }
-            }
-        }
+			private set
+			{
+				if (_allFeeEstimate != value)
+				{
+					_allFeeEstimate = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AllFeeEstimate)));
+				}
+			}
+		}
 
-        private TorStatus _torStatus;
+		private TorStatus _torStatus;
 
-        public TorStatus TorStatus
-        {
-            get => _torStatus;
+		public TorStatus TorStatus
+		{
+			get => _torStatus;
 
-            private set
-            {
-                if (_torStatus != value)
-                {
-                    _torStatus = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TorStatus)));
-                }
-            }
-        }
+			private set
+			{
+				if (_torStatus != value)
+				{
+					_torStatus = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TorStatus)));
+				}
+			}
+		}
 
-        private BackendStatus _backendStatus;
+		private BackendStatus _backendStatus;
 
-        public BackendStatus BackendStatus
-        {
-            get => _backendStatus;
+		public BackendStatus BackendStatus
+		{
+			get => _backendStatus;
 
-            private set
-            {
-                if (_backendStatus != value)
-                {
-                    _backendStatus = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BackendStatus)));
-                }
-            }
-        }
+			private set
+			{
+				if (_backendStatus != value)
+				{
+					_backendStatus = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BackendStatus)));
+				}
+			}
+		}
 
-        public TimeSpan MaxRequestIntervalForMixing { get; set; }
-        private long _blockRequests; // There are priority requests in queue.
+		public TimeSpan MaxRequestIntervalForMixing { get; set; }
+		private long _blockRequests; // There are priority requests in queue.
 
-        public bool AreRequestsBlocked() => Interlocked.Read(ref _blockRequests) == 1;
+		public bool AreRequestsBlocked() => Interlocked.Read(ref _blockRequests) == 1;
 
-        public void BlockRequests() => Interlocked.Exchange(ref _blockRequests, 1);
+		public void BlockRequests() => Interlocked.Exchange(ref _blockRequests, 1);
 
-        public void EnableRequests() => Interlocked.Exchange(ref _blockRequests, 0);
+		public void EnableRequests() => Interlocked.Exchange(ref _blockRequests, 0);
 
-        public BitcoinStore BitcoinStore { get; private set; }
+		public BitcoinStore BitcoinStore { get; private set; }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler PropertyChanged;
 
-        public event EventHandler<bool> ResponseArrivedIsGenSocksServFail;
+		public event EventHandler<bool> ResponseArrivedIsGenSocksServFail;
 
-        public event EventHandler<SynchronizeResponse> ResponseArrived;
+		public event EventHandler<SynchronizeResponse> ResponseArrived;
 
-        /// <summary>
-        /// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
-        /// </summary>
-        private long _running;
+		/// <summary>
+		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
+		/// </summary>
+		private long _running;
 
-        public bool IsRunning => Interlocked.Read(ref _running) == 1;
+		public bool IsRunning => Interlocked.Read(ref _running) == 1;
 
-        private CancellationTokenSource Cancel { get; set; }
+		private CancellationTokenSource Cancel { get; set; }
 
-        #endregion MembersPropertiesEvents
+		#endregion MembersPropertiesEvents
 
-        #region ConstructorsAndInitializers
+		#region ConstructorsAndInitializers
 
-        public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, WasabiClient client)
-        {
-            CreateNew(network, bitcoinStore, client);
-        }
+		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, WasabiClient client)
+		{
+			CreateNew(network, bitcoinStore, client);
+		}
 
-        public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
-        {
-            var client = new WasabiClient(baseUriAction, torSocks5EndPoint);
-            CreateNew(network, bitcoinStore, client);
-        }
+		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
+		{
+			var client = new WasabiClient(baseUriAction, torSocks5EndPoint);
+			CreateNew(network, bitcoinStore, client);
+		}
 
-        public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Uri baseUri, EndPoint torSocks5EndPoint)
-        {
-            var client = new WasabiClient(baseUri, torSocks5EndPoint);
-            CreateNew(network, bitcoinStore, client);
-        }
+		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Uri baseUri, EndPoint torSocks5EndPoint)
+		{
+			var client = new WasabiClient(baseUri, torSocks5EndPoint);
+			CreateNew(network, bitcoinStore, client);
+		}
 
-        private void CreateNew(Network network, BitcoinStore bitcoinStore, WasabiClient client)
-        {
-            Network = Guard.NotNull(nameof(network), network);
-            WasabiClient = Guard.NotNull(nameof(client), client);
-            LastResponse = null;
-            _running = 0;
-            Cancel = new CancellationTokenSource();
-            BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
-        }
+		private void CreateNew(Network network, BitcoinStore bitcoinStore, WasabiClient client)
+		{
+			Network = Guard.NotNull(nameof(network), network);
+			WasabiClient = Guard.NotNull(nameof(client), client);
+			LastResponse = null;
+			_running = 0;
+			Cancel = new CancellationTokenSource();
+			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+		}
 
-        public void Start(TimeSpan requestInterval, TimeSpan feeQueryRequestInterval, int maxFiltersToSyncAtInitialization)
-        {
-            Guard.NotNull(nameof(requestInterval), requestInterval);
-            Guard.MinimumAndNotNull(nameof(feeQueryRequestInterval), feeQueryRequestInterval, requestInterval);
-            Guard.MinimumAndNotNull(nameof(maxFiltersToSyncAtInitialization), maxFiltersToSyncAtInitialization, 0);
+		public void Start(TimeSpan requestInterval, TimeSpan feeQueryRequestInterval, int maxFiltersToSyncAtInitialization)
+		{
+			Guard.NotNull(nameof(requestInterval), requestInterval);
+			Guard.MinimumAndNotNull(nameof(feeQueryRequestInterval), feeQueryRequestInterval, requestInterval);
+			Guard.MinimumAndNotNull(nameof(maxFiltersToSyncAtInitialization), maxFiltersToSyncAtInitialization, 0);
 
-            MaxRequestIntervalForMixing = requestInterval; // Let's start with this, it'll be modified from outside.
+			MaxRequestIntervalForMixing = requestInterval; // Let's start with this, it'll be modified from outside.
 
-            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
-            {
-                return;
-            }
+			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+			{
+				return;
+			}
 
-            Task.Run(async () =>
-            {
-                try
-                {
-                    DateTimeOffset lastFeeQueried = DateTimeOffset.UtcNow - feeQueryRequestInterval;
-                    bool ignoreRequestInterval = false;
-                    var hashChain = BitcoinStore.HashChain;
-                    EnableRequests();
-                    while (IsRunning)
-                    {
-                        try
-                        {
-                            while (AreRequestsBlocked())
-                            {
-                                await Task.Delay(3000, Cancel.Token);
-                            }
+			Task.Run(async () =>
+			{
+				try
+				{
+					DateTimeOffset lastFeeQueried = DateTimeOffset.UtcNow - feeQueryRequestInterval;
+					bool ignoreRequestInterval = false;
+					var hashChain = BitcoinStore.HashChain;
+					EnableRequests();
+					while (IsRunning)
+					{
+						try
+						{
+							while (AreRequestsBlocked())
+							{
+								await Task.Delay(3000, Cancel.Token);
+							}
 
-                            EstimateSmartFeeMode? estimateMode = null;
-                            TimeSpan elapsed = DateTimeOffset.UtcNow - lastFeeQueried;
-                            if (elapsed >= feeQueryRequestInterval)
-                            {
-                                estimateMode = EstimateSmartFeeMode.Conservative;
-                            }
+							EstimateSmartFeeMode? estimateMode = null;
+							TimeSpan elapsed = DateTimeOffset.UtcNow - lastFeeQueried;
+							if (elapsed >= feeQueryRequestInterval)
+							{
+								estimateMode = EstimateSmartFeeMode.Conservative;
+							}
 
-                            SynchronizeResponse response;
-                            try
-                            {
-                                if (!IsRunning)
-                                {
-                                    return;
-                                }
+							SynchronizeResponse response;
+							try
+							{
+								if (!IsRunning)
+								{
+									return;
+								}
 
-                                response = await WasabiClient.GetSynchronizeAsync(hashChain.TipHash, maxFiltersToSyncAtInitialization, estimateMode, Cancel.Token).WithAwaitCancellationAsync(Cancel.Token, 300);
-                                // NOT GenSocksServErr
-                                BackendStatus = BackendStatus.Connected;
-                                TorStatus = TorStatus.Running;
-                                DoNotGenSocksServFail();
-                            }
-                            catch (ConnectionException ex)
-                            {
-                                TorStatus = TorStatus.NotRunning;
-                                BackendStatus = BackendStatus.NotConnected;
-                                HandleIfGenSocksServFail(ex);
-                                throw;
-                            }
-                            catch (TorSocks5FailureResponseException ex)
-                            {
-                                TorStatus = TorStatus.Running;
-                                BackendStatus = BackendStatus.NotConnected;
-                                HandleIfGenSocksServFail(ex);
-                                throw;
-                            }
-                            catch (Exception ex)
-                            {
-                                TorStatus = TorStatus.Running;
-                                BackendStatus = BackendStatus.Connected;
-                                HandleIfGenSocksServFail(ex);
-                                throw;
-                            }
+								response = await WasabiClient.GetSynchronizeAsync(hashChain.TipHash, maxFiltersToSyncAtInitialization, estimateMode, Cancel.Token).WithAwaitCancellationAsync(Cancel.Token, 300);
+								// NOT GenSocksServErr
+								BackendStatus = BackendStatus.Connected;
+								TorStatus = TorStatus.Running;
+								DoNotGenSocksServFail();
+							}
+							catch (ConnectionException ex)
+							{
+								TorStatus = TorStatus.NotRunning;
+								BackendStatus = BackendStatus.NotConnected;
+								HandleIfGenSocksServFail(ex);
+								throw;
+							}
+							catch (TorSocks5FailureResponseException ex)
+							{
+								TorStatus = TorStatus.Running;
+								BackendStatus = BackendStatus.NotConnected;
+								HandleIfGenSocksServFail(ex);
+								throw;
+							}
+							catch (Exception ex)
+							{
+								TorStatus = TorStatus.Running;
+								BackendStatus = BackendStatus.Connected;
+								HandleIfGenSocksServFail(ex);
+								throw;
+							}
 
-                            if (response.AllFeeEstimate != null && response.AllFeeEstimate.Estimations.Any())
-                            {
-                                lastFeeQueried = DateTimeOffset.UtcNow;
-                                AllFeeEstimate = response.AllFeeEstimate;
-                            }
+							if (response.AllFeeEstimate != null && response.AllFeeEstimate.Estimations.Any())
+							{
+								lastFeeQueried = DateTimeOffset.UtcNow;
+								AllFeeEstimate = response.AllFeeEstimate;
+							}
 
-                            if (response.Filters.Count() == maxFiltersToSyncAtInitialization)
-                            {
-                                ignoreRequestInterval = true;
-                            }
-                            else
-                            {
-                                ignoreRequestInterval = false;
-                            }
+							if (response.Filters.Count() == maxFiltersToSyncAtInitialization)
+							{
+								ignoreRequestInterval = true;
+							}
+							else
+							{
+								ignoreRequestInterval = false;
+							}
 
-                            hashChain.UpdateServerTipHeight(response.BestHeight);
-                            ExchangeRate exchangeRate = response.ExchangeRates.FirstOrDefault();
-                            if (exchangeRate != default && exchangeRate.Rate != 0)
-                            {
-                                UsdExchangeRate = exchangeRate.Rate;
-                            }
+							hashChain.UpdateServerTipHeight(response.BestHeight);
+							ExchangeRate exchangeRate = response.ExchangeRates.FirstOrDefault();
+							if (exchangeRate != default && exchangeRate.Rate != 0)
+							{
+								UsdExchangeRate = exchangeRate.Rate;
+							}
 
-                            if (response.FiltersResponseState == FiltersResponseState.NewFilters)
-                            {
-                                var filters = response.Filters;
+							if (response.FiltersResponseState == FiltersResponseState.NewFilters)
+							{
+								var filters = response.Filters;
 
-                                var firstFilter = filters.First();
-                                if (hashChain.TipHeight + 1 != firstFilter.BlockHeight)
-                                {
-                                    // We have a problem.
-                                    // We have wrong filters, the heights are not in sync with the server's.
-                                    Logger.LogError<WasabiSynchronizer>($"Inconsistent index state detected.{Environment.NewLine}" +
-                                        $"{nameof(hashChain)}.{nameof(hashChain.TipHeight)}:{hashChain.TipHeight}{Environment.NewLine}" +
-                                        $"{nameof(hashChain)}.{nameof(hashChain.HashesLeft)}:{hashChain.HashesLeft}{Environment.NewLine}" +
-                                        $"{nameof(hashChain)}.{nameof(hashChain.TipHash)}:{hashChain.TipHash}{Environment.NewLine}" +
-                                        $"{nameof(hashChain)}.{nameof(hashChain.HashCount)}:{hashChain.HashCount}{Environment.NewLine}" +
-                                        $"{nameof(hashChain)}.{nameof(hashChain.ServerTipHeight)}:{hashChain.ServerTipHeight}{Environment.NewLine}" +
-                                        $"{nameof(firstFilter)}.{nameof(firstFilter.BlockHash)}:{firstFilter.BlockHash}{Environment.NewLine}" +
-                                        $"{nameof(firstFilter)}.{nameof(firstFilter.BlockHeight)}:{firstFilter.BlockHeight}");
+								var firstFilter = filters.First();
+								if (hashChain.TipHeight + 1 != firstFilter.BlockHeight)
+								{
+									// We have a problem.
+									// We have wrong filters, the heights are not in sync with the server's.
+									Logger.LogError<WasabiSynchronizer>($"Inconsistent index state detected.{Environment.NewLine}" +
+										$"{nameof(hashChain)}.{nameof(hashChain.TipHeight)}:{hashChain.TipHeight}{Environment.NewLine}" +
+										$"{nameof(hashChain)}.{nameof(hashChain.HashesLeft)}:{hashChain.HashesLeft}{Environment.NewLine}" +
+										$"{nameof(hashChain)}.{nameof(hashChain.TipHash)}:{hashChain.TipHash}{Environment.NewLine}" +
+										$"{nameof(hashChain)}.{nameof(hashChain.HashCount)}:{hashChain.HashCount}{Environment.NewLine}" +
+										$"{nameof(hashChain)}.{nameof(hashChain.ServerTipHeight)}:{hashChain.ServerTipHeight}{Environment.NewLine}" +
+										$"{nameof(firstFilter)}.{nameof(firstFilter.BlockHash)}:{firstFilter.BlockHash}{Environment.NewLine}" +
+										$"{nameof(firstFilter)}.{nameof(firstFilter.BlockHeight)}:{firstFilter.BlockHeight}");
 
-                                    await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
-                                }
-                                else
-                                {
-                                    await BitcoinStore.IndexStore.AddNewFiltersAsync(filters, Cancel.Token);
+									await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
+								}
+								else
+								{
+									await BitcoinStore.IndexStore.AddNewFiltersAsync(filters, Cancel.Token);
 
-                                    if (filters.Count() == 1)
-                                    {
-                                        Logger.LogInfo<WasabiSynchronizer>($"Downloaded filter for block {firstFilter.BlockHeight}.");
-                                    }
-                                    else
-                                    {
-                                        Logger.LogInfo<WasabiSynchronizer>($"Downloaded filters for blocks from {firstFilter.BlockHeight} to {filters.Last().BlockHeight}.");
-                                    }
-                                }
-                            }
-                            else if (response.FiltersResponseState == FiltersResponseState.BestKnownHashNotFound)
-                            {
-                                // Reorg happened
-                                // 1. Rollback index
-                                FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token);
-                                Logger.LogInfo<WasabiSynchronizer>($"REORG Invalid Block: {reorgedFilter.BlockHash}");
+									if (filters.Count() == 1)
+									{
+										Logger.LogInfo<WasabiSynchronizer>($"Downloaded filter for block {firstFilter.BlockHeight}.");
+									}
+									else
+									{
+										Logger.LogInfo<WasabiSynchronizer>($"Downloaded filters for blocks from {firstFilter.BlockHeight} to {filters.Last().BlockHeight}.");
+									}
+								}
+							}
+							else if (response.FiltersResponseState == FiltersResponseState.BestKnownHashNotFound)
+							{
+								// Reorg happened
+								// 1. Rollback index
+								FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token);
+								Logger.LogInfo<WasabiSynchronizer>($"REORG Invalid Block: {reorgedFilter.BlockHash}");
 
-                                ignoreRequestInterval = true;
-                            }
-                            else if (response.FiltersResponseState == FiltersResponseState.NoNewFilter)
-                            {
-                                // We are synced.
-                                // Assert index state.
-                                if (response.BestHeight > hashChain.TipHeight) // If the server's tip height is larger than ours, we're missing a filter, our index got corrupted.
-                                {
-                                    await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
-                                    // If still bad delete filters and crash the software?
-                                }
-                            }
+								ignoreRequestInterval = true;
+							}
+							else if (response.FiltersResponseState == FiltersResponseState.NoNewFilter)
+							{
+								// We are synced.
+								// Assert index state.
+								if (response.BestHeight > hashChain.TipHeight) // If the server's tip height is larger than ours, we're missing a filter, our index got corrupted.
+								{
+									await BitcoinStore.IndexStore.RemoveAllImmmatureFiltersAsync(Cancel.Token, deleteAndCrashIfMature: true);
+									// If still bad delete filters and crash the software?
+								}
+							}
 
-                            LastResponse = response;
-                            ResponseArrived?.Invoke(this, response);
-                        }
-                        catch (ConnectionException ex)
-                        {
-                            Logger.LogError<CcjClient>(ex);
-                            try
-                            {
-                                await Task.Delay(3000, Cancel.Token); // Give other threads time to do stuff.
-                            }
-                            catch (TaskCanceledException ex2)
-                            {
-                                Logger.LogTrace<CcjClient>(ex2);
-                            }
-                        }
-                        catch (Exception ex) when (ex is OperationCanceledException
-                                                || ex is TaskCanceledException
-                                                || ex is TimeoutException)
-                        {
-                            Logger.LogTrace<WasabiSynchronizer>(ex);
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogError<WasabiSynchronizer>(ex);
-                        }
-                        finally
-                        {
-                            if (IsRunning && !ignoreRequestInterval)
-                            {
-                                try
-                                {
-                                    int delay = (int)Math.Min(requestInterval.TotalMilliseconds, MaxRequestIntervalForMixing.TotalMilliseconds);
-                                    await Task.Delay(delay, Cancel.Token); // Ask for new index in every requestInterval.
-                                }
-                                catch (TaskCanceledException ex)
-                                {
-                                    Logger.LogTrace<CcjClient>(ex);
-                                }
-                            }
-                        }
-                    }
-                }
-                finally
-                {
-                    Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
-                }
-            });
-        }
+							LastResponse = response;
+							ResponseArrived?.Invoke(this, response);
+						}
+						catch (ConnectionException ex)
+						{
+							Logger.LogError<CcjClient>(ex);
+							try
+							{
+								await Task.Delay(3000, Cancel.Token); // Give other threads time to do stuff.
+							}
+							catch (TaskCanceledException ex2)
+							{
+								Logger.LogTrace<CcjClient>(ex2);
+							}
+						}
+						catch (Exception ex) when (ex is OperationCanceledException
+												|| ex is TaskCanceledException
+												|| ex is TimeoutException)
+						{
+							Logger.LogTrace<WasabiSynchronizer>(ex);
+						}
+						catch (Exception ex)
+						{
+							Logger.LogError<WasabiSynchronizer>(ex);
+						}
+						finally
+						{
+							if (IsRunning && !ignoreRequestInterval)
+							{
+								try
+								{
+									int delay = (int)Math.Min(requestInterval.TotalMilliseconds, MaxRequestIntervalForMixing.TotalMilliseconds);
+									await Task.Delay(delay, Cancel.Token); // Ask for new index in every requestInterval.
+								}
+								catch (TaskCanceledException ex)
+								{
+									Logger.LogTrace<CcjClient>(ex);
+								}
+							}
+						}
+					}
+				}
+				finally
+				{
+					Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
+				}
+			});
+		}
 
-        #endregion ConstructorsAndInitializers
+		#endregion ConstructorsAndInitializers
 
-        #region Methods
+		#region Methods
 
-        private void HandleIfGenSocksServFail(Exception ex)
-        {
-            // IS GenSocksServFail?
-            if (ex.ToString().Contains("GeneralSocksServerFailure", StringComparison.OrdinalIgnoreCase))
-            {
-                // IS GenSocksServFail
-                DoGenSocksServFail();
-            }
-            else
-            {
-                // NOT GenSocksServFail
-                DoNotGenSocksServFail();
-            }
-        }
+		private void HandleIfGenSocksServFail(Exception ex)
+		{
+			// IS GenSocksServFail?
+			if (ex.ToString().Contains("GeneralSocksServerFailure", StringComparison.OrdinalIgnoreCase))
+			{
+				// IS GenSocksServFail
+				DoGenSocksServFail();
+			}
+			else
+			{
+				// NOT GenSocksServFail
+				DoNotGenSocksServFail();
+			}
+		}
 
-        private void DoGenSocksServFail()
-        {
-            ResponseArrivedIsGenSocksServFail?.Invoke(this, true);
-        }
+		private void DoGenSocksServFail()
+		{
+			ResponseArrivedIsGenSocksServFail?.Invoke(this, true);
+		}
 
-        private void DoNotGenSocksServFail()
-        {
-            ResponseArrivedIsGenSocksServFail?.Invoke(this, false);
-        }
+		private void DoNotGenSocksServFail()
+		{
+			ResponseArrivedIsGenSocksServFail?.Invoke(this, false);
+		}
 
-        public Money GetFeeRate(int feeTarget)
-        {
-            if (AllFeeEstimate is null)
-            {
-                throw new InvalidOperationException("Cannot get fee estimations.");
-            }
-            return AllFeeEstimate.GetFeeRate(feeTarget);
-        }
+		public Money GetFeeRate(int feeTarget)
+		{
+			if (AllFeeEstimate is null)
+			{
+				throw new InvalidOperationException("Cannot get fee estimations.");
+			}
+			return AllFeeEstimate.GetFeeRate(feeTarget);
+		}
 
-        #endregion Methods
+		#endregion Methods
 
-        public async Task StopAsync()
-        {
-            Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
-            Cancel?.Cancel();
-            while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
-            {
-                await Task.Delay(50);
-            }
+		public async Task StopAsync()
+		{
+			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+			Cancel?.Cancel();
+			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+			{
+				await Task.Delay(50);
+			}
 
-            Cancel?.Dispose();
-            Cancel = null;
-            WasabiClient?.Dispose();
-            WasabiClient = null;
+			Cancel?.Dispose();
+			Cancel = null;
+			WasabiClient?.Dispose();
+			WasabiClient = null;
 
-            EnableRequests(); // Enable requests (it's possible something is being blocked outside the class by AreRequestsBlocked.
-        }
-    }
+			EnableRequests(); // Enable requests (it's possible something is being blocked outside the class by AreRequestsBlocked.
+		}
+	}
 }

--- a/WalletWasabi/TorSocks5/TorHttpClient.cs
+++ b/WalletWasabi/TorSocks5/TorHttpClient.cs
@@ -19,291 +19,291 @@ using WalletWasabi.TorSocks5.Models.Fields.OctetFields;
 
 namespace WalletWasabi.TorSocks5
 {
-    public class TorHttpClient : IDisposable
-    {
-        private static DateTimeOffset? TorDoesntWorkSinceBacking = null;
+	public class TorHttpClient : IDisposable
+	{
+		private static DateTimeOffset? TorDoesntWorkSinceBacking = null;
 
-        public static DateTimeOffset? TorDoesntWorkSince
-        {
-            get => TorDoesntWorkSinceBacking;
-            private set
-            {
-                if (value != TorDoesntWorkSinceBacking)
-                {
-                    TorDoesntWorkSinceBacking = value;
-                    if (value is null)
-                    {
-                        LatestTorException = null;
-                    }
-                }
-            }
-        }
+		public static DateTimeOffset? TorDoesntWorkSince
+		{
+			get => TorDoesntWorkSinceBacking;
+			private set
+			{
+				if (value != TorDoesntWorkSinceBacking)
+				{
+					TorDoesntWorkSinceBacking = value;
+					if (value is null)
+					{
+						LatestTorException = null;
+					}
+				}
+			}
+		}
 
-        public static Exception LatestTorException { get; private set; } = null;
+		public static Exception LatestTorException { get; private set; } = null;
 
-        public Uri DestinationUri => DestinationUriAction();
-        public Func<Uri> DestinationUriAction { get; private set; }
-        public EndPoint TorSocks5EndPoint { get; private set; }
-        public bool IsTorUsed => TorSocks5EndPoint != null;
+		public Uri DestinationUri => DestinationUriAction();
+		public Func<Uri> DestinationUriAction { get; private set; }
+		public EndPoint TorSocks5EndPoint { get; private set; }
+		public bool IsTorUsed => TorSocks5EndPoint != null;
 
-        public bool IsolateStream { get; private set; }
+		public bool IsolateStream { get; private set; }
 
-        public TorSocks5Client TorSocks5Client { get; private set; }
+		public TorSocks5Client TorSocks5Client { get; private set; }
 
-        private static AsyncLock AsyncLock { get; } = new AsyncLock(); // We make everything synchronous, so slow, but at least stable.
+		private static AsyncLock AsyncLock { get; } = new AsyncLock(); // We make everything synchronous, so slow, but at least stable.
 
-        public TorHttpClient(Uri baseUri, EndPoint torSocks5EndPoint, bool isolateStream = false)
-        {
-            baseUri = Guard.NotNull(nameof(baseUri), baseUri);
-            Create(torSocks5EndPoint, isolateStream, () => baseUri);
-        }
+		public TorHttpClient(Uri baseUri, EndPoint torSocks5EndPoint, bool isolateStream = false)
+		{
+			baseUri = Guard.NotNull(nameof(baseUri), baseUri);
+			Create(torSocks5EndPoint, isolateStream, () => baseUri);
+		}
 
-        public TorHttpClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint, bool isolateStream = false)
-        {
-            Create(torSocks5EndPoint, isolateStream, baseUriAction);
-        }
+		public TorHttpClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint, bool isolateStream = false)
+		{
+			Create(torSocks5EndPoint, isolateStream, baseUriAction);
+		}
 
-        private void Create(EndPoint torSocks5EndPoint, bool isolateStream, Func<Uri> baseUriAction)
-        {
-            DestinationUriAction = Guard.NotNull(nameof(baseUriAction), baseUriAction);
-            if (DestinationUri.IsLoopback)
-            {
-                TorSocks5EndPoint = null;
-            }
-            else
-            {
-                TorSocks5EndPoint = torSocks5EndPoint;
-            }
-            TorSocks5Client = null;
-            IsolateStream = isolateStream;
-        }
+		private void Create(EndPoint torSocks5EndPoint, bool isolateStream, Func<Uri> baseUriAction)
+		{
+			DestinationUriAction = Guard.NotNull(nameof(baseUriAction), baseUriAction);
+			if (DestinationUri.IsLoopback)
+			{
+				TorSocks5EndPoint = null;
+			}
+			else
+			{
+				TorSocks5EndPoint = torSocks5EndPoint;
+			}
+			TorSocks5Client = null;
+			IsolateStream = isolateStream;
+		}
 
-        /// <remarks>
-        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-        /// </remarks>
-        public async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent content = null, CancellationToken cancel = default)
-        {
-            Guard.NotNull(nameof(method), method);
-            relativeUri = Guard.NotNull(nameof(relativeUri), relativeUri);
-            var requestUri = new Uri(DestinationUri, relativeUri);
-            var request = new HttpRequestMessage(method, requestUri);
-            if (content != null)
-            {
-                request.Content = content;
-            }
-            request.Headers.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
+		/// <remarks>
+		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+		/// </remarks>
+		public async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent content = null, CancellationToken cancel = default)
+		{
+			Guard.NotNull(nameof(method), method);
+			relativeUri = Guard.NotNull(nameof(relativeUri), relativeUri);
+			var requestUri = new Uri(DestinationUri, relativeUri);
+			var request = new HttpRequestMessage(method, requestUri);
+			if (content != null)
+			{
+				request.Content = content;
+			}
+			request.Headers.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
 
-            try
-            {
-                using (await AsyncLock.LockAsync(cancel))
-                {
-                    try
-                    {
-                        HttpResponseMessage ret = await SendAsync(request);
-                        TorDoesntWorkSince = null;
-                        return ret;
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogTrace<TorHttpClient>(ex);
+			try
+			{
+				using (await AsyncLock.LockAsync(cancel))
+				{
+					try
+					{
+						HttpResponseMessage ret = await SendAsync(request);
+						TorDoesntWorkSince = null;
+						return ret;
+					}
+					catch (Exception ex)
+					{
+						Logger.LogTrace<TorHttpClient>(ex);
 
-                        TorSocks5Client?.Dispose(); // rebuild the connection and retry
-                        TorSocks5Client = null;
+						TorSocks5Client?.Dispose(); // rebuild the connection and retry
+						TorSocks5Client = null;
 
-                        cancel.ThrowIfCancellationRequested();
-                        try
-                        {
-                            HttpResponseMessage ret2 = await SendAsync(request);
-                            TorDoesntWorkSince = null;
-                            return ret2;
-                        }
-                        // If we get ttlexpired then wait and retry again linux often do this.
-                        catch (TorSocks5FailureResponseException ex2) when (ex2.RepField == RepField.TtlExpired)
-                        {
-                            Logger.LogTrace<TorHttpClient>(ex);
+						cancel.ThrowIfCancellationRequested();
+						try
+						{
+							HttpResponseMessage ret2 = await SendAsync(request);
+							TorDoesntWorkSince = null;
+							return ret2;
+						}
+						// If we get ttlexpired then wait and retry again linux often do this.
+						catch (TorSocks5FailureResponseException ex2) when (ex2.RepField == RepField.TtlExpired)
+						{
+							Logger.LogTrace<TorHttpClient>(ex);
 
-                            TorSocks5Client?.Dispose(); // rebuild the connection and retry
-                            TorSocks5Client = null;
+							TorSocks5Client?.Dispose(); // rebuild the connection and retry
+							TorSocks5Client = null;
 
-                            try
-                            {
-                                await Task.Delay(1000, cancel);
-                            }
-                            catch (TaskCanceledException tce)
-                            {
-                                throw new OperationCanceledException(tce.Message, tce, cancel);
-                            }
-                        }
-                        catch (SocketException ex3) when (ex3.ErrorCode == (int)SocketError.ConnectionRefused)
-                        {
-                            throw new ConnectionException("Connection was refused.", ex3);
-                        }
+							try
+							{
+								await Task.Delay(1000, cancel);
+							}
+							catch (TaskCanceledException tce)
+							{
+								throw new OperationCanceledException(tce.Message, tce, cancel);
+							}
+						}
+						catch (SocketException ex3) when (ex3.ErrorCode == (int)SocketError.ConnectionRefused)
+						{
+							throw new ConnectionException("Connection was refused.", ex3);
+						}
 
-                        cancel.ThrowIfCancellationRequested();
+						cancel.ThrowIfCancellationRequested();
 
-                        HttpResponseMessage ret3 = await SendAsync(request);
-                        TorDoesntWorkSince = null;
-                        return ret3;
-                    }
-                }
-            }
-            catch (TaskCanceledException ex)
-            {
-                SetTorNotWorkingState(ex);
-                throw new OperationCanceledException(ex.Message, ex, cancel);
-            }
-            catch (Exception ex)
-            {
-                SetTorNotWorkingState(ex);
-                throw;
-            }
-        }
+						HttpResponseMessage ret3 = await SendAsync(request);
+						TorDoesntWorkSince = null;
+						return ret3;
+					}
+				}
+			}
+			catch (TaskCanceledException ex)
+			{
+				SetTorNotWorkingState(ex);
+				throw new OperationCanceledException(ex.Message, ex, cancel);
+			}
+			catch (Exception ex)
+			{
+				SetTorNotWorkingState(ex);
+				throw;
+			}
+		}
 
-        private static void SetTorNotWorkingState(Exception ex)
-        {
-            if (TorDoesntWorkSince is null)
-            {
-                TorDoesntWorkSince = DateTimeOffset.UtcNow;
-            }
-            LatestTorException = ex;
-        }
+		private static void SetTorNotWorkingState(Exception ex)
+		{
+			if (TorDoesntWorkSince is null)
+			{
+				TorDoesntWorkSince = DateTimeOffset.UtcNow;
+			}
+			LatestTorException = ex;
+		}
 
-        /// <remarks>
-        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-        /// </remarks>
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancel = default)
-        {
-            Guard.NotNull(nameof(request), request);
+		/// <remarks>
+		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+		/// </remarks>
+		public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancel = default)
+		{
+			Guard.NotNull(nameof(request), request);
 
-            // https://tools.ietf.org/html/rfc7230#section-2.7.1
-            // A sender MUST NOT generate an "http" URI with an empty host identifier.
-            var host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
+			// https://tools.ietf.org/html/rfc7230#section-2.7.1
+			// A sender MUST NOT generate an "http" URI with an empty host identifier.
+			var host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
 
-            // https://tools.ietf.org/html/rfc7230#section-2.6
-            // Intermediaries that process HTTP messages (i.e., all intermediaries
-            // other than those acting as tunnels) MUST send their own HTTP - version
-            // in forwarded messages.
-            request.Version = HttpProtocol.HTTP11.Version;
+			// https://tools.ietf.org/html/rfc7230#section-2.6
+			// Intermediaries that process HTTP messages (i.e., all intermediaries
+			// other than those acting as tunnels) MUST send their own HTTP - version
+			// in forwarded messages.
+			request.Version = HttpProtocol.HTTP11.Version;
 
-            if (TorSocks5Client != null && !TorSocks5Client.IsConnected)
-            {
-                TorSocks5Client?.Dispose();
-                TorSocks5Client = null;
-            }
+			if (TorSocks5Client != null && !TorSocks5Client.IsConnected)
+			{
+				TorSocks5Client?.Dispose();
+				TorSocks5Client = null;
+			}
 
-            if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
-            {
-                TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
-                await TorSocks5Client.ConnectAsync();
-                await TorSocks5Client.HandshakeAsync(IsolateStream);
-                await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port);
+			if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
+			{
+				TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
+				await TorSocks5Client.ConnectAsync();
+				await TorSocks5Client.HandshakeAsync(IsolateStream);
+				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port);
 
-                Stream stream = TorSocks5Client.TcpClient.GetStream();
-                if (request.RequestUri.Scheme == "https")
-                {
-                    SslStream sslStream;
-                    // On Linux and OSX ignore certificate, because of a .NET Core bug
-                    // This is a security vulnerability, has to be fixed as soon as the bug get fixed
-                    // Details:
-                    // https://github.com/dotnet/corefx/issues/21761
-                    // https://github.com/nopara73/DotNetTor/issues/4
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        sslStream = new SslStream(
-                            stream,
-                            leaveInnerStreamOpen: true);
-                    }
-                    else
-                    {
-                        sslStream = new SslStream(
-                            stream,
-                            leaveInnerStreamOpen: true,
-                            userCertificateValidationCallback: (a, b, c, d) => true);
-                    }
+				Stream stream = TorSocks5Client.TcpClient.GetStream();
+				if (request.RequestUri.Scheme == "https")
+				{
+					SslStream sslStream;
+					// On Linux and OSX ignore certificate, because of a .NET Core bug
+					// This is a security vulnerability, has to be fixed as soon as the bug get fixed
+					// Details:
+					// https://github.com/dotnet/corefx/issues/21761
+					// https://github.com/nopara73/DotNetTor/issues/4
+					if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+					{
+						sslStream = new SslStream(
+							stream,
+							leaveInnerStreamOpen: true);
+					}
+					else
+					{
+						sslStream = new SslStream(
+							stream,
+							leaveInnerStreamOpen: true,
+							userCertificateValidationCallback: (a, b, c, d) => true);
+					}
 
-                    await sslStream
-                        .AuthenticateAsClientAsync(
-                            host,
-                            new X509CertificateCollection(),
-                            SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
-                            checkCertificateRevocation: true);
-                    stream = sslStream;
-                }
+					await sslStream
+						.AuthenticateAsClientAsync(
+							host,
+							new X509CertificateCollection(),
+							SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
+							checkCertificateRevocation: true);
+					stream = sslStream;
+				}
 
-                TorSocks5Client.Stream = stream;
-            }
-            cancel.ThrowIfCancellationRequested();
+				TorSocks5Client.Stream = stream;
+			}
+			cancel.ThrowIfCancellationRequested();
 
-            // https://tools.ietf.org/html/rfc7230#section-3.3.2
-            // A user agent SHOULD send a Content - Length in a request message when
-            // no Transfer-Encoding is sent and the request method defines a meaning
-            // for an enclosed payload body.For example, a Content - Length header
-            // field is normally sent in a POST request even when the value is 0
-            // (indicating an empty payload body).A user agent SHOULD NOT send a
-            // Content - Length header field when the request message does not contain
-            // a payload body and the method semantics do not anticipate such a
-            // body.
-            if (request.Method == HttpMethod.Post)
-            {
-                if (request.Headers.TransferEncoding.Count == 0)
-                {
-                    if (request.Content is null)
-                    {
-                        request.Content = new ByteArrayContent(new byte[] { }); // dummy empty content
-                        request.Content.Headers.ContentLength = 0;
-                    }
-                    else
-                    {
-                        if (request.Content.Headers.ContentLength is null)
-                        {
-                            request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync()).Length;
-                        }
-                    }
-                }
-            }
+			// https://tools.ietf.org/html/rfc7230#section-3.3.2
+			// A user agent SHOULD send a Content - Length in a request message when
+			// no Transfer-Encoding is sent and the request method defines a meaning
+			// for an enclosed payload body.For example, a Content - Length header
+			// field is normally sent in a POST request even when the value is 0
+			// (indicating an empty payload body).A user agent SHOULD NOT send a
+			// Content - Length header field when the request message does not contain
+			// a payload body and the method semantics do not anticipate such a
+			// body.
+			if (request.Method == HttpMethod.Post)
+			{
+				if (request.Headers.TransferEncoding.Count == 0)
+				{
+					if (request.Content is null)
+					{
+						request.Content = new ByteArrayContent(new byte[] { }); // dummy empty content
+						request.Content.Headers.ContentLength = 0;
+					}
+					else
+					{
+						if (request.Content.Headers.ContentLength is null)
+						{
+							request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync()).Length;
+						}
+					}
+				}
+			}
 
-            var requestString = await request.ToHttpStringAsync();
+			var requestString = await request.ToHttpStringAsync();
 
-            var bytes = Encoding.UTF8.GetBytes(requestString);
+			var bytes = Encoding.UTF8.GetBytes(requestString);
 
-            await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length);
-            await TorSocks5Client.Stream.FlushAsync();
-            using (var httpResponseMessage = new HttpResponseMessage())
-            {
-                return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method);
-            }
-        }
+			await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length);
+			await TorSocks5Client.Stream.FlushAsync();
+			using (var httpResponseMessage = new HttpResponseMessage())
+			{
+				return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method);
+			}
+		}
 
-        #region IDisposable Support
+		#region IDisposable Support
 
-        private volatile bool _disposedValue = false; // To detect redundant calls
+		private volatile bool _disposedValue = false; // To detect redundant calls
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    TorSocks5Client?.Dispose();
-                }
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					TorSocks5Client?.Dispose();
+				}
 
-                _disposedValue = true;
-            }
-        }
+				_disposedValue = true;
+			}
+		}
 
-        // ~TorHttpClient() {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
+		// ~TorHttpClient() {
+		// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+		//   Dispose(false);
+		// }
 
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // GC.SuppressFinalize(this);
-        }
+		// This code added to correctly implement the disposable pattern.
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+			Dispose(true);
+			// GC.SuppressFinalize(this);
+		}
 
-        #endregion IDisposable Support
-    }
+		#endregion IDisposable Support
+	}
 }

--- a/WalletWasabi/TorSocks5/TorHttpClient.cs
+++ b/WalletWasabi/TorSocks5/TorHttpClient.cs
@@ -19,291 +19,291 @@ using WalletWasabi.TorSocks5.Models.Fields.OctetFields;
 
 namespace WalletWasabi.TorSocks5
 {
-	public class TorHttpClient : IDisposable
-	{
-		private static DateTimeOffset? TorDoesntWorkSinceBacking = null;
+    public class TorHttpClient : IDisposable
+    {
+        private static DateTimeOffset? TorDoesntWorkSinceBacking = null;
 
-		public static DateTimeOffset? TorDoesntWorkSince
-		{
-			get => TorDoesntWorkSinceBacking;
-			private set
-			{
-				if (value != TorDoesntWorkSinceBacking)
-				{
-					TorDoesntWorkSinceBacking = value;
-					if (value is null)
-					{
-						LatestTorException = null;
-					}
-				}
-			}
-		}
+        public static DateTimeOffset? TorDoesntWorkSince
+        {
+            get => TorDoesntWorkSinceBacking;
+            private set
+            {
+                if (value != TorDoesntWorkSinceBacking)
+                {
+                    TorDoesntWorkSinceBacking = value;
+                    if (value is null)
+                    {
+                        LatestTorException = null;
+                    }
+                }
+            }
+        }
 
-		public static Exception LatestTorException { get; private set; } = null;
+        public static Exception LatestTorException { get; private set; } = null;
 
-		public Uri DestinationUri => DestinationUriAction();
-		public Func<Uri> DestinationUriAction { get; private set; }
-		public IPEndPoint TorSocks5EndPoint { get; private set; }
-		public bool IsTorUsed => TorSocks5EndPoint != null;
+        public Uri DestinationUri => DestinationUriAction();
+        public Func<Uri> DestinationUriAction { get; private set; }
+        public EndPoint TorSocks5EndPoint { get; private set; }
+        public bool IsTorUsed => TorSocks5EndPoint != null;
 
-		public bool IsolateStream { get; private set; }
+        public bool IsolateStream { get; private set; }
 
-		public TorSocks5Client TorSocks5Client { get; private set; }
+        public TorSocks5Client TorSocks5Client { get; private set; }
 
-		private static AsyncLock AsyncLock { get; } = new AsyncLock(); // We make everything synchronous, so slow, but at least stable.
+        private static AsyncLock AsyncLock { get; } = new AsyncLock(); // We make everything synchronous, so slow, but at least stable.
 
-		public TorHttpClient(Uri baseUri, IPEndPoint torSocks5EndPoint, bool isolateStream = false)
-		{
-			baseUri = Guard.NotNull(nameof(baseUri), baseUri);
-			Create(torSocks5EndPoint, isolateStream, () => baseUri);
-		}
+        public TorHttpClient(Uri baseUri, EndPoint torSocks5EndPoint, bool isolateStream = false)
+        {
+            baseUri = Guard.NotNull(nameof(baseUri), baseUri);
+            Create(torSocks5EndPoint, isolateStream, () => baseUri);
+        }
 
-		public TorHttpClient(Func<Uri> baseUriAction, IPEndPoint torSocks5EndPoint, bool isolateStream = false)
-		{
-			Create(torSocks5EndPoint, isolateStream, baseUriAction);
-		}
+        public TorHttpClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint, bool isolateStream = false)
+        {
+            Create(torSocks5EndPoint, isolateStream, baseUriAction);
+        }
 
-		private void Create(IPEndPoint torSocks5EndPoint, bool isolateStream, Func<Uri> baseUriAction)
-		{
-			DestinationUriAction = Guard.NotNull(nameof(baseUriAction), baseUriAction);
-			if (DestinationUri.IsLoopback)
-			{
-				TorSocks5EndPoint = null;
-			}
-			else
-			{
-				TorSocks5EndPoint = torSocks5EndPoint;
-			}
-			TorSocks5Client = null;
-			IsolateStream = isolateStream;
-		}
+        private void Create(EndPoint torSocks5EndPoint, bool isolateStream, Func<Uri> baseUriAction)
+        {
+            DestinationUriAction = Guard.NotNull(nameof(baseUriAction), baseUriAction);
+            if (DestinationUri.IsLoopback)
+            {
+                TorSocks5EndPoint = null;
+            }
+            else
+            {
+                TorSocks5EndPoint = torSocks5EndPoint;
+            }
+            TorSocks5Client = null;
+            IsolateStream = isolateStream;
+        }
 
-		/// <remarks>
-		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-		/// </remarks>
-		public async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent content = null, CancellationToken cancel = default)
-		{
-			Guard.NotNull(nameof(method), method);
-			relativeUri = Guard.NotNull(nameof(relativeUri), relativeUri);
-			var requestUri = new Uri(DestinationUri, relativeUri);
-			var request = new HttpRequestMessage(method, requestUri);
-			if (content != null)
-			{
-				request.Content = content;
-			}
-			request.Headers.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
+        /// <remarks>
+        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+        /// </remarks>
+        public async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent content = null, CancellationToken cancel = default)
+        {
+            Guard.NotNull(nameof(method), method);
+            relativeUri = Guard.NotNull(nameof(relativeUri), relativeUri);
+            var requestUri = new Uri(DestinationUri, relativeUri);
+            var request = new HttpRequestMessage(method, requestUri);
+            if (content != null)
+            {
+                request.Content = content;
+            }
+            request.Headers.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
 
-			try
-			{
-				using (await AsyncLock.LockAsync(cancel))
-				{
-					try
-					{
-						HttpResponseMessage ret = await SendAsync(request);
-						TorDoesntWorkSince = null;
-						return ret;
-					}
-					catch (Exception ex)
-					{
-						Logger.LogTrace<TorHttpClient>(ex);
+            try
+            {
+                using (await AsyncLock.LockAsync(cancel))
+                {
+                    try
+                    {
+                        HttpResponseMessage ret = await SendAsync(request);
+                        TorDoesntWorkSince = null;
+                        return ret;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogTrace<TorHttpClient>(ex);
 
-						TorSocks5Client?.Dispose(); // rebuild the connection and retry
-						TorSocks5Client = null;
+                        TorSocks5Client?.Dispose(); // rebuild the connection and retry
+                        TorSocks5Client = null;
 
-						cancel.ThrowIfCancellationRequested();
-						try
-						{
-							HttpResponseMessage ret2 = await SendAsync(request);
-							TorDoesntWorkSince = null;
-							return ret2;
-						}
-						// If we get ttlexpired then wait and retry again linux often do this.
-						catch (TorSocks5FailureResponseException ex2) when (ex2.RepField == RepField.TtlExpired)
-						{
-							Logger.LogTrace<TorHttpClient>(ex);
+                        cancel.ThrowIfCancellationRequested();
+                        try
+                        {
+                            HttpResponseMessage ret2 = await SendAsync(request);
+                            TorDoesntWorkSince = null;
+                            return ret2;
+                        }
+                        // If we get ttlexpired then wait and retry again linux often do this.
+                        catch (TorSocks5FailureResponseException ex2) when (ex2.RepField == RepField.TtlExpired)
+                        {
+                            Logger.LogTrace<TorHttpClient>(ex);
 
-							TorSocks5Client?.Dispose(); // rebuild the connection and retry
-							TorSocks5Client = null;
+                            TorSocks5Client?.Dispose(); // rebuild the connection and retry
+                            TorSocks5Client = null;
 
-							try
-							{
-								await Task.Delay(1000, cancel);
-							}
-							catch (TaskCanceledException tce)
-							{
-								throw new OperationCanceledException(tce.Message, tce, cancel);
-							}
-						}
-						catch (SocketException ex3) when (ex3.ErrorCode == (int)SocketError.ConnectionRefused)
-						{
-							throw new ConnectionException("Connection was refused.", ex3);
-						}
+                            try
+                            {
+                                await Task.Delay(1000, cancel);
+                            }
+                            catch (TaskCanceledException tce)
+                            {
+                                throw new OperationCanceledException(tce.Message, tce, cancel);
+                            }
+                        }
+                        catch (SocketException ex3) when (ex3.ErrorCode == (int)SocketError.ConnectionRefused)
+                        {
+                            throw new ConnectionException("Connection was refused.", ex3);
+                        }
 
-						cancel.ThrowIfCancellationRequested();
+                        cancel.ThrowIfCancellationRequested();
 
-						HttpResponseMessage ret3 = await SendAsync(request);
-						TorDoesntWorkSince = null;
-						return ret3;
-					}
-				}
-			}
-			catch (TaskCanceledException ex)
-			{
-				SetTorNotWorkingState(ex);
-				throw new OperationCanceledException(ex.Message, ex, cancel);
-			}
-			catch (Exception ex)
-			{
-				SetTorNotWorkingState(ex);
-				throw;
-			}
-		}
+                        HttpResponseMessage ret3 = await SendAsync(request);
+                        TorDoesntWorkSince = null;
+                        return ret3;
+                    }
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                SetTorNotWorkingState(ex);
+                throw new OperationCanceledException(ex.Message, ex, cancel);
+            }
+            catch (Exception ex)
+            {
+                SetTorNotWorkingState(ex);
+                throw;
+            }
+        }
 
-		private static void SetTorNotWorkingState(Exception ex)
-		{
-			if (TorDoesntWorkSince is null)
-			{
-				TorDoesntWorkSince = DateTimeOffset.UtcNow;
-			}
-			LatestTorException = ex;
-		}
+        private static void SetTorNotWorkingState(Exception ex)
+        {
+            if (TorDoesntWorkSince is null)
+            {
+                TorDoesntWorkSince = DateTimeOffset.UtcNow;
+            }
+            LatestTorException = ex;
+        }
 
-		/// <remarks>
-		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-		/// </remarks>
-		public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancel = default)
-		{
-			Guard.NotNull(nameof(request), request);
+        /// <remarks>
+        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+        /// </remarks>
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancel = default)
+        {
+            Guard.NotNull(nameof(request), request);
 
-			// https://tools.ietf.org/html/rfc7230#section-2.7.1
-			// A sender MUST NOT generate an "http" URI with an empty host identifier.
-			var host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
+            // https://tools.ietf.org/html/rfc7230#section-2.7.1
+            // A sender MUST NOT generate an "http" URI with an empty host identifier.
+            var host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
 
-			// https://tools.ietf.org/html/rfc7230#section-2.6
-			// Intermediaries that process HTTP messages (i.e., all intermediaries
-			// other than those acting as tunnels) MUST send their own HTTP - version
-			// in forwarded messages.
-			request.Version = HttpProtocol.HTTP11.Version;
+            // https://tools.ietf.org/html/rfc7230#section-2.6
+            // Intermediaries that process HTTP messages (i.e., all intermediaries
+            // other than those acting as tunnels) MUST send their own HTTP - version
+            // in forwarded messages.
+            request.Version = HttpProtocol.HTTP11.Version;
 
-			if (TorSocks5Client != null && !TorSocks5Client.IsConnected)
-			{
-				TorSocks5Client?.Dispose();
-				TorSocks5Client = null;
-			}
+            if (TorSocks5Client != null && !TorSocks5Client.IsConnected)
+            {
+                TorSocks5Client?.Dispose();
+                TorSocks5Client = null;
+            }
 
-			if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
-			{
-				TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
-				await TorSocks5Client.ConnectAsync();
-				await TorSocks5Client.HandshakeAsync(IsolateStream);
-				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port);
+            if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
+            {
+                TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
+                await TorSocks5Client.ConnectAsync();
+                await TorSocks5Client.HandshakeAsync(IsolateStream);
+                await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port);
 
-				Stream stream = TorSocks5Client.TcpClient.GetStream();
-				if (request.RequestUri.Scheme == "https")
-				{
-					SslStream sslStream;
-					// On Linux and OSX ignore certificate, because of a .NET Core bug
-					// This is a security vulnerability, has to be fixed as soon as the bug get fixed
-					// Details:
-					// https://github.com/dotnet/corefx/issues/21761
-					// https://github.com/nopara73/DotNetTor/issues/4
-					if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-					{
-						sslStream = new SslStream(
-							stream,
-							leaveInnerStreamOpen: true);
-					}
-					else
-					{
-						sslStream = new SslStream(
-							stream,
-							leaveInnerStreamOpen: true,
-							userCertificateValidationCallback: (a, b, c, d) => true);
-					}
+                Stream stream = TorSocks5Client.TcpClient.GetStream();
+                if (request.RequestUri.Scheme == "https")
+                {
+                    SslStream sslStream;
+                    // On Linux and OSX ignore certificate, because of a .NET Core bug
+                    // This is a security vulnerability, has to be fixed as soon as the bug get fixed
+                    // Details:
+                    // https://github.com/dotnet/corefx/issues/21761
+                    // https://github.com/nopara73/DotNetTor/issues/4
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        sslStream = new SslStream(
+                            stream,
+                            leaveInnerStreamOpen: true);
+                    }
+                    else
+                    {
+                        sslStream = new SslStream(
+                            stream,
+                            leaveInnerStreamOpen: true,
+                            userCertificateValidationCallback: (a, b, c, d) => true);
+                    }
 
-					await sslStream
-						.AuthenticateAsClientAsync(
-							host,
-							new X509CertificateCollection(),
-							SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
-							checkCertificateRevocation: true);
-					stream = sslStream;
-				}
+                    await sslStream
+                        .AuthenticateAsClientAsync(
+                            host,
+                            new X509CertificateCollection(),
+                            SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
+                            checkCertificateRevocation: true);
+                    stream = sslStream;
+                }
 
-				TorSocks5Client.Stream = stream;
-			}
-			cancel.ThrowIfCancellationRequested();
+                TorSocks5Client.Stream = stream;
+            }
+            cancel.ThrowIfCancellationRequested();
 
-			// https://tools.ietf.org/html/rfc7230#section-3.3.2
-			// A user agent SHOULD send a Content - Length in a request message when
-			// no Transfer-Encoding is sent and the request method defines a meaning
-			// for an enclosed payload body.For example, a Content - Length header
-			// field is normally sent in a POST request even when the value is 0
-			// (indicating an empty payload body).A user agent SHOULD NOT send a
-			// Content - Length header field when the request message does not contain
-			// a payload body and the method semantics do not anticipate such a
-			// body.
-			if (request.Method == HttpMethod.Post)
-			{
-				if (request.Headers.TransferEncoding.Count == 0)
-				{
-					if (request.Content is null)
-					{
-						request.Content = new ByteArrayContent(new byte[] { }); // dummy empty content
-						request.Content.Headers.ContentLength = 0;
-					}
-					else
-					{
-						if (request.Content.Headers.ContentLength is null)
-						{
-							request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync()).Length;
-						}
-					}
-				}
-			}
+            // https://tools.ietf.org/html/rfc7230#section-3.3.2
+            // A user agent SHOULD send a Content - Length in a request message when
+            // no Transfer-Encoding is sent and the request method defines a meaning
+            // for an enclosed payload body.For example, a Content - Length header
+            // field is normally sent in a POST request even when the value is 0
+            // (indicating an empty payload body).A user agent SHOULD NOT send a
+            // Content - Length header field when the request message does not contain
+            // a payload body and the method semantics do not anticipate such a
+            // body.
+            if (request.Method == HttpMethod.Post)
+            {
+                if (request.Headers.TransferEncoding.Count == 0)
+                {
+                    if (request.Content is null)
+                    {
+                        request.Content = new ByteArrayContent(new byte[] { }); // dummy empty content
+                        request.Content.Headers.ContentLength = 0;
+                    }
+                    else
+                    {
+                        if (request.Content.Headers.ContentLength is null)
+                        {
+                            request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync()).Length;
+                        }
+                    }
+                }
+            }
 
-			var requestString = await request.ToHttpStringAsync();
+            var requestString = await request.ToHttpStringAsync();
 
-			var bytes = Encoding.UTF8.GetBytes(requestString);
+            var bytes = Encoding.UTF8.GetBytes(requestString);
 
-			await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length);
-			await TorSocks5Client.Stream.FlushAsync();
-			using (var httpResponseMessage = new HttpResponseMessage())
-			{
-				return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method);
-			}
-		}
+            await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length);
+            await TorSocks5Client.Stream.FlushAsync();
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method);
+            }
+        }
 
-		#region IDisposable Support
+        #region IDisposable Support
 
-		private volatile bool _disposedValue = false; // To detect redundant calls
+        private volatile bool _disposedValue = false; // To detect redundant calls
 
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!_disposedValue)
-			{
-				if (disposing)
-				{
-					TorSocks5Client?.Dispose();
-				}
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    TorSocks5Client?.Dispose();
+                }
 
-				_disposedValue = true;
-			}
-		}
+                _disposedValue = true;
+            }
+        }
 
-		// ~TorHttpClient() {
-		// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-		//   Dispose(false);
-		// }
+        // ~TorHttpClient() {
+        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
 
-		// This code added to correctly implement the disposable pattern.
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(true);
-			// GC.SuppressFinalize(this);
-		}
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // GC.SuppressFinalize(this);
+        }
 
-		#endregion IDisposable Support
-	}
+        #endregion IDisposable Support
+    }
 }

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -14,331 +14,331 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.TorSocks5
 {
-	public class TorProcessManager
-	{
-		/// <summary>
-		/// If null then it's just a mock, clearnet is used.
-		/// </summary>
-		public IPEndPoint TorSocks5EndPoint { get; }
+    public class TorProcessManager
+    {
+        /// <summary>
+        /// If null then it's just a mock, clearnet is used.
+        /// </summary>
+        public EndPoint TorSocks5EndPoint { get; }
 
-		public string LogFile { get; }
+        public string LogFile { get; }
 
-		public static bool RequestFallbackAddressUsage { get; private set; } = false;
+        public static bool RequestFallbackAddressUsage { get; private set; } = false;
 
-		public Process TorProcess { get; private set; }
+        public Process TorProcess { get; private set; }
 
-		/// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
-		/// <param name="logFile">Opt out of logging with null.</param>
-		public TorProcessManager(IPEndPoint torSocks5EndPoint, string logFile)
-		{
-			TorSocks5EndPoint = torSocks5EndPoint;
-			LogFile = logFile;
-			_running = 0;
-			Stop = new CancellationTokenSource();
-			TorProcess = null;
-		}
+        /// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
+        /// <param name="logFile">Opt out of logging with null.</param>
+        public TorProcessManager(EndPoint torSocks5EndPoint, string logFile)
+        {
+            TorSocks5EndPoint = torSocks5EndPoint;
+            LogFile = logFile;
+            _running = 0;
+            Stop = new CancellationTokenSource();
+            TorProcess = null;
+        }
 
-		public static TorProcessManager Mock() // Mock, do not use Tor at all for debug.
-		{
-			return new TorProcessManager(null, null);
-		}
+        public static TorProcessManager Mock() // Mock, do not use Tor at all for debug.
+        {
+            return new TorProcessManager(null, null);
+        }
 
-		public void Start(bool ensureRunning, string dataDir)
-		{
-			if (TorSocks5EndPoint is null)
-			{
-				return;
-			}
+        public void Start(bool ensureRunning, string dataDir)
+        {
+            if (TorSocks5EndPoint is null)
+            {
+                return;
+            }
 
-			new Thread(delegate () // Do not ask. This is the only way it worked on Win10/Ubuntu18.04/Manjuro(1 processor VM)/Fedora(1 processor VM)
-			{
-				try
-				{
-					// 1. Is it already running?
-					// 2. Can I simply run it from output directory?
-					// 3. Can I copy and unzip it from assets?
-					// 4. Throw exception.
+            new Thread(delegate () // Do not ask. This is the only way it worked on Win10/Ubuntu18.04/Manjuro(1 processor VM)/Fedora(1 processor VM)
+            {
+                try
+                {
+                    // 1. Is it already running?
+                    // 2. Can I simply run it from output directory?
+                    // 3. Can I copy and unzip it from assets?
+                    // 4. Throw exception.
 
-					try
-					{
-						if (IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
-						{
-							Logger.LogInfo<TorProcessManager>("Tor is already running.");
-							return;
-						}
+                    try
+                    {
+                        if (IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
+                        {
+                            Logger.LogInfo<TorProcessManager>("Tor is already running.");
+                            return;
+                        }
 
-						var torDir = Path.Combine(dataDir, "tor");
-						var torPath = "";
-						var fullBaseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
-						if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-						{
-							if (!fullBaseDirectory.StartsWith('/'))
-							{
-								fullBaseDirectory.Insert(0, "/");
-							}
+                        var torDir = Path.Combine(dataDir, "tor");
+                        var torPath = "";
+                        var fullBaseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
+                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            if (!fullBaseDirectory.StartsWith('/'))
+                            {
+                                fullBaseDirectory.Insert(0, "/");
+                            }
 
-							torPath = $@"{torDir}/Tor/tor";
-						}
-						else // If Windows
-						{
-							torPath = $@"{torDir}\Tor\tor.exe";
-						}
+                            torPath = $@"{torDir}/Tor/tor";
+                        }
+                        else // If Windows
+                        {
+                            torPath = $@"{torDir}\Tor\tor.exe";
+                        }
 
-						if (!File.Exists(torPath))
-						{
-							Logger.LogInfo<TorProcessManager>($"Tor instance NOT found at {torPath}. Attempting to acquire it...");
-							InstallTor(fullBaseDirectory, torDir);
-						}
-						else if (!IoHelpers.CheckExpectedHash(torPath, Path.Combine(fullBaseDirectory, "TorDaemons")))
-						{
-							Logger.LogInfo<TorProcessManager>($"Updating Tor...");
+                        if (!File.Exists(torPath))
+                        {
+                            Logger.LogInfo<TorProcessManager>($"Tor instance NOT found at {torPath}. Attempting to acquire it...");
+                            InstallTor(fullBaseDirectory, torDir);
+                        }
+                        else if (!IoHelpers.CheckExpectedHash(torPath, Path.Combine(fullBaseDirectory, "TorDaemons")))
+                        {
+                            Logger.LogInfo<TorProcessManager>($"Updating Tor...");
 
-							string backupTorDir = $"{torDir}_backup";
-							if (Directory.Exists(backupTorDir))
-							{
-								Directory.Delete(backupTorDir, true);
-							}
-							Directory.Move(torDir, backupTorDir);
+                            string backupTorDir = $"{torDir}_backup";
+                            if (Directory.Exists(backupTorDir))
+                            {
+                                Directory.Delete(backupTorDir, true);
+                            }
+                            Directory.Move(torDir, backupTorDir);
 
-							InstallTor(fullBaseDirectory, torDir);
-						}
-						else
-						{
-							Logger.LogInfo<TorProcessManager>($"Tor instance found at {torPath}.");
-						}
+                            InstallTor(fullBaseDirectory, torDir);
+                        }
+                        else
+                        {
+                            Logger.LogInfo<TorProcessManager>($"Tor instance found at {torPath}.");
+                        }
 
-						string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
-						if (!string.IsNullOrEmpty(LogFile))
-						{
-							IoHelpers.EnsureContainingDirectoryExists(LogFile);
-							var logFileFullPath = Path.GetFullPath(LogFile);
-							torArguments += $" --Log \"notice file {logFileFullPath}\"";
-						}
+                        string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
+                        if (!string.IsNullOrEmpty(LogFile))
+                        {
+                            IoHelpers.EnsureContainingDirectoryExists(LogFile);
+                            var logFileFullPath = Path.GetFullPath(LogFile);
+                            torArguments += $" --Log \"notice file {logFileFullPath}\"";
+                        }
 
-						if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-						{
-							TorProcess = Process.Start(new ProcessStartInfo
-							{
-								FileName = torPath,
-								Arguments = torArguments,
-								UseShellExecute = false,
-								CreateNoWindow = true,
-								RedirectStandardOutput = true
-							});
-							Logger.LogInfo<TorProcessManager>($"Starting Tor process with Process.Start.");
-						}
-						else // Linux and OSX
-						{
-							string runTorCmd = $"LD_LIBRARY_PATH=$LD_LIBRARY_PATH:={torDir}/Tor && export LD_LIBRARY_PATH && cd {torDir}/Tor && ./tor {torArguments}";
-							EnvironmentHelpers.ShellExec(runTorCmd, false);
-							Logger.LogInfo<TorProcessManager>($"Started Tor process with shell command: {runTorCmd}.");
-						}
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            TorProcess = Process.Start(new ProcessStartInfo
+                            {
+                                FileName = torPath,
+                                Arguments = torArguments,
+                                UseShellExecute = false,
+                                CreateNoWindow = true,
+                                RedirectStandardOutput = true
+                            });
+                            Logger.LogInfo<TorProcessManager>($"Starting Tor process with Process.Start.");
+                        }
+                        else // Linux and OSX
+                        {
+                            string runTorCmd = $"LD_LIBRARY_PATH=$LD_LIBRARY_PATH:={torDir}/Tor && export LD_LIBRARY_PATH && cd {torDir}/Tor && ./tor {torArguments}";
+                            EnvironmentHelpers.ShellExec(runTorCmd, false);
+                            Logger.LogInfo<TorProcessManager>($"Started Tor process with shell command: {runTorCmd}.");
+                        }
 
-						if (ensureRunning)
-						{
-							Task.Delay(3000).ConfigureAwait(false).GetAwaiter().GetResult(); // dotnet brainfart, ConfigureAwait(false) IS NEEDED HERE otherwise (only on) Manjuro Linux fails, WTF?!!
-							if (!IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
-							{
-								throw new TorException("Attempted to start Tor, but it is not running.");
-							}
-							Logger.LogInfo<TorProcessManager>("Tor is running.");
-						}
-					}
-					catch (Exception ex)
-					{
-						throw new TorException("Could not automatically start Tor. Try running Tor manually.", ex);
-					}
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError<TorProcessManager>(ex);
-				}
-			}).Start();
-		}
+                        if (ensureRunning)
+                        {
+                            Task.Delay(3000).ConfigureAwait(false).GetAwaiter().GetResult(); // dotnet brainfart, ConfigureAwait(false) IS NEEDED HERE otherwise (only on) Manjuro Linux fails, WTF?!!
+                            if (!IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
+                            {
+                                throw new TorException("Attempted to start Tor, but it is not running.");
+                            }
+                            Logger.LogInfo<TorProcessManager>("Tor is running.");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new TorException("Could not automatically start Tor. Try running Tor manually.", ex);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError<TorProcessManager>(ex);
+                }
+            }).Start();
+        }
 
-		private static void InstallTor(string fullBaseDirectory, string torDir)
-		{
-			string torDaemonsDir = Path.Combine(fullBaseDirectory, "TorDaemons");
+        private static void InstallTor(string fullBaseDirectory, string torDir)
+        {
+            string torDaemonsDir = Path.Combine(fullBaseDirectory, "TorDaemons");
 
-			string dataZip = Path.Combine(torDaemonsDir, "data-folder.zip");
-			IoHelpers.BetterExtractZipToDirectoryAsync(dataZip, torDir).GetAwaiter().GetResult();
-			Logger.LogInfo<TorProcessManager>($"Extracted {dataZip} to {torDir}.");
+            string dataZip = Path.Combine(torDaemonsDir, "data-folder.zip");
+            IoHelpers.BetterExtractZipToDirectoryAsync(dataZip, torDir).GetAwaiter().GetResult();
+            Logger.LogInfo<TorProcessManager>($"Extracted {dataZip} to {torDir}.");
 
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				string torWinZip = Path.Combine(torDaemonsDir, "tor-win32.zip");
-				IoHelpers.BetterExtractZipToDirectoryAsync(torWinZip, torDir).GetAwaiter().GetResult();
-				Logger.LogInfo<TorProcessManager>($"Extracted {torWinZip} to {torDir}.");
-			}
-			else // Linux or OSX
-			{
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-				{
-					string torLinuxZip = Path.Combine(torDaemonsDir, "tor-linux64.zip");
-					IoHelpers.BetterExtractZipToDirectoryAsync(torLinuxZip, torDir).GetAwaiter().GetResult();
-					Logger.LogInfo<TorProcessManager>($"Extracted {torLinuxZip} to {torDir}.");
-				}
-				else // OSX
-				{
-					string torOsxZip = Path.Combine(torDaemonsDir, "tor-osx64.zip");
-					IoHelpers.BetterExtractZipToDirectoryAsync(torOsxZip, torDir).GetAwaiter().GetResult();
-					Logger.LogInfo<TorProcessManager>($"Extracted {torOsxZip} to {torDir}.");
-				}
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string torWinZip = Path.Combine(torDaemonsDir, "tor-win32.zip");
+                IoHelpers.BetterExtractZipToDirectoryAsync(torWinZip, torDir).GetAwaiter().GetResult();
+                Logger.LogInfo<TorProcessManager>($"Extracted {torWinZip} to {torDir}.");
+            }
+            else // Linux or OSX
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    string torLinuxZip = Path.Combine(torDaemonsDir, "tor-linux64.zip");
+                    IoHelpers.BetterExtractZipToDirectoryAsync(torLinuxZip, torDir).GetAwaiter().GetResult();
+                    Logger.LogInfo<TorProcessManager>($"Extracted {torLinuxZip} to {torDir}.");
+                }
+                else // OSX
+                {
+                    string torOsxZip = Path.Combine(torDaemonsDir, "tor-osx64.zip");
+                    IoHelpers.BetterExtractZipToDirectoryAsync(torOsxZip, torDir).GetAwaiter().GetResult();
+                    Logger.LogInfo<TorProcessManager>($"Extracted {torOsxZip} to {torDir}.");
+                }
 
-				// Make sure there's sufficient permission.
-				string chmodTorDirCmd = $"chmod -R 750 {torDir}";
-				EnvironmentHelpers.ShellExec(chmodTorDirCmd);
-				Logger.LogInfo<TorProcessManager>($"Shell command executed: {chmodTorDirCmd}.");
-			}
-		}
+                // Make sure there's sufficient permission.
+                string chmodTorDirCmd = $"chmod -R 750 {torDir}";
+                EnvironmentHelpers.ShellExec(chmodTorDirCmd);
+                Logger.LogInfo<TorProcessManager>($"Shell command executed: {chmodTorDirCmd}.");
+            }
+        }
 
-		/// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
-		public static async Task<bool> IsTorRunningAsync(IPEndPoint torSocks5EndPoint)
-		{
-			using (var client = new TorSocks5Client(torSocks5EndPoint))
-			{
-				try
-				{
-					await client.ConnectAsync();
-					await client.HandshakeAsync();
-				}
-				catch (ConnectionException)
-				{
-					return false;
-				}
-				return true;
-			}
-		}
+        /// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
+        public static async Task<bool> IsTorRunningAsync(EndPoint torSocks5EndPoint)
+        {
+            using (var client = new TorSocks5Client(torSocks5EndPoint))
+            {
+                try
+                {
+                    await client.ConnectAsync();
+                    await client.HandshakeAsync();
+                }
+                catch (ConnectionException)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
 
-		public async Task<bool> IsTorRunningAsync()
-		{
-			if (TorSocks5EndPoint is null)
-			{
-				return true;
-			}
+        public async Task<bool> IsTorRunningAsync()
+        {
+            if (TorSocks5EndPoint is null)
+            {
+                return true;
+            }
 
-			using (var client = new TorSocks5Client(TorSocks5EndPoint))
-			{
-				try
-				{
-					await client.ConnectAsync();
-					await client.HandshakeAsync();
-				}
-				catch (ConnectionException)
-				{
-					return false;
-				}
-				return true;
-			}
-		}
+            using (var client = new TorSocks5Client(TorSocks5EndPoint))
+            {
+                try
+                {
+                    await client.ConnectAsync();
+                    await client.HandshakeAsync();
+                }
+                catch (ConnectionException)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
 
-		#region Monitor
+        #region Monitor
 
-		/// <summary>
-		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
-		/// </summary>
-		private long _running;
+        /// <summary>
+        /// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
+        /// </summary>
+        private long _running;
 
-		public bool IsRunning => Interlocked.Read(ref _running) == 1;
+        public bool IsRunning => Interlocked.Read(ref _running) == 1;
 
-		private CancellationTokenSource Stop { get; set; }
+        private CancellationTokenSource Stop { get; set; }
 
-		public void StartMonitor(TimeSpan torMisbehaviorCheckPeriod, TimeSpan checkIfRunningAfterTorMisbehavedFor, string dataDirToStartWith, Uri fallBackTestRequestUri)
-		{
-			if (TorSocks5EndPoint is null)
-			{
-				return;
-			}
+        public void StartMonitor(TimeSpan torMisbehaviorCheckPeriod, TimeSpan checkIfRunningAfterTorMisbehavedFor, string dataDirToStartWith, Uri fallBackTestRequestUri)
+        {
+            if (TorSocks5EndPoint is null)
+            {
+                return;
+            }
 
-			Logger.LogInfo<TorProcessManager>("Starting Tor monitor...");
-			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
-			{
-				return;
-			}
+            Logger.LogInfo<TorProcessManager>("Starting Tor monitor...");
+            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+            {
+                return;
+            }
 
-			Task.Run(async () =>
-			{
-				try
-				{
-					while (IsRunning)
-					{
-						try
-						{
-							await Task.Delay(torMisbehaviorCheckPeriod, Stop.Token).ConfigureAwait(false);
+            Task.Run(async () =>
+            {
+                try
+                {
+                    while (IsRunning)
+                    {
+                        try
+                        {
+                            await Task.Delay(torMisbehaviorCheckPeriod, Stop.Token).ConfigureAwait(false);
 
-							if (TorHttpClient.TorDoesntWorkSince != null) // If Tor misbehaves.
-							{
-								TimeSpan torMisbehavedFor = (DateTimeOffset.UtcNow - TorHttpClient.TorDoesntWorkSince) ?? TimeSpan.Zero;
+                            if (TorHttpClient.TorDoesntWorkSince != null) // If Tor misbehaves.
+                            {
+                                TimeSpan torMisbehavedFor = (DateTimeOffset.UtcNow - TorHttpClient.TorDoesntWorkSince) ?? TimeSpan.Zero;
 
-								if (torMisbehavedFor > checkIfRunningAfterTorMisbehavedFor)
-								{
-									if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx)
-									{
-										if (torEx.RepField == RepField.HostUnreachable)
-										{
-											Uri baseUri = new Uri($"{fallBackTestRequestUri.Scheme}://{fallBackTestRequestUri.DnsSafeHost}");
-											using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
-											{
-												var message = new HttpRequestMessage(HttpMethod.Get, fallBackTestRequestUri);
-												await client.SendAsync(message, Stop.Token);
-											}
+                                if (torMisbehavedFor > checkIfRunningAfterTorMisbehavedFor)
+                                {
+                                    if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx)
+                                    {
+                                        if (torEx.RepField == RepField.HostUnreachable)
+                                        {
+                                            Uri baseUri = new Uri($"{fallBackTestRequestUri.Scheme}://{fallBackTestRequestUri.DnsSafeHost}");
+                                            using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
+                                            {
+                                                var message = new HttpRequestMessage(HttpMethod.Get, fallBackTestRequestUri);
+                                                await client.SendAsync(message, Stop.Token);
+                                            }
 
-											// Check if it changed in the meantime...
-											if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx2 && torEx2.RepField == RepField.HostUnreachable)
-											{
-												// Fallback here...
-												RequestFallbackAddressUsage = true;
-											}
-										}
-									}
-									else
-									{
-										Logger.LogInfo<TorProcessManager>($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
-										Start(true, dataDirToStartWith); // Try starting Tor, if it does not work it'll be another issue.
-										await Task.Delay(14000, Stop.Token).ConfigureAwait(false);
-									}
-								}
-							}
-						}
-						catch (Exception ex) when (ex is OperationCanceledException
-												|| ex is TaskCanceledException
-												|| ex is TimeoutException)
-						{
-							Logger.LogTrace<TorProcessManager>(ex);
-						}
-						catch (Exception ex)
-						{
-							Logger.LogDebug<TorProcessManager>(ex);
-						}
-					}
-				}
-				finally
-				{
-					Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
-				}
-			});
-		}
+                                            // Check if it changed in the meantime...
+                                            if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx2 && torEx2.RepField == RepField.HostUnreachable)
+                                            {
+                                                // Fallback here...
+                                                RequestFallbackAddressUsage = true;
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        Logger.LogInfo<TorProcessManager>($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
+                                        Start(true, dataDirToStartWith); // Try starting Tor, if it does not work it'll be another issue.
+                                        await Task.Delay(14000, Stop.Token).ConfigureAwait(false);
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception ex) when (ex is OperationCanceledException
+                                                || ex is TaskCanceledException
+                                                || ex is TimeoutException)
+                        {
+                            Logger.LogTrace<TorProcessManager>(ex);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogDebug<TorProcessManager>(ex);
+                        }
+                    }
+                }
+                finally
+                {
+                    Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
+                }
+            });
+        }
 
-		public async Task StopAsync()
-		{
-			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+        public async Task StopAsync()
+        {
+            Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
 
-			if (TorSocks5EndPoint is null)
-			{
-				Interlocked.Exchange(ref _running, 3);
-			}
+            if (TorSocks5EndPoint is null)
+            {
+                Interlocked.Exchange(ref _running, 3);
+            }
 
-			Stop?.Cancel();
-			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
-			{
-				await Task.Delay(50);
-			}
-			Stop?.Dispose();
-			Stop = null;
-			TorProcess?.Dispose();
-			TorProcess = null;
-		}
+            Stop?.Cancel();
+            while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+            {
+                await Task.Delay(50);
+            }
+            Stop?.Dispose();
+            Stop = null;
+            TorProcess?.Dispose();
+            TorProcess = null;
+        }
 
-		#endregion Monitor
-	}
+        #endregion Monitor
+    }
 }

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -14,331 +14,331 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.TorSocks5
 {
-    public class TorProcessManager
-    {
-        /// <summary>
-        /// If null then it's just a mock, clearnet is used.
-        /// </summary>
-        public EndPoint TorSocks5EndPoint { get; }
+	public class TorProcessManager
+	{
+		/// <summary>
+		/// If null then it's just a mock, clearnet is used.
+		/// </summary>
+		public EndPoint TorSocks5EndPoint { get; }
 
-        public string LogFile { get; }
+		public string LogFile { get; }
 
-        public static bool RequestFallbackAddressUsage { get; private set; } = false;
+		public static bool RequestFallbackAddressUsage { get; private set; } = false;
 
-        public Process TorProcess { get; private set; }
+		public Process TorProcess { get; private set; }
 
-        /// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
-        /// <param name="logFile">Opt out of logging with null.</param>
-        public TorProcessManager(EndPoint torSocks5EndPoint, string logFile)
-        {
-            TorSocks5EndPoint = torSocks5EndPoint;
-            LogFile = logFile;
-            _running = 0;
-            Stop = new CancellationTokenSource();
-            TorProcess = null;
-        }
+		/// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
+		/// <param name="logFile">Opt out of logging with null.</param>
+		public TorProcessManager(EndPoint torSocks5EndPoint, string logFile)
+		{
+			TorSocks5EndPoint = torSocks5EndPoint;
+			LogFile = logFile;
+			_running = 0;
+			Stop = new CancellationTokenSource();
+			TorProcess = null;
+		}
 
-        public static TorProcessManager Mock() // Mock, do not use Tor at all for debug.
-        {
-            return new TorProcessManager(null, null);
-        }
+		public static TorProcessManager Mock() // Mock, do not use Tor at all for debug.
+		{
+			return new TorProcessManager(null, null);
+		}
 
-        public void Start(bool ensureRunning, string dataDir)
-        {
-            if (TorSocks5EndPoint is null)
-            {
-                return;
-            }
+		public void Start(bool ensureRunning, string dataDir)
+		{
+			if (TorSocks5EndPoint is null)
+			{
+				return;
+			}
 
-            new Thread(delegate () // Do not ask. This is the only way it worked on Win10/Ubuntu18.04/Manjuro(1 processor VM)/Fedora(1 processor VM)
-            {
-                try
-                {
-                    // 1. Is it already running?
-                    // 2. Can I simply run it from output directory?
-                    // 3. Can I copy and unzip it from assets?
-                    // 4. Throw exception.
+			new Thread(delegate () // Do not ask. This is the only way it worked on Win10/Ubuntu18.04/Manjuro(1 processor VM)/Fedora(1 processor VM)
+			{
+				try
+				{
+					// 1. Is it already running?
+					// 2. Can I simply run it from output directory?
+					// 3. Can I copy and unzip it from assets?
+					// 4. Throw exception.
 
-                    try
-                    {
-                        if (IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
-                        {
-                            Logger.LogInfo<TorProcessManager>("Tor is already running.");
-                            return;
-                        }
+					try
+					{
+						if (IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
+						{
+							Logger.LogInfo<TorProcessManager>("Tor is already running.");
+							return;
+						}
 
-                        var torDir = Path.Combine(dataDir, "tor");
-                        var torPath = "";
-                        var fullBaseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
-                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        {
-                            if (!fullBaseDirectory.StartsWith('/'))
-                            {
-                                fullBaseDirectory.Insert(0, "/");
-                            }
+						var torDir = Path.Combine(dataDir, "tor");
+						var torPath = "";
+						var fullBaseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
+						if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+						{
+							if (!fullBaseDirectory.StartsWith('/'))
+							{
+								fullBaseDirectory.Insert(0, "/");
+							}
 
-                            torPath = $@"{torDir}/Tor/tor";
-                        }
-                        else // If Windows
-                        {
-                            torPath = $@"{torDir}\Tor\tor.exe";
-                        }
+							torPath = $@"{torDir}/Tor/tor";
+						}
+						else // If Windows
+						{
+							torPath = $@"{torDir}\Tor\tor.exe";
+						}
 
-                        if (!File.Exists(torPath))
-                        {
-                            Logger.LogInfo<TorProcessManager>($"Tor instance NOT found at {torPath}. Attempting to acquire it...");
-                            InstallTor(fullBaseDirectory, torDir);
-                        }
-                        else if (!IoHelpers.CheckExpectedHash(torPath, Path.Combine(fullBaseDirectory, "TorDaemons")))
-                        {
-                            Logger.LogInfo<TorProcessManager>($"Updating Tor...");
+						if (!File.Exists(torPath))
+						{
+							Logger.LogInfo<TorProcessManager>($"Tor instance NOT found at {torPath}. Attempting to acquire it...");
+							InstallTor(fullBaseDirectory, torDir);
+						}
+						else if (!IoHelpers.CheckExpectedHash(torPath, Path.Combine(fullBaseDirectory, "TorDaemons")))
+						{
+							Logger.LogInfo<TorProcessManager>($"Updating Tor...");
 
-                            string backupTorDir = $"{torDir}_backup";
-                            if (Directory.Exists(backupTorDir))
-                            {
-                                Directory.Delete(backupTorDir, true);
-                            }
-                            Directory.Move(torDir, backupTorDir);
+							string backupTorDir = $"{torDir}_backup";
+							if (Directory.Exists(backupTorDir))
+							{
+								Directory.Delete(backupTorDir, true);
+							}
+							Directory.Move(torDir, backupTorDir);
 
-                            InstallTor(fullBaseDirectory, torDir);
-                        }
-                        else
-                        {
-                            Logger.LogInfo<TorProcessManager>($"Tor instance found at {torPath}.");
-                        }
+							InstallTor(fullBaseDirectory, torDir);
+						}
+						else
+						{
+							Logger.LogInfo<TorProcessManager>($"Tor instance found at {torPath}.");
+						}
 
-                        string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
-                        if (!string.IsNullOrEmpty(LogFile))
-                        {
-                            IoHelpers.EnsureContainingDirectoryExists(LogFile);
-                            var logFileFullPath = Path.GetFullPath(LogFile);
-                            torArguments += $" --Log \"notice file {logFileFullPath}\"";
-                        }
+						string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
+						if (!string.IsNullOrEmpty(LogFile))
+						{
+							IoHelpers.EnsureContainingDirectoryExists(LogFile);
+							var logFileFullPath = Path.GetFullPath(LogFile);
+							torArguments += $" --Log \"notice file {logFileFullPath}\"";
+						}
 
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        {
-                            TorProcess = Process.Start(new ProcessStartInfo
-                            {
-                                FileName = torPath,
-                                Arguments = torArguments,
-                                UseShellExecute = false,
-                                CreateNoWindow = true,
-                                RedirectStandardOutput = true
-                            });
-                            Logger.LogInfo<TorProcessManager>($"Starting Tor process with Process.Start.");
-                        }
-                        else // Linux and OSX
-                        {
-                            string runTorCmd = $"LD_LIBRARY_PATH=$LD_LIBRARY_PATH:={torDir}/Tor && export LD_LIBRARY_PATH && cd {torDir}/Tor && ./tor {torArguments}";
-                            EnvironmentHelpers.ShellExec(runTorCmd, false);
-                            Logger.LogInfo<TorProcessManager>($"Started Tor process with shell command: {runTorCmd}.");
-                        }
+						if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+						{
+							TorProcess = Process.Start(new ProcessStartInfo
+							{
+								FileName = torPath,
+								Arguments = torArguments,
+								UseShellExecute = false,
+								CreateNoWindow = true,
+								RedirectStandardOutput = true
+							});
+							Logger.LogInfo<TorProcessManager>($"Starting Tor process with Process.Start.");
+						}
+						else // Linux and OSX
+						{
+							string runTorCmd = $"LD_LIBRARY_PATH=$LD_LIBRARY_PATH:={torDir}/Tor && export LD_LIBRARY_PATH && cd {torDir}/Tor && ./tor {torArguments}";
+							EnvironmentHelpers.ShellExec(runTorCmd, false);
+							Logger.LogInfo<TorProcessManager>($"Started Tor process with shell command: {runTorCmd}.");
+						}
 
-                        if (ensureRunning)
-                        {
-                            Task.Delay(3000).ConfigureAwait(false).GetAwaiter().GetResult(); // dotnet brainfart, ConfigureAwait(false) IS NEEDED HERE otherwise (only on) Manjuro Linux fails, WTF?!!
-                            if (!IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
-                            {
-                                throw new TorException("Attempted to start Tor, but it is not running.");
-                            }
-                            Logger.LogInfo<TorProcessManager>("Tor is running.");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new TorException("Could not automatically start Tor. Try running Tor manually.", ex);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError<TorProcessManager>(ex);
-                }
-            }).Start();
-        }
+						if (ensureRunning)
+						{
+							Task.Delay(3000).ConfigureAwait(false).GetAwaiter().GetResult(); // dotnet brainfart, ConfigureAwait(false) IS NEEDED HERE otherwise (only on) Manjuro Linux fails, WTF?!!
+							if (!IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
+							{
+								throw new TorException("Attempted to start Tor, but it is not running.");
+							}
+							Logger.LogInfo<TorProcessManager>("Tor is running.");
+						}
+					}
+					catch (Exception ex)
+					{
+						throw new TorException("Could not automatically start Tor. Try running Tor manually.", ex);
+					}
+				}
+				catch (Exception ex)
+				{
+					Logger.LogError<TorProcessManager>(ex);
+				}
+			}).Start();
+		}
 
-        private static void InstallTor(string fullBaseDirectory, string torDir)
-        {
-            string torDaemonsDir = Path.Combine(fullBaseDirectory, "TorDaemons");
+		private static void InstallTor(string fullBaseDirectory, string torDir)
+		{
+			string torDaemonsDir = Path.Combine(fullBaseDirectory, "TorDaemons");
 
-            string dataZip = Path.Combine(torDaemonsDir, "data-folder.zip");
-            IoHelpers.BetterExtractZipToDirectoryAsync(dataZip, torDir).GetAwaiter().GetResult();
-            Logger.LogInfo<TorProcessManager>($"Extracted {dataZip} to {torDir}.");
+			string dataZip = Path.Combine(torDaemonsDir, "data-folder.zip");
+			IoHelpers.BetterExtractZipToDirectoryAsync(dataZip, torDir).GetAwaiter().GetResult();
+			Logger.LogInfo<TorProcessManager>($"Extracted {dataZip} to {torDir}.");
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                string torWinZip = Path.Combine(torDaemonsDir, "tor-win32.zip");
-                IoHelpers.BetterExtractZipToDirectoryAsync(torWinZip, torDir).GetAwaiter().GetResult();
-                Logger.LogInfo<TorProcessManager>($"Extracted {torWinZip} to {torDir}.");
-            }
-            else // Linux or OSX
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    string torLinuxZip = Path.Combine(torDaemonsDir, "tor-linux64.zip");
-                    IoHelpers.BetterExtractZipToDirectoryAsync(torLinuxZip, torDir).GetAwaiter().GetResult();
-                    Logger.LogInfo<TorProcessManager>($"Extracted {torLinuxZip} to {torDir}.");
-                }
-                else // OSX
-                {
-                    string torOsxZip = Path.Combine(torDaemonsDir, "tor-osx64.zip");
-                    IoHelpers.BetterExtractZipToDirectoryAsync(torOsxZip, torDir).GetAwaiter().GetResult();
-                    Logger.LogInfo<TorProcessManager>($"Extracted {torOsxZip} to {torDir}.");
-                }
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				string torWinZip = Path.Combine(torDaemonsDir, "tor-win32.zip");
+				IoHelpers.BetterExtractZipToDirectoryAsync(torWinZip, torDir).GetAwaiter().GetResult();
+				Logger.LogInfo<TorProcessManager>($"Extracted {torWinZip} to {torDir}.");
+			}
+			else // Linux or OSX
+			{
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+				{
+					string torLinuxZip = Path.Combine(torDaemonsDir, "tor-linux64.zip");
+					IoHelpers.BetterExtractZipToDirectoryAsync(torLinuxZip, torDir).GetAwaiter().GetResult();
+					Logger.LogInfo<TorProcessManager>($"Extracted {torLinuxZip} to {torDir}.");
+				}
+				else // OSX
+				{
+					string torOsxZip = Path.Combine(torDaemonsDir, "tor-osx64.zip");
+					IoHelpers.BetterExtractZipToDirectoryAsync(torOsxZip, torDir).GetAwaiter().GetResult();
+					Logger.LogInfo<TorProcessManager>($"Extracted {torOsxZip} to {torDir}.");
+				}
 
-                // Make sure there's sufficient permission.
-                string chmodTorDirCmd = $"chmod -R 750 {torDir}";
-                EnvironmentHelpers.ShellExec(chmodTorDirCmd);
-                Logger.LogInfo<TorProcessManager>($"Shell command executed: {chmodTorDirCmd}.");
-            }
-        }
+				// Make sure there's sufficient permission.
+				string chmodTorDirCmd = $"chmod -R 750 {torDir}";
+				EnvironmentHelpers.ShellExec(chmodTorDirCmd);
+				Logger.LogInfo<TorProcessManager>($"Shell command executed: {chmodTorDirCmd}.");
+			}
+		}
 
-        /// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
-        public static async Task<bool> IsTorRunningAsync(EndPoint torSocks5EndPoint)
-        {
-            using (var client = new TorSocks5Client(torSocks5EndPoint))
-            {
-                try
-                {
-                    await client.ConnectAsync();
-                    await client.HandshakeAsync();
-                }
-                catch (ConnectionException)
-                {
-                    return false;
-                }
-                return true;
-            }
-        }
+		/// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
+		public static async Task<bool> IsTorRunningAsync(EndPoint torSocks5EndPoint)
+		{
+			using (var client = new TorSocks5Client(torSocks5EndPoint))
+			{
+				try
+				{
+					await client.ConnectAsync();
+					await client.HandshakeAsync();
+				}
+				catch (ConnectionException)
+				{
+					return false;
+				}
+				return true;
+			}
+		}
 
-        public async Task<bool> IsTorRunningAsync()
-        {
-            if (TorSocks5EndPoint is null)
-            {
-                return true;
-            }
+		public async Task<bool> IsTorRunningAsync()
+		{
+			if (TorSocks5EndPoint is null)
+			{
+				return true;
+			}
 
-            using (var client = new TorSocks5Client(TorSocks5EndPoint))
-            {
-                try
-                {
-                    await client.ConnectAsync();
-                    await client.HandshakeAsync();
-                }
-                catch (ConnectionException)
-                {
-                    return false;
-                }
-                return true;
-            }
-        }
+			using (var client = new TorSocks5Client(TorSocks5EndPoint))
+			{
+				try
+				{
+					await client.ConnectAsync();
+					await client.HandshakeAsync();
+				}
+				catch (ConnectionException)
+				{
+					return false;
+				}
+				return true;
+			}
+		}
 
-        #region Monitor
+		#region Monitor
 
-        /// <summary>
-        /// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
-        /// </summary>
-        private long _running;
+		/// <summary>
+		/// 0: Not started, 1: Running, 2: Stopping, 3: Stopped
+		/// </summary>
+		private long _running;
 
-        public bool IsRunning => Interlocked.Read(ref _running) == 1;
+		public bool IsRunning => Interlocked.Read(ref _running) == 1;
 
-        private CancellationTokenSource Stop { get; set; }
+		private CancellationTokenSource Stop { get; set; }
 
-        public void StartMonitor(TimeSpan torMisbehaviorCheckPeriod, TimeSpan checkIfRunningAfterTorMisbehavedFor, string dataDirToStartWith, Uri fallBackTestRequestUri)
-        {
-            if (TorSocks5EndPoint is null)
-            {
-                return;
-            }
+		public void StartMonitor(TimeSpan torMisbehaviorCheckPeriod, TimeSpan checkIfRunningAfterTorMisbehavedFor, string dataDirToStartWith, Uri fallBackTestRequestUri)
+		{
+			if (TorSocks5EndPoint is null)
+			{
+				return;
+			}
 
-            Logger.LogInfo<TorProcessManager>("Starting Tor monitor...");
-            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
-            {
-                return;
-            }
+			Logger.LogInfo<TorProcessManager>("Starting Tor monitor...");
+			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+			{
+				return;
+			}
 
-            Task.Run(async () =>
-            {
-                try
-                {
-                    while (IsRunning)
-                    {
-                        try
-                        {
-                            await Task.Delay(torMisbehaviorCheckPeriod, Stop.Token).ConfigureAwait(false);
+			Task.Run(async () =>
+			{
+				try
+				{
+					while (IsRunning)
+					{
+						try
+						{
+							await Task.Delay(torMisbehaviorCheckPeriod, Stop.Token).ConfigureAwait(false);
 
-                            if (TorHttpClient.TorDoesntWorkSince != null) // If Tor misbehaves.
-                            {
-                                TimeSpan torMisbehavedFor = (DateTimeOffset.UtcNow - TorHttpClient.TorDoesntWorkSince) ?? TimeSpan.Zero;
+							if (TorHttpClient.TorDoesntWorkSince != null) // If Tor misbehaves.
+							{
+								TimeSpan torMisbehavedFor = (DateTimeOffset.UtcNow - TorHttpClient.TorDoesntWorkSince) ?? TimeSpan.Zero;
 
-                                if (torMisbehavedFor > checkIfRunningAfterTorMisbehavedFor)
-                                {
-                                    if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx)
-                                    {
-                                        if (torEx.RepField == RepField.HostUnreachable)
-                                        {
-                                            Uri baseUri = new Uri($"{fallBackTestRequestUri.Scheme}://{fallBackTestRequestUri.DnsSafeHost}");
-                                            using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
-                                            {
-                                                var message = new HttpRequestMessage(HttpMethod.Get, fallBackTestRequestUri);
-                                                await client.SendAsync(message, Stop.Token);
-                                            }
+								if (torMisbehavedFor > checkIfRunningAfterTorMisbehavedFor)
+								{
+									if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx)
+									{
+										if (torEx.RepField == RepField.HostUnreachable)
+										{
+											Uri baseUri = new Uri($"{fallBackTestRequestUri.Scheme}://{fallBackTestRequestUri.DnsSafeHost}");
+											using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
+											{
+												var message = new HttpRequestMessage(HttpMethod.Get, fallBackTestRequestUri);
+												await client.SendAsync(message, Stop.Token);
+											}
 
-                                            // Check if it changed in the meantime...
-                                            if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx2 && torEx2.RepField == RepField.HostUnreachable)
-                                            {
-                                                // Fallback here...
-                                                RequestFallbackAddressUsage = true;
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        Logger.LogInfo<TorProcessManager>($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
-                                        Start(true, dataDirToStartWith); // Try starting Tor, if it does not work it'll be another issue.
-                                        await Task.Delay(14000, Stop.Token).ConfigureAwait(false);
-                                    }
-                                }
-                            }
-                        }
-                        catch (Exception ex) when (ex is OperationCanceledException
-                                                || ex is TaskCanceledException
-                                                || ex is TimeoutException)
-                        {
-                            Logger.LogTrace<TorProcessManager>(ex);
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogDebug<TorProcessManager>(ex);
-                        }
-                    }
-                }
-                finally
-                {
-                    Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
-                }
-            });
-        }
+											// Check if it changed in the meantime...
+											if (TorHttpClient.LatestTorException is TorSocks5FailureResponseException torEx2 && torEx2.RepField == RepField.HostUnreachable)
+											{
+												// Fallback here...
+												RequestFallbackAddressUsage = true;
+											}
+										}
+									}
+									else
+									{
+										Logger.LogInfo<TorProcessManager>($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
+										Start(true, dataDirToStartWith); // Try starting Tor, if it does not work it'll be another issue.
+										await Task.Delay(14000, Stop.Token).ConfigureAwait(false);
+									}
+								}
+							}
+						}
+						catch (Exception ex) when (ex is OperationCanceledException
+												|| ex is TaskCanceledException
+												|| ex is TimeoutException)
+						{
+							Logger.LogTrace<TorProcessManager>(ex);
+						}
+						catch (Exception ex)
+						{
+							Logger.LogDebug<TorProcessManager>(ex);
+						}
+					}
+				}
+				finally
+				{
+					Interlocked.CompareExchange(ref _running, 3, 2); // If IsStopping, make it stopped.
+				}
+			});
+		}
 
-        public async Task StopAsync()
-        {
-            Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
+		public async Task StopAsync()
+		{
+			Interlocked.CompareExchange(ref _running, 2, 1); // If running, make it stopping.
 
-            if (TorSocks5EndPoint is null)
-            {
-                Interlocked.Exchange(ref _running, 3);
-            }
+			if (TorSocks5EndPoint is null)
+			{
+				Interlocked.Exchange(ref _running, 3);
+			}
 
-            Stop?.Cancel();
-            while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
-            {
-                await Task.Delay(50);
-            }
-            Stop?.Dispose();
-            Stop = null;
-            TorProcess?.Dispose();
-            TorProcess = null;
-        }
+			Stop?.Cancel();
+			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
+			{
+				await Task.Delay(50);
+			}
+			Stop?.Dispose();
+			Stop = null;
+			TorProcess?.Dispose();
+			TorProcess = null;
+		}
 
-        #endregion Monitor
-    }
+		#endregion Monitor
+	}
 }

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -15,544 +15,545 @@ using WalletWasabi.TorSocks5.TorSocks5.Models.Fields.ByteArrayFields;
 
 namespace WalletWasabi.TorSocks5
 {
-	/// <summary>
-	/// Create an instance with the TorSocks5Manager
-	/// </summary>
-	public class TorSocks5Client : IDisposable
-	{
-		#region PropertiesAndMembers
-
-		public TcpClient TcpClient { get; private set; }
-
-		public IPEndPoint TorSocks5EndPoint { get; private set; }
-
-		public Stream Stream { get; internal set; }
-
-		public string DestinationHost { get; private set; }
-
-		public int DestinationPort { get; private set; }
-
-		private IPEndPoint RemoteEndPoint { get; set; }
-
-		public bool IsConnected
-		{
-			get
-			{
-				try
-				{
-					return !(TcpClient is null) && TcpClient.Connected;
-				}
-				catch (Exception ex)
-				{
-					Logger.LogWarning<TorSocks5Client>(ex);
-					return false;
-				}
-			}
-		}
-
-		internal AsyncLock AsyncLock { get; }
-
-		#endregion PropertiesAndMembers
-
-		#region ConstructorsAndInitializers
-
-		/// <param name="ipEndPoint">Opt out Tor with null.</param>
-		internal TorSocks5Client(IPEndPoint ipEndPoint)
-		{
-			TorSocks5EndPoint = ipEndPoint;
-			TcpClient = ipEndPoint is null ? new TcpClient() : new TcpClient(ipEndPoint.AddressFamily);
-			AsyncLock = new AsyncLock();
-		}
-
-		/// <param name="tcpClient">Must be already connected.</param>
-		internal TorSocks5Client(TcpClient tcpClient)
-		{
-			Guard.NotNull(nameof(tcpClient), tcpClient);
-			TcpClient = tcpClient;
-			AsyncLock = new AsyncLock();
-			Stream = tcpClient.GetStream();
-			TorSocks5EndPoint = null;
-			var remoteEndPoint = tcpClient.Client.RemoteEndPoint as IPEndPoint;
-			DestinationHost = remoteEndPoint.Address.ToString();
-			DestinationPort = remoteEndPoint.Port;
-			RemoteEndPoint = remoteEndPoint;
-			if (!IsConnected)
-			{
-				throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
-			}
-		}
-
-		internal async Task ConnectAsync()
-		{
-			if (TorSocks5EndPoint is null)
-			{
-				return;
-			}
-
-			using (await AsyncLock.LockAsync())
-			{
-				try
-				{
-					await TcpClient.ConnectAsync(TorSocks5EndPoint.Address, TorSocks5EndPoint.Port);
-				}
-				catch (Exception ex) when (IsConnectionRefused(ex))
-				{
-					throw new ConnectionException(
-						$"Could not connect to Tor SOCKSPort at {TorSocks5EndPoint.Address}:{TorSocks5EndPoint.Port}. Is Tor running?", ex);
-				}
-
-				Stream = TcpClient.GetStream();
-				RemoteEndPoint = TcpClient.Client.RemoteEndPoint as IPEndPoint;
-			}
-		}
-
-		/// <summary>
-		/// IsolateSOCKSAuth must be on (on by default)
-		/// https://www.torproject.org/docs/tor-manual.html.en
-		/// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
-		/// </summary>
-		internal async Task HandshakeAsync(bool isolateStream = true)
-		{
-			await HandshakeAsync(isolateStream ? RandomString.Generate(21) : "");
-		}
-
-		/// <summary>
-		/// IsolateSOCKSAuth must be on (on by default)
-		/// https://www.torproject.org/docs/tor-manual.html.en
-		/// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
-		/// </summary>
-		/// <param name="identity">Isolates streams by identity. If identity is empty string, it won't isolate stream.</param>
-		internal async Task HandshakeAsync(string identity)
-		{
-			if (TorSocks5EndPoint is null)
-			{
-				return;
-			}
-
-			Guard.NotNull(nameof(identity), identity);
-
-			MethodsField methods;
-			if (string.IsNullOrWhiteSpace(identity))
-			{
-				methods = new MethodsField(MethodField.NoAuthenticationRequired);
-			}
-			else
-			{
-				methods = new MethodsField(MethodField.UsernamePassword);
-			}
-
-			var sendBuffer = new VersionMethodRequest(methods).ToBytes();
-
-			var receiveBuffer = await SendAsync(sendBuffer, 2);
-
-			var methodSelection = new MethodSelectionResponse();
-			methodSelection.FromBytes(receiveBuffer);
-			if (methodSelection.Ver != VerField.Socks5)
-			{
-				throw new NotSupportedException($"`SOCKS{methodSelection.Ver.Value} is not supported. Only SOCKS5 is supported.");
-			}
-			if (methodSelection.Method == MethodField.NoAcceptableMethods)
-			{
-				// https://www.ietf.org/rfc/rfc1928.txt
-				// If the selected METHOD is X'FF', none of the methods listed by the
-				// client are acceptable, and the client MUST close the connection.
-				DisposeTcpClient();
-				throw new NotSupportedException("Tor's SOCKS5 proxy does not support any of the client's authentication methods.");
-			}
-			if (methodSelection.Method == MethodField.UsernamePassword)
-			{
-				// https://tools.ietf.org/html/rfc1929#section-2
-				// Once the SOCKS V5 server has started, and the client has selected the
-				// Username / Password Authentication protocol, the Username / Password
-				// subnegotiation begins.  This begins with the client producing a
-				// Username / Password request:
-				var username = identity;
-				var password = identity;
-				var uName = new UNameField(username);
-				var passwd = new PasswdField(password);
-				var usernamePasswordRequest = new UsernamePasswordRequest(uName, passwd);
-				sendBuffer = usernamePasswordRequest.ToBytes();
-
-				Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
-				receiveBuffer = await SendAsync(sendBuffer, 2);
-
-				var userNamePasswordResponse = new UsernamePasswordResponse();
-				userNamePasswordResponse.FromBytes(receiveBuffer);
-				if (userNamePasswordResponse.Ver != usernamePasswordRequest.Ver)
-				{
-					throw new NotSupportedException($"Authentication version {userNamePasswordResponse.Ver.Value} is not supported. Only version {usernamePasswordRequest.Ver} is supported.");
-				}
-
-				if (!userNamePasswordResponse.Status.IsSuccess()) // Tor authentication is different, this will never happen;
-				{
-					// https://tools.ietf.org/html/rfc1929#section-2
-					// A STATUS field of X'00' indicates success. If the server returns a
-					// `failure' (STATUS value other than X'00') status, it MUST close the
-					// connection.
-					DisposeTcpClient();
-					throw new InvalidOperationException("Wrong username and/or password.");
-				}
-			}
-		}
-
-		internal async Task ConnectToDestinationAsync(IPEndPoint destination, bool isRecursiveCall = false)
-		{
-			Guard.NotNull(nameof(destination), destination);
-			await ConnectToDestinationAsync(destination.Address.ToString(), destination.Port, isRecursiveCall: isRecursiveCall);
-		}
-
-		/// <param name="host">IPv4 or domain</param>
-		internal async Task ConnectToDestinationAsync(string host, int port, bool isRecursiveCall = false)
-		{
-			host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
-			Guard.MinimumAndNotNull(nameof(port), port, 0);
-
-			if (TorSocks5EndPoint is null)
-			{
-				using (await AsyncLock.LockAsync())
-				{
-					TcpClient?.Dispose();
-					if (IPAddress.TryParse(host, out IPAddress ip))
-					{
-						TcpClient = new TcpClient(ip.AddressFamily);
-					}
-					else
-					{
-						TcpClient = new TcpClient();
-					}
-					await TcpClient.ConnectAsync(host, port);
-					Stream = TcpClient.GetStream();
-					RemoteEndPoint = TcpClient.Client.RemoteEndPoint as IPEndPoint;
-				}
-
-				return;
-			}
-
-			var cmd = CmdField.Connect;
-
-			var dstAddr = new AddrField(host);
-			DestinationHost = dstAddr.DomainOrIPv4;
-
-			var dstPort = new PortField(port);
-			DestinationPort = dstPort.DstPort;
-
-			var connectionRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-			var sendBuffer = connectionRequest.ToBytes();
-
-			var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall);
-
-			var connectionResponse = new TorSocks5Response();
-			connectionResponse.FromBytes(receiveBuffer);
-
-			if (connectionResponse.Rep != RepField.Succeeded)
-			{
-				// https://www.ietf.org/rfc/rfc1928.txt
-				// When a reply(REP value other than X'00') indicates a failure, the
-				// SOCKS server MUST terminate the TCP connection shortly after sending
-				// the reply.This must be no more than 10 seconds after detecting the
-				// condition that caused a failure.
-				DisposeTcpClient();
-				throw new TorSocks5FailureResponseException(connectionResponse.Rep);
-			}
-
-			// Do not check the Bnd. Address and Bnd. Port. because Tor does not seem to return any, ever. It returns zeros instead.
-			// Generally also do not check anything but the success response, according to Socks5 RFC
-
-			// If the reply code(REP value of X'00') indicates a success, and the
-			// request was either a BIND or a CONNECT, the client may now start
-			// passing data.  If the selected authentication method supports
-			// encapsulation for the purposes of integrity, authentication and / or
-			// confidentiality, the data are encapsulated using the method-dependent
-			// encapsulation.Similarly, when data arrives at the SOCKS server for
-			// the client, the server MUST encapsulate the data as appropriate for
-			// the authentication method in use.
-		}
-
-		public async Task AssertConnectedAsync(bool isRecursiveCall = false)
-		{
-			if (!IsConnected)
-			{
-				// try reconnect, maybe the server came online already
-				try
-				{
-					await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: isRecursiveCall);
-				}
-				catch (Exception ex) when (IsConnectionRefused(ex))
-				{
-					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
-				}
-				if (!IsConnected)
-				{
-					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
-				}
-			}
-		}
-
-		#endregion ConstructorsAndInitializers
-
-		#region Methods
-
-		private bool IsConnectionRefused(Exception exc)
-		{
-			Exception error = null;
-			try
-			{
-				throw exc;
-			}
-			// ex.Message must be checked, because I'm having difficulty catching SocketExceptionFactory+ExtendedSocketException
-			// Only works on English Os-es.
-			catch (Exception ex) when (ex.Message.StartsWith(
-										   "No connection could be made because the target machine actively refused it") // Windows
-									   || ex.Message.StartsWith("Connection refused")) // Linux && OSX
-			{
-				error = ex;
-			}
-			// "No connection could be made because the target machine actively refused it" for non-English Windows.
-			catch (SocketException ex) when (ex.ErrorCode == 10061)
-			{
-				error = ex;
-			}
-			// "Connection refused" for non-English Linux.
-			catch (SocketException ex) when (ex.ErrorCode == 111)
-			{
-				error = ex;
-			}
-			// "Connection refused" for non-English OSX.
-			catch (SocketException ex) when (ex.ErrorCode == 61)
-			{
-				error = ex;
-			}
-			catch
-			{
-				// Ignored, since error is null.
-			}
-
-			return error != null;
-		}
-
-		/// <summary>
-		/// Sends bytes to the Tor Socks5 connection
-		/// </summary>
-		/// <param name="sendBuffer">Sent data</param>
-		/// <param name="receiveBufferSize">Maximum number of bytes expected to be received in the reply</param>
-		/// <returns>Reply</returns>
-		public async Task<byte[]> SendAsync(byte[] sendBuffer, int? receiveBufferSize = null, bool isRecursiveCall = false)
-		{
-			Guard.NotNullOrEmpty(nameof(sendBuffer), sendBuffer);
-
-			try
-			{
-				if (!isRecursiveCall) // Because AssertConnectedAsync would be calling it again.
-				{
-					await AssertConnectedAsync(isRecursiveCall: true);
-				}
-
-				using (await AsyncLock.LockAsync())
-				{
-					var stream = TcpClient.GetStream();
-
-					// Write data to the stream
-					await stream.WriteAsync(sendBuffer, 0, sendBuffer.Length);
-					await stream.FlushAsync();
-
-					// If receiveBufferSize is null, zero or negative or bigger than TcpClient.ReceiveBufferSize
-					// then work with TcpClient.ReceiveBufferSize
-					var tcpReceiveBuffSize = TcpClient.ReceiveBufferSize;
-					var actualReceiveBufferSize = 0;
-					if (receiveBufferSize is null || receiveBufferSize <= 0 || receiveBufferSize > tcpReceiveBuffSize)
-					{
-						actualReceiveBufferSize = tcpReceiveBuffSize;
-					}
-					else
-					{
-						actualReceiveBufferSize = (int)receiveBufferSize;
-					}
-
-					// Receive the response
-					var receiveBuffer = new byte[actualReceiveBufferSize];
-
-					int receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
-
-					if (receiveCount <= 0)
-					{
-						throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
-					}
-					// if we could fit everything into our buffer, then return it
-					if (!stream.DataAvailable)
-					{
-						return receiveBuffer.Take(receiveCount).ToArray();
-					}
-
-					// while we have data available, start building a bytearray
-					var builder = new ByteArrayBuilder();
-					builder.Append(receiveBuffer.Take(receiveCount).ToArray());
-					while (stream.DataAvailable)
-					{
-						Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
-						receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
-						if (receiveCount <= 0)
-						{
-							throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
-						}
-						builder.Append(receiveBuffer.Take(receiveCount).ToArray());
-					}
-
-					return builder.ToArray();
-				}
-			}
-			catch (IOException ex)
-			{
-				if (isRecursiveCall)
-				{
-					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
-				}
-				else
-				{
-					// try reconnect, maybe the server came online already
-					try
-					{
-						await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: true);
-					}
-					catch (Exception ex2) when (IsConnectionRefused(ex2))
-					{
-						throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex2);
-					}
-					return await SendAsync(sendBuffer, receiveBufferSize, isRecursiveCall: true);
-				}
-			}
-		}
-
-		/// <summary>
-		/// When Tor receives a "RESOLVE" SOCKS command, it initiates
-		/// a remote lookup of the hostname provided as the target address in the SOCKS
-		/// request.
-		/// </summary>
-		internal async Task<IPAddress> ResolveAsync(string host)
-		{
-			// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n44
-
-			host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
-
-			if (TorSocks5EndPoint is null)
-			{
-				var hostAddresses = await Dns.GetHostAddressesAsync(host);
-				return hostAddresses.First();
-			}
-
-			var cmd = CmdField.Resolve;
-
-			var dstAddr = new AddrField(host);
-
-			var dstPort = new PortField(0);
-
-			var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-			var sendBuffer = resolveRequest.ToBytes();
-
-			var receiveBuffer = await SendAsync(sendBuffer);
-
-			var resolveResponse = new TorSocks5Response();
-			resolveResponse.FromBytes(receiveBuffer);
-
-			if (resolveResponse.Rep != RepField.Succeeded)
-			{
-				throw new TorSocks5FailureResponseException(resolveResponse.Rep);
-			}
-			return IPAddress.Parse(resolveResponse.BndAddr.DomainOrIPv4);
-		}
-
-		/// <summary>
-		/// Tor attempts to find the canonical hostname for that IPv4 record
-		/// </summary>
-		internal async Task<string> ReverseResolveAsync(IPAddress iPv4)
-		{
-			// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n55
-
-			Guard.NotNull(nameof(iPv4), iPv4);
-
-			if (TorSocks5EndPoint is null) // Only Tor is iPv4 dependent
-			{
-				var host = await Dns.GetHostEntryAsync(iPv4);
-				return host.HostName;
-			}
-
-			Guard.Same($"{nameof(iPv4)}.{nameof(iPv4.AddressFamily)}", AddressFamily.InterNetwork, iPv4.AddressFamily);
-
-			var cmd = CmdField.ResolvePtr;
-
-			var dstAddr = new AddrField(iPv4.ToString());
-
-			var dstPort = new PortField(0);
-
-			var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-			var sendBuffer = resolveRequest.ToBytes();
-
-			var receiveBuffer = await SendAsync(sendBuffer);
-
-			var resolveResponse = new TorSocks5Response();
-			resolveResponse.FromBytes(receiveBuffer);
-
-			if (resolveResponse.Rep != RepField.Succeeded)
-			{
-				throw new TorSocks5FailureResponseException(resolveResponse.Rep);
-			}
-			return resolveResponse.BndAddr.DomainOrIPv4;
-		}
-
-		#endregion Methods
-
-		#region IDisposable Support
-
-		private volatile bool _disposedValue = false; // To detect redundant calls
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!_disposedValue)
-			{
-				if (disposing)
-				{
-					DisposeTcpClient();
-				}
-
-				_disposedValue = true;
-			}
-		}
-
-		// ~TorSocks5Client() {
-		//   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-		//   Dispose(false);
-		// }
-
-		// This code added to correctly implement the disposable pattern.
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(true);
-			// GC.SuppressFinalize(this);
-		}
-
-		private void DisposeTcpClient()
-		{
-			try
-			{
-				if (TcpClient != null)
-				{
-					if (TcpClient.Connected)
-					{
-						Stream?.Dispose();
-					}
-					TcpClient?.Dispose();
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning<TorSocks5Client>(ex);
-			}
-			finally
-			{
-				TcpClient = null; // need to be called, .net bug
-			}
-		}
-
-		#endregion IDisposable Support
-	}
+    /// <summary>
+    /// Create an instance with the TorSocks5Manager
+    /// </summary>
+    public class TorSocks5Client : IDisposable
+    {
+        #region PropertiesAndMembers
+
+        public TcpClient TcpClient { get; private set; }
+
+        public EndPoint TorSocks5EndPoint { get; private set; }
+
+        public Stream Stream { get; internal set; }
+
+        public string DestinationHost { get; private set; }
+
+        public int DestinationPort { get; private set; }
+
+        private EndPoint RemoteEndPoint { get; set; }
+
+        public bool IsConnected
+        {
+            get
+            {
+                try
+                {
+                    return !(TcpClient is null) && TcpClient.Connected;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning<TorSocks5Client>(ex);
+                    return false;
+                }
+            }
+        }
+
+        internal AsyncLock AsyncLock { get; }
+
+        #endregion PropertiesAndMembers
+
+        #region ConstructorsAndInitializers
+
+        /// <param name="endPoint">Opt out Tor with null.</param>
+        internal TorSocks5Client(EndPoint endPoint)
+        {
+            TorSocks5EndPoint = endPoint;
+            TcpClient = endPoint is null ? new TcpClient() : new TcpClient(endPoint.AddressFamily);
+            AsyncLock = new AsyncLock();
+        }
+
+        /// <param name="tcpClient">Must be already connected.</param>
+        internal TorSocks5Client(TcpClient tcpClient)
+        {
+            Guard.NotNull(nameof(tcpClient), tcpClient);
+            TcpClient = tcpClient;
+            AsyncLock = new AsyncLock();
+            Stream = tcpClient.GetStream();
+            TorSocks5EndPoint = null;
+            DestinationHost = tcpClient.Client.RemoteEndPoint.GetHostOrDefault();
+            DestinationPort = tcpClient.Client.RemoteEndPoint.GetPortOrDefault().Value;
+            RemoteEndPoint = tcpClient.Client.RemoteEndPoint;
+            if (!IsConnected)
+            {
+                throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
+            }
+        }
+
+        internal async Task ConnectAsync()
+        {
+            if (TorSocks5EndPoint is null)
+            {
+                return;
+            }
+
+            using (await AsyncLock.LockAsync())
+            {
+                string host = TorSocks5EndPoint.GetHostOrDefault();
+                int? port = TorSocks5EndPoint.GetPortOrDefault();
+                try
+                {
+                    await TcpClient.ConnectAsync(host, port.Value);
+                }
+                catch (Exception ex) when (IsConnectionRefused(ex))
+                {
+                    throw new ConnectionException(
+                        $"Could not connect to Tor SOCKSPort at {host}:{port}. Is Tor running?", ex);
+                }
+
+                Stream = TcpClient.GetStream();
+                RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
+            }
+        }
+
+        /// <summary>
+        /// IsolateSOCKSAuth must be on (on by default)
+        /// https://www.torproject.org/docs/tor-manual.html.en
+        /// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
+        /// </summary>
+        internal async Task HandshakeAsync(bool isolateStream = true)
+        {
+            await HandshakeAsync(isolateStream ? RandomString.Generate(21) : "");
+        }
+
+        /// <summary>
+        /// IsolateSOCKSAuth must be on (on by default)
+        /// https://www.torproject.org/docs/tor-manual.html.en
+        /// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
+        /// </summary>
+        /// <param name="identity">Isolates streams by identity. If identity is empty string, it won't isolate stream.</param>
+        internal async Task HandshakeAsync(string identity)
+        {
+            if (TorSocks5EndPoint is null)
+            {
+                return;
+            }
+
+            Guard.NotNull(nameof(identity), identity);
+
+            MethodsField methods;
+            if (string.IsNullOrWhiteSpace(identity))
+            {
+                methods = new MethodsField(MethodField.NoAuthenticationRequired);
+            }
+            else
+            {
+                methods = new MethodsField(MethodField.UsernamePassword);
+            }
+
+            var sendBuffer = new VersionMethodRequest(methods).ToBytes();
+
+            var receiveBuffer = await SendAsync(sendBuffer, 2);
+
+            var methodSelection = new MethodSelectionResponse();
+            methodSelection.FromBytes(receiveBuffer);
+            if (methodSelection.Ver != VerField.Socks5)
+            {
+                throw new NotSupportedException($"`SOCKS{methodSelection.Ver.Value} is not supported. Only SOCKS5 is supported.");
+            }
+            if (methodSelection.Method == MethodField.NoAcceptableMethods)
+            {
+                // https://www.ietf.org/rfc/rfc1928.txt
+                // If the selected METHOD is X'FF', none of the methods listed by the
+                // client are acceptable, and the client MUST close the connection.
+                DisposeTcpClient();
+                throw new NotSupportedException("Tor's SOCKS5 proxy does not support any of the client's authentication methods.");
+            }
+            if (methodSelection.Method == MethodField.UsernamePassword)
+            {
+                // https://tools.ietf.org/html/rfc1929#section-2
+                // Once the SOCKS V5 server has started, and the client has selected the
+                // Username / Password Authentication protocol, the Username / Password
+                // subnegotiation begins.  This begins with the client producing a
+                // Username / Password request:
+                var username = identity;
+                var password = identity;
+                var uName = new UNameField(username);
+                var passwd = new PasswdField(password);
+                var usernamePasswordRequest = new UsernamePasswordRequest(uName, passwd);
+                sendBuffer = usernamePasswordRequest.ToBytes();
+
+                Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
+                receiveBuffer = await SendAsync(sendBuffer, 2);
+
+                var userNamePasswordResponse = new UsernamePasswordResponse();
+                userNamePasswordResponse.FromBytes(receiveBuffer);
+                if (userNamePasswordResponse.Ver != usernamePasswordRequest.Ver)
+                {
+                    throw new NotSupportedException($"Authentication version {userNamePasswordResponse.Ver.Value} is not supported. Only version {usernamePasswordRequest.Ver} is supported.");
+                }
+
+                if (!userNamePasswordResponse.Status.IsSuccess()) // Tor authentication is different, this will never happen;
+                {
+                    // https://tools.ietf.org/html/rfc1929#section-2
+                    // A STATUS field of X'00' indicates success. If the server returns a
+                    // `failure' (STATUS value other than X'00') status, it MUST close the
+                    // connection.
+                    DisposeTcpClient();
+                    throw new InvalidOperationException("Wrong username and/or password.");
+                }
+            }
+        }
+
+        internal async Task ConnectToDestinationAsync(EndPoint destination, bool isRecursiveCall = false)
+        {
+            Guard.NotNull(nameof(destination), destination);
+            await ConnectToDestinationAsync(destination.GetHostOrDefault(), destination.GetPortOrDefault().Value, isRecursiveCall: isRecursiveCall);
+        }
+
+        /// <param name="host">IPv4 or domain</param>
+        internal async Task ConnectToDestinationAsync(string host, int port, bool isRecursiveCall = false)
+        {
+            host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
+            Guard.MinimumAndNotNull(nameof(port), port, 0);
+
+            if (TorSocks5EndPoint is null)
+            {
+                using (await AsyncLock.LockAsync())
+                {
+                    TcpClient?.Dispose();
+                    if (IPAddress.TryParse(host, out IPAddress ip))
+                    {
+                        TcpClient = new TcpClient(ip.AddressFamily);
+                    }
+                    else
+                    {
+                        TcpClient = new TcpClient();
+                    }
+                    await TcpClient.ConnectAsync(host, port);
+                    Stream = TcpClient.GetStream();
+                    RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
+                }
+
+                return;
+            }
+
+            var cmd = CmdField.Connect;
+
+            var dstAddr = new AddrField(host);
+            DestinationHost = dstAddr.DomainOrIPv4;
+
+            var dstPort = new PortField(port);
+            DestinationPort = dstPort.DstPort;
+
+            var connectionRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
+            var sendBuffer = connectionRequest.ToBytes();
+
+            var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall);
+
+            var connectionResponse = new TorSocks5Response();
+            connectionResponse.FromBytes(receiveBuffer);
+
+            if (connectionResponse.Rep != RepField.Succeeded)
+            {
+                // https://www.ietf.org/rfc/rfc1928.txt
+                // When a reply(REP value other than X'00') indicates a failure, the
+                // SOCKS server MUST terminate the TCP connection shortly after sending
+                // the reply.This must be no more than 10 seconds after detecting the
+                // condition that caused a failure.
+                DisposeTcpClient();
+                throw new TorSocks5FailureResponseException(connectionResponse.Rep);
+            }
+
+            // Do not check the Bnd. Address and Bnd. Port. because Tor does not seem to return any, ever. It returns zeros instead.
+            // Generally also do not check anything but the success response, according to Socks5 RFC
+
+            // If the reply code(REP value of X'00') indicates a success, and the
+            // request was either a BIND or a CONNECT, the client may now start
+            // passing data.  If the selected authentication method supports
+            // encapsulation for the purposes of integrity, authentication and / or
+            // confidentiality, the data are encapsulated using the method-dependent
+            // encapsulation.Similarly, when data arrives at the SOCKS server for
+            // the client, the server MUST encapsulate the data as appropriate for
+            // the authentication method in use.
+        }
+
+        public async Task AssertConnectedAsync(bool isRecursiveCall = false)
+        {
+            if (!IsConnected)
+            {
+                // try reconnect, maybe the server came online already
+                try
+                {
+                    await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: isRecursiveCall);
+                }
+                catch (Exception ex) when (IsConnectionRefused(ex))
+                {
+                    throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
+                }
+                if (!IsConnected)
+                {
+                    throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
+                }
+            }
+        }
+
+        #endregion ConstructorsAndInitializers
+
+        #region Methods
+
+        private bool IsConnectionRefused(Exception exc)
+        {
+            Exception error = null;
+            try
+            {
+                throw exc;
+            }
+            // ex.Message must be checked, because I'm having difficulty catching SocketExceptionFactory+ExtendedSocketException
+            // Only works on English Os-es.
+            catch (Exception ex) when (ex.Message.StartsWith(
+                                           "No connection could be made because the target machine actively refused it") // Windows
+                                       || ex.Message.StartsWith("Connection refused")) // Linux && OSX
+            {
+                error = ex;
+            }
+            // "No connection could be made because the target machine actively refused it" for non-English Windows.
+            catch (SocketException ex) when (ex.ErrorCode == 10061)
+            {
+                error = ex;
+            }
+            // "Connection refused" for non-English Linux.
+            catch (SocketException ex) when (ex.ErrorCode == 111)
+            {
+                error = ex;
+            }
+            // "Connection refused" for non-English OSX.
+            catch (SocketException ex) when (ex.ErrorCode == 61)
+            {
+                error = ex;
+            }
+            catch
+            {
+                // Ignored, since error is null.
+            }
+
+            return error != null;
+        }
+
+        /// <summary>
+        /// Sends bytes to the Tor Socks5 connection
+        /// </summary>
+        /// <param name="sendBuffer">Sent data</param>
+        /// <param name="receiveBufferSize">Maximum number of bytes expected to be received in the reply</param>
+        /// <returns>Reply</returns>
+        public async Task<byte[]> SendAsync(byte[] sendBuffer, int? receiveBufferSize = null, bool isRecursiveCall = false)
+        {
+            Guard.NotNullOrEmpty(nameof(sendBuffer), sendBuffer);
+
+            try
+            {
+                if (!isRecursiveCall) // Because AssertConnectedAsync would be calling it again.
+                {
+                    await AssertConnectedAsync(isRecursiveCall: true);
+                }
+
+                using (await AsyncLock.LockAsync())
+                {
+                    var stream = TcpClient.GetStream();
+
+                    // Write data to the stream
+                    await stream.WriteAsync(sendBuffer, 0, sendBuffer.Length);
+                    await stream.FlushAsync();
+
+                    // If receiveBufferSize is null, zero or negative or bigger than TcpClient.ReceiveBufferSize
+                    // then work with TcpClient.ReceiveBufferSize
+                    var tcpReceiveBuffSize = TcpClient.ReceiveBufferSize;
+                    var actualReceiveBufferSize = 0;
+                    if (receiveBufferSize is null || receiveBufferSize <= 0 || receiveBufferSize > tcpReceiveBuffSize)
+                    {
+                        actualReceiveBufferSize = tcpReceiveBuffSize;
+                    }
+                    else
+                    {
+                        actualReceiveBufferSize = (int)receiveBufferSize;
+                    }
+
+                    // Receive the response
+                    var receiveBuffer = new byte[actualReceiveBufferSize];
+
+                    int receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
+
+                    if (receiveCount <= 0)
+                    {
+                        throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
+                    }
+                    // if we could fit everything into our buffer, then return it
+                    if (!stream.DataAvailable)
+                    {
+                        return receiveBuffer.Take(receiveCount).ToArray();
+                    }
+
+                    // while we have data available, start building a bytearray
+                    var builder = new ByteArrayBuilder();
+                    builder.Append(receiveBuffer.Take(receiveCount).ToArray());
+                    while (stream.DataAvailable)
+                    {
+                        Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
+                        receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
+                        if (receiveCount <= 0)
+                        {
+                            throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
+                        }
+                        builder.Append(receiveBuffer.Take(receiveCount).ToArray());
+                    }
+
+                    return builder.ToArray();
+                }
+            }
+            catch (IOException ex)
+            {
+                if (isRecursiveCall)
+                {
+                    throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
+                }
+                else
+                {
+                    // try reconnect, maybe the server came online already
+                    try
+                    {
+                        await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: true);
+                    }
+                    catch (Exception ex2) when (IsConnectionRefused(ex2))
+                    {
+                        throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex2);
+                    }
+                    return await SendAsync(sendBuffer, receiveBufferSize, isRecursiveCall: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// When Tor receives a "RESOLVE" SOCKS command, it initiates
+        /// a remote lookup of the hostname provided as the target address in the SOCKS
+        /// request.
+        /// </summary>
+        internal async Task<IPAddress> ResolveAsync(string host)
+        {
+            // https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n44
+
+            host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
+
+            if (TorSocks5EndPoint is null)
+            {
+                var hostAddresses = await Dns.GetHostAddressesAsync(host);
+                return hostAddresses.First();
+            }
+
+            var cmd = CmdField.Resolve;
+
+            var dstAddr = new AddrField(host);
+
+            var dstPort = new PortField(0);
+
+            var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
+            var sendBuffer = resolveRequest.ToBytes();
+
+            var receiveBuffer = await SendAsync(sendBuffer);
+
+            var resolveResponse = new TorSocks5Response();
+            resolveResponse.FromBytes(receiveBuffer);
+
+            if (resolveResponse.Rep != RepField.Succeeded)
+            {
+                throw new TorSocks5FailureResponseException(resolveResponse.Rep);
+            }
+            return IPAddress.Parse(resolveResponse.BndAddr.DomainOrIPv4);
+        }
+
+        /// <summary>
+        /// Tor attempts to find the canonical hostname for that IPv4 record
+        /// </summary>
+        internal async Task<string> ReverseResolveAsync(IPAddress iPv4)
+        {
+            // https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n55
+
+            Guard.NotNull(nameof(iPv4), iPv4);
+
+            if (TorSocks5EndPoint is null) // Only Tor is iPv4 dependent
+            {
+                var host = await Dns.GetHostEntryAsync(iPv4);
+                return host.HostName;
+            }
+
+            Guard.Same($"{nameof(iPv4)}.{nameof(iPv4.AddressFamily)}", AddressFamily.InterNetwork, iPv4.AddressFamily);
+
+            var cmd = CmdField.ResolvePtr;
+
+            var dstAddr = new AddrField(iPv4.ToString());
+
+            var dstPort = new PortField(0);
+
+            var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
+            var sendBuffer = resolveRequest.ToBytes();
+
+            var receiveBuffer = await SendAsync(sendBuffer);
+
+            var resolveResponse = new TorSocks5Response();
+            resolveResponse.FromBytes(receiveBuffer);
+
+            if (resolveResponse.Rep != RepField.Succeeded)
+            {
+                throw new TorSocks5FailureResponseException(resolveResponse.Rep);
+            }
+            return resolveResponse.BndAddr.DomainOrIPv4;
+        }
+
+        #endregion Methods
+
+        #region IDisposable Support
+
+        private volatile bool _disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    DisposeTcpClient();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        // ~TorSocks5Client() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // GC.SuppressFinalize(this);
+        }
+
+        private void DisposeTcpClient()
+        {
+            try
+            {
+                if (TcpClient != null)
+                {
+                    if (TcpClient.Connected)
+                    {
+                        Stream?.Dispose();
+                    }
+                    TcpClient?.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning<TorSocks5Client>(ex);
+            }
+            finally
+            {
+                TcpClient = null; // need to be called, .net bug
+            }
+        }
+
+        #endregion IDisposable Support
+    }
 }

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -15,545 +15,545 @@ using WalletWasabi.TorSocks5.TorSocks5.Models.Fields.ByteArrayFields;
 
 namespace WalletWasabi.TorSocks5
 {
-    /// <summary>
-    /// Create an instance with the TorSocks5Manager
-    /// </summary>
-    public class TorSocks5Client : IDisposable
-    {
-        #region PropertiesAndMembers
-
-        public TcpClient TcpClient { get; private set; }
-
-        public EndPoint TorSocks5EndPoint { get; private set; }
-
-        public Stream Stream { get; internal set; }
-
-        public string DestinationHost { get; private set; }
-
-        public int DestinationPort { get; private set; }
-
-        private EndPoint RemoteEndPoint { get; set; }
-
-        public bool IsConnected
-        {
-            get
-            {
-                try
-                {
-                    return !(TcpClient is null) && TcpClient.Connected;
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogWarning<TorSocks5Client>(ex);
-                    return false;
-                }
-            }
-        }
-
-        internal AsyncLock AsyncLock { get; }
-
-        #endregion PropertiesAndMembers
-
-        #region ConstructorsAndInitializers
-
-        /// <param name="endPoint">Opt out Tor with null.</param>
-        internal TorSocks5Client(EndPoint endPoint)
-        {
-            TorSocks5EndPoint = endPoint;
-            TcpClient = endPoint is null ? new TcpClient() : new TcpClient(endPoint.AddressFamily);
-            AsyncLock = new AsyncLock();
-        }
-
-        /// <param name="tcpClient">Must be already connected.</param>
-        internal TorSocks5Client(TcpClient tcpClient)
-        {
-            Guard.NotNull(nameof(tcpClient), tcpClient);
-            TcpClient = tcpClient;
-            AsyncLock = new AsyncLock();
-            Stream = tcpClient.GetStream();
-            TorSocks5EndPoint = null;
-            DestinationHost = tcpClient.Client.RemoteEndPoint.GetHostOrDefault();
-            DestinationPort = tcpClient.Client.RemoteEndPoint.GetPortOrDefault().Value;
-            RemoteEndPoint = tcpClient.Client.RemoteEndPoint;
-            if (!IsConnected)
-            {
-                throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
-            }
-        }
-
-        internal async Task ConnectAsync()
-        {
-            if (TorSocks5EndPoint is null)
-            {
-                return;
-            }
-
-            using (await AsyncLock.LockAsync())
-            {
-                string host = TorSocks5EndPoint.GetHostOrDefault();
-                int? port = TorSocks5EndPoint.GetPortOrDefault();
-                try
-                {
-                    await TcpClient.ConnectAsync(host, port.Value);
-                }
-                catch (Exception ex) when (IsConnectionRefused(ex))
-                {
-                    throw new ConnectionException(
-                        $"Could not connect to Tor SOCKSPort at {host}:{port}. Is Tor running?", ex);
-                }
-
-                Stream = TcpClient.GetStream();
-                RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
-            }
-        }
-
-        /// <summary>
-        /// IsolateSOCKSAuth must be on (on by default)
-        /// https://www.torproject.org/docs/tor-manual.html.en
-        /// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
-        /// </summary>
-        internal async Task HandshakeAsync(bool isolateStream = true)
-        {
-            await HandshakeAsync(isolateStream ? RandomString.Generate(21) : "");
-        }
-
-        /// <summary>
-        /// IsolateSOCKSAuth must be on (on by default)
-        /// https://www.torproject.org/docs/tor-manual.html.en
-        /// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
-        /// </summary>
-        /// <param name="identity">Isolates streams by identity. If identity is empty string, it won't isolate stream.</param>
-        internal async Task HandshakeAsync(string identity)
-        {
-            if (TorSocks5EndPoint is null)
-            {
-                return;
-            }
-
-            Guard.NotNull(nameof(identity), identity);
-
-            MethodsField methods;
-            if (string.IsNullOrWhiteSpace(identity))
-            {
-                methods = new MethodsField(MethodField.NoAuthenticationRequired);
-            }
-            else
-            {
-                methods = new MethodsField(MethodField.UsernamePassword);
-            }
-
-            var sendBuffer = new VersionMethodRequest(methods).ToBytes();
-
-            var receiveBuffer = await SendAsync(sendBuffer, 2);
-
-            var methodSelection = new MethodSelectionResponse();
-            methodSelection.FromBytes(receiveBuffer);
-            if (methodSelection.Ver != VerField.Socks5)
-            {
-                throw new NotSupportedException($"`SOCKS{methodSelection.Ver.Value} is not supported. Only SOCKS5 is supported.");
-            }
-            if (methodSelection.Method == MethodField.NoAcceptableMethods)
-            {
-                // https://www.ietf.org/rfc/rfc1928.txt
-                // If the selected METHOD is X'FF', none of the methods listed by the
-                // client are acceptable, and the client MUST close the connection.
-                DisposeTcpClient();
-                throw new NotSupportedException("Tor's SOCKS5 proxy does not support any of the client's authentication methods.");
-            }
-            if (methodSelection.Method == MethodField.UsernamePassword)
-            {
-                // https://tools.ietf.org/html/rfc1929#section-2
-                // Once the SOCKS V5 server has started, and the client has selected the
-                // Username / Password Authentication protocol, the Username / Password
-                // subnegotiation begins.  This begins with the client producing a
-                // Username / Password request:
-                var username = identity;
-                var password = identity;
-                var uName = new UNameField(username);
-                var passwd = new PasswdField(password);
-                var usernamePasswordRequest = new UsernamePasswordRequest(uName, passwd);
-                sendBuffer = usernamePasswordRequest.ToBytes();
-
-                Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
-                receiveBuffer = await SendAsync(sendBuffer, 2);
-
-                var userNamePasswordResponse = new UsernamePasswordResponse();
-                userNamePasswordResponse.FromBytes(receiveBuffer);
-                if (userNamePasswordResponse.Ver != usernamePasswordRequest.Ver)
-                {
-                    throw new NotSupportedException($"Authentication version {userNamePasswordResponse.Ver.Value} is not supported. Only version {usernamePasswordRequest.Ver} is supported.");
-                }
-
-                if (!userNamePasswordResponse.Status.IsSuccess()) // Tor authentication is different, this will never happen;
-                {
-                    // https://tools.ietf.org/html/rfc1929#section-2
-                    // A STATUS field of X'00' indicates success. If the server returns a
-                    // `failure' (STATUS value other than X'00') status, it MUST close the
-                    // connection.
-                    DisposeTcpClient();
-                    throw new InvalidOperationException("Wrong username and/or password.");
-                }
-            }
-        }
-
-        internal async Task ConnectToDestinationAsync(EndPoint destination, bool isRecursiveCall = false)
-        {
-            Guard.NotNull(nameof(destination), destination);
-            await ConnectToDestinationAsync(destination.GetHostOrDefault(), destination.GetPortOrDefault().Value, isRecursiveCall: isRecursiveCall);
-        }
-
-        /// <param name="host">IPv4 or domain</param>
-        internal async Task ConnectToDestinationAsync(string host, int port, bool isRecursiveCall = false)
-        {
-            host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
-            Guard.MinimumAndNotNull(nameof(port), port, 0);
-
-            if (TorSocks5EndPoint is null)
-            {
-                using (await AsyncLock.LockAsync())
-                {
-                    TcpClient?.Dispose();
-                    if (IPAddress.TryParse(host, out IPAddress ip))
-                    {
-                        TcpClient = new TcpClient(ip.AddressFamily);
-                    }
-                    else
-                    {
-                        TcpClient = new TcpClient();
-                    }
-                    await TcpClient.ConnectAsync(host, port);
-                    Stream = TcpClient.GetStream();
-                    RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
-                }
-
-                return;
-            }
-
-            var cmd = CmdField.Connect;
-
-            var dstAddr = new AddrField(host);
-            DestinationHost = dstAddr.DomainOrIPv4;
-
-            var dstPort = new PortField(port);
-            DestinationPort = dstPort.DstPort;
-
-            var connectionRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-            var sendBuffer = connectionRequest.ToBytes();
-
-            var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall);
-
-            var connectionResponse = new TorSocks5Response();
-            connectionResponse.FromBytes(receiveBuffer);
-
-            if (connectionResponse.Rep != RepField.Succeeded)
-            {
-                // https://www.ietf.org/rfc/rfc1928.txt
-                // When a reply(REP value other than X'00') indicates a failure, the
-                // SOCKS server MUST terminate the TCP connection shortly after sending
-                // the reply.This must be no more than 10 seconds after detecting the
-                // condition that caused a failure.
-                DisposeTcpClient();
-                throw new TorSocks5FailureResponseException(connectionResponse.Rep);
-            }
-
-            // Do not check the Bnd. Address and Bnd. Port. because Tor does not seem to return any, ever. It returns zeros instead.
-            // Generally also do not check anything but the success response, according to Socks5 RFC
-
-            // If the reply code(REP value of X'00') indicates a success, and the
-            // request was either a BIND or a CONNECT, the client may now start
-            // passing data.  If the selected authentication method supports
-            // encapsulation for the purposes of integrity, authentication and / or
-            // confidentiality, the data are encapsulated using the method-dependent
-            // encapsulation.Similarly, when data arrives at the SOCKS server for
-            // the client, the server MUST encapsulate the data as appropriate for
-            // the authentication method in use.
-        }
-
-        public async Task AssertConnectedAsync(bool isRecursiveCall = false)
-        {
-            if (!IsConnected)
-            {
-                // try reconnect, maybe the server came online already
-                try
-                {
-                    await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: isRecursiveCall);
-                }
-                catch (Exception ex) when (IsConnectionRefused(ex))
-                {
-                    throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
-                }
-                if (!IsConnected)
-                {
-                    throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
-                }
-            }
-        }
-
-        #endregion ConstructorsAndInitializers
-
-        #region Methods
-
-        private bool IsConnectionRefused(Exception exc)
-        {
-            Exception error = null;
-            try
-            {
-                throw exc;
-            }
-            // ex.Message must be checked, because I'm having difficulty catching SocketExceptionFactory+ExtendedSocketException
-            // Only works on English Os-es.
-            catch (Exception ex) when (ex.Message.StartsWith(
-                                           "No connection could be made because the target machine actively refused it") // Windows
-                                       || ex.Message.StartsWith("Connection refused")) // Linux && OSX
-            {
-                error = ex;
-            }
-            // "No connection could be made because the target machine actively refused it" for non-English Windows.
-            catch (SocketException ex) when (ex.ErrorCode == 10061)
-            {
-                error = ex;
-            }
-            // "Connection refused" for non-English Linux.
-            catch (SocketException ex) when (ex.ErrorCode == 111)
-            {
-                error = ex;
-            }
-            // "Connection refused" for non-English OSX.
-            catch (SocketException ex) when (ex.ErrorCode == 61)
-            {
-                error = ex;
-            }
-            catch
-            {
-                // Ignored, since error is null.
-            }
-
-            return error != null;
-        }
-
-        /// <summary>
-        /// Sends bytes to the Tor Socks5 connection
-        /// </summary>
-        /// <param name="sendBuffer">Sent data</param>
-        /// <param name="receiveBufferSize">Maximum number of bytes expected to be received in the reply</param>
-        /// <returns>Reply</returns>
-        public async Task<byte[]> SendAsync(byte[] sendBuffer, int? receiveBufferSize = null, bool isRecursiveCall = false)
-        {
-            Guard.NotNullOrEmpty(nameof(sendBuffer), sendBuffer);
-
-            try
-            {
-                if (!isRecursiveCall) // Because AssertConnectedAsync would be calling it again.
-                {
-                    await AssertConnectedAsync(isRecursiveCall: true);
-                }
-
-                using (await AsyncLock.LockAsync())
-                {
-                    var stream = TcpClient.GetStream();
-
-                    // Write data to the stream
-                    await stream.WriteAsync(sendBuffer, 0, sendBuffer.Length);
-                    await stream.FlushAsync();
-
-                    // If receiveBufferSize is null, zero or negative or bigger than TcpClient.ReceiveBufferSize
-                    // then work with TcpClient.ReceiveBufferSize
-                    var tcpReceiveBuffSize = TcpClient.ReceiveBufferSize;
-                    var actualReceiveBufferSize = 0;
-                    if (receiveBufferSize is null || receiveBufferSize <= 0 || receiveBufferSize > tcpReceiveBuffSize)
-                    {
-                        actualReceiveBufferSize = tcpReceiveBuffSize;
-                    }
-                    else
-                    {
-                        actualReceiveBufferSize = (int)receiveBufferSize;
-                    }
-
-                    // Receive the response
-                    var receiveBuffer = new byte[actualReceiveBufferSize];
-
-                    int receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
-
-                    if (receiveCount <= 0)
-                    {
-                        throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
-                    }
-                    // if we could fit everything into our buffer, then return it
-                    if (!stream.DataAvailable)
-                    {
-                        return receiveBuffer.Take(receiveCount).ToArray();
-                    }
-
-                    // while we have data available, start building a bytearray
-                    var builder = new ByteArrayBuilder();
-                    builder.Append(receiveBuffer.Take(receiveCount).ToArray());
-                    while (stream.DataAvailable)
-                    {
-                        Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
-                        receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
-                        if (receiveCount <= 0)
-                        {
-                            throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
-                        }
-                        builder.Append(receiveBuffer.Take(receiveCount).ToArray());
-                    }
-
-                    return builder.ToArray();
-                }
-            }
-            catch (IOException ex)
-            {
-                if (isRecursiveCall)
-                {
-                    throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
-                }
-                else
-                {
-                    // try reconnect, maybe the server came online already
-                    try
-                    {
-                        await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: true);
-                    }
-                    catch (Exception ex2) when (IsConnectionRefused(ex2))
-                    {
-                        throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex2);
-                    }
-                    return await SendAsync(sendBuffer, receiveBufferSize, isRecursiveCall: true);
-                }
-            }
-        }
-
-        /// <summary>
-        /// When Tor receives a "RESOLVE" SOCKS command, it initiates
-        /// a remote lookup of the hostname provided as the target address in the SOCKS
-        /// request.
-        /// </summary>
-        internal async Task<IPAddress> ResolveAsync(string host)
-        {
-            // https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n44
-
-            host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
-
-            if (TorSocks5EndPoint is null)
-            {
-                var hostAddresses = await Dns.GetHostAddressesAsync(host);
-                return hostAddresses.First();
-            }
-
-            var cmd = CmdField.Resolve;
-
-            var dstAddr = new AddrField(host);
-
-            var dstPort = new PortField(0);
-
-            var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-            var sendBuffer = resolveRequest.ToBytes();
-
-            var receiveBuffer = await SendAsync(sendBuffer);
-
-            var resolveResponse = new TorSocks5Response();
-            resolveResponse.FromBytes(receiveBuffer);
-
-            if (resolveResponse.Rep != RepField.Succeeded)
-            {
-                throw new TorSocks5FailureResponseException(resolveResponse.Rep);
-            }
-            return IPAddress.Parse(resolveResponse.BndAddr.DomainOrIPv4);
-        }
-
-        /// <summary>
-        /// Tor attempts to find the canonical hostname for that IPv4 record
-        /// </summary>
-        internal async Task<string> ReverseResolveAsync(IPAddress iPv4)
-        {
-            // https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n55
-
-            Guard.NotNull(nameof(iPv4), iPv4);
-
-            if (TorSocks5EndPoint is null) // Only Tor is iPv4 dependent
-            {
-                var host = await Dns.GetHostEntryAsync(iPv4);
-                return host.HostName;
-            }
-
-            Guard.Same($"{nameof(iPv4)}.{nameof(iPv4.AddressFamily)}", AddressFamily.InterNetwork, iPv4.AddressFamily);
-
-            var cmd = CmdField.ResolvePtr;
-
-            var dstAddr = new AddrField(iPv4.ToString());
-
-            var dstPort = new PortField(0);
-
-            var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-            var sendBuffer = resolveRequest.ToBytes();
-
-            var receiveBuffer = await SendAsync(sendBuffer);
-
-            var resolveResponse = new TorSocks5Response();
-            resolveResponse.FromBytes(receiveBuffer);
-
-            if (resolveResponse.Rep != RepField.Succeeded)
-            {
-                throw new TorSocks5FailureResponseException(resolveResponse.Rep);
-            }
-            return resolveResponse.BndAddr.DomainOrIPv4;
-        }
-
-        #endregion Methods
-
-        #region IDisposable Support
-
-        private volatile bool _disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    DisposeTcpClient();
-                }
-
-                _disposedValue = true;
-            }
-        }
-
-        // ~TorSocks5Client() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // GC.SuppressFinalize(this);
-        }
-
-        private void DisposeTcpClient()
-        {
-            try
-            {
-                if (TcpClient != null)
-                {
-                    if (TcpClient.Connected)
-                    {
-                        Stream?.Dispose();
-                    }
-                    TcpClient?.Dispose();
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning<TorSocks5Client>(ex);
-            }
-            finally
-            {
-                TcpClient = null; // need to be called, .net bug
-            }
-        }
-
-        #endregion IDisposable Support
-    }
+	/// <summary>
+	/// Create an instance with the TorSocks5Manager
+	/// </summary>
+	public class TorSocks5Client : IDisposable
+	{
+		#region PropertiesAndMembers
+
+		public TcpClient TcpClient { get; private set; }
+
+		public EndPoint TorSocks5EndPoint { get; private set; }
+
+		public Stream Stream { get; internal set; }
+
+		public string DestinationHost { get; private set; }
+
+		public int DestinationPort { get; private set; }
+
+		private EndPoint RemoteEndPoint { get; set; }
+
+		public bool IsConnected
+		{
+			get
+			{
+				try
+				{
+					return !(TcpClient is null) && TcpClient.Connected;
+				}
+				catch (Exception ex)
+				{
+					Logger.LogWarning<TorSocks5Client>(ex);
+					return false;
+				}
+			}
+		}
+
+		internal AsyncLock AsyncLock { get; }
+
+		#endregion PropertiesAndMembers
+
+		#region ConstructorsAndInitializers
+
+		/// <param name="endPoint">Opt out Tor with null.</param>
+		internal TorSocks5Client(EndPoint endPoint)
+		{
+			TorSocks5EndPoint = endPoint;
+			TcpClient = endPoint is null ? new TcpClient() : new TcpClient(endPoint.AddressFamily);
+			AsyncLock = new AsyncLock();
+		}
+
+		/// <param name="tcpClient">Must be already connected.</param>
+		internal TorSocks5Client(TcpClient tcpClient)
+		{
+			Guard.NotNull(nameof(tcpClient), tcpClient);
+			TcpClient = tcpClient;
+			AsyncLock = new AsyncLock();
+			Stream = tcpClient.GetStream();
+			TorSocks5EndPoint = null;
+			DestinationHost = tcpClient.Client.RemoteEndPoint.GetHostOrDefault();
+			DestinationPort = tcpClient.Client.RemoteEndPoint.GetPortOrDefault().Value;
+			RemoteEndPoint = tcpClient.Client.RemoteEndPoint;
+			if (!IsConnected)
+			{
+				throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
+			}
+		}
+
+		internal async Task ConnectAsync()
+		{
+			if (TorSocks5EndPoint is null)
+			{
+				return;
+			}
+
+			using (await AsyncLock.LockAsync())
+			{
+				string host = TorSocks5EndPoint.GetHostOrDefault();
+				int? port = TorSocks5EndPoint.GetPortOrDefault();
+				try
+				{
+					await TcpClient.ConnectAsync(host, port.Value);
+				}
+				catch (Exception ex) when (IsConnectionRefused(ex))
+				{
+					throw new ConnectionException(
+						$"Could not connect to Tor SOCKSPort at {host}:{port}. Is Tor running?", ex);
+				}
+
+				Stream = TcpClient.GetStream();
+				RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
+			}
+		}
+
+		/// <summary>
+		/// IsolateSOCKSAuth must be on (on by default)
+		/// https://www.torproject.org/docs/tor-manual.html.en
+		/// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
+		/// </summary>
+		internal async Task HandshakeAsync(bool isolateStream = true)
+		{
+			await HandshakeAsync(isolateStream ? RandomString.Generate(21) : "");
+		}
+
+		/// <summary>
+		/// IsolateSOCKSAuth must be on (on by default)
+		/// https://www.torproject.org/docs/tor-manual.html.en
+		/// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
+		/// </summary>
+		/// <param name="identity">Isolates streams by identity. If identity is empty string, it won't isolate stream.</param>
+		internal async Task HandshakeAsync(string identity)
+		{
+			if (TorSocks5EndPoint is null)
+			{
+				return;
+			}
+
+			Guard.NotNull(nameof(identity), identity);
+
+			MethodsField methods;
+			if (string.IsNullOrWhiteSpace(identity))
+			{
+				methods = new MethodsField(MethodField.NoAuthenticationRequired);
+			}
+			else
+			{
+				methods = new MethodsField(MethodField.UsernamePassword);
+			}
+
+			var sendBuffer = new VersionMethodRequest(methods).ToBytes();
+
+			var receiveBuffer = await SendAsync(sendBuffer, 2);
+
+			var methodSelection = new MethodSelectionResponse();
+			methodSelection.FromBytes(receiveBuffer);
+			if (methodSelection.Ver != VerField.Socks5)
+			{
+				throw new NotSupportedException($"`SOCKS{methodSelection.Ver.Value} is not supported. Only SOCKS5 is supported.");
+			}
+			if (methodSelection.Method == MethodField.NoAcceptableMethods)
+			{
+				// https://www.ietf.org/rfc/rfc1928.txt
+				// If the selected METHOD is X'FF', none of the methods listed by the
+				// client are acceptable, and the client MUST close the connection.
+				DisposeTcpClient();
+				throw new NotSupportedException("Tor's SOCKS5 proxy does not support any of the client's authentication methods.");
+			}
+			if (methodSelection.Method == MethodField.UsernamePassword)
+			{
+				// https://tools.ietf.org/html/rfc1929#section-2
+				// Once the SOCKS V5 server has started, and the client has selected the
+				// Username / Password Authentication protocol, the Username / Password
+				// subnegotiation begins.  This begins with the client producing a
+				// Username / Password request:
+				var username = identity;
+				var password = identity;
+				var uName = new UNameField(username);
+				var passwd = new PasswdField(password);
+				var usernamePasswordRequest = new UsernamePasswordRequest(uName, passwd);
+				sendBuffer = usernamePasswordRequest.ToBytes();
+
+				Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
+				receiveBuffer = await SendAsync(sendBuffer, 2);
+
+				var userNamePasswordResponse = new UsernamePasswordResponse();
+				userNamePasswordResponse.FromBytes(receiveBuffer);
+				if (userNamePasswordResponse.Ver != usernamePasswordRequest.Ver)
+				{
+					throw new NotSupportedException($"Authentication version {userNamePasswordResponse.Ver.Value} is not supported. Only version {usernamePasswordRequest.Ver} is supported.");
+				}
+
+				if (!userNamePasswordResponse.Status.IsSuccess()) // Tor authentication is different, this will never happen;
+				{
+					// https://tools.ietf.org/html/rfc1929#section-2
+					// A STATUS field of X'00' indicates success. If the server returns a
+					// `failure' (STATUS value other than X'00') status, it MUST close the
+					// connection.
+					DisposeTcpClient();
+					throw new InvalidOperationException("Wrong username and/or password.");
+				}
+			}
+		}
+
+		internal async Task ConnectToDestinationAsync(EndPoint destination, bool isRecursiveCall = false)
+		{
+			Guard.NotNull(nameof(destination), destination);
+			await ConnectToDestinationAsync(destination.GetHostOrDefault(), destination.GetPortOrDefault().Value, isRecursiveCall: isRecursiveCall);
+		}
+
+		/// <param name="host">IPv4 or domain</param>
+		internal async Task ConnectToDestinationAsync(string host, int port, bool isRecursiveCall = false)
+		{
+			host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
+			Guard.MinimumAndNotNull(nameof(port), port, 0);
+
+			if (TorSocks5EndPoint is null)
+			{
+				using (await AsyncLock.LockAsync())
+				{
+					TcpClient?.Dispose();
+					if (IPAddress.TryParse(host, out IPAddress ip))
+					{
+						TcpClient = new TcpClient(ip.AddressFamily);
+					}
+					else
+					{
+						TcpClient = new TcpClient();
+					}
+					await TcpClient.ConnectAsync(host, port);
+					Stream = TcpClient.GetStream();
+					RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
+				}
+
+				return;
+			}
+
+			var cmd = CmdField.Connect;
+
+			var dstAddr = new AddrField(host);
+			DestinationHost = dstAddr.DomainOrIPv4;
+
+			var dstPort = new PortField(port);
+			DestinationPort = dstPort.DstPort;
+
+			var connectionRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
+			var sendBuffer = connectionRequest.ToBytes();
+
+			var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall);
+
+			var connectionResponse = new TorSocks5Response();
+			connectionResponse.FromBytes(receiveBuffer);
+
+			if (connectionResponse.Rep != RepField.Succeeded)
+			{
+				// https://www.ietf.org/rfc/rfc1928.txt
+				// When a reply(REP value other than X'00') indicates a failure, the
+				// SOCKS server MUST terminate the TCP connection shortly after sending
+				// the reply.This must be no more than 10 seconds after detecting the
+				// condition that caused a failure.
+				DisposeTcpClient();
+				throw new TorSocks5FailureResponseException(connectionResponse.Rep);
+			}
+
+			// Do not check the Bnd. Address and Bnd. Port. because Tor does not seem to return any, ever. It returns zeros instead.
+			// Generally also do not check anything but the success response, according to Socks5 RFC
+
+			// If the reply code(REP value of X'00') indicates a success, and the
+			// request was either a BIND or a CONNECT, the client may now start
+			// passing data.  If the selected authentication method supports
+			// encapsulation for the purposes of integrity, authentication and / or
+			// confidentiality, the data are encapsulated using the method-dependent
+			// encapsulation.Similarly, when data arrives at the SOCKS server for
+			// the client, the server MUST encapsulate the data as appropriate for
+			// the authentication method in use.
+		}
+
+		public async Task AssertConnectedAsync(bool isRecursiveCall = false)
+		{
+			if (!IsConnected)
+			{
+				// try reconnect, maybe the server came online already
+				try
+				{
+					await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: isRecursiveCall);
+				}
+				catch (Exception ex) when (IsConnectionRefused(ex))
+				{
+					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
+				}
+				if (!IsConnected)
+				{
+					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
+				}
+			}
+		}
+
+		#endregion ConstructorsAndInitializers
+
+		#region Methods
+
+		private bool IsConnectionRefused(Exception exc)
+		{
+			Exception error = null;
+			try
+			{
+				throw exc;
+			}
+			// ex.Message must be checked, because I'm having difficulty catching SocketExceptionFactory+ExtendedSocketException
+			// Only works on English Os-es.
+			catch (Exception ex) when (ex.Message.StartsWith(
+										   "No connection could be made because the target machine actively refused it") // Windows
+									   || ex.Message.StartsWith("Connection refused")) // Linux && OSX
+			{
+				error = ex;
+			}
+			// "No connection could be made because the target machine actively refused it" for non-English Windows.
+			catch (SocketException ex) when (ex.ErrorCode == 10061)
+			{
+				error = ex;
+			}
+			// "Connection refused" for non-English Linux.
+			catch (SocketException ex) when (ex.ErrorCode == 111)
+			{
+				error = ex;
+			}
+			// "Connection refused" for non-English OSX.
+			catch (SocketException ex) when (ex.ErrorCode == 61)
+			{
+				error = ex;
+			}
+			catch
+			{
+				// Ignored, since error is null.
+			}
+
+			return error != null;
+		}
+
+		/// <summary>
+		/// Sends bytes to the Tor Socks5 connection
+		/// </summary>
+		/// <param name="sendBuffer">Sent data</param>
+		/// <param name="receiveBufferSize">Maximum number of bytes expected to be received in the reply</param>
+		/// <returns>Reply</returns>
+		public async Task<byte[]> SendAsync(byte[] sendBuffer, int? receiveBufferSize = null, bool isRecursiveCall = false)
+		{
+			Guard.NotNullOrEmpty(nameof(sendBuffer), sendBuffer);
+
+			try
+			{
+				if (!isRecursiveCall) // Because AssertConnectedAsync would be calling it again.
+				{
+					await AssertConnectedAsync(isRecursiveCall: true);
+				}
+
+				using (await AsyncLock.LockAsync())
+				{
+					var stream = TcpClient.GetStream();
+
+					// Write data to the stream
+					await stream.WriteAsync(sendBuffer, 0, sendBuffer.Length);
+					await stream.FlushAsync();
+
+					// If receiveBufferSize is null, zero or negative or bigger than TcpClient.ReceiveBufferSize
+					// then work with TcpClient.ReceiveBufferSize
+					var tcpReceiveBuffSize = TcpClient.ReceiveBufferSize;
+					var actualReceiveBufferSize = 0;
+					if (receiveBufferSize is null || receiveBufferSize <= 0 || receiveBufferSize > tcpReceiveBuffSize)
+					{
+						actualReceiveBufferSize = tcpReceiveBuffSize;
+					}
+					else
+					{
+						actualReceiveBufferSize = (int)receiveBufferSize;
+					}
+
+					// Receive the response
+					var receiveBuffer = new byte[actualReceiveBufferSize];
+
+					int receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
+
+					if (receiveCount <= 0)
+					{
+						throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
+					}
+					// if we could fit everything into our buffer, then return it
+					if (!stream.DataAvailable)
+					{
+						return receiveBuffer.Take(receiveCount).ToArray();
+					}
+
+					// while we have data available, start building a bytearray
+					var builder = new ByteArrayBuilder();
+					builder.Append(receiveBuffer.Take(receiveCount).ToArray());
+					while (stream.DataAvailable)
+					{
+						Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
+						receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
+						if (receiveCount <= 0)
+						{
+							throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
+						}
+						builder.Append(receiveBuffer.Take(receiveCount).ToArray());
+					}
+
+					return builder.ToArray();
+				}
+			}
+			catch (IOException ex)
+			{
+				if (isRecursiveCall)
+				{
+					throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex);
+				}
+				else
+				{
+					// try reconnect, maybe the server came online already
+					try
+					{
+						await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: true);
+					}
+					catch (Exception ex2) when (IsConnectionRefused(ex2))
+					{
+						throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex2);
+					}
+					return await SendAsync(sendBuffer, receiveBufferSize, isRecursiveCall: true);
+				}
+			}
+		}
+
+		/// <summary>
+		/// When Tor receives a "RESOLVE" SOCKS command, it initiates
+		/// a remote lookup of the hostname provided as the target address in the SOCKS
+		/// request.
+		/// </summary>
+		internal async Task<IPAddress> ResolveAsync(string host)
+		{
+			// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n44
+
+			host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
+
+			if (TorSocks5EndPoint is null)
+			{
+				var hostAddresses = await Dns.GetHostAddressesAsync(host);
+				return hostAddresses.First();
+			}
+
+			var cmd = CmdField.Resolve;
+
+			var dstAddr = new AddrField(host);
+
+			var dstPort = new PortField(0);
+
+			var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
+			var sendBuffer = resolveRequest.ToBytes();
+
+			var receiveBuffer = await SendAsync(sendBuffer);
+
+			var resolveResponse = new TorSocks5Response();
+			resolveResponse.FromBytes(receiveBuffer);
+
+			if (resolveResponse.Rep != RepField.Succeeded)
+			{
+				throw new TorSocks5FailureResponseException(resolveResponse.Rep);
+			}
+			return IPAddress.Parse(resolveResponse.BndAddr.DomainOrIPv4);
+		}
+
+		/// <summary>
+		/// Tor attempts to find the canonical hostname for that IPv4 record
+		/// </summary>
+		internal async Task<string> ReverseResolveAsync(IPAddress iPv4)
+		{
+			// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n55
+
+			Guard.NotNull(nameof(iPv4), iPv4);
+
+			if (TorSocks5EndPoint is null) // Only Tor is iPv4 dependent
+			{
+				var host = await Dns.GetHostEntryAsync(iPv4);
+				return host.HostName;
+			}
+
+			Guard.Same($"{nameof(iPv4)}.{nameof(iPv4.AddressFamily)}", AddressFamily.InterNetwork, iPv4.AddressFamily);
+
+			var cmd = CmdField.ResolvePtr;
+
+			var dstAddr = new AddrField(iPv4.ToString());
+
+			var dstPort = new PortField(0);
+
+			var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
+			var sendBuffer = resolveRequest.ToBytes();
+
+			var receiveBuffer = await SendAsync(sendBuffer);
+
+			var resolveResponse = new TorSocks5Response();
+			resolveResponse.FromBytes(receiveBuffer);
+
+			if (resolveResponse.Rep != RepField.Succeeded)
+			{
+				throw new TorSocks5FailureResponseException(resolveResponse.Rep);
+			}
+			return resolveResponse.BndAddr.DomainOrIPv4;
+		}
+
+		#endregion Methods
+
+		#region IDisposable Support
+
+		private volatile bool _disposedValue = false; // To detect redundant calls
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					DisposeTcpClient();
+				}
+
+				_disposedValue = true;
+			}
+		}
+
+		// ~TorSocks5Client() {
+		//   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+		//   Dispose(false);
+		// }
+
+		// This code added to correctly implement the disposable pattern.
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+			Dispose(true);
+			// GC.SuppressFinalize(this);
+		}
+
+		private void DisposeTcpClient()
+		{
+			try
+			{
+				if (TcpClient != null)
+				{
+					if (TcpClient.Connected)
+					{
+						Stream?.Dispose();
+					}
+					TcpClient?.Dispose();
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning<TorSocks5Client>(ex);
+			}
+			finally
+			{
+				TcpClient = null; // need to be called, .net bug
+			}
+		}
+
+		#endregion IDisposable Support
+	}
 }

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
@@ -21,248 +21,248 @@ using static NBitcoin.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 {
-    public class AliceClient : TorDisposableBase
-    {
-        public Guid UniqueId { get; private set; }
+	public class AliceClient : TorDisposableBase
+	{
+		public Guid UniqueId { get; private set; }
 
-        public long RoundId { get; }
-        public Network Network { get; }
+		public long RoundId { get; }
+		public Network Network { get; }
 
-        public BitcoinAddress[] RegisteredAddresses { get; }
-        public SchnorrPubKey[] SchnorrPubKeys { get; }
-        public Requester[] Requesters { get; }
+		public BitcoinAddress[] RegisteredAddresses { get; }
+		public SchnorrPubKey[] SchnorrPubKeys { get; }
+		public Requester[] Requesters { get; }
 
-        /// <inheritdoc/>
-        private AliceClient(
-            long roundId,
-            IEnumerable<BitcoinAddress> registeredAddresses,
-            IEnumerable<SchnorrPubKey> schnorrPubKeys,
-            IEnumerable<Requester> requesters,
-            Network network,
-            Func<Uri> baseUriAction,
-            EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-        {
-            RoundId = roundId;
-            RegisteredAddresses = registeredAddresses.ToArray();
-            SchnorrPubKeys = schnorrPubKeys.ToArray();
-            Requesters = requesters.ToArray();
-            Network = network;
-        }
+		/// <inheritdoc/>
+		private AliceClient(
+			long roundId,
+			IEnumerable<BitcoinAddress> registeredAddresses,
+			IEnumerable<SchnorrPubKey> schnorrPubKeys,
+			IEnumerable<Requester> requesters,
+			Network network,
+			Func<Uri> baseUriAction,
+			EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+		{
+			RoundId = roundId;
+			RegisteredAddresses = registeredAddresses.ToArray();
+			SchnorrPubKeys = schnorrPubKeys.ToArray();
+			Requesters = requesters.ToArray();
+			Network = network;
+		}
 
-        public static async Task<AliceClient> CreateNewAsync(
-            long roundId,
-            IEnumerable<BitcoinAddress> registeredAddresses,
-            IEnumerable<SchnorrPubKey> schnorrPubKeys,
-            IEnumerable<Requester> requesters,
-            Network network,
-            InputsRequest request,
-            Uri baseUri,
-            EndPoint torSocks5EndPoint)
-        {
-            return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, () => baseUri, torSocks5EndPoint);
-        }
+		public static async Task<AliceClient> CreateNewAsync(
+			long roundId,
+			IEnumerable<BitcoinAddress> registeredAddresses,
+			IEnumerable<SchnorrPubKey> schnorrPubKeys,
+			IEnumerable<Requester> requesters,
+			Network network,
+			InputsRequest request,
+			Uri baseUri,
+			EndPoint torSocks5EndPoint)
+		{
+			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, () => baseUri, torSocks5EndPoint);
+		}
 
-        public static async Task<AliceClient> CreateNewAsync(long roundId,
-            IEnumerable<BitcoinAddress> registeredAddresses,
-            IEnumerable<SchnorrPubKey> schnorrPubKeys,
-            IEnumerable<Requester> requesters,
-            Network network,
-            InputsRequest request,
-            Func<Uri> baseUriAction,
-            EndPoint torSocks5EndPoint)
-        {
-            AliceClient client = new AliceClient(roundId, registeredAddresses, schnorrPubKeys, requesters, network, baseUriAction, torSocks5EndPoint);
-            try
-            {
-                // Correct it if forgot to set.
-                if (request.RoundId != roundId)
-                {
-                    if (request.RoundId == 0)
-                    {
-                        request.RoundId = roundId;
-                    }
-                    else
-                    {
-                        throw new NotSupportedException($"InputRequest roundId does not match to the provided roundId: {request.RoundId} != {roundId}.");
-                    }
-                }
-                using (HttpResponseMessage response = await client.TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()))
-                {
-                    if (response.StatusCode != HttpStatusCode.OK)
-                    {
-                        await response.ThrowRequestExceptionFromContentAsync();
-                    }
+		public static async Task<AliceClient> CreateNewAsync(long roundId,
+			IEnumerable<BitcoinAddress> registeredAddresses,
+			IEnumerable<SchnorrPubKey> schnorrPubKeys,
+			IEnumerable<Requester> requesters,
+			Network network,
+			InputsRequest request,
+			Func<Uri> baseUriAction,
+			EndPoint torSocks5EndPoint)
+		{
+			AliceClient client = new AliceClient(roundId, registeredAddresses, schnorrPubKeys, requesters, network, baseUriAction, torSocks5EndPoint);
+			try
+			{
+				// Correct it if forgot to set.
+				if (request.RoundId != roundId)
+				{
+					if (request.RoundId == 0)
+					{
+						request.RoundId = roundId;
+					}
+					else
+					{
+						throw new NotSupportedException($"InputRequest roundId does not match to the provided roundId: {request.RoundId} != {roundId}.");
+					}
+				}
+				using (HttpResponseMessage response = await client.TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()))
+				{
+					if (response.StatusCode != HttpStatusCode.OK)
+					{
+						await response.ThrowRequestExceptionFromContentAsync();
+					}
 
-                    var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>();
+					var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>();
 
-                    if (inputsResponse.RoundId != roundId) // This should never happen. If it does, that's a bug in the coordinator.
-                    {
-                        throw new NotSupportedException($"Coordinator assigned us to the wrong round: {inputsResponse.RoundId}. Requested round: {roundId}.");
-                    }
+					if (inputsResponse.RoundId != roundId) // This should never happen. If it does, that's a bug in the coordinator.
+					{
+						throw new NotSupportedException($"Coordinator assigned us to the wrong round: {inputsResponse.RoundId}. Requested round: {roundId}.");
+					}
 
-                    client.UniqueId = inputsResponse.UniqueId;
-                    Logger.LogInfo<AliceClient>($"Round ({client.RoundId}), Alice ({client.UniqueId}): Registered {request.Inputs.Count()} inputs.");
+					client.UniqueId = inputsResponse.UniqueId;
+					Logger.LogInfo<AliceClient>($"Round ({client.RoundId}), Alice ({client.UniqueId}): Registered {request.Inputs.Count()} inputs.");
 
-                    return client;
-                }
-            }
-            catch
-            {
-                client?.Dispose();
-                throw;
-            }
-        }
+					return client;
+				}
+			}
+			catch
+			{
+				client?.Dispose();
+				throw;
+			}
+		}
 
-        public static async Task<AliceClient> CreateNewAsync(
-            long roundId,
-            IEnumerable<BitcoinAddress> registeredAddresses,
-            IEnumerable<SchnorrPubKey> schnorrPubKeys,
-            IEnumerable<Requester> requesters,
-            Network network,
-            BitcoinAddress changeOutput,
-            IEnumerable<uint256> blindedOutputScriptHashes,
-            IEnumerable<InputProofModel> inputs,
-            Uri baseUri,
-            EndPoint torSocks5EndPoint)
-        {
-            return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, changeOutput, blindedOutputScriptHashes, inputs, () => baseUri, torSocks5EndPoint);
-        }
+		public static async Task<AliceClient> CreateNewAsync(
+			long roundId,
+			IEnumerable<BitcoinAddress> registeredAddresses,
+			IEnumerable<SchnorrPubKey> schnorrPubKeys,
+			IEnumerable<Requester> requesters,
+			Network network,
+			BitcoinAddress changeOutput,
+			IEnumerable<uint256> blindedOutputScriptHashes,
+			IEnumerable<InputProofModel> inputs,
+			Uri baseUri,
+			EndPoint torSocks5EndPoint)
+		{
+			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, changeOutput, blindedOutputScriptHashes, inputs, () => baseUri, torSocks5EndPoint);
+		}
 
-        public static async Task<AliceClient> CreateNewAsync(long roundId,
-            IEnumerable<BitcoinAddress> registeredAddresses,
-            IEnumerable<SchnorrPubKey> schnorrPubKeys,
-            IEnumerable<Requester> requesters,
-            Network network,
-            BitcoinAddress changeOutput,
-            IEnumerable<uint256> blindedOutputScriptHashes,
-            IEnumerable<InputProofModel> inputs,
-            Func<Uri> baseUriAction,
-            EndPoint torSocks5EndPoint)
-        {
-            var request = new InputsRequest
-            {
-                RoundId = roundId,
-                BlindedOutputScripts = blindedOutputScriptHashes,
-                ChangeOutputAddress = changeOutput,
-                Inputs = inputs
-            };
-            return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, baseUriAction, torSocks5EndPoint);
-        }
+		public static async Task<AliceClient> CreateNewAsync(long roundId,
+			IEnumerable<BitcoinAddress> registeredAddresses,
+			IEnumerable<SchnorrPubKey> schnorrPubKeys,
+			IEnumerable<Requester> requesters,
+			Network network,
+			BitcoinAddress changeOutput,
+			IEnumerable<uint256> blindedOutputScriptHashes,
+			IEnumerable<InputProofModel> inputs,
+			Func<Uri> baseUriAction,
+			EndPoint torSocks5EndPoint)
+		{
+			var request = new InputsRequest
+			{
+				RoundId = roundId,
+				BlindedOutputScripts = blindedOutputScriptHashes,
+				ChangeOutputAddress = changeOutput,
+				Inputs = inputs
+			};
+			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, baseUriAction, torSocks5EndPoint);
+		}
 
-        public async Task<(CcjRoundPhase currentPhase, IEnumerable<ActiveOutput> activeOutputs)> PostConfirmationAsync()
-        {
-            using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/confirmation?uniqueId={UniqueId}&roundId={RoundId}"))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		public async Task<(CcjRoundPhase currentPhase, IEnumerable<ActiveOutput> activeOutputs)> PostConfirmationAsync()
+		{
+			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/confirmation?uniqueId={UniqueId}&roundId={RoundId}"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>();
-                Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
+				ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>();
+				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
 
-                var activeOutputs = new List<ActiveOutput>();
-                if (resp.BlindedOutputSignatures != null && resp.BlindedOutputSignatures.Any())
-                {
-                    var unblindedSignatures = new List<UnblindedSignature>();
-                    var blindedSignatures = resp.BlindedOutputSignatures.ToArray();
-                    for (int i = 0; i < blindedSignatures.Length; i++)
-                    {
-                        uint256 blindedSignature = blindedSignatures[i];
-                        Requester requester = Requesters[i];
-                        UnblindedSignature unblindedSignature = requester.UnblindSignature(blindedSignature);
+				var activeOutputs = new List<ActiveOutput>();
+				if (resp.BlindedOutputSignatures != null && resp.BlindedOutputSignatures.Any())
+				{
+					var unblindedSignatures = new List<UnblindedSignature>();
+					var blindedSignatures = resp.BlindedOutputSignatures.ToArray();
+					for (int i = 0; i < blindedSignatures.Length; i++)
+					{
+						uint256 blindedSignature = blindedSignatures[i];
+						Requester requester = Requesters[i];
+						UnblindedSignature unblindedSignature = requester.UnblindSignature(blindedSignature);
 
-                        var address = RegisteredAddresses[i];
+						var address = RegisteredAddresses[i];
 
-                        uint256 outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
-                        PubKey signerPubKey = SchnorrPubKeys[i].SignerPubKey;
-                        if (!VerifySignature(outputScriptHash, unblindedSignature, signerPubKey))
-                        {
-                            throw new NotSupportedException($"Coordinator did not sign the blinded output properly for level: {i}.");
-                        }
+						uint256 outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
+						PubKey signerPubKey = SchnorrPubKeys[i].SignerPubKey;
+						if (!VerifySignature(outputScriptHash, unblindedSignature, signerPubKey))
+						{
+							throw new NotSupportedException($"Coordinator did not sign the blinded output properly for level: {i}.");
+						}
 
-                        unblindedSignatures.Add(unblindedSignature);
-                    }
+						unblindedSignatures.Add(unblindedSignature);
+					}
 
-                    for (int i = 0; i < Math.Min(unblindedSignatures.Count, RegisteredAddresses.Length); i++)
-                    {
-                        var sig = unblindedSignatures[i];
-                        var addr = RegisteredAddresses[i];
-                        var lvl = i;
+					for (int i = 0; i < Math.Min(unblindedSignatures.Count, RegisteredAddresses.Length); i++)
+					{
+						var sig = unblindedSignatures[i];
+						var addr = RegisteredAddresses[i];
+						var lvl = i;
 
-                        var actOut = new ActiveOutput(addr, sig, lvl);
-                        activeOutputs.Add(actOut);
-                    }
-                }
+						var actOut = new ActiveOutput(addr, sig, lvl);
+						activeOutputs.Add(actOut);
+					}
+				}
 
-                return (resp.CurrentPhase, activeOutputs);
-            }
-        }
+				return (resp.CurrentPhase, activeOutputs);
+			}
+		}
 
-        public async Task PostUnConfirmationAsync()
-        {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-            {
-                try
-                {
-                    using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/unconfirmation?uniqueId={UniqueId}&roundId={RoundId}", cancel: cts.Token))
-                    {
-                        if (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Gone) // Otherwise maybe some internet connection issue there's. Let's consider that as timed out.
-                        {
-                            await response.ThrowRequestExceptionFromContentAsync();
-                        }
-                    }
-                }
-                catch (Exception ex) when (ex is OperationCanceledException // If could not do it within 3 seconds then it'll likely time out and take it as unconfirmed.
-                                        || ex is TaskCanceledException
-                                        || ex is TimeoutException)
-                {
-                    return;
-                }
-                catch (ConnectionException)  // If some internet connection issue then it'll likely time out and take it as unconfirmed.
-                {
-                    return;
-                }
-                catch (TorSocks5FailureResponseException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
-                {
-                    return;
-                }
-            }
-            Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
-        }
+		public async Task PostUnConfirmationAsync()
+		{
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+			{
+				try
+				{
+					using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/unconfirmation?uniqueId={UniqueId}&roundId={RoundId}", cancel: cts.Token))
+					{
+						if (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Gone) // Otherwise maybe some internet connection issue there's. Let's consider that as timed out.
+						{
+							await response.ThrowRequestExceptionFromContentAsync();
+						}
+					}
+				}
+				catch (Exception ex) when (ex is OperationCanceledException // If could not do it within 3 seconds then it'll likely time out and take it as unconfirmed.
+										|| ex is TaskCanceledException
+										|| ex is TimeoutException)
+				{
+					return;
+				}
+				catch (ConnectionException)  // If some internet connection issue then it'll likely time out and take it as unconfirmed.
+				{
+					return;
+				}
+				catch (TorSocks5FailureResponseException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
+				{
+					return;
+				}
+			}
+			Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
+		}
 
-        public async Task<Transaction> GetUnsignedCoinJoinAsync()
-        {
-            using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/coinjoin?uniqueId={UniqueId}&roundId={RoundId}"))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		public async Task<Transaction> GetUnsignedCoinJoinAsync()
+		{
+			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/coinjoin?uniqueId={UniqueId}&roundId={RoundId}"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
+				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
 
-                Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
-                Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
-                return coinJoin;
-            }
-        }
+				Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
+				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
+				return coinJoin;
+			}
+		}
 
-        public async Task PostSignaturesAsync(IDictionary<int, WitScript> signatures)
-        {
-            var myDic = signatures.ToDictionary(signature => signature.Key, signature => signature.Value.ToString());
+		public async Task PostSignaturesAsync(IDictionary<int, WitScript> signatures)
+		{
+			var myDic = signatures.ToDictionary(signature => signature.Key, signature => signature.Value.ToString());
 
-            var jsonSignatures = JsonConvert.SerializeObject(myDic, Formatting.None);
-            var signatureRequestContent = new StringContent(jsonSignatures, Encoding.UTF8, "application/json");
+			var jsonSignatures = JsonConvert.SerializeObject(myDic, Formatting.None);
+			var signatureRequestContent = new StringContent(jsonSignatures, Encoding.UTF8, "application/json");
 
-            using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/signatures?uniqueId={UniqueId}&roundId={RoundId}", signatureRequestContent))
-            {
-                if (response.StatusCode != HttpStatusCode.NoContent)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
-                Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
-            }
-        }
-    }
+			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/signatures?uniqueId={UniqueId}&roundId={RoundId}", signatureRequestContent))
+			{
+				if (response.StatusCode != HttpStatusCode.NoContent)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
+				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
+			}
+		}
+	}
 }

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
@@ -21,248 +21,248 @@ using static NBitcoin.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 {
-	public class AliceClient : TorDisposableBase
-	{
-		public Guid UniqueId { get; private set; }
+    public class AliceClient : TorDisposableBase
+    {
+        public Guid UniqueId { get; private set; }
 
-		public long RoundId { get; }
-		public Network Network { get; }
+        public long RoundId { get; }
+        public Network Network { get; }
 
-		public BitcoinAddress[] RegisteredAddresses { get; }
-		public SchnorrPubKey[] SchnorrPubKeys { get; }
-		public Requester[] Requesters { get; }
+        public BitcoinAddress[] RegisteredAddresses { get; }
+        public SchnorrPubKey[] SchnorrPubKeys { get; }
+        public Requester[] Requesters { get; }
 
-		/// <inheritdoc/>
-		private AliceClient(
-			long roundId,
-			IEnumerable<BitcoinAddress> registeredAddresses,
-			IEnumerable<SchnorrPubKey> schnorrPubKeys,
-			IEnumerable<Requester> requesters,
-			Network network,
-			Func<Uri> baseUriAction,
-			IPEndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-		{
-			RoundId = roundId;
-			RegisteredAddresses = registeredAddresses.ToArray();
-			SchnorrPubKeys = schnorrPubKeys.ToArray();
-			Requesters = requesters.ToArray();
-			Network = network;
-		}
+        /// <inheritdoc/>
+        private AliceClient(
+            long roundId,
+            IEnumerable<BitcoinAddress> registeredAddresses,
+            IEnumerable<SchnorrPubKey> schnorrPubKeys,
+            IEnumerable<Requester> requesters,
+            Network network,
+            Func<Uri> baseUriAction,
+            EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+        {
+            RoundId = roundId;
+            RegisteredAddresses = registeredAddresses.ToArray();
+            SchnorrPubKeys = schnorrPubKeys.ToArray();
+            Requesters = requesters.ToArray();
+            Network = network;
+        }
 
-		public static async Task<AliceClient> CreateNewAsync(
-			long roundId,
-			IEnumerable<BitcoinAddress> registeredAddresses,
-			IEnumerable<SchnorrPubKey> schnorrPubKeys,
-			IEnumerable<Requester> requesters,
-			Network network,
-			InputsRequest request,
-			Uri baseUri,
-			IPEndPoint torSocks5EndPoint)
-		{
-			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, () => baseUri, torSocks5EndPoint);
-		}
+        public static async Task<AliceClient> CreateNewAsync(
+            long roundId,
+            IEnumerable<BitcoinAddress> registeredAddresses,
+            IEnumerable<SchnorrPubKey> schnorrPubKeys,
+            IEnumerable<Requester> requesters,
+            Network network,
+            InputsRequest request,
+            Uri baseUri,
+            EndPoint torSocks5EndPoint)
+        {
+            return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, () => baseUri, torSocks5EndPoint);
+        }
 
-		public static async Task<AliceClient> CreateNewAsync(long roundId,
-			IEnumerable<BitcoinAddress> registeredAddresses,
-			IEnumerable<SchnorrPubKey> schnorrPubKeys,
-			IEnumerable<Requester> requesters,
-			Network network,
-			InputsRequest request,
-			Func<Uri> baseUriAction,
-			IPEndPoint torSocks5EndPoint)
-		{
-			AliceClient client = new AliceClient(roundId, registeredAddresses, schnorrPubKeys, requesters, network, baseUriAction, torSocks5EndPoint);
-			try
-			{
-				// Correct it if forgot to set.
-				if (request.RoundId != roundId)
-				{
-					if (request.RoundId == 0)
-					{
-						request.RoundId = roundId;
-					}
-					else
-					{
-						throw new NotSupportedException($"InputRequest roundId does not match to the provided roundId: {request.RoundId} != {roundId}.");
-					}
-				}
-				using (HttpResponseMessage response = await client.TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()))
-				{
-					if (response.StatusCode != HttpStatusCode.OK)
-					{
-						await response.ThrowRequestExceptionFromContentAsync();
-					}
+        public static async Task<AliceClient> CreateNewAsync(long roundId,
+            IEnumerable<BitcoinAddress> registeredAddresses,
+            IEnumerable<SchnorrPubKey> schnorrPubKeys,
+            IEnumerable<Requester> requesters,
+            Network network,
+            InputsRequest request,
+            Func<Uri> baseUriAction,
+            EndPoint torSocks5EndPoint)
+        {
+            AliceClient client = new AliceClient(roundId, registeredAddresses, schnorrPubKeys, requesters, network, baseUriAction, torSocks5EndPoint);
+            try
+            {
+                // Correct it if forgot to set.
+                if (request.RoundId != roundId)
+                {
+                    if (request.RoundId == 0)
+                    {
+                        request.RoundId = roundId;
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"InputRequest roundId does not match to the provided roundId: {request.RoundId} != {roundId}.");
+                    }
+                }
+                using (HttpResponseMessage response = await client.TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/inputs/", request.ToHttpStringContent()))
+                {
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        await response.ThrowRequestExceptionFromContentAsync();
+                    }
 
-					var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>();
+                    var inputsResponse = await response.Content.ReadAsJsonAsync<InputsResponse>();
 
-					if (inputsResponse.RoundId != roundId) // This should never happen. If it does, that's a bug in the coordinator.
-					{
-						throw new NotSupportedException($"Coordinator assigned us to the wrong round: {inputsResponse.RoundId}. Requested round: {roundId}.");
-					}
+                    if (inputsResponse.RoundId != roundId) // This should never happen. If it does, that's a bug in the coordinator.
+                    {
+                        throw new NotSupportedException($"Coordinator assigned us to the wrong round: {inputsResponse.RoundId}. Requested round: {roundId}.");
+                    }
 
-					client.UniqueId = inputsResponse.UniqueId;
-					Logger.LogInfo<AliceClient>($"Round ({client.RoundId}), Alice ({client.UniqueId}): Registered {request.Inputs.Count()} inputs.");
+                    client.UniqueId = inputsResponse.UniqueId;
+                    Logger.LogInfo<AliceClient>($"Round ({client.RoundId}), Alice ({client.UniqueId}): Registered {request.Inputs.Count()} inputs.");
 
-					return client;
-				}
-			}
-			catch
-			{
-				client?.Dispose();
-				throw;
-			}
-		}
+                    return client;
+                }
+            }
+            catch
+            {
+                client?.Dispose();
+                throw;
+            }
+        }
 
-		public static async Task<AliceClient> CreateNewAsync(
-			long roundId,
-			IEnumerable<BitcoinAddress> registeredAddresses,
-			IEnumerable<SchnorrPubKey> schnorrPubKeys,
-			IEnumerable<Requester> requesters,
-			Network network,
-			BitcoinAddress changeOutput,
-			IEnumerable<uint256> blindedOutputScriptHashes,
-			IEnumerable<InputProofModel> inputs,
-			Uri baseUri,
-			IPEndPoint torSocks5EndPoint)
-		{
-			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, changeOutput, blindedOutputScriptHashes, inputs, () => baseUri, torSocks5EndPoint);
-		}
+        public static async Task<AliceClient> CreateNewAsync(
+            long roundId,
+            IEnumerable<BitcoinAddress> registeredAddresses,
+            IEnumerable<SchnorrPubKey> schnorrPubKeys,
+            IEnumerable<Requester> requesters,
+            Network network,
+            BitcoinAddress changeOutput,
+            IEnumerable<uint256> blindedOutputScriptHashes,
+            IEnumerable<InputProofModel> inputs,
+            Uri baseUri,
+            EndPoint torSocks5EndPoint)
+        {
+            return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, changeOutput, blindedOutputScriptHashes, inputs, () => baseUri, torSocks5EndPoint);
+        }
 
-		public static async Task<AliceClient> CreateNewAsync(long roundId,
-			IEnumerable<BitcoinAddress> registeredAddresses,
-			IEnumerable<SchnorrPubKey> schnorrPubKeys,
-			IEnumerable<Requester> requesters,
-			Network network,
-			BitcoinAddress changeOutput,
-			IEnumerable<uint256> blindedOutputScriptHashes,
-			IEnumerable<InputProofModel> inputs,
-			Func<Uri> baseUriAction,
-			IPEndPoint torSocks5EndPoint)
-		{
-			var request = new InputsRequest
-			{
-				RoundId = roundId,
-				BlindedOutputScripts = blindedOutputScriptHashes,
-				ChangeOutputAddress = changeOutput,
-				Inputs = inputs
-			};
-			return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, baseUriAction, torSocks5EndPoint);
-		}
+        public static async Task<AliceClient> CreateNewAsync(long roundId,
+            IEnumerable<BitcoinAddress> registeredAddresses,
+            IEnumerable<SchnorrPubKey> schnorrPubKeys,
+            IEnumerable<Requester> requesters,
+            Network network,
+            BitcoinAddress changeOutput,
+            IEnumerable<uint256> blindedOutputScriptHashes,
+            IEnumerable<InputProofModel> inputs,
+            Func<Uri> baseUriAction,
+            EndPoint torSocks5EndPoint)
+        {
+            var request = new InputsRequest
+            {
+                RoundId = roundId,
+                BlindedOutputScripts = blindedOutputScriptHashes,
+                ChangeOutputAddress = changeOutput,
+                Inputs = inputs
+            };
+            return await CreateNewAsync(roundId, registeredAddresses, schnorrPubKeys, requesters, network, request, baseUriAction, torSocks5EndPoint);
+        }
 
-		public async Task<(CcjRoundPhase currentPhase, IEnumerable<ActiveOutput> activeOutputs)> PostConfirmationAsync()
-		{
-			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/confirmation?uniqueId={UniqueId}&roundId={RoundId}"))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        public async Task<(CcjRoundPhase currentPhase, IEnumerable<ActiveOutput> activeOutputs)> PostConfirmationAsync()
+        {
+            using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/confirmation?uniqueId={UniqueId}&roundId={RoundId}"))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>();
-				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
+                ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>();
+                Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
 
-				var activeOutputs = new List<ActiveOutput>();
-				if (resp.BlindedOutputSignatures != null && resp.BlindedOutputSignatures.Any())
-				{
-					var unblindedSignatures = new List<UnblindedSignature>();
-					var blindedSignatures = resp.BlindedOutputSignatures.ToArray();
-					for (int i = 0; i < blindedSignatures.Length; i++)
-					{
-						uint256 blindedSignature = blindedSignatures[i];
-						Requester requester = Requesters[i];
-						UnblindedSignature unblindedSignature = requester.UnblindSignature(blindedSignature);
+                var activeOutputs = new List<ActiveOutput>();
+                if (resp.BlindedOutputSignatures != null && resp.BlindedOutputSignatures.Any())
+                {
+                    var unblindedSignatures = new List<UnblindedSignature>();
+                    var blindedSignatures = resp.BlindedOutputSignatures.ToArray();
+                    for (int i = 0; i < blindedSignatures.Length; i++)
+                    {
+                        uint256 blindedSignature = blindedSignatures[i];
+                        Requester requester = Requesters[i];
+                        UnblindedSignature unblindedSignature = requester.UnblindSignature(blindedSignature);
 
-						var address = RegisteredAddresses[i];
+                        var address = RegisteredAddresses[i];
 
-						uint256 outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
-						PubKey signerPubKey = SchnorrPubKeys[i].SignerPubKey;
-						if (!VerifySignature(outputScriptHash, unblindedSignature, signerPubKey))
-						{
-							throw new NotSupportedException($"Coordinator did not sign the blinded output properly for level: {i}.");
-						}
+                        uint256 outputScriptHash = new uint256(Hashes.SHA256(address.ScriptPubKey.ToBytes()));
+                        PubKey signerPubKey = SchnorrPubKeys[i].SignerPubKey;
+                        if (!VerifySignature(outputScriptHash, unblindedSignature, signerPubKey))
+                        {
+                            throw new NotSupportedException($"Coordinator did not sign the blinded output properly for level: {i}.");
+                        }
 
-						unblindedSignatures.Add(unblindedSignature);
-					}
+                        unblindedSignatures.Add(unblindedSignature);
+                    }
 
-					for (int i = 0; i < Math.Min(unblindedSignatures.Count, RegisteredAddresses.Length); i++)
-					{
-						var sig = unblindedSignatures[i];
-						var addr = RegisteredAddresses[i];
-						var lvl = i;
+                    for (int i = 0; i < Math.Min(unblindedSignatures.Count, RegisteredAddresses.Length); i++)
+                    {
+                        var sig = unblindedSignatures[i];
+                        var addr = RegisteredAddresses[i];
+                        var lvl = i;
 
-						var actOut = new ActiveOutput(addr, sig, lvl);
-						activeOutputs.Add(actOut);
-					}
-				}
+                        var actOut = new ActiveOutput(addr, sig, lvl);
+                        activeOutputs.Add(actOut);
+                    }
+                }
 
-				return (resp.CurrentPhase, activeOutputs);
-			}
-		}
+                return (resp.CurrentPhase, activeOutputs);
+            }
+        }
 
-		public async Task PostUnConfirmationAsync()
-		{
-			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
-			{
-				try
-				{
-					using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/unconfirmation?uniqueId={UniqueId}&roundId={RoundId}", cancel: cts.Token))
-					{
-						if (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Gone) // Otherwise maybe some internet connection issue there's. Let's consider that as timed out.
-						{
-							await response.ThrowRequestExceptionFromContentAsync();
-						}
-					}
-				}
-				catch (Exception ex) when (ex is OperationCanceledException // If could not do it within 3 seconds then it'll likely time out and take it as unconfirmed.
-										|| ex is TaskCanceledException
-										|| ex is TimeoutException)
-				{
-					return;
-				}
-				catch (ConnectionException)  // If some internet connection issue then it'll likely time out and take it as unconfirmed.
-				{
-					return;
-				}
-				catch (TorSocks5FailureResponseException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
-				{
-					return;
-				}
-			}
-			Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
-		}
+        public async Task PostUnConfirmationAsync()
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+            {
+                try
+                {
+                    using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/unconfirmation?uniqueId={UniqueId}&roundId={RoundId}", cancel: cts.Token))
+                    {
+                        if (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Gone) // Otherwise maybe some internet connection issue there's. Let's consider that as timed out.
+                        {
+                            await response.ThrowRequestExceptionFromContentAsync();
+                        }
+                    }
+                }
+                catch (Exception ex) when (ex is OperationCanceledException // If could not do it within 3 seconds then it'll likely time out and take it as unconfirmed.
+                                        || ex is TaskCanceledException
+                                        || ex is TimeoutException)
+                {
+                    return;
+                }
+                catch (ConnectionException)  // If some internet connection issue then it'll likely time out and take it as unconfirmed.
+                {
+                    return;
+                }
+                catch (TorSocks5FailureResponseException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
+                {
+                    return;
+                }
+            }
+            Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
+        }
 
-		public async Task<Transaction> GetUnsignedCoinJoinAsync()
-		{
-			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/coinjoin?uniqueId={UniqueId}&roundId={RoundId}"))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        public async Task<Transaction> GetUnsignedCoinJoinAsync()
+        {
+            using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/coinjoin?uniqueId={UniqueId}&roundId={RoundId}"))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
+                var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
 
-				Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
-				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
-				return coinJoin;
-			}
-		}
+                Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
+                Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
+                return coinJoin;
+            }
+        }
 
-		public async Task PostSignaturesAsync(IDictionary<int, WitScript> signatures)
-		{
-			var myDic = signatures.ToDictionary(signature => signature.Key, signature => signature.Value.ToString());
+        public async Task PostSignaturesAsync(IDictionary<int, WitScript> signatures)
+        {
+            var myDic = signatures.ToDictionary(signature => signature.Key, signature => signature.Value.ToString());
 
-			var jsonSignatures = JsonConvert.SerializeObject(myDic, Formatting.None);
-			var signatureRequestContent = new StringContent(jsonSignatures, Encoding.UTF8, "application/json");
+            var jsonSignatures = JsonConvert.SerializeObject(myDic, Formatting.None);
+            var signatureRequestContent = new StringContent(jsonSignatures, Encoding.UTF8, "application/json");
 
-			using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/signatures?uniqueId={UniqueId}&roundId={RoundId}", signatureRequestContent))
-			{
-				if (response.StatusCode != HttpStatusCode.NoContent)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
-				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
-			}
-		}
-	}
+            using (HttpResponseMessage response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/signatures?uniqueId={UniqueId}&roundId={RoundId}", signatureRequestContent))
+            {
+                if (response.StatusCode != HttpStatusCode.NoContent)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
+                Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
+            }
+        }
+    }
 }

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/BobClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/BobClient.cs
@@ -11,38 +11,38 @@ using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 {
-	public class BobClient : TorDisposableBase
-	{
-		/// <inheritdoc/>
-		public BobClient(Func<Uri> baseUriAction, IPEndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-		{
-		}
+    public class BobClient : TorDisposableBase
+    {
+        /// <inheritdoc/>
+        public BobClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+        {
+        }
 
-		/// <inheritdoc/>
-		public BobClient(Uri baseUri, IPEndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-		{
-		}
+        /// <inheritdoc/>
+        public BobClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
+        {
+        }
 
-		/// <returns>If the phase is still in OutputRegistration.</returns>
-		public async Task<bool> PostOutputAsync(long roundId, ActiveOutput activeOutput)
-		{
-			Guard.MinimumAndNotNull(nameof(roundId), roundId, 0);
-			Guard.NotNull(nameof(activeOutput), activeOutput);
+        /// <returns>If the phase is still in OutputRegistration.</returns>
+        public async Task<bool> PostOutputAsync(long roundId, ActiveOutput activeOutput)
+        {
+            Guard.MinimumAndNotNull(nameof(roundId), roundId, 0);
+            Guard.NotNull(nameof(activeOutput), activeOutput);
 
-			var request = new OutputRequest { OutputAddress = activeOutput.Address, UnblindedSignature = activeOutput.Signature, Level = activeOutput.MixingLevel };
-			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Constants.BackendMajorVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()))
-			{
-				if (response.StatusCode == HttpStatusCode.Conflict)
-				{
-					return false;
-				}
-				else if (response.StatusCode != HttpStatusCode.NoContent)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+            var request = new OutputRequest { OutputAddress = activeOutput.Address, UnblindedSignature = activeOutput.Signature, Level = activeOutput.MixingLevel };
+            using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Constants.BackendMajorVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()))
+            {
+                if (response.StatusCode == HttpStatusCode.Conflict)
+                {
+                    return false;
+                }
+                else if (response.StatusCode != HttpStatusCode.NoContent)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				return true;
-			}
-		}
-	}
+                return true;
+            }
+        }
+    }
 }

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/BobClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/BobClient.cs
@@ -11,38 +11,38 @@ using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 {
-    public class BobClient : TorDisposableBase
-    {
-        /// <inheritdoc/>
-        public BobClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-        {
-        }
+	public class BobClient : TorDisposableBase
+	{
+		/// <inheritdoc/>
+		public BobClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+		{
+		}
 
-        /// <inheritdoc/>
-        public BobClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-        {
-        }
+		/// <inheritdoc/>
+		public BobClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
+		{
+		}
 
-        /// <returns>If the phase is still in OutputRegistration.</returns>
-        public async Task<bool> PostOutputAsync(long roundId, ActiveOutput activeOutput)
-        {
-            Guard.MinimumAndNotNull(nameof(roundId), roundId, 0);
-            Guard.NotNull(nameof(activeOutput), activeOutput);
+		/// <returns>If the phase is still in OutputRegistration.</returns>
+		public async Task<bool> PostOutputAsync(long roundId, ActiveOutput activeOutput)
+		{
+			Guard.MinimumAndNotNull(nameof(roundId), roundId, 0);
+			Guard.NotNull(nameof(activeOutput), activeOutput);
 
-            var request = new OutputRequest { OutputAddress = activeOutput.Address, UnblindedSignature = activeOutput.Signature, Level = activeOutput.MixingLevel };
-            using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Constants.BackendMajorVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()))
-            {
-                if (response.StatusCode == HttpStatusCode.Conflict)
-                {
-                    return false;
-                }
-                else if (response.StatusCode != HttpStatusCode.NoContent)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+			var request = new OutputRequest { OutputAddress = activeOutput.Address, UnblindedSignature = activeOutput.Signature, Level = activeOutput.MixingLevel };
+			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Constants.BackendMajorVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()))
+			{
+				if (response.StatusCode == HttpStatusCode.Conflict)
+				{
+					return false;
+				}
+				else if (response.StatusCode != HttpStatusCode.NoContent)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                return true;
-            }
-        }
-    }
+				return true;
+			}
+		}
+	}
 }

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/SatoshiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/SatoshiClient.cs
@@ -10,43 +10,43 @@ using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 {
-    public class SatoshiClient : TorDisposableBase
-    {
-        /// <inheritdoc/>
-        public SatoshiClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-        {
-        }
+	public class SatoshiClient : TorDisposableBase
+	{
+		/// <inheritdoc/>
+		public SatoshiClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+		{
+		}
 
-        /// <inheritdoc/>
-        public SatoshiClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-        {
-        }
+		/// <inheritdoc/>
+		public SatoshiClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
+		{
+		}
 
-        public async Task<IEnumerable<CcjRunningRoundState>> GetAllRoundStatesAsync()
-        {
-            using (var response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/states/"))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		public async Task<IEnumerable<CcjRunningRoundState>> GetAllRoundStatesAsync()
+		{
+			using (var response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/states/"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();
+				var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();
 
-                return states;
-            }
-        }
+				return states;
+			}
+		}
 
-        public async Task<CcjRunningRoundState> GetRoundStateAsync(long roundId)
-        {
-            IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
-            return states.Single(x => x.RoundId == roundId);
-        }
+		public async Task<CcjRunningRoundState> GetRoundStateAsync(long roundId)
+		{
+			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
+			return states.Single(x => x.RoundId == roundId);
+		}
 
-        public async Task<CcjRunningRoundState> GetRegistrableRoundStateAsync()
-        {
-            IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
-            return states.First(x => x.Phase == CcjRoundPhase.InputRegistration);
-        }
-    }
+		public async Task<CcjRunningRoundState> GetRegistrableRoundStateAsync()
+		{
+			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
+			return states.First(x => x.Phase == CcjRoundPhase.InputRegistration);
+		}
+	}
 }

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/SatoshiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/SatoshiClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -10,43 +10,43 @@ using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 {
-	public class SatoshiClient : TorDisposableBase
-	{
-		/// <inheritdoc/>
-		public SatoshiClient(Func<Uri> baseUriAction, IPEndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-		{
-		}
+    public class SatoshiClient : TorDisposableBase
+    {
+        /// <inheritdoc/>
+        public SatoshiClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+        {
+        }
 
-		/// <inheritdoc/>
-		public SatoshiClient(Uri baseUri, IPEndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-		{
-		}
+        /// <inheritdoc/>
+        public SatoshiClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
+        {
+        }
 
-		public async Task<IEnumerable<CcjRunningRoundState>> GetAllRoundStatesAsync()
-		{
-			using (var response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/states/"))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        public async Task<IEnumerable<CcjRunningRoundState>> GetAllRoundStatesAsync()
+        {
+            using (var response = await TorClient.SendAsync(HttpMethod.Get, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/chaumiancoinjoin/states/"))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();
+                var states = await response.Content.ReadAsJsonAsync<IEnumerable<CcjRunningRoundState>>();
 
-				return states;
-			}
-		}
+                return states;
+            }
+        }
 
-		public async Task<CcjRunningRoundState> GetRoundStateAsync(long roundId)
-		{
-			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
-			return states.Single(x => x.RoundId == roundId);
-		}
+        public async Task<CcjRunningRoundState> GetRoundStateAsync(long roundId)
+        {
+            IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
+            return states.Single(x => x.RoundId == roundId);
+        }
 
-		public async Task<CcjRunningRoundState> GetRegistrableRoundStateAsync()
-		{
-			IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
-			return states.First(x => x.Phase == CcjRoundPhase.InputRegistration);
-		}
-	}
+        public async Task<CcjRunningRoundState> GetRegistrableRoundStateAsync()
+        {
+            IEnumerable<CcjRunningRoundState> states = await GetAllRoundStatesAsync();
+            return states.First(x => x.Phase == CcjRoundPhase.InputRegistration);
+        }
+    }
 }

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -15,223 +15,223 @@ using WalletWasabi.Models;
 
 namespace WalletWasabi.WebClients.Wasabi
 {
-	public class WasabiClient : TorDisposableBase
-	{
-		/// <inheritdoc/>
-		public WasabiClient(Func<Uri> baseUriAction, IPEndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-		{
-		}
+    public class WasabiClient : TorDisposableBase
+    {
+        /// <inheritdoc/>
+        public WasabiClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+        {
+        }
 
-		/// <inheritdoc/>
-		public WasabiClient(Uri baseUri, IPEndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-		{
-		}
+        /// <inheritdoc/>
+        public WasabiClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
+        {
+        }
 
-		#region batch
+        #region batch
 
-		/// <remarks>
-		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-		/// </remarks>
-		public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
-		{
-			string relativeUri = $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
-			if (estimateMode != null)
-			{
-				relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";
-			}
+        /// <remarks>
+        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+        /// </remarks>
+        public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
+        {
+            string relativeUri = $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
+            if (estimateMode != null)
+            {
+                relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";
+            }
 
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-																	HttpStatusCode.OK,
-																	relativeUri,
-																	cancel: cancel))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+                                                                    HttpStatusCode.OK,
+                                                                    relativeUri,
+                                                                    cancel: cancel))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var ret = await content.ReadAsJsonAsync<SynchronizeResponse>();
-					return ret;
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var ret = await content.ReadAsJsonAsync<SynchronizeResponse>();
+                    return ret;
+                }
+            }
+        }
 
-		#endregion batch
+        #endregion batch
 
-		#region blockchain
+        #region blockchain
 
-		/// <remarks>
-		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-		/// </remarks>
-		public async Task<FiltersResponse> GetFiltersAsync(uint256 bestKnownBlockHash, int count, CancellationToken cancel = default)
-		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-																	HttpStatusCode.OK,
-																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
-																	cancel: cancel))
-			{
-				if (response.StatusCode == HttpStatusCode.NoContent)
-				{
-					return null;
-				}
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        /// <remarks>
+        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+        /// </remarks>
+        public async Task<FiltersResponse> GetFiltersAsync(uint256 bestKnownBlockHash, int count, CancellationToken cancel = default)
+        {
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+                                                                    HttpStatusCode.OK,
+                                                                    $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
+                                                                    cancel: cancel))
+            {
+                if (response.StatusCode == HttpStatusCode.NoContent)
+                {
+                    return null;
+                }
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var ret = await content.ReadAsJsonAsync<FiltersResponse>();
-					return ret;
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var ret = await content.ReadAsJsonAsync<FiltersResponse>();
+                    return ret;
+                }
+            }
+        }
 
-		public async Task<IDictionary<int, FeeEstimationPair>> GetFeesAsync(params int[] confirmationTargets)
-		{
-			var confirmationTargetsString = string.Join(",", confirmationTargets);
+        public async Task<IDictionary<int, FeeEstimationPair>> GetFeesAsync(params int[] confirmationTargets)
+        {
+            var confirmationTargetsString = string.Join(",", confirmationTargets);
 
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/fees/{confirmationTargetsString}"))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/fees/{confirmationTargetsString}"))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>();
-					return ret;
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>();
+                    return ret;
+                }
+            }
+        }
 
-		public async Task BroadcastAsync(string hex)
-		{
-			using (var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json"))
-			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/broadcast", content))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
-			}
-		}
+        public async Task BroadcastAsync(string hex)
+        {
+            using (var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json"))
+            using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/broadcast", content))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
+            }
+        }
 
-		public async Task BroadcastAsync(Transaction transaction)
-		{
-			await BroadcastAsync(transaction.ToHex());
-		}
+        public async Task BroadcastAsync(Transaction transaction)
+        {
+            await BroadcastAsync(transaction.ToHex());
+        }
 
-		public async Task BroadcastAsync(SmartTransaction transaction)
-		{
-			await BroadcastAsync(transaction.Transaction);
-		}
+        public async Task BroadcastAsync(SmartTransaction transaction)
+        {
+            await BroadcastAsync(transaction.Transaction);
+        }
 
-		public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
-		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-																	HttpStatusCode.OK,
-																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
-																	cancel: cancel))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
+        {
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+                                                                    HttpStatusCode.OK,
+                                                                    $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
+                                                                    cancel: cancel))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
-					var ret = strings.Select(x => new uint256(x));
-					return ret;
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
+                    var ret = strings.Select(x => new uint256(x));
+                    return ret;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Gets mempool hashes, but strips the last x characters of each hash.
-		/// </summary>
-		/// <param name="compactness">1 to 64</param>
-		public async Task<ISet<string>> GetMempoolHashesAsync(int compactness, CancellationToken cancel = default)
-		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-																	HttpStatusCode.OK,
-																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
-																	cancel: cancel))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        /// <summary>
+        /// Gets mempool hashes, but strips the last x characters of each hash.
+        /// </summary>
+        /// <param name="compactness">1 to 64</param>
+        public async Task<ISet<string>> GetMempoolHashesAsync(int compactness, CancellationToken cancel = default)
+        {
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+                                                                    HttpStatusCode.OK,
+                                                                    $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
+                                                                    cancel: cancel))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var strings = await content.ReadAsJsonAsync<ISet<string>>();
-					return strings;
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var strings = await content.ReadAsJsonAsync<ISet<string>>();
+                    return strings;
+                }
+            }
+        }
 
-		#endregion blockchain
+        #endregion blockchain
 
-		#region offchain
+        #region offchain
 
-		public async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync()
-		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/offchain/exchange-rates"))
-			{
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+        public async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync()
+        {
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/offchain/exchange-rates"))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var ret = await content.ReadAsJsonAsync<IEnumerable<ExchangeRate>>();
-					return ret;
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var ret = await content.ReadAsJsonAsync<IEnumerable<ExchangeRate>>();
+                    return ret;
+                }
+            }
+        }
 
-		#endregion offchain
+        #endregion offchain
 
-		#region software
+        #region software
 
-		public async Task<(Version ClientVersion, int BackendMajorVersion)> GetVersionsAsync(CancellationToken cancel)
-		{
-			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, "/api/software/versions", cancel: cancel))
-			{
-				if (response.StatusCode == HttpStatusCode.NotFound)
-				{
-					// Meaning this things was not just yet implemented on the running server.
-					return (new Version(0, 7), 1);
-				}
+        public async Task<(Version ClientVersion, int BackendMajorVersion)> GetVersionsAsync(CancellationToken cancel)
+        {
+            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, "/api/software/versions", cancel: cancel))
+            {
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // Meaning this things was not just yet implemented on the running server.
+                    return (new Version(0, 7), 1);
+                }
 
-				if (response.StatusCode != HttpStatusCode.OK)
-				{
-					await response.ThrowRequestExceptionFromContentAsync();
-				}
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    await response.ThrowRequestExceptionFromContentAsync();
+                }
 
-				using (HttpContent content = response.Content)
-				{
-					var resp = await content.ReadAsJsonAsync<VersionsResponse>();
-					return (Version.Parse(resp.ClientVersion), int.Parse(resp.BackendMajorVersion));
-				}
-			}
-		}
+                using (HttpContent content = response.Content)
+                {
+                    var resp = await content.ReadAsJsonAsync<VersionsResponse>();
+                    return (Version.Parse(resp.ClientVersion), int.Parse(resp.BackendMajorVersion));
+                }
+            }
+        }
 
-		public async Task<(bool backendCompatible, bool clientUpToDate)> CheckUpdatesAsync(CancellationToken cancel)
-		{
-			var versions = await GetVersionsAsync(cancel);
-			var clientUpToDate = Helpers.Constants.ClientVersion >= versions.ClientVersion; // If the client version locally is greater than or equal to the backend's reported client version, then good.
-			var backendCompatible = int.Parse(Helpers.Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major are equal, then our softwares are compatible.
+        public async Task<(bool backendCompatible, bool clientUpToDate)> CheckUpdatesAsync(CancellationToken cancel)
+        {
+            var versions = await GetVersionsAsync(cancel);
+            var clientUpToDate = Helpers.Constants.ClientVersion >= versions.ClientVersion; // If the client version locally is greater than or equal to the backend's reported client version, then good.
+            var backendCompatible = int.Parse(Helpers.Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major are equal, then our softwares are compatible.
 
-			return (backendCompatible, clientUpToDate);
-		}
+            return (backendCompatible, clientUpToDate);
+        }
 
-		#endregion software
-	}
+        #endregion software
+    }
 }

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -15,223 +15,223 @@ using WalletWasabi.Models;
 
 namespace WalletWasabi.WebClients.Wasabi
 {
-    public class WasabiClient : TorDisposableBase
-    {
-        /// <inheritdoc/>
-        public WasabiClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
-        {
-        }
+	public class WasabiClient : TorDisposableBase
+	{
+		/// <inheritdoc/>
+		public WasabiClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+		{
+		}
 
-        /// <inheritdoc/>
-        public WasabiClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-        {
-        }
+		/// <inheritdoc/>
+		public WasabiClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
+		{
+		}
 
-        #region batch
+		#region batch
 
-        /// <remarks>
-        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-        /// </remarks>
-        public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
-        {
-            string relativeUri = $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
-            if (estimateMode != null)
-            {
-                relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";
-            }
+		/// <remarks>
+		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+		/// </remarks>
+		public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
+		{
+			string relativeUri = $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
+			if (estimateMode != null)
+			{
+				relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";
+			}
 
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-                                                                    HttpStatusCode.OK,
-                                                                    relativeUri,
-                                                                    cancel: cancel))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+																	HttpStatusCode.OK,
+																	relativeUri,
+																	cancel: cancel))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var ret = await content.ReadAsJsonAsync<SynchronizeResponse>();
-                    return ret;
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var ret = await content.ReadAsJsonAsync<SynchronizeResponse>();
+					return ret;
+				}
+			}
+		}
 
-        #endregion batch
+		#endregion batch
 
-        #region blockchain
+		#region blockchain
 
-        /// <remarks>
-        /// Throws OperationCancelledException if <paramref name="cancel"/> is set.
-        /// </remarks>
-        public async Task<FiltersResponse> GetFiltersAsync(uint256 bestKnownBlockHash, int count, CancellationToken cancel = default)
-        {
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-                                                                    HttpStatusCode.OK,
-                                                                    $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
-                                                                    cancel: cancel))
-            {
-                if (response.StatusCode == HttpStatusCode.NoContent)
-                {
-                    return null;
-                }
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		/// <remarks>
+		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
+		/// </remarks>
+		public async Task<FiltersResponse> GetFiltersAsync(uint256 bestKnownBlockHash, int count, CancellationToken cancel = default)
+		{
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+																	HttpStatusCode.OK,
+																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
+																	cancel: cancel))
+			{
+				if (response.StatusCode == HttpStatusCode.NoContent)
+				{
+					return null;
+				}
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var ret = await content.ReadAsJsonAsync<FiltersResponse>();
-                    return ret;
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var ret = await content.ReadAsJsonAsync<FiltersResponse>();
+					return ret;
+				}
+			}
+		}
 
-        public async Task<IDictionary<int, FeeEstimationPair>> GetFeesAsync(params int[] confirmationTargets)
-        {
-            var confirmationTargetsString = string.Join(",", confirmationTargets);
+		public async Task<IDictionary<int, FeeEstimationPair>> GetFeesAsync(params int[] confirmationTargets)
+		{
+			var confirmationTargetsString = string.Join(",", confirmationTargets);
 
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/fees/{confirmationTargetsString}"))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/fees/{confirmationTargetsString}"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>();
-                    return ret;
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>();
+					return ret;
+				}
+			}
+		}
 
-        public async Task BroadcastAsync(string hex)
-        {
-            using (var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json"))
-            using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/broadcast", content))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
-            }
-        }
+		public async Task BroadcastAsync(string hex)
+		{
+			using (var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json"))
+			using (var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/broadcast", content))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
+			}
+		}
 
-        public async Task BroadcastAsync(Transaction transaction)
-        {
-            await BroadcastAsync(transaction.ToHex());
-        }
+		public async Task BroadcastAsync(Transaction transaction)
+		{
+			await BroadcastAsync(transaction.ToHex());
+		}
 
-        public async Task BroadcastAsync(SmartTransaction transaction)
-        {
-            await BroadcastAsync(transaction.Transaction);
-        }
+		public async Task BroadcastAsync(SmartTransaction transaction)
+		{
+			await BroadcastAsync(transaction.Transaction);
+		}
 
-        public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
-        {
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-                                                                    HttpStatusCode.OK,
-                                                                    $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
-                                                                    cancel: cancel))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
+		{
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+																	HttpStatusCode.OK,
+																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
+																	cancel: cancel))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
-                    var ret = strings.Select(x => new uint256(x));
-                    return ret;
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
+					var ret = strings.Select(x => new uint256(x));
+					return ret;
+				}
+			}
+		}
 
-        /// <summary>
-        /// Gets mempool hashes, but strips the last x characters of each hash.
-        /// </summary>
-        /// <param name="compactness">1 to 64</param>
-        public async Task<ISet<string>> GetMempoolHashesAsync(int compactness, CancellationToken cancel = default)
-        {
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
-                                                                    HttpStatusCode.OK,
-                                                                    $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
-                                                                    cancel: cancel))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		/// <summary>
+		/// Gets mempool hashes, but strips the last x characters of each hash.
+		/// </summary>
+		/// <param name="compactness">1 to 64</param>
+		public async Task<ISet<string>> GetMempoolHashesAsync(int compactness, CancellationToken cancel = default)
+		{
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get,
+																	HttpStatusCode.OK,
+																	$"/api/v{Helpers.Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
+																	cancel: cancel))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var strings = await content.ReadAsJsonAsync<ISet<string>>();
-                    return strings;
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var strings = await content.ReadAsJsonAsync<ISet<string>>();
+					return strings;
+				}
+			}
+		}
 
-        #endregion blockchain
+		#endregion blockchain
 
-        #region offchain
+		#region offchain
 
-        public async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync()
-        {
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/offchain/exchange-rates"))
-            {
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+		public async Task<IEnumerable<ExchangeRate>> GetExchangeRatesAsync()
+		{
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{Helpers.Constants.BackendMajorVersion}/btc/offchain/exchange-rates"))
+			{
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var ret = await content.ReadAsJsonAsync<IEnumerable<ExchangeRate>>();
-                    return ret;
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var ret = await content.ReadAsJsonAsync<IEnumerable<ExchangeRate>>();
+					return ret;
+				}
+			}
+		}
 
-        #endregion offchain
+		#endregion offchain
 
-        #region software
+		#region software
 
-        public async Task<(Version ClientVersion, int BackendMajorVersion)> GetVersionsAsync(CancellationToken cancel)
-        {
-            using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, "/api/software/versions", cancel: cancel))
-            {
-                if (response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    // Meaning this things was not just yet implemented on the running server.
-                    return (new Version(0, 7), 1);
-                }
+		public async Task<(Version ClientVersion, int BackendMajorVersion)> GetVersionsAsync(CancellationToken cancel)
+		{
+			using (var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, "/api/software/versions", cancel: cancel))
+			{
+				if (response.StatusCode == HttpStatusCode.NotFound)
+				{
+					// Meaning this things was not just yet implemented on the running server.
+					return (new Version(0, 7), 1);
+				}
 
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    await response.ThrowRequestExceptionFromContentAsync();
-                }
+				if (response.StatusCode != HttpStatusCode.OK)
+				{
+					await response.ThrowRequestExceptionFromContentAsync();
+				}
 
-                using (HttpContent content = response.Content)
-                {
-                    var resp = await content.ReadAsJsonAsync<VersionsResponse>();
-                    return (Version.Parse(resp.ClientVersion), int.Parse(resp.BackendMajorVersion));
-                }
-            }
-        }
+				using (HttpContent content = response.Content)
+				{
+					var resp = await content.ReadAsJsonAsync<VersionsResponse>();
+					return (Version.Parse(resp.ClientVersion), int.Parse(resp.BackendMajorVersion));
+				}
+			}
+		}
 
-        public async Task<(bool backendCompatible, bool clientUpToDate)> CheckUpdatesAsync(CancellationToken cancel)
-        {
-            var versions = await GetVersionsAsync(cancel);
-            var clientUpToDate = Helpers.Constants.ClientVersion >= versions.ClientVersion; // If the client version locally is greater than or equal to the backend's reported client version, then good.
-            var backendCompatible = int.Parse(Helpers.Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major are equal, then our softwares are compatible.
+		public async Task<(bool backendCompatible, bool clientUpToDate)> CheckUpdatesAsync(CancellationToken cancel)
+		{
+			var versions = await GetVersionsAsync(cancel);
+			var clientUpToDate = Helpers.Constants.ClientVersion >= versions.ClientVersion; // If the client version locally is greater than or equal to the backend's reported client version, then good.
+			var backendCompatible = int.Parse(Helpers.Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major are equal, then our softwares are compatible.
 
-            return (backendCompatible, clientUpToDate);
-        }
+			return (backendCompatible, clientUpToDate);
+		}
 
-        #endregion software
-    }
+		#endregion software
+	}
 }

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests | NBitcoinTests"

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests"

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests"

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests| NBitcoinTests"

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests"

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests| NBitcoinTests"


### PR DESCRIPTION

# Update

This PR now fixes all the config/settings related issues brought up.

Closes https://github.com/zkSNACKs/WalletWasabi/pull/1934
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/1932
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/1867
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/1738
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/1785
Closes https://github.com/zkSNACKs/WalletWasabi/pull/1956
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/1955
Closes https://github.com/zkSNACKs/WalletWasabi/pull/1852/files
Closes https://github.com/zkSNACKs/WalletWasabi/pull/1928

This PR makes P2P and Tor configuration options to be oneliners. This PR does not attempt to fix the bug described in https://github.com/zkSNACKs/WalletWasabi/issues/1738 nor tries to accepts `bitcoin-p2p://` or `tcp://` urls, like PR https://github.com/zkSNACKs/WalletWasabi/pull/1928

This PR is a prerequisite for cleanly implementing @NicolasDorier's PR: https://github.com/zkSNACKs/WalletWasabi/pull/1928.

Both in the Backend's and the Gui's configs, I removed `TorHost`-`TorPort`, `CoreHost`-`CorePort` pairs and rather used `TorEndPoint` and `CoreEndPoint` instead (Note, these are pseudovariables.)

To ensure backwards compatibility, instead of obsolating fields, like in PR (https://github.com/zkSNACKs/WalletWasabi/pull/1928) I used the functional pattern we use at other places across the codebase (`TryEnsureBackwardsCompatibility()`.)

Then I cleaned up the settings viewmodel accordingly.
