### PR TITLE
Remove Replaced transactions from cache

### DIFF
--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -168,6 +168,11 @@ namespace WalletWasabi.Services
 					}
 				}
 				Mempool.TransactionHashes.TryRemove(toRemove.TransactionId);
+				var txToRemove = TransactionCache.FirstOrDefault(x=>x.GetHash() == toRemove.TransactionId);
+				if (txToRemove != default(SmartTransaction))
+				{
+					TransactionCache.TryRemove(txToRemove);
+				}
 			}
 
 			RefreshCoinHistories();


### PR DESCRIPTION
In case a transaction is replaced (RBF) by other one or when there is a chain reorg the coins created by those transactions are removed from the Coins list. The transactions that created those coins has to be removed too.