### PR TITLE
Select clusters already known by the receiver

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/Clustering/Cluster.cs
+++ b/WalletWasabi/Blockchain/Analysis/Clustering/Cluster.cs
@@ -51,6 +51,15 @@ namespace WalletWasabi.Blockchain.Analysis.Clustering
 			}
 		}
 
+		internal bool IsKnownBy(string userOrEntity)
+		{
+			if(string.IsNullOrWhiteSpace(userOrEntity))
+			{
+				return false;
+			}
+			return Labels.Any(label => string.Equals(label, userOrEntity, StringComparison.OrdinalIgnoreCase));
+		}
+
 		#region EqualityAndComparison
 
 		public override bool Equals(object obj) => obj is Cluster clus && this == clus;

--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -14,10 +14,12 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 	public class SmartCoinSelector : ICoinSelector
 	{
 		private IEnumerable<SmartCoin> UnspentCoins { get; }
+		private string Receiver { get; }
 
-		public SmartCoinSelector(IEnumerable<SmartCoin> unspentCoins)
+		public SmartCoinSelector(IEnumerable<SmartCoin> unspentCoins, string receiver = null)
 		{
 			UnspentCoins = Guard.NotNull(nameof(unspentCoins), unspentCoins).Distinct();
+			Receiver = receiver;
 		}
 
 		public IEnumerable<ICoin> Select(IEnumerable<ICoin> coins, IMoney target)
@@ -33,6 +35,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 			// Get unique clusters.
 			IEnumerable<Cluster> uniqueClusters = UnspentCoins
 				.Select(coin => coin.Clusters)
+				.Where(cluster => Receiver is {} ? cluster.IsKnownBy(Receiver) : true )
 				.Distinct();
 
 			// Build all the possible coin clusters, except when it's computationally too expensive.


### PR DESCRIPTION
This is WIP to create a smarter `SmartCoinSelector` which can select coins in clusters already known by the receiver. This same class can be used in the future to help the user to select the best combination of coins for a transaction given a receiver and an amount.