### PR TITLE
Fix confirmations off by 1 error

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -105,7 +105,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					DateTime = txr.dateTime.ToLocalTime(),
 					Confirmed = txr.height.Type == HeightType.Chain,
-					Confirmations = txr.height.Type == HeightType.Chain ? Global.BitcoinStore.HashChain.TipHeight - txr.height.Value + 1 : 0,
+					Confirmations = txr.height.Type == HeightType.Chain ? (Global.BitcoinStore.HashChain.TipHeight - txr.height.Value) + 1 : 0,
 					AmountBtc = $"{txr.amount.ToString(fplus: true, trimExcessZero: true)}",
 					Label = txr.label,
 					TransactionId = txr.transactionId.ToString()


### PR DESCRIPTION
Without this the confirmations differ on on the history tab from the coin list on the coinjoin and send tab