### PR TITLE
Remove previous versions after installing a new version of Wasabi

### DIFF
--- a/WalletWasabi.WindowsInstaller/Product.wxs
+++ b/WalletWasabi.WindowsInstaller/Product.wxs
@@ -23,8 +23,8 @@
       Languages="!(loc.Language)" />
 
     <Property Id="REINSTALLMODE" Value="amus" />
-    <!-- Downgrade error message. -->
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <!-- Downgrade error message. https://wixtoolset.org/documentation/manual/v3/xsd/wix/majorupgrade.html -->
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="yes" />
 
     <!-- Include .cab file into the .msi file. -->
     <MediaTemplate


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/2433

> This is useful when two product versions differ only in the fourth version field. MSI specifically ignores that field when comparing product versions, so two products that differ only in the fourth version field are the same product and need this attribute set to yes to be detected.

WARNING!
> Note that because MSI ignores the fourth product version field, setting this attribute to yes also allows downgrades when the first three product version fields are identical. For example, product version 1.0.0.1 will "upgrade" 1.0.0.2998 because they're seen as the same version (1.0.0). That could reintroduce serious bugs so the safest choice is to change the first three version fields and omit this attribute to get the default of no.

Despite the warning, we have not other choices as we are using the revision number already. Silent releases are for users who have specific problems - so IMO it is not an issue. They won't accidentally downgrade their software.  

Source:
https://wixtoolset.org/documentation/manual/v3/xsd/wix/majorupgrade.html