### PR TITLE
Fix Missing Member exceptions in Logs from Wallet Manager tab

### DIFF
--- a/WalletWasabi.Gui/Converters/ErrorDescriptorToBorderColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/ErrorDescriptorToBorderColorConverter.cs
@@ -17,17 +17,9 @@ namespace WalletWasabi.Gui.Converters
 			{
 				var descriptors = new ErrorDescriptors();
 
-				foreach (var obj in rawObj)
+				foreach (var error in rawObj.OfType<ErrorDescriptor>())
 				{
-					switch (obj)
-					{
-						case ErrorDescriptor ed:
-							descriptors.Add(ed);
-							break;
-						case Exception ex:
-							Logger.LogError(ex);
-							break;
-					}
+					descriptors.Add(error);
 				}
 
 				return GetColorFromDescriptors(descriptors);


### PR DESCRIPTION
Iv stopped the border converter printing exceptions because:

1) It shouldnt be the responsibility of a converter to intercept and log exceptions.
2) These exceptions are not uncaught exceptions.
3) Avalonia handles these internally. Its an allowed state when you have changed your datacontext, but not updated your UI.

This now has the same behavior as previous version of Wasabi.

Closes https://github.com/zkSNACKs/WalletWasabi/issues/2513
Closes https://github.com/zkSNACKs/WalletWasabi/issues/2552