### PR TITLE
Remove WalletWasabi.Community folder

### DIFF
--- a/WalletWasabi.Community/Dojo.md
+++ b/WalletWasabi.Community/Dojo.md
@@ -1,1 +1,0 @@
-The dojo can be found in the [documentation](https://docs.wasabiwallet.io/building-wasabi/Dojo.html).


### PR DESCRIPTION
The folder contains only Dojo.md file that contains one line to the documentation link.