### PR TITLE
BIP79 Support

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -42,7 +42,7 @@
             </i:Interaction.Behaviors>
           </controls:ExtendedTextBox>
 
-          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding BIP79Url}" Watermark="Payjoin endpoint" UseFloatingWatermark="True">
+          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding Bip79Url}" Watermark="Payjoin endpoint" UseFloatingWatermark="True">
             <i:Interaction.Behaviors>
               <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
             </i:Interaction.Behaviors>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -42,13 +42,9 @@
             </i:Interaction.Behaviors>
           </controls:ExtendedTextBox>
 
-          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding Bip79Url}" Watermark="Payjoin endpoint" UseFloatingWatermark="True">
-            <i:Interaction.Behaviors>
-              <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
-            </i:Interaction.Behaviors>
-          </controls:ExtendedTextBox>
-          <suggestions:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
+          <controls:ExtendedTextBox IsVisible="{Binding Bip79UrlIsVisible}" Classes="monospaceFont" Text="{Binding Bip79Url}" Watermark="PayJoin EndPoint" UseFloatingWatermark="True" />
 
+          <suggestions:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
           <StackPanel Orientation="Horizontal" Spacing="10">
             <Button Content="{Binding IsMax, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Clear:Max}" Command="{Binding MaxCommand}" VerticalAlignment="Top" Height="40" />
             <controls:ExtendedTextBox

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -30,7 +30,7 @@
       <DockPanel LastChildFill="True" Margin="20">
         <StackPanel DockPanel.Dock="Bottom" Margin="0 10" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Select coins you want to spend.</TextBlock>
-          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding Address}" Watermark="Address" UseFloatingWatermark="True">
+          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding Address}" Watermark="Destination" UseFloatingWatermark="True">
             <i:Interaction.Behaviors>
               <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
             </i:Interaction.Behaviors>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -42,7 +42,6 @@
             </i:Interaction.Behaviors>
           </controls:ExtendedTextBox>
 
-          <suggestions:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
           <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding BIP79Url}" Watermark="Payjoin endpoint" UseFloatingWatermark="True">
             <i:Interaction.Behaviors>
               <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -30,7 +30,7 @@
       <DockPanel LastChildFill="True" Margin="20">
         <StackPanel DockPanel.Dock="Bottom" Margin="0 10" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Select coins you want to spend.</TextBlock>
-          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding Address}" Watermark="Destination" UseFloatingWatermark="True">
+          <controls:ExtendedTextBox IsVisible="{Binding !Bip79UrlIsVisible}" Classes="monospaceFont" Text="{Binding Address}" Watermark="Destination" UseFloatingWatermark="True">
             <i:Interaction.Behaviors>
               <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
             </i:Interaction.Behaviors>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -48,7 +48,7 @@
               <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
             </i:Interaction.Behaviors>
           </controls:ExtendedTextBox>
-          <controls:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
+          <suggestions:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
 
           <StackPanel Orientation="Horizontal" Spacing="10">
             <Button Content="{Binding IsMax, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Clear:Max}" Command="{Binding MaxCommand}" VerticalAlignment="Top" Height="40" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -43,6 +43,12 @@
           </controls:ExtendedTextBox>
 
           <suggestions:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
+          <controls:ExtendedTextBox Classes="monospaceFont" Text="{Binding BIP79Url}" Watermark="Payjoin endpoint" UseFloatingWatermark="True">
+            <i:Interaction.Behaviors>
+              <behaviors:PasteAddressOnClickBehavior Command="{Binding OnAddressPasteCommand}" />
+            </i:Interaction.Behaviors>
+          </controls:ExtendedTextBox>
+          <controls:SuggestLabelView DataContext="{Binding LabelSuggestion}" />
 
           <StackPanel Orientation="Horizontal" Spacing="10">
             <Button Content="{Binding IsMax, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Clear:Max}" Command="{Binding MaxCommand}" VerticalAlignment="Top" Height="40" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -72,6 +72,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private bool _isCustomFee;
 		private bool _isCustomChangeAddress;
 		private string _bip79;
+		private ObservableAsPropertyHelper<bool> _bip79UrlIsVisible;
 
 		private const string WaitingForHardwareWalletButtonTextString = "Waiting for Hardware Wallet...";
 
@@ -230,6 +231,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			this.WhenAnyValue(x => x.CustomChangeAddress)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => this.RaisePropertyChanged(nameof(Address)));
+
+			_bip79UrlIsVisible = this.WhenAnyValue(x => x.Bip79Url)
+				.Select(x => !string.IsNullOrWhiteSpace(x))
+				.ToProperty(this, x => x.Bip79UrlIsVisible, scheduler: RxApp.MainThreadScheduler);
 
 			FeeRateCommand = ReactiveCommand.Create(ChangeFeeRateDisplay, outputScheduler: RxApp.MainThreadScheduler);
 
@@ -797,6 +802,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		}
 
 		public decimal UsdExchangeRate => _usdExchangeRate?.Value ?? 0m;
+		public bool Bip79UrlIsVisible => _bip79UrlIsVisible?.Value ?? false;
 
 		public Money AllSelectedAmount
 		{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -839,10 +839,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			return new ErrorDescriptors(new ErrorDescriptor(ErrorSeverity.Error, "Invalid address."));
 		}
-		
+
 		public ErrorDescriptors ValidateBIP79Url()
 		{
-			if (string.IsNullOrEmpty(BIP79Url))
+			if (string.IsNullOrWhiteSpace(BIP79Url))
 			{
 				return ErrorDescriptors.Empty;
 			}
@@ -891,7 +891,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			get => _customChangeAddress;
 			set => this.RaiseAndSetIfChanged(ref _customChangeAddress, value?.Trim());
 		}
-		
+
 		[ValidateMethod(nameof(ValidateBIP79Url))]
 		public string BIP79Url
 		{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -248,11 +248,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 				if (url.UnknowParameters.ContainsKey("bpu"))
 				{
-					BIP79Url = url.UnknowParameters["bpu"];
+					Bip79Url = url.UnknowParameters["bpu"];
 				}
 				else
 				{
-					BIP79Url = "";
+					Bip79Url = "";
 				}
 			});
 
@@ -390,7 +390,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						}
 					}
 
-					BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, intent, feeStrategy, allowUnconfirmed: true, allowedInputs: selectedCoinReferences, BIP79Url));
+					BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, intent, feeStrategy, allowUnconfirmed: true, allowedInputs: selectedCoinReferences, Bip79Url));
 
 					await DoAfterBuildTransaction(result);
 				}
@@ -840,13 +840,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			return new ErrorDescriptors(new ErrorDescriptor(ErrorSeverity.Error, "Invalid address."));
 		}
 
-		public ErrorDescriptors ValidateBIP79Url()
+		public ErrorDescriptors ValidateBip79Url()
 		{
-			if (string.IsNullOrWhiteSpace(BIP79Url))
+			if (string.IsNullOrWhiteSpace(Bip79Url))
 			{
 				return ErrorDescriptors.Empty;
 			}
-			if (Uri.TryCreate(BIP79Url, UriKind.Absolute, out _))
+			if (Uri.TryCreate(Bip79Url, UriKind.Absolute, out _))
 			{
 				return ErrorDescriptors.Empty;
 			}
@@ -892,8 +892,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _customChangeAddress, value?.Trim());
 		}
 
-		[ValidateMethod(nameof(ValidateBIP79Url))]
-		public string BIP79Url
+		[ValidateMethod(nameof(ValidateBip79Url))]
+		public string Bip79Url
 		{
 			get => _bip79;
 			set => this.RaiseAndSetIfChanged(ref _bip79, value);

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -227,7 +227,7 @@ namespace WalletWasabi.Blockchain.Transactions
 				builder.SetLockTime(lockTimeSelector());
 				builder.SignPSBT(psbt);
 				psbt.Finalize();
-				if (uri != null && httpClient != null)
+				if (uri is { } && httpClient is { })
 				{
 					using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri)
 					{
@@ -241,7 +241,7 @@ namespace WalletWasabi.Blockchain.Transactions
 						foreach (var input in payjoinPSBT.Inputs)
 						{
 							var existingInput = existingInputs.SingleOrDefault(point => point == input.PrevOut);
-							if (existingInput != null)
+							if (existingInput is { })
 							{
 								existingInputs.Remove(existingInput);
 								continue;

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Blockchain.Transactions
 			IEnumerable<OutPoint> allowedInputs = null,
 			Func<LockTime> lockTimeSelector = null,
 			ITorHttpClient httpClient = null,
-			string  uri= null)
+			string uri = null)
 		{
 			payments = Guard.NotNull(nameof(payments), payments);
 			lockTimeSelector ??= () => LockTime.Zero;
@@ -227,14 +227,14 @@ namespace WalletWasabi.Blockchain.Transactions
 				builder.SetLockTime(lockTimeSelector());
 				builder.SignPSBT(psbt);
 				psbt.Finalize();
-				if (uri != null && httpClient!= null)
+				if (uri != null && httpClient != null)
 				{
-					var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri)
+					using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri)
 					{
 						Content = new StringContent(psbt.ToBase64(), Encoding.UTF8, "text/plain")
 					};
-					var response = httpClient.SendAsync(httpRequestMessage).Result;
-					if (response.IsSuccessStatusCode && PSBT.TryParse( response.Content.ReadAsStringAsync().Result, Network, out var payjoinPSBT))
+					using var response = httpClient.SendAsync(httpRequestMessage).Result;
+					if (response.IsSuccessStatusCode && PSBT.TryParse(response.Content.ReadAsStringAsync().Result, Network, out var payjoinPSBT))
 					{
 						bool valid = false;
 						var existingInputs = psbt.Inputs.Select(input => input.PrevOut).ToList();

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -289,7 +289,8 @@ namespace WalletWasabi.Wallets
 			PaymentIntent payments,
 			FeeStrategy feeStrategy,
 			bool allowUnconfirmed = false,
-			IEnumerable<OutPoint> allowedInputs = null)
+			IEnumerable<OutPoint> allowedInputs = null,
+			string bip79 = null)
 		{
 			var builder = new TransactionFactory(Network, KeyManager, Coins, password, allowUnconfirmed);
 			return builder.BuildTransaction(
@@ -310,7 +311,9 @@ namespace WalletWasabi.Wallets
 					}
 				},
 				allowedInputs,
-				SelectLockTimeForTransaction);
+				SelectLockTimeForTransaction,
+				Synchronizer.WasabiClient.TorClient, 
+				bip79);
 		}
 
 		public void RenameLabel(SmartCoin coin, SmartLabel newLabel)


### PR DESCRIPTION
This PR adds support for BIP79 Payjoin sender support.
When a BIP21 is pasted into the address field and the `bpu` parameter is specified, it will attempt to send the signed transaction to the specified endpoint. If the response is successful, you should have  updated, partially signed transaction with more inputs which is then verified, signed and broadcasted.

This is a very rough implementation as my knowledge of the wasabi codebase is limited.

ToDo (Incomplete)

- [x] Make sure CustomChangeAddress text box isn't visible when payjoin is used - https://github.com/AvaloniaUI/Avalonia/issues/3666