### PR TITLE
Make easier to identify backend connection

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -126,6 +126,7 @@ namespace WalletWasabi.Backend
 			handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
 			var nodeConnectionParameters = new NodeConnectionParameters()
 			{
+				UserAgent = $"/WasabiCoordinator:{Constants.BackendMajorVersion.ToString()}/",
 				ConnectCancellation = handshakeTimeout.Token,
 				IsRelay = true
 			};


### PR DESCRIPTION
This makes a bit easier to find the Wasabi Coordinator connection when we do `bitcoin-cli getpeerinfo`. Currently we are using the `/NBitcoin:4.0.14/` user agent.

Basically, we can check if wasabi backend is connected to the bitcoin full node by doing something like:

```
$ bitcoin-cli getpeerinfo | grep Wasabi 
```