### PR TITLE
Add status request API - for filters 

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -435,8 +435,8 @@ namespace WalletWasabi.Backend.Controllers
 					var lastFilter = Global.IndexBuilderService.GetLastFilter();
 					var lastFilterHash = lastFilter.Header.BlockHash;
 					var bestHash = await RpcClient.GetBestBlockHashAsync();
-					var lastBlock = await RpcClient.GetBlockAsync(bestHash);
-					var prevHash = lastBlock.Header.HashPrevBlock;
+					var lastBlockHeader = await RpcClient.GetBlockHeaderAsync(bestHash);
+					var prevHash = lastBlockHeader.HashPrevBlock;
 
 					if (bestHash == lastFilterHash || prevHash == lastFilterHash)
 					{

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -419,5 +419,33 @@ namespace WalletWasabi.Backend.Controllers
 
 			return feeResponse;
 		}
+
+		[HttpGet("status")]
+		[ProducesResponseType(typeof(StatusResponse), 200)]
+		[ResponseCache(Duration = 10, Location = ResponseCacheLocation.Client)]
+		public async Task<StatusResponse> GetStatusAsync()
+		{
+			var result = new StatusResponse();
+
+			try
+			{
+				var lastFilter = Global.IndexBuilderService.GetLastFilter();
+				var lastFilterHash = lastFilter.Header.BlockHash;
+
+				var bestHash = await RpcClient.GetBestBlockHashAsync();
+				var lastBlock = await RpcClient.GetBlockAsync(bestHash);
+				var prevHash = lastBlock.Header.HashPrevBlock;
+
+				if (bestHash == lastFilterHash || prevHash == lastFilterHash)
+				{
+					result.FilterCreationActive = true;
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogDebug(ex);
+			}
+			return result;
+		}
 	}
 }

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -18,6 +18,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend;
+using WalletWasabi.Backend.Controllers;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Blockchain.Analysis.Clustering;
@@ -283,6 +284,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 				}
 
 				await rpc.GenerateAsync(1);
+
+				var blockchainController = (BlockchainController)RegTestFixture.BackendHost.Services.GetService(typeof(BlockchainController));
+				blockchainController.Cache.Remove($"{nameof(BlockchainController.GetStatusAsync)}");
 
 				response = await client.TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, request);
 				using (HttpContent content = response.Content)

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -232,7 +232,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			finally
 			{
-				if (indexBuilderService != null)
+				if (indexBuilderService is { })
 				{
 					await indexBuilderService.StopAsync();
 				}

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -238,6 +238,68 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 		}
 
+		[Fact]
+		public async Task StatusRequestTestAsync()
+		{
+			const string request = "/api/v3/btc/Blockchain/status";
+			(string password, RPCClient rpc, Network network, Coordinator coordinator, ServiceConfiguration serviceConfiguration, BitcoinStore bitcoinStore, Backend.Global global) = await InitializeTestEnvironmentAsync(1);
+
+			var indexBuilderService = global.IndexBuilderService;
+			try
+			{
+				indexBuilderService.Synchronize();
+				// Test initial synchronization.
+				var times = 0;
+				uint256 firstHash = await rpc.GetBlockHashAsync(0);
+				while (indexBuilderService.GetFilterLinesExcluding(firstHash, 101, out _).filters.Count() != 101)
+				{
+					if (times > 500) // 30 sec
+					{
+						throw new TimeoutException($"{nameof(IndexBuilderService)} test timed out.");
+					}
+					await Task.Delay(100);
+					times++;
+				}
+
+				using var client = new WasabiClient(new Uri(RegTestFixture.BackendEndPoint), null);
+				var response = await client.TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, request);
+				using (HttpContent content = response.Content)
+				{
+					var resp = await content.ReadAsJsonAsync<StatusResponse>();
+					Assert.True(resp.FilterCreationActive);
+				}
+
+				// Simulate an unintended stop
+				await indexBuilderService.StopAsync();
+				indexBuilderService = null;
+
+				await rpc.GenerateAsync(1);
+
+				response = await client.TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, request);
+				using (HttpContent content = response.Content)
+				{
+					var resp = await content.ReadAsJsonAsync<StatusResponse>();
+					Assert.True(resp.FilterCreationActive);
+				}
+
+				await rpc.GenerateAsync(1);
+
+				response = await client.TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, request);
+				using (HttpContent content = response.Content)
+				{
+					var resp = await content.ReadAsJsonAsync<StatusResponse>();
+					Assert.False(resp.FilterCreationActive);
+				}
+			}
+			finally
+			{
+				if (indexBuilderService != null)
+				{
+					await indexBuilderService.StopAsync();
+				}
+			}
+		}
+
 		#endregion BackendTests
 
 		#region ServicesTests

--- a/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
@@ -1,0 +1,7 @@
+namespace WalletWasabi.Backend.Models.Responses
+{
+	public class StatusResponse
+	{
+		public bool FilterCreationActive { get; set; }
+	}
+}

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -407,6 +407,14 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			}
 		}
 
+		public FilterModel GetLastFilter()
+		{
+			using (IndexLock.Lock())
+			{
+				return Index.Last();
+			}
+		}
+
 		public async Task StopAsync()
 		{
 			if (BlockNotifier != null)

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -155,7 +155,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 								{
 									if (Index.Count != 0)
 									{
-										var lastIndex = Index.Last();
+										var lastIndex = Index[^1];
 										heightToRequest = lastIndex.Header.Height + 1;
 										currentHash = lastIndex.Header.BlockHash;
 									}
@@ -343,7 +343,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			// 1. Rollback index
 			using (await IndexLock.LockAsync())
 			{
-				Logger.LogInfo($"REORG invalid block: {Index.Last().Header.BlockHash}");
+				Logger.LogInfo($"REORG invalid block: {Index[^1].Header.BlockHash}");
 				Index.RemoveLast();
 			}
 
@@ -402,7 +402,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 				}
 				else
 				{
-					return ((int)Index.Last().Header.Height, filters);
+					return ((int)Index[^1].Header.Height, filters);
 				}
 			}
 		}

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -411,7 +411,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 		{
 			using (IndexLock.Lock())
 			{
-				return Index.Last();
+				return Index[^1];
 			}
 		}
 


### PR DESCRIPTION
Recreating this: https://github.com/zkSNACKs/WalletWasabi/pull/2425

The status of filter generation on the Backend server is fundamental for clients without a full node. If the filter creation stops for some reason, the wallet will not refresh the statuses related to blockchain. 

This PR created an API request which can be monitored with our monitoring system UptimeRobot which can detect the existence of some keywords in responses. 

1. Merge this PR into the master.
2. Deploy it on Testnet/Mainnet backend.
3. Add the monitor to UptimeRobot. 

As a result, we will get notifications on our maintenance channels, so actions can be made.  
