### PR TITLE
Add VirusTotal source link (.zip)

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -222,7 +222,7 @@
                             <br />
                             <small><a href="https://github.com/zkSNACKs/WalletWasabi#build-from-source-code" class="text-muted">Or build it from source</a></small>
                             <br />
-                            <small><a href="https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt">PGP</a> / <a href="https://github.com/zkSNACKs/WalletWasabi/releases" itemprop="releaseNotes">RELEASE NOTES</a></small>
+                            <small><a href="https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt">PGP</a> / <a href="https://github.com/zkSNACKs/WalletWasabi/releases" itemprop="releaseNotes">RELEASE NOTES</a> / <a href="https://www.virustotal.com/gui/file/e0d33dbdf4f213229b48479bfe05fb4789a92ddb205dd2e15975382f2d6a34df/detection" target="_blank" rel="external nofollow">VIRUSTOTAL</a></small>
                         </div>
                         <div class="row">
                             <div class="col-6">


### PR DESCRIPTION
Following https://github.com/zkSNACKs/WasabiDoc/pull/399

Many inexperienced users are afraid of having downloaded the wrong software because their antivirus marks Wasabi as a virus, denying even the possibility of starting it.

This PR adds a link to a VirusTotal scan of Wasabi's source (in .zip format) in wasabiwallet.io.

In my opinion, we should start a communication campaign to ensure that all users report to their antivirus that Wasabi is safe / false positive. It is unacceptable that 16 out of 60 antiviruses report it as positive:
https://www.virustotal.com/gui/file/e0d33dbdf4f213229b48479bfe05fb4789a92ddb205dd2e15975382f2d6a34df/detection

Examples:
https://www.reddit.com/r/WasabiWallet/comments/dyc9i0/hwi_file_is_being_quarantined_for_malware_any/

![wasabi false positive virus](https://user-images.githubusercontent.com/46527252/70866894-7865f480-1f6f-11ea-9957-e7fe51f52082.png)
![wasabi false positive virus 2](https://user-images.githubusercontent.com/46527252/70866949-04781c00-1f70-11ea-9348-7e3272cd8bfe.png)
