### PR TITLE
Double rpcworkqueue

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -169,7 +169,7 @@ pico ~/.bitcoin/bitcoin.conf
 ```sh
 testnet=[0/1]
 
-[main/test].rpcworkqueue=64
+[main/test].rpcworkqueue=128
 
 [main/test].txindex=1
 


### PR DESCRIPTION
Looks like @osagga was experimenting with values of 1000 so doubling 64 should be fine: https://github.com/bitpay/bitcore-node/issues/463#issuecomment-413379440

Reason: 

```
2020-02-07T11:37:53Z WARNING: request rejected because http work queue depth exceeded, it can be increased with the -rpcworkqueue= setting
2020-02-07T11:37:53Z WARNING: request rejected because http work queue depth exceeded, it can be increased with the -rpcworkqueue= setting
```