### PR TITLE
Trigger both validation on Address or CustomChangeAddress

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -220,12 +220,19 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 				});
 
-			this.WhenAnyValue(x => x.Address, x => x.CustomChangeAddress)
+			// Triggering the detection of same address values.
+			this.WhenAnyValue(x => x.Address)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ =>
+				{
+					this.RaisePropertyChanged(nameof(CustomChangeAddress));
+				});
+
+			this.WhenAnyValue(x => x.CustomChangeAddress)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ =>
 				{
 					this.RaisePropertyChanged(nameof(Address));
-					this.RaisePropertyChanged(nameof(CustomChangeAddress));
 				});
 
 			FeeRateCommand = ReactiveCommand.Create(ChangeFeeRateDisplay, outputScheduler: RxApp.MainThreadScheduler);

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -223,17 +223,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			// Triggering the detection of same address values.
 			this.WhenAnyValue(x => x.Address)
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(_ =>
-				{
-					this.RaisePropertyChanged(nameof(CustomChangeAddress));
-				});
+				.Subscribe(_ => this.RaisePropertyChanged(nameof(CustomChangeAddress)));
 
 			this.WhenAnyValue(x => x.CustomChangeAddress)
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(_ =>
-				{
-					this.RaisePropertyChanged(nameof(Address));
-				});
+				.Subscribe(_ => this.RaisePropertyChanged(nameof(Address)));
 
 			FeeRateCommand = ReactiveCommand.Create(ChangeFeeRateDisplay, outputScheduler: RxApp.MainThreadScheduler);
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -220,6 +220,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 				});
 
+			this.WhenAnyValue(x => x.Address, x => x.CustomChangeAddress)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ =>
+				{
+					this.RaisePropertyChanged(nameof(Address));
+					this.RaisePropertyChanged(nameof(CustomChangeAddress));
+				});
+
 			FeeRateCommand = ReactiveCommand.Create(ChangeFeeRateDisplay, outputScheduler: RxApp.MainThreadScheduler);
 
 			OnAddressPasteCommand = ReactiveCommand.Create((BitcoinUrlBuilder url) =>


### PR DESCRIPTION
When the user inserts the same address and custom-change-address, then he changes on of them to another address, only the one which was changed updates the validation around the control. Now with this PR both validation will be updated. 

Related: https://github.com/zkSNACKs/WalletWasabi/issues/3223