### PR TITLE
Add Schema.org JSON-LD Microdata for SEO

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -29,7 +29,7 @@
         ],
         "releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
         "screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
-        "softwareVersion": "1.1.7",
+        "softwareVersion": "1.1.8",
         "aggregateRating": {
         "@type": "AggregateRating",
         "ratingValue": "5",

--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -7,40 +7,40 @@
     <meta name="description" content="Open-source, non-custodial, privacy-focused Bitcoin wallet, that implements trustless coin shuffling with mathematically provable anonymity - Chaumian CoinJoin.">
 
     <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
-<script type='application/ld+json'>
-{
-	"@context": "https://schema.org/",
-	"@type": "SoftwareApplication",
-	"applicationCategory": "FinanceApplication",
-	"name": "Wasabi Wallet",
-	"image": "https://wasabiwallet.io/images/wasabi_wallet_logo_2-1.png",
-	"availableOnDevice": "Desktop",
-	"author": {
-    "@type": "Organization",
-    "url": "https://zksnacks.com/",
-    "name": "zkSNACKs Ltd."
-},
-	"downloadUrl": "https://wasabiwallet.io/#download",
-	"fileSize": "60MB",
-	"operatingSystem": [
-		"Windows 7",
-		"OSX 10.12",
-		"Linux"
-	],
-	"releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
-	"screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
-	"softwareVersion": "1.1.7",
-    "aggregateRating": {
-    "@type": "AggregateRating",
-    "ratingValue": "5",
-    "ratingCount": "20"
-  },
-  "offers": {
-    "@type": "Offer",
-    "price": "0"
-  }
-}
-</script>
+    <script type='application/ld+json'>
+    {
+    	"@context": "https://schema.org/",
+    	"@type": "SoftwareApplication",
+    	"applicationCategory": "FinanceApplication",
+    	"name": "Wasabi Wallet",
+    	"image": "https://wasabiwallet.io/images/wasabi_wallet_logo_2-1.png",
+    	"availableOnDevice": "Desktop",
+    	"author": {
+        "@type": "Organization",
+        "url": "https://zksnacks.com/",
+        "name": "zkSNACKs Ltd."
+    },
+    	"downloadUrl": "https://wasabiwallet.io/#download",
+    	"fileSize": "60MB",
+    	"operatingSystem": [
+    		"Windows 7",
+    		"OSX 10.12",
+    		"Linux"
+    	],
+    	"releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
+    	"screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
+    	"softwareVersion": "1.1.7",
+        "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "20"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "0"
+      }
+    }
+    </script>
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">

--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -9,27 +9,27 @@
     <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
     <script type='application/ld+json'>
     {
-    	"@context": "https://schema.org/",
-    	"@type": "SoftwareApplication",
-    	"applicationCategory": "FinanceApplication",
-    	"name": "Wasabi Wallet",
-    	"image": "https://wasabiwallet.io/images/wasabi_wallet_logo_2-1.png",
-    	"availableOnDevice": "Desktop",
-    	"author": {
+        "@context": "https://schema.org/",
+        "@type": "SoftwareApplication",
+        "applicationCategory": "FinanceApplication",
+        "name": "Wasabi Wallet",
+        "image": "https://wasabiwallet.io/images/wasabi_wallet_logo_2-1.png",
+        "availableOnDevice": "Desktop",
+        "author": {
         "@type": "Organization",
         "url": "https://zksnacks.com/",
         "name": "zkSNACKs Ltd."
     },
-    	"downloadUrl": "https://wasabiwallet.io/#download",
-    	"fileSize": "60MB",
-    	"operatingSystem": [
-    		"Windows 7",
-    		"OSX 10.12",
-    		"Linux"
-    	],
-    	"releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
-    	"screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
-    	"softwareVersion": "1.1.7",
+        "downloadUrl": "https://wasabiwallet.io/#download",
+        "fileSize": "60MB",
+        "operatingSystem": [
+            "Windows 7",
+            "OSX 10.12",
+            "Linux"
+        ],
+        "releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
+        "screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
+        "softwareVersion": "1.1.7",
         "aggregateRating": {
         "@type": "AggregateRating",
         "ratingValue": "5",

--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -6,6 +6,37 @@
     <meta name="title" content="Wasabi Wallet - Unfairly Private">
     <meta name="description" content="Open-source, non-custodial, privacy-focused Bitcoin wallet, that implements trustless coin shuffling with mathematically provable anonymity - Chaumian CoinJoin.">
 
+    <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
+    <script type='application/ld+json'>
+{
+	"@context": "https://schema.org/",
+	"@type": "SoftwareApplication",
+	"applicationCategory": "FinanceApplication",
+	"name": "Wasabi Wallet",
+	"image": "https://wasabiwallet.io/images/wasabi_wallet_logo_2-1.png",
+	"availableOnDevice": "Desktop",
+	"author": {
+    "@type": "Organization",
+    "url": "https://zksnacks.com/",
+    "name": "zkSNACKs Ltd."
+},
+	"downloadUrl": "https://wasabiwallet.io/#download",
+	"fileSize": "60MB",
+	"operatingSystem": [
+		"Windows 7",
+		"OSX 10.12",
+		"Linux"
+	],
+	"releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
+	"screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
+	"softwareVersion": "1.1.7"
+	"offers": {
+    "@type": "Offer",
+    "price": "0.00",
+      }
+}
+</script>
+    
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.wasabiwallet.io">

--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Open-source, non-custodial, privacy-focused Bitcoin wallet, that implements trustless coin shuffling with mathematically provable anonymity - Chaumian CoinJoin.">
 
     <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
-    <script type='application/ld+json'>
+<script type='application/ld+json'>
 {
 	"@context": "https://schema.org/",
 	"@type": "SoftwareApplication",
@@ -29,11 +29,16 @@
 	],
 	"releaseNotes": "https://github.com/zkSNACKs/WalletWasabi/releases",
 	"screenshot": "https://wasabiwallet.io/images/wasabi-wallet-laptop.png",
-	"softwareVersion": "1.1.7"
-	"offers": {
+	"softwareVersion": "1.1.7",
+    "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "5",
+    "ratingCount": "20"
+  },
+  "offers": {
     "@type": "Offer",
-    "price": "0.00",
-      }
+    "price": "0"
+  }
 }
 </script>
     


### PR DESCRIPTION
We should add schema.org microdata to [WasabiWallet.io](https://wasabiwallet.io) for a better Search Engine Optimization as specified on [https://schema.org/SoftwareApplication](https://schema.org/SoftwareApplication) and [https://developers.google.com/search/docs/data-types/software-app?hl=en](https://developers.google.com/search/docs/data-types/software-app?hl=en).

Example of a Rich Snippet inside Google's SERP (search engine result page):
![Google Rich Snippet](https://developers.google.com/search/docs/data-types/images/software-apps.png)

### What is Microdata?
Microdata (like RDFa and Microformats) is a form of semantic mark-up designed to describe elements on a web page e.g. review, person, event etc. This mark-up can be combined with typical HTML properties to dedlfine each item type through the use of associated attributes. For example, ‘Person’ has the properties name, url and title – attributes can be applied to HTML tags to describe each property.

### What is Schema.org?
Schema.org is a universally supported vocabulary extension by Google, Microsoft and Yahoo! for mark-up languages such as Microdata. It is designed to make the lives of webmasters easier, by offering one standardised mark-up understood by all the major search engines. Currently, Schema.org is compatible with Microdata, RDFa and JSON-LD.

### What is JSON-LD?
Based on the popular JSON format, the linked data format JSON-LD allows webmasters to define the context of the data contained through the use of types and properties. When combined with Schema.org, these properties follow a standardised mark-up supported by major search engines, and joins Microdata & RDFa as methods for integration. Unlike Microdata & RDFa, JSON-LD offers greater ease of implementation with all the necessary mark-up contained within inline <script> tags, instead of wrapping HTML properties. However, as elegant and lightweight that JSON-LD is, there are some potential road blocks. In some instances it’s just not practical to mark-up content, for example that on a larger scale, as the content would need to be effectively repeated within the script tags in order to validate. Also as the mark-up is invisible, the likelihood of marking up content that is not on the visible page increases, which is against search engine usage guidelines. It is for these reasons that Google in particular still favours Microdata & RDFa for marking up HTML content.

### Why use markups on Wasabi Wallet website?
Marking up content on Wasabi ebsite can:
- Lead to the generation of rich snippets in search engine results like the one showed on top
- Enhance CTR (Click Through Rate) from the search result
- Provide greater information to search engines to improve their understanding of the content on Wasabi website

Read more about the importance of Rich Snippets: [https://yoast.com/what-are-rich-snippets/](https://yoast.com/what-are-rich-snippets/)