### PR TITLE
Potential spent coins issue fix

### DIFF
--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -215,7 +215,7 @@ namespace WalletWasabi.Services
 			}
 
 			Coins.TryRemove(toRemove);
-			Mempool.TransactionHashes.TryRemove(toRemove.SpenderTransactionId);
+			Mempool.TransactionHashes.TryRemove(toRemove.TransactionId);
 		}
 
 		private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)


### PR DESCRIPTION
We are attempting to remove `toRemove.SpenderTransactionId` but that should be queued up to remove in the recursive calls. We are removing the coin from out personal list of coins and then should remove the same coin from our mempool.