### PR TITLE
Update Avalonia 0.9 with a couple of fixes

### DIFF
--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -56,10 +56,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.0-preview8" />
-    <PackageReference Include="AvalonStudio.Shell" Version="0.9.0-preview8" />
-    <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.0-preview8" />
-    <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.0-preview8" />
+    <PackageReference Include="Avalonia" Version="0.9.0-preview9" />
+    <PackageReference Include="AvalonStudio.Shell" Version="0.9.0-preview9" />
+    <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.0-preview9" />
+    <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.0-preview9" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes:
#2549 OSX menu not working on Catalina
#2644 Warning / Exception when closing Wasabi.
