### PR TITLE
Remove possible redundant check

### DIFF
--- a/WalletWasabi/Io/DigestableSafeMutexIoManager.cs
+++ b/WalletWasabi/Io/DigestableSafeMutexIoManager.cs
@@ -110,7 +110,7 @@ namespace WalletWasabi.Io
 							line = await lineTask;
 						}
 
-						lineTask = sr.EndOfStream ? null : sr.ReadLineAsync();
+						lineTask = sr.ReadLineAsync();
 
 						if (linesArray[linesIndex] == line) // If the line is a line we want to write, then we know that someone else have worked into the file.
 						{

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -97,7 +97,7 @@ namespace WalletWasabi.Stores
 									line = await lineTask;
 								}
 
-								lineTask = sr.EndOfStream ? null : sr.ReadLineAsync();
+								lineTask = sr.ReadLineAsync();
 
 								ProcessLine(height, line, enqueue: false);
 								height++;
@@ -359,7 +359,7 @@ namespace WalletWasabi.Stores
 										line = await lineTask;
 									}
 
-									lineTask = sr.EndOfStream ? null : sr.ReadLineAsync();
+									lineTask = sr.ReadLineAsync();
 
 									if (height < fromHeight.Value)
 									{


### PR DESCRIPTION
These lines are inside `if (!sr.EndOfStream)` block, isn't it redundant to check that again?