### PR TITLE
refocus the textbox when context menu closes.

### DIFF
--- a/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
@@ -124,7 +124,7 @@ namespace WalletWasabi.Gui.Controls
 				return "";
 			}
 
-			return text.Substring(start, end - start);
+			return text[start..end];
 		}
 
 		protected virtual async Task CopyAsync()

--- a/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Gui.Controls
 	{
 		private TextPresenter _presenter;
 		private MenuItem _pasteItem = null;
-		private CompositeDisposable _disposables;
+		private CompositeDisposable Disposables { get; }
 
 		private Subject<string> _textPasted;
 
@@ -32,7 +32,7 @@ namespace WalletWasabi.Gui.Controls
 
 		public ExtendedTextBox()
 		{
-			_disposables = new CompositeDisposable();
+			Disposables = new CompositeDisposable();
 
 			_textPasted = new Subject<string>();
 
@@ -193,7 +193,7 @@ namespace WalletWasabi.Gui.Controls
 
 			Observable.FromEventPattern(ContextMenu, nameof(ContextMenu.MenuClosed))
 				.Subscribe(_ => Focus())
-				.DisposeWith(_disposables);
+				.DisposeWith(Disposables);
 
 			var menuItems = (ContextMenu.Items as Avalonia.Controls.Controls);
 			if (IsCopyEnabled)
@@ -212,7 +212,7 @@ namespace WalletWasabi.Gui.Controls
 		{
 			base.OnDetachedFromVisualTree(e);
 
-			_disposables?.Dispose();
+			Disposables?.Dispose();
 		}
 
 		protected override void OnLostFocus(RoutedEventArgs e)

--- a/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
@@ -121,7 +121,7 @@ namespace WalletWasabi.Gui.Controls
 
 			if (start == end || (Text?.Length ?? 0) < end)
 			{
-				return "";
+				return string.Empty;
 			}
 
 			return text[start..end];

--- a/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
+++ b/WalletWasabi.Gui/Controls/ExtendedTextBox.cs
@@ -192,6 +192,7 @@ namespace WalletWasabi.Gui.Controls
 			};
 
 			Observable.FromEventPattern(ContextMenu, nameof(ContextMenu.MenuClosed))
+				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => Focus())
 				.DisposeWith(Disposables);
 


### PR DESCRIPTION
Fixes #2771 

Context menu opening causes the textbox to loose focus, as the context menu gets focused.

Textbox detects when context menu closes, and refocuses itself.