### PR TITLE
Add Lazy Loading to website

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -38,7 +38,7 @@
     <header>
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark m-auto rounded-bottom">
             <a class="navbar-brand" href="#">
-                <img src="images/wasabi-wallet-logo.svg?ver=1.1.0" style="height: 40px; width: auto" alt="">
+                <img src="images/wasabi-wallet-logo.svg?ver=1.1.0" style="height: 40px; width: auto" alt="" loading="lazy">
             </a>
             <input type="checkbox" id="navbar-toggle-cbox">
             <label for="navbar-toggle-cbox" class="navbar-toggler border-0 p-0 collapsed" data-toggle="collapse" data-target="#navbarColor02" aria-controls="navbarColor02" aria-expanded="false" aria-label="Toggle navigation">
@@ -109,7 +109,7 @@
                 </div>
             </div>
 
-            <img src="images/shader-wasabi.svg?ver=1.1.0" class="shader" />
+            <img src="images/shader-wasabi.svg?ver=1.1.0" class="shader" loading="lazy" />
         </section>
 
         <!-- Features Bar -->
@@ -176,23 +176,23 @@
                                 </label>
                                 <ul class="list-group list-group-flush toggle-content toggle-xs">
                                     <li class="tx list-group-item text-ellipsis">
-                                        <img src="images/icon-external.svg?ver=1.1.0" />
+                                        <img src="images/icon-external.svg?ver=1.1.0" loading="lazy" />
                                         <a class="text-light" href="https://blockstream.info/tx/e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174" target="_blank"> e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174 </a>
                                     </li>
                                     <li class="tx list-group-item text-ellipsis">
-                                        <img src="images/icon-external.svg?ver=1.1.0" />
+                                        <img src="images/icon-external.svg?ver=1.1.0" loading="lazy" />
                                         <a class="text-light" href="https://blockstream.info/tx/c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8" target="_blank"> c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8 </a>
                                     </li>
                                     <li class="tx list-group-item text-ellipsis">
-                                        <img src="images/icon-external.svg?ver=1.1.0" />
+                                        <img src="images/icon-external.svg?ver=1.1.0" loading="lazy" />
                                         <a class="text-light" href="https://blockstream.info/tx/ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce" target="_blank"> ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce </a>
                                     </li>
                                     <li class="tx list-group-item text-ellipsis">
-                                        <img src="images/icon-external.svg?ver=1.1.0" />
+                                        <img src="images/icon-external.svg?ver=1.1.0" loading="lazy" />
                                         <a class="text-light" href="https://blockstream.info/tx/f82206145413db5c1272d5609c88581c414815e36e400aee6410e0de9a2d46b5" target="_blank"> f82206145413db5c1272d5609c88581c414815e36e400aee6410e0de9a2d46b5 </a>
                                     </li>
                                     <li class="tx list-group-item text-ellipsis">
-                                        <img src="images/icon-external.svg?ver=1.1.0" />
+                                        <img src="images/icon-external.svg?ver=1.1.0" loading="lazy" />
                                         <a class="text-light" href="https://blockstream.info/tx/a7157780b7c696ab24767113d9d34cdbc0eba5c394c89aec4ed1a9feb326bea5" target="_blank"> a7157780b7c696ab24767113d9d34cdbc0eba5c394c89aec4ed1a9feb326bea5 </a>
                                     </li>
                                 </ul>
@@ -200,7 +200,7 @@
                         </div>
                     </div>
                     <div class="col-sm-6">
-                        <img class="illustration" src="images/illustration-coinjoin.svg?ver=1.1.0" />
+                        <img class="illustration" src="images/illustration-coinjoin.svg?ver=1.1.0" loading="lazy" />
                     </div>
                 </div>
             </div>
@@ -230,7 +230,7 @@
                         <div class="row">
                             <div class="col-6">
                                 <div class="text-center mb-4 ">
-                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-finder.svg?ver=1.1.0" />
+                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-finder.svg?ver=1.1.0" loading="lazy" />
 
                                     <!-- macOS Download Link -->
                                     <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.10.2/Wasabi-1.1.10.2.dmg" itemprop="downloadUrl" class="btn btn-success btn-block btn-labeled text-uppercase font-weight-bold mb-1">
@@ -249,7 +249,7 @@
 
                             <div class="col-6">
                                 <div class="text-center mb-4 ">
-                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-windows.svg?ver=1.1.0" />
+                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-windows.svg?ver=1.1.0" loading="lazy" />
 
                                     <!-- Windows Download Link -->
                                     <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.10.2/Wasabi-1.1.10.2.msi" itemprop="downloadUrl" class="btn btn-success btn-block btn-labeled text-uppercase font-weight-bold mb-1">
@@ -268,7 +268,7 @@
 
                             <div class="col-6">
                                 <div class="text-center mb-4 ">
-                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-ubuntu.svg?ver=1.1.0" />
+                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-ubuntu.svg?ver=1.1.0" loading="lazy" />
 
                                     <!-- Debian/Ubuntu Download Link -->
                                     <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.10.2/Wasabi-1.1.10.2.deb" itemprop="downloadUrl" class="btn btn-success btn-block btn-labeled text-uppercase font-weight-bold mb-1">
@@ -287,7 +287,7 @@
 
                             <div class="col-6">
                                 <div class="text-center mb-4 ">
-                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-linux.svg?ver=1.1.0" />
+                                    <img class="d-block mx-auto mb-2" src="images/icon-colored-linux.svg?ver=1.1.0" loading="lazy" />
 
                                     <!-- Linux Download Link -->
                                     <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v1.1.10.2/WasabiLinux-1.1.10.2.tar.gz" itemprop="downloadUrl" class="btn btn-success btn-block btn-labeled text-uppercase font-weight-bold mb-1">
@@ -306,7 +306,7 @@
                         </div>
                     </div>
                     <div class="col-sm-6 order-sm-1">
-                        <img class="screenshot" itemprop="screenshot" src="images/wasabi-wallet-laptop.png?ver=1.1.0" />
+                        <img class="screenshot" itemprop="screenshot" src="images/wasabi-wallet-laptop.png?ver=1.1.0" loading="lazy" />
                     </div>
                 </div>
             </div>
@@ -534,7 +534,7 @@
     <footer class="footer bg-dark">
         <div class="text-center">
             <p class="text-light p-2 mb-0 text-ellipsis">
-                <img src="images/icon-colored-onion.png?ver=1.1.0" class="" style="width: 17px; height: auto" alt="other_network">&nbsp;
+                <img src="images/icon-colored-onion.png?ver=1.1.0" class="" style="width: 17px; height: auto" alt="other_network" loading="lazy">&nbsp;
                 <small class="align-middle" itemprop="sameAs">http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion</small>
             </p>
         </div>


### PR DESCRIPTION
### Why native lazy-loading?

According to HTTPArchive, **images are the most requested asset type for most websites and usually take up more bandwidth than any other resource**. At the 90th percentile, sites send about 4.7 MB of images on desktop and mobile. That's a lot of cat pictures.

Embedded iframes also use a lot of data and can harm page performance. Only loading non-critical, below-the-fold images and iframes when the user is likely to see them **improves page load times, minimizes user bandwidth, and reduces memory usage**.

### SEO Benefits
Google has indicated site speed (and as a result, page speed) is one of the signals used by its algorithm to rank pages. And research has shown that Google might be specifically measuring time to first byte as when it considers page speed. In addition, a slow page speed means that search engines can crawl fewer pages using their allocated crawl budget, and this could negatively affect your indexation.

**Page speed is also important to user experience. Pages with a longer load time tend to have higher bounce rates and lower average time on page. Longer load times have also been shown to negatively affect conversions.**

Currently, there are two ways to defer the loading of off-screen images and iframes:

- Using the Intersection Observer API
- Using scroll, resize, or orientationchange event handlers

Either option can let developers include lazy-loading functionality, and many developers have built third-party libraries to provide abstractions that are even easier to use. With lazy-loading supported directly by the browser, however, there's no need for an external library. Native lazy loading also ensures that deferred loading of images and iframes still works even if JavaScript is disabled on the client.

Starting with Chrome 76, we are able to use the new `loading` attribute to lazy-load resources without the need to write custom lazy-loading code or use a separate JavaScript library.

Demo:
![ezgif-7-61e4604beabd](https://user-images.githubusercontent.com/46527252/72471613-4a303a80-37e3-11ea-9d0d-a8f143857e6b.gif)


Source: https://web.dev/native-lazy-loading/