### PR TITLE
Fix bug: mixall + keepalive

### DIFF
--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -103,7 +103,7 @@ namespace WalletWasabi.Gui.CommandLine
 					bool anyCoinsQueued = WalletService.ChaumianClient.State.AnyCoinsQueued();
 					if (!anyCoinsQueued && keepMixAlive) // If no coins queued and mixing is asked to be kept alive then try to queue coins.
 					{
-						// Don't do mixall here, the mixall says all the coins has to be mixed all once, not all the time.
+						// Don't do mixall here, the mixall says all the coins has to be mixed once, it doesn't says it has to be requeued all the time.
 						await TryQueueCoinsToMixAsync(mixAll: false, password);
 					}
 

--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -103,7 +103,8 @@ namespace WalletWasabi.Gui.CommandLine
 					bool anyCoinsQueued = WalletService.ChaumianClient.State.AnyCoinsQueued();
 					if (!anyCoinsQueued && keepMixAlive) // If no coins queued and mixing is asked to be kept alive then try to queue coins.
 					{
-						await TryQueueCoinsToMixAsync(mixAll, password);
+						// Don't do mixall here, the mixall says all the coins has to be mixed all once, not all the time.
+						await TryQueueCoinsToMixAsync(mixAll: false, password);
 					}
 
 					if (Global.KillRequested)


### PR DESCRIPTION
If the user specifies `--mixall` to the daemon, then it should go through all the coins exactly once and not keep re-enqueueing them forever, which is the case when both `--mixall` AND `--keepalive` is specified.