### PR TITLE
Fee display format as settings option

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -11,6 +11,7 @@
   <UserControl.Resources>
     <converters:AmountForegroundConverter x:Key="AmountForegroundConverter" />
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
+    <converters:FeeDisplayFormatConverter x:Key="FeeDisplayFormatConverter" />
     <converters:FeeTargetTimeConverter x:Key="FeeTargetTimeConverter" />
   </UserControl.Resources>
   <i:Interaction.Behaviors>
@@ -87,7 +88,7 @@
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="4">
                 <TextBlock Text="Confirmation Expected In:" VerticalAlignment="Center" />
                 <TextBlock Foreground="YellowGreen" Text="{Binding FeeTarget, Converter={StaticResource FeeTargetTimeConverter}}" Width="80" VerticalAlignment="Center" />
-                <Button Content="{Binding FeeText}" ToolTip.Tip="{Binding FeeToolTip}" Command="{Binding FeeRateCommand}" Padding="0" Background="{DynamicResource EditorBackgroundBrush}" BorderBrush="{DynamicResource EditorBackgroundBrush}" VerticalAlignment="Top" />
+                <Button DataContext="{Binding TransactionFeeInfo, Converter={StaticResource FeeDisplayFormatConverter}}" Content="{Binding FeeText}" ToolTip.Tip="{Binding FeeToolTip}" Command="{Binding RelativeSource={RelativeSource AncestorType=StackPanel}, Path=DataContext.FeeRateCommand}" Padding="0" Background="{DynamicResource EditorBackgroundBrush}" BorderBrush="{DynamicResource EditorBackgroundBrush}" VerticalAlignment="Top" />
               </StackPanel>
             </StackPanel>
             <StackPanel IsVisible="{Binding IsCustomFee}" VerticalAlignment="Center" Orientation="Horizontal" Spacing="10">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -113,8 +113,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				x => x.FeePercentage,
 				x => x.FeeRate,
 				x => x.EstimatedBtcFee,
-				(a, b, c, d, e) => new TransactionFeeInfo(a, b, c, d, e))
+				(usdFee, usdExchangeRate, feePercentage, feeRate, estimatedBtcFee) => new TransactionFeeInfo(usdFee, usdExchangeRate, feePercentage, feeRate, estimatedBtcFee))
 				.ToProperty(this, x => x.TransactionFeeInfo, scheduler: RxApp.MainThreadScheduler);
+
 			SetFeesAndTexts();
 
 			this.WhenAnyValue(x => x.AmountText).Select(_ => Unit.Default)
@@ -771,6 +772,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				AllSelectedAmount = Math.Max(Money.Zero, all - EstimatedBtcFee);
 			}
 		}
+
 		private void SetAmountIfMax()
 		{
 			if (IsMax)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -100,7 +100,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			if (Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat))
 			{
-				FeeDisplayFormat = (FeeDisplayFormat) Global.UiConfig.FeeDisplayFormat;
+				FeeDisplayFormat = (FeeDisplayFormat)Global.UiConfig.FeeDisplayFormat;
 			}
 			else
 			{
@@ -912,7 +912,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					if (Enum.IsDefined(typeof(FeeDisplayFormat), format))
 					{
-						FeeDisplayFormat = (FeeDisplayFormat) format;
+						FeeDisplayFormat = (FeeDisplayFormat)format;
 					}
 					else
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -97,7 +97,16 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			SetFeeTargetLimits();
 			FeeTarget = Global.UiConfig.FeeTarget;
-			FeeDisplayFormat = (FeeDisplayFormat)(Enum.ToObject(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat) ?? FeeDisplayFormat.SatoshiPerByte);
+
+			if (Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat))
+			{
+				FeeDisplayFormat = (FeeDisplayFormat) Global.UiConfig.FeeDisplayFormat;
+			}
+			else
+			{
+				FeeDisplayFormat = FeeDisplayFormat.SatoshiPerByte;
+			}
+
 			_transactionFeeInfo = this.WhenAnyValue(
 				x => x.UsdFee,
 				x => x.UsdExchangeRate,
@@ -900,8 +909,16 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Global.UiConfig.WhenAnyValue(x => x.FeeDisplayFormat)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(format =>
-					FeeDisplayFormat = (FeeDisplayFormat)(Enum.ToObject(typeof(FeeDisplayFormat), format) ?? FeeDisplayFormat.SatoshiPerByte))
-				.DisposeWith(disposables);
+				{
+					if (Enum.IsDefined(typeof(FeeDisplayFormat), format))
+					{
+						FeeDisplayFormat = (FeeDisplayFormat) format;
+					}
+					else
+					{
+						FeeDisplayFormat = FeeDisplayFormat.SatoshiPerByte;
+					}
+				}).DisposeWith(disposables);
 
 			Observable
 				.Merge(Global.UiConfig.WhenAnyValue(x => x.IsCustomChangeAddress))

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -55,7 +55,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private string _address;
 		private string _customChangeAddress;
 		private string _labelToolTip;
-		private ObservableAsPropertyHelper<TransactionFeeInfo> _transactionFeeInfo;
+		private ObservableAsPropertyHelper<TransactionFeeInfo?> _transactionFeeInfo;
 		private bool _isBusy;
 		private bool _isHardwareBusy;
 		private bool _isCustomFee;

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionFeeInfo.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionFeeInfo.cs
@@ -1,0 +1,62 @@
+using NBitcoin;
+using ReactiveUI;
+
+namespace WalletWasabi.Gui.Controls.WalletExplorer
+{
+	public class TransactionFeeInfo : ReactiveObject
+	{
+		private decimal _feePercentage;
+		private decimal _usdExchangeRate;
+		private decimal _usdFee;
+		private FeeRate _feeRate;
+		private Money _estimatedBtcFee;
+
+		public TransactionFeeInfo()
+		{
+			FeePercentage = 0;
+			UsdExchangeRate = 0;
+			UsdFee = 0;
+			FeeRate = new FeeRate(0L);
+			EstimatedBtcFee = new Money(0L);
+		}
+
+		public TransactionFeeInfo(decimal feePercentage, decimal usdExchangeRate, decimal usdFee, FeeRate feeRate, Money estimatedBtcFee)
+		{
+			FeePercentage = feePercentage;
+			UsdExchangeRate = usdExchangeRate;
+			UsdFee = usdFee;
+			FeeRate = feeRate;
+			EstimatedBtcFee = estimatedBtcFee;
+		}
+
+		public decimal FeePercentage
+		{
+			get => _feePercentage;
+			set => this.RaiseAndSetIfChanged(ref _feePercentage, value);
+		}
+
+		public decimal UsdExchangeRate
+		{
+			get => _usdExchangeRate;
+			set => this.RaiseAndSetIfChanged(ref _usdExchangeRate, value);
+		}
+
+		public decimal UsdFee
+		{
+			get => _usdFee;
+			set => this.RaiseAndSetIfChanged(ref _usdFee, value);
+		}
+
+		public FeeRate FeeRate
+		{
+			get => _feeRate;
+			set => this.RaiseAndSetIfChanged(ref _feeRate, value);
+		}
+
+		public Money EstimatedBtcFee
+		{
+			get => _estimatedBtcFee;
+			set => this.RaiseAndSetIfChanged(ref _estimatedBtcFee, value);
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionFeeInfo.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionFeeInfo.cs
@@ -8,16 +8,16 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private decimal _feePercentage;
 		private decimal _usdExchangeRate;
 		private decimal _usdFee;
-		private FeeRate _feeRate;
-		private Money _estimatedBtcFee;
+		private FeeRate? _feeRate;
+		private Money? _estimatedBtcFee;
 
 		public TransactionFeeInfo()
 		{
 			FeePercentage = 0;
 			UsdExchangeRate = 0;
 			UsdFee = 0;
-			FeeRate = new FeeRate(0L);
-			EstimatedBtcFee = new Money(0L);
+			FeeRate = FeeRate.Zero;
+			EstimatedBtcFee = Money.Zero;
 		}
 
 		public TransactionFeeInfo(decimal feePercentage, decimal usdExchangeRate, decimal usdFee, FeeRate feeRate, Money estimatedBtcFee)

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Gui.Converters
 
 				if (Enum.IsDefined(typeof(FeeDisplayFormat), configFeeFormat))
 				{
-					displayFormat = (FeeDisplayFormat) configFeeFormat;
+					displayFormat = (FeeDisplayFormat)configFeeFormat;
 				}
 
 				string feeText;
@@ -29,8 +29,8 @@ namespace WalletWasabi.Gui.Converters
 				switch (displayFormat)
 				{
 					case FeeDisplayFormat.SatoshiPerByte:
-						feeText = $"(~ {feeInfo.FeeRate.SatoshiPerByte} sat/vbyte)";
-						feeToolTip = "Expected fee rate in satoshi / vbyte.";
+						feeText = $"(~ {feeInfo.FeeRate.SatoshiPerByte} sat/vByte)";
+						feeToolTip = "Expected fee rate in sat/vByte.";
 						break;
 
 					case FeeDisplayFormat.USD:

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
@@ -1,0 +1,63 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+using NBitcoin;
+using Splat;
+using System;
+using System.Globalization;
+using WalletWasabi.Exceptions;
+using WalletWasabi.Gui.Models;
+using WalletWasabi.Gui.Controls.WalletExplorer;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class FeeDisplayFormatConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is TransactionFeeInfo feeInfo)
+			{
+				FeeDisplayFormat displayFormat = (FeeDisplayFormat)Enum.ToObject(typeof(FeeDisplayFormat), Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat);
+
+				string feeText;
+				string feeToolTip;
+
+				switch (displayFormat)
+				{
+					case FeeDisplayFormat.SatoshiPerByte:
+						feeText = $"(~ {feeInfo.FeeRate.SatoshiPerByte} sat/vbyte)";
+						feeToolTip = "Expected fee rate in satoshi / vbyte.";
+						break;
+
+					case FeeDisplayFormat.USD:
+						feeText = $"(~ ${feeInfo.UsdFee:0.##})";
+						feeToolTip = $"Estimated total fees in USD. Exchange Rate: {(long)feeInfo.UsdExchangeRate} BTC/USD.";
+						break;
+
+					case FeeDisplayFormat.BTC:
+						feeText = $"(~ {feeInfo.EstimatedBtcFee.ToString(false, false)} BTC)";
+						feeToolTip = "Estimated total fees in BTC.";
+						break;
+
+					case FeeDisplayFormat.Percentage:
+						feeText = $"(~ {feeInfo.FeePercentage:0.#} %)";
+						feeToolTip = "Expected percentage of fees against the amount to be sent.";
+						break;
+
+					default:
+						throw new NotSupportedException("This is impossible.");
+				}
+
+				return new { FeeText = feeText, FeeToolTip = feeToolTip };
+			}
+			else
+			{
+				throw new TypeArgumentException(value, typeof(TransactionFeeInfo), nameof(value));
+			}
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
@@ -16,9 +16,11 @@ namespace WalletWasabi.Gui.Converters
 			{
 				FeeDisplayFormat displayFormat = FeeDisplayFormat.SatoshiPerByte;
 
-				if (Enum.IsDefined(typeof(FeeDisplayFormat), Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat))
+				var configFeeFormat = Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat;
+
+				if (Enum.IsDefined(typeof(FeeDisplayFormat), configFeeFormat))
 				{
-					displayFormat = (FeeDisplayFormat) Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat;
+					displayFormat = (FeeDisplayFormat) configFeeFormat;
 				}
 
 				string feeText;

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatConverter.cs
@@ -1,6 +1,4 @@
-using Avalonia;
 using Avalonia.Data.Converters;
-using NBitcoin;
 using Splat;
 using System;
 using System.Globalization;
@@ -16,7 +14,12 @@ namespace WalletWasabi.Gui.Converters
 		{
 			if (value is TransactionFeeInfo feeInfo)
 			{
-				FeeDisplayFormat displayFormat = (FeeDisplayFormat)Enum.ToObject(typeof(FeeDisplayFormat), Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat);
+				FeeDisplayFormat displayFormat = FeeDisplayFormat.SatoshiPerByte;
+
+				if (Enum.IsDefined(typeof(FeeDisplayFormat), Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat))
+				{
+					displayFormat = (FeeDisplayFormat) Locator.Current.GetService<Global>().UiConfig.FeeDisplayFormat;
+				}
 
 				string feeText;
 				string feeToolTip;

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatJsonConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatJsonConverter.cs
@@ -1,22 +1,12 @@
-using Avalonia.Data.Converters;
 using System;
-using System.Globalization;
-using WalletWasabi.Gui.Models;
-using WalletWasabi.Exceptions;
-using System.Collections.Generic;
 using Newtonsoft.Json;
+using WalletWasabi.Gui.Models;
+using static WalletWasabi.Gui.Models.FeeDisplayFormat;
 
 namespace WalletWasabi.Gui.Converters
 {
 	public class FeeDisplayFormatJsonConverter : JsonConverter
 	{
-		private Dictionary<string, FeeDisplayFormat> Texts { get; } = new Dictionary<string, FeeDisplayFormat>
-		{
-			{ "satoshiperbyte", FeeDisplayFormat.SatoshiPerByte },
-			{ "usd", FeeDisplayFormat.USD },
-			{ "btc", FeeDisplayFormat.BTC },
-			{ "percentage", FeeDisplayFormat.Percentage },
-		};
 
 		/// <inheritdoc />
 		public override bool CanConvert(Type objectType)
@@ -33,23 +23,28 @@ namespace WalletWasabi.Gui.Converters
 
 				if (string.IsNullOrWhiteSpace(value))
 				{
-					return FeeDisplayFormat.SatoshiPerByte;
+					return SatoshiPerByte;
 				}
 
-				var displayFormatString = value.Trim().ToLower();
+				var displayFormatString = value.Trim();
 
-				return Texts[displayFormatString];
+				if (Enum.TryParse(displayFormatString, true, out FeeDisplayFormat displayFormat))
+				{
+					return displayFormat;
+				}
+
+				return SatoshiPerByte;
 			}
 			catch
 			{
-				return FeeDisplayFormat.SatoshiPerByte;
+				return SatoshiPerByte;
 			}
 		}
 
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			writer.WriteValue(((FeeDisplayFormat)value).ToString());
+			writer.WriteValue(((FeeDisplayFormat)value).ToString().ToLower());
 		}
 	}
 }

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatJsonConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatJsonConverter.cs
@@ -7,7 +7,6 @@ namespace WalletWasabi.Gui.Converters
 {
 	public class FeeDisplayFormatJsonConverter : JsonConverter
 	{
-
 		/// <inheritdoc />
 		public override bool CanConvert(Type objectType)
 		{

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatJsonConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatJsonConverter.cs
@@ -1,0 +1,55 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+using WalletWasabi.Gui.Models;
+using WalletWasabi.Exceptions;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class FeeDisplayFormatJsonConverter : JsonConverter
+	{
+		private Dictionary<string, FeeDisplayFormat> Texts { get; } = new Dictionary<string, FeeDisplayFormat>
+		{
+			{ "satoshiperbyte", FeeDisplayFormat.SatoshiPerByte },
+			{ "usd", FeeDisplayFormat.USD },
+			{ "btc", FeeDisplayFormat.BTC },
+			{ "percentage", FeeDisplayFormat.Percentage },
+		};
+
+		/// <inheritdoc />
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(FeeDisplayFormat);
+		}
+
+		/// <inheritdoc />
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			try
+			{
+				var value = reader.Value as string;
+
+				if (string.IsNullOrWhiteSpace(value))
+				{
+					return FeeDisplayFormat.SatoshiPerByte;
+				}
+
+				var displayFormatString = value.Trim().ToLower();
+
+				return Texts[displayFormatString];
+			}
+			catch
+			{
+				return FeeDisplayFormat.SatoshiPerByte;
+			}
+		}
+
+		/// <inheritdoc />
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(((FeeDisplayFormat)value).ToString());
+		}
+	}
+}

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatStringConverter.cs
@@ -1,0 +1,35 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+using WalletWasabi.Gui.Models;
+using WalletWasabi.Exceptions;
+using System.Collections.Generic;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class FeeDisplayFormatStringConverter : IValueConverter
+	{
+		private Dictionary<FeeDisplayFormat, string> Texts { get; } = new Dictionary<FeeDisplayFormat, string>
+		{
+			{ FeeDisplayFormat.SatoshiPerByte, "Satoshi / vbyte" },
+			{ FeeDisplayFormat.USD, "USD" },
+			{ FeeDisplayFormat.BTC, "BTC" },
+			{ FeeDisplayFormat.Percentage, "Percentage" },
+		};
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is FeeDisplayFormat format)
+			{
+				return Texts[format];
+			}
+
+			throw new TypeArgumentException(value, typeof(FeeDisplayFormat), nameof(value));
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatStringConverter.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Gui.Converters
 	{
 		private Dictionary<FeeDisplayFormat, string> Texts { get; } = new Dictionary<FeeDisplayFormat, string>
 		{
-			{ FeeDisplayFormat.SatoshiPerByte, "Satoshi / vbyte" },
+			{ FeeDisplayFormat.SatoshiPerByte, "sat/vByte" },
 			{ FeeDisplayFormat.USD, "USD" },
 			{ FeeDisplayFormat.BTC, "BTC" },
 			{ FeeDisplayFormat.Percentage, "Percentage" },

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -7,6 +7,7 @@
              x:Class="WalletWasabi.Gui.Tabs.SettingsView">
   <UserControl.Resources>
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
+    <converters:FeeDisplayFormatStringConverter x:Key="FeeDisplayFormatStringConverter" />
     <converters:NetworkStringConverter x:Key="NetworkStringConverter" />
     <converters:VersionStringConverter x:Key="VersionStringConverter" />
   </UserControl.Resources>
@@ -102,6 +103,16 @@
                 <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
                   <ToggleButton IsChecked="{Binding LurkingWifeMode}" Content="{Binding LurkingWifeMode, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" Command="{Binding LurkingWifeModeCommand}" />
                   <TextBlock VerticalAlignment="Center">Lurking Wife Mode, hides sensitive content.</TextBlock>
+                </StackPanel>
+                <StackPanel Margin="0 10" Orientation="Vertical" Spacing="5">
+                  <TextBlock>Fee Display Format</TextBlock>
+                  <DropDown Items="{Binding FeeDisplayFormats}" SelectedItem="{Binding FeeDisplayFormat}">
+                    <DropDown.ItemTemplate>
+                      <DataTemplate>
+                        <TextBlock Text="{Binding Converter={StaticResource FeeDisplayFormatStringConverter}}" />
+                      </DataTemplate>
+                    </DropDown.ItemTemplate>
+                  </DropDown>
                 </StackPanel>
               </StackPanel>
             </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -58,7 +58,7 @@ namespace WalletWasabi.Gui.Tabs
 			Autocopy = Global.UiConfig.Autocopy;
 			if (Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat))
 			{
-				FeeDisplayFormat = (FeeDisplayFormat) Global.UiConfig.FeeDisplayFormat;
+				FeeDisplayFormat = (FeeDisplayFormat)Global.UiConfig.FeeDisplayFormat;
 			}
 			else
 			{

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -56,7 +56,14 @@ namespace WalletWasabi.Gui.Tabs
 			this.ValidateProperty(x => x.BitcoinP2pEndPoint, ValidateBitcoinP2pEndPoint);
 
 			Autocopy = Global.UiConfig.Autocopy;
-			FeeDisplayFormat = (FeeDisplayFormat)(Enum.ToObject(typeof(FeeDisplayFormat), Global.UiConfig?.FeeDisplayFormat) ?? FeeDisplayFormat.SatoshiPerByte);
+			if (Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat))
+			{
+				FeeDisplayFormat = (FeeDisplayFormat) Global.UiConfig.FeeDisplayFormat;
+			}
+			else
+			{
+				FeeDisplayFormat = FeeDisplayFormat.SatoshiPerByte;
+			}
 			CustomFee = Global.UiConfig.IsCustomFee;
 			CustomChangeAddress = Global.UiConfig.IsCustomChangeAddress;
 

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -204,13 +204,8 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _network, value);
 		}
 
-		public IEnumerable<FeeDisplayFormat> FeeDisplayFormats => new[]
-		{
-			Models.FeeDisplayFormat.USD,
-			Models.FeeDisplayFormat.BTC,
-			Models.FeeDisplayFormat.SatoshiPerByte,
-			Models.FeeDisplayFormat.Percentage
-		};
+		public IEnumerable<FeeDisplayFormat> FeeDisplayFormats =>
+			Enum.GetValues(typeof(FeeDisplayFormat)).Cast<FeeDisplayFormat>();
 
 		public FeeDisplayFormat FeeDisplayFormat
 		{

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -22,6 +22,7 @@ namespace WalletWasabi.Gui
 	[JsonObject(MemberSerialization.OptIn)]
 	public class UiConfig : ConfigBase
 	{
+		private int _feeDisplayFormat;
 		private bool _lurkingWifeMode;
 		private bool _lockScreenActive;
 		private string _lockScreenPinHash = "";
@@ -45,9 +46,14 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "FeeTarget", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public int FeeTarget { get; internal set; }
 
-		[DefaultValue(0)]
-		[JsonProperty(PropertyName = "FeeDisplayFormat", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public int FeeDisplayFormat { get; internal set; }
+		[DefaultValue(Models.FeeDisplayFormat.SatoshiPerByte)]
+		[JsonProperty(PropertyName = "FeeDisplayFormat")]
+		[JsonConverter(typeof(FeeDisplayFormatJsonConverter))]
+		public int FeeDisplayFormat
+		{
+			get => _feeDisplayFormat;
+			set => RaiseAndSetIfChanged(ref _feeDisplayFormat, value);
+		}
 
 		[DefaultValue("")]
 		[JsonProperty(PropertyName = "LastActiveTab", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
In [this comment](https://github.com/zkSNACKs/WalletWasabi/issues/752#issuecomment-489363612) it shows that a lot of people miss the fact that you can change the fee display format by clicking the text.  This PR gives the user the ability to change it in the settings tab as well.  

![](https://user-images.githubusercontent.com/15256660/62172890-89cc9e00-b2f9-11e9-82ca-bd49cff528bd.png)

With this PR and #2006 we are starting to fill up the settings page and would understand in closing this in favor of keeping the settings page not as cluttered.