### PR TITLE
Dust sent by me to myself is not an attack

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -661,7 +661,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				Assert.Empty(e.NewlyConfirmedReceivedCoins);
 			};
 
-			var coinsToSpend = new [] { result.ReceivedCoins[0].GetCoin() };
+			var coinsToSpend = new[] { result.ReceivedCoins[0].GetCoin() };
 			var tx1 = CreateSpendingTransaction(coinsToSpend, keys[1].P2wpkhScript, keys[2].P2wpkhScript, coinPercentage: 0.9999m);
 			result = transactionProcessor.Process(tx1);
 
@@ -1095,7 +1095,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			return new SmartTransaction(tx, height == 0 ? Height.Mempool : new Height(height));
 		}
 
-		private static SmartTransaction CreateSpendingTransaction(IEnumerable<Coin> coins, Script scriptPubKey, Script scriptPubKeyChange, bool replaceable = false, int height = 0, decimal coinPercentage=0.6m)
+		private static SmartTransaction CreateSpendingTransaction(IEnumerable<Coin> coins, Script scriptPubKey, Script scriptPubKeyChange, bool replaceable = false, int height = 0, decimal coinPercentage = 0.6m)
 		{
 			var tx = Network.RegTest.CreateTransaction();
 			var amount = Money.Zero;

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -646,6 +646,38 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		}
 
 		[Fact]
+		public async Task ReceiveTransactionWithDustFromSameWalletAsync()
+		{
+			var transactionProcessor = await CreateTransactionProcessorAsync();
+			var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
+			var tx0 = CreateCreditingTransaction(keys[0].P2wpkhScript, Money.Coins(0.01m));
+			var result = transactionProcessor.Process(tx0);
+
+			transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
+			{
+				Assert.Empty(e.ReceivedDusts);
+				Assert.NotEmpty(e.ReceivedCoins);
+				Assert.NotEmpty(e.NewlyReceivedCoins);
+				Assert.Empty(e.NewlyConfirmedReceivedCoins);
+			};
+
+			var coinsToSpend = new [] { result.ReceivedCoins[0].GetCoin() };
+			var tx1 = CreateSpendingTransaction(coinsToSpend, keys[1].P2wpkhScript, keys[2].P2wpkhScript, coinPercentage: 0.9999m);
+			result = transactionProcessor.Process(tx1);
+
+			// It is relevant even when all the coins can be dust.
+			Assert.True(result.IsNews);
+			Assert.Equal(2, transactionProcessor.Coins.Count());
+
+			// Transaction store assertions
+			var mempool = transactionProcessor.TransactionStore.MempoolStore.GetTransactions();
+			Assert.Equal(2, mempool.Count());  // The crediting and spending transactions are saved
+
+			var matureTxs = transactionProcessor.TransactionStore.ConfirmedStore.GetTransactions().ToArray();
+			Assert.Empty(matureTxs);
+		}
+
+		[Fact]
 		public async Task ReceiveCoinJoinTransactionAsync()
 		{
 			var transactionProcessor = await CreateTransactionProcessorAsync();
@@ -1063,7 +1095,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			return new SmartTransaction(tx, height == 0 ? Height.Mempool : new Height(height));
 		}
 
-		private static SmartTransaction CreateSpendingTransaction(IEnumerable<Coin> coins, Script scriptPubKey, Script scriptPubKeyChange, bool replaceable = false, int height = 0)
+		private static SmartTransaction CreateSpendingTransaction(IEnumerable<Coin> coins, Script scriptPubKey, Script scriptPubKeyChange, bool replaceable = false, int height = 0, decimal coinPercentage=0.6m)
 		{
 			var tx = Network.RegTest.CreateTransaction();
 			var amount = Money.Zero;
@@ -1072,8 +1104,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				tx.Inputs.Add(coin.Outpoint, Script.Empty, WitScript.Empty, replaceable ? Sequence.MAX_BIP125_RBF_SEQUENCE : Sequence.SEQUENCE_FINAL);
 				amount += coin.Amount;
 			}
-			tx.Outputs.Add(amount.Percentage(60), scriptPubKey ?? Script.Empty);
-			tx.Outputs.Add(amount.Percentage(40), scriptPubKeyChange);
+			tx.Outputs.Add(Money.Satoshis(amount.Satoshi * coinPercentage), scriptPubKey ?? Script.Empty);
+			tx.Outputs.Add(Money.Satoshis(amount.Satoshi * (1.0m - coinPercentage)), scriptPubKeyChange);
 			return new SmartTransaction(tx, height == 0 ? Height.Mempool : new Height(height));
 		}
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -172,16 +172,17 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 					HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
 					if (foundKey != default)
 					{
-						if (output.Value <= DustThreshold)
+						foundKey.SetKeyState(KeyState.Used, KeyManager);
+						spentOwnCoins ??= Coins.OutPoints(tx.Transaction.Inputs).ToList();
+						var isOwnTransaction = spentOwnCoins.Count > 0;
+						if (!isOwnTransaction && output.Value <= DustThreshold)
 						{
 							result.ReceivedDusts.Add(output);
 							continue;
 						}
 
-						foundKey.SetKeyState(KeyState.Used, KeyManager);
-						spentOwnCoins ??= Coins.OutPoints(tx.Transaction.Inputs).ToList();
 						var anonset = tx.Transaction.GetAnonymitySet(i);
-						if (spentOwnCoins.Count != 0)
+						if (isOwnTransaction)
 						{
 							anonset += spentOwnCoins.Min(x => x.AnonymitySet) - 1; // Minus 1, because do not count own.
 						}


### PR DESCRIPTION
Dust utxo sent by the user to himself is not an attack. In other words, if I send bitcoins to someone else and as result I receive back the change that is below my dust threshold that utxo is not toxic in any way and should be listed among my coins.

Related to: https://github.com/zkSNACKs/WalletWasabi/issues/2672