### PR TITLE
Update masOS guide link

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -239,7 +239,7 @@
                                         <!-- macOS Signature Link -->
                                         <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.9.2/Wasabi-1.1.9.2.dmg.asc" class="text-uppercase">Signature</a>&nbsp;/
                                         <!-- macOS Installation Guide Link -->
-                                        <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#osx" class="text-uppercase">Guide</a>
+                                        <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" class="text-uppercase">Guide</a>
                                     </small>
                                 </div>
                             </div>


### PR DESCRIPTION
The macOS guide link changed after https://github.com/zkSNACKs/WasabiDoc/pull/373
There is this file `/WalletWasabi.Backend/wwwroot/onion-index.html` that is ignored in `.gitignore`, should that file not be updated?

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/2729