### PR TITLE
Xaml fixes

### DIFF
--- a/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
@@ -8,7 +8,7 @@ using System.Reactive.Linq;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class BindSelectedTextBehavior : Behavior<TextBox>
+	public class BindSelectedTextBehavior : Behavior<TextBox>
 	{
 		private CompositeDisposable Disposables { get; } = new CompositeDisposable();
 

--- a/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Gui.Behaviors
 	{
 		private CompositeDisposable Disposables { get; } = new CompositeDisposable();
 
-		private static readonly AvaloniaProperty<string> SelectedTextProperty =
+		public static readonly AvaloniaProperty<string> SelectedTextProperty =
 			AvaloniaProperty.Register<BindSelectedTextBehavior, string>(nameof(SelectedText), defaultBindingMode: BindingMode.TwoWay);
 
 		public string SelectedText

--- a/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
@@ -5,7 +5,7 @@ using System.Reactive.Linq;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class CommandOnFirstVisible : CommandBasedBehavior<InputElement>
+	public class CommandOnFirstVisible : CommandBasedBehavior<InputElement>
 	{
 		private CompositeDisposable Disposables { get; set; }
 

--- a/WalletWasabi.Gui/Behaviors/CommandOnLostFocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnLostFocusBehavior.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class CommandOnLostFocusBehavior : CommandBasedBehavior<Control>
+	public class CommandOnLostFocusBehavior : CommandBasedBehavior<Control>
 	{
 		private CompositeDisposable Disposables { get; set; }
 

--- a/WalletWasabi.Gui/Behaviors/CommandOnPointerEnterLeaveBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnPointerEnterLeaveBehavior.cs
@@ -4,7 +4,7 @@ using System.Reactive.Disposables;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class CommandOnPointerEnterLeaveBehavior : CommandBasedBehavior<Control>
+	public class CommandOnPointerEnterLeaveBehavior : CommandBasedBehavior<Control>
 	{
 		private CompositeDisposable Disposables { get; set; }
 

--- a/WalletWasabi.Gui/Behaviors/FocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/FocusBehavior.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Gui.Behaviors
 	{
 		private CompositeDisposable Disposables { get; } = new CompositeDisposable();
 
-		private static readonly AvaloniaProperty<bool> IsFocusedProperty =
+		public static readonly AvaloniaProperty<bool> IsFocusedProperty =
 			AvaloniaProperty.Register<FocusBehavior, bool>(nameof(IsFocused), defaultBindingMode: BindingMode.TwoWay);
 
 		public bool IsFocused

--- a/WalletWasabi.Gui/Behaviors/FocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/FocusBehavior.cs
@@ -7,7 +7,7 @@ using System.Reactive.Disposables;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class FocusBehavior : Behavior<Control>
+	public class FocusBehavior : Behavior<Control>
 	{
 		private CompositeDisposable Disposables { get; } = new CompositeDisposable();
 

--- a/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PasteAddressOnClickBehavior.cs
@@ -16,7 +16,7 @@ using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class PasteAddressOnClickBehavior : CommandBasedBehavior<TextBox>
+	public class PasteAddressOnClickBehavior : CommandBasedBehavior<TextBox>
 	{
 		private CompositeDisposable Disposables { get; set; }
 		private Global Global { get; }

--- a/WalletWasabi.Gui/Behaviors/SuggestionBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/SuggestionBehavior.cs
@@ -12,11 +12,11 @@ using WalletWasabi.Gui.Tabs.WalletManager;
 
 namespace WalletWasabi.Gui.Behaviors
 {
-	internal class SuggestionBehavior : Behavior<TextBox>
+	public class SuggestionBehavior : Behavior<TextBox>
 	{
 		private CompositeDisposable Disposables { get; set; }
 
-		private static readonly AvaloniaProperty<IEnumerable<SuggestionViewModel>> SuggestionItemsProperty =
+		public static readonly AvaloniaProperty<IEnumerable<SuggestionViewModel>> SuggestionItemsProperty =
 			AvaloniaProperty.Register<SuggestionBehavior, IEnumerable<SuggestionViewModel>>(nameof(SuggestionItems), defaultBindingMode: BindingMode.TwoWay);
 
 		public IEnumerable<SuggestionViewModel> SuggestionItems

--- a/WalletWasabi.Gui/Controls/BusyIndicator.xaml
+++ b/WalletWasabi.Gui/Controls/BusyIndicator.xaml
@@ -1,6 +1,6 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+﻿<Styles xmlns="https://github.com/avaloniaui" 
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"        
         xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="local|BusyIndicator">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />

--- a/WalletWasabi.Gui/Controls/EditableTextBlock.xaml
+++ b/WalletWasabi.Gui/Controls/EditableTextBlock.xaml
@@ -1,4 +1,5 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:cont="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="cont|EditableTextBlock">
     <Setter Property="BorderThickness" Value="0" />

--- a/WalletWasabi.Gui/Controls/GroupBox.xaml
+++ b/WalletWasabi.Gui/Controls/GroupBox.xaml
@@ -1,4 +1,4 @@
-﻿<Styles xmlns="https://github.com/avaloniaui" 
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="local|GroupBox">

--- a/WalletWasabi.Gui/Controls/GroupBox.xaml
+++ b/WalletWasabi.Gui/Controls/GroupBox.xaml
@@ -1,6 +1,6 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<Styles xmlns="https://github.com/avaloniaui" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="local|GroupBox">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
     <Setter Property="BorderThickness" Value="1" />

--- a/WalletWasabi.Gui/Controls/LockScreen/LockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/LockScreen.xaml
@@ -1,6 +1,6 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"             
              x:Class="WalletWasabi.Gui.Controls.LockScreen.LockScreen"
              IsHitTestVisible="{Binding IsLocked}">
   <UserControl.DataTemplates>

--- a/WalletWasabi.Gui/Controls/LockScreen/LockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/LockScreen.xaml
@@ -1,6 +1,7 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="WalletWasabi.Gui.Controls.LockScreen.LockScreen"
              IsHitTestVisible="{Binding IsLocked}">
   <UserControl.DataTemplates>
     <DataTemplate DataType="{x:Type lockscreen:PinLockScreenViewModel}">

--- a/WalletWasabi.Gui/Controls/LockScreen/PinLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/PinLockScreen.xaml
@@ -1,7 +1,7 @@
-﻿<lockscreen:PinLockScreen xmlns="https://github.com/avaloniaui"
-                          xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-                          xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
+﻿<lockscreen:PinLockScreen xmlns="https://github.com/avaloniaui" 
                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+                          xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"                          
                           x:Class="WalletWasabi.Gui.Controls.LockScreen.PinLockScreen"
                           IsLocked="{Binding IsLocked}">
   <lockscreen:PinLockScreen.Styles>

--- a/WalletWasabi.Gui/Controls/LockScreen/PinLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/PinLockScreen.xaml
@@ -2,6 +2,7 @@
                           xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
                           xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                          x:Class="WalletWasabi.Gui.Controls.LockScreen.PinLockScreen"
                           IsLocked="{Binding IsLocked}">
   <lockscreen:PinLockScreen.Styles>
     <Style Selector="Grid.Shade">

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
@@ -1,6 +1,7 @@
 ﻿<lockscreen:SlideLockScreen xmlns="https://github.com/avaloniaui"
                             xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                            x:Class="WalletWasabi.Gui.Controls.LockScreen.SlideLockScreen"
                             IsLocked="{Binding IsLocked}"
                             Offset="{Binding Offset}">
   <lockscreen:SlideLockScreen.Clock>

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
@@ -1,6 +1,6 @@
-﻿<lockscreen:SlideLockScreen xmlns="https://github.com/avaloniaui"
-                            xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
+﻿<lockscreen:SlideLockScreen xmlns="https://github.com/avaloniaui" 
                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                            xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"                            
                             x:Class="WalletWasabi.Gui.Controls.LockScreen.SlideLockScreen"
                             IsLocked="{Binding IsLocked}"
                             Offset="{Binding Offset}">

--- a/WalletWasabi.Gui/Controls/ModalDialog.xaml
+++ b/WalletWasabi.Gui/Controls/ModalDialog.xaml
@@ -1,5 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility"
+             x:Class="WalletWasabi.Gui.Controls.ModalDialog">
   <Grid Background="#EF2D2D2D" IsVisible="{Binding IsVisible, FallbackValue=False}">
     <Grid Height="500" Background="{DynamicResource ThemeControlBackgroundBrush}" Margin="10 0">
       <DockPanel LastChildFill="True" Margin="200 0 200 100">

--- a/WalletWasabi.Gui/Controls/ModalDialog.xaml
+++ b/WalletWasabi.Gui/Controls/ModalDialog.xaml
@@ -1,4 +1,4 @@
-<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility"
              x:Class="WalletWasabi.Gui.Controls.ModalDialog">

--- a/WalletWasabi.Gui/Controls/MultiTextBox.xaml
+++ b/WalletWasabi.Gui/Controls/MultiTextBox.xaml
@@ -1,5 +1,5 @@
-﻿<Styles xmlns="https://github.com/avaloniaui" 
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"        
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
         xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
         xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity">

--- a/WalletWasabi.Gui/Controls/MultiTextBox.xaml
+++ b/WalletWasabi.Gui/Controls/MultiTextBox.xaml
@@ -1,5 +1,5 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+﻿<Styles xmlns="https://github.com/avaloniaui" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"        
         xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
         xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
         xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity">

--- a/WalletWasabi.Gui/Controls/NoparaPasswordBox.xaml
+++ b/WalletWasabi.Gui/Controls/NoparaPasswordBox.xaml
@@ -1,5 +1,5 @@
-﻿<Styles xmlns="https://github.com/avaloniaui" 
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"        
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="controls|NoparaPasswordBox">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />

--- a/WalletWasabi.Gui/Controls/NoparaPasswordBox.xaml
+++ b/WalletWasabi.Gui/Controls/NoparaPasswordBox.xaml
@@ -1,5 +1,5 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+﻿<Styles xmlns="https://github.com/avaloniaui" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"        
         xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="controls|NoparaPasswordBox">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />

--- a/WalletWasabi.Gui/Controls/Spinner.xaml
+++ b/WalletWasabi.Gui/Controls/Spinner.xaml
@@ -1,4 +1,6 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="WalletWasabi.Gui.Controls.Spinner">
   <Grid>
     <Grid.Styles>
       <Style Selector="DrawingPresenter">

--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -2,7 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui" Height="25">
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.StatusBar" Height="25">
   <UserControl.Resources>
     <converters:FilterLeftStatusConverter x:Key="FilterLeftStatusConverter" />
     <converters:StatusColorConverter x:Key="StatusColorConverter" />

--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -1,5 +1,5 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui" 
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"             
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"

--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -1,5 +1,5 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"             
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+<UserControl xmlns="https://github.com/avaloniaui" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"             
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
-             xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui">
+             xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.CoinJoinTabView">
   <UserControl.Resources>
     <converters:CoinJoinedVisibilityConverter x:Key="CoinJoinedVisibilityConverter" />
     <converters:MoneyStringConverter x:Key="MoneyStringConverter" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -1,9 +1,10 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"             
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui">
+             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.CoinListView">
   <UserControl.Resources>
     <converters:PrivacyLevelValueConverter x:Key="PrivacyLevelValueConverter" />
     <converters:CoinStatusStringConverter x:Key="CoinStatusStringConverter" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -3,7 +3,8 @@
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.HistoryTabView">
   <i:Interaction.Behaviors>
     <behaviors:ClearPropertyOnLostFocusBehavior TargetProperty="{Binding SelectedTransaction}" />
   </i:Interaction.Behaviors>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/PinPadView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/PinPadView.xaml
@@ -1,9 +1,10 @@
-﻿<UserControl x:Class="WalletWasabi.Gui.Controls.WalletExplorer.PinPadView"
-             xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.PinPadView"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450">
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
     <DockPanel LastChildFill="True">
       <controls:NoparaPasswordBox DockPanel.Dock="Top" Margin="4 0 4 20" Password="{Binding MaskedPin}" Watermark="PIN" UseFloatingWatermark="True"></controls:NoparaPasswordBox>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -4,7 +4,8 @@
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions.Custom"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui" Name="ReceiveTabViewerUserControl">
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.ReceiveTabView">
   <UserControl.Resources>
     <converters:CoinItemExpanderColorConverter x:Key="CoinItemExpanderColorConverter" />
     <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -1,11 +1,12 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"             
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions.Custom"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
-             xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui">
+             xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.SendTabView">
   <UserControl.Resources>
     <converters:AmountForegroundConverter x:Key="AmountForegroundConverter" />
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterView.xaml
@@ -1,5 +1,4 @@
-﻿<UserControl x:Class="WalletWasabi.Gui.Controls.WalletExplorer.TransactionBroadcasterView"
-             xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -8,7 +7,9 @@
              xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions.Custom"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
-             xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui" mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450">
+             xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui" 
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.TransactionBroadcasterView"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450">
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
     <Grid Classes="content">
       <DockPanel LastChildFill="True">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerView.xaml
@@ -1,12 +1,12 @@
-<UserControl x:Class="WalletWasabi.Gui.Controls.WalletExplorer.TransactionViewerView"
-             xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"             
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions.Custom"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              xmlns:local="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.TransactionViewerView"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450">
   <UserControl.Resources>
     <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -1,5 +1,7 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:ViewModels="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui">
+<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ViewModels="clr-namespace:WalletWasabi.Gui.Controls.WalletExplorer;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.WalletExplorerView">
   <Grid>
     <TreeView BorderThickness="0" Items="{Binding Wallets}" SelectedItem="{Binding SelectedItem}">
       <TreeView.Styles>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
@@ -3,7 +3,8 @@
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui">
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Controls.WalletExplorer.WalletInfoView">
   <UserControl.Resources>
     <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
@@ -1,5 +1,8 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui" Design.Width="800" Design.Height="400">
+<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Dialogs.CannotCloseDialogView"
+             Design.Width="800" Design.Height="400">
   <controls:GroupBox Title="Closing Wasabi..." Background="{DynamicResource ThemeControlBackgroundBrush}" TextBlock.FontSize="30" BorderThickness="0" Margin="0 80 0 0">
     <DockPanel LastChildFill="True">
       <StackPanel DockPanel.Dock="Bottom" HorizontalAlignment="Right" TextBlock.FontSize="16" Orientation="Horizontal" Margin="10" Spacing="10">

--- a/WalletWasabi.Gui/Dialogs/GenSocksServFailDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/GenSocksServFailDialogView.xaml
@@ -1,5 +1,7 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui" Design.Width="800" Design.Height="400">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui" Design.Width="800" Design.Height="400"
+             x:Class="WalletWasabi.Gui.Dialogs.GenSocksServFailDialogView">
   <controls:GroupBox Title="Tor: General SOCKS Server Failure" Background="{DynamicResource ThemeControlBackgroundBrush}" TextBlock.FontSize="30" BorderThickness="0" Margin="0 80">
     <Grid Classes="content">
       <Panel Margin="10">

--- a/WalletWasabi.Gui/MainWindow.xaml
+++ b/WalletWasabi.Gui/MainWindow.xaml
@@ -22,8 +22,15 @@
                   RenderOptions.BitmapInterpolationMode="HighQuality"
                   id:DragBehavior.IsEnabled="False" id:DropBehavior.IsEnabled="False">
   <cont:MetroWindow.TitleBarContent>
-    <menu:MainMenuView DataContext="{Binding Shell.MainMenu}" Margin="4 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Stretch" FontSize="13" />
-    
+    <StackPanel Orientation="Horizontal" IsVisible="{Binding !LockScreen.IsLocked}">
+      <menu:MainMenuView DataContext="{Binding Shell.MainMenu}" Margin="4 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Stretch" FontSize="13" />
+      <Button Command="{Binding LockScreenCommand}" Margin="10 0" Background="Transparent" BorderBrush="Transparent">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <DrawingPresenter Height="10" Width="10" Drawing="{StaticResource Lock}" />
+          <TextBlock FontSize="13" Text="Lock Screen" />
+        </StackPanel>
+      </Button>
+    </StackPanel>
   </cont:MetroWindow.TitleBarContent>
   <cont:MetroWindow.Styles>
     <Style Selector="Menu > MenuItem:selected /template/ Border#root">

--- a/WalletWasabi.Gui/MainWindow.xaml
+++ b/WalletWasabi.Gui/MainWindow.xaml
@@ -22,7 +22,7 @@
                   RenderOptions.BitmapInterpolationMode="HighQuality"
                   id:DragBehavior.IsEnabled="False" id:DropBehavior.IsEnabled="False">
   <cont:MetroWindow.TitleBarContent>
-    <StackPanel Orientation="Horizontal" IsVisible="{Binding !$parent[cont|MetroWindow].DataContext.LockScreen.IsLocked}">
+    <StackPanel Orientation="Horizontal" IsVisible="{Binding LockScreen.IsLocked}">
       <menu:MainMenuView DataContext="{Binding Shell.MainMenu}" Margin="4 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Stretch" FontSize="13" />
       <Button Command="{Binding LockScreenCommand}" Margin="10 0" Background="Transparent" BorderBrush="Transparent">
         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/WalletWasabi.Gui/MainWindow.xaml
+++ b/WalletWasabi.Gui/MainWindow.xaml
@@ -22,15 +22,8 @@
                   RenderOptions.BitmapInterpolationMode="HighQuality"
                   id:DragBehavior.IsEnabled="False" id:DropBehavior.IsEnabled="False">
   <cont:MetroWindow.TitleBarContent>
-    <StackPanel Orientation="Horizontal" IsVisible="{Binding LockScreen.IsLocked}">
-      <menu:MainMenuView DataContext="{Binding Shell.MainMenu}" Margin="4 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Stretch" FontSize="13" />
-      <Button Command="{Binding LockScreenCommand}" Margin="10 0" Background="Transparent" BorderBrush="Transparent">
-        <StackPanel Orientation="Horizontal" Spacing="8">
-          <DrawingPresenter Height="10" Width="10" Drawing="{StaticResource Lock}" />
-          <TextBlock FontSize="13" Text="Lock Screen" />
-        </StackPanel>
-      </Button>
-    </StackPanel>
+    <menu:MainMenuView DataContext="{Binding Shell.MainMenu}" Margin="4 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Stretch" FontSize="13" />
+    
   </cont:MetroWindow.TitleBarContent>
   <cont:MetroWindow.Styles>
     <Style Selector="Menu > MenuItem:selected /template/ Border#root">

--- a/WalletWasabi.Gui/ManagedDialogs/ManagedFileChooser.xaml
+++ b/WalletWasabi.Gui/ManagedDialogs/ManagedFileChooser.xaml
@@ -4,7 +4,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dialogs="clr-namespace:WalletWasabi.Gui.ManagedDialogs"
              xmlns:internal="clr-namespace:WalletWasabi.Gui.ManagedDialogs"
-             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui">
+             xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.ManagedDialogs.ManagedFileChooser">
   <UserControl.Resources>
     <converters:FileSizeStringConverter x:Key="FileSizeConverter" />
     <DrawingGroup x:Key="LevelUp">

--- a/WalletWasabi.Gui/ManagedDialogs/ManagedFileDialog.xaml
+++ b/WalletWasabi.Gui/ManagedDialogs/ManagedFileDialog.xaml
@@ -3,6 +3,7 @@
         xmlns:dialogs="clr-namespace:WalletWasabi.Gui.ManagedDialogs"
         xmlns:internal="clr-namespace:WalletWasabi.Gui.ManagedDialogs"
         xmlns:cont="clr-namespace:AvalonStudio.Shell.Controls;assembly=AvalonStudio.Shell"
+        x:Class="WalletWasabi.Gui.ManagedDialogs.ManagedFileDialog"
         Icon="resm:WalletWasabi.Gui.Assets.WasabiLogo256.png?assembly=WalletWasabi.Gui"
         Title="{Binding Title}" Width="1100" Height="500" MinWidth="1100" MinHeight="500"
                       FontFamily="{DynamicResource UiFont}" FontSize="14"

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -4,10 +4,8 @@ using Avalonia.Threading;
 using AvalonStudio.Shell;
 using AvalonStudio.Shell.Extensibility.Platforms;
 using NBitcoin;
-using ReactiveUI;
 using System;
 using System.IO;
-using System.Reactive.Concurrency;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using WalletWasabi.Gui.CommandLine;
@@ -60,9 +58,8 @@ namespace WalletWasabi.Gui
 						{
 							MainWindowViewModel.Instance.Title += $" - {Global.Network}";
 						}
-
 						Dispatcher.UIThread.Post(GC.Collect);
-					});
+					}).StartShellApp<AppBuilder, MainWindow>("Wasabi Wallet", null, () => MainWindowViewModel.Instance);
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -4,8 +4,10 @@ using Avalonia.Threading;
 using AvalonStudio.Shell;
 using AvalonStudio.Shell.Extensibility.Platforms;
 using NBitcoin;
+using ReactiveUI;
 using System;
 using System.IO;
+using System.Reactive.Concurrency;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using WalletWasabi.Gui.CommandLine;
@@ -58,8 +60,9 @@ namespace WalletWasabi.Gui
 						{
 							MainWindowViewModel.Instance.Title += $" - {Global.Network}";
 						}
+
 						Dispatcher.UIThread.Post(GC.Collect);
-					}).StartShellApp<AppBuilder, MainWindow>("Wasabi Wallet", null, () => MainWindowViewModel.Instance);
+					});
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Gui/Styles/Styles.xaml
+++ b/WalletWasabi.Gui/Styles/Styles.xaml
@@ -1,7 +1,7 @@
-<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:dock="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
-        xmlns:shell="clr-namespace:AvalonStudio.Shell.Controls;assembly=AvalonStudio.Shell"
+<Styles xmlns="https://github.com/avaloniaui" 
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dock="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:shell="clr-namespace:AvalonStudio.Shell.Controls;assembly=AvalonStudio.Shell"        
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style>

--- a/WalletWasabi.Gui/Tabs/AboutView.xaml
+++ b/WalletWasabi.Gui/Tabs/AboutView.xaml
@@ -1,5 +1,7 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.AboutView">
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
     <StackPanel>
       <Grid Classes="content" Margin="0 10 0 0">

--- a/WalletWasabi.Gui/Tabs/LegalIssuesView.xaml
+++ b/WalletWasabi.Gui/Tabs/LegalIssuesView.xaml
@@ -1,5 +1,7 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.LegalIssuesView">
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
     <Grid Classes="content" Margin="10">
       <controls:ExtendedTextBox Text="{Binding Text}" Classes="selectableTextBlock" TextWrapping="Wrap" AcceptsReturn="True" />

--- a/WalletWasabi.Gui/Tabs/PrivacyPolicyView.xaml
+++ b/WalletWasabi.Gui/Tabs/PrivacyPolicyView.xaml
@@ -1,5 +1,7 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.PrivacyPolicyView">
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
     <Grid Classes="content" Margin="10">
       <controls:ExtendedTextBox Text="{Binding Text}" Classes="selectableTextBlock" TextWrapping="Wrap" AcceptsReturn="True" />

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -1,5 +1,5 @@
-<UserControl xmlns="https://github.com/avaloniaui" 
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"             
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -1,9 +1,10 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"             
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui">
+             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.SettingsView">
   <UserControl.Resources>
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
     <converters:NetworkStringConverter x:Key="NetworkStringConverter" />

--- a/WalletWasabi.Gui/Tabs/TermsAndConditionsView.xaml
+++ b/WalletWasabi.Gui/Tabs/TermsAndConditionsView.xaml
@@ -1,5 +1,7 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.TermsAndConditionsView">
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
     <Grid Classes="content" Margin="10">
       <controls:ExtendedTextBox Text="{Binding Text}" Classes="selectableTextBlock" TextWrapping="Wrap" AcceptsReturn="True" />

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessView.xaml
@@ -1,5 +1,7 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.WalletManager.GenerateWalletSuccessView">
   <StackPanel Margin="20" Spacing="10">
     <TextBlock Text="Write down these Recovery Words!" FontWeight="Bold" />
     <Border Padding="2" Background="White" HorizontalAlignment="Stretch" Opacity="0.8">

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
@@ -1,5 +1,7 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.WalletManager.GenerateWalletView">
   <StackPanel Margin="10" Spacing="10">
     <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="30">
       <Grid Classes="content">

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletView.xaml
@@ -1,7 +1,9 @@
-<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui">
+             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.WalletManager.LoadWalletView">
   <DockPanel LastChildFill="True">
     <StackPanel DockPanel.Dock="Bottom" Spacing="10">
       <controls:GroupBox IsVisible="{Binding !IsDesktopWallet}" TextBlock.FontSize="30" Padding="30" Margin="20 0">

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletView.xaml
@@ -1,7 +1,9 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui">
+             xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
+             x:Class="WalletWasabi.Gui.Tabs.WalletManager.RecoverWalletView">
   <StackPanel Margin="10" Spacing="10">
     <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="30">
       <Grid Classes="content">

--- a/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerView.xaml
@@ -1,6 +1,8 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
-             xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility">
+             xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility"
+             x:Class="WalletWasabi.Gui.Tabs.WalletManager.WalletManagerView">
   <Grid Classes="content">
     <DockPanel>
       <Grid DockPanel.Dock="Left" Width="200">


### PR DESCRIPTION
Really this PR is about putting in x:Class directives and fixing any bad Xaml that will crash the 0.9 Avalonias Xaml compiler.

x:Class is required so that the xaml compiler can resolve types and properties.

Id like to merge this to prevent a huge mess of merge conflicts when we do the 0.9 update.

It also makes some classes and properties public, these will cause crashes when we update.