### PR TITLE
Precompute transaction hashes on deserialization

### DIFF
--- a/WalletWasabi/JsonConverters/TransactionJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/TransactionJsonConverter.cs
@@ -17,8 +17,6 @@ namespace WalletWasabi.JsonConverters
 		{
 			var txHex = reader.Value.ToString();
 			var tx = Transaction.Parse(txHex, Network.Main);
-			// Because we don't modify those transactions, we can cache the hash
-			tx.PrecomputeHash(false, true);
 			return tx;
 		}
 

--- a/WalletWasabi/JsonConverters/TransactionJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/TransactionJsonConverter.cs
@@ -17,6 +17,8 @@ namespace WalletWasabi.JsonConverters
 		{
 			var txHex = reader.Value.ToString();
 			var tx = Transaction.Parse(txHex, Network.Main);
+			// Because we don't modify those transactions, we can cache the hash
+			tx.PrecomputeHash(false, true);
 			return tx;
 		}
 

--- a/WalletWasabi/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Transactions/SmartTransaction.cs
@@ -80,6 +80,9 @@ namespace WalletWasabi.Transactions
 		public SmartTransaction(Transaction transaction, Height height, uint256 blockHash = null, int blockIndex = 0, SmartLabel label = null, bool isReplacement = false, DateTimeOffset firstSeen = default)
 		{
 			Transaction = transaction;
+			// Because we don't modify those transactions, we can cache the hash
+			Transaction.PrecomputeHash(false, true);
+
 			Label = label ?? SmartLabel.Empty;
 
 			Height = height;


### PR DESCRIPTION
~70%~ 40% of my CPU is consumed calculating transaction hashes.

This PR make NBitcoin cache the hash after first computation. This is safe as there is no reason to modify transactions that we deserialize.

![image (6)](https://user-images.githubusercontent.com/3020646/67651674-79be6c00-f985-11e9-9088-4339e191bb8b.png)
