### PR TITLE
Make sure transactions are processed

### DIFF
--- a/WalletWasabi.Tests/UnitTests/EventHandlerExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/EventHandlerExtensionsTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests
+{
+	public class EventHandlerExtensionsTests
+	{
+		public event EventHandler<EventArgs> handler;
+
+		[Fact]
+		public void InvokeAllSubscribers()
+		{
+			var count = 0;
+			handler += (s, e) => count++;
+			handler += (s, e) => count++;
+			handler += (s, e) => count++;
+
+			handler.SafeInvoke(this, null);
+			Assert.Equal(3, count);
+		}
+
+		[Fact]
+		public void InvokeAllSubscribersEvenIfExceptions()
+		{
+			var count = 0;
+			handler += (s, e) => count++;
+			handler += (s, e) => throw new Exception("Something really bad happened here!");
+			handler += (s, e) => count++;
+
+			// In a normal Invoke, if there is an exception in one of the handlers the next handlers are not invoked.
+			try
+			{
+				handler.Invoke(this, null);
+				throw new Exception("An exception was expected but never happened.");
+			}
+			catch(Exception)
+			{
+				Assert.Equal(1, count);
+			}
+
+			count = 0;
+			// The SafeInvoke makes sure that even if one handler fails, the others are invoked anyway.
+			handler.SafeInvoke(this, null);
+			Assert.Equal(2, count);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/EventHandlerExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/EventHandlerExtensionsTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests
@@ -13,21 +11,29 @@ namespace WalletWasabi.Tests.UnitTests
 		public void InvokeAllSubscribers()
 		{
 			var count = 0;
-			handler += (s, e) => count++;
-			handler += (s, e) => count++;
-			handler += (s, e) => count++;
+			var action = new EventHandler<EventArgs>((s, e) => count++);
+			handler += action;
+			handler += action;
+			handler += action;
 
 			handler.SafeInvoke(this, null);
 			Assert.Equal(3, count);
+
+			handler -= action;
+			handler -= action;
+			handler -= action;
 		}
 
 		[Fact]
 		public void InvokeAllSubscribersEvenIfExceptions()
 		{
 			var count = 0;
-			handler += (s, e) => count++;
-			handler += (s, e) => throw new Exception("Something really bad happened here!");
-			handler += (s, e) => count++;
+			var action = new EventHandler<EventArgs>((s, e) => count++);
+			var failingAction = new EventHandler<EventArgs>((s, e) => throw new Exception("Something really bad happened here!"));
+
+			handler += action;
+			handler += failingAction;
+			handler += action;
 
 			// In a normal Invoke, if there is an exception in one of the handlers the next handlers are not invoked.
 			try
@@ -44,6 +50,10 @@ namespace WalletWasabi.Tests.UnitTests
 			// The SafeInvoke makes sure that even if one handler fails, the others are invoked anyway.
 			handler.SafeInvoke(this, null);
 			Assert.Equal(2, count);
+
+			handler -= action;
+			handler -= action;
+			handler -= failingAction;
 		}
 	}
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionProcessor.cs
@@ -110,14 +110,14 @@ namespace WalletWasabi.Blockchain.Transactions
 							var replacedTxId = doubleSpends.First().TransactionId;
 							var (destroyed, restored) = Coins.Undo(replacedTxId);
 
-							ReplaceTransactionReceived?.Invoke(this, new ReplaceTransactionReceivedEventArgs(tx, destroyed, restored));
+							ReplaceTransactionReceived.SafeInvoke(this, new ReplaceTransactionReceivedEventArgs(tx, destroyed, restored));
 
 							tx.SetReplacement();
 							walletRelevant = true;
 						}
 						else
 						{
-							DoubleSpendReceived?.Invoke(this, new DoubleSpendReceivedEventArgs(tx, Enumerable.Empty<SmartCoin>()));
+							DoubleSpendReceived.SafeInvoke(this, new DoubleSpendReceivedEventArgs(tx, Enumerable.Empty<SmartCoin>()));
 							return false;
 						}
 					}
@@ -129,7 +129,7 @@ namespace WalletWasabi.Blockchain.Transactions
 							Coins.Remove(doubleSpentCoin);
 						}
 
-						DoubleSpendReceived?.Invoke(this, new DoubleSpendReceivedEventArgs(tx, doubleSpends));
+						DoubleSpendReceived.SafeInvoke(this, new DoubleSpendReceivedEventArgs(tx, doubleSpends));
 						walletRelevant = true;
 					}
 				}
@@ -223,12 +223,12 @@ namespace WalletWasabi.Blockchain.Transactions
 					if (!alreadyKnown)
 					{
 						Coins.Spend(foundCoin);
-						CoinSpent?.Invoke(this, foundCoin);
+						CoinSpent.SafeInvoke(this, foundCoin);
 					}
 
 					if (tx.Confirmed)
 					{
-						SpenderConfirmed?.Invoke(this, foundCoin);
+						SpenderConfirmed.SafeInvoke(this, foundCoin);
 					}
 				}
 			}
@@ -240,7 +240,7 @@ namespace WalletWasabi.Blockchain.Transactions
 
 			foreach (var newCoin in newCoins)
 			{
-				CoinReceived?.Invoke(this, newCoin);
+				CoinReceived.SafeInvoke(this, newCoin);
 			}
 
 			return walletRelevant;

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -114,7 +114,14 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 
 		private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse e)
 		{
-			await TryProcessStatusAsync(e?.CcjRoundStates).ConfigureAwait(false);
+			try
+			{
+				await TryProcessStatusAsync(e?.CcjRoundStates).ConfigureAwait(false);
+			}
+			catch(Exception ex)
+			{
+				Logger.LogWarning(ex);
+			}
 		}
 
 		public void Start()

--- a/WalletWasabi/Extensions/EventExtensions.cs
+++ b/WalletWasabi/Extensions/EventExtensions.cs
@@ -11,7 +11,7 @@ namespace System
 			{
 				try
 				{
-					h.Invoke(null, args);
+					h.Invoke(sender, args);
 				}
 				catch(Exception ex)
 				{

--- a/WalletWasabi/Extensions/EventExtensions.cs
+++ b/WalletWasabi/Extensions/EventExtensions.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using WalletWasabi.Logging;
 
 namespace System
@@ -9,13 +13,19 @@ namespace System
 			var h = handler;
 			if (h != null)
 			{
-				try
+				// Invokes every handler and makes sure the exceptions are caught. This is not possible
+				// for async event handlers because they are fire-and-forget methods that require
+				// being wrap around try-catch blocks
+				foreach ( Delegate individualHandler in h.GetInvocationList() )
 				{
-					h.Invoke(sender, args);
-				}
-				catch(Exception ex)
-				{
-					Logger.LogError(ex);
+					try
+					{
+						individualHandler.DynamicInvoke(sender, args);
+					}
+					catch(Exception ex)
+					{
+						Logger.LogError(ex);
+					}
 				}
 			}
 		}

--- a/WalletWasabi/Extensions/EventExtensions.cs
+++ b/WalletWasabi/Extensions/EventExtensions.cs
@@ -11,11 +11,11 @@ namespace System
 			{
 				try
 				{
-					h(null, args);
+					h.Invoke(null, args);
 				}
 				catch(Exception ex)
 				{
-					Logger.LogInfo(ex);
+					Logger.LogError(ex);
 				}
 			}
 		}

--- a/WalletWasabi/Extensions/EventExtensions.cs
+++ b/WalletWasabi/Extensions/EventExtensions.cs
@@ -1,0 +1,23 @@
+using WalletWasabi.Logging;
+
+namespace System
+{
+	public static class EventExtensions
+	{
+		public static void SafeInvoke<T>(this EventHandler<T> handler, object sender, T args)
+		{
+			var h = handler;
+			if (h != null)
+			{
+				try
+				{
+					h(null, args);
+				}
+				catch(Exception ex)
+				{
+					Logger.LogInfo(ex);
+				}
+			}
+		}
+	}
+}

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -150,19 +150,19 @@ namespace WalletWasabi.Services
 
 		private async void TransactionProcessor_CoinReceivedAsync(object sender, SmartCoin newCoin)
 		{
-			// If it's being mixed and anonset is not sufficient, then queue it.
-			if (newCoin.Unspent && ChaumianClient.HasIngredients
-				&& newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet
-				&& ChaumianClient.State.Contains(newCoin.SpentOutputs))
+			try
 			{
-				try
+				// If it's being mixed and anonset is not sufficient, then queue it.
+				if (newCoin.Unspent && ChaumianClient.HasIngredients
+					&& newCoin.AnonymitySet < ServiceConfiguration.MixUntilAnonymitySet
+					&& ChaumianClient.State.Contains(newCoin.SpentOutputs))
 				{
 					await ChaumianClient.QueueCoinsToMixAsync(newCoin);
 				}
-				catch (Exception ex)
-				{
-					Logger.LogError(ex);
-				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError(ex);
 			}
 		}
 


### PR DESCRIPTION
In case the transaction processor raises an event that fails with an exception the processing is aborted and it could potentially kill the thread. This PR prevents such a situations. This same pattern could be used everywhere a component raises events.