### PR TITLE
Simplify logging

### DIFF
--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -172,8 +172,8 @@ namespace WalletWasabi.Backend
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<Config>("Backwards compatibility couldn't be ensured.");
-				Logger.LogInfo<Config>(ex);
+				Logger.LogWarning("Backwards compatibility couldn't be ensured.");
+				Logger.LogInfo(ex);
 				return false;
 			}
 		}

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -227,7 +227,7 @@ namespace WalletWasabi.Backend.Controllers
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug<BlockchainController>(ex);
+				Logger.LogDebug(ex);
 				return BadRequest("Invalid hex.");
 			}
 
@@ -241,7 +241,7 @@ namespace WalletWasabi.Backend.Controllers
 			}
 			catch (RPCException ex)
 			{
-				Logger.LogDebug<BlockchainController>(ex);
+				Logger.LogDebug(ex);
 				return BadRequest(ex.Message);
 			}
 

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -341,7 +341,7 @@ namespace WalletWasabi.Backend.Controllers
 				}
 				catch (Exception ex)
 				{
-					Logger.LogDebug<ChaumianCoinJoinController>(ex);
+					Logger.LogDebug(ex);
 					return BadRequest(ex.Message);
 				}
 			}
@@ -535,7 +535,7 @@ namespace WalletWasabi.Backend.Controllers
 
 			if (request.OutputAddress == Constants.GetCoordinatorAddress(Network))
 			{
-				Logger.LogWarning<ChaumianCoinJoinController>($"Bob is registering the coordinator's address. Address: {request.OutputAddress}, Level: {request.Level}, Signature: {request.UnblindedSignature}.");
+				Logger.LogWarning($"Bob is registering the coordinator's address. Address: {request.OutputAddress}, Level: {request.Level}, Signature: {request.UnblindedSignature}.");
 			}
 
 			if (request.Level > round.MixingLevels.GetMaxLevel())
@@ -747,12 +747,12 @@ namespace WalletWasabi.Backend.Controllers
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug<ChaumianCoinJoinController>(ex);
+				Logger.LogDebug(ex);
 				returnFailureResponse = BadRequest($"Invalid {nameof(uniqueId)} provided.");
 			}
 			if (aliceGuid == Guid.Empty) // Probably not possible
 			{
-				Logger.LogDebug<ChaumianCoinJoinController>($"Empty {nameof(uniqueId)} GID provided in {nameof(GetCoinJoin)} function.");
+				Logger.LogDebug($"Empty {nameof(uniqueId)} GID provided in {nameof(GetCoinJoin)} function.");
 				returnFailureResponse = BadRequest($"Invalid {nameof(uniqueId)} provided.");
 			}
 
@@ -803,12 +803,12 @@ namespace WalletWasabi.Backend.Controllers
 				DateTimeOffset ended = CcjRound.PhaseTimeoutLog.TryGet((roundId, desiredPhase));
 				if (ended != default)
 				{
-					Logger.LogInfo<ChaumianCoinJoinController>($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} {desiredPhase} {(int)(DateTimeOffset.UtcNow - ended).TotalSeconds} seconds late.");
+					Logger.LogInfo($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} {desiredPhase} {(int)(DateTimeOffset.UtcNow - ended).TotalSeconds} seconds late.");
 				}
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug<ChaumianCoinJoinController>(ex);
+				Logger.LogDebug(ex);
 			}
 		}
 

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -61,10 +61,10 @@ namespace WalletWasabi.Backend
 			IndexBuilderService = new IndexBuilderService(RpcClient, TrustedNodeNotifyingBehavior, indexFilePath, utxoSetFilePath);
 			Coordinator = new CcjCoordinator(RpcClient.Network, TrustedNodeNotifyingBehavior, Path.Combine(DataDir, "CcjCoordinator"), RpcClient, roundConfig);
 			IndexBuilderService.Synchronize();
-			Logger.LogInfo<IndexBuilderService>($"{nameof(IndexBuilderService)} is successfully initialized and started synchronization.");
+			Logger.LogInfo($"{nameof(IndexBuilderService)} is successfully initialized and started synchronization.");
 
 			await Coordinator.MakeSureTwoRunningRoundsAsync();
-			Logger.LogInfo<CcjCoordinator>("Chaumian CoinJoin Coordinator is successfully initialized and started two new rounds.");
+			Logger.LogInfo("Chaumian CoinJoin Coordinator is successfully initialized and started two new rounds.");
 
 			if (roundConfig.FilePath != null)
 			{
@@ -75,14 +75,14 @@ namespace WalletWasabi.Backend
 					{
 						await Coordinator.RoundConfig.UpdateOrDefaultAsync(RoundConfig, toFile: false);
 
-						Coordinator.AbortAllRoundsInInputRegistration(nameof(ConfigWatcher), $"{nameof(RoundConfig)} has changed.");
+						Coordinator.AbortAllRoundsInInputRegistration($"{nameof(RoundConfig)} has changed.");
 					}
 					catch (Exception ex)
 					{
-						Logger.LogDebug<ConfigWatcher>(ex);
+						Logger.LogDebug(ex);
 					}
 				}); // Every 10 seconds check the config
-				Logger.LogInfo<ConfigWatcher>($"{nameof(RoundConfigWatcher)} is successfully started.");
+				Logger.LogInfo($"{nameof(RoundConfigWatcher)} is successfully started.");
 			}
 		}
 
@@ -96,7 +96,7 @@ namespace WalletWasabi.Backend
 				}
 				catch (Exception ex)
 				{
-					Logger.LogDebug<WalletService>(ex);
+					Logger.LogDebug(ex);
 				}
 				finally
 				{
@@ -106,12 +106,12 @@ namespace WalletWasabi.Backend
 					}
 					catch (Exception ex)
 					{
-						Logger.LogDebug<WalletService>(ex);
+						Logger.LogDebug(ex);
 					}
 					finally
 					{
 						LocalNode = null;
-						Logger.LogInfo<WalletService>("Local Bitcoin node is disconnected.");
+						Logger.LogInfo("Local Bitcoin node is disconnected.");
 					}
 				}
 			}
@@ -137,7 +137,7 @@ namespace WalletWasabi.Backend
 				TrustedNodeNotifyingBehavior = node.Behaviors.Find<TrustedNodeNotifyingBehavior>();
 				try
 				{
-					Logger.LogInfo<Node>("TCP Connection succeeded, handshaking...");
+					Logger.LogInfo("TCP Connection succeeded, handshaking...");
 					node.VersionHandshake(Constants.LocalBackendNodeRequirements, handshakeTimeout.Token);
 					var peerServices = node.PeerVersion.Services;
 
@@ -146,7 +146,7 @@ namespace WalletWasabi.Backend
 						throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
 					}
 
-					Logger.LogInfo<Node>("Handshake completed successfully.");
+					Logger.LogInfo("Handshake completed successfully.");
 
 					if (!node.IsConnected)
 					{
@@ -157,7 +157,7 @@ namespace WalletWasabi.Backend
 				}
 				catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
 				{
-					Logger.LogWarning<Node>($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
+					Logger.LogWarning($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
 						"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
 					throw;
 				}
@@ -187,7 +187,7 @@ namespace WalletWasabi.Backend
 					throw new NotSupportedException("Bitcoin Core is not fully synchronized.");
 				}
 
-				Logger.LogInfo<RPCClient>("Bitcoin Core is fully synchronized.");
+				Logger.LogInfo("Bitcoin Core is fully synchronized.");
 
 				var estimateSmartFeeResponse = await RpcClient.TryEstimateSmartFeeAsync(2, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true);
 				if (estimateSmartFeeResponse is null)
@@ -195,7 +195,7 @@ namespace WalletWasabi.Backend
 					throw new NotSupportedException("Bitcoin Core cannot estimate network fees yet.");
 				}
 
-				Logger.LogInfo<RPCClient>("Bitcoin Core fee estimation is working.");
+				Logger.LogInfo("Bitcoin Core fee estimation is working.");
 
 				if (Config.Network == Network.RegTest) // Make sure there's at least 101 block, if not generate it
 				{
@@ -213,7 +213,7 @@ namespace WalletWasabi.Backend
 						{
 							throw new NotSupportedException($"{nameof(blocks)} == 0");
 						}
-						Logger.LogInfo<RPCClient>($"Generated 101 block on {Network.RegTest}. Number of blocks {blocks}.");
+						Logger.LogInfo($"Generated 101 block on {Network.RegTest}. Number of blocks {blocks}.");
 					}
 				}
 			}

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -35,12 +35,12 @@ namespace WalletWasabi.Backend
 			var configFilePath = Path.Combine(Global.DataDir, "Config.json");
 			var config = new Config(configFilePath);
 			await config.LoadOrCreateDefaultFileAsync();
-			Logger.LogInfo<Config>("Config is successfully initialized.");
+			Logger.LogInfo("Config is successfully initialized.");
 
 			var roundConfigFilePath = Path.Combine(Global.DataDir, "CcjRoundConfig.json");
 			var roundConfig = new CcjRoundConfig(roundConfigFilePath);
 			await roundConfig.LoadOrCreateDefaultFileAsync();
-			Logger.LogInfo<CcjRoundConfig>("RoundConfig is successfully initialized.");
+			Logger.LogInfo("RoundConfig is successfully initialized.");
 
 			string host = config.GetBitcoinCoreRpcEndPoint().ToString(config.Network.RPCPort);
 			var rpc = new RPCClient(
@@ -56,18 +56,18 @@ namespace WalletWasabi.Backend
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning(ex, nameof(Program));
+				Logger.LogWarning(ex);
 			}
 		}
 
 		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
 		{
-			Logger.LogWarning(e?.Exception, $"{nameof(TaskScheduler.UnobservedTaskException)}");
+			Logger.LogWarning(e?.Exception);
 		}
 
 		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
 		{
-			Logger.LogWarning(e?.ExceptionObject as Exception, $"{nameof(AppDomain.CurrentDomain.UnhandledException)}");
+			Logger.LogWarning(e?.ExceptionObject as Exception);
 		}
 	}
 }

--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.Backend
 			}
 			catch (Exception ex)
 			{
-				Logger.LogCritical<Program>(ex);
+				Logger.LogCritical(ex);
 			}
 		}
 	}

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -65,6 +65,7 @@ namespace WalletWasabi.Backend
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 #pragma warning disable IDE0060 // Remove unused parameter
+
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, Global global)
 #pragma warning restore IDE0060 // Remove unused parameter
 		{
@@ -100,27 +101,27 @@ namespace WalletWasabi.Backend
 		private async Task CleanupAsync(Global global)
 		{
 			global.Coordinator?.Dispose();
-			Logger.LogInfo<Startup>($"{nameof(global.Coordinator)} is disposed.");
+			Logger.LogInfo($"{nameof(global.Coordinator)} is disposed.");
 
 			if (global.IndexBuilderService != null)
 			{
 				await global.IndexBuilderService.StopAsync();
-				Logger.LogInfo<Startup>($"{nameof(global.IndexBuilderService)} is disposed.");
+				Logger.LogInfo($"{nameof(global.IndexBuilderService)} is disposed.");
 			}
 
 			if (global.RoundConfigWatcher != null)
 			{
 				await global.RoundConfigWatcher.StopAsync();
-				Logger.LogInfo<Startup>($"{nameof(global.RoundConfigWatcher)} is disposed.");
+				Logger.LogInfo($"{nameof(global.RoundConfigWatcher)} is disposed.");
 			}
 
 			if (global.LocalNode != null)
 			{
 				global.DisconnectDisposeNullLocalNode();
-				Logger.LogInfo<Startup>($"{nameof(global.LocalNode)} is disposed.");
+				Logger.LogInfo($"{nameof(global.LocalNode)} is disposed.");
 			}
 
-			Logger.LogInfo("Wasabi Backend stopped gracefully.", Logger.InstanceGuid.ToString());
+			Logger.LogInfo("Wasabi Backend stopped gracefully.");
 		}
 	}
 }

--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -143,7 +143,7 @@ namespace WalletWasabi.Gui.CommandLine
 					if (!File.Exists(walletFullPath) && !File.Exists(walletBackupFullPath))
 					{
 						// The selected wallet is not available any more (someone deleted it?).
-						Logger.LogCritical("The selected wallet does not exist, did you delete it?", nameof(Daemon));
+						Logger.LogCritical("The selected wallet does not exist, did you delete it?");
 						return null;
 					}
 
@@ -153,21 +153,21 @@ namespace WalletWasabi.Gui.CommandLine
 					}
 					catch (Exception ex)
 					{
-						Logger.LogCritical(ex, nameof(Daemon));
+						Logger.LogCritical(ex);
 						return null;
 					}
 				}
 
 				if (keyManager is null)
 				{
-					Logger.LogCritical("Wallet was not supplied. Add --wallet:WalletName", nameof(Daemon));
+					Logger.LogCritical("Wallet was not supplied. Add --wallet:WalletName");
 				}
 
 				return keyManager;
 			}
 			catch (Exception ex)
 			{
-				Logger.LogCritical(ex, nameof(Daemon));
+				Logger.LogCritical(ex);
 				return null;
 			}
 		}
@@ -187,7 +187,7 @@ namespace WalletWasabi.Gui.CommandLine
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning(ex, nameof(Daemon));
+				Logger.LogWarning(ex);
 			}
 		}
 	}

--- a/WalletWasabi.Gui/CommandLine/MixerCommand.cs
+++ b/WalletWasabi.Gui/CommandLine/MixerCommand.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Gui.CommandLine
 			catch (Exception ex)
 			{
 				Console.WriteLine($"commands: There was a problem interpreting the command, please review it.");
-				Logger.LogDebug<MixerCommand>(ex);
+				Logger.LogDebug(ex);
 				error = true;
 			}
 			Environment.Exit(error ? 1 : 0);

--- a/WalletWasabi.Gui/CommandLine/PasswordFinder.cs
+++ b/WalletWasabi.Gui/CommandLine/PasswordFinder.cs
@@ -32,8 +32,8 @@ namespace WalletWasabi.Gui.CommandLine
 				return;
 			}
 
-			Logging.Logger.LogWarning<PasswordFinder>($"WARNING: This tool will display your password if it finds it.");
-			Logging.Logger.LogWarning<PasswordFinder>($"         You can cancel this by CTRL+C combination anytime.{Environment.NewLine}");
+			Logging.Logger.LogWarning($"WARNING: This tool will display your password if it finds it.");
+			Logging.Logger.LogWarning($"         You can cancel this by CTRL+C combination anytime.{Environment.NewLine}");
 
 			Console.Write("Enter a likely password: ");
 
@@ -69,7 +69,7 @@ namespace WalletWasabi.Gui.CommandLine
 
 			Console.WriteLine();
 			Console.WriteLine();
-			Logging.Logger.LogInfo<PasswordFinder>($"Completed in {sw.Elapsed}");
+			Logging.Logger.LogInfo($"Completed in {sw.Elapsed}");
 			Console.WriteLine(found ? $"SUCCESS: Password found: >>> {lastpwd} <<<" : "FAILED: Password not found");
 			Console.WriteLine();
 		}

--- a/WalletWasabi.Gui/CommandLine/PasswordFinderCommand.cs
+++ b/WalletWasabi.Gui/CommandLine/PasswordFinderCommand.cs
@@ -51,14 +51,14 @@ namespace WalletWasabi.Gui.CommandLine
 				}
 				else if (string.IsNullOrWhiteSpace(WalletName) && string.IsNullOrWhiteSpace(EncryptedSecret))
 				{
-					Logging.Logger.LogCritical<PasswordFinderCommand>("Missing required argument `--wallet=WalletName`.");
-					Logging.Logger.LogCritical<PasswordFinderCommand>("Use `findpassword --help` for details.");
+					Logging.Logger.LogCritical("Missing required argument `--wallet=WalletName`.");
+					Logging.Logger.LogCritical("Use `findpassword --help` for details.");
 					error = true;
 				}
 				else if (!PasswordFinder.Charsets.ContainsKey(Language))
 				{
-					Logging.Logger.LogCritical<PasswordFinderCommand>($"`{Language}` is not available language, try with `en, es, pt, it or fr`.");
-					Logging.Logger.LogCritical<PasswordFinderCommand>("Use `findpassword --help` for details.");
+					Logging.Logger.LogCritical($"`{Language}` is not available language, try with `en, es, pt, it or fr`.");
+					Logging.Logger.LogCritical("Use `findpassword --help` for details.");
 					error = true;
 				}
 				else if (!string.IsNullOrWhiteSpace(WalletName))
@@ -77,7 +77,7 @@ namespace WalletWasabi.Gui.CommandLine
 			}
 			catch (Exception)
 			{
-				Logging.Logger.LogCritical<PasswordFinderCommand>($"There was a problem interpreting the command, please review it.");
+				Logging.Logger.LogCritical($"There was a problem interpreting the command, please review it.");
 				error = true;
 			}
 			Environment.Exit(error ? 1 : 0);

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -426,8 +426,8 @@ namespace WalletWasabi.Gui
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<Config>("Backwards compatibility couldn't be ensured.");
-				Logger.LogInfo<Config>(ex);
+				Logger.LogWarning("Backwards compatibility couldn't be ensured.");
+				Logger.LogInfo(ex);
 				return false;
 			}
 		}

--- a/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
@@ -48,8 +48,8 @@ namespace WalletWasabi.Gui.Controls
 				}
 			});
 
-			CopyCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<ExtendedTextBox>);
-			PasteCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<ExtendedTextBox>);
+			CopyCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
+			PasteCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
 
 			this.GetObservable(IsReadOnlyProperty).Subscribe(isReadOnly =>
 			{

--- a/WalletWasabi.Gui/Controls/MultiTextBox.cs
+++ b/WalletWasabi.Gui/Controls/MultiTextBox.cs
@@ -167,11 +167,11 @@ namespace WalletWasabi.Gui.Controls
 									|| ex is TaskCanceledException
 									|| ex is TimeoutException)
 			{
-				Logging.Logger.LogTrace<MultiTextBox>(ex);
+				Logging.Logger.LogTrace(ex);
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<MultiTextBox>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 			finally
 			{
@@ -189,7 +189,7 @@ namespace WalletWasabi.Gui.Controls
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<MultiTextBox>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 		}
 
@@ -218,7 +218,7 @@ namespace WalletWasabi.Gui.Controls
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<MultiTextBox>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 		}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -197,7 +197,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning<CoinJoinTabViewModel>(ex);
+					Logger.LogWarning(ex);
 					var builder = new StringBuilder(ex.ToTypeMessageString());
 					if (ex is AggregateException aggex)
 					{
@@ -241,7 +241,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning<CoinJoinTabViewModel>(ex);
+					Logger.LogWarning(ex);
 					var builder = new StringBuilder(ex.ToTypeMessageString());
 					if (ex is AggregateException aggex)
 					{
@@ -354,7 +354,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CoinJoinTabViewModel>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -372,7 +372,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 			}, outputScheduler: RxApp.MainThreadScheduler);
 
-			InitList.ThrownExceptions.Subscribe(Logging.Logger.LogError<CoinListViewModel>);
+			InitList.ThrownExceptions.Subscribe(ex => Logging.Logger.LogError(ex));
 		}
 
 		private void OnOpen()
@@ -435,7 +435,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogDebug<Dispatcher>(ex);
+						Logging.Logger.LogDebug(ex);
 					}
 				}).DisposeWith(Disposables);
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -121,7 +121,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<HistoryTabViewModel>($"Error while RewriteTable on HistoryTab: {ex}.");
+				Logger.LogError($"Error while RewriteTable on HistoryTab: {ex}.");
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -593,7 +593,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 				catch (OverflowException ex)
 				{
-					Logging.Logger.LogTrace<SendTabViewModel>(ex);
+					Logging.Logger.LogTrace(ex);
 				}
 
 				AmountWatermarkText = amountUsd != 0
@@ -814,7 +814,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogInfo<SendTabViewModel>(ex);
+				Logging.Logger.LogInfo(ex);
 			}
 		}
 
@@ -834,7 +834,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<SendTabViewModel>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 		}
 
@@ -856,7 +856,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<CoinJoinTabViewModel>(ex);
+				Logging.Logger.LogWarning(ex);
 				var builder = new StringBuilder(ex.ToTypeMessageString());
 				if (ex is AggregateException aggex)
 				{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
@@ -127,7 +127,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				catch (Exception ex)
 				{
 					SetWarningMessage(ex.ToTypeMessageString());
-					Logging.Logger.LogError<TransactionBroadcasterViewModel>(ex);
+					Logging.Logger.LogError(ex);
 				}
 			}, outputScheduler: RxApp.MainThreadScheduler);
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewModel.cs
@@ -86,11 +86,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 									|| ex is TaskCanceledException
 									|| ex is TimeoutException)
 			{
-				Logging.Logger.LogTrace<AddressViewModel>(ex);
+				Logging.Logger.LogTrace(ex);
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<AddressViewModel>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
@@ -91,7 +91,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				catch (Exception ex)
 				{
 					SetWarningMessage(ex.ToTypeMessageString());
-					Logging.Logger.LogError<TransactionViewerViewModel>(ex);
+					Logging.Logger.LogError(ex);
 				}
 			}, outputScheduler: RxApp.MainThreadScheduler);
 		}

--- a/WalletWasabi.Gui/Dialogs/AvaloniaControlsExtensions.cs
+++ b/WalletWasabi.Gui/Dialogs/AvaloniaControlsExtensions.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Controls
 				}
 				catch (Exception ex)
 				{
-					WalletWasabi.Logging.Logger.LogWarning(ex, me.GetType().Name);
+					WalletWasabi.Logging.Logger.LogWarning(ex);
 
 					string title = !string.IsNullOrWhiteSpace(me.Title)
 						? me.Title

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
@@ -78,8 +78,8 @@ namespace WalletWasabi.Gui.Dialogs
 			},
 			canCancel);
 
-			OKCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<CannotCloseDialogViewModel>);
-			CancelCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<CannotCloseDialogViewModel>);
+			OKCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
+			CancelCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
 		}
 
 		public override void OnOpen()
@@ -201,7 +201,7 @@ namespace WalletWasabi.Gui.Dialogs
 				}
 				catch (TaskCanceledException ex)
 				{
-					Logging.Logger.LogTrace<CannotCloseDialogViewModel>(ex);
+					Logging.Logger.LogTrace(ex);
 				}
 
 				if (WarningMessage == message)

--- a/WalletWasabi.Gui/Dialogs/TextInputDialogViewModel.cs
+++ b/WalletWasabi.Gui/Dialogs/TextInputDialogViewModel.cs
@@ -37,8 +37,8 @@ namespace WalletWasabi.Gui.Dialogs
 				Close(false);
 			});
 
-			OKCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<TextInputDialogViewModel>);
-			CancelCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<TextInputDialogViewModel>);
+			OKCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
+			CancelCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
 		}
 
 		public string TextInput

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -99,11 +99,11 @@ namespace WalletWasabi.Gui
 			}
 			catch (NotSupportedException ex)
 			{
-				Logger.LogWarning(ex.Message, nameof(Global));
+				Logger.LogWarning(ex.Message);
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning(ex, nameof(Global));
+				Logger.LogWarning(ex);
 			}
 			finally
 			{
@@ -121,7 +121,7 @@ namespace WalletWasabi.Gui
 			SmartCoin[] enqueuedCoins = WalletService.Coins.Where(x => x.CoinJoinInProgress).ToArray();
 			if (enqueuedCoins.Any())
 			{
-				Logger.LogWarning("Unregistering coins in CoinJoin process.", nameof(Global));
+				Logger.LogWarning("Unregistering coins in CoinJoin process.");
 				await ChaumianClient.DequeueCoinsFromMixAsync(enqueuedCoins, "Process was signaled to kill.");
 			}
 		}
@@ -139,7 +139,7 @@ namespace WalletWasabi.Gui
 
 			Config = new Config(Path.Combine(DataDir, "Config.json"));
 			await Config.LoadOrCreateDefaultFileAsync();
-			Logger.LogInfo<Config>($"{nameof(Config)} is successfully initialized.");
+			Logger.LogInfo($"{nameof(Config)} is successfully initialized.");
 
 			#endregion ConfigInitialization
 
@@ -170,7 +170,7 @@ namespace WalletWasabi.Gui
 			Console.CancelKeyPress += async (s, e) =>
 			{
 				e.Cancel = true;
-				Logger.LogWarning("Process was signaled for killing.", nameof(Global));
+				Logger.LogWarning("Process was signaled for killing.");
 
 				KillRequested = true;
 				await TryDesperateDequeueAllCoinsAsync();
@@ -180,7 +180,7 @@ namespace WalletWasabi.Gui
 				});
 				await DisposeAsync();
 
-				Logger.LogInfo($"Wasabi stopped gracefully.", Logger.InstanceGuid.ToString());
+				Logger.LogInfo($"Wasabi stopped gracefully.");
 			};
 
 			#endregion ProcessKillSubscription
@@ -200,7 +200,7 @@ namespace WalletWasabi.Gui
 			var fallbackRequestTestUri = new Uri(Config.GetFallbackBackendUri(), "/api/software/versions");
 			TorManager.StartMonitor(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(7), DataDir, fallbackRequestTestUri);
 
-			Logger.LogInfo<TorProcessManager>($"{nameof(TorProcessManager)} is initialized.");
+			Logger.LogInfo($"{nameof(TorProcessManager)} is initialized.");
 
 			#endregion TorProcessInitialization
 
@@ -219,7 +219,7 @@ namespace WalletWasabi.Gui
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError(ex, nameof(Global));
+				Logger.LogError(ex);
 			}
 
 			#endregion HwiProcessInitialization
@@ -253,7 +253,7 @@ namespace WalletWasabi.Gui
 				}
 				catch (SocketException ex)
 				{
-					Logger.LogError(ex, nameof(Global));
+					Logger.LogError(ex);
 				}
 			}
 			else
@@ -308,7 +308,7 @@ namespace WalletWasabi.Gui
 			if (Network == Network.RegTest)
 			{
 				AddressManager = new AddressManager();
-				Logger.LogInfo<AddressManager>($"Fake {nameof(AddressManager)} is initialized on the {Network.RegTest}.");
+				Logger.LogInfo($"Fake {nameof(AddressManager)} is initialized on the {Network.RegTest}.");
 			}
 			else
 			{
@@ -325,37 +325,37 @@ namespace WalletWasabi.Gui
 					// On the other side, increasing this number forces users that do not need to discover more peers
 					// to spend resources (CPU/bandwith) to discover new peers.
 					needsToDiscoverPeers = Config.UseTor is true || AddressManager.Count < 500;
-					Logger.LogInfo<AddressManager>($"Loaded {nameof(AddressManager)} from `{AddressManagerFilePath}`.");
+					Logger.LogInfo($"Loaded {nameof(AddressManager)} from `{AddressManagerFilePath}`.");
 				}
 				catch (DirectoryNotFoundException ex)
 				{
-					Logger.LogInfo<AddressManager>($"{nameof(AddressManager)} did not exist at `{AddressManagerFilePath}`. Initializing new one.");
-					Logger.LogTrace<AddressManager>(ex);
+					Logger.LogInfo($"{nameof(AddressManager)} did not exist at `{AddressManagerFilePath}`. Initializing new one.");
+					Logger.LogTrace(ex);
 					AddressManager = new AddressManager();
 				}
 				catch (FileNotFoundException ex)
 				{
-					Logger.LogInfo<AddressManager>($"{nameof(AddressManager)} did not exist at `{AddressManagerFilePath}`. Initializing new one.");
-					Logger.LogTrace<AddressManager>(ex);
+					Logger.LogInfo($"{nameof(AddressManager)} did not exist at `{AddressManagerFilePath}`. Initializing new one.");
+					Logger.LogTrace(ex);
 					AddressManager = new AddressManager();
 				}
 				catch (OverflowException ex)
 				{
 					// https://github.com/zkSNACKs/WalletWasabi/issues/712
-					Logger.LogInfo<AddressManager>($"{nameof(AddressManager)} has thrown `{nameof(OverflowException)}`. Attempting to autocorrect.");
+					Logger.LogInfo($"{nameof(AddressManager)} has thrown `{nameof(OverflowException)}`. Attempting to autocorrect.");
 					File.Delete(AddressManagerFilePath);
-					Logger.LogTrace<AddressManager>(ex);
+					Logger.LogTrace(ex);
 					AddressManager = new AddressManager();
-					Logger.LogInfo<AddressManager>($"{nameof(AddressManager)} autocorrection is successful.");
+					Logger.LogInfo($"{nameof(AddressManager)} autocorrection is successful.");
 				}
 				catch (FormatException ex)
 				{
 					// https://github.com/zkSNACKs/WalletWasabi/issues/880
-					Logger.LogInfo<AddressManager>($"{nameof(AddressManager)} has thrown `{nameof(FormatException)}`. Attempting to autocorrect.");
+					Logger.LogInfo($"{nameof(AddressManager)} has thrown `{nameof(FormatException)}`. Attempting to autocorrect.");
 					File.Delete(AddressManagerFilePath);
-					Logger.LogTrace<AddressManager>(ex);
+					Logger.LogTrace(ex);
 					AddressManager = new AddressManager();
-					Logger.LogInfo<AddressManager>($"{nameof(AddressManager)} autocorrection is successful.");
+					Logger.LogInfo($"{nameof(AddressManager)} autocorrection is successful.");
 				}
 			}
 
@@ -423,7 +423,7 @@ namespace WalletWasabi.Gui
 				}
 				catch (Exception ex) // Whatever this is not critical, but let's log it.
 				{
-					Logger.LogWarning(ex, nameof(Global));
+					Logger.LogWarning(ex);
 				}
 
 				WalletService = new WalletService(BitcoinStore, keyManager, Synchronizer, ChaumianClient, MempoolService, Nodes, DataDir, Config.ServiceConfiguration);
@@ -540,7 +540,7 @@ namespace WalletWasabi.Gui
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning(ex, nameof(Global));
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -556,7 +556,7 @@ namespace WalletWasabi.Gui
 			}
 			catch (ObjectDisposedException)
 			{
-				Logger.LogWarning($"{nameof(_cancelWalletServiceInitialization)} is disposed. This can occur due to an error while processing the wallet.", nameof(Global));
+				Logger.LogWarning($"{nameof(_cancelWalletServiceInitialization)} is disposed. This can occur due to an error while processing the wallet.");
 			}
 			_cancelWalletServiceInitialization = null;
 
@@ -566,21 +566,21 @@ namespace WalletWasabi.Gui
 				{
 					string backupWalletFilePath = Path.Combine(WalletBackupsDir, Path.GetFileName(WalletService.KeyManager.FilePath));
 					WalletService.KeyManager?.ToFile(backupWalletFilePath);
-					Logger.LogInfo($"{nameof(KeyManager)} backup saved to `{backupWalletFilePath}`.", nameof(Global));
+					Logger.LogInfo($"{nameof(KeyManager)} backup saved to `{backupWalletFilePath}`.");
 				}
 				if (WalletService != null)
 				{
 					await WalletService.StopAsync();
 				}
 				WalletService = null;
-				Logger.LogInfo($"{nameof(WalletService)} is stopped.", nameof(Global));
+				Logger.LogInfo($"{nameof(WalletService)} is stopped.");
 			}
 
 			if (ChaumianClient != null)
 			{
 				await ChaumianClient.StopAsync();
 				ChaumianClient = null;
-				Logger.LogInfo($"{nameof(ChaumianClient)} is stopped.", nameof(Global));
+				Logger.LogInfo($"{nameof(ChaumianClient)} is stopped.");
 			}
 		}
 
@@ -614,13 +614,13 @@ namespace WalletWasabi.Gui
 				if (UpdateChecker != null)
 				{
 					await UpdateChecker?.StopAsync();
-					Logger.LogInfo($"{nameof(UpdateChecker)} is stopped.", nameof(Global));
+					Logger.LogInfo($"{nameof(UpdateChecker)} is stopped.");
 				}
 
 				if (Synchronizer != null)
 				{
 					await Synchronizer?.StopAsync();
-					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.", nameof(Global));
+					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
 				}
 
 				if (AddressManagerFilePath != null)
@@ -629,7 +629,7 @@ namespace WalletWasabi.Gui
 					if (AddressManager != null)
 					{
 						AddressManager?.SavePeerFile(AddressManagerFilePath, Config.Network);
-						Logger.LogInfo($"{nameof(AddressManager)} is saved to `{AddressManagerFilePath}`.", nameof(Global));
+						Logger.LogInfo($"{nameof(AddressManager)} is saved to `{AddressManagerFilePath}`.");
 					}
 				}
 
@@ -641,19 +641,19 @@ namespace WalletWasabi.Gui
 						await Task.Delay(50);
 					}
 					Nodes?.Dispose();
-					Logger.LogInfo($"{nameof(Nodes)} are disposed.", nameof(Global));
+					Logger.LogInfo($"{nameof(Nodes)} are disposed.");
 				}
 
 				if (RegTestMempoolServingNode != null)
 				{
 					RegTestMempoolServingNode.Disconnect();
-					Logger.LogInfo($"{nameof(RegTestMempoolServingNode)} is disposed.", nameof(Global));
+					Logger.LogInfo($"{nameof(RegTestMempoolServingNode)} is disposed.");
 				}
 
 				if (TorManager != null)
 				{
 					await TorManager?.StopAsync();
-					Logger.LogInfo($"{nameof(TorManager)} is stopped.", nameof(Global));
+					Logger.LogInfo($"{nameof(TorManager)} is stopped.");
 				}
 
 				if (AsyncMutex.IsAny)
@@ -661,17 +661,17 @@ namespace WalletWasabi.Gui
 					try
 					{
 						await AsyncMutex.WaitForAllMutexToCloseAsync();
-						Logger.LogInfo($"{nameof(AsyncMutex)}(es) are stopped.", nameof(Global));
+						Logger.LogInfo($"{nameof(AsyncMutex)}(es) are stopped.");
 					}
 					catch (Exception ex)
 					{
-						Logger.LogError($"Error during stopping {nameof(AsyncMutex)}: {ex}", nameof(Global));
+						Logger.LogError($"Error during stopping {nameof(AsyncMutex)}: {ex}");
 					}
 				}
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning(ex, nameof(Global));
+				Logger.LogWarning(ex);
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/Helpers/AvaloniaThreadingExtensions.cs
+++ b/WalletWasabi.Gui/Helpers/AvaloniaThreadingExtensions.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Threading
 				}
 				catch (Exception ex)
 				{
-					WalletWasabi.Logging.Logger.LogDebug<Dispatcher>(ex);
+					WalletWasabi.Logging.Logger.LogDebug(ex);
 				}
 			}, priority);
 		}
@@ -32,7 +32,7 @@ namespace Avalonia.Threading
 				}
 				catch (Exception ex)
 				{
-					WalletWasabi.Logging.Logger.LogDebug<Dispatcher>(ex);
+					WalletWasabi.Logging.Logger.LogDebug(ex);
 				}
 			}, priority);
 		}

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Gui
 					{
 						Global.InitializeUiConfig(uiConfig);
 						Application.Current.Resources.AddOrReplace(Global.UiConfigResourceKey, Global.UiConfig);
-						Logging.Logger.LogInfo<UiConfig>($"{nameof(Global.UiConfig)} is successfully initialized.");
+						Logging.Logger.LogInfo($"{nameof(Global.UiConfig)} is successfully initialized.");
 
 						if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 						{
@@ -84,9 +84,9 @@ namespace WalletWasabi.Gui
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogError<MainWindowViewModel>(ex);
+						Logging.Logger.LogError(ex);
 					}
-				}, onError: ex => Logging.Logger.LogError<MainWindowViewModel>(ex));
+				}, onError: ex => Logging.Logger.LogError(ex));
 		}
 
 		protected override void OnDataContextEndUpdate()
@@ -125,7 +125,7 @@ namespace WalletWasabi.Gui
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogError<MainWindow>(ex);
+				Logging.Logger.LogError(ex);
 			}
 		}
 
@@ -160,7 +160,7 @@ namespace WalletWasabi.Gui
 							Global.UiConfig.Width = Width;
 							Global.UiConfig.Height = Height;
 							await Global.UiConfig.ToFileAsync();
-							Logging.Logger.LogInfo<UiConfig>($"{nameof(Global.UiConfig)} is saved.");
+							Logging.Logger.LogInfo($"{nameof(Global.UiConfig)} is saved.");
 						}
 
 						Hide();
@@ -168,14 +168,14 @@ namespace WalletWasabi.Gui
 						if (wm != null)
 						{
 							wm.OnClose();
-							Logging.Logger.LogInfo<MainWindowViewModel>($"{nameof(WalletManagerViewModel)} closed, hwi enumeration stopped.");
+							Logging.Logger.LogInfo($"{nameof(WalletManagerViewModel)} closed, hwi enumeration stopped.");
 						}
 
 						await Global.DisposeAsync();
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogWarning<MainWindow>(ex);
+						Logging.Logger.LogWarning(ex);
 					}
 
 					Interlocked.Exchange(ref _closingState, 2); //now we can close the app
@@ -186,7 +186,7 @@ namespace WalletWasabi.Gui
 			catch (Exception ex)
 			{
 				Interlocked.Exchange(ref _closingState, 0); //something happened back to starting point
-				Logging.Logger.LogWarning<MainWindow>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -63,7 +63,7 @@ namespace WalletWasabi.Gui
 			}
 			catch (Exception ex)
 			{
-				Logger.LogCritical<Program>(ex);
+				Logger.LogCritical(ex);
 				throw;
 			}
 			finally
@@ -75,19 +75,19 @@ namespace WalletWasabi.Gui
 
 				if (runGui)
 				{
-					Logger.LogInfo($"Wasabi GUI stopped gracefully.", Logger.InstanceGuid.ToString());
+					Logger.LogInfo($"Wasabi GUI stopped gracefully.");
 				}
 			}
 		}
 
 		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
 		{
-			Logger.LogWarning(e?.Exception, $"{nameof(TaskScheduler.UnobservedTaskException)}");
+			Logger.LogWarning(e?.Exception);
 		}
 
 		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
 		{
-			Logger.LogWarning(e?.ExceptionObject as Exception, $"{nameof(AppDomain.CurrentDomain.UnhandledException)}");
+			Logger.LogWarning(e?.ExceptionObject as Exception);
 		}
 
 		private static AppBuilder BuildAvaloniaApp()

--- a/WalletWasabi.Gui/Shell/Commands/DiskCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/DiskCommands.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnFileOpenException(Exception ex)
 		{
-			Logging.Logger.LogError<DiskCommands>(ex);
+			Logging.Logger.LogError(ex);
 		}
 
 		[ExportCommandDefinition("File.Open.DataFolder")]

--- a/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/HelpCommands.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogWarning<HelpCommands>(ex);
+						Logging.Logger.LogWarning(ex);
 						IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 					}
 				}));
@@ -57,7 +57,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogWarning<HelpCommands>(ex);
+						Logging.Logger.LogWarning(ex);
 						IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 					}
 				}));
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogWarning<HelpCommands>(ex);
+						Logging.Logger.LogWarning(ex);
 						IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 					}
 				}));

--- a/WalletWasabi.Gui/Shell/Commands/SystemCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/SystemCommands.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 			var exit = ReactiveCommand.Create(OnExit);
 
-			exit.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<SystemCommands>);
+			exit.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
 
 			ExitCommand = new CommandDefinition(
 				"Exit",

--- a/WalletWasabi.Gui/Shell/Commands/ToolCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/ToolCommands.cs
@@ -92,7 +92,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnException(Exception ex)
 		{
-			Logging.Logger.LogError<ToolCommands>(ex);
+			Logging.Logger.LogError(ex);
 		}
 
 		[ExportCommandDefinition("Tools.WalletManager")]

--- a/WalletWasabi.Gui/Tabs/AboutViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/AboutViewModel.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Gui.Tabs
 				}
 				catch (Exception ex)
 				{
-					Logging.Logger.LogError<AboutViewModel>(ex);
+					Logging.Logger.LogError(ex);
 				}
 			});
 		}

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
@@ -74,7 +74,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				catch (Exception ex)
 				{
 					ValidationMessage = ex.ToTypeMessageString();
-					Logger.LogError<GenerateWalletViewModel>(ex);
+					Logger.LogError(ex);
 				}
 			}
 		}

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -125,7 +125,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 						}
 						HDFingerprint mfp = NBitcoinHelpers.BetterParseHDFingerprint(mfpString, reverseByteOrder: reverseByteOrder);
 						ExtPubKey extPubKey = NBitcoinHelpers.BetterParseExtPubKey(xpubString);
-						Logger.LogInfo<LoadWalletViewModel>("Creating new wallet file.");
+						Logger.LogInfo("Creating new wallet file.");
 						var walletName = Global.GetNextHardwareWalletName(customPrefix: "Coldcard");
 						var walletFullPath = Global.GetWalletFullPath(walletName);
 						KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, walletFullPath);
@@ -135,7 +135,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				catch (Exception ex)
 				{
 					SetWarningMessage(ex.ToTypeMessageString());
-					Logger.LogError<LoadWalletViewModel>(ex);
+					Logger.LogError(ex);
 				}
 			}, outputScheduler: RxApp.MainThreadScheduler);
 
@@ -144,11 +144,11 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				IoHelpers.OpenBrowser(x);
 			});
 
-			OpenBrowserCommand.ThrownExceptions.Subscribe(Logger.LogWarning<LoadWalletViewModel>);
-			LoadCommand.ThrownExceptions.Subscribe(Logger.LogWarning<LoadWalletViewModel>);
-			TestPasswordCommand.ThrownExceptions.Subscribe(Logger.LogWarning<LoadWalletViewModel>);
-			OpenFolderCommand.ThrownExceptions.Subscribe(Logger.LogWarning<LoadWalletViewModel>);
-			ImportColdcardCommand.ThrownExceptions.Subscribe(Logger.LogWarning<LoadWalletViewModel>);
+			OpenBrowserCommand.ThrownExceptions.Subscribe(ex => Logger.LogWarning(ex));
+			LoadCommand.ThrownExceptions.Subscribe(ex => Logger.LogWarning(ex));
+			TestPasswordCommand.ThrownExceptions.Subscribe(ex => Logger.LogWarning(ex));
+			OpenFolderCommand.ThrownExceptions.Subscribe(ex => Logger.LogWarning(ex));
+			ImportColdcardCommand.ThrownExceptions.Subscribe(ex => Logger.LogWarning(ex));
 
 			SetLoadButtonText();
 
@@ -284,7 +284,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				}
 				catch (Exception ex)
 				{
-					Logger.LogInfo<LoadWalletViewModel>(ex);
+					Logger.LogInfo(ex);
 				}
 			}
 		}
@@ -353,7 +353,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<LoadWalletViewModel>(ex);
+				Logger.LogWarning(ex);
 			}
 
 			return false;
@@ -546,7 +546,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 						MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusBarStatus.AcquiringXpubFromHardwareWallet);
 					}
 
-					Logger.LogInfo<LoadWalletViewModel>("Hardware wallet was not used previously on this computer. Creating new wallet file.");
+					Logger.LogInfo("Hardware wallet was not used previously on this computer. Creating new wallet file.");
 
 					if (TryFindWalletByExtPubKey(extPubKey, out string wn))
 					{
@@ -616,7 +616,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 				// Initialization failed.
 				SetValidationMessage(ex.ToTypeMessageString());
-				Logger.LogError<LoadWalletViewModel>(ex);
+				Logger.LogError(ex);
 
 				return null;
 			}
@@ -703,7 +703,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					SetValidationMessage(ex.ToTypeMessageString());
 					if (!(ex is OperationCanceledException))
 					{
-						Logger.LogError<LoadWalletViewModel>(ex);
+						Logger.LogError(ex);
 					}
 					await Global.DisposeInWalletDependentServicesAsync();
 				}

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWalletViewModel.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					catch (Exception ex)
 					{
 						ValidationMessage = ex.ToTypeMessageString();
-						Logger.LogError<RecoverWalletViewModel>(ex);
+						Logger.LogError(ex);
 					}
 				}
 			});

--- a/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerViewModel.cs
@@ -137,7 +137,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 								}
 								catch (Exception ex)
 								{
-									Logger.LogWarning<MainWindow>(ex);
+									Logger.LogWarning(ex);
 								}
 							}
 
@@ -174,7 +174,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					catch (Exception ex)
 					{
 						LoadWalletViewModelHardware.SetValidationMessage(ex.ToTypeMessageString());
-						Logger.LogWarning<WalletManagerViewModel>(ex);
+						Logger.LogWarning(ex);
 					}
 					finally
 					{
@@ -184,7 +184,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			}
 			catch (TaskCanceledException ex)
 			{
-				Logger.LogTrace<WalletManagerViewModel>(ex);
+				Logger.LogTrace(ex);
 			}
 		}
 

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Gui.ViewModels
 					}
 					catch (Exception ex)
 					{
-						Logging.Logger.LogError<AddressViewModel>(ex);
+						Logging.Logger.LogError(ex);
 					}
 				});
 
@@ -157,11 +157,11 @@ namespace WalletWasabi.Gui.ViewModels
 									|| ex is TaskCanceledException
 									|| ex is TimeoutException)
 			{
-				Logging.Logger.LogTrace<AddressViewModel>(ex);
+				Logging.Logger.LogTrace(ex);
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<AddressViewModel>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
@@ -74,7 +74,7 @@ namespace WalletWasabi.Gui.ViewModels
 				Global.UiConfig.LockScreenActive = true;
 			});
 
-			LockScreenCommand.ThrownExceptions.Subscribe(Logging.Logger.LogWarning<MainWindowViewModel>);
+			LockScreenCommand.ThrownExceptions.Subscribe(ex => Logging.Logger.LogWarning(ex));
 		}
 
 		public IShell Shell { get; }

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -198,7 +198,7 @@ namespace WalletWasabi.Gui.ViewModels
 				}
 				catch (Exception ex)
 				{
-					Logging.Logger.LogWarning<StatusBarViewModel>(ex);
+					Logging.Logger.LogWarning(ex);
 					IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 				}
 			}, this.WhenAnyValue(x => x.UpdateStatus)
@@ -339,7 +339,7 @@ namespace WalletWasabi.Gui.ViewModels
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<StatusBarViewModel>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 		}
 
@@ -351,7 +351,7 @@ namespace WalletWasabi.Gui.ViewModels
 			}
 			catch (Exception ex)
 			{
-				Logging.Logger.LogWarning<StatusBarViewModel>(ex);
+				Logging.Logger.LogWarning(ex);
 			}
 		}
 

--- a/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
@@ -102,8 +102,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug<ExternalApiTests>($"Uri was not reachable: {uri}");
-				Logger.LogDebug<ExternalApiTests>(ex);
+				Logger.LogDebug($"Uri was not reachable: {uri}");
+				Logger.LogDebug(ex);
 			}
 			return false;
 		}

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -58,7 +58,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			try
 			{
 				addressManager = await NBitcoinHelpers.LoadAddressManagerFromPeerFileAsync(addressManagerFilePath);
-				Logger.LogInfo<AddressManager>($"Loaded {nameof(AddressManager)} from `{addressManagerFilePath}`.");
+				Logger.LogInfo($"Loaded {nameof(AddressManager)} from `{addressManagerFilePath}`.");
 			}
 			catch (DirectoryNotFoundException)
 			{
@@ -134,7 +134,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 					{
 						var block = await walletService.FetchBlockAsync(hash, cts.Token);
 						Assert.True(File.Exists(Path.Combine(blocksFolderPath, hash.ToString())));
-						Logger.LogInfo<P2pTests>($"Full block is downloaded: {hash}.");
+						Logger.LogInfo($"Full block is downloaded: {hash}.");
 					}
 				}
 			}
@@ -161,7 +161,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				IoHelpers.EnsureContainingDirectoryExists(addressManagerFilePath);
 				addressManager?.SavePeerFile(addressManagerFilePath, network);
-				Logger.LogInfo<P2pTests>($"Saved {nameof(AddressManager)} to `{addressManagerFilePath}`.");
+				Logger.LogInfo($"Saved {nameof(AddressManager)} to `{addressManagerFilePath}`.");
 				nodes?.Dispose();
 
 				await syncer?.StopAsync();
@@ -175,17 +175,17 @@ namespace WalletWasabi.Tests.IntegrationTests
 			long nodeCount = Interlocked.Increment(ref _nodeCount);
 			if (nodeCount == 8)
 			{
-				Logger.LogTrace<P2pTests>($"Max node count reached: {nodeCount}.");
+				Logger.LogTrace($"Max node count reached: {nodeCount}.");
 			}
 
-			Logger.LogTrace<P2pTests>($"Node count: {nodeCount}.");
+			Logger.LogTrace($"Node count: {nodeCount}.");
 		}
 
 		private void ConnectedNodes_Removed(object sender, NodeEventArgs e)
 		{
 			var nodeCount = Interlocked.Decrement(ref _nodeCount);
 			// Trace is fine here, building the connections is more exciting than removing them.
-			Logger.LogTrace<P2pTests>($"Node count: {nodeCount}.");
+			Logger.LogTrace($"Node count: {nodeCount}.");
 		}
 
 		private long _mempoolTransactionCount = 0;
@@ -193,7 +193,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		private void MempoolService_TransactionReceived(object sender, SmartTransaction e)
 		{
 			Interlocked.Increment(ref _mempoolTransactionCount);
-			Logger.LogDebug<P2pTests>($"Mempool transaction received: {e.GetHash()}.");
+			Logger.LogDebug($"Mempool transaction received: {e.GetHash()}.");
 		}
 	}
 }

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -299,7 +299,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		private void MempoolAsync_MempoolService_TransactionReceived(object sender, SmartTransaction e)
 		{
 			Interlocked.Increment(ref _mempoolTransactionCount);
-			Logger.LogDebug<RegTests>($"Mempool transaction received: {e.GetHash()}.");
+			Logger.LogDebug($"Mempool transaction received: {e.GetHash()}.");
 		}
 
 		[Fact]
@@ -812,7 +812,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 					waitCount++;
 					if (waitCount >= 21)
 					{
-						Logger.LogError<RegTests>("Funding transaction to the wallet did not arrive.");
+						Logger.LogInfo("Funding transaction to the wallet did not arrive.");
 						return; // Very rarely this test fails. I have no clue why. Probably because all these RegTests are interconnected, anyway let's not bother the CI with it.
 					}
 				}
@@ -859,13 +859,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 				if (res.SpentCoins.Sum(x => x.Amount) - activeOutput.Amount == res.Fee) // this happens when change is too small
 				{
 					Assert.Contains(res.Transaction.Transaction.Outputs, x => x.Value == activeOutput.Amount);
-					Logger.LogInfo<RegTests>($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+					Logger.LogInfo($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
 				}
-				Logger.LogInfo<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogInfo<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogInfo($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogInfo($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogInfo($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogInfo($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"TxId: {res.Transaction.GetHash()}");
 
 				var foundReceive = false;
 				Assert.InRange(res.Transaction.Transaction.Outputs.Count, 1, 2);
@@ -897,12 +897,12 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
 				Assert.Equal(amountToSend - res.Fee, activeOutput.Amount);
 				Assert.Contains(res.Transaction.Transaction.Outputs, x => x.Value == changeOutput.Amount);
-				Logger.LogInfo<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogInfo<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogInfo($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogInfo($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogInfo($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogInfo($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"TxId: {res.Transaction.GetHash()}");
 
 				foundReceive = false;
 				Assert.InRange(res.Transaction.Transaction.Outputs.Count, 1, 2);
@@ -930,12 +930,12 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
 				Assert.Equal(amountToSend, activeOutput.Amount);
 				Assert.Contains(res.Transaction.Transaction.Outputs, x => x.Value == changeOutput.Amount);
-				Logger.LogInfo<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogInfo<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogInfo($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogInfo($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogInfo($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogInfo($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"TxId: {res.Transaction.GetHash()}");
 
 				foundReceive = false;
 				Assert.InRange(res.Transaction.Transaction.Outputs.Count, 1, 2);
@@ -963,12 +963,12 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
 				Assert.Equal(amountToSend, activeOutput.Amount);
 				Assert.Contains(res.Transaction.Transaction.Outputs, x => x.Value == changeOutput.Amount);
-				Logger.LogInfo<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogInfo<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogInfo($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogInfo($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogInfo($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogInfo($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"TxId: {res.Transaction.GetHash()}");
 
 				foundReceive = false;
 				Assert.InRange(res.Transaction.Transaction.Outputs.Count, 1, 2);
@@ -996,12 +996,12 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
 				Assert.Equal(amountToSend, activeOutput.Amount);
 				Assert.Contains(res.Transaction.Transaction.Outputs, x => x.Value == changeOutput.Amount);
-				Logger.LogInfo<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogInfo<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogInfo($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogInfo($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogInfo($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogInfo($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"Change Output: {changeOutput.Amount.ToString(false, true)} {changeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"TxId: {res.Transaction.GetHash()}");
 
 				foundReceive = false;
 				Assert.InRange(res.Transaction.Transaction.Outputs.Count, 1, 2);
@@ -1061,11 +1061,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(res.SpentCoins.Count(), res.Transaction.Transaction.Inputs.Count);
 
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
-				Logger.LogInfo<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogInfo<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogInfo<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogInfo<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogInfo<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogInfo($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogInfo($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogInfo($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogInfo($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogInfo($"TxId: {res.Transaction.GetHash()}");
 
 				Assert.Single(res.Transaction.Transaction.Outputs);
 
@@ -1137,11 +1137,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Empty(res.OuterWalletOutputs);
 
 				Assert.Equal(receive, activeOutput.ScriptPubKey);
-				Logger.LogDebug<RegTests>($"{nameof(res.Fee)}: {res.Fee}");
-				Logger.LogDebug<RegTests>($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
-				Logger.LogDebug<RegTests>($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
-				Logger.LogDebug<RegTests>($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
-				Logger.LogDebug<RegTests>($"TxId: {res.Transaction.GetHash()}");
+				Logger.LogDebug($"{nameof(res.Fee)}: {res.Fee}");
+				Logger.LogDebug($"{nameof(res.FeePercentOfSent)}: {res.FeePercentOfSent} %");
+				Logger.LogDebug($"{nameof(res.SpendsUnconfirmed)}: {res.SpendsUnconfirmed}");
+				Logger.LogDebug($"Active Output: {activeOutput.Amount.ToString(false, true)} {activeOutput.ScriptPubKey.GetDestinationAddress(network)}");
+				Logger.LogDebug($"TxId: {res.Transaction.GetHash()}");
 
 				Assert.True(inputCountBefore >= res.SpentCoins.Count());
 				Assert.False(res.SpendsUnconfirmed);
@@ -1671,7 +1671,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				}
 				catch (TimeoutException)
 				{
-					Logger.LogError<RegTests>("Index was not processed.");
+					Logger.LogInfo("Index was not processed.");
 					return; // Very rarely this test fails. I have no clue why. Probably because all these RegTests are interconnected, anyway let's not bother the CI with it.
 				}
 
@@ -1879,7 +1879,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 50;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, 2, 0.7, coordinatorFeePercent, anonymitySet, 100, connectionConfirmationTimeout, 50, 50, 2, 24, false, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 
 			Uri baseUri = new Uri(RegTestFixture.BackendEndPoint);
 			using (var torClient = new TorHttpClient(baseUri, Global.Instance.TorSocks5Endpoint))
@@ -1997,7 +1997,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				roundConfig.Denomination = Money.Coins(0.01m); // exactly the same as our output
 				await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-				coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+				coordinator.AbortAllRoundsInInputRegistration( "");
 				round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
 				roundId = round.RoundId;
 				inputsRequest.RoundId = roundId;
@@ -2007,7 +2007,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				roundConfig.Denomination = Money.Coins(0.00999999m); // one satoshi less than our output
 				await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-				coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+				coordinator.AbortAllRoundsInInputRegistration( "");
 				round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
 				roundId = round.RoundId;
 				inputsRequest.RoundId = roundId;
@@ -2018,7 +2018,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				roundConfig.Denomination = Money.Coins(0.008m); // one satoshi less than our output
 				roundConfig.ConnectionConfirmationTimeout = 2;
 				await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-				coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+				coordinator.AbortAllRoundsInInputRegistration( "");
 				round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
 				roundId = round.RoundId;
 				inputsRequest.RoundId = roundId;
@@ -2120,7 +2120,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 					roundConfig.ConnectionConfirmationTimeout = 1; // One second.
 					await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-					coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+					coordinator.AbortAllRoundsInInputRegistration( "");
 					round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
 					roundId = round.RoundId;
 					inputsRequest.RoundId = roundId;
@@ -2211,7 +2211,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 					roundConfig.ConnectionConfirmationTimeout = 60;
 					await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-					coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+					coordinator.AbortAllRoundsInInputRegistration( "");
 					round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
 					roundId = round.RoundId;
 					inputsRequest.RoundId = roundId;
@@ -2400,7 +2400,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 50;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, 2, 0.7, coordinatorFeePercent, anonymitySet, 100, connectionConfirmationTimeout, 50, 50, 2, 24, false, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 
 			Uri baseUri = new Uri(RegTestFixture.BackendEndPoint);
 			using (var torClient = new TorHttpClient(baseUri, Global.Instance.TorSocks5Endpoint))
@@ -2549,7 +2549,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			bool doesNoteBeforeBan = true;
 			CcjRoundConfig roundConfig = RegTestFixture.CreateRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 1, 1, 1, 24, doesNoteBeforeBan, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 
 			Uri baseUri = new Uri(RegTestFixture.BackendEndPoint);
 
@@ -2629,7 +2629,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 120;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 1, 1, 1, 24, true, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 
 			await rpc.GenerateAsync(3); // So to make sure we have enough money.
 
@@ -2831,7 +2831,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 120;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, Constants.OneDayConfirmationTarget, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 			await rpc.GenerateAsync(100); // So to make sure we have enough money.
 
 			Uri baseUri = new Uri(RegTestFixture.BackendEndPoint);
@@ -3057,7 +3057,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 14;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 
 			var participants = new List<dynamic>();
 
@@ -3181,7 +3181,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 14;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 			await rpc.GenerateAsync(3); // So to make sure we have enough money.
 			var keyManager = KeyManager.CreateNew(out _, password);
 			var key1 = keyManager.GenerateNewKey(new SmartLabel("foo"), KeyState.Clean, false);
@@ -3281,7 +3281,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				connectionConfirmationTimeout = 1;
 				roundConfig = RegTestFixture.CreateRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 				await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-				coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+				coordinator.AbortAllRoundsInInputRegistration( "");
 				Assert.NotEmpty(chaumianClient1.State.GetAllQueuedCoins());
 				await chaumianClient1.DequeueAllCoinsFromMixAsync("");
 				Assert.Empty(chaumianClient1.State.GetAllQueuedCoins());
@@ -3334,7 +3334,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			int connectionConfirmationTimeout = 14;
 			var roundConfig = RegTestFixture.CreateRoundConfig(denomination, 140, 0.7, coordinatorFeePercent, anonymitySet, 240, connectionConfirmationTimeout, 50, 50, 1, 24, true, 11);
 			await coordinator.RoundConfig.UpdateOrDefaultAsync(roundConfig, toFile: true);
-			coordinator.AbortAllRoundsInInputRegistration(nameof(RegTests), "");
+			coordinator.AbortAllRoundsInInputRegistration( "");
 
 			// Create the services.
 			// 1. Create connection service.

--- a/WalletWasabi.Tests/NodeBuilding/NodeBuilder.cs
+++ b/WalletWasabi.Tests/NodeBuilding/NodeBuilder.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Tests.NodeBuilding
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<NodeBuilder>(ex);
+				Logger.LogError(ex);
 			}
 		}
 

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -68,7 +68,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 					.Build();
 			Global = (Backend.Global)BackendHost.Services.GetService(typeof(Backend.Global));
 			var hostInitializationTask = BackendHost.RunWithTasksAsync();
-			Logger.LogInfo($"Started Backend webhost: {BackendEndPoint}", nameof(Global));
+			Logger.LogInfo($"Started Backend webhost: {BackendEndPoint}");
 
 			var delayTask = Task.Delay(3000);
 			Task.WaitAny(delayTask, hostInitializationTask); // Wait for server to initialize (Without this OSX CI will fail)

--- a/WalletWasabi/Bases/ConfigBase.cs
+++ b/WalletWasabi/Bases/ConfigBase.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Bases
 
 			if (!File.Exists(FilePath))
 			{
-				Logger.LogInfo<ConfigBase>($"{GetType().Name} file did not exist. Created at path: `{FilePath}`.");
+				Logger.LogInfo($"{GetType().Name} file did not exist. Created at path: `{FilePath}`.");
 			}
 			else
 			{

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -50,7 +50,7 @@ namespace NBitcoin.RPC
 				}
 				catch (RPCException ex)
 				{
-					Logger.LogTrace<RPCClient>(ex);
+					Logger.LogTrace(ex);
 					// Hopefully Bitcoin Core brainfart: https://github.com/bitcoin/bitcoin/issues/14431
 					for (int i = 2; i <= Constants.SevenDaysConfirmationTarget; i++)
 					{
@@ -60,7 +60,7 @@ namespace NBitcoin.RPC
 						}
 						catch (RPCException ex2)
 						{
-							Logger.LogTrace<RPCClient>(ex2);
+							Logger.LogTrace(ex2);
 						}
 					}
 				}

--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -125,7 +125,7 @@ namespace WalletWasabi.Helpers
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug(ex, nameof(EnvironmentHelpers));
+				Logger.LogDebug(ex);
 			}
 
 			return directory;
@@ -157,7 +157,7 @@ namespace WalletWasabi.Helpers
 					process.WaitForExit();
 					if (process.ExitCode != 0)
 					{
-						Logger.LogError($"{nameof(ShellExec)} command: {cmd} exited with exit code: {process.ExitCode}, instead of 0.", nameof(EnvironmentHelpers));
+						Logger.LogError($"{nameof(ShellExec)} command: {cmd} exited with exit code: {process.ExitCode}, instead of 0.");
 					}
 				}
 			}

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -34,7 +34,7 @@ namespace System.IO
 						throw;
 					}
 					// System.IO.IOException: The directory is not empty
-					Logger.LogDebug($"Gnomes prevent deletion of {destinationDir}! Applying magic dust, attempt #{gnomes}.", nameof(IoHelpers));
+					Logger.LogDebug($"Gnomes prevent deletion of {destinationDir}! Applying magic dust, attempt #{gnomes}.");
 
 					// see http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true for more magic
 					await Task.Delay(100);
@@ -47,7 +47,7 @@ namespace System.IO
 						throw;
 					}
 					// Wait, maybe another software make us authorized a little later
-					Logger.LogDebug($"Gnomes prevent deletion of {destinationDir}! Applying magic dust, attempt #{gnomes}.", nameof(IoHelpers));
+					Logger.LogDebug($"Gnomes prevent deletion of {destinationDir}! Applying magic dust, attempt #{gnomes}.");
 
 					// see http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true for more magic
 					await Task.Delay(100);
@@ -157,7 +157,7 @@ namespace System.IO
 						}
 						catch (Exception ex)
 						{
-							Logger.LogError(ex, nameof(IoHelpers));
+							Logger.LogError(ex);
 						}
 
 						if (openWithNotepad)

--- a/WalletWasabi/Helpers/PasswordHelper.cs
+++ b/WalletWasabi/Helpers/PasswordHelper.cs
@@ -125,7 +125,7 @@ namespace WalletWasabi.Helpers
 					if (resultException != null) // Now the password is OK but if we had SecurityException before than we used a cmp password.
 					{
 						compatiblityPassword = pw;
-						Logger.LogError<KeyManager>(CompatibilityPasswordWarnMessage);
+						Logger.LogError(CompatibilityPasswordWarnMessage);
 					}
 					return result;
 				}

--- a/WalletWasabi/Helpers/RuntimeParams.cs
+++ b/WalletWasabi/Helpers/RuntimeParams.cs
@@ -68,7 +68,7 @@ namespace WalletWasabi.Helpers
 			}
 			catch (Exception ex)
 			{
-				Logger.LogInfo<RuntimeParams>($"Could not save {nameof(RuntimeParams)}: {ex}.");
+				Logger.LogInfo($"Could not save {nameof(RuntimeParams)}: {ex}.");
 			}
 		}
 
@@ -88,7 +88,7 @@ namespace WalletWasabi.Helpers
 			}
 			catch (Exception ex)
 			{
-				Logger.LogInfo<RuntimeParams>($"Could not load {nameof(RuntimeParams)}: {ex}.");
+				Logger.LogInfo($"Could not load {nameof(RuntimeParams)}: {ex}.");
 			}
 			InternalInstance = new RuntimeParams();
 		}

--- a/WalletWasabi/Http/Models/StatusLine.cs
+++ b/WalletWasabi/Http/Models/StatusLine.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.Http.Models
 			}
 			catch (Exception ex)
 			{
-				Logger.LogTrace<StatusLine>(ex); // Often happens when internet connection is lost mid request.
+				Logger.LogTrace(ex); // Often happens when internet connection is lost mid request.
 				throw new NotSupportedException($"Invalid {nameof(StatusLine)}: {statusLineString}.", ex);
 			}
 		}

--- a/WalletWasabi/Hwi/HwiProcessManager.cs
+++ b/WalletWasabi/Hwi/HwiProcessManager.cs
@@ -232,12 +232,12 @@ namespace WalletWasabi.Hwi
 
 			if (!File.Exists(hwiPath))
 			{
-				Logger.LogInfo($"HWI instance NOT found at `{hwiPath}`. Attempting to acquire it...", nameof(HwiProcessManager));
+				Logger.LogInfo($"HWI instance NOT found at `{hwiPath}`. Attempting to acquire it...");
 				await InstallHwiAsync(fullBaseDirectory, hwiDir);
 			}
 			else if (!IoHelpers.CheckExpectedHash(hwiPath, Path.Combine(fullBaseDirectory, "Hwi", "Software")))
 			{
-				Logger.LogInfo($"Updating HWI...", nameof(HwiProcessManager));
+				Logger.LogInfo($"Updating HWI...");
 
 				string backupHwiDir = $"{hwiDir}_backup";
 				if (Directory.Exists(backupHwiDir))
@@ -252,7 +252,7 @@ namespace WalletWasabi.Hwi
 			{
 				if (logFound)
 				{
-					Logger.LogInfo($"HWI instance found at `{hwiPath}`.", nameof(HwiProcessManager));
+					Logger.LogInfo($"HWI instance found at `{hwiPath}`.");
 				}
 			}
 
@@ -267,19 +267,19 @@ namespace WalletWasabi.Hwi
 			{
 				string hwiLinuxZip = Path.Combine(hwiSoftwareDir, "hwi-linux64.zip");
 				await IoHelpers.BetterExtractZipToDirectoryAsync(hwiLinuxZip, hwiDir);
-				Logger.LogInfo($"Extracted {hwiLinuxZip} to `{hwiDir}`.", nameof(HwiProcessManager));
+				Logger.LogInfo($"Extracted {hwiLinuxZip} to `{hwiDir}`.");
 			}
 			else // OSX
 			{
 				string hwiOsxZip = Path.Combine(hwiSoftwareDir, "hwi-osx64.zip");
 				await IoHelpers.BetterExtractZipToDirectoryAsync(hwiOsxZip, hwiDir);
-				Logger.LogInfo($"Extracted {hwiOsxZip} to `{hwiDir}`.", nameof(HwiProcessManager));
+				Logger.LogInfo($"Extracted {hwiOsxZip} to `{hwiDir}`.");
 			}
 
 			// Make sure there's sufficient permission.
 			string chmodHwiDirCmd = $"chmod -R 750 {hwiDir}";
 			EnvironmentHelpers.ShellExec(chmodHwiDirCmd);
-			Logger.LogInfo($"Shell command executed: {chmodHwiDirCmd}.", nameof(HwiProcessManager));
+			Logger.LogInfo($"Shell command executed: {chmodHwiDirCmd}.");
 		}
 	}
 }

--- a/WalletWasabi/Io/DigestableSafeMutexIoManager.cs
+++ b/WalletWasabi/Io/DigestableSafeMutexIoManager.cs
@@ -168,8 +168,8 @@ namespace WalletWasabi.Io
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<DigestableSafeMutexIoManager>("Failed to create digest.");
-				Logger.LogInfo<DigestableSafeMutexIoManager>(ex);
+				Logger.LogWarning("Failed to create digest.");
+				Logger.LogInfo(ex);
 			}
 		}
 
@@ -195,8 +195,8 @@ namespace WalletWasabi.Io
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<DigestableSafeMutexIoManager>("Failed to read digest.");
-				Logger.LogInfo<DigestableSafeMutexIoManager>(ex);
+				Logger.LogWarning("Failed to read digest.");
+				Logger.LogInfo(ex);
 			}
 
 			return (false, hash);

--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -672,7 +672,7 @@ namespace WalletWasabi.KeyManagement
 				if (toRemove.Any())
 				{
 					ToFileNoBlockchainStateLock();
-					Logger.LogInfo<KeyManager>($"Corrected {toRemove.Count} heights.");
+					Logger.LogInfo($"Corrected {toRemove.Count} heights.");
 				}
 			}
 		}
@@ -790,9 +790,9 @@ namespace WalletWasabi.KeyManagement
 
 					if (lastNetwork != null)
 					{
-						Logger.LogWarning<KeyManager>($"Wallet is opened on {expectedNetwork}. Last time it was opened on {lastNetwork}.");
+						Logger.LogWarning($"Wallet is opened on {expectedNetwork}. Last time it was opened on {lastNetwork}.");
 					}
-					Logger.LogInfo<KeyManager>("Blockchain cache is cleared.");
+					Logger.LogInfo("Blockchain cache is cleared.");
 				}
 			}
 		}

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using WalletWasabi.Crypto;
@@ -107,7 +108,7 @@ namespace WalletWasabi.Logging
 
 		#region GeneralLoggingMethods
 
-		private static void Log(LogLevel level, string message, string category, int additionalEntrySeparators = 0, bool additionalEntrySeparatorsLogFileOnlyMode = true)
+		private static void Log(LogLevel level, string message, int additionalEntrySeparators = 0, bool additionalEntrySeparatorsLogFileOnlyMode = true, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
 			try
 			{
@@ -122,10 +123,10 @@ namespace WalletWasabi.Logging
 				}
 
 				message = string.IsNullOrWhiteSpace(message) ? "" : message;
-				category = string.IsNullOrWhiteSpace(category) ? "" : category;
+				var category = string.IsNullOrWhiteSpace(callerFilePath) ? "" : $"{Path.GetFileNameWithoutExtension(callerFilePath)} ({callerLineNumber})";
 
 				var messageBuilder = new StringBuilder();
-				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} {level.ToString().ToUpperInvariant()}");
+				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} {level.ToString().ToUpperInvariant()}\t");
 
 				if (message == "")
 				{
@@ -135,18 +136,18 @@ namespace WalletWasabi.Logging
 					}
 					else // If only the message is empty.
 					{
-						messageBuilder.Append($" {category}{EntrySeparator}");
+						messageBuilder.Append($"{category}{EntrySeparator}");
 					}
 				}
 				else
 				{
 					if (category == "") // If only the category is empty.
 					{
-						messageBuilder.Append($": {message}{EntrySeparator}");
+						messageBuilder.Append($"{message}{EntrySeparator}");
 					}
 					else // If none of them empty.
 					{
-						messageBuilder.Append($" {category}: {message}{EntrySeparator}");
+						messageBuilder.Append($"{category}\t{message}{EntrySeparator}");
 					}
 				}
 
@@ -218,7 +219,7 @@ namespace WalletWasabi.Logging
 			{
 				if (Interlocked.Increment(ref LoggingFailedCount) == 1) // If it only failed the first time, try log the failure.
 				{
-					LogDebug($"Logging failed: {ex}", $"{nameof(Logger)}.{nameof(Logging)}.{nameof(Logger)}");
+					LogDebug($"Logging failed: {ex}");
 				}
 				// If logging the failure is successful then clear the failure counter.
 				// If it's not the first time the logging failed, then we do not try to log logging failure, so clear the failure counter.
@@ -226,37 +227,13 @@ namespace WalletWasabi.Logging
 			}
 		}
 
-		private static void Log(LogLevel level, string message, Type category)
-		{
-			if (category is null)
-			{
-				Log(level, message, "");
-			}
-			else
-			{
-				Log(level, message, category.ToString());
-			}
-		}
-
-		private static void Log<T>(LogLevel level, string message) => Log(level, message, typeof(T).Name);
-
 		#endregion GeneralLoggingMethods
 
 		#region ExceptionLoggingMethods
 
-		private static void Log(Exception ex, LogLevel level, string category = "")
+		private static void Log(Exception ex, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
-			Log(level, ExceptionToStringHandleNull(ex), category);
-		}
-
-		private static void Log<T>(Exception ex, LogLevel level)
-		{
-			Log<T>(level, ExceptionToStringHandleNull(ex));
-		}
-
-		private static void Log(Exception ex, LogLevel level, Type category = null)
-		{
-			Log(level, ExceptionToStringHandleNull(ex), category);
+			Log(level, ExceptionToStringHandleNull(ex), callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 		}
 
 		private static string ExceptionToStringHandleNull(Exception ex)
@@ -273,21 +250,7 @@ namespace WalletWasabi.Logging
 		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
 		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
 		/// </summary>
-		public static void LogTrace<T>(string message) => Log<T>(LogLevel.Trace, message);
-
-		/// <summary>
-		/// For information that is valuable only to a developer debugging an issue.
-		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
-		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
-		/// </summary>
-		public static void LogTrace(string message, Type category) => Log(LogLevel.Trace, message, category);
-
-		/// <summary>
-		/// For information that is valuable only to a developer debugging an issue.
-		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
-		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
-		/// </summary>
-		public static void LogTrace(string message, string category = "") => Log(LogLevel.Trace, message, category);
+		public static void LogTrace(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Trace, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Trace level.
@@ -296,25 +259,7 @@ namespace WalletWasabi.Logging
 		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
 		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
 		/// </summary>
-		public static void LogTrace<T>(Exception ex) => Log<T>(ex, LogLevel.Trace);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Trace level.
-		///
-		/// For information that is valuable only to a developer debugging an issue.
-		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
-		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
-		/// </summary>
-		public static void LogTrace(Exception ex, Type category) => Log(ex, LogLevel.Trace, category);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Trace level.
-		///
-		/// For information that is valuable only to a developer debugging an issue.
-		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
-		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
-		/// </summary>
-		public static void LogTrace(Exception ex, string category = "") => Log(ex, LogLevel.Trace, category);
+		public static void LogTrace(Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(ex, LogLevel.Trace, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		#endregion TraceLoggingMethods
 
@@ -325,21 +270,7 @@ namespace WalletWasabi.Logging
 		/// Example: "Entering method Configure with flag set to true."
 		/// You typically would not enable Debug level logs in production unless you are troubleshooting, due to the high volume of logs.
 		/// </summary>
-		public static void LogDebug<T>(string message) => Log<T>(LogLevel.Debug, message);
-
-		/// <summary>
-		/// For information that has short-term usefulness during development and debugging.
-		/// Example: "Entering method Configure with flag set to true."
-		/// You typically would not enable Debug level logs in production unless you are troubleshooting, due to the high volume of logs.
-		/// </summary>
-		public static void LogDebug(string message, Type category) => Log(LogLevel.Debug, message, category);
-
-		/// <summary>
-		/// For information that has short-term usefulness during development and debugging.
-		/// Example: "Entering method Configure with flag set to true."
-		/// You typically would not enable Debug level logs in production unless you are troubleshooting, due to the high volume of logs.
-		/// </summary>
-		public static void LogDebug(string message, string category = "") => Log(LogLevel.Debug, message, category);
+		public static void LogDebug(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Debug, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Debug level, if only Debug level logging is set.
@@ -348,25 +279,7 @@ namespace WalletWasabi.Logging
 		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
 		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
 		/// </summary>
-		public static void LogDebug<T>(Exception ex) => Log<T>(ex, LogLevel.Debug);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Debug level, if only Debug level logging is set.
-		///
-		/// For information that is valuable only to a developer debugging an issue.
-		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
-		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
-		/// </summary>
-		public static void LogDebug(Exception ex, Type category = null) => Log(ex, LogLevel.Debug, category);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Debug level.
-		///
-		/// For information that is valuable only to a developer debugging an issue.
-		/// These messages may contain sensitive application data and so should not be enabled in a production environment.
-		/// Example: "Credentials: {"User":"someuser", "Password":"P@ssword"}"
-		/// </summary>
-		public static void LogDebug(Exception ex, string category = "") => Log(ex, LogLevel.Debug, category);
+		public static void LogDebug(Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(ex, LogLevel.Debug, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		#endregion DebugLoggingMethods
 
@@ -376,28 +289,14 @@ namespace WalletWasabi.Logging
 		/// Logs software start with category InstanceGuid and insert three newlines.
 		/// </summary>
 		/// <param name="appName">The name of the app.</param>
-		public static void LogStarting(string appName) => Log(LogLevel.Info, $"{appName} is starting...", category: InstanceGuid.ToString(), additionalEntrySeparators: 3, additionalEntrySeparatorsLogFileOnlyMode: true);
+		public static void LogStarting(string appName, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Info, $"{appName} is starting...", additionalEntrySeparators: 3, additionalEntrySeparatorsLogFileOnlyMode: true, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// For tracking the general flow of the application.
 		/// These logs typically have some long-term value.
 		/// Example: "Request received for path /api/my-controller"
 		/// </summary>
-		public static void LogInfo<T>(string message) => Log<T>(LogLevel.Info, message);
-
-		/// <summary>
-		/// For tracking the general flow of the application.
-		/// These logs typically have some long-term value.
-		/// Example: "Request received for path /api/my-controller"
-		/// </summary>
-		public static void LogInfo(string message, Type category) => Log(LogLevel.Info, message, category);
-
-		/// <summary>
-		/// For tracking the general flow of the application.
-		/// These logs typically have some long-term value.
-		/// Example: "Request received for path /api/my-controller"
-		/// </summary>
-		public static void LogInfo(string message, string category = "") => Log(LogLevel.Info, message, category);
+		public static void LogInfo(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Info, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Info level.
@@ -406,23 +305,7 @@ namespace WalletWasabi.Logging
 		/// These logs typically have some long-term value.
 		/// Example: "Request received for path /api/my-controller"
 		/// </summary>
-		public static void LogInfo<T>(Exception ex) => Log<T>(ex, LogLevel.Info);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Info level.
-		///
-		/// For tracking the general flow of the application.
-		/// These logs typically have some long-term value.
-		/// </summary>
-		public static void LogInfo(Exception ex, Type category = null) => Log(ex, LogLevel.Info, category);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Info level.
-		///
-		/// For tracking the general flow of the application.
-		/// These logs typically have some long-term value.
-		/// </summary>
-		public static void LogInfo(Exception ex, string category = "") => Log(ex, LogLevel.Info, category);
+		public static void LogInfo(Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(ex, LogLevel.Info, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		#endregion InfoLoggingMethods
 
@@ -434,23 +317,7 @@ namespace WalletWasabi.Logging
 		/// Handled exceptions are a common place to use the Warning log level.
 		/// Example: "FileNotFoundException for file quotes.txt."
 		/// </summary>
-		public static void LogWarning<T>(string message) => Log<T>(LogLevel.Warning, message);
-
-		/// <summary>
-		/// For abnormal or unexpected events in the application flow.
-		/// These may include errors or other conditions that do not cause the application to stop, but which may need to be investigated.
-		/// Handled exceptions are a common place to use the Warning log level.
-		/// Example: "FileNotFoundException for file quotes.txt."
-		/// </summary>
-		public static void LogWarning(string message, Type category) => Log(LogLevel.Warning, message, category);
-
-		/// <summary>
-		/// For abnormal or unexpected events in the application flow.
-		/// These may include errors or other conditions that do not cause the application to stop, but which may need to be investigated.
-		/// Handled exceptions are a common place to use the Warning log level.
-		/// Example: "FileNotFoundException for file quotes.txt."
-		/// </summary>
-		public static void LogWarning(string message, string category = "") => Log(LogLevel.Warning, message, category);
+		public static void LogWarning(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Warning, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Warning level.
@@ -460,27 +327,7 @@ namespace WalletWasabi.Logging
 		/// Handled exceptions are a common place to use the Warning log level.
 		/// Example: "FileNotFoundException for file quotes.txt."
 		/// </summary>
-		public static void LogWarning<T>(Exception ex) => Log<T>(ex, LogLevel.Warning);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Warning level.
-		///
-		/// For abnormal or unexpected events in the application flow.
-		/// These may include errors or other conditions that do not cause the application to stop, but which may need to be investigated.
-		/// Handled exceptions are a common place to use the Warning log level.
-		/// Example: "FileNotFoundException for file quotes.txt."
-		/// </summary>
-		public static void LogWarning(Exception ex, Type category = null) => Log(ex, LogLevel.Warning, category);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Warning level.
-		///
-		/// For abnormal or unexpected events in the application flow.
-		/// These may include errors or other conditions that do not cause the application to stop, but which may need to be investigated.
-		/// Handled exceptions are a common place to use the Warning log level.
-		/// Example: "FileNotFoundException for file quotes.txt."
-		/// </summary>
-		public static void LogWarning(Exception ex, string category = "") => Log(ex, LogLevel.Warning, category);
+		public static void LogWarning(Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(ex, LogLevel.Warning, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		#endregion WarningLoggingMethods
 
@@ -491,21 +338,7 @@ namespace WalletWasabi.Logging
 		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
 		/// Example log message: "Cannot insert record due to duplicate key violation."
 		/// </summary>
-		public static void LogError<T>(string message) => Log<T>(LogLevel.Error, message);
-
-		/// <summary>
-		/// For errors and exceptions that cannot be handled.
-		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
-		/// Example log message: "Cannot insert record due to duplicate key violation."
-		/// </summary>
-		public static void LogError(string message, Type category) => Log(LogLevel.Error, message, category);
-
-		/// <summary>
-		/// For errors and exceptions that cannot be handled.
-		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
-		/// Example log message: "Cannot insert record due to duplicate key violation."
-		/// </summary>
-		public static void LogError(string message, string category = "") => Log(LogLevel.Error, message, category);
+		public static void LogError(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Error, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Error level.
@@ -514,25 +347,7 @@ namespace WalletWasabi.Logging
 		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
 		/// Example log message: "Cannot insert record due to duplicate key violation."
 		/// </summary>
-		public static void LogError<T>(Exception ex) => Log<T>(ex, LogLevel.Error);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Error level.
-		///
-		/// For errors and exceptions that cannot be handled.
-		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
-		/// Example log message: "Cannot insert record due to duplicate key violation."
-		/// </summary>
-		public static void LogError(Exception ex, Type category = null) => Log(ex, LogLevel.Error, category);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.ToString() at Error level.
-		///
-		/// For errors and exceptions that cannot be handled.
-		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
-		/// Example log message: "Cannot insert record due to duplicate key violation."
-		/// </summary>
-		public static void LogError(Exception ex, string category = "") => Log(ex, LogLevel.Error, category);
+		public static void LogError(Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(ex, LogLevel.Error, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		#endregion ErrorLoggingMethods
 
@@ -542,19 +357,7 @@ namespace WalletWasabi.Logging
 		/// For failures that require immediate attention.
 		/// Examples: data loss scenarios, out of disk space.
 		/// </summary>
-		public static void LogCritical<T>(string message) => Log<T>(LogLevel.Critical, message);
-
-		/// <summary>
-		/// For failures that require immediate attention.
-		/// Examples: data loss scenarios, out of disk space.
-		/// </summary>
-		public static void LogCritical(string message, Type category) => Log(LogLevel.Critical, message, category);
-
-		/// <summary>
-		/// For failures that require immediate attention.
-		/// Examples: data loss scenarios, out of disk space.
-		/// </summary>
-		public static void LogCritical(string message, string category = "") => Log(LogLevel.Critical, message, category);
+		public static void LogCritical(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Critical, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.Message at Critical level.
@@ -562,23 +365,7 @@ namespace WalletWasabi.Logging
 		/// For failures that require immediate attention.
 		/// Examples: data loss scenarios, out of disk space.
 		/// </summary>
-		public static void LogCritical<T>(Exception ex) => Log<T>(ex, LogLevel.Critical);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.Message at Critical level.
-		///
-		/// For failures that require immediate attention.
-		/// Examples: data loss scenarios, out of disk space.
-		/// </summary>
-		public static void LogCritical(Exception ex, Type category = null) => Log(ex, LogLevel.Critical, category);
-
-		/// <summary>
-		/// Logs the <paramref name="ex"/>.Message at Critical level.
-		///
-		/// For failures that require immediate attention.
-		/// Examples: data loss scenarios, out of disk space.
-		/// </summary>
-		public static void LogCritical(Exception ex, string category = "") => Log(ex, LogLevel.Critical, category);
+		public static void LogCritical(Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(ex, LogLevel.Critical, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
 		#endregion CriticalLoggingMethods
 

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjClientState.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				if (!(WaitingList.ContainsKey(coin) || Rounds.Any(x => x.CoinsRegistered.Contains(coin))))
 				{
 					WaitingList.Add(coin, DateTimeOffset.UtcNow);
-					Logger.LogInfo<CcjClientState>($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}.");
+					Logger.LogInfo($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}.");
 				}
 			}
 		}
@@ -54,7 +54,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				if (WaitingList.ContainsKey(coin))
 				{
 					WaitingList.Remove(coin);
-					Logger.LogInfo<CcjClientState>($"Coin removed from the waiting list: {coin.Index}:{coin.TransactionId}.");
+					Logger.LogInfo($"Coin removed from the waiting list: {coin.Index}:{coin.TransactionId}.");
 				}
 			}
 		}
@@ -423,7 +423,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						{
 							var delayRegistration = TimeSpan.FromSeconds(60);
 							WaitingList.Add(coin, DateTimeOffset.UtcNow + delayRegistration);
-							Logger.LogInfo<CcjClientState>($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}, but its registration is not allowed till {delayRegistration.TotalSeconds} seconds, because this coin might already be spent.");
+							Logger.LogInfo($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}, but its registration is not allowed till {delayRegistration.TotalSeconds} seconds, because this coin might already be spent.");
 
 							if (roundFailed)
 							{
@@ -440,13 +440,13 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						else
 						{
 							WaitingList.Add(coin, DateTimeOffset.UtcNow);
-							Logger.LogInfo<CcjClientState>($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}.");
+							Logger.LogInfo($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}.");
 						}
 					}
 
 					round?.Registration?.AliceClient?.Dispose();
 
-					Logger.LogInfo<CcjClientState>($"Round ({round.State.RoundId}) removed. Reason: It's not running anymore.");
+					Logger.LogInfo($"Round ({round.State.RoundId}) removed. Reason: It's not running anymore.");
 				}
 				Rounds.RemoveAll(x => roundsToRemove.Contains(x.State.RoundId));
 
@@ -464,7 +464,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					{
 						var r = new CcjClientRound(state);
 						Rounds.Add(r);
-						Logger.LogInfo<CcjClientState>($"Round ({r.State.RoundId}) added.");
+						Logger.LogInfo($"Round ({r.State.RoundId}) added.");
 					}
 				}
 			}
@@ -479,11 +479,11 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				foreach (var r in Rounds.Where(x => x.State.RoundId == round.State.RoundId))
 				{
 					r?.Registration?.AliceClient?.Dispose();
-					Logger.LogInfo<CcjClientState>($"Round ({round.State.RoundId}) removed. Reason: It's being replaced.");
+					Logger.LogInfo($"Round ({round.State.RoundId}) removed. Reason: It's being replaced.");
 				}
 				Rounds.RemoveAll(x => x.State.RoundId == round.State.RoundId);
 				Rounds.Add(round);
-				Logger.LogInfo<CcjClientState>($"Round ({round.State.RoundId}) added.");
+				Logger.LogInfo($"Round ({round.State.RoundId}) added.");
 			}
 		}
 
@@ -496,10 +496,10 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					foreach (var coin in round.CoinsRegistered)
 					{
 						WaitingList.Add(coin, DateTimeOffset.UtcNow);
-						Logger.LogInfo<CcjClientState>($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}.");
+						Logger.LogInfo($"Coin added to the waiting list: {coin.Index}:{coin.TransactionId}.");
 					}
 					round.ClearRegistration();
-					Logger.LogInfo<CcjClientState>($"Round ({round.State.RoundId}) registration is cleared.");
+					Logger.LogInfo($"Round ({round.State.RoundId}) registration is cleared.");
 				}
 			}
 		}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -194,7 +194,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				Alices = new List<Alice>();
 				Bobs = new List<Bob>();
 
-				Logger.LogInfo<CcjRound>($"New round ({RoundId}) is created.\n\t" +
+				Logger.LogInfo($"New round ({RoundId}) is created.\n\t" +
 					$"BaseDenomination: {MixingLevels.GetBaseDenomination().ToString(false, true)} BTC.\n\t" +
 					$"{nameof(AdjustedConfirmationTarget)}: {AdjustedConfirmationTarget}.\n\t" +
 					$"{nameof(CoordinatorFeePercent)}: {CoordinatorFeePercent}%.\n\t" +
@@ -202,8 +202,8 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<CcjRound>($"Round ({RoundId}): Could not create.");
-				Logger.LogError<CcjRound>(ex);
+				Logger.LogError($"Round ({RoundId}): Could not create.");
+				Logger.LogError(ex);
 				throw;
 			}
 		}
@@ -221,7 +221,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			{
 				try
 				{
-					Logger.LogInfo<CcjRound>($"Round ({RoundId}): Phase change requested: {expectedPhase.ToString()}.");
+					Logger.LogInfo($"Round ({RoundId}): Phase change requested: {expectedPhase.ToString()}.");
 
 					if (Status == CcjRoundStatus.NotStarted) // So start the input registration phase
 					{
@@ -426,11 +426,11 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 						return;
 					}
 
-					Logger.LogInfo<CcjRound>($"Round ({RoundId}): Phase initialized: {expectedPhase.ToString()}.");
+					Logger.LogInfo($"Round ({RoundId}): Phase initialized: {expectedPhase.ToString()}.");
 				}
 				catch (Exception ex)
 				{
-					Logger.LogError<CcjRound>(ex);
+					Logger.LogError(ex);
 					Status = CcjRoundStatus.Aborted;
 					throw;
 				}
@@ -481,15 +481,15 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 							if (expectedPhase == CcjRoundPhase.ConnectionConfirmation)
 							{
-								Logger.LogInfo<CcjRound>(timedOutLogString);
+								Logger.LogInfo(timedOutLogString);
 							}
 							else if (expectedPhase == CcjRoundPhase.OutputRegistration)
 							{
-								Logger.LogInfo<CcjRound>($"{timedOutLogString} Progressing to signing phase to blame...");
+								Logger.LogInfo($"{timedOutLogString} Progressing to signing phase to blame...");
 							}
 							else
 							{
-								Logger.LogInfo<CcjRound>($"{timedOutLogString} Aborting...");
+								Logger.LogInfo($"{timedOutLogString} Aborting...");
 							}
 
 							// This will happen outside the lock.
@@ -507,7 +507,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 													int aliceCountAfterInputRegistrationTimeout = CountAlices();
 													if (aliceCountAfterInputRegistrationTimeout < 2)
 													{
-														Abort(nameof(CcjRound), $"Only {aliceCountAfterInputRegistrationTimeout} Alices registered.");
+														Abort($"Only {aliceCountAfterInputRegistrationTimeout} Alices registered.");
 													}
 													else
 													{
@@ -544,7 +544,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 														await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, alicesToBan.SelectMany(x => x.Inputs.Select(y => y.Outpoint)).ToArray());
 													}
 
-													Abort(nameof(CcjRound), $"{alicesToBan.Length} Alices did not sign.");
+													Abort($"{alicesToBan.Length} Alices did not sign.");
 												}
 												break;
 
@@ -554,14 +554,14 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 									}
 									catch (Exception ex)
 									{
-										Logger.LogWarning<CcjRound>($"Round ({RoundId}): {expectedPhase.ToString()} timeout failed with exception: {ex}.");
+										Logger.LogWarning($"Round ({RoundId}): {expectedPhase.ToString()} timeout failed with exception: {ex}.");
 									}
 								});
 						}
 					}
 					catch (Exception ex)
 					{
-						Logger.LogWarning<CcjRound>($"Round ({RoundId}): {expectedPhase.ToString()} timeout failed with exception: {ex}.");
+						Logger.LogWarning($"Round ({RoundId}): {expectedPhase.ToString()} timeout failed with exception: {ex}.");
 					}
 				});
 		}
@@ -596,7 +596,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			int didNotConfirmeCount = AnonymitySet - aliceCountAfterConnectionConfirmationTimeout;
 			if (aliceCountAfterConnectionConfirmationTimeout < 2)
 			{
-				Abort(nameof(CcjRound), $"{didNotConfirmeCount} Alices did not confirm their connection.");
+				Abort($"{didNotConfirmeCount} Alices did not confirm their connection.");
 			}
 			else
 			{
@@ -760,13 +760,13 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				}
 				else
 				{
-					Logger.LogError<CcjRound>($"This is impossible. {nameof(optimalFeeRate)}: {optimalFeeRate}, {nameof(currentFeeRate)}: {currentFeeRate}.");
+					Logger.LogError($"This is impossible. {nameof(optimalFeeRate)}: {optimalFeeRate}, {nameof(currentFeeRate)}: {currentFeeRate}.");
 				}
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CcjRound>("Failed to optimize fees. Fallback to normal fees.");
-				Logger.LogWarning<CcjRound>(ex);
+				Logger.LogWarning("Failed to optimize fees. Fallback to normal fees.");
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -783,13 +783,13 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 				if (originalConfirmationTarget != AdjustedConfirmationTarget)
 				{
-					Logger.LogInfo<CcjRound>($"Confirmation target is optimized from {originalConfirmationTarget} blocks to {AdjustedConfirmationTarget} blocks.");
+					Logger.LogInfo($"Confirmation target is optimized from {originalConfirmationTarget} blocks to {AdjustedConfirmationTarget} blocks.");
 				}
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CcjRound>($"Failed to optimize confirmation target. Fallback using the original one: {AdjustedConfirmationTarget} blocks.");
-				Logger.LogWarning<CcjRound>(ex);
+				Logger.LogWarning($"Failed to optimize confirmation target. Fallback using the original one: {AdjustedConfirmationTarget} blocks.");
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -829,7 +829,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 					feePerOutputs = Math.Max(feePerBytes * outputSizeInBytes, Money.Satoshis(250));
 				}
 
-				Logger.LogError<CcjRound>(ex);
+				Logger.LogError(ex);
 			}
 
 			return (feePerInputs, feePerOutputs);
@@ -848,10 +848,10 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 			{
 				Status = CcjRoundStatus.Succeded;
 			}
-			Logger.LogInfo<CcjRound>($"Round ({RoundId}): Succeeded.");
+			Logger.LogInfo($"Round ({RoundId}): Succeeded.");
 		}
 
-		public void Abort(string loggingCategory, string reason, bool syncLock = true)
+		public void Abort(string reason, bool syncLock = true)
 		{
 			if (syncLock)
 			{
@@ -865,15 +865,13 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				Status = CcjRoundStatus.Aborted;
 			}
 
-			string category = string.IsNullOrWhiteSpace(loggingCategory) ? loggingCategory : nameof(CcjRound);
-
 			if (string.IsNullOrWhiteSpace(reason))
 			{
-				Logger.LogInfo($"Round ({RoundId}): Aborted.", category);
+				Logger.LogInfo($"Round ({RoundId}): Aborted.");
 			}
 			else
 			{
-				Logger.LogInfo($"Round ({RoundId}): Aborted. Reason: {reason}.", category);
+				Logger.LogInfo($"Round ({RoundId}): Aborted. Reason: {reason}.");
 			}
 		}
 
@@ -1037,7 +1035,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 								if (alice.LastSeen == started)
 								{
 									Alices.Remove(alice);
-									Logger.LogInfo<CcjRound>($"Round ({RoundId}): Alice ({alice.UniqueId}) timed out.");
+									Logger.LogInfo($"Round ({RoundId}): Alice ({alice.UniqueId}) timed out.");
 								}
 							}
 						}
@@ -1066,34 +1064,34 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				// Check if fully signed.
 				if (SignedCoinJoin.Inputs.All(x => x.HasWitScript()))
 				{
-					Logger.LogInfo<CcjRound>($"Round ({RoundId}): Trying to broadcast coinjoin.");
+					Logger.LogInfo($"Round ({RoundId}): Trying to broadcast coinjoin.");
 
 					try
 					{
 						Coin[] spentCoins = Alices.SelectMany(x => x.Inputs).ToArray();
 						Money networkFee = SignedCoinJoin.GetFee(spentCoins);
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Network Fee: {networkFee.ToString(false, false)} BTC.");
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Coordinator Fee: {SignedCoinJoin.Outputs.SingleOrDefault(x => x.ScriptPubKey == Constants.GetCoordinatorAddress(Network).ScriptPubKey)?.Value?.ToString(false, false) ?? "0"} BTC.");
+						Logger.LogInfo($"Round ({RoundId}): Network Fee: {networkFee.ToString(false, false)} BTC.");
+						Logger.LogInfo($"Round ({RoundId}): Coordinator Fee: {SignedCoinJoin.Outputs.SingleOrDefault(x => x.ScriptPubKey == Constants.GetCoordinatorAddress(Network).ScriptPubKey)?.Value?.ToString(false, false) ?? "0"} BTC.");
 						FeeRate feeRate = SignedCoinJoin.GetFeeRate(spentCoins);
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Network Fee Rate: {feeRate.FeePerK.ToDecimal(MoneyUnit.Satoshi) / 1000} sat/byte.");
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Number of inputs: {SignedCoinJoin.Inputs.Count}.");
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Number of outputs: {SignedCoinJoin.Outputs.Count}.");
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Serialized Size: {SignedCoinJoin.GetSerializedSize() / 1024} KB.");
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): VSize: {SignedCoinJoin.GetVirtualSize() / 1024} KB.");
+						Logger.LogInfo($"Round ({RoundId}): Network Fee Rate: {feeRate.FeePerK.ToDecimal(MoneyUnit.Satoshi) / 1000} sat/byte.");
+						Logger.LogInfo($"Round ({RoundId}): Number of inputs: {SignedCoinJoin.Inputs.Count}.");
+						Logger.LogInfo($"Round ({RoundId}): Number of outputs: {SignedCoinJoin.Outputs.Count}.");
+						Logger.LogInfo($"Round ({RoundId}): Serialized Size: {SignedCoinJoin.GetSerializedSize() / 1024} KB.");
+						Logger.LogInfo($"Round ({RoundId}): VSize: {SignedCoinJoin.GetVirtualSize() / 1024} KB.");
 						foreach (var o in SignedCoinJoin.GetIndistinguishableOutputs(includeSingle: false))
 						{
-							Logger.LogInfo<CcjRound>($"Round ({RoundId}): There are {o.count} occurrences of {o.value.ToString(true, false)} BTC output.");
+							Logger.LogInfo($"Round ({RoundId}): There are {o.count} occurrences of {o.value.ToString(true, false)} BTC output.");
 						}
 
 						await RpcClient.SendRawTransactionAsync(SignedCoinJoin);
 						CoinJoinBroadcasted?.Invoke(this, SignedCoinJoin);
 						Succeed(syncLock: false);
-						Logger.LogInfo<CcjRound>($"Round ({RoundId}): Successfully broadcasted the CoinJoin: {SignedCoinJoin.GetHash()}.");
+						Logger.LogInfo($"Round ({RoundId}): Successfully broadcasted the CoinJoin: {SignedCoinJoin.GetHash()}.");
 					}
 					catch (Exception ex)
 					{
-						Abort(nameof(CcjRound), $"Could not broadcast the CoinJoin: {SignedCoinJoin.GetHash()}.", syncLock: false);
-						Logger.LogError<CcjRound>(ex);
+						Abort($"Could not broadcast the CoinJoin: {SignedCoinJoin.GetHash()}.", syncLock: false);
+						Logger.LogError(ex);
 					}
 				}
 			}
@@ -1120,7 +1118,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				}
 				AnonymitySet = anonymitySet;
 			}
-			Logger.LogInfo<CcjRound>($"Round ({RoundId}): {nameof(AnonymitySet)} updated: {AnonymitySet}.");
+			Logger.LogInfo($"Round ({RoundId}): {nameof(AnonymitySet)} updated: {AnonymitySet}.");
 		}
 
 		public void AddAlice(Alice alice)
@@ -1136,7 +1134,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			StartAliceTimeout(alice.UniqueId);
 
-			Logger.LogInfo<CcjRound>($"Round ({RoundId}): Alice ({alice.InputSum.ToString(false, false)}) added.");
+			Logger.LogInfo($"Round ({RoundId}): Alice ({alice.InputSum.ToString(false, false)}) added.");
 		}
 
 		public void AddBob(Bob bob)
@@ -1152,7 +1150,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				Bobs.Add(bob);
 			}
 
-			Logger.LogInfo<CcjRound>($"Round ({RoundId}): Bob ({bob.Level.Denomination}) added.");
+			Logger.LogInfo($"Round ({RoundId}): Bob ({bob.Level.Denomination}) added.");
 		}
 
 		public async Task<IEnumerable<Alice>> RemoveAlicesIfAnInputRefusedByMempoolAsync()
@@ -1192,7 +1190,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			foreach (var alice in alicesRemoved)
 			{
-				Logger.LogInfo<CcjRound>($"Round ({RoundId}): Alice ({alice.UniqueId}) removed.");
+				Logger.LogInfo($"Round ({RoundId}): Alice ({alice.UniqueId}) removed.");
 			}
 
 			return alicesRemoved;
@@ -1215,7 +1213,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 
 			if (numberOfRemovedAlices > 0)
 			{
-				Logger.LogInfo<CcjRound>($"Round ({RoundId}): {numberOfRemovedAlices} alices are removed.");
+				Logger.LogInfo($"Round ({RoundId}): {numberOfRemovedAlices} alices are removed.");
 			}
 
 			return numberOfRemovedAlices;

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -305,7 +305,7 @@ namespace Nito.AsyncEx
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning<AsyncMutex>(ex);
+					Logger.LogWarning(ex);
 					// If the thread is still alive we must stop it
 					StopThread();
 
@@ -326,12 +326,12 @@ namespace Nito.AsyncEx
 			{
 				// abandoned mutexes are still acquired, we just need
 				// to handle the exception and treat it as acquisition
-				Logger.LogWarning($"{nameof(AbandonedMutexException)} in {ShortName}.", nameof(AsyncMutex));
+				Logger.LogWarning($"{nameof(AbandonedMutexException)} in {ShortName}.");
 				return new Key(this);
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError($"{ex.ToTypeMessageString()} in {ShortName}.", nameof(AsyncMutex));
+				Logger.LogError($"{ex.ToTypeMessageString()} in {ShortName}.");
 				inner = ex;
 				// Let it go.
 			}
@@ -364,7 +364,7 @@ namespace Nito.AsyncEx
 			catch (Exception ex)
 			{
 				// Let it go...
-				Logger.LogWarning<AsyncMutex>(ex);
+				Logger.LogWarning(ex);
 			}
 
 			// Final solution, abort the thread.
@@ -410,7 +410,7 @@ namespace Nito.AsyncEx
 					{
 						return;
 					}
-					Logger.LogDebug($"Waiting for: {string.Join(", ", AsyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName))}.", nameof(AsyncMutex));
+					Logger.LogDebug($"Waiting for: {string.Join(", ", AsyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName))}.");
 				}
 				await Task.Delay(200);
 				if (DateTime.Now - start > TimeSpan.FromSeconds(60))
@@ -454,7 +454,7 @@ namespace Nito.AsyncEx
 						}
 						catch (Exception ex)
 						{
-							Logger.LogWarning<AsyncMutex>(ex);
+							Logger.LogWarning(ex);
 						}
 					}
 

--- a/WalletWasabi/Services/CcjClient.cs
+++ b/WalletWasabi/Services/CcjClient.cs
@@ -134,7 +134,7 @@ namespace WalletWasabi.Services
 			{
 				try
 				{
-					Logger.LogInfo<CcjClient>($"{nameof(CcjClient)} is successfully initialized.");
+					Logger.LogInfo($"{nameof(CcjClient)} is successfully initialized.");
 
 					while (IsRunning)
 					{
@@ -171,7 +171,7 @@ namespace WalletWasabi.Services
 						}
 						catch (Exception ex)
 						{
-							Logger.LogError<CcjClient>(ex);
+							Logger.LogError(ex);
 						}
 						finally
 						{
@@ -181,7 +181,7 @@ namespace WalletWasabi.Services
 							}
 							catch (TaskCanceledException ex)
 							{
-								Logger.LogTrace<CcjClient>(ex);
+								Logger.LogTrace(ex);
 							}
 						}
 					}
@@ -274,11 +274,11 @@ namespace WalletWasabi.Services
 			}
 			catch (TaskCanceledException ex)
 			{
-				Logger.LogTrace<CcjClient>(ex);
+				Logger.LogTrace(ex);
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<CcjClient>(ex);
+				Logger.LogError(ex);
 			}
 			finally
 			{
@@ -330,7 +330,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<CcjClient>(ex); // Keep this in front of the logic (Logs will make more sense.)
+				Logger.LogError(ex); // Keep this in front of the logic (Logs will make more sense.)
 				if (ex.Message.StartsWith("Not Found", StringComparison.Ordinal)) // Alice timed out.
 				{
 					State.ClearRoundRegistration(ongoingRoundId);
@@ -424,7 +424,7 @@ namespace WalletWasabi.Services
 				{
 					if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput))
 					{
-						Logger.LogWarning<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.");
+						Logger.LogWarning($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.");
 						break;
 					}
 
@@ -449,7 +449,7 @@ namespace WalletWasabi.Services
 			}
 
 			ongoingRound.Registration.SetPhaseCompleted(CcjRoundPhase.OutputRegistration);
-			Logger.LogInfo<AliceClient>($"Round ({ongoingRound.State.RoundId}) Bob Posted outputs: {ongoingRound.Registration.ActiveOutputs.Count()}.");
+			Logger.LogInfo($"Round ({ongoingRound.State.RoundId}) Bob Posted outputs: {ongoingRound.Registration.ActiveOutputs.Count()}.");
 		}
 
 		private async Task TryConfirmConnectionAsync(CcjClientRound inputRegistrableRound)
@@ -475,7 +475,7 @@ namespace WalletWasabi.Services
 				{
 					State.ClearRoundRegistration(inputRegistrableRound.State.RoundId);
 				}
-				Logger.LogError<CcjClient>(ex);
+				Logger.LogError(ex);
 			}
 		}
 
@@ -563,7 +563,7 @@ namespace WalletWasabi.Services
 
 					coin.BannedUntilUtc = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(minuteInt);
 
-					Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
+					Logger.LogWarning(ex.Message.Split('\n')[1]);
 
 					await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator.");
 					aliceClient?.Dispose();
@@ -583,7 +583,7 @@ namespace WalletWasabi.Services
 
 					coin.SpentAccordingToBackend = true;
 
-					Logger.LogWarning<CcjClient>(ex.Message.Split('\n')[1]);
+					Logger.LogWarning(ex.Message.Split('\n')[1]);
 
 					await DequeueCoinsFromMixNoLockAsync(coinReference, "Failed to register the coin with the coordinator. The coin is already spent.");
 					aliceClient?.Dispose();
@@ -591,13 +591,13 @@ namespace WalletWasabi.Services
 				}
 				catch (HttpRequestException ex) when (ex.Message.Contains("No such running round in InputRegistration.", StringComparison.InvariantCultureIgnoreCase))
 				{
-					Logger.LogInfo<CcjClient>("Client tried to register a round that is not in InputRegistration anymore. Trying again later.");
+					Logger.LogInfo("Client tried to register a round that is not in InputRegistration anymore. Trying again later.");
 					aliceClient?.Dispose();
 					return;
 				}
 				catch (HttpRequestException ex) when (ex.Message.Contains("too-long-mempool-chain", StringComparison.InvariantCultureIgnoreCase))
 				{
-					Logger.LogInfo<CcjClient>("Coordinator failed because too much unconfirmed parent transactions. Trying again later.");
+					Logger.LogInfo("Coordinator failed because too much unconfirmed parent transactions. Trying again later.");
 					aliceClient?.Dispose();
 					return;
 				}
@@ -629,7 +629,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<CcjClient>(ex);
+				Logger.LogError(ex);
 			}
 		}
 
@@ -802,7 +802,7 @@ namespace WalletWasabi.Services
 
 					State.AddCoinToWaitingList(coin);
 					successful.Add(coin);
-					Logger.LogInfo<CcjClient>($"Coin queued: {coin.Index}:{coin.TransactionId}.");
+					Logger.LogInfo($"Coin queued: {coin.Index}:{coin.TransactionId}.");
 				}
 			}
 
@@ -1031,7 +1031,7 @@ namespace WalletWasabi.Services
 			CoinDequeued?.Invoke(this, coinWaitingForMix);
 			var correctReason = Guard.Correct(reason);
 			var reasonText = correctReason != "" ? $" Reason: {correctReason}" : "";
-			Logger.LogInfo<CcjClient>($"Coin dequeued: {coinWaitingForMix.Index}:{coinWaitingForMix.TransactionId}.{reasonText}.");
+			Logger.LogInfo($"Coin dequeued: {coinWaitingForMix.Index}:{coinWaitingForMix.TransactionId}.{reasonText}.");
 		}
 
 		public async Task StopAsync()
@@ -1068,17 +1068,17 @@ namespace WalletWasabi.Services
 					}
 					catch (Exception ex)
 					{
-						Logger.LogError<CcjClient>("Could not dequeue all coins. Some coins will likely be banned from mixing.");
+						Logger.LogError("Could not dequeue all coins. Some coins will likely be banned from mixing.");
 						if (ex is AggregateException aggrEx)
 						{
 							foreach (var innerEx in aggrEx.InnerExceptions)
 							{
-								Logger.LogError<CcjClient>(innerEx);
+								Logger.LogError(innerEx);
 							}
 						}
 						else
 						{
-							Logger.LogError<CcjClient>(ex);
+							Logger.LogError(ex);
 						}
 					}
 				}

--- a/WalletWasabi/Services/CcjCoordinator.cs
+++ b/WalletWasabi/Services/CcjCoordinator.cs
@@ -78,7 +78,7 @@ namespace WalletWasabi.Services
 								? $"CoinJoins file contains invalid transaction ID {line}"
 								: $"CoinJoins file got corrupted. Deleting offending line \"{line.Substring(0, 20)}\".";
 
-							Logger.LogWarning<CcjCoordinator>($"{logEntry}. {ex.GetType()}: {ex.Message}");
+							Logger.LogWarning($"{logEntry}. {ex.GetType()}: {ex.Message}");
 						}
 					}
 
@@ -99,7 +99,7 @@ namespace WalletWasabi.Services
 								? $"CoinJoins file contains invalid transaction ID {task.line}"
 								: $"CoinJoins file got corrupted. Deleting offending line \"{task.line.Substring(0, 20)}\".";
 
-							Logger.LogWarning<CcjCoordinator>($"{logEntry}. {ex.GetType()}: {ex.Message}");
+							Logger.LogWarning($"{logEntry}. {ex.GetType()}: {ex.Message}");
 						}
 					}
 
@@ -111,7 +111,7 @@ namespace WalletWasabi.Services
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning<CcjCoordinator>($"CoinJoins file got corrupted. Deleting {CoinJoinsFilePath}. {ex.GetType()}: {ex.Message}");
+					Logger.LogWarning($"CoinJoins file got corrupted. Deleting {CoinJoinsFilePath}. {ex.GetType()}: {ex.Message}");
 					File.Delete(CoinJoinsFilePath);
 				}
 			}
@@ -133,8 +133,8 @@ namespace WalletWasabi.Services
 			catch (Exception ex)
 			{
 				CcjRound.RoundCount = 0;
-				Logger.LogInfo<CcjCoordinator>($"{nameof(CcjRound.RoundCount)} file was corrupt. Resetting to 0.");
-				Logger.LogDebug<CcjCoordinator>(ex);
+				Logger.LogInfo($"{nameof(CcjRound.RoundCount)} file was corrupt. Resetting to 0.");
+				Logger.LogDebug(ex);
 			}
 
 			TrustedNodeNotifyingBehavior.Block += TrustedNodeNotifyingBehavior_BlockAsync;
@@ -151,7 +151,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CcjCoordinator>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -252,8 +252,8 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CcjCoordinator>("Adjusting confirmation target failed. Falling back to default, specified in config.");
-				Logger.LogWarning<CcjCoordinator>(ex);
+				Logger.LogWarning("Adjusting confirmation target failed. Falling back to default, specified in config.");
+				Logger.LogWarning(ex);
 
 				return RoundConfig.ConfirmationTarget;
 			}
@@ -356,18 +356,17 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<CcjCoordinator>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
-		public void AbortAllRoundsInInputRegistration(string loggingCategory, string reason)
+		public void AbortAllRoundsInInputRegistration(string reason)
 		{
-			string category = string.IsNullOrWhiteSpace(loggingCategory) ? nameof(CcjCoordinator) : loggingCategory;
 			using (RoundsListLock.Lock())
 			{
 				foreach (var r in Rounds.Where(x => x.Status == CcjRoundStatus.Running && x.Phase == CcjRoundPhase.InputRegistration))
 				{
-					r.Abort(category, reason);
+					r.Abort(reason);
 				}
 			}
 		}
@@ -465,7 +464,7 @@ namespace WalletWasabi.Services
 						}
 						catch (Exception ex)
 						{
-							Logger.LogDebug<CcjCoordinator>(ex);
+							Logger.LogDebug(ex);
 						}
 					}
 				}

--- a/WalletWasabi/Services/ConfigWatcher.cs
+++ b/WalletWasabi/Services/ConfigWatcher.cs
@@ -55,11 +55,11 @@ namespace WalletWasabi.Services
 						}
 						catch (TaskCanceledException ex)
 						{
-							Logger.LogTrace<ConfigWatcher>(ex);
+							Logger.LogTrace(ex);
 						}
 						catch (Exception ex)
 						{
-							Logger.LogDebug<ConfigWatcher>(ex);
+							Logger.LogDebug(ex);
 						}
 					}
 				}

--- a/WalletWasabi/Services/IndexBuilderService.cs
+++ b/WalletWasabi/Services/IndexBuilderService.cs
@@ -271,7 +271,7 @@ namespace WalletWasabi.Services
 									}
 									else
 									{
-										Logger.LogCritical<IndexBuilderService>("This is something serious! Over 100 block reorg is noticed! We cannot handle that!");
+										Logger.LogCritical("This is something serious! Over 100 block reorg is noticed! We cannot handle that!");
 									}
 
 									// Skip the current block.
@@ -359,16 +359,16 @@ namespace WalletWasabi.Services
 								// Use height.Value instead of simply height, because it cannot be negative height.
 								if (syncInfo.BlockCount - heightToRequest.Value <= 3 || heightToRequest % 100 == 0)
 								{
-									Logger.LogInfo<IndexBuilderService>($"Created filter for block: {heightToRequest}.");
+									Logger.LogInfo($"Created filter for block: {heightToRequest}.");
 								}
 								else
 								{
-									Logger.LogDebug<IndexBuilderService>($"Created filter for block: {heightToRequest}.");
+									Logger.LogDebug($"Created filter for block: {heightToRequest}.");
 								}
 							}
 							catch (Exception ex)
 							{
-								Logger.LogDebug<IndexBuilderService>(ex);
+								Logger.LogDebug(ex);
 							}
 						}
 					}
@@ -380,7 +380,7 @@ namespace WalletWasabi.Services
 				}
 				catch (Exception ex)
 				{
-					Logger.LogError<IndexBuilderService>($"Synchronization attempt failed to start: {ex}");
+					Logger.LogError($"Synchronization attempt failed to start: {ex}");
 				}
 			});
 		}
@@ -401,7 +401,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<IndexBuilderService>(ex);
+				Logger.LogError(ex);
 			}
 		}
 
@@ -410,7 +410,7 @@ namespace WalletWasabi.Services
 			// 1. Rollback index
 			using (await IndexLock.LockAsync())
 			{
-				Logger.LogInfo<IndexBuilderService>($"REORG invalid block: {Index.Last().BlockHash}");
+				Logger.LogInfo($"REORG invalid block: {Index.Last().BlockHash}");
 				Index.RemoveLast();
 			}
 

--- a/WalletWasabi/Services/MempoolBehavior.cs
+++ b/WalletWasabi/Services/MempoolBehavior.cs
@@ -55,12 +55,12 @@ namespace WalletWasabi.Services
 			}
 			catch (OperationCanceledException ex)
 			{
-				Logger.LogDebug<MempoolBehavior>(ex);
+				Logger.LogDebug(ex);
 			}
 			catch (Exception ex)
 			{
-				Logger.LogInfo<MempoolBehavior>($"Ignoring {ex.GetType()}: {ex.Message}");
-				Logger.LogDebug<MempoolBehavior>(ex);
+				Logger.LogInfo($"Ignoring {ex.GetType()}: {ex.Message}");
+				Logger.LogDebug(ex);
 			}
 		}
 
@@ -68,7 +68,7 @@ namespace WalletWasabi.Services
 		{
 			if (payload.Inventory.Count > MaxInvSize)
 			{
-				Logger.LogDebug<MempoolBehavior>($"Received inventory too big. {nameof(MaxInvSize)}: {MaxInvSize}, Node: {node.RemoteSocketEndpoint}");
+				Logger.LogDebug($"Received inventory too big. {nameof(MaxInvSize)}: {MaxInvSize}, Node: {node.RemoteSocketEndpoint}");
 				return;
 			}
 
@@ -86,18 +86,18 @@ namespace WalletWasabi.Services
 						var txPayload = new TxPayload(entry.Transaction);
 						if (!node.IsConnected)
 						{
-							Logger.LogInfo<MempoolBehavior>($"Could not serve transaction. Node ({node.RemoteSocketEndpoint}) is not connected anymore: {entry.TransactionId}.");
+							Logger.LogInfo($"Could not serve transaction. Node ({node.RemoteSocketEndpoint}) is not connected anymore: {entry.TransactionId}.");
 						}
 						else
 						{
 							await node.SendMessageAsync(txPayload);
 							entry.MakeBroadcasted();
-							Logger.LogInfo<MempoolBehavior>($"Successfully served transaction to node ({node.RemoteSocketEndpoint}): {entry.TransactionId}.");
+							Logger.LogInfo($"Successfully served transaction to node ({node.RemoteSocketEndpoint}): {entry.TransactionId}.");
 						}
 					}
 					catch (Exception ex)
 					{
-						Logger.LogInfo<MempoolBehavior>(ex);
+						Logger.LogInfo(ex);
 					}
 				}
 			}
@@ -107,7 +107,7 @@ namespace WalletWasabi.Services
 		{
 			if (payload.Inventory.Count > MaxInvSize)
 			{
-				Logger.LogDebug<MempoolBehavior>($"Received inventory too big. {nameof(MaxInvSize)}: {MaxInvSize}, Node: {node.RemoteSocketEndpoint}");
+				Logger.LogDebug($"Received inventory too big. {nameof(MaxInvSize)}: {MaxInvSize}, Node: {node.RemoteSocketEndpoint}");
 				return;
 			}
 
@@ -127,7 +127,7 @@ namespace WalletWasabi.Services
 					}
 					catch (Exception ex)
 					{
-						Logger.LogInfo<MempoolBehavior>(ex);
+						Logger.LogInfo(ex);
 					}
 				}
 

--- a/WalletWasabi/Services/MempoolService.cs
+++ b/WalletWasabi/Services/MempoolService.cs
@@ -111,7 +111,7 @@ namespace WalletWasabi.Services
 					return true; // There's nothing to cleanup.
 				}
 
-				Logger.LogInfo<MempoolService>("Start cleaning out mempool...");
+				Logger.LogInfo("Start cleaning out mempool...");
 				using (var client = new WasabiClient(destAction, torSocks))
 				{
 					var compactness = 10;
@@ -128,14 +128,14 @@ namespace WalletWasabi.Services
 						}
 					}
 
-					Logger.LogInfo<MempoolService>($"{removedTxCount} transactions were cleaned from mempool.");
+					Logger.LogInfo($"{removedTxCount} transactions were cleaned from mempool.");
 				}
 
 				return true;
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<MempoolService>(ex);
+				Logger.LogWarning(ex);
 			}
 			finally
 			{

--- a/WalletWasabi/Services/TrustedNodeNotifyingBehavior.cs
+++ b/WalletWasabi/Services/TrustedNodeNotifyingBehavior.cs
@@ -71,12 +71,12 @@ namespace WalletWasabi.Services
 			}
 			catch (OperationCanceledException ex)
 			{
-				Logger.LogDebug<TrustedNodeNotifyingBehavior>(ex);
+				Logger.LogDebug(ex);
 			}
 			catch (Exception ex)
 			{
-				Logger.LogInfo<TrustedNodeNotifyingBehavior>($"Ignoring {ex.GetType()}: {ex.Message}");
-				Logger.LogDebug<TrustedNodeNotifyingBehavior>(ex);
+				Logger.LogInfo($"Ignoring {ex.GetType()}: {ex.Message}");
+				Logger.LogDebug(ex);
 			}
 		}
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -56,25 +56,25 @@ namespace WalletWasabi.Services
 						}
 						catch (ConnectionException ex)
 						{
-							Logger.LogError<UpdateChecker>(ex);
+							Logger.LogError(ex);
 							try
 							{
 								await Task.Delay(period, Stop.Token); // Give other threads time to do stuff, update check is not crucial.
 							}
 							catch (TaskCanceledException ex2)
 							{
-								Logger.LogTrace<UpdateChecker>(ex2);
+								Logger.LogTrace(ex2);
 							}
 						}
 						catch (Exception ex) when (ex is OperationCanceledException
 												|| ex is TaskCanceledException
 												|| ex is TimeoutException)
 						{
-							Logger.LogTrace<UpdateChecker>(ex);
+							Logger.LogTrace(ex);
 						}
 						catch (Exception ex)
 						{
-							Logger.LogDebug<UpdateChecker>(ex);
+							Logger.LogDebug(ex);
 						}
 						finally
 						{

--- a/WalletWasabi/Services/UtxoReferee.cs
+++ b/WalletWasabi/Services/UtxoReferee.cs
@@ -67,17 +67,17 @@ namespace WalletWasabi.Services
 						File.WriteAllLines(BannedUtxosFilePath, newAllLines);
 					}
 
-					Logger.LogInfo<UtxoReferee>($"{allLines.Length} banned UTXOs are loaded from {BannedUtxosFilePath}.");
+					Logger.LogInfo($"{allLines.Length} banned UTXOs are loaded from {BannedUtxosFilePath}.");
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning<UtxoReferee>($"Banned UTXO file got corrupted. Deleting {BannedUtxosFilePath}. {ex.GetType()}: {ex.Message}");
+					Logger.LogWarning($"Banned UTXO file got corrupted. Deleting {BannedUtxosFilePath}. {ex.GetType()}: {ex.Message}");
 					File.Delete(BannedUtxosFilePath);
 				}
 			}
 			else
 			{
-				Logger.LogInfo<UtxoReferee>($"No banned UTXOs are loaded from {BannedUtxosFilePath}.");
+				Logger.LogInfo($"No banned UTXOs are loaded from {BannedUtxosFilePath}.");
 			}
 		}
 
@@ -135,7 +135,7 @@ namespace WalletWasabi.Services
 					}
 				}
 
-				Logger.LogInfo<UtxoReferee>($"UTXO {(isNoted ? "noted" : "banned")} with severity: {severity}. UTXO: {utxo.N}:{utxo.Hash} for disrupting Round {bannedForRound}.");
+				Logger.LogInfo($"UTXO {(isNoted ? "noted" : "banned")} with severity: {severity}. UTXO: {utxo.N}:{utxo.Hash} for disrupting Round {bannedForRound}.");
 			}
 
 			if (updated) // If at any time we set updated then we must update the whole thing.
@@ -155,7 +155,7 @@ namespace WalletWasabi.Services
 			{
 				IEnumerable<string> lines = BannedUtxos.Select(x => x.ToString());
 				await File.WriteAllLinesAsync(BannedUtxosFilePath, lines);
-				Logger.LogInfo<UtxoReferee>($"UTXO unbanned: {output.N}:{output.Hash}.");
+				Logger.LogInfo($"UTXO unbanned: {output.N}:{output.Hash}.");
 			}
 		}
 

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -179,7 +179,7 @@ namespace WalletWasabi.Services
 				}
 				catch (Exception ex)
 				{
-					Logger.LogError<WalletService>(ex);
+					Logger.LogError(ex);
 				}
 			}
 		}
@@ -226,7 +226,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<WalletService>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -251,7 +251,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<WalletService>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -286,7 +286,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<WalletService>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -319,8 +319,8 @@ namespace WalletWasabi.Services
 					}
 					catch (Exception ex)
 					{
-						Logger.LogWarning<WalletService>(ex);
-						Logger.LogWarning<WalletService>($"Transaction cache got corrupted. Deleting {TransactionsFilePath}.");
+						Logger.LogWarning(ex);
+						Logger.LogWarning($"Transaction cache got corrupted. Deleting {TransactionsFilePath}.");
 						File.Delete(TransactionsFilePath);
 					}
 				}
@@ -386,7 +386,7 @@ namespace WalletWasabi.Services
 							await ProcessTransactionAsync(tx);
 							Mempool.TransactionHashes.TryAdd(tx.GetHash());
 
-							Logger.LogInfo<WalletService>($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
+							Logger.LogInfo($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
 							count++;
 						}
 					}
@@ -407,7 +407,7 @@ namespace WalletWasabi.Services
 					Mempool.TransactionHashes.TryAdd(tx.GetHash());
 				}
 
-				Logger.LogWarning<WalletService>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -626,7 +626,7 @@ namespace WalletWasabi.Services
 					{
 						// In case the block file is corrupted and we get an EndOfStreamException exception
 						// Ignore any error and continue to re-downloading the block.
-						Logger.LogDebug<WalletService>($"Block {hash} file corrupted, deleting file and block will be re-downloaded.");
+						Logger.LogDebug($"Block {hash} file corrupted, deleting file and block will be re-downloaded.");
 						File.Delete(filePath);
 					}
 				}
@@ -683,14 +683,14 @@ namespace WalletWasabi.Services
 							// Validate block
 							if (!block.Check())
 							{
-								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
+								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
 								node.DisconnectAsync("Invalid block received.");
 								continue;
 							}
 
 							if (Nodes.ConnectedNodes.Count > 1) // To minimize risking missing unconfirmed transactions.
 							{
-								Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
+								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
 								node.DisconnectAsync("Thank you!");
 							}
 
@@ -700,7 +700,7 @@ namespace WalletWasabi.Services
 												|| ex is TaskCanceledException
 												|| ex is TimeoutException)
 						{
-							Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
+							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
 
 							await NodeTimeoutsAsync(true);
 
@@ -709,8 +709,8 @@ namespace WalletWasabi.Services
 						}
 						catch (Exception ex)
 						{
-							Logger.LogDebug<WalletService>(ex);
-							Logger.LogInfo<WalletService>($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.");
+							Logger.LogDebug(ex);
+							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.");
 							node.DisconnectAsync("Block download failed.");
 							continue;
 						}
@@ -719,7 +719,7 @@ namespace WalletWasabi.Services
 					}
 					catch (Exception ex)
 					{
-						Logger.LogDebug<WalletService>(ex);
+						Logger.LogDebug(ex);
 					}
 				}
 
@@ -767,7 +767,7 @@ namespace WalletWasabi.Services
 						var localNode = await Node.ConnectAsync(Network, localEndPoint, nodeConnectionParameters);
 						try
 						{
-							Logger.LogInfo<WalletService>("TCP Connection succeeded, handshaking...");
+							Logger.LogInfo("TCP Connection succeeded, handshaking...");
 							localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
 							var peerServices = localNode.PeerVersion.Services;
 
@@ -776,7 +776,7 @@ namespace WalletWasabi.Services
 							//	throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
 							//}
 
-							Logger.LogInfo<WalletService>("Handshake completed successfully.");
+							Logger.LogInfo("Handshake completed successfully.");
 
 							if (!localNode.IsConnected)
 							{
@@ -787,7 +787,7 @@ namespace WalletWasabi.Services
 						}
 						catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
 						{
-							Logger.LogWarning<Node>($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
+							Logger.LogWarning($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
 								"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
 							throw;
 						}
@@ -809,7 +809,7 @@ namespace WalletWasabi.Services
 				}
 
 				// Retrieved block from local node and block is valid
-				Logger.LogInfo<WalletService>($"Block acquired from local P2P connection: {hash}.");
+				Logger.LogInfo($"Block acquired from local P2P connection: {hash}.");
 				return blockFromLocalNode;
 			}
 			catch (Exception ex)
@@ -818,11 +818,11 @@ namespace WalletWasabi.Services
 
 				if (ex is SocketException)
 				{
-					Logger.LogTrace<WalletService>("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
+					Logger.LogTrace("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
 				}
 				else
 				{
-					Logger.LogWarning<WalletService>(ex);
+					Logger.LogWarning(ex);
 				}
 			}
 
@@ -839,7 +839,7 @@ namespace WalletWasabi.Services
 				}
 				catch (Exception ex)
 				{
-					Logger.LogDebug<WalletService>(ex);
+					Logger.LogDebug(ex);
 				}
 				finally
 				{
@@ -849,12 +849,12 @@ namespace WalletWasabi.Services
 					}
 					catch (Exception ex)
 					{
-						Logger.LogDebug<WalletService>(ex);
+						Logger.LogDebug(ex);
 					}
 					finally
 					{
 						LocalBitcoinCoreNode = null;
-						Logger.LogInfo<WalletService>("Local Bitcoin Core node disconnected.");
+						Logger.LogInfo("Local Bitcoin Core node disconnected.");
 					}
 				}
 			}
@@ -881,7 +881,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<WalletService>(ex);
+				Logger.LogWarning(ex);
 			}
 		}
 
@@ -951,7 +951,7 @@ namespace WalletWasabi.Services
 			}
 
 			// Get and calculate fee
-			Logger.LogInfo<WalletService>("Calculating dynamic transaction fee...");
+			Logger.LogInfo("Calculating dynamic transaction fee...");
 
 			FeeRate feeRate;
 			if (feeStrategy.Type == FeeStrategyType.Target)
@@ -1030,10 +1030,10 @@ namespace WalletWasabi.Services
 			{
 				throw new InvalidOperationException("Impossible to get the fees of the PSBT, this should never happen.");
 			}
-			Logger.LogInfo<WalletService>($"Fee: {fee.Satoshi} Satoshi.");
+			Logger.LogInfo($"Fee: {fee.Satoshi} Satoshi.");
 
 			var vSize = builder.EstimateSize(psbt.GetOriginalTransaction(), true);
-			Logger.LogInfo<WalletService>($"Estimated tx size: {vSize} vbytes.");
+			Logger.LogInfo($"Estimated tx size: {vSize} vbytes.");
 
 			// Do some checks
 			Money totalSendAmountNoFee = realToSend.Sum(x => x.amount);
@@ -1059,7 +1059,7 @@ namespace WalletWasabi.Services
 
 			if (feePc > 1)
 			{
-				Logger.LogInfo<WalletService>($"The transaction fee is {totalOutgoingAmountNoFee:0.#}% of your transaction amount.{Environment.NewLine}"
+				Logger.LogInfo($"The transaction fee is {totalOutgoingAmountNoFee:0.#}% of your transaction amount.{Environment.NewLine}"
 					+ $"Sending:\t {totalSendAmount.ToString(fplus: false, trimExcessZero: true)} BTC.{Environment.NewLine}"
 					+ $"Fee:\t\t {fee.Satoshi} Satoshi.");
 			}
@@ -1070,11 +1070,11 @@ namespace WalletWasabi.Services
 
 			if (spentCoins.Any(u => !u.Confirmed))
 			{
-				Logger.LogInfo<WalletService>("Unconfirmed transaction is spent.");
+				Logger.LogInfo("Unconfirmed transaction is spent.");
 			}
 
 			// Build the transaction
-			Logger.LogInfo<WalletService>("Signing transaction...");
+			Logger.LogInfo("Signing transaction...");
 			// It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
 
 			Transaction tx = null;
@@ -1158,7 +1158,7 @@ namespace WalletWasabi.Services
 				foundKey?.SetLabel(coin.Label); // The foundkeylabel has already been added previously, so no need to concatenate.
 			}
 
-			Logger.LogInfo<WalletService>($"Transaction is successfully built: {tx.GetHash()}.");
+			Logger.LogInfo($"Transaction is successfully built: {tx.GetHash()}.");
 			var sign = !KeyManager.IsWatchOnly;
 			var spendsUnconfirmed = spentCoins.Any(c => !c.Confirmed);
 			return new BuildTransactionResult(new SmartTransaction(tx, Height.Unknown), psbt, spendsUnconfirmed, sign, fee, feePc, outerWalletOutputs, innerWalletOutputs, spentCoins);
@@ -1212,11 +1212,11 @@ namespace WalletWasabi.Services
 						continue;
 					}
 
-					Logger.LogInfo<WalletService>($"Trying to broadcast transaction with random node ({node.RemoteSocketAddress}):{transaction.GetHash()}.");
+					Logger.LogInfo($"Trying to broadcast transaction with random node ({node.RemoteSocketAddress}):{transaction.GetHash()}.");
 					var addedToBroadcastStore = Mempool.TryAddToBroadcastStore(transaction.Transaction, node.RemoteSocketEndpoint.ToString()); // So we'll reply to INV with this transaction.
 					if (!addedToBroadcastStore)
 					{
-						Logger.LogWarning<WalletService>($"Transaction {transaction.GetHash()} was already present in the broadcast store.");
+						Logger.LogWarning($"Transaction {transaction.GetHash()} was already present in the broadcast store.");
 					}
 					var invPayload = new InvPayload(transaction.Transaction);
 					// Give 7 seconds to send the inv payload.
@@ -1239,7 +1239,7 @@ namespace WalletWasabi.Services
 							timeout++;
 						}
 						node.DisconnectAsync("Thank you!");
-						Logger.LogInfo<MempoolBehavior>($"Disconnected node: {node.RemoteSocketAddress}. Successfully broadcasted transaction: {transaction.GetHash()}.");
+						Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Successfully broadcasted transaction: {transaction.GetHash()}.");
 
 						// Give 21 seconds for propagation.
 						timeout = 0;
@@ -1252,19 +1252,19 @@ namespace WalletWasabi.Services
 							await Task.Delay(1_000);
 							timeout++;
 						}
-						Logger.LogInfo<MempoolBehavior>($"Transaction is successfully propagated: {transaction.GetHash()}.");
+						Logger.LogInfo($"Transaction is successfully propagated: {transaction.GetHash()}.");
 					}
 					else
 					{
-						Logger.LogWarning<WalletService>($"Expected transaction {transaction.GetHash()} was not found in the broadcast store.");
+						Logger.LogWarning($"Expected transaction {transaction.GetHash()} was not found in the broadcast store.");
 					}
 					break;
 				}
 			}
 			catch (Exception ex)
 			{
-				Logger.LogInfo<WalletService>($"Random node could not broadcast transaction. Broadcasting with backend... Reason: {ex.Message}.");
-				Logger.LogDebug<WalletService>(ex);
+				Logger.LogInfo($"Random node could not broadcast transaction. Broadcasting with backend... Reason: {ex.Message}.");
+				Logger.LogDebug(ex);
 
 				using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
 				{
@@ -1299,7 +1299,7 @@ namespace WalletWasabi.Services
 					Mempool.TransactionHashes.TryAdd(transaction.GetHash());
 				}
 
-				Logger.LogInfo<WalletService>($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
+				Logger.LogInfo($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
 			}
 			finally
 			{
@@ -1351,7 +1351,7 @@ namespace WalletWasabi.Services
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<WalletService>($"Refreshing coin clusters failed: {ex}.");
+				Logger.LogError($"Refreshing coin clusters failed: {ex}.");
 			}
 			finally
 			{
@@ -1428,7 +1428,7 @@ namespace WalletWasabi.Services
 			RuntimeParams.Instance.NetworkNodeTimeout = timeout;
 			await RuntimeParams.Instance.SaveAsync();
 
-			Logger.LogInfo<WalletService>($"Current timeout value used on block download is: {timeout} seconds.");
+			Logger.LogInfo($"Current timeout value used on block download is: {timeout} seconds.");
 		}
 
 		public async Task StopAsync()

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -227,7 +227,7 @@ namespace WalletWasabi.Services
 								{
 									// We have a problem.
 									// We have wrong filters, the heights are not in sync with the server's.
-									Logger.LogError<WasabiSynchronizer>($"Inconsistent index state detected.{Environment.NewLine}" +
+									Logger.LogError($"Inconsistent index state detected.{Environment.NewLine}" +
 										$"{nameof(hashChain)}.{nameof(hashChain.TipHeight)}:{hashChain.TipHeight}{Environment.NewLine}" +
 										$"{nameof(hashChain)}.{nameof(hashChain.HashesLeft)}:{hashChain.HashesLeft}{Environment.NewLine}" +
 										$"{nameof(hashChain)}.{nameof(hashChain.TipHash)}:{hashChain.TipHash}{Environment.NewLine}" +
@@ -244,11 +244,11 @@ namespace WalletWasabi.Services
 
 									if (filters.Count() == 1)
 									{
-										Logger.LogInfo<WasabiSynchronizer>($"Downloaded filter for block {firstFilter.BlockHeight}.");
+										Logger.LogInfo($"Downloaded filter for block {firstFilter.BlockHeight}.");
 									}
 									else
 									{
-										Logger.LogInfo<WasabiSynchronizer>($"Downloaded filters for blocks from {firstFilter.BlockHeight} to {filters.Last().BlockHeight}.");
+										Logger.LogInfo($"Downloaded filters for blocks from {firstFilter.BlockHeight} to {filters.Last().BlockHeight}.");
 									}
 								}
 							}
@@ -257,7 +257,7 @@ namespace WalletWasabi.Services
 								// Reorg happened
 								// 1. Rollback index
 								FilterModel reorgedFilter = await BitcoinStore.IndexStore.RemoveLastFilterAsync(Cancel.Token);
-								Logger.LogInfo<WasabiSynchronizer>($"REORG Invalid Block: {reorgedFilter.BlockHash}.");
+								Logger.LogInfo($"REORG Invalid Block: {reorgedFilter.BlockHash}.");
 
 								ignoreRequestInterval = true;
 							}
@@ -277,25 +277,25 @@ namespace WalletWasabi.Services
 						}
 						catch (ConnectionException ex)
 						{
-							Logger.LogError<CcjClient>(ex);
+							Logger.LogError(ex);
 							try
 							{
 								await Task.Delay(3000, Cancel.Token); // Give other threads time to do stuff.
 							}
 							catch (TaskCanceledException ex2)
 							{
-								Logger.LogTrace<CcjClient>(ex2);
+								Logger.LogTrace(ex2);
 							}
 						}
 						catch (Exception ex) when (ex is OperationCanceledException
 												|| ex is TaskCanceledException
 												|| ex is TimeoutException)
 						{
-							Logger.LogTrace<WasabiSynchronizer>(ex);
+							Logger.LogTrace(ex);
 						}
 						catch (Exception ex)
 						{
-							Logger.LogError<WasabiSynchronizer>(ex);
+							Logger.LogError(ex);
 						}
 						finally
 						{
@@ -308,7 +308,7 @@ namespace WalletWasabi.Services
 								}
 								catch (TaskCanceledException ex)
 								{
-									Logger.LogTrace<CcjClient>(ex);
+									Logger.LogTrace(ex);
 								}
 							}
 						}

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -122,7 +122,7 @@ namespace WalletWasabi.Stores
 				// We found a corrupted entry. Stop here.
 				// Delete the currupted file.
 				// Do not try to autocorrect, because the internal data structures are throwing events that may confuse the consumers of those events.
-				Logger.LogError<IndexStore>("An index file got corrupted. Deleting index files...");
+				Logger.LogError("An index file got corrupted. Deleting index files...");
 				MatureIndexFileManager.DeleteMe();
 				ImmatureIndexFileManager.DeleteMe();
 				throw;
@@ -191,7 +191,7 @@ namespace WalletWasabi.Stores
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<IndexStore>($"Backwards compatibility could not be ensured. Exception: {ex}.");
+				Logger.LogWarning($"Backwards compatibility could not be ensured. Exception: {ex}.");
 			}
 		}
 
@@ -239,15 +239,15 @@ namespace WalletWasabi.Stores
 			{
 				if (ImmatureFilters.Any())
 				{
-					Logger.LogWarning<IndexStore>($"Filters got corrupted. Reorging {ImmatureFilters.Count} immature filters in an attempt to fix them.");
+					Logger.LogWarning($"Filters got corrupted. Reorging {ImmatureFilters.Count} immature filters in an attempt to fix them.");
 				}
 				else
 				{
-					Logger.LogCritical<IndexStore>($"Filters got corrupted and have no more immature filters.");
+					Logger.LogCritical($"Filters got corrupted and have no more immature filters.");
 
 					if (deleteAndCrashIfMature)
 					{
-						Logger.LogCritical<IndexStore>($"Deleting all filters and crashing the software...");
+						Logger.LogCritical($"Deleting all filters and crashing the software...");
 
 						using (await MatureIndexFileManager.Mutex.LockAsync(cancel))
 						using (await ImmatureIndexFileManager.Mutex.LockAsync(cancel))
@@ -323,11 +323,11 @@ namespace WalletWasabi.Stores
 												|| ex is TaskCanceledException
 												|| ex is TimeoutException)
 			{
-				Logger.LogTrace<IndexStore>(ex);
+				Logger.LogTrace(ex);
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError<IndexStore>(ex);
+				Logger.LogError(ex);
 			}
 		}
 

--- a/WalletWasabi/TorSocks5/TorHttpClient.cs
+++ b/WalletWasabi/TorSocks5/TorHttpClient.cs
@@ -99,7 +99,7 @@ namespace WalletWasabi.TorSocks5
 					}
 					catch (Exception ex)
 					{
-						Logger.LogTrace<TorHttpClient>(ex);
+						Logger.LogTrace(ex);
 
 						TorSocks5Client?.Dispose(); // rebuild the connection and retry
 						TorSocks5Client = null;
@@ -114,7 +114,7 @@ namespace WalletWasabi.TorSocks5
 						// If we get ttlexpired then wait and retry again linux often do this.
 						catch (TorSocks5FailureResponseException ex2) when (ex2.RepField == RepField.TtlExpired)
 						{
-							Logger.LogTrace<TorHttpClient>(ex);
+							Logger.LogTrace(ex);
 
 							TorSocks5Client?.Dispose(); // rebuild the connection and retry
 							TorSocks5Client = null;

--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -63,7 +63,7 @@ namespace WalletWasabi.TorSocks5
 					{
 						if (IsTorRunningAsync(TorSocks5EndPoint).GetAwaiter().GetResult())
 						{
-							Logger.LogInfo<TorProcessManager>("Tor is already running.");
+							Logger.LogInfo("Tor is already running.");
 							return;
 						}
 
@@ -86,12 +86,12 @@ namespace WalletWasabi.TorSocks5
 
 						if (!File.Exists(torPath))
 						{
-							Logger.LogInfo<TorProcessManager>($"Tor instance NOT found at {torPath}. Attempting to acquire it...");
+							Logger.LogInfo($"Tor instance NOT found at {torPath}. Attempting to acquire it...");
 							InstallTor(fullBaseDirectory, torDir);
 						}
 						else if (!IoHelpers.CheckExpectedHash(torPath, Path.Combine(fullBaseDirectory, "TorDaemons")))
 						{
-							Logger.LogInfo<TorProcessManager>($"Updating Tor...");
+							Logger.LogInfo($"Updating Tor...");
 
 							string backupTorDir = $"{torDir}_backup";
 							if (Directory.Exists(backupTorDir))
@@ -104,7 +104,7 @@ namespace WalletWasabi.TorSocks5
 						}
 						else
 						{
-							Logger.LogInfo<TorProcessManager>($"Tor instance found at {torPath}.");
+							Logger.LogInfo($"Tor instance found at {torPath}.");
 						}
 
 						string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
@@ -125,13 +125,13 @@ namespace WalletWasabi.TorSocks5
 								CreateNoWindow = true,
 								RedirectStandardOutput = true
 							});
-							Logger.LogInfo<TorProcessManager>($"Starting Tor process with Process.Start.");
+							Logger.LogInfo($"Starting Tor process with Process.Start.");
 						}
 						else // Linux and OSX
 						{
 							string runTorCmd = $"LD_LIBRARY_PATH=$LD_LIBRARY_PATH:={torDir}/Tor && export LD_LIBRARY_PATH && cd {torDir}/Tor && ./tor {torArguments}";
 							EnvironmentHelpers.ShellExec(runTorCmd, false);
-							Logger.LogInfo<TorProcessManager>($"Started Tor process with shell command: {runTorCmd}.");
+							Logger.LogInfo($"Started Tor process with shell command: {runTorCmd}.");
 						}
 
 						if (ensureRunning)
@@ -141,7 +141,7 @@ namespace WalletWasabi.TorSocks5
 							{
 								throw new TorException("Attempted to start Tor, but it is not running.");
 							}
-							Logger.LogInfo<TorProcessManager>("Tor is running.");
+							Logger.LogInfo("Tor is running.");
 						}
 					}
 					catch (Exception ex)
@@ -151,7 +151,7 @@ namespace WalletWasabi.TorSocks5
 				}
 				catch (Exception ex)
 				{
-					Logger.LogError<TorProcessManager>(ex);
+					Logger.LogError(ex);
 				}
 			}).Start();
 		}
@@ -162,13 +162,13 @@ namespace WalletWasabi.TorSocks5
 
 			string dataZip = Path.Combine(torDaemonsDir, "data-folder.zip");
 			IoHelpers.BetterExtractZipToDirectoryAsync(dataZip, torDir).GetAwaiter().GetResult();
-			Logger.LogInfo<TorProcessManager>($"Extracted {dataZip} to {torDir}.");
+			Logger.LogInfo($"Extracted {dataZip} to {torDir}.");
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
 				string torWinZip = Path.Combine(torDaemonsDir, "tor-win32.zip");
 				IoHelpers.BetterExtractZipToDirectoryAsync(torWinZip, torDir).GetAwaiter().GetResult();
-				Logger.LogInfo<TorProcessManager>($"Extracted {torWinZip} to {torDir}.");
+				Logger.LogInfo($"Extracted {torWinZip} to {torDir}.");
 			}
 			else // Linux or OSX
 			{
@@ -176,19 +176,19 @@ namespace WalletWasabi.TorSocks5
 				{
 					string torLinuxZip = Path.Combine(torDaemonsDir, "tor-linux64.zip");
 					IoHelpers.BetterExtractZipToDirectoryAsync(torLinuxZip, torDir).GetAwaiter().GetResult();
-					Logger.LogInfo<TorProcessManager>($"Extracted {torLinuxZip} to {torDir}.");
+					Logger.LogInfo($"Extracted {torLinuxZip} to {torDir}.");
 				}
 				else // OSX
 				{
 					string torOsxZip = Path.Combine(torDaemonsDir, "tor-osx64.zip");
 					IoHelpers.BetterExtractZipToDirectoryAsync(torOsxZip, torDir).GetAwaiter().GetResult();
-					Logger.LogInfo<TorProcessManager>($"Extracted {torOsxZip} to {torDir}.");
+					Logger.LogInfo($"Extracted {torOsxZip} to {torDir}.");
 				}
 
 				// Make sure there's sufficient permission.
 				string chmodTorDirCmd = $"chmod -R 750 {torDir}";
 				EnvironmentHelpers.ShellExec(chmodTorDirCmd);
-				Logger.LogInfo<TorProcessManager>($"Shell command executed: {chmodTorDirCmd}.");
+				Logger.LogInfo($"Shell command executed: {chmodTorDirCmd}.");
 			}
 		}
 
@@ -250,7 +250,7 @@ namespace WalletWasabi.TorSocks5
 				return;
 			}
 
-			Logger.LogInfo<TorProcessManager>("Starting Tor monitor...");
+			Logger.LogInfo("Starting Tor monitor...");
 			if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
 			{
 				return;
@@ -293,7 +293,7 @@ namespace WalletWasabi.TorSocks5
 									}
 									else
 									{
-										Logger.LogInfo<TorProcessManager>($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
+										Logger.LogInfo($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
 										Start(true, dataDirToStartWith); // Try starting Tor, if it does not work it'll be another issue.
 										await Task.Delay(14000, Stop.Token).ConfigureAwait(false);
 									}
@@ -304,11 +304,11 @@ namespace WalletWasabi.TorSocks5
 												|| ex is TaskCanceledException
 												|| ex is TimeoutException)
 						{
-							Logger.LogTrace<TorProcessManager>(ex);
+							Logger.LogTrace(ex);
 						}
 						catch (Exception ex)
 						{
-							Logger.LogDebug<TorProcessManager>(ex);
+							Logger.LogDebug(ex);
 						}
 					}
 				}

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.TorSocks5
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning<TorSocks5Client>(ex);
+					Logger.LogWarning(ex);
 					return false;
 				}
 			}
@@ -527,7 +527,7 @@ namespace WalletWasabi.TorSocks5
 			}
 			catch (Exception ex)
 			{
-				Logger.LogWarning<TorSocks5Client>(ex);
+				Logger.LogWarning(ex);
 			}
 			finally
 			{

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.WebClients
 				catch (Exception ex)
 				{
 					// Ignore it and try with the next one
-					Logger.LogTrace<ExchangeRateProvider>(ex);
+					Logger.LogTrace(ex);
 				}
 			}
 			return exchangeRates;

--- a/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/ChaumianCoinJoin/AliceClient.cs
@@ -101,7 +101,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 					}
 
 					client.UniqueId = inputsResponse.UniqueId;
-					Logger.LogInfo<AliceClient>($"Round ({client.RoundId}), Alice ({client.UniqueId}): Registered {request.Inputs.Count()} inputs.");
+					Logger.LogInfo($"Round ({client.RoundId}), Alice ({client.UniqueId}): Registered {request.Inputs.Count()} inputs.");
 
 					return client;
 				}
@@ -159,7 +159,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 				}
 
 				ConnConfResp resp = await response.Content.ReadAsJsonAsync<ConnConfResp>();
-				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
+				Logger.LogInfo($"Round ({RoundId}), Alice ({UniqueId}): Confirmed connection. Phase: {resp.CurrentPhase}.");
 
 				var activeOutputs = new List<ActiveOutput>();
 				if (resp.BlindedOutputSignatures != null && resp.BlindedOutputSignatures.Any())
@@ -228,7 +228,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 					return;
 				}
 			}
-			Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({UniqueId}): Unconfirmed connection.");
 		}
 
 		public async Task<Transaction> GetUnsignedCoinJoinAsync()
@@ -243,7 +243,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 				var coinjoinHex = await response.Content.ReadAsJsonAsync<string>();
 
 				Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
-				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
+				Logger.LogInfo($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
 				return coinJoin;
 			}
 		}
@@ -261,7 +261,7 @@ namespace WalletWasabi.WebClients.Wasabi.ChaumianCoinJoin
 				{
 					await response.ThrowRequestExceptionFromContentAsync();
 				}
-				Logger.LogInfo<AliceClient>($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
+				Logger.LogInfo($"Round ({RoundId}), Alice ({UniqueId}): Posted {signatures.Count} signatures.");
 			}
 		}
 	}


### PR DESCRIPTION
I don't know how to review this, but this is important. Previously you wrote `Logger.LogError<ClassName>(ex)`. Now you'll write `Logger.LogError(ex)` instead.