### PR TITLE
Correct path correction

### DIFF
--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -74,7 +74,7 @@ namespace WalletWasabi.TorSocks5
 						{
 							if (!fullBaseDirectory.StartsWith('/'))
 							{
-								fullBaseDirectory.Insert(0, "/");
+								fullBaseDirectory = fullBaseDirectory.Insert(0, "/");
 							}
 
 							torPath = $@"{torDir}/Tor/tor";


### PR DESCRIPTION
I found this while investigating #2289

```c#
var a = "ello";
var b = a.Insert(0, "H");
b
"Hello"
a
"ello"
```