### PR TITLE
Add block height to the log file after downloading

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -120,9 +120,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				var downloadTasks = new List<Task<Block>>();
 				using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(4));
+				uint height = 0;
 				foreach (var hash in blocksToDownload)
 				{
-					downloadTasks.Add(walletService.FetchBlockAsync(hash, cts.Token));
+					downloadTasks.Add(walletService.FetchBlockAsync(hash, height++, cts.Token));
 				}
 
 				await nodeConnectionAwaiter.WaitAsync(TimeSpan.FromMinutes(3));

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -338,7 +338,7 @@ namespace WalletWasabi.Services
 				return;
 			}
 
-			Block currentBlock = await FetchBlockAsync(filterModel.Header.BlockHash, cancel); // Wait until not downloaded.
+			Block currentBlock = await FetchBlockAsync(filterModel.Header.BlockHash, filterModel.Header.Height, cancel); // Wait until not downloaded.
 			var height = new Height(filterModel.Header.Height);
 
 			var txsToProcess = new List<SmartTransaction>();
@@ -396,12 +396,12 @@ namespace WalletWasabi.Services
 
 		/// <param name="hash">Block hash of the desired block, represented as a 256 bit integer.</param>
 		/// <exception cref="OperationCanceledException"></exception>
-		public async Task<Block> FetchBlockAsync(uint256 hash, CancellationToken cancel)
+		public async Task<Block> FetchBlockAsync(uint256 hash, uint height, CancellationToken cancel)
 		{
 			Block block = await TryGetBlockFromFileAsync(hash, cancel);
 			if (block is null)
 			{
-				block = await DownloadBlockAsync(hash, cancel);
+				block = await DownloadBlockAsync(hash, height, cancel);
 			}
 			return block;
 		}
@@ -438,7 +438,7 @@ namespace WalletWasabi.Services
 
 		/// <param name="hash">Block hash of the desired block, represented as a 256 bit integer.</param>
 		/// <exception cref="OperationCanceledException"></exception>
-		private async Task<Block> DownloadBlockAsync(uint256 hash, CancellationToken cancel)
+		private async Task<Block> DownloadBlockAsync(uint256 hash, uint height, CancellationToken cancel)
 		{
 			Block block = null;
 			try
@@ -491,7 +491,7 @@ namespace WalletWasabi.Services
 
 							if (Nodes.ConnectedNodes.Count > 1) // To minimize risking missing unconfirmed transactions.
 							{
-								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
+								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: ({height}) {block.GetHash()}.");
 								node.DisconnectAsync("Thank you!");
 							}
 


### PR DESCRIPTION
Closes #2677

It is a bit controversial because we are passing the `height` only for logging it. This is how it looks like now.

```
2019-11-30 11:02:07 INFO        WalletService (499)     Disconnected node: ::ffff:34.205.25.251. Block downloaded: (1610462) 0000000000000182b1c113f5f264bec72e04eb13c1f0a2f8b02046783960f107.
```