### PR TITLE
Remove unreachable case

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -372,6 +372,7 @@ namespace WalletWasabi.Gui
 			{
 				return TargetPrivacy.Strong;
 			}
+
 			//the levels changed in the config file, adjust
 			if (MixUntilAnonymitySet < PrivacyLevelSome)
 			{
@@ -388,12 +389,7 @@ namespace WalletWasabi.Gui
 				return TargetPrivacy.Fine;
 			}
 
-			if (MixUntilAnonymitySet > PrivacyLevelFine)
-			{
-				return TargetPrivacy.Strong;
-			}
-
-			return TargetPrivacy.None;
+			return TargetPrivacy.Strong;
 		}
 
 		public int GetTargetLevel(TargetPrivacy target)


### PR DESCRIPTION
The last `return TargetPrivacy.None;` can never be reached, and the
`if (MixUntilAnonymitySet > PrivacyLevelFine)` should have been
`if (MixUntilAnonymitySet > PrivacyLevelStrong)` but anyway.