### PR TITLE
Update NBitcoin

### DIFF
--- a/WalletWasabi/Helpers/NBitcoinHelpers.cs
+++ b/WalletWasabi/Helpers/NBitcoinHelpers.cs
@@ -115,6 +115,30 @@ namespace WalletWasabi.Helpers
 			return ba;
 		}
 
+		public static Key BetterParseKey(string keyString)
+		{
+			keyString = Guard.NotNullOrEmptyOrWhitespace(nameof(keyString), keyString, trim: true);
+
+			Key k;
+			try
+			{
+				k = Key.Parse(keyString, Network.Main);
+			}
+			catch
+			{
+				try
+				{
+					k = Key.Parse(keyString, Network.TestNet);
+				}
+				catch
+				{
+					k = Key.Parse(keyString, Network.RegTest);
+				}
+			}
+
+			return k;
+		}
+
 		public static async Task<AddressManager> LoadAddressManagerFromPeerFileAsync(string filePath, Network expectedNetwork = null)
 		{
 			byte[] data, hash;

--- a/WalletWasabi/JsonConverters/KeyJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/KeyJsonConverter.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.JsonConverters
 {
@@ -17,18 +18,15 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			var serializedKey = ((string)reader.Value).Trim();
-			foreach (var network in Network.GetNetworks())
+			var keyString = reader.Value as string;
+			if (string.IsNullOrWhiteSpace(keyString))
 			{
-				try
-				{
-					return Key.Parse(serializedKey, network);
-				}
-				catch (FormatException)
-				{
-				}
+				return default;
 			}
-			return null;
+			else
+			{
+				return NBitcoinHelpers.BetterParseKey(keyString);
+			}
 		}
 
 		/// <inheritdoc />

--- a/WalletWasabi/JsonConverters/KeyJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/KeyJsonConverter.cs
@@ -17,7 +17,18 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			return Key.Parse(((string)reader.Value).Trim());
+			var serializedKey = ((string)reader.Value).Trim();
+			foreach (var network in Network.GetNetworks())
+			{
+				try
+				{
+					return Key.Parse(serializedKey, network);
+				}
+				catch (FormatException)
+				{
+				}
+			}
+			return null;
 		}
 
 		/// <inheritdoc />

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-	  <PackageReference Include="NBitcoin" Version="5.0.13" />
+	  <PackageReference Include="NBitcoin" Version="5.0.15" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
   </ItemGroup>
   


### PR DESCRIPTION
Use new NBitcoin version that requires passing the network when parsing bese58-enconded material.