### PR TITLE
Fix race condition on legal version check

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -260,7 +260,7 @@ namespace WalletWasabi.Gui.ViewModels
 
 					try
 					{
-						if (Global.LegalDocuments is null || Global.LegalDocuments.Version != x.LegalDocumentsVersion)
+						if (Global.LegalDocuments is null || Global.LegalDocuments.Version < x.LegalDocumentsVersion)
 						{
 							using var client = new WasabiClient(() => Global.Config.UseTor ? Global.Config.GetCurrentBackendUri() : Global.Config.GetFallbackBackendUri(), Global.Config.UseTor ? Global.Config.TorSocks5EndPoint : null);
 							var versions = await client.GetVersionsAsync(CancellationToken.None);


### PR DESCRIPTION
In some cases the default value is being checked, which is 0. Since we're never downgrading legal docs remotely, a `<` is a better check than a `!=` and also solves this race condition.