### PR TITLE
Make sure `TransactionProcessor` updates the `TransactionHashes`, too (MempoolStore Breakdown Part 6) 

### DIFF
--- a/WalletWasabi.Tests/UnitTests/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/TransactionProcessorTests.cs
@@ -127,7 +127,8 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent);
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent);
 			Assert.Equal(2, transactionProcessor.TransactionCache.Count());
-			Assert.Empty(transactionProcessor.TransactionHashes);
+			Assert.Equal(2, transactionProcessor.TransactionCache.Count(x => !x.Confirmed));
+			Assert.Equal(2, transactionProcessor.TransactionHashes.Count);
 		}
 
 		[Fact]
@@ -153,7 +154,8 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.True(relevant);
 			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent && coin.Confirmed);
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Confirmed);
-			Assert.Empty(transactionProcessor.TransactionHashes);
+			Assert.Single(transactionProcessor.TransactionCache.Where(x => !x.Confirmed));
+			Assert.Single(transactionProcessor.TransactionHashes);
 		}
 
 		[Fact]
@@ -182,7 +184,8 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.True(relevant);
 			Assert.Single(transactionProcessor.Coins, coin => coin.Unspent && coin.Amount == Money.Coins(0.9m) && coin.IsReplaceable);
 			Assert.Single(transactionProcessor.Coins, coin => !coin.Unspent && coin.Amount == Money.Coins(1.0m) && !coin.IsReplaceable);
-			Assert.Empty(transactionProcessor.TransactionHashes);
+			Assert.Equal(2, transactionProcessor.TransactionCache.Count(x => !x.Confirmed));
+			Assert.Equal(2, transactionProcessor.TransactionHashes.Count);
 		}
 
 		[Fact]

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -176,6 +176,10 @@ namespace WalletWasabi.Services
 					if (Coins.TryAdd(newCoin))
 					{
 						TransactionCache.TryAdd(tx);
+						if (!newCoin.Confirmed)
+						{
+							TransactionHashes.TryAdd(tx.GetHash());
+						}
 						CoinReceived?.Invoke(this, newCoin);
 
 						// Make sure there's always 21 clean keys generated and indexed.


### PR DESCRIPTION
I decided to break down PR #2188 to reviewable parts. In this PR I simplify and improve logging a lot.

I'd also like to note that, there's a non-dangerous conceptual issue here, that this PR is not attempting to resolve. 

Right now `TransactionHashes` are used for the mempool to be able to reply to an `INV` that we already processed the transaction.  This is being compared against the backend's mempool at every block confirmation and cleared.

These two things rule out each other, because what we want to tell to nodes if we met this tx before, but what the cleanup does is it removes the invalid txs, too.