### PR TITLE
Status page change the link to zkSNACKs.

### DIFF
--- a/WalletWasabi.Gui/Tabs/AboutViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/AboutViewModel.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Gui.Tabs
 
 		public string SourceCodeLink => "https://github.com/zkSNACKs/WalletWasabi/";
 
-		public string StatusPageLink => "https://stats.uptimerobot.com/W7q65in4y";
+		public string StatusPageLink => "https://stats.uptimerobot.com/YQqGyUL8A7";
 
 		public string CustomerSupportLink => "https://www.reddit.com/r/WasabiWallet/";
 


### PR DESCRIPTION
Currently, uptime robot registration is under my personal account. Change it to zkSNACKs'.

The new link is here:
https://stats.uptimerobot.com/YQqGyUL8A7

Also, we can consider adding something like a redirection URL like we did at docs.wasabiwallet.io.
status.wasabiwallet.io and add the uptime robot link there.
In Wasabi we could link status.wasabiwallet.io in this way we would have more control on the status page. 