### PR TITLE
Adjust release filename 1.1.10.0 => 1.1.10

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Packager
 		public static string WixProjectDirectory = Path.GetFullPath(Path.Combine(SolutionDirectory, "WalletWasabi.WindowsInstaller\\"));
 		public static string BinDistDirectory = Path.GetFullPath(Path.Combine(GuiProjectDirectory, "bin\\dist"));
 
-		public static string VersionPrefix = Constants.ClientVersion.ToString();
+		public static string VersionPrefix = Constants.ClientVersion.Revision == 0 ? Constants.ClientVersion.ToString(3) : Constants.ClientVersion.ToString();
 
 		public static bool OnlyBinaries;
 		public static bool OnlyCreateDigests;


### PR DESCRIPTION
When I released I got Wasabi-1.1.10.0.dmg and so on. It looks awkward so I remove revision number if it is zero. 
Installed on macOS and on windows and looks fine. Old versions upgraded to new ones. 