### PR TITLE
WIP: Add "loadwallet" RPC Call

### DIFF
--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -28,54 +28,13 @@ namespace WalletWasabi.Gui.Rpc
 		{
 			Global = global;
 		}
-		
-		public KeyManager TryGetKeyManagerFromWalletName(string walletName)
-		{
-			try
-			{
-				KeyManager keyManager = null;
-				if (walletName != null)
-				{
-					var walletFullPath = Global.GetWalletFullPath(walletName);
-					var walletBackupFullPath = Global.GetWalletBackupFullPath(walletName);
-					if (!File.Exists(walletFullPath) && !File.Exists(walletBackupFullPath))
-					{
-						throw new Exception("NO wallet by that name");
-					}
-
-					try
-					{
-						keyManager = Global.LoadKeyManager(walletFullPath, walletBackupFullPath);
-					}
-					catch (Exception ex)
-					{
-						throw new Exception("Error getting wallet.", ex);
-					}
-				}
-
-				if (keyManager is null)
-				{
-					throw new Exception("Error getting wallet 2.");
-				}
-
-				return keyManager;
-			}
-			catch (Exception ex)
-			{
-				return null;
-			}
-		}
 
 		[JsonRpcMethod(("loadwallet"))]
 		public object LoadWallet(string walletName, string password)
 		{
-			//Global.WalletService.
-			//Global.WalletService.CoreNode.
-			var wm = IoC.Get<IShell>().Documents?.OfType<WalletManagerViewModel>().FirstOrDefault();
 			var lwvm = (wm.Categories
 				.Where(x => (x as LoadWalletViewModel) != null && (x as LoadWalletViewModel).IsDesktopWallet)
 				.FirstOrDefault() as LoadWalletViewModel);
-			//Dispatcher.UIThread.InvokeAsync(lwvm.LoadWalletAsync).Wait();
 			Dispatcher.UIThread.InvokeAsync(new Action(() =>
 			{
 				lwvm.SelectedWallet = new LoadWalletEntry(walletName);
@@ -84,23 +43,6 @@ namespace WalletWasabi.Gui.Rpc
 				Task.Run(async () => await Global.InitializeWalletServiceAsync(keyManager)).Wait();
 			})).Wait();
 			
-			//wm.SelectLoadWallet();
-			/*
-			var keyManager = TryGetKeyManagerFromWalletName(walletName);
-			Global.InitializeNoWalletAsync();
-			if (Global.KillRequested)
-			{
-				throw new Exception("Kil requested 1");
-			}
-
-			Global.InitializeWalletServiceAsync(keyManager);
-			if (Global.KillRequested)
-			{
-				throw new Exception("Kil requested 2");
-			}
-			WalletViewModel walletViewModel = new WalletViewModel(Global.WalletService, true); // No idea what is true or false
-			walletViewModel.OnWalletOpened();
-			*/
 			return "IT WORKS!?";
 		}
 

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -523,11 +523,13 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 				}
 				else
 				{
+					/* NOTE: There is no way to do this from the Rpc call....
 					if (keyManager.PasswordVerified == false)
 					{
 						Owner.SelectTestPassword();
 						return null;
 					}
+					*/
 				}
 
 				return keyManager;


### PR DESCRIPTION
Hello,
I am interested in improving the "command line like" functionality of Wasabi. After creating a JavaScript api that would connect to all current RPC calls I quickly ran into the issue that there is no way to load a wallet via these calls.

Enclosed I created a (hacked) attempt at building this loadwallet call and wanted to get feedback from the maintainers to see if this approach would be considered.

(At the moment please ignore the major programming faux pas that need cleaning up, such as the namespaces which are likely not needed, lack of error handling, abbreviations, no comments, and one hilariously useful return message for success.)

I want to draw your attention to two points of concern.

1. Line 40 and 41 of WasabiJsonRpcService.cs
In order to set the Wallet correctly, behind the scenes there was a lot of unexpected behavior with setting SelectedWallet. Everytime I set the SelectedWallet, it would go into a loop where it would event out the change, but would change the value back to null _after_ it had already set it to the new value. In order to get around this, I set the walletName directly. **I have no idea if side effects will come from this. Probably not???**

Is this "ok"? Any other ways?

2. Line 526 of LoadWalletViewModel.cs 
I do not understand enough about what is going on with creation of the KeyManager to think about solving this problem well enough. Note: The intended usage of this RPC call is to run it from the command line, without a user to "enter the password" or whatever this is attempting to do.

Without knowing more, I didn't want to rewire or do anything else without getting a bit of pointers.


Note: This code 100% works (note the message of success). At the command line I can change wallets. Get History. Change to another wallet. Etc, etc.

Thoughts before I clean this up and "officially" submit this?
