### PR TITLE
GetMasterExtKey(password==null) => password = ""

### DIFF
--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -567,6 +567,11 @@ namespace WalletWasabi.KeyManagement
 
 		public ExtKey GetMasterExtKey(string password)
 		{
+			if (password is null)
+			{
+				password = "";
+			}
+			
 			if (IsWatchOnly)
 			{
 				throw new SecurityException("This is a watchonly wallet.");


### PR DESCRIPTION
This is consistent this KeyManager.CreateNew. Doing so allows for front end ignorance to the implementation of KeyManager. It shouldn't have to handle NullReferenceException or initialize the password to empty string.