### PR TITLE
Put BusyIndicator back to CoinLists

### DIFF
--- a/WalletWasabi.Gui/App.xaml
+++ b/WalletWasabi.Gui/App.xaml
@@ -5,22 +5,23 @@
              xmlns:Views="clr-namespace:AvaloniaDemo.ViewModels.Views;assembly=AvalonStudio.Shell"
              x:Class="WalletWasabi.Gui.App">
   <Application.Styles>
-    <StyleInclude Source="avares://Avalonia.Themes.Default/DefaultTheme.xaml"/>
-    <StyleInclude Source="avares://AvalonStudio.Shell/Themes/BaseDark.xaml"/>
-    <StyleInclude Source="avares://AvalonStudio.Shell/Themes/Accents/DarkAccent.xaml"/>
-    <StyleInclude Source="avares://AvalonStudio.Shell/Icons/Icons.xaml"/>
+    <StyleInclude Source="avares://Avalonia.Themes.Default/DefaultTheme.xaml" />
+    <StyleInclude Source="avares://AvalonStudio.Shell/Themes/BaseDark.xaml" />
+    <StyleInclude Source="avares://AvalonStudio.Shell/Themes/Accents/DarkAccent.xaml" />
+    <StyleInclude Source="avares://AvalonStudio.Shell/Icons/Icons.xaml" />
     <StyleInclude Source="avares://AvalonStudio.Shell/Controls/MetroWindowTheme.paml" />
     <StyleInclude Source="avares://AvalonStudio.Shell.Extensibility/Controls/ControlTheme.paml" />
     <StyleInclude Source="avares://AvalonStudio.Shell/Styles/GlobalStyles.xaml" />
-    <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/DefaultTheme.xaml"/>
-    <StyleInclude Source="avares://Dock.Avalonia.Themes.Metro/DefaultTheme.xaml"/>
+    <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/DefaultTheme.xaml" />
+    <StyleInclude Source="avares://Dock.Avalonia.Themes.Metro/DefaultTheme.xaml" />
     <StyleInclude Source="avares://WalletWasabi.Gui/Controls/GroupBox.xaml" />
     <StyleInclude Source="avares://WalletWasabi.Gui/Controls/TogglePasswordBox.xaml" />
     <StyleInclude Source="avares://WalletWasabi.Gui/Controls/MultiTextBox.xaml" />
     <StyleInclude Source="avares://WalletWasabi.Gui/Controls/EditableTextBlock.xaml" />
-	<StyleInclude Source="avares://WalletWasabi.Gui/Controls/Shields.xaml" />
+    <StyleInclude Source="avares://WalletWasabi.Gui/Controls/Shields.xaml" />
     <StyleInclude Source="avares://WalletWasabi.Gui/Styles/Styles.xaml" />
     <StyleInclude Source="avares://WalletWasabi.Gui/Icons/Icons.xaml" />
+    <StyleInclude Source="avares://WalletWasabi.Gui/Controls/BusyIndicator.xaml" />
   </Application.Styles>
   <Application.DataTemplates>
     <DataTemplate DataType="Views:MainView">

--- a/WalletWasabi.Gui/Controls/BusyIndicator.cs
+++ b/WalletWasabi.Gui/Controls/BusyIndicator.cs
@@ -1,0 +1,30 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Styling;
+using System;
+
+namespace WalletWasabi.Gui.Controls
+{
+	public class BusyIndicator : ContentControl, IStyleable
+	{
+		Type IStyleable.StyleKey => typeof(BusyIndicator);
+
+		public static readonly StyledProperty<string> TextProperty =
+			AvaloniaProperty.Register<BusyIndicator, string>(nameof(Text));
+
+		public static readonly StyledProperty<bool> IsBusyProperty =
+			AvaloniaProperty.Register<BusyIndicator, bool>(nameof(IsBusy));
+
+		public string Text
+		{
+			get => GetValue(TextProperty);
+			set => SetValue(TextProperty, value);
+		}
+
+		public bool IsBusy
+		{
+			get => GetValue(IsBusyProperty);
+			set => SetValue(IsBusyProperty, value);
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/BusyIndicator.xaml
+++ b/WalletWasabi.Gui/Controls/BusyIndicator.xaml
@@ -1,0 +1,29 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
+        xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+  <Style Selector="local|BusyIndicator">
+    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid>
+          <StackPanel ZIndex="2" Orientation="Horizontal" VerticalAlignment="Top" IsVisible="{TemplateBinding IsBusy}">
+            <controls:Spinner Height="20" Width="20" IsVisible="True" Margin="8" />
+            <TextBlock Text="{TemplateBinding Text}" VerticalAlignment="Center" />
+          </StackPanel>
+          <Border Name="PART_Border" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{DynamicResource ThemeBorderLowBrush}">
+            <ContentPresenter
+              Name="PART_ContentPresenter"
+              Background="{TemplateBinding Background}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              Content="{TemplateBinding Content}"
+              Padding="{TemplateBinding Padding}"
+              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+          </Border>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+</Styles>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -72,78 +72,80 @@
           <TextBlock Text="Merging unmixed coins with mixed ones undoes those mixes." Classes="warningMessage" IsVisible="{Binding LabelExposeCommonOwnershipWarning}" />
         </StackPanel>
       </StackPanel>
-      <controls:ExtendedListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
-        <controls:ExtendedListBox.ContextMenu>
-          <ContextMenu>
-            <!--Enqueuing needs password, TODO: jump to password box OR display pw box in context menu + send button-->
-            <MenuItem Command="{Binding EnqueueCoin}" IsVisible="false">
-              <MenuItem.Header>
-                <Grid>
+      <controls:BusyIndicator IsBusy="{Binding IsCoinListLoading}" Text="Loading...">
+        <controls:ExtendedListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
+          <controls:ExtendedListBox.ContextMenu>
+            <ContextMenu>
+              <!--Enqueuing needs password, TODO: jump to password box OR display pw box in context menu + send button-->
+              <MenuItem Command="{Binding EnqueueCoin}" IsVisible="false">
+                <MenuItem.Header>
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition />
+                      <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Enqueue Coin, password:" VerticalAlignment="Center" />
+                    <TextBox Width="50" Grid.Column="1" />
+                  </Grid>
+                </MenuItem.Header>
+              </MenuItem>
+              <MenuItem Header="Dequeue from CoinJoin" Command="{Binding DequeueCoin}">
+                <MenuItem.Icon>
+                  <Path HorizontalAlignment="Left" Data="M3.24,7.51c-0.146,0.142-0.146,0.381,0,0.523l5.199,5.193c0.234,0.238,0.633,0.064,0.633-0.262v-2.634c0.105-0.007,0.212-0.011,0.321-0.011c2.373,0,4.302,1.91,4.302,4.258c0,0.957-0.33,1.809-1.008,2.602c-0.259,0.307,0.084,0.762,0.451,0.572c2.336-1.195,3.73-3.408,3.73-5.924c0-3.741-3.103-6.783-6.916-6.783c-0.307,0-0.615,0.028-0.881,0.063V2.575c0-0.327-0.398-0.5-0.633-0.261L3.24,7.51 M4.027,7.771l4.301-4.3v2.073c0,0.232,0.21,0.409,0.441,0.366c0.298-0.056,0.746-0.123,1.184-0.123c3.402,0,6.172,2.709,6.172,6.041c0,1.695-0.718,3.24-1.979,4.352c0.193-0.51,0.293-1.045,0.293-1.602c0-2.76-2.266-5-5.046-5c-0.256,0-0.528,0.018-0.747,0.05C8.465,9.653,8.328,9.81,8.328,9.995v2.074L4.027,7.771z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
+                </MenuItem.Icon>
+              </MenuItem>
+            </ContextMenu>
+          </controls:ExtendedListBox.ContextMenu>
+          <controls:ExtendedListBox.ItemTemplate>
+            <DataTemplate>
+              <Grid>
+                <Expander Name="coinExpander" ExpandDirection="Down" Classes="coloredExpander" Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
+                  <Grid HorizontalAlignment="Left" ColumnDefinitions="150, *" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" MaxWidth="800" Margin="35 10 0 25">
+                    <TextBlock Classes="monospaceFont" Text="Transaction Id:" Grid.Row="0" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding TransactionId}" Background="Transparent" Grid.Column="1" Grid.Row="0" />
+                    <TextBlock Classes="monospaceFont" Text="Output Index:" Grid.Row="1" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding OutputIndex}" Grid.Column="1" Grid.Row="1" />
+                    <TextBlock Classes="monospaceFont" Text="Label:" Grid.Row="2" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Label}" Grid.Column="1" Grid.Row="2" />
+                    <TextBlock Classes="monospaceFont" Text="Address:" Grid.Row="3" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Address}" Grid.Column="1" Grid.Row="3" />
+                    <TextBlock Classes="monospaceFont" Text="Confirmations:" Grid.Row="4" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Confirmations}" Grid.Column="1" Grid.Row="4" />
+                    <TextBlock Classes="monospaceFont" Text="Anonymity Set:" Grid.Row="5" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding AnonymitySet}" Grid.Column="1" Grid.Row="5" />
+                    <TextBlock Classes="monospaceFont" Text="Key Path:" Grid.Row="6" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding KeyPath}" Grid.Column="1" Grid.Row="6" />
+                    <TextBlock Classes="monospaceFont" Text="Public Key:" Grid.Row="7" />
+                    <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding PubKey}" Grid.Column="1" Grid.Row="7" />
+                  </Grid>
+                </Expander>
+                <Grid Margin="30 0 0 0" VerticalAlignment="Top">
                   <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition />
+                    <ColumnDefinition Width="30" />
+                    <ColumnDefinition Width="30" />
+                    <ColumnDefinition SharedSizeGroup="A" />
+                    <ColumnDefinition Width="150" />
+                    <ColumnDefinition Width="100" />
+                    <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
-                  <TextBlock Text="Enqueue Coin, password:" VerticalAlignment="Center" />
-                  <TextBox Width="50" Grid.Column="1" />
+                  <CheckBox HorizontalContentAlignment="Left" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />
+                  <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="1" ToolTip.Tip="{Binding Confirmations, StringFormat=\{0\} Confirmations}">
+                    <Path HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
+                  </Border>
+                  <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left" BorderThickness="1" CornerRadius="0,6,6,0">
+                    <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
+                  </Border>
+                  <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+                  <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent" DataContext="{Binding AnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}" ToolTip.Tip="{Binding ToolTip}">
+                    <DrawingPresenter Drawing="{Binding Icon}" Height="16" Width="16" Margin="0 0 25 0" />
+                  </Panel>
+                  <controls:ExtendedTextBox Grid.Column="5" Classes="selectableTextBlock" Background="Transparent" Text="{Binding Clusters, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
                 </Grid>
-              </MenuItem.Header>
-            </MenuItem>
-            <MenuItem Header="Dequeue from CoinJoin" Command="{Binding DequeueCoin}">
-              <MenuItem.Icon>
-                <Path HorizontalAlignment="Left" Data="M3.24,7.51c-0.146,0.142-0.146,0.381,0,0.523l5.199,5.193c0.234,0.238,0.633,0.064,0.633-0.262v-2.634c0.105-0.007,0.212-0.011,0.321-0.011c2.373,0,4.302,1.91,4.302,4.258c0,0.957-0.33,1.809-1.008,2.602c-0.259,0.307,0.084,0.762,0.451,0.572c2.336-1.195,3.73-3.408,3.73-5.924c0-3.741-3.103-6.783-6.916-6.783c-0.307,0-0.615,0.028-0.881,0.063V2.575c0-0.327-0.398-0.5-0.633-0.261L3.24,7.51 M4.027,7.771l4.301-4.3v2.073c0,0.232,0.21,0.409,0.441,0.366c0.298-0.056,0.746-0.123,1.184-0.123c3.402,0,6.172,2.709,6.172,6.041c0,1.695-0.718,3.24-1.979,4.352c0.193-0.51,0.293-1.045,0.293-1.602c0-2.76-2.266-5-5.046-5c-0.256,0-0.528,0.018-0.747,0.05C8.465,9.653,8.328,9.81,8.328,9.995v2.074L4.027,7.771z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
-              </MenuItem.Icon>
-            </MenuItem>
-          </ContextMenu>
-        </controls:ExtendedListBox.ContextMenu>
-        <controls:ExtendedListBox.ItemTemplate>
-          <DataTemplate>
-            <Grid>
-              <Expander Name="coinExpander" ExpandDirection="Down" Classes="coloredExpander" Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
-                <Grid HorizontalAlignment="Left" ColumnDefinitions="150, *" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" MaxWidth="800" Margin="35 10 0 25">
-                  <TextBlock Classes="monospaceFont" Text="Transaction Id:" Grid.Row="0" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding TransactionId}" Background="Transparent" Grid.Column="1" Grid.Row="0" />
-                  <TextBlock Classes="monospaceFont" Text="Output Index:" Grid.Row="1" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding OutputIndex}" Grid.Column="1" Grid.Row="1" />
-                  <TextBlock Classes="monospaceFont" Text="Label:" Grid.Row="2" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Label}" Grid.Column="1" Grid.Row="2" />
-                  <TextBlock Classes="monospaceFont" Text="Address:" Grid.Row="3" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Address}" Grid.Column="1" Grid.Row="3" />
-                  <TextBlock Classes="monospaceFont" Text="Confirmations:" Grid.Row="4" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Confirmations}" Grid.Column="1" Grid.Row="4" />
-                  <TextBlock Classes="monospaceFont" Text="Anonymity Set:" Grid.Row="5" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding AnonymitySet}" Grid.Column="1" Grid.Row="5" />
-                  <TextBlock Classes="monospaceFont" Text="Key Path:" Grid.Row="6" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding KeyPath}" Grid.Column="1" Grid.Row="6" />
-                  <TextBlock Classes="monospaceFont" Text="Public Key:" Grid.Row="7" />
-                  <controls:ExtendedTextBox Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding PubKey}" Grid.Column="1" Grid.Row="7" />
-                </Grid>
-              </Expander>
-              <Grid Margin="30 0 0 0" VerticalAlignment="Top">
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="30" />
-                  <ColumnDefinition Width="30" />
-                  <ColumnDefinition SharedSizeGroup="A" />
-                  <ColumnDefinition Width="150" />
-                  <ColumnDefinition Width="100" />
-                  <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <CheckBox HorizontalContentAlignment="Left" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />
-                <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="1" ToolTip.Tip="{Binding Confirmations, StringFormat=\{0\} Confirmations}">
-                  <Path HorizontalAlignment="Left" Data="F1 M 23.7501,33.25L 34.8334,44.3333L 52.2499,22.1668L 56.9999,26.9168L 34.8334,53.8333L 19.0001,38L 23.7501,33.25 Z" Fill="#22B14C" Height="16" Width="16" Stretch="Fill" />
-                </Border>
-                <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left" BorderThickness="1" CornerRadius="0,6,6,0">
-                  <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
-                </Border>
-                <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
-                <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent" DataContext="{Binding AnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}" ToolTip.Tip="{Binding ToolTip}">
-                  <DrawingPresenter Drawing="{Binding Icon}" Height="16" Width="16" Margin="0 0 25 0" />
-                </Panel>
-                <controls:ExtendedTextBox Grid.Column="5" Classes="selectableTextBlock" Background="Transparent" Text="{Binding Clusters, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
               </Grid>
-            </Grid>
-          </DataTemplate>
-        </controls:ExtendedListBox.ItemTemplate>
-      </controls:ExtendedListBox>
+            </DataTemplate>
+          </controls:ExtendedListBox.ItemTemplate>
+        </controls:ExtendedListBox>
+      </controls:BusyIndicator>
     </DockPanel>
   </Grid>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -406,7 +406,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					IsCoinListLoading = false;
 				}
-			}, outputScheduler: RxApp.MainThreadScheduler);
+			});
 
 			InitList.ThrownExceptions.Subscribe(ex => Logger.LogError(ex));
 		}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -253,15 +253,17 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			SelectPrivateCheckBoxState = false;
 			SelectNonPrivateCheckBoxState = false;
 
-			var sortChanged = this.WhenValueChanged(@this => MyComparer)
+			var sortChanged = this
+				.WhenAnyValue(x => x.MyComparer)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Select(_ => MyComparer);
 
 			RootList = new SourceList<CoinViewModel>();
-			RootList.Connect()
+			RootList
+				.Connect()
 				.Sort(MyComparer, comparerChanged: sortChanged, resetThreshold: 5)
-				.Bind(out _coinViewModels)
 				.ObserveOn(RxApp.MainThreadScheduler)
+				.Bind(out _coinViewModels)
 				.Subscribe();
 
 			SortCommand = ReactiveCommand.Create(RefreshOrdering);
@@ -332,8 +334,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 					DequeueCoinsPressed?.Invoke(this, EventArgs.Empty);
 				},
-				this.WhenAnyValue(x => x.CanDeqeue)
-					.ObserveOn(RxApp.MainThreadScheduler));
+				this.WhenAnyValue(x => x.CanDeqeue));
 
 			SelectAllCheckBoxCommand = ReactiveCommand.Create(() =>
 				{
@@ -415,14 +416,17 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
-			foreach (var sc in Global.WalletService.Coins)
+			var list = Global.WalletService.Coins.Select(x => new CoinViewModel(this, x)).ToList();
+
+			foreach (var vm in list)
 			{
-				var newCoinVm = new CoinViewModel(this, sc);
-				newCoinVm.SubscribeEvents();
-				RootList.Add(newCoinVm);
+				vm.SubscribeEvents();
 			}
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
+			RootList.AddRange(list);
+
+			Global.UiConfig
+				.WhenAnyValue(x => x.LurkingWifeMode)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => this.RaisePropertyChanged(nameof(SelectedAmount)))
 				.DisposeWith(Disposables);
@@ -504,7 +508,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				})
 				.DisposeWith(Disposables);
 
-			Global.Config.WhenAnyValue(x => x.MixUntilAnonymitySet)
+			Global.Config
+				.WhenAnyValue(x => x.MixUntilAnonymitySet)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x => RefreshSelectCheckBoxesShields(x))
 				.DisposeWith(Disposables);


### PR DESCRIPTION
In some specific wallets with a lot of coins, the loading time is still a lot. This PR put back the loading animation into the CoinList of SendTab and CoinJoin tab. 
History tab will remain as it is now, it is fast. 
The delay not caused by the business logic instead of the UI elements creation and binding. 
Virtualization or optimization of the list can solve this, but until that BusyIndicator will remain. 

Partially reverts: https://github.com/zkSNACKs/WalletWasabi/pull/2479

Related: 
https://github.com/zkSNACKs/WalletWasabi/issues/1298
https://github.com/zkSNACKs/WalletWasabi/pull/2076#issuecomment-518807315
https://github.com/zkSNACKs/WalletWasabi/issues/597