### PR TITLE
Fix regtest

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -751,13 +751,8 @@ namespace WalletWasabi.Tests.RegressionTests
 				Interlocked.Exchange(ref Common.FiltersProcessedByWalletCount, 0);
 				await rpc.GenerateAsync(1);
 				await Common.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 1);
-				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-				{
-					await wallet.StartAsync(cts.Token); // Initialize wallet service.
-				}
 
-				var coin = wallet.Coins.First();
-				Assert.Single(wallet.Coins);
+				var coin = Assert.Single(wallet.Coins);
 				Assert.True(coin.Confirmed);
 				Assert.False(coin.IsReplaceable);
 				Assert.Equal(tx2Id, coin.TransactionId);


### PR DESCRIPTION
For some reason we start the wallet twice which makes no sense and throws an exception. We were able to get away with this bug before but now with @molnard we're throwing exceptions if the things aren't called in the right time.