### PR TITLE
Stylistic changes

### DIFF
--- a/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
@@ -44,11 +44,9 @@ namespace WalletWasabi.Gui.Behaviors
 		{
 			base.OnAttached();
 
-			AssociatedObject.GetObservable(TextBox.SelectionStartProperty).Merge(
-				AssociatedObject.GetObservable(TextBox.SelectionEndProperty)).Subscribe(_ =>
-				{
-					SelectedText = GetSelection();
-				});
+			AssociatedObject.GetObservable(TextBox.SelectionStartProperty)
+				.Merge(AssociatedObject.GetObservable(TextBox.SelectionEndProperty))
+				.Subscribe(_ => { SelectedText = GetSelection(); });
 		}
 
 		protected override void OnDetaching()

--- a/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/BindSelectedTextBehavior.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.Gui.Behaviors
 
 			AssociatedObject.GetObservable(TextBox.SelectionStartProperty)
 				.Merge(AssociatedObject.GetObservable(TextBox.SelectionEndProperty))
-				.Subscribe(_ => { SelectedText = GetSelection(); });
+				.Subscribe(_ => SelectedText = GetSelection());
 		}
 
 		protected override void OnDetaching()

--- a/WalletWasabi.Gui/Behaviors/ClearPropertyOnLostFocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/ClearPropertyOnLostFocusBehavior.cs
@@ -27,7 +27,7 @@ namespace WalletWasabi.Gui.Behaviors
 			Disposables = new CompositeDisposable
 			{
 				Observable.FromEventPattern<RoutedEventArgs>(AssociatedObject, nameof(AssociatedObject.LostFocus))
-				.Subscribe(_=> { TargetProperty = null; })
+				.Subscribe(_=> TargetProperty = null)
 			};
 
 			base.OnAttached();

--- a/WalletWasabi.Gui/Behaviors/ClearPropertyOnLostFocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/ClearPropertyOnLostFocusBehavior.cs
@@ -26,10 +26,8 @@ namespace WalletWasabi.Gui.Behaviors
 		{
 			Disposables = new CompositeDisposable
 			{
-				Observable.FromEventPattern<RoutedEventArgs>(AssociatedObject, nameof(AssociatedObject.LostFocus)).Subscribe(_=>
-				{
-					TargetProperty = null;
-				})
+				Observable.FromEventPattern<RoutedEventArgs>(AssociatedObject, nameof(AssociatedObject.LostFocus))
+				.Subscribe(_=> { TargetProperty = null; })
 			};
 
 			base.OnAttached();

--- a/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
@@ -17,10 +17,8 @@ namespace WalletWasabi.Gui.Behaviors
 
 			Observable.FromEventPattern(AssociatedObject, nameof(AssociatedObject.AttachedToVisualTree))
 			.Take(1) // Only on first appearance.
-			.Subscribe(_ =>
-			{
-				ExecuteCommand();
-			}).DisposeWith(Disposables);
+			.Subscribe(_ => { ExecuteCommand(); })
+			.DisposeWith(Disposables);
 		}
 
 		protected override void OnDetaching()

--- a/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
+++ b/WalletWasabi.Gui/Behaviors/CommandOnFirstVisible.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.Gui.Behaviors
 
 			Observable.FromEventPattern(AssociatedObject, nameof(AssociatedObject.AttachedToVisualTree))
 			.Take(1) // Only on first appearance.
-			.Subscribe(_ => { ExecuteCommand(); })
+			.Subscribe(_ => ExecuteCommand())
 			.DisposeWith(Disposables);
 		}
 

--- a/WalletWasabi.Gui/Behaviors/FocusBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/FocusBehavior.cs
@@ -26,13 +26,14 @@ namespace WalletWasabi.Gui.Behaviors
 
 			AssociatedObject.AttachedToLogicalTree += (sender, e) =>
 			{
-				Disposables.Add(this.GetObservable(IsFocusedProperty).Subscribe(focused =>
-				{
-					if (focused)
+				Disposables.Add(this.GetObservable(IsFocusedProperty)
+					.Subscribe(focused =>
 					{
-						AssociatedObject.Focus();
-					}
-				}));
+						if (focused)
+						{
+							AssociatedObject.Focus();
+						}
+					}));
 			};
 		}
 


### PR DESCRIPTION
Is this more readable. If so I would like to do that with the rest of extension methods that can be written in one line.