### PR TITLE
Simplify GroupBox

### DIFF
--- a/WalletWasabi.Gui/Controls/GroupBox.cs
+++ b/WalletWasabi.Gui/Controls/GroupBox.cs
@@ -10,13 +10,8 @@ using System.Text;
 
 namespace WalletWasabi.Gui.Controls
 {
-	public class GroupBox : ContentControl, IStyleable
+	public class GroupBox : ContentControl
 	{
-		private ContentPresenter _titlePresenter;
-		private Border _border;
-
-		Type IStyleable.StyleKey => typeof(GroupBox);
-
 		public static readonly StyledProperty<object> TitleProperty =
 			AvaloniaProperty.Register<GroupBox, object>(nameof(Title));
 
@@ -24,25 +19,6 @@ namespace WalletWasabi.Gui.Controls
 		{
 			get => GetValue(TitleProperty);
 			set => SetValue(TitleProperty, value);
-		}
-
-		protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
-		{
-			base.OnTemplateApplied(e);
-
-			_titlePresenter = e.NameScope.Find<ContentPresenter>("PART_TitlePresenter");
-
-			_border = e.NameScope.Find<Border>("PART_Border");
-		}
-
-		protected override Size ArrangeOverride(Size finalSize)
-		{
-			_border.Margin = new Thickness(0, -(_titlePresenter.DesiredSize.Height / 3), 0, 0);
-			_border.Padding = new Thickness(0, (_titlePresenter.DesiredSize.Height / 3), 0, 0);
-
-			_titlePresenter.Margin = new Thickness(Padding.Left, 0, 0, 0);
-
-			return base.ArrangeOverride(finalSize);
 		}
 	}
 }

--- a/WalletWasabi.Gui/Controls/GroupBox.xaml
+++ b/WalletWasabi.Gui/Controls/GroupBox.xaml
@@ -1,21 +1,21 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui" 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
   xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+  <!-- This source file contains a derivative code from the Windows Presentation Foundation project (https://github.com/dotnet/wpf/). Derivative use with attribution is permitted under the terms of MIT License, courtesy of the .NET Foundation. -->
   <Style Selector="local|GroupBox">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
-    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Template">
-      <ControlTemplate>
-        <Grid UseLayoutRounding="True" ColumnDefinitions="6,Auto,*,6" RowDefinitions="Auto,Auto,*,6">
-          <Border CornerRadius="4" Grid.Row="1" Grid.RowSpan="3" Grid.Column="0" Grid.ColumnSpan="4" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" Background="{TemplateBinding Background}" />
-          <Border CornerRadius="4" Grid.Row="1" Grid.RowSpan="3" Grid.ColumnSpan="4" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" />
-          <Border x:Name="Header" Padding="3,0,3,0" Grid.Row="0" Grid.RowSpan="2" Grid.Column="1">
-            <ContentPresenter Content="{TemplateBinding Title}" />
-          </Border>
-          <ContentPresenter Content="{TemplateBinding Content}" /> 
-        </Grid>
-      </ControlTemplate>
+      <Setter.Value>
+        <ControlTemplate>
+          <Grid ColumnDefinitions="6,Auto,*,6" RowDefinitions="Auto,Auto,*,6">
+            <Border Grid.Row="1" Grid.RowSpan="3" Grid.ColumnSpan="4" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" />
+            <ContentPresenter Padding="3" Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Background="{TemplateBinding Background}" Content="{TemplateBinding Title}" />
+            <ContentPresenter Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Margin="{TemplateBinding Padding}" Content="{TemplateBinding Content}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
     </Setter>
   </Style>
 </Styles>

--- a/WalletWasabi.Gui/Controls/GroupBox.xaml
+++ b/WalletWasabi.Gui/Controls/GroupBox.xaml
@@ -1,6 +1,6 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui" 
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-  xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <!-- This source file contains a derivative code from the Windows Presentation Foundation project (https://github.com/dotnet/wpf/). Derivative use with attribution is permitted under the terms of MIT License, courtesy of the .NET Foundation. -->
   <Style Selector="local|GroupBox">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />

--- a/WalletWasabi.Gui/Controls/GroupBox.xaml
+++ b/WalletWasabi.Gui/Controls/GroupBox.xaml
@@ -1,31 +1,20 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
+﻿<Styles xmlns="https://github.com/avaloniaui" 
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+  xmlns:local="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui">
   <Style Selector="local|GroupBox">
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Template">
       <ControlTemplate>
-        <DockPanel LastChildFill="True">
-          <ContentPresenter
-            Name="PART_TitlePresenter"
-            DockPanel.Dock="Top"
-            Background="{TemplateBinding Background}"
-            Content="{TemplateBinding Title}"
-            HorizontalAlignment="Left"
-            ZIndex="1"
-            Padding="10 0 10 0" />
-          <Border Name="PART_Border" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{DynamicResource ThemeBorderLowBrush}">
-            <ContentPresenter
-              Name="PART_ContentPresenter"
-              Background="{TemplateBinding Background}"
-              ContentTemplate="{TemplateBinding ContentTemplate}"
-              Content="{TemplateBinding Content}"
-              Padding="{TemplateBinding Padding}"
-              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+        <Grid UseLayoutRounding="True" ColumnDefinitions="6,Auto,*,6" RowDefinitions="Auto,Auto,*,6">
+          <Border CornerRadius="4" Grid.Row="1" Grid.RowSpan="3" Grid.Column="0" Grid.ColumnSpan="4" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" Background="{TemplateBinding Background}" />
+          <Border CornerRadius="4" Grid.Row="1" Grid.RowSpan="3" Grid.ColumnSpan="4" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" />
+          <Border x:Name="Header" Padding="3,0,3,0" Grid.Row="0" Grid.RowSpan="2" Grid.Column="1">
+            <ContentPresenter Content="{TemplateBinding Title}" />
           </Border>
-        </DockPanel>
+          <ContentPresenter Content="{TemplateBinding Content}" /> 
+        </Grid>
       </ControlTemplate>
     </Setter>
   </Style>


### PR DESCRIPTION
Simplifying GroupBox by just using grid col/rows instead of hacking around the arrange methods. Grid alignment is derived from WPF's PresentationFramework.Aero style xaml.

cc: @nopara73 @molnard 