### PR TITLE
Add local function to the naming rule that enforces them to be PascalCase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -186,7 +186,7 @@ dotnet_naming_rule.most_members_must_be_pascal_case.severity = error
 dotnet_naming_rule.most_members_must_be_pascal_case.symbols  = most_members_symbols
 dotnet_naming_rule.most_members_must_be_pascal_case.style    = pascal_case_style
 
-dotnet_naming_symbols.most_members_symbols.applicable_kinds   = class, struct, enum, property, method, event, namespace
+dotnet_naming_symbols.most_members_symbols.applicable_kinds   = class, struct, enum, property, method, event, namespace, local_function
 dotnet_naming_symbols.most_members_symbols.applicable_accessibilities = *
 
 # name Local variables & parameters using camelCase


### PR DESCRIPTION
[Here](https://github.com/zkSNACKs/WalletWasabi/pull/1919#issuecomment-512223958) nopara suggested to remove `local function` from the rule but I think we should add them because they are used sometimes.