### PR TITLE
Move RBF rate to Constants.cs

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -99,7 +99,7 @@ namespace WalletWasabi.Helpers
 
 		public const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
-		public const float TransactionRBFSignalRate = 0.02F; // 2% RBF transactions
+		public const double TransactionRBFSignalRate = 0.02; // 2% RBF transactions
 
 		public const decimal DefaultDustThreshold = 0.00005m;
 	}

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -99,6 +99,8 @@ namespace WalletWasabi.Helpers
 
 		public const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
+		public const float TransactionRBFSignalRate = 0.02F; // 2% RBF transactions
+
 		public const decimal DefaultDustThreshold = 0.00005m;
 	}
 }

--- a/WalletWasabi/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Transactions/TransactionFactory.cs
@@ -141,7 +141,7 @@ namespace WalletWasabi.Transactions
 				builder.SetChange(changeHdPubKey.P2wpkhScript);
 			}
 
-			builder.OptInRBF = new Random().NextDouble() < 0.02; // 2% RBF transactions
+			builder.OptInRBF = new Random().NextDouble() < Constants.TransactionRBFSignalRate;
 
 			FeeRate feeRate = feeRateFetcher();
 			builder.SendEstimatedFees(feeRate);


### PR DESCRIPTION
This will be need to be changed in the future either due to the rise or fall in transactions signaling rbf or needing to be reassessed because wasabi switches to a future segwit version.  I think it makes more sense to have things like this in the constants file.