### PR TITLE
Add naming rule for local const (PascalCase)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -201,6 +201,16 @@ dotnet_naming_symbols.local_variables_and_parameters_symbols.applicable_kinds = 
 
 dotnet_naming_style.camel_case_style.capitalization = camel_case
 
+# name local constant using PascalCase
+dotnet_naming_rule.local_const_pascal_case.severity = error
+dotnet_naming_rule.local_const_pascal_case.symbols  = local_const
+dotnet_naming_rule.local_const_pascal_case.style    = pascal_case_style
+
+dotnet_naming_symbols.local_const.applicable_kinds   = local
+dotnet_naming_symbols.local_const.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
 # all type parameters should be TPascalCase
 dotnet_naming_rule.type_parameters_T_pascal_case.severity = error
 dotnet_naming_rule.type_parameters_T_pascal_case.symbols  = type_parameters_symbols

--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			string path = HwiParser.NormalizeRawDevicePath(rawPath);
 			string devicePathAndTypeArgumentString = $"--device-path \"{path}\" --device-type \"{model}\"";
 
-			const string successTrueResponse = "{\"success\": true}\r\n";
+			const string SuccessTrueResponse = "{\"success\": true}\r\n";
 
 			string response = null;
 			int code = 0;
@@ -85,7 +85,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			{
 				if (Model == HardwareWalletModels.Trezor_T || Model == HardwareWalletModels.Trezor_1)
 				{
-					response = successTrueResponse;
+					response = SuccessTrueResponse;
 				}
 				else if (Model == HardwareWalletModels.Coldcard)
 				{
@@ -115,7 +115,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			{
 				if (Model == HardwareWalletModels.Trezor_T || Model == HardwareWalletModels.Trezor_1)
 				{
-					response = successTrueResponse;
+					response = SuccessTrueResponse;
 				}
 				else if (Model == HardwareWalletModels.Coldcard)
 				{
@@ -130,7 +130,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			{
 				if (Model == HardwareWalletModels.Trezor_T || Model == HardwareWalletModels.Trezor_1)
 				{
-					response = successTrueResponse;
+					response = SuccessTrueResponse;
 				}
 				else if (Model == HardwareWalletModels.Coldcard)
 				{

--- a/WalletWasabi.Tests/UnitTests/IoTests.cs
+++ b/WalletWasabi.Tests/UnitTests/IoTests.cs
@@ -230,11 +230,11 @@ namespace WalletWasabi.Tests.UnitTests
 				}
 			};
 
-			const int iterations = 200;
+			const int Iterations = 200;
 
 			var t1 = new Thread(() =>
 			{
-				for (var i = 0; i < iterations; i++)
+				for (var i = 0; i < Iterations; i++)
 				{
 					/* We have to block the Thread.
 					 * If we use async/await pattern then Join() function at the end will indicate that the Thread is finished -
@@ -246,14 +246,14 @@ namespace WalletWasabi.Tests.UnitTests
 			});
 			var t2 = new Thread(() =>
 			{
-				for (var i = 0; i < iterations; i++)
+				for (var i = 0; i < Iterations; i++)
 				{
 					WriteNextLineAsync().Wait();
 				}
 			});
 			var t3 = new Thread(() =>
 			{
-				for (var i = 0; i < iterations; i++)
+				for (var i = 0; i < Iterations; i++)
 				{
 					WriteNextLineAsync().Wait();
 				}

--- a/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
@@ -354,11 +354,11 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.False(myUnconfirmedTx2.Confirmed);
 
 			// Create the same transaction but now with a Height to make it confirmed.
-			const int reorgedBlockHeight = 34532;
+			const int ReorgedBlockHeight = 34532;
 			uint256 reorgedBlockHash = new uint256(5);
 
-			var tx1Confirmed = new SmartTransaction(uTx1.Transaction, new Height(reorgedBlockHeight), blockHash: reorgedBlockHash, label: "buz, qux");
-			var tx2Confirmed = new SmartTransaction(uTx2.Transaction, new Height(reorgedBlockHeight), blockHash: reorgedBlockHash, label: "buz, qux");
+			var tx1Confirmed = new SmartTransaction(uTx1.Transaction, new Height(ReorgedBlockHeight), blockHash: reorgedBlockHash, label: "buz, qux");
+			var tx2Confirmed = new SmartTransaction(uTx2.Transaction, new Height(ReorgedBlockHeight), blockHash: reorgedBlockHash, label: "buz, qux");
 			Assert.True(txStore.TryUpdate(tx1Confirmed));
 			Assert.True(txStore.TryUpdate(tx2Confirmed));
 

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -13,8 +13,8 @@ namespace System.IO
 		// http://stackoverflow.com/a/14933880/2061103
 		public static async Task DeleteRecursivelyWithMagicDustAsync(string destinationDir)
 		{
-			const int magicDust = 10;
-			for (var gnomes = 1; gnomes <= magicDust; gnomes++)
+			const int MagicDust = 10;
+			for (var gnomes = 1; gnomes <= MagicDust; gnomes++)
 			{
 				try
 				{
@@ -26,7 +26,7 @@ namespace System.IO
 				}
 				catch (IOException)
 				{
-					if (gnomes == magicDust)
+					if (gnomes == MagicDust)
 					{
 						throw;
 					}
@@ -39,7 +39,7 @@ namespace System.IO
 				}
 				catch (UnauthorizedAccessException)
 				{
-					if (gnomes == magicDust)
+					if (gnomes == MagicDust)
 					{
 						throw;
 					}

--- a/WalletWasabi/Mono/StringCoda.cs
+++ b/WalletWasabi/Mono/StringCoda.cs
@@ -224,11 +224,11 @@ namespace Mono.Options
 			{
 				curWidth = (eValid = eWidths.MoveNext()).Value ? eWidths.Current : curWidth;
 				// '.' is any character, - is for a continuation
-				const string minWidth = ".-";
-				if (curWidth < minWidth.Length)
+				const string MinWidth = ".-";
+				if (curWidth < MinWidth.Length)
 				{
 					throw new ArgumentOutOfRangeException("widths",
-						$"Element must be greater than or equal to {minWidth.Length}, was {curWidth}.");
+						$"Element must be greater than or equal to {MinWidth.Length}, was {curWidth}.");
 				}
 
 				return curWidth;


### PR DESCRIPTION
To be aligned with StyleCop's rule `ConstFieldNamesMustBeginWithUpperCaseLetter`
https://github.com/zkSNACKs/WalletWasabi/blob/master/Settings.StyleCop#L37-L39