### PR TITLE
Fix ANE when new installations

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -243,6 +243,7 @@ namespace WalletWasabi.Gui
 
 		public Config(string filePath) : base(filePath)
 		{
+			ServiceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet, PrivacyLevelSome, PrivacyLevelFine, PrivacyLevelStrong, GetBitcoinP2pEndPoint(), DustThreshold);
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/2262. When the Config.json file does not exist (first-time installation) the `ServiceConfiguration` is `null`.