### PR TITLE
Correct TypeArgumentException's namespace

### DIFF
--- a/WalletWasabi.Gui/Converters/AmountForegroundConverter.cs
+++ b/WalletWasabi.Gui/Converters/AmountForegroundConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/BooleanStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/BooleanStringConverter.cs
@@ -1,6 +1,7 @@
 using Avalonia.Data.Converters;
 using System;
 using System.Globalization;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/CoinItemExpanderColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/CoinItemExpanderColorConverter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/CoinJoinedVisibilityConverter.cs
+++ b/WalletWasabi.Gui/Converters/CoinJoinedVisibilityConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/CoinStatusBorderBrushConverter.cs
+++ b/WalletWasabi.Gui/Converters/CoinStatusBorderBrushConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Gui.Controls.WalletExplorer;
 using WalletWasabi.Gui.Models;
 using WalletWasabi.Models.ChaumianCoinJoin;

--- a/WalletWasabi.Gui/Converters/CoinStatusColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/CoinStatusColorConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Gui.Controls.WalletExplorer;
 using WalletWasabi.Gui.Models;
 using WalletWasabi.Models.ChaumianCoinJoin;

--- a/WalletWasabi.Gui/Converters/CoinStatusForegroundConverter.cs
+++ b/WalletWasabi.Gui/Converters/CoinStatusForegroundConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Gui.Controls.WalletExplorer;
 using WalletWasabi.Gui.Models;
 using WalletWasabi.Models.ChaumianCoinJoin;

--- a/WalletWasabi.Gui/Converters/CoinStatusStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/CoinStatusStringConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Gui.Controls.WalletExplorer;
 using WalletWasabi.Gui.Models;
 using WalletWasabi.Models.ChaumianCoinJoin;

--- a/WalletWasabi.Gui/Converters/FeeTargetTimeConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeTargetTimeConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Globalization;
 using WalletWasabi.Helpers;
 using WalletWasabi.Gui.Models;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/FilterLeftStatusConverter.cs
+++ b/WalletWasabi.Gui/Converters/FilterLeftStatusConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/InverseBooleanConverter.cs
+++ b/WalletWasabi.Gui/Converters/InverseBooleanConverter.cs
@@ -1,6 +1,7 @@
 using Avalonia.Data.Converters;
 using System;
 using System.Globalization;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/MoneyBrushConverter.cs
+++ b/WalletWasabi.Gui/Converters/MoneyBrushConverter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Gui.Converters

--- a/WalletWasabi.Gui/Converters/MoneyStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/MoneyStringConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/NetworkStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/NetworkStringConverter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/PhaseStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/PhaseStringConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Models.ChaumianCoinJoin;
 
 namespace WalletWasabi.Gui.Converters

--- a/WalletWasabi.Gui/Converters/PrivacyLevelValueConverter.cs
+++ b/WalletWasabi.Gui/Converters/PrivacyLevelValueConverter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Drawing;
 using System.Globalization;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/StatusBarStatusStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/StatusBarStatusStringConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Gui.Models;
 
 namespace WalletWasabi.Gui.Converters

--- a/WalletWasabi.Gui/Converters/TimeSpanStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/TimeSpanStringConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/TimeSpanVisibilityConverter.cs
+++ b/WalletWasabi.Gui/Converters/TimeSpanVisibilityConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi.Gui/Converters/UsdExchangeRateAmountToolTipConverter.cs
+++ b/WalletWasabi.Gui/Converters/UsdExchangeRateAmountToolTipConverter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using WalletWasabi.Exceptions;
 
 namespace WalletWasabi.Gui.Converters
 {

--- a/WalletWasabi/Exceptions/TypeArgumentException.cs
+++ b/WalletWasabi/Exceptions/TypeArgumentException.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace System
+namespace WalletWasabi.Exceptions
 {
 	public class TypeArgumentException : ArgumentException
 	{


### PR DESCRIPTION
If this is correct should I do the same for all the classes in `\WalletWasabi\WalletWasabi\Extensions` folder?
Note that `TorHttpClientExtensions` class doesn't have a namespace.