### PR TITLE
Reduce log rate in AsyncMutex class.

### DIFF
--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -141,13 +141,13 @@ namespace Nito.AsyncEx
 						else
 						{
 							// The mutex already exists so we will try to acquire it.
-							DateTime start = DateTime.Now;
+							var start = DateTimeOffset.UtcNow;
 							bool acquired = false;
 
 							// Timeout logic.
 							while (true)
 							{
-								if (DateTime.Now - start > TimeSpan.FromSeconds(90))
+								if (DateTimeOffset.UtcNow - start > TimeSpan.FromSeconds(90))
 								{
 									throw new TimeoutException("Could not acquire mutex in time.");
 								}
@@ -347,13 +347,13 @@ namespace Nito.AsyncEx
 		{
 			try
 			{
-				var start = DateTime.Now;
+				var start = DateTimeOffset.UtcNow;
 				while (IsAlive)
 				{
 					SetCommand(2);
 					MutexThread?.Join(TimeSpan.FromSeconds(1));
 
-					if (DateTime.Now - start > TimeSpan.FromSeconds(10))
+					if (DateTimeOffset.UtcNow - start > TimeSpan.FromSeconds(10))
 					{
 						throw new TimeoutException($"Could not stop {nameof(MutexThread)}, aborting it.");
 					}
@@ -392,7 +392,7 @@ namespace Nito.AsyncEx
 
 		public static async Task WaitForAllMutexToCloseAsync()
 		{
-			DateTime start = DateTime.Now;
+			var start = DateTimeOffset.UtcNow;
 			lock (AsyncMutexesLock)
 			{
 				foreach (var mutex in AsyncMutexes)
@@ -401,32 +401,35 @@ namespace Nito.AsyncEx
 				}
 			}
 
-			var lastLog = DateTime.MinValue;
+			var lastLog = DateTimeOffset.MinValue;
 			var lastNumberOfAliveMutexes = 0;
 
 			while (true)
 			{
+				KeyValuePair<string, AsyncMutex>[] asyncMutexes = null;
 				lock (AsyncMutexesLock)
 				{
-					int numberOfAliveMutexes = AsyncMutexes.Count(am => am.Value.IsAlive);
-					if (numberOfAliveMutexes == 0)
-					{
-						return;
-					}
+					asyncMutexes = AsyncMutexes.ToArray();
+				}
 
-					// Log every 10 second or status change.
-					if ((DateTime.Now - lastLog) > TimeSpan.FromSeconds(10) || lastNumberOfAliveMutexes != numberOfAliveMutexes)
-					{
-						Logger.LogDebug($"Waiting for: {string.Join(", ", AsyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName))}.");
-						lastNumberOfAliveMutexes = numberOfAliveMutexes;
-						lastLog = DateTime.Now;
-					}
+				int numberOfAliveMutexes = asyncMutexes.Count(am => am.Value.IsAlive);
+				if (numberOfAliveMutexes == 0)
+				{
+					return;
+				}
+
+				// Log every 10 second or status change.
+				if ((DateTimeOffset.UtcNow - lastLog) > TimeSpan.FromSeconds(10) || lastNumberOfAliveMutexes != numberOfAliveMutexes)
+				{
+					Logger.LogDebug($"Waiting for: {string.Join(", ", asyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName))}.");
+					lastNumberOfAliveMutexes = numberOfAliveMutexes;
+					lastLog = DateTimeOffset.UtcNow;
 				}
 
 				await Task.Delay(500).ConfigureAwait(false);
-				if (DateTime.Now - start > TimeSpan.FromSeconds(60))
+				if (DateTimeOffset.UtcNow - start > TimeSpan.FromSeconds(60))
 				{
-					var mutexesAlive = AsyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName);
+					var mutexesAlive = asyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName);
 					var names = string.Join(", ", mutexesAlive);
 					throw new TimeoutException($"{nameof(AsyncMutex)}(es) still alive after Timeout: {names}.");
 				}

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -418,7 +418,7 @@ namespace Nito.AsyncEx
 					return;
 				}
 
-				// Log every 10 second or status change.
+				// Log every 10 seconds or status change.
 				if ((DateTimeOffset.UtcNow - lastLog) > TimeSpan.FromSeconds(10) || lastNumberOfAliveMutexes != numberOfAliveMutexes)
 				{
 					Logger.LogDebug($"Waiting for: {string.Join(", ", asyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName))}.");

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -426,7 +426,7 @@ namespace Nito.AsyncEx
 					lastLog = DateTimeOffset.UtcNow;
 				}
 
-				await Task.Delay(500).ConfigureAwait(false);
+				await Task.Delay(100).ConfigureAwait(false);
 				if (DateTimeOffset.UtcNow - start > TimeSpan.FromSeconds(60))
 				{
 					var mutexesAlive = asyncMutexes.Where(am => am.Value.IsAlive).Select(m => m.Value.ShortName);


### PR DESCRIPTION
Reduce log rate in AsyncMutex class.

@MaxHillebrand reported:
However, it does take forever to close the wallet now, with this showing up hundreds of times in the logs.
DEBUG	AsyncMutex (413)	Waiting for: MatureIndex-76A7981.