### PR TITLE
Update to .NET Core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For step by step instructions of PGP verification and package installation, see 
 ## Get The Requirements
 
 1. Get Git: https://git-scm.com/downloads
-2. Get .NET Core 3.0 SDKs: https://www.microsoft.com/net/download (Note, you can disable .NET's telemetry by typing `export DOTNET_CLI_TELEMETRY_OPTOUT=1` on Linux and OSX or `set DOTNET_CLI_TELEMETRY_OPTOUT=1` on Windows.)
+2. Get .NET Core 3.1 SDK: https://www.microsoft.com/net/download (Note, you can disable .NET's telemetry by typing `export DOTNET_CLI_TELEMETRY_OPTOUT=1` on Linux and OSX or `set DOTNET_CLI_TELEMETRY_OPTOUT=1` on Windows.)
 
 ## Get Wasabi
 

--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>1701;1702;1705;1591;1573;CA1031</NoWarn>
-    <Version>3.0</Version>
+    <Version>3.1</Version>
     <Product>WalletWasabiApi</Product>
     <Copyright>MIT</Copyright>
     <PackageTags>walletwasabi, wasabiwallet, wasabi, hiddenwallet, wallet, bitcoin, hbitcoin, nbitcoin, magicalcryptowallet, magicalwallet, tor, chaum, chaumian, zerolink, coinjoin, fungibility, privacy, anonymity</PackageTags>
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp3.0\WalletWasabi.Backend.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netcoreapp3.1\WalletWasabi.Backend.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <!-- Needed for Swagger! -->
-    <DocumentationFile>bin\Release\netcoreapp3.0\WalletWasabi.Backend.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netcoreapp3.1\WalletWasabi.Backend.xml</DocumentationFile>
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
     <ErrorReport>none</ErrorReport>

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -185,12 +185,12 @@ cd WalletWasabi
 dotnet restore
 dotnet build
 dotnet publish WalletWasabi.Backend --configuration Release --self-contained false
-dotnet WalletWasabi.Backend/bin/Release/netcoreapp3.0/publish/WalletWasabi.Backend.dll
+dotnet WalletWasabi.Backend/bin/Release/netcoreapp3.1/publish/WalletWasabi.Backend.dll
 cd ..
 cat .walletwasabi/backend/Logs.txt
 pico .walletwasabi/backend/Config.json
 pico .walletwasabi/backend/CcjRoundConfig.json
-dotnet WalletWasabi/WalletWasabi.Backend/bin/Release/netcoreapp3.0/publish/WalletWasabi.Backend.dll
+dotnet WalletWasabi/WalletWasabi.Backend/bin/Release/netcoreapp3.1/publish/WalletWasabi.Backend.dll
 cat .walletwasabi/backend/Logs.txt
 ```
 
@@ -209,8 +209,8 @@ sudo pico /etc/systemd/system/walletwasabi.service
 Description=WalletWasabi Backend API
 
 [Service]
-WorkingDirectory=/home/user/WalletWasabi/WalletWasabi.Backend/bin/Release/netcoreapp3.0/publish
-ExecStart=/usr/bin/dotnet /home/user/WalletWasabi/WalletWasabi.Backend/bin/Release/netcoreapp3.0/publish/WalletWasabi.Backend.dll
+WorkingDirectory=/home/user/WalletWasabi/WalletWasabi.Backend/bin/Release/netcoreapp3.1/publish
+ExecStart=/usr/bin/dotnet /home/user/WalletWasabi/WalletWasabi.Backend/bin/Release/netcoreapp3.1/publish/WalletWasabi.Backend.dll
 Restart=always
 RestartSec=10  # Restart service after 10 seconds if dotnet service crashes
 SyslogIdentifier=walletwasabi-backend

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>1701;1702;1705;1591;1573;CA1031</NoWarn>
   </PropertyGroup>
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp3.0\WalletWasabi.Gui.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netcoreapp3.1\WalletWasabi.Gui.xml</DocumentationFile>
     <OutputPath />
   </PropertyGroup>
 

--- a/WalletWasabi.Packager/WalletWasabi.Packager.csproj
+++ b/WalletWasabi.Packager/WalletWasabi.Packager.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>1701;1702;1705;1591;1573;CA1031</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp3.0\WalletWasabi.Packager.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netcoreapp3.1\WalletWasabi.Packager.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <NoWarn>1701;1702;1705;1591;CA1031</NoWarn>

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <LangVersion>latest</LangVersion>
     <NoWarn>1701;1702;1705;1591;1573;CA1031</NoWarn>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp3.0\WalletWasabi.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netcoreapp3.1\WalletWasabi.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -9,7 +9,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.0.x
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -9,7 +9,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.0.x
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -9,7 +9,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.0.x
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:


### PR DESCRIPTION
Note, this needs to be deployed to the backend in the same way as the .NET Core 3.0 had to, due to it changing the release directory structure.

resolves https://github.com/zkSNACKs/WalletWasabi/issues/2821

Also note if this is not merged before the release, then the deterministic guide won't work, since there our instruction is "In order to reproduce Wasabi's builds you need Git, Windows 10 and the version of .NET Core SDK that was the most recent in the time of building the release."

https://docs.wasabiwallet.io/using-wasabi/DeterministicBuild.html

- [x] Integration tests
- [x] CI is ready for upgrade
- [x] Test packager