### PR TITLE
Allow entering amounts over 10,000,000 btc

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -144,7 +144,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						}
 					}
 					var dotIndex = betterAmount.IndexOf('.');
-					if (betterAmount.Length - dotIndex > 8) // Enable max 8 decimals.
+					if (dotIndex != -1 && betterAmount.Length - dotIndex > 8) // Enable max 8 decimals.
 					{
 						betterAmount = betterAmount.Substring(0, dotIndex + 1 + 8);
 					}


### PR DESCRIPTION
If you do not have a `.`  in the amount text, then `dotIndex` will be `-1` so the substring will only allow you to have an amount of 9,999,999 (7 digits)

If this edge case every actually happens that person owes me 1 btc 