### PR TITLE
Violate ElementsMustAppearInTheCorrectOrder rule in class with already ordered elements

### DIFF
--- a/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
+++ b/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
@@ -10,6 +10,8 @@ namespace WalletWasabi.Bases
 	{
 		#region Events
 
+		public int MyProperty { get; set; }
+
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/pull/3043#issuecomment-583394081

Properties should be under events.