### PR TITLE
Opt-in RBF in 2% of transactions

### DIFF
--- a/WalletWasabi/Services/TransactionFactory.cs
+++ b/WalletWasabi/Services/TransactionFactory.cs
@@ -140,6 +140,8 @@ namespace WalletWasabi.Services
 				builder.SetChange(changeHdPubKey.P2wpkhScript);
 			}
 
+			builder.OptInRBF = new Random().NextDouble() < 0.02; // 2% RBF transactions
+
 			FeeRate feeRate = feeRateFetcher();
 			builder.SendEstimatedFees(feeRate);
 


### PR DESCRIPTION
This PR is to start discussing a first step to address the https://github.com/zkSNACKs/WalletWasabi/issues/1543.
The idea is to opt-in RBF in the 10% of the Wasabi wallet transactions. IMO this is better for privacy that do not having any RBF at all because in that case the WW txs are even more obvious.