### PR TITLE
Test transaction processing code

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -64,7 +64,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
 				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.NewBlockProcessed)))
-				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.CoinSpentOrSpenderConfirmed)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpentOrSpenderConfirmed)))
 				.Throttle(TimeSpan.FromSeconds(5))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(async _ => await TryRewriteTableAsync())
@@ -144,7 +144,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			{
 				var found = txRecordList.FirstOrDefault(x => x.transactionId == coin.TransactionId);
 
-				SmartTransaction foundTransaction = walletService.TransactionCache?.FirstOrDefault(x => x.GetHash() == coin.TransactionId);
+				SmartTransaction foundTransaction = walletService.TransactionProcessor.TransactionCache?.FirstOrDefault(x => x.GetHash() == coin.TransactionId);
 				if (foundTransaction is null)
 				{
 					continue;
@@ -181,7 +181,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 				if (coin.SpenderTransactionId != null)
 				{
-					SmartTransaction foundSpenderTransaction = walletService.TransactionCache.First(x => x.GetHash() == coin.SpenderTransactionId);
+					SmartTransaction foundSpenderTransaction = walletService.TransactionProcessor.TransactionCache.First(x => x.GetHash() == coin.SpenderTransactionId);
 
 					if (foundSpenderTransaction.Height.Type == HeightType.Chain)
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -145,7 +145,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			{
 				var found = txRecordList.FirstOrDefault(x => x.transactionId == coin.TransactionId);
 
-				SmartTransaction foundTransaction = walletService.TransactionProcessor.TransactionCache?.FirstOrDefault(x => x.GetHash() == coin.TransactionId);
+				var foundTransaction = walletService.TryGetTxFromCache(coin.TransactionId);
 				if (foundTransaction is null)
 				{
 					continue;
@@ -182,7 +182,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 				if (coin.SpenderTransactionId != null)
 				{
-					SmartTransaction foundSpenderTransaction = walletService.TransactionProcessor.TransactionCache.First(x => x.GetHash() == coin.SpenderTransactionId);
+					var foundSpenderTransaction = walletService.TryGetTxFromCache(coin.SpenderTransactionId);
+					if (foundSpenderTransaction is null)
+					{
+						throw new InvalidOperationException($"Transaction {coin.SpenderTransactionId} not found.");
+					}
 
 					if (foundSpenderTransaction.Height.Type == HeightType.Chain)
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -64,7 +64,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
 				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.NewBlockProcessed)))
-				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpentOrSpenderConfirmed)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpent)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.SpenderConfirmed)))
 				.Throttle(TimeSpan.FromSeconds(5))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(async _ => await TryRewriteTableAsync())

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -33,8 +33,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			var keyManager = WalletService.KeyManager;
 			Name = Path.GetFileNameWithoutExtension(keyManager.FilePath);
 
-			SetBalance(Name);
-
 			Actions = new ObservableCollection<WalletActionViewModel>();
 
 			SendTabViewModel sendTab = null;
@@ -95,16 +93,22 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
-			Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
-				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpentOrSpenderConfirmed)))
-				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(o => SetBalance(Name))
+			var observed = Observable.Merge(
+				Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Select(_ => Unit.Default),
+				Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged)).Select(_ => Unit.Default),
+				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpent)).Select(_ => Unit.Default))
+				.Throttle(TimeSpan.FromSeconds(1))
+				.ObserveOn(RxApp.MainThreadScheduler);
+
+			observed.Subscribe(_ =>
+				{
+					Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
+
+					Title = $"{Name} ({(Global.UiConfig.LurkingWifeMode ? "#########" : balance.ToString(false, true))} BTC)";
+				})
 				.DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(x =>
-			{
-				SetBalance(Name);
-			}).DisposeWith(Disposables);
+			observed.Next();
 
 			IsExpanded = true;
 		}
@@ -124,13 +128,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			get => _actions;
 			set => this.RaiseAndSetIfChanged(ref _actions, value);
-		}
-
-		private void SetBalance(string walletName)
-		{
-			Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
-
-			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode ? "#########" : balance.ToString(false, true))} BTC)";
 		}
 	}
 }

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -96,7 +96,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 			Observable.FromEventPattern(Global.WalletService.Coins, nameof(Global.WalletService.Coins.CollectionChanged))
-				.Merge(Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.CoinSpentOrSpenderConfirmed)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpentOrSpenderConfirmed)))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(o => SetBalance(Name))
 				.DisposeWith(Disposables);

--- a/WalletWasabi.Tests/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/TransactionProcessorTests.cs
@@ -1,0 +1,321 @@
+using NBitcoin;
+using NBitcoin.Crypto;
+using System;
+using System.Linq;
+using WalletWasabi.KeyManagement;
+using WalletWasabi.Models;
+using WalletWasabi.Services;
+using Xunit;
+
+namespace WalletWasabi.Tests
+{
+	public class TransactionProcessorTests
+	{
+		[Fact]
+		public void TransactionDoesNotCointainCoinsForTheWallet()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			// This transaction doesn't have any coin for the wallet. It is not relevant.
+			var tx = CreateCreditingTransaction(new Key().PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.False(relevant); 
+			Assert.Empty(transactionProcessor.Coins);
+			Assert.Empty(transactionProcessor.TransactionCache);
+		}
+
+
+		[Fact]
+		public void SpendToLegacyScripts()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+			var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
+
+			// A payment to a key under our control but using P2PKH script (legacy)
+			var tx = CreateCreditingTransaction(keys.First().P2pkhScript, Money.Coins(1.0m));
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.False(relevant); 
+			Assert.Empty(transactionProcessor.Coins);
+		}
+
+
+		[Fact]
+		public void UnconfirmedTransactionIsNotSegWit()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			// No segwit transaction. Ignore it.
+			var tx = CreateCreditingTransaction(new Key().PubKey.Hash.ScriptPubKey, Money.Coins(1.0m));
+
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.False(relevant); 
+			Assert.Empty(transactionProcessor.Coins);
+			Assert.Empty(transactionProcessor.TransactionCache);
+		}
+
+
+		[Fact]
+		public void ConfirmedTransactionIsNotSegWit()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			// No segwit transaction. Ignore it.
+			var tx = CreateCreditingTransaction(new Key().PubKey.Hash.ScriptPubKey, Money.Coins(1.0m), isConfirmed: true);
+			transactionProcessor.TransactionHashes.Append(tx.GetHash()); // This transaction was already seen before
+
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.False(relevant); 
+			Assert.Empty(transactionProcessor.Coins);
+			Assert.Empty(transactionProcessor.TransactionCache);
+			Assert.Empty(transactionProcessor.TransactionHashes);
+		}
+
+
+		[Fact]
+		public void UpdateTransactionHeightAfterConfirmation()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			// An unconfirmed segwit transaction for us
+			var key = transactionProcessor.KeyManager.GetKeys().First();
+
+			var tx = CreateCreditingTransaction(key.PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+			transactionProcessor.TransactionHashes.Append(tx.GetHash()); // This transaction was already seen before
+			transactionProcessor.Process(tx);
+
+			var cachedTx = Assert.Single(transactionProcessor.TransactionCache);
+			var coin = Assert.Single(transactionProcessor.Coins);
+			Assert.Equal(Height.Mempool, cachedTx.Height);
+			Assert.Equal(Height.Mempool, coin.Height);
+
+			// Now it is confirmed
+			var blockHeight = new Height(77551);
+			tx = new SmartTransaction(tx.Transaction, blockHeight);
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.True(relevant); 
+			Assert.Single(transactionProcessor.Coins);
+			cachedTx = Assert.Single(transactionProcessor.TransactionCache);
+			Assert.NotEqual(Height.Mempool, cachedTx.Height);
+			coin = Assert.Single(transactionProcessor.Coins);
+			Assert.Equal(blockHeight, coin.Height);
+
+			Assert.Empty(transactionProcessor.TransactionHashes);
+		}
+
+
+		[Fact]
+		public void IgnoreDoubleSpend()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
+
+			// An unconfirmed segwit transaction for us
+			var tx = CreateCreditingTransaction(keys[0].PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+			transactionProcessor.Process(tx);
+
+			var createdCoin = tx.Transaction.Outputs.AsCoins().First();
+			// Spend the received coin
+			tx = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
+			transactionProcessor.Process(tx);
+
+			// Spend it coin
+			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey);
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.False(relevant); 
+			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent);
+			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent);
+			Assert.Equal(2, transactionProcessor.TransactionCache.Count());
+			Assert.Empty(transactionProcessor.TransactionHashes);
+		}
+
+
+		[Fact]
+		public void ConfirmedDoubleSpend()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
+
+			// An unconfirmed segwit transaction for us
+			var tx = CreateCreditingTransaction(keys[0].PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m), isConfirmed: true);
+			transactionProcessor.Process(tx);
+
+			var createdCoin = tx.Transaction.Outputs.AsCoins().First();
+			// Spend the received coin
+			tx = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
+			transactionProcessor.Process(tx);
+
+			// Spend it coin
+			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey, isConfirmed: true);
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.True(relevant); 
+			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent  && coin.Confirmed);
+			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Confirmed);
+			Assert.Empty(transactionProcessor.TransactionHashes);
+		}
+
+
+		[Fact]
+		public void HandlesRBF()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+
+			var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
+
+			// A confirmed segwit transaction for us
+			var tx = CreateCreditingTransaction(keys[0].PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m), isConfirmed: true);
+			transactionProcessor.Process(tx);
+
+			var createdCoin = tx.Transaction.Outputs.AsCoins().First();
+			// Spend the received coin
+			tx = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
+			tx.Transaction.Inputs[0].Sequence = Sequence.OptInRBF;
+			var relevant = transactionProcessor.Process(tx);
+			Assert.True(relevant); 
+
+			// Spend it coin
+			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey);
+			tx.Transaction.Outputs[0].Value = Money.Coins(0.9m);
+			relevant = transactionProcessor.Process(tx);
+
+			Assert.True(relevant); 
+			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent && coin.Amount == Money.Coins(0.9m) && coin.IsReplaceable);
+			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Amount == Money.Coins(1.0m) && !coin.IsReplaceable);
+			Assert.Empty(transactionProcessor.TransactionHashes);
+		}
+
+
+		[Fact]
+		public void ReceiveTransactionForWallet()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+			SmartCoin receivedCoin = null;
+			transactionProcessor.CoinReceived += (s, theCoin)=>receivedCoin = theCoin;
+			var keys = transactionProcessor.KeyManager.GetKeys();
+			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(1.0m));
+
+			var relevant = transactionProcessor.Process(tx);
+
+			// It is relevant because is funding the wallet
+			Assert.True(relevant); 
+			var coin = Assert.Single(transactionProcessor.Coins);
+			Assert.Equal(Money.Coins(1.0m), coin.Amount);
+			Assert.Contains(transactionProcessor.TransactionCache, x=>x == tx);
+			Assert.NotNull(receivedCoin);
+		}
+
+
+		[Fact]
+		public void SpendCoin()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+			SmartCoin spentCoin = null;
+			transactionProcessor.CoinSpentOrSpenderConfirmed += (s, theCoin)=>spentCoin = theCoin;
+			var keys = transactionProcessor.KeyManager.GetKeys();
+			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(1.0m));
+			transactionProcessor.Process(tx);
+
+			var createdCoin = tx.Transaction.Outputs.AsCoins().First();
+			// Spend the received coin
+			tx = CreateSpendingTransaction(createdCoin, new Key().PubKey.ScriptPubKey);
+			var relevant = transactionProcessor.Process(tx);
+
+			Assert.True(relevant); 
+			var coin = Assert.Single(transactionProcessor.Coins);
+			Assert.False(coin.Unspent);
+			Assert.NotNull(spentCoin);
+			Assert.Equal(coin, spentCoin);
+		}
+
+
+
+		[Fact]
+		public void ReceiveTransactionWithDustForWallet()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+			transactionProcessor.CoinReceived += (s, theCoin)
+				=> throw new Exception("The dust coin raised event when it shouldn't");
+			var keys = transactionProcessor.KeyManager.GetKeys();
+			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(0.000099m));
+
+			var relevant = transactionProcessor.Process(tx);
+
+			// It is relevant even when all the coins can be dust.
+			Assert.True(relevant); 
+			Assert.Empty(transactionProcessor.Coins);
+		}
+
+
+		[Fact]
+		public void ReceiveCoinjoinTransaction()
+		{
+			var transactionProcessor = CreateTransactionProcessor();
+			var keys = transactionProcessor.KeyManager.GetKeys();
+
+			var amount = Money.Coins(0.1m);
+
+			var tx = Network.RegTest.CreateTransaction();
+			tx.Version = 1;
+			tx.LockTime = LockTime.Zero;
+			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
+			var txout = new TxOut(Money.Coins(0.1m), new Key().PubKey.WitHash.ScriptPubKey);
+			tx.Outputs.AddRange(Enumerable.Repeat(txout, 5)); // 6 indistinguishable txouts 
+			tx.Inputs.AddRange(Enumerable.Repeat(new TxIn(GetRandomOutPoint(), Script.Empty), 4));
+
+
+			var relevant = transactionProcessor.Process(new SmartTransaction(tx, Height.Mempool));
+
+			// It is relevant even when all the coins can be dust.
+			Assert.True(relevant); 
+			var coin = Assert.Single(transactionProcessor.Coins);
+			Assert.Equal(4, coin.AnonymitySet);
+			Assert.Equal(Money.Coins(0.1m), coin.Amount);
+		}
+
+
+
+		private static TransactionProcessor CreateTransactionProcessor()
+		{
+			var keyManager = KeyManager.CreateNew(out _, "password");
+			keyManager.AssertCleanKeysIndexed();
+			return new TransactionProcessor(
+				keyManager,
+				new ConcurrentHashSet<uint256>(), 
+				new ObservableConcurrentHashSet<SmartCoin>(),
+				Money.Coins(0.0001m));
+		}
+
+
+		private static SmartTransaction CreateSpendingTransaction(Coin coin, Script scriptPubKey = null, bool isConfirmed = false)
+		{
+			var tx = Network.RegTest.CreateTransaction();
+			tx.Inputs.Add(coin.Outpoint, Script.Empty, WitScript.Empty);
+			tx.Outputs.Add(coin.Amount, scriptPubKey ?? Script.Empty);
+			return new SmartTransaction(tx, isConfirmed ? new Height(9999) : Height.Mempool);
+		}
+
+		private static SmartTransaction CreateCreditingTransaction(Script scriptPubKey, Money amount, bool isConfirmed = false)
+		{
+			var tx = Network.RegTest.CreateTransaction();
+			tx.Version = 1;
+			tx.LockTime = LockTime.Zero;
+			tx.Inputs.Add( GetRandomOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
+			tx.Outputs.Add(amount, scriptPubKey);
+			return new SmartTransaction(tx, isConfirmed ? new Height(9999) : Height.Mempool);
+		}
+
+		private static OutPoint GetRandomOutPoint()
+		{
+			return new OutPoint(RandomUtils.GetUInt256(), 0);
+		}
+	}
+}

--- a/WalletWasabi.Tests/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/TransactionProcessorTests.cs
@@ -254,8 +254,8 @@ namespace WalletWasabi.Tests
 			tx.Version = 1;
 			tx.LockTime = LockTime.Zero;
 			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
-			var txout = new TxOut(amount, new Key().PubKey.WitHash.ScriptPubKey);
-			tx.Outputs.AddRange(Enumerable.Repeat(txout, 5)); // 6 indistinguishable txouts 
+			var txOut = new TxOut(amount, new Key().PubKey.WitHash.ScriptPubKey);
+			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts 
 			tx.Inputs.AddRange(Enumerable.Repeat(new TxIn(GetRandomOutPoint(), Script.Empty), 4));
 
 			var relevant = transactionProcessor.Process(new SmartTransaction(tx, Height.Mempool));
@@ -284,8 +284,8 @@ namespace WalletWasabi.Tests
 			tx.Version = 1;
 			tx.LockTime = LockTime.Zero;
 			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
-			var txout = new TxOut(Money.Coins(0.1m), new Key().PubKey.WitHash.ScriptPubKey);
-			tx.Outputs.AddRange(Enumerable.Repeat(txout, 5)); // 6 indistinguishable txouts 
+			var txOut = new TxOut(Money.Coins(0.1m), new Key().PubKey.WitHash.ScriptPubKey);
+			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts 
 			tx.Inputs.Add(createdCoin.Outpoint, Script.Empty, WitScript.Empty);
 			tx.Inputs.AddRange(Enumerable.Repeat(new TxIn(GetRandomOutPoint(), Script.Empty), 4));
 

--- a/WalletWasabi.Tests/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/TransactionProcessorTests.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Tests
 
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.False(relevant); 
+			Assert.False(relevant);
 			Assert.Empty(transactionProcessor.Coins);
 			Assert.Empty(transactionProcessor.TransactionCache);
 		}
@@ -35,7 +35,7 @@ namespace WalletWasabi.Tests
 			var tx = CreateCreditingTransaction(keys.First().P2pkhScript, Money.Coins(1.0m));
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.False(relevant); 
+			Assert.False(relevant);
 			Assert.Empty(transactionProcessor.Coins);
 		}
 
@@ -49,7 +49,7 @@ namespace WalletWasabi.Tests
 
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.False(relevant); 
+			Assert.False(relevant);
 			Assert.Empty(transactionProcessor.Coins);
 			Assert.Empty(transactionProcessor.TransactionCache);
 		}
@@ -65,7 +65,7 @@ namespace WalletWasabi.Tests
 
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.False(relevant); 
+			Assert.False(relevant);
 			Assert.Empty(transactionProcessor.Coins);
 			Assert.Empty(transactionProcessor.TransactionCache);
 			Assert.Empty(transactionProcessor.TransactionHashes);
@@ -93,7 +93,7 @@ namespace WalletWasabi.Tests
 			tx = new SmartTransaction(tx.Transaction, blockHeight);
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			Assert.Single(transactionProcessor.Coins);
 			cachedTx = Assert.Single(transactionProcessor.TransactionCache);
 			Assert.NotEqual(Height.Mempool, cachedTx.Height);
@@ -123,7 +123,7 @@ namespace WalletWasabi.Tests
 			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey);
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.False(relevant); 
+			Assert.False(relevant);
 			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent);
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent);
 			Assert.Equal(2, transactionProcessor.TransactionCache.Count());
@@ -150,8 +150,8 @@ namespace WalletWasabi.Tests
 			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey, isConfirmed: true);
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.True(relevant); 
-			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent  && coin.Confirmed);
+			Assert.True(relevant);
+			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent && coin.Confirmed);
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Confirmed);
 			Assert.Empty(transactionProcessor.TransactionHashes);
 		}
@@ -172,14 +172,14 @@ namespace WalletWasabi.Tests
 			tx = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
 			tx.Transaction.Inputs[0].Sequence = Sequence.OptInRBF;
 			var relevant = transactionProcessor.Process(tx);
-			Assert.True(relevant); 
+			Assert.True(relevant);
 
 			// Spend it coin
 			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey);
 			tx.Transaction.Outputs[0].Value = Money.Coins(0.9m);
 			relevant = transactionProcessor.Process(tx);
 
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent && coin.Amount == Money.Coins(0.9m) && coin.IsReplaceable);
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Amount == Money.Coins(1.0m) && !coin.IsReplaceable);
 			Assert.Empty(transactionProcessor.TransactionHashes);
@@ -197,10 +197,10 @@ namespace WalletWasabi.Tests
 			var relevant = transactionProcessor.Process(tx);
 
 			// It is relevant because is funding the wallet
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			var coin = Assert.Single(transactionProcessor.Coins);
 			Assert.Equal(Money.Coins(1.0m), coin.Amount);
-			Assert.Contains(transactionProcessor.TransactionCache, x=>x == tx);
+			Assert.Contains(transactionProcessor.TransactionCache, x => x == tx);
 			Assert.NotNull(receivedCoin);
 		}
 
@@ -209,7 +209,7 @@ namespace WalletWasabi.Tests
 		{
 			var transactionProcessor = CreateTransactionProcessor();
 			SmartCoin spentCoin = null;
-			transactionProcessor.CoinSpentOrSpenderConfirmed += (s, theCoin) => spentCoin = theCoin;
+			transactionProcessor.CoinSpent += (s, theCoin) => spentCoin = theCoin;
 			var keys = transactionProcessor.KeyManager.GetKeys();
 			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(1.0m));
 			transactionProcessor.Process(tx);
@@ -219,7 +219,7 @@ namespace WalletWasabi.Tests
 			tx = CreateSpendingTransaction(createdCoin, new Key().PubKey.ScriptPubKey);
 			var relevant = transactionProcessor.Process(tx);
 
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			var coin = Assert.Single(transactionProcessor.Coins);
 			Assert.False(coin.Unspent);
 			Assert.NotNull(spentCoin);
@@ -238,7 +238,7 @@ namespace WalletWasabi.Tests
 			var relevant = transactionProcessor.Process(tx);
 
 			// It is relevant even when all the coins can be dust.
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			Assert.Empty(transactionProcessor.Coins);
 		}
 
@@ -255,13 +255,13 @@ namespace WalletWasabi.Tests
 			tx.LockTime = LockTime.Zero;
 			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
 			var txOut = new TxOut(amount, new Key().PubKey.WitHash.ScriptPubKey);
-			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts 
+			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts
 			tx.Inputs.AddRange(Enumerable.Repeat(new TxIn(GetRandomOutPoint(), Script.Empty), 4));
 
 			var relevant = transactionProcessor.Process(new SmartTransaction(tx, Height.Mempool));
 
 			// It is relevant even when all the coins can be dust.
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			var coin = Assert.Single(transactionProcessor.Coins);
 			Assert.Equal(4, coin.AnonymitySet);
 			Assert.Equal(amount, coin.Amount);
@@ -285,14 +285,14 @@ namespace WalletWasabi.Tests
 			tx.LockTime = LockTime.Zero;
 			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
 			var txOut = new TxOut(Money.Coins(0.1m), new Key().PubKey.WitHash.ScriptPubKey);
-			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts 
+			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts
 			tx.Inputs.Add(createdCoin.Outpoint, Script.Empty, WitScript.Empty);
 			tx.Inputs.AddRange(Enumerable.Repeat(new TxIn(GetRandomOutPoint(), Script.Empty), 4));
 
 			var relevant = transactionProcessor.Process(new SmartTransaction(tx, Height.Mempool));
 
 			// It is relevant even when all the coins can be dust.
-			Assert.True(relevant); 
+			Assert.True(relevant);
 			var coin = Assert.Single(transactionProcessor.Coins, c => c.AnonymitySet > 1);
 			Assert.Equal(5, coin.AnonymitySet);
 			Assert.Equal(amount, coin.Amount);
@@ -305,7 +305,7 @@ namespace WalletWasabi.Tests
 			keyManager.AssertCleanKeysIndexed();
 			return new TransactionProcessor(
 				keyManager,
-				new ConcurrentHashSet<uint256>(), 
+				new ConcurrentHashSet<uint256>(),
 				new ObservableConcurrentHashSet<SmartCoin>(),
 				Money.Coins(0.0001m));
 		}
@@ -323,10 +323,11 @@ namespace WalletWasabi.Tests
 			var tx = Network.RegTest.CreateTransaction();
 			tx.Version = 1;
 			tx.LockTime = LockTime.Zero;
-			tx.Inputs.Add( GetRandomOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
+			tx.Inputs.Add(GetRandomOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
 			tx.Outputs.Add(amount, scriptPubKey);
 			return new SmartTransaction(tx, isConfirmed ? new Height(9999) : Height.Mempool);
 		}
+
 		private static OutPoint GetRandomOutPoint()
 		{
 			return new OutPoint(RandomUtils.GetUInt256(), 0);

--- a/WalletWasabi.Tests/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/TransactionProcessorTests.cs
@@ -25,7 +25,6 @@ namespace WalletWasabi.Tests
 			Assert.Empty(transactionProcessor.TransactionCache);
 		}
 
-
 		[Fact]
 		public void SpendToLegacyScripts()
 		{
@@ -39,7 +38,6 @@ namespace WalletWasabi.Tests
 			Assert.False(relevant); 
 			Assert.Empty(transactionProcessor.Coins);
 		}
-
 
 		[Fact]
 		public void UnconfirmedTransactionIsNotSegWit()
@@ -55,7 +53,6 @@ namespace WalletWasabi.Tests
 			Assert.Empty(transactionProcessor.Coins);
 			Assert.Empty(transactionProcessor.TransactionCache);
 		}
-
 
 		[Fact]
 		public void ConfirmedTransactionIsNotSegWit()
@@ -73,7 +70,6 @@ namespace WalletWasabi.Tests
 			Assert.Empty(transactionProcessor.TransactionCache);
 			Assert.Empty(transactionProcessor.TransactionHashes);
 		}
-
 
 		[Fact]
 		public void UpdateTransactionHeightAfterConfirmation()
@@ -107,7 +103,6 @@ namespace WalletWasabi.Tests
 			Assert.Empty(transactionProcessor.TransactionHashes);
 		}
 
-
 		[Fact]
 		public void IgnoreDoubleSpend()
 		{
@@ -124,7 +119,7 @@ namespace WalletWasabi.Tests
 			tx = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
 			transactionProcessor.Process(tx);
 
-			// Spend it coin
+			// Spend the same coin again
 			tx = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey);
 			var relevant = transactionProcessor.Process(tx);
 
@@ -134,7 +129,6 @@ namespace WalletWasabi.Tests
 			Assert.Equal(2, transactionProcessor.TransactionCache.Count());
 			Assert.Empty(transactionProcessor.TransactionHashes);
 		}
-
 
 		[Fact]
 		public void ConfirmedDoubleSpend()
@@ -161,7 +155,6 @@ namespace WalletWasabi.Tests
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Confirmed);
 			Assert.Empty(transactionProcessor.TransactionHashes);
 		}
-
 
 		[Fact]
 		public void HandlesRBF()
@@ -192,13 +185,12 @@ namespace WalletWasabi.Tests
 			Assert.Empty(transactionProcessor.TransactionHashes);
 		}
 
-
 		[Fact]
 		public void ReceiveTransactionForWallet()
 		{
 			var transactionProcessor = CreateTransactionProcessor();
 			SmartCoin receivedCoin = null;
-			transactionProcessor.CoinReceived += (s, theCoin)=>receivedCoin = theCoin;
+			transactionProcessor.CoinReceived += (s, theCoin) => receivedCoin = theCoin;
 			var keys = transactionProcessor.KeyManager.GetKeys();
 			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(1.0m));
 
@@ -212,13 +204,12 @@ namespace WalletWasabi.Tests
 			Assert.NotNull(receivedCoin);
 		}
 
-
 		[Fact]
 		public void SpendCoin()
 		{
 			var transactionProcessor = CreateTransactionProcessor();
 			SmartCoin spentCoin = null;
-			transactionProcessor.CoinSpentOrSpenderConfirmed += (s, theCoin)=>spentCoin = theCoin;
+			transactionProcessor.CoinSpentOrSpenderConfirmed += (s, theCoin) => spentCoin = theCoin;
 			var keys = transactionProcessor.KeyManager.GetKeys();
 			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(1.0m));
 			transactionProcessor.Process(tx);
@@ -235,13 +226,12 @@ namespace WalletWasabi.Tests
 			Assert.Equal(coin, spentCoin);
 		}
 
-
 		[Fact]
 		public void ReceiveTransactionWithDustForWallet()
 		{
 			var transactionProcessor = CreateTransactionProcessor();
 			transactionProcessor.CoinReceived += (s, theCoin)
-				=> throw new Exception("The dust coin raised event when it shouldn't");
+				=> throw new Exception("The dust coin raised an event when it shouldn't.");
 			var keys = transactionProcessor.KeyManager.GetKeys();
 			var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(0.000099m));
 
@@ -252,9 +242,8 @@ namespace WalletWasabi.Tests
 			Assert.Empty(transactionProcessor.Coins);
 		}
 
-
 		[Fact]
-		public void ReceiveCoinjoinTransaction()
+		public void ReceiveCoinJoinTransaction()
 		{
 			var transactionProcessor = CreateTransactionProcessor();
 			var keys = transactionProcessor.KeyManager.GetKeys();
@@ -279,9 +268,8 @@ namespace WalletWasabi.Tests
 			Assert.False(coin.IsLikelyCoinJoinOutput);  // It is a coinjoin however we are reveiving but not spending.
 		}
 
-
 		[Fact]
-		public void ReceiveWasabiCoinjoinTransaction()
+		public void ReceiveWasabiCoinJoinTransaction()
 		{
 			var transactionProcessor = CreateTransactionProcessor();
 			var keys = transactionProcessor.KeyManager.GetKeys();
@@ -311,7 +299,6 @@ namespace WalletWasabi.Tests
 			Assert.True(coin.IsLikelyCoinJoinOutput);  // because we are spanding and receiving almost the same amount
 		}
 
-
 		private static TransactionProcessor CreateTransactionProcessor()
 		{
 			var keyManager = KeyManager.CreateNew(out _, "password");
@@ -322,7 +309,6 @@ namespace WalletWasabi.Tests
 				new ObservableConcurrentHashSet<SmartCoin>(),
 				Money.Coins(0.0001m));
 		}
-
 
 		private static SmartTransaction CreateSpendingTransaction(Coin coin, Script scriptPubKey = null, bool isConfirmed = false)
 		{
@@ -341,7 +327,6 @@ namespace WalletWasabi.Tests
 			tx.Outputs.Add(amount, scriptPubKey);
 			return new SmartTransaction(tx, isConfirmed ? new Height(9999) : Height.Mempool);
 		}
-
 		private static OutPoint GetRandomOutPoint()
 		{
 			return new OutPoint(RandomUtils.GetUInt256(), 0);

--- a/WalletWasabi.Tests/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/TransactionProcessorTests.cs
@@ -307,7 +307,8 @@ namespace WalletWasabi.Tests
 				keyManager,
 				new ConcurrentHashSet<uint256>(),
 				new ObservableConcurrentHashSet<SmartCoin>(),
-				Money.Coins(0.0001m));
+				Money.Coins(0.0001m),
+				new ConcurrentHashSet<SmartTransaction>());
 		}
 
 		private static SmartTransaction CreateSpendingTransaction(Coin coin, Script scriptPubKey = null, bool isConfirmed = false)

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using WalletWasabi.KeyManagement;
+using WalletWasabi.Models;
+
+namespace WalletWasabi.Services
+{
+	public class TransactionProcessor
+	{
+		public KeyManager KeyManager { get; }
+		public ConcurrentHashSet<uint256> TransactionHashes { get; }
+		public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
+		public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
+		public Money DustThreshold { get; }
+		public event EventHandler<SmartCoin> CoinSpentOrSpenderConfirmed;
+		public event EventHandler<SmartCoin> CoinReceived; 
+
+		public TransactionProcessor(KeyManager keyManager, 
+			ConcurrentHashSet<uint256> transactionHashes, 
+			ObservableConcurrentHashSet<SmartCoin> coins,
+			Money dustThreshold
+		)
+		{
+			KeyManager = keyManager;
+			TransactionHashes = transactionHashes;
+			TransactionCache = new ConcurrentHashSet<SmartTransaction>();
+			Coins = coins;
+			DustThreshold = dustThreshold;
+		}
+
+		public bool Process(SmartTransaction tx)
+		{
+			uint256 txId = tx.GetHash();
+			var walletRelevant = false;
+
+			bool justUpdate = false;
+			if (tx.Confirmed)
+			{
+				TransactionHashes.TryRemove(txId); // If we have in mempool, remove.
+				if (!tx.Transaction.PossiblyP2WPKHInvolved())
+				{
+					return false; // We do not care about non-witness transactions for other than mempool cleanup.
+				}
+
+				bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
+				if (isFoundTx)
+				{
+					SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
+					if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
+					{
+						foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
+						walletRelevant = true;
+						justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
+					}
+				}
+			}
+			else if (!tx.Transaction.PossiblyP2WPKHInvolved())
+			{
+				return false; // We do not care about non-witness transactions for other than mempool cleanup.
+			}
+
+			if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
+			{
+				var doubleSpends = new List<SmartCoin>();
+				foreach (SmartCoin coin in Coins)
+				{
+					var spent = false;
+					foreach (TxoRef spentOutput in coin.SpentOutputs)
+					{
+						foreach (TxIn txIn in tx.Transaction.Inputs)
+						{
+							if (spentOutput.TransactionId == txIn.PrevOut.Hash && spentOutput.Index == txIn.PrevOut.N) // Do not do (spentOutput == txIn.PrevOut), it's faster this way, because it won't check for null.
+							{
+								doubleSpends.Add(coin);
+								spent = true;
+								walletRelevant = true;
+								break;
+							}
+						}
+						if (spent)
+						{
+							break;
+						}
+					}
+				}
+
+				if (doubleSpends.Any())
+				{
+					if (tx.Height == Height.Mempool)
+					{
+						// if the received transaction is spending at least one input already
+						// spent by a previous unconfirmed transaction signaling RBF then it is not a double
+						// spanding transaction but a replacement transaction.
+						if (doubleSpends.Any(x => x.IsReplaceable))
+						{
+							// remove double spent coins (if other coin spends it, remove that too and so on)
+							// will add later if they came to our keys
+							foreach (SmartCoin doubleSpentCoin in doubleSpends.Where(x => !x.Confirmed))
+							{
+								Coins.TryRemove(doubleSpentCoin);
+							}
+							tx.SetReplacement();
+							walletRelevant = true;
+						}
+						else
+						{
+							return false;
+						}
+					}
+					else // new confirmation always enjoys priority
+					{
+						// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
+						foreach (SmartCoin doubleSpentCoin in doubleSpends)
+						{
+							Coins.TryRemove(doubleSpentCoin);
+						}
+						walletRelevant = true;
+					}
+				}
+			}
+
+			var isLikelyCoinJoinOutput = false;
+			bool hasEqualOutputs = tx.Transaction.GetIndistinguishableOutputs(includeSingle: false).FirstOrDefault() != default;
+			if (hasEqualOutputs)
+			{
+				var receiveKeys = KeyManager.GetKeys(x => tx.Transaction.Outputs.Any(y => y.ScriptPubKey == x.P2wpkhScript));
+				bool allReceivedInternal = receiveKeys.All(x => x.IsInternal);
+				if (allReceivedInternal)
+				{
+					// It is likely a coinjoin if the diff between receive and sent amount is small and have at least 2 equal outputs.
+					Money spentAmount = Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).Sum(x => x.Amount);
+					Money receivedAmount = tx.Transaction.Outputs.Where(x => receiveKeys.Any(y => y.P2wpkhScript == x.ScriptPubKey)).Sum(x => x.Value);
+					bool receivedAlmostAsMuchAsSpent = spentAmount.Almost(receivedAmount, Money.Coins(0.005m));
+
+					if (receivedAlmostAsMuchAsSpent)
+					{
+						isLikelyCoinJoinOutput = true;
+					}
+				}
+			}
+
+			List<SmartCoin> spentOwnCoins = null;
+			for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
+			{
+				// If transaction received to any of the wallet keys:
+				var output = tx.Transaction.Outputs[i];
+				HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
+				if (foundKey != default)
+				{
+					walletRelevant = true;
+
+					if (output.Value <= DustThreshold)
+					{
+						continue;
+					}
+
+					foundKey.SetKeyState(KeyState.Used, KeyManager);
+					spentOwnCoins = spentOwnCoins ?? Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
+					var anonset = tx.Transaction.GetAnonymitySet(i);
+					if (spentOwnCoins.Count != 0)
+					{
+						anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
+					}
+
+					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, isLikelyCoinJoinOutput, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
+																																																												   // If we did not have it.
+					if (Coins.TryAdd(newCoin))
+					{
+						TransactionCache.TryAdd(tx);
+						CoinReceived?.Invoke(this, newCoin);
+						
+						// Make sure there's always 21 clean keys generated and indexed.
+						KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
+
+						if (foundKey.IsInternal)
+						{
+							// Make sure there's always 14 internal locked keys generated and indexed.
+							KeyManager.AssertLockedInternalKeysIndexed(14);
+						}
+					}
+					else // If we had this coin already.
+					{
+						if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
+						{
+							SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
+							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
+							{
+								oldCoin.Height = newCoin.Height;
+							}
+						}
+					}
+				}
+			}
+
+			// If spends any of our coin
+			for (var i = 0; i < tx.Transaction.Inputs.Count; i++)
+			{
+				var input = tx.Transaction.Inputs[i];
+
+				var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
+				if (foundCoin != null)
+				{
+					walletRelevant = true;
+					foundCoin.SpenderTransactionId = txId;
+					TransactionCache.TryAdd(tx);
+					CoinSpentOrSpenderConfirmed?.Invoke(this, foundCoin);
+				}
+			}
+
+			return walletRelevant;
+		}
+	}
+}

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
+using WalletWasabi.Helpers;
 using WalletWasabi.KeyManagement;
 using WalletWasabi.Models;
 
@@ -9,9 +10,11 @@ namespace WalletWasabi.Services
 {
 	public class TransactionProcessor
 	{
+		private ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
+
 		public KeyManager KeyManager { get; }
 		public ConcurrentHashSet<uint256> TransactionHashes { get; }
-		public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
+
 		public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
 		public Money DustThreshold { get; }
 
@@ -24,14 +27,14 @@ namespace WalletWasabi.Services
 		public TransactionProcessor(KeyManager keyManager,
 			ConcurrentHashSet<uint256> transactionHashes,
 			ObservableConcurrentHashSet<SmartCoin> coins,
-			Money dustThreshold
-		)
+			Money dustThreshold,
+			ConcurrentHashSet<SmartTransaction> transactionCache)
 		{
-			KeyManager = keyManager;
-			TransactionHashes = transactionHashes;
-			TransactionCache = new ConcurrentHashSet<SmartTransaction>();
-			Coins = coins;
-			DustThreshold = dustThreshold;
+			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+			TransactionHashes = Guard.NotNull(nameof(transactionHashes), transactionHashes);
+			Coins = Guard.NotNull(nameof(coins), coins);
+			DustThreshold = Guard.NotNull(nameof(dustThreshold), dustThreshold);
+			TransactionCache = Guard.NotNull(nameof(transactionCache), transactionCache);
 		}
 
 		public bool Process(SmartTransaction tx)

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -10,7 +10,7 @@ namespace WalletWasabi.Services
 {
 	public class TransactionProcessor
 	{
-		private ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
+		public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
 
 		public KeyManager KeyManager { get; }
 		public ConcurrentHashSet<uint256> TransactionHashes { get; }

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -120,7 +120,7 @@ namespace WalletWasabi.Services
 
 			TransactionProcessor = new TransactionProcessor(KeyManager, Mempool.TransactionHashes, Coins, ServiceConfiguration.DustThreshold, TransactionCache);
 			TransactionProcessor.CoinSpent += TransactionProcessor_CoinSpent;
-			TransactionProcessor.CoinReceived += OnNewCoinFoundAsync;
+			TransactionProcessor.CoinReceived += TransactionProcessor_CoinReceivedAsync;
 
 			if (Directory.Exists(BlocksFolderPath))
 			{
@@ -165,7 +165,7 @@ namespace WalletWasabi.Services
 			ChaumianClient.ExposedLinks.TryRemove(spentCoin.GetTxoRef(), out _);
 		}
 
-		private async void OnNewCoinFoundAsync(object sender, SmartCoin newCoin)
+		private async void TransactionProcessor_CoinReceivedAsync(object sender, SmartCoin newCoin)
 		{
 			// If it's being mixed and anonset is not sufficient, then queue it.
 			if (newCoin.Unspent && ChaumianClient.HasIngredients
@@ -197,7 +197,7 @@ namespace WalletWasabi.Services
 				}
 
 				Mempool.TransactionHashes.TryRemove(toRemove.TransactionId);
-				var txToRemove = TransactionCache.FirstOrDefault(x => x.GetHash() == toRemove.TransactionId);
+				var txToRemove = TryGetTxFromCache(toRemove.TransactionId);
 				if (txToRemove != default(SmartTransaction))
 				{
 					TransactionCache.TryRemove(txToRemove);
@@ -1539,7 +1539,7 @@ namespace WalletWasabi.Services
 			Mempool.TransactionReceived -= Mempool_TransactionReceivedAsync;
 			Coins.CollectionChanged -= Coins_CollectionChanged;
 			TransactionProcessor.CoinSpent -= TransactionProcessor_CoinSpent;
-			TransactionProcessor.CoinReceived -= OnNewCoinFoundAsync;
+			TransactionProcessor.CoinReceived -= TransactionProcessor_CoinReceivedAsync;
 
 			DisconnectDisposeNullLocalBitcoinCoreNode();
 		}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -181,7 +181,7 @@ namespace WalletWasabi.Services
 
 		private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
-			if(e.Action == NotifyCollectionChangedAction.Remove)
+			if (e.Action == NotifyCollectionChangedAction.Remove)
 			{
 				var toRemove = e.OldItems[0] as SmartCoin;
 				if (toRemove.SpenderTransactionId != null)
@@ -194,7 +194,7 @@ namespace WalletWasabi.Services
 				
 				Mempool.TransactionHashes.TryRemove(toRemove.TransactionId);
 				var txToRemove = TransactionProcessor.TransactionCache.FirstOrDefault(x=>x.GetHash() == toRemove.TransactionId);
-				if( txToRemove != default(SmartTransaction))
+				if (txToRemove != default(SmartTransaction))
 				{
 					TransactionProcessor.TransactionCache.TryRemove(txToRemove);
 				}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -1538,6 +1538,8 @@ namespace WalletWasabi.Services
 			BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
 			Mempool.TransactionReceived -= Mempool_TransactionReceivedAsync;
 			Coins.CollectionChanged -= Coins_CollectionChanged;
+			TransactionProcessor.CoinSpent -= TransactionProcessor_CoinSpent;
+			TransactionProcessor.CoinReceived -= OnNewCoinFoundAsync;
 
 			DisconnectDisposeNullLocalBitcoinCoreNode();
 		}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -183,7 +183,7 @@ namespace WalletWasabi.Services
 			}
 		}
 
-		private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		private void Coins_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.Action == NotifyCollectionChangedAction.Remove)
 			{

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -57,7 +57,6 @@ namespace WalletWasabi.Services
 		public WasabiSynchronizer Synchronizer { get; }
 		public CcjClient ChaumianClient { get; }
 		public MempoolService Mempool { get; }
-
 		public NodesGroup Nodes { get; }
 		public string BlocksFolderPath { get; }
 		public string TransactionsFolderPath { get; }
@@ -75,15 +74,13 @@ namespace WalletWasabi.Services
 
 		public ObservableConcurrentHashSet<SmartCoin> Coins { get; }
 
-		public ConcurrentHashSet<SmartTransaction> TransactionCache { get; }
-
 		public event EventHandler<FilterModel> NewFilterProcessed;
-
-		public event EventHandler<SmartCoin> CoinSpentOrSpenderConfirmed;
 
 		public event EventHandler<Block> NewBlockProcessed;
 
 		public Network Network => Synchronizer.Network;
+
+		public TransactionProcessor TransactionProcessor { get; }
 
 		public WalletService(
 			BitcoinStore bitcoinStore,
@@ -107,7 +104,6 @@ namespace WalletWasabi.Services
 			HandleFiltersLock = new AsyncLock();
 
 			Coins = new ObservableConcurrentHashSet<SmartCoin>();
-			TransactionCache = new ConcurrentHashSet<SmartTransaction>();
 
 			BlocksFolderPath = Path.Combine(workFolderDir, "Blocks", Network.ToString());
 			TransactionsFolderPath = Path.Combine(workFolderDir, "Transactions", Network.ToString());
@@ -117,6 +113,10 @@ namespace WalletWasabi.Services
 
 			KeyManager.AssertCleanKeysIndexed();
 			KeyManager.AssertLockedInternalKeysIndexed(14);
+
+			TransactionProcessor = new TransactionProcessor(KeyManager, Mempool.TransactionHashes, Coins, ServiceConfiguration.DustThreshold);
+			TransactionProcessor.CoinSpentOrSpenderConfirmed += OnNewSpendindCoinFound;
+			TransactionProcessor.CoinReceived += OnNewCoinFound;
 
 			if (Directory.Exists(BlocksFolderPath))
 			{
@@ -156,9 +156,32 @@ namespace WalletWasabi.Services
 			Mempool.TransactionReceived += Mempool_TransactionReceivedAsync;
 		}
 
-		private void Coins_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		private void OnNewSpendindCoinFound(object sender, SmartCoin spentCoin)
 		{
-			if (e.Action == NotifyCollectionChangedAction.Remove)
+ 			ChaumianClient.ExposedLinks.TryRemove(spentCoin.GetTxoRef(), out _);
+ 		}
+
+		private async void OnNewCoinFound(object sender, SmartCoin newCoin)
+		{
+			// If it's being mixed and anonset is not sufficient, then queue it.
+			if (newCoin.Unspent && ChaumianClient.HasIngredients 
+				&& newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet 
+				&& ChaumianClient.State.Contains(newCoin.SpentOutputs))
+			{
+					try
+					{
+							await ChaumianClient.QueueCoinsToMixAsync(newCoin);
+					}
+					catch (Exception ex)
+					{
+							Logger.LogError<WalletService>(ex);
+					}
+			}
+		}
+
+		private void Coins_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			if(e.Action == NotifyCollectionChangedAction.Remove)
 			{
 				var toRemove = e.OldItems[0] as SmartCoin;
 				if (toRemove.SpenderTransactionId != null)
@@ -168,13 +191,14 @@ namespace WalletWasabi.Services
 						Coins.TryRemove(toAlsoRemove);
 					}
 				}
+				
 				Mempool.TransactionHashes.TryRemove(toRemove.TransactionId);
-        
-				var txToRemove = TransactionCache.FirstOrDefault(x=>x.GetHash() == toRemove.TransactionId);
-				if (txToRemove != default(SmartTransaction))
+				var txToRemove = TransactionProcessor.TransactionCache.FirstOrDefault(x=>x.GetHash() == toRemove.TransactionId);
+				if( txToRemove != default(SmartTransaction))
 				{
-					TransactionCache.TryRemove(txToRemove);
+					TransactionProcessor.TransactionCache.TryRemove(txToRemove);
 				}
+
 			}
 
 			RefreshCoinHistories();
@@ -540,197 +564,7 @@ namespace WalletWasabi.Services
 
 		private async Task<bool> ProcessTransactionAsync(SmartTransaction tx)
 		{
-			uint256 txId = tx.GetHash();
-			var walletRelevant = false;
-
-			bool justUpdate = false;
-			if (tx.Confirmed)
-			{
-				Mempool.TransactionHashes.TryRemove(txId); // If we have in mempool, remove.
-				if (!tx.Transaction.PossiblyP2WPKHInvolved())
-				{
-					return false; // We do not care about non-witness transactions for other than mempool cleanup.
-				}
-
-				bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
-				if (isFoundTx)
-				{
-					SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
-					if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
-					{
-						foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
-						walletRelevant = true;
-						justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
-					}
-				}
-			}
-			else if (!tx.Transaction.PossiblyP2WPKHInvolved())
-			{
-				return false; // We do not care about non-witness transactions for other than mempool cleanup.
-			}
-
-			if (!justUpdate && !tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
-			{
-				var doubleSpends = new List<SmartCoin>();
-				foreach (SmartCoin coin in Coins)
-				{
-					var spent = false;
-					foreach (TxoRef spentOutput in coin.SpentOutputs)
-					{
-						foreach (TxIn txIn in tx.Transaction.Inputs)
-						{
-							if (spentOutput.TransactionId == txIn.PrevOut.Hash && spentOutput.Index == txIn.PrevOut.N) // Do not do (spentOutput == txIn.PrevOut), it's faster this way, because it won't check for null.
-							{
-								doubleSpends.Add(coin);
-								spent = true;
-								walletRelevant = true;
-								break;
-							}
-						}
-						if (spent)
-						{
-							break;
-						}
-					}
-				}
-
-				if (doubleSpends.Any())
-				{
-					if (tx.Height == Height.Mempool)
-					{
-						// if the received transaction is spending at least one input already
-						// spent by a previous unconfirmed transaction signaling RBF then it is not a double
-						// spanding transaction but a replacement transaction.
-						if (doubleSpends.Any(x => x.IsReplaceable))
-						{
-							// remove double spent coins (if other coin spends it, remove that too and so on)
-							// will add later if they came to our keys
-							foreach (SmartCoin doubleSpentCoin in doubleSpends.Where(x => !x.Confirmed))
-							{
-								Coins.TryRemove(doubleSpentCoin);
-							}
-							tx.SetReplacement();
-							walletRelevant = true;
-						}
-						else
-						{
-							return false;
-						}
-					}
-					else // new confirmation always enjoys priority
-					{
-						// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
-						foreach (SmartCoin doubleSpentCoin in doubleSpends)
-						{
-							Coins.TryRemove(doubleSpentCoin);
-						}
-						walletRelevant = true;
-					}
-				}
-			}
-
-			var isLikelyCoinJoinOutput = false;
-			bool hasEqualOutputs = tx.Transaction.GetIndistinguishableOutputs(includeSingle: false).FirstOrDefault() != default;
-			if (hasEqualOutputs)
-			{
-				var receiveKeys = KeyManager.GetKeys(x => tx.Transaction.Outputs.Any(y => y.ScriptPubKey == x.P2wpkhScript));
-				bool allReceivedInternal = receiveKeys.All(x => x.IsInternal);
-				if (allReceivedInternal)
-				{
-					// It is likely a coinjoin if the diff between receive and sent amount is small and have at least 2 equal outputs.
-					Money spentAmount = Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).Sum(x => x.Amount);
-					Money receivedAmount = tx.Transaction.Outputs.Where(x => receiveKeys.Any(y => y.P2wpkhScript == x.ScriptPubKey)).Sum(x => x.Value);
-					bool receivedAlmostAsMuchAsSpent = spentAmount.Almost(receivedAmount, Money.Coins(0.005m));
-
-					if (receivedAlmostAsMuchAsSpent)
-					{
-						isLikelyCoinJoinOutput = true;
-					}
-				}
-			}
-
-			List<SmartCoin> spentOwnCoins = null;
-			for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
-			{
-				// If transaction received to any of the wallet keys:
-				var output = tx.Transaction.Outputs[i];
-				HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
-				if (foundKey != default)
-				{
-					walletRelevant = true;
-
-					foundKey.SetKeyState(KeyState.Used, KeyManager);
-					if (output.Value <= ServiceConfiguration.DustThreshold)
-					{
-						continue;
-					}
-
-					spentOwnCoins = spentOwnCoins ?? Coins.Where(x => tx.Transaction.Inputs.Any(y => y.PrevOut.Hash == x.TransactionId && y.PrevOut.N == x.Index)).ToList();
-					var anonset = tx.Transaction.GetAnonymitySet(i);
-					if (spentOwnCoins.Count != 0)
-					{
-						anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
-					}
-
-					SmartCoin newCoin = new SmartCoin(txId, i, output.ScriptPubKey, output.Value, tx.Transaction.Inputs.ToTxoRefs().ToArray(), tx.Height, tx.IsRBF, anonset, isLikelyCoinJoinOutput, foundKey.Label, spenderTransactionId: null, false, pubKey: foundKey); // Do not inherit locked status from key, that's different.
-
-					if (Coins.TryAdd(newCoin))
-					{
-						TransactionCache.TryAdd(tx);
-
-						// If it's being mixed and anonset is not sufficient, then queue it.
-						if (newCoin.Unspent && ChaumianClient.HasIngredients && newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet && newCoin.IsLikelyCoinJoinOutput && ChaumianClient.State.Contains(newCoin.SpentOutputs))
-						{
-							try
-							{
-								await ChaumianClient.QueueCoinsToMixAsync(newCoin);
-							}
-							catch (Exception ex)
-							{
-								Logger.LogError<WalletService>(ex);
-							}
-						}
-
-						// Make sure there's always 21 clean keys generated and indexed.
-						KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
-
-						if (foundKey.IsInternal)
-						{
-							// Make sure there's always 14 internal locked keys generated and indexed.
-							KeyManager.AssertLockedInternalKeysIndexed(14);
-						}
-					}
-					else // If we had this coin already.
-					{
-						if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
-						{
-							SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
-							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
-							{
-								oldCoin.Height = newCoin.Height;
-							}
-						}
-					}
-				}
-			}
-
-			// If spends any of our coin
-			for (var i = 0; i < tx.Transaction.Inputs.Count; i++)
-			{
-				var input = tx.Transaction.Inputs[i];
-
-				var foundCoin = Coins.FirstOrDefault(x => x.TransactionId == input.PrevOut.Hash && x.Index == input.PrevOut.N);
-				if (foundCoin != null)
-				{
-					walletRelevant = true;
-					ChaumianClient.ExposedLinks.TryRemove(foundCoin.GetTxoRef(), out _);
-					foundCoin.SpenderTransactionId = txId;
-					TransactionCache.TryAdd(tx);
-					CoinSpentOrSpenderConfirmed?.Invoke(this, foundCoin);
-				}
-			}
-
-			return walletRelevant;
+			return await Task.FromResult(TransactionProcessor.Process(tx));
 		}
 
 		private Node _localBitcoinCoreNode = null;
@@ -1635,7 +1469,7 @@ namespace WalletWasabi.Services
 			}
 
 			IoHelpers.EnsureContainingDirectoryExists(TransactionsFilePath);
-			string jsonString = JsonConvert.SerializeObject(TransactionCache.OrderByBlockchain(), Formatting.Indented);
+			string jsonString = JsonConvert.SerializeObject(TransactionProcessor.TransactionCache.OrderByBlockchain(), Formatting.Indented);
 			File.WriteAllText(TransactionsFilePath,
 				jsonString,
 				Encoding.UTF8);

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests | NBitcoinTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests | NBitcoinTests | TransactionProcessorTests"

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests| NBitcoinTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests| NBitcoinTests | TransactionProcessorTests"

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -18,4 +18,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests| NBitcoinTests"
+      arguments: --configuration $(testConfiguration) --filter "CryptoTests | ExtPubKeyExplorerTests | KeyManagementTests | ModelTests | StoreTests | ParserTests| NBitcoinTests | TransactionProcessorTests"


### PR DESCRIPTION
Move the transaction processing code from `WalletService` to a new testeable `TransactionProcessor` class and creates tests for each scenario. This is important because this piece of code is `complex` and has been modified many times in the past to improve performance, add support for RBF, check for transaction relevance, detect coinjoins, fix TransactionCache status and other small changes and fixes; and it is also a `critical` in the sense that a bug here can have big consecuences. That's why IMO we need unit tests here.

 

