### PR TITLE
Solve hang on filter crash

### DIFF
--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Gui
 			finally
 			{
 				StatusBar?.Dispose();
-				await Global.DisposeAsync();
+				await Global.DisposeAsync().ConfigureAwait(false);
 				AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
 				TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
 


### PR DESCRIPTION
There is no need to sync back to anywhere on exit.

For me, on windows, this solved the issue.