### PR TITLE
Upgrade to Bitcoin Core 19 + Small Improvements

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -618,7 +618,15 @@ namespace WalletWasabi.Backend.Controllers
 			{
 				case RoundPhase.Signing:
 					{
-						return Ok(round.GetUnsignedCoinJoinHex());
+						var hex = round.UnsignedCoinJoinHex;
+						if (hex is { })
+						{
+							return Ok(hex);
+						}
+						else
+						{
+							return NotFound("Hex not found. Thi is impossible.");
+						}
 					}
 				default:
 					{
@@ -689,21 +697,21 @@ namespace WalletWasabi.Backend.Controllers
 								{
 									return BadRequest($"Malformed witness is provided. Details: {ex.Message}");
 								}
-								int maxIndex = round.UnsignedCoinJoin.Inputs.Count - 1;
+								int maxIndex = round.CoinJoin.Inputs.Count - 1;
 								if (maxIndex < index)
 								{
 									return BadRequest($"Index out of range. Maximum value: {maxIndex}. Provided value: {index}");
 								}
 
 								// Check duplicates.
-								if (round.SignedCoinJoin.Inputs[index].HasWitScript())
+								if (round.CoinJoin.Inputs[index].HasWitScript())
 								{
 									return BadRequest("Input is already signed.");
 								}
 
 								// Verify witness.
 								// 1. Copy UnsignedCoinJoin.
-								Transaction cjCopy = Transaction.Parse(round.UnsignedCoinJoin.ToHex(), Network);
+								Transaction cjCopy = Transaction.Parse(round.CoinJoin.ToHex(), Network);
 								// 2. Sign the copy.
 								cjCopy.Inputs[index].WitScript = witness;
 								// 3. Convert the current input to IndexedTxIn.
@@ -717,7 +725,7 @@ namespace WalletWasabi.Backend.Controllers
 								}
 
 								// Finally add it to our CJ.
-								round.SignedCoinJoin.Inputs[index].WitScript = witness;
+								round.CoinJoin.Inputs[index].WitScript = witness;
 							}
 
 							alice.State = AliceState.SignedCoinJoin;

--- a/WalletWasabi.Documentation/ClientDeployment.md
+++ b/WalletWasabi.Documentation/ClientDeployment.md
@@ -49,7 +49,7 @@
 # 5. Notify
 
 1. Refresh website download and signature links.
-2. Update InstallationGuide and DeterministicBuildGuide download links, [here](https://github.com/molnard/WasabiDoc/blob/master/docs/.vuepress/variables.js#L3)
+2. Update InstallationGuide and DeterministicBuildGuide download links, [here](https://github.com/zkSNACKs/WasabiDoc/blob/master/docs/.vuepress/variables.js)
 3. Make sure CI and CodeFactor checks out.
 4. [Deploy testnet and mainnet backend.](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/BackendDeployment.md#update)
 

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -1235,8 +1235,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				false));
 
 			// Get some money, make it confirm.
-			var key = keyManager.GetNextReceiveKey("foo label", out _);
-			var txId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(1m));
+			var txId = await rpc.SendToAddressAsync(keyManager.GetNextReceiveKey("foo", out _).GetP2wpkhAddress(network), Money.Coins(1m));
 
 			// Generate some coins
 			await rpc.GenerateAsync(2);
@@ -1271,7 +1270,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				Assert.Throws<InsufficientBalanceException>(() => wallet.BuildTransaction(null, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy, true));
 
 				// Add new money with no confirmation
-				var txId2 = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(2m));
+				var txId2 = await rpc.SendToAddressAsync(keyManager.GetNextReceiveKey("bar", out _).GetP2wpkhAddress(network), Money.Coins(2m));
 				await Task.Delay(1000); // Wait tx to arrive and get processed.
 
 				// Enough money (one confirmed coin and one unconfirmed coin, unconfirmed are NOT allowed)

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTests.cs
@@ -9,6 +9,24 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 	public class ConfigTests
 	{
 		[Fact]
+		public void RemovesEmptyDuplications()
+		{
+			var configStringBuilder = new StringBuilder("foo=bar");
+			configStringBuilder.Append(Environment.NewLine);
+			configStringBuilder.Append(Environment.NewLine);
+			configStringBuilder.Append(Environment.NewLine);
+			configStringBuilder.Append("bar=bar");
+			var config = new CoreConfig();
+			config.AddOrUpdate(configStringBuilder.ToString());
+			var expectedConfig =
+@"foo = bar
+
+bar = bar
+";
+			Assert.Equal(expectedConfig, config.ToString());
+		}
+
+		[Fact]
 		public void CanParse()
 		{
 			var testConfig =
@@ -27,10 +45,10 @@ foo
 bar
 #qoo=boo";
 			var coreConfig = new CoreConfig();
-			coreConfig.TryAdd(testConfig);
+			coreConfig.AddOrUpdate(testConfig);
 
 			var expectedConfig =
-@"foo = buz
+@"foo = bar
 
 foo bar = buz quxx
 
@@ -50,7 +68,7 @@ bar
 			Assert.False(configDic.TryGetValue("bar", out _));
 			Assert.True(configDic.TryGetValue("foo bar", out string v3));
 
-			Assert.Equal("buz", v1);
+			Assert.Equal("bar", v1);
 			Assert.Equal("1", v2);
 			Assert.Equal("buz quxx", v3);
 
@@ -73,11 +91,11 @@ bar
 			var add2 = "foo=bar";
 			var add3 = "too=0";
 
-			coreConfig.TryAdd(add1);
+			coreConfig.AddOrUpdate(add1);
 			coreConfig2.AddOrUpdate(add1);
-			coreConfig.TryAdd(add2);
+			coreConfig.AddOrUpdate(add2);
 			coreConfig2.AddOrUpdate(add2);
-			coreConfig.TryAdd(add3);
+			coreConfig.AddOrUpdate(add3);
 			coreConfig2.AddOrUpdate(add3);
 
 			configDic = coreConfig.ToDictionary();
@@ -87,8 +105,8 @@ bar
 			Assert.True(configDic.TryGetValue("foo", out string fooValue));
 			Assert.True(configDic.TryGetValue("too", out string tooValue));
 			Assert.Equal("1", mooValue);
-			Assert.Equal("buz", fooValue);
-			Assert.Equal("1", tooValue);
+			Assert.Equal("bar", fooValue);
+			Assert.Equal("0", tooValue);
 
 			Assert.True(configDic2.TryGetValue("moo", out mooValue));
 			Assert.True(configDic2.TryGetValue("foo", out fooValue));
@@ -98,15 +116,15 @@ bar
 			Assert.Equal("0", tooValue);
 
 			expectedConfig =
-@"foo = buz
+@"foo = bar
 
 foo bar = buz quxx
 
-too = 1
 foo
 bar
 #qoo=boo
 moo = 1
+too = 0
 ";
 
 			Assert.Equal(expectedConfig, coreConfig.ToString());
@@ -132,7 +150,7 @@ too = 0
 @"foo=bar
 buz=qux";
 			var coreConfig = new CoreConfig();
-			coreConfig.TryAdd(testConfig);
+			coreConfig.AddOrUpdate(testConfig);
 
 			var expectedConfig =
 @"foo = bar
@@ -165,7 +183,7 @@ bar=4
 buz=1
 test.buz=2";
 			var coreConfig = new CoreConfig();
-			coreConfig.TryAdd(testConfig);
+			coreConfig.AddOrUpdate(testConfig);
 
 			var expectedConfig =
 @"qux = 1

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTranslatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTranslatorTests.cs
@@ -63,10 +63,10 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			Assert.Null(translator.TryGetRpcPort());
 
 			config.AddOrUpdate("main.rpcport=1");
-			Assert.Equal(1, translator.TryGetRpcPort());
+			Assert.Equal((ushort)1, translator.TryGetRpcPort());
 
 			config.AddOrUpdate("rpcport=2");
-			Assert.Equal(2, translator.TryGetRpcPort());
+			Assert.Equal((ushort)2, translator.TryGetRpcPort());
 
 			config.AddOrUpdate("main.rpcport=foo");
 			Assert.Null(translator.TryGetRpcPort());

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTranslatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTranslatorTests.cs
@@ -1,0 +1,125 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using WalletWasabi.BitcoinCore.Configuration;
+using WalletWasabi.BitcoinCore.Configuration.Whitening;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.BitcoinCore
+{
+	public class ConfigTranslatorTests
+	{
+		[Fact]
+		public void TryGetRpcUserTests()
+		{
+			var config = new CoreConfig();
+			var translatorMain = new CoreConfigTranslator(config, Network.Main);
+			var translatorTest = new CoreConfigTranslator(config, Network.TestNet);
+			var translatorReg = new CoreConfigTranslator(config, Network.RegTest);
+			Assert.Null(translatorMain.TryGetRpcUser());
+			Assert.Null(translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+
+			config.AddOrUpdate("rpcuser");
+			Assert.Null(translatorMain.TryGetRpcUser());
+			Assert.Null(translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+			config.AddOrUpdate("rpcuser=foo");
+			Assert.Equal("foo", translatorMain.TryGetRpcUser());
+			Assert.Null(translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+			config.AddOrUpdate("rpcuser=boo");
+			Assert.Equal("boo", translatorMain.TryGetRpcUser());
+			Assert.Null(translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+			config.AddOrUpdate("main.rpcuser=ooh");
+			Assert.Equal("ooh", translatorMain.TryGetRpcUser());
+			Assert.Null(translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+			config.AddOrUpdate("rpcuser=boo");
+			Assert.Equal("boo", translatorMain.TryGetRpcUser());
+			Assert.Null(translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+			config.AddOrUpdate("test.rpcuser=boo");
+			Assert.Equal("boo", translatorMain.TryGetRpcUser());
+			Assert.Equal("boo", translatorTest.TryGetRpcUser());
+			Assert.Null(translatorReg.TryGetRpcUser());
+			config.AddOrUpdate("regtest.rpcuser=boo");
+			Assert.Equal("boo", translatorMain.TryGetRpcUser());
+			Assert.Equal("boo", translatorTest.TryGetRpcUser());
+			Assert.Equal("boo", translatorReg.TryGetRpcUser());
+		}
+
+		[Fact]
+		public void TryGetRpcPortTests()
+		{
+			var config = new CoreConfig();
+			var translator = new CoreConfigTranslator(config, Network.Main);
+			Assert.Null(translator.TryGetRpcPort());
+
+			config.AddOrUpdate("rpcport");
+			Assert.Null(translator.TryGetRpcPort());
+
+			config.AddOrUpdate("main.rpcport=1");
+			Assert.Equal(1, translator.TryGetRpcPort());
+
+			config.AddOrUpdate("rpcport=2");
+			Assert.Equal(2, translator.TryGetRpcPort());
+
+			config.AddOrUpdate("main.rpcport=foo");
+			Assert.Null(translator.TryGetRpcPort());
+		}
+
+		[Fact]
+		public void TryGetWhiteBindTests()
+		{
+			var config = new CoreConfig();
+			var translator = new CoreConfigTranslator(config, Network.Main);
+			Assert.Null(translator.TryGetWhiteBind());
+
+			config.AddOrUpdate("whitebind");
+			Assert.Null(translator.TryGetWhiteBind());
+
+			config.AddOrUpdate("main.whitebind=127.0.0.1:18444");
+			WhiteBind whiteBind = translator.TryGetWhiteBind();
+			var ipEndPoint = whiteBind.EndPoint as IPEndPoint;
+			Assert.Equal(IPAddress.Loopback, ipEndPoint.Address);
+			Assert.Equal(18444, ipEndPoint.Port);
+			Assert.Equal(string.Empty, whiteBind.Permissions);
+
+			config.AddOrUpdate("whitebind=127.0.0.1:0");
+			whiteBind = translator.TryGetWhiteBind();
+			ipEndPoint = whiteBind.EndPoint as IPEndPoint;
+			Assert.Equal(IPAddress.Loopback, ipEndPoint.Address);
+			Assert.Equal(0, ipEndPoint.Port);
+			Assert.Equal(string.Empty, whiteBind.Permissions);
+
+			config.AddOrUpdate("whitebind=127.0.0.1");
+			whiteBind = translator.TryGetWhiteBind();
+			ipEndPoint = whiteBind.EndPoint as IPEndPoint;
+			Assert.Equal(IPAddress.Loopback, ipEndPoint.Address);
+			// Default port.
+			Assert.Equal(8333, ipEndPoint.Port);
+			Assert.Equal(string.Empty, whiteBind.Permissions);
+
+			config.AddOrUpdate("whitebind=foo@127.0.0.1");
+			whiteBind = translator.TryGetWhiteBind();
+			ipEndPoint = whiteBind.EndPoint as IPEndPoint;
+			Assert.Equal(IPAddress.Loopback, ipEndPoint.Address);
+			Assert.Equal(8333, ipEndPoint.Port);
+			Assert.Equal("foo", whiteBind.Permissions);
+
+			config.AddOrUpdate("whitebind=foo,boo@127.0.0.1");
+			whiteBind = translator.TryGetWhiteBind();
+			ipEndPoint = whiteBind.EndPoint as IPEndPoint;
+			Assert.Equal(IPAddress.Loopback, ipEndPoint.Address);
+			Assert.Equal(8333, ipEndPoint.Port);
+			Assert.Equal("foo,boo", whiteBind.Permissions);
+
+			config.AddOrUpdate("main.whitebind=@@@");
+			Assert.Null(translator.TryGetWhiteBind());
+		}
+	}
+}

--- a/WalletWasabi/BitcoinCore/Configuration/CoreConfig.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/CoreConfig.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.BitcoinCore.Configuration
 				{
 					var foundLine = Lines.FirstOrDefault(x =>
 							x.Key == line.Key
-							|| $"main.{x.Key}" == line.Key
+							|| line.Key == $"main.{x.Key}"
 							|| x.Key == $"main.{line.Key}");
 
 					if (foundLine is null)

--- a/WalletWasabi/BitcoinCore/Configuration/CoreConfig.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/CoreConfig.cs
@@ -38,32 +38,6 @@ namespace WalletWasabi.BitcoinCore.Configuration
 
 		public override string ToString() => $"{Guard.Correct(string.Join(Environment.NewLine, Lines))}{Environment.NewLine}"; // Good practice to end with a newline.
 
-		/// <summary>
-		/// TryAdd and AddOrUpdate are sisters. TryAdd always considers the first occurrence of a key as valid, while AddOrUpdate considers the last occurrence of it.
-		/// </summary>
-		public void TryAdd(string configString)
-		{
-			foreach (var line in ParseConfigLines(configString))
-			{
-				if (line.HasKeyValuePair)
-				{
-					var foundLine = Lines.FirstOrDefault(x => x.Key == line.Key);
-					if (foundLine is null)
-					{
-						Lines.Add(line);
-					}
-				}
-				else
-				{
-					Lines.Add(line);
-				}
-				RemoveFirstEmptyDuplication();
-			}
-		}
-
-		/// <summary>
-		/// TryAdd and AddOrUpdate are sisters. TryAdd always considers the first occurrence of a key as valid, while AddOrUpdate considers the last occurrence of it.
-		/// </summary>
 		public bool AddOrUpdate(string configString)
 		{
 			var ret = false;
@@ -89,9 +63,20 @@ namespace WalletWasabi.BitcoinCore.Configuration
 					Lines.Add(line);
 					ret = true;
 				}
-				ret = ret || RemoveFirstEmptyDuplication();
 			}
 
+			ret = RemoveEmptyDuplications() || ret;
+
+			return ret;
+		}
+
+		private bool RemoveEmptyDuplications()
+		{
+			var ret = false;
+			while (RemoveFirstEmptyDuplication())
+			{
+				ret = true;
+			}
 			return ret;
 		}
 

--- a/WalletWasabi/BitcoinCore/Configuration/CoreConfig.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/CoreConfig.cs
@@ -1,3 +1,4 @@
+using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,7 +46,11 @@ namespace WalletWasabi.BitcoinCore.Configuration
 			{
 				if (line.HasKeyValuePair)
 				{
-					var foundLine = Lines.FirstOrDefault(x => x.Key == line.Key);
+					var foundLine = Lines.FirstOrDefault(x =>
+							x.Key == line.Key
+							|| $"main.{x.Key}" == line.Key
+							|| x.Key == $"main.{line.Key}");
+
 					if (foundLine is null)
 					{
 						Lines.Add(line);

--- a/WalletWasabi/BitcoinCore/Configuration/CoreConfigTranslator.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/CoreConfigTranslator.cs
@@ -1,0 +1,78 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.BitcoinCore.Configuration.Whitening;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.BitcoinCore.Configuration
+{
+	public class CoreConfigTranslator
+	{
+		public CoreConfig Config { get; }
+		public Network Network { get; }
+
+		public CoreConfigTranslator(CoreConfig config, Network network)
+		{
+			Config = Guard.NotNull(nameof(config), config);
+			Network = Guard.NotNull(nameof(network), network);
+		}
+
+		public string TryGetValue(string key)
+		{
+			var configDic = Config.ToDictionary();
+			string result = null;
+			foreach (var networkPrefixWithDot in NetworkTranslator.GetConfigPrefixesWithDots(Network))
+			{
+				var found = configDic.TryGet($"{networkPrefixWithDot}{key}");
+				if (found is { })
+				{
+					result = found;
+				}
+			}
+
+			return result;
+		}
+
+		public string TryGetRpcUser() => TryGetValue("rpcuser");
+
+		public string TryGetRpcPassword() => TryGetValue("rpcpassword");
+
+		public string TryGetRpcCookieFile() => TryGetValue("rpccookiefile");
+
+		public string TryGetRpcHost() => TryGetValue("rpchost");
+
+		public int? TryGetRpcPort()
+		{
+			var stringValue = TryGetValue("rpcport");
+			if (stringValue is { } && int.TryParse(stringValue, out int value))
+			{
+				return value;
+			}
+
+			return null;
+		}
+
+		public WhiteBind TryGetWhiteBind()
+		{
+			var stringValue = TryGetValue("whitebind");
+			if (stringValue is { } && WhiteBind.TryParse(stringValue, Network, out WhiteBind value))
+			{
+				return value;
+			}
+
+			return null;
+		}
+
+		public WhiteList TryGetWhiteList()
+		{
+			var stringValue = TryGetValue("whitelist");
+			if (stringValue is { } && WhiteList.TryParse(stringValue, Network, out WhiteList value))
+			{
+				return value;
+			}
+
+			return null;
+		}
+	}
+}

--- a/WalletWasabi/BitcoinCore/Configuration/CoreConfigTranslator.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/CoreConfigTranslator.cs
@@ -42,10 +42,10 @@ namespace WalletWasabi.BitcoinCore.Configuration
 
 		public string TryGetRpcHost() => TryGetValue("rpchost");
 
-		public int? TryGetRpcPort()
+		public ushort? TryGetRpcPort()
 		{
 			var stringValue = TryGetValue("rpcport");
-			if (stringValue is { } && int.TryParse(stringValue, out int value))
+			if (stringValue is { } && ushort.TryParse(stringValue, out ushort value))
 			{
 				return value;
 			}

--- a/WalletWasabi/BitcoinCore/Configuration/NetworkTranslator.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/NetworkTranslator.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;

--- a/WalletWasabi/BitcoinCore/Configuration/Whitening/WhiteBind.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/Whitening/WhiteBind.cs
@@ -1,0 +1,14 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace WalletWasabi.BitcoinCore.Configuration.Whitening
+{
+	public class WhiteBind : WhiteEntry
+	{
+		public static bool TryParse(string value, Network network, out WhiteBind white)
+			=> TryParse<WhiteBind>(value, network, out white);
+	}
+}

--- a/WalletWasabi/BitcoinCore/Configuration/Whitening/WhiteEntry.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/Whitening/WhiteEntry.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.BitcoinCore.Configuration.Whitening
+{
+	public abstract class WhiteEntry
+	{
+		public string Permissions { get; private set; } = string.Empty;
+		public EndPoint EndPoint { get; private set; } = null;
+
+		public static bool TryParse<T>(string value, Network network, out T whiteEntry) where T : WhiteEntry, new()
+		{
+			whiteEntry = null;
+			// https://github.com/bitcoin/bitcoin/pull/16248
+			var parts = value?.Split('@');
+			if (parts is { })
+			{
+				if (EndPointParser.TryParse(parts.LastOrDefault(), network.DefaultPort, out EndPoint endPoint))
+				{
+					whiteEntry = new T();
+					whiteEntry.EndPoint = endPoint;
+					if (parts.Length > 1)
+					{
+						whiteEntry.Permissions = parts.First();
+					}
+
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/WalletWasabi/BitcoinCore/Configuration/Whitening/WhiteList.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/Whitening/WhiteList.cs
@@ -1,0 +1,14 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace WalletWasabi.BitcoinCore.Configuration.Whitening
+{
+	public class WhiteList : WhiteEntry
+	{
+		public static bool TryParse(string value, Network network, out WhiteList white)
+			=> TryParse<WhiteList>(value, network, out white);
+	}
+}

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -193,7 +193,7 @@ namespace WalletWasabi.BitcoinCore
 					|| !File.Exists(configPath))
 				{
 					IoHelpers.EnsureContainingDirectoryExists(configPath);
-					await File.WriteAllTextAsync(configPath, coreNode.Config.ToString());
+					await File.WriteAllTextAsync(configPath, coreNode.Config.ToString()).ConfigureAwait(false);
 				}
 				cancel.ThrowIfCancellationRequested();
 

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.BitcoinCore
 				if (File.Exists(configPath))
 				{
 					var configString = await File.ReadAllTextAsync(configPath).ConfigureAwait(false);
-					coreNode.Config.TryAdd(configString);
+					coreNode.Config.AddOrUpdate(configString); // Bitcoin Core considers the last entry to be valid.
 				}
 				cancel.ThrowIfCancellationRequested();
 

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -188,7 +188,7 @@ namespace WalletWasabi.BitcoinCore
 				throw new BitcoindException($"'bitcoind {arguments}' exited with incorrect exit code: {exitCode}.");
 			}
 			var firstLine = responseString.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).First();
-			var versionString = firstLine.TrimStart("Bitcoin Core Daemon version v", StringComparison.OrdinalIgnoreCase);
+			string versionString = firstLine.Split("version v", StringSplitOptions.RemoveEmptyEntries).Last();
 			var version = new Version(versionString);
 			return version;
 		}

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -78,15 +78,15 @@ namespace WalletWasabi.BitcoinCore
 					var rpst = configDic.TryGet($"{networkPrefixWithDot}rpchost");
 					var rpts = configDic.TryGet($"{networkPrefixWithDot}rpcport");
 
-					if (rpcc != null)
+					if (rpcc is { })
 					{
 						rpcCookieFilePath = rpcc;
 					}
-					if (ru != null)
+					if (ru is { })
 					{
 						rpcUser = ru;
 					}
-					if (rp != null)
+					if (rp is { })
 					{
 						rpcPassword = rp;
 					}
@@ -106,18 +106,18 @@ namespace WalletWasabi.BitcoinCore
 						}
 					}
 
-					if (rpst != null)
+					if (rpst is { })
 					{
 						rpcHost = rpst;
 					}
-					if (rpts != null && int.TryParse(rpts, out int rpt))
+					if (rpts is { } && int.TryParse(rpts, out int rpt))
 					{
 						rpcPort = rpt;
 					}
 				}
 
 				string authString;
-				bool cookieAuth = rpcCookieFilePath != null;
+				bool cookieAuth = rpcCookieFilePath is { };
 				if (cookieAuth)
 				{
 					authString = $"cookiefile={rpcCookieFilePath}";
@@ -168,12 +168,12 @@ namespace WalletWasabi.BitcoinCore
 					desiredConfigLines.Add($"{configPrefix}.rpcpassword	= {coreNode.RpcClient.CredentialString.UserPassword.Password}");
 				}
 
-				if (coreNodeParams.TxIndex != null)
+				if (coreNodeParams.TxIndex is { })
 				{
 					desiredConfigLines.Add($"{configPrefix}.txindex = {coreNodeParams.TxIndex}");
 				}
 
-				if (coreNodeParams.Prune != null)
+				if (coreNodeParams.Prune is { })
 				{
 					desiredConfigLines.Add($"{configPrefix}.prune = {coreNodeParams.Prune}");
 				}
@@ -269,7 +269,7 @@ namespace WalletWasabi.BitcoinCore
 			Exception exThrown = null;
 
 			BitcoindRpcProcessBridge bridge = null;
-			if (Bridge != null)
+			if (Bridge is { })
 			{
 				bridge = Bridge;
 			}
@@ -278,7 +278,7 @@ namespace WalletWasabi.BitcoinCore
 				bridge = new BitcoindRpcProcessBridge(RpcClient, DataDir, printToConsole: false);
 			}
 
-			if (bridge != null)
+			if (bridge is { })
 			{
 				try
 				{

--- a/WalletWasabi/BitcoinCore/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/IRPCClient.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using System.Threading.Tasks;
 
 namespace WalletWasabi.BitcoinCore
@@ -6,8 +6,11 @@ namespace WalletWasabi.BitcoinCore
 	public interface IRPCClient
 	{
 		Network Network { get; }
+
 		Task<uint256> GetBestBlockHashAsync();
+
 		Task<Block> GetBlockAsync(uint256 blockId);
+
 		Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash);
 	}
 }

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 			}
 			catch
 			{
-				if (AllFeeEstimate != null)
+				if (AllFeeEstimate is { })
 				{
 					AllFeeEstimate = new AllFeeEstimate(AllFeeEstimate, false);
 				}

--- a/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
@@ -295,13 +295,13 @@ namespace WalletWasabi.CoinJoin.Coordinator
 				{
 					using (await CoinJoinsLock.LockAsync().ConfigureAwait(false))
 					{
-						uint256 coinJoinHash = round.SignedCoinJoin.GetHash();
+						uint256 coinJoinHash = round.CoinJoin.GetHash();
 						CoinJoins.Add(coinJoinHash);
 						UnconfirmedCoinJoins.Add(coinJoinHash);
 						await File.AppendAllLinesAsync(CoinJoinsFilePath, new[] { coinJoinHash.ToString() }).ConfigureAwait(false);
 
 						// When a round succeeded, adjust the denomination as to users still be able to register with the latest round's active output amount.
-						IEnumerable<(Money value, int count)> outputs = round.SignedCoinJoin.GetIndistinguishableOutputs(includeSingle: true);
+						IEnumerable<(Money value, int count)> outputs = round.CoinJoin.GetIndistinguishableOutputs(includeSingle: true);
 						var bestOutput = outputs.OrderByDescending(x => x.count).FirstOrDefault();
 						if (bestOutput != default)
 						{

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -51,7 +51,7 @@ namespace NBitcoin.RPC
 				{
 					return await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode);
 				}
-				catch (RPCException ex)
+				catch (Exception ex) when (ex is RPCException || ex is NoEstimationException)
 				{
 					Logger.LogTrace(ex);
 					// Hopefully Bitcoin Core brainfart: https://github.com/bitcoin/bitcoin/issues/14431
@@ -61,7 +61,7 @@ namespace NBitcoin.RPC
 						{
 							return await rpc.EstimateSmartFeeAsync(i, estimateMode);
 						}
-						catch (RPCException ex2)
+						catch (Exception ex2) when (ex2 is RPCException || ex2 is NoEstimationException)
 						{
 							Logger.LogTrace(ex2);
 						}

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -124,7 +124,7 @@ namespace NBitcoin.RPC
 		{
 			try
 			{
-				await rpc.GetBlockchainInfoAsync().ConfigureAwait(false);
+				await rpc.UptimeAsync().ConfigureAwait(false);
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Helpers
 		public static readonly Version ClientVersion = new Version(1, 1, 10, 1);
 		public const string BackendMajorVersion = "3";
 		public static readonly Version HwiVersion = new Version("1.0.3");
-		public static readonly Version BitcoinCoreVersion = new Version("0.18.1");
+		public static readonly Version BitcoinCoreVersion = new Version("0.19.0.1");
 
 		/// <summary>
 		/// By changing this, we can force to start over the transactions file, so old incorrect transactions would be cleared.

--- a/WalletWasabi/Microservices/Binaries/README.md
+++ b/WalletWasabi/Microservices/Binaries/README.md
@@ -1,7 +1,7 @@
 # Updating Executables
 
 1. Replace executables.
-2. Properties/Copy to Output: Copy if newer. (VSBUG: Sometimes Copy Always is needed. It's generally ok to do copy always then set it back to Copy if newer, so already running Bitcoin Core will not be tried to recopied all the time.)
+2. Properties/Copy to Output: Copy if newer. (VSBUG: Sometimes Copy Always is needed. It's generally ok to do copy always then set it back to Copy if newer, so already running Bitcoin Core will not be tried to get recopied all the time.)
 3. Make sure the Linux and the OSX binaries are executable:
 	`git update-index --chmod=+x hwi`
 	`git update-index --chmod=+x bitcoind`

--- a/WalletWasabi/Microservices/Binaries/README.md
+++ b/WalletWasabi/Microservices/Binaries/README.md
@@ -1,7 +1,7 @@
 # Updating Executables
 
 1. Replace executables.
-2. Properties/Copy to Output: Copy if newer.
+2. Properties/Copy to Output: Copy if newer. (VSBUG: Sometimes Copy Always is needed. It's generally ok to do copy always then set it back to Copy if newer, so already running Bitcoin Core will not be tried to recopied all the time.)
 3. Make sure the Linux and the OSX binaries are executable:
 	`git update-index --chmod=+x hwi`
 	`git update-index --chmod=+x bitcoind`

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-	  <PackageReference Include="NBitcoin" Version="5.0.5" />
+	  <PackageReference Include="NBitcoin" Version="5.0.13" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
   </ItemGroup>
   


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/pull/2885
Closes https://github.com/zkSNACKs/WalletWasabi/pull/2612

In this PR I want to add some small improvements for Bitcoin Core and I'm hoping to add these to the next backport release to reduce the Bitcoin Core related support requests.

## Changes

- Make sure we don't ruin the config of Bitcoin Core 19 users who are using advanced whitebinded options, added here: https://github.com/bitcoin/bitcoin/pull/16248 - commit: https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/e92f75de3ffb747095fe67c2c34165a23d4947e3
- Improve start and stop mechanism. Wasabi gets stuck when we are quickly opening and closing it. This PR fixes that (in expense of throwing an exception.) https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/58f4b6512dcaf7c6caf7418ac8c0b26321bd0e20
- This PR improves logging of monitoring the startup of Bitcoin Core. https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/58f4b6512dcaf7c6caf7418ac8c0b26321bd0e20
- Add 100ms delay before RPC check so the UI will have time to breathe while Bitcoin Core is being initialized. https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/58f4b6512dcaf7c6caf7418ac8c0b26321bd0e20
- We can now cancel Bitcoin Core initialization gracefully (and stop will be issued.) Although the RPC stop issuance throws an exception while Core is not yet initialized, it seems to be effective in stopping Core regardless. I log the exception regardless, there may be cases when the command fails for good. https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/58f4b6512dcaf7c6caf7418ac8c0b26321bd0e20
- Make sure the user can work with (and our backend) both with Bitcoin Core 18 and 19. Waiting for dependency: https://github.com/MetacoSA/NBitcoin/pull/791, https://github.com/MetacoSA/NBitcoin/pull/790
- Add best practice `.ConfigureAwait(false)` https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/ee09ce7747d53aa3469d39d86da94b20fd636f41
- Add best practice `is { }` https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/cf5d178748a3d05a7c053367ae860ac0abbba36d
- CodeMaid https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/4823efc3ba81771b9b8a429d63fc99d26521327c
- Improve hotspot at CoreNode creation by introducing a `NetworkTranslator` https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/745ccae7962b7c0527173e266140d5e194fe4567
- Fix config reading minor bug so .main and no dot stuff to be considered the same https://github.com/zkSNACKs/WalletWasabi/commit/745ccae7962b7c0527173e266140d5e194fe4567
- In config, use AddOrUpdate instead of TryAdd, as Bitcoin Core is using that logic, too. https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/b673661e45bc2c7de610c1ff7b767183f3c43f18
- Update NBitcoin (it is compatible with Core 18 after my PRs into NBitcoin) https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/5ccd7d4a3b0bf777b1a80a871411b38313d02dc7
- Replace getblockchaininfo testing function with uptime, as it's more appropriate: https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/0b77a91ffe037e81d4d28d47c97cf797fb8a0f4d
- Update to Bitcoin Core 19 https://github.com/zkSNACKs/WalletWasabi/pull/2899/commits/50465dc4334d952dfe8a9a9ea1a11e428b7c8a4d

## Details

Regarding monitoring the startup of Bitcoin Core, the logs look like this now:

```
2019-12-21 15:13:54 INFO	BitcoindRpcProcessBridge (58)	Bitcoin Core is not yet ready... Reason: Verifying wallet(s)...
2019-12-21 15:13:55 INFO	BitcoindRpcProcessBridge (58)	Bitcoin Core is not yet ready... Reason: Loading block index...
2019-12-21 15:13:59 INFO	BitcoindRpcProcessBridge (58)	Bitcoin Core is not yet ready... Reason: Rewinding blocks...
2019-12-21 15:13:59 INFO	BitcoindRpcProcessBridge (58)	Bitcoin Core is not yet ready... Reason: Verifying blocks...
2019-12-21 15:14:00 INFO	BitcoindRpcProcessBridge (58)	Bitcoin Core is not yet ready... Reason: Loading wallet...
2019-12-21 15:14:01 INFO	BitcoindRpcProcessBridge (58)	Bitcoin Core is not yet ready... Reason: Loading P2P addresses...
2019-12-21 15:14:02 INFO	BitcoindRpcProcessBridge (52)	RPC connection is sucessfully established.
2019-12-21 15:14:02 INFO	CoreNode (209)	Started Bitcoin Core.
```