### PR TITLE
Fix CI on linux

### DIFF
--- a/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
@@ -14,7 +14,9 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public async Task AsyncMutexTestsAsync()
 		{
-			AsyncMutex asyncMutex = new AsyncMutex("mutex1");
+			var mutexName1 = $"mutex1-{DateTime.Now.Ticks.ToString()}"; // Randomize the name to avoid system wide collisions.
+
+			AsyncMutex asyncMutex = new AsyncMutex(mutexName1);
 
 			// Cannot be IDisposable because the pattern is like Nito's AsyncLock.
 			Assert.False(asyncMutex is IDisposable);
@@ -110,8 +112,10 @@ namespace WalletWasabi.Tests.UnitTests
 				Assert.Equal(prevnum + 1, num);
 			}
 
+			var mutexName2 = $"mutex2-{DateTime.Now.Ticks.ToString()}";
+
 			// Test that asynclock cancellation is going to throw IOException.
-			var mutex = new AsyncMutex("foo");
+			var mutex = new AsyncMutex(mutexName2);
 			using (await mutex.LockAsync())
 			{
 				using (var cts = new CancellationTokenSource(100))
@@ -126,12 +130,12 @@ namespace WalletWasabi.Tests.UnitTests
 			}
 
 			// Test same mutex gets same asynclock.
-			var mutex1 = new AsyncMutex("foo");
+			var mutex1 = new AsyncMutex(mutexName2);
 			using (await mutex1.LockAsync())
 			{
 				using (var cts = new CancellationTokenSource(100))
 				{
-					var mutex2 = new AsyncMutex("foo");
+					var mutex2 = new AsyncMutex(mutexName2);
 					await Assert.ThrowsAsync<IOException>(async () =>
 					{
 						using (await mutex2.LockAsync(cts.Token))
@@ -142,7 +146,7 @@ namespace WalletWasabi.Tests.UnitTests
 			}
 
 			// Different AsyncMutex object but same name.
-			AsyncMutex asyncMutex2 = new AsyncMutex("mutex1");
+			AsyncMutex asyncMutex2 = new AsyncMutex(mutexName1);
 
 			locked.Reset();
 			// Acquire the first mutex with a background thread and hold it for a while.

--- a/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests
 {
+	[Collection("AsyncMutexTest collection")]
 	public class AsyncMutexTests
 	{
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 			// Wait for the Task.Run to Acquire the Mutex.
 
-			locked.WaitOne(TimeSpan.FromSeconds(5));
+			Assert.True(locked.WaitOne(TimeSpan.FromSeconds(5)));
 
 			// Try to get the Mutex and save the time.
 			DateTime timeOfstart = DateTime.Now;
@@ -156,7 +156,7 @@ namespace WalletWasabi.Tests.UnitTests
 			});
 
 			// Make sure the task started.
-			locked.WaitOne(TimeSpan.FromSeconds(5));
+			Assert.True(locked.WaitOne(TimeSpan.FromSeconds(5)));
 
 			timeOfstart = DateTime.Now;
 			timeOfAcquired = default;

--- a/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
@@ -46,18 +46,21 @@ namespace WalletWasabi.Tests.UnitTests
 				await Task.Delay(1);
 			}
 
+			ManualResetEvent locked = new ManualResetEvent(false);
 			// Acquire the Mutex with a background thread.
 
 			var myTask = Task.Run(async () =>
 			{
 				using (await asyncMutex.LockAsync())
 				{
+					locked.Set();
 					await Task.Delay(3000);
 				}
 			});
 
 			// Wait for the Task.Run to Acquire the Mutex.
-			await Task.Delay(100);
+
+			locked.WaitOne(TimeSpan.FromSeconds(5));
 
 			// Try to get the Mutex and save the time.
 			DateTime timeOfstart = DateTime.Now;
@@ -141,17 +144,19 @@ namespace WalletWasabi.Tests.UnitTests
 			// Different AsyncMutex object but same name.
 			AsyncMutex asyncMutex2 = new AsyncMutex("mutex1");
 
+			locked.Reset();
 			// Acquire the first mutex with a background thread and hold it for a while.
 			var myTask2 = Task.Run(async () =>
 			{
 				using (await asyncMutex.LockAsync())
 				{
+					locked.Set();
 					await Task.Delay(3000);
 				}
 			});
 
 			// Make sure the task started.
-			await Task.Delay(100);
+			locked.WaitOne(TimeSpan.FromSeconds(5));
 
 			timeOfstart = DateTime.Now;
 			timeOfAcquired = default;
@@ -169,3 +174,4 @@ namespace WalletWasabi.Tests.UnitTests
 		}
 	}
 }
+;

--- a/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AsyncMutexTests.cs
@@ -76,7 +76,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.True(myTask.IsCompletedSuccessfully);
 
 			var elapsed = timeOfAcquired - timeOfstart;
-			Assert.InRange(elapsed, TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(4000));
+			Assert.InRange(elapsed, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4));
 
 			// Standard Mutex test.
 			int cnt = 0;
@@ -174,7 +174,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.True(myTask2.IsCompletedSuccessfully);
 
 			elapsed = timeOfAcquired - timeOfstart;
-			Assert.InRange(elapsed, TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(4000));
+			Assert.InRange(elapsed, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4));
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/IoTests.cs
+++ b/WalletWasabi.Tests/UnitTests/IoTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests
 {
+	[Collection("AsyncMutexTest collection")]
 	public class IoTests
 	{
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/IoTests.cs
+++ b/WalletWasabi.Tests/UnitTests/IoTests.cs
@@ -142,7 +142,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.True(myTask.IsCompletedSuccessfully);
 
 			var elapsed = timeOfAcquired - timeOfstart;
-			Assert.InRange(elapsed, TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(4000));
+			Assert.InRange(elapsed, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4));
 
 			// Simulate file write error and recovery logic.
 

--- a/WalletWasabi.Tests/UnitTests/IoTests.cs
+++ b/WalletWasabi.Tests/UnitTests/IoTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests
 {
-	[Collection("AsyncMutexTest collection")]
 	public class IoTests
 	{
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/IoTests.cs
+++ b/WalletWasabi.Tests/UnitTests/IoTests.cs
@@ -115,38 +115,6 @@ namespace WalletWasabi.Tests.UnitTests
 
 			await ioman1.WriteAllLinesAsync(lines);
 
-			// Mutex tests.
-
-			using (ManualResetEvent locked = new ManualResetEvent(false))
-			{
-				// Acquire the Mutex with a background thread.
-
-				var myTask = Task.Run(async () =>
-				{
-					using (await ioman1.Mutex.LockAsync())
-					{
-						locked.Set();
-						await Task.Delay(3000);
-					}
-				});
-
-				// Wait for the Task.Run to Acquire the Mutex.
-				Assert.True(locked.WaitOne(TimeSpan.FromSeconds(5)));
-
-				// Try to get the Mutex and save the time.
-				DateTime timeOfstart = DateTime.Now;
-				DateTime timeOfAcquired = default;
-
-				using (await ioman1.Mutex.LockAsync())
-				{
-					timeOfAcquired = DateTime.Now;
-				}
-
-				Assert.True(myTask.IsCompletedSuccessfully);
-
-				var elapsed = timeOfAcquired - timeOfstart;
-				Assert.InRange(elapsed, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4));
-			}
 			// Simulate file write error and recovery logic.
 
 			// We have only *.new and *.old files.
@@ -262,9 +230,11 @@ namespace WalletWasabi.Tests.UnitTests
 				}
 			};
 
+			const int iterations = 200;
+
 			var t1 = new Thread(() =>
 			{
-				for (var i = 0; i < 500; i++)
+				for (var i = 0; i < iterations; i++)
 				{
 					/* We have to block the Thread.
 					 * If we use async/await pattern then Join() function at the end will indicate that the Thread is finished -
@@ -276,14 +246,14 @@ namespace WalletWasabi.Tests.UnitTests
 			});
 			var t2 = new Thread(() =>
 			{
-				for (var i = 0; i < 500; i++)
+				for (var i = 0; i < iterations; i++)
 				{
 					WriteNextLineAsync().Wait();
 				}
 			});
 			var t3 = new Thread(() =>
 			{
-				for (var i = 0; i < 500; i++)
+				for (var i = 0; i < iterations; i++)
 				{
 					WriteNextLineAsync().Wait();
 				}

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -301,7 +301,7 @@ namespace Nito.AsyncEx
 				try
 				{
 					// Create the mutex and acquire it.
-					await SetCommandAsync(1, cancellationToken, pollInterval);
+					await SetCommandAsync(10, cancellationToken, pollInterval);
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -281,10 +281,10 @@ namespace Nito.AsyncEx
 				{
 					throw new OperationCanceledException($"{nameof(AsyncMutex)}.{nameof(AsyncMutex.LockAsync)} failed because quit is pending on: {ShortName}.");
 				}
-				Logger.LogInfo("Locking asynclock");
+
 				// Local lock for thread safety.
 				await AsyncLock.LockAsync(cancellationToken);
-				Logger.LogInfo("Locked asynclock");
+
 				if (IsAlive)
 				{
 					throw new InvalidOperationException("Thread should not be alive.");
@@ -300,10 +300,8 @@ namespace Nito.AsyncEx
 
 				try
 				{
-					Logger.LogInfo("Acquire Mutex");
 					// Create the mutex and acquire it.
 					await SetCommandAsync(1, cancellationToken, pollInterval);
-					Logger.LogInfo("Acquired");
 				}
 				catch (Exception ex)
 				{
@@ -384,14 +382,12 @@ namespace Nito.AsyncEx
 
 			// On multiply call we will get an exception. This is not a dispose so we can throw here.
 			ChangeStatus(AsyncLockStatus.StatusReleasing, AsyncLockStatus.StatusAcquired);
-			Logger.LogInfo("Stopping thread");
+
 			StopThread();
-			Logger.LogInfo("Stopped");
+
 			ChangeStatus(AsyncLockStatus.StatusReady, AsyncLockStatus.StatusReleasing);
-			Logger.LogInfo("Releasing lock");
 			// Release the local lock.
 			AsyncLock?.ReleaseLock();
-			Logger.LogInfo("Released");
 		}
 
 		public static async Task WaitForAllMutexToCloseAsync()

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -281,10 +281,10 @@ namespace Nito.AsyncEx
 				{
 					throw new OperationCanceledException($"{nameof(AsyncMutex)}.{nameof(AsyncMutex.LockAsync)} failed because quit is pending on: {ShortName}.");
 				}
-
+				Logger.LogInfo("Locking asynclock");
 				// Local lock for thread safety.
 				await AsyncLock.LockAsync(cancellationToken);
-
+				Logger.LogInfo("Locked asynclock");
 				if (IsAlive)
 				{
 					throw new InvalidOperationException("Thread should not be alive.");
@@ -300,8 +300,10 @@ namespace Nito.AsyncEx
 
 				try
 				{
+					Logger.LogInfo("Acquire Mutex");
 					// Create the mutex and acquire it.
 					await SetCommandAsync(1, cancellationToken, pollInterval);
+					Logger.LogInfo("Acquired");
 				}
 				catch (Exception ex)
 				{
@@ -382,12 +384,14 @@ namespace Nito.AsyncEx
 
 			// On multiply call we will get an exception. This is not a dispose so we can throw here.
 			ChangeStatus(AsyncLockStatus.StatusReleasing, AsyncLockStatus.StatusAcquired);
-
+			Logger.LogInfo("Stopping thread");
 			StopThread();
-
+			Logger.LogInfo("Stopped");
 			ChangeStatus(AsyncLockStatus.StatusReady, AsyncLockStatus.StatusReleasing);
+			Logger.LogInfo("Releasing lock");
 			// Release the local lock.
 			AsyncLock?.ReleaseLock();
+			Logger.LogInfo("Released");
 		}
 
 		public static async Task WaitForAllMutexToCloseAsync()

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -301,7 +301,7 @@ namespace Nito.AsyncEx
 				try
 				{
 					// Create the mutex and acquire it.
-					await SetCommandAsync(10, cancellationToken, pollInterval);
+					await SetCommandAsync(1, cancellationToken, pollInterval);
 				}
 				catch (Exception ex)
 				{

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -6,7 +6,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-    - task: UseDotNet@2
+  - task: UseDotNet@2
     displayName: 'Use .NET Core sdk'
     inputs:
       packageType: sdk

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -14,11 +14,11 @@ jobs:
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     inputs:
-      command: build
+      command: rebuild
       arguments: --configuration Debug
   - task: DotNetCoreCLI@2
     inputs:
-      command: build
+      command: rebuild
       arguments: --configuration Release
   - task: DotNetCoreCLI@2
     inputs:

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -6,6 +6,12 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+    - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 2.2.402
+      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     inputs:
       command: build

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -12,15 +12,18 @@ jobs:
       packageType: sdk
       version: 2.2.402
       installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: Build debug
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Debug'
     inputs:
       command: build
-      arguments: --configuration Debug --no-incremental
-  - task: Build release
+      arguments: --configuration Debug
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Release'
     inputs:
       command: build
-      arguments: --configuration Release --no-incremental
-  - task: Run tests
+      arguments: --configuration Release
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Debug'
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -12,15 +12,15 @@ jobs:
       packageType: sdk
       version: 2.2.402
       installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: DotNetCoreCLI@2
+  - task: Build debug
     inputs:
       command: build
       arguments: --configuration Debug --no-incremental
-  - task: DotNetCoreCLI@2
+  - task: Build release
     inputs:
       command: build
       arguments: --configuration Release --no-incremental
-  - task: DotNetCoreCLI@2
+  - task: Run tests
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -6,12 +6,6 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      packageType: sdk
-      version: 2.2.402
-      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -12,15 +12,18 @@ jobs:
       packageType: sdk
       version: 2.2.402
       installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: Build debug
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Debug'
     inputs:
       command: build
-      arguments: --configuration Debug --no-incremental
-  - task: Build release
+      arguments: --configuration Debug
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Release'
     inputs:
       command: build
-      arguments: --configuration Release --no-incremental
-  - task: Run tests
+      arguments: --configuration Release
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Debug'
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -12,15 +12,15 @@ jobs:
       packageType: sdk
       version: 2.2.402
       installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: DotNetCoreCLI@2
+  - task: Build debug
     inputs:
       command: build
-      arguments: --configuration Debug
-  - task: DotNetCoreCLI@2
+      arguments: --configuration Debug --no-incremental
+  - task: Build release
     inputs:
       command: build
-      arguments: --configuration Release
-  - task: DotNetCoreCLI@2
+      arguments: --configuration Release --no-incremental
+  - task: Run tests
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -6,6 +6,12 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 2.2.402
+      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     inputs:
       command: build

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -6,12 +6,6 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      packageType: sdk
-      version: 2.2.402
-      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -6,6 +6,12 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 2.2.402
+      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     inputs:
       command: build

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -12,15 +12,18 @@ jobs:
       packageType: sdk
       version: 2.2.402
       installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: Build debug
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Debug'
     inputs:
       command: build
-      arguments: --configuration Debug --no-incremental
-  - task: Build release
+      arguments: --configuration Debug
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Release'
     inputs:
       command: build
-      arguments: --configuration Release --no-incremental
-  - task: Run tests
+      arguments: --configuration Release
+  - task: DotNetCoreCLI@2
+    displayName: 'Test Debug'
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -12,15 +12,15 @@ jobs:
       packageType: sdk
       version: 2.2.402
       installationPath: $(Agent.ToolsDirectory)/dotnet
-  - task: DotNetCoreCLI@2
+  - task: Build debug
     inputs:
       command: build
-      arguments: --configuration Debug
-  - task: DotNetCoreCLI@2
+      arguments: --configuration Debug --no-incremental
+  - task: Build release
     inputs:
       command: build
-      arguments: --configuration Release
-  - task: DotNetCoreCLI@2
+      arguments: --configuration Release --no-incremental
+  - task: Run tests
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -6,12 +6,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      packageType: sdk
-      version: 2.2.402
-      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:


### PR DESCRIPTION
Continuation of this PR: https://github.com/zkSNACKs/WalletWasabi/pull/2346

- Instead of constant wait, detect the start of the task. This will improve stability if the CI is slow.
- Define exact dotnet core version in yaml.