### PR TITLE
Sats denomination option

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -45,14 +45,14 @@
             <StackPanel Orientation="Horizontal" Spacing="4">
               <TextBlock Text="Minimum" />
               <TextBlock Foreground="YellowGreen" Text="{Binding RequiredBTC, Converter={StaticResource MoneyStringConverter}}" />
-              <TextBlock Foreground="YellowGreen" Text="BTC" />
+              <TextBlock Foreground="YellowGreen" Text="{Binding AmountUnit}" />
               <TextBlock Text="is required to be queued for CoinJoin." />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="4" IsVisible="{Binding AmountQueued, Converter={StaticResource CoinJoinedVisibilityConverter}}">
               <TextBlock Text="You have queued" />
               <TextBlock Foreground="YellowGreen" IsVisible="{Binding IsLurkingWifeMode, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding AmountQueued, Converter={StaticResource MoneyStringConverter}}" />
               <TextBlock Foreground="YellowGreen" IsVisible="{Binding IsLurkingWifeMode}" Text="{Binding AmountQueued, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
-              <TextBlock Foreground="YellowGreen" Text="BTC" />
+              <TextBlock Foreground="YellowGreen" Text="{Binding AmountUnit}" />
               <TextBlock Text="for CoinJoin." />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="4">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -172,10 +172,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				PeersNeeded = 100;
 			}
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(x =>
+			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode, x => x.SatsDenominated)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(x =>
 			{
 				this.RaisePropertyChanged(nameof(AmountQueued));
+				this.RaisePropertyChanged(nameof(AmountUnit));
 				this.RaisePropertyChanged(nameof(IsLurkingWifeMode));
+				this.RaisePropertyChanged(nameof(RequiredBTC));
 			}).DisposeWith(Disposables);
 
 			Observable.Interval(TimeSpan.FromSeconds(1))
@@ -459,6 +463,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		}
 
 		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+
+		public string AmountUnit => Global.UiConfig.SatsDenominated ? "sats" : "BTC";
 
 		public ReactiveCommand<Unit, Unit> EnqueueCommand { get; }
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -39,7 +39,7 @@
         <TextBlock Text="" Width="0" />
         <TextBlock Text="" Grid.Column="1" />
         <controls:SortingArrow Grid.Column="2" Text="Status" Command="{Binding SortCommand}" SortDirection="{Binding StatusSortDirection}" />
-        <controls:SortingArrow Grid.Column="3" Text="Amount (BTC)" Command="{Binding SortCommand}" SortDirection="{Binding AmountSortDirection}" />
+        <controls:SortingArrow Grid.Column="3" Text="{Binding AmountUnit, StringFormat=Amount (\{0\}), Mode=OneWay}" Command="{Binding SortCommand}" SortDirection="{Binding AmountSortDirection}" />
         <controls:SortingArrow Grid.Column="4" Text="Privacy" Command="{Binding SortCommand}" SortDirection="{Binding PrivacySortDirection}" />
         <controls:SortingArrow Grid.Column="5" Text="Clusters" Command="{Binding SortCommand}" SortDirection="{Binding ClustersSortDirection}" />
       </Grid>
@@ -50,8 +50,8 @@
         <StackPanel Spacing="10" DockPanel.Dock="Bottom" Orientation="Horizontal" IsVisible="{Binding IsAnyCoinSelected}">
           <TextBlock Text="|" />
           <TextBlock Text="Selected Amount:" />
-          <TextBlock Foreground="YellowGreen" Text="{Binding SelectedAmount, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}}" />
-          <TextBlock Text="BTC" />
+          <TextBlock Foreground="YellowGreen" Text="{Binding SelectedAmountStr, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}}" />
+          <TextBlock Text="{Binding AmountUnit}" />
           <TextBlock Text="Merging unmixed coins with mixed ones undoes those mixes." Classes="warningMessage" IsVisible="{Binding LabelExposeCommonOwnershipWarning}" />
         </StackPanel>
       </StackPanel>
@@ -118,7 +118,7 @@
                   <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left" BorderThickness="1" CornerRadius="0,6,6,0">
                     <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
                   </Border>
-                  <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+                  <TextBlock TextAlignment="Right" Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
                   <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent" DataContext="{Binding AnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}" ToolTip.Tip="{Binding ToolTip}">
                     <DrawingPresenter Drawing="{Binding Icon}" Height="16" Width="16" Margin="0 0 25 0" />
                   </Panel>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -97,7 +97,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					this.RaisePropertyChanged(nameof(Confirmations));
 				}).DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
+			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode, x => x.SatsDenominated)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 			{
@@ -157,7 +157,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public Money Amount => Model.Amount;
 
-		public string AmountBtc => Model.Amount.ToString(false, true);
+		public string AmountBtc => Global.UiConfig.SatsDenominated ? Model.Amount.ToFormattedSatsString() : Model.Amount.ToFormattedString();
 
 		public string Label => Model.Label;
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -18,7 +18,7 @@
           <Grid ColumnDefinitions="40, 160, 150, *" Margin="10 0 0 0" DockPanel.Dock="Top">
             <TextBlock Text="" />
             <controls:SortingArrow Grid.Column="1" Command="{Binding SortCommand}" Text="Date" SortDirection="{Binding DateSortDirection}" />
-            <controls:SortingArrow Grid.Column="2" Command="{Binding SortCommand}" Text="Amount (BTC)" SortDirection="{Binding AmountSortDirection}" />
+            <controls:SortingArrow Grid.Column="2" Command="{Binding SortCommand}" Text="{Binding AmountUnit, StringFormat=Amount (\{0\}), Mode=OneWay}" SortDirection="{Binding AmountSortDirection}" />
             <controls:SortingArrow Grid.Column="3" Command="{Binding SortCommand}" Text="Transaction ID" SortDirection="{Binding TransactionSortDirection}" />
           </Grid>
           <controls:BusyIndicator Text="Loading..." IsBusy="{Binding IsFirstLoading}">
@@ -35,7 +35,7 @@
                       <Path HorizontalAlignment="Center" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
                     </Border>
                     <TextBlock Text="{Binding DateTime, ConverterParameter=11, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="1" />
-                    <TextBlock Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="2" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
+                    <TextBlock Margin="0 0 20 0" TextAlignment="Right" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="2" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
                     <TextBlock IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding TransactionId, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="3" />
                     <Grid IsVisible="{Binding ClipboardNotificationVisible}" Grid.Column="3">
                       <Grid Opacity="{Binding ClipboardNotificationOpacity}">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionInfo.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionInfo.cs
@@ -1,3 +1,4 @@
+using NBitcoin;
 using ReactiveUI;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private int _confirmations;
 		private bool _confirmed;
 		private DateTimeOffset _dateTime;
-		private string _amountBtc;
+		private Money _amount;
 		private string _label;
 		private string _transactionId;
 
@@ -32,10 +33,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _confirmed, value);
 		}
 
-		public string AmountBtc
+		public Money Amount
 		{
-			get => _amountBtc;
-			set => this.RaiseAndSetIfChanged(ref _amountBtc, value);
+			get => _amount;
+			set => this.RaiseAndSetIfChanged(ref _amount, value);
 		}
 
 		public string Label

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewModel.cs
@@ -13,11 +13,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 	public class TransactionViewModel : ViewModelBase
 	{
 		private TransactionInfo Model { get; }
+		public Global Global { get; }
+
 		private bool _clipboardNotificationVisible;
 		private double _clipboardNotificationOpacity;
 
-		public TransactionViewModel(TransactionInfo model)
+		public TransactionViewModel(Global global, TransactionInfo model)
 		{
+			Global = global;
 			Model = model;
 			ClipboardNotificationVisible = false;
 			ClipboardNotificationOpacity = 0;
@@ -36,9 +39,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public int Confirmations => Model.Confirmations;
 
-		public string AmountBtc => Model.AmountBtc;
+		public string AmountBtc => Global.UiConfig.SatsDenominated ? Model.Amount.ToFormattedSatsString(fplus: true) : Model.Amount.ToFormattedString(fplus: true);
 
-		public Money Amount => Money.TryParse(Model.AmountBtc, out Money money) ? money : Money.Zero;
+		public Money Amount => Model.Amount;
 
 		public string Label => Model.Label;
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -105,7 +105,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(_ => SetBalance(Name))
 				.DisposeWith(Disposables);
 
-
 			IsExpanded = true;
 		}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -101,10 +101,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(o => SetBalance(Name))
 				.DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(x =>
-			{
-				SetBalance(Name);
-			}).DisposeWith(Disposables);
+			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode, x => x.SatsDenominated)
+				.Subscribe(_ => SetBalance(Name))
+				.DisposeWith(Disposables);
+
 
 			IsExpanded = true;
 		}
@@ -129,8 +129,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private void SetBalance(string walletName)
 		{
 			Money balance = Enumerable.Where(WalletService.Coins, c => c.Unspent && !c.SpentAccordingToBackend).Sum(c => (long?)c.Amount) ?? 0;
+			string balanceStr = Global.UiConfig.SatsDenominated ? balance.ToFormattedSatsString() : balance.ToFormattedString();
+			string unitStr = Global.UiConfig.SatsDenominated ? "sats" : "BTC";
 
-			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode ? "#########" : balance.ToString(false, true))} BTC)";
+			Title = $"{walletName} ({(Global.UiConfig.LurkingWifeMode ? "#########" : balanceStr)} {unitStr})";
 		}
 	}
 }

--- a/WalletWasabi.Gui/Converters/MoneyBrushConverter.cs
+++ b/WalletWasabi.Gui/Converters/MoneyBrushConverter.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.Gui.Converters
 		{
 			if (value is string moneyString)
 			{
-				var money = decimal.Parse(moneyString);
+				var money = decimal.Parse(moneyString.Replace(" ", string.Empty));
 				return money < 0 ? Brushes.IndianRed : Brushes.MediumSeaGreen;
 			}
 			else

--- a/WalletWasabi.Gui/Converters/MoneyStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/MoneyStringConverter.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Data.Converters;
 using NBitcoin;
 using System;
@@ -17,7 +18,9 @@ namespace WalletWasabi.Gui.Converters
 			}
 			else if (value is Money money)
 			{
-				return money.ToString(fplus: false, trimExcessZero: true);
+				var uiConfig = Application.Current.Resources[Global.UiConfigResourceKey] as UiConfig;
+
+				return uiConfig.SatsDenominated ? money.ToFormattedSatsString() : money.ToString(fplus: false, trimExcessZero: true);
 			}
 			else
 			{

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -70,6 +70,10 @@
                   <TextBlock VerticalAlignment="Center">Enable manual fee entry.</TextBlock>
                 </StackPanel>
                 <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
+                  <ToggleButton IsChecked="{Binding SatsDenominated}" Content="{Binding SatsDenominated, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Sats:BTC}" Margin="0 0 10 0" />
+                  <TextBlock VerticalAlignment="Center">Amount denomination.</TextBlock>
+                </StackPanel>
+                <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
                   <ToggleButton IsChecked="{Binding LurkingWifeMode}" Content="{Binding LurkingWifeMode, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" Command="{Binding LurkingWifeModeCommand}" />
                   <TextBlock VerticalAlignment="Center">Lurking Wife Mode, hides sensitive content.</TextBlock>
                 </StackPanel>

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -28,6 +28,7 @@ namespace WalletWasabi.Gui.Tabs
 		private string _bitcoinP2pEndPoint;
 		private bool _autocopy;
 		private bool _customFee;
+		private bool _satsDenominated;
 		private bool _useTor;
 		private bool _isModified;
 		private string _somePrivacyLevel;
@@ -51,6 +52,7 @@ namespace WalletWasabi.Gui.Tabs
 		{
 			Autocopy = Global.UiConfig?.Autocopy is true;
 			CustomFee = Global.UiConfig?.IsCustomFee is true;
+			SatsDenominated = Global.UiConfig?.SatsDenominated is true;
 
 			// Use global config's data as default filler until the real data is filled out by the loading of the config onopen.
 			var globalConfig = Global.Config;
@@ -77,6 +79,10 @@ namespace WalletWasabi.Gui.Tabs
 			this.WhenAnyValue(x => x.CustomFee)
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(x => Global.UiConfig.IsCustomFee = x);
+
+			this.WhenAnyValue(x => x.SatsDenominated)
+				.ObserveOn(RxApp.TaskpoolScheduler)
+				.Subscribe(x => Global.UiConfig.SatsDenominated = x);
 
 			OpenConfigFileCommand = ReactiveCommand.Create(OpenConfigFile);
 
@@ -168,7 +174,7 @@ namespace WalletWasabi.Gui.Tabs
 				.ToProperty(this, x => x.IsPinSet, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LockScreenPinHash, x => x.Autocopy, x => x.IsCustomFee)
+			Global.UiConfig.WhenAnyValue(x => x.LockScreenPinHash, x => x.Autocopy, x => x.IsCustomFee, x => x.SatsDenominated)
 				.Throttle(TimeSpan.FromSeconds(1))
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(async _ => await Global.UiConfig.ToFileAsync())
@@ -222,6 +228,12 @@ namespace WalletWasabi.Gui.Tabs
 		{
 			get => _autocopy;
 			set => this.RaiseAndSetIfChanged(ref _autocopy, value);
+		}
+
+		public bool SatsDenominated
+		{
+			get => _satsDenominated;
+			set => this.RaiseAndSetIfChanged(ref _satsDenominated, value);
 		}
 
 		public bool CustomFee

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -25,6 +25,7 @@ namespace WalletWasabi.Gui
 		private bool _lockScreenActive;
 		private string _lockScreenPinHash;
 		private bool _isCustomFee;
+		private bool _satsDenominated;
 
 		[JsonProperty(PropertyName = "WindowState")]
 		[JsonConverter(typeof(WindowStateAfterStartJsonConverter))]
@@ -56,6 +57,14 @@ namespace WalletWasabi.Gui
 		{
 			get => _isCustomFee;
 			set => RaiseAndSetIfChanged(ref _isCustomFee, value);
+		}
+
+		[DefaultValue(false)]
+		[JsonProperty(PropertyName = "SatsDenominated", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public bool SatsDenominated
+		{
+			get => _satsDenominated;
+			set => RaiseAndSetIfChanged(ref _satsDenominated, value);
 		}
 
 		[DefaultValue(false)]

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -3,6 +3,7 @@ using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -277,6 +278,40 @@ namespace NBitcoin
 		public static Money GetTotalFee(this FeeRate me, int vsize)
 		{
 			return Money.Satoshis(Math.Round(me.SatoshiPerByte * vsize));
+		}
+
+		public static string ToFormattedString(this Money money, bool fplus = false)
+		{
+			if (money is null || money == Money.Zero)
+				return "0.0000 0000";
+
+			string str = "";
+
+			if (fplus)
+			{
+				str += money.Satoshi > 0 ? "+" : "-";
+			}
+
+			str += string.Format(CultureInfo.InvariantCulture, "{0:#,0.0000 0000}", money.Abs().ToUnit(MoneyUnit.BTC)).Replace(',', ' ');
+
+			return str;
+		}
+
+		public static string ToFormattedSatsString(this Money money, bool fplus = false)
+		{
+			if (money is null || money == Money.Zero)
+				return "0";
+
+			string str = "";
+
+			if (fplus)
+			{
+				str += money.Satoshi > 0 ? "+" : "-";
+			}
+
+			str += string.Format(CultureInfo.InvariantCulture, "{0:#,#0}", money.Abs().Satoshi).Replace(',', ' ');
+
+			return str;
 		}
 	}
 }


### PR DESCRIPTION
Closes #2110 

Creates an option to allow viewing all amounts in sats:
![](https://user-images.githubusercontent.com/15256660/62847608-c9519d80-bc9c-11e9-872e-95290970c13b.png)

This also affects the send tab as it will take satoshis for the amount input.

This PR adds to functions to display amounts `ToFormattedString(fplus = false)` and `ToFormattedSatsString(fplus = false)`

`ToFormattedString` will convert a BTC amount as follows:
`2 btc` -> `2.0000 0000 btc`
(🍕) `10,000 btc` -> `10,000.0000 0000 btc`
`0.00203213 btc` -> `0.0020 3212 btc`

`ToFormattedSatString` will convert a BTC amount as follows:
`200,000,000 sats` -> `200 000 000 sats`
`4000 sats` -> `4 000 sats`
`2 sats` -> `2 sats`

This also fixed a super edge case bug for if you are trying to send 10,000,000 BTC or more and don't input a `.` it won't work correctly.
