### PR TITLE
Decouple P2P stuff from Global

### DIFF
--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -101,7 +101,7 @@ namespace WalletWasabi.Gui.Rpc
 				filtersLeft = sync.BitcoinStore.SmartHeaderChain.HashesLeft,
 				network = sync.Network.Name,
 				exchangeRate = sync.UsdExchangeRate,
-				peers = Global.Nodes.ConnectedNodes.Select(x => new
+				peers = Global.P2pClient.Nodes.ConnectedNodes.Select(x => new
 				{
 					isConnected = x.IsConnected,
 					lastSeen = x.LastSeen,

--- a/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
@@ -142,7 +142,7 @@ namespace WalletWasabi.Gui.ViewModels
 		{
 			var global = Locator.Current.GetService<Global>();
 
-			StatusBar.Initialize(global.Nodes.ConnectedNodes, global.Synchronizer);
+			StatusBar.Initialize(global.P2pClient.Nodes.ConnectedNodes, global.Synchronizer);
 
 			if (global.Network != Network.Main)
 			{

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -61,7 +61,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			KeyManager keyManager = KeyManager.CreateNew(out _, "password");
 			WasabiSynchronizer syncer = new WasabiSynchronizer(network, bitcoinStore, new Uri("http://localhost:12345"), Global.Instance.TorSocks5Endpoint);
 
-			using var client = new P2pClient(dataDir, network, useTor: true, new IPEndPoint(IPAddress.Loopback, 1234), Global.Instance.TorSocks5Endpoint, bitcoinStore);
+			using var client = new P2pClient(dataDir, network, useTor: false, new IPEndPoint(IPAddress.Loopback, 1234), Global.Instance.TorSocks5Endpoint, bitcoinStore);
 			using var startTimeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(7));
 			await client.StartAsync(startTimeoutSource.Token);
 

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -35,6 +35,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData("main")]
 		public async Task TestServicesAsync(string networkString)
 		{
+			await RuntimeParams.LoadAsync();
+
 			var network = Network.GetNetwork(networkString);
 			var blocksToDownload = new List<uint256>();
 			if (network == Network.Main)

--- a/WalletWasabi.Tests/RegressionTests/Common.cs
+++ b/WalletWasabi.Tests/RegressionTests/Common.cs
@@ -85,9 +85,9 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			var network = global.RpcClient.Network;
 			var serviceConfiguration = new ServiceConfiguration(2, 2, 21, 50, regTestFixture.BackendRegTestNode.P2pEndPoint, Money.Coins(Constants.DefaultDustThreshold));
-			var bitcoinStore = new BitcoinStore();
 			var dir = GetWorkDir(callerFilePath, callerMemberName);
-			await bitcoinStore.InitializeAsync(dir, network);
+			var bitcoinStore = new BitcoinStore(dir, network);
+			await bitcoinStore.InitializeAsync();
 			return ("password", global.RpcClient, network, global.Coordinator, serviceConfiguration, bitcoinStore, global);
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -30,9 +30,9 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			{
 				var network = coreNode.Network;
 				var rpc = coreNode.RpcClient;
-				var bitcoinStore = new BitcoinStore();
 				var dir = Path.Combine(Global.Instance.DataDir, EnvironmentHelpers.GetCallerFileName(), EnvironmentHelpers.GetMethodName());
-				await bitcoinStore.InitializeAsync(dir, network);
+				var bitcoinStore = new BitcoinStore(dir, network);
+				await bitcoinStore.InitializeAsync();
 
 				await rpc.GenerateAsync(101);
 

--- a/WalletWasabi/Helpers/NBitcoinHelpers.cs
+++ b/WalletWasabi/Helpers/NBitcoinHelpers.cs
@@ -139,15 +139,15 @@ namespace WalletWasabi.Helpers
 			return k;
 		}
 
-		public static async Task<AddressManager> LoadAddressManagerFromPeerFileAsync(string filePath, Network expectedNetwork = null)
+		public static AddressManager LoadAddressManagerFromPeerFile(string filePath, Network expectedNetwork = null)
 		{
 			byte[] data, hash;
 			using (var fs = File.Open(filePath, FileMode.Open, FileAccess.Read))
 			{
 				data = new byte[fs.Length - 32];
-				await fs.ReadAsync(data, 0, data.Length);
+				fs.Read(data, 0, data.Length);
 				hash = new byte[32];
-				await fs.ReadAsync(hash, 0, 32);
+				fs.Read(hash, 0, 32);
 			}
 			var actual = Hashes.Hash256(data);
 			var expected = new uint256(hash);

--- a/WalletWasabi/P2p/P2pClient.cs
+++ b/WalletWasabi/P2p/P2pClient.cs
@@ -1,0 +1,224 @@
+using Microsoft.Extensions.Hosting;
+using NBitcoin;
+using NBitcoin.Protocol;
+using NBitcoin.Protocol.Behaviors;
+using NBitcoin.Protocol.Connectors;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+using WalletWasabi.Stores;
+
+namespace WalletWasabi.P2p
+{
+	public class P2pClient : BackgroundService
+	{
+		public P2pClient(string dataDir, Network network, bool useTor, EndPoint bitcoinCoreEndpoint, EndPoint torSocks5EndPoint, BitcoinStore bitcoinStore)
+		{
+			using (BenchmarkLogger.Measure())
+			{
+				DataDir = Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
+				Network = Guard.NotNull(nameof(network), network);
+				UseTor = useTor;
+				BitcoinCoreEndpoint = Guard.NotNull(nameof(bitcoinCoreEndpoint), bitcoinCoreEndpoint);
+				TorSocks5EndPoint = Guard.NotNull(nameof(torSocks5EndPoint), torSocks5EndPoint);
+				BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+
+				var needsToDiscoverPeers = true;
+				if (Network == Network.RegTest)
+				{
+					AddressManager = new AddressManager();
+					Logger.LogInfo($"Fake {nameof(AddressManager)} is initialized on the {Network.RegTest}.");
+				}
+				else
+				{
+					try
+					{
+						AddressManager = NBitcoinHelpers.LoadAddressManagerFromPeerFile(AddressManagerFilePath);
+
+						// Most of the times we do not need to discover new peers. Instead, we can connect to
+						// some of those that we already discovered in the past. In this case we assume that
+						// discovering new peers could be necessary if our address manager has less
+						// than 500 addresses. 500 addresses could be okay because previously we tried with
+						// 200 and only one user reported he/she was not able to connect (there could be many others,
+						// of course).
+						// On the other side, increasing this number forces users that do not need to discover more peers
+						// to spend resources (CPU/bandwidth) to discover new peers.
+						needsToDiscoverPeers = UseTor || AddressManager.Count < 500;
+						Logger.LogInfo($"Loaded {nameof(AddressManager)} from `{AddressManagerFilePath}`.");
+					}
+					catch (DirectoryNotFoundException ex)
+					{
+						Logger.LogInfo($"{nameof(AddressManager)} did not exist at `{AddressManagerFilePath}`. Initializing new one.");
+						Logger.LogTrace(ex);
+						AddressManager = new AddressManager();
+					}
+					catch (FileNotFoundException ex)
+					{
+						Logger.LogInfo($"{nameof(AddressManager)} did not exist at `{AddressManagerFilePath}`. Initializing new one.");
+						Logger.LogTrace(ex);
+						AddressManager = new AddressManager();
+					}
+					catch (OverflowException ex)
+					{
+						// https://github.com/zkSNACKs/WalletWasabi/issues/712
+						Logger.LogInfo($"{nameof(AddressManager)} has thrown `{nameof(OverflowException)}`. Attempting to autocorrect.");
+						File.Delete(AddressManagerFilePath);
+						Logger.LogTrace(ex);
+						AddressManager = new AddressManager();
+						Logger.LogInfo($"{nameof(AddressManager)} autocorrection is successful.");
+					}
+					catch (FormatException ex)
+					{
+						// https://github.com/zkSNACKs/WalletWasabi/issues/880
+						Logger.LogInfo($"{nameof(AddressManager)} has thrown `{nameof(FormatException)}`. Attempting to autocorrect.");
+						File.Delete(AddressManagerFilePath);
+						Logger.LogTrace(ex);
+						AddressManager = new AddressManager();
+						Logger.LogInfo($"{nameof(AddressManager)} autocorrection is successful.");
+					}
+				}
+
+				var addressManagerBehavior = new AddressManagerBehavior(AddressManager)
+				{
+					Mode = needsToDiscoverPeers ? AddressManagerBehaviorMode.Discover : AddressManagerBehaviorMode.None
+				};
+
+				ConnectionParameters = new NodeConnectionParameters { UserAgent = $"/Satoshi:{Constants.BitcoinCoreVersion}/" };
+				ConnectionParameters.TemplateBehaviors.Add(addressManagerBehavior);
+				ConnectionParameters.TemplateBehaviors.Add(BitcoinStore.CreateUntrustedP2pBehavior());
+			}
+		}
+
+		public string DataDir { get; }
+		public Network Network { get; }
+		public bool UseTor { get; }
+		public AddressManager AddressManager { get; }
+		public string AddressManagerFolderPath => Path.Combine(DataDir, "AddressManager");
+		public string AddressManagerFilePath => Path.Combine(AddressManagerFolderPath, $"AddressManager{Network}.dat");
+
+		public EndPoint BitcoinCoreEndpoint { get; }
+		public NodesGroup Nodes { get; private set; }
+		public Node RegTestMempoolServingNode { get; private set; }
+		public NodeConnectionParameters ConnectionParameters { get; }
+		public EndPoint TorSocks5EndPoint { get; }
+		public BitcoinStore BitcoinStore { get; }
+
+		public override async Task StartAsync(CancellationToken cancellationToken)
+		{
+			if (Network == Network.RegTest)
+			{
+				Nodes = new NodesGroup(Network, requirements: Constants.NodeRequirements);
+				try
+				{
+					Node node = await Node.ConnectAsync(Network.RegTest, BitcoinCoreEndpoint).ConfigureAwait(false);
+					cancellationToken.ThrowIfCancellationRequested();
+
+					Nodes.ConnectedNodes.Add(node);
+
+					RegTestMempoolServingNode = await Node.ConnectAsync(Network.RegTest, BitcoinCoreEndpoint).ConfigureAwait(false);
+					cancellationToken.ThrowIfCancellationRequested();
+
+					RegTestMempoolServingNode.Behaviors.Add(BitcoinStore.CreateUntrustedP2pBehavior());
+				}
+				catch (SocketException ex)
+				{
+					Logger.LogError(ex);
+				}
+			}
+			else
+			{
+				if (UseTor)
+				{
+					// onlyForOnionHosts: false - Connect to clearnet IPs through Tor, too.
+					ConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(TorSocks5EndPoint, onlyForOnionHosts: false, networkCredential: null, streamIsolation: true));
+					// allowOnlyTorEndpoints: true - Connect only to onions and do not connect to clearnet IPs at all.
+					// This of course makes the first setting unnecessary, but it's better if that's around, in case someone wants to tinker here.
+					ConnectionParameters.EndpointConnector = new DefaultEndpointConnector(allowOnlyTorEndpoints: Network == Network.Main);
+
+					if (Network == Network.RegTest)
+					{
+						return;
+					}
+
+					// curl -s https://bitnodes.21.co/api/v1/snapshots/latest/ | egrep -o '[a-z0-9]{16}\.onion:?[0-9]*' | sort -ru
+					// Then filtered to include only /Satoshi:0.17.x
+					var fullBaseDirectory = EnvironmentHelpers.GetFullBaseDirectory();
+
+					var onions = await File.ReadAllLinesAsync(Path.Combine(fullBaseDirectory, "OnionSeeds", $"{Network}OnionSeeds.txt"));
+					cancellationToken.ThrowIfCancellationRequested();
+
+					onions.Shuffle();
+					foreach (var onion in onions.Take(60))
+					{
+						if (EndPointParser.TryParse(onion, Network.DefaultPort, out var endpoint))
+						{
+							await AddressManager.AddAsync(endpoint);
+							cancellationToken.ThrowIfCancellationRequested();
+						}
+					}
+				}
+				Nodes = new NodesGroup(Network, ConnectionParameters, requirements: Constants.NodeRequirements);
+
+				RegTestMempoolServingNode = null;
+			}
+
+			Nodes.Connect();
+			Logger.LogInfo("Start connecting to nodes...");
+
+			var regTestMempoolServingNode = RegTestMempoolServingNode;
+			if (regTestMempoolServingNode is { })
+			{
+				regTestMempoolServingNode.VersionHandshake();
+				Logger.LogInfo("Start connecting to mempool serving regtest node...");
+			}
+
+			await base.StartAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+		public override async Task StopAsync(CancellationToken cancellationToken)
+		{
+			await base.StopAsync(cancellationToken).ConfigureAwait(false);
+
+			var addressManagerFilePath = AddressManagerFilePath;
+			if (addressManagerFilePath is { })
+			{
+				IoHelpers.EnsureContainingDirectoryExists(addressManagerFilePath);
+				var addressManager = AddressManager;
+				if (addressManager is { })
+				{
+					addressManager.SavePeerFile(AddressManagerFilePath, Network);
+					Logger.LogInfo($"{nameof(AddressManager)} is saved to `{AddressManagerFilePath}`.");
+				}
+			}
+
+			var nodes = Nodes;
+			if (nodes is { })
+			{
+				nodes.Disconnect();
+				while (nodes.ConnectedNodes.Any(x => x.IsConnected))
+				{
+					await Task.Delay(50);
+				}
+				nodes.Dispose();
+				Logger.LogInfo($"{nameof(Nodes)} are disposed.");
+			}
+
+			var regTestMempoolServingNode = RegTestMempoolServingNode;
+			if (regTestMempoolServingNode is { })
+			{
+				regTestMempoolServingNode.Disconnect();
+				Logger.LogInfo($"{nameof(RegTestMempoolServingNode)} is disposed.");
+			}
+		}
+	}
+}

--- a/WalletWasabi/P2p/P2pClient.cs
+++ b/WalletWasabi/P2p/P2pClient.cs
@@ -135,18 +135,13 @@ namespace WalletWasabi.P2p
 			}
 			else
 			{
-				if (UseTor)
+				if (UseTor && Network != Network.RegTest)
 				{
 					// onlyForOnionHosts: false - Connect to clearnet IPs through Tor, too.
 					ConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(TorSocks5EndPoint, onlyForOnionHosts: false, networkCredential: null, streamIsolation: true));
 					// allowOnlyTorEndpoints: true - Connect only to onions and do not connect to clearnet IPs at all.
 					// This of course makes the first setting unnecessary, but it's better if that's around, in case someone wants to tinker here.
 					ConnectionParameters.EndpointConnector = new DefaultEndpointConnector(allowOnlyTorEndpoints: Network == Network.Main);
-
-					if (Network == Network.RegTest)
-					{
-						return;
-					}
 
 					// curl -s https://bitnodes.21.co/api/v1/snapshots/latest/ | egrep -o '[a-z0-9]{16}\.onion:?[0-9]*' | sort -ru
 					// Then filtered to include only /Satoshi:0.17.x

--- a/WalletWasabi/P2p/P2pClient.cs
+++ b/WalletWasabi/P2p/P2pClient.cs
@@ -135,7 +135,7 @@ namespace WalletWasabi.P2p
 			}
 			else
 			{
-				if (UseTor && Network != Network.RegTest)
+				if (UseTor)
 				{
 					// onlyForOnionHosts: false - Connect to clearnet IPs through Tor, too.
 					ConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(TorSocks5EndPoint, onlyForOnionHosts: false, networkCredential: null, streamIsolation: true));

--- a/WalletWasabi/Stores/BitcoinStore.cs
+++ b/WalletWasabi/Stores/BitcoinStore.cs
@@ -19,14 +19,31 @@ namespace WalletWasabi.Stores
 	/// </summary>
 	public class BitcoinStore
 	{
-		public bool IsInitialized { get; private set; }
-		private string WorkFolderPath { get; set; }
-		public Network Network { get; private set; }
+		public BitcoinStore(string workFolderPath, Network network)
+		{
+			WorkFolderPath = Guard.NotNullOrEmptyOrWhitespace(nameof(workFolderPath), workFolderPath, trim: true);
+			IoHelpers.EnsureDirectoryExists(WorkFolderPath);
 
-		public IndexStore IndexStore { get; private set; }
-		public AllTransactionStore TransactionStore { get; private set; }
-		public SmartHeaderChain SmartHeaderChain { get; private set; }
-		public MempoolService MempoolService { get; private set; }
+			Network = Guard.NotNull(nameof(network), network);
+
+			IndexStore = new IndexStore();
+			TransactionStore = new AllTransactionStore();
+			NetworkWorkFolderPath = Path.Combine(WorkFolderPath, Network.ToString());
+			IndexStoreFolderPath = Path.Combine(NetworkWorkFolderPath, "IndexStore");
+			SmartHeaderChain = new SmartHeaderChain();
+			MempoolService = new MempoolService();
+		}
+
+		public bool IsInitialized { get; private set; }
+		private string WorkFolderPath { get; }
+		public Network Network { get; }
+
+		public IndexStore IndexStore { get; }
+		public AllTransactionStore TransactionStore { get; }
+		public string NetworkWorkFolderPath { get; }
+		public string IndexStoreFolderPath { get; }
+		public SmartHeaderChain SmartHeaderChain { get; }
+		public MempoolService MempoolService { get; }
 
 		/// <summary>
 		/// This should not be a property, but a creator function, because it'll be cloned left and right by NBitcoin later.
@@ -34,26 +51,14 @@ namespace WalletWasabi.Stores
 		/// </summary>
 		public UntrustedP2pBehavior CreateUntrustedP2pBehavior() => new UntrustedP2pBehavior(MempoolService);
 
-		public async Task InitializeAsync(string workFolderPath, Network network)
+		public async Task InitializeAsync()
 		{
 			using (BenchmarkLogger.Measure())
 			{
-				WorkFolderPath = Guard.NotNullOrEmptyOrWhitespace(nameof(workFolderPath), workFolderPath, trim: true);
-				IoHelpers.EnsureDirectoryExists(WorkFolderPath);
-
-				Network = Guard.NotNull(nameof(network), network);
-
-				IndexStore = new IndexStore();
-				TransactionStore = new AllTransactionStore();
-				var networkWorkFolderPath = Path.Combine(WorkFolderPath, Network.ToString());
-				var indexStoreFolderPath = Path.Combine(networkWorkFolderPath, "IndexStore");
-				SmartHeaderChain = new SmartHeaderChain();
-				MempoolService = new MempoolService();
-
 				var initTasks = new[]
 				{
-					IndexStore.InitializeAsync(indexStoreFolderPath, Network, SmartHeaderChain),
-					TransactionStore.InitializeAsync(networkWorkFolderPath, Network)
+					IndexStore.InitializeAsync(IndexStoreFolderPath, Network, SmartHeaderChain),
+					TransactionStore.InitializeAsync(NetworkWorkFolderPath, Network)
 				};
 
 				await Task.WhenAll(initTasks).ConfigureAwait(false);


### PR DESCRIPTION
It takes out all the P2P stuff from Global and fixes the P2P test that was previously uncommented on the testnet.  

In more detail, I created a class: `P2pClient` which encapsulates the `AddressManager` and `NodesGroup` services. This class now is managed by the `HostedServices` itself.

Closes https://github.com/zkSNACKs/WalletWasabi/pull/1466
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/1775

- [x] P2P tests pass on both networks.
- [x] All tests pass.
- [ ] P2P tests pass with removed data folder.
- [ ] Do Manual Testing on mainnet with Core turned on.
- [ ] Do Manual Testing mainnet with Core turned off.
- [ ] Do Manual Testing on testnet with Core turned on.
- [ ] Do Manual Testing testnet with Core turned off.
- [ ] Do Manual Testing on regtest with Core turned on.
- [ ] Do Manual Testing regtest with Core turned off.
- [ ] Do Manual Testing on mainnet with Core turned on and with removed data folder.
- [ ] Do Manual Testing mainnet with Core turned off and with removed data folder.

### Manual Testing

Manual testing is intended to test all the touched services: mempool, tx send, block download.

0. Start Wasabi
1. Create new wallet
2. Stop Wasabi
3. Change block height of new wallet to 0
4. Start Wasabi
5. Load Wallet
6. Check if (false positive) blocks are downloaded
7. Send money to yourself
8. Make sure unconfirmed tx appears.
9. Send money out.