### PR TITLE
Better log for coinjoin tx fee errors.

### DIFF
--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -725,7 +725,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				FeeRate currentFeeRate = null;
 				if (fee is null)
 				{
-					Logger.LogError("Cannot calculate CoinJoin transaction fee. (some spentCoins are missing or spentCoins is null)");
+					Logger.LogError($"Cannot calculate CoinJoin transaction fee. (some spent coins are missing or {nameof(spentCoins)} is null)");
 				}
 				else if (fee == Money.Zero)
 				{

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -725,11 +725,11 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				FeeRate currentFeeRate = null;
 				if (fee is null)
 				{
-					Logger.LogError($"Cannot calculate CoinJoin transaction fee (some spentCoins are missing or spentCoins is null");
+					Logger.LogError("Cannot calculate CoinJoin transaction fee. (some spentCoins are missing or spentCoins is null)");
 				}
 				else if (fee == Money.Zero)
 				{
-					Logger.LogError($"CoinJoin transaction is not paying any fee.");
+					Logger.LogError("CoinJoin transaction is not paying any fee.");
 				}
 				else
 				{

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -720,8 +720,21 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				int estimatedSigSizeBytes = UnsignedCoinJoin.Inputs.Count * Constants.P2wpkhInputSizeInBytes;
 				int estimatedFinalTxSize = UnsignedCoinJoin.GetSerializedSize() + estimatedSigSizeBytes;
 				Money fee = UnsignedCoinJoin.GetFee(spentCoins.ToArray());
+
 				// There is a currentFeeRate null check later.
-				FeeRate currentFeeRate = fee is null ? null : new FeeRate(fee, estimatedFinalTxSize);
+				FeeRate currentFeeRate = null;
+				if (fee is null)
+				{
+					Logger.LogError($"Cannot calculate CoinJoin transaction fee (some spentCoins are missing or spentCoins is null");
+				}
+				else if (fee == Money.Zero)
+				{
+					Logger.LogError($"CoinJoin transaction is not paying any fee.");
+				}
+				else
+				{
+					currentFeeRate = new FeeRate(fee, estimatedFinalTxSize);
+				}
 
 				// 8.2. Get the most optimal FeeRate.
 				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true);

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -727,7 +727,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				{
 					Logger.LogError($"Cannot calculate CoinJoin transaction fee. (some spent coins are missing or {nameof(spentCoins)} is null)");
 				}
-				else if (fee == Money.Zero)
+				else if (fee <= Money.Zero)
 				{
 					Logger.LogError("CoinJoin transaction is not paying any fee.");
 				}

--- a/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
+++ b/WalletWasabi/Models/ChaumianCoinJoin/CcjRound.cs
@@ -725,7 +725,7 @@ namespace WalletWasabi.Models.ChaumianCoinJoin
 				FeeRate currentFeeRate = null;
 				if (fee is null)
 				{
-					Logger.LogError($"Cannot calculate CoinJoin transaction fee. (some spent coins are missing or {nameof(spentCoins)} is null)");
+					Logger.LogError($"Cannot calculate CoinJoin transaction fee. Some spent coins are missing.");
 				}
 				else if (fee <= Money.Zero)
 				{


### PR DESCRIPTION
In the server log file there are several entries like the following:
```
2019-10-15 09:57:18 WARNING	CcjRound (771)	Failed to optimize fees. Fallback to normal fees.
2019-10-15 09:57:18 WARNING	CcjRound (772)	System.ArgumentOutOfRangeException: Cannot be less than 0.
Parameter name: feePaid
   at NBitcoin.FeeRate..ctor(Money feePaid, Int32 size)
   at WalletWasabi.Models.ChaumianCoinJoin.CcjRound.TryOptimizeFeesAsync(IEnumerable`1 spentCoins)
```

That error occurs when the `sum(inputs.value) < sum(output.value)`. In other words, we have a bug or `NBitcoin` has a bug. I will take a look at `NBitcoin` code just in case.