### PR TITLE
Improve the dequeuing of coins on exit

### DIFF
--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
@@ -1,11 +1,11 @@
-<UserControl xmlns="https://github.com/avaloniaui" 
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              x:Class="WalletWasabi.Gui.Dialogs.CannotCloseDialogView"
              Design.Width="800" Design.Height="400">
   <controls:GroupBox Title="Closing Wasabi..." Background="{DynamicResource ThemeControlBackgroundBrush}" TextBlock.FontSize="30" BorderThickness="0" Margin="0 80 0 0">
     <DockPanel LastChildFill="True">
-      <StackPanel DockPanel.Dock="Bottom" HorizontalAlignment="Right" TextBlock.FontSize="16" Orientation="Horizontal" Margin="10" Spacing="10">
+      <StackPanel DockPanel.Dock="Bottom" HorizontalAlignment="Left" TextBlock.FontSize="16" Orientation="Horizontal" Margin="10" Spacing="10">
         <Button Width="100" Content="Ok" Command="{Binding OKCommand}" IsVisible="{Binding !IsBusy}" />
         <Button Width="100" Content="Cancel" Command="{Binding CancelCommand}" IsVisible="{Binding IsBusy}" />
       </StackPanel>

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -717,7 +717,7 @@ namespace WalletWasabi.Gui
 				}
 				catch (Exception ex)
 				{
-					Logger.LogError(ex);
+					Logger.LogError($"Error during {nameof(WaitForInitializationCompletedAsync)}: {ex}");
 				}
 
 				try
@@ -727,7 +727,7 @@ namespace WalletWasabi.Gui
 				}
 				catch (Exception ex)
 				{
-					Logger.LogError(ex);
+					Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
 				}
 
 				Dispatcher.UIThread.PostLogException(() =>

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWalletViewModel.cs
@@ -631,7 +631,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 
 				try
 				{
-					bool isSuccessful = await Global.WaitForInitializationCompletedAsync();
+					bool isSuccessful = await Global.WaitForInitializationCompletedAsync(CancellationToken.None);
 					if (!isSuccessful)
 					{
 						return;

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -23,6 +23,7 @@ using WalletWasabi.CoinJoin.Common.Models;
 using WalletWasabi.Crypto;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.Models;
 using WalletWasabi.Services;
 using static NBitcoin.Crypto.SchnorrBlinding;
 
@@ -861,6 +862,10 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 
 		public async Task DequeueAllCoinsFromMixAsync(DequeueReason reason)
 		{
+			if (reason == DequeueReason.ApplicationExit && Synchronizer.BackendStatus == BackendStatus.NotConnected)
+			{
+				return;
+			}
 			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
 			try
 			{

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -116,6 +116,10 @@ namespace WalletWasabi.Wallets
 
 		public async Task DequeueAllCoinsGracefullyAsync(DequeueReason reason, CancellationToken token)
 		{
+			if (Synchronizer.BackendStatus == BackendStatus.NotConnected)
+			{
+				return;
+			}
 			IEnumerable<Task> tasks = null;
 			lock (Lock)
 			{

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -116,10 +116,6 @@ namespace WalletWasabi.Wallets
 
 		public async Task DequeueAllCoinsGracefullyAsync(DequeueReason reason, CancellationToken token)
 		{
-			if (Synchronizer.BackendStatus == BackendStatus.NotConnected)
-			{
-				return;
-			}
 			IEnumerable<Task> tasks = null;
 			lock (Lock)
 			{


### PR DESCRIPTION
I somehow get in the unfortunate situation on RegTest that I could not exit from Wasabi. 

1. I was continuously getting the notification that Coin cannot be dequeued
2. The backend was disconnected so there was no way successful dequeue. 

The cancel button was hidden behind the notifications so I moved it one the left. 
I added the checking of backend status before trying to dequeue. 

Something to consider: after 1 minute of trying to add a button force exit which will exit Wasabi anyway without dequeuing. 

UPDATE!
A force quit button is not required. If the backend is not connected the user doesn't have to wait 6 minutes it will quit immediately.