### PR TITLE
Test TransactionStore states

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionProcessor.cs
@@ -112,6 +112,11 @@ namespace WalletWasabi.Blockchain.Transactions
 
 							ReplaceTransactionReceived?.Invoke(this, new ReplaceTransactionReceivedEventArgs(tx, destroyed, restored));
 
+							foreach(var replacedTransactionId in destroyed.Select(coin => coin.TransactionId))
+							{
+								TransactionStore.MempoolStore.TryRemove(replacedTransactionId, out _);
+							}
+
 							tx.SetReplacement();
 							walletRelevant = true;
 						}

--- a/WalletWasabi/Blockchain/Transactions/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionProcessor.cs
@@ -130,6 +130,9 @@ namespace WalletWasabi.Blockchain.Transactions
 						}
 
 						DoubleSpendReceived?.Invoke(this, new DoubleSpendReceivedEventArgs(tx, doubleSpends));
+
+						var unconfirmedDoubleSpentTxId = doubleSpends.First().TransactionId;
+						TransactionStore.MempoolStore.TryRemove(unconfirmedDoubleSpentTxId, out _);
 						walletRelevant = true;
 					}
 				}


### PR DESCRIPTION
This PR add asserts to the current tests in order to verify the `TransactionStore` state is always correct.   