### PR TITLE
Refactoring/stop exit

### DIFF
--- a/WalletWasabi/Extensions/ReflectionExtensions.cs
+++ b/WalletWasabi/Extensions/ReflectionExtensions.cs
@@ -1,0 +1,16 @@
+using System.Runtime.CompilerServices;
+
+namespace System.Reflection
+{
+	public static class MethodInfoExtensions
+	{
+		public static bool IsAsync(this MethodInfo mi)
+		{
+			Type attType = typeof(AsyncStateMachineAttribute);
+
+			var attrib = (AsyncStateMachineAttribute)mi.GetCustomAttribute(attType);
+
+			return attrib is {};
+		}
+	}
+}


### PR DESCRIPTION
This PR is for reducing noise in the revision of the RPC PR. It includes two changes:

+ Adds a new extension method that is not used anywhere yet (it is used in the rpc server) and,
+ Moves the `CancelKeyPress` handler to its own method (this is a good change by itself). This method can be used by the rpc server in order to stop wasabi with the rpc `stop` command. 