### PR TITLE
Remove "rpchost"

### DIFF
--- a/WalletWasabi/BitcoinCore/Configuration/CoreConfigTranslator.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/CoreConfigTranslator.cs
@@ -40,8 +40,6 @@ namespace WalletWasabi.BitcoinCore.Configuration
 
 		public string TryGetRpcCookieFile() => TryGetValue("rpccookiefile");
 
-		public string TryGetRpcHost() => TryGetValue("rpchost");
-
 		public ushort? TryGetRpcPort()
 		{
 			var stringValue = TryGetValue("rpcport");

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.BitcoinCore
 				string rpcUser = configTranslator.TryGetRpcUser();
 				string rpcPassword = configTranslator.TryGetRpcPassword();
 				string rpcCookieFilePath = configTranslator.TryGetRpcCookieFile();
-				string rpcHost = configTranslator.TryGetRpcHost();
+				string rpcHost = IPAddress.Loopback.ToString();
 				int? rpcPort = configTranslator.TryGetRpcPort();
 				WhiteBind whiteBind = configTranslator.TryGetWhiteBind();
 
@@ -113,7 +113,6 @@ namespace WalletWasabi.BitcoinCore
 					$"{configPrefix}.server			= 1",
 					$"{configPrefix}.listen			= 1",
 					$"{configPrefix}.whitebind		= {whiteBindPermissionsPart}{coreNode.P2pEndPoint.ToString(coreNode.Network.DefaultPort)}",
-					$"{configPrefix}.rpchost		= {coreNode.RpcEndPoint.GetHostOrDefault()}",
 					$"{configPrefix}.rpcport		= {coreNode.RpcEndPoint.GetPortOrDefault()}"
 				};
 


### PR DESCRIPTION
Since it's an invalid Bitcoin Core configuration option. It will always default to localhost, even if it's specified, so picking up the specified "rpchost" in Wasabi doesn't make sense, rather we should default to localhost, too.

Closes https://github.com/zkSNACKs/WalletWasabi/issues/2955

Possibly it was removed here? https://github.com/bitcoin/bitcoin/pull/9929

But searching Core's repo I'm not sure it ever existed.