### PR TITLE
Anonymity set saved to wallet.json file

### DIFF
--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -37,12 +37,25 @@ namespace WalletWasabi.KeyManagement
 		[JsonProperty(Order = 4)]
 		public KeyState KeyState { get; private set; }
 
-		public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, string label, KeyState keyState)
+		private int _anonymitySet;
+
+		[JsonProperty(Order = 4)]
+		public int AnonymitySet
+		{
+			get => _anonymitySet;
+			private set
+			{
+				_anonymitySet = value;
+			}
+		}
+
+		public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, string label, KeyState keyState, int anonymitySet = 0)
 		{
 			PubKey = Guard.NotNull(nameof(pubKey), pubKey);
 			FullKeyPath = Guard.NotNull(nameof(fullKeyPath), fullKeyPath);
 			SetLabel(label, null);
 			KeyState = keyState;
+			AnonymitySet = anonymitySet;
 
 			P2pkScript = PubKey.ScriptPubKey;
 			P2pkhScript = PubKey.Hash.ScriptPubKey;
@@ -79,6 +92,18 @@ namespace WalletWasabi.KeyManagement
 			}
 
 			Label = label;
+
+			kmToFile?.ToFile();
+		}
+
+		public void SetAnonymitySet(int anonset, KeyManager kmToFile = null)
+		{
+			if (AnonymitySet == anonset)
+			{
+				return;
+			}
+
+			AnonymitySet = anonset;
 
 			kmToFile?.ToFile();
 		}

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -449,7 +449,7 @@ namespace WalletWasabi.KeyManagement
 				var fullPath = AccountKeyPath.Derive(path);
 				var pubKey = ExtPubKey.Derive(path).PubKey;
 
-				var hdPubKey = new HdPubKey(pubKey, fullPath, label, keyState);
+				var hdPubKey = new HdPubKey(pubKey, fullPath, label, keyState, 0);
 				HdPubKeys.Add(hdPubKey);
 				lock (HdPubKeyScriptBytesLock)
 				{

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -638,6 +638,16 @@ namespace WalletWasabi.Services
 					{
 						anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
 
+						// If the key has not had it's anonymity set then set it here
+						if (foundKey.AnonymitySet == 0)
+						{
+							foundKey.SetAnonymitySet(anonset, KeyManager);
+						}
+						else // Otherwise, use the anonymity set already set.
+						{
+							anonset = foundKey.AnonymitySet;
+						}
+
 						// Cleanup exposed links where the txo has been spent.
 						foreach (var input in spentOwnCoins.Select(x => x.GetTxoRef()))
 						{


### PR DESCRIPTION
Fixes #1442 

This saves anonymity set per `HdPubKey`, so this would break with address reuse, however, the users should not be doing that anyways.

Implementation will currently set the anon set to 0 if there is no corresponding coin or it will set it to the properly calculated anon set.