### PR TITLE
Disable search engine crawling on secondary domains

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -162,7 +162,7 @@ testnet=[0/1]
 [main/test].rpcuser=bitcoinuser
 [main/test].rpcpassword=password
 [main/test].whitebind=127.0.0.1:[8333/18333]
-#[main/test].debug=rpc     # in some cases it could be good to uncomment this line. 
+#[main/test].debug=rpc     # in some cases it could be good to uncomment this line.
 ```
 https://bitcoincore.org/en/releases/0.17.0/  
 https://medium.com/@loopring/how-to-run-lighting-btc-node-and-start-mining-b55c4bab8ad  
@@ -265,7 +265,20 @@ server {
     listen        [::]:80;
     listen        443 ssl;
     listen        [::]:443 ssl;
-    server_name   [InsertServerIPHere] wasabiwallet.io www.wasabiwallet.io wasabiwallet.net www.wasabiwallet.net wasabiwallet.org www.wasabiwallet.org wasabiwallet.info www.wasabiwallet.info wasabiwallet.co www.wasabiwallet.co zerolink.info www.zerolink.info hiddenwallet.org www.hiddenwallet.org;
+    server_name   [InsertServerIPHere] wasabiwallet.net www.wasabiwallet.net wasabiwallet.org www.wasabiwallet.org wasabiwallet.info www.wasabiwallet.info wasabiwallet.co www.wasabiwallet.co zerolink.info www.zerolink.info hiddenwallet.org www.hiddenwallet.org;
+    location / {
+        sub_filter '<head>'  '<head><meta name="robots" content="noindex, nofollow" />';
+        sub_filter_once on;
+        proxy_pass         http://localhost:37127;
+    }
+}
+
+server {
+    listen        80;
+    listen        [::]:80;
+    listen        443 ssl;
+    listen        [::]:443 ssl;
+    server_name   wasabiwallet.io www.wasabiwallet.io;
     location / {
         proxy_pass         http://localhost:37127;
     }
@@ -356,7 +369,7 @@ sudo tee -a /etc/motd <<EOS
 EOS
 ```
 
-## Prompt 
+## Prompt
 
 Additionally to the welcome banner it could be good to know in what server we are all the time, in this case update the prompt as follow:
 

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -257,7 +257,7 @@ The landing page is reachable at `http://<server_IP_address>/index.nginx-debian.
 sudo pico /etc/nginx/sites-available/default
 ```
 
-Fill out the server name with the server's IP and domain, and remove the unneeded domains. (Note that I use `wasabiwallet.co` for testnet.)
+Fill out the first server's name with the server's IP and domain, and remove the unneeded domains and the second server. (Note that I use `wasabiwallet.co` for testnet.)
 
 ```
 server {


### PR DESCRIPTION
@nopara73 please confirm if `--with-http_sub_module` submodule is packaged with nginx on the server (and your local machine for testing) by running `ngingx -V`. 

Then update the nginx configuration at `/etc/nginx/sites-available/default` with the one in this PR.

Please test locally before updating the server's nginx config. 

It should add `<meta name="robots" content="noindex, nofollow" />` in the `<head>` of HTML served by all the domains except www.wasabiwallet.io. 