### PR TITLE
Remove suggestion to try Max button

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -279,11 +279,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 							return;
 						}
 
-						if (amount == selectedCoinViewModels.Sum(x => x.Amount))
-						{
-							NotificationHelpers.Warning("Looks like you want to spend whole coins. Try Max button instead.", "");
-							return;
-						}
 						moneyRequest = MoneyRequest.Create(amount);
 					}
 


### PR DESCRIPTION
I think we don't need this notification.

If the users types an amount and selects a coin with exactly the same amount most likely they want to send that amount.
Using the Max button as suggested in this case will change the amount which is not what the user expects.