### PR TITLE
Fix double click outside text (Load Wallet tab)

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletView.xaml
@@ -43,7 +43,7 @@
           <controls:ExtendedListBox Items="{Binding Wallets}" SelectedItem="{Binding SelectedWallet, Mode=TwoWay}">
             <controls:ExtendedListBox.ItemTemplate>
               <DataTemplate>
-                <TextBlock Text="{Binding WalletName}">
+                <TextBlock Text="{Binding WalletName}" Background="Transparent">
                   <i:Interaction.Behaviors>
                     <behaviors:CommandOnDoubleClickBehavior Command="{Binding RelativeSource={RelativeSource AncestorType=ListBox}, Path=DataContext.LoadCommand}" />
                   </i:Interaction.Behaviors>


### PR DESCRIPTION
I don't know if this is the best way to do this, but this would allow the user to double click an item in the Load Wallet tab outside the text.