### PR TITLE
fix exchange rate unit: USD/BTC

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -626,7 +626,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 						case FeeDisplayFormat.USD:
 							FeeText = $"(~ ${UsdFee.ToString("0.##")})";
-							FeeToolTip = $"Estimated total fees in USD. Exchange Rate: {(long)UsdExchangeRate} BTC/USD.";
+							FeeToolTip = $"Estimated total fees in USD. Exchange Rate: {(long)UsdExchangeRate} USD/BTC.";
 							break;
 
 						case FeeDisplayFormat.BTC:

--- a/WalletWasabi.Gui/Converters/UsdExchangeRateAmountToolTipConverter.cs
+++ b/WalletWasabi.Gui/Converters/UsdExchangeRateAmountToolTipConverter.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Gui.Converters
 		{
 			if (value is decimal usdExchangeRate)
 			{
-				return $"Exchange Rate: {(long)usdExchangeRate} BTC/USD.";
+				return $"Exchange Rate: {(long)usdExchangeRate} USD/BTC.";
 			}
 			else
 			{


### PR DESCRIPTION
On two occations, the USD price of bitcoin is shown as `BTC/USD`, when the unit should be `USD/BTC`. This pull request replaces these two instances in the code with `USD/BTC`.

I am aware that there are others working on making fee display more flexible, but this seems to be a simple enough change to be included without bigger repercussions.