### PR TITLE
Remove null-conditional operator

### DIFF
--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -94,31 +94,39 @@ namespace WalletWasabi.Backend
 
 		private async Task CleanupAsync(Global global)
 		{
-			global.Coordinator?.Dispose();
-			Logger.LogInfo($"{nameof(global.Coordinator)} is disposed.");
-
-			if (global.IndexBuilderService is { })
+			var coordinator = global.Coordinator;
+			if (coordinator is { })
 			{
-				await global.IndexBuilderService.StopAsync();
-				Logger.LogInfo($"{nameof(global.IndexBuilderService)} is disposed.");
+				coordinator.Dispose();
+				Logger.LogInfo($"{nameof(coordinator)} is disposed.");
 			}
 
-			if (global.BlockNotifier is { })
+			var indexBuilderService = global.IndexBuilderService;
+			if (indexBuilderService is { })
 			{
-				await global.BlockNotifier.StopAsync();
-				Logger.LogInfo($"{nameof(global.BlockNotifier)} is disposed.");
+				await indexBuilderService.StopAsync();
+				Logger.LogInfo($"{nameof(indexBuilderService)} is stopped.");
 			}
 
-			if (global.RoundConfigWatcher is { })
+			var blockNotifier = global.BlockNotifier;
+			if (blockNotifier is { })
 			{
-				await global.RoundConfigWatcher.StopAsync();
-				Logger.LogInfo($"{nameof(global.RoundConfigWatcher)} is disposed.");
+				await blockNotifier.StopAsync();
+				Logger.LogInfo($"{nameof(blockNotifier)} is stopped.");
 			}
 
-			if (global.P2pNode is { })
+			var roundConfigWatcher = global.RoundConfigWatcher;
+			if (roundConfigWatcher is { })
 			{
-				global.P2pNode.Dispose();
-				Logger.LogInfo($"{nameof(global.P2pNode)} is disposed.");
+				await roundConfigWatcher.StopAsync();
+				Logger.LogInfo($"{nameof(roundConfigWatcher)} is stopped.");
+			}
+
+			var p2pNode = global.P2pNode;
+			if (p2pNode is { })
+			{
+				p2pNode.Dispose();
+				Logger.LogInfo($"{nameof(p2pNode)} is disposed.");
 			}
 
 			Logger.LogSoftwareStopped("Wasabi Backend");

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -117,7 +117,7 @@ namespace WalletWasabi.Backend
 
 			if (global.P2pNode is { })
 			{
-				global.P2pNode?.Dispose();
+				global.P2pNode.Dispose();
 				Logger.LogInfo($"{nameof(global.P2pNode)} is disposed.");
 			}
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -603,7 +603,7 @@ namespace WalletWasabi.Gui
 					keyManager.ToFile(backupWalletFilePath);
 					Logger.LogInfo($"{nameof(walletService.KeyManager)} backup saved to `{backupWalletFilePath}`.");
 				}
-				walletService?.Dispose();
+				walletService.Dispose();
 				WalletService = null;
 				Logger.LogInfo($"{nameof(WalletService)} is stopped.");
 			}

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -155,7 +155,8 @@ namespace WalletWasabi.BitcoinCore
 		/// </summary>
 		public void Disconnect()
 		{
-			if (Node is { })
+			Node node = Node;
+			if (node is { })
 			{
 				lock (SubscriptionLock)
 				{
@@ -166,15 +167,15 @@ namespace WalletWasabi.BitcoinCore
 						{
 							TrustedP2pBehavior.BlockInv -= TrustedP2pBehavior_BlockInv;
 						}
-						Node.Disconnected -= Node_DisconnectedAsync;
-						Node.StateChanged -= P2pNode_StateChanged;
+						node.Disconnected -= Node_DisconnectedAsync;
+						node.StateChanged -= P2pNode_StateChanged;
 						NodeEventsSubscribed = false;
 					}
 				}
 
 				try
 				{
-					Node.Disconnect();
+					node.Disconnect();
 				}
 				catch (Exception ex)
 				{
@@ -184,7 +185,7 @@ namespace WalletWasabi.BitcoinCore
 				{
 					try
 					{
-						Node.Dispose();
+						node.Dispose();
 					}
 					catch (Exception ex)
 					{

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -174,7 +174,7 @@ namespace WalletWasabi.BitcoinCore
 
 				try
 				{
-					Node?.Disconnect();
+					Node.Disconnect();
 				}
 				catch (Exception ex)
 				{
@@ -184,7 +184,7 @@ namespace WalletWasabi.BitcoinCore
 				{
 					try
 					{
-						Node?.Dispose();
+						Node.Dispose();
 					}
 					catch (Exception ex)
 					{

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -163,9 +163,10 @@ namespace WalletWasabi.BitcoinCore
 					MempoolService.TrustedNodeMode = false;
 					if (NodeEventsSubscribed)
 					{
-						if (TrustedP2pBehavior is { })
+						var trustedP2pBehavior = TrustedP2pBehavior;
+						if (trustedP2pBehavior is { })
 						{
-							TrustedP2pBehavior.BlockInv -= TrustedP2pBehavior_BlockInv;
+							trustedP2pBehavior.BlockInv -= TrustedP2pBehavior_BlockInv;
 						}
 						node.Disconnected -= Node_DisconnectedAsync;
 						node.StateChanged -= P2pNode_StateChanged;


### PR DESCRIPTION
Please verify if this is correct.

In `Startup.cs` in `CleanupAsync` method we have:
```
global.Coordinator?.Dispose();
Logger.LogInfo($"{nameof(global.Coordinator)} is disposed.");
```
if `global.Coordinator` is null should we log?