### PR TITLE
Enable Reorganizing elements (CodeMaid)

### DIFF
--- a/CodeMaid.config
+++ b/CodeMaid.config
@@ -27,6 +27,9 @@
             <setting name="Cleaning_PerformPartialCleanupOnExternal" serializeAs="String">
                 <value>2</value>
             </setting>
+            <setting name="Reorganizing_RunAtStartOfCleanup" serializeAs="String">
+                <value>True</value>
+            </setting>
         </SteveCadwallader.CodeMaid.Properties.Settings>
     </userSettings>
 </configuration>

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -22,12 +22,12 @@ namespace WalletWasabi.Backend
 {
 	public class Startup
 	{
-		public IConfiguration Configuration { get; }
-
 		public Startup(IConfiguration configuration)
 		{
 			Configuration = configuration;
 		}
+
+		public IConfiguration Configuration { get; }
 
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -16,27 +16,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
 	public class WalletViewModel : ViewModelBase
 	{
-		private CompositeDisposable Disposables { get; set; }
-
 		private ObservableCollection<WalletActionViewModel> _actions;
-
 		private bool _isExpanded;
-
 		private string _title;
-
-		public Guid Id { get; set; } = Guid.NewGuid();
-
-		public bool IsExpanded
-		{
-			get => _isExpanded;
-			set => this.RaiseAndSetIfChanged(ref _isExpanded, value);
-		}
-
-		public string Title
-		{
-			get => _title;
-			set => this.RaiseAndSetIfChanged(ref _title, value);
-		}
 
 		public WalletViewModel(bool receiveDominant)
 		{
@@ -116,6 +98,32 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(ex => Logger.LogError(ex));
 		}
 
+		public Guid Id { get; set; } = Guid.NewGuid();
+
+		public bool IsExpanded
+		{
+			get => _isExpanded;
+			set => this.RaiseAndSetIfChanged(ref _isExpanded, value);
+		}
+
+		public string Title
+		{
+			get => _title;
+			set => this.RaiseAndSetIfChanged(ref _title, value);
+		}
+
+		public string Name { get; }
+		public WalletService WalletService { get; }
+		public ReactiveCommand<Unit, Unit> LurkingWifeModeCommand { get; }
+
+		public ObservableCollection<WalletActionViewModel> Actions
+		{
+			get => _actions;
+			set => this.RaiseAndSetIfChanged(ref _actions, value);
+		}
+
+		private CompositeDisposable Disposables { get; set; }
+
 		public void OnWalletOpened()
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
@@ -147,18 +155,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public void OnWalletClosed()
 		{
 			Disposables?.Dispose();
-		}
-
-		public string Name { get; }
-
-		public WalletService WalletService { get; }
-
-		public ReactiveCommand<Unit, Unit> LurkingWifeModeCommand { get; }
-
-		public ObservableCollection<WalletActionViewModel> Actions
-		{
-			get => _actions;
-			set => this.RaiseAndSetIfChanged(ref _actions, value);
 		}
 	}
 }

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Gui
 {
 	public class MainWindow : MetroWindow
 	{
-		public bool IsQuitPending { get; private set; }
+		private int _closingState;
 
 		public MainWindow()
 		{
@@ -43,14 +43,13 @@ namespace WalletWasabi.Gui
 			Closing += MainWindow_ClosingAsync;
 		}
 
+		public bool IsQuitPending { get; private set; }
 		private Global Global { get; }
 
 		private void InitializeComponent()
 		{
 			AvaloniaXamlLoader.Load(this);
 		}
-
-		private int _closingState;
 
 		private async void MainWindow_ClosingAsync(object sender, CancelEventArgs e)
 		{

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -27,6 +27,14 @@ namespace WalletWasabi.Gui
 		private bool _isCustomFee;
 		private bool _autocopy;
 
+		public UiConfig() : base()
+		{
+		}
+
+		public UiConfig(string filePath) : base(filePath)
+		{
+		}
+
 		[JsonProperty(PropertyName = "WindowState")]
 		[JsonConverter(typeof(WindowStateAfterStartJsonConverter))]
 		public WindowState WindowState { get; internal set; } = WindowState.Maximized;
@@ -89,14 +97,6 @@ namespace WalletWasabi.Gui
 		{
 			get => _lockScreenPinHash;
 			set => RaiseAndSetIfChanged(ref _lockScreenPinHash, value);
-		}
-
-		public UiConfig() : base()
-		{
-		}
-
-		public UiConfig(string filePath) : base(filePath)
-		{
 		}
 	}
 }


### PR DESCRIPTION
This will reorganize elements at start of cleanup (when saving) of files.

```
Within a class, struct, or interface, elements should be positioned in the following order:

- Fields
- Constructors
- Finalizers (Destructors)
- Delegates
- Events
- Enums
- Interfaces
- Properties
- Indexers
- Methods
- Structs
- Classes*
```
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
https://stackoverflow.com/questions/150479/order-of-items-in-classes-fields-properties-constructors-methods

Do not merge this until we cleanup all the files and we enable the `ElementsMustAppearInTheCorrectOrder` in the `Setting.StyleCop` file.