### PR TITLE
Revert "Add canonical to website"

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -24,7 +24,6 @@
     <link rel="stylesheet" href="css/bootstrap.css?ver=1.1.0">
     <link rel="stylesheet" href="css/style.css?ver=1.1.0">
     <link rel="shortcut icon" href="images/favicon.ico" />
-    <link rel="canonical" href="https://wasabiwallet.io/" />
     <title>Wasabi Wallet - Unfairly Private</title>
 </head>
 <body>


### PR DESCRIPTION
Reverts zkSNACKs/WalletWasabi#2351

According to @RiccardoMasutti we do not need to add canonical because only the .io will be indexed because of nofollow/noindex.

> @nopara73 @molnard Just checked wasabiwallet.co source/response.
> Nofollow, noindex code is applied so now we just have to wait Google to remove .co version from SERPs.
> 
> We can close this PR