### PR TITLE
Fix Hardware wallet loading

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using DynamicData;
+using DynamicData.Binding;
 using NBitcoin;
 using Newtonsoft.Json.Linq;
 using ReactiveUI;
@@ -30,9 +32,6 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 	{
 		private ObservableCollection<HardwareWalletViewModel> _wallets;
 		private HardwareWalletViewModel _selectedWallet;
-		private bool _isWalletSelected;
-		private bool _isWalletOpened;
-		private bool _canLoadWallet;
 		private bool _isBusy;
 		private bool _isHardwareBusy;
 		private string _loadButtonText;
@@ -47,15 +46,30 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 			IsHwWalletSearchTextVisible = false;
 
 			this.WhenAnyValue(x => x.SelectedWallet)
-				.Subscribe(_ => TrySetWalletStates());
+				.Where(x => x is null)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ =>
+				{
+					SelectedWallet = Wallets.FirstOrDefault();
+					SetLoadButtonText();
+				});
 
-			this.WhenAnyValue(x => x.IsWalletOpened)
-				.Subscribe(_ => TrySetWalletStates());
+			Wallets
+				.ToObservableChangeSet()
+				.ToCollection()
+				.Where(items => items.Any() && SelectedWallet is null)
+				.Select(items => items.First())
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(x => SelectedWallet = x);
 
-			this.WhenAnyValue(x => x.IsBusy)
-				.Subscribe(_ => TrySetWalletStates());
+			this.WhenAnyValue(x => x.IsBusy, x => x.IsHardwareBusy)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ =>
+				{
+					SetLoadButtonText();
+				});
 
-			LoadCommand = ReactiveCommand.CreateFromTask(LoadWalletAsync, this.WhenAnyValue(x => x.CanLoadWallet));
+			LoadCommand = ReactiveCommand.CreateFromTask(LoadWalletAsync, this.WhenAnyValue(x => x.SelectedWallet, x => x.IsBusy).Select(x => x.Item1 is { } && !x.Item2));
 			ImportColdcardCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
 				var ofd = new OpenFileDialog
@@ -110,8 +124,9 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 					Logger.LogInfo("Creating a new wallet file.");
 					var walletName = WalletManager.WalletDirectories.GetNextWalletName("Coldcard");
 					var walletFullPath = WalletManager.WalletDirectories.GetWalletFilePaths(walletName).walletFilePath;
-					WalletManager.AddWallet(KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, walletFullPath));
-					owner.SelectLoadWallet();
+					var keymanager = KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, walletFullPath);
+					WalletManager.AddWallet(keymanager);
+					owner.SelectLoadWallet(keymanager);
 				}
 			});
 			EnumerateHardwareWalletsCommand = ReactiveCommand.CreateFromTask(async () => await EnumerateIfHardwareWalletsAsync());
@@ -148,28 +163,10 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 			set => this.RaiseAndSetIfChanged(ref _selectedWallet, value);
 		}
 
-		public bool IsWalletSelected
-		{
-			get => _isWalletSelected;
-			set => this.RaiseAndSetIfChanged(ref _isWalletSelected, value);
-		}
-
-		public bool IsWalletOpened
-		{
-			get => _isWalletOpened;
-			set => this.RaiseAndSetIfChanged(ref _isWalletOpened, value);
-		}
-
 		public string LoadButtonText
 		{
 			get => _loadButtonText;
 			set => this.RaiseAndSetIfChanged(ref _loadButtonText, value);
-		}
-
-		public bool CanLoadWallet
-		{
-			get => _canLoadWallet;
-			set => this.RaiseAndSetIfChanged(ref _canLoadWallet, value);
 		}
 
 		public bool IsBusy
@@ -323,14 +320,14 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 					MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusType.AcquiringXpubFromHardwareWallet);
 				}
 
-				Logger.LogInfo("Hardware wallet was not used previously on this computer. Creating a new wallet file.");
-
 				if (TryFindWalletByExtPubKey(extPubKey, out string wn))
 				{
-					walletName = wn;
+					walletName = wn.TrimEnd(".json", StringComparison.OrdinalIgnoreCase);
 				}
 				else
 				{
+					Logger.LogInfo("Hardware wallet was not used previously on this computer. Creating a new wallet file.");
+
 					var prefix = selectedWallet.HardwareWalletInfo is null ? "HardwareWallet" : selectedWallet.HardwareWalletInfo.Model.ToString();
 
 					walletName = WalletManager.WalletDirectories.GetNextWalletName(prefix);
@@ -370,6 +367,10 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 
 				return null;
 			}
+			finally
+			{
+				SetLoadButtonText();
+			}
 		}
 
 		public async Task LoadWalletAsync()
@@ -406,43 +407,6 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 			}
 		}
 
-		private bool TrySetWalletStates()
-		{
-			try
-			{
-				if (SelectedWallet is null)
-				{
-					SelectedWallet = Wallets.FirstOrDefault();
-				}
-
-				IsWalletSelected = SelectedWallet is { };
-
-				if (WalletManager.AnyWallet())
-				{
-					IsWalletOpened = true;
-					CanLoadWallet = false;
-				}
-				else
-				{
-					IsWalletOpened = false;
-
-					// If not busy loading.
-					// And wallet is selected.
-					// And no wallet is opened.
-					CanLoadWallet = !IsBusy && IsWalletSelected;
-				}
-
-				SetLoadButtonText();
-				return true;
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning(ex);
-			}
-
-			return false;
-		}
-
 		protected async Task EnumerateIfHardwareWalletsAsync()
 		{
 			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -458,7 +422,6 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 					var walletEntry = new HardwareWalletViewModel(dev);
 					Wallets.Add(walletEntry);
 				}
-				TrySetWalletStates();
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
@@ -64,10 +64,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 
 			this.WhenAnyValue(x => x.IsBusy, x => x.IsHardwareBusy)
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(_ =>
-				{
-					SetLoadButtonText();
-				});
+				.Subscribe(_ => SetLoadButtonText());
 
 			LoadCommand = ReactiveCommand.CreateFromTask(LoadWalletAsync, this.WhenAnyValue(x => x.SelectedWallet, x => x.IsBusy).Select(x => x.Item1 is { } && !x.Item2));
 			ImportColdcardCommand = ReactiveCommand.CreateFromTask(async () =>

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
@@ -218,6 +218,18 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.LoadWallets
 
 		public void OpenWalletsFolder() => IoHelpers.OpenFolderInFileExplorer(Global.WalletManager.WalletDirectories.WalletsDir);
 
+		public void SelectWallet(string walletName)
+		{
+			var keyman = Wallets.FirstOrDefault(w => w.Wallet.WalletName == walletName)?.Wallet.KeyManager;
+			SelectWallet(keyman);
+		}
+
+		public void SelectWallet(KeyManager keymanager)
+		{
+			var wallet = Wallets.FirstOrDefault(w => w.Wallet.KeyManager == keymanager);
+			SelectedWallet = wallet;
+		}
+
 		#region IDisposable Support
 
 		private bool _disposedValue = false; // To detect redundant calls

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -87,7 +87,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 
 						NotificationHelpers.Success("Wallet was recovered.");
 
-						owner.SelectLoadWallet();
+						owner.SelectLoadWallet(km);
 					}
 					catch (Exception ex)
 					{

--- a/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Composition;
 using System.Linq;
 using System.Reactive.Disposables;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Gui.Tabs.WalletManager.GenerateWallets;
 using WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets;
 using WalletWasabi.Gui.Tabs.WalletManager.LoadWallets;
@@ -43,6 +44,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 		}
 
 		private LoadWalletViewModel LoadWalletDesktop { get; set; }
+		public LoadWalletViewModel LoadWalletPassword { get; private set; }
 
 		public void SelectGenerateWallet()
 		{
@@ -54,17 +56,16 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			SelectedCategory = Categories.First(x => x is RecoverWalletViewModel);
 		}
 
-		public void SelectLoadWallet()
+		public void SelectLoadWallet(KeyManager keymanager = null)
 		{
-			SelectedCategory = Categories.First(x => x is LoadWalletViewModel model && model.LoadWalletType == LoadWalletType.Desktop);
+			SelectedCategory = LoadWalletDesktop;
+			LoadWalletDesktop.SelectWallet(keymanager);
 		}
 
-		public void SelectTestPassword(string walletName)
+		public void SelectTestPassword(string walletname)
 		{
-			var passwordTestViewModel = Categories.OfType<LoadWalletViewModel>().First(x => x.LoadWalletType == LoadWalletType.Password);
-			SelectedCategory = passwordTestViewModel;
-
-			passwordTestViewModel.SelectedWallet = passwordTestViewModel.Wallets.FirstOrDefault(w => w.WalletName == walletName);
+			SelectedCategory = LoadWalletPassword;
+			LoadWalletPassword.SelectWallet(walletname);
 		}
 
 		public override void OnOpen(CompositeDisposable disposables)
@@ -72,13 +73,14 @@ namespace WalletWasabi.Gui.Tabs.WalletManager
 			base.OnOpen(disposables);
 
 			LoadWalletDesktop = new LoadWalletViewModel(this, LoadWalletType.Desktop);
+			LoadWalletPassword = new LoadWalletViewModel(this, LoadWalletType.Password);
 
 			Categories = new ObservableCollection<CategoryViewModel>
 			{
 				new GenerateWalletViewModel(this),
 				new RecoverWalletViewModel(this),
 				LoadWalletDesktop,
-				new LoadWalletViewModel(this, LoadWalletType.Password),
+				LoadWalletPassword,
 				new ConnectHardwareWalletViewModel(this)
 			};
 


### PR DESCRIPTION
I had a small bug when trying to load my second hardware wallet. The load button was disabled. 

So I refactored it according to https://github.com/zkSNACKs/WalletWasabi/pull/3400

Now it is working fine. 

I was trying to reduce the code duplication among `ConnectHardwareWalletViewModel` and `LoadWalletViewModel` but it ended up changing our current user workflow - so I did not do that. My idea was that instead of loading the wallet you can just add at ConnectHardwareWalletViewModel and then it will change to LoadWalletViewModel and the selection. We can talk about this on dev call. 

Another idea was, which I do not prefer is to call LoadWalletViewModel.LoadWalletAsync() from ConnectHardwareWalletViewModel but it is a hacky solution. ViewModels should not call each others methods directly. 