### PR TITLE
Use merged events

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -443,9 +443,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Observable
 				.Merge(Observable.FromEventPattern<ReplaceTransactionReceivedEventArgs>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.ReplaceTransactionReceived)).Select(_ => Unit.Default))
-				.Merge(Observable.FromEventPattern<DoubleSpendReceivedEventArgs>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.DoubleSpendReceived)).Select(_ => Unit.Default))
-				.Merge(Observable.FromEventPattern<SmartCoin>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpent)).Select(_ => Unit.Default))
-				.Merge(Observable.FromEventPattern<SmartCoin>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinReceived)).Select(_ => Unit.Default))
+				.Merge(Observable.FromEventPattern<TxCoinsEventArgs>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.DoubleSpendReceived)).Select(_ => Unit.Default))
+				.Merge(Observable.FromEventPattern<TxCoinsEventArgs>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsSpent)).Select(_ => Unit.Default))
+				.Merge(Observable.FromEventPattern<TxCoinsEventArgs>(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsReceived)).Select(_ => Unit.Default))
 				.Throttle(TimeSpan.FromSeconds(2)) // Throttle TransactionProcessor events adds/removes.
 				.Merge(Observable.FromEventPattern(this, nameof(CoinListShown), RxApp.MainThreadScheduler).Select(_ => Unit.Default)) // Load the list immediately.
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -54,9 +54,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 			Observable.FromEventPattern(Global.WalletService, nameof(Global.WalletService.NewBlockProcessed))
-				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpent)))
-				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.SpenderConfirmed)))
-				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinReceived)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsSpent)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.SpendersConfirmed)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsReceived)))
 				.Throttle(TimeSpan.FromSeconds(5))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(async _ => await TryRewriteTableAsync())

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -157,7 +157,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 			Observable
-				.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinReceived))
+				.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsReceived))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => InitializeAddresses())
 				.DisposeWith(Disposables);
@@ -190,7 +190,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					_addresses.Add(new AddressViewModel(key, Global));
 				}
 			}
-			catch(Exception ex)
+			catch (Exception ex)
 			{
 				Logger.LogError(ex);
 			}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -93,8 +93,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 			Observable.Merge(
-				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinReceived)).Select(_ => Unit.Default),
-				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinSpent)).Select(_ => Unit.Default))
+				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsReceived)).Select(_ => Unit.Default),
+				Observable.FromEventPattern(Global.WalletService.TransactionProcessor, nameof(Global.WalletService.TransactionProcessor.CoinsSpent)).Select(_ => Unit.Default))
 				.Throttle(TimeSpan.FromSeconds(0.5))
 				.Merge(Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Select(_ => Unit.Default))
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -1475,22 +1475,22 @@ namespace WalletWasabi.Tests.IntegrationTests
 				srtxwwreq.Transaction = overwriteTx;
 				var srtxwwres = await rpc.SignRawTransactionWithWalletAsync(srtxwwreq);
 
-				var doubleSpendAwaiter = new EventAwaiter<DoubleSpendReceivedEventArgs>(
+				var doubleSpendAwaiter = new EventAwaiter<TxCoinsEventArgs>(
 					h => wallet.TransactionProcessor.DoubleSpendReceived += h,
 					h => wallet.TransactionProcessor.DoubleSpendReceived -= h);
 				await rpc.SendRawTransactionAsync(srtxwwres.SignedTransaction);
 				var doubleSpend = await doubleSpendAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
 				Assert.Equal(srtxwwres.SignedTransaction.GetHash(), doubleSpend.SmartTransaction.GetHash());
-				Assert.Empty(doubleSpend.Remove);
+				Assert.Empty(doubleSpend.Coins);
 
-				doubleSpendAwaiter = new EventAwaiter<DoubleSpendReceivedEventArgs>(
+				doubleSpendAwaiter = new EventAwaiter<TxCoinsEventArgs>(
 					h => wallet.TransactionProcessor.DoubleSpendReceived += h,
 					h => wallet.TransactionProcessor.DoubleSpendReceived -= h);
 				await rpc.GenerateAsync(10);
 				await WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 10);
 				doubleSpend = await doubleSpendAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
 				Assert.Equal(srtxwwres.SignedTransaction.GetHash(), doubleSpend.SmartTransaction.GetHash());
-				Assert.NotEmpty(doubleSpend.Remove);
+				Assert.NotEmpty(doubleSpend.Coins);
 
 				var curBlockHash = await rpc.GetBestBlockHashAsync();
 				blockCount = await rpc.GetBlockCountAsync();

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -157,7 +157,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			int doubleSpendReceivedCalled = 0;
 			transactionProcessor.DoubleSpendReceived += (s, e) =>
 			{
-				var coin = Assert.Single(e.Remove);
+				var coin = Assert.Single(e.Coins);
 				// Double spend to ourselves but to a different address. So checking the address.
 				Assert.Equal(keys[1].PubKey.WitHash.ScriptPubKey, coin.ScriptPubKey);
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TxCoinsEventArgs.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TxCoinsEventArgs.cs
@@ -1,19 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 
 namespace WalletWasabi.Blockchain.TransactionProcessing
 {
-	public class DoubleSpendReceivedEventArgs : EventArgs
+	public class TxCoinsEventArgs : EventArgs
 	{
-		public DoubleSpendReceivedEventArgs(SmartTransaction smartTransaction, IEnumerable<SmartCoin> remove) : base()
+		public TxCoinsEventArgs(SmartTransaction smartTransaction, IEnumerable<SmartCoin> coins) : base()
 		{
 			SmartTransaction = smartTransaction;
-			Remove = remove;
+			Coins = coins;
 		}
 
 		public SmartTransaction SmartTransaction { get; }
-		public IEnumerable<SmartCoin> Remove { get; }
+		public IEnumerable<SmartCoin> Coins { get; }
 	}
 }

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -737,6 +737,9 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			return (change, actives);
 		}
 
+		public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)
+			=> await QueueCoinsToMixAsync(coins as IEnumerable<SmartCoin>).ConfigureAwait(false);
+
 		public async Task QueueCoinsToMixAsync(IEnumerable<SmartCoin> coins)
 		{
 			await QueueCoinsToMixAsync(SaltSoup(), coins).ConfigureAwait(false);
@@ -755,6 +758,9 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 		private string Salt { get; set; } = null;
 		private string Soup { get; set; } = null;
 		private object RefrigeratorLock { get; } = new object();
+
+		public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, params SmartCoin[] coins)
+			=> await QueueCoinsToMixAsync(password, coins as IEnumerable<SmartCoin>).ConfigureAwait(false);
 
 		public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, IEnumerable<SmartCoin> coins)
 		{

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -737,7 +737,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			return (change, actives);
 		}
 
-		public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)
+		public async Task QueueCoinsToMixAsync(IEnumerable<SmartCoin> coins)
 		{
 			await QueueCoinsToMixAsync(SaltSoup(), coins).ConfigureAwait(false);
 		}
@@ -756,7 +756,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 		private string Soup { get; set; } = null;
 		private object RefrigeratorLock { get; } = new object();
 
-		public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, params SmartCoin[] coins)
+		public async Task<IEnumerable<SmartCoin>> QueueCoinsToMixAsync(string password, IEnumerable<SmartCoin> coins)
 		{
 			if (coins is null || !coins.Any() || IsQuitPending)
 			{

--- a/WalletWasabi/CoinJoin/Client/Rounds/ClientState.cs
+++ b/WalletWasabi/CoinJoin/Client/Rounds/ClientState.cs
@@ -68,7 +68,7 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 			}
 		}
 
-		public bool Contains(params TxoRef[] txos)
+		public bool Contains(IEnumerable<TxoRef> txos)
 		{
 			lock (StateLock)
 			{


### PR DESCRIPTION
So events raised from txprocessing are merged together. Eg, if we receive 50 coins in one tx, then we only raise 1 event that contains all 50 coins instead of 50 separate events.

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/2641