### PR TITLE
Faster keys gap counting algorithm

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -535,26 +535,26 @@ namespace WalletWasabi.Blockchain.Keys
 			var keyIndexes = GetKeys(KeyState.Clean, isInternal).Select(x => x.Index).ToArray();
 
 			var hs = keyIndexes.ToHashSet();
-			int largerConsecutiveSequence = 0; 
+			int largerConsecutiveSequence = 0;
 
-			for (int i = 0; i < keyIndexes.Length; ++i) 
-			{ 
-				if (!hs.Contains(keyIndexes[i] - 1)) 
-				{ 
-					int j = keyIndexes[i]; 
-					while (hs.Contains(j)) 
-					{ 
-						j++; 
-					} 
-	
+			for (int i = 0; i < keyIndexes.Length; ++i)
+			{
+				if (!hs.Contains(keyIndexes[i] - 1))
+				{
+					int j = keyIndexes[i];
+					while (hs.Contains(j))
+					{
+						j++;
+					}
+
 					var sequenceLength = j - keyIndexes[i];
-					if (largerConsecutiveSequence < sequenceLength) 
-					{ 
-						largerConsecutiveSequence = sequenceLength; 
-					} 
-				} 
-			} 
-			return largerConsecutiveSequence; 
+					if (largerConsecutiveSequence < sequenceLength)
+					{
+						largerConsecutiveSequence = sequenceLength;
+					}
+				}
+			}
+			return largerConsecutiveSequence;
 		}
 
 		public IEnumerable<byte[]> GetPubKeyScriptBytes()

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -532,29 +532,29 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public int CountConsecutiveCleanKeys(bool isInternal)
 		{
-			var keys = GetKeys(KeyState.Clean, isInternal).OrderBy(x => x.Index).ToArray();
-			var keyCount = keys.Length;
-			if (keyCount < 2)
-			{
-				return keyCount;
-			}
+			var keyIndexes = GetKeys(KeyState.Clean, isInternal).Select(x => x.Index).ToArray();
 
-			var largerConsecutiveSequence = 1;
-			var consecutives = 1;
-			for (int i = 1; i < keyCount; i++)
-			{
-				if (keys[i].Index == keys[i - 1].Index + 1)
-				{
-					consecutives++;
-				}
-				else if (consecutives > largerConsecutiveSequence)
-				{
-					largerConsecutiveSequence = consecutives;
-					consecutives = 1;
-				}
-			}
+			var hs = keyIndexes.ToHashSet();
+			int largerConsecutiveSequence = 0; 
 
-			return Math.Max(consecutives, largerConsecutiveSequence);
+			for (int i = 0; i < keyIndexes.Length; ++i) 
+			{ 
+				if (!hs.Contains(keyIndexes[i] - 1)) 
+				{ 
+					int j = keyIndexes[i]; 
+					while (hs.Contains(j)) 
+					{ 
+						j++; 
+					} 
+	
+					var sequenceLength = j - keyIndexes[i];
+					if (largerConsecutiveSequence < sequenceLength) 
+					{ 
+						largerConsecutiveSequence = sequenceLength; 
+					} 
+				} 
+			} 
+			return largerConsecutiveSequence; 
 		}
 
 		public IEnumerable<byte[]> GetPubKeyScriptBytes()


### PR DESCRIPTION
This PR uses a faster mechanism for counting the largest sequence of consecutive key indexes. The new algorithm is just as performant as the previous one when there is no holes (or few holes) in the sequence and the MinGapLimit is small (for example 21). However, when the MinGapLimit is bigger, let say 100 or greater, and there are holes in the sequence the new algorithm is much faster. 