### PR TITLE
Edit generation wallet workflow

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessViewModel.cs
@@ -5,6 +5,10 @@ using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Logging;
 using System;
 using System.Reactive.Linq;
+using WalletWasabi.Helpers;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Models;
+using WalletWasabi.Gui.Helpers;
 
 namespace WalletWasabi.Gui.Tabs.WalletManager
 {
@@ -12,15 +16,33 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 	{
 		private string _mnemonicWords;
 
-		public GenerateWalletSuccessViewModel(WalletManagerViewModel owner, Mnemonic mnemonic) : base("Wallet Generated Successfully!")
+		public GenerateWalletSuccessViewModel(WalletManagerViewModel owner, string password, string walletFilePath, Global global) : base("Wallet Generated Successfully!")
 		{
+			// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password bacause of compatibility.
+			PasswordHelper.Guard(password);
+
+			var keyManager = KeyManager.CreateNew(out Mnemonic mnemonic, password);
 			_mnemonicWords = mnemonic.ToString();
 
-			ConfirmCommand = ReactiveCommand.Create(() => owner.SelectTestPassword());
+			ConfirmCommand = ReactiveCommand.Create(() =>
+				{
+					DoConfirmCommand(keyManager, walletFilePath, global);
+					owner.SelectTestPassword();
+				});
 
 			ConfirmCommand.ThrownExceptions
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(ex => Logger.LogError(ex));
+		}
+
+		private void DoConfirmCommand(KeyManager keyManager, string walletFilePath, Global global)
+		{
+			keyManager.SetNetwork(global.Network);
+			keyManager.SetBestHeight(new Height(global.BitcoinStore.SmartHeaderChain.TipHeight));
+			keyManager.SetFilePath(walletFilePath);
+			keyManager.ToFile();
+
+			NotificationHelpers.Success("Wallet is successfully generated!");
 		}
 
 		public string MnemonicWords

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessViewModel.cs
@@ -21,21 +21,15 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			_mnemonicWords = mnemonic.ToString();
 
 			ConfirmCommand = ReactiveCommand.Create(() =>
-				{
-					DoConfirmCommand(keyManager);
-					owner.SelectTestPassword();
-				});
+			{
+				keyManager.ToFile();
+				NotificationHelpers.Success("Wallet is successfully generated!");
+				owner.SelectTestPassword();
+			});
 
 			ConfirmCommand.ThrownExceptions
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(ex => Logger.LogError(ex));
-		}
-
-		private void DoConfirmCommand(KeyManager keyManager)
-		{
-			keyManager.ToFile();
-
-			NotificationHelpers.Success("Wallet is successfully generated!");
 		}
 
 		public string MnemonicWords

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletSuccessViewModel.cs
@@ -16,17 +16,13 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 	{
 		private string _mnemonicWords;
 
-		public GenerateWalletSuccessViewModel(WalletManagerViewModel owner, string password, string walletFilePath, Global global) : base("Wallet Generated Successfully!")
+		public GenerateWalletSuccessViewModel(WalletManagerViewModel owner, KeyManager keyManager, Mnemonic mnemonic) : base("Wallet Generated Successfully!")
 		{
-			// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password bacause of compatibility.
-			PasswordHelper.Guard(password);
-
-			var keyManager = KeyManager.CreateNew(out Mnemonic mnemonic, password);
 			_mnemonicWords = mnemonic.ToString();
 
 			ConfirmCommand = ReactiveCommand.Create(() =>
 				{
-					DoConfirmCommand(keyManager, walletFilePath, global);
+					DoConfirmCommand(keyManager);
 					owner.SelectTestPassword();
 				});
 
@@ -35,11 +31,8 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				.Subscribe(ex => Logger.LogError(ex));
 		}
 
-		private void DoConfirmCommand(KeyManager keyManager, string walletFilePath, Global global)
+		private void DoConfirmCommand(KeyManager keyManager)
 		{
-			keyManager.SetNetwork(global.Network);
-			keyManager.SetBestHeight(new Height(global.BitcoinStore.SmartHeaderChain.TipHeight));
-			keyManager.SetFilePath(walletFilePath);
 			keyManager.ToFile();
 
 			NotificationHelpers.Success("Wallet is successfully generated!");

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletView.xaml
@@ -15,7 +15,7 @@
           <controls:ExtendedTextBox Text="{Binding WalletName}" Watermark="Wallet Name" UseFloatingWatermark="True" />
           <controls:TogglePasswordBox Text="{Binding Password}" Watermark="Choose a password">
             <i:Interaction.Behaviors>
-              <behaviors:CommandOnEnterBehavior Command="{Binding GenerateCommand}" />
+              <behaviors:CommandOnEnterBehavior Command="{Binding NextCommand}" />
             </i:Interaction.Behaviors>
           </controls:TogglePasswordBox>
         </StackPanel>
@@ -29,7 +29,7 @@
           <TextBlock Text=" documents." />
         </StackPanel>
       </CheckBox>
-      <Button Content="Generate" Command="{Binding GenerateCommand}" DockPanel.Dock="Right" />
+      <Button Content="Next" Command="{Binding NextCommand}" DockPanel.Dock="Right" />
       <Grid></Grid>
     </DockPanel>
   </StackPanel>

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
@@ -70,7 +70,13 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			{
 				try
 				{
-					Owner.CurrentView = new GenerateWalletSuccessViewModel(Owner, Password, walletFilePath, Global);
+					PasswordHelper.Guard(Password); // Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password bacause of compatibility.						Owner.CurrentView = new GenerateWalletSuccessViewModel(Owner, Password, walletFilePath, Global);
+
+					var km = KeyManager.CreateNew(out Mnemonic mnemonic, Password);
+					km.SetNetwork(Global.Network);
+					km.SetBestHeight(new Height(Global.BitcoinStore.SmartHeaderChain.TipHeight));
+					km.SetFilePath(walletFilePath);
+					Owner.CurrentView = new GenerateWalletSuccessViewModel(Owner, km, mnemonic);
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
@@ -35,14 +35,14 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				this.WhenAnyValue(x => x.Password).Select(pw => !ValidatePassword().HasErrors),
 				(terms, pw) => terms && pw);
 
-			GenerateCommand = ReactiveCommand.Create(DoGenerateCommand, canGenerate);
+			NextCommand = ReactiveCommand.Create(DoNextCommand, canGenerate);
 
-			GenerateCommand.ThrownExceptions
+			NextCommand.ThrownExceptions
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(ex => Logger.LogError(ex));
 		}
 
-		private void DoGenerateCommand()
+		private void DoNextCommand()
 		{
 			WalletName = Guard.Correct(WalletName);
 
@@ -70,17 +70,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			{
 				try
 				{
-					PasswordHelper.Guard(Password); // Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password bacause of compatibility.
-
-					var km = KeyManager.CreateNew(out Mnemonic mnemonic, Password);
-					km.SetNetwork(Global.Network);
-					km.SetBestHeight(new Height(Global.BitcoinStore.SmartHeaderChain.TipHeight));
-					km.SetFilePath(walletFilePath);
-					km.ToFile();
-
-					NotificationHelpers.Success("Wallet is successfully generated!");
-
-					Owner.CurrentView = new GenerateWalletSuccessViewModel(Owner, mnemonic);
+					Owner.CurrentView = new GenerateWalletSuccessViewModel(Owner, Password, walletFilePath, Global);
 				}
 				catch (Exception ex)
 				{
@@ -143,7 +133,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			set => this.RaiseAndSetIfChanged(ref _termsAccepted, value);
 		}
 
-		public ReactiveCommand<Unit, Unit> GenerateCommand { get; }
+		public ReactiveCommand<Unit, Unit> NextCommand { get; }
 
 		public void OnLegalClicked()
 		{

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWalletViewModel.cs
@@ -70,7 +70,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			{
 				try
 				{
-					PasswordHelper.Guard(Password); // Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password bacause of compatibility.						Owner.CurrentView = new GenerateWalletSuccessViewModel(Owner, Password, walletFilePath, Global);
+					PasswordHelper.Guard(Password); // Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password bacause of compatibility.
 
 					var km = KeyManager.CreateNew(out Mnemonic mnemonic, Password);
 					km.SetNetwork(Global.Network);


### PR DESCRIPTION
Fixes #2777

This makes sure to generate the wallet file only after the user confirms that he has written the recovery words.

Please verify that there is nothing changed in the wallet generation process.

Note:
Should we rename `GenerateWalletViewModel.cs` to `StartWalletGenerationViewModel.cs` & `GenerateWalletSuccessViewModel.cs` to `GenerateWalletViewModel.cs`?
Should we change `base("Generate Wallet")` to `base("Start Wallet Generation")` & `base("Wallet Generated Successfully!")` to `base("Generate Wallet")`?