### PR TITLE
Fix CoinJoin confirmed notification

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -602,6 +602,10 @@ namespace WalletWasabi.Gui
 					{
 						NotifyAndLog($"Mining Fee: {amountString} BTC", "Self Spend Confirmed", NotificationType.Information, e);
 					}
+					else if (isConfirmedSpent && receiveSpentDiff.Almost(Money.Zero, Money.Coins(0.01m)) && e.IsLikelyOwnCoinJoin)
+					{
+						NotifyAndLog($"CoinJoin Confirmed!", "", NotificationType.Information, e);
+					}
 					else if (incoming > Money.Zero)
 					{
 						NotifyAndLog($"{amountString} BTC", "Receive Confirmed", NotificationType.Information, e);

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -157,7 +157,7 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 					if (allReceivedInternal)
 					{
 						// It is likely a coinjoin if the diff between receive and sent amount is small and have at least 2 equal outputs.
-						Money spentAmount = Coins.OutPoints(tx.Transaction.Inputs.ToTxoRefs()).TotalAmount();
+						Money spentAmount = Coins.AsAllCoinsView().OutPoints(tx.Transaction.Inputs.ToTxoRefs()).TotalAmount();
 						Money receivedAmount = tx.Transaction.Outputs.Where(x => receiveKeys.Any(y => y.P2wpkhScript == x.ScriptPubKey)).Sum(x => x.Value);
 						bool receivedAlmostAsMuchAsSpent = spentAmount.Almost(receivedAmount, Money.Coins(0.005m));
 


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/2699

On the one hand, we weren't checking CJ confirmed, on the other hand we had a bug in our "IsLikelyCoinJoin" calculation at the transaction processor. It was only going through unspent coins, where it must go through all the coins instead, because when we're only processing the tx for confirmation, we must look for spent coins, too.