### PR TITLE
Fix Manual Fee box not showing up on first instance.

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -62,7 +62,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private string _amountWaterMarkText;
 		private bool _isBusy;
 		private bool _isHardwareBusy;
-		private ObservableAsPropertyHelper<bool> _isCustomFee;
+		private bool _isCustomFee;
 
 		private const string SendTransactionButtonTextString = "Send Transaction";
 		private const string WaitingForHardwareWalletButtonTextString = "Waiting for Hardware Wallet...";
@@ -864,7 +864,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _feeControlOpacity, value);
 		}
 
-		public bool IsCustomFee => _isCustomFee?.Value ?? false;
+		public bool IsCustomFee 
+		{
+			get => _isCustomFee;
+			private set => this.RaiseAndSetIfChanged(ref _isCustomFee, value);
+		}
 
 		public ReactiveCommand<Unit, Unit> BuildTransactionCommand { get; }
 
@@ -915,8 +919,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => SetFeesAndTexts());
 
-			_isCustomFee = Global.UiConfig.WhenAnyValue(x => x.IsCustomFee)
-				.ToProperty(this, x => x.IsCustomFee, scheduler: RxApp.MainThreadScheduler)
+			Global.UiConfig.WhenAnyValue(x => x.IsCustomFee)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(x => IsCustomFee = x)
 				.DisposeWith(Disposables);
 
 			this.WhenAnyValue(x => x.IsCustomFee)


### PR DESCRIPTION
Fixes #2623 but I'm not sure if this is the correct fix...

For some reason, the `ObservableAsPropertyHelper` version of `IsCustomFee` is not sending any change notifications to the binding so i changed it into a regular rx property and it works.

I need some guidance here @molnard @nopara73  