### PR TITLE
Throw exception when wallet has no fingerprint

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -479,7 +479,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 						}
 						if (!selectedWallet.HardwareWalletInfo.Fingerprint.HasValue)
 						{
-							throw new InvalidOperationException("Wallet doesn't contain the fingerprint.");
+							throw new InvalidOperationException("Hardware wallet did not provide fingerprint.");
 						}
 						KeyManager.CreateNewHardwareWalletWatchOnly(selectedWallet.HardwareWalletInfo.Fingerprint.Value, extPubKey, path);
 					}

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -477,6 +477,10 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 							await EnumerateHardwareWalletsAsync();
 							selectedWallet = Wallets.FirstOrDefault(x => x.HardwareWalletInfo.Model == selectedWallet.HardwareWalletInfo.Model && x.HardwareWalletInfo.Path == selectedWallet.HardwareWalletInfo.Path);
 						}
+						if (!selectedWallet.HardwareWalletInfo.Fingerprint.HasValue)
+						{
+							throw new InvalidOperationException("Wallet doesn't contain the fingerprint.");
+						}
 						KeyManager.CreateNewHardwareWalletWatchOnly(selectedWallet.HardwareWalletInfo.Fingerprint.Value, extPubKey, path);
 					}
 				}


### PR DESCRIPTION
Throws a better exception when hardware wallet has no fingerprint. 

Related: #2928