### PR TITLE
Replace SmartTransaction SetHeight with Update

### DIFF
--- a/WalletWasabi/Models/SmartTransaction.cs
+++ b/WalletWasabi/Models/SmartTransaction.cs
@@ -117,7 +117,10 @@ namespace WalletWasabi.Models
 			}
 
 			// Merge labels.
-			Label = SmartLabel.Merge(Label, tx.Label);
+			if (Label != tx.Label)
+			{
+				Label = SmartLabel.Merge(Label, tx.Label);
+			}
 		}
 
 		public void SetReplacement()

--- a/WalletWasabi/Models/SmartTransaction.cs
+++ b/WalletWasabi/Models/SmartTransaction.cs
@@ -94,8 +94,7 @@ namespace WalletWasabi.Models
 		/// <summary>
 		/// Update the transaction with the data acquired from another transaction. (For example merge their labels.)
 		/// </summary>
-		/// <param name="canUnconfirm">By default confirmed transaction won't get unconfirmed. You can override this option.</param>
-		public void Update(SmartTransaction tx, bool canUnconfirm = false)
+		public void Update(SmartTransaction tx)
 		{
 			// If this is not the same tx, then don't update.
 			if (this != tx)
@@ -103,14 +102,8 @@ namespace WalletWasabi.Models
 				throw new InvalidOperationException($"{GetHash()} != {tx.GetHash()}");
 			}
 
-			// Set the height related properties.
-			if (canUnconfirm)
-			{
-				Height = tx.Height;
-				BlockHash = tx.BlockHash;
-				BlockIndex = tx.BlockIndex;
-			}
-			else if (tx.Confirmed)
+			// Set the height related properties, only if confirmed.
+			if (tx.Confirmed)
 			{
 				Height = tx.Height;
 				BlockHash = tx.BlockHash;

--- a/WalletWasabi/Models/SmartTransaction.cs
+++ b/WalletWasabi/Models/SmartTransaction.cs
@@ -80,7 +80,9 @@ namespace WalletWasabi.Models
 			Transaction = transaction;
 			Label = label ?? SmartLabel.Empty;
 
-			SetHeight(height, blockHash, blockIndex);
+			Height = height;
+			BlockHash = blockHash;
+			BlockIndex = blockIndex;
 
 			FirstSeen = firstSeen == default ? DateTimeOffset.UtcNow : firstSeen;
 
@@ -89,11 +91,40 @@ namespace WalletWasabi.Models
 
 		#endregion Constructors
 
-		public void SetHeight(Height height, uint256 blockHash = null, int blockIndex = 0)
+		/// <summary>
+		/// Update the transaction with the data acquired from another transaction. (For example merge their labels.)
+		/// </summary>
+		/// <param name="canUnconfirm">By default confirmed transaction won't get unconfirmed. You can override this option.</param>
+		public void Update(SmartTransaction tx, bool canUnconfirm = false)
 		{
-			Height = height;
-			BlockHash = blockHash;
-			BlockIndex = blockIndex;
+			// If this is not the same tx, then don't update.
+			if (this != tx)
+			{
+				throw new InvalidOperationException($"{GetHash()} != {tx.GetHash()}");
+			}
+
+			// Set the height related properties.
+			if (canUnconfirm)
+			{
+				Height = tx.Height;
+				BlockHash = tx.BlockHash;
+				BlockIndex = tx.BlockIndex;
+			}
+			else if (tx.Confirmed)
+			{
+				Height = tx.Height;
+				BlockHash = tx.BlockHash;
+				BlockIndex = tx.BlockIndex;
+			}
+
+			// Always the earlier seen is the firstSeen.
+			if (tx.FirstSeen < FirstSeen)
+			{
+				FirstSeen = tx.FirstSeen;
+			}
+
+			// Merge labels.
+			Label = SmartLabel.Merge(Label, tx.Label);
 		}
 
 		public void SetReplacement()

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -51,9 +51,9 @@ namespace WalletWasabi.Services
 				if (isFoundTx)
 				{
 					SmartTransaction foundTx = TransactionCache.FirstOrDefault(x => x == tx);
-					if (foundTx != default(SmartTransaction)) // Must check again, because it's a concurrent collection!
+					if (foundTx != default) // Must check again, because it's a concurrent collection!
 					{
-						foundTx.SetHeight(tx.Height, tx.BlockHash, tx.BlockIndex);
+						foundTx.Update(tx);
 						walletRelevant = true;
 						justUpdate = true; // No need to check for double spend, we already processed this transaction, just update it.
 					}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -200,7 +200,7 @@ namespace WalletWasabi.Services
 					}
 
 					var txToRemove = TryGetTxFromCache(toRemove.TransactionId);
-					if (txToRemove != default(SmartTransaction))
+					if (txToRemove != default)
 					{
 						TransactionCache.TryRemove(txToRemove);
 					}
@@ -383,7 +383,6 @@ namespace WalletWasabi.Services
 					{
 						if (mempoolHashes.Contains(tx.GetHash().ToString().Substring(0, compactness)))
 						{
-							tx.SetHeight(Height.Mempool);
 							await ProcessTransactionAsync(tx);
 
 							Logger.LogInfo($"Transaction was successfully tested against the backend's mempool hashes: {tx.GetHash()}.");
@@ -402,7 +401,6 @@ namespace WalletWasabi.Services
 				// When there's a connection failure do not clean the transactions, add them to processing.
 				foreach (var tx in unconfirmedTransactions)
 				{
-					tx.SetHeight(Height.Mempool);
 					await ProcessTransactionAsync(tx);
 				}
 


### PR DESCRIPTION
It merges labels for example, so if one wallet sets label, then the other wallet can pick it up and merge them (after the TransactionStore PR)