### PR TITLE
Check if coin is still banned when updating status

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -190,6 +190,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private SmartCoinStatus GetSmartCoinStatus()
 		{
+			Model.SetIsBanned(); // Recheck if the coin's ban has expired.
 			if (Model.IsBanned)
 			{
 				return SmartCoinStatus.MixingBanned;

--- a/WalletWasabi/Models/SmartCoin.cs
+++ b/WalletWasabi/Models/SmartCoin.cs
@@ -286,7 +286,7 @@ namespace WalletWasabi.Models
 			Unspent = SpenderTransactionId is null;
 		}
 
-		private void SetIsBanned()
+		public void SetIsBanned()
 		{
 			IsBanned = BannedUntilUtc != null && BannedUntilUtc > DateTimeOffset.UtcNow;
 		}


### PR DESCRIPTION
Currently we never update the coin's status to check if the ban has elapsed.  This PR will recheck it every time `GetSmartCoinStatus()`, which should be called at least every block because it is called when a coin receives a confirmation.