### PR TITLE
Fix exception thrown by substring call on empty string

### DIFF
--- a/WalletWasabi/Helpers/PasswordHelper.cs
+++ b/WalletWasabi/Helpers/PasswordHelper.cs
@@ -26,7 +26,7 @@ namespace WalletWasabi.Helpers
 			{
 				originalPassword,
 				buggyClipboard, // Should be here for every OP system. If I created a buggy wallet on OSX and transfered it to other system, it should also work.
-				$"{(string.IsNullOrWhiteSpace(buggyClipboard) ? "" : buggyClipboard. Substring(0,buggyClipboard.Length-1))}\ufffd" // Later I tested the functionality and experienced that the last character replaced by invalid character.
+				$"{(string.IsNullOrWhiteSpace(buggyClipboard) ? "" : buggyClipboard.Substring(0,buggyClipboard.Length-1))}\ufffd" // Later I tested the functionality and experienced that the last character replaced by invalid character.
 			};
 
 			return possiblePasswords.ToArray();


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/2253 https://github.com/zkSNACKs/WalletWasabi/issues/2251