### PR TITLE
Fix azure CI dotnet core 3 install

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -13,7 +13,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.x
+      version: 3.0.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -13,7 +13,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.x
+      version: 3.0.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -13,7 +13,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.x
+      version: 3.0.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:


### PR DESCRIPTION
There is a new 3.1 preview release that messed up azure versioning. 
Had to change 3.x to 3.0.x. 

"The issue seems with the latest 3.1 version which is in preview state."
https://github.com/microsoft/azure-pipelines-tasks/issues/11569