### PR TITLE
Correct capitalization

### DIFF
--- a/WalletWasabi/Coins/CoinsRegistry.cs
+++ b/WalletWasabi/Coins/CoinsRegistry.cs
@@ -183,7 +183,7 @@ namespace WalletWasabi.Coins
 
 		public ICoinsView Unconfirmed() => AsCoinsView().Unconfirmed();
 
-		public ICoinsView UnSpent() => AsCoinsView().UnSpent();
+		public ICoinsView Unspent() => AsCoinsView().Unspent();
 
 		IEnumerator IEnumerable.GetEnumerator() => AsCoinsView().GetEnumerator();
 	}

--- a/WalletWasabi/Coins/CoinsView.cs
+++ b/WalletWasabi/Coins/CoinsView.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.Coins
 			Coins = Guard.NotNull(nameof(coins), coins);
 		}
 
-		public ICoinsView UnSpent() => new CoinsView(Coins.Where(x => x.Unspent && !x.SpentAccordingToBackend));
+		public ICoinsView Unspent() => new CoinsView(Coins.Where(x => x.Unspent && !x.SpentAccordingToBackend));
 
 		public ICoinsView Available() => new CoinsView(Coins.Where(x => !x.Unavailable));
 

--- a/WalletWasabi/Coins/ICoinsView.cs
+++ b/WalletWasabi/Coins/ICoinsView.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.Coins
 
 		ICoinsView Unconfirmed();
 
-		ICoinsView UnSpent();
+		ICoinsView Unspent();
 
 		SmartCoin GetByOutPoint(OutPoint outpoint);
 	}


### PR DESCRIPTION
`UnSpent` --> `Unspent`