### PR TITLE
Align WalletExplorer's Header text & Icons

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -24,6 +24,9 @@
       <Setter Property="Spacing" Value="6" />
       <Setter Property="Height" Value="20" />
     </Style>
+    <Style Selector="StackPanel.TreeViewRoot > :is(Control)">
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
   </UserControl.Styles>
   <DockPanel LastChildFill="True">
     <Panel DockPanel.Dock="Top" HorizontalAlignment="Stretch" Background="{DynamicResource ThemeControlLowBrush}">
@@ -48,29 +51,25 @@
         </TreeView.Styles>
         <TreeView.DataTemplates>
           <TreeDataTemplate DataType="ViewModels:ClosedWalletViewModel" ItemsSource="{Binding Actions}">
-            <Panel Height="20" Background="Transparent">
+            <StackPanel Classes="TreeViewRoot">
               <i:Interaction.Behaviors>
                 <behaviors:CommandOnDoubleClickBehavior Command="{Binding OpenWalletCommand}" />
               </i:Interaction.Behaviors>
-              <Panel.ContextMenu>
+              <StackPanel.ContextMenu>
                 <ContextMenu>
                   <MenuItem Header="Open Wallet" Command="{Binding OpenWalletCommand}" />
                 </ContextMenu>
-              </Panel.ContextMenu>
-              <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-                <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_ClosedWallet}" />
-                <TextBlock Text="{Binding Title}" />
-                <DrawingPresenter Name="PART_Spinner" Width="16" Height="16" IsVisible="{Binding IsBusy}" Drawing="{DynamicResource WalletExplorer_Spinner}" />
-              </StackPanel>
-            </Panel>
+              </StackPanel.ContextMenu>
+              <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_ClosedWallet}" />
+              <TextBlock Text="{Binding Title}" />
+              <DrawingPresenter Name="PART_Spinner" Width="16" Height="16" IsVisible="{Binding IsBusy}" Drawing="{DynamicResource WalletExplorer_Spinner}" />
+            </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletViewModel" ItemsSource="{Binding Actions}">
-            <Panel Height="20" Background="Transparent">
-              <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
-                <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_OpenWallet}" />
-                <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
-              </StackPanel>
-            </Panel>
+            <StackPanel Classes="TreeViewRoot">
+              <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_OpenWallet}" />
+              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+            </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:SendTabViewModel">
             <StackPanel Classes="TreeViewRoot">

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -5,7 +5,7 @@
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              x:Class="WalletWasabi.Gui.Controls.WalletExplorer.WalletExplorerView">
-<UserControl.Resources>
+  <UserControl.Resources>
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
   </UserControl.Resources>
   <UserControl.Styles>
@@ -47,29 +47,29 @@
         </TreeView.Styles>
         <TreeView.DataTemplates>
           <TreeDataTemplate DataType="ViewModels:ClosedWalletViewModel" ItemsSource="{Binding Actions}">
-            <StackPanel Classes="TreeViewRoot">
+            <Panel Height="20" Background="Transparent">
               <i:Interaction.Behaviors>
                 <behaviors:CommandOnDoubleClickBehavior Command="{Binding OpenWalletCommand}" />
               </i:Interaction.Behaviors>
-              <StackPanel.ContextMenu>
+              <Panel.ContextMenu>
                 <ContextMenu>
                   <MenuItem Header="Open Wallet" Command="{Binding OpenWalletCommand}" />
                 </ContextMenu>
-              </StackPanel.ContextMenu>
-              <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_ClosedWallet}" />
-              <Panel>
-                <TextBlock Text="{Binding Title}" Height="19" VerticalAlignment="Center" />
-              </Panel>
-              <DrawingPresenter Name="PART_Spinner" Width="16" Height="16" IsVisible="{Binding IsBusy}" Drawing="{DynamicResource WalletExplorer_Spinner}" />
-            </StackPanel>
+              </Panel.ContextMenu>
+              <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_ClosedWallet}" />
+                <TextBlock Text="{Binding Title}" />
+                <DrawingPresenter Name="PART_Spinner" Width="16" Height="16" IsVisible="{Binding IsBusy}" Drawing="{DynamicResource WalletExplorer_Spinner}" />
+              </StackPanel>
+            </Panel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletViewModel" ItemsSource="{Binding Actions}">
-            <StackPanel Classes="TreeViewRoot">
-              <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_OpenWallet}" />
-              <Panel>
-                <TextBlock Text="{Binding Title}" Height="19" VerticalAlignment="Center" />
-              </Panel>
-            </StackPanel>
+            <Panel Height="20" Background="Transparent">
+              <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_OpenWallet}" />
+                <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              </StackPanel>
+            </Panel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:SendTabViewModel">
             <StackPanel Classes="TreeViewRoot">
@@ -90,7 +90,7 @@
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:CoinJoinTabViewModel">
-            <StackPanel >
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_CoinJoin}" />
               <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
             </StackPanel>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -5,7 +5,7 @@
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui"
              xmlns:converters="clr-namespace:WalletWasabi.Gui.Converters;assembly=WalletWasabi.Gui"
              x:Class="WalletWasabi.Gui.Controls.WalletExplorer.WalletExplorerView">
-  <UserControl.Resources>
+<UserControl.Resources>
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
   </UserControl.Resources>
   <UserControl.Styles>
@@ -13,10 +13,15 @@
       <Style.Animations>
         <Animation Duration="0:0:2.5" IterationCount="Infinite">
           <KeyFrame Cue="100%">
-            <Setter Property="RotateTransform.Angle" Value="360" />
           </KeyFrame>
         </Animation>
       </Style.Animations>
+    </Style>
+    <Style Selector="StackPanel.TreeViewRoot">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Orientation" Value="Horizontal" />
+      <Setter Property="Spacing" Value="6" />
+      <Setter Property="Height" Value="20" />
     </Style>
   </UserControl.Styles>
   <DockPanel LastChildFill="True">
@@ -42,7 +47,7 @@
         </TreeView.Styles>
         <TreeView.DataTemplates>
           <TreeDataTemplate DataType="ViewModels:ClosedWalletViewModel" ItemsSource="{Binding Actions}">
-            <StackPanel Orientation="Horizontal" Spacing="6" Background="Transparent">
+            <StackPanel Classes="TreeViewRoot">
               <i:Interaction.Behaviors>
                 <behaviors:CommandOnDoubleClickBehavior Command="{Binding OpenWalletCommand}" />
               </i:Interaction.Behaviors>
@@ -52,54 +57,58 @@
                 </ContextMenu>
               </StackPanel.ContextMenu>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_ClosedWallet}" />
-              <TextBlock Text="{Binding Title}" Height="19" VerticalAlignment="Center" />
+              <Panel>
+                <TextBlock Text="{Binding Title}" Height="19" VerticalAlignment="Center" />
+              </Panel>
               <DrawingPresenter Name="PART_Spinner" Width="16" Height="16" IsVisible="{Binding IsBusy}" Drawing="{DynamicResource WalletExplorer_Spinner}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletViewModel" ItemsSource="{Binding Actions}">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_OpenWallet}" />
-              <TextBlock Text="{Binding Title}" Height="19" VerticalAlignment="Center" />
+              <Panel>
+                <TextBlock Text="{Binding Title}" Height="19" VerticalAlignment="Center" />
+              </Panel>
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:SendTabViewModel">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Send}" />
               <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:BuildTabViewModel">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Builder}" />
               <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:ReceiveTabViewModel">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Receive}" />
               <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:CoinJoinTabViewModel">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel >
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_CoinJoin}" />
               <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:HistoryTabViewModel">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_History}" />
               <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletInfoViewModel">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Info}" />
               <TextBlock Text="Wallet Info" VerticalAlignment="Center" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletAdvancedViewModel" ItemsSource="{Binding Items}">
-            <StackPanel Orientation="Horizontal" Spacing="6">
+            <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Advanced}" />
               <TextBlock Text="Advanced" VerticalAlignment="Center" />
             </StackPanel>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -13,6 +13,7 @@
       <Style.Animations>
         <Animation Duration="0:0:2.5" IterationCount="Infinite">
           <KeyFrame Cue="100%">
+            <Setter Property="RotateTransform.Angle" Value="360" />
           </KeyFrame>
         </Animation>
       </Style.Animations>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -68,49 +68,49 @@
           <TreeDataTemplate DataType="ViewModels:WalletViewModel" ItemsSource="{Binding Actions}">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_OpenWallet}" />
-              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:SendTabViewModel">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Send}" />
-              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:BuildTabViewModel">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Builder}" />
-              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:ReceiveTabViewModel">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Receive}" />
-              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:CoinJoinTabViewModel">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_CoinJoin}" />
-              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:HistoryTabViewModel">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_History}" />
-              <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletInfoViewModel">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Info}" />
-              <TextBlock Text="Wallet Info" VerticalAlignment="Center" />
+              <TextBlock Text="Wallet Info" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletAdvancedViewModel" ItemsSource="{Binding Items}">
             <StackPanel Classes="TreeViewRoot">
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Advanced}" />
-              <TextBlock Text="Advanced" VerticalAlignment="Center" />
+              <TextBlock Text="Advanced" />
             </StackPanel>
           </TreeDataTemplate>
         </TreeView.DataTemplates>


### PR DESCRIPTION
Builds upon #3345 and #3387; This PR aligns the elements of `TreeViewItem`s in the sidebar. It also adjusts the height to be uniform to all the sidebar's items.

cc: @molnard @danwalmsley 