### PR TITLE
Improve transaction privacy by taking clusters info into account

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -159,7 +159,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string AmountBtc => Model.Amount.ToString(false, true);
 
-		public string Label => Model.Label.ToString();
+		public string Label => Model.Label;
 
 		public int Height => Model.Height;
 
@@ -171,7 +171,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string InCoinJoin => Model.CoinJoinInProgress ? "Yes" : "No";
 
-		public string Clusters => Model.Clusters.Labels; //If the value is null the bind do not update the view. It shows the previous state for example: ##### even if PrivMode false.
+		public string Clusters => Model.Clusters.Labels; // If the value is null the bind do not update the view. It shows the previous state for example: ##### even if PrivMode false.
 
 		public string PubKey => Model.HdPubKey?.PubKey?.ToString() ?? "";
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			GenerateCommand = ReactiveCommand.Create(() =>
 				{
 					var label = new SmartLabel(Label);
-					Label = label.ToString();
+					Label = label;
 					if (label.IsEmpty)
 					{
 						LabelRequiredNotificationVisible = true;
@@ -69,7 +69,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 					Dispatcher.UIThread.PostLogException(() =>
 						{
-							HdPubKey newKey = Global.WalletService.GetReceiveKey(new SmartLabel(Label), Addresses.Select(x => x.Model).Take(7)); // Never touch the first 7 keys.
+							HdPubKey newKey = Global.WalletService.GetReceiveKey(Label, Addresses.Select(x => x.Model).Take(7)); // Never touch the first 7 keys.
 
 							AddressViewModel found = Addresses.FirstOrDefault(x => x.Model == newKey);
 							if (found != default)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -220,10 +220,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			OnAddressPasteCommand = ReactiveCommand.Create((BitcoinUrlBuilder url) =>
 			{
-				var label = new SmartLabel(url.Label);
+				SmartLabel label = url.Label;
 				if (!label.IsEmpty)
 				{
-					Label = label.ToString();
+					Label = label;
 				}
 
 				if (url.Amount != null)
@@ -241,7 +241,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusBarStatus.BuildingTransaction);
 
 					var label = new SmartLabel(Label);
-					Label = label.ToString();
+					Label = label;
 					if (!IsMax && label.IsEmpty)
 					{
 						SetWarningMessage($"{nameof(Label)} is required.");

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.Gui.ViewModels
 			Model = model;
 			ClipboardNotificationVisible = false;
 			ClipboardNotificationOpacity = 0;
-			_label = model.Label.ToString();
+			_label = model.Label;
 
 			this.WhenAnyValue(x => x.IsExpanded)
 				.ObserveOn(RxApp.TaskpoolScheduler)
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui.ViewModels
 
 						if (hdPubKey != default)
 						{
-							hdPubKey.SetLabel(new SmartLabel(newLabel), kmToFile: keyManager);
+							hdPubKey.SetLabel(newLabel, kmToFile: keyManager);
 						}
 					}
 				});

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -1270,8 +1270,14 @@ namespace WalletWasabi.Tests.IntegrationTests
 				// Enough money (one confirmed coin and one unconfirmed coin, unconfirmed are NOT allowed)
 				Assert.Throws<InsufficientBalanceException>(() => wallet.BuildTransaction(null, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy, false));
 
-				// Enough money (one confirmed coin and one unconfirmed coin, unconfirmed are allowed)
+				// Enough money (one unconfirmed coin, unconfirmed are allowed)
 				var btx = wallet.BuildTransaction(password, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy, true);
+				var spentCoin = Assert.Single(btx.SpentCoins);
+				Assert.False(spentCoin.Confirmed);
+
+				// Enough money (one confirmed coin and one unconfirmed coin, unconfirmed are allowed)
+				operations = new PaymentIntent(scp, Money.Coins(2.5m));
+				btx = wallet.BuildTransaction(password, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy, true);
 				Assert.Equal(2, btx.SpentCoins.Count());
 				Assert.Equal(1, btx.SpentCoins.Count(c => c.Confirmed));
 				Assert.Equal(1, btx.SpentCoins.Count(c => !c.Confirmed));

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -469,7 +469,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("foo label"));
+			var key = wallet.GetReceiveKey("foo label");
 			var txId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(0.1m));
 			await rpc.GenerateAsync(1);
 
@@ -497,17 +497,17 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(new Height(bitcoinStore.HashChain.TipHeight), firstCoin.Height);
 				Assert.InRange(firstCoin.Index, 0U, 1U);
 				Assert.False(firstCoin.Unavailable);
-				Assert.Equal(new SmartLabel("foo label"), firstCoin.Label);
+				Assert.Equal("foo label", firstCoin.Label);
 				Assert.Equal(key.P2wpkhScript, firstCoin.ScriptPubKey);
 				Assert.Null(firstCoin.SpenderTransactionId);
 				Assert.NotNull(firstCoin.SpentOutputs);
 				Assert.NotEmpty(firstCoin.SpentOutputs);
 				Assert.Equal(txId, firstCoin.TransactionId);
 				Assert.Single(keyManager.GetKeys(KeyState.Used, false));
-				Assert.Equal(new SmartLabel("foo label"), keyManager.GetKeys(KeyState.Used, false).Single().Label);
+				Assert.Equal("foo label", keyManager.GetKeys(KeyState.Used, false).Single().Label);
 
 				// Get some money, make it confirm.
-				var key2 = wallet.GetReceiveKey(new SmartLabel("bar label"));
+				var key2 = wallet.GetReceiveKey("bar label");
 				var txId2 = await rpc.SendToAddressAsync(key2.GetP2wpkhAddress(network), Money.Coins(0.01m));
 				Interlocked.Exchange(ref _filtersProcessedByWalletCount, 0);
 				await rpc.GenerateAsync(1);
@@ -527,9 +527,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(new Height(bitcoinStore.HashChain.TipHeight).Value - 1, secondCoin.Height.Value);
 				Assert.Equal(new Height(bitcoinStore.HashChain.TipHeight), thirdCoin.Height);
 				Assert.False(thirdCoin.Unavailable);
-				Assert.Equal(new SmartLabel("foo label"), firstCoin.Label);
-				Assert.Equal(new SmartLabel("bar label"), secondCoin.Label);
-				Assert.Equal(new SmartLabel("bar label"), thirdCoin.Label);
+				Assert.Equal("foo label", firstCoin.Label);
+				Assert.Equal("bar label", secondCoin.Label);
+				Assert.Equal("bar label", thirdCoin.Label);
 				Assert.Equal(key.P2wpkhScript, firstCoin.ScriptPubKey);
 				Assert.Equal(key2.P2wpkhScript, secondCoin.ScriptPubKey);
 				Assert.Equal(key2.P2wpkhScript, thirdCoin.ScriptPubKey);
@@ -555,8 +555,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(42, keyManager.GetKeys(KeyState.Clean).Count());
 				Assert.Equal(58, keyManager.GetKeys().Count());
 
-				Assert.Single(keyManager.GetKeys(x => x.Label == new SmartLabel("foo label") && x.KeyState == KeyState.Used && !x.IsInternal));
-				Assert.Single(keyManager.GetKeys(x => x.Label == new SmartLabel("bar label") && x.KeyState == KeyState.Used && !x.IsInternal));
+				Assert.Single(keyManager.GetKeys(x => x.Label == "foo label" && x.KeyState == KeyState.Used && !x.IsInternal));
+				Assert.Single(keyManager.GetKeys(x => x.Label == "bar label" && x.KeyState == KeyState.Used && !x.IsInternal));
 
 				// REORG TESTS
 				var txId4 = await rpc.SendToAddressAsync(key2.GetP2wpkhAddress(network), Money.Coins(0.03m), replaceable: true);
@@ -584,7 +584,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(Money.Coins(0.03m), rbfCoin.Amount);
 				Assert.Equal(new Height(bitcoinStore.HashChain.TipHeight).Value - 2, rbfCoin.Height.Value);
 				Assert.False(rbfCoin.Unavailable);
-				Assert.Equal(new SmartLabel("bar label"), rbfCoin.Label);
+				Assert.Equal("bar label", rbfCoin.Label);
 				Assert.Equal(key2.P2wpkhScript, rbfCoin.ScriptPubKey);
 				Assert.Null(rbfCoin.SpenderTransactionId);
 				Assert.NotNull(rbfCoin.SpentOutputs);
@@ -602,8 +602,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Equal(42, keyManager.GetKeys(KeyState.Clean).Count());
 				Assert.Equal(58, keyManager.GetKeys().Count());
 
-				Assert.Single(keyManager.GetKeys(KeyState.Used, false).Where(x => x.Label == new SmartLabel("foo label")));
-				Assert.Single(keyManager.GetKeys(KeyState.Used, false).Where(x => x.Label == new SmartLabel("bar label")));
+				Assert.Single(keyManager.GetKeys(KeyState.Used, false).Where(x => x.Label == "foo label"));
+				Assert.Single(keyManager.GetKeys(KeyState.Used, false).Where(x => x.Label == "bar label"));
 
 				// TEST MEMPOOL
 				var txId5 = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(0.1m));
@@ -693,8 +693,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("foo label"));
-			var key2 = wallet.GetReceiveKey(new SmartLabel("foo label"));
+			var key = wallet.GetReceiveKey("foo label");
+			var key2 = wallet.GetReceiveKey("foo label");
 			var txId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(1m));
 			Assert.NotNull(txId);
 			await rpc.GenerateAsync(1);
@@ -732,7 +732,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				}
 
 				var scp = new Key().ScriptPubKey;
-				var res2 = wallet.BuildTransaction(password, new PaymentIntent(scp, Money.Coins(0.05m), label: new SmartLabel("foo")), FeeStrategy.CreateFromConfirmationTarget(5), allowUnconfirmed: false);
+				var res2 = wallet.BuildTransaction(password, new PaymentIntent(scp, Money.Coins(0.05m), label: "foo"), FeeStrategy.CreateFromConfirmationTarget(5), allowUnconfirmed: false);
 
 				Assert.NotNull(res2.Transaction);
 				Assert.Single(res2.OuterWalletOutputs);
@@ -752,9 +752,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region Basic
 
-				Script receive = wallet.GetReceiveKey(new SmartLabel("Basic")).P2wpkhScript;
+				Script receive = wallet.GetReceiveKey("Basic").P2wpkhScript;
 				Money amountToSend = wallet.Coins.Where(x => !x.Unavailable).Sum(x => x.Amount) / 2;
-				var res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: new SmartLabel("foo")), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+				var res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: "foo"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				foreach (SmartCoin coin in res.SpentCoins)
 				{
@@ -800,9 +800,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region SubtractFeeFromAmount
 
-				receive = wallet.GetReceiveKey(new SmartLabel("SubtractFeeFromAmount")).P2wpkhScript;
+				receive = wallet.GetReceiveKey("SubtractFeeFromAmount").P2wpkhScript;
 				amountToSend = wallet.Coins.Where(x => !x.Unavailable).Sum(x => x.Amount) / 3;
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, subtractFee: true, label: new SmartLabel("foo")), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, subtractFee: true, label: "foo"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -835,7 +835,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region LowFee
 
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: new SmartLabel("foo")), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: "foo"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -868,7 +868,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region MediumFee
 
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: new SmartLabel("foo")), FeeStrategy.OneDayConfirmationTargetStrategy, allowUnconfirmed: true);
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: "foo"), FeeStrategy.OneDayConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -901,7 +901,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region HighFee
 
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: new SmartLabel("foo")), FeeStrategy.TwentyMinutesConfirmationTargetStrategy, allowUnconfirmed: true);
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, amountToSend, label: "foo"), FeeStrategy.TwentyMinutesConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -939,9 +939,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region MaxAmount
 
-				receive = wallet.GetReceiveKey(new SmartLabel("MaxAmount")).P2wpkhScript;
+				receive = wallet.GetReceiveKey("MaxAmount").P2wpkhScript;
 
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), new SmartLabel("foo")), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), "foo"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Single(res.InnerWalletOutputs);
 				Assert.Empty(res.OuterWalletOutputs);
@@ -960,11 +960,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				#region InputSelection
 
-				receive = wallet.GetReceiveKey(new SmartLabel("InputSelection")).P2wpkhScript;
+				receive = wallet.GetReceiveKey("InputSelection").P2wpkhScript;
 
 				var inputCountBefore = res.SpentCoins.Count();
 
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), new SmartLabel("foo")), FeeStrategy.SevenDaysConfirmationTargetStrategy,
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), "foo"), FeeStrategy.SevenDaysConfirmationTargetStrategy,
 					allowUnconfirmed: true,
 					allowedInputs: wallet.Coins.Where(x => !x.Unavailable).Select(x => new TxoRef(x.TransactionId, x.Index)).Take(1));
 
@@ -984,7 +984,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				Assert.Single(res.Transaction.Transaction.Outputs);
 
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), new SmartLabel("foo")), FeeStrategy.SevenDaysConfirmationTargetStrategy,
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), "foo"), FeeStrategy.SevenDaysConfirmationTargetStrategy,
 					allowUnconfirmed: true,
 					allowedInputs: new[] { res.SpentCoins.Select(x => new TxoRef(x.TransactionId, x.Index)).First() });
 
@@ -1001,17 +1001,17 @@ namespace WalletWasabi.Tests.IntegrationTests
 				#region Labeling
 
 				Script receive2 = wallet.GetReceiveKey(SmartLabel.Empty).P2wpkhScript;
-				res = wallet.BuildTransaction(password, new PaymentIntent(receive2, MoneyRequest.CreateAllRemaining(), new SmartLabel("my label")), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+				res = wallet.BuildTransaction(password, new PaymentIntent(receive2, MoneyRequest.CreateAllRemaining(), "my label"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Single(res.InnerWalletOutputs);
-				Assert.Equal(new SmartLabel("my label"), res.InnerWalletOutputs.Single().Label);
+				Assert.Equal("my label", res.InnerWalletOutputs.Single().Label);
 
 				amountToSend = wallet.Coins.Where(x => !x.Unavailable).Sum(x => x.Amount) / 3;
 				res = wallet.BuildTransaction(
 					password,
 					new PaymentIntent(
-						new DestinationRequest(new Key(), amountToSend, label: new SmartLabel("outgoing")),
-						new DestinationRequest(new Key(), amountToSend, label: new SmartLabel("outgoing2"))),
+						new DestinationRequest(new Key(), amountToSend, label: "outgoing"),
+						new DestinationRequest(new Key(), amountToSend, label: "outgoing2")),
 					FeeStrategy.SevenDaysConfirmationTargetStrategy,
 					allowUnconfirmed: true);
 
@@ -1048,10 +1048,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				inputCountBefore = res.SpentCoins.Count();
 
-				receive = wallet.GetReceiveKey(new SmartLabel("AllowedInputsDisallowUnconfirmed")).P2wpkhScript;
+				receive = wallet.GetReceiveKey("AllowedInputsDisallowUnconfirmed").P2wpkhScript;
 
 				var allowedInputs = wallet.Coins.Where(x => !x.Unavailable).Select(x => new TxoRef(x.TransactionId, x.Index)).Take(1);
-				var toSend = new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), new SmartLabel("fizz"));
+				var toSend = new PaymentIntent(receive, MoneyRequest.CreateAllRemaining(), "fizz");
 
 				// covers:
 				// disallow unconfirmed with allowed inputs
@@ -1091,7 +1091,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 					password,
 					new PaymentIntent(
 						new DestinationRequest(k1, MoneyRequest.CreateChange()),
-						new DestinationRequest(k2, Money.Coins(0.0003m), label: new SmartLabel("outgoing"))),
+						new DestinationRequest(k2, Money.Coins(0.0003m), label: "outgoing")),
 					FeeStrategy.TwentyMinutesConfirmationTargetStrategy);
 
 				Assert.Contains(k1.ScriptPubKey, res.OuterWalletOutputs.Select(x => x.ScriptPubKey));
@@ -1103,17 +1103,17 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				res = wallet.BuildTransaction(
 					password,
-					new PaymentIntent(new Key(), Money.Coins(0.0003m), label: new SmartLabel("outgoing")),
+					new PaymentIntent(new Key(), Money.Coins(0.0003m), label: "outgoing"),
 					FeeStrategy.TwentyMinutesConfirmationTargetStrategy);
 
 				Assert.True(res.FeePercentOfSent > 1);
 
-				var newChangeK = keyManager.GenerateNewKey(new SmartLabel("foo"), KeyState.Clean, isInternal: true);
+				var newChangeK = keyManager.GenerateNewKey("foo", KeyState.Clean, isInternal: true);
 				res = wallet.BuildTransaction(
 					password,
 					new PaymentIntent(
-						new DestinationRequest(newChangeK.P2wpkhScript, MoneyRequest.CreateChange(), new SmartLabel("boo")),
-						new DestinationRequest(new Key(), Money.Coins(0.0003m), label: new SmartLabel("outgoing"))),
+						new DestinationRequest(newChangeK.P2wpkhScript, MoneyRequest.CreateChange(), "boo"),
+						new DestinationRequest(new Key(), Money.Coins(0.0003m), label: "outgoing")),
 					FeeStrategy.TwentyMinutesConfirmationTargetStrategy);
 
 				Assert.True(res.FeePercentOfSent > 1);
@@ -1222,13 +1222,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 			Assert.Throws<ArgumentException>(() => wallet.BuildTransaction(
 				password,
 				new PaymentIntent(
-					new DestinationRequest(scp, MoneyRequest.CreateAllRemaining(), new SmartLabel("zero")),
-					new DestinationRequest(scp, MoneyRequest.CreateAllRemaining(), new SmartLabel("zero"))),
+					new DestinationRequest(scp, MoneyRequest.CreateAllRemaining(), "zero"),
+					new DestinationRequest(scp, MoneyRequest.CreateAllRemaining(), "zero")),
 				FeeStrategy.SevenDaysConfirmationTargetStrategy,
 				false));
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("foo label"));
+			var key = wallet.GetReceiveKey("foo label");
 			var txId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(1m));
 
 			// Generate some coins
@@ -1352,7 +1352,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			var scp = new Key().ScriptPubKey;
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("foo label"));
+			var key = wallet.GetReceiveKey("foo label");
 			var fundingTxId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(0.1m));
 
 			// Generate some coins
@@ -1511,7 +1511,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			Assert.Empty(wallet.Coins);
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("foo label"));
+			var key = wallet.GetReceiveKey("foo label");
 
 			try
 			{
@@ -1619,8 +1619,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 				// Test coin basic count.
 				ICoinsView GetAllCoins() => wallet.TransactionProcessor.Coins.AsAllCoinsView();
 				var coinCount = GetAllCoins().Count();
-				var to = wallet.GetReceiveKey(new SmartLabel("foo"));
-				var res = wallet.BuildTransaction(password, new PaymentIntent(to.P2wpkhScript, Money.Coins(0.2345m), label: new SmartLabel("bar")), FeeStrategy.TwentyMinutesConfirmationTargetStrategy, allowUnconfirmed: true);
+				var to = wallet.GetReceiveKey("foo");
+				var res = wallet.BuildTransaction(password, new PaymentIntent(to.P2wpkhScript, Money.Coins(0.2345m), label: "bar"), FeeStrategy.TwentyMinutesConfirmationTargetStrategy, allowUnconfirmed: true);
 				await wallet.SendTransactionAsync(res.Transaction);
 				Assert.Equal(coinCount + 2, GetAllCoins().Count());
 				Assert.Equal(2, GetAllCoins().Count(x => !x.Confirmed));
@@ -1682,7 +1682,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			Assert.Empty(wallet.Coins);
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("foo label"));
+			var key = wallet.GetReceiveKey("foo label");
 
 			try
 			{
@@ -3006,7 +3006,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				var amount = Money.Coins((decimal)damount);
 
 				var keyManager = KeyManager.CreateNew(out _, password);
-				var key = keyManager.GenerateNewKey(new SmartLabel("foo"), KeyState.Clean, false);
+				var key = keyManager.GenerateNewKey("foo", KeyState.Clean, false);
 				var bech = key.GetP2wpkhAddress(network);
 				var txId = await rpc.SendToAddressAsync(bech, amount, replaceable: false);
 				key.SetKeyState(KeyState.Used);
@@ -3029,8 +3029,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 				foreach (var participant in participants)
 				{
 					SmartCoin coin = participant.Item1;
+
 					CoinJoinClient chaumianClient = participant.Item2;
 					chaumianClient.Start();
+
 					await chaumianClient.QueueCoinsToMixAsync(password, coin);
 				}
 
@@ -3041,6 +3043,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 					{
 						throw new TimeoutException("CoinJoin was not propagated.");
 					}
+
 					await Task.Delay(1000);
 				}
 			}
@@ -3087,10 +3090,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 			coordinator.AbortAllRoundsInInputRegistration("");
 			await rpc.GenerateAsync(3); // So to make sure we have enough money.
 			var keyManager = KeyManager.CreateNew(out _, password);
-			var key1 = keyManager.GenerateNewKey(new SmartLabel("foo"), KeyState.Clean, false);
-			var key2 = keyManager.GenerateNewKey(new SmartLabel("bar"), KeyState.Clean, false);
-			var key3 = keyManager.GenerateNewKey(new SmartLabel("baz"), KeyState.Clean, false);
-			var key4 = keyManager.GenerateNewKey(new SmartLabel("qux"), KeyState.Clean, false);
+			var key1 = keyManager.GenerateNewKey("foo", KeyState.Clean, false);
+			var key2 = keyManager.GenerateNewKey("bar", KeyState.Clean, false);
+			var key3 = keyManager.GenerateNewKey("baz", KeyState.Clean, false);
+			var key4 = keyManager.GenerateNewKey("qux", KeyState.Clean, false);
 			var bech1 = key1.GetP2wpkhAddress(network);
 			var bech2 = key2.GetP2wpkhAddress(network);
 			var bech3 = key3.GetP2wpkhAddress(network);
@@ -3280,12 +3283,12 @@ namespace WalletWasabi.Tests.IntegrationTests
 			var wallet2 = new WalletService(bitcoinStore, keyManager2, synchronizer2, chaumianClient2, nodes2, workDir2, serviceConfiguration);
 
 			// Get some money, make it confirm.
-			var key = wallet.GetReceiveKey(new SmartLabel("fundZeroLink"));
+			var key = wallet.GetReceiveKey("fundZeroLink");
 			var txId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(1m));
 			Assert.NotNull(txId);
-			var key2 = wallet2.GetReceiveKey(new SmartLabel("fundZeroLink"));
-			var key3 = wallet2.GetReceiveKey(new SmartLabel("fundZeroLink"));
-			var key4 = wallet2.GetReceiveKey(new SmartLabel("fundZeroLink"));
+			var key2 = wallet2.GetReceiveKey("fundZeroLink");
+			var key3 = wallet2.GetReceiveKey("fundZeroLink");
+			var key4 = wallet2.GetReceiveKey("fundZeroLink");
 			var txId2 = await rpc.SendToAddressAsync(key2.GetP2wpkhAddress(network), Money.Coins(0.11m));
 			var txId3 = await rpc.SendToAddressAsync(key3.GetP2wpkhAddress(network), Money.Coins(0.12m));
 			var txId4 = await rpc.SendToAddressAsync(key4.GetP2wpkhAddress(network), Money.Coins(0.13m));

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -80,7 +80,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.NotEqual(manager.ExtPubKey, differentManager.ExtPubKey);
 
 			differentManager.AssertCleanKeysIndexed();
-			var newKey = differentManager.GenerateNewKey(new SmartLabel("some-label"), KeyState.Clean, true, false);
+			var newKey = differentManager.GenerateNewKey("some-label", KeyState.Clean, true, false);
 			Assert.Equal(newKey.Index, differentManager.MinGapLimit);
 			Assert.Equal("999'/999'/999'/1/55", newKey.FullKeyPath.ToString());
 		}
@@ -109,7 +109,7 @@ namespace WalletWasabi.Tests.UnitTests
 			for (int i = 0; i < 1000; i++)
 			{
 				var isInternal = random.Next(2) == 0;
-				var label = new SmartLabel(RandomString.Generate(21));
+				var label = RandomString.Generate(21);
 				var keyState = (KeyState)random.Next(3);
 				manager.GenerateNewKey(label, keyState, isInternal, toFile: false);
 			}
@@ -142,7 +142,7 @@ namespace WalletWasabi.Tests.UnitTests
 			for (int i = 0; i < 1000; i++)
 			{
 				var isInternal = random.Next(2) == 0;
-				var label = new SmartLabel(RandomString.Generate(21));
+				var label = RandomString.Generate(21);
 				var keyState = (KeyState)random.Next(3);
 				var generatedKey = manager.GenerateNewKey(label, keyState, isInternal);
 

--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CombinationsWithoutRepetitionOfFixedLength()
 		{
 			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 3);
-			var AsString = combinations.Select(x=> string.Join(", ", x)).ToArray();
+			var AsString = combinations.Select(x => string.Join(", ", x)).ToArray();
 
 			Assert.Equal(10, AsString.Length);
 			Assert.Equal(combinations.Count(), combinations.Distinct().Count());
@@ -30,37 +30,37 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CombinationsWithoutRepetitionUpToLenth()
 		{
 			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 1, upToLength: 4);
-			var AsString = combinations.Select(x=> string.Join(", ", x)).ToArray();
+			var AsString = combinations.Select(x => string.Join(", ", x)).ToArray();
 
 			Assert.Equal(30, AsString.Length);
 			Assert.Equal(combinations.Count(), combinations.Distinct().Count());
 
 			var i = 0;
-			Assert.Equal(         "0", AsString[i++]);
-			Assert.Equal(         "1", AsString[i++]);
-			Assert.Equal(         "2", AsString[i++]);
-			Assert.Equal(         "3", AsString[i++]);
-			Assert.Equal(         "4", AsString[i++]);
-			Assert.Equal(      "0, 1", AsString[i++]);
-			Assert.Equal(      "0, 2", AsString[i++]);
-			Assert.Equal(      "0, 3", AsString[i++]);
-			Assert.Equal(      "0, 4", AsString[i++]);
-			Assert.Equal(      "1, 2", AsString[i++]);
-			Assert.Equal(      "1, 3", AsString[i++]);
-			Assert.Equal(      "1, 4", AsString[i++]);
-			Assert.Equal(      "2, 3", AsString[i++]);
-			Assert.Equal(      "2, 4", AsString[i++]);
-			Assert.Equal(      "3, 4", AsString[i++]);
-			Assert.Equal(   "0, 1, 2", AsString[i++]);
-			Assert.Equal(   "0, 1, 3", AsString[i++]);
-			Assert.Equal(   "0, 1, 4", AsString[i++]);
-			Assert.Equal(   "0, 2, 3", AsString[i++]);
-			Assert.Equal(   "0, 2, 4", AsString[i++]);
-			Assert.Equal(   "0, 3, 4", AsString[i++]);
-			Assert.Equal(   "1, 2, 3", AsString[i++]);
-			Assert.Equal(   "1, 2, 4", AsString[i++]);
-			Assert.Equal(   "1, 3, 4", AsString[i++]);
-			Assert.Equal(   "2, 3, 4", AsString[i++]);
+			Assert.Equal("0", AsString[i++]);
+			Assert.Equal("1", AsString[i++]);
+			Assert.Equal("2", AsString[i++]);
+			Assert.Equal("3", AsString[i++]);
+			Assert.Equal("4", AsString[i++]);
+			Assert.Equal("0, 1", AsString[i++]);
+			Assert.Equal("0, 2", AsString[i++]);
+			Assert.Equal("0, 3", AsString[i++]);
+			Assert.Equal("0, 4", AsString[i++]);
+			Assert.Equal("1, 2", AsString[i++]);
+			Assert.Equal("1, 3", AsString[i++]);
+			Assert.Equal("1, 4", AsString[i++]);
+			Assert.Equal("2, 3", AsString[i++]);
+			Assert.Equal("2, 4", AsString[i++]);
+			Assert.Equal("3, 4", AsString[i++]);
+			Assert.Equal("0, 1, 2", AsString[i++]);
+			Assert.Equal("0, 1, 3", AsString[i++]);
+			Assert.Equal("0, 1, 4", AsString[i++]);
+			Assert.Equal("0, 2, 3", AsString[i++]);
+			Assert.Equal("0, 2, 4", AsString[i++]);
+			Assert.Equal("0, 3, 4", AsString[i++]);
+			Assert.Equal("1, 2, 3", AsString[i++]);
+			Assert.Equal("1, 2, 4", AsString[i++]);
+			Assert.Equal("1, 3, 4", AsString[i++]);
+			Assert.Equal("2, 3, 4", AsString[i++]);
 			Assert.Equal("0, 1, 2, 3", AsString[i++]);
 			Assert.Equal("0, 1, 2, 4", AsString[i++]);
 			Assert.Equal("0, 1, 3, 4", AsString[i++]);

--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests
+{
+	public class LinqExtensionsTests
+	{
+		[Fact]
+		public void CombinationsWithoutRepetitionOfFixedLength()
+		{
+			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 3);
+			var AsString = combinations.Select(x=> string.Join(", ", x)).ToArray();
+
+			Assert.Equal(10, AsString.Length);
+			Assert.Equal(combinations.Count(), combinations.Distinct().Count());
+
+			Assert.Equal("0, 1, 2", AsString[0]);
+			Assert.Equal("0, 1, 3", AsString[1]);
+			Assert.Equal("0, 1, 4", AsString[2]);
+			Assert.Equal("0, 2, 3", AsString[3]);
+			Assert.Equal("0, 2, 4", AsString[4]);
+			Assert.Equal("0, 3, 4", AsString[5]);
+			Assert.Equal("1, 2, 3", AsString[6]);
+			Assert.Equal("1, 2, 4", AsString[7]);
+			Assert.Equal("1, 3, 4", AsString[8]);
+			Assert.Equal("2, 3, 4", AsString[9]);
+		}
+
+		[Fact]
+		public void CombinationsWithoutRepetitionUpToLenth()
+		{
+			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 1, upToLength: 4);
+			var AsString = combinations.Select(x=> string.Join(", ", x)).ToArray();
+
+			Assert.Equal(30, AsString.Length);
+			Assert.Equal(combinations.Count(), combinations.Distinct().Count());
+
+			var i = 0;
+			Assert.Equal(         "0", AsString[i++]);
+			Assert.Equal(         "1", AsString[i++]);
+			Assert.Equal(         "2", AsString[i++]);
+			Assert.Equal(         "3", AsString[i++]);
+			Assert.Equal(         "4", AsString[i++]);
+			Assert.Equal(      "0, 1", AsString[i++]);
+			Assert.Equal(      "0, 2", AsString[i++]);
+			Assert.Equal(      "0, 3", AsString[i++]);
+			Assert.Equal(      "0, 4", AsString[i++]);
+			Assert.Equal(      "1, 2", AsString[i++]);
+			Assert.Equal(      "1, 3", AsString[i++]);
+			Assert.Equal(      "1, 4", AsString[i++]);
+			Assert.Equal(      "2, 3", AsString[i++]);
+			Assert.Equal(      "2, 4", AsString[i++]);
+			Assert.Equal(      "3, 4", AsString[i++]);
+			Assert.Equal(   "0, 1, 2", AsString[i++]);
+			Assert.Equal(   "0, 1, 3", AsString[i++]);
+			Assert.Equal(   "0, 1, 4", AsString[i++]);
+			Assert.Equal(   "0, 2, 3", AsString[i++]);
+			Assert.Equal(   "0, 2, 4", AsString[i++]);
+			Assert.Equal(   "0, 3, 4", AsString[i++]);
+			Assert.Equal(   "1, 2, 3", AsString[i++]);
+			Assert.Equal(   "1, 2, 4", AsString[i++]);
+			Assert.Equal(   "1, 3, 4", AsString[i++]);
+			Assert.Equal(   "2, 3, 4", AsString[i++]);
+			Assert.Equal("0, 1, 2, 3", AsString[i++]);
+			Assert.Equal("0, 1, 2, 4", AsString[i++]);
+			Assert.Equal("0, 1, 3, 4", AsString[i++]);
+			Assert.Equal("0, 2, 3, 4", AsString[i++]);
+			Assert.Equal("1, 2, 3, 4", AsString[i++]);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace WalletWasabi.Tests.UnitTests
 		}
 
 		[Fact]
-		public void CombinationsWithoutRepetitionUpToLenth()
+		public void CombinationsWithoutRepetitionUpToLength()
 		{
 			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 1, upToLength: 4);
 			var asString = combinations.Select(x => string.Join(", ", x)).ToArray();

--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -9,63 +9,63 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CombinationsWithoutRepetitionOfFixedLength()
 		{
 			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 3);
-			var AsString = combinations.Select(x => string.Join(", ", x)).ToArray();
+			var asString = combinations.Select(x => string.Join(", ", x)).ToArray();
 
-			Assert.Equal(10, AsString.Length);
+			Assert.Equal(10, asString.Length);
 			Assert.Equal(combinations.Count(), combinations.Distinct().Count());
 
-			Assert.Equal("0, 1, 2", AsString[0]);
-			Assert.Equal("0, 1, 3", AsString[1]);
-			Assert.Equal("0, 1, 4", AsString[2]);
-			Assert.Equal("0, 2, 3", AsString[3]);
-			Assert.Equal("0, 2, 4", AsString[4]);
-			Assert.Equal("0, 3, 4", AsString[5]);
-			Assert.Equal("1, 2, 3", AsString[6]);
-			Assert.Equal("1, 2, 4", AsString[7]);
-			Assert.Equal("1, 3, 4", AsString[8]);
-			Assert.Equal("2, 3, 4", AsString[9]);
+			Assert.Equal("0, 1, 2", asString[0]);
+			Assert.Equal("0, 1, 3", asString[1]);
+			Assert.Equal("0, 1, 4", asString[2]);
+			Assert.Equal("0, 2, 3", asString[3]);
+			Assert.Equal("0, 2, 4", asString[4]);
+			Assert.Equal("0, 3, 4", asString[5]);
+			Assert.Equal("1, 2, 3", asString[6]);
+			Assert.Equal("1, 2, 4", asString[7]);
+			Assert.Equal("1, 3, 4", asString[8]);
+			Assert.Equal("2, 3, 4", asString[9]);
 		}
 
 		[Fact]
 		public void CombinationsWithoutRepetitionUpToLenth()
 		{
 			var combinations = Enumerable.Range(0, 5).CombinationsWithoutRepetition(ofLength: 1, upToLength: 4);
-			var AsString = combinations.Select(x => string.Join(", ", x)).ToArray();
+			var asString = combinations.Select(x => string.Join(", ", x)).ToArray();
 
-			Assert.Equal(30, AsString.Length);
+			Assert.Equal(30, asString.Length);
 			Assert.Equal(combinations.Count(), combinations.Distinct().Count());
 
 			var i = 0;
-			Assert.Equal("0", AsString[i++]);
-			Assert.Equal("1", AsString[i++]);
-			Assert.Equal("2", AsString[i++]);
-			Assert.Equal("3", AsString[i++]);
-			Assert.Equal("4", AsString[i++]);
-			Assert.Equal("0, 1", AsString[i++]);
-			Assert.Equal("0, 2", AsString[i++]);
-			Assert.Equal("0, 3", AsString[i++]);
-			Assert.Equal("0, 4", AsString[i++]);
-			Assert.Equal("1, 2", AsString[i++]);
-			Assert.Equal("1, 3", AsString[i++]);
-			Assert.Equal("1, 4", AsString[i++]);
-			Assert.Equal("2, 3", AsString[i++]);
-			Assert.Equal("2, 4", AsString[i++]);
-			Assert.Equal("3, 4", AsString[i++]);
-			Assert.Equal("0, 1, 2", AsString[i++]);
-			Assert.Equal("0, 1, 3", AsString[i++]);
-			Assert.Equal("0, 1, 4", AsString[i++]);
-			Assert.Equal("0, 2, 3", AsString[i++]);
-			Assert.Equal("0, 2, 4", AsString[i++]);
-			Assert.Equal("0, 3, 4", AsString[i++]);
-			Assert.Equal("1, 2, 3", AsString[i++]);
-			Assert.Equal("1, 2, 4", AsString[i++]);
-			Assert.Equal("1, 3, 4", AsString[i++]);
-			Assert.Equal("2, 3, 4", AsString[i++]);
-			Assert.Equal("0, 1, 2, 3", AsString[i++]);
-			Assert.Equal("0, 1, 2, 4", AsString[i++]);
-			Assert.Equal("0, 1, 3, 4", AsString[i++]);
-			Assert.Equal("0, 2, 3, 4", AsString[i++]);
-			Assert.Equal("1, 2, 3, 4", AsString[i++]);
+			Assert.Equal("0", asString[i++]);
+			Assert.Equal("1", asString[i++]);
+			Assert.Equal("2", asString[i++]);
+			Assert.Equal("3", asString[i++]);
+			Assert.Equal("4", asString[i++]);
+			Assert.Equal("0, 1", asString[i++]);
+			Assert.Equal("0, 2", asString[i++]);
+			Assert.Equal("0, 3", asString[i++]);
+			Assert.Equal("0, 4", asString[i++]);
+			Assert.Equal("1, 2", asString[i++]);
+			Assert.Equal("1, 3", asString[i++]);
+			Assert.Equal("1, 4", asString[i++]);
+			Assert.Equal("2, 3", asString[i++]);
+			Assert.Equal("2, 4", asString[i++]);
+			Assert.Equal("3, 4", asString[i++]);
+			Assert.Equal("0, 1, 2", asString[i++]);
+			Assert.Equal("0, 1, 3", asString[i++]);
+			Assert.Equal("0, 1, 4", asString[i++]);
+			Assert.Equal("0, 2, 3", asString[i++]);
+			Assert.Equal("0, 2, 4", asString[i++]);
+			Assert.Equal("0, 3, 4", asString[i++]);
+			Assert.Equal("1, 2, 3", asString[i++]);
+			Assert.Equal("1, 2, 4", asString[i++]);
+			Assert.Equal("1, 3, 4", asString[i++]);
+			Assert.Equal("2, 3, 4", asString[i++]);
+			Assert.Equal("0, 1, 2, 3", asString[i++]);
+			Assert.Equal("0, 1, 2, 4", asString[i++]);
+			Assert.Equal("0, 1, 3, 4", asString[i++]);
+			Assert.Equal("0, 2, 3, 4", asString[i++]);
+			Assert.Equal("1, 2, 3, 4", asString[i++]);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -41,43 +40,6 @@ namespace WalletWasabi.Tests.UnitTests
 
 			Assert.Equal(coin, sameCoin);
 			Assert.NotEqual(coin, differentCoin);
-		}
-
-		[Fact]
-		public void SmartCoinSerialization()
-		{
-			var tx = Transaction.Parse("02000000040aa8d0af84518df6e3a60c5bb19d9c3fcc3dc6e26b2f2449e8d7bf8d3fe84b87010000006a473044022018dfe9216c1209dd6c2b6c1607dbac4e499c1fce4878bc7d5d83fccbf3e24c9402202cac351c9c6a2b5eef338cbf0ec000d8de1c05e96a904cbba2b9e6ffc2d4e19501210364cc39da1091b1a9c12ec905a14a9e8478f951f7a1accdabeb40180533f2eaa5feffffff112c07d0f5e0617d720534f0b2b84dc0d5b7314b358c3ab338823b9e5bfbddf5010000006b483045022100ec155e7141e74661ee511ae980150a6c89261f31070999858738369afc28f2b6022006230d2aa24fac110b74ef15b84371486cf76c539b335a253c14462447912a300121020c2f41390f031d471b22abdb856e6cdbe0f4d74e72c197469bfd54e5a08f7e67feffffff38e799b8f6cf04fd021a9b135cdcd347da7aac4fd8bb8d0da9316a9fb228bb6e000000006b483045022100fc1944544a3f96edd8c8a9795c691e2725612b5ab2e1c999be11a2a4e3f841f1022077b2e088877829edeada0c707a9bb577aa79f26dafacba3d1d2d047f52524296012102e6015963dff9826836400cf8f45597c0705757d5dcdc6bf734f661c7dab89e69feffffff64c3f0377e86625123f2f1ee229319ed238e8ca8b7dda5bc080a2c5ecb984629000000006a47304402204233a90d6296182914424fd2901e16e6f5b13b451b67b0eec25a5eaacc5033c902203d8a13ef0b494c12009663475458e51da6bd55cc67688264230ece81d3eeca24012102f806d7152da2b52c1d9ad928e4a6253ccba080a5b9ab9efdd80e37274ac67f9bfeffffff0290406900000000001976a91491ac4e49b66f845180d98d8f8be6121588be6e3b88ac52371600000000001976a9142f44ed6749e8c84fd476e4440741f7e6f55542fa88acadd30700", Network.TestNet);
-			var txId = tx.GetHash();
-			var index = 0U;
-			var output = tx.Outputs[0];
-			var scriptPubKey = output.ScriptPubKey;
-			var amount = output.Value;
-			var spentOutputs = tx.Inputs.ToTxoRefs().ToArray();
-			var height = Height.Mempool;
-			var label = new SmartLabel("foo");
-			var bannedUntil = DateTimeOffset.UtcNow;
-
-			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index), isLikelyCoinJoinOutput: false, label, txId);
-			coin.BannedUntilUtc = bannedUntil;
-
-			var serialized = JsonConvert.SerializeObject(coin);
-			var deserialized = JsonConvert.DeserializeObject<SmartCoin>(serialized);
-
-			Assert.Equal(coin, deserialized);
-			Assert.Equal(coin.Height, deserialized.Height);
-			Assert.Equal(coin.Amount, deserialized.Amount);
-			Assert.Equal(coin.Index, deserialized.Index);
-			Assert.Equal(coin.Unavailable, deserialized.Unavailable);
-			Assert.Equal(coin.Label, deserialized.Label);
-			Assert.Equal(coin.ScriptPubKey, deserialized.ScriptPubKey);
-			Assert.Equal(coin.SpenderTransactionId, deserialized.SpenderTransactionId);
-			Assert.Equal(coin.TransactionId, deserialized.TransactionId);
-			Assert.Equal(coin.SpentOutputs.Length, deserialized.SpentOutputs.Length);
-			Assert.Equal(coin.BannedUntilUtc, deserialized.BannedUntilUtc);
-			for (int i = 0; i < coin.SpentOutputs.Length; i++)
-			{
-				Assert.Equal(coin.SpentOutputs[0], deserialized.SpentOutputs[0]);
-			}
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Tests.UnitTests
 			var spentOutputs = tx.Inputs.ToTxoRefs().ToArray();
 
 			var height = Height.Mempool;
-			var label = new SmartLabel("foo");
+			var label = "foo";
 
 			var coin = new SmartCoin(txId, index, scriptPubKey, amount, spentOutputs, height, tx.RBF, tx.GetAnonymitySet(index), isLikelyCoinJoinOutput: false, label, txId);
 			// If the txId or the index differ, equality should think it's a different coin.
@@ -36,7 +36,7 @@ namespace WalletWasabi.Tests.UnitTests
 			};
 
 			// If the txId and the index are the same, equality should think it's the same coin.
-			var sameCoin = new SmartCoin(txId, index, differentOutput.ScriptPubKey, differentOutput.Value, differentSpentOutputs, Height.Unknown, tx.RBF, tx.GetAnonymitySet(index), isLikelyCoinJoinOutput: false, new SmartLabel("boo"), null);
+			var sameCoin = new SmartCoin(txId, index, differentOutput.ScriptPubKey, differentOutput.Value, differentSpentOutputs, Height.Unknown, tx.RBF, tx.GetAnonymitySet(index), isLikelyCoinJoinOutput: false, "boo", null);
 
 			Assert.Equal(coin, sameCoin);
 			Assert.NotEqual(coin, differentCoin);

--- a/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
@@ -13,55 +13,55 @@ namespace WalletWasabi.Tests.UnitTests
 		public void LabelParsingTests()
 		{
 			var label = new SmartLabel();
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel("");
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel(null);
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel(null, null);
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel(" ");
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel(",");
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel(":");
-			Assert.Equal("", label.ToString());
+			Assert.Equal("", label);
 
 			label = new SmartLabel("foo");
-			Assert.Equal("foo", label.ToString());
+			Assert.Equal("foo", label);
 
 			label = new SmartLabel("foo", "bar");
-			Assert.Equal("bar, foo", label.ToString());
+			Assert.Equal("bar, foo", label);
 
 			label = new SmartLabel("foo bar");
-			Assert.Equal("foo bar", label.ToString());
+			Assert.Equal("foo bar", label);
 
 			label = new SmartLabel("foo bar", "Buz quX@");
-			Assert.Equal("Buz quX@, foo bar", label.ToString());
+			Assert.Equal("Buz quX@, foo bar", label);
 
 			label = new SmartLabel(new List<string>() { "foo", "bar" });
-			Assert.Equal("bar, foo", label.ToString());
+			Assert.Equal("bar, foo", label);
 
 			label = new SmartLabel("  foo    ");
-			Assert.Equal("foo", label.ToString());
+			Assert.Equal("foo", label);
 
 			label = new SmartLabel("foo      ", "      bar");
-			Assert.Equal("bar, foo", label.ToString());
+			Assert.Equal("bar, foo", label);
 
 			label = new SmartLabel(new List<string>() { "   foo   ", "   bar    " });
-			Assert.Equal("bar, foo", label.ToString());
+			Assert.Equal("bar, foo", label);
 
 			label = new SmartLabel(new List<string>() { "foo:", ":bar", null, ":buz:", ",", ": , :", "qux:quux", "corge,grault", "", "  ", " , garply, waldo,", " : ,  :  ,  fred  , : , :   plugh, : , : ," });
-			Assert.Equal("bar, buz, corge, foo, fred, garply, grault, plugh, quux, qux, waldo", label.ToString());
+			Assert.Equal("bar, buz, corge, foo, fred, garply, grault, plugh, quux, qux, waldo", label);
 
 			label = new SmartLabel(",: foo::bar :buz:,: , :qux:quux, corge,grault  , garply, waldo, : ,  :  ,  fred  , : , :   plugh, : , : ,");
-			Assert.Equal("bar, buz, corge, foo, fred, garply, grault, plugh, quux, qux, waldo", label.ToString());
+			Assert.Equal("bar, buz, corge, foo, fred, garply, grault, plugh, quux, qux, waldo", label);
 		}
 
 		[Fact]
@@ -100,17 +100,17 @@ namespace WalletWasabi.Tests.UnitTests
 			var label2 = new SmartLabel("qux");
 
 			label = SmartLabel.Merge(label, label2);
-			Assert.Equal("bar, buz, foo, qux", label.ToString());
+			Assert.Equal("bar, buz, foo, qux", label);
 
 			label2 = new SmartLabel("qux", "bar");
 			label = SmartLabel.Merge(label, label2);
 			Assert.Equal(4, label.Labels.Count());
-			Assert.Equal("bar, buz, foo, qux", label.ToString());
+			Assert.Equal("bar, buz, foo, qux", label);
 
 			label2 = new SmartLabel("Qux", "Bar");
 			label = SmartLabel.Merge(label, label2, null);
 			Assert.Equal(4, label.Labels.Count());
-			Assert.Equal("bar, buz, foo, qux", label.ToString());
+			Assert.Equal("bar, buz, foo, qux", label);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
@@ -157,9 +157,9 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			// Duplication is resolved with labels merged.
 			var mempoolFileContent = new[]
 			{
-				new SmartTransaction(uTx1.Transaction, uTx1.Height, label: new SmartLabel("buz, qux")).ToLine(),
-				new SmartTransaction(uTx2.Transaction, uTx2.Height, label: new SmartLabel("buz, qux")).ToLine(),
-				new SmartTransaction(uTx2.Transaction, uTx2.Height, label: new SmartLabel("foo, bar")).ToLine(),
+				new SmartTransaction(uTx1.Transaction, uTx1.Height, label: "buz, qux").ToLine(),
+				new SmartTransaction(uTx2.Transaction, uTx2.Height, label: "buz, qux").ToLine(),
+				new SmartTransaction(uTx2.Transaction, uTx2.Height, label: "foo, bar").ToLine(),
 				uTx3.ToLine(),
 				new SmartTransaction(cTx1.Transaction, Height.Mempool, label: new SmartLabel("buz", "qux")).ToLine()
 			};
@@ -168,7 +168,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				new SmartTransaction(cTx1.Transaction, cTx1.Height, label: new SmartLabel("foo", "bar")).ToLine(),
 				cTx2.ToLine(),
 				cTx3.ToLine(),
-				new SmartTransaction(uTx1.Transaction, new Height(2), label: new SmartLabel("foo, bar")).ToLine()
+				new SmartTransaction(uTx1.Transaction, new Height(2), label: "foo, bar").ToLine()
 			};
 			await File.WriteAllLinesAsync(mempoolFile, mempoolFileContent);
 			await File.WriteAllLinesAsync(txFile, txFileContent);

--- a/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var tx3 = Transaction.Parse("02000000040aa8d0af84518df6e3a60c5bb19d9c3fcc3dc6e26b2f2449e8d7bf8d3fe84b87010000006a473044022018dfe9216c1209dd6c2b6c1607dbac4e499c1fce4878bc7d5d83fccbf3e24c9402202cac351c9c6a2b5eef338cbf0ec000d8de1c05e96a904cbba2b9e6ffc2d4e19501210364cc39da1091b1a9c12ec905a14a9e8478f951f7a1accdabeb40180533f2eaa5feffffff112c07d0f5e0617d720534f0b2b84dc0d5b7314b358c3ab338823b9e5bfbddf5010000006b483045022100ec155e7141e74661ee511ae980150a6c89261f31070999858738369afc28f2b6022006230d2aa24fac110b74ef15b84371486cf76c539b335a253c14462447912a300121020c2f41390f031d471b22abdb856e6cdbe0f4d74e72c197469bfd54e5a08f7e67feffffff38e799b8f6cf04fd021a9b135cdcd347da7aac4fd8bb8d0da9316a9fb228bb6e000000006b483045022100fc1944544a3f96edd8c8a9795c691e2725612b5ab2e1c999be11a2a4e3f841f1022077b2e088877829edeada0c707a9bb577aa79f26dafacba3d1d2d047f52524296012102e6015963dff9826836400cf8f45597c0705757d5dcdc6bf734f661c7dab89e69feffffff64c3f0377e86625123f2f1ee229319ed238e8ca8b7dda5bc080a2c5ecb984629000000006a47304402204233a90d6296182914424fd2901e16e6f5b13b451b67b0eec25a5eaacc5033c902203d8a13ef0b494c12009663475458e51da6bd55cc67688264230ece81d3eeca24012102f806d7152da2b52c1d9ad928e4a6253ccba080a5b9ab9efdd80e37274ac67f9bfeffffff0290406900000000001976a91491ac4e49b66f845180d98d8f8be6121588be6e3b88ac52371600000000001976a9142f44ed6749e8c84fd476e4440741f7e6f55542fa88acadd30700", Network.RegTest);
 			var height = Height.Mempool;
 
-			var label = new SmartLabel("foo");
+			var label = "foo";
 			var smartTx = new SmartTransaction(tx, height, label: label);
 			var smartTx2 = new SmartTransaction(tx2, height);
 			var smartTx3 = new SmartTransaction(tx3, height);
@@ -192,7 +192,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 						Assert.Equal(height, stx.Height.ToString());
 						Assert.Equal(blockHash, Guard.Correct(stx.BlockHash?.ToString()));
 						Assert.Equal(blockIndex, stx.BlockIndex.ToString());
-						Assert.Equal(label, stx.Label.ToString());
+						Assert.Equal(label, stx.Label);
 						Assert.Equal(unixSeconds, stx.FirstSeen.ToUnixTimeSeconds().ToString());
 						Assert.Equal(isReplacement, stx.IsReplacement.ToString());
 					}
@@ -303,7 +303,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			foreach (var label in labels)
 			{
-				yield return new object[] { new SmartTransaction(defaultTx, defaultHeight, label: new SmartLabel(label)), defaultNetwork };
+				yield return new object[] { new SmartTransaction(defaultTx, defaultHeight, label: label), defaultNetwork };
 			}
 
 			foreach (var firstSeen in firstSeens)

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -150,7 +150,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			keyManager.AssertCleanKeysIndexed();
 
 			HdPubKey NewKey() => keyManager.GenerateNewKey("", KeyState.Used, true, false);
-			var scoins = new[] {
+			var scoins = new[]
+			{
 				Coin("Pablo",  NewKey(), 0.9m),
 				Coin("Daniel", NewKey(), 0.9m),
 				Coin("Adolf",  NewKey(), 0.9m),

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -149,7 +149,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			keyManager.AssertCleanKeysIndexed();
 
-			Func<HdPubKey> newKey = ()=> keyManager.GenerateNewKey(new SmartLabel(""), KeyState.Used, true, false);
+			Func<HdPubKey> newKey = () => keyManager.GenerateNewKey(new SmartLabel(""), KeyState.Used, true, false);
 			var scoins = new[] {
 				Coin("Pablo",  newKey(), 0.9m),
 				Coin("Daniel", newKey(), 0.9m),
@@ -162,20 +162,20 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				Coin("Donald, Jean, Lee, Onur", newKey(), 0.9m),
 				Coin("Satoshi",newKey(), 0.9m)
 			};
-			var coinsByLabel = scoins.ToDictionary(x=>x.Label.ToString());
+			var coinsByLabel = scoins.ToDictionary(x => x.Label.ToString());
 
 			// cluster 1 is known by 7 people: Pablo, Daniel, Adolf, Maria, Ding, Joseph and Eve
-			var coinsCluster1 = new[]{scoins[0], scoins[1], scoins[2], scoins[3], scoins[4], scoins[5], scoins[6]};
+			var coinsCluster1 = new[] { scoins[0], scoins[1], scoins[2], scoins[3], scoins[4], scoins[5], scoins[6] };
 			var cluster1 = new Cluster(coinsCluster1);
-			foreach(var coin in coinsCluster1)
+			foreach (var coin in coinsCluster1)
 			{
 				coin.Clusters = cluster1;
 			}
-			
+
 			// cluster 2 is known by 6 people: Julio, Lee, Jean, Donald, Onur and Satoshi
-			var coinsCluster2 = new[]{scoins[7], scoins[8], scoins[9]};
+			var coinsCluster2 = new[] { scoins[7], scoins[8], scoins[9] };
 			var cluster2 = new Cluster(coinsCluster2);
-			foreach(var coin in coinsCluster2)
+			foreach (var coin in coinsCluster2)
 			{
 				coin.Clusters = cluster2;
 			}
@@ -189,7 +189,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var result = transactionFactory.BuildTransaction(payment, feeRate);
 
 			Assert.Equal(2, result.SpentCoins.Count());
-			Assert.All(result.SpentCoins, c=> Assert.Equal(c.Clusters, cluster2));
+			Assert.All(result.SpentCoins, c => Assert.Equal(c.Clusters, cluster2));
 			Assert.Contains(coinsByLabel["Julio"], result.SpentCoins);
 			Assert.Contains(coinsByLabel["Donald, Jean, Lee, Onur"], result.SpentCoins);
 
@@ -199,7 +199,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			result = transactionFactory.BuildTransaction(payment, feeRate);
 
 			Assert.Equal(3, result.SpentCoins.Count());
-			Assert.All(result.SpentCoins, c=> Assert.Equal(c.Clusters, cluster2));
+			Assert.All(result.SpentCoins, c => Assert.Equal(c.Clusters, cluster2));
 			Assert.Contains(coinsByLabel["Julio"], result.SpentCoins);
 			Assert.Contains(coinsByLabel["Donald, Jean, Lee, Onur"], result.SpentCoins);
 			Assert.Contains(coinsByLabel["Satoshi"], result.SpentCoins);
@@ -211,7 +211,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			result = transactionFactory.BuildTransaction(payment, feeRate);
 
 			Assert.Equal(4, result.SpentCoins.Count());
-			Assert.All(result.SpentCoins, c=> Assert.Equal(c.Clusters, cluster1));
+			Assert.All(result.SpentCoins, c => Assert.Equal(c.Clusters, cluster1));
 			Assert.Contains(coinsByLabel["Pablo"], result.SpentCoins);
 			Assert.Contains(coinsByLabel["Daniel"], result.SpentCoins);
 			Assert.Contains(coinsByLabel["Adolf"], result.SpentCoins);
@@ -520,9 +520,9 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			var keys = keyManager.GetKeys().Take(10).ToArray();
 			var scoins = coins.Select(x => Coin(x.Label, keys[x.KeyIndex], x.Amount, x.Confirmed, x.AnonymitySet)).ToArray();
-			foreach(var coin in scoins)
+			foreach (var coin in scoins)
 			{
-				foreach(var sameLabelCoin in scoins.Where(c=>c.Label == coin.Label))
+				foreach (var sameLabelCoin in scoins.Where(c => c.Label == coin.Label))
 				{
 					sameLabelCoin.Clusters = coin.Clusters;
 				}

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -64,7 +64,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// There is a 0.8 coin with AS=50. However it selects the most private one with AS= 200
 			var destination = new Key().ScriptPubKey;
-			var payment = new PaymentIntent(destination, Money.Coins(0.07m), label: new SmartLabel("Sophie"));
+			var payment = new PaymentIntent(destination, Money.Coins(0.07m), label: "Sophie");
 			var feeRate = new FeeRate(2m);
 			var result = transactionFactory.BuildTransaction(payment, feeRate);
 
@@ -78,7 +78,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			var changeCoin = Assert.Single(result.InnerWalletOutputs);
 			Assert.True(changeCoin.HdPubKey.IsInternal);
-			Assert.Equal("Joseph, Sophie", changeCoin.Label.ToString());
+			Assert.Equal("Joseph, Sophie", changeCoin.Label);
 		}
 
 		[Fact]
@@ -124,7 +124,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			});
 
 			// Selecting 0.08 + 0.04 should be enough but it has to select 0.02 too because it is the same address
-			var payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(0.1m), label: new SmartLabel("Sophie"));
+			var payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(0.1m), label: "Sophie");
 			var feeRate = new FeeRate(2m);
 			var result = transactionFactory.BuildTransaction(payment, feeRate);
 
@@ -134,7 +134,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Equal(Money.Coins(0.14m), result.SpentCoins.Select(x => x.Amount).Sum());
 
 			var changeCoin = Assert.Single(result.InnerWalletOutputs);
-			Assert.Equal("Daniel, Maria, Sophie", changeCoin.Label.ToString());
+			Assert.Equal("Daniel, Maria, Sophie", changeCoin.Label);
 
 			var tx = result.Transaction.Transaction;
 			// it must select the unconfirm coin even when the anonymity set is lower
@@ -149,7 +149,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			keyManager.AssertCleanKeysIndexed();
 
-			HdPubKey NewKey() => keyManager.GenerateNewKey(new SmartLabel(""), KeyState.Used, true, false);
+			HdPubKey NewKey() => keyManager.GenerateNewKey("", KeyState.Used, true, false);
 			var scoins = new[] {
 				Coin("Pablo",  NewKey(), 0.9m),
 				Coin("Daniel", NewKey(), 0.9m),
@@ -162,7 +162,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				Coin("Donald, Jean, Lee, Onur", NewKey(), 0.9m),
 				Coin("Satoshi",NewKey(), 0.9m)
 			};
-			var coinsByLabel = scoins.ToDictionary(x => x.Label.ToString());
+			var coinsByLabel = scoins.ToDictionary(x => x.Label);
 
 			// cluster 1 is known by 7 people: Pablo, Daniel, Adolf, Maria, Ding, Joseph and Eve
 			var coinsCluster1 = new[] { scoins[0], scoins[1], scoins[2], scoins[3], scoins[4], scoins[5], scoins[6] };
@@ -184,7 +184,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var transactionFactory = new TransactionFactory(Network.Main, keyManager, coinsView, password);
 
 			// Two 0.9btc coins are enough
-			var payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(1.75m), label: new SmartLabel("Sophie"));
+			var payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(1.75m), label: "Sophie");
 			var feeRate = new FeeRate(2m);
 			var result = transactionFactory.BuildTransaction(payment, feeRate);
 
@@ -194,7 +194,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Contains(coinsByLabel["Donald, Jean, Lee, Onur"], result.SpentCoins);
 
 			// Three 0.9btc coins are enough
-			payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(1.85m), label: new SmartLabel("Sophie"));
+			payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(1.85m), label: "Sophie");
 			feeRate = new FeeRate(2m);
 			result = transactionFactory.BuildTransaction(payment, feeRate);
 
@@ -206,7 +206,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// Four 0.9btc coins are enough but this time the more private cluster is NOT enough
 			// That's why it has to use the coins in the cluster number 1
-			payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(3.5m), label: new SmartLabel("Sophie"));
+			payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(3.5m), label: "Sophie");
 			feeRate = new FeeRate(2m);
 			result = transactionFactory.BuildTransaction(payment, feeRate);
 
@@ -219,7 +219,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// Nine 0.9btc coins are enough but there is no cluster big enough
 			// That's why it has to use the coins from both the clusters
-			payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(7.4m), label: new SmartLabel("Sophie"));
+			payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(7.4m), label: "Sophie");
 			feeRate = new FeeRate(2m);
 			result = transactionFactory.BuildTransaction(payment, feeRate);
 
@@ -389,8 +389,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var coins = transactionFactory.Coins;
 			var allowedCoins = new[]
 			{
-				coins.Single(x => x.Label.ToString() == "Maria"),
-				coins.Single(x => x.Label.ToString() == "Suyin")
+				coins.Single(x => x.Label == "Maria"),
+				coins.Single(x => x.Label == "Suyin")
 			}.ToArray();
 			var result = transactionFactory.BuildTransaction(payment, feeRate, allowedCoins.Select(x => x.GetTxoRef()));
 
@@ -418,9 +418,9 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var coins = transactionFactory.Coins;
 			var allowedCoins = new[]
 			{
-				coins.Single(x => x.Label.ToString() == "Pablo"),
-				coins.Single(x => x.Label.ToString() == "Maria"),
-				coins.Single(x => x.Label.ToString() == "Suyin")
+				coins.Single(x => x.Label == "Pablo"),
+				coins.Single(x => x.Label == "Maria"),
+				coins.Single(x => x.Label == "Suyin")
 			}.ToArray();
 			var result = transactionFactory.BuildTransaction(payment, feeRate, allowedCoins.Select(x => x.GetTxoRef()));
 
@@ -448,7 +448,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			var allowedCoins = new[]
 			{
-				transactionFactory.Coins.Single(x => x.Label.ToString() == "Pablo")
+				transactionFactory.Coins.Single(x => x.Label == "Pablo")
 			}.ToArray();
 
 			var amount = Money.Coins(0.5m); // it is not enough
@@ -489,7 +489,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.True(result.Signed);
 			Assert.Equal(Money.Coins(0.14m), result.SpentCoins.Select(x => x.Amount).Sum());
 			Assert.Equal(3, result.SpentCoins.Count());
-			var danielCoin = coins.Where(x => x.Label.ToString() == "Daniel").ToArray();
+			var danielCoin = coins.Where(x => x.Label == "Daniel").ToArray();
 			Assert.Contains(danielCoin[0], result.SpentCoins);
 			Assert.Contains(danielCoin[1], result.SpentCoins);
 		}
@@ -547,7 +547,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		{
 			var randomIndex = new Func<int>(() => new Random().Next(0, 200));
 			var height = confirmed ? new Height(randomIndex()) : Height.Mempool;
-			var slabel = new SmartLabel(label);
+			SmartLabel slabel = label;
 			var spentOutput = new[]
 			{
 				new TxoRef(RandomUtils.GetUInt256(), (uint)randomIndex())

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -149,18 +149,18 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			keyManager.AssertCleanKeysIndexed();
 
-			Func<HdPubKey> newKey = () => keyManager.GenerateNewKey(new SmartLabel(""), KeyState.Used, true, false);
+			HdPubKey NewKey() => keyManager.GenerateNewKey(new SmartLabel(""), KeyState.Used, true, false);
 			var scoins = new[] {
-				Coin("Pablo",  newKey(), 0.9m),
-				Coin("Daniel", newKey(), 0.9m),
-				Coin("Adolf",  newKey(), 0.9m),
-				Coin("Maria",  newKey(), 0.9m),
-				Coin("Ding",   newKey(), 0.9m),
-				Coin("Joseph", newKey(), 0.9m),
-				Coin("Eve",    newKey(), 0.9m),
-				Coin("Julio",  newKey(), 0.9m),
-				Coin("Donald, Jean, Lee, Onur", newKey(), 0.9m),
-				Coin("Satoshi",newKey(), 0.9m)
+				Coin("Pablo",  NewKey(), 0.9m),
+				Coin("Daniel", NewKey(), 0.9m),
+				Coin("Adolf",  NewKey(), 0.9m),
+				Coin("Maria",  NewKey(), 0.9m),
+				Coin("Ding",   NewKey(), 0.9m),
+				Coin("Joseph", NewKey(), 0.9m),
+				Coin("Eve",    NewKey(), 0.9m),
+				Coin("Julio",  NewKey(), 0.9m),
+				Coin("Donald, Jean, Lee, Onur", NewKey(), 0.9m),
+				Coin("Satoshi",NewKey(), 0.9m)
 			};
 			var coinsByLabel = scoins.ToDictionary(x => x.Label.ToString());
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -323,7 +323,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var tx1 = CreateSpendingTransaction(new[] { createdCoin.GetCoin() }, new Key().ScriptPubKey, changeScript1);
 			transactionProcessor.Process(tx1);
 			createdCoin = transactionProcessor.Coins.First();
-			Assert.Equal("B, A", createdCoin.Clusters.Labels);
+			Assert.Equal("A, B", createdCoin.Clusters.Labels);
 
 			// Spend the received coin to mylself else C
 			var myselfScript = transactionProcessor.NewKey("C").P2wpkhScript;
@@ -333,10 +333,10 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			Assert.Equal(2, transactionProcessor.Coins.Count());
 			createdCoin = transactionProcessor.Coins.First();
-			Assert.Equal("C, B, A", createdCoin.Clusters.Labels);
+			Assert.Equal("A, B, C", createdCoin.Clusters.Labels);
 
 			var createdchangeCoin = transactionProcessor.Coins.Last();
-			Assert.Equal("C, B, A", createdchangeCoin.Clusters.Labels);
+			Assert.Equal("A, B, C", createdchangeCoin.Clusters.Labels);
 		}
 
 		[Fact]
@@ -374,7 +374,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx3);
 
 			var changeCoinD = Assert.Single(transactionProcessor.Coins);
-			Assert.Equal("D, A, B, C", changeCoinD.Clusters.Labels);
+			Assert.Equal("A, B, C, D", changeCoinD.Clusters.Labels);
 
 			key = transactionProcessor.NewKey("E");
 			var tx4 = CreateCreditingTransaction(key.P2wpkhScript, Money.Coins(1.0m));
@@ -387,7 +387,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx5);
 
 			var changeCoin = Assert.Single(transactionProcessor.Coins);
-			Assert.Equal("F, D, A, B, C, E", changeCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D, E, F", changeCoin.Clusters.Labels);
 		}
 
 		[Fact]
@@ -424,13 +424,13 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx3);
 
 			var paymentCoin = Assert.Single(transactionProcessor.Coins, c => c.ScriptPubKey == myself);
-			Assert.Equal("D, A, B, C", paymentCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D", paymentCoin.Clusters.Labels);
 
 			var tx4 = CreateCreditingTransaction(myself, Money.Coins(7.0m));
 			transactionProcessor.Process(tx4);
 			Assert.Equal(2, transactionProcessor.Coins.Count(c => c.ScriptPubKey == myself));
 			var newPaymentCoin = Assert.Single(transactionProcessor.Coins, c => c.Amount == Money.Coins(7.0m));
-			Assert.Equal("D, A, B, C", newPaymentCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D", newPaymentCoin.Clusters.Labels);
 		}
 
 		[Fact]
@@ -466,14 +466,14 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx3);
 
 			var paymentCoin = Assert.Single(transactionProcessor.Coins, c => c.ScriptPubKey == myself);
-			Assert.Equal("D, A, B, C", paymentCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D", paymentCoin.Clusters.Labels);
 
 			coins = new[] { scoinB.GetCoin(), scoinC.GetCoin(), scoinA.GetCoin() };
 			var tx4 = CreateSpendingTransaction(coins, myself, changeScript);
 			transactionProcessor.Process(tx4);
 
 			paymentCoin = Assert.Single(transactionProcessor.Coins, c => c.ScriptPubKey == myself);
-			Assert.Equal("D, A, B, C", paymentCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D", paymentCoin.Clusters.Labels);
 		}
 
 		[Fact]
@@ -510,7 +510,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx3);
 
 			var paymentCoin = Assert.Single(transactionProcessor.Coins, c => c.ScriptPubKey == myself);
-			Assert.Equal("D, A, B, C", paymentCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D", paymentCoin.Clusters.Labels);
 
 			key = transactionProcessor.NewKey("X");
 			var tx4 = CreateCreditingTransaction(key.P2wpkhScript, Money.Coins(1.0m));
@@ -522,7 +522,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx5);
 
 			paymentCoin = Assert.Single(transactionProcessor.Coins, c => c.ScriptPubKey == myself);
-			Assert.Equal("D, A, B, C, X", paymentCoin.Clusters.Labels);
+			Assert.Equal("A, B, C, D, X", paymentCoin.Clusters.Labels);
 		}
 
 		[Fact]
@@ -558,7 +558,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			transactionProcessor.Process(tx3);
 
 			var changeCoinD = Assert.Single(transactionProcessor.Coins);
-			Assert.Equal("D, A, B, C", changeCoinD.Clusters.Labels);
+			Assert.Equal("A, B, C, D", changeCoinD.Clusters.Labels);
 			Assert.Equal(scoinA.Clusters, changeCoinD.Clusters);
 			Assert.Equal(scoinB.Clusters, changeCoinD.Clusters);
 			Assert.Equal(scoinC.Clusters, changeCoinD.Clusters);
@@ -566,7 +566,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			// reorg
 			transactionProcessor.UndoBlock(tx3.Height);
 			Assert.DoesNotContain(changeCoinD, transactionProcessor.Coins);
-			Assert.Equal("D, A, B, C", changeCoinD.Clusters.Labels);
+			Assert.Equal("A, B, C, D", changeCoinD.Clusters.Labels);
 			Assert.Equal(scoinA.Clusters, changeCoinD.Clusters);
 			Assert.Equal(scoinB.Clusters, changeCoinD.Clusters);
 			Assert.Equal(scoinC.Clusters, changeCoinD.Clusters);
@@ -668,8 +668,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 	{
 		public static HdPubKey NewKey(this TransactionProcessor me, string label)
 		{
-			var slable = new SmartLabel(label);
-			return me.KeyManager.GenerateNewKey(slable, KeyState.Clean, true);
+			return me.KeyManager.GenerateNewKey(label, KeyState.Clean, true);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionStoreTests.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 					height: stx.Height,
 					stx.BlockHash,
 					stx.BlockIndex,
-					new SmartLabel("totally random new label"),
+					"totally random new label",
 					stx.IsReplacement,
 					stx.FirstSeen));
 			Assert.False(operation.isAdded);

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Bases;
@@ -6,11 +7,19 @@ using WalletWasabi.Coins;
 
 namespace WalletWasabi.BlockchainAnalysis
 {
-	public class Cluster : NotifyPropertyChangedBase
+	public class Cluster : NotifyPropertyChangedBase, IEquatable<Cluster>
 	{
 		private List<SmartCoin> Coins { get; set; }
 
 		private SmartLabel _labels;
+
+		public SmartLabel Labels
+		{
+			get => _labels;
+			private set => RaiseAndSetIfChanged(ref _labels, value);
+		}
+
+		public int Size => Coins.Count;
 
 		public Cluster(params SmartCoin[] coins)
 			: this(coins as IEnumerable<SmartCoin>)
@@ -22,14 +31,6 @@ namespace WalletWasabi.BlockchainAnalysis
 			Coins = coins.ToList();
 			Labels = SmartLabel.Merge(Coins.Select(x => x.Label));
 		}
-
-		public SmartLabel Labels
-		{
-			get => _labels;
-			private set => RaiseAndSetIfChanged(ref _labels, value);
-		}
-
-		public int Size => Coins.Count;
 
 		public void Merge(Cluster clusters) => Merge(clusters.Coins);
 
@@ -49,5 +50,54 @@ namespace WalletWasabi.BlockchainAnalysis
 				Labels = SmartLabel.Merge(Coins.Select(x => x.Label));
 			}
 		}
+
+		#region EqualityAndComparison
+
+		public override bool Equals(object obj) => obj is Cluster clus && this == clus;
+
+		public bool Equals(Cluster other) => this == other;
+
+		public override int GetHashCode()
+		{
+			int hash = 0;
+			if (Coins != null)
+			{
+				foreach (var coin in Coins)
+				{
+					hash ^= coin.GetHashCode();
+				}
+			}
+			return hash;
+		}
+
+		public static bool operator ==(Cluster x, Cluster y)
+		{
+			if (x is null)
+			{
+				if (y is null)
+				{
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			}
+			else
+			{
+				if (y is null)
+				{
+					return false;
+				}
+				else
+				{
+					return x.Coins.SequenceEqual(y.Coins);
+				}
+			}
+		}
+
+		public static bool operator !=(Cluster x, Cluster y) => !(x == y);
+
+		#endregion EqualityAndComparison
 	}
 }

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.BlockchainAnalysis
 			private set => RaiseAndSetIfChanged(ref _labels, value);
 		}
 
-		public int Size => Coins.Count();
+		public int Size => Coins.Count;
 
 		public IEnumerable<string> KnownBy => Coins.SelectMany(x => x.Label.Labels).Distinct(StringComparer.OrdinalIgnoreCase);
 

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -10,7 +10,7 @@ namespace WalletWasabi.BlockchainAnalysis
 	{
 		private List<SmartCoin> Coins { get; set; }
 
-		private string _labels;
+		private SmartLabel _labels;
 
 		public Cluster(params SmartCoin[] coins)
 			: this(coins as IEnumerable<SmartCoin>)
@@ -20,18 +20,16 @@ namespace WalletWasabi.BlockchainAnalysis
 		public Cluster(IEnumerable<SmartCoin> coins)
 		{
 			Coins = coins.ToList();
-			Labels = string.Join(", ", KnownBy);
+			Labels = SmartLabel.Merge(Coins.Select(x => x.Label));
 		}
 
-		public string Labels
+		public SmartLabel Labels
 		{
 			get => _labels;
 			private set => RaiseAndSetIfChanged(ref _labels, value);
 		}
 
 		public int Size => Coins.Count;
-
-		public IEnumerable<string> KnownBy => Coins.SelectMany(x => x.Label.Labels).Distinct(StringComparer.OrdinalIgnoreCase);
 
 		public void Merge(Cluster clusters) => Merge(clusters.Coins);
 
@@ -48,7 +46,7 @@ namespace WalletWasabi.BlockchainAnalysis
 			}
 			if (insertPosition > 0) // at least one element was inserted
 			{
-				Labels = string.Join(", ", KnownBy);
+				Labels = SmartLabel.Merge(Coins.Select(x => x.Label));
 			}
 		}
 	}

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -12,7 +12,6 @@ namespace WalletWasabi.BlockchainAnalysis
 
 		private string _labels;
 
-
 		public Cluster(params SmartCoin[] coins)
 			: this(coins as IEnumerable<SmartCoin>)
 		{

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -13,10 +13,14 @@ namespace WalletWasabi.BlockchainAnalysis
 		private string _labels;
 
 		public Cluster(SmartCoin coin)
+			: this( new[] { coin })
 		{
-			Labels = "";
-			Coins = new List<SmartCoin>() { coin };
-			Labels = string.Join(", ", coin.Label.Labels);
+		}
+
+		public Cluster(IEnumerable<SmartCoin> coins)
+		{
+			Coins = coins.ToList();
+			Labels = string.Join(", ", KnownBy);
 		}
 
 		public string Labels
@@ -24,6 +28,10 @@ namespace WalletWasabi.BlockchainAnalysis
 			get => _labels;
 			private set => RaiseAndSetIfChanged(ref _labels, value);
 		}
+
+		public int Size => Coins.Count();
+		
+		public IEnumerable<string> KnownBy => Coins.SelectMany(x => x.Label.Labels).Distinct(StringComparer.OrdinalIgnoreCase);
 
 		public void Merge(Cluster clusters) => Merge(clusters.Coins);
 
@@ -40,7 +48,7 @@ namespace WalletWasabi.BlockchainAnalysis
 			}
 			if (insertPosition > 0) // at least one element was inserted
 			{
-				Labels = string.Join(", ", Coins.SelectMany(x => x.Label.Labels).Distinct(StringComparer.OrdinalIgnoreCase));
+				Labels = string.Join(", ", KnownBy);
 			}
 		}
 	}

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.BlockchainAnalysis
 		}
 
 		public int Size => Coins.Count();
-		
+
 		public IEnumerable<string> KnownBy => Coins.SelectMany(x => x.Label.Labels).Distinct(StringComparer.OrdinalIgnoreCase);
 
 		public void Merge(Cluster clusters) => Merge(clusters.Coins);

--- a/WalletWasabi/BlockchainAnalysis/Cluster.cs
+++ b/WalletWasabi/BlockchainAnalysis/Cluster.cs
@@ -12,8 +12,9 @@ namespace WalletWasabi.BlockchainAnalysis
 
 		private string _labels;
 
-		public Cluster(SmartCoin coin)
-			: this( new[] { coin })
+
+		public Cluster(params SmartCoin[] coins)
+			: this(coins as IEnumerable<SmartCoin>)
 		{
 		}
 

--- a/WalletWasabi/BlockchainAnalysis/SmartLabel.cs
+++ b/WalletWasabi/BlockchainAnalysis/SmartLabel.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace WalletWasabi.BlockchainAnalysis
 {
-	public class SmartLabel : IEquatable<SmartLabel>
+	public class SmartLabel : IEquatable<SmartLabel>, IEquatable<string>, IEnumerable<string>
 	{
 		public static SmartLabel Empty { get; } = new SmartLabel();
 		public static char[] Separators { get; } = new[] { ',', ':' };
@@ -51,11 +51,17 @@ namespace WalletWasabi.BlockchainAnalysis
 
 		public static SmartLabel Merge(params SmartLabel[] labels) => Merge(labels as IEnumerable<SmartLabel>);
 
+		public IEnumerator<string> GetEnumerator() => Labels.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
 		#region Equality
 
-		public override bool Equals(object obj) => obj is SmartLabel label && this == label;
+		public override bool Equals(object obj) => (obj is SmartLabel slabel && this == slabel) || (obj is string label && this == label);
 
 		public bool Equals(SmartLabel other) => this == other;
+
+		public bool Equals(string other) => this == other;
 
 		private int HashCode { get; }
 
@@ -87,7 +93,43 @@ namespace WalletWasabi.BlockchainAnalysis
 			}
 		}
 
+		public static bool operator ==(string x, SmartLabel y)
+		{
+			if (x is null)
+			{
+				if (y is null)
+				{
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			}
+			else
+			{
+				if (y is null)
+				{
+					return false;
+				}
+				else
+				{
+					return x == y.LabelString;
+				}
+			}
+		}
+
+		public static bool operator ==(SmartLabel x, string y) => y == x;
+
 		public static bool operator !=(SmartLabel x, SmartLabel y) => !(x == y);
+
+		public static bool operator !=(string x, SmartLabel y) => !(x == y);
+
+		public static bool operator !=(SmartLabel x, string y) => !(x == y);
+
+		public static implicit operator SmartLabel(string labels) => labels is null ? null : new SmartLabel(labels);
+
+		public static implicit operator string(SmartLabel label) => label?.LabelString;
 
 		#endregion Equality
 	}

--- a/WalletWasabi/BlockchainAnalysis/SmartLabel.cs
+++ b/WalletWasabi/BlockchainAnalysis/SmartLabel.cs
@@ -30,7 +30,6 @@ namespace WalletWasabi.BlockchainAnalysis
 				   .OrderBy(x => x)
 				   .ToArray();
 
-			HashCode = ((IStructuralEquatable)Labels).GetHashCode(EqualityComparer<string>.Default);
 			IsEmpty = !Labels.Any();
 
 			LabelString = string.Join(", ", Labels);
@@ -63,9 +62,7 @@ namespace WalletWasabi.BlockchainAnalysis
 
 		public bool Equals(string other) => this == other;
 
-		private int HashCode { get; }
-
-		public override int GetHashCode() => HashCode;
+		public override int GetHashCode() => ((IStructuralEquatable)Labels).GetHashCode(EqualityComparer<string>.Default);
 
 		public static bool operator ==(SmartLabel x, SmartLabel y)
 		{

--- a/WalletWasabi/BlockchainAnalysis/SmartLabel.cs
+++ b/WalletWasabi/BlockchainAnalysis/SmartLabel.cs
@@ -124,7 +124,7 @@ namespace WalletWasabi.BlockchainAnalysis
 
 		public static bool operator !=(SmartLabel x, string y) => !(x == y);
 
-		public static implicit operator SmartLabel(string labels) => labels is null ? null : new SmartLabel(labels);
+		public static implicit operator SmartLabel(string labels) => new SmartLabel(labels);
 
 		public static implicit operator string(SmartLabel label) => label?.LabelString;
 

--- a/WalletWasabi/Coins/SmartCoin.cs
+++ b/WalletWasabi/Coins/SmartCoin.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -7,7 +6,6 @@ using System.Runtime.CompilerServices;
 using WalletWasabi.Bases;
 using WalletWasabi.BlockchainAnalysis;
 using WalletWasabi.Helpers;
-using WalletWasabi.JsonConverters;
 using WalletWasabi.KeyManagement;
 using WalletWasabi.Models;
 
@@ -16,7 +14,6 @@ namespace WalletWasabi.Coins
 	/// <summary>
 	/// An UTXO that knows more.
 	/// </summary>
-	[JsonObject(MemberSerialization.OptIn)]
 	public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>
 	{
 		#region Fields
@@ -49,41 +46,30 @@ namespace WalletWasabi.Coins
 
 		#region Properties
 
-		#region SerializableProperties
-
-		[JsonProperty]
-		[JsonConverter(typeof(Uint256JsonConverter))]
 		public uint256 TransactionId
 		{
 			get => _transactionId;
 			set => RaiseAndSetIfChanged(ref _transactionId, value);
 		}
 
-		[JsonProperty]
 		public uint Index
 		{
 			get => _index;
 			set => RaiseAndSetIfChanged(ref _index, value);
 		}
 
-		[JsonProperty]
-		[JsonConverter(typeof(ScriptJsonConverter))]
 		public Script ScriptPubKey
 		{
 			get => _scriptPubKey;
 			set => RaiseAndSetIfChanged(ref _scriptPubKey, value);
 		}
 
-		[JsonProperty]
-		[JsonConverter(typeof(MoneyBtcJsonConverter))]
 		public Money Amount
 		{
 			get => _amount;
 			set => RaiseAndSetIfChanged(ref _amount, value);
 		}
 
-		[JsonProperty]
-		[JsonConverter(typeof(HeightJsonConverter))]
 		public Height Height
 		{
 			get => _height;
@@ -101,38 +87,30 @@ namespace WalletWasabi.Coins
 		/// <summary>
 		/// Always set it before the Amount!
 		/// </summary>
-		[JsonProperty]
-		[JsonConverter(typeof(SmartLabelJsonConverter))]
 		public SmartLabel Label
 		{
 			get => _label;
 			set => RaiseAndSetIfChanged(ref _label, value);
 		}
 
-		[JsonProperty]
 		public TxoRef[] SpentOutputs
 		{
 			get => _spentOutputs;
 			set => RaiseAndSetIfChanged(ref _spentOutputs, value);
 		}
 
-		[JsonProperty]
-		[JsonConverter(typeof(FunnyBoolJsonConverter))]
 		public bool IsReplaceable
 		{
 			get => _replaceable && !Confirmed;
 			set => RaiseAndSetIfChanged(ref _replaceable, value);
 		}
 
-		[JsonProperty]
 		public int AnonymitySet
 		{
 			get => _anonymitySet;
 			private set => RaiseAndSetIfChanged(ref _anonymitySet, value);
 		}
 
-		[JsonProperty]
-		[JsonConverter(typeof(Uint256JsonConverter))]
 		public uint256 SpenderTransactionId
 		{
 			get => _spenderTransactionId;
@@ -148,8 +126,6 @@ namespace WalletWasabi.Coins
 			}
 		}
 
-		[JsonProperty]
-		[JsonConverter(typeof(FunnyBoolJsonConverter))]
 		public bool CoinJoinInProgress
 		{
 			get => _coinJoinInProgress;
@@ -165,7 +141,6 @@ namespace WalletWasabi.Coins
 			}
 		}
 
-		[JsonProperty]
 		public DateTimeOffset? BannedUntilUtc
 		{
 			get => _bannedUntilUtc;
@@ -184,7 +159,6 @@ namespace WalletWasabi.Coins
 		/// <summary>
 		/// If the backend thinks it's spent, but Wasabi does not yet know.
 		/// </summary>
-		[JsonProperty]
 		public bool SpentAccordingToBackend
 		{
 			get => _spentAccordingToBackend;
@@ -200,19 +174,13 @@ namespace WalletWasabi.Coins
 			}
 		}
 
-		[JsonProperty]
 		public HdPubKey HdPubKey
 		{
 			get => _hdPubKey;
 			private set => RaiseAndSetIfChanged(ref _hdPubKey, value);
 		}
 
-		[JsonProperty]
 		public bool IsLikelyCoinJoinOutput { get; private set; }
-
-		#endregion SerializableProperties
-
-		#region NonSerializableProperties
 
 		/// <summary>
 		/// It's a secret, so it's usually going to be null. Do not use it.
@@ -229,8 +197,6 @@ namespace WalletWasabi.Coins
 			get => _clusters;
 			set => RaiseAndSetIfChanged(ref _clusters, value);
 		}
-
-		#endregion NonSerializableProperties
 
 		#region DependentProperties
 
@@ -300,7 +266,6 @@ namespace WalletWasabi.Coins
 
 		#region Constructors
 
-		[JsonConstructor]
 		public SmartCoin(uint256 transactionId, uint index, Script scriptPubKey, Money amount, TxoRef[] spentOutputs, Height height, bool replaceable, int anonymitySet, bool isLikelyCoinJoinOutput, SmartLabel label = null, uint256 spenderTransactionId = null, bool coinJoinInProgress = false, DateTimeOffset? bannedUntilUtc = null, bool spentAccordingToBackend = false, HdPubKey pubKey = null)
 		{
 			Create(transactionId, index, scriptPubKey, amount, spentOutputs, height, replaceable, anonymitySet, isLikelyCoinJoinOutput, label, spenderTransactionId, coinJoinInProgress, bannedUntilUtc, spentAccordingToBackend, pubKey);

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -89,7 +89,8 @@ namespace System.Linq
 		{
 			return (ofLength == 1)
 				? items.Select(item => new[] { item })
-				: items.SelectMany((item, i) => items.Skip(i + 1)
+				: items.SelectMany((item, i) => items
+					.Skip(i + 1)
 					.CombinationsWithoutRepetition(ofLength - 1)
 					.Select(result => new T[] { item }
 					.Concat(result)));

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -87,11 +87,12 @@ namespace System.Linq
 			this IEnumerable<T> items,
 			int ofLength)
 		{
-			return (ofLength == 1) ?
-				items.Select(item => new[] { item }) :
-				items.SelectMany((item, i) => items.Skip(i + 1)
-												.CombinationsWithoutRepetition(ofLength - 1)
-												.Select(result => new T[] { item }.Concat(result)));
+			return (ofLength == 1)
+				? items.Select(item => new[] { item })
+				: items.SelectMany((item, i) => items.Skip(i + 1)
+					.CombinationsWithoutRepetition(ofLength - 1)
+					.Select(result => new T[] { item }
+					.Concat(result)));
 		}
 
 		public static IEnumerable<IEnumerable<T>> CombinationsWithoutRepetition<T>(
@@ -99,8 +100,9 @@ namespace System.Linq
 			int ofLength,
 			int upToLength)
 		{
-			return Enumerable.Range(ofLength, Math.Max(0, upToLength - ofLength + 1))
-							.SelectMany(len => items.CombinationsWithoutRepetition(ofLength: len));
+			return Enumerable
+				.Range(ofLength, Math.Max(0, upToLength - ofLength + 1))
+				.SelectMany(len => items.CombinationsWithoutRepetition(ofLength: len));
 		}
 
 		public static IEnumerable<IEnumerable<T>> GetPermutations<T>(this IEnumerable<T> items, int count)

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -83,6 +83,26 @@ namespace System.Linq
 			return !(source is null) && source.Any();
 		}
 
+		public static IEnumerable<IEnumerable<T>> CombinationsWithoutRepetition<T>(
+			this IEnumerable<T> items,
+			int ofLength)
+		{
+			return (ofLength == 1) ?
+				items.Select(item => new[] { item }) :
+				items.SelectMany((item, i) => items.Skip(i + 1)
+												.CombinationsWithoutRepetition(ofLength - 1)
+												.Select(result => new T[] { item }.Concat(result)));
+		}
+
+		public static IEnumerable<IEnumerable<T>> CombinationsWithoutRepetition<T>(
+			this IEnumerable<T> items,
+			int ofLength,
+			int upToLength)
+		{
+			return Enumerable.Range(ofLength, Math.Max(0, upToLength - ofLength + 1))
+							.SelectMany(len => items.CombinationsWithoutRepetition(ofLength: len));
+		}
+
 		public static IEnumerable<IEnumerable<T>> GetPermutations<T>(this IEnumerable<T> items, int count)
 		{
 			int i = 0;

--- a/WalletWasabi/JsonConverters/SmartLabelJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/SmartLabelJsonConverter.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.JsonConverters
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
 			var label = value as SmartLabel;
-			writer.WriteValue(label?.ToString() ?? "");
+			writer.WriteValue(label ?? "");
 		}
 	}
 }

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -30,12 +30,16 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 				throw new InsufficientBalanceException(targetMoney, available);
 			}
 
-			var clusters = UnspentCoins
+			var uniqueClusters = UnspentCoins
 				.Select(coin => coin.Clusters)
-				.Distinct()
-				.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
-				.Select(clusterCombination => UnspentCoins.Where(coin=> clusterCombination.Contains(coin.Clusters)))
-				.ToList();
+				.Distinct();
+
+			var clusters = (uniqueClusters.Count() < 10)
+				? uniqueClusters
+					.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
+					.Select(clusterCombination => UnspentCoins.Where(coin=> clusterCombination.Contains(coin.Clusters)))
+					.ToList()
+				: new List<IEnumerable<SmartCoin>>();
 
 			clusters.Add(UnspentCoins);
 

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -67,12 +67,7 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 				.GroupBy(c => c.ScriptPubKey)
 				.Select(group => new
 				{
-					Coins = group,
-					Unconfirmed = group.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
-					AnonymitySet = group.Min(x => x.AnonymitySet), // The group is as anonymous as its weakest member.
-					ClusterPrivacy = 1.0 / group.First().Clusters.KnownBy.Count(), // The number people/entities that know the cluster.
-					ClusterSize = group.First().Clusters.Size,    // The number of coins in the cluster.
-					Amount = group.Sum(x => x.Amount)
+					Coins = group
 				});
 
 			var coinsToSpend = new List<SmartCoin>();

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -7,6 +7,7 @@ using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Coins;
+using WalletWasabi.BlockchainAnalysis;
 
 namespace WalletWasabi.Transactions.TransactionBuilding
 {
@@ -29,23 +30,50 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 				throw new InsufficientBalanceException(targetMoney, available);
 			}
 
-			// Group coins by scriptPubKey in order to treat them all as one.
-			var coinsByScriptPubKey = UnspentCoins
+			var clusters = UnspentCoins
+				.Select(coin => coin.Clusters)
+				.Distinct()
+				.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
+				.Select(clusterCombination => UnspentCoins.Where(coin=> clusterCombination.Contains(coin.Clusters)))
+				.ToList();
+
+			clusters.Add(UnspentCoins);
+
+			var coinsByCluster = clusters
+				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.SelectMany(x=>x.Clusters.KnownBy).Count()))
+				.Select(group => new
+				{
+					Coins = group.Coins,
+					Unconfirmed = group.Coins.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
+					AnonymitySet = group.Coins.Min(x => x.AnonymitySet), // The group is as anonymous as its weakest member.
+					ClusterPrivacy = group.Privacy, // The number people/entities that know the cluster.
+					Amount = group.Coins.Sum(x => x.Amount)
+				});
+
+			var coinsInBestCluster = coinsByCluster
+				.Where(group => group.Amount >= targetMoney)
+				.OrderBy(group => group.Unconfirmed)
+				.ThenByDescending(group => group.AnonymitySet)     // Always try to spend/merge the largest anonset coins first.
+				.ThenByDescending(group => group.ClusterPrivacy)   // Select lesser-known coins.
+				.ThenByDescending(group => group.Amount)           // Then always try to spend by amount.
+				.First()
+				.Coins;
+
+			var coinsInBestClusterByScript = coinsInBestCluster
 				.GroupBy(c => c.ScriptPubKey)
 				.Select(group => new
 				{
 					Coins = group,
 					Unconfirmed = group.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
 					AnonymitySet = group.Min(x => x.AnonymitySet), // The group is as anonymous as its weakest member.
+					ClusterPrivacy = 1.0 / group.First().Clusters.KnownBy.Count(), // The number people/entities that know the cluster.
+					ClusterSize  = group.First().Clusters.Size,    // The number of coins in the cluster.
 					Amount = group.Sum(x => x.Amount)
 				});
 
 			var coinsToSpend = new List<SmartCoin>();
 
-			foreach (IGrouping<Script, SmartCoin> coinsGroup in coinsByScriptPubKey
-				.OrderBy(group => group.Unconfirmed)
-				.ThenByDescending(group => group.AnonymitySet)     // Always try to spend/merge the largest anonset coins first.
-				.ThenByDescending(group => group.Amount)           // Then always try to spend by amount.
+			foreach (IGrouping<Script, SmartCoin> coinsGroup in coinsInBestClusterByScript
 				.Select(group => group.Coins))
 			{
 				coinsToSpend.AddRange(coinsGroup);

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -22,28 +22,31 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 
 		public IEnumerable<ICoin> Select(IEnumerable<ICoin> coins, IMoney target)
 		{
-			var targetMoney = target as Money;
+			Money targetMoney = target as Money;
 
-			var available = UnspentCoins.Sum(x => x.Amount);
+			long available = UnspentCoins.Sum(x => x.Amount);
 			if (available < targetMoney)
 			{
 				throw new InsufficientBalanceException(targetMoney, available);
 			}
 
-			var uniqueClusters = UnspentCoins
+			// Get unique clusters.
+			IEnumerable<Cluster> uniqueClusters = UnspentCoins
 				.Select(coin => coin.Clusters)
 				.Distinct();
 
-			var clusters = (uniqueClusters.Count() < 10)
+			// Build all the possible coin clusters, except when it's computationally too expensive.
+			List<IEnumerable<SmartCoin>> coinClusters = (uniqueClusters.Count() < 10)
 				? uniqueClusters
 					.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
 					.Select(clusterCombination => UnspentCoins.Where(coin => clusterCombination.Contains(coin.Clusters)))
 					.ToList()
 				: new List<IEnumerable<SmartCoin>>();
 
-			clusters.Add(UnspentCoins);
+			coinClusters.Add(UnspentCoins);
 
-			var coinsByCluster = clusters
+			// This operation is doing super advanced grouping on the coin clusters and adding properties to each of them.
+			var sayajinCoinClusters = coinClusters
 				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.Sum(x => x.Clusters.Labels.Count())))
 				.Select(group => new
 				{
@@ -54,7 +57,8 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 					Amount = group.Coins.Sum(x => x.Amount)
 				});
 
-			var coinsInBestCluster = coinsByCluster
+			// Find the best coin cluster that we are going to use.
+			IEnumerable<SmartCoin> bestCoinCluster = sayajinCoinClusters
 				.Where(group => group.Amount >= targetMoney)
 				.OrderBy(group => group.Unconfirmed)
 				.ThenByDescending(group => group.AnonymitySet)     // Always try to spend/merge the largest anonset coins first.
@@ -63,14 +67,14 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 				.First()
 				.Coins;
 
-			var coinsInBestClusterByScript = coinsInBestCluster
+			var coinsInBestClusterByScript = bestCoinCluster
 				.GroupBy(c => c.ScriptPubKey)
 				.Select(group => new
 				{
 					Coins = group
 				});
 
-			var coinsToSpend = new List<SmartCoin>();
+			List<SmartCoin> coinsToSpend = new List<SmartCoin>();
 
 			foreach (IGrouping<Script, SmartCoin> coinsGroup in coinsInBestClusterByScript
 				.Select(group => group.Coins))

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -47,7 +47,7 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.SelectMany(x => x.Clusters.KnownBy).Count()))
 				.Select(group => new
 				{
-					Coins = group.Coins,
+					group.Coins,
 					Unconfirmed = group.Coins.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
 					AnonymitySet = group.Coins.Min(x => x.AnonymitySet), // The group is as anonymous as its weakest member.
 					ClusterPrivacy = group.Privacy, // The number people/entities that know the cluster.

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -37,14 +37,14 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 			var clusters = (uniqueClusters.Count() < 10)
 				? uniqueClusters
 					.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
-					.Select(clusterCombination => UnspentCoins.Where(coin=> clusterCombination.Contains(coin.Clusters)))
+					.Select(clusterCombination => UnspentCoins.Where(coin => clusterCombination.Contains(coin.Clusters)))
 					.ToList()
 				: new List<IEnumerable<SmartCoin>>();
 
 			clusters.Add(UnspentCoins);
 
 			var coinsByCluster = clusters
-				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.SelectMany(x=>x.Clusters.KnownBy).Count()))
+				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.SelectMany(x => x.Clusters.KnownBy).Count()))
 				.Select(group => new
 				{
 					Coins = group.Coins,
@@ -71,7 +71,7 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 					Unconfirmed = group.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
 					AnonymitySet = group.Min(x => x.AnonymitySet), // The group is as anonymous as its weakest member.
 					ClusterPrivacy = 1.0 / group.First().Clusters.KnownBy.Count(), // The number people/entities that know the cluster.
-					ClusterSize  = group.First().Clusters.Size,    // The number of coins in the cluster.
+					ClusterSize = group.First().Clusters.Size,    // The number of coins in the cluster.
 					Amount = group.Sum(x => x.Amount)
 				});
 

--- a/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Transactions/TransactionBuilding/SmartCoinSelector.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Transactions.TransactionBuilding
 			clusters.Add(UnspentCoins);
 
 			var coinsByCluster = clusters
-				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.SelectMany(x => x.Clusters.KnownBy).Count()))
+				.Select(coins => (Coins: coins, Privacy: 1.0m / coins.Sum(x => x.Clusters.Labels.Count())))
 				.Select(group => new
 				{
 					group.Coins,

--- a/WalletWasabi/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Transactions/TransactionHistoryBuilder.cs
@@ -70,7 +70,7 @@ namespace WalletWasabi.Transactions
 						DateTime = dateTime,
 						Height = coin.Height,
 						Amount = coin.Amount,
-						Label = coin.Label.ToString(),
+						Label = coin.Label,
 						TransactionId = coin.TransactionId,
 						BlockIndex = foundTransaction.BlockIndex
 					});


### PR DESCRIPTION
This PR builds transactions with a better privacy level by taking the coins' cluster information into account during the coins selection process.

## Things to have in mind

* Coins with the same `ScriptPubKey` belong always to the same cluster
* Coins with anonymity set higher than the `StrongPrivacyThreshold` belong to a one-element cluster (a cluster with only one coin)

## How does this work now?

The `SmartCoinSelector` tries to avoid merging coins from different clusters in order to minimize the number of people/entities that can know about the built transaction. It does that by creating a small set of clusters combinations sorted by their privacy levels and selecting the best cluster (or clusters combination) big enough to cover the spending target. 

In case no cluster, nor clusters combination, candidate is found it fallback to the original list of coins. This is because the clusters combinations has to be limited for performance reasons.

## Example

Lets see how the `SmartCoinSelector` worked before. In the `SelectSameScriptPubKeyCoins` test we had 4 coins (see below) and want to send 0.1btc.

| Cluster | Amount | Confirmed | AnonSet |
|--------|--------|-----------|------------|
|Pablo|  0.01btc| false| 10|
|Daniel| 0.02btc| false|  1|
|Daniel| 0.04btc| true|  1|
|Maria|  0.08btc| true|  20|

### Version on master branch

The `SmartCoinSelector` selects the more private coins first 0.08btc from `Maria` (20), then 0.01btc from `Pablo` (10) and finally 0.04btc from `Daniel` (those coins sum 0.13btc, it is enough) However, given there are two coins with the same scriptPubKey (Daniel) it has to select it too.

The result is a 0.15btc transaction spending all the _four_ coins and then the resulting coins (spending and change) are known by the three people `Pablo`, `Daniel` and `Maria`.

### Version on this PR branch

The `SmartCoinSelector` selects the combination of clusters that result in the more private selection of coins, this is the union of cluster `Maria` and `Daniel`.

The result is a 0.14btc transaction spending _three_ coins and then the resulting coins (spending and change) are known by only two people `Daniel` and `Maria`.

**Note** this is not very important and probably is not always possible but in this case the transaction is also cheaper because the transaction is smaller.

Closes https://github.com/zkSNACKs/WalletWasabi/issues/2441