### PR TITLE
Let the keyup event tunneling deeper

### DIFF
--- a/WalletWasabi.Gui/Behaviors/CommandOnKeyUpBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnKeyUpBehavior.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.Gui.Behaviors
 			Disposables.Add(AssociatedObject.AddHandler(InputElement.KeyUpEvent, (sender, e) =>
 			{
 				CommandParameter = e;
-				e.Handled = ExecuteCommand();
+				ExecuteCommand();
 			}, RoutingStrategies.Tunnel));
 		}
 


### PR DESCRIPTION
Here we just only want to detect the key-up but do not want to interrupt the bubbling or tunneling of it.  Before this on OSX when you pressed the arrows the cursor in the textbox not moved.  