### PR TITLE
Fix enless loop when exiting during filter processing

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/ClosedWalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ClosedWalletViewModel.cs
@@ -25,7 +25,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 					await global.WalletManager.StartWalletAsync(Wallet);
 				}
-				catch (TaskCanceledException ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
+				catch (OperationCanceledException ex)
 				{
 					Logger.LogTrace(ex);
 				}

--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
@@ -365,8 +365,8 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 				}
 
 				// Initialization failed.
-				NotificationHelpers.Error(ex.ToUserFriendlyString());
 				Logger.LogError(ex);
+				NotificationHelpers.Error(ex.ToUserFriendlyString());
 
 				return null;
 			}
@@ -396,8 +396,8 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 				}
 				catch (Exception ex)
 				{
-					NotificationHelpers.Error(ex.ToUserFriendlyString());
 					Logger.LogError(ex);
+					NotificationHelpers.Error(ex.ToUserFriendlyString());
 				}
 			}
 			finally

--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
@@ -390,14 +390,14 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 					// Successfully initialized.
 					Owner.OnClose();
 				}
+				catch (OperationCanceledException ex)
+				{
+					Logger.LogTrace(ex);
+				}
 				catch (Exception ex)
 				{
-					// Initialization failed.
 					NotificationHelpers.Error(ex.ToUserFriendlyString());
-					if (!(ex is OperationCanceledException))
-					{
-						Logger.LogError(ex);
-					}
+					Logger.LogError(ex);
 				}
 			}
 			finally

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
@@ -205,7 +205,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.LoadWallets
 					Owner.OnClose();
 				}
 			}
-			catch (TaskCanceledException ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
+			catch (OperationCanceledException ex)
 			{
 				Logger.LogTrace(ex);
 			}

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -398,10 +398,10 @@ namespace WalletWasabi.Stores
 			}
 		}
 
-		public async Task ForeachFiltersAsync(Func<FilterModel, Task> todo, Height fromHeight)
+		public async Task ForeachFiltersAsync(Func<FilterModel, Task> todo, Height fromHeight, CancellationToken cancel)
 		{
-			using (await MatureIndexFileManager.Mutex.LockAsync().ConfigureAwait(false))
-			using (await IndexLock.LockAsync().ConfigureAwait(false))
+			using (await MatureIndexFileManager.Mutex.LockAsync(cancel).ConfigureAwait(false))
+			using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
 			{
 				var firstImmatureHeight = ImmatureFilters.FirstOrDefault()?.Header?.Height;
 				if (!firstImmatureHeight.HasValue || firstImmatureHeight.Value > fromHeight)

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -398,7 +398,7 @@ namespace WalletWasabi.Stores
 			}
 		}
 
-		public async Task ForeachFiltersAsync(Func<FilterModel, Task> todo, Height fromHeight, CancellationToken cancel)
+		public async Task ForeachFiltersAsync(Func<FilterModel, Task> todo, Height fromHeight, CancellationToken cancel = default)
 		{
 			using (await MatureIndexFileManager.Mutex.LockAsync(cancel).ConfigureAwait(false))
 			using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -800,10 +800,6 @@ namespace WalletWasabi.Wallets
 					Logger.LogInfo($"Block acquired from local P2P connection: {hash}.");
 					return blockFromLocalNode;
 				}
-				catch (OperationCanceledException ex)
-				{
-					Logger.LogTrace(ex);
-				}
 				catch (Exception ex)
 				{
 					DisconnectDisposeNullLocalBitcoinCoreNode();
@@ -811,6 +807,10 @@ namespace WalletWasabi.Wallets
 					if (ex is SocketException)
 					{
 						Logger.LogTrace("Did not find local listening and running full node instance. Trying to fetch needed block from other source.");
+					}
+					else if (ex is OperationCanceledException)
+					{
+						Logger.LogTrace(ex);
 					}
 					else
 					{

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -800,6 +800,10 @@ namespace WalletWasabi.Wallets
 					Logger.LogInfo($"Block acquired from local P2P connection: {hash}.");
 					return blockFromLocalNode;
 				}
+				catch (OperationCanceledException ex)
+				{
+					Logger.LogTrace(ex);
+				}
 				catch (Exception ex)
 				{
 					DisconnectDisposeNullLocalBitcoinCoreNode();

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -522,7 +522,7 @@ namespace WalletWasabi.Wallets
 					await ProcessFilterModelAsync(filterModel, cancel);
 				}
 			},
-			new Height(bestKeyManagerHeight.Value + 1));
+			new Height(bestKeyManagerHeight.Value + 1), cancel);
 		}
 
 		private async Task LoadDummyMempoolAsync()
@@ -651,14 +651,14 @@ namespace WalletWasabi.Wallets
 						// If no connection, wait, then continue.
 						while (Nodes.ConnectedNodes.Count == 0)
 						{
-							await Task.Delay(100);
+							await Task.Delay(100, cancel);
 						}
 
 						// Select a random node we are connected to.
 						Node node = Nodes.ConnectedNodes.RandomElement();
 						if (node is null || !node.IsConnected)
 						{
-							await Task.Delay(100);
+							await Task.Delay(100, cancel);
 							continue;
 						}
 
@@ -667,7 +667,8 @@ namespace WalletWasabi.Wallets
 						{
 							using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(RuntimeParams.Instance.NetworkNodeTimeout))) // 1/2 ADSL	512 kbit/s	00:00:32
 							{
-								block = await node.DownloadBlockAsync(hash, cts.Token);
+								using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancel);
+								block = await node.DownloadBlockAsync(hash, lts.Token);
 							}
 
 							// Validate block
@@ -712,7 +713,7 @@ namespace WalletWasabi.Wallets
 				}
 
 				// Save the block
-				using (await BlockFolderLock.LockAsync())
+				using (await BlockFolderLock.LockAsync(cancel))
 				{
 					var path = Path.Combine(BlockFolderPath, hash.ToString());
 					await File.WriteAllBytesAsync(path, block.ToBytes());


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/3403

The problem was caused by this line:
https://github.com/molnard/WalletWasabi/blob/3e83310a20f513877b6b34a2b359b158a1e40313/WalletWasabi/Wallets/Wallet.cs#L654

Added CancellationToken to more places and handle the logs correctly. 