### PR TITLE
Fix missing error border color

### DIFF
--- a/WalletWasabi.Gui/Converters/ErrorDescriptorToBorderColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/ErrorDescriptorToBorderColorConverter.cs
@@ -11,21 +11,38 @@ namespace WalletWasabi.Gui.Converters
 {
 	public class ErrorDescriptorToBorderColorConverter : IValueConverter
 	{
+		private ErrorDescriptor UndefinedExceptionToErrorDescriptor(Exception ex)
+		{
+			var newErrDescMessage = ExceptionExtensions.ToTypeMessageString(ex);
+			return new ErrorDescriptor(ErrorSeverity.Warning, newErrDescMessage);
+		}
+
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
+			var descriptors = new ErrorDescriptors();
+
 			if (value is IEnumerable<object> rawObj)
 			{
-				var descriptors = new ErrorDescriptors();
-
 				foreach (var error in rawObj.OfType<ErrorDescriptor>())
 				{
 					descriptors.Add(error);
 				}
 
-				return GetColorFromDescriptors(descriptors);
+				foreach (var ex in rawObj.OfType<Exception>())
+				{
+					descriptors.Add(UndefinedExceptionToErrorDescriptor(ex));
+				}
+			}
+			else if (value is Exception ex)
+			{
+				descriptors.Add(UndefinedExceptionToErrorDescriptor(ex));
+			}
+			else
+			{
+				return null;
 			}
 
-			return null;
+			return GetColorFromDescriptors(descriptors);
 		}
 
 		private SolidColorBrush GetColorFromDescriptors(ErrorDescriptors descriptors)


### PR DESCRIPTION
Fixes #2610 by handling the exception that is thrown by avalonia bindings system when the textbox string value doesnt match the target property's type.