### PR TITLE
Log Mempool dis-acceptance reason on Backend

### DIFF
--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -1204,6 +1204,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 					{
 						alicesRemoved.Add(t.alice);
 						Alices.Remove(t.alice);
+						Logger.LogInfo($"Mempool acceptance failed: {result.reason}.");
 					}
 				}
 			}

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -1204,7 +1204,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 					{
 						alicesRemoved.Add(t.alice);
 						Alices.Remove(t.alice);
-						Logger.LogInfo($"Mempool acceptance failed: {result.reason}.");
+						Logger.LogInfo($"Mempool acceptance failed: {result.reason ?? "no reason"}.");
 					}
 				}
 			}


### PR DESCRIPTION
We receive `Alice not found` reports from users (it is in the client log). It means that the backend removed Alice for some reason from the CoinJoin round without notifying the client about this at that point. In many cases, the notification is impossible as the Backend doesn't know who to notify and also only clients can initialize communication.
`Alice not found` is not an issue it is an intended behavior when the server removes invalid Alices to maintain successful CoinJoins. 

With this PR we will have a server-side log record when Alice removed by mempool dis-acceptance. The log will contain the reason for this.

