### PR TITLE
Use using statement for IDisposable http objects

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
@@ -27,7 +27,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task SmartBitExchangeRateProviderTestAsync(string networkString)
 		{
 			var network = Network.GetNetwork(networkString);
-			using var client = new SmartBitClient(network);
+			var client = new SmartBitClient(network);
 			var rateProvider = new SmartBitExchangeRateProvider(client);
 			IEnumerable<ExchangeRate> rates = await rateProvider.GetExchangeRateAsync();
 

--- a/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
@@ -25,8 +25,9 @@ namespace WalletWasabi.WebClients.BlockchainInfo
 		{
 			using var httpClient = new HttpClient();
 			httpClient.BaseAddress = new Uri("https://blockchain.info");
-			var response = await httpClient.GetAsync("/ticker");
-			var rates = await response.Content.ReadAsJsonAsync<BlockchainInfoExchangeRates>();
+			using var response = await httpClient.GetAsync("/ticker");
+			using var content = response.Content;
+			var rates = await content.ReadAsJsonAsync<BlockchainInfoExchangeRates>();
 
 			var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
@@ -28,8 +28,9 @@ namespace WalletWasabi.WebClients.Coinbase
 		{
 			using var httpClient = new HttpClient();
 			httpClient.BaseAddress = new Uri("https://api.coinbase.com");
-			var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC");
-			var wrapper = await response.Content.ReadAsJsonAsync<DataWrapper>();
+			using var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC");
+			using var content = response.Content; 
+			var wrapper = await content.ReadAsJsonAsync<DataWrapper>();
 
 			var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.WebClients
 	{
 		private readonly IExchangeRateProvider[] ExchangeRateProviders =
 		{
-			new SmartBitExchangeRateProvider(new SmartBitClient(Network.Main, disposeHandler: true)),
+			new SmartBitExchangeRateProvider(new SmartBitClient(Network.Main)),
 			new BlockchainInfoExchangeRateProvider(),
 			new CoinbaseExchangeRateProvider(),
 			new GeminiExchangeRateProvider(),

--- a/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
@@ -18,8 +18,9 @@ namespace WalletWasabi.WebClients.Gemini
 		{
 			using var httpClient = new HttpClient();
 			httpClient.BaseAddress = new Uri("https://api.gemini.com");
-			var response = await httpClient.GetAsync("/v1/pubticker/btcusd");
-			var data = await response.Content.ReadAsJsonAsync<GeminiExchangeRateInfo>();
+			using var response = await httpClient.GetAsync("/v1/pubticker/btcusd");
+			using var content = response.Content;
+			var data = await content.ReadAsJsonAsync<GeminiExchangeRateInfo>();
 
 			var exchangeRates = new List<ExchangeRate>
 				{

--- a/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
@@ -18,8 +18,9 @@ namespace WalletWasabi.WebClients.ItBit
 		{
 			using var httpClient = new HttpClient();
 			httpClient.BaseAddress = new Uri("https://api.itbit.com");
-			var response = await httpClient.GetAsync("v1/markets/XBTUSD/ticker");
-			var data = await response.Content.ReadAsJsonAsync<ItBitExchangeRateInfo>();
+			using var response = await httpClient.GetAsync("v1/markets/XBTUSD/ticker");
+			using var content = response.Content;
+			var data = await content.ReadAsJsonAsync<ItBitExchangeRateInfo>();
 
 			var exchangeRates = new List<ExchangeRate>
 				{


### PR DESCRIPTION
Related https://github.com/zkSNACKs/WalletWasabi/issues/3017

I was researching the problem with "IOException: too many open files" and nothing seems to point to swagger. Most of the people that suffered this problem point out to this article: https://medium.com/@mshanak/soved-dotnet-core-too-many-open-files-in-system-when-using-postgress-with-entity-framework-c6e30eeff6d1 which in its point 2.2 talks about `HttpClient`.

I've found this forum where the problem was solved by disposing the `HttpWebResponse` instances:
https://forums.servicestack.net/t/servicestack-on-kestrel-holds-open-files/5615 so, I am disposing all the `IDisposable` instances returned by the `HttpClient`.

Here is the controversial part. The documentation says that the `HttpClient` class was designed with the idea that an instance should live as long as the application does. However, in this PR I am just disposing the instances. 
https://stackoverflow.com/questions/15705092/do-httpclient-and-httpclienthandler-have-to-be-disposed

I am doing this because i suspect the problem happened after we started using `SmartBitExchangeRateProvider` instead of `AverageBitcoinExchangeRateProvider` as our main source of external fee rates and the `SmartBitExchangeRateProvider` implementation was the only one different to the rest.