### PR TITLE
StatusBar fixes (Part I)

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -192,7 +192,10 @@ namespace WalletWasabi.Gui.ViewModels
 			{
 				try
 				{
-					IoHelpers.OpenBrowser("https://wasabiwallet.io/#download");
+					if (UpdateAvailable || CriticalUpdateAvailable)
+					{
+						IoHelpers.OpenBrowser("https://wasabiwallet.io/#download");
+					}
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -192,17 +192,14 @@ namespace WalletWasabi.Gui.ViewModels
 			{
 				try
 				{
-					if (UpdateAvailable || CriticalUpdateAvailable)
-					{
-						IoHelpers.OpenBrowser("https://wasabiwallet.io/#download");
-					}
+					IoHelpers.OpenBrowser("https://wasabiwallet.io/#download");
 				}
 				catch (Exception ex)
 				{
 					Logger.LogWarning(ex);
 					IoC.Get<IShell>().AddOrSelectDocument(() => new AboutViewModel(Global));
 				}
-			});
+			}, this.WhenAnyValue(x => x.UpdateAvailable, x => x.CriticalUpdateAvailable, (x, y) => x || y));
 
 			this.RaisePropertyChanged(nameof(UpdateCommand)); // The binding happens after the constructor. So, if the command is not in constructor, then we need this line.
 


### PR DESCRIPTION
Issue: Whenever you click on the status bar, it opens the download link even though there's no updates available yet. This fixes that issue by checking the `UpdateAvailable` & `CriticalUpdateAvailable` properties.

cc: @molnard @nopara73 