### PR TITLE
Remove coins spent by replaced txs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -103,9 +103,10 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Single(transactionProcessor.Coins);
 			Assert.True(transactionProcessor.TransactionStore.MempoolStore.IsEmpty());
 			cachedTx = Assert.Single(transactionProcessor.TransactionStore.ConfirmedStore.GetTransactions());
-			Assert.NotEqual(Height.Mempool, cachedTx.Height);
+			Assert.Equal(blockHeight, cachedTx.Height);
 			coin = Assert.Single(transactionProcessor.Coins);
 			Assert.Equal(blockHeight, coin.Height);
+			Assert.True(coin.Confirmed);
 		}
 
 		[Fact]
@@ -244,12 +245,14 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			tx = CreateSpendingTransaction(createdCoin, transactionProcessor.NewKey("E").P2wpkhScript);
 			tx.Transaction.Outputs[0].Value = Money.Coins(0.9m);
 			relevant = transactionProcessor.Process(tx);
-			Assert.Equal(1, replaceTransactionReceivedCalled);
 
 			Assert.True(relevant);
+			Assert.Equal(1, replaceTransactionReceivedCalled);
 			var finalCoin = Assert.Single(transactionProcessor.Coins);
 			Assert.True(finalCoin.IsReplaceable);
 			Assert.Equal("E", finalCoin.HdPubKey.Label);
+
+			Assert.False(transactionProcessor.Coins.AsAllCoinsView().Contains(unconfirmedCoin1));
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -252,7 +252,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.True(finalCoin.IsReplaceable);
 			Assert.Equal("E", finalCoin.HdPubKey.Label);
 
-			Assert.False(transactionProcessor.Coins.AsAllCoinsView().Contains(unconfirmedCoin1));
+			Assert.DoesNotContain(unconfirmedCoin1, transactionProcessor.Coins.AsAllCoinsView());
 		}
 
 		[Fact]

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -104,9 +104,12 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 				var coinsToRemove = DescendantOfAndSelfNoLock(coin);
 				foreach (var toRemove in coinsToRemove)
 				{
-					if (Coins.Remove(toRemove))
+					if (!Coins.Remove(toRemove))
 					{
-						//Clusters.Remove(toRemove);
+						if (SpentCoins.Remove(toRemove))
+						{
+							//Clusters.Remove(toRemove);
+						}
 					}
 				}
 				InvalidateSnapshot = true;


### PR DESCRIPTION
When a transaction replace another one that is the root of a long chain of other transactions, all the coins created by those transactions that will be replaced must be removed from the spent coins list too. I've found this today during a walk-through with @yahiheb