### PR TITLE
Faster search of empty keys gap

### DIFF
--- a/WalletWasabi/KeyManagement/KeyManager.cs
+++ b/WalletWasabi/KeyManagement/KeyManager.cs
@@ -409,26 +409,28 @@ namespace WalletWasabi.KeyManagement
 
 			lock (HdPubKeysLock)
 			{
-				IEnumerable<HdPubKey> relevantHdPubKeys = isInternal ? HdPubKeys.Where(x => x.IsInternal) : HdPubKeys.Where(x => !x.IsInternal);
+				HdPubKey[] relevantHdPubKeys = HdPubKeys.Where(x => x.IsInternal == isInternal).ToArray();
 
-				KeyPath path;
+				KeyPath path = new KeyPath($"{change}/0");
 				if (relevantHdPubKeys.Any())
 				{
 					int largestIndex = relevantHdPubKeys.Max(x => x.Index);
-					List<int> missingIndexes = Enumerable.Range(0, largestIndex).Except(relevantHdPubKeys.Select(x => x.Index)).ToList();
-					if (missingIndexes.Any())
+					var smallestMissingIndex = largestIndex;
+					var present = new bool[largestIndex+1];
+					for (int i = 0; i < relevantHdPubKeys.Length; ++i)
 					{
-						int smallestMissingIndex = missingIndexes.Min();
-						path = relevantHdPubKeys.First(x => x.Index == (smallestMissingIndex - 1)).NonHardenedKeyPath.Increment();
+						present[relevantHdPubKeys[i].Index] = true;
 					}
-					else
+					for (int i = 1; i < present.Length; ++i)
 					{
-						path = relevantHdPubKeys.First(x => x.Index == largestIndex).NonHardenedKeyPath.Increment();
+						if (!present[i]) 
+						{
+							smallestMissingIndex = i-1;
+							break;
+						}
 					}
-				}
-				else
-				{
-					path = new KeyPath($"{change}/0");
+
+					path = relevantHdPubKeys[smallestMissingIndex].NonHardenedKeyPath.Increment();
 				}
 
 				var fullPath = AccountKeyPath.Derive(path);


### PR DESCRIPTION
This PR introduces a minor performance improvement in the new key generation algorithm by using a O(n) approach. This is important only for really huge wallets (lots of pubkeys). 

This is how this works: lets say our wallet contains keys with the following indexes: `KI=[0, 1, 2, 3, 7, 4, 8, 9, 12, 10]`. All keys with index greater than 12 are available however we can see that there are gaps in our key list that should be filled (`[5, 6]` and `[11]`).  The first available key index is 5.

The new algorithm gets the greater used index (12) and creates a boolean array `present` of 13: `[F, F, F, F, F, F, F, F, F, F, F, F, F]` and iterates the array `KI` flagging the presence of its index key in the `present` array, this is: `present[KI[i].Index] = true`. So, after this step the `present` array is: `[T, T, T, T, T, F, F, T, T, T, T, F, T]`. The first missing element is at position 5 and then that's the key index we have to generate.   