### PR TITLE
Validate transaction before adding to mempool

### DIFF
--- a/WalletWasabi/Services/MempoolBehavior.cs
+++ b/WalletWasabi/Services/MempoolBehavior.cs
@@ -150,7 +150,10 @@ namespace WalletWasabi.Services
 		private void ProcessTx(TxPayload payload)
 		{
 			Transaction transaction = payload.Object;
-			MempoolService.OnTransactionReceived(new SmartTransaction(transaction, Height.Mempool));
+			if (transaction.Check() == TransactionCheckResult.Success)
+			{
+				MempoolService.OnTransactionReceived(new SmartTransaction(transaction, Height.Mempool));
+			}
 		}
 
 		public override object Clone()


### PR DESCRIPTION
We verify blocks and their subsequent transactions but never transactions entering our mempool