### PR TITLE
Fixes/wallet manager load multiple wallets

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/ClosedWalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ClosedWalletViewModel.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					var global = Locator.Current.GetService<Global>();
 
-					await global.WalletManager.StartWalletAsync(Wallet);
+					await Task.Run(async ()=> await global.WalletManager.StartWalletAsync(Wallet));
 				}
 				catch (TaskCanceledException ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
 				{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ClosedWalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ClosedWalletViewModel.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					var global = Locator.Current.GetService<Global>();
 
-					await Task.Run(async ()=> await global.WalletManager.StartWalletAsync(Wallet));
+					await Task.Run(async () => await global.WalletManager.StartWalletAsync(Wallet));
 				}
 				catch (TaskCanceledException ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
 				{


### PR DESCRIPTION
On Wallet Load Screen, the Load Button is disabled until the Wallet finishes loading.

This PR make sure that the button can be re-used immediately to load another wallet, so you can queue wallet loads.