### PR TITLE
Avoid multiple enumeration on Select(x => new...)

### DIFF
--- a/WalletWasabi.Gui/ManagedDialogs/ManagedFileChooserViewModel.cs
+++ b/WalletWasabi.Gui/ManagedDialogs/ManagedFileChooserViewModel.cs
@@ -246,30 +246,32 @@ namespace WalletWasabi.Gui.ManagedDialogs
 						infos = infos.Where(i => i is DirectoryInfo || SelectedFilter.Match(i.Name));
 					}
 
-					Items.AddRange(infos.Where(x =>
-					{
-						if (SelectingFolder)
+					var items = infos.Where(x =>
 						{
-							if (!(x is DirectoryInfo))
+							if (SelectingFolder)
 							{
-								return false;
+								if (!(x is DirectoryInfo))
+								{
+									return false;
+								}
 							}
-						}
 
-						return true;
-					})
-					.Where(x => x.Exists)
-					.Select(info => new ManagedFileChooserItemViewModel
-					{
-						DisplayName = info.Name,
-						Path = info.FullName,
-						IsDirectory = info is DirectoryInfo,
-						Type = info is FileInfo ? info.Extension : "File Folder",
-						Size = info is FileInfo f ? f.Length : 0,
-						Modified = info.LastWriteTime
-					})
-					.OrderByDescending(x => x.IsDirectory)
-					.ThenBy(x => x.DisplayName, StringComparer.InvariantCultureIgnoreCase));
+							return true;
+						})
+						.Where(x => x.Exists)
+						.Select(info => new ManagedFileChooserItemViewModel
+						{
+							DisplayName = info.Name,
+							Path = info.FullName,
+							IsDirectory = info is DirectoryInfo,
+							Type = info is FileInfo ? info.Extension : "File Folder",
+							Size = info is FileInfo f ? f.Length : 0,
+							Modified = info.LastWriteTime
+						})
+						.OrderByDescending(x => x.IsDirectory)
+						.ThenBy(x => x.DisplayName, StringComparer.InvariantCultureIgnoreCase);
+
+					Items.AddRange(items);
 
 					if (initialSelectionName != null)
 					{

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -2488,7 +2488,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				// Save alice client and the outputs, requesters, etc
 				var changeOutput = new Key().PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
-				var inputProof = inputs.Select(x => new InputProofModel { Input = x.input, Proof = x.proof });
+				var inputProof = inputs.Select(x => new InputProofModel { Input = x.input, Proof = x.proof }).ToArray();
 				var aliceClient = await AliceClient.CreateNewAsync(
 					round.RoundId,
 					outputs.Select(x => x.outputAddress),
@@ -3019,7 +3019,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				partSignedCj = Network.RegTest.CreateTransactionBuilder()
 							.ContinueToBuild(partSignedCj)
 							.AddKeys(user.userInputData.Select(x => x.key).ToArray())
-							.AddCoins(user.userInputData.Select(x => new Coin(x.tx, x.input.N)))
+							.AddCoins(user.userInputData.Select(x => new Coin(x.tx, x.input.N)).ToArray())
 							.BuildTransaction(true);
 
 				var myDic = new Dictionary<int, WitScript>();

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -116,6 +116,24 @@ namespace WalletWasabi.WebClients.Wasabi
 			await BroadcastAsync(transaction.Transaction);
 		}
 
+		public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
+		{
+			using var response = await TorClient.SendAndRetryAsync(
+				HttpMethod.Get,
+				HttpStatusCode.OK,
+				$"/api/v{Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
+				cancel: cancel);
+			if (response.StatusCode != HttpStatusCode.OK)
+			{
+				await response.ThrowRequestExceptionFromContentAsync();
+			}
+
+			using HttpContent content = response.Content;
+			var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
+			var ret = strings.Select(x => new uint256(x));
+			return ret;
+		}
+
 		/// <summary>
 		/// Gets mempool hashes, but strips the last x characters of each hash.
 		/// </summary>

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -116,24 +116,6 @@ namespace WalletWasabi.WebClients.Wasabi
 			await BroadcastAsync(transaction.Transaction);
 		}
 
-		public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
-		{
-			using var response = await TorClient.SendAndRetryAsync(
-				HttpMethod.Get,
-				HttpStatusCode.OK,
-				$"/api/v{Constants.BackendMajorVersion}/btc/blockchain/mempool-hashes",
-				cancel: cancel);
-			if (response.StatusCode != HttpStatusCode.OK)
-			{
-				await response.ThrowRequestExceptionFromContentAsync();
-			}
-
-			using HttpContent content = response.Content;
-			var strings = await content.ReadAsJsonAsync<IEnumerable<string>>();
-			var ret = strings.Select(x => new uint256(x));
-			return ret;
-		}
-
 		/// <summary>
 		/// Gets mempool hashes, but strips the last x characters of each hash.
 		/// </summary>


### PR DESCRIPTION
Make sure to use to convert `IEnumerable` into object (`First`) or array (`ToArray()`) when using `Select(x => new MyClasse(x))`. 

To avoid accidental multiple creations of the objects. 

I did not find anything suspicious so just nitpicking.