### PR TITLE
Extract away block fetching from wallet class (part 1)

### DIFF
--- a/WalletWasabi/Wallets/FileSystemBlockRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlockRepository.cs
@@ -1,0 +1,133 @@
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using Nito.AsyncEx;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// FileSystemBlocksRepository is a blocks repository that keep the blocks in the file system.
+	/// </summary>
+	public class FileSystemBlockRepository : IRepository<uint256, Block>
+	{
+		public FileSystemBlockRepository(string blocksFolderPath, Network network)
+		{
+			BlocksFolderPath = blocksFolderPath;
+			Network = network;
+			CreateFolders();
+		}
+
+		public string BlocksFolderPath { get; }
+		public Network Network { get; }
+		private AsyncLock BlockFolderLock { get; } = new AsyncLock();
+
+		/// <summary>
+		/// Gets a bitcoin block from the file system.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<Block> GetAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			// Try get the block
+			Block block = null;
+			using (await BlockFolderLock.LockAsync())
+			{
+				var encoder = new HexEncoder();
+				var filePath = Path.Combine(BlocksFolderPath, hash.ToString());
+				if (File.Exists(filePath))
+				{
+					try
+					{
+						var blockBytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+						block = Block.Load(blockBytes, Network);
+					}
+					catch
+					{
+						// In case the block file is corrupted and we get an EndOfStreamException exception
+						// Ignore any error and continue to re-downloading the block.
+						Logger.LogDebug($"Block {hash} file corrupted, deleting file and block will be re-downloaded.");
+						File.Delete(filePath);
+					}
+				}
+			}
+
+			return block;
+		}
+
+		/// <summary>
+		/// Saves a bitcoin block in the file system.
+		/// </summary>
+		/// <param name="block">The block to be persisted in the file system.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public async Task SaveAsync(Block block, CancellationToken cancellationToken)
+		{
+			using (await BlockFolderLock.LockAsync())
+			{
+				var path = Path.Combine(BlocksFolderPath, block.GetHash().ToString());
+				await File.WriteAllBytesAsync(path, block.ToBytes());
+			}
+		}
+
+		/// <summary>
+		/// Deletes a bitcoin block from the file system.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public async Task RemoveAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			try
+			{
+				using (await BlockFolderLock.LockAsync())
+				{
+					var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
+					var fileNames = filePaths.Select(Path.GetFileName);
+					var hashes = fileNames.Select(x => new uint256(x));
+
+					if (hashes.Contains(hash))
+					{
+						File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning(ex);
+			}
+		}
+
+		/// <summary>
+		/// Returns the number of blocks available in the file system. (for testing only)
+		/// </summary>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<int> CountAsync(CancellationToken cancellationToken)
+		{
+			using (await BlockFolderLock.LockAsync())
+			{
+				return Directory.EnumerateFiles(BlocksFolderPath).Count();
+			}
+		}
+
+		private void CreateFolders()
+		{
+			if (Directory.Exists(BlocksFolderPath))
+			{
+				if (Network == Network.RegTest)
+				{
+					Directory.Delete(BlocksFolderPath, true);
+					Directory.CreateDirectory(BlocksFolderPath);
+				}
+			}
+			else
+			{
+				Directory.CreateDirectory(BlocksFolderPath);
+			}
+		}
+	}
+}

--- a/WalletWasabi/Wallets/FileSystemBlocksRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlocksRepository.cs
@@ -1,0 +1,133 @@
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using Nito.AsyncEx;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// FileSystemBlocksRepository is a blocks repository that keep the blocks in the file system.
+	/// </summary>
+	public class FileSystemBlocksRepository : IRepository<uint256, Block>
+	{
+		public FileSystemBlocksRepository(string blocksFolderPath, Network network)
+		{
+			BlocksFolderPath = blocksFolderPath;
+			Network = network;
+			CreateFolders();
+		}
+
+		public string BlocksFolderPath { get; }
+		public Network Network { get; }
+		private AsyncLock BlockFolderLock { get; } = new AsyncLock();
+
+		/// <summary>
+		/// Gets a bitcoin block from the file system.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<Block> GetAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			// Try get the block
+			Block block = null;
+			using (await BlockFolderLock.LockAsync())
+			{
+				var encoder = new HexEncoder();
+				var filePath = Path.Combine(BlocksFolderPath, hash.ToString());
+				if (File.Exists(filePath))
+				{
+					try
+					{
+						var blockBytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+						block = Block.Load(blockBytes, Network);
+					}
+					catch
+					{
+						// In case the block file is corrupted and we get an EndOfStreamException exception
+						// Ignore any error and continue to re-downloading the block.
+						Logger.LogDebug($"Block {hash} file corrupted, deleting file and block will be re-downloaded.");
+						File.Delete(filePath);
+					}
+				}
+			}
+
+			return block;
+		}
+
+		/// <summary>
+		/// Saves a bitcoin block in the file system.
+		/// </summary>
+		/// <param name="block">The block to be persisted in the file system.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public async Task SaveAsync(Block block, CancellationToken cancellationToken)
+		{
+			var path = Path.Combine(BlocksFolderPath, block.GetHash().ToString());
+			using (await BlockFolderLock.LockAsync())
+			{
+				await File.WriteAllBytesAsync(path, block.ToBytes());
+			}
+		}
+
+		/// <summary>
+		/// Deletes a bitcoin block from the file system.
+		/// </summary>
+		/// <param name="hash">The block's hash that identifies the requested block.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		public async Task RemoveAsync(uint256 hash, CancellationToken cancellationToken)
+		{
+			try
+			{
+				using (await BlockFolderLock.LockAsync())
+				{
+					var filePaths = Directory.EnumerateFiles(BlocksFolderPath);
+					var fileNames = filePaths.Select(Path.GetFileName);
+					var hashes = fileNames.Select(x => new uint256(x));
+
+					if (hashes.Contains(hash))
+					{
+						File.Delete(Path.Combine(BlocksFolderPath, hash.ToString()));
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning(ex);
+			}
+		}
+
+		/// <summary>
+		/// Returns the number of blocks available in the file system. (for testing only)
+		/// </summary>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The requested bitcoin block.</returns>
+		public async Task<int> CountAsync(CancellationToken cancellationToken)
+		{
+			using (await BlockFolderLock.LockAsync())
+			{
+				return Directory.EnumerateFiles(BlocksFolderPath).Count();
+			}
+		}
+
+		private void CreateFolders()
+		{
+			if (Directory.Exists(BlocksFolderPath))
+			{
+				if (Network == Network.RegTest)
+				{
+					Directory.Delete(BlocksFolderPath, true);
+					Directory.CreateDirectory(BlocksFolderPath);
+				}
+			}
+			else
+			{
+				Directory.CreateDirectory(BlocksFolderPath);
+			}
+		}
+	}
+}

--- a/WalletWasabi/Wallets/IRepository.cs
+++ b/WalletWasabi/Wallets/IRepository.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Wallets
+{
+	/// <summary>
+	/// IRepository is a generic abstraction of a repository pattern
+	/// </summary>
+	public interface IRepository<TID, TElement>
+	{
+		Task<TElement> GetAsync(TID id, CancellationToken cancel);
+		Task SaveAsync(TElement element, CancellationToken cancel);
+		Task RemoveAsync(TID id, CancellationToken cancel);
+		Task<int> CountAsync(CancellationToken cancel);
+	}
+}


### PR DESCRIPTION
Breakdown of https://github.com/zkSNACKs/WalletWasabi/pull/3298.

---------------------------

This PR is the first of a serie of PRs to simplify the Wallet class by taking away the block fetching and storing parts from it. The first part consists of one new class and a couple of interfaces that will be used to moved code from wallet.cs to new clases.

The class `FileSystemBlocksRepository` is used to abstract the the persistence mecanism for storing blocks in the file system. It can _Save_, _Remove_ and _Get_ blocks from the blocks' folder (file system)

Following PRs will use these class, and others, to finally remove the fetching blocks parts from the wallet class.