### PR TITLE
Add build rpc call

### DIFF
--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -100,8 +100,8 @@ namespace WalletWasabi.Gui.Rpc
 			};
 		}
 
-		[JsonRpcMethod("send")]
-		public async Task<object> SendTransactionAsync(PaymentInfo[] payments, TxoRef[] coins, int feeTarget, string password = null)
+		[JsonRpcMethod("build")]
+		public string BuildTransaction(PaymentInfo[] payments, TxoRef[] coins, int feeTarget, string password = null)
 		{
 			Guard.NotNull(nameof(payments), payments);
 			Guard.NotNull(nameof(coins), coins);
@@ -121,6 +121,15 @@ namespace WalletWasabi.Gui.Rpc
 				allowedInputs: coins);
 			var smartTx = result.Transaction;
 
+			return smartTx.Transaction.ToHex();
+		}
+
+		[JsonRpcMethod("send")]
+		public async Task<object> SendTransactionAsync(PaymentInfo[] payments, TxoRef[] coins, int feeTarget, string password = null)
+		{
+			var txHex = BuildTransaction(payments, coins, feeTarget, password);
+			var smartTx = new SmartTransaction(Transaction.Parse(txHex, Global.Network), Height.Mempool);
+
 			// dequeue the coins we are going to spend
 			var toDequeue = Global.WalletService.Coins
 				.Where(x => x.CoinJoinInProgress && coins.Contains(x.GetTxoRef()))
@@ -134,7 +143,7 @@ namespace WalletWasabi.Gui.Rpc
 			return new
 			{
 				txid = smartTx.Transaction.GetHash(),
-				tx = smartTx.Transaction.ToHex()
+				tx = txHex
 			};
 		}
 


### PR DESCRIPTION
This PR allows to build signed transactions using rpc but without sending. The built transaction can be broadcasted using the Wasabi transaction broadcaster or any other service. 
 
Closes https://github.com/zkSNACKs/WalletWasabi/issues/2991

```sh
curl -s --data-binary '{"jsonrpc":"2.0","id":"1","method":"buildtransaction", "p
arams": { "payments":[ {"sendto": "tb1qgvnht40a08gumw32kp05hs8mny954hp2snhxcz", "amount": 5000, "label": "Davi
d2 } ], "coins":[{"transactionid":"d279916a9ea2679e6672839862e269c271fe4eed96f00e08aae3b82f20d469bd", "index"
:0}], "feeTarget":2, password:null }}' http://127.0.0.1:37128/ | jq                                           
{                                                                                                             
  "jsonrpc": "2.0",                                                                                           
  "result": "01000000000101bd69d4202fb8e3aa080ef096ed4efe71c269e262988372669e67a29e6a9179d20000000000ffffffff0
2cb4c0f00000000001600146e165828878c31ac65a157e7e35dfd3ed949978d8813000000000000160014432775d5fd79d1cdba2ab05f4
bc0fb990b4adc2a024730440220365fba6ac1197dbdd4e230a321cd1c2c78590eed3bd413138b193891dffc7b1602204504550e6992b9b
8dd7aa29fac0ea0a062f35efeb741499045a1aeec9b1df8db0121030cf3262d0186844ca0621d53a17857897c20ba7847e33020b527c30
a9a90495900000000",                                                                                           
  "id": "1"                                                                                                   
}        
```
