### PR TITLE
[WIP] Label typing

### DIFF
--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -70,7 +70,7 @@ namespace WalletWasabi.Gui.ViewModels
 
 						if (hdPubKey != default)
 						{
-							hdPubKey.SetLabel(newLabel, kmToFile: keyManager);
+							hdPubKey.SetLabel(newLabel, hdPubKey.LabelType, kmToFile: keyManager);
 						}
 					}
 				});

--- a/WalletWasabi.Tests/ModelTests.cs
+++ b/WalletWasabi.Tests/ModelTests.cs
@@ -12,6 +12,7 @@ using WalletWasabi.Backend.Models.Requests;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.Models;
+using WalletWasabi.KeyManagement;
 using WalletWasabi.Models.ChaumianCoinJoin;
 using WalletWasabi.Services;
 using WalletWasabi.Tests.XunitConfiguration;
@@ -59,16 +60,16 @@ namespace WalletWasabi.Tests
 			var height = Height.Mempool;
 			var label = "foo";
 
-			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index), label, txId);
+			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index), label, LabelType.Standard, txId);
 			// If the txId or the index differs, equality should think it's a different coin.
-			var differentCoin = new SmartCoin(txId, index + 1, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index + 1), label, txId);
+			var differentCoin = new SmartCoin(txId, index + 1, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index + 1), label, LabelType.Standard, txId);
 			var differentOutput = tx.Outputs[1];
 			var differentSpentOutputs = new[]
 			{
 				new TxoRef(txId, 0)
 			};
 			// If the txId and the index is the same, equality should think it's the same coin.
-			var sameCoin = new SmartCoin(txId, index, differentOutput.ScriptPubKey, differentOutput.Value, differentSpentOutputs, Height.Unknown, tx.RBF, tx.GetAnonymitySet(index), "boo", null);
+			var sameCoin = new SmartCoin(txId, index, differentOutput.ScriptPubKey, differentOutput.Value, differentSpentOutputs, Height.Unknown, tx.RBF, tx.GetAnonymitySet(index), "boo",  LabelType.Standard, null);
 
 			Assert.Equal(coin, sameCoin);
 			Assert.NotEqual(coin, differentCoin);
@@ -153,7 +154,7 @@ namespace WalletWasabi.Tests
 			var label = "foo";
 			var bannedUntil = DateTimeOffset.UtcNow;
 
-			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index), label, txId);
+			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index), label,  LabelType.Standard, txId);
 			coin.BannedUntilUtc = bannedUntil;
 
 			var serialized = JsonConvert.SerializeObject(coin);

--- a/WalletWasabi/KeyManagement/HdPubKey.cs
+++ b/WalletWasabi/KeyManagement/HdPubKey.cs
@@ -37,11 +37,14 @@ namespace WalletWasabi.KeyManagement
 		[JsonProperty(Order = 4)]
 		public KeyState KeyState { get; private set; }
 
-		public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, string label, KeyState keyState)
+		[JsonProperty(Order = 5)]
+		public LabelType LabelType { get; private set; }
+
+		public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, string label, KeyState keyState, LabelType labelType)
 		{
 			PubKey = Guard.NotNull(nameof(pubKey), pubKey);
 			FullKeyPath = Guard.NotNull(nameof(fullKeyPath), fullKeyPath);
-			SetLabel(label, null);
+			SetLabel(label, labelType, null);
 			KeyState = keyState;
 
 			P2pkScript = PubKey.ScriptPubKey;
@@ -70,7 +73,7 @@ namespace WalletWasabi.KeyManagement
 			}
 		}
 
-		public void SetLabel(string label, KeyManager kmToFile = null)
+		public void SetLabel(string label, LabelType type, KeyManager kmToFile = null)
 		{
 			label = Guard.Correct(label);
 			if (Label == label)
@@ -79,6 +82,7 @@ namespace WalletWasabi.KeyManagement
 			}
 
 			Label = label;
+			LabelType = type;
 
 			kmToFile?.ToFile();
 		}

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -434,7 +434,7 @@ namespace WalletWasabi.KeyManagement
 				var fullPath = AccountKeyPath.Derive(path);
 				var pubKey = ExtPubKey.Derive(path).PubKey;
 
-				var hdPubKey = new HdPubKey(pubKey, fullPath, label, keyState);
+				var hdPubKey = new HdPubKey(pubKey, fullPath, label, keyState, LabelType.Standard);
 				HdPubKeys.Add(hdPubKey);
 				lock (HdPubKeyScriptBytesLock)
 				{

--- a/WalletWasabi/KeyManagement/LabelType.cs
+++ b/WalletWasabi/KeyManagement/LabelType.cs
@@ -1,0 +1,9 @@
+namespace WalletWasabi.KeyManagement
+{
+	public enum LabelType
+	{
+		Standard,
+		CoinJoin,
+		CoinJoinChange
+	}
+}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.KeyManagement;
 
 namespace WalletWasabi.Models.ChaumianCoinJoin
 {
@@ -197,7 +198,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			Func<SmartCoin, bool> confirmationPredicate;
 			if (allowUnconfirmedZeroLink)
 			{
-				confirmationPredicate = x => x.Confirmed || x.Label.StartsWith("ZeroLink", StringComparison.Ordinal);
+				confirmationPredicate = x => x.Confirmed || x.LabelType == LabelType.CoinJoin || x.LabelType == LabelType.CoinJoinChange;
 			}
 			else
 			{

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -25,6 +25,7 @@ namespace WalletWasabi.Models
 		private Money _amount;
 		private Height _height;
 		private string _label;
+		private LabelType _labelType;
 		private TxoRef[] _spentOutputs;
 		private bool _replaceable;
 		private int _anonymitySet;
@@ -110,6 +111,20 @@ namespace WalletWasabi.Models
 					_label = value;
 					OnPropertyChanged(nameof(Label));
 					HasLabel = !string.IsNullOrEmpty(value);
+				}
+			}
+		}
+
+		[JsonProperty]
+		public LabelType LabelType
+		{
+			get => _labelType;
+			set
+			{
+				if (value != _labelType)
+				{
+					_labelType = value;
+					OnPropertyChanged(nameof(LabelType));
 				}
 			}
 		}
@@ -303,12 +318,12 @@ namespace WalletWasabi.Models
 		#region Constructors
 
 		[JsonConstructor]
-		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
+		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label = "", LabelType labelType = LabelType.Standard, uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
-			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
+			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, label, labelType, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
 		}
 
-		public SmartCoin(Coin coin, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label = "", uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
+		public SmartCoin(Coin coin, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label = "", LabelType labelType = LabelType.Standard, uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
 			OutPoint outpoint = Guard.NotNull($"{coin}.{coin?.Outpoint}", coin?.Outpoint);
 			uint256 transactionId = outpoint.Hash;
@@ -316,10 +331,10 @@ namespace WalletWasabi.Models
 			Script scriptPubKey = Guard.NotNull($"{coin}.{coin?.ScriptPubKey}", coin?.ScriptPubKey);
 			Money amount = Guard.NotNull($"{coin}.{coin?.Amount}", coin?.Amount);
 
-			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
+			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, label, labelType,spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);
 		}
 
-		private void Create(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label, uint256 spenderTransactionId, bool coinJoinInProgress, DateTimeOffset? bannedUntilUtc, bool spentAccordingToBackend, HdPubKey pubKey)
+		private void Create(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, string label, LabelType labelType, uint256 spenderTransactionId, bool coinJoinInProgress, DateTimeOffset? bannedUntilUtc, bool spentAccordingToBackend, HdPubKey pubKey)
 		{
 			TransactionId = Guard.NotNull(nameof(transactionId), transactionId);
 			Index = Guard.NotNull(nameof(index), index);
@@ -327,6 +342,7 @@ namespace WalletWasabi.Models
 			Amount = Guard.NotNull(nameof(amount), amount);
 			Height = height;
 			Label = Guard.Correct(label);
+			LabelType = labelType;
 			SpentOutputs = Guard.NotNullOrEmpty(nameof(spentOutputs), spentOutputs);
 			IsReplaceable = replaceable;
 			AnonymitySet = Guard.InRangeAndNotNull(nameof(anonymitySet), anonymitySet, 1, int.MaxValue);

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -688,13 +688,13 @@ namespace WalletWasabi.Services
 
 			// Select the change and active keys to register and label them accordingly.
 			HdPubKey change = allLockedInternalKeys.First();
-			change.SetLabel(changeLabel);
+			change.SetLabel(changeLabel, LabelType.CoinJoinChange);
 
 			var actives = new List<HdPubKey>();
 			foreach (HdPubKey active in allLockedInternalKeys.Skip(1).Take(maximumMixingLevelCount))
 			{
 				actives.Add(active);
-				active.SetLabel(activeLabel);
+				active.SetLabel(activeLabel, LabelType.CoinJoin);
 			}
 
 			// Remember which links we are exposing.
@@ -1033,13 +1033,13 @@ namespace WalletWasabi.Services
 			State.RemoveCoinFromWaitingList(coinWaitingForMix);
 			coinWaitingForMix.CoinJoinInProgress = false;
 			coinWaitingForMix.Secret = null;
-			if (coinWaitingForMix.Label == "ZeroLink Change" && coinWaitingForMix.Unspent)
+			if (coinWaitingForMix.LabelType == LabelType.CoinJoinChange && coinWaitingForMix.Unspent)
 			{
 				coinWaitingForMix.Label = "ZeroLink Dequeued Change";
 				var key = KeyManager.GetKeys(x => x.P2wpkhScript == coinWaitingForMix.ScriptPubKey).SingleOrDefault();
 				if (key != null)
 				{
-					key.SetLabel(coinWaitingForMix.Label, KeyManager);
+					key.SetLabel(coinWaitingForMix.Label, LabelType.CoinJoinChange, KeyManager);
 				}
 			}
 			CoinDequeued?.Invoke(this, coinWaitingForMix);

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -409,7 +409,7 @@ namespace WalletWasabi.Services
 			var foundLabelless = keys.FirstOrDefault(x => !x.HasLabel); // Return the first labelless.
 			HdPubKey ret = foundLabelless ?? keys.RandomElement(); // Return the first, because that's the oldest.
 
-			ret.SetLabel(label, KeyManager);
+			ret.SetLabel(label, LabelType.Standard, KeyManager);
 
 			return ret;
 		}
@@ -650,7 +650,7 @@ namespace WalletWasabi.Services
 						continue;
 					}
 
-					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
+					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, foundKey.Label, foundKey.LabelType, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
 																																																												   // If we did not have it.
 					if (Coins.TryAdd(newCoin))
 					{
@@ -1183,7 +1183,7 @@ namespace WalletWasabi.Services
 				KeyManager.AssertLockedInternalKeysIndexed(14);
 				var changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
 
-				changeHdPubKey.SetLabel(changeLabel, KeyManager);
+				changeHdPubKey.SetLabel(changeLabel, LabelType.Standard, KeyManager);
 				changeScriptPubKey = changeHdPubKey.P2wpkhScript;
 			}
 			else
@@ -1272,6 +1272,7 @@ namespace WalletWasabi.Services
 				if (foundKey != null)
 				{
 					coin.Label = changeLabel;
+					coin.LabelType = foundKey.LabelType;
 					innerWalletOutputs.Add(coin);
 				}
 				else
@@ -1389,7 +1390,7 @@ namespace WalletWasabi.Services
 			var key = KeyManager.GetKeys(x => x.P2wpkhScript == coin.ScriptPubKey).SingleOrDefault();
 			if (key != null)
 			{
-				key.SetLabel(newLabel, KeyManager);
+				key.SetLabel(newLabel, key.LabelType, KeyManager);
 			}
 		}
 
@@ -1529,7 +1530,7 @@ namespace WalletWasabi.Services
 
 		public IEnumerable<string> GetNonSpecialLabels()
 		{
-			return Coins.Where(x => !x.Label.StartsWith("ZeroLink", StringComparison.Ordinal))
+			return Coins.Where(x => x.LabelType != LabelType.CoinJoin && x.LabelType != LabelType.CoinJoinChange)
 				.SelectMany(x => x.Label.Split(new string[] { Constants.ChangeOfSpecialLabelStart, Constants.ChangeOfSpecialLabelEnd, "(", "," }, StringSplitOptions.RemoveEmptyEntries))
 				.Select(x => x.Trim())
 				.Distinct();


### PR DESCRIPTION
This is my attempt at removing the need to check a coin's label for "ZeroLink".

I think this change makes sense because

- The user does not see any changes

- Allows us to change labels like "ZeroLink Dequeued Change" to something shorter and easier for the user to understand

- Gives us the ability to add more types in the future that can be use in other ways to have an internal flag for different things
    - Ideas off top of my head: `Non-Private` type that resets the anonset to 1, `Inter-wallet` send/receive, etc (things that must be recorded because we cannot know by looking at the history).

Drawbacks of this change:

- Compatibility: Currently this will break with an old wallet because label types have not been set properly for previous CoinJoins.
    - This can be solved by either on initial start up checking all current labels and setting the proper label types or leaving the old checks for "ZeroLink" in the label and maintain both versions.

- Adds more data to the `walletName.json` file.

- Adds another data type we need to keep track of

Let me know what you guys think about this idea.

Edit: Created a [draft pull request](https://github.com/benthecarman/WalletWasabi/pull/1) that shows a cool feature than can be implemented with this