### PR TITLE
Wasabi document tab vm implements disposables for us

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -133,13 +133,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		private WalletService WalletService { get; }
 
-		private CompositeDisposable Disposables { get; set; }
-
-		public override void OnOpen()
+		public override void OnOpen(CompositeDisposable disposables)
 		{
-			base.OnOpen();
-
-			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
+			base.OnOpen(disposables);
 
 			TargetPrivacy = Global.Config.GetTargetPrivacy();
 
@@ -154,7 +150,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Merge(Observable.FromEventPattern(WalletService.ChaumianClient, nameof(WalletService.ChaumianClient.StateUpdated)))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => UpdateStates())
-				.DisposeWith(Disposables);
+				.DisposeWith(disposables);
 
 			ClientRound mostAdvancedRound = WalletService.ChaumianClient?.State?.GetMostAdvancedRoundOrDefault();
 
@@ -179,7 +175,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					this.RaisePropertyChanged(nameof(AmountQueued));
 					this.RaisePropertyChanged(nameof(IsLurkingWifeMode));
-				}).DisposeWith(Disposables);
+				}).DisposeWith(disposables);
 
 			Observable.Interval(TimeSpan.FromSeconds(1))
 				.ObserveOn(RxApp.MainThreadScheduler)
@@ -187,15 +183,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					TimeSpan left = RoundTimesout - DateTimeOffset.UtcNow;
 					TimeLeftTillRoundTimeout = left > TimeSpan.Zero ? left : TimeSpan.Zero; // Make sure cannot be less than zero.
-				}).DisposeWith(Disposables);
+				}).DisposeWith(disposables);
 		}
 
 		public override bool OnClose()
 		{
 			CoinsList.OnClose();
-
-			Disposables?.Dispose();
-			Disposables = null;
 
 			return base.OnClose();
 		}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/PinPadViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/PinPadViewModel.cs
@@ -23,7 +23,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
 	internal class PinPadViewModel : WasabiDocumentTabViewModel
 	{
-		private CompositeDisposable Disposables { get; set; }
 		private string _maskedPin;
 
 		public ReactiveCommand<Unit, Unit> SendPinCommand { get; }
@@ -61,21 +60,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					Logger.LogError(ex);
 					NotificationHelpers.Error(ex.ToUserFriendlyString());
 				});
-		}
-
-		public override void OnOpen()
-		{
-			base.OnOpen();
-
-			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
-		}
-
-		public override bool OnClose()
-		{
-			Disposables.Dispose();
-			Disposables = null;
-
-			return base.OnClose();
 		}
 
 		public static async Task UnlockAsync()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabViewModel.cs
@@ -25,8 +25,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
 	public class ReceiveTabViewModel : WasabiDocumentTabViewModel
 	{
-		private CompositeDisposable Disposables { get; set; }
-
 		private ObservableCollection<AddressViewModel> _addresses;
 		private AddressViewModel _selectedAddress;
 
@@ -98,26 +96,15 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public SuggestLabelViewModel LabelSuggestion { get; }
 
-		public override void OnOpen()
+		public override void OnOpen(CompositeDisposable disposables)
 		{
-			base.OnOpen();
-
-			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
+			base.OnOpen(disposables);			
 
 			Observable
 				.FromEventPattern(WalletService.TransactionProcessor, nameof(WalletService.TransactionProcessor.WalletRelevantTransactionProcessed))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => InitializeAddresses())
-				.DisposeWith(Disposables);
-		}
-
-		public override bool OnClose()
-		{
-			Disposables.Dispose();
-
-			Disposables = null;
-
-			return base.OnClose();
+				.DisposeWith(disposables);
 		}
 
 		private void InitializeAddresses()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterViewModel.cs
@@ -31,8 +31,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private string _buttonText;
 		private int _caretIndex;
 
-		private CompositeDisposable Disposables { get; set; }
-
 		private Global Global { get; }
 
 		public ReactiveCommand<Unit, Unit> PasteCommand { get; set; }
@@ -174,18 +172,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				});
 		}
 
-		public override void OnOpen()
-		{
-			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
-
-			base.OnOpen();
-		}
-
 		public override bool OnClose()
 		{
-			Disposables?.Dispose();
-			Disposables = null;
-
 			TransactionString = "";
 
 			return base.OnClose();

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerViewModel.cs
@@ -84,7 +84,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				});
 		}
 
-		private CompositeDisposable Disposables { get; set; }
 		private Global Global { get; }
 		public ReactiveCommand<Unit, Unit> ExportBinaryPsbt { get; set; }
 		public ReactiveCommand<Unit, Unit> OpenTransactionBroadcaster { get; set; }
@@ -121,11 +120,9 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _psbtBytes, value);
 		}
 
-		public override void OnOpen()
+		public override void OnOpen(CompositeDisposable disposables)
 		{
-			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
-
-			base.OnOpen();
+			base.OnOpen(disposables);
 
 			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode)
 				.ObserveOn(RxApp.MainThreadScheduler)
@@ -136,15 +133,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					this.RaisePropertyChanged(nameof(PsbtJsonText));
 					this.RaisePropertyChanged(nameof(TransactionHexText));
 					this.RaisePropertyChanged(nameof(PsbtBase64Text));
-				}).DisposeWith(Disposables);
-		}
-
-		public override bool OnClose()
-		{
-			Disposables?.Dispose();
-			Disposables = null;
-
-			return base.OnClose();
+				}).DisposeWith(disposables);
 		}
 
 		public void Update(BuildTransactionResult result)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -22,8 +22,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
 	public class WalletInfoViewModel : WasabiDocumentTabViewModel
 	{
-		private CompositeDisposable Disposables { get; set; }
-
 		private bool _showSensitiveKeys;
 		private string _password;
 		private string _extendedMasterPrivateKey;
@@ -161,21 +159,19 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				});
 		}
 
-		public override void OnOpen()
+		public override void OnOpen(CompositeDisposable disposables)
 		{
-			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
-
 			Closing = new CancellationTokenSource();
 
 			Global.UiConfig.WhenAnyValue(x => x.LurkingWifeMode).Subscribe(_ =>
 				{
 					this.RaisePropertyChanged(nameof(ExtendedAccountPublicKey));
 					this.RaisePropertyChanged(nameof(ExtendedAccountZpub));
-				}).DisposeWith(Disposables);
+				}).DisposeWith(disposables);
 
-			Closing.DisposeWith(Disposables);
+			Closing.DisposeWith(disposables);
 
-			base.OnOpen();
+			base.OnOpen(disposables);
 		}
 
 		public override void OnDeselected()
@@ -193,8 +189,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public override bool OnClose()
 		{
 			Closing.Cancel();
-			Disposables?.Dispose();
-			Disposables = null;
 
 			ClearSensitiveData(true);
 			return base.OnClose();

--- a/WalletWasabi.Gui/ViewModels/TextResourceViewModelBase.cs
+++ b/WalletWasabi.Gui/ViewModels/TextResourceViewModelBase.cs
@@ -14,8 +14,6 @@ namespace WalletWasabi.Gui.ViewModels
 {
 	public abstract class TextResourceViewModelBase : WasabiDocumentTabViewModel
 	{
-		protected CompositeDisposable Disposables { get; private set; }
-
 		private string _text;
 
 		protected TextResourceViewModelBase(string title, Uri target) : base(title)
@@ -41,25 +39,16 @@ namespace WalletWasabi.Gui.ViewModels
 			return await reader.ReadToEndAsync();
 		}
 
-		public override void OnOpen()
+		public override void OnOpen(CompositeDisposable disposables)
 		{
-			base.OnOpen();
-
-			Disposables = new CompositeDisposable();
+			base.OnOpen(disposables);
+			
 			LoadDocumentAsync(Target)
 				.ToObservable(RxApp.TaskpoolScheduler)
 				.Take(1)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x => Text = x)
-				.DisposeWith(Disposables);
-		}
-
-		public override bool OnClose()
-		{
-			Disposables?.Dispose();
-			Disposables = null;
-
-			return base.OnClose();
+				.DisposeWith(disposables);
 		}
 	}
 }

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -79,9 +79,9 @@ namespace WalletWasabi.Gui.ViewModels
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
-			OnOpen(Disposables);
-
 			IsClosed = false;
+
+			OnOpen(Disposables);
 		}
 
 		/// <summary>
@@ -113,6 +113,7 @@ namespace WalletWasabi.Gui.ViewModels
 		}
 
 		public ReactiveCommand<Unit, Unit> DoItCommand { get; }
+
 		public void Select()
 		{
 			IoC.Get<IShell>().Select(this);

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Gui.ViewModels
 		private string _title;
 		private bool _isSelected;
 		private bool _isClosed;
-		private object _dialogResult;		
+		private object _dialogResult;
 
 		protected WasabiDocumentTabViewModel(string title)
 		{

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -80,11 +80,12 @@ namespace WalletWasabi.Gui.ViewModels
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 			OnOpen(Disposables);
+
+			IsClosed = false;
 		}
 
 		public virtual void OnOpen(CompositeDisposable disposables)
-		{			
-			IsClosed = false;
+		{
 		}
 
 		public virtual bool OnClose()

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -75,7 +75,7 @@ namespace WalletWasabi.Gui.ViewModels
 			IsSelected = false;
 		}
 
-		void IDockableViewModel.OnOpen()
+		void IDockableViewModel.OnOpen() // This interface member is implemented Explicitly so that it is hidden as we dont want users of this class to know about it.
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
@@ -84,10 +84,18 @@ namespace WalletWasabi.Gui.ViewModels
 			IsClosed = false;
 		}
 
+		/// <summary>
+		/// Called when a tab is opened in the dock for the fist time.
+		/// </summary>
+		/// <param name="disposables">Disposables add IDisposables to this where Dispose will be called when tab is closed.</param>
 		public virtual void OnOpen(CompositeDisposable disposables)
 		{
 		}
 
+		/// <summary>
+		/// Called when the close button on the tab is clicked.
+		/// </summary>
+		/// <returns>true to confirm close, false to cancel.</returns>
 		public virtual bool OnClose()
 		{
 			Disposables.Dispose();

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -75,7 +75,8 @@ namespace WalletWasabi.Gui.ViewModels
 			IsSelected = false;
 		}
 
-		void IDockableViewModel.OnOpen() // This interface member is called explicitly from Avalonia after the Tab was opened.
+		// This interface member is called explicitly from Avalonia after the Tab was opened.
+		void IDockableViewModel.OnOpen()
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -75,7 +75,7 @@ namespace WalletWasabi.Gui.ViewModels
 			IsSelected = false;
 		}
 
-		void IDockableViewModel.OnOpen() // This interface member is implemented Explicitly so that it is hidden as we dont want users of this class to know about it.
+		void IDockableViewModel.OnOpen() // This interface member is called explicitly from Avalonia after the Tab was opened.
 		{
 			Disposables = Disposables is null ? new CompositeDisposable() : throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 

--- a/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/WasabiDocumentTabViewModel.cs
@@ -104,7 +104,6 @@ namespace WalletWasabi.Gui.ViewModels
 		}
 
 		public ReactiveCommand<Unit, Unit> DoItCommand { get; }
-		
 		public void Select()
 		{
 			IoC.Get<IShell>().Select(this);


### PR DESCRIPTION
Currently we have almost every viewmodel implementing its own Disposables property, this just moves that to the base class.

The advantages are:

- less repeated code
- developer cant make a mistake by repeating code in incorrect way.
- no longer implemented on classes that were not using this.
- cleaner code, simpler interface (onopen onclose)

Follow up PR that solves the 7 CodeFactor issues here: 
https://github.com/zkSNACKs/WalletWasabi/pull/3169

will make it too hard to review otherwise.