### PR TITLE
Specify Tor data dir arg to be our own directory

### DIFF
--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -77,6 +77,7 @@ namespace WalletWasabi.TorSocks5
 						}
 
 						var torDir = Path.Combine(dataDir, "tor");
+						var torDataDir = Path.Combine(dataDir, "tordata");
 						var torPath = "";
 						var fullBaseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
 						if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -116,7 +117,7 @@ namespace WalletWasabi.TorSocks5
 							Logger.LogInfo($"Tor instance found at {torPath}.");
 						}
 
-						string torArguments = $"--SOCKSPort {TorSocks5EndPoint}";
+						string torArguments = $"--SOCKSPort {TorSocks5EndPoint} --DataDirectory {torDataDir}";
 						if (!string.IsNullOrEmpty(LogFile))
 						{
 							IoHelpers.EnsureContainingDirectoryExists(LogFile);


### PR DESCRIPTION
@MaxHillebrand noted that "30 users have reported issues with Tor from the last release, when we updated Tor." He also reported that deleting the tor data dir fixes this issue.

This PR asks Tor to use the `tordata` directory under Wasabi's datadir, so it fixes the issue.