### PR TITLE
Display tab that was selected when Wasabi closed

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -52,14 +52,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private TargetPrivacy _targetPrivacy;
 
 		public CoinJoinTabViewModel(WalletViewModel walletViewModel)
-			: base("CoinJoin", walletViewModel)
+			: base("CoinJoin", walletViewModel, WalletTab.CoinJoin)
 		{
 			Global = Locator.Current.GetService<Global>();
 
 			Password = "";
 			TimeLeftTillRoundTimeout = TimeSpan.Zero;
 
-			CoinsList = new CoinListViewModel(CoinListContainerType.CoinJoinTabViewModel);
+			CoinsList = new CoinListViewModel(WalletTab.CoinJoin);
 
 			Observable
 				.FromEventPattern<SmartCoin>(CoinsList, nameof(CoinsList.DequeueCoinsPressed))

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private object SelectionChangedLock { get; } = new object();
 		private object StateChangedLock { get; } = new object();
 		private Global Global { get; }
-		public CoinListContainerType CoinListContainerType { get; }
+		public WalletTab WalletTab { get; }
 		public ReactiveCommand<Unit, Unit> SelectAllCheckBoxCommand { get; }
 		public ReactiveCommand<Unit, Unit> SelectPrivateCheckBoxCommand { get; }
 		public ReactiveCommand<Unit, Unit> SelectNonPrivateCheckBoxCommand { get; }
@@ -246,11 +246,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 		}
 
-		public CoinListViewModel(CoinListContainerType coinListContainerType)
+		public CoinListViewModel(WalletTab walletTab)
 		{
 			Global = Locator.Current.GetService<Global>();
 
-			CoinListContainerType = coinListContainerType;
+			WalletTab = walletTab;
 			AmountSortDirection = SortOrder.Decreasing;
 
 			CoinJoinStatusWidth = new GridLength(0);
@@ -499,7 +499,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						SelectedAmount = selectedCoins.Sum(x => x.Amount);
 						IsAnyCoinSelected = selectedCoins.Any();
 
-						LabelExposeCommonOwnershipWarning = CoinListContainerType == CoinListContainerType.CoinJoinTabViewModel
+						LabelExposeCommonOwnershipWarning = WalletTab == WalletTab.CoinJoin
 							? false
 							: selectedCoins
 								.Where(c => c.AnonymitySet == 1)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Model = model;
 			Owner = owner;
-			InCoinJoinContainer = owner.CoinListContainerType == CoinListContainerType.CoinJoinTabViewModel;
+			InCoinJoinContainer = owner.WalletTab == WalletTab.CoinJoin;
 
 			RefreshSmartCoinStatus();
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -11,6 +11,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Gui.Helpers;
+using WalletWasabi.Gui.Models;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 
@@ -31,7 +32,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public ReactiveCommand<Unit, Unit> SortCommand { get; }
 
 		public HistoryTabViewModel(WalletViewModel walletViewModel)
-			: base("History", walletViewModel)
+			: base("History", walletViewModel, WalletTab.History)
 		{
 			Global = Locator.Current.GetService<Global>();
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -19,6 +19,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.Hwi;
 using WalletWasabi.Hwi.Exceptions;
 using Splat;
+using WalletWasabi.Gui.Models;
 
 namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
@@ -34,7 +35,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public ReactiveCommand<Unit, Unit> GenerateCommand { get; }
 
 		public ReceiveTabViewModel(WalletViewModel walletViewModel)
-			: base("Receive", walletViewModel)
+			: base("Receive", walletViewModel, WalletTab.Receive)
 		{
 			Global = Locator.Current.GetService<Global>();
 			LabelSuggestion = new SuggestLabelViewModel();

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -101,7 +101,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		}
 
 		public SendTabViewModel(WalletViewModel walletViewModel, bool isTransactionBuilder = false)
-			: base(isTransactionBuilder ? "Build Transaction" : "Send", walletViewModel)
+			: base(isTransactionBuilder ? "Build Transaction" : "Send",
+				  walletViewModel,
+				  isTransactionBuilder ? WalletTab.Build : WalletTab.Send)
 		{
 			Global = Locator.Current.GetService<Global>();
 			LabelSuggestion = new SuggestLabelViewModel();
@@ -111,7 +113,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			ResetUi();
 			SetAmountWatermark(Money.Zero);
 
-			CoinList = new CoinListViewModel(CoinListContainerType.SendTabViewModel);
+			CoinList = new CoinListViewModel(WalletTab.Send);
 
 			Observable.FromEventPattern(CoinList, nameof(CoinList.SelectionChanged))
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletActionViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletActionViewModel.cs
@@ -5,6 +5,7 @@ using ReactiveUI;
 using System.Reactive;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Gui.Models;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Services;
 
@@ -13,6 +14,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 	public class WalletActionViewModel : WasabiDocumentTabViewModel
 	{
 		public WalletViewModel Wallet { get; }
+		public WalletTab WalletTab { get; set; }
 
 		public WalletService WalletService => Wallet.WalletService;
 		public KeyManager KeyManager => WalletService.KeyManager;
@@ -23,6 +25,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			: base(title)
 		{
 			Wallet = walletViewModel;
+		}
+
+		public WalletActionViewModel(string title, WalletViewModel walletViewModel, WalletTab walletTab)
+			: this(title, walletViewModel)
+		{
+			WalletTab = walletTab;
 		}
 	}
 }

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -80,19 +80,24 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			advancedAction.Items.Add(infoTab);
 			advancedAction.Items.Add(buildTab);
 
-			// Open and select tabs.
+			// Open tabs.
 			sendTab?.DisplayActionTab();
-			if (receiveDominant)
+			receiveTab.DisplayActionTab();
+			coinjoinTab.DisplayActionTab();
+			historyTab.DisplayActionTab();
+
+			// Select tab
+			if (receiveDominant || global.UiConfig.Tab == receiveTab.Title)
 			{
-				coinjoinTab.DisplayActionTab();
-				historyTab.DisplayActionTab();
 				receiveTab.DisplayActionTab(); // So receive should be shown to the user.
+			}
+			else if (global.UiConfig.Tab == historyTab.Title)
+			{
+				historyTab.DisplayActionTab(); // So history should be shown to the user.
 			}
 			else
 			{
-				receiveTab.DisplayActionTab();
-				coinjoinTab.DisplayActionTab();
-				historyTab.DisplayActionTab(); // So history should be shown to the user.
+				coinjoinTab.DisplayActionTab(); // So coinjoin should be shown to the user.
 			}
 
 			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -91,6 +91,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			{
 				receiveTab.DisplayActionTab(); // So receive should be shown to the user.
 			}
+			else if (global.UiConfig.LastActiveTab == sendTab?.Title)
+			{
+				sendTab.DisplayActionTab(); // So send should be shown to the user.
+			}
 			else if (global.UiConfig.LastActiveTab == historyTab.Title)
 			{
 				historyTab.DisplayActionTab(); // So history should be shown to the user.

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -11,6 +11,7 @@ using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Services;
 using WalletWasabi.Logging;
 using Splat;
+using WalletWasabi.Gui.Models;
 
 namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
@@ -87,21 +88,35 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			historyTab.DisplayActionTab();
 
 			// Select tab
-			if (receiveDominant || global.UiConfig.LastActiveTab == receiveTab.Title)
+			if (receiveDominant)
 			{
-				receiveTab.DisplayActionTab(); // So receive should be shown to the user.
-			}
-			else if (global.UiConfig.LastActiveTab == sendTab?.Title)
-			{
-				sendTab.DisplayActionTab(); // So send should be shown to the user.
-			}
-			else if (global.UiConfig.LastActiveTab == historyTab.Title)
-			{
-				historyTab.DisplayActionTab(); // So history should be shown to the user.
+				receiveTab.DisplayActionTab();
 			}
 			else
 			{
-				coinjoinTab.DisplayActionTab(); // So coinjoin should be shown to the user.
+				switch (global.UiConfig.LastActiveTab)
+				{
+					case WalletTab.Send when sendTab is { }:
+						sendTab.DisplayActionTab();
+						break;
+
+					case WalletTab.Receive:
+						receiveTab.DisplayActionTab();
+						break;
+
+					case WalletTab.History:
+						historyTab.DisplayActionTab();
+						break;
+
+					case WalletTab.Build:
+						buildTab.DisplayActionTab();
+						break;
+
+					case WalletTab.CoinJoin:
+					default:
+						coinjoinTab.DisplayActionTab();
+						break;
+				}
 			}
 
 			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -87,11 +87,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			historyTab.DisplayActionTab();
 
 			// Select tab
-			if (receiveDominant || global.UiConfig.Tab == receiveTab.Title)
+			if (receiveDominant || global.UiConfig.LastActiveTab == receiveTab.Title)
 			{
 				receiveTab.DisplayActionTab(); // So receive should be shown to the user.
 			}
-			else if (global.UiConfig.Tab == historyTab.Title)
+			else if (global.UiConfig.LastActiveTab == historyTab.Title)
 			{
 				historyTab.DisplayActionTab(); // So history should be shown to the user.
 			}

--- a/WalletWasabi.Gui/Converters/WalletTabJsonConverter.cs
+++ b/WalletWasabi.Gui/Converters/WalletTabJsonConverter.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.Gui.Models;
+
+namespace WalletWasabi.Gui.Converters
+{
+	internal class WalletTabJsonConverter : JsonConverter
+	{
+		/// <inheritdoc />
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(WalletTab);
+		}
+
+		/// <inheritdoc />
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			try
+			{
+				var value = reader.Value as string;
+				if (string.IsNullOrEmpty(value))
+				{
+					return WalletTab.CoinJoin;
+				}
+
+				if (value == WalletTab.Send.ToString())
+				{
+					return WalletTab.Send;
+				}
+				else if (value == WalletTab.Receive.ToString())
+				{
+					return WalletTab.Receive;
+				}
+				else if (value == WalletTab.History.ToString())
+				{
+					return WalletTab.History;
+				}
+				else if (value == WalletTab.Build.ToString())
+				{
+					return WalletTab.Build;
+				}
+				else
+				{
+					return WalletTab.CoinJoin;
+				}
+			}
+			catch
+			{
+				return WalletTab.CoinJoin;
+			}
+		}
+
+		/// <inheritdoc />
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(((WalletTab)value).ToString());
+		}
+	}
+}

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -153,7 +153,7 @@ namespace WalletWasabi.Gui
 							Global.UiConfig.WindowState = WindowState;
 							Global.UiConfig.Width = Width;
 							Global.UiConfig.Height = Height;
-							Global.UiConfig.Tab = IoC.Get<IShell>().SelectedDocument.Title;
+							Global.UiConfig.LastActiveTab = IoC.Get<IShell>().SelectedDocument.Title;
 							await Global.UiConfig.ToFileAsync();
 							Logger.LogInfo($"{nameof(Global.UiConfig)} is saved.");
 						}

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -153,7 +153,7 @@ namespace WalletWasabi.Gui
 							Global.UiConfig.WindowState = WindowState;
 							Global.UiConfig.Width = Width;
 							Global.UiConfig.Height = Height;
-							Global.UiConfig.LastActiveTab = IoC.Get<IShell>().SelectedDocument.Title;
+							Global.UiConfig.LastActiveTab = IoC.Get<IShell>().SelectedDocument?.Title;
 							await Global.UiConfig.ToFileAsync();
 							Logger.LogInfo($"{nameof(Global.UiConfig)} is saved.");
 						}

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -153,6 +153,7 @@ namespace WalletWasabi.Gui
 							Global.UiConfig.WindowState = WindowState;
 							Global.UiConfig.Width = Width;
 							Global.UiConfig.Height = Height;
+							Global.UiConfig.Tab = IoC.Get<IShell>().SelectedDocument.Title;
 							await Global.UiConfig.ToFileAsync();
 							Logger.LogInfo($"{nameof(Global.UiConfig)} is saved.");
 						}

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Gui.Dialogs;
 using WalletWasabi.Gui.Helpers;
+using WalletWasabi.Gui.Models;
 using WalletWasabi.Gui.Tabs.WalletManager;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Logging;
@@ -153,7 +154,8 @@ namespace WalletWasabi.Gui
 							Global.UiConfig.WindowState = WindowState;
 							Global.UiConfig.Width = Width;
 							Global.UiConfig.Height = Height;
-							Global.UiConfig.LastActiveTab = IoC.Get<IShell>().SelectedDocument?.Title;
+							Global.UiConfig.LastActiveTab = GetLastActiveTab(IoC.Get<IShell>().SelectedDocument?.Title);
+
 							await Global.UiConfig.ToFileAsync();
 							Logger.LogInfo($"{nameof(Global.UiConfig)} is saved.");
 						}
@@ -193,6 +195,35 @@ namespace WalletWasabi.Gui
 						Global.ChaumianClient.IsQuitPending = false; //re-enable enqueuing coins
 					}
 				}
+			}
+		}
+
+		private WalletTab GetLastActiveTab(string tabTitle)
+		{
+			if (tabTitle is null)
+			{
+				return WalletTab.CoinJoin;
+			}
+
+			if (tabTitle.StartsWith("Send", StringComparison.OrdinalIgnoreCase))
+			{
+				return WalletTab.Send;
+			}
+			else if (tabTitle.StartsWith("Receive", StringComparison.OrdinalIgnoreCase))
+			{
+				return WalletTab.Receive;
+			}
+			else if (tabTitle.StartsWith("History", StringComparison.OrdinalIgnoreCase))
+			{
+				return WalletTab.History;
+			}
+			else if (tabTitle.StartsWith("Build", StringComparison.OrdinalIgnoreCase))
+			{
+				return WalletTab.Build;
+			}
+			else
+			{
+				return WalletTab.CoinJoin;
 			}
 		}
 

--- a/WalletWasabi.Gui/Models/WalletTab.cs
+++ b/WalletWasabi.Gui/Models/WalletTab.cs
@@ -4,9 +4,12 @@ using System.Text;
 
 namespace WalletWasabi.Gui.Models
 {
-	public enum CoinListContainerType
+	public enum WalletTab
 	{
-		SendTabViewModel,
-		CoinJoinTabViewModel
+		Send,
+		CoinJoin,
+		Receive,
+		History,
+		Build
 	}
 }

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -637,7 +637,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					// Open Wallet Explorer tabs
 					if (Global.WalletService.Coins.Any())
 					{
-						// If already have coins then open with History tab first.
+						// If already have coins then open the tab that was selected when Wasabi closed first.
 						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.WalletService, receiveDominant: false);
 					}
 					else // Else open with Receive tab first.

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -637,7 +637,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					// Open Wallet Explorer tabs
 					if (Global.WalletService.Coins.Any())
 					{
-						// If already have coins then open the tab that was selected when Wasabi closed first.
+						// If already have coins then open the last active tab first.
 						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.WalletService, receiveDominant: false);
 					}
 					else // Else open with Receive tab first.

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -47,6 +47,10 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "FeeDisplayFormat", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public int FeeDisplayFormat { get; internal set; }
 
+		[DefaultValue("")]
+		[JsonProperty(PropertyName = "Tab", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public string Tab { get; internal set; }
+
 		[DefaultValue(true)]
 		[JsonProperty(PropertyName = "Autocopy", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public bool Autocopy

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -47,9 +47,9 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "FeeDisplayFormat", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public int FeeDisplayFormat { get; internal set; }
 
-		[DefaultValue("")]
-		[JsonProperty(PropertyName = "LastActiveTab", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public string LastActiveTab { get; internal set; }
+		[JsonProperty(PropertyName = "LastActiveTab")]
+		[JsonConverter(typeof(WalletTabJsonConverter))]
+		public WalletTab LastActiveTab { get; internal set; } = WalletTab.CoinJoin;
 
 		[DefaultValue(true)]
 		[JsonProperty(PropertyName = "Autocopy", DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -48,8 +48,8 @@ namespace WalletWasabi.Gui
 		public int FeeDisplayFormat { get; internal set; }
 
 		[DefaultValue("")]
-		[JsonProperty(PropertyName = "Tab", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public string Tab { get; internal set; }
+		[JsonProperty(PropertyName = "LastActiveTab", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public string LastActiveTab { get; internal set; }
 
 		[DefaultValue(true)]
 		[JsonProperty(PropertyName = "Autocopy", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
Closes #1490

If the user closes Wasabi with either `Send` or `Receive` or `History` or `CoinJoin` or `Build Transaction` as the last active tab, Wasabi will display that tab in the next run.
If the user closes Wasabi with any other tab, Wasabi will display the `CoinJoin` tab in the next run.