### PR TITLE
Open last active tab

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -80,19 +80,32 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			advancedAction.Items.Add(infoTab);
 			advancedAction.Items.Add(buildTab);
 
-			// Open and select tabs.
+			// Open tabs.
 			sendTab?.DisplayActionTab();
-			if (receiveDominant)
+			receiveTab.DisplayActionTab();
+			coinjoinTab.DisplayActionTab();
+			historyTab.DisplayActionTab();
+
+			// Select tab
+			if (receiveDominant || global.UiConfig.LastActiveTab == receiveTab.GetType().Name)
 			{
-				coinjoinTab.DisplayActionTab();
-				historyTab.DisplayActionTab();
 				receiveTab.DisplayActionTab(); // So receive should be shown to the user.
+			}
+			else if (global.UiConfig.LastActiveTab == sendTab?.GetType().Name)
+			{
+				sendTab.DisplayActionTab(); // So send should be shown to the user.
+			}
+			else if (global.UiConfig.LastActiveTab == buildTab.GetType().Name)
+			{
+				buildTab.DisplayActionTab(); // So build should be shown to the user.
+			}
+			else if (global.UiConfig.LastActiveTab == historyTab.GetType().Name)
+			{
+				historyTab.DisplayActionTab(); // So history should be shown to the user.
 			}
 			else
 			{
-				receiveTab.DisplayActionTab();
-				coinjoinTab.DisplayActionTab();
-				historyTab.DisplayActionTab(); // So history should be shown to the user.
+				coinjoinTab.DisplayActionTab(); // So coinjoin should be shown to the user.
 			}
 
 			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -87,25 +87,22 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			historyTab.DisplayActionTab();
 
 			// Select tab
-			if (receiveDominant || global.UiConfig.LastActiveTab == receiveTab.GetType().Name)
+			if (receiveDominant)
 			{
-				receiveTab.DisplayActionTab(); // So receive should be shown to the user.
-			}
-			else if (global.UiConfig.LastActiveTab == sendTab?.GetType().Name)
-			{
-				sendTab.DisplayActionTab(); // So send should be shown to the user.
-			}
-			else if (global.UiConfig.LastActiveTab == buildTab.GetType().Name)
-			{
-				buildTab.DisplayActionTab(); // So build should be shown to the user.
-			}
-			else if (global.UiConfig.LastActiveTab == historyTab.GetType().Name)
-			{
-				historyTab.DisplayActionTab(); // So history should be shown to the user.
+				receiveTab.DisplayActionTab();
 			}
 			else
 			{
-				coinjoinTab.DisplayActionTab(); // So coinjoin should be shown to the user.
+				WalletActionViewModel tabToOpen = global.UiConfig.LastActiveTab switch
+				{
+					nameof(SendTabViewModel) => sendTab,
+					nameof(ReceiveTabViewModel) => receiveTab,
+					nameof(CoinJoinTabViewModel) => coinjoinTab,
+					nameof(BuildTabViewModel) => buildTab,
+					_ => historyTab
+				};
+
+				tabToOpen?.DisplayActionTab();
 			}
 
 			LurkingWifeModeCommand = ReactiveCommand.CreateFromTask(async () =>

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -108,6 +108,7 @@ namespace WalletWasabi.Gui
 							Global.UiConfig.WindowState = WindowState;
 							Global.UiConfig.Width = Width;
 							Global.UiConfig.Height = Height;
+							Global.UiConfig.LastActiveTab = IoC.Get<IShell>().SelectedDocument?.GetType().Name;
 							await Global.UiConfig.ToFileAsync();
 							Logger.LogInfo($"{nameof(Global.UiConfig)} is saved.");
 						}

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -637,7 +637,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 					// Open Wallet Explorer tabs
 					if (Global.WalletService.Coins.Any())
 					{
-						// If already have coins then open with History tab first.
+						// If already have coins then open the last active tab first.
 						IoC.Get<WalletExplorerViewModel>().OpenWallet(Global.WalletService, receiveDominant: false);
 					}
 					else // Else open with Receive tab first.

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -47,6 +47,10 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "FeeDisplayFormat", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public int FeeDisplayFormat { get; internal set; }
 
+		[DefaultValue("")]
+		[JsonProperty(PropertyName = "LastActiveTab", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public string LastActiveTab { get; internal set; }
+
 		[DefaultValue(true)]
 		[JsonProperty(PropertyName = "Autocopy", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public bool Autocopy


### PR DESCRIPTION
Closes #1490

If the user closes Wasabi with either `Send` or `Receive` or `History` or `CoinJoin` or `Build Transaction` as the last active tab, Wasabi will display that tab in the next run.
If the user closes Wasabi with any other tab, Wasabi will display the `CoinJoin` tab in the next run.