### PR TITLE
Count locked external keys to get consecutive unused keys

### DIFF
--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -171,17 +171,17 @@ namespace WalletWasabi.Tests.UnitTests
 		public void GapCountingTests()
 		{
 			var km = KeyManager.CreateNew(out _, "");
-			Assert.Equal(0, km.CountConsecutiveCleanKeys(true));
-			Assert.Equal(0, km.CountConsecutiveCleanKeys(false));
+			Assert.Equal(0, km.CountConsecutiveUnusedKeys(true));
+			Assert.Equal(0, km.CountConsecutiveUnusedKeys(false));
 
 			var k = km.GenerateNewKey("", KeyState.Clean, true);
-			Assert.Equal(1, km.CountConsecutiveCleanKeys(true));
+			Assert.Equal(1, km.CountConsecutiveUnusedKeys(true));
 
 			km.GenerateNewKey("", KeyState.Locked, true);
-			Assert.Equal(1, km.CountConsecutiveCleanKeys(true));
+			Assert.Equal(1, km.CountConsecutiveUnusedKeys(true));
 
 			k.SetKeyState(KeyState.Used);
-			Assert.Equal(0, km.CountConsecutiveCleanKeys(true));
+			Assert.Equal(0, km.CountConsecutiveUnusedKeys(true));
 
 			for (int i = 0; i < 100; i++)
 			{
@@ -191,9 +191,9 @@ namespace WalletWasabi.Tests.UnitTests
 					k = k2;
 				}
 			}
-			Assert.Equal(100, km.CountConsecutiveCleanKeys(true));
+			Assert.Equal(100, km.CountConsecutiveUnusedKeys(true));
 			k.SetKeyState(KeyState.Locked);
-			Assert.Equal(50, km.CountConsecutiveCleanKeys(true));
+			Assert.Equal(50, km.CountConsecutiveUnusedKeys(true));
 		}
 
 		private static void DeleteFileAndDirectoryIfExists(string filePath)

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -178,10 +178,10 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.Equal(1, km.CountConsecutiveUnusedKeys(true));
 
 			km.GenerateNewKey("", KeyState.Locked, true);
-			Assert.Equal(1, km.CountConsecutiveUnusedKeys(true));
+			Assert.Equal(2, km.CountConsecutiveUnusedKeys(true));
 
 			k.SetKeyState(KeyState.Used);
-			Assert.Equal(0, km.CountConsecutiveUnusedKeys(true));
+			Assert.Equal(1, km.CountConsecutiveUnusedKeys(true));
 
 			for (int i = 0; i < 100; i++)
 			{
@@ -191,9 +191,11 @@ namespace WalletWasabi.Tests.UnitTests
 					k = k2;
 				}
 			}
-			Assert.Equal(100, km.CountConsecutiveUnusedKeys(true));
+			Assert.Equal(101, km.CountConsecutiveUnusedKeys(true));
 			k.SetKeyState(KeyState.Locked);
-			Assert.Equal(50, km.CountConsecutiveUnusedKeys(true));
+			Assert.Equal(101, km.CountConsecutiveUnusedKeys(true));
+			k.SetKeyState(KeyState.Used);
+			Assert.Equal(51, km.CountConsecutiveUnusedKeys(true));
 		}
 
 		private static void DeleteFileAndDirectoryIfExists(string filePath)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -543,7 +543,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public int CountConsecutiveUnusedKeys(bool isInternal)
 		{
-			var keyIndexes = GetKeys(x => x.IsInternal == isInternal && x.KeyState != KeyState.Used).OrderBy(x => x.Index).Select(x => x.Index).ToArray();
+			var keyIndexes = GetKeys(x => x.IsInternal == isInternal && x.KeyState != KeyState.Used).Select(x => x.Index).OrderBy(x => x).ToArray();
 
 			var hs = keyIndexes.ToHashSet();
 			int largerConsecutiveSequence = 0;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -540,7 +540,7 @@ namespace WalletWasabi.Blockchain.Keys
 			}
 		}
 
-		public int CountConsecutiveCleanKeys(bool isInternal)
+		public int CountConsecutiveUnusedKeys(bool isInternal)
 		{
 			var cleankKeyIndexes = GetKeys(KeyState.Clean, isInternal).Select(x => x.Index);
 			var lockedKeyIndexes = GetKeys(KeyState.Locked, false).Select(x => x.Index);
@@ -656,18 +656,18 @@ namespace WalletWasabi.Blockchain.Keys
 
 			if (isInternal.HasValue)
 			{
-				while (CountConsecutiveCleanKeys(isInternal.Value) < MinGapLimit)
+				while (CountConsecutiveUnusedKeys(isInternal.Value) < MinGapLimit)
 				{
 					newKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, isInternal.Value, toFile: false));
 				}
 			}
 			else
 			{
-				while (CountConsecutiveCleanKeys(true) < MinGapLimit)
+				while (CountConsecutiveUnusedKeys(true) < MinGapLimit)
 				{
 					newKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, true, toFile: false));
 				}
-				while (CountConsecutiveCleanKeys(false) < MinGapLimit)
+				while (CountConsecutiveUnusedKeys(false) < MinGapLimit)
 				{
 					newKeys.Add(GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false, toFile: false));
 				}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -543,7 +543,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public int CountConsecutiveUnusedKeys(bool isInternal)
 		{
-			var keyIndexes = GetKeys(x => x.IsInternal == isInternal && x.KeyState != KeyState.Used).Select(x => x.Index).OrderBy(x => x).ToArray();
+			var keyIndexes = GetKeys(x => x.IsInternal == isInternal && x.KeyState != KeyState.Used).Select(x => x.Index).ToArray();
 
 			var hs = keyIndexes.ToHashSet();
 			int largerConsecutiveSequence = 0;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -542,9 +542,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public int CountConsecutiveUnusedKeys(bool isInternal)
 		{
-			var cleankKeyIndexes = GetKeys(KeyState.Clean, isInternal).Select(x => x.Index);
-			var lockedKeyIndexes = GetKeys(KeyState.Locked, false).Select(x => x.Index);
-			var keyIndexes = cleankKeyIndexes.Concat(lockedKeyIndexes).ToArray();
+			var keyIndexes = GetKeys(x => (x.IsInternal == isInternal && x.KeyState == KeyState.Clean) || (!x.IsInternal && x.KeyState == KeyState.Locked)).OrderBy(x => x.Index).Select(x => x.Index).ToArray();
 
 			var hs = keyIndexes.ToHashSet();
 			int largerConsecutiveSequence = 0;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -542,7 +542,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public int CountConsecutiveUnusedKeys(bool isInternal)
 		{
-			var keyIndexes = GetKeys(x => (x.IsInternal == isInternal && x.KeyState == KeyState.Clean) || (!x.IsInternal && x.KeyState == KeyState.Locked)).OrderBy(x => x.Index).Select(x => x.Index).ToArray();
+			var keyIndexes = GetKeys(x => x.IsInternal == isInternal && x.KeyState != KeyState.Used).OrderBy(x => x.Index).Select(x => x.Index).ToArray();
 
 			var hs = keyIndexes.ToHashSet();
 			int largerConsecutiveSequence = 0;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -542,7 +542,9 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public int CountConsecutiveCleanKeys(bool isInternal)
 		{
-			var keyIndexes = GetKeys(KeyState.Clean, isInternal).Select(x => x.Index).ToArray();
+			var cleankKeyIndexes = GetKeys(KeyState.Clean, isInternal).Select(x => x.Index);
+			var lockedKeyIndexes = GetKeys(KeyState.Locked, false).Select(x => x.Index);
+			var keyIndexes = cleankKeyIndexes.Concat(lockedKeyIndexes).ToArray();
 
 			var hs = keyIndexes.ToHashSet();
 			int largerConsecutiveSequence = 0;


### PR DESCRIPTION
Rational: If we will add a feature to hide (lock) addresses, then we need to also count the locked external keys to get the consecutive unused key.

Fixes #3131

Should the `CountConsecutiveCleanKeys` method be renamed to `CountConsecutiveUnusedKeys`?

Please check if this has any side effects, like when there should always be 21 change addresses or something like that.