### PR TITLE
Fix recursive coin deletion

### DIFF
--- a/WalletWasabi/Coins/CoinsView.cs
+++ b/WalletWasabi/Coins/CoinsView.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.Coins
 			{
 				foreach (var child in ChildrenOf(scoin))
 				{
-					foreach (var childDescendant in ChildrenOf(child))
+					foreach (var childDescendant in Generator(child))
 					{
 						yield return childDescendant;
 					}


### PR DESCRIPTION
The current version on master only deletes two levels of coins (children and children's children)