### PR TITLE
Use KeyUp instead of Text property

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabView.xaml
@@ -52,7 +52,11 @@
               Watermark="{Binding AmountWatermarkText}"
               UseFloatingWatermark="True"
               MinWidth="124"
-              MinHeight="46" />
+              MinHeight="46">
+              <i:Interaction.Behaviors>
+                <behaviors:CommandOnKeyUpBehavior Command="{Binding AmountKeyUpCommand}" />
+              </i:Interaction.Behaviors>
+            </controls:ExtendedTextBox>
             <StackPanel Opacity="{Binding FeeControlOpacity}">
               <StackPanel IsVisible="{Binding !MinMaxFeeTargetsEqual}" Orientation="Horizontal" Spacing="10">
                 <TextBlock Text="Fee:" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -121,49 +121,48 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			FeeDisplayFormat = (FeeDisplayFormat)(Enum.ToObject(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat) ?? FeeDisplayFormat.SatoshiPerByte);
 			SetFeesAndTexts();
 
-			this.WhenAnyValue(x => x.AmountText)
-				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(amount =>
+			AmountKeyUpCommand = ReactiveCommand.Create((KeyEventArgs key) =>
+			{
+				var amount = AmountText;
+				if (!IsMax)
 				{
-					if (!IsMax)
+					// Correct amount
+					Regex digitsOnly = new Regex(@"[^\d,.]");
+					string betterAmount = digitsOnly.Replace(amount, ""); // Make it digits , and . only.
+
+					betterAmount = betterAmount.Replace(',', '.');
+					int countBetterAmount = betterAmount.Count(x => x == '.');
+					if (countBetterAmount > 1) // Do not enable typing two dots.
 					{
-						// Correct amount
-						Regex digitsOnly = new Regex(@"[^\d,.]");
-						string betterAmount = digitsOnly.Replace(amount, ""); // Make it digits , and . only.
-
-						betterAmount = betterAmount.Replace(',', '.');
-						int countBetterAmount = betterAmount.Count(x => x == '.');
-						if (countBetterAmount > 1) // Do not enable typing two dots.
+						var index = betterAmount.IndexOf('.', betterAmount.IndexOf('.') + 1);
+						if (index > 0)
 						{
-							var index = betterAmount.IndexOf('.', betterAmount.IndexOf('.') + 1);
-							if (index > 0)
-							{
-								betterAmount = betterAmount.Substring(0, index);
-							}
-						}
-						var dotIndex = betterAmount.IndexOf('.');
-						if (dotIndex != -1 && betterAmount.Length - dotIndex > 8) // Enable max 8 decimals.
-						{
-							betterAmount = betterAmount.Substring(0, dotIndex + 1 + 8);
-						}
-
-						if (betterAmount != amount)
-						{
-							AmountText = betterAmount;
+							betterAmount = betterAmount.Substring(0, index);
 						}
 					}
-
-					if (Money.TryParse(amount.TrimStart('~', ' '), out Money amountBtc))
+					var dotIndex = betterAmount.IndexOf('.');
+					if (dotIndex != -1 && betterAmount.Length - dotIndex > 8) // Enable max 8 decimals.
 					{
-						SetAmountWatermark(amountBtc);
-					}
-					else
-					{
-						SetAmountWatermark(Money.Zero);
+						betterAmount = betterAmount.Substring(0, dotIndex + 1 + 8);
 					}
 
-					SetFeesAndTexts();
-				});
+					if (betterAmount != amount)
+					{
+						AmountText = betterAmount;
+					}
+				}
+
+				if (Money.TryParse(amount.TrimStart('~', ' '), out Money amountBtc))
+				{
+					SetAmountWatermark(amountBtc);
+				}
+				else
+				{
+					SetAmountWatermark(Money.Zero);
+				}
+
+				SetFeesAndTexts();
+			});
 
 			this.WhenAnyValue(x => x.IsBusy)
 				.ObserveOn(RxApp.MainThreadScheduler)
@@ -869,6 +868,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public ReactiveCommand<PointerPressedEventArgs, Unit> FeeSliderClickedCommand { get; }
 
 		public ReactiveCommand<bool, Unit> HighLightFeeSliderCommand { get; }
+
+		public ReactiveCommand<KeyEventArgs, Unit> AmountKeyUpCommand { get; }
 
 		public bool IsTransactionBuilder { get; }
 


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/2237

If you subscribe with `WhenAnyValue` to a property and want to modify that inside the subscription it causes deadlock randomly on OSX. It is the same with `AmountText` property. So instead of Subscribing the change, I subscribe to the `KeyUp` event. 
The same walkaround already used elsewhere in Wasabi. 

Hide whitespace changes!