### PR TITLE
Allow entering spaces with keyboard into Passwordbox

### DIFF
--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -34,6 +34,7 @@ namespace WalletWasabi.Gui.CommandLine
 				string password = null;
 				var count = 3;
 				string compatibilityPassword = null;
+				bool trimmedPassword = false;
 				do
 				{
 					if (password != null)
@@ -61,12 +62,17 @@ namespace WalletWasabi.Gui.CommandLine
 						Console.WriteLine(PasswordHelper.TrimmedMessage);
 					}
 				}
-				while (!PasswordHelper.TryPassword(keyManager, password, out compatibilityPassword));
+				while (!PasswordHelper.TryPassword(keyManager, password, out compatibilityPassword, out trimmedPassword));
 
 				if (compatibilityPassword != null)
 				{
 					password = compatibilityPassword;
 					Logger.LogInfo(PasswordHelper.CompatibilityPasswordWarnMessage);
+				}
+
+				if (trimmedPassword)
+				{
+					Logger.LogInfo(PasswordHelper.TrimmedMessage);
 				}
 
 				Logger.LogInfo("Correct password.");

--- a/WalletWasabi.Gui/Controls/NoparaPasswordBox.cs
+++ b/WalletWasabi.Gui/Controls/NoparaPasswordBox.cs
@@ -393,7 +393,10 @@ namespace WalletWasabi.Gui.Controls
 			}
 			var password = Sb.ToString();
 
-			if (PasswordHelper.IsTrimable(password, out string trimmedPassword))
+            var trimmedPassword = password.TrimStart(); 
+			// Trim only the beginning of the password. Spaces have to be allowed, trailing will be trimmed from outside.
+
+            if (trimmedPassword != password)
 			{
 				password = trimmedPassword;
 				Sb.Clear();

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -240,16 +240,30 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			try
 			{
 				SetWarningMessage("");
-				Password = Guard.Correct(Password);
-
-				if (!selectedCoins.Any())
-				{
-					SetWarningMessage("No coins are selected to enqueue.");
-					return;
-				}
 
 				try
 				{
+					PasswordHelper.GetMasterExtKey(KeyManager, Password, out string compatibilityPasswordUsed, out bool isEndTrimmed); // Test password, throw if wrong.
+
+					if (isEndTrimmed)
+					{
+						PasswordHelper.IsTrimable(Password, out string trimmedPassword);
+						Password = trimmedPassword;
+						SetWarningMessage(PasswordHelper.TrimmedMessage);
+					}
+
+					if (compatibilityPasswordUsed != null)
+					{
+						Password = compatibilityPasswordUsed;
+						SetWarningMessage(PasswordHelper.CompatibilityPasswordWarnMessage);
+					}
+
+					if (!selectedCoins.Any())
+					{
+						SetWarningMessage("No coins are selected to enqueue.");
+						return;
+					}
+
 					await Global.ChaumianClient.QueueCoinsToMixAsync(Password, selectedCoins.Select(c => c.Model).ToArray());
 				}
 				catch (Exception ex)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -58,12 +58,17 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 					else
 					{
-						var secret = PasswordHelper.GetMasterExtKey(KeyManager, Password, out string isCompatibilityPasswordUsed);
+						var secret = PasswordHelper.GetMasterExtKey(KeyManager, Password, out string isCompatibilityPasswordUsed, out bool isEndTrimmed);
 						Password = "";
 
 						if (isCompatibilityPasswordUsed != null)
 						{
 							SetWarningMessage(PasswordHelper.CompatibilityPasswordWarnMessage);
+						}
+
+						if (isEndTrimmed)
+						{
+							SetWarningMessage(PasswordHelper.TrimmedMessage);
 						}
 
 						string master = secret.GetWif(Global.Network).ToWif();

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
@@ -40,7 +40,6 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			}
 
 			string walletFilePath = Path.Combine(Global.WalletsDir, $"{WalletName}.json");
-			Password = Guard.Correct(Password); // Do not let whitespaces to the beginning and to the end.
 
 			if (!TermsAccepted)
 			{
@@ -58,7 +57,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			{
 				try
 				{
-					PasswordHelper.Guard(Password);
+					PasswordHelper.Guard(Password); // Not trying to fix the password, any violation will cause error.
 
 					KeyManager.CreateNew(out Mnemonic mnemonic, Password, walletFilePath);
 

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -445,7 +445,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			{
 				SetValidationMessage("");
 				CanTestPassword = false;
-				var password = Guard.Correct(Password); // Do not let whitespaces to the beginning and to the end.
+				var password = Password; // Create a local copy.
 				Password = ""; // Clear password field.
 
 				var selectedWallet = SelectedWallet;
@@ -592,9 +592,16 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				// Only check requirepassword here, because the above checks are applicable to loadwallet, too and we are using this function from load wallet.
 				if (requirePassword)
 				{
-					if (PasswordHelper.TryPassword(keyManager, password, out string compatibilityPasswordUsed))
+					if (PasswordHelper.TryPassword(keyManager, password, out string compatibilityPasswordUsed, out bool trimmedPassword))
 					{
 						SuccessMessage = "Correct password.";
+
+						if (trimmedPassword)
+						{
+							WarningMessage = PasswordHelper.TrimmedMessage;
+							ValidationMessage = "";
+						}
+
 						if (compatibilityPasswordUsed != null)
 						{
 							WarningMessage = PasswordHelper.CompatibilityPasswordWarnMessage;

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -37,7 +37,12 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			{
 				WalletName = Guard.Correct(WalletName);
 				MnemonicWords = Guard.Correct(MnemonicWords);
-				Password = Guard.Correct(Password); // Do not let whitespaces to the beginning and to the end.
+
+				if (PasswordHelper.IsTrimable(Password, out string trimmedPassword)) // Do not let whitespaces to the beginning and to the end.
+				{
+					Password = trimmedPassword;
+					ValidationMessage = PasswordHelper.TrimmedMessage;
+				}
 
 				string walletFilePath = Path.Combine(Global.WalletsDir, $"{WalletName}.json");
 

--- a/WalletWasabi.Tests/PasswordTests.cs
+++ b/WalletWasabi.Tests/PasswordTests.cs
@@ -43,29 +43,29 @@ namespace WalletWasabi.Tests
 			var keyManager = KeyManager.CreateNew(out _, buggy);
 
 			// Password should be formatted, before entering here.
-			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, original, out _));
+			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, original, out _, out _));
 
 			// This should not throw format exception but pw is not correct.
-			Assert.Throws<SecurityException>(() => PasswordHelper.GetMasterExtKey(keyManager, RandomString.Generate(PasswordHelper.MaxPasswordLength), out _));
+			Assert.Throws<SecurityException>(() => PasswordHelper.GetMasterExtKey(keyManager, RandomString.Generate(PasswordHelper.MaxPasswordLength), out _, out _));
 
 			// Password should be formatted, before entering here.
-			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, RandomString.Generate(PasswordHelper.MaxPasswordLength + 1), out _));
+			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, RandomString.Generate(PasswordHelper.MaxPasswordLength + 1), out _, out _));
 
 			// Too long password with extra spaces.
 			var badPassword = $"   {RandomString.Generate(PasswordHelper.MaxPasswordLength + 1)}   ";
 
 			// Password should be formatted, before entering here.
-			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _));
+			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _, out _));
 
 			Assert.True(PasswordHelper.IsTrimable(badPassword, out badPassword));
 
 			// Still too long.
-			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _));
+			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _, out _));
 
 			Assert.True(PasswordHelper.IsTooLong(badPassword, out badPassword));
 
 			// This should not throw format exception but pw is not correct.
-			Assert.Throws<SecurityException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _));
+			Assert.Throws<SecurityException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _, out _));
 		}
 
 		[Fact]
@@ -83,15 +83,15 @@ namespace WalletWasabi.Tests
 
 			Assert.True(PasswordHelper.IsTrimable(original, out original));
 
-			Assert.False(PasswordHelper.TryPassword(keyManager, "falsepassword", out _));
+			Assert.False(PasswordHelper.TryPassword(keyManager, "falsepassword", out _, out _));
 
 			// This should pass
-			Assert.NotNull(PasswordHelper.GetMasterExtKey(keyManager, original, out _));
+			Assert.NotNull(PasswordHelper.GetMasterExtKey(keyManager, original, out _, out _));
 
-			Assert.True(PasswordHelper.TryPassword(keyManager, buggy, out string compatiblePasswordNotUsed));
+			Assert.True(PasswordHelper.TryPassword(keyManager, buggy, out string compatiblePasswordNotUsed, out _));
 			Assert.Null(compatiblePasswordNotUsed);
 
-			Assert.True(PasswordHelper.TryPassword(keyManager, original, out string compatiblePassword));
+			Assert.True(PasswordHelper.TryPassword(keyManager, original, out string compatiblePassword, out _));
 			Assert.Equal(buggy, compatiblePassword);
 		}
 	}

--- a/WalletWasabi.Tests/PasswordTests.cs
+++ b/WalletWasabi.Tests/PasswordTests.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.Tests
 			string original = "    w¾3AÍ-dCdï×¾M\\Øò¹ãÔÕýÈÝÁÐ9oEp¨}r:SR¦·ßNó±¥*W!¢ê#ikÇå<ðtÇf·a\\]§,à±H7«®È4nèNmæo4.qØ-¾ûda¯ºíö¾,¥¢½\\¹õèKeÁìÍSÈ@r±ØÙ2[r©UQÞ¶xN\"?:Ö@°&\n";
 
 			// Creating a wallet with buggy password.
-			var keyManager = KeyManager.CreateNew(out _, buggy);
+			var keyManager = KeyManager.CreateNew(out _, Guard.Correct(buggy)); // Using the old method -> Guard.Correct.
 
 			// Password should be formatted, before entering here.
 			Assert.Throws<FormatException>(() => PasswordHelper.GetMasterExtKey(keyManager, original, out _, out _));
@@ -66,6 +66,15 @@ namespace WalletWasabi.Tests
 
 			// This should not throw format exception but pw is not correct.
 			Assert.Throws<SecurityException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword, out _, out _));
+
+			// Password with only trailing spaces.
+			var goodButSpaces = "w¾3AÍ-dCdï×¾M\\Øò¹ãÔÕýÈÝÁÐ9oEp¨}r:SR¦·ßNó±¥*W!¢ê#ikÇå<ðtÇf·a\\]§,à±H7«®È4nèNmæo4.qØ-¾ûda¯    ";
+
+			PasswordHelper.GetMasterExtKey(keyManager, goodButSpaces, out _, out bool isTrimmed);
+
+			Assert.True(isTrimmed);
+
+			Assert.True(PasswordHelper.IsTrimable(goodButSpaces, out _));
 		}
 
 		[Fact]

--- a/WalletWasabi/Helpers/PasswordHelper.cs
+++ b/WalletWasabi/Helpers/PasswordHelper.cs
@@ -79,12 +79,13 @@ namespace WalletWasabi.Helpers
 			return false;
 		}
 
-		public static bool TryPassword(KeyManager keyManager, string password, out string compatibilityPasswordUsed)
+		public static bool TryPassword(KeyManager keyManager, string password, out string compatibilityPasswordUsed, out bool isEndTrimmed)
 		{
 			compatibilityPasswordUsed = null;
+			isEndTrimmed = false;
 			try
 			{
-				GetMasterExtKey(keyManager, password, out compatibilityPasswordUsed);
+				GetMasterExtKey(keyManager, password, out compatibilityPasswordUsed, out isEndTrimmed);
 			}
 			catch (Exception)
 			{
@@ -106,8 +107,16 @@ namespace WalletWasabi.Helpers
 			}
 		}
 
-		public static ExtKey GetMasterExtKey(KeyManager keyManager, string password, out string compatiblityPassword)
+		public static ExtKey GetMasterExtKey(KeyManager keyManager, string password, out string compatiblityPassword, out bool isEndTrimmed)
 		{
+			isEndTrimmed = false;
+			var trimmedPassword = password.TrimEnd(); // Trim the end of the password. This can only be done only here as we are letting spaces in password.
+			if (trimmedPassword != password)
+			{
+				isEndTrimmed = true;
+				password = trimmedPassword;
+			}
+
 			Guard(password);
 
 			compatiblityPassword = null;


### PR DESCRIPTION
At the beginning for stability reasons the leading and the trailing spaces were removed from the Password string. Some of the format validation logic moved into the UI control (length, white-spaces), which give the user immediate feedback. For this reason the validation messages of the pwbox are shown inside the UI control so every notification about format problems are appeared there. This is a bad practice IMO, it is not easy neither clean to do any validation or auto-formatting from "outside" unfortunately both are required. 
If there will be notification messages I suggest to move the password related messages there until that we will have this solution to ensure:

- Compatibility
- Auto formatting
- Warn the user if different password was used compared to the entered one
