### PR TITLE
Fix same scriptpubkey tracking

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -26,6 +26,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private ObservableAsPropertyHelper<bool> _unspent;
 		private ObservableAsPropertyHelper<bool> _confirmed;
 		private ObservableAsPropertyHelper<bool> _unavailable;
+		private ObservableAsPropertyHelper<string> _cluster;
 		private ObservableAsPropertyHelper<string> _expandMenuCaption;
 		private bool _isExpanded;
 		public ReactiveCommand<Unit, bool> ToggleDetails { get; }
@@ -60,6 +61,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			_confirmed = Model
 				.WhenAnyValue(x => x.Confirmed)
 				.ToProperty(this, x => x.Confirmed, scheduler: RxApp.MainThreadScheduler)
+				.DisposeWith(Disposables);
+
+			_cluster = Model
+				.WhenAnyValue(x => x.Clusters, x => x.Clusters.Labels)
+				.Select(x => x.Item2.ToString())
+				.ToProperty(this, x => x.Clusters, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
 			_unavailable = Model
@@ -178,7 +185,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public string InCoinJoin => Model.CoinJoinInProgress ? "Yes" : "No";
 
-		public string Clusters => Model.Clusters.Labels; // If the value is null the bind do not update the view. It shows the previous state for example: ##### even if PrivMode false.
+		public string Clusters => _cluster?.Value ?? "";
 
 		public string PubKey => Model.HdPubKey?.PubKey?.ToString() ?? "";
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -90,6 +90,10 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 						{
 							coin.Clusters = cluster;
 						}
+						else
+						{
+							ClustersByScriptPubKey.Add(coin.ScriptPubKey, coin.Clusters);
+						}
 						InvalidateSnapshot = true;
 					}
 				}


### PR DESCRIPTION
Fixes a problem tracking the clusters of same-scriptPubKey coins. This is necessary to fix #2903 but it is not enough because we are not refreshing the UI when a cluster changes. This means that internally the data structures are okay but the UI remains inconsistent. We can see the changes after closing and reopening the Send tab (or the CoinJoin tab). 