### PR TITLE
Change default dust threshold to 0.00001

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -27,7 +27,7 @@ namespace WalletWasabi.Gui
 		public const int DefaultPrivacyLevelStrong = 50;
 		public const int DefaultMixUntilAnonymitySet = 50;
 		public const int DefaultTorSock5Port = 9050;
-		public static readonly Money DefaultDustThreshold = Money.Coins(0.0001m);
+		public static readonly Money DefaultDustThreshold = Money.Coins(0.00001m);
 
 		[JsonProperty(PropertyName = "Network")]
 		[JsonConverter(typeof(NetworkJsonConverter))]

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -119,7 +119,7 @@
             <controls:GroupBox Title="Other settings" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
               <StackPanel Orientation="Vertical" Spacing="5">
                 <StackPanel Margin="0 10" Spacing="5">
-                  <TextBlock ToolTip.Tip="Under the dust threshold coins are not appearing in the coin lists.">Dust Threshold (BTC)</TextBlock>
+                  <TextBlock ToolTip.Tip="Coins under the dust threshold won't appear in the coin lists.">Dust Threshold (BTC)</TextBlock>
                   <TextBox Text="{Binding DustThreshold}">
                     <i:Interaction.Behaviors>
                       <behaviors:CommandOnLostFocusBehavior Command="{Binding TextBoxLostFocusCommand}" />

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -99,7 +99,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				new CoinJoinClient(syncer, network, keyManager, new Uri("http://localhost:12345"), Global.Instance.TorSocks5Endpoint),
 				nodes,
 				Global.Instance.DataDir,
-				new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(0.0001m)));
+				new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(0.00001m)));
 			Assert.True(Directory.Exists(blocksFolderPath));
 
 			try

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -85,7 +85,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			global.Coordinator.UtxoReferee.Clear();
 
 			var network = global.RpcClient.Network;
-			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.P2pEndPoint, Money.Coins(0.0001m));
+			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, RegTestFixture.BackendRegTestNode.P2pEndPoint, Money.Coins(0.00001m));
 			var bitcoinStore = new BitcoinStore();
 			var dir = Path.Combine(Global.Instance.DataDir, caller);
 			await bitcoinStore.InitializeAsync(dir, network);


### PR DESCRIPTION
and edited the tooltip.

In `TransactionProcessorTests.cs`
```
return new TransactionProcessor(
				txStore,
				keyManager,
				new ObservableConcurrentHashSet<SmartCoin>(),
				Money.Coins(0.0001m));
```
Should `0.0001m` change?
I changed that but then the test didn't pass.