### PR TITLE
Explicitly check for regtest network

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -173,9 +173,13 @@ namespace WalletWasabi.Gui
 			{
 				_backendUri = new Uri(TestNetBackendUriV3);
 			}
-			else // RegTest
+			else if (Network == Network.RegTest)
 			{
 				_backendUri = new Uri(RegTestBackendUriV3);
+			}
+			else
+			{
+				throw new NotSupportedException($"{nameof(Network)} not supported: {Network}.");
 			}
 
 			return _backendUri;
@@ -196,9 +200,13 @@ namespace WalletWasabi.Gui
 			{
 				_fallbackBackendUri = new Uri(TestNetFallbackBackendUri);
 			}
-			else // RegTest
+			else if (Network == Network.RegTest)
 			{
 				_fallbackBackendUri = new Uri(RegTestBackendUriV3);
+			}
+			else
+			{
+				throw new NotSupportedException($"{nameof(Network)} not supported: {Network}.");
 			}
 
 			return _fallbackBackendUri;

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -68,9 +68,13 @@ namespace WalletWasabi.Helpers
 			{
 				return TestNetCoordinatorAddress;
 			}
-			else // else regtest
+			else if (network == Network.RegTest)
 			{
 				return RegTestCoordinatorAddress;
+			}
+			else
+			{
+				throw new NotSupportedException($"{nameof(network)} not supported: {network}.");
 			}
 		}
 


### PR DESCRIPTION
We should explicitly check that it is the regtest network, future networks could be added, segnet for example.