### PR TITLE
Clear warning message before search hw.

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -570,6 +570,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 		{
 			var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
 			IsHwWalletSearchTextVisible = true;
+			SetWarningMessage("");
 			try
 			{
 				var client = new HwiClient(Global.Network);


### PR DESCRIPTION
If the HW search or load failed for some reason there will be an error message. This message should be cleared after the search button pressed again.