### PR TITLE
Use C# 8 on CI

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -6,6 +6,14 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 2'
+    inputs:
+      version: 2.x
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 3'
+    inputs:
+      version: 3.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -6,6 +6,14 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
   steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 2'
+    inputs:
+      version: 2.x
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 3'
+    inputs:
+      version: 3.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -6,6 +6,14 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 2'
+    inputs:
+      version: 2.x
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 3'
+    inputs:
+      version: 3.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:


### PR DESCRIPTION
In order for the CI to be able to use C# 8 we need to add a .NET Core 3 installer task. However since we don't want to use .NET Core 3 just yet, only C# 8, we also need to add a .NET Core 2 installer, so the CI can build our projects.