### PR TITLE
Bitcoin URL support

### DIFF
--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -99,7 +99,7 @@ namespace WalletWasabi.Gui.Behaviors
 			return false;
 		}
 
-		public (bool isValid, BitcoinUrlBuilder url) IsBitcoinAddress(string text, Network expectedNetwork)
+		private (bool isValid, BitcoinUrlBuilder url) IsBitcoinAddress(string text, Network expectedNetwork)
 		{
 			if (text.Length > 100)
 			{
@@ -117,7 +117,7 @@ namespace WalletWasabi.Gui.Behaviors
 			}
 		}
 
-		public (bool isValid, BitcoinUrlBuilder url) IsBitcoinUrl(string text, Network expectedNetwork)
+		private (bool isValid, BitcoinUrlBuilder url) IsBitcoinUrl(string text, Network expectedNetwork)
 		{
 			try
 			{
@@ -148,14 +148,15 @@ namespace WalletWasabi.Gui.Behaviors
 						MyTextBoxState = TextBoxState.None;
 					}
 				}),
-				AssociatedObject.WhenAnyValue(x => x.Text)
-								.Throttle(TimeSpan.FromMilliseconds(200))
-								.ObserveOn(RxApp.MainThreadScheduler)
-								.Subscribe(text =>
-								{
-									ProcessText(text);
-									MyTextBoxState = TextBoxState.NormalTextBoxOperation;
-								})
+				AssociatedObject
+					.WhenAnyValue(x => x.Text)
+					.Throttle(TimeSpan.FromMilliseconds(200)) // Do not remove this we need to make sure we are running on a separate Task.
+					.ObserveOn(RxApp.MainThreadScheduler)
+					.Subscribe(text =>
+					{
+						ProcessText(text);
+						MyTextBoxState = TextBoxState.NormalTextBoxOperation;
+					})
 			};
 
 			Disposables.Add(

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -12,6 +12,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.Gui.Controls;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Gui.Behaviors
 {
@@ -68,18 +69,16 @@ namespace WalletWasabi.Gui.Behaviors
 			}
 
 			text = text.Trim();
-			var addressText = IsBitcoinAddress(text, Global.Network);
-			if (addressText.isValid)
+			if (AddressStringParser.TryParseBitcoinAddress(text, Global.Network, out BitcoinUrlBuilder addressResult))
 			{
-				result = addressText.url;
+				result = addressResult;
 				return true;
 			}
 			else
 			{
-				var urlText = IsBitcoinUrl(text, Global.Network);
-				if (urlText.isValid)
+				if (AddressStringParser.TryParseBitcoinUrl(text, Global.Network, out BitcoinUrlBuilder urlResult))
 				{
-					result = urlText.url;
+					result = urlResult;
 					return true;
 				}
 			}
@@ -97,37 +96,6 @@ namespace WalletWasabi.Gui.Behaviors
 			}
 
 			return false;
-		}
-
-		private (bool isValid, BitcoinUrlBuilder url) IsBitcoinAddress(string text, Network expectedNetwork)
-		{
-			if (text.Length > 100)
-			{
-				return (false, null);
-			}
-
-			try
-			{
-				var bitcoinAddress = BitcoinAddress.Create(text, expectedNetwork);
-				return (true, new BitcoinUrlBuilder($"bitcoin:{bitcoinAddress}"));
-			}
-			catch (FormatException)
-			{
-				return (false, null);
-			}
-		}
-
-		private (bool isValid, BitcoinUrlBuilder url) IsBitcoinUrl(string text, Network expectedNetwork)
-		{
-			try
-			{
-				var bitcoinUrl = new BitcoinUrlBuilder(text);
-				return (bitcoinUrl.Address.Network == expectedNetwork, bitcoinUrl);
-			}
-			catch (FormatException)
-			{
-				return (false, null);
-			}
 		}
 
 		public PasteAddressOnClickBehavior()

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -149,15 +149,25 @@ namespace WalletWasabi.Gui.Behaviors
 					}
 				}),
 				AssociatedObject
-					.WhenAnyValue(x => x.Text)
-					.Throttle(TimeSpan.FromMilliseconds(200)) // Do not remove this we need to make sure we are running on a separate Task.
+					.GetObservable(InputElement.KeyUpEvent)
+					.Throttle(TimeSpan.FromMilliseconds(500)) // Do not remove this we need to make sure we are running on a separate Task.
 					.ObserveOn(RxApp.MainThreadScheduler)
+					.Subscribe(_ =>
+					{
+						ProcessText(AssociatedObject.Text);
+						MyTextBoxState = TextBoxState.NormalTextBoxOperation;
+					})
+			};
+
+			if (AssociatedObject is ExtendedTextBox extendedTextBox)
+			{
+				Disposables.Add(extendedTextBox.TextPasted
 					.Subscribe(text =>
 					{
 						ProcessText(text);
 						MyTextBoxState = TextBoxState.NormalTextBoxOperation;
-					})
-			};
+					}));
+			}
 
 			Disposables.Add(
 				AssociatedObject.GetObservable(InputElement.PointerReleasedEvent).Subscribe(async pointer =>

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -60,34 +60,9 @@ namespace WalletWasabi.Gui.Behaviors
 
 		private TextBoxState _textBoxState = TextBoxState.None;
 
-		private bool TryParse(string text, out BitcoinUrlBuilder result)
-		{
-			result = null;
-			if (string.IsNullOrWhiteSpace(text) || text.Length > 1000)
-			{
-				return false;
-			}
-
-			text = text.Trim();
-			if (AddressStringParser.TryParseBitcoinAddress(text, Global.Network, out BitcoinUrlBuilder addressResult))
-			{
-				result = addressResult;
-				return true;
-			}
-			else
-			{
-				if (AddressStringParser.TryParseBitcoinUrl(text, Global.Network, out BitcoinUrlBuilder urlResult))
-				{
-					result = urlResult;
-					return true;
-				}
-			}
-			return false;
-		}
-
 		private bool ProcessText(string text)
 		{
-			if (TryParse(text, out BitcoinUrlBuilder result))
+			if (AddressStringParser.TryParse(text, Global.Network, out BitcoinUrlBuilder result))
 			{
 				AssociatedObject.Text = result?.Address?.ToString();
 				CommandParameter = result;
@@ -189,7 +164,7 @@ namespace WalletWasabi.Gui.Behaviors
 					{
 						string text = await Application.Current.Clipboard.GetTextAsync();
 
-						if (TryParse(text, out _))
+						if (AddressStringParser.TryParse(text, Global.Network, out _))
 						{
 							MyTextBoxState = TextBoxState.AddressInsert;
 						}

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -130,6 +130,7 @@ namespace WalletWasabi.Gui.Behaviors
 			if (AssociatedObject is ExtendedTextBox extendedTextBox)
 			{
 				Disposables.Add(extendedTextBox.TextPasted
+					.ObserveOn(RxApp.MainThreadScheduler)
 					.Subscribe(text =>
 					{
 						ProcessText(text);

--- a/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
@@ -21,18 +21,14 @@ namespace WalletWasabi.Gui.Controls
 	{
 		private MenuItem _pasteItem = null;
 
-		private Subject<string> _textPasted = new Subject<string>();
+		private Subject<string> _textPasted;
 
-		public IObservable<string> TextPasted
-		{
-			get
-			{
-				return _textPasted.AsObservable();
-			}
-		}
+		public IObservable<string> TextPasted => _textPasted.AsObservable();
 
 		public ExtendedTextBox()
 		{
+			_textPasted = new Subject<string>();
+
 			CopyCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
 				await CopyAsync();

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -33,7 +33,7 @@
           <TextBlock>You must select coins you want to spend from.</TextBlock>
           <controls:ExtendedTextBox Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True">
             <i:Interaction.Behaviors>
-              <behaviors:PasteAddressOnClickBehavior />
+              <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
             </i:Interaction.Behaviors>
           </controls:ExtendedTextBox>
           <StackPanel Spacing="8">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -60,7 +60,7 @@
           </StackPanel>
           <StackPanel Orientation="Horizontal" Spacing="10">
             <Button Content="{Binding IsMax, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Clear:Max}" Command="{Binding MaxCommand}" VerticalAlignment="Top" Height="40" />
-            <controls:ExtendedTextBox x:Name="AmountTextBox" Foreground="{Binding AmountText, Converter={StaticResource AmountForegroundConverter}}"
+            <controls:ExtendedTextBox Foreground="{Binding AmountText, Converter={StaticResource AmountForegroundConverter}}"
                                       IsReadOnly="{Binding IsMax}" Text="{Binding AmountText, Mode=TwoWay}"
                                       ToolTip.Tip="{Binding UsdExchangeRate, Converter={StaticResource UsdExchangeRateAmountToolTipConverter}}"
                                       Watermark="{Binding AmountWatermarkText}"

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -60,7 +60,7 @@
           </StackPanel>
           <StackPanel Orientation="Horizontal" Spacing="10">
             <Button Content="{Binding IsMax, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Clear:Max}" Command="{Binding MaxCommand}" VerticalAlignment="Top" Height="40" />
-            <controls:ExtendedTextBox Foreground="{Binding AmountText, Converter={StaticResource AmountForegroundConverter}}"
+            <controls:ExtendedTextBox x:Name="AmountTextBox" Foreground="{Binding AmountText, Converter={StaticResource AmountForegroundConverter}}"
                                       IsReadOnly="{Binding IsMax}" Text="{Binding AmountText, Mode=TwoWay}"
                                       ToolTip.Tip="{Binding UsdExchangeRate, Converter={StaticResource UsdExchangeRateAmountToolTipConverter}}"
                                       Watermark="{Binding AmountWatermarkText}"

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -969,7 +969,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string ValidateAddress()
 		{
-			if (string.IsNullOrEmpty(Address))
+			if (string.IsNullOrWhiteSpace(Address))
 			{
 				return "";
 			}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -974,17 +974,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				return "";
 			}
 
-			if (!string.IsNullOrWhiteSpace(Address))
+			if (AddressStringParser.TryParseBitcoinAddress(Address, Global.Network, out _))
 			{
-				var trimmed = Address.Trim();
-				try
-				{
-					BitcoinAddress.Create(trimmed, Global.Network);
-					return "";
-				}
-				catch
-				{
-				}
+				return "";
 			}
 
 			return $"Invalid {nameof(Address)}";

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -979,6 +979,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				return "";
 			}
 
+			if (AddressStringParser.TryParseBitcoinUrl(Address, Global.Network, out _))
+			{
+				return "";
+			}
+
 			return $"Invalid {nameof(Address)}";
 		}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -227,11 +227,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			OnAddressPasteCommand = ReactiveCommand.Create((BitcoinUrlBuilder url) =>
 			{
-				if (url.Address != null)
-				{
-					Address = url.Address.ToString();
-				}
-
 				if (!string.IsNullOrWhiteSpace(url.Label))
 				{
 					Label = url.Label;

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Threading;
 using AvalonStudio.Extensibility;
 using AvalonStudio.Shell;
 using NBitcoin;
+using NBitcoin.Payment;
 using ReactiveUI;
 using System;
 using System.Collections.Generic;
@@ -223,6 +224,24 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				});
 
 			FeeRateCommand = ReactiveCommand.Create(ChangeFeeRateDisplay, outputScheduler: RxApp.MainThreadScheduler);
+
+			OnAddressPasteCommand = ReactiveCommand.Create((BitcoinUrlBuilder url) =>
+			{
+				if (url.Address != null)
+				{
+					Address = url.Address.ToString();
+				}
+
+				if (!string.IsNullOrWhiteSpace(url.Label))
+				{
+					Label = url.Label;
+				}
+
+				if (url.Amount != null)
+				{
+					AmountText = url.Amount.ToString(false, true);
+				}
+			});
 
 			BuildTransactionCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
@@ -1007,6 +1026,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public ReactiveCommand<Unit, Unit> MaxCommand { get; }
 
 		public ReactiveCommand<Unit, Unit> FeeRateCommand { get; }
+
+		public ReactiveCommand<BitcoinUrlBuilder, Unit> OnAddressPasteCommand { get; }
+
 		public bool IsTransactionBuilder { get; }
 
 		public override void OnOpen()

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -163,6 +163,9 @@ namespace WalletWasabi.Tests
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Remove(5, 1), test.network, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(1, "b"), test.network, out _));
 
+				AddressStringParser.TryParseBitcoinAddress(test.address, null, out _);
+				AddressStringParser.TryParseBitcoinAddress(null, test.network, out _);
+
 				Assert.True(AddressStringParser.TryParseBitcoinAddress(test.address, test.network, out BitcoinUrlBuilder result));
 				Assert.Equal(test.address, result.Address.ToString());
 
@@ -190,6 +193,9 @@ namespace WalletWasabi.Tests
 				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Substring(1), test.network, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Remove(5, 4), test.network, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Insert(1, "b"), test.network, out _));
+
+				AddressStringParser.TryParseBitcoinUrl(test.url, null, out _);
+				AddressStringParser.TryParseBitcoinUrl(null, test.network, out _);
 
 				Assert.True(AddressStringParser.TryParseBitcoinUrl(test.url, test.network, out BitcoinUrlBuilder result));
 				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result.Address.ToString());

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -163,8 +163,8 @@ namespace WalletWasabi.Tests
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Remove(5, 1), test.network, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(1, "b"), test.network, out _));
 
-				AddressStringParser.TryParseBitcoinAddress(test.address, null, out _);
-				AddressStringParser.TryParseBitcoinAddress(null, test.network, out _);
+				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address, null, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinAddress(null, test.network, out _));
 
 				Assert.True(AddressStringParser.TryParseBitcoinAddress(test.address, test.network, out BitcoinUrlBuilder result));
 				Assert.Equal(test.address, result.Address.ToString());
@@ -194,8 +194,8 @@ namespace WalletWasabi.Tests
 				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Remove(5, 4), test.network, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Insert(1, "b"), test.network, out _));
 
-				AddressStringParser.TryParseBitcoinUrl(test.url, null, out _);
-				AddressStringParser.TryParseBitcoinUrl(null, test.network, out _);
+				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url, null, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinUrl(null, test.network, out _));
 
 				Assert.True(AddressStringParser.TryParseBitcoinUrl(test.url, test.network, out BitcoinUrlBuilder result));
 				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result.Address.ToString());

--- a/WalletWasabi.Tests/ParserTests.cs
+++ b/WalletWasabi.Tests/ParserTests.cs
@@ -1,8 +1,11 @@
+using NBitcoin;
+using NBitcoin.Payment;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using WalletWasabi.Helpers;
 using Xunit;
 
 namespace WalletWasabi.Tests
@@ -138,6 +141,64 @@ namespace WalletWasabi.Tests
 			}
 			Assert.Equal((string)expectedHost, actualHost);
 			Assert.Equal($"{actualHost}:{actualPort}", endPoint.ToString(expectedPort));
+		}
+
+		[Fact]
+		public void BitcoinAddressParserTests()
+		{
+			(string address, Network network)[] tests = new[]
+			{
+				("18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX", Network.Main),
+				("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem", Network.Main),
+				("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX", Network.Main),
+				("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", Network.Main),
+				("mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn", Network.TestNet),
+				("2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc", Network.TestNet),
+				("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx", Network.TestNet),
+			};
+
+			foreach (var test in tests)
+			{
+				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Remove(0, 1), test.network, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Remove(5, 1), test.network, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(1, "b"), test.network, out _));
+
+				Assert.True(AddressStringParser.TryParseBitcoinAddress(test.address, test.network, out BitcoinUrlBuilder result));
+				Assert.Equal(test.address, result.Address.ToString());
+
+				Assert.True(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(0, "   "), test.network, out result));
+				Assert.Equal(test.address.Trim(), result.Address.ToString());
+			}
+		}
+
+		[Fact]
+		public void BitcoinUrlParserTests()
+		{
+			(string url, Network network)[] tests = new[]
+			{
+				("bitcoin:18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.Main),
+				("bitcoin:17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.Main),
+				("bitcoin:3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.Main),
+				("bitcoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.Main),
+				("bitcoin:mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.TestNet),
+				("bitcoin:2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.TestNet),
+				("bitcoin:tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz", Network.TestNet),
+			};
+
+			foreach (var test in tests)
+			{
+				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Substring(1), test.network, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Remove(5, 4), test.network, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinUrl(test.url.Insert(1, "b"), test.network, out _));
+
+				Assert.True(AddressStringParser.TryParseBitcoinUrl(test.url, test.network, out BitcoinUrlBuilder result));
+				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result.Address.ToString());
+
+				Assert.True(AddressStringParser.TryParseBitcoinUrl(test.url.Insert(0, "   "), test.network, out result));
+				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result.Address.ToString());
+				Assert.Equal("Luke-Jr", result.Label);
+				Assert.Equal(Money.Coins(50m), result.Amount);
+			}
 		}
 	}
 }

--- a/WalletWasabi/Helpers/AddressStringParser.cs
+++ b/WalletWasabi/Helpers/AddressStringParser.cs
@@ -73,5 +73,29 @@ namespace WalletWasabi.Helpers
 				return false;
 			}
 		}
+
+		public static bool TryParse(string text, Network expectedNetwork, out BitcoinUrlBuilder result)
+		{
+			result = null;
+			if (string.IsNullOrWhiteSpace(text) || text.Length > 1000)
+			{
+				return false;
+			}
+
+			if (TryParseBitcoinAddress(text, expectedNetwork, out BitcoinUrlBuilder addressResult))
+			{
+				result = addressResult;
+				return true;
+			}
+			else
+			{
+				if (TryParseBitcoinUrl(text, expectedNetwork, out BitcoinUrlBuilder urlResult))
+				{
+					result = urlResult;
+					return true;
+				}
+			}
+			return false;
+		}
 	}
 }

--- a/WalletWasabi/Helpers/AddressStringParser.cs
+++ b/WalletWasabi/Helpers/AddressStringParser.cs
@@ -1,0 +1,58 @@
+using NBitcoin;
+using NBitcoin.Payment;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Helpers
+{
+	public static class AddressStringParser
+	{
+		public static bool TryParseBitcoinAddress(string text, Network expectedNetwork, out BitcoinUrlBuilder url)
+		{
+			url = null;
+
+			if (text is null || text.Length > 100 || text.Length < 20)
+			{
+				return false;
+			}
+
+			try
+			{
+				var bitcoinAddress = BitcoinAddress.Create(text, expectedNetwork);
+				url = new BitcoinUrlBuilder($"bitcoin:{bitcoinAddress}");
+				return true;
+			}
+			catch (FormatException)
+			{
+				return false;
+			}
+		}
+
+		public static bool TryParseBitcoinUrl(string text, Network expectedNetwork, out BitcoinUrlBuilder url)
+		{
+			url = null;
+
+			if (text is null || text.Length > 1000 || text.Length < 20)
+			{
+				return false;
+			}
+
+			try
+			{
+				var bitcoinUrl = new BitcoinUrlBuilder(text);
+				if (bitcoinUrl.Address.Network == expectedNetwork)
+				{
+					url = bitcoinUrl;
+					return true;
+				}
+
+				return false;
+			}
+			catch (FormatException)
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/WalletWasabi/Helpers/AddressStringParser.cs
+++ b/WalletWasabi/Helpers/AddressStringParser.cs
@@ -54,6 +54,11 @@ namespace WalletWasabi.Helpers
 
 			try
 			{
+				if (!text.StartsWith("bitcoin:", true, System.Globalization.CultureInfo.InvariantCulture))
+				{
+					return false;
+				}
+
 				var bitcoinUrl = new BitcoinUrlBuilder(text);
 				if (bitcoinUrl?.Address.Network == expectedNetwork)
 				{

--- a/WalletWasabi/Helpers/AddressStringParser.cs
+++ b/WalletWasabi/Helpers/AddressStringParser.cs
@@ -12,12 +12,12 @@ namespace WalletWasabi.Helpers
 		{
 			url = null;
 
-			text = text.Trim();
-
-			if (text is null || text.Length > 100 || text.Length < 20)
+			if (text is null || text.Length > 100 || text.Length < 20 || expectedNetwork is null)
 			{
 				return false;
 			}
+
+			text = text.Trim();
 
 			try
 			{
@@ -35,17 +35,17 @@ namespace WalletWasabi.Helpers
 		{
 			url = null;
 
-			text = text.Trim();
-
-			if (text is null || text.Length > 1000 || text.Length < 20)
+			if (text is null || text.Length > 1000 || text.Length < 20 || expectedNetwork is null)
 			{
 				return false;
 			}
 
+			text = text.Trim();
+
 			try
 			{
 				var bitcoinUrl = new BitcoinUrlBuilder(text);
-				if (bitcoinUrl.Address.Network == expectedNetwork)
+				if (bitcoinUrl?.Address.Network == expectedNetwork)
 				{
 					url = bitcoinUrl;
 					return true;

--- a/WalletWasabi/Helpers/AddressStringParser.cs
+++ b/WalletWasabi/Helpers/AddressStringParser.cs
@@ -12,12 +12,17 @@ namespace WalletWasabi.Helpers
 		{
 			url = null;
 
-			if (text is null || text.Length > 100 || text.Length < 20 || expectedNetwork is null)
+			if (text is null || expectedNetwork is null)
 			{
 				return false;
 			}
 
 			text = text.Trim();
+
+			if (text.Length > 100 || text.Length < 20)
+			{
+				return false;
+			}
 
 			try
 			{
@@ -35,12 +40,17 @@ namespace WalletWasabi.Helpers
 		{
 			url = null;
 
-			if (text is null || text.Length > 1000 || text.Length < 20 || expectedNetwork is null)
+			if (text is null || expectedNetwork is null)
 			{
 				return false;
 			}
 
 			text = text.Trim();
+
+			if (text.Length > 1000 || text.Length < 20)
+			{
+				return false;
+			}
 
 			try
 			{

--- a/WalletWasabi/Helpers/AddressStringParser.cs
+++ b/WalletWasabi/Helpers/AddressStringParser.cs
@@ -12,6 +12,8 @@ namespace WalletWasabi.Helpers
 		{
 			url = null;
 
+			text = text.Trim();
+
 			if (text is null || text.Length > 100 || text.Length < 20)
 			{
 				return false;
@@ -32,6 +34,8 @@ namespace WalletWasabi.Helpers
 		public static bool TryParseBitcoinUrl(string text, Network expectedNetwork, out BitcoinUrlBuilder url)
 		{
 			url = null;
+
+			text = text.Trim();
 
 			if (text is null || text.Length > 1000 || text.Length < 20)
 			{


### PR DESCRIPTION
Closes #732
Works similar to when you have an address on your clipboard.  If you have a bitcoin url on your clipboard and click the address field, it will auto fill the address, label, and amount using the url's respective fields.  The message field is currently ignored, unsure if we should concatenate this with the label, display it elsewhere, or simply continue ignoring it.