### PR TITLE
Apply async best practices to Tor library

### DIFF
--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
 
 			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken);
 
-			var requestLine = await RequestLine.CreateNewAsync(startLine);
+			var requestLine = RequestLine.FromString(startLine);
 			var request = new HttpRequestMessage(requestLine.Method, requestLine.URI);
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken);

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
 
 			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken);
 
-			var requestLine = RequestLine.CreateNew(startLine);
+			var requestLine = await RequestLine.CreateNewAsync(startLine);
 			var request = new HttpRequestMessage(requestLine.Method, requestLine.URI);
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken);

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -37,7 +37,7 @@ namespace System.Net.Http
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken);
 
-			var headerSection = HeaderSection.CreateNew(headers);
+			var headerSection = await HeaderSection.CreateNewAsync(headers);
 			var headerStruct = headerSection.ToHttpRequestHeaders();
 
 			HttpMessageHelper.AssertValidHeaders(headerStruct.RequestHeaders, headerStruct.ContentHeaders);

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -30,18 +30,18 @@ namespace System.Net.Http
 			//					CRLF
 			//					[message - body]
 
-			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken);
+			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken).ConfigureAwait(false);
 
 			var requestLine = RequestLine.FromString(startLine);
 			var request = new HttpRequestMessage(requestLine.Method, requestLine.URI);
 
-			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken);
+			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken).ConfigureAwait(false);
 
-			var headerSection = await HeaderSection.CreateNewAsync(headers);
+			var headerSection = await HeaderSection.CreateNewAsync(headers).ConfigureAwait(false);
 			var headerStruct = headerSection.ToHttpRequestHeaders();
 
 			HttpMessageHelper.AssertValidHeaders(headerStruct.RequestHeaders, headerStruct.ContentHeaders);
-			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(requestStream, headerStruct, ctsToken);
+			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(requestStream, headerStruct, ctsToken).ConfigureAwait(false);
 			contentBytes = HttpMessageHelper.HandleGzipCompression(headerStruct.ContentHeaders, contentBytes);
 			request.Content = contentBytes is null ? null : new ByteArrayContent(contentBytes);
 
@@ -95,7 +95,7 @@ namespace System.Net.Http
 					headers += headerSection.ToString(endWithTwoCRLF: false);
 				}
 
-				messageBody = await me.Content.ReadAsStringAsync();
+				messageBody = await me.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}
 
 			return startLine + headers + CRLF + messageBody;
@@ -119,7 +119,7 @@ namespace System.Net.Http
 			}
 
 			var ms = new MemoryStream();
-			await me.Content.CopyToAsync(ms);
+			await me.Content.CopyToAsync(ms).ConfigureAwait(false);
 			ms.Position = 0;
 			var newContent = new StreamContent(ms);
 

--- a/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpRequestMessageExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
 
 			string startLine = await HttpMessageHelper.ReadStartLineAsync(requestStream, ctsToken).ConfigureAwait(false);
 
-			var requestLine = RequestLine.FromString(startLine);
+			var requestLine = RequestLine.Parse(startLine);
 			var request = new HttpRequestMessage(requestLine.Method, requestLine.URI);
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(requestStream, ctsToken).ConfigureAwait(false);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
 
 			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream);
 
-			var statusLine = await StatusLine.CreateNewAsync(startLine);
+			var statusLine = StatusLine.FromString(startLine);
 			var response = new HttpResponseMessage(statusLine.StatusCode);
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -37,7 +37,7 @@ namespace System.Net.Http
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream);
 
-			var headerSection = HeaderSection.CreateNew(headers);
+			var headerSection = await HeaderSection.CreateNewAsync(headers);
 			var headerStruct = headerSection.ToHttpResponseHeaders();
 
 			HttpMessageHelper.AssertValidHeaders(headerStruct.ResponseHeaders, headerStruct.ContentHeaders);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
 
 			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream).ConfigureAwait(false);
 
-			var statusLine = StatusLine.FromString(startLine);
+			var statusLine = StatusLine.Parse(startLine);
 			var response = new HttpResponseMessage(statusLine.StatusCode);
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream).ConfigureAwait(false);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
 
 			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream);
 
-			var statusLine = StatusLine.CreateNew(startLine);
+			var statusLine = await StatusLine.CreateNewAsync(startLine);
 			var response = new HttpResponseMessage(statusLine.StatusCode);
 
 			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream);

--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -30,18 +30,18 @@ namespace System.Net.Http
 			//					CRLF
 			//					[message - body]
 
-			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream);
+			string startLine = await HttpMessageHelper.ReadStartLineAsync(responseStream).ConfigureAwait(false);
 
 			var statusLine = StatusLine.FromString(startLine);
 			var response = new HttpResponseMessage(statusLine.StatusCode);
 
-			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream);
+			string headers = await HttpMessageHelper.ReadHeadersAsync(responseStream).ConfigureAwait(false);
 
 			var headerSection = await HeaderSection.CreateNewAsync(headers);
 			var headerStruct = headerSection.ToHttpResponseHeaders();
 
 			HttpMessageHelper.AssertValidHeaders(headerStruct.ResponseHeaders, headerStruct.ContentHeaders);
-			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(responseStream, headerStruct, requestMethod, statusLine);
+			byte[] contentBytes = await HttpMessageHelper.GetContentBytesAsync(responseStream, headerStruct, requestMethod, statusLine).ConfigureAwait(false);
 			contentBytes = HttpMessageHelper.HandleGzipCompression(headerStruct.ContentHeaders, contentBytes);
 			response.Content = contentBytes is null ? null : new ByteArrayContent(contentBytes);
 
@@ -55,7 +55,7 @@ namespace System.Net.Http
 
 		public static async Task<Stream> ToStreamAsync(this HttpResponseMessage me)
 		{
-			return new MemoryStream(Encoding.UTF8.GetBytes(await me.ToHttpStringAsync()));
+			return new MemoryStream(Encoding.UTF8.GetBytes(await me.ToHttpStringAsync().ConfigureAwait(false)));
 		}
 
 		public static async Task<string> ToHttpStringAsync(this HttpResponseMessage me)
@@ -78,7 +78,7 @@ namespace System.Net.Http
 					headers += headerSection.ToString(endWithTwoCRLF: false);
 				}
 
-				messageBody = await me.Content.ReadAsStringAsync();
+				messageBody = await me.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}
 
 			return startLine + headers + CRLF + messageBody;
@@ -86,7 +86,7 @@ namespace System.Net.Http
 
 		public static async Task ThrowRequestExceptionFromContentAsync(this HttpResponseMessage me)
 		{
-			var error = await me.Content.ReadAsJsonAsync<string>();
+			var error = await me.Content.ReadAsJsonAsync<string>().ConfigureAwait(false);
 			string errorMessage = error is null ? string.Empty : $"\n{error}";
 			throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}");
 		}

--- a/WalletWasabi/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Helpers/HttpMessageHelper.cs
@@ -359,7 +359,7 @@ namespace System.Net.Http
 			// of a chunked message in order to supply metadata that might be
 			// dynamically generated while the message body is sent
 			string trailerHeaders = await ReadHeadersAsync(stream, ctsToken);
-			var trailerHeaderSection = HeaderSection.CreateNew(trailerHeaders);
+			var trailerHeaderSection = await HeaderSection.CreateNewAsync(trailerHeaders);
 			RemoveInvalidTrailers(trailerHeaderSection);
 			if (responseHeaders != null)
 			{

--- a/WalletWasabi/Http/Models/HeaderField.cs
+++ b/WalletWasabi/Http/Models/HeaderField.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Http.Models
 					throw new FormatException($"Wrong {nameof(HeaderField)}: {fieldString}.");
 				}
 
-				var value = await reader.ReadToEndAsync();
+				var value = await reader.ReadToEndAsync().ConfigureAwait(false);
 				value = Guard.Correct(value);
 
 				return new HeaderField(name, value);

--- a/WalletWasabi/Http/Models/HeaderField.cs
+++ b/WalletWasabi/Http/Models/HeaderField.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using static WalletWasabi.Http.Constants;
 
@@ -49,7 +50,7 @@ namespace WalletWasabi.Http.Models
 			return ToString(true);
 		}
 
-		public static HeaderField CreateNew(string fieldString)
+		public static async Task<HeaderField> CreateNewAsync(string fieldString)
 		{
 			fieldString = fieldString.TrimEnd(CRLF, StringComparison.Ordinal);
 
@@ -71,7 +72,7 @@ namespace WalletWasabi.Http.Models
 					throw new FormatException($"Wrong {nameof(HeaderField)}: {fieldString}.");
 				}
 
-				var value = reader.ReadToEnd();
+				var value = await reader.ReadToEndAsync();
 				value = Guard.Correct(value);
 
 				return new HeaderField(name, value);

--- a/WalletWasabi/Http/Models/HeaderSection.cs
+++ b/WalletWasabi/Http/Models/HeaderSection.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using static WalletWasabi.Http.Constants;
 
 namespace WalletWasabi.Http.Models
@@ -32,7 +33,7 @@ namespace WalletWasabi.Http.Models
 			return ToString(false);
 		}
 
-		public static HeaderSection CreateNew(string headersString)
+		public static async Task<HeaderSection> CreateNewAsync(string headersString)
 		{
 			headersString = HeaderField.CorrectObsFolding(headersString);
 
@@ -51,7 +52,7 @@ namespace WalletWasabi.Http.Models
 					{
 						break;
 					}
-					hs.Fields.Add(HeaderField.CreateNew(field));
+					hs.Fields.Add(await HeaderField.CreateNewAsync(field));
 				}
 
 				ValidateAndCorrectHeaders(hs);

--- a/WalletWasabi/Http/Models/HeaderSection.cs
+++ b/WalletWasabi/Http/Models/HeaderSection.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Http.Models
 					{
 						break;
 					}
-					hs.Fields.Add(await HeaderField.CreateNewAsync(field));
+					hs.Fields.Add(await HeaderField.CreateNewAsync(field).ConfigureAwait(false));
 				}
 
 				ValidateAndCorrectHeaders(hs);

--- a/WalletWasabi/Http/Models/RequestLine.cs
+++ b/WalletWasabi/Http/Models/RequestLine.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.Http.Models
 			return $"{Method.Method}{SP}{URI.AbsolutePath}{URI.Query}{SP}{Protocol}{CRLF}";
 		}
 
-		public static RequestLine FromString(string requestLineString)
+		public static RequestLine Parse(string requestLineString)
 		{
 			try
 			{

--- a/WalletWasabi/Http/Models/RequestLine.cs
+++ b/WalletWasabi/Http/Models/RequestLine.cs
@@ -10,10 +10,10 @@ namespace WalletWasabi.Http.Models
 	// request-line   = method SP request-target SP HTTP-version CRLF
 	public class RequestLine : StartLine
 	{
-		public HttpMethod Method { get; private set; }
-		public Uri URI { get; private set; }
+		public HttpMethod Method { get; }
+		public Uri URI { get; }
 
-		public RequestLine(HttpMethod method, Uri uri, HttpProtocol protocol)
+		public RequestLine(HttpMethod method, Uri uri, HttpProtocol protocol) : base(protocol)
 		{
 			Method = method;
 			// https://tools.ietf.org/html/rfc7230#section-2.7.1
@@ -24,16 +24,18 @@ namespace WalletWasabi.Http.Models
 			}
 
 			URI = uri;
-			Protocol = protocol;
-
-			StartLineString = Method.Method + SP + URI.AbsolutePath + URI.Query + SP + Protocol + CRLF;
 		}
 
-		public static async Task<RequestLine> CreateNewAsync(string requestLineString)
+		public override string ToString()
+		{
+			return $"{Method.Method}{SP}{URI.AbsolutePath}{URI.Query}{SP}{Protocol}{CRLF}";
+		}
+
+		public static RequestLine FromString(string requestLineString)
 		{
 			try
 			{
-				var parts = (await GetPartsAsync(requestLineString).ConfigureAwait(false)).ToArray();
+				var parts = GetParts(requestLineString);
 				var methodString = parts[0];
 				var uri = new Uri(parts[1]);
 				var protocolString = parts[2];

--- a/WalletWasabi/Http/Models/RequestLine.cs
+++ b/WalletWasabi/Http/Models/RequestLine.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Http.Models
 		{
 			try
 			{
-				var parts = (await GetPartsAsync(requestLineString)).ToArray();
+				var parts = (await GetPartsAsync(requestLineString).ConfigureAwait(false)).ToArray();
 				var methodString = parts[0];
 				var uri = new Uri(parts[1]);
 				var protocolString = parts[2];

--- a/WalletWasabi/Http/Models/RequestLine.cs
+++ b/WalletWasabi/Http/Models/RequestLine.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using static WalletWasabi.Http.Constants;
 
 namespace WalletWasabi.Http.Models
@@ -27,11 +29,11 @@ namespace WalletWasabi.Http.Models
 			StartLineString = Method.Method + SP + URI.AbsolutePath + URI.Query + SP + Protocol + CRLF;
 		}
 
-		public static RequestLine CreateNew(string requestLineString)
+		public static async Task<RequestLine> CreateNewAsync(string requestLineString)
 		{
 			try
 			{
-				var parts = GetParts(requestLineString);
+				var parts = (await GetPartsAsync(requestLineString)).ToArray();
 				var methodString = parts[0];
 				var uri = new Uri(parts[1]);
 				var protocolString = parts[2];

--- a/WalletWasabi/Http/Models/StartLine.cs
+++ b/WalletWasabi/Http/Models/StartLine.cs
@@ -45,7 +45,7 @@ namespace WalletWasabi.Http.Models
 
 					if (parts.Count == 2)
 					{
-						var rest = await reader.ReadToEndAsync();
+						var rest = await reader.ReadToEndAsync().ConfigureAwait(false);
 
 						// startLineString must end here, the ReadToEnd returns "" if nothing to read instead of null
 						if (rest != "")

--- a/WalletWasabi/Http/Models/StartLine.cs
+++ b/WalletWasabi/Http/Models/StartLine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using static WalletWasabi.Http.Constants;
 
 namespace WalletWasabi.Http.Models
@@ -9,14 +10,13 @@ namespace WalletWasabi.Http.Models
 	{
 		public HttpProtocol Protocol { get; protected set; }
 		public string StartLineString { get; protected set; }
-		public List<string> Parts => GetParts(StartLineString);
 
 		public override string ToString()
 		{
 			return StartLineString;
 		}
 
-		public static List<string> GetParts(string startLineString)
+		public static async Task<IEnumerable<string>> GetPartsAsync(string startLineString)
 		{
 			var trimmed = "";
 			// check if an unexpected crlf in the startlinestring
@@ -45,7 +45,7 @@ namespace WalletWasabi.Http.Models
 
 					if (parts.Count == 2)
 					{
-						var rest = reader.ReadToEnd();
+						var rest = await reader.ReadToEndAsync();
 
 						// startLineString must end here, the ReadToEnd returns "" if nothing to read instead of null
 						if (rest != "")

--- a/WalletWasabi/Http/Models/StartLine.cs
+++ b/WalletWasabi/Http/Models/StartLine.cs
@@ -1,62 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using static WalletWasabi.Http.Constants;
 
 namespace WalletWasabi.Http.Models
 {
 	public abstract class StartLine
 	{
-		public HttpProtocol Protocol { get; protected set; }
-		public string StartLineString { get; protected set; }
+		public HttpProtocol Protocol { get; }
 
-		public override string ToString()
+		protected StartLine(HttpProtocol protocol)
 		{
-			return StartLineString;
+			Protocol = protocol;
 		}
 
-		public static async Task<IEnumerable<string>> GetPartsAsync(string startLineString)
+		public static string[] GetParts(string startLineString)
 		{
-			var trimmed = "";
-			// check if an unexpected crlf in the startlinestring
-			using (var reader = new StringReader(startLineString))
-			{
-				// read to CRLF, if it does not end with that it reads to end, if it does, it removes it
-				trimmed = reader.ReadLine(strictCRLF: true);
-				// startLineString must end here
-				if (reader.Read() != -1)
-				{
-					throw new Exception($"Wrong {startLineString} provided.");
-				}
-			}
-
-			var parts = new List<string>();
-			using (var reader = new StringReader(trimmed))
-			{
-				while (true)
-				{
-					var part = reader.ReadPart(SP.ToCharArray()[0]);
-
-					if (part is null || part == "")
-					{
-						break;
-					}
-
-					if (parts.Count == 2)
-					{
-						var rest = await reader.ReadToEndAsync().ConfigureAwait(false);
-
-						// startLineString must end here, the ReadToEnd returns "" if nothing to read instead of null
-						if (rest != "")
-						{
-							part += SP + rest;
-						}
-					}
-					parts.Add(part);
-				}
-			}
-			return parts;
+			var trimmed = Guard.NotNullOrEmptyOrWhitespace(nameof(startLineString), startLineString, trim: true);
+			return trimmed.Split(SP, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToArray();
 		}
 	}
 }

--- a/WalletWasabi/Http/Models/StatusLine.cs
+++ b/WalletWasabi/Http/Models/StatusLine.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Http.Models
 		{
 			try
 			{
-				var parts = (await GetPartsAsync(statusLineString)).ToArray();
+				var parts = (await GetPartsAsync(statusLineString).ConfigureAwait(false)).ToArray();
 				var protocolString = parts[0];
 				var codeString = parts[1];
 				var reason = parts[2];

--- a/WalletWasabi/Http/Models/StatusLine.cs
+++ b/WalletWasabi/Http/Models/StatusLine.cs
@@ -9,21 +9,23 @@ namespace WalletWasabi.Http.Models
 {
 	public class StatusLine : StartLine
 	{
-		public HttpStatusCode StatusCode { get; private set; }
+		public HttpStatusCode StatusCode { get; }
 
-		public StatusLine(HttpProtocol protocol, HttpStatusCode status)
+		public StatusLine(HttpProtocol protocol, HttpStatusCode status) : base(protocol)
 		{
-			Protocol = protocol;
 			StatusCode = status;
-
-			StartLineString = Protocol + SP + (int)StatusCode + SP + StatusCode.ToReasonString() + CRLF;
 		}
 
-		public static async Task<StatusLine> CreateNewAsync(string statusLineString)
+		public override string ToString()
+		{
+			return $"{Protocol}{SP}{(int)StatusCode}{SP}{StatusCode.ToReasonString()}{CRLF}";
+		}
+
+		public static StatusLine FromString(string statusLineString)
 		{
 			try
 			{
-				var parts = (await GetPartsAsync(statusLineString).ConfigureAwait(false)).ToArray();
+				var parts = GetParts(statusLineString);
 				var protocolString = parts[0];
 				var codeString = parts[1];
 				var reason = parts[2];

--- a/WalletWasabi/Http/Models/StatusLine.cs
+++ b/WalletWasabi/Http/Models/StatusLine.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using WalletWasabi.Logging;
 using static WalletWasabi.Http.Constants;
 
@@ -17,11 +19,11 @@ namespace WalletWasabi.Http.Models
 			StartLineString = Protocol + SP + (int)StatusCode + SP + StatusCode.ToReasonString() + CRLF;
 		}
 
-		public static StatusLine CreateNew(string statusLineString)
+		public static async Task<StatusLine> CreateNewAsync(string statusLineString)
 		{
 			try
 			{
-				var parts = GetParts(statusLineString);
+				var parts = (await GetPartsAsync(statusLineString)).ToArray();
 				var protocolString = parts[0];
 				var codeString = parts[1];
 				var reason = parts[2];

--- a/WalletWasabi/Http/Models/StatusLine.cs
+++ b/WalletWasabi/Http/Models/StatusLine.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Http.Models
 			return $"{Protocol}{SP}{(int)StatusCode}{SP}{StatusCode.ToReasonString()}{CRLF}";
 		}
 
-		public static StatusLine FromString(string statusLineString)
+		public static StatusLine Parse(string statusLineString)
 		{
 			try
 			{

--- a/WalletWasabi/TorSocks5/TorHttpClient.cs
+++ b/WalletWasabi/TorSocks5/TorHttpClient.cs
@@ -88,11 +88,11 @@ namespace WalletWasabi.TorSocks5
 
 			try
 			{
-				using (await AsyncLock.LockAsync(cancel))
+				using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
 				{
 					try
 					{
-						HttpResponseMessage ret = await SendAsync(request);
+						HttpResponseMessage ret = await SendAsync(request).ConfigureAwait(false);
 						TorDoesntWorkSince = null;
 						return ret;
 					}
@@ -106,7 +106,7 @@ namespace WalletWasabi.TorSocks5
 						cancel.ThrowIfCancellationRequested();
 						try
 						{
-							HttpResponseMessage ret2 = await SendAsync(request);
+							HttpResponseMessage ret2 = await SendAsync(request).ConfigureAwait(false);
 							TorDoesntWorkSince = null;
 							return ret2;
 						}
@@ -120,7 +120,7 @@ namespace WalletWasabi.TorSocks5
 
 							try
 							{
-								await Task.Delay(1000, cancel);
+								await Task.Delay(1000, cancel).ConfigureAwait(false);
 							}
 							catch (TaskCanceledException tce)
 							{
@@ -134,7 +134,7 @@ namespace WalletWasabi.TorSocks5
 
 						cancel.ThrowIfCancellationRequested();
 
-						HttpResponseMessage ret3 = await SendAsync(request);
+						HttpResponseMessage ret3 = await SendAsync(request).ConfigureAwait(false);
 						TorDoesntWorkSince = null;
 						return ret3;
 					}
@@ -187,9 +187,9 @@ namespace WalletWasabi.TorSocks5
 			if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
 			{
 				TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
-				await TorSocks5Client.ConnectAsync();
-				await TorSocks5Client.HandshakeAsync(IsolateStream);
-				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port);
+				await TorSocks5Client.ConnectAsync().ConfigureAwait(false);
+				await TorSocks5Client.HandshakeAsync(IsolateStream).ConfigureAwait(false);
+				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port).ConfigureAwait(false);
 
 				Stream stream = TorSocks5Client.TcpClient.GetStream();
 				if (request.RequestUri.Scheme == "https")
@@ -219,7 +219,7 @@ namespace WalletWasabi.TorSocks5
 							host,
 							new X509CertificateCollection(),
 							SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
-							checkCertificateRevocation: true);
+							checkCertificateRevocation: true).ConfigureAwait(false);
 					stream = sslStream;
 				}
 
@@ -249,21 +249,21 @@ namespace WalletWasabi.TorSocks5
 					{
 						if (request.Content.Headers.ContentLength is null)
 						{
-							request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync()).Length;
+							request.Content.Headers.ContentLength = (await request.Content.ReadAsStringAsync().ConfigureAwait(false)).Length;
 						}
 					}
 				}
 			}
 
-			var requestString = await request.ToHttpStringAsync();
+			var requestString = await request.ToHttpStringAsync().ConfigureAwait(false);
 
 			var bytes = Encoding.UTF8.GetBytes(requestString);
 
-			await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length);
-			await TorSocks5Client.Stream.FlushAsync();
+			await TorSocks5Client.Stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+			await TorSocks5Client.Stream.FlushAsync().ConfigureAwait(false);
 			using (var httpResponseMessage = new HttpResponseMessage())
 			{
-				return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method);
+				return await HttpResponseMessageExtensions.CreateNewAsync(TorSocks5Client.Stream, request.Method).ConfigureAwait(false);
 			}
 		}
 

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -199,8 +199,8 @@ namespace WalletWasabi.TorSocks5
 			{
 				try
 				{
-					await client.ConnectAsync();
-					await client.HandshakeAsync();
+					await client.ConnectAsync().ConfigureAwait(false);
+					await client.HandshakeAsync().ConfigureAwait(false);
 				}
 				catch (ConnectionException)
 				{
@@ -221,8 +221,8 @@ namespace WalletWasabi.TorSocks5
 			{
 				try
 				{
-					await client.ConnectAsync();
-					await client.HandshakeAsync();
+					await client.ConnectAsync().ConfigureAwait(false);
+					await client.HandshakeAsync().ConfigureAwait(false);
 				}
 				catch (ConnectionException)
 				{
@@ -280,7 +280,7 @@ namespace WalletWasabi.TorSocks5
 											using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
 											{
 												var message = new HttpRequestMessage(HttpMethod.Get, fallBackTestRequestUri);
-												await client.SendAsync(message, Stop.Token);
+												await client.SendAsync(message, Stop.Token).ConfigureAwait(false);
 											}
 
 											// Check if it changed in the meantime...
@@ -331,7 +331,7 @@ namespace WalletWasabi.TorSocks5
 			Stop?.Cancel();
 			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
 			{
-				await Task.Delay(50);
+				await Task.Delay(50).ConfigureAwait(false);
 			}
 			Stop?.Dispose();
 			Stop = null;

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -88,13 +88,13 @@ namespace WalletWasabi.TorSocks5
 				return;
 			}
 
-			using (await AsyncLock.LockAsync())
+			using (await AsyncLock.LockAsync().ConfigureAwait(false))
 			{
 				string host = TorSocks5EndPoint.GetHostOrDefault();
 				int? port = TorSocks5EndPoint.GetPortOrDefault();
 				try
 				{
-					await TcpClient.ConnectAsync(host, port.Value);
+					await TcpClient.ConnectAsync(host, port.Value).ConfigureAwait(false);
 				}
 				catch (Exception ex) when (IsConnectionRefused(ex))
 				{
@@ -114,7 +114,7 @@ namespace WalletWasabi.TorSocks5
 		/// </summary>
 		internal async Task HandshakeAsync(bool isolateStream = true)
 		{
-			await HandshakeAsync(isolateStream ? RandomString.Generate(21) : "");
+			await HandshakeAsync(isolateStream ? RandomString.Generate(21) : "").ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace WalletWasabi.TorSocks5
 
 			var sendBuffer = new VersionMethodRequest(methods).ToBytes();
 
-			var receiveBuffer = await SendAsync(sendBuffer, 2);
+			var receiveBuffer = await SendAsync(sendBuffer, 2).ConfigureAwait(false);
 
 			var methodSelection = new MethodSelectionResponse();
 			methodSelection.FromBytes(receiveBuffer);
@@ -169,7 +169,7 @@ namespace WalletWasabi.TorSocks5
 				sendBuffer = usernamePasswordRequest.ToBytes();
 
 				Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
-				receiveBuffer = await SendAsync(sendBuffer, 2);
+				receiveBuffer = await SendAsync(sendBuffer, 2).ConfigureAwait(false);
 
 				var userNamePasswordResponse = new UsernamePasswordResponse();
 				userNamePasswordResponse.FromBytes(receiveBuffer);
@@ -193,7 +193,7 @@ namespace WalletWasabi.TorSocks5
 		internal async Task ConnectToDestinationAsync(EndPoint destination, bool isRecursiveCall = false)
 		{
 			Guard.NotNull(nameof(destination), destination);
-			await ConnectToDestinationAsync(destination.GetHostOrDefault(), destination.GetPortOrDefault().Value, isRecursiveCall: isRecursiveCall);
+			await ConnectToDestinationAsync(destination.GetHostOrDefault(), destination.GetPortOrDefault().Value, isRecursiveCall: isRecursiveCall).ConfigureAwait(false);
 		}
 
 		/// <param name="host">IPv4 or domain</param>
@@ -204,11 +204,11 @@ namespace WalletWasabi.TorSocks5
 
 			if (TorSocks5EndPoint is null)
 			{
-				using (await AsyncLock.LockAsync())
+				using (await AsyncLock.LockAsync().ConfigureAwait(false))
 				{
 					TcpClient?.Dispose();
 					TcpClient = IPAddress.TryParse(host, out IPAddress ip) ? new TcpClient(ip.AddressFamily) : new TcpClient();
-					await TcpClient.ConnectAsync(host, port);
+					await TcpClient.ConnectAsync(host, port).ConfigureAwait(false);
 					Stream = TcpClient.GetStream();
 					RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
 				}
@@ -227,7 +227,7 @@ namespace WalletWasabi.TorSocks5
 			var connectionRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
 			var sendBuffer = connectionRequest.ToBytes();
 
-			var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall);
+			var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall).ConfigureAwait(false);
 
 			var connectionResponse = new TorSocks5Response();
 			connectionResponse.FromBytes(receiveBuffer);
@@ -263,7 +263,7 @@ namespace WalletWasabi.TorSocks5
 				// try reconnect, maybe the server came online already
 				try
 				{
-					await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: isRecursiveCall);
+					await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: isRecursiveCall).ConfigureAwait(false);
 				}
 				catch (Exception ex) when (IsConnectionRefused(ex))
 				{
@@ -332,16 +332,16 @@ namespace WalletWasabi.TorSocks5
 			{
 				if (!isRecursiveCall) // Because AssertConnectedAsync would be calling it again.
 				{
-					await AssertConnectedAsync(isRecursiveCall: true);
+					await AssertConnectedAsync(isRecursiveCall: true).ConfigureAwait(false);
 				}
 
-				using (await AsyncLock.LockAsync())
+				using (await AsyncLock.LockAsync().ConfigureAwait(false))
 				{
 					var stream = TcpClient.GetStream();
 
 					// Write data to the stream
-					await stream.WriteAsync(sendBuffer, 0, sendBuffer.Length);
-					await stream.FlushAsync();
+					await stream.WriteAsync(sendBuffer, 0, sendBuffer.Length).ConfigureAwait(false);
+					await stream.FlushAsync().ConfigureAwait(false);
 
 					// If receiveBufferSize is null, zero or negative or bigger than TcpClient.ReceiveBufferSize
 					// then work with TcpClient.ReceiveBufferSize
@@ -353,7 +353,7 @@ namespace WalletWasabi.TorSocks5
 					// Receive the response
 					var receiveBuffer = new byte[actualReceiveBufferSize];
 
-					int receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
+					int receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize).ConfigureAwait(false);
 
 					if (receiveCount <= 0)
 					{
@@ -371,7 +371,7 @@ namespace WalletWasabi.TorSocks5
 					while (stream.DataAvailable)
 					{
 						Array.Clear(receiveBuffer, 0, receiveBuffer.Length);
-						receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize);
+						receiveCount = await stream.ReadAsync(receiveBuffer, 0, actualReceiveBufferSize).ConfigureAwait(false);
 						if (receiveCount <= 0)
 						{
 							throw new ConnectionException($"Not connected to Tor SOCKS5 proxy: {TorSocks5EndPoint}.");
@@ -393,13 +393,13 @@ namespace WalletWasabi.TorSocks5
 					// try reconnect, maybe the server came online already
 					try
 					{
-						await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: true);
+						await ConnectToDestinationAsync(RemoteEndPoint, isRecursiveCall: true).ConfigureAwait(false);
 					}
 					catch (Exception ex2) when (IsConnectionRefused(ex2))
 					{
 						throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.", ex2);
 					}
-					return await SendAsync(sendBuffer, receiveBufferSize, isRecursiveCall: true);
+					return await SendAsync(sendBuffer, receiveBufferSize, isRecursiveCall: true).ConfigureAwait(false);
 				}
 			}
 		}
@@ -417,7 +417,7 @@ namespace WalletWasabi.TorSocks5
 
 			if (TorSocks5EndPoint is null)
 			{
-				var hostAddresses = await Dns.GetHostAddressesAsync(host);
+				var hostAddresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
 				return hostAddresses.First();
 			}
 
@@ -430,7 +430,7 @@ namespace WalletWasabi.TorSocks5
 			var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
 			var sendBuffer = resolveRequest.ToBytes();
 
-			var receiveBuffer = await SendAsync(sendBuffer);
+			var receiveBuffer = await SendAsync(sendBuffer).ConfigureAwait(false);
 
 			var resolveResponse = new TorSocks5Response();
 			resolveResponse.FromBytes(receiveBuffer);
@@ -453,7 +453,7 @@ namespace WalletWasabi.TorSocks5
 
 			if (TorSocks5EndPoint is null) // Only Tor is iPv4 dependent
 			{
-				var host = await Dns.GetHostEntryAsync(iPv4);
+				var host = await Dns.GetHostEntryAsync(iPv4).ConfigureAwait(false);
 				return host.HostName;
 			}
 
@@ -468,7 +468,7 @@ namespace WalletWasabi.TorSocks5
 			var resolveRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
 			var sendBuffer = resolveRequest.ToBytes();
 
-			var receiveBuffer = await SendAsync(sendBuffer);
+			var receiveBuffer = await SendAsync(sendBuffer).ConfigureAwait(false);
 
 			var resolveResponse = new TorSocks5Response();
 			resolveResponse.FromBytes(receiveBuffer);


### PR DESCRIPTION
This PR has 3 changes in 3 commits. They can be merged altogether or cherry-picked separately.  

In commits https://github.com/zkSNACKs/WalletWasabi/commit/0fac56e07299151b77574450fe8a21b49927d18f and https://github.com/zkSNACKs/WalletWasabi/commit/950df84c5876425f9cdd5c9011ee454b19d1dba9 I made sure we use the non-blocking version of `ReadToEnd`, which is `ReadToEndAsync`.  

In commit https://github.com/zkSNACKs/WalletWasabi/commit/6bb7d252ebab34e4d4ef3f5251d57a8c83089bec I made sure the Tor library is consistently using `ConfigureAwait(false)`, since it does not have to synchronize back the context ever. This may result in some performance increase.  

This PR follows the same pattern as the HWI PR does. I'm `ConfigureAwait(false)`-ing there, too: https://github.com/zkSNACKs/WalletWasabi/pull/1905

Since we decided that using `ConfigureAwait(false)` on the library project makes sense, but too risky to do this system wide, it's a reasonable way to do this for subsystems first.