### PR TITLE
Place CoinJoin client to WalletService

### DIFF
--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -100,7 +100,7 @@ namespace WalletWasabi.Gui.CommandLine
 						break;
 					}
 
-					bool anyCoinsQueued = Global.ChaumianClient.State.AnyCoinsQueued();
+					bool anyCoinsQueued = Global.WalletService.ChaumianClient.State.AnyCoinsQueued();
 					if (!anyCoinsQueued && keepMixAlive) // If no coins queued and mixing is asked to be kept alive then try to queue coins.
 					{
 						await TryQueueCoinsToMixAsync(mixAll, password);
@@ -117,7 +117,7 @@ namespace WalletWasabi.Gui.CommandLine
 
 				if (!Global.KillRequested) // This only has to run if it finishes by itself. Otherwise the Ctrl+c runs it.
 				{
-					await Global.ChaumianClient?.DequeueAllCoinsFromMixAsync(DequeueReason.ApplicationExit);
+					await Global.WalletService.ChaumianClient?.DequeueAllCoinsFromMixAsync(DequeueReason.ApplicationExit);
 				}
 			}
 			catch
@@ -184,7 +184,7 @@ namespace WalletWasabi.Gui.CommandLine
 				{
 					coinsToMix = coinsToMix.FilterBy(x => x.AnonymitySet < Global.WalletService.ServiceConfiguration.MixUntilAnonymitySet);
 				}
-				await Global.ChaumianClient.QueueCoinsToMixAsync(password, coinsToMix.ToArray());
+				await Global.WalletService.ChaumianClient.QueueCoinsToMixAsync(password, coinsToMix.ToArray());
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -141,20 +141,20 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			TargetPrivacy = Global.Config.GetTargetPrivacy();
 
-			var registrableRound = Global.ChaumianClient.State.GetRegistrableRoundOrDefault();
+			var registrableRound = Global.WalletService.ChaumianClient.State.GetRegistrableRoundOrDefault();
 
 			UpdateRequiredBtcLabel(registrableRound);
 
 			CoordinatorFeePercent = registrableRound?.State?.CoordinatorFeePercent.ToString() ?? "0.003";
 
-			Observable.FromEventPattern(Global.ChaumianClient, nameof(Global.ChaumianClient.CoinQueued))
-				.Merge(Observable.FromEventPattern(Global.ChaumianClient, nameof(Global.ChaumianClient.OnDequeue)))
-				.Merge(Observable.FromEventPattern(Global.ChaumianClient, nameof(Global.ChaumianClient.StateUpdated)))
+			Observable.FromEventPattern(Global.WalletService.ChaumianClient, nameof(Global.WalletService.ChaumianClient.CoinQueued))
+				.Merge(Observable.FromEventPattern(Global.WalletService.ChaumianClient, nameof(Global.WalletService.ChaumianClient.OnDequeue)))
+				.Merge(Observable.FromEventPattern(Global.WalletService.ChaumianClient, nameof(Global.WalletService.ChaumianClient.StateUpdated)))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => UpdateStates())
 				.DisposeWith(Disposables);
 
-			ClientRound mostAdvancedRound = Global.ChaumianClient?.State?.GetMostAdvancedRoundOrDefault();
+			ClientRound mostAdvancedRound = Global.WalletService.ChaumianClient?.State?.GetMostAdvancedRoundOrDefault();
 
 			if (mostAdvancedRound != default)
 			{
@@ -214,7 +214,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 				try
 				{
-					await Global.ChaumianClient.DequeueCoinsFromMixAsync(coins.ToArray(), DequeueReason.UserRequested);
+					await Global.WalletService.ChaumianClient.DequeueCoinsFromMixAsync(coins.ToArray(), DequeueReason.UserRequested);
 				}
 				catch (Exception ex)
 				{
@@ -249,7 +249,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						NotificationHelpers.Warning(PasswordHelper.CompatibilityPasswordWarnMessage);
 					}
 
-					await Global.ChaumianClient.QueueCoinsToMixAsync(Password, coins.ToArray());
+					await Global.WalletService.ChaumianClient.QueueCoinsToMixAsync(Password, coins.ToArray());
 				}
 				catch (SecurityException ex)
 				{
@@ -279,7 +279,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private void UpdateStates()
 		{
-			var chaumianClient = Global?.ChaumianClient;
+			var chaumianClient = Global?.WalletService?.ChaumianClient;
 			if (chaumianClient is null)
 			{
 				return;
@@ -330,7 +330,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				var queued = coins.CoinJoinInProcess();
 				if (queued.Any())
 				{
-					RequiredBTC = registrableRound.State.CalculateRequiredAmount(Global.ChaumianClient.State.GetAllQueuedCoinAmounts().ToArray());
+					RequiredBTC = registrableRound.State.CalculateRequiredAmount(Global.WalletService.ChaumianClient.State.GetAllQueuedCoinAmounts().ToArray());
 				}
 				else
 				{
@@ -344,12 +344,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public override void OnSelected()
 		{
-			Global.ChaumianClient.ActivateFrequentStatusProcessing();
+			Global.WalletService.ChaumianClient.ActivateFrequentStatusProcessing();
 		}
 
 		public override void OnDeselected()
 		{
-			Global.ChaumianClient.DeactivateFrequentStatusProcessingIfNotMixing();
+			Global.WalletService.ChaumianClient.DeactivateFrequentStatusProcessingIfNotMixing();
 		}
 
 		public ErrorDescriptors ValidatePassword() => PasswordHelper.ValidatePassword(Password);

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public bool DisplayCommonOwnershipWarning { get; set; } = false;
 		public bool CanDequeueCoins { get; set; } = false;
-		
+
 		private SortExpressionComparer<CoinViewModel> MyComparer
 		{
 			get => _myComparer;
@@ -257,7 +257,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			CoinJoinStatusWidth = new GridLength(0);
 			CanDequeueCoins = canDequeueCoins;
 			DisplayCommonOwnershipWarning = displayCommonOwnershipWarning;
-			
+
 			RefreshOrdering();
 
 			// Otherwise they're all selected as null on load.
@@ -519,7 +519,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Observable
 				.Merge(cvm.Model.WhenAnyValue(x => x.IsBanned, x => x.SpentAccordingToBackend, x => x.Confirmed, x => x.CoinJoinInProgress).Select(_ => Unit.Default))
-				.Merge(Observable.FromEventPattern(Global.ChaumianClient, nameof(Global.ChaumianClient.StateUpdated)).Select(_ => Unit.Default))
+				.Merge(Observable.FromEventPattern(Global.WalletService.ChaumianClient, nameof(Global.WalletService.ChaumianClient.StateUpdated)).Select(_ => Unit.Default))
 				.Synchronize(StateChangedLock) // Use the same lock to ensure thread safety.
 				.Throttle(TimeSpan.FromSeconds(1))
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -83,7 +83,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Observable
 				.Merge(Model.WhenAnyValue(x => x.IsBanned, x => x.SpentAccordingToBackend, x => x.Confirmed, x => x.CoinJoinInProgress).Select(_ => Unit.Default))
-				.Merge(Observable.FromEventPattern(Global.ChaumianClient, nameof(Global.ChaumianClient.StateUpdated)).Select(_ => Unit.Default))
+				.Merge(Observable.FromEventPattern(Global.WalletService.ChaumianClient, nameof(Global.WalletService.ChaumianClient.StateUpdated)).Select(_ => Unit.Default))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => RefreshSmartCoinStatus())
 				.DisposeWith(Disposables);
@@ -208,9 +208,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				return SmartCoinStatus.MixingBanned;
 			}
 
-			if (Model.CoinJoinInProgress && Global.ChaumianClient != null)
+			if (Model.CoinJoinInProgress && Global.WalletService.ChaumianClient != null)
 			{
-				ClientState clientState = Global.ChaumianClient.State;
+				ClientState clientState = Global.WalletService.ChaumianClient.State;
 				foreach (var round in clientState.GetAllMixingRounds())
 				{
 					if (round.CoinsRegistered.Contains(Model))

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -302,7 +302,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						TxoRef[] toDequeue = selectedCoinViewModels.Where(x => x.CoinJoinInProgress).Select(x => x.Model.GetTxoRef()).ToArray();
 						if (toDequeue != null && toDequeue.Any())
 						{
-							await Global.ChaumianClient.DequeueCoinsFromMixAsync(toDequeue, DequeueReason.TransactionBuilding);
+							await Global.WalletService.ChaumianClient.DequeueCoinsFromMixAsync(toDequeue, DequeueReason.TransactionBuilding);
 						}
 					}
 					catch

--- a/WalletWasabi.Gui/Converters/PhaseColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/PhaseColorConverter.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Gui.Converters
 			}
 
 			var global = Locator.Current.GetService<Global>();
-			var phaseError = global.ChaumianClient.State.IsInErrorState;
+			var phaseError = global.WalletService.ChaumianClient.State.IsInErrorState;
 
 			return (RoundPhase)p <= (RoundPhase)value
 				? phaseError

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogViewModel.cs
@@ -137,7 +137,7 @@ namespace WalletWasabi.Gui.Dialogs
 
 					try
 					{
-						if (Global.WalletService is null || Global.ChaumianClient is null)
+						if (Global.WalletService is null || Global.WalletService.ChaumianClient is null)
 						{
 							return;
 						}
@@ -153,7 +153,7 @@ namespace WalletWasabi.Gui.Dialogs
 									break;
 								}
 
-								await Global.ChaumianClient.DequeueCoinsFromMixAsync(new SmartCoin[] { coin }, DequeueReason.ApplicationExit); // Dequeue coins one-by-one to check cancel flag more frequently.
+								await Global.WalletService.ChaumianClient.DequeueCoinsFromMixAsync(new SmartCoin[] { coin }, DequeueReason.ApplicationExit); // Dequeue coins one-by-one to check cancel flag more frequently.
 							}
 							catch (Exception ex)
 							{

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -83,9 +83,9 @@ namespace WalletWasabi.Gui
 			bool closeApplication = false;
 			try
 			{
-				if (Global.ChaumianClient != null)
+				if (Global.WalletService?.ChaumianClient != null)
 				{
-					Global.ChaumianClient.IsQuitPending = true; // indicate -> do not add any more alices to the coinjoin
+					Global.WalletService.ChaumianClient.IsQuitPending = true; // indicate -> do not add any more alices to the coinjoin
 				}
 
 				if (!MainWindowViewModel.Instance.CanClose)
@@ -143,9 +143,9 @@ namespace WalletWasabi.Gui
 				if (!closeApplication) //we are not closing the application for some reason
 				{
 					Interlocked.Exchange(ref _closingState, 0);
-					if (Global.ChaumianClient != null)
+					if (Global.WalletService?.ChaumianClient != null)
 					{
-						Global.ChaumianClient.IsQuitPending = false; //re-enable enqueuing coins
+						Global.WalletService.ChaumianClient.IsQuitPending = false; //re-enable enqueuing coins
 					}
 				}
 			}

--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -146,7 +146,7 @@ namespace WalletWasabi.Gui.Rpc
 				.ToArray();
 			if (toDequeue.Any())
 			{
-				await Global.ChaumianClient.DequeueCoinsFromMixAsync(toDequeue, DequeueReason.TransactionBuilding).ConfigureAwait(false);
+				await Global.WalletService.ChaumianClient.DequeueCoinsFromMixAsync(toDequeue, DequeueReason.TransactionBuilding).ConfigureAwait(false);
 			}
 
 			await Global.TransactionBroadcaster.SendTransactionAsync(smartTx).ConfigureAwait(false);

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -97,7 +97,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				bitcoinStore,
 				keyManager,
 				syncer,
-				new CoinJoinClient(syncer, network, keyManager, new Uri("http://localhost:12345"), Global.Instance.TorSocks5Endpoint),
 				nodes,
 				dataDir,
 				new ServiceConfiguration(50, 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold)),
@@ -144,7 +143,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 				{
 					await walletService?.DeleteBlockAsync(hash);
 				}
-				walletService?.Dispose();
+				if (walletService is { })
+				{
+					await walletService.StopAsync(CancellationToken.None);
+				}
 
 				if (Directory.Exists(blocksFolderPath))
 				{

--- a/WalletWasabi.Tests/IntegrationTests/RegTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/RegTests.cs
@@ -537,12 +537,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			// 4. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 5. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			// Get some money, make it confirm.
@@ -556,7 +553,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 1000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -564,7 +560,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 				Assert.Equal(1, await wallet.CountBlocksAsync());
 
@@ -697,7 +693,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			finally
 			{
 				wallet.NewFilterProcessed -= Wallet_NewFilterProcessed;
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 
@@ -706,12 +702,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				// Dispose mempool serving node.
 				node?.Disconnect();
-
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
 			}
 		}
 
@@ -757,12 +747,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			// 4. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 6. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			// Get some money, make it confirm.
@@ -781,7 +768,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -789,7 +775,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 				var broadcaster = new TransactionBroadcaster(network, bitcoinStore, synchronizer, nodes, rpc);
 				broadcaster.AddWalletService(wallet);
@@ -1205,18 +1191,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 			finally
 			{
 				wallet.NewFilterProcessed -= Wallet_NewFilterProcessed;
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 				// Dispose connection service.
 				nodes?.Dispose();
 				// Dispose mempool serving node.
 				node?.Disconnect();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
 			}
 		}
 
@@ -1241,12 +1222,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			// 4. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 6. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			var scp = new Key().ScriptPubKey;
@@ -1311,7 +1289,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -1319,7 +1296,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 
 				// subtract Fee from amount index with no enough money
@@ -1370,18 +1347,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			finally
 			{
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 				// Dispose connection service.
 				nodes?.Dispose();
 				// Dispose mempool serving node.
 				node?.Disconnect();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
 			}
 		}
 
@@ -1406,12 +1378,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			// 4. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 6. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			Assert.Empty(wallet.Coins);
@@ -1432,7 +1401,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -1440,7 +1408,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 				var coin = Assert.Single(wallet.Coins);
 				Assert.True(coin.Confirmed);
@@ -1594,18 +1562,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			finally
 			{
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 				// Dispose connection service.
 				nodes?.Dispose();
 				// Dispose mempool serving node.
 				node?.Disconnect();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
 			}
 		}
 
@@ -1630,12 +1593,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			// 4. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 6. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			Assert.Empty(wallet.Coins);
@@ -1648,7 +1608,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -1656,7 +1615,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 
 				Assert.Empty(wallet.Coins);
@@ -1774,18 +1733,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			finally
 			{
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 				// Dispose connection service.
 				nodes?.Dispose();
 				// Dispose mempool serving node.
 				node?.Disconnect();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
 			}
 		}
 
@@ -1810,12 +1764,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			// 4. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 6. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			Assert.Empty(wallet.Coins);
@@ -1828,7 +1779,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -1836,7 +1786,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 
 				Assert.Empty(wallet.Coins);
@@ -1869,7 +1819,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				await WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 1);
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 
 				var coin = wallet.Coins.First();
@@ -1880,18 +1830,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			finally
 			{
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 				// Dispose connection service.
 				nodes?.Dispose();
 				// Dispose mempool serving node.
 				node?.Disconnect();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
 			}
 		}
 
@@ -3169,8 +3114,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				var bechCoin = tx.Outputs.GetCoins(bech.ScriptPubKey).Single();
 
 				var smartCoin = new SmartCoin(bechCoin, tx.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height + 1, replaceable: false, anonymitySet: tx.GetAnonymitySet(bechCoin.Outpoint.N), isLikelyCoinJoinOutput: false);
-
-				var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
+				var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager);
 
 				participants.Add((smartCoin, chaumianClient));
 			}
@@ -3221,7 +3165,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 					if (chaumianClient != null)
 					{
 						await chaumianClient.DequeueAllCoinsFromMixAsync(DequeueReason.UserRequested);
-						await chaumianClient.StopAsync();
+						await chaumianClient.StopAsync(CancellationToken.None);
 					}
 				}
 			}
@@ -3280,8 +3224,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 			var smartCoin3 = new SmartCoin(bech3Coin, tx3.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, replaceable: false, anonymitySet: tx3.GetAnonymitySet(bech3Coin.Outpoint.N), isLikelyCoinJoinOutput: false);
 			var smartCoin4 = new SmartCoin(bech4Coin, tx4.Inputs.Select(x => new TxoRef(x.PrevOut)).ToArray(), height, replaceable: false, anonymitySet: tx4.GetAnonymitySet(bech4Coin.Outpoint.N), isLikelyCoinJoinOutput: false);
 
-			var chaumianClient1 = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-			var chaumianClient2 = new CoinJoinClient(synchronizer, rpc.Network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
+			var chaumianClient1 = new CoinJoinClient(synchronizer, rpc.Network, keyManager);
+			var chaumianClient2 = new CoinJoinClient(synchronizer, rpc.Network, keyManager);
 			try
 			{
 				chaumianClient1.Start(); // Exactly delay it for 2 seconds, this will make sure of timeout later.
@@ -3374,11 +3318,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 			{
 				if (chaumianClient1 != null)
 				{
-					await chaumianClient1.StopAsync();
+					await chaumianClient1.StopAsync(CancellationToken.None);
 				}
 				if (chaumianClient2 != null)
 				{
-					await chaumianClient2.StopAsync();
+					await chaumianClient2.StopAsync(CancellationToken.None);
 				}
 			}
 		}
@@ -3423,18 +3367,13 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 			var keyManager2 = KeyManager.CreateNew(out _, password);
 
-			// 5. Create chaumian coinjoin client.
-			var chaumianClient = new CoinJoinClient(synchronizer, network, keyManager, new Uri(RegTestFixture.BackendEndPoint), null);
-
-			var chaumianClient2 = new CoinJoinClient(synchronizer, network, keyManager2, new Uri(RegTestFixture.BackendEndPoint), null);
-
 			// 6. Create wallet service.
 			var workDir = GetWorkDir();
-			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, chaumianClient, nodes, workDir, serviceConfiguration, synchronizer);
+			var wallet = new WalletService(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
 			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
 
 			var workDir2 = Path.Combine(GetWorkDir(), "2");
-			var wallet2 = new WalletService(bitcoinStore, keyManager2, synchronizer2, chaumianClient2, nodes2, workDir2, serviceConfiguration, synchronizer2);
+			var wallet2 = new WalletService(bitcoinStore, keyManager2, synchronizer2, nodes2, workDir2, serviceConfiguration, synchronizer2);
 
 			// Get some money, make it confirm.
 			var key = keyManager.GetNextReceiveKey("fundZeroLink", out _);
@@ -3455,11 +3394,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient.Start(); // Start chaumian coinjoin client.
+
 				nodes2.Connect(); // Start connection service.
 				node2.VersionHandshake(); // Start mempool service.
 				synchronizer2.Start(requestInterval: TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), 10000); // Start wasabi synchronizer service.
-				chaumianClient2.Start(); // Start chaumian coinjoin client.
 
 				// Wait until the filter our previous transaction is present.
 				var blockCount = await rpc.GetBlockCountAsync();
@@ -3467,11 +3405,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
 				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
 				{
-					await wallet2.InitializeAsync(cts.Token); // Initialize wallet service.
+					await wallet2.StartAsync(cts.Token); // Initialize wallet service.
 				}
 
 				var waitCount = 0;
@@ -3495,8 +3433,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 					}
 				}
 
-				Assert.True(1 == (await chaumianClient.QueueCoinsToMixAsync(password, wallet.Coins.ToArray())).Count());
-				Assert.True(3 == (await chaumianClient2.QueueCoinsToMixAsync(password, wallet2.Coins.ToArray())).Count());
+				Assert.True(1 == (await wallet.ChaumianClient.QueueCoinsToMixAsync(password, wallet.Coins.ToArray())).Count());
+				Assert.True(3 == (await wallet2.ChaumianClient.QueueCoinsToMixAsync(password, wallet2.Coins.ToArray())).Count());
 
 				Task timeout = Task.Delay(TimeSpan.FromSeconds(2 * (1 + 11 + 7 + 3 * (3 + 7))));
 				while (wallet.Coins.Count() != 4)
@@ -3524,8 +3462,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 				{
 					try
 					{
-						await chaumianClient.DequeueAllCoinsFromMixAsync(DequeueReason.UserRequested);
-						await chaumianClient2.DequeueAllCoinsFromMixAsync(DequeueReason.UserRequested);
+						await wallet.ChaumianClient.DequeueAllCoinsFromMixAsync(DequeueReason.UserRequested);
+						await wallet2.ChaumianClient.DequeueAllCoinsFromMixAsync(DequeueReason.UserRequested);
 						break;
 					}
 					catch (NotSupportedException)
@@ -3553,26 +3491,16 @@ namespace WalletWasabi.Tests.IntegrationTests
 			finally
 			{
 				wallet.NewFilterProcessed -= Wallet_NewFilterProcessed;
-				wallet?.Dispose();
+				await wallet.StopAsync(CancellationToken.None);
 				// Dispose connection service.
 				nodes?.Dispose();
 				// Dispose mempool serving node.
 				node?.Disconnect();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient != null)
-				{
-					await chaumianClient.StopAsync();
-				}
-				wallet2?.Dispose();
+				await wallet2.StopAsync(CancellationToken.None);
 				// Dispose wasabi synchronizer service.
 				await synchronizer?.StopAsync();
 				// Dispose connection service.
 				nodes2?.Dispose();
-				// Dispose chaumian coinjoin client.
-				if (chaumianClient2 != null)
-				{
-					await chaumianClient2.StopAsync();
-				}
 			}
 		}
 

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -27,7 +27,7 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 		public Network Network { get; }
 		public NodesGroup Nodes { get; }
 		public List<WalletService> WalletServices { get; }
-		public IEnumerable<WalletService> AliveWalletServices => WalletServices.Where(x => x != null && !x.IsDisposed);
+		public IEnumerable<WalletService> AliveWalletServices => WalletServices.Where(x => x != null && !x.IsStoppingOrStopped);
 		public object WalletServicesLock { get; }
 		public RPCClient RpcClient { get; private set; }
 

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -74,8 +74,8 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 		{
 			Network = Guard.NotNull(nameof(network), network);
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-			CcjHostUriAction = Synchronizer.WasabiClient.TorClient.DestinationUriAction;
 			Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
+			CcjHostUriAction = Synchronizer.WasabiClient.TorClient.DestinationUriAction;
 			TorSocks5EndPoint = Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint;
 			CoordinatorFeepercentToCheck = null;
 

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -70,30 +70,13 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 		public CoinJoinClient(
 			WasabiSynchronizer synchronizer,
 			Network network,
-			KeyManager keyManager,
-			Func<Uri> ccjHostUriAction,
-			EndPoint torSocks5EndPoint)
-		{
-			Create(synchronizer, network, keyManager, ccjHostUriAction, torSocks5EndPoint);
-		}
-
-		public CoinJoinClient(
-			WasabiSynchronizer synchronizer,
-			Network network,
-			KeyManager keyManager,
-			Uri ccjHostUri,
-			EndPoint torSocks5EndPoint)
-		{
-			Create(synchronizer, network, keyManager, () => ccjHostUri, torSocks5EndPoint);
-		}
-
-		private void Create(WasabiSynchronizer synchronizer, Network network, KeyManager keyManager, Func<Uri> ccjHostUriAction, EndPoint torSocks5EndPoint)
+			KeyManager keyManager)
 		{
 			Network = Guard.NotNull(nameof(network), network);
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-			CcjHostUriAction = Guard.NotNull(nameof(ccjHostUriAction), ccjHostUriAction);
+			CcjHostUriAction = Synchronizer.WasabiClient.TorClient.DestinationUriAction;
 			Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
-			TorSocks5EndPoint = torSocks5EndPoint;
+			TorSocks5EndPoint = Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint;
 			CoordinatorFeepercentToCheck = null;
 
 			ExposedLinks = new ConcurrentDictionary<TxoRef, IEnumerable<HdPubKeyBlindedPair>>();
@@ -1029,7 +1012,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			}
 		}
 
-		public async Task StopAsync()
+		public async Task StopAsync(CancellationToken cancel)
 		{
 			Synchronizer.ResponseArrived -= Synchronizer_ResponseArrivedAsync;
 
@@ -1037,13 +1020,13 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			Cancel?.Cancel();
 			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
 			{
-				await Task.Delay(50).ConfigureAwait(false);
+				await Task.Delay(50, cancel).ConfigureAwait(false);
 			}
 
 			Cancel?.Dispose();
 			Cancel = null;
 
-			using (await MixLock.LockAsync().ConfigureAwait(false))
+			using (await MixLock.LockAsync(cancel).ConfigureAwait(false))
 			{
 				await DequeueSpentCoinsFromMixNoLockAsync().ConfigureAwait(false);
 

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.CoinJoin.Client
 	{
 		public WasabiSynchronizer Synchronizer { get; }
 		public Dictionary<WalletService, HashSet<uint256>> WalletServices { get; }
-		public IEnumerable<KeyValuePair<WalletService, HashSet<uint256>>> AliveWalletServices => WalletServices.Where(x => x.Key is { IsDisposed: var isDisposed } && !isDisposed);
+		public IEnumerable<KeyValuePair<WalletService, HashSet<uint256>>> AliveWalletServices => WalletServices.Where(x => x.Key is { IsStoppingOrStopped: var isDisposed } && !isDisposed);
 		public object WalletServicesLock { get; }
 		public RPCClient RpcClient { get; private set; }
 		private AsyncLock ProcessLock { get; }

--- a/WalletWasabi/Services/WalletService.cs
+++ b/WalletWasabi/Services/WalletService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Hosting;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
@@ -32,11 +33,12 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services
 {
-	public class WalletService : IDisposable
+	public class WalletService : IHostedService
 	{
 		public static event EventHandler<bool> DownloadingBlockChanged;
 
 		public static event EventHandler<bool> InitializingChanged;
+
 		private static Random Random { get; } = new Random();
 
 		public BitcoinStore BitcoinStore { get; }
@@ -71,7 +73,6 @@ namespace WalletWasabi.Services
 			BitcoinStore bitcoinStore,
 			KeyManager keyManager,
 			WasabiSynchronizer syncer,
-			CoinJoinClient chaumianClient,
 			NodesGroup nodes,
 			string workFolderDir,
 			ServiceConfiguration serviceConfiguration,
@@ -82,10 +83,11 @@ namespace WalletWasabi.Services
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
 			Nodes = Guard.NotNull(nameof(nodes), nodes);
 			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
-			ChaumianClient = Guard.NotNull(nameof(chaumianClient), chaumianClient);
 			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
 			FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
 			CoreNode = coreNode;
+
+			ChaumianClient = new CoinJoinClient(Synchronizer, Network, keyManager);
 
 			HandleFiltersLock = new AsyncLock();
 
@@ -228,7 +230,8 @@ namespace WalletWasabi.Services
 			}
 		}
 
-		public async Task InitializeAsync(CancellationToken cancel)
+		/// <inheritdoc/>
+		public async Task StartAsync(CancellationToken cancel)
 		{
 			try
 			{
@@ -247,6 +250,8 @@ namespace WalletWasabi.Services
 				}
 
 				await RuntimeParams.LoadAsync();
+
+				ChaumianClient.Start();
 
 				using (await HandleFiltersLock.LockAsync())
 				{
@@ -728,7 +733,7 @@ namespace WalletWasabi.Services
 				// We use the timelock distribution observed in the bitcoin network
 				// in order to reduce the wasabi wallet transactions fingerprinting
 				// chances.
-				// 
+				//
 				// Network observations:
 				// 90.0% uses locktime = 0
 				//  7.5% uses locktime = current tip
@@ -815,40 +820,25 @@ namespace WalletWasabi.Services
 			Logger.LogInfo($"Current timeout value used on block download is: {timeout} seconds.");
 		}
 
-		#region IDisposable Support
-
-		private volatile bool _disposedValue = false; // To detect redundant calls
-
-		public bool IsDisposed => _disposedValue;
+		public bool IsStoppingOrStopped { get; private set; }
 
 		public CoreNode CoreNode { get; }
 		public FilterModel LastProcessedFilter { get; private set; }
 
-		protected virtual void Dispose(bool disposing)
+		/// <inheritdoc/>
+		public async Task StopAsync(CancellationToken cancel)
 		{
-			if (!_disposedValue)
-			{
-				if (disposing)
-				{
-					BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
-					BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
-					BitcoinStore.MempoolService.TransactionReceived -= Mempool_TransactionReceived;
-					TransactionProcessor.WalletRelevantTransactionProcessed -= TransactionProcessor_WalletRelevantTransactionProcessedAsync;
+			IsStoppingOrStopped = true;
 
-					DisconnectDisposeNullLocalBitcoinCoreNode();
-				}
+			BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
+			BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
+			BitcoinStore.MempoolService.TransactionReceived -= Mempool_TransactionReceived;
+			TransactionProcessor.WalletRelevantTransactionProcessed -= TransactionProcessor_WalletRelevantTransactionProcessedAsync;
 
-				_disposedValue = true;
-			}
+			DisconnectDisposeNullLocalBitcoinCoreNode();
+
+			await ChaumianClient.StopAsync(cancel).ConfigureAwait(false);
+			Logger.LogInfo($"{nameof(ChaumianClient)} is stopped.");
 		}
-
-		// This code added to correctly implement the disposable pattern.
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(true);
-		}
-
-		#endregion IDisposable Support
 	}
 }


### PR DESCRIPTION
In this PR the coinjoin client become implicitly wallet dependent. A better approach than creating "DefaultChaumianClient" and such so it won't need to be managed explicitly: https://github.com/zkSNACKs/WalletWasabi/pull/3104

Closes https://github.com/zkSNACKs/WalletWasabi/pull/3104