### PR TITLE
Unit tests for BlockNotifier

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -103,7 +103,8 @@ namespace WalletWasabi.Backend
 			// We have to find it, because it's cloned by the node and not perfectly cloned (event handlers cannot be cloned.)
 			P2pNode = new P2pNode(network, endPoint, new MempoolService(), $"/WasabiCoordinator:{Constants.BackendMajorVersion.ToString()}/");
 			await P2pNode.ConnectAsync(cancel).ConfigureAwait(false);
-			BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), RpcClient, P2pNode);
+			BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), new RpcWrappedClient(RpcClient));
+			P2pNode.BlockInv += (s, e) => BlockNotifier.TriggerRound();
 			BlockNotifier.Start();
 		}
 

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -103,8 +103,7 @@ namespace WalletWasabi.Backend
 			// We have to find it, because it's cloned by the node and not perfectly cloned (event handlers cannot be cloned.)
 			P2pNode = new P2pNode(network, endPoint, new MempoolService(), $"/WasabiCoordinator:{Constants.BackendMajorVersion.ToString()}/");
 			await P2pNode.ConnectAsync(cancel).ConfigureAwait(false);
-			BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), new RpcWrappedClient(RpcClient));
-			P2pNode.BlockInv += (s, e) => BlockNotifier.TriggerRound();
+			BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), new RpcWrappedClient(RpcClient), P2pNode);
 			BlockNotifier.Start();
 		}
 

--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.BitcoinCore;
+using WalletWasabi.Blockchain.Blocks;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests
+{
+	public class BlockNotifierTests
+	{
+		[Fact]
+		public async Task GenesisBlockOny()
+		{
+			var chain = new ConcurrentChain(Network.RegTest);
+			var notifier = CreateNotifier(chain);
+			var blockAwaiter = new EventAwaiter<Block>(
+				h => notifier.OnBlock += h,
+				h => notifier.OnBlock -= h);
+			var reorgAwaiter = new EventAwaiter<BlockHeader>(
+				h => notifier.OnReorg += h,
+				h => notifier.OnReorg -= h);
+
+			notifier.Start();
+
+			// No block notifications nor reorg notifications
+			await Assert.ThrowsAsync<OperationCanceledException>(() => blockAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+			await Assert.ThrowsAsync<OperationCanceledException>(() => reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+
+			Assert.Equal(Network.RegTest.GenesisHash, notifier.Status);
+
+			await notifier.StopAsync();
+		}
+
+		[Fact]
+		public async Task HitGenesisBlockDuringInitialization()
+		{
+			var chain = new ConcurrentChain(Network.RegTest);
+			foreach(var n in Enumerable.Range(0, 3))
+			{
+				await AddBlockAsync(chain);
+			}
+			var notifier = CreateNotifier(chain);
+			var blockAwaiter = new EventAwaiter<Block>(
+				h => notifier.OnBlock += h,
+				h => notifier.OnBlock -= h);
+			var reorgAwaiter = new EventAwaiter<BlockHeader>(
+				h => notifier.OnReorg += h,
+				h => notifier.OnReorg -= h);
+
+			notifier.Start();
+
+			// No block notifications nor reorg notifications
+			await Assert.ThrowsAsync<OperationCanceledException>(() => blockAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+			await Assert.ThrowsAsync<OperationCanceledException>(() => reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+
+			Assert.Equal(chain.Tip.HashBlock, notifier.Status);
+
+			await notifier.StopAsync();
+		}
+
+		[Fact]
+		public async Task NotifyBlocks()
+		{
+			var chain = new ConcurrentChain(Network.RegTest);
+			var notifier = CreateNotifier(chain);
+			var blockCount = 3;
+
+			var reorgAwaiter = new EventAwaiter<BlockHeader>(
+				h => notifier.OnReorg += h,
+				h => notifier.OnReorg -= h);
+
+			notifier.Start();
+
+			// Assert that the blocks come in the right order
+			var height = 0;
+			EventHandler<Block> onBlockInv = (s, b) => Assert.Equal(b.GetHash(), chain.GetBlock(height++).HashBlock);
+			notifier.OnBlock += onBlockInv;
+
+			foreach(var n in Enumerable.Range(0, blockCount))
+			{
+				await AddBlockAsync(chain);
+			}
+
+			notifier.TriggerRound();
+			await Task.Delay(TimeSpan.FromMilliseconds(100)); // give it time to process the blocks
+
+			// Three blocks notifications  
+			Assert.Equal(chain.Height, height);
+
+			// No reorg notifications
+			await Assert.ThrowsAsync<OperationCanceledException>(() => reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+			Assert.Equal(chain.Tip.HashBlock, notifier.Status);
+
+
+			notifier.OnBlock -= onBlockInv;
+			await notifier.StopAsync();
+		}
+
+		[Fact]
+		public async Task SimpleReorg()
+		{
+			var chain = new ConcurrentChain(Network.RegTest);
+			var notifier = CreateNotifier(chain);
+
+			var blockAwaiter = new EventsAwaiter<Block>(
+				h => notifier.OnBlock += h,
+				h => notifier.OnBlock -= h,
+				5);
+
+			var reorgAwaiter = new EventAwaiter<BlockHeader>(
+				h => notifier.OnReorg += h,
+				h => notifier.OnReorg -= h);
+
+			notifier.Start();
+
+			await AddBlockAsync(chain);
+			var forkPoint = chain.Tip;
+			var blockToBeReorged = await AddBlockAsync(chain);
+
+			chain.SetTip(forkPoint);
+			await AddBlockAsync(chain, wait: false);
+			await AddBlockAsync(chain, wait: false);
+			await AddBlockAsync(chain);
+			notifier.TriggerRound();
+
+			// Three blocks notifications  
+			await blockAwaiter.WaitAsync(TimeSpan.FromSeconds(2));
+
+			// No reorg notifications
+			var reorgedkBlock = await reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1));
+			Assert.Equal(forkPoint.HashBlock, reorgedkBlock.HashPrevBlock);
+			Assert.Equal(blockToBeReorged.HashBlock, reorgedkBlock.GetHash());
+			Assert.Equal(chain.Tip.HashBlock, notifier.Status);
+
+			await notifier.StopAsync();
+		}
+
+		[Fact]
+		public async Task LongChainReorg()
+		{
+			var chain = new ConcurrentChain(Network.RegTest);
+			var notifier = CreateNotifier(chain);
+
+			var blockAwaiter = new EventsAwaiter<Block>(
+				h => notifier.OnBlock += h,
+				h => notifier.OnBlock -= h,
+				11);
+
+			var reorgAwaiter = new EventsAwaiter<BlockHeader>(
+				h => notifier.OnReorg += h,
+				h => notifier.OnReorg -= h,
+				3);
+
+			notifier.Start();
+
+			await AddBlockAsync(chain);
+
+			var forkPoint = chain.Tip;
+			var firstReorgedChain = new[]
+			{
+				await AddBlockAsync(chain, wait: false),
+				await AddBlockAsync(chain)
+			};
+
+			chain.SetTip(forkPoint);
+			var secondReorgedChain = new[]
+			{
+				await AddBlockAsync(chain, wait: false),
+				await AddBlockAsync(chain, wait: false),
+				await AddBlockAsync(chain)
+			};
+
+			chain.SetTip(secondReorgedChain[1]);
+			await AddBlockAsync(chain, wait: false);
+			await AddBlockAsync(chain, wait: false);
+			await AddBlockAsync(chain, wait: false);
+			await AddBlockAsync(chain, wait: false);
+			await AddBlockAsync(chain);
+
+			// Three blocks notifications  
+			await blockAwaiter.WaitAsync(TimeSpan.FromSeconds(2));
+
+			// No reorg notifications
+			var reorgedkBlock = await reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1));
+			var expectedReorgedBlocks = firstReorgedChain.ToList().Concat(new[]{ secondReorgedChain[2]});
+			Assert.Subset(reorgedkBlock.Select(x=>x.GetHash()).ToHashSet(), expectedReorgedBlocks.Select(x=>x.Header.GetHash()).ToHashSet());
+			Assert.Equal(chain.Tip.HashBlock, notifier.Status);
+
+			await notifier.StopAsync();
+		}
+
+
+		[Fact]
+		public async Task SuperFastNodeValidation()
+		{
+			var chain = new ConcurrentChain(Network.RegTest);
+			var notifier = CreateNotifier(chain);
+			var blockAwaiter = new EventsAwaiter<Block>(
+				h => notifier.OnBlock += h,
+				h => notifier.OnBlock -= h,
+				144);
+
+			notifier.Start();
+
+			var lastKnownBlock = await AddBlockAsync(chain);
+
+			foreach(var i in Enumerable.Range(0, 200))
+			{
+				await AddBlockAsync(chain, wait: false);
+			}
+			await AddBlockAsync(chain, wait: true);
+			notifier.TriggerRound();
+			
+			Assert.Equal(chain.Tip.HashBlock, notifier.Status);
+
+			var nofifiedBlocks = (await blockAwaiter.WaitAsync(TimeSpan.FromSeconds(1))).ToArray();
+			
+			var tip = chain.Tip;
+			var pos = nofifiedBlocks.Length -1;
+			while( tip.HashBlock != nofifiedBlocks[pos].GetHash())
+			{
+				tip = tip.Previous;
+			}
+
+			while(pos >= 0)
+			{
+				Assert.Equal(tip.HashBlock, nofifiedBlocks[pos].GetHash());
+				tip = tip.Previous;
+				pos--;
+			}
+
+			await notifier.StopAsync();
+		}
+
+		private BlockNotifier CreateNotifier(ConcurrentChain chain)
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBestBlockHashAsync = () => Task.FromResult(chain.Tip.HashBlock);
+			rpc.OnGetBlockAsync = (blockHash) => Task.FromResult(Block.CreateBlock(chain.GetBlock(blockHash).Header, rpc.Network));
+			rpc.OnGetBlockHeaderAsync = (blockHash) => Task.FromResult(chain.GetBlock(blockHash).Header);
+
+			var notifier = new BlockNotifier(TimeSpan.FromMilliseconds(100), rpc);
+			return notifier;
+		}
+
+		private async Task<ChainedBlock> AddBlockAsync(ConcurrentChain chain, bool wait = true)
+		{
+			BlockHeader header = Network.RegTest.Consensus.ConsensusFactory.CreateBlockHeader();
+			header.Nonce = RandomUtils.GetUInt32();
+			header.HashPrevBlock = chain.Tip.HashBlock;
+			chain.SetTip(header);
+			var block = chain.GetBlock(header.GetHash());
+			if (wait)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+			}
+			return block;
+		}
+	}
+
+	class MockRpcClient : IRPCClient
+	{
+		public Func<Task<uint256>> OnGetBestBlockHashAsync { get; set; }
+		public Func<uint256, Task<Block>> OnGetBlockAsync { get; set; }
+		public Func<uint256, Task<BlockHeader>> OnGetBlockHeaderAsync { get; set; }
+
+		public Network Network => Network.RegTest;
+
+		public Task<uint256> GetBestBlockHashAsync()
+		{
+			return OnGetBestBlockHashAsync();;
+		}
+
+		public Task<Block> GetBlockAsync(uint256 blockId)
+		{
+			return OnGetBlockAsync(blockId);
+		}
+
+		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		{
+			return OnGetBlockHeaderAsync(blockHash);
+		}
+	}
+}

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -191,18 +191,12 @@ namespace WalletWasabi.BitcoinCore
 
 				coreNode.P2pNode = new P2pNode(coreNode.Network, coreNode.P2pEndPoint, coreNode.MempoolService, coreNodeParams.UserAgent);
 				await coreNode.P2pNode.ConnectAsync(cancel).ConfigureAwait(false);
-				coreNode.BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), new RpcWrappedClient(coreNode.RpcClient));
-				coreNode.P2pNode.BlockInv += coreNode.OnP2pBlockInv; 
-				
+				coreNode.BlockNotifier = new BlockNotifier(TimeSpan.FromSeconds(7), new RpcWrappedClient(coreNode.RpcClient), coreNode.P2pNode);
+
 				coreNode.BlockNotifier.Start();
 
 				return coreNode;
 			}
-		}
-
-		private void OnP2pBlockInv(object sender, uint256 e)
-		{
-			BlockNotifier.TriggerRound();
 		}
 
 		public static async Task<Version> GetVersionAsync(CancellationToken cancel)
@@ -249,7 +243,6 @@ namespace WalletWasabi.BitcoinCore
 				var p2pNode = P2pNode;
 				if (p2pNode is { })
 				{
-					p2pNode.BlockInv -= OnP2pBlockInv;
 					p2pNode.Dispose();
 				}
 				_disposedValue = true;

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -240,11 +240,7 @@ namespace WalletWasabi.BitcoinCore
 				{
 					await blockNotifier.StopAsync().ConfigureAwait(false);
 				}
-				var p2pNode = P2pNode;
-				if (p2pNode is { })
-				{
-					p2pNode.Dispose();
-				}
+				P2pNode?.Dispose();
 				_disposedValue = true;
 			}
 		}

--- a/WalletWasabi/BitcoinCore/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/IRPCClient.cs
@@ -1,0 +1,42 @@
+﻿using NBitcoin;
+using NBitcoin.RPC;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.BitcoinCore
+{
+	public interface IRPCClient 
+	{
+		Network Network { get; }
+		Task<uint256> GetBestBlockHashAsync();
+		Task<Block> GetBlockAsync(uint256 blockId);
+		Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash);
+
+	}
+
+	public class RpcWrappedClient : IRPCClient
+	{
+		private RPCClient Rpc { get; }
+
+		public RpcWrappedClient(RPCClient rpc)
+		{
+			Rpc = rpc;
+		}
+		
+		public Network Network => Rpc.Network;
+
+		public Task<uint256> GetBestBlockHashAsync()
+		{
+			return Rpc.GetBestBlockHashAsync();
+		}
+
+		public Task<Block> GetBlockAsync(uint256 blockId)
+		{
+			return Rpc.GetBlockAsync(blockId);
+		}
+
+		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		{
+			return Rpc.GetBlockHeaderAsync(blockHash);
+		}
+	}
+}

--- a/WalletWasabi/BitcoinCore/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/IRPCClient.cs
@@ -1,5 +1,4 @@
 ﻿using NBitcoin;
-using NBitcoin.RPC;
 using System.Threading.Tasks;
 
 namespace WalletWasabi.BitcoinCore
@@ -10,33 +9,5 @@ namespace WalletWasabi.BitcoinCore
 		Task<uint256> GetBestBlockHashAsync();
 		Task<Block> GetBlockAsync(uint256 blockId);
 		Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash);
-
-	}
-
-	public class RpcWrappedClient : IRPCClient
-	{
-		private RPCClient Rpc { get; }
-
-		public RpcWrappedClient(RPCClient rpc)
-		{
-			Rpc = rpc;
-		}
-		
-		public Network Network => Rpc.Network;
-
-		public Task<uint256> GetBestBlockHashAsync()
-		{
-			return Rpc.GetBestBlockHashAsync();
-		}
-
-		public Task<Block> GetBlockAsync(uint256 blockId)
-		{
-			return Rpc.GetBlockAsync(blockId);
-		}
-
-		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
-		{
-			return Rpc.GetBlockHeaderAsync(blockHash);
-		}
 	}
 }

--- a/WalletWasabi/BitcoinCore/RpcWrappedClient.cs
+++ b/WalletWasabi/BitcoinCore/RpcWrappedClient.cs
@@ -12,22 +12,22 @@ namespace WalletWasabi.BitcoinCore
 		{
 			Rpc = rpc;
 		}
-		
+
 		public Network Network => Rpc.Network;
 
-		public Task<uint256> GetBestBlockHashAsync()
+		public async Task<uint256> GetBestBlockHashAsync()
 		{
-			return Rpc.GetBestBlockHashAsync();
+			return await Rpc.GetBestBlockHashAsync().ConfigureAwait(false);
 		}
 
-		public Task<Block> GetBlockAsync(uint256 blockId)
+		public async Task<Block> GetBlockAsync(uint256 blockId)
 		{
-			return Rpc.GetBlockAsync(blockId);
+			return await Rpc.GetBlockAsync(blockId).ConfigureAwait(false);
 		}
 
-		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		public async Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
 		{
-			return Rpc.GetBlockHeaderAsync(blockHash);
+			return await Rpc.GetBlockHeaderAsync(blockHash).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/BitcoinCore/RpcWrappedClient.cs
+++ b/WalletWasabi/BitcoinCore/RpcWrappedClient.cs
@@ -1,0 +1,33 @@
+using NBitcoin;
+using NBitcoin.RPC;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.BitcoinCore
+{
+	public class RpcWrappedClient : IRPCClient
+	{
+		private RPCClient Rpc { get; }
+
+		public RpcWrappedClient(RPCClient rpc)
+		{
+			Rpc = rpc;
+		}
+		
+		public Network Network => Rpc.Network;
+
+		public Task<uint256> GetBestBlockHashAsync()
+		{
+			return Rpc.GetBestBlockHashAsync();
+		}
+
+		public Task<Block> GetBlockAsync(uint256 blockId)
+		{
+			return Rpc.GetBlockAsync(blockId);
+		}
+
+		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		{
+			return Rpc.GetBlockHeaderAsync(blockHash);
+		}
+	}
+}

--- a/WalletWasabi/BitcoinCore/RpcWrappedClient.cs
+++ b/WalletWasabi/BitcoinCore/RpcWrappedClient.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using NBitcoin.RPC;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.BitcoinCore
 {
@@ -10,7 +11,7 @@ namespace WalletWasabi.BitcoinCore
 
 		public RpcWrappedClient(RPCClient rpc)
 		{
-			Rpc = rpc;
+			Rpc = Guard.NotNull(nameof(rpc), rpc);
 		}
 
 		public Network Network => Rpc.Network;

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -22,22 +22,14 @@ namespace WalletWasabi.Blockchain.Blocks
 
 		public event EventHandler<BlockHeader> OnReorg;
 
-		public RPCClient RpcClient { get; set; }
+		public IRPCClient RpcClient { get; set; }
 		public Network Network => RpcClient.Network;
 		private List<BlockHeader> ProcessedBlocks { get; }
-		public P2pNode P2pNode { get; }
 
-		public BlockNotifier(TimeSpan period, RPCClient rpcClient, P2pNode p2pNode) : base(period, null)
+		public BlockNotifier(TimeSpan period, IRPCClient rpcClient) : base(period, null)
 		{
 			RpcClient = Guard.NotNull(nameof(rpcClient), rpcClient);
-			P2pNode = p2pNode;
 			ProcessedBlocks = new List<BlockHeader>();
-			P2pNode.BlockInv += P2pNode_BlockInv;
-		}
-
-		private void P2pNode_BlockInv(object sender, uint256 blockHash)
-		{
-			TriggerRound();
 		}
 
 		protected override async Task<uint256> ActionAsync(CancellationToken cancel)
@@ -191,7 +183,6 @@ namespace WalletWasabi.Blockchain.Blocks
 
 		public new async Task StopAsync()
 		{
-			P2pNode.BlockInv -= P2pNode_BlockInv;
 			await base.StopAsync().ConfigureAwait(false);
 		}
 	}


### PR DESCRIPTION
This PR contains unit tests for the `BlockNotifier` class in order to be able to validate its correctness as part of the continuous integration process. These are no a replace for the existing integration tests.

In order to be able to unittest it, it was necessary to isolate the component from external dependencies like the RPC client and the P2pNode.  