### PR TITLE
Extract away block fetching from wallet class

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -329,7 +329,15 @@ namespace WalletWasabi.Gui
 
 				#endregion JsonRpcServerInitialization
 
-				WalletManager.RegisterServices(BitcoinStore, Synchronizer, Nodes, Config.ServiceConfiguration, FeeProviders, BitcoinCoreNode);
+				#region Blocks provider
+
+				var blocksProvider = new CachedBlocksProvider(
+					new P2pBlocksProvider(Nodes, BitcoinCoreNode, Synchronizer, Config.ServiceConfiguration, Network), 
+					new FileSystemBlocksRepository(blocksFolderPath, Network));
+
+				#endregion Blocks provider
+
+				WalletManager.RegisterServices(BitcoinStore, Synchronizer, Nodes, Config.ServiceConfiguration, FeeProviders, BitcoinCoreNode, blocksProvider);
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -104,7 +104,7 @@ namespace WalletWasabi.Gui.ViewModels
 
 			Peers = Tor == TorStatus.NotRunning ? 0 : Nodes.Count;
 
-			Observable.FromEventPattern<bool>(typeof(Wallet), nameof(Wallet.DownloadingBlockChanged))
+			Observable.FromEventPattern<bool>(typeof(P2pBlocksProvider), nameof(P2pBlocksProvider.DownloadingBlockChanged))
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x => DownloadingBlock = x.EventArgs)
 				.DisposeWith(Disposables);

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -3,6 +3,7 @@ using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,8 +58,14 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			// 5. Create wallet service.
 			var workDir = Common.GetWorkDir();
+			var blocksFolderPath = Path.Combine(workDir, "Blocks", network.ToString());
+
+			CachedBlocksProvider blocksProvider = new CachedBlocksProvider(
+				new P2pBlocksProvider(nodes, null, synchronizer, serviceConfiguration, network), 
+				new FileSystemBlocksRepository(blocksFolderPath, network));
+
 			var walletManager = new WalletManager(network, new WalletDirectories(workDir));
-			walletManager.RegisterServices(bitcoinStore, synchronizer, nodes, serviceConfiguration, synchronizer, null);
+			walletManager.RegisterServices(bitcoinStore, synchronizer, nodes, serviceConfiguration, synchronizer, null, blocksProvider);
 
 			// Get some money, make it confirm.
 			var key = keyManager.GetNextReceiveKey("foo label", out _);
@@ -531,8 +538,14 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			// 5. Create wallet service.
 			var workDir = Common.GetWorkDir();
+			var blocksFolderPath = Path.Combine(workDir, "Blocks", network.ToString());
+
+			CachedBlocksProvider blocksProvider = new CachedBlocksProvider(
+				new P2pBlocksProvider(nodes, null, synchronizer, serviceConfiguration, network), 
+				new FileSystemBlocksRepository(blocksFolderPath, network));
+
 			var walletManager = new WalletManager(network, new WalletDirectories(workDir));
-			walletManager.RegisterServices(bitcoinStore, synchronizer, nodes, serviceConfiguration, synchronizer, null);
+			walletManager.RegisterServices(bitcoinStore, synchronizer, nodes, serviceConfiguration, synchronizer, null, blocksProvider);
 
 			// Get some money, make it confirm.
 			var key = keyManager.GetNextReceiveKey("foo label", out _);
@@ -699,7 +712,13 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			// 5. Create wallet service.
 			var workDir = Common.GetWorkDir();
-			using var wallet = new Wallet(network, bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
+			var blocksFolderPath = Path.Combine(workDir, "Blocks", network.ToString());
+
+			CachedBlocksProvider blocksProvider = new CachedBlocksProvider(
+				new P2pBlocksProvider(nodes, null, synchronizer, serviceConfiguration, network), 
+				new FileSystemBlocksRepository(blocksFolderPath, network));
+			
+			using var wallet = new Wallet(network, bitcoinStore, keyManager, synchronizer, workDir, serviceConfiguration, synchronizer, blocksProvider);
 			wallet.NewFilterProcessed += Common.Wallet_NewFilterProcessed;
 
 			Assert.Empty(wallet.Coins);

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -294,9 +294,16 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create key manager service.
 			var keyManager = KeyManager.CreateNew(out _, password);
 
-			// 4. Create wallet service.
+			// 4. Create block provider.
 			var workDir = Common.GetWorkDir();
-			using var wallet = new Wallet(network, bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer);
+			var blocksFolderPath = Path.Combine(workDir, "Blocks", network.ToString());
+
+			CachedBlocksProvider blocksProvider = new CachedBlocksProvider(
+				new P2pBlocksProvider(nodes, null, synchronizer, serviceConfiguration, network), 
+				new FileSystemBlocksRepository(blocksFolderPath, network));
+
+			// 5. Create wallet service.
+			using var wallet = new Wallet(network, bitcoinStore, keyManager, synchronizer, workDir, serviceConfiguration, synchronizer, blocksProvider);
 			wallet.NewFilterProcessed += Common.Wallet_NewFilterProcessed;
 
 			// Get some money, make it confirm.
@@ -319,7 +326,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				{
 					await wallet.StartAsync(cts.Token); // Initialize wallet service.
 				}
-				Assert.Equal(1, await wallet.CountBlocksAsync());
+				Assert.Equal(1, await blocksProvider.BlocksRepository.CountAsync(CancellationToken.None));
 
 				Assert.Single(wallet.Coins);
 				var firstCoin = wallet.Coins.Single();
@@ -345,7 +352,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				await rpc.GenerateAsync(1);
 
 				await Common.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 2);
-				Assert.Equal(3, await wallet.CountBlocksAsync());
+				Assert.Equal(3, await blocksProvider.BlocksRepository.CountAsync(CancellationToken.None));
 
 				Assert.Equal(3, wallet.Coins.Count());
 				firstCoin = wallet.Coins.OrderBy(x => x.Height).First();
@@ -403,7 +410,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				Interlocked.Exchange(ref Common.FiltersProcessedByWalletCount, 0);
 				await rpc.GenerateAsync(3);
 				await Common.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 3);
-				Assert.Equal(4, await wallet.CountBlocksAsync());
+				Assert.Equal(4, await blocksProvider.BlocksRepository.CountAsync(CancellationToken.None));
 
 				Assert.Equal(4, wallet.Coins.Count());
 				Assert.Empty(wallet.Coins.Where(x => x.TransactionId == txId4));

--- a/WalletWasabi/Wallets/CachedBlocksProvider.cs
+++ b/WalletWasabi/Wallets/CachedBlocksProvider.cs
@@ -1,0 +1,51 @@
+﻿using NBitcoin;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// CachedBlocksProvider is a blocks provider that keep the blocks on a repository to satify future requests.
+	/// </summary>
+	public class CachedBlocksProvider : IBlocksProvider
+	{
+		public CachedBlocksProvider(IBlocksProvider blocksSourceProvider, IRepository<uint256, Block> blocksRepository)
+		{
+			BlocksRepository = blocksRepository;
+			BlocksSourceProvider = blocksSourceProvider;
+		}
+
+		public IRepository<uint256, Block> BlocksRepository { get; } 
+		public IBlocksProvider BlocksSourceProvider { get; }
+
+		/// <summary>
+		/// Gets a bitcoin block. In case the requested block is not available in the repository it is returned 
+		/// inmediately to the caller; otherwise it obtains the block from the source provider and store it in
+		/// the repository to satisfy future requests.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			Block block = await BlocksRepository.GetAsync(hash, cancellationToken);
+			if (block is null)
+			{
+				block = await BlocksSourceProvider.GetBlockAsync(hash, cancellationToken);
+				await BlocksRepository.SaveAsync(block, cancellationToken);
+			}
+			return block;
+		}
+
+		/// <summary>
+		/// Removes the specified block from the cache repository.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public Task InvalidateAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			return BlocksRepository.RemoveAsync(hash, cancellationToken);
+		}
+	}
+}

--- a/WalletWasabi/Wallets/FileSystemBlocksRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlocksRepository.cs
@@ -1,0 +1,133 @@
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using Nito.AsyncEx;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// FileSystemBlocksRepository is a blocks repository that keep the blocks in the file system.
+	/// </summary>
+	public class FileSystemBlocksRepository : IRepository<uint256, Block>
+	{
+		public FileSystemBlocksRepository(string blocksFolderPath, Network network)
+		{
+			BlocksFolderPath = blocksFolderPath;
+			Network = network;
+			CreateFolders();
+		}
+
+		public string BlocksFolderPath { get; }
+		public Network Network { get; }
+		private AsyncLock BlockFolderLock { get; } = new AsyncLock();
+
+		/// <summary>
+		/// Gets a bitcoin block from the file system.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<Block> GetAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			// Try get the block
+			Block block = null;
+			using (await BlockFolderLock.LockAsync())
+			{
+				var encoder = new HexEncoder();
+				var filePath = Path.Combine(BlocksFolderPath, hash.ToString());
+				if (File.Exists(filePath))
+				{
+					try
+					{
+						var blockBytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+						block = Block.Load(blockBytes, Network);
+					}
+					catch
+					{
+						// In case the block file is corrupted and we get an EndOfStreamException exception
+						// Ignore any error and continue to re-downloading the block.
+						Logger.LogDebug($"Block {hash} file corrupted, deleting file and block will be re-downloaded.");
+						File.Delete(filePath);
+					}
+				}
+			}
+
+			return block;
+		}
+
+		/// <summary>
+		/// Saves a bitcoin block in the file system.
+		/// </summary>
+		/// <param name="block">The block to be persisted in the file system.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public async Task SaveAsync(Block block, CancellationToken cancellationToken)
+		{
+			var path = Path.Combine(BlocksFolderPath, block.GetHash().ToString());
+			using (await BlockFolderLock.LockAsync())
+			{
+				await File.WriteAllBytesAsync(path, block.ToBytes());
+			}
+		}
+
+		/// <summary>
+		/// Deletes a bitcoin block from the file system.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public async Task RemoveAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			try
+			{
+				using (await BlockFolderLock.LockAsync())
+				{
+					var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
+					var fileNames = filePaths.Select(Path.GetFileName);
+					var hashes = fileNames.Select(x => new uint256(x));
+
+					if (hashes.Contains(hash))
+					{
+						File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning(ex);
+			}
+		}
+
+		/// <summary>
+		/// Returns the number of blocks available in the file system. (for testing only)
+		/// </summary>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<int> CountAsync(CancellationToken cancellationToken)
+		{
+			using (await BlockFolderLock.LockAsync())
+			{
+				return Directory.EnumerateFiles(BlocksFolderPath).Count();
+			}
+		}
+
+		private void CreateFolders()
+		{
+			if (Directory.Exists(BlocksFolderPath))
+			{
+				if (Network == Network.RegTest)
+				{
+					Directory.Delete(BlocksFolderPath, true);
+					Directory.CreateDirectory(BlocksFolderPath);
+				}
+			}
+			else
+			{
+				Directory.CreateDirectory(BlocksFolderPath);
+			}
+		}
+	}
+}

--- a/WalletWasabi/Wallets/IBlocksProvider.cs
+++ b/WalletWasabi/Wallets/IBlocksProvider.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// IBlocksProvider is an abstraction for types that can return blocks.
+	/// </summary>
+	public interface IBlocksProvider
+	{
+		Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancel);
+	}
+}

--- a/WalletWasabi/Wallets/IRepository.cs
+++ b/WalletWasabi/Wallets/IRepository.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// IRepository is a generic abstraction of a repository pattern
+	/// </summary>
+	public interface IRepository<TID, TElement>
+	{
+		Task<TElement> GetAsync(TID id, CancellationToken cancel);
+		Task SaveAsync(TElement element, CancellationToken cancel);
+		Task RemoveAsync(TID id, CancellationToken cancel);
+		Task<int> CountAsync(CancellationToken cancel);
+	}
+}

--- a/WalletWasabi/Wallets/P2pBlocksProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlocksProvider.cs
@@ -1,0 +1,340 @@
+using NBitcoin;
+using NBitcoin.Protocol;
+using NBitcoin.Protocol.Behaviors;
+using System;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.BitcoinCore;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+using WalletWasabi.Models;
+using WalletWasabi.Services;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// P2pBlocksProvider is a blocks provider that provides blocks 
+	/// from bitcoin nodes using the P2P bitcoin protocol.
+	/// </summary>
+	public class P2pBlocksProvider : IBlocksProvider
+	{
+		private Node _localBitcoinCoreNode = null;
+
+		public P2pBlocksProvider(NodesGroup nodes, CoreNode coreNode, WasabiSynchronizer syncer, ServiceConfiguration serviceConfiguration, Network network)
+		{
+			Nodes = nodes;
+			CoreNode = coreNode;
+			Synchronizer = syncer;
+			ServiceConfiguration = serviceConfiguration;
+			Network = network;
+		}
+
+		public static event EventHandler<bool> DownloadingBlockChanged;
+		public NodesGroup Nodes { get; }
+		public CoreNode CoreNode { get; }
+		public WasabiSynchronizer Synchronizer { get; }
+		public ServiceConfiguration ServiceConfiguration { get; }
+		public Network Network { get; }
+
+		public Node LocalBitcoinCoreNode
+		{
+			get
+			{
+				if (Network == Network.RegTest)
+				{
+					return Nodes.ConnectedNodes.First();
+				}
+
+				return _localBitcoinCoreNode;
+			}
+			private set => _localBitcoinCoreNode = value;
+		}
+
+		private int NodeTimeouts { get; set; }
+
+		/// <summary>
+		/// Gets a bitcoin block from bitcoin nodes using the p2p bitcoin protocol.
+		/// If a CoreNode is available it fetches the blocks using the rpc interface.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			Block block = null;
+			try
+			{
+				DownloadingBlockChanged?.Invoke(null, true);
+
+				while (true)
+				{
+					cancellationToken.ThrowIfCancellationRequested();
+					try
+					{
+						// Try to get block information from local running Core node first.
+						block = await TryDownloadBlockFromLocalNodeAsync(hash, cancellationToken);
+
+						if (block is {})
+						{
+							break;
+						}
+
+						// If no connection, wait, then continue.
+						while (Nodes.ConnectedNodes.Count == 0)
+						{
+							await Task.Delay(100);
+						}
+
+						// Select a random node we are connected to.
+						Node node = Nodes.ConnectedNodes.RandomElement();
+						if (node is null || !node.IsConnected)
+						{
+							await Task.Delay(100);
+							continue;
+						}
+
+						// Download block from selected node.
+						try
+						{
+							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
+							{
+								block = await node.DownloadBlockAsync(hash, cts.Token);
+							}
+
+							// Validate block
+							if (!block.Check())
+							{
+								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
+								node.DisconnectAsync("Invalid block received.");
+								continue;
+							}
+
+							if (Nodes.ConnectedNodes.Count > 1) // To minimize risking missing unconfirmed transactions.
+							{
+								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
+								node.DisconnectAsync("Thank you!");
+							}
+
+							await NodeTimeoutsAsync(false);
+						}
+						catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException || ex is TimeoutException)
+						{
+							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
+
+							await NodeTimeoutsAsync(true);
+
+							node.DisconnectAsync("Block download took too long.");
+							continue;
+						}
+						catch (Exception ex)
+						{
+							Logger.LogDebug(ex);
+							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.");
+							node.DisconnectAsync("Block download failed.");
+							continue;
+						}
+
+						break; // If got this far, then we have the block and it's valid. Break.
+					}
+					catch (Exception ex)
+					{
+						Logger.LogDebug(ex);
+					}
+				}
+			}
+			finally
+			{
+				DownloadingBlockChanged?.Invoke(null, false);
+			}
+
+			return block;
+		}
+
+		private async Task<Block> TryDownloadBlockFromLocalNodeAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			if (CoreNode?.RpcClient is null)
+			{
+				try
+				{
+					if (LocalBitcoinCoreNode is null || (!LocalBitcoinCoreNode.IsConnected && Network != Network.RegTest)) // If RegTest then we're already connected do not try again.
+					{
+						DisconnectDisposeNullLocalBitcoinCoreNode();
+						using var handshakeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+						handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
+						var nodeConnectionParameters = new NodeConnectionParameters()
+						{
+							ConnectCancellation = handshakeTimeout.Token,
+							IsRelay = false,
+							UserAgent = $"/Wasabi:{Constants.ClientVersion.ToString()}/"
+						};
+
+						// If an onion was added must try to use Tor.
+						// onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
+						if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
+						{
+							nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
+						}
+
+						var localEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;
+						var localNode = await Node.ConnectAsync(Network, localEndPoint, nodeConnectionParameters);
+						try
+						{
+							Logger.LogInfo("TCP Connection succeeded, handshaking...");
+							localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
+							var peerServices = localNode.PeerVersion.Services;
+
+							//if (!peerServices.HasFlag(NodeServices.Network) && !peerServices.HasFlag(NodeServices.NODE_NETWORK_LIMITED))
+							//{
+							//	throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
+							//}
+
+							Logger.LogInfo("Handshake completed successfully.");
+
+							if (!localNode.IsConnected)
+							{
+								throw new InvalidOperationException($"Wasabi could not complete the handshake with the local node and dropped the connection.{Environment.NewLine}" +
+									"Probably this is because the node does not support retrieving full blocks or segwit serialization.");
+							}
+							LocalBitcoinCoreNode = localNode;
+						}
+						catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
+						{
+							Logger.LogWarning($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
+								"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
+							throw;
+						}
+					}
+
+					// Get Block from local node
+					Block blockFromLocalNode = null;
+					// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
+					using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
+					{
+						blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
+					}
+
+					// Validate retrieved block
+					if (!blockFromLocalNode.Check())
+					{
+						throw new InvalidOperationException("Disconnected node, because invalid block received!");
+					}
+
+					// Retrieved block from local node and block is valid
+					Logger.LogInfo($"Block acquired from local P2P connection: {hash}.");
+					return blockFromLocalNode;
+				}
+				catch (Exception ex)
+				{
+					DisconnectDisposeNullLocalBitcoinCoreNode();
+
+					if (ex is SocketException)
+					{
+						Logger.LogTrace("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
+					}
+					else
+					{
+						Logger.LogWarning(ex);
+					}
+				}
+			}
+			else
+			{
+				try
+				{
+					var block = await CoreNode.RpcClient.GetBlockAsync(hash).ConfigureAwait(false);
+					Logger.LogInfo($"Block acquired from RPC connection: {hash}.");
+					return block;
+				}
+				catch (Exception ex)
+				{
+					Logger.LogWarning(ex);
+				}
+			}
+
+			return null;
+		}
+
+		private void DisconnectDisposeNullLocalBitcoinCoreNode()
+		{
+			if (LocalBitcoinCoreNode != null)
+			{
+				try
+				{
+					LocalBitcoinCoreNode?.Disconnect();
+				}
+				catch (Exception ex)
+				{
+					Logger.LogDebug(ex);
+				}
+				finally
+				{
+					try
+					{
+						LocalBitcoinCoreNode?.Dispose();
+					}
+					catch (Exception ex)
+					{
+						Logger.LogDebug(ex);
+					}
+					finally
+					{
+						LocalBitcoinCoreNode = null;
+						Logger.LogInfo("Local Bitcoin Core node disconnected.");
+					}
+				}
+			}
+		}
+
+
+		/// <summary>
+		/// Current timeout used when downloading a block from the remote node. It is defined in seconds.
+		/// </summary>
+		private async Task NodeTimeoutsAsync(bool increaseDecrease)
+		{
+			if (increaseDecrease)
+			{
+				NodeTimeouts++;
+			}
+			else
+			{
+				NodeTimeouts--;
+			}
+
+			var timeout = RuntimeParams.Instance.NetworkNodeTimeout;
+
+			// If it times out 2 times in a row then increase the timeout.
+			if (NodeTimeouts >= 2)
+			{
+				NodeTimeouts = 0;
+				timeout *= 2;
+			}
+			else if (NodeTimeouts <= -3) // If it does not time out 3 times in a row, lower the timeout.
+			{
+				NodeTimeouts = 0;
+				timeout = (int)Math.Round(timeout * 0.7);
+			}
+
+			// Sanity check
+			if (timeout < 32)
+			{
+				timeout = 32;
+			}
+			else if (timeout > 600)
+			{
+				timeout = 600;
+			}
+
+			if (timeout == RuntimeParams.Instance.NetworkNodeTimeout)
+			{
+				return;
+			}
+
+			RuntimeParams.Instance.NetworkNodeTimeout = timeout;
+			await RuntimeParams.Instance.SaveAsync();
+
+			Logger.LogInfo($"Current timeout value used on block download is: {timeout} seconds.");
+		}
+	}
+}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -1,17 +1,11 @@
 using Microsoft.Extensions.Hosting;
 using NBitcoin;
-using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
-using NBitcoin.Protocol.Behaviors;
-using NBitcoin.RPC;
 using Nito.AsyncEx;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
@@ -25,7 +19,6 @@ using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
-using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
@@ -37,35 +30,27 @@ namespace WalletWasabi.Wallets
 {
 	public class Wallet : BackgroundService
 	{
-		private Node _localBitcoinCoreNode = null;
-
 		public Wallet(
 			Network network,
 			BitcoinStore bitcoinStore,
 			KeyManager keyManager,
 			WasabiSynchronizer syncer,
-			NodesGroup nodes,
 			string workFolderDir,
 			ServiceConfiguration serviceConfiguration,
 			IFeeProvider feeProvider,
-			CoreNode coreNode = null)
+			IBlocksProvider blocksProvider)
 		{
 			Network = Guard.NotNull(nameof(network), network);
 			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-			Nodes = Guard.NotNull(nameof(nodes), nodes);
 			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
 			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
 			FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
-			CoreNode = coreNode;
 
 			ChaumianClient = new CoinJoinClient(Synchronizer, Network, keyManager);
 			HandleFiltersLock = new AsyncLock();
 
-			BlocksFolderPath = Path.Combine(workFolderDir, "Blocks", Network.ToString());
 			RuntimeParams.SetDataDir(workFolderDir);
-
-			BlockFolderLock = new AsyncLock();
 
 			KeyManager.AssertCleanKeysIndexed();
 			KeyManager.AssertLockedInternalKeysIndexed(14);
@@ -76,22 +61,11 @@ namespace WalletWasabi.Wallets
 			TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessedAsync;
 			ChaumianClient.OnDequeue += ChaumianClient_OnDequeue;
 
-			if (Directory.Exists(BlocksFolderPath))
-			{
-				if (Network == Network.RegTest)
-				{
-					Directory.Delete(BlocksFolderPath, true);
-					Directory.CreateDirectory(BlocksFolderPath);
-				}
-			}
-			else
-			{
-				Directory.CreateDirectory(BlocksFolderPath);
-			}
-
 			BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
 			BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
 			BitcoinStore.MempoolService.TransactionReceived += Mempool_TransactionReceived;
+
+			BlocksProvider = blocksProvider;
 
 			State = WalletState.Initialized;
 		}
@@ -99,8 +73,6 @@ namespace WalletWasabi.Wallets
 		public event EventHandler<ProcessedResult> WalletRelevantTransactionProcessed;
 
 		public event EventHandler<DequeueResult> OnDequeue;
-
-		public static event EventHandler<bool> DownloadingBlockChanged;
 
 		public static event EventHandler<bool> InitializingChanged;
 
@@ -113,8 +85,6 @@ namespace WalletWasabi.Wallets
 		public KeyManager KeyManager { get; }
 		public WasabiSynchronizer Synchronizer { get; }
 		public CoinJoinClient ChaumianClient { get; }
-		public NodesGroup Nodes { get; }
-		public string BlocksFolderPath { get; }
 		public ServiceConfiguration ServiceConfiguration { get; }
 		public string WalletName => KeyManager.WalletName;
 
@@ -126,29 +96,12 @@ namespace WalletWasabi.Wallets
 		public Network Network { get; }
 		public TransactionProcessor TransactionProcessor { get; }
 
-		public Node LocalBitcoinCoreNode
-		{
-			get
-			{
-				if (Network == Network.RegTest)
-				{
-					return Nodes.ConnectedNodes.First();
-				}
-
-				return _localBitcoinCoreNode;
-			}
-			private set => _localBitcoinCoreNode = value;
-		}
-
 		public IFeeProvider FeeProvider { get; }
-		public CoreNode CoreNode { get; }
 		public FilterModel LastProcessedFilter { get; private set; }
+		public IBlocksProvider BlocksProvider { get; }
+
 		private static Random Random { get; } = new Random();
 		private AsyncLock HandleFiltersLock { get; }
-
-		private AsyncLock BlockFolderLock { get; }
-
-		private int NodeTimeouts { get; set; }
 
 		/// <inheritdoc/>
 		public override async Task StartAsync(CancellationToken cancel)
@@ -210,51 +163,6 @@ namespace WalletWasabi.Wallets
 
 		/// <inheritdoc />
 		protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
-
-		/// <param name="hash">Block hash of the desired block, represented as a 256 bit integer.</param>
-		/// <exception cref="OperationCanceledException"></exception>
-		public async Task<Block> FetchBlockAsync(uint256 hash, CancellationToken cancel)
-		{
-			Block block = await TryGetBlockFromFileAsync(hash, cancel);
-			if (block is null)
-			{
-				block = await DownloadBlockAsync(hash, cancel);
-			}
-			return block;
-		}
-
-		/// <remarks>
-		/// Use it at reorgs.
-		/// </remarks>
-		public async Task DeleteBlockAsync(uint256 hash)
-		{
-			try
-			{
-				using (await BlockFolderLock.LockAsync())
-				{
-					var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
-					var fileNames = filePaths.Select(Path.GetFileName);
-					var hashes = fileNames.Select(x => new uint256(x));
-
-					if (hashes.Contains(hash))
-					{
-						File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning(ex);
-			}
-		}
-
-		public async Task<int> CountBlocksAsync()
-		{
-			using (await BlockFolderLock.LockAsync())
-			{
-				return Directory.EnumerateFiles(BlocksFolderPath).Count();
-			}
-		}
 
 		/// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
 		/// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
@@ -328,7 +236,6 @@ namespace WalletWasabi.Wallets
 					await ChaumianClient.StopAsync(cancel).ConfigureAwait(false);
 				}
 
-				DisconnectDisposeNullLocalBitcoinCoreNode();
 				Logger.LogInfo($"{nameof(ChaumianClient)} is stopped.");
 			}
 			finally
@@ -436,7 +343,10 @@ namespace WalletWasabi.Wallets
 				using (await HandleFiltersLock.LockAsync())
 				{
 					uint256 invalidBlockHash = invalidFilter.Header.BlockHash;
-					await DeleteBlockAsync(invalidBlockHash);
+					if (BlocksProvider is CachedBlocksProvider blockCache)
+					{
+						await blockCache.InvalidateAsync(invalidBlockHash, CancellationToken.None).ConfigureAwait(false);
+					}
 					KeyManager.SetMaxBestHeight(new Height(invalidFilter.Header.Height - 1));
 					TransactionProcessor.UndoBlock((int)invalidFilter.Header.Height);
 					BitcoinStore.TransactionStore.ReleaseToMempoolFromBlock(invalidBlockHash);
@@ -554,7 +464,7 @@ namespace WalletWasabi.Wallets
 			var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
 			if (matchFound)
 			{
-				Block currentBlock = await FetchBlockAsync(filterModel.Header.BlockHash, cancel); // Wait until not downloaded.
+				Block currentBlock = await BlocksProvider.GetBlockAsync(filterModel.Header.BlockHash, cancel); // Wait until not downloaded.
 				var height = new Height(filterModel.Header.Height);
 
 				var txsToProcess = new List<SmartTransaction>();
@@ -572,325 +482,12 @@ namespace WalletWasabi.Wallets
 			LastProcessedFilter = filterModel;
 		}
 
-		/// <param name="hash">Block hash of the desired block, represented as a 256 bit integer.</param>
-		/// <exception cref="OperationCanceledException"></exception>
-		private async Task<Block> TryGetBlockFromFileAsync(uint256 hash, CancellationToken cancel)
-		{
-			// Try get the block
-			Block block = null;
-			using (await BlockFolderLock.LockAsync())
-			{
-				var encoder = new HexEncoder();
-				var filePath = Path.Combine(BlocksFolderPath, hash.ToString());
-				if (File.Exists(filePath))
-				{
-					try
-					{
-						var blockBytes = await File.ReadAllBytesAsync(filePath, cancel);
-						block = Block.Load(blockBytes, Network);
-					}
-					catch
-					{
-						// In case the block file is corrupted and we get an EndOfStreamException exception
-						// Ignore any error and continue to re-downloading the block.
-						Logger.LogDebug($"Block {hash} file corrupted, deleting file and block will be re-downloaded.");
-						File.Delete(filePath);
-					}
-				}
-			}
-
-			return block;
-		}
-
-		/// <param name="hash">Block hash of the desired block, represented as a 256 bit integer.</param>
-		/// <exception cref="OperationCanceledException"></exception>
-		private async Task<Block> DownloadBlockAsync(uint256 hash, CancellationToken cancel)
-		{
-			Block block = null;
-			try
-			{
-				DownloadingBlockChanged?.Invoke(null, true);
-
-				while (true)
-				{
-					cancel.ThrowIfCancellationRequested();
-					try
-					{
-						// Try to get block information from local running Core node first.
-						block = await TryDownloadBlockFromLocalNodeAsync(hash, cancel);
-
-						if (block != null)
-						{
-							break;
-						}
-
-						// If no connection, wait, then continue.
-						while (Nodes.ConnectedNodes.Count == 0)
-						{
-							await Task.Delay(100);
-						}
-
-						// Select a random node we are connected to.
-						Node node = Nodes.ConnectedNodes.RandomElement();
-						if (node is null || !node.IsConnected)
-						{
-							await Task.Delay(100);
-							continue;
-						}
-
-						// Download block from selected node.
-						try
-						{
-							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
-							{
-								block = await node.DownloadBlockAsync(hash, cts.Token);
-							}
-
-							// Validate block
-							if (!block.Check())
-							{
-								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
-								node.DisconnectAsync("Invalid block received.");
-								continue;
-							}
-
-							if (Nodes.ConnectedNodes.Count > 1) // To minimize risking missing unconfirmed transactions.
-							{
-								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
-								node.DisconnectAsync("Thank you!");
-							}
-
-							await NodeTimeoutsAsync(false);
-						}
-						catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException || ex is TimeoutException)
-						{
-							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
-
-							await NodeTimeoutsAsync(true);
-
-							node.DisconnectAsync("Block download took too long.");
-							continue;
-						}
-						catch (Exception ex)
-						{
-							Logger.LogDebug(ex);
-							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.");
-							node.DisconnectAsync("Block download failed.");
-							continue;
-						}
-
-						break; // If got this far, then we have the block and it's valid. Break.
-					}
-					catch (Exception ex)
-					{
-						Logger.LogDebug(ex);
-					}
-				}
-
-				// Save the block
-				using (await BlockFolderLock.LockAsync())
-				{
-					var path = Path.Combine(BlocksFolderPath, hash.ToString());
-					await File.WriteAllBytesAsync(path, block.ToBytes());
-				}
-			}
-			finally
-			{
-				DownloadingBlockChanged?.Invoke(null, false);
-			}
-
-			return block;
-		}
-
-		private async Task<Block> TryDownloadBlockFromLocalNodeAsync(uint256 hash, CancellationToken cancel)
-		{
-			if (CoreNode?.RpcClient is null)
-			{
-				try
-				{
-					if (LocalBitcoinCoreNode is null || (!LocalBitcoinCoreNode.IsConnected && Network != Network.RegTest)) // If RegTest then we're already connected do not try again.
-					{
-						DisconnectDisposeNullLocalBitcoinCoreNode();
-						using var handshakeTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancel);
-						handshakeTimeout.CancelAfter(TimeSpan.FromSeconds(10));
-						var nodeConnectionParameters = new NodeConnectionParameters()
-						{
-							ConnectCancellation = handshakeTimeout.Token,
-							IsRelay = false,
-							UserAgent = $"/Wasabi:{Constants.ClientVersion.ToString()}/"
-						};
-
-						// If an onion was added must try to use Tor.
-						// onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
-						if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
-						{
-							nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
-						}
-
-						var localEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;
-						var localNode = await Node.ConnectAsync(Network, localEndPoint, nodeConnectionParameters);
-						try
-						{
-							Logger.LogInfo("TCP Connection succeeded, handshaking...");
-							localNode.VersionHandshake(Constants.LocalNodeRequirements, handshakeTimeout.Token);
-							var peerServices = localNode.PeerVersion.Services;
-
-							//if (!peerServices.HasFlag(NodeServices.Network) && !peerServices.HasFlag(NodeServices.NODE_NETWORK_LIMITED))
-							//{
-							//	throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
-							//}
-
-							Logger.LogInfo("Handshake completed successfully.");
-
-							if (!localNode.IsConnected)
-							{
-								throw new InvalidOperationException($"Wasabi could not complete the handshake with the local node and dropped the connection.{Environment.NewLine}" +
-									"Probably this is because the node does not support retrieving full blocks or segwit serialization.");
-							}
-							LocalBitcoinCoreNode = localNode;
-						}
-						catch (OperationCanceledException) when (handshakeTimeout.IsCancellationRequested)
-						{
-							Logger.LogWarning($"Wasabi could not complete the handshake with the local node. Probably Wasabi is not whitelisted by the node.{Environment.NewLine}" +
-								"Use \"whitebind\" in the node configuration. (Typically whitebind=127.0.0.1:8333 if Wasabi and the node are on the same machine and whitelist=1.2.3.4 if they are not.)");
-							throw;
-						}
-					}
-
-					// Get Block from local node
-					Block blockFromLocalNode = null;
-					// Should timeout faster. Not sure if it should ever fail though. Maybe let's keep like this later for remote node connection.
-					using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(64)))
-					{
-						blockFromLocalNode = await LocalBitcoinCoreNode.DownloadBlockAsync(hash, cts.Token);
-					}
-
-					// Validate retrieved block
-					if (!blockFromLocalNode.Check())
-					{
-						throw new InvalidOperationException("Disconnected node, because invalid block received!");
-					}
-
-					// Retrieved block from local node and block is valid
-					Logger.LogInfo($"Block acquired from local P2P connection: {hash}.");
-					return blockFromLocalNode;
-				}
-				catch (Exception ex)
-				{
-					DisconnectDisposeNullLocalBitcoinCoreNode();
-
-					if (ex is SocketException)
-					{
-						Logger.LogTrace("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
-					}
-					else
-					{
-						Logger.LogWarning(ex);
-					}
-				}
-			}
-			else
-			{
-				try
-				{
-					var block = await CoreNode.RpcClient.GetBlockAsync(hash).ConfigureAwait(false);
-					Logger.LogInfo($"Block acquired from RPC connection: {hash}.");
-					return block;
-				}
-				catch (Exception ex)
-				{
-					Logger.LogWarning(ex);
-				}
-			}
-
-			return null;
-		}
-
-		private void DisconnectDisposeNullLocalBitcoinCoreNode()
-		{
-			if (LocalBitcoinCoreNode != null)
-			{
-				try
-				{
-					LocalBitcoinCoreNode?.Disconnect();
-				}
-				catch (Exception ex)
-				{
-					Logger.LogDebug(ex);
-				}
-				finally
-				{
-					try
-					{
-						LocalBitcoinCoreNode?.Dispose();
-					}
-					catch (Exception ex)
-					{
-						Logger.LogDebug(ex);
-					}
-					finally
-					{
-						LocalBitcoinCoreNode = null;
-						Logger.LogInfo("Local Bitcoin Core node disconnected.");
-					}
-				}
-			}
-		}
 
 		private LockTime SelectLockTimeForTransaction()
 		{
 			var currentTipHeight = Synchronizer.BitcoinStore.SmartHeaderChain.TipHeight;
 
 			return InternalSelectLockTimeForTransaction(currentTipHeight, Random);
-		}
-
-		/// <summary>
-		/// Current timeout used when downloading a block from the remote node. It is defined in seconds.
-		/// </summary>
-		private async Task NodeTimeoutsAsync(bool increaseDecrease)
-		{
-			if (increaseDecrease)
-			{
-				NodeTimeouts++;
-			}
-			else
-			{
-				NodeTimeouts--;
-			}
-
-			var timeout = RuntimeParams.Instance.NetworkNodeTimeout;
-
-			// If it times out 2 times in a row then increase the timeout.
-			if (NodeTimeouts >= 2)
-			{
-				NodeTimeouts = 0;
-				timeout *= 2;
-			}
-			else if (NodeTimeouts <= -3) // If it does not time out 3 times in a row, lower the timeout.
-			{
-				NodeTimeouts = 0;
-				timeout = (int)Math.Round(timeout * 0.7);
-			}
-
-			// Sanity check
-			if (timeout < 32)
-			{
-				timeout = 32;
-			}
-			else if (timeout > 600)
-			{
-				timeout = 600;
-			}
-
-			if (timeout == RuntimeParams.Instance.NetworkNodeTimeout)
-			{
-				return;
-			}
-
-			RuntimeParams.Instance.NetworkNodeTimeout = timeout;
-			await RuntimeParams.Instance.SaveAsync();
-
-			Logger.LogInfo($"Current timeout value used on block download is: {timeout} seconds.");
 		}
 	}
 }

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -53,6 +53,8 @@ namespace WalletWasabi.Wallets
 		private NodesGroup Nodes { get; set; }
 		private ServiceConfiguration ServiceConfiguration { get; set; }
 
+		private IBlocksProvider BlocksProvider { get; set; }
+
 		public void SignalQuitPending(bool isQuitPending)
 		{
 			lock (Lock)
@@ -92,7 +94,7 @@ namespace WalletWasabi.Wallets
 				Wallet wallet = null;
 				try
 				{
-					wallet = new Wallet(Network, BitcoinStore, keyManager, Synchronizer, Nodes, WalletDirectories.WorkDir, ServiceConfiguration, FeeProvider, BitcoinCoreNode);
+					wallet = new Wallet(Network, BitcoinStore, keyManager, Synchronizer, WalletDirectories.WorkDir, ServiceConfiguration, FeeProvider, BlocksProvider);
 
 					var cancel = CancelAllInitialization.Token;
 					lock (Lock)
@@ -262,7 +264,7 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		public void RegisterServices(BitcoinStore bitcoinStore, WasabiSynchronizer synchronizer, NodesGroup nodes, ServiceConfiguration serviceConfiguration, IFeeProvider feeProvider, CoreNode bitcoinCoreNode)
+		public void RegisterServices(BitcoinStore bitcoinStore, WasabiSynchronizer synchronizer, NodesGroup nodes, ServiceConfiguration serviceConfiguration, IFeeProvider feeProvider, CoreNode bitcoinCoreNode, IBlocksProvider blocksProvider)
 		{
 			BitcoinStore = bitcoinStore;
 			Synchronizer = synchronizer;
@@ -270,6 +272,7 @@ namespace WalletWasabi.Wallets
 			ServiceConfiguration = serviceConfiguration;
 			FeeProvider = feeProvider;
 			BitcoinCoreNode = bitcoinCoreNode;
+			BlocksProvider = blocksProvider;
 		}
 	}
 }


### PR DESCRIPTION
This PR simplifies the `Wallet` class by taking away the block fetching and storing responsabilities from it.

The main new abstractions are two:

* `FileSystemBlocksRepository` which can *Save*, *Remove* and *Get* blocks from the blocks' folder (file system)
* `P2pBlocksProvider` which can fetch blocks from the P2p network (and also from the CoreNode.RpcClient)

Additionally there is a third class `CachedBlocksProvider` that is the one that integrates the previous two. This means that this is a blocks provider that tries to get the block from the file system first, using the `FileSystemBlocksRepository`, and in case the requested block is not available fetches the block from the `P2pBlocksProvider` and save the block on disk.

None of this is new in any way, it is the same that before but organized in a more modular way. This design will allow us to write tests on these components ( i didn't do it because otherwise the PR would be huge).

The PR can be reviewed commit by commit.  RFC.

