### PR TITLE
Adjust gap limit for too many receive instead of recycling.

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -53,28 +53,24 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					if (label.IsEmpty)
 					{
 						NotificationHelpers.Warning("Label is required.");
-
 						return;
 					}
 
-					Dispatcher.UIThread.PostLogException(() =>
-						{
-							HdPubKey newKey = Global.WalletService.GetReceiveKey(_labelSuggestion.Label, Addresses.Select(x => x.Model).Take(7)); // Never touch the first 7 keys.
+					AvaloniaThreadingExtensions.PostLogException(Dispatcher.UIThread, () =>
+					 {
+						 var newKey = KeyManager.GetNextReceiveKey(label, out bool minGapLimitIncreased);
+						 if (minGapLimitIncreased)
+						 {
+							 int minGapLimit = KeyManager.MinGapLimit.Value;
+							 int prevMinGapLimit = minGapLimit - 1;
+							 NotificationHelpers.Warning($"{nameof(KeyManager.MinGapLimit)} increased from {prevMinGapLimit} to {minGapLimit}.");
+						 }
 
-							AddressViewModel found = Addresses.FirstOrDefault(x => x.Model == newKey);
-							if (found != default)
-							{
-								Addresses.Remove(found);
-							}
-
-							var newAddress = new AddressViewModel(newKey, Global);
-
-							Addresses.Insert(0, newAddress);
-
-							SelectedAddress = newAddress;
-
-							_labelSuggestion.Label = "";
-						});
+						 var newAddress = new AddressViewModel(newKey, Global);
+						 Addresses.Insert(0, newAddress);
+						 SelectedAddress = newAddress;
+						 _labelSuggestion.Label = "";
+					 });
 				});
 
 			this.WhenAnyValue(x => x.SelectedAddress).Subscribe(async address =>

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -8,6 +8,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Logging;
 
@@ -108,7 +109,7 @@ namespace WalletWasabi.Gui.ViewModels
 			get => _label;
 			set
 			{
-				if (!IsLurkingWifeMode)
+				if (!IsLurkingWifeMode && !new SmartLabel(value).IsEmpty)
 				{
 					this.RaiseAndSetIfChanged(ref _label, value);
 				}

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -1012,7 +1012,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				res = wallet.BuildTransaction(password, new PaymentIntent(receive2, MoneyRequest.CreateAllRemaining(), "my label"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
 
 				Assert.Single(res.InnerWalletOutputs);
-				Assert.Equal("my label", res.InnerWalletOutputs.Single().Label);
+				Assert.Equal("foo, my label", res.InnerWalletOutputs.Single().Label);
 
 				amountToSend = wallet.Coins.Where(x => !x.Unavailable).Sum(x => x.Amount) / 3;
 				res = wallet.BuildTransaction(

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -613,33 +613,33 @@ namespace WalletWasabi.Blockchain.Keys
 		/// </summary>
 		public IEnumerable<HdPubKey> AssertCleanKeysIndexed(bool? isInternal = null)
 		{
-			var newNewKeys = new List<HdPubKey>();
+			var newKeys = new List<HdPubKey>();
 
 			if (isInternal is null)
 			{
 				while (GetKeys(KeyState.Clean, true).Count() < MinGapLimit)
 				{
-					newNewKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, true, toFile: false));
+					newKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, true, toFile: false));
 				}
 				while (GetKeys(KeyState.Clean, false).Count() < MinGapLimit)
 				{
-					newNewKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false, toFile: false));
+					newKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false, toFile: false));
 				}
 			}
 			else
 			{
 				while (GetKeys(KeyState.Clean, isInternal).Count() < MinGapLimit)
 				{
-					newNewKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, (bool)isInternal, toFile: false));
+					newKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, (bool)isInternal, toFile: false));
 				}
 			}
 
-			if (newNewKeys.Any())
+			if (newKeys.Any())
 			{
 				ToFile();
 			}
 
-			return newNewKeys;
+			return newKeys;
 		}
 
 		/// <summary>

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -353,29 +353,6 @@ namespace WalletWasabi.Services
 			NewBlockProcessed?.Invoke(this, currentBlock);
 		}
 
-		public HdPubKey GetReceiveKey(SmartLabel label, IEnumerable<HdPubKey> dontTouch = null)
-		{
-			// Make sure there's always 21 clean keys generated and indexed.
-			KeyManager.AssertCleanKeysIndexed(isInternal: false);
-
-			IEnumerable<HdPubKey> keys = KeyManager.GetKeys(KeyState.Clean, isInternal: false);
-			if (dontTouch != null)
-			{
-				keys = keys.Except(dontTouch);
-				if (!keys.Any())
-				{
-					throw new InvalidOperationException($"{nameof(dontTouch)} covers all the possible keys.");
-				}
-			}
-
-			var foundLabelless = keys.FirstOrDefault(x => x.Label.IsEmpty); // Return the first labelless.
-			HdPubKey ret = foundLabelless ?? keys.RandomElement(); // Return the first, because that's the oldest.
-
-			ret.SetLabel(label, KeyManager);
-
-			return ret;
-		}
-
 		private Node _localBitcoinCoreNode = null;
 
 		public Node LocalBitcoinCoreNode


### PR DESCRIPTION
Based on and closes https://github.com/zkSNACKs/WalletWasabi/pull/2659
Closes https://github.com/zkSNACKs/WalletWasabi/issues/2624
Closes https://github.com/zkSNACKs/WalletWasabi/issues/2340

As @btcpirate described in https://github.com/zkSNACKs/WalletWasabi/issues/2340, we were recycling receive addresses when the user created too much. In this PR, I decided to stop recycling and instead give notifications to the user if the gap limit is exceeded for new address generation:

![image](https://user-images.githubusercontent.com/9156103/69902250-239a7980-13c6-11ea-973c-6235a2d861c4.png)

I realized the restore issue should practically never happen because we are restoring wallets with 100 gap limit by default unlike the wallet generation that's only using 21, so we have a nice 79 addresses leeway there.