### PR TITLE
[WIP] Remove IsVisible which causing the deadlock

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -29,7 +29,7 @@
           </Grid>
           <controls:ExtendedListBox Items="{Binding Transactions}" SelectedItem="{Binding SelectedTransaction, Mode=TwoWay}">
             <controls:ExtendedListBox.ContextMenu>
-              <ContextMenu IsVisible="{Binding IsItemSelected}">
+              <ContextMenu>
                 <MenuItem Header="Copy transaction ID" Command="{Binding CopyTransactionId}">
                   <MenuItem.Icon>
                     <DrawingPresenter HorizontalAlignment="Left" Height="16" Width="16" Stretch="Fill" Drawing="{StaticResource ReceiveTabView_CopyIcon}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -40,7 +40,7 @@
             </Style>
           </controls:ExtendedListBox.Styles>
           <controls:ExtendedListBox.ContextMenu>
-            <ContextMenu IsVisible="{Binding IsItemSelected}">
+            <ContextMenu>
               <MenuItem Header="{Binding SelectedAddress.ExpandMenuCaption}" Command="{Binding ToggleQrCode}">
                 <MenuItem.Icon>
                   <DrawingPresenter HorizontalAlignment="Left" Height="16" Width="16" Stretch="Fill" Drawing="{StaticResource ReceiveTabView_ToggleQrCode}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -41,12 +41,12 @@
           </controls:ExtendedListBox.Styles>
           <controls:ExtendedListBox.ContextMenu>
             <ContextMenu>
-              <MenuItem Header="{Binding SelectedAddress.ExpandMenuCaption}" Command="{Binding ToggleQrCode}">
+              <MenuItem Header="{Binding ExpandMenuCaption}" Command="{Binding ToggleQrCode}">
                 <MenuItem.Icon>
                   <DrawingPresenter HorizontalAlignment="Left" Height="16" Width="16" Stretch="Fill" Drawing="{StaticResource ReceiveTabView_ToggleQrCode}" />
                 </MenuItem.Icon>
               </MenuItem>
-              <MenuItem Header="Save QR Code" Command="{Binding SaveQRCodeCommand}" IsVisible="{Binding SelectedAddress.IsExpanded}">
+              <MenuItem Header="Save QR Code" Command="{Binding SaveQRCodeCommand}" IsVisible="{Binding IsItemExpanded}">
                 <MenuItem.Icon>
                   <Path HorizontalAlignment="Left" Data="M13,9V3.5L18.5,9M6,2C4.89,2 4,2.89 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6Z" Stretch="Fill" Fill="#22B14C" />
                 </MenuItem.Icon>


### PR DESCRIPTION
Removing ContextMenu `IsVisible` is improving the macOS deadlock situation significantly - sometimes still hangs.

Also removed invalid bindings when `SelectedAddress` is null. According to @danwalmsley it is handled inside Avalonia and the result is that the value is just not updated but still there is an empty menu item there which looks awkward - so I fixed it. 