### PR TITLE
Fixes duplicate key exception

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
@@ -106,18 +106,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					{
 						_walletDictionary[wvm.Wallet].IsExpanded = true;
 					}
+
 					_inSelecting = false;
 				});
 
 			this.WhenAnyValue(x => x.SelectedItem)
 				.OfType<WasabiDocumentTabViewModel>()
-				.Subscribe(x =>
-				{
-					if (!_inSelecting)
-					{
-						shell.AddOrSelectDocument(x);
-					}
-				});
+				.Where(_ => !_inSelecting)
+				.Subscribe(x => shell.AddOrSelectDocument(x));
 		}
 
 		private void ToggleLurkingWifeMode()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
@@ -97,23 +97,31 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.WhenAnyValue(x => x.SelectedDocument)
 				.OfType<ViewModelBase>()
 				.Where(x => x != SelectedItem)
-				.Subscribe(x =>
-				{
-					_inSelecting = true;
-					SelectedItem = x;
-
-					if (x is IWalletViewModel wvm && _walletDictionary.ContainsKey(wvm.Wallet))
-					{
-						_walletDictionary[wvm.Wallet].IsExpanded = true;
-					}
-
-					_inSelecting = false;
-				});
+				.Subscribe(x => OnShellDocumentSelected(x));
 
 			this.WhenAnyValue(x => x.SelectedItem)
 				.OfType<WasabiDocumentTabViewModel>()
 				.Where(_ => !_inSelecting)
 				.Subscribe(x => shell.AddOrSelectDocument(x));
+		}
+
+		private void OnShellDocumentSelected(ViewModelBase document)
+		{
+			_inSelecting = true;
+
+			try
+			{
+				SelectedItem = document;
+
+				if (document is IWalletViewModel wvm && _walletDictionary.ContainsKey(wvm.Wallet))
+				{
+					_walletDictionary[wvm.Wallet].IsExpanded = true;
+				}
+			}
+			finally
+			{
+				_inSelecting = false;
+			}
 		}
 
 		private void ToggleLurkingWifeMode()

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
@@ -64,10 +64,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				});
 
 			Observable
-				.FromEventPattern<Wallet>(WalletManager, nameof(WalletManager.WalletAdded))
-				.ObserveOn(RxApp.MainThreadScheduler)
+				.FromEventPattern<Wallet>(WalletManager, nameof(WalletManager.WalletAdded))				
 				.Select(x => x.EventArgs)
 				.Where(x => x is { })
+				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(wallet =>
 				{
 					WalletViewModelBase vm = (wallet.State <= WalletState.Starting) ?
@@ -97,11 +97,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.WhenAnyValue(x => x.SelectedDocument)
 				.OfType<ViewModelBase>()
 				.Where(x => x != SelectedItem)
+				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x => OnShellDocumentSelected(x));
 
 			this.WhenAnyValue(x => x.SelectedItem)
 				.OfType<WasabiDocumentTabViewModel>()
 				.Where(_ => !_inSelecting)
+				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(x => shell.AddOrSelectDocument(x));
 		}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
@@ -28,6 +28,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private Dictionary<Wallet, WalletViewModelBase> _walletDictionary;
 		private ObservableAsPropertyHelper<bool> _isLurkingWifeMode;
 		private bool _anyWalletStarted;
+		private bool _inSelecting;
 
 		public WalletExplorerViewModel() : base("Wallet Explorer")
 		{
@@ -98,17 +99,25 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Where(x => x != SelectedItem)
 				.Subscribe(x =>
 				{
+					_inSelecting = true;
 					SelectedItem = x;
 
 					if (x is IWalletViewModel wvm && _walletDictionary.ContainsKey(wvm.Wallet))
 					{
 						_walletDictionary[wvm.Wallet].IsExpanded = true;
 					}
+					_inSelecting = false;
 				});
 
 			this.WhenAnyValue(x => x.SelectedItem)
 				.OfType<WasabiDocumentTabViewModel>()
-				.Subscribe(x => shell.AddOrSelectDocument(x));
+				.Subscribe(x =>
+				{
+					if (!_inSelecting)
+					{
+						shell.AddOrSelectDocument(x);
+					}
+				});
 		}
 
 		private void ToggleLurkingWifeMode()

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -56,11 +56,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.5" />
-    <PackageReference Include="Avalonia.Native" Version="0.9.6" />
-    <PackageReference Include="AvalonStudio.Shell" Version="0.9.5" />
-    <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.5" />
-    <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.6" />    
+    <PackageReference Include="AvalonStudio.Shell" Version="0.9.6" />
+    <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.6" />
+    <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.6" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
originally reported by @MaxHillebrand 

I was able to code a reliable repro and caught the same bug Max had.

Its caused because we are binding SelectedItem on the Shell and calling AddOrSelectDocument in the handler for that.

Calling AddOrSelectDocument can trigger SelectedItem to change before its finished. Meaning we were calling AddOrSelectDocument before the item was added.

It can only happen when the main window is closing.

This fixes in 2 ways:
1) protect against recursion in the viewmodel with a flag.
2) add fixes to the shell to make account for this scenario. (https://github.com/VitalElement/AvalonStudio.Shell/commit/66d4f5e6c1ac06c5d9b79d5f6f448466f3bfa778)

Updates: Avalonia and AvalonStudio.Shell to 0.9.6 (only fixes this)