### PR TITLE
Use expression body for lambdas => Suggestion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -104,7 +104,7 @@ csharp_prefer_braces = true:error
 dotnet_style_readonly_field = false:error
 
 # use expression body for lambdas
-csharp_style_expression_bodied_lambdas = true:error
+csharp_style_expression_bodied_lambdas = true:suggestion
 
 # IDE0066: Convert switch statement to expression
 csharp_style_prefer_switch_expression = true:error


### PR DESCRIPTION
Sometimes it is much better to have a body for lambdas. Let the coder decide. 

![image](https://user-images.githubusercontent.com/9844978/69474266-f49a6b80-0df9-11ea-9ef4-c62c042db683.png)
