### PR TITLE
Simplify transaction processing code

### DIFF
--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -182,6 +182,17 @@ namespace WalletWasabi.Services
 							KeyManager.AssertLockedInternalKeysIndexed(14);
 						}
 					}
+					else // If we had this coin already.
+					{
+						if (newCoin.Height != Height.Mempool) // Update the height of this old coin we already had.
+						{
+							SmartCoin oldCoin = Coins.FirstOrDefault(x => x.TransactionId == txId && x.Index == i);
+							if (oldCoin != null) // Just to be sure, it is a concurrent collection.
+							{
+								oldCoin.Height = newCoin.Height;
+							}
+						}
+					}
 				}
 			}
 

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -39,13 +39,13 @@ namespace WalletWasabi.Services
 			uint256 txId = tx.GetHash();
 			var walletRelevant = false;
 
+			if (!tx.Transaction.PossiblyP2WPKHInvolved())
+			{
+				return false; // We do not care about non-witness transactions for other than mempool cleanup.
+			}
+
 			if (tx.Confirmed)
 			{
-				if (!tx.Transaction.PossiblyP2WPKHInvolved())
-				{
-					return false; // We do not care about non-witness transactions for other than mempool cleanup.
-				}
-
 				bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
 				if (isFoundTx)
 				{
@@ -61,10 +61,6 @@ namespace WalletWasabi.Services
 						return true; // relevant
 					}
 				}
-			}
-			else if (!tx.Transaction.PossiblyP2WPKHInvolved())
-			{
-				return false; // We do not care about non-witness transactions for other than mempool cleanup.
 			}
 
 			if (!tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -36,14 +36,12 @@ namespace WalletWasabi.Services
 
 		public bool Process(SmartTransaction tx)
 		{
-			uint256 txId = tx.GetHash();
-			var walletRelevant = false;
-
 			if (!tx.Transaction.PossiblyP2WPKHInvolved())
 			{
 				return false; // We do not care about non-witness transactions for other than mempool cleanup.
 			}
 
+			uint256 txId = tx.GetHash();
 			if (tx.Confirmed)
 			{
 				bool isFoundTx = TransactionCache.Contains(tx); // If we have in cache, update height.
@@ -62,6 +60,8 @@ namespace WalletWasabi.Services
 					}
 				}
 			}
+
+			var walletRelevant = false;
 
 			if (!tx.Transaction.IsCoinBase) // Transactions we already have and processed would be "double spends" but they shouldn't.
 			{

--- a/WalletWasabi/Services/TransactionProcessor.cs
+++ b/WalletWasabi/Services/TransactionProcessor.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Services
 					if (foundTx != default) // Must check again, because it's a concurrent collection!
 					{
 						foundTx.Update(tx);
-						foreach(var coin in Coins.Where(x => x.TransactionId == txId))
+						foreach (var coin in Coins.Where(x => x.TransactionId == txId))
 						{
 							coin.Height = tx.Height;
 						}


### PR DESCRIPTION
When a confirmed transaction is received and we were already aware of it (it was already processed before) it is not necessary to reprocess it; we can update the Height of its coins and abort the process.