### PR TITLE
Add rel="nofollow" to weareblockspace link

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -541,7 +541,7 @@
         </div>
         <div class="pt-0 pb-2">
             <div class="container text-center">
-                <a href="https://weareblock.space" class="d-block text-light" style="color: #FF859D !important;" target="_blank"><small>designed with <svg width="13" height="12" xmlns="http://www.w3.org/2000/svg"><path d="M6.461 2.12C6.986.872 8.184 0 9.58 0c1.878 0 3.23 1.612 3.4 3.533 0 0 .092.477-.11 1.336a5.908 5.908 0 0 1-1.794 3L6.461 12 1.925 7.87A5.907 5.907 0 0 1 .13 4.867c-.202-.858-.11-1.335-.11-1.335C.19 1.612 1.543 0 3.42 0c1.395 0 2.515.872 3.04 2.12z" fill="#FF859D" fill-rule="nonzero" /></svg> (not js) by blockspace</small></a>
+                <a href="https://weareblock.space" rel="nofollow" class="d-block text-light" style="color: #FF859D !important;" target="_blank"><small>designed with <svg width="13" height="12" xmlns="http://www.w3.org/2000/svg"><path d="M6.461 2.12C6.986.872 8.184 0 9.58 0c1.878 0 3.23 1.612 3.4 3.533 0 0 .092.477-.11 1.336a5.908 5.908 0 0 1-1.794 3L6.461 12 1.925 7.87A5.907 5.907 0 0 1 .13 4.867c-.202-.858-.11-1.335-.11-1.335C.19 1.612 1.543 0 3.42 0c1.395 0 2.515.872 3.04 2.12z" fill="#FF859D" fill-rule="nonzero" /></svg> (not js) by blockspace</small></a>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Sorry @mayankchhabra but I think we should add `rel="nofollow"` to weareblockspace link.
Please listen to [Google Webmaster Video at 19:47](https://www.youtube.com/watch?v=vfSFcImNFX4#t=1187).

Google's John Mueller said "definitely put a nofollow rule for those links." That is even if the site owner wants the link there, you should still nofollow it.

For those unfamiliar with the importance of nofollow SEO links:
[https://ahrefs.com/blog/nofollow-links/](https://ahrefs.com/blog/nofollow-links/)

