### PR TITLE
Add rule to not prefer simple using statement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -106,6 +106,9 @@ dotnet_style_readonly_field = false:error
 # use expression body for lambdas
 csharp_style_expression_bodied_lambdas = true:error
 
+# IDE0063: Use simple 'using' statement
+csharp_prefer_simple_using_statement = false:error
+
 
 # name all constant or static fields using PascalCase
 dotnet_naming_rule.constant_or_static_fields_should_be_pascal_case.severity = error


### PR DESCRIPTION
Applicable languages: C# 8.0+
If we don't add this rule and use C# 8.0 we will get lots of suggestions to `Use simple 'Using' statement`.

rule = false (for me this more readable)
```
using (var aes = CreateAES())
{
	using (var decryptor = aes.CreateDecryptor(key, iv))
	{
		memoryStream.Seek(-cipherLength, SeekOrigin.End);
		using (var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read))
		{
			var plainTextBytes = new byte[cipherLength];
			var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
			memoryStream.Close();
			cryptoStream.Close();
			return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
		}
	}
}
```
rule = true (for me this is not readable)
```
using var aes = CreateAES();
using var decryptor = aes.CreateDecryptor(key, iv);
memoryStream.Seek(-cipherLength, SeekOrigin.End);
using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
var plainTextBytes = new byte[cipherLength];
var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
memoryStream.Close();
cryptoStream.Close();
return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
```