### PR TITLE
Hide the lockscreens on visual tree when not displayed.

### DIFF
--- a/WalletWasabi.Gui/Controls/LockScreen/PinLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/PinLockScreen.xaml
@@ -12,9 +12,13 @@
     <Style Selector="lockscreen|PinLockScreen[IsLocked=true] Grid.Shade">
       <Style.Animations>
         <Animation FillMode="Both" Duration="0:0:1.5" Easing="QuarticEaseInOut">
+          <KeyFrame Cue="0%">
+            <Setter Property="IsVisible" Value="True" />
+          </KeyFrame>
           <KeyFrame Cue="100%">
             <Setter Property="Opacity" Value="1" />
             <Setter Property="TranslateTransform.Y" Value="0" />
+            <Setter Property="IsVisible" Value="True" />
           </KeyFrame>
         </Animation>
       </Style.Animations>
@@ -22,7 +26,11 @@
     <Style Selector="lockscreen|PinLockScreen[IsLocked=false] Grid.Shade">
       <Style.Animations>
         <Animation FillMode="Both" Duration="0:0:1.5" Easing="QuarticEaseInOut">
+          <KeyFrame Cue="99%">
+            <Setter Property="IsVisible" Value="True" />
+          </KeyFrame>
           <KeyFrame Cue="100%">
+            <Setter Property="IsVisible" Value="False" />
             <Setter Property="Opacity" Value="0" />
             <Setter Property="TranslateTransform.Y" Value="-100" />
           </KeyFrame>

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
@@ -93,6 +93,30 @@
           </Animation>
         </Style.Animations>
       </Style>
+      <Style Selector="lockscreen|SlideLockScreen[IsLocked=true]">
+        <Style.Animations>
+          <Animation FillMode="Both" Duration="0:0:1.5" Easing="QuarticEaseInOut">
+            <KeyFrame Cue="0%">
+              <Setter Property="IsVisible" Value="True" />
+            </KeyFrame>
+            <KeyFrame Cue="100%"> 
+              <Setter Property="IsVisible" Value="True" />
+            </KeyFrame>
+          </Animation>
+        </Style.Animations>
+      </Style>
+      <Style Selector="lockscreen|SlideLockScreen[IsLocked=false]">
+        <Style.Animations>
+          <Animation FillMode="Both" Duration="0:0:1.5" Easing="QuarticEaseInOut">
+            <KeyFrame Cue="99%">
+              <Setter Property="IsVisible" Value="True" />
+            </KeyFrame>
+            <KeyFrame Cue="100%">
+              <Setter Property="IsVisible" Value="False" />
+            </KeyFrame>
+          </Animation>
+        </Style.Animations>
+      </Style>
     </Styles>
   </lockscreen:SlideLockScreen.Styles>
   <Grid>

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreen.xaml
@@ -95,7 +95,7 @@
       </Style>
       <Style Selector="lockscreen|SlideLockScreen[IsLocked=true]">
         <Style.Animations>
-          <Animation FillMode="Both" Duration="0:0:1.5" Easing="QuarticEaseInOut">
+          <Animation FillMode="Both" Duration="0:0:1.5">
             <KeyFrame Cue="0%">
               <Setter Property="IsVisible" Value="True" />
             </KeyFrame>
@@ -107,7 +107,7 @@
       </Style>
       <Style Selector="lockscreen|SlideLockScreen[IsLocked=false]">
         <Style.Animations>
-          <Animation FillMode="Both" Duration="0:0:1.5" Easing="QuarticEaseInOut">
+          <Animation FillMode="Both" Duration="0:0:1.5">
             <KeyFrame Cue="99%">
               <Setter Property="IsVisible" Value="True" />
             </KeyFrame>


### PR DESCRIPTION
This fixes the problem when a dev wants to debug the controls via Dev Tools and the hidden lockscreens are eating the focus up.

Fixes #2086