### PR TITLE
Make Block notifications reliable

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -140,6 +140,8 @@ namespace WalletWasabi.Backend
 			var node = await Node.ConnectAsync(network, endPoint, nodeConnectionParameters);
 			// We have to find it, because it's cloned by the node and not perfectly cloned (event handlers cannot be cloned.)
 			BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), RpcClient, node.Behaviors.Find<TrustedNodeNotifyingBehavior>());
+			BlockNotifier.Start();
+
 			try
 			{
 				Logger.LogInfo("TCP Connection succeeded, handshaking...");

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.CoinJoin.Coordinator;
 using WalletWasabi.CoinJoin.Coordinator.Rounds;

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -103,6 +103,12 @@ namespace WalletWasabi.Backend
 				Logger.LogInfo($"{nameof(global.IndexBuilderService)} is disposed.");
 			}
 
+			if (global.BlockNotifier != null)
+			{
+				await global.BlockNotifier.StopAsync();
+				Logger.LogInfo($"{nameof(global.BlockNotifier)} is disposed.");
+			}
+
 			if (global.RoundConfigWatcher != null)
 			{
 				await global.RoundConfigWatcher.StopAsync();

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -21,6 +21,7 @@ using WalletWasabi.Backend;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBroadcasting;
 using WalletWasabi.Blockchain.TransactionBuilding;

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -169,7 +169,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			var indexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{rpc.Network}.dat");
 			var utxoSetFilePath = Path.Combine(indexBuilderServiceDir, $"UtxoSet{rpc.Network}.dat");
 
-			var indexBuilderService = new IndexBuilderService(rpc, global.TrustedNodeNotifyingBehavior, indexFilePath, utxoSetFilePath);
+			var indexBuilderService = new IndexBuilderService(rpc, global.BlockNotifier, indexFilePath, utxoSetFilePath);
 			try
 			{
 				indexBuilderService.Synchronize();
@@ -1838,7 +1838,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			var cjfile = Path.Combine(folder, $"CoinJoins{network}.txt");
 			File.WriteAllLines(cjfile, new[] { coinbaseTxId.ToString(), offchainTxId.ToString(), mempoolTxId.ToString() });
 
-			using (var coordinatorToTest = new Coordinator(network, global.TrustedNodeNotifyingBehavior, folder, rpc, coordinator.RoundConfig))
+			using (var coordinatorToTest = new Coordinator(network, global.BlockNotifier, folder, rpc, coordinator.RoundConfig))
 			{
 				var txIds = await File.ReadAllLinesAsync(cjfile);
 
@@ -1850,7 +1850,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Directory.CreateDirectory(folder);
 				File.WriteAllLines(cjfile, new[] { coinbaseTxId.ToString(), "This line is invalid (the file is corrupted)", offchainTxId.ToString() });
 
-				var coordinatorToTest2 = new Coordinator(network, global.TrustedNodeNotifyingBehavior, folder, rpc, coordinatorToTest.RoundConfig);
+				var coordinatorToTest2 = new Coordinator(network, global.BlockNotifier, folder, rpc, coordinatorToTest.RoundConfig);
 				coordinatorToTest2?.Dispose();
 				txIds = await File.ReadAllLinesAsync(cjfile);
 				Assert.Single(txIds);

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Stores;
@@ -122,47 +123,80 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			}
 		}
 
-		//[Fact]
-		//public async Task TrustedNotifierNotifiesBlockAsync()
-		//{
-		//	var coreNode = await TestNodeBuilder.CreateAsync();
-		//	try
-		//	{
-		//		var rpc = coreNode.RpcClient;
+		[Fact]
+		public async Task BlockNotifierTestsAsync()
+		{
+			var coreNode = await TestNodeBuilder.CreateAsync();
+			try
+			{
+				var rpc = coreNode.RpcClient;
+				BlockNotifier notifier = coreNode.BlockNotifier;
 
-		//		var addr = new Key().PubKey.GetSegwitAddress(rpc.Network);
-		//		var notifier = coreNode.TrustedNodeNotifyingBehavior;
+				// Make we get notification for one block.
+				var blockEventAwaiter = new EventAwaiter<Block>(
+					h => notifier.OnBlock += h,
+					h => notifier.OnBlock -= h);
 
-		//		var blockNum = 10;
-		//		var blockInvEventAwaiter = new EventsAwaiter<uint256>(
-		//			h => notifier.BlockInv += h,
-		//			h => notifier.BlockInv -= h,
-		//			blockNum);
+				var hash = (await rpc.GenerateAsync(1)).First();
+				var block = await blockEventAwaiter.WaitAsync(TimeSpan.FromSeconds(7));
+				Assert.Equal(hash, block.GetHash());
 
-		//		var blockEventAwaiter = new EventsAwaiter<Block>(
-		//			h => notifier.Block += h,
-		//			h => notifier.Block -= h,
-		//			blockNum);
+				// Make sure we get notifications about 10 blocks created the same time.
+				var blockNum = 10;
+				var blockEventsAwaiter = new EventsAwaiter<Block>(
+					h => notifier.OnBlock += h,
+					h => notifier.OnBlock -= h,
+					blockNum);
 
-		//		var hashes = await rpc.GenerateToAddressAsync(blockNum, addr);
+				var hashes = (await rpc.GenerateAsync(blockNum)).ToArray();
 
-		//		var aht = blockInvEventAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
-		//		var arrivedBlocks = await blockEventAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
-		//		var arrivedHashes = await aht;
+				var arrivedBlocks = (await blockEventsAwaiter.WaitAsync(TimeSpan.FromSeconds(21))).ToArray();
 
-		//		foreach (var hash in arrivedHashes)
-		//		{
-		//			Assert.Contains(hash, hashes);
-		//		}
-		//		foreach (var hash in arrivedBlocks.Select(x => x.GetHash()))
-		//		{
-		//			Assert.Contains(hash, hashes);
-		//		}
-		//	}
-		//	finally
-		//	{
-		//		await coreNode.TryStopAsync();
-		//	}
-		//}
+				for (int i = 0; i < hashes.Length; i++)
+				{
+					var expected = hashes[i];
+					var actual = arrivedBlocks[i].GetHash();
+					Assert.Equal(expected, actual);
+				}
+
+				// Make sure we get reorg notifications.
+				var reorgNum = 3;
+				var newBlockNum = reorgNum + 1;
+				var reorgEventsAwaiter = new EventsAwaiter<BlockHeader>(
+					h => notifier.OnReorg += h,
+					h => notifier.OnReorg -= h,
+					reorgNum);
+				blockNum = 10;
+				blockEventsAwaiter = new EventsAwaiter<Block>(
+					h => notifier.OnBlock += h,
+					h => notifier.OnBlock -= h,
+					newBlockNum);
+
+				var reorgedHashes = hashes.TakeLast(reorgNum).ToArray();
+				await rpc.InvalidateBlockAsync(reorgedHashes[0]);
+				var newHashes = (await rpc.GenerateAsync(newBlockNum)).ToArray();
+
+				var reorgedHeaders = (await reorgEventsAwaiter.WaitAsync(TimeSpan.FromSeconds(21))).ToArray();
+				var newBlocks = (await blockEventsAwaiter.WaitAsync(TimeSpan.FromSeconds(21))).ToArray();
+
+				for (int i = 0; i < reorgedHashes.Length; i++)
+				{
+					var expected = reorgedHashes[i];
+					var actual = reorgedHeaders[i].GetHash();
+					Assert.Equal(expected, actual);
+				}
+
+				for (int i = 0; i < newHashes.Length; i++)
+				{
+					var expected = newHashes[i];
+					var actual = newBlocks[i].GetHash();
+					Assert.Equal(expected, actual);
+				}
+			}
+			finally
+			{
+				await coreNode.TryStopAsync();
+			}
+		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -138,7 +138,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 					h => notifier.OnBlock -= h);
 
 				var hash = (await rpc.GenerateAsync(1)).First();
-				var block = await blockEventAwaiter.WaitAsync(TimeSpan.FromSeconds(7));
+				var block = await blockEventAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
 				Assert.Equal(hash, block.GetHash());
 
 				// Make sure we get notifications about 10 blocks created the same time.
@@ -166,7 +166,6 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 					h => notifier.OnReorg += h,
 					h => notifier.OnReorg -= h,
 					reorgNum);
-				blockNum = 10;
 				blockEventsAwaiter = new EventsAwaiter<Block>(
 					h => notifier.OnBlock += h,
 					h => notifier.OnBlock -= h,

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -178,6 +178,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				var reorgedHeaders = (await reorgEventsAwaiter.WaitAsync(TimeSpan.FromSeconds(21))).ToArray();
 				var newBlocks = (await blockEventsAwaiter.WaitAsync(TimeSpan.FromSeconds(21))).ToArray();
 
+				reorgedHashes = reorgedHashes.Reverse().ToArray();
 				for (int i = 0; i < reorgedHashes.Length; i++)
 				{
 					var expected = reorgedHashes[i];

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -27,6 +27,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 
 		public RegTestFixture()
 		{
+			RuntimeParams.SetDataDir(Path.Combine(Tests.Global.Instance.DataDir, nameof(RegTestFixture)));
 			RuntimeParams.LoadAsync().GetAwaiter().GetResult();
 			BackendRegTestNode = TestNodeBuilder.CreateAsync(callerMemberName: "RegTests").GetAwaiter().GetResult();
 

--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -18,6 +18,8 @@ namespace WalletWasabi.Bases
 		}
 
 		private CancellationTokenSource Stop { get; set; }
+		private CancellationTokenSource Trigger { get; set; }
+		private object TriggerLock { get; }
 		public TimeSpan Period { get; }
 		private Task ForeverTask { get; set; }
 		public Exception LastException { get; set; }
@@ -27,6 +29,8 @@ namespace WalletWasabi.Bases
 		protected PeriodicRunner(TimeSpan period, T defaultResult)
 		{
 			Stop = new CancellationTokenSource();
+			Trigger = new CancellationTokenSource();
+			TriggerLock = new object();
 			Period = period;
 			ForeverTask = Task.CompletedTask;
 			Status = defaultResult;
@@ -40,7 +44,21 @@ namespace WalletWasabi.Bases
 			LastExceptionFirstAppeared = DateTimeOffset.MinValue;
 		}
 
-		public abstract Task<T> ActionAsync(CancellationToken cancel);
+		public void TriggerRound()
+		{
+			lock (TriggerLock)
+			{
+				if (Trigger != null)
+				{
+					if (!Trigger.IsCancellationRequested)
+					{
+						Trigger.Cancel();
+					}
+				}
+			}
+		}
+
+		protected abstract Task<T> ActionAsync(CancellationToken cancel);
 
 		public void Start()
 		{
@@ -85,11 +103,24 @@ namespace WalletWasabi.Bases
 				{
 					try
 					{
-						await Task.Delay(Period, Stop.Token).ConfigureAwait(false);
+						using var linked = CancellationTokenSource.CreateLinkedTokenSource(Stop.Token, Trigger.Token);
+						await Task.Delay(Period, linked.Token).ConfigureAwait(false);
 					}
 					catch (TaskCanceledException ex)
 					{
 						Logger.LogTrace(ex);
+					}
+					finally
+					{
+						lock (TriggerLock)
+						{
+							if (Trigger.IsCancellationRequested)
+							{
+								Trigger?.Dispose();
+								Trigger = null;
+								Trigger = new CancellationTokenSource();
+							}
+						}
 					}
 				}
 			}
@@ -110,6 +141,8 @@ namespace WalletWasabi.Bases
 			await ForeverTask.ConfigureAwait(false);
 			Stop?.Dispose();
 			Stop = null;
+			Trigger?.Dispose();
+			Trigger = null;
 		}
 	}
 }

--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -48,13 +48,7 @@ namespace WalletWasabi.Bases
 		{
 			lock (TriggerLock)
 			{
-				if (Trigger != null)
-				{
-					if (!Trigger.IsCancellationRequested)
-					{
-						Trigger.Cancel();
-					}
-				}
+				Trigger?.Cancel();
 			}
 		}
 

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -172,7 +172,6 @@ namespace WalletWasabi.BitcoinCore
 					IoHelpers.EnsureContainingDirectoryExists(configPath);
 					await File.WriteAllTextAsync(configPath, coreNode.Config.ToString());
 				}
-				var configFileName = Path.GetFileName(configPath);
 
 				// If it isn't already running, then we run it.
 				if (await coreNode.RpcClient.TestAsync().ConfigureAwait(false) is null)

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 			RpcClient = Guard.NotNull(nameof(rpcClient), rpcClient);
 		}
 
-		public override async Task<AllFeeEstimate> ActionAsync(CancellationToken cancel)
+		protected override async Task<AllFeeEstimate> ActionAsync(CancellationToken cancel)
 		{
 			try
 			{

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcMonitor.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcMonitor.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 		{
 		}
 
-		public override async Task<RpcStatus> ActionAsync(CancellationToken cancel)
+		protected override async Task<RpcStatus> ActionAsync(CancellationToken cancel)
 		{
 			return await RpcClient.GetRpcStatusAsync(cancel).ConfigureAwait(false);
 		}

--- a/WalletWasabi/Blockchain/BlockFilters/History/ActionHistoryHelper.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/History/ActionHistoryHelper.cs
@@ -1,0 +1,49 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Blockchain.BlockFilters.History
+{
+	public class ActionHistoryHelper
+	{
+		private List<ActionItem> ActionHistory { get; }
+
+		public ActionHistoryHelper()
+		{
+			ActionHistory = new List<ActionItem>();
+		}
+
+		public void StoreAction(ActionItem actionItem)
+		{
+			ActionHistory.Add(actionItem);
+		}
+
+		public void StoreAction(Operation action, OutPoint outpoint, Script script)
+		{
+			StoreAction(new ActionItem(action, outpoint, script));
+		}
+
+		public void Rollback(Dictionary<OutPoint, Script> toRollBack)
+		{
+			for (var i = ActionHistory.Count - 1; i >= 0; i--)
+			{
+				ActionItem act = ActionHistory[i];
+				switch (act.Action)
+				{
+					case Operation.Add:
+						toRollBack.Remove(act.OutPoint);
+						break;
+
+					case Operation.Remove:
+						toRollBack.Add(act.OutPoint, act.Script);
+						break;
+
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			ActionHistory.Clear();
+		}
+	}
+}

--- a/WalletWasabi/Blockchain/BlockFilters/History/ActionItem.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/History/ActionItem.cs
@@ -1,0 +1,21 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Blockchain.BlockFilters.History
+{
+	public class ActionItem
+	{
+		public Operation Action { get; }
+		public OutPoint OutPoint { get; }
+		public Script Script { get; }
+
+		public ActionItem(Operation action, OutPoint outPoint, Script script)
+		{
+			Action = action;
+			OutPoint = outPoint;
+			Script = script;
+		}
+	}
+}

--- a/WalletWasabi/Blockchain/BlockFilters/History/Operation.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/History/Operation.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Blockchain.BlockFilters.History
+{
+	public enum Operation
+	{
+		Add,
+		Remove
+	}
+}

--- a/WalletWasabi/Blockchain/BlockFilters/SyncInfo.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/SyncInfo.cs
@@ -1,0 +1,25 @@
+using NBitcoin.RPC;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.Blockchain.BlockFilters
+{
+	public class SyncInfo
+	{
+		public BlockchainInfo BlockchainInfo { get; }
+		public int BlockCount { get; }
+		public DateTimeOffset BlockchainInfoUpdated { get; }
+		public bool IsCoreSynchornized { get; }
+
+		public SyncInfo(BlockchainInfo bcinfo)
+		{
+			Guard.NotNull(nameof(bcinfo), bcinfo);
+			BlockCount = (int)bcinfo.Blocks;
+			int headerCount = (int)bcinfo.Headers;
+			BlockchainInfoUpdated = DateTimeOffset.UtcNow;
+			IsCoreSynchornized = BlockCount == headerCount;
+		}
+	}
+}

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -37,11 +37,12 @@ namespace WalletWasabi.Blockchain.Blocks
 
 		private void P2pNotifier_BlockInv(object sender, uint256 blockHash)
 		{
+			TriggerRound();
 		}
 
-		public override async Task<uint256> ActionAsync(CancellationToken cancel)
+		protected override async Task<uint256> ActionAsync(CancellationToken cancel)
 		{
-			using (await Lock.LockAsync().ConfigureAwait(false))
+			using (await Lock.LockAsync(cancel).ConfigureAwait(false))
 			{
 				var bestBlockHash = await RpcClient.GetBestBlockHashAsync().ConfigureAwait(false);
 
@@ -63,6 +64,75 @@ namespace WalletWasabi.Blockchain.Blocks
 					return bestBlockHash;
 				}
 
+				// If block was already processed return.
+				if (ProcessedBlocks.Any(x => x.GetHash() == arrivedHeader.GetHash()))
+				{
+					return bestBlockHash;
+				}
+
+				// If this block follows the proper order then add.
+				if (ProcessedBlocks.Last().GetHash() == arrivedHeader.HashPrevBlock)
+				{
+					AddBlock(arrivedBlock);
+					return bestBlockHash;
+				}
+
+				// Else let's sort out things.
+				var foundPrevBlock = ProcessedBlocks.FirstOrDefault(x => x.GetHash() == arrivedHeader.HashPrevBlock);
+				// Missed notifications on some previous blocks.
+				if (foundPrevBlock != null)
+				{
+					// Reorg happened.
+					ReorgToBlock(foundPrevBlock);
+					AddBlock(arrivedBlock);
+					return bestBlockHash;
+				}
+
+				var missedBlocks = new List<Block>
+				{
+					arrivedBlock
+				};
+				var currentHeader = arrivedHeader;
+				while (true)
+				{
+					Block missedBlock = missedBlock = await RpcClient.GetBlockAsync(currentHeader.HashPrevBlock).ConfigureAwait(false);
+
+					currentHeader = missedBlock.Header;
+					currentHeader.PrecomputeHash(false, true);
+					missedBlocks.Add(missedBlock);
+
+					if (missedBlocks.Count > 100)
+					{
+						var processedBlocksClone = ProcessedBlocks.ToList();
+						ProcessedBlocks.Clear();
+						foreach (var processedBlock in processedBlocksClone)
+						{
+							OnReorg?.Invoke(this, processedBlock);
+						}
+						Logger.LogCritical("A reorg detected over 100 blocks. Wasabi cannot handle that.");
+						break;
+					}
+
+					// If we found the proper chain.
+					foundPrevBlock = ProcessedBlocks.FirstOrDefault(x => x.GetHash() == currentHeader.HashPrevBlock);
+					if (foundPrevBlock != null)
+					{
+						// If the last block hash is not what we found, then we missed a reorg also.
+						if (foundPrevBlock.GetHash() != ProcessedBlocks.Last().GetHash())
+						{
+							ReorgToBlock(foundPrevBlock);
+						}
+
+						break;
+					}
+				}
+
+				missedBlocks.Reverse();
+				foreach (var b in missedBlocks)
+				{
+					AddBlock(b);
+				}
+
 				return bestBlockHash;
 			}
 		}
@@ -71,6 +141,18 @@ namespace WalletWasabi.Blockchain.Blocks
 		{
 			ProcessedBlocks.Add(block.Header);
 			OnBlock?.Invoke(this, block);
+		}
+
+		private void ReorgToBlock(BlockHeader correctBlock)
+		{
+			var index = ProcessedBlocks.IndexOf(correctBlock);
+			int countToRemove = ProcessedBlocks.Count - (index + 1);
+			var toRemoves = ProcessedBlocks.TakeLast(countToRemove).ToList();
+			ProcessedBlocks.RemoveRange(index + 1, countToRemove);
+			foreach (var toRemove in toRemoves)
+			{
+				OnReorg?.Invoke(this, toRemove);
+			}
 		}
 
 		public new async Task StopAsync()

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -1,12 +1,15 @@
 using NBitcoin;
 using NBitcoin.RPC;
+using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
 using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
 using WalletWasabi.Services;
 
 namespace WalletWasabi.Blockchain.Blocks
@@ -19,23 +22,55 @@ namespace WalletWasabi.Blockchain.Blocks
 
 		public RPCClient RpcClient { get; set; }
 		public TrustedNodeNotifyingBehavior P2pNotifier { get; }
+		private List<BlockHeader> ProcessedBlocks { get; }
+		private AsyncLock Lock { get; } = new AsyncLock();
 
 		public BlockNotifier(TimeSpan period, RPCClient rpcClient, TrustedNodeNotifyingBehavior p2pNotifier) : base(period, null)
 		{
 			RpcClient = Guard.NotNull(nameof(rpcClient), rpcClient);
 			P2pNotifier = Guard.NotNull(nameof(p2pNotifier), p2pNotifier);
 
+			ProcessedBlocks = new List<BlockHeader>();
+
 			P2pNotifier.BlockInv += P2pNotifier_BlockInv;
 		}
 
-		private void P2pNotifier_BlockInv(object sender, uint256 e)
+		private void P2pNotifier_BlockInv(object sender, uint256 blockHash)
 		{
-			throw new NotImplementedException();
 		}
 
 		public override async Task<uint256> ActionAsync(CancellationToken cancel)
 		{
-			throw new NotImplementedException();
+			using (await Lock.LockAsync().ConfigureAwait(false))
+			{
+				var bestBlockHash = await RpcClient.GetBestBlockHashAsync().ConfigureAwait(false);
+
+				// If there's no new block.
+				// Don't notify about the genesis block.
+				if (bestBlockHash == Status || bestBlockHash == RpcClient.Network.GenesisHash)
+				{
+					return bestBlockHash;
+				}
+
+				var arrivedBlock = await RpcClient.GetBlockAsync(bestBlockHash).ConfigureAwait(false);
+				var arrivedHeader = arrivedBlock.Header;
+				arrivedHeader.PrecomputeHash(false, true);
+
+				// If we haven't processed any block yet then we're processing it without checks.
+				if (!ProcessedBlocks.Any())
+				{
+					AddBlock(arrivedBlock);
+					return bestBlockHash;
+				}
+
+				return bestBlockHash;
+			}
+		}
+
+		private void AddBlock(Block block)
+		{
+			ProcessedBlocks.Add(block.Header);
+			OnBlock?.Invoke(this, block);
 		}
 
 		public new async Task StopAsync()

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -100,9 +100,10 @@ namespace WalletWasabi.Blockchain.Blocks
 
 				if (missedBlocks.Count > 100)
 				{
-					var processedBlocksClone = ProcessedBlocks.ToList();
+					var processedBlocksClone = ProcessedBlocks.ToArray();
+					var processedReversedBlocks = processedBlocksClone.Reverse();
 					ProcessedBlocks.Clear();
-					foreach (var processedBlock in processedBlocksClone)
+					foreach (var processedBlock in processedReversedBlocks)
 					{
 						OnReorg?.Invoke(this, processedBlock);
 					}
@@ -145,6 +146,7 @@ namespace WalletWasabi.Blockchain.Blocks
 			int countToRemove = ProcessedBlocks.Count - (index + 1);
 			var toRemoves = ProcessedBlocks.TakeLast(countToRemove).ToList();
 			ProcessedBlocks.RemoveRange(index + 1, countToRemove);
+			toRemoves.Reverse();
 			foreach (var toRemove in toRemoves)
 			{
 				OnReorg?.Invoke(this, toRemove);

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -1,0 +1,47 @@
+using NBitcoin;
+using NBitcoin.RPC;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Bases;
+using WalletWasabi.Helpers;
+using WalletWasabi.Services;
+
+namespace WalletWasabi.Blockchain.Blocks
+{
+	public class BlockNotifier : PeriodicRunner<uint256>
+	{
+		public event EventHandler<Block> OnBlock;
+
+		public event EventHandler<BlockHeader> OnReorg;
+
+		public RPCClient RpcClient { get; set; }
+		public TrustedNodeNotifyingBehavior P2pNotifier { get; }
+
+		public BlockNotifier(TimeSpan period, RPCClient rpcClient, TrustedNodeNotifyingBehavior p2pNotifier) : base(period, null)
+		{
+			RpcClient = Guard.NotNull(nameof(rpcClient), rpcClient);
+			P2pNotifier = Guard.NotNull(nameof(p2pNotifier), p2pNotifier);
+
+			P2pNotifier.BlockInv += P2pNotifier_BlockInv;
+		}
+
+		private void P2pNotifier_BlockInv(object sender, uint256 e)
+		{
+			throw new NotImplementedException();
+		}
+
+		public override async Task<uint256> ActionAsync(CancellationToken cancel)
+		{
+			throw new NotImplementedException();
+		}
+
+		public new async Task StopAsync()
+		{
+			P2pNotifier.BlockInv -= P2pNotifier_BlockInv;
+			await base.StopAsync().ConfigureAwait(false);
+		}
+	}
+}

--- a/WalletWasabi/Services/ConfigWatcher.cs
+++ b/WalletWasabi/Services/ConfigWatcher.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Services
 			config.AssertFilePathSet();
 		}
 
-		public override async Task<bool> ActionAsync(CancellationToken cancel)
+		protected override async Task<bool> ActionAsync(CancellationToken cancel)
 		{
 			if (await Config.CheckFileChangeAsync().ConfigureAwait(false))
 			{

--- a/WalletWasabi/Services/TrustedNodeNotifyingBehavior.cs
+++ b/WalletWasabi/Services/TrustedNodeNotifyingBehavior.cs
@@ -19,8 +19,6 @@ namespace WalletWasabi.Services
 
 		public event EventHandler<SmartTransaction> Transaction;
 
-		public event EventHandler<Block> Block;
-
 		public TrustedNodeNotifyingBehavior()
 		{
 		}
@@ -43,10 +41,6 @@ namespace WalletWasabi.Services
 				{
 					Transaction?.Invoke(this, new SmartTransaction(txPayload.Object, Height.Mempool));
 				}
-				else if (message.Message.Payload is BlockPayload blockPayload)
-				{
-					Block?.Invoke(this, blockPayload.Object);
-				}
 				else if (message.Message.Payload is InvPayload invPayload)
 				{
 					var getDataPayload = new GetDataPayload();
@@ -61,7 +55,6 @@ namespace WalletWasabi.Services
 						if (inv.Type.HasFlag(InventoryType.MSG_BLOCK))
 						{
 							BlockInv?.Invoke(this, inv.Hash);
-							getDataPayload.Inventory.Add(inv);
 						}
 					}
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.Services
 			WasabiClient = Guard.NotNull(nameof(client), client);
 		}
 
-		public override async Task<UpdateStatus> ActionAsync(CancellationToken cancel)
+		protected override async Task<UpdateStatus> ActionAsync(CancellationToken cancel)
 		{
 			return await WasabiClient.CheckUpdatesAsync(cancel).ConfigureAwait(false);
 		}


### PR DESCRIPTION
Periodically query block notifications through RPC, except if they're triggered manually by P2P.

Closes https://github.com/zkSNACKs/WalletWasabi/pull/2523

It is a workaround for this bug/safety measure: https://github.com/bitcoin/bitcoin/issues/17451