### PR TITLE
Correct sort order arrow icons

### DIFF
--- a/WalletWasabi.Gui/Controls/SortingArrow.cs
+++ b/WalletWasabi.Gui/Controls/SortingArrow.cs
@@ -138,11 +138,11 @@ namespace WalletWasabi.Gui.Controls
 					break;
 
 				case SortOrder.Increasing:
-					IconPath.Data = DownArrow;
+					IconPath.Data = UpArrow;
 					break;
 
 				case SortOrder.Decreasing:
-					IconPath.Data = UpArrow;
+					IconPath.Data = DownArrow;
 					break;
 			}
 		}


### PR DESCRIPTION
Current version has the arrow icons when sorting table columns the wrong way around.

When the list would go from big to small (descending) it would show the triangle with the small end at top and large end at bottom. This is the opposite to the presented data with big at top and small at bottom.

![image](https://user-images.githubusercontent.com/8009243/71677491-e0dc1080-2d7a-11ea-985f-a92382b36f8b.png)
