### PR TITLE
Revert buggy Azure CI fix

### DIFF
--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -9,7 +9,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.1.101
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:


### PR DESCRIPTION
Do not merge!

CI on macOS was failed so I did https://github.com/zkSNACKs/WalletWasabi/commit/005f5f516f441d517e66a9654e9d9958463fa4ab. There are already reports on that it looks like a bug in Azure.
https://developercommunity.visualstudio.com/content/problem/922217/pipeline-task-usedotnet.html

If it is fixed by MS this should be merged to let Azure use the newest version.