### PR TITLE
Make sure to update transactions those would be processed as duplicate.

### DIFF
--- a/WalletWasabi/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Transactions/TransactionStore.cs
@@ -134,7 +134,16 @@ namespace WalletWasabi.Transactions
 		private bool TryAddNoLockNoSerialization(SmartTransaction tx)
 		{
 			var hash = tx.GetHash();
-			return Transactions.TryAdd(hash, tx);
+
+			if (Transactions.TryAdd(hash, tx))
+			{
+				return true;
+			}
+			else
+			{
+				Transactions[hash].Update(tx);
+				return false;
+			}
 		}
 
 		public bool TryRemove(uint256 hash, out SmartTransaction stx)


### PR DESCRIPTION
It enables things like (after txstore is used) if we're sending from one of our wallet to another one of our wallet that the labels to be merged from both wallets instead of preferring randomly one.