### PR TITLE
Revert "Remove unneeded code"

### DIFF
--- a/WalletWasabi.Gui/Helpers/AvalonStudioShellExtensions.cs
+++ b/WalletWasabi.Gui/Helpers/AvalonStudioShellExtensions.cs
@@ -15,6 +15,13 @@ namespace AvalonStudio.Shell
 {
 	public static class AvalonStudioShellExtensions
 	{
+		// Replacement of avalonia's https://github.com/VitalElement/AvalonStudio.Shell/blob/eaa708e6c1428afd142e364dc6dbbd7ff5ba69dc/src/AvalonStudio.Shell.Extensibility/Shell/IShellExtensions.cs
+		// because we want to use IoC to create T
+		public static T GetOrCreateByType<T>(this IShell me) where T : IDocumentTabViewModel
+		{
+			return me.GetOrCreate<T>(() => IoC.Get<T>());
+		}
+
 		public static ReactiveCommand<Unit, Unit> GetReactiveCommand(this CommandDefinition cmd)
 		{
 			return cmd.Command as ReactiveCommand<Unit, Unit>;

--- a/WalletWasabi.Gui/Shell/Commands/ToolCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/ToolCommands.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui.Shell.Commands
 		{
 			var global = Locator.Current.GetService<Global>();
 
-			var walletManagerViewModel = IoC.Get<IShell>().GetOrCreate<WalletManagerViewModel>();
+			var walletManagerViewModel = IoC.Get<IShell>().GetOrCreateByType<WalletManagerViewModel>();
 			if (Directory.Exists(global.WalletsDir) && Directory.EnumerateFiles(global.WalletsDir).Any())
 			{
 				walletManagerViewModel.SelectLoadWallet();

--- a/WalletWasabi.Gui/Shell/Commands/WalletCommands.cs
+++ b/WalletWasabi.Gui/Shell/Commands/WalletCommands.cs
@@ -42,17 +42,17 @@ namespace WalletWasabi.Gui.Shell.Commands
 
 		private void OnGenerateWallet()
 		{
-			IoC.Get<IShell>().GetOrCreate<WalletManagerViewModel>().SelectGenerateWallet();
+			IoC.Get<IShell>().GetOrCreateByType<WalletManagerViewModel>().SelectGenerateWallet();
 		}
 
 		private void OnRecoverWallet()
 		{
-			IoC.Get<IShell>().GetOrCreate<WalletManagerViewModel>().SelectRecoverWallet();
+			IoC.Get<IShell>().GetOrCreateByType<WalletManagerViewModel>().SelectRecoverWallet();
 		}
 
 		private void OnLoadWallet()
 		{
-			IoC.Get<IShell>().GetOrCreate<WalletManagerViewModel>().SelectLoadWallet();
+			IoC.Get<IShell>().GetOrCreateByType<WalletManagerViewModel>().SelectLoadWallet();
 		}
 
 		[ExportCommandDefinition("File.GenerateWallet")]


### PR DESCRIPTION
This reverts commit 75c3b81dd65a3190f50889e059dd9b401d24b21b.

@nopara73 unfortunately this code is required. I move most of the code to the Shell, but allowed passing a lamda to control how the item is retreived.

We need to keep this code as is for now.

Part of my plan for future refactoring should eliminate this need in future, however I believe we need to keep this for now, otherwise might break stuff in subtle ways.