### PR TITLE
Treat same-scriptpubkey coins as one big coin

### DIFF
--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -967,9 +967,8 @@ namespace WalletWasabi.Services
 				throw new NotSupportedException(feeStrategy.Type.ToString());
 			}
 
-			var smartCoinsByOutpoint = allowedSmartCoinInputs.ToDictionary(s => s.GetOutPoint());
 			TransactionBuilder builder = Network.CreateTransactionBuilder();
-			builder.SetCoinSelector(new SmartCoinSelector(smartCoinsByOutpoint));
+			builder.SetCoinSelector(new SmartCoinSelector(allowedSmartCoinInputs));
 			builder.AddCoins(allowedSmartCoinInputs.Select(c => c.GetCoin()));
 
 			foreach (var request in payments.Requests.Where(x => x.Amount.Type == MoneyRequestType.Value))
@@ -1017,7 +1016,7 @@ namespace WalletWasabi.Services
 
 			var psbt = builder.BuildPSBT(false);
 
-			var spentCoins = psbt.Inputs.Select(txin => smartCoinsByOutpoint[txin.PrevOut]).ToArray();
+			var spentCoins = psbt.Inputs.Select(txin => allowedSmartCoinInputs.First(y => y.GetOutPoint() == txin.PrevOut)).ToArray();
 
 			var realToSend = payments.Requests
 				.Select(t =>


### PR DESCRIPTION
Comes from https://github.com/zkSNACKs/WalletWasabi/pull/2334 

> This PR modifies the SmartCoinSelector coin selector in order to treat all the coins with the same scriptPubKey as one coin in order to spend them all together making sure the selection is made always in the same way preventing the selection of different-scriptpubkey coins in between of same-scriptpubkey coins set.

Fixes #2304