### PR TITLE
[WEBSITE] change broken link

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -139,7 +139,7 @@
                     </a>
                 </div>
                 <div class="col-6 col-sm-3 p-0">
-                    <a href="https://docs.wasabiwallet.io/why-wasabi/10Commandments.html#_2-verify-the-integrity-of-your-software" class="feature text-center py-3 px-2 px-md-3 d-block text-dark" target="_blank">
+                    <a href="https://docs.wasabiwallet.io/FAQ/FAQ-Introduction.html#why-is-wasabi-libre-and-open-source-software" class="feature text-center py-3 px-2 px-md-3 d-block text-dark" target="_blank">
                         <svg class="d-block mb-2 m-auto" width="52" height="50" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-rule="nonzero"><path d="M51.911 15.242C51.152 6.888 45.239.827 37.839.827c-4.93 0-9.444 2.653-11.984 6.905C23.338 3.425 19.009.826 14.158.826 6.759.826.845 6.887.087 15.241c-.06.369-.306 2.311.442 5.478 1.078 4.568 3.568 8.723 7.199 12.013l18.115 16.439 18.426-16.438c3.631-3.291 6.121-7.445 7.199-12.014.748-3.166.502-5.108.443-5.477zm-2.39 5.019c-.984 4.172-3.265 7.973-6.59 10.985L25.855 46.481 9.072 31.25c-3.331-3.018-5.611-6.818-6.596-10.99-.708-2.997-.417-4.69-.416-4.701l.015-.101c.65-7.319 5.731-12.632 12.083-12.632 4.687 0 8.813 2.88 10.771 7.515l.921 2.183.921-2.183c1.927-4.564 6.271-7.514 11.069-7.514 6.351 0 11.433 5.313 12.096 12.727.002.016.293 1.71-.415 4.707z" /><path d="M15.999 6.904c-5.514 0-10 4.486-10 10a1 1 0 1 0 2 0c0-4.411 3.589-8 8-8a1 1 0 1 0 0-2z" /></g></svg>
                         <br />
                         <span class="text-uppercase font-weight-bold">Free &amp; Open Source</span>


### PR DESCRIPTION
The `free and open source` block on the website linked to the 10 commandments on verifying the PGP signatures. This is not really important in the context of why wasabi is free software. Further, since we changed the 10 commandments, this sub link is broken.

Thus this changes the hyperlink to the FAQ where it is beautifully written [why Wasabi is open source](https://docs.wasabiwallet.io/FAQ/FAQ-Introduction.html#why-is-wasabi-libre-and-open-source-software) - in my opinion a much better fit for this block.

It should be a trivial merge.