### PR TITLE
Code formatting fix to help linter

### DIFF
--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -273,16 +273,11 @@ namespace WalletWasabi.Services
 					{
 						IEnumerable<SmartTransaction> transactions = null;
 						string jsonString = File.ReadAllText(TransactionsFilePath, Encoding.UTF8);
-						transactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?
-							.OrderByBlockchain();
+						transactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?.OrderByBlockchain();
 
-						confirmedTransactions = transactions?
-							.Where(x => x.Confirmed)?
-							.ToArray() ?? new SmartTransaction[0];
+						confirmedTransactions = transactions?.Where(x => x.Confirmed)?.ToArray() ?? new SmartTransaction[0];
 
-						unconfirmedTransactions = transactions?
-							.Where(x => !x.Confirmed)?
-							.ToArray() ?? new SmartTransaction[0];
+						unconfirmedTransactions = transactions?.Where(x => !x.Confirmed)?.ToArray() ?? new SmartTransaction[0];
 					}
 					catch (Exception ex)
 					{


### PR DESCRIPTION
These lines mess with the VSCode C# linter, this formatting change fixes it.  

Not really a pressing change, would help me read the code though.