### PR TITLE
Enable CoinListView Item Virtualization

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -78,7 +78,7 @@
         </StackPanel>
       </StackPanel>
       <controls:BusyIndicator IsBusy="{Binding IsCoinListLoading}" Text="Loading...">
-        <controls:ExtendedListBox Items="{Binding Coins}" VirtualizationMode="None" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
+        <controls:ExtendedListBox Items="{Binding Coins}" SelectedItem="{Binding Path=SelectedCoin, Mode=TwoWay}">
           <controls:ExtendedListBox.ItemTemplate>
             <DataTemplate>
               <Grid Classes="CoinItemGrid">


### PR DESCRIPTION
Enable item virtualization on `CoinListView`'s `ListBox` to have a smoother scroll and less memory usage.

fixes #2614