### PR TITLE
Add CoinJoin status monitor

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -431,6 +431,7 @@ namespace WalletWasabi.Backend.Controllers
 				{
 					status = new StatusResponse();
 
+					// Updating the status of the filters.
 					var lastFilter = Global.IndexBuilderService.GetLastFilter();
 					var lastFilterHash = lastFilter.Header.BlockHash;
 					var bestHash = await RpcClient.GetBestBlockHashAsync();
@@ -442,6 +443,11 @@ namespace WalletWasabi.Backend.Controllers
 						status.FilterCreationActive = true;
 					}
 
+					// Updating the status of CoinJoin
+					if (DateTimeOffset.UtcNow - Global.Coordinator.LastSuccessfulCoinJoinTime < TimeSpan.FromHours(3))
+					{
+						status.CoinJoinCreationActive = true;
+					}
 					var cacheEntryOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(30));
 
 					Cache.Set(cacheKey, status, cacheEntryOptions);

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -444,7 +444,12 @@ namespace WalletWasabi.Backend.Controllers
 					}
 
 					// Updating the status of CoinJoin
-					if (DateTimeOffset.UtcNow - Global.Coordinator.LastSuccessfulCoinJoinTime < TimeSpan.FromHours(3))
+					var validInterval = TimeSpan.FromSeconds(Global.Coordinator.RoundConfig.InputRegistrationTimeout * 2);
+					if (validInterval < TimeSpan.FromHours(1))
+					{
+						validInterval = TimeSpan.FromHours(1);
+					}
+					if (DateTimeOffset.UtcNow - Global.Coordinator.LastSuccessfulCoinJoinTime < validInterval)
 					{
 						status.CoinJoinCreationActive = true;
 					}

--- a/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
@@ -3,5 +3,6 @@ namespace WalletWasabi.Backend.Models.Responses
 	public class StatusResponse
 	{
 		public bool FilterCreationActive { get; set; }
+		public bool CoinJoinCreationActive { get; set; }
 	}
 }

--- a/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
@@ -45,6 +45,8 @@ namespace WalletWasabi.CoinJoin.Coordinator
 
 		public UtxoReferee UtxoReferee { get; }
 
+		public DateTimeOffset LastSuccessfulCoinJoinTime { get; private set; }
+
 		public Coordinator(Network network, BlockNotifier blockNotifier, string folderPath, RPCClient rpc, CoordinatorRoundConfig roundConfig)
 		{
 			Network = Guard.NotNull(nameof(network), network);
@@ -59,6 +61,7 @@ namespace WalletWasabi.CoinJoin.Coordinator
 			CoinJoins = new List<uint256>();
 			UnconfirmedCoinJoins = new List<uint256>();
 			CoinJoinsLock = new AsyncLock();
+			LastSuccessfulCoinJoinTime = DateTimeOffset.UtcNow;
 
 			Directory.CreateDirectory(FolderPath);
 
@@ -298,6 +301,7 @@ namespace WalletWasabi.CoinJoin.Coordinator
 						uint256 coinJoinHash = round.CoinJoin.GetHash();
 						CoinJoins.Add(coinJoinHash);
 						UnconfirmedCoinJoins.Add(coinJoinHash);
+						LastSuccessfulCoinJoinTime = DateTimeOffset.UtcNow;
 						await File.AppendAllLinesAsync(CoinJoinsFilePath, new[] { coinJoinHash.ToString() }).ConfigureAwait(false);
 
 						// When a round succeeded, adjust the denomination as to users still be able to register with the latest round's active output amount.


### PR DESCRIPTION
This PR is for adding new data into our existing status request query. 

I tried to do some RPC magic but getting the time/height of the last CoinJoin tx is not so easy. 

Concept review.