### PR TITLE
remove avalonia hack

### DIFF
--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -122,16 +122,6 @@ namespace WalletWasabi.Gui
 				result.UsePlatformDetect();
 			}
 
-			// TODO remove this overriding of RenderTimer when Avalonia 0.9 is released.
-			// fixes "Thread Leak" issue in 0.8.1 Avalonia.
-			var old = result.WindowingSubsystemInitializer;
-
-			result.UseWindowingSubsystem(() =>
-			{
-				old();
-
-				AvaloniaLocator.CurrentMutable.Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60));
-			});
 			return result
 				.With(new Win32PlatformOptions { AllowEglInitialization = true, UseDeferredRendering = true })
 				.With(new X11PlatformOptions { UseGpu = useGpuLinux, WmClass = "Wasabi Wallet" })


### PR DESCRIPTION
This is no longer needed, because Avalonia release has this fix in...

https://github.com/AvaloniaUI/Avalonia/blob/master/src/Windows/Avalonia.Win32/Win32Platform.cs#L89