### PR TITLE
Use Task.WhenAll

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -271,9 +271,8 @@ namespace WalletWasabi.Backend.Controllers
 				{
 					await batchingRpc.SendBatchAsync();
 
-					foreach (var txTask in tasks)
+					foreach (var tx in await Task.WhenAll(tasks))
 					{
-						var tx = await txTask;
 						string hex = tx.ToHex();
 						hexes.Add(tx.GetHash(), hex);
 


### PR DESCRIPTION
Alternative to https://github.com/zkSNACKs/WalletWasabi/pull/3081

closes https://github.com/zkSNACKs/WalletWasabi/pull/3081
probably fixes https://github.com/zkSNACKs/WalletWasabi/issues/3039

Based on my tests whenall will wait until all the tasks finished and throws the first exception. While our current foreach will throw the first exception and abandon the remaining tasks.  
Task waitall would block and throw an aggregate exception.

I also tried to catch unobserved exceptions but my small console app doesn't catch any, not even for the first foreach solution. So I'm not 100% sure this fixes the issue, but if it does it does it elegantly.