### PR TITLE
Returns BadRequest when invalid bestKnownBlockHash

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -55,7 +55,7 @@ namespace WalletWasabi.Backend.Controllers
 
 			if (!uint256.TryParse(bestKnownBlockHash, out var knownHash))
 			{
-				return BadRequest("Invalid bestKnownBlockHash.");
+				return BadRequest($"Invalid {nameof(bestKnownBlockHash)}.");
 			}
 
 			(Height bestHeight, IEnumerable<FilterModel> filters) = Global.IndexBuilderService.GetFilterLinesExcluding(knownHash, maxNumberOfFilters, out bool found);

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -53,7 +53,10 @@ namespace WalletWasabi.Backend.Controllers
 				}
 			}
 
-			var knownHash = new uint256(bestKnownBlockHash);
+			if (!uint256.TryParse(bestKnownBlockHash, out var knownHash))
+			{
+				return BadRequest("Invalid bestKnownBlockHash.");
+			}
 
 			(Height bestHeight, IEnumerable<FilterModel> filters) = Global.IndexBuilderService.GetFilterLinesExcluding(knownHash, maxNumberOfFilters, out bool found);
 


### PR DESCRIPTION
There are some NRE in the server logs. This PR fixes that.
 
```
Sep 14 03:01:18 WalletWasabi walletwasabi-backend[9532]: System.NullReferenceException: Object reference not set to an instance of an object.
Sep 14 03:01:18 WalletWasabi walletwasabi-backend[9532]:    at NBitcoin.uint256..ctor(String str)
Sep 14 03:01:18 WalletWasabi walletwasabi-backend[9532]:    at WalletWasabi.Backend.Controllers.BatchController.GetSynchronizeAsync(String bestKnownBlockHash, Int32 maxNumberOfFilters, String estimateSmartFeeMode)
```