### PR TITLE
Update software version on the website

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -218,7 +218,7 @@
                 <div class="row align-items-end">
                     <div class="col-sm-6 order-sm-6">
                         <div class="my-4 text-center">
-                            <span class="text-uppercase font-weight-bold">Download Wasabi Wallet <span itemprop="softwareVersion">1.1.9.2</span></span>
+                            <span class="text-uppercase font-weight-bold">Download Wasabi Wallet <span itemprop="softwareVersion">1.1.10</span></span>
                             <br />
                             <small><a href="https://github.com/zkSNACKs/WalletWasabi#build-from-source-code" class="text-muted">Or build it from source</a></small>
                             <br />


### PR DESCRIPTION
Closes #2797 

Update software version from 1.1.9.2 to 1.1.10.

> For technical reasons, v1.1.10rc1 is v1.1.9.3.
(https://github.com/zkSNACKs/WalletWasabi/releases/tag/v1.1.10rc1)

should we put 1.1.10 or 1.1.9.3?