### PR TITLE
Fix: When you have no wallets and Click Load Wallet it says Wallet already loaded

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -300,7 +300,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 			TrySetWalletStates();
 
-			if (!CanLoadWallet)
+			if (!CanLoadWallet && Wallets.Count > 0)
 			{
 				NotificationHelpers.Warning("There is already an open wallet. Restart the application in order to open a different one.");
 			}


### PR DESCRIPTION
new users might come across this as they start with no wallets, probably why non of us have noticed this before.