### PR TITLE
Renaming "Lurking Wife" to "Shielded Screen"

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -13,7 +13,7 @@
     <converters:PhaseStringConverter x:Key="PhaseStringConverter" />
     <converters:PhaseColorConverter x:Key="PhaseColorConverter" />
     <converters:PrivacyLevelValueConverter x:Key="PrivacyLevelValueConverter" />
-    <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShieldedScreenModeStringConverter x:Key="ShieldedScreenModeStringConverter" />
     <converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
     <converters:TimeSpanStringConverter x:Key="TimeSpanStringConverter" />
     <converters:TimeSpanVisibilityConverter x:Key="TimeSpanVisibilityConverter" />
@@ -51,8 +51,8 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="4" IsVisible="{Binding AmountQueued, Converter={StaticResource CoinJoinedVisibilityConverter}}">
               <TextBlock Text="You have queued" />
-              <TextBlock Foreground="YellowGreen" IsVisible="{Binding IsLurkingWifeMode, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding AmountQueued, Converter={StaticResource MoneyStringConverter}}" />
-              <TextBlock Foreground="YellowGreen" IsVisible="{Binding IsLurkingWifeMode}" Text="{Binding AmountQueued, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+              <TextBlock Foreground="YellowGreen" IsVisible="{Binding IsShieldedScreenMode, Converter={StaticResource InverseBooleanConverter}}" Text="{Binding AmountQueued, Converter={StaticResource MoneyStringConverter}}" />
+              <TextBlock Foreground="YellowGreen" IsVisible="{Binding IsShieldedScreenMode}" Text="{Binding AmountQueued, ConverterParameter=8, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" />
               <TextBlock Foreground="YellowGreen" Text="BTC" />
               <TextBlock Text="for CoinJoin." />
             </StackPanel>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -152,10 +152,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				PeersNeeded = 100;
 			}
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
+			Global.UiConfig.WhenAnyValue(x => x.ShieldedScreenMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
 				{
 					this.RaisePropertyChanged(nameof(AmountQueued));
-					this.RaisePropertyChanged(nameof(IsLurkingWifeMode));
+					this.RaisePropertyChanged(nameof(IsShieldedScreenMode));
 				}).DisposeWith(Disposables);
 
 			Observable.Interval(TimeSpan.FromSeconds(1))
@@ -454,7 +454,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _targetPrivacy, value);
 		}
 
-		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool IsShieldedScreenMode => Global.UiConfig.ShieldedScreenMode is true;
 
 		public ReactiveCommand<Unit, Unit> EnqueueCommand { get; }
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -12,7 +12,7 @@
     <converters:CoinStatusBorderBrushConverter x:Key="CoinStatusBorderBrushConverter" />
     <converters:CoinStatusForegroundConverter x:Key="CoinStatusForegroundConverter" />
     <converters:CoinItemExpanderColorConverter x:Key="CoinItemExpanderColorConverter" />
-    <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShieldedScreenModeStringConverter x:Key="ShieldedScreenModeStringConverter" />
   </UserControl.Resources>
   <UserControl.Styles>
     <Style Selector="TextBlock">
@@ -67,7 +67,7 @@
         <StackPanel Spacing="10" DockPanel.Dock="Bottom" Orientation="Horizontal" IsVisible="{Binding IsAnyCoinSelected}">
           <TextBlock Text="|" />
           <TextBlock Text="Selected Amount:" />
-          <TextBlock Foreground="YellowGreen" Text="{Binding SelectedAmount, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}}" />
+          <TextBlock Foreground="YellowGreen" Text="{Binding SelectedAmount, ConverterParameter=8, Converter={StaticResource ShieldedScreenModeStringConverter}}" />
           <TextBlock Text="BTC" />
           <TextBlock Text="Merging unmixed coins with mixed ones undoes those mixes." Classes="warningMessage" IsVisible="{Binding LabelExposeCommonOwnershipWarning}" />
         </StackPanel>
@@ -135,11 +135,11 @@
                   <Border ToolTip.Tip="{Binding ToolTip}" Padding="1" Grid.Column="2" Background="{Binding Status, Converter={StaticResource CoinStatusColorConverter}}" BorderBrush="{Binding Status, Converter={StaticResource CoinStatusBorderBrushConverter}}" HorizontalAlignment="Left" BorderThickness="1" CornerRadius="0,6,6,0">
                     <TextBlock Text="{Binding Status, Converter={StaticResource CoinStatusStringConverter}, Mode=OneWay}" Foreground="{Binding Status, Converter={StaticResource CoinStatusForegroundConverter}}" />
                   </Border>
-                  <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+                  <TextBlock Grid.Column="3" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" />
                   <Panel Grid.Column="4" VerticalAlignment="Center" HorizontalAlignment="Center" Background="Transparent" DataContext="{Binding AnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}" ToolTip.Tip="{Binding ToolTip}">
                     <DrawingPresenter Drawing="{Binding Icon}" Height="16" Width="16" Margin="0 0 25 0" />
                   </Panel>
-                  <controls:ExtendedTextBox Grid.Column="5" Classes="selectableTextBlock" Background="Transparent" Text="{Binding Clusters, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" />
+                  <controls:ExtendedTextBox Grid.Column="5" Classes="selectableTextBlock" Background="Transparent" Text="{Binding Clusters, ConverterParameter=50, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" />
                 </Grid>
               </Grid>
             </DataTemplate>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -426,7 +426,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			RootList.AddRange(list);
 
 			Global.UiConfig
-				.WhenAnyValue(x => x.LurkingWifeMode)
+				.WhenAnyValue(x => x.ShieldedScreenMode)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => this.RaisePropertyChanged(nameof(SelectedAmount)))
 				.DisposeWith(Disposables);

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -106,7 +106,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					.DisposeWith(Disposables);
 
 				Global.UiConfig
-					.WhenAnyValue(x => x.LurkingWifeMode)
+					.WhenAnyValue(x => x.ShieldedScreenMode)
 					.ObserveOn(RxApp.MainThreadScheduler)
 					.Subscribe(_ =>
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -10,7 +10,7 @@
   </i:Interaction.Behaviors>
   <UserControl.Resources>
     <converters:MoneyBrushConverter x:Key="MoneyBrushConverter" />
-    <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShieldedScreenModeStringConverter x:Key="ShieldedScreenModeStringConverter" />
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
     <controls:GroupBox.Styles>
@@ -39,9 +39,9 @@
                   <Border Background="Transparent" IsVisible="{Binding Confirmed}" Grid.Column="0" ToolTip.Tip="{Binding Confirmations, StringFormat=\{0\} Confirmations}">
                     <DrawingPresenter HorizontalAlignment="Center" Height="16" Width="16" Stretch="Fill" Drawing="{StaticResource ConfirmationIcon}"/>
                   </Border>
-                  <TextBlock Classes="monospaceFont" Text="{Binding DateTime, ConverterParameter=11, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="1" />
-                  <TextBlock Classes="monospaceFont" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="2" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
-                  <TextBlock Classes="monospaceFont" IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding TransactionId, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Grid.Column="3" />
+                  <TextBlock Classes="monospaceFont" Text="{Binding DateTime, ConverterParameter=11, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" Grid.Column="1" />
+                  <TextBlock Classes="monospaceFont" Text="{Binding AmountBtc, ConverterParameter=8, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" Grid.Column="2" Foreground="{Binding AmountBtc, Converter={StaticResource MoneyBrushConverter}}" />
+                  <TextBlock Classes="monospaceFont" IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding TransactionId, ConverterParameter=50, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" Grid.Column="3" />
                   <Grid IsVisible="{Binding ClipboardNotificationVisible}" Grid.Column="3">
                     <Grid Opacity="{Binding ClipboardNotificationOpacity}">
                       <Grid.Transitions>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -61,7 +61,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(async _ => await TryRewriteTableAsync())
 				.DisposeWith(Disposables);
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
+			Global.UiConfig.WhenAnyValue(x => x.ShieldedScreenMode).ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ =>
 				{
 					foreach (var transaction in Transactions)
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -8,7 +8,7 @@
              x:Class="WalletWasabi.Gui.Controls.WalletExplorer.ReceiveTabView">
   <UserControl.Resources>
     <converters:CoinItemExpanderColorConverter x:Key="CoinItemExpanderColorConverter" />
-    <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShieldedScreenModeStringConverter x:Key="ShieldedScreenModeStringConverter" />
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
     <controls:GroupBox.Styles>
@@ -116,7 +116,7 @@
                     </StackPanel>
                   </Expander>
                   <Grid ColumnDefinitions="400, *, 100" Margin="30 0 0 0">
-                    <TextBlock Classes="monospaceFont" IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding Address, ConverterParameter=27, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}"></TextBlock>
+                    <TextBlock Classes="monospaceFont" IsVisible="{Binding !ClipboardNotificationVisible}" Text="{Binding Address, ConverterParameter=27, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}"></TextBlock>
                     <Grid IsVisible="{Binding ClipboardNotificationVisible}">
                       <Grid Opacity="{Binding ClipboardNotificationOpacity}">
                         <Grid.Transitions>
@@ -125,7 +125,7 @@
                         <TextBlock Text="Copied" Foreground="White" FontWeight="Bold" />
                       </Grid>
                     </Grid>
-                    <controls:EditableTextBlock VerticalAlignment="Top" Text="{Binding Label, ConverterParameter=27, Converter={StaticResource LurkingWifeModeStringConverter}}" InEditMode="{Binding InEditMode}" ReadOnlyMode="{Binding IsLurkingWifeMode}" Grid.Column="1" />
+                    <controls:EditableTextBlock VerticalAlignment="Top" Text="{Binding Label, ConverterParameter=27, Converter={StaticResource ShieldedScreenModeStringConverter}}" InEditMode="{Binding InEditMode}" ReadOnlyMode="{Binding IsShieldedScreenMode}" Grid.Column="1" />
                   </Grid>
                 </Grid>
               </DataTemplate>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerView.xaml
@@ -9,7 +9,7 @@
              x:Class="WalletWasabi.Gui.Controls.WalletExplorer.TransactionViewerView"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450">
   <UserControl.Resources>
-    <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShieldedScreenModeStringConverter x:Key="ShieldedScreenModeStringConverter" />
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
     <DockPanel LastChildFill="True">
@@ -31,19 +31,19 @@
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0 8 0 0" Spacing="5">
           <TextBlock Text="Transaction ID:" FontWeight="Bold" />
-          <controls:ExtendedTextBox Text="{Binding TxId, ConverterParameter=50, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Classes="selectableTextBlock" />
+          <controls:ExtendedTextBox Text="{Binding TxId, ConverterParameter=50, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" Classes="selectableTextBlock" />
         </StackPanel>
         <DockPanel LastChildFill="True" Grid.Row="1" Margin="0 8 0 0">
           <TextBlock DockPanel.Dock="Top" Text="PSBT Json" FontWeight="Bold" />
-          <controls:MultiTextBox Margin="0 8 0 0" Text="{Binding PsbtJsonText, ConverterParameter=1536, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" CopyOnClick="{Binding !IsLurkingWifeMode}" IsSelectable="False" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+          <controls:MultiTextBox Margin="0 8 0 0" Text="{Binding PsbtJsonText, ConverterParameter=1536, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" CopyOnClick="{Binding !IsShieldedScreenMode}" IsSelectable="False" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
         </DockPanel>
         <DockPanel LastChildFill="True" Grid.Row="2" Margin="0 8 0 0">
           <TextBlock DockPanel.Dock="Top" Text="Transaction Hex" FontWeight="Bold" />
-          <controls:MultiTextBox Margin="0 8 0 0" Text="{Binding TransactionHexText, ConverterParameter=382, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" CopyOnClick="{Binding !IsLurkingWifeMode}" IsSelectable="False" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+          <controls:MultiTextBox Margin="0 8 0 0" Text="{Binding TransactionHexText, ConverterParameter=382, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" CopyOnClick="{Binding !IsShieldedScreenMode}" IsSelectable="False" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
         </DockPanel>
         <DockPanel LastChildFill="True" Grid.Row="3" Margin="0 8 0 0">
           <TextBlock DockPanel.Dock="Top" Text="PSBT Base64 String" FontWeight="Bold" />
-          <controls:MultiTextBox Margin="0 8" VerticalAlignment="Stretch" Text="{Binding PsbtBase64Text, ConverterParameter=472, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" CopyOnClick="{Binding !IsLurkingWifeMode}" IsSelectable="False" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+          <controls:MultiTextBox Margin="0 8" VerticalAlignment="Stretch" Text="{Binding PsbtBase64Text, ConverterParameter=472, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" CopyOnClick="{Binding !IsShieldedScreenMode}" IsSelectable="False" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
         </DockPanel>
       </Grid>
     </DockPanel>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private byte[] _psbtBytes;
 		public ReactiveCommand<Unit, Unit> ExportBinaryPsbtCommand { get; set; }
 
-		public bool? IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode;
+		public bool? IsShieldedScreenMode => Global.UiConfig.ShieldedScreenMode;
 
 		public string TxId
 		{
@@ -120,11 +120,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			base.OnOpen();
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
+			Global.UiConfig.WhenAnyValue(x => x.ShieldedScreenMode)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 				{
-					this.RaisePropertyChanged(nameof(IsLurkingWifeMode));
+					this.RaisePropertyChanged(nameof(IsShieldedScreenMode));
 					this.RaisePropertyChanged(nameof(TxId));
 					this.RaisePropertyChanged(nameof(PsbtJsonText));
 					this.RaisePropertyChanged(nameof(TransactionHexText));

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -16,7 +16,7 @@
         <TreeDataTemplate DataType="ViewModels:WalletViewModel" ItemsSource="{Binding Actions}">
           <StackPanel Orientation="Horizontal" Spacing="6">
             <DrawingPresenter Width="20" Height="20" Drawing="{DynamicResource WalletExplorerView_OpenFolder}" />
-            <Button Content="{Binding Title}" Command="{Binding LurkingWifeModeCommand}" Height="19" VerticalAlignment="Center" BorderThickness="0" Margin="0" Padding="0" Background="Transparent" />
+            <Button Content="{Binding Title}" Command="{Binding ShieldedScreenModeCommand}" Height="19" VerticalAlignment="Center" BorderThickness="0" Margin="0" Padding="0" Background="Transparent" />
           </StackPanel>
         </TreeDataTemplate>
         <TreeDataTemplate DataType="ViewModels:SendTabViewModel">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
@@ -6,7 +6,7 @@
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              x:Class="WalletWasabi.Gui.Controls.WalletExplorer.WalletInfoView">
   <UserControl.Resources>
-    <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
+    <converters:ShieldedScreenModeStringConverter x:Key="ShieldedScreenModeStringConverter" />
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
@@ -40,7 +40,7 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal">
               <TextBlock Text="Extended Account Public Key: " />
-              <controls:ExtendedTextBox Text="{Binding ExtendedAccountPublicKey, ConverterParameter=60, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Classes="selectableTextBlock">
+              <controls:ExtendedTextBox Text="{Binding ExtendedAccountPublicKey, ConverterParameter=60, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" Classes="selectableTextBlock">
                 <ToolTip.Tip>
                   <TextBlock TextWrapping="Wrap" Width="400" Text="Your extended public key can be used to calculate all of your addresses and find out exactly how many coins you have in this wallet, do not share this to anyone you do not trust." />
                 </ToolTip.Tip>
@@ -48,7 +48,7 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal">
               <TextBlock Text="Extended Account zpub: " />
-              <controls:ExtendedTextBox Text="{Binding ExtendedAccountZpub, ConverterParameter=60, Converter={StaticResource LurkingWifeModeStringConverter}, Mode=OneWay}" Classes="selectableTextBlock">
+              <controls:ExtendedTextBox Text="{Binding ExtendedAccountZpub, ConverterParameter=60, Converter={StaticResource ShieldedScreenModeStringConverter}, Mode=OneWay}" Classes="selectableTextBlock">
                 <ToolTip.Tip>
                   <TextBlock TextWrapping="Wrap" Width="400" Text="Your zpub can be used to calculate all of your addresses and find out exactly how many coins you have in this wallet, do not share this to anyone you do not trust." />
                 </ToolTip.Tip>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -154,7 +154,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Closing = new CancellationTokenSource();
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
+			Global.UiConfig.WhenAnyValue(x => x.ShieldedScreenMode).Subscribe(_ =>
 				{
 					this.RaisePropertyChanged(nameof(ExtendedAccountPublicKey));
 					this.RaisePropertyChanged(nameof(ExtendedAccountZpub));

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -82,9 +82,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				historyTab.DisplayActionTab(); // So history should be shown to the user.
 			}
 
-			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>
+			ShieldedScreenModeCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
-				Global.UiConfig.LurkingWifeMode = !Global.UiConfig.LurkingWifeMode;
+				Global.UiConfig.ShieldedScreenMode = !Global.UiConfig.ShieldedScreenMode;
 				await Global.UiConfig.ToFileAsync();
 			});
 		}
@@ -94,7 +94,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 			var observed = Observable.Merge(
-				Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Select(_ => Unit.Default),
+				Global.UiConfig.WhenAnyValue(x => x.ShieldedScreenMode).Select(_ => Unit.Default),
 				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinReceived)).Select(_ => Unit.Default),
 				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpent)).Select(_ => Unit.Default))
 				.Throttle(TimeSpan.FromSeconds(1))
@@ -104,7 +104,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					Money balance = WalletService.Coins.TotalAmount();
 
-					Title = $"{Name} ({(Global.UiConfig.LurkingWifeMode ? "#########" : balance.ToString(false, true))} BTC)";
+					Title = $"{Name} ({(Global.UiConfig.ShieldedScreenMode ? "#########" : balance.ToString(false, true))} BTC)";
 				})
 				.DisposeWith(Disposables);
 
@@ -122,7 +122,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public WalletService WalletService { get; }
 
-		public ReactiveCommand<Unit, Unit> LurkingWifeModeCommand { get; }
+		public ReactiveCommand<Unit, Unit> ShieldedScreenModeCommand { get; }
 
 		public ObservableCollection<WalletActionViewModel> Actions
 		{

--- a/WalletWasabi.Gui/Converters/ShieldedScreenModeStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/ShieldedScreenModeStringConverter.cs
@@ -9,12 +9,12 @@ using System.Text;
 
 namespace WalletWasabi.Gui.Converters
 {
-	public class LurkingWifeModeStringConverter : IValueConverter
+	public class ShieldedScreenModeStringConverter : IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
 			var uiConfig = Application.Current.Resources[Global.UiConfigResourceKey] as UiConfig;
-			if (uiConfig.LurkingWifeMode is true)
+			if (uiConfig.ShieldedScreenMode is true)
 			{
 				int len = 10;
 				if (int.TryParse(parameter.ToString(), out int newLength))

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -554,7 +554,7 @@ namespace WalletWasabi.Gui
 					return;
 				}
 
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || UiConfig?.LurkingWifeMode is true)
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || UiConfig?.ShieldedScreenMode is true)
 				{
 					return;
 				}

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -95,8 +95,8 @@
                   <TextBlock VerticalAlignment="Center">Manual fee entry.</TextBlock>
                 </StackPanel>
                 <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
-                  <ToggleButton IsChecked="{Binding LurkingWifeMode}" Content="{Binding LurkingWifeMode, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" Command="{Binding LurkingWifeModeCommand}" />
-                  <TextBlock VerticalAlignment="Center">Lurking Wife Mode, hides sensitive content.</TextBlock>
+                  <ToggleButton IsChecked="{Binding ShieldedScreenMode}" Content="{Binding ShieldedScreenMode, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" Command="{Binding ShieldedScreenModeCommand}" />
+                  <TextBlock VerticalAlignment="Center">Shielded Screen Mode, hides sensitive content.</TextBlock>
                 </StackPanel>
               </StackPanel>
             </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -47,7 +47,7 @@ namespace WalletWasabi.Gui.Tabs
 		private AsyncLock ConfigLock { get; } = new AsyncLock();
 
 		public ReactiveCommand<Unit, Unit> OpenConfigFileCommand { get; }
-		public ReactiveCommand<Unit, Unit> LurkingWifeModeCommand { get; }
+		public ReactiveCommand<Unit, Unit> ShieldedScreenModeCommand { get; }
 		public ReactiveCommand<Unit, Unit> SetClearPinCommand { get; }
 		public ReactiveCommand<Unit, Unit> TextBoxLostFocusCommand { get; }
 
@@ -89,9 +89,9 @@ namespace WalletWasabi.Gui.Tabs
 
 			OpenConfigFileCommand = ReactiveCommand.Create(OpenConfigFile);
 
-			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>
+			ShieldedScreenModeCommand = ReactiveCommand.CreateFromTask(async () =>
 				{
-					Global.UiConfig.LurkingWifeMode = !LurkingWifeMode;
+					Global.UiConfig.ShieldedScreenMode = !ShieldedScreenMode;
 					await Global.UiConfig.ToFileAsync();
 				});
 
@@ -172,8 +172,8 @@ namespace WalletWasabi.Gui.Tabs
 				.DisposeWith(Disposables);
 
 			Global.UiConfig
-				.WhenAnyValue(x => x.LurkingWifeMode)
-				.Subscribe(_ => this.RaisePropertyChanged(nameof(LurkingWifeMode)))
+				.WhenAnyValue(x => x.ShieldedScreenMode)
+				.Subscribe(_ => this.RaisePropertyChanged(nameof(ShieldedScreenMode)))
 				.DisposeWith(Disposables);
 
 			_isPinSet = Global.UiConfig.WhenAnyValue(x => x.LockScreenPinHash, x => !string.IsNullOrWhiteSpace(x))
@@ -296,7 +296,7 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _dustThreshold, value);
 		}
 
-		public bool LurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool ShieldedScreenMode => Global.UiConfig.ShieldedScreenMode is true;
 
 		public string PinBoxText
 		{

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Gui
 	[JsonObject(MemberSerialization.OptIn)]
 	public class UiConfig : ConfigBase
 	{
-		private bool _lurkingWifeMode;
+		private bool _ShieldedScreenMode;
 		private bool _lockScreenActive;
 		private string _lockScreenPinHash;
 		private bool _isCustomFee;
@@ -64,11 +64,11 @@ namespace WalletWasabi.Gui
 		}
 
 		[DefaultValue(false)]
-		[JsonProperty(PropertyName = "LurkingWifeMode", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public bool LurkingWifeMode
+		[JsonProperty(PropertyName = "ShieldedScreenMode", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public bool ShieldedScreenMode
 		{
-			get => _lurkingWifeMode;
-			set => RaiseAndSetIfChanged(ref _lurkingWifeMode, value);
+			get => _ShieldedScreenMode;
+			set => RaiseAndSetIfChanged(ref _ShieldedScreenMode, value);
 		}
 
 		[DefaultValue(false)]

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -55,9 +55,9 @@ namespace WalletWasabi.Gui.ViewModels
 					}
 				});
 
-			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
+			Global.UiConfig.WhenAnyValue(x => x.ShieldedScreenMode).Subscribe(_ =>
 				{
-					this.RaisePropertyChanged(nameof(IsLurkingWifeMode));
+					this.RaisePropertyChanged(nameof(IsShieldedScreenMode));
 					this.RaisePropertyChanged(nameof(Address));
 					this.RaisePropertyChanged(nameof(Label));
 				}).DisposeWith(Disposables);
@@ -84,7 +84,7 @@ namespace WalletWasabi.Gui.ViewModels
 				.DisposeWith(Disposables);
 		}
 
-		public bool IsLurkingWifeMode => Global.UiConfig.LurkingWifeMode is true;
+		public bool IsShieldedScreenMode => Global.UiConfig.ShieldedScreenMode is true;
 
 		public bool ClipboardNotificationVisible
 		{
@@ -109,7 +109,7 @@ namespace WalletWasabi.Gui.ViewModels
 			get => _label;
 			set
 			{
-				if (!IsLurkingWifeMode)
+				if (!IsShieldedScreenMode)
 				{
 					this.RaiseAndSetIfChanged(ref _label, value);
 				}


### PR DESCRIPTION
Changes variable names, converter name, file name, and text references.

"Lurking Wife Mode" as explained in #2234: "It is intended to use it in public areas like coffee places."

The name, while somewhat amusing as harmless fun, is also vaguely off-putting as it makes unnecessary assumptions about the typical Wasabi Wallet user.

This PR changes all "Lurking Wife" references (those visible in the UI and internally in the code) to more neutral "Shielded Screen" language. This change has the added benefit of being slightly more descriptive of this mode's purpose. If a different, more descriptive or preferred alternate name is suggested, I'll be happy to update this PR with that change.

Matching PR update to the docs will be on its way.

Compiled and verified on macOS 10.15.