### PR TITLE
Delete ManualTesting.md

### DIFF
--- a/WalletWasabi.Documentation/ManualTesting.md
+++ b/WalletWasabi.Documentation/ManualTesting.md
@@ -1,1 +1,0 @@
-The workflow for manual testing can be found in the [documentation](https://docs.wasabiwallet.io/building-wasabi/ManualTesting.html).


### PR DESCRIPTION
The link inside that file doesn't work. It got deleted in the docs repo I think.