### PR TITLE
Refactor EndPointParser to remove some code duplication

### DIFF
--- a/WalletWasabi/Helpers/EndPointParser.cs
+++ b/WalletWasabi/Helpers/EndPointParser.cs
@@ -56,27 +56,30 @@ namespace System.Net
 
 				var parts = endPointString.Split(':', StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().TrimEnd('/').TrimEnd()).ToArray();
 
-				var isDefaultPortInvalid = !ushort.TryParse(defaultPort.ToString(), out ushort dp) || dp < IPEndPoint.MinPort || dp > IPEndPoint.MaxPort;
-				int port;
 				if (parts.Length == 0)
 				{
 					return false;
 				}
-				else if (parts.Length == 1)
+
+				ushort p;
+				int port;
+
+				if (parts.Length == 1)
 				{
-					if (isDefaultPortInvalid)
+					if (IsValidPort(defaultPort.ToString(), out p))
 					{
-						return false;
+						port = p;
 					}
 					else
 					{
-						port = defaultPort;
+						return false;
 					}
 				}
 				else if (parts.Length == 2)
 				{
 					var portString = parts[1];
-					if (ushort.TryParse(portString, out ushort p) && p >= IPEndPoint.MinPort && p <= IPEndPoint.MaxPort)
+
+					if (IsValidPort(portString, out p))
 					{
 						port = p;
 					}
@@ -90,7 +93,8 @@ namespace System.Net
 					return false;
 				}
 
-				string host = parts[0];
+				var host = parts[0];
+
 				if (host == "localhost")
 				{
 					host = IPAddress.Loopback.ToString();
@@ -111,6 +115,12 @@ namespace System.Net
 			{
 				return false;
 			}
+		}
+
+		// Checks a port is a number within the valid port range (0 - 65535).
+		private static bool IsValidPort(string port, out ushort p)
+		{
+			return ushort.TryParse(port, out p);
 		}
 	}
 }


### PR DESCRIPTION
There were a couple of checks for:

```c#
ushort.TryParse(portString, out ushort p) && p >= IPEndPoint.MinPort && p <= IPEndPoint.MaxPort
```

Refactored into its own method to hopefully improve readability/remove duplication. I also refactored an if/else into a switch statement which should be a bit more efficient.

Prior to merge, I did have a question why we essentially perform the same checks twice. `ushort.TryParse(portString, out ushort p)` would be the same as `p >= IPEndPoint.MinPort && p <= IPEndPoint.MaxPort` in regards to min/max values.

The `ushort` min/max is 0/65535 and `IPEndPoint.MinPort` is 0 and `IPEndPoint.MaxPort` is 65535. Is there a reason behind this?