### PR TITLE
No password check in WatchOnly wallets

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -319,19 +319,22 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.DequeuingSelectedCoins);
 					}
 
-					try
+					if (!KeyManager.IsWatchOnly)
 					{
-						PasswordHelper.GetMasterExtKey(KeyManager, Password, out string compatiblityPasswordUsed); // We could use TryPassword but we need the exception.
-						if (compatiblityPasswordUsed != null)
+						try
 						{
-							isCompatibilityPasswordUsed = true;
-							Password = compatiblityPasswordUsed; // Overwrite the password for BuildTransaction function.
+							PasswordHelper.GetMasterExtKey(KeyManager, Password, out string compatiblityPasswordUsed); // We could use TryPassword but we need the exception.
+							if (compatiblityPasswordUsed != null)
+							{
+								isCompatibilityPasswordUsed = true;
+								Password = compatiblityPasswordUsed; // Overwrite the password for BuildTransaction function.
+							}
 						}
-					}
-					catch (Exception ex)
-					{
-						SetWarningMessage(ex.ToTypeMessageString());
-						return;
+						catch (Exception ex)
+						{
+							SetWarningMessage(ex.ToTypeMessageString());
+							return;
+						}
 					}
 
 					BuildTransactionResult result = await Task.Run(() => Global.WalletService.BuildTransaction(Password, intent, feeStrategy, allowUnconfirmed: true, allowedInputs: selectedCoinReferences));


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/2184
When I added the compatibility/notification functions I also added a Password check before the BuildTx which cannot be done with watch-only wallets.
https://github.com/zkSNACKs/WalletWasabi/commit/d7fde2d8a0b2c0c1dfc58ed7529a16014feacb08#diff-bc431b4bc31acb6d49cd62c6288310e7R321
