### PR TITLE
Final round of Typo fixes

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -356,7 +356,7 @@ namespace WalletWasabi.Backend.Controllers
 		/// <param name="uniqueId">Unique identifier, obtained previously.</param>
 		/// <param name="roundId">Round identifier, obtained previously.</param>
 		/// <returns>Current phase and blinded output sinatures if Alice is found.</returns>
-		/// <response code="200">Current phase and blinded output sinatures if Alice is found.</response>
+		/// <response code="200">Current phase and blinded output signatures if Alice is found.</response>
 		/// <response code="400">The provided uniqueId or roundId was malformed.</response>
 		/// <response code="404">If Alice or the round is not found.</response>
 		/// <response code="410">Participation can be only confirmed from a Running round's InputRegistration or ConnectionConfirmation phase.</response>
@@ -427,7 +427,7 @@ namespace WalletWasabi.Backend.Controllers
 		/// <param name="uniqueId">Unique identifier, obtained previously.</param>
 		/// <param name="roundId">Round identifier, obtained previously.</param>
 		/// <response code="200">Alice or the round was not found.</response>
-		/// <response code="204">Alice sucessfully uncofirmed her participation.</response>
+		/// <response code="204">Alice sucessfully unconfirmed her participation.</response>
 		/// <response code="400">The provided uniqueId or roundId was malformed.</response>
 		/// <response code="410">Participation can be only unconfirmed from a Running round's InputRegistration phase.</response>
 		[HttpPost("unconfirmation")]

--- a/WalletWasabi.Gui/Helpers/FileHelpers.cs
+++ b/WalletWasabi.Gui/Helpers/FileHelpers.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.Gui.Helpers
 						}
 					}
 
-					// Open file wtih the default editor.
+					// Open file with the default editor.
 					using Process defaultEditorProcess = Process.Start(new ProcessStartInfo
 					{
 						FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? filePath : "open",

--- a/WalletWasabi.Gui/Models/StatusBarStatuses/StatusType.cs
+++ b/WalletWasabi.Gui/Models/StatusBarStatuses/StatusType.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace WalletWasabi.Gui.Models.StatusBarStatuses
 {
 	/// <summary>
-	/// Order: piority the lower.
+	/// Order: priority the lower.
 	/// </summary>
 	public enum StatusType
 	{

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -632,7 +632,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				try
 				{
 					await Task.Run(async () => await Global.InitializeWalletServiceAsync(keyManager));
-					// Successffully initialized.
+					// Successfully initialized.
 					Owner.OnClose();
 					// Open Wallet Explorer tabs
 					if (Global.WalletService.Coins.Any())

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -2357,7 +2357,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				Assert.Contains(outputAddress1.ScriptPubKey, unsignedCoinJoin.Outputs.Select(x => x.ScriptPubKey));
 				Assert.Contains(outputAddress2.ScriptPubKey, unsignedCoinJoin.Outputs.Select(x => x.ScriptPubKey));
-				Assert.True(2 == unsignedCoinJoin.Outputs.Count); // Because the two input is equal, so change addresses won't be used, nor coordinator fee will be taken.
+				Assert.True(2 == unsignedCoinJoin.Outputs.Count); // Because the two inputs are equal, so change addresses won't be used, nor coordinator fee will be taken.
 				Assert.Contains(input1, unsignedCoinJoin.Inputs.Select(x => x.PrevOut));
 				Assert.Contains(input2, unsignedCoinJoin.Inputs.Select(x => x.PrevOut));
 				Assert.True(2 == unsignedCoinJoin.Inputs.Count);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -122,7 +122,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				("Joseph", 4, 0.16m, confirmed: true, anonymitySet: 200)
 			});
 
-			// It has to select the most private coins regarless of the amounts
+			// It has to select the most private coins regardless of the amounts
 			var payment = new PaymentIntent(new Key().ScriptPubKey, Money.Coins(0.17m));
 			var feeRate = new FeeRate(2m);
 			var result = transactionFactory.BuildTransaction(payment, feeRate);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -667,7 +667,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var coin = Assert.Single(transactionProcessor.Coins);
 			Assert.Equal(4, coin.AnonymitySet);
 			Assert.Equal(amount, coin.Amount);
-			Assert.False(coin.IsLikelyCoinJoinOutput);  // It is a coinjoin however we are reveiving but not spending.
+			Assert.False(coin.IsLikelyCoinJoinOutput);  // It is a coinjoin however we are receiving but not spending.
 		}
 
 		[Fact]
@@ -698,7 +698,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var coin = Assert.Single(transactionProcessor.Coins, c => c.AnonymitySet > 1);
 			Assert.Equal(5, coin.AnonymitySet);
 			Assert.Equal(amount, coin.Amount);
-			Assert.True(coin.IsLikelyCoinJoinOutput);  // because we are spanding and receiving almost the same amount
+			Assert.True(coin.IsLikelyCoinJoinOutput);  // because we are spending and receiving almost the same amount
 		}
 
 		[Fact]

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -133,7 +133,7 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 						{
 							// if the received transaction is spending at least one input already
 							// spent by a previous unconfirmed transaction signaling RBF then it is not a double
-							// spanding transaction but a replacement transaction.
+							// spending transaction but a replacement transaction.
 							var isReplacemenetTx = doubleSpends.Any(x => x.IsReplaceable && !x.Confirmed);
 							if (isReplacemenetTx)
 							{

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -208,7 +208,7 @@ namespace WalletWasabi.Blockchain.Transactions
 
 			try
 			{
-				// First is redundand txhash serialization.
+				// First is redundant txhash serialization.
 				var heightString = parts[2];
 				var blockHashString = parts[3];
 				var blockIndexString = parts[4];

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -483,7 +483,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 		{
 			try
 			{
-				// Select the most suitable coins to regiter.
+				// Select the most suitable coins to register.
 				List<TxoRef> registrableCoins = State.GetRegistrableCoins(
 					inputRegistrableRound.State.MaximumInputCountPerPeer,
 					inputRegistrableRound.State.Denomination,

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -1003,7 +1003,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 
 		public void StartAliceTimeout(Guid uniqueId)
 		{
-			// 1. Find Alice and set its LastSeen propery.
+			// 1. Find Alice and set its LastSeen property.
 			var foundAlice = false;
 			var started = DateTimeOffset.UtcNow;
 			using (RoundSynchronizerLock.Lock())

--- a/WalletWasabi/Gma/QrCodeNet/Encoding/EncodingRegion/FormatInformation.cs
+++ b/WalletWasabi/Gma/QrCodeNet/Encoding/EncodingRegion/FormatInformation.cs
@@ -91,7 +91,7 @@ namespace Gma.QrCodeNet.Encoding.EncodingRegion
 		}
 
 		//According Table 25 — Error correction level indicators
-		//Using this bits as enum values would destroy thir order which currently correspond to error correction strength.
+		//Using these bits as enum values would destroy their order which currently corresponds to error correction strength.
 		internal static int GetErrorCorrectionIndicatorBits(ErrorCorrectionLevel errorLevel)
 		{
 			//L 01

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -260,7 +260,7 @@ namespace WalletWasabi.WebClients.Wasabi
 		{
 			var versions = await GetVersionsAsync(cancel);
 			var clientUpToDate = Constants.ClientVersion >= versions.ClientVersion; // If the client version locally is greater than or equal to the backend's reported client version, then good.
-			var backendCompatible = int.Parse(Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major are equal, then our softwares are compatible.
+			var backendCompatible = int.Parse(Constants.BackendMajorVersion) == versions.BackendMajorVersion; // If the backend major and the client major are equal, then our software is compatible.
 
 			return new UpdateStatus(backendCompatible, clientUpToDate);
 		}


### PR DESCRIPTION
This is the final round of Typo fixes in these Series.

Some background : i used a little bit of bash code
and ispell to find potential typos , and then manually
reviewed the Output and fixed where needed .

For instance:

( find -iname "*.md" -exec cat {} \; ) | ispell -a | grep ^\& | cut -d " " -f 1-2 | sort -u -f

It was the first time I tried something like this and
I'm pretty happy with the results . I was able to find
and fix around 40 typos in the complete Series :)

I think a big Thanks to ispell is appropriate here !