### PR TITLE
Fix incompatible serialization

### DIFF
--- a/WalletWasabi/Services/UtxoReferee.cs
+++ b/WalletWasabi/Services/UtxoReferee.cs
@@ -140,7 +140,7 @@ namespace WalletWasabi.Services
 
 			if (updated) // If at any time we set updated then we must update the whole thing.
 			{
-				var allLines = BannedUtxos.Select(x => $"{x.Value.TimeOfBan.ToString(CultureInfo.InvariantCulture)}:{x.Value.Severity}:{x.Key.N}:{x.Key.Hash}:{x.Value.IsNoted}:{x.Value.BannedForRound}");
+				var allLines = BannedUtxos.Select(x => x.Value.ToString());
 				await File.WriteAllLinesAsync(BannedUtxosFilePath, allLines);
 			}
 			else if (lines.Count != 0) // If we do not have to update the whole thing, we must check if we added a line and so only append.
@@ -153,7 +153,7 @@ namespace WalletWasabi.Services
 		{
 			if (BannedUtxos.TryRemove(output, out _))
 			{
-				IEnumerable<string> lines = BannedUtxos.Select(x => x.ToString());
+				IEnumerable<string> lines = BannedUtxos.Select(x => x.Value.ToString());
 				await File.WriteAllLinesAsync(BannedUtxosFilePath, lines);
 				Logger.LogInfo($"UTXO unbanned: {output.N}:{output.Hash}.");
 			}


### PR DESCRIPTION
This fixes a serialization bug in the banned utxo file. Entries were serialized with two different formats (see below) and then when loaded after a restart the file was considered always broken. 

```
$ cat BannedUtxosMain.txt 
[fc693cf83ee579a02610ac08239783a7253a1f91ca834509d07dc7052d895bbd-43, 2019-09-15 23-11-04:1:43:fc693cf83ee579a02610ac08239783a7253a1f91ca834509d07dc7052d895bbd:True:9577]
[32d0f39f10116587b0d268c74544a490da9b30aa18522f9b4d7f35665ffa070d-25, 2019-09-14 18-37-02:1:25:32d0f39f10116587b0d268c74544a490da9b30aa18522f9b4d7f35665ffa070d:True:9548]
2019-09-16 09-27-27:1:14:3a0b48a4ef5a4282f846fca8c9ee6e95fede25cd135758b8b009da6567eb2dbd:True:9587
2019-09-16 09-34-15:1:111:e29d088dac20326dc1d155fb2e86a797aea16796053ffff2af3424bb781190a5:True:9589
```