### PR TITLE
Do not overwrite existing block

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -712,11 +712,8 @@ namespace WalletWasabi.Wallets
 				}
 
 				// Save the block
-				using (await BlockFolderLock.LockAsync())
-				{
-					var path = Path.Combine(BlockFolderPath, hash.ToString());
-					await File.WriteAllBytesAsync(path, block.ToBytes());
-				}
+				var path = Path.Combine(BlockFolderPath, hash.ToString());
+				await SaveBlockToDiskAsync(path, block);
 			}
 			finally
 			{
@@ -724,6 +721,20 @@ namespace WalletWasabi.Wallets
 			}
 
 			return block;
+		}
+
+		private async Task SaveBlockToDiskAsync(string path, Block block)
+		{
+			if (!File.Exists(path))
+			{
+				using (await BlockFolderLock.LockAsync())
+				{
+					if (!File.Exists(path))
+					{
+						await File.WriteAllBytesAsync(path, block.ToBytes());
+					}
+				}
+			}
 		}
 
 		private async Task<Block> TryDownloadBlockFromLocalNodeAsync(uint256 hash, CancellationToken cancel)


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/3415

I moved the code to a new method in order to do not create additional complexity in the already complex method.

The pattern is:

* If the block file is already there then there is nothing to do (some other wallet downloaded the block first and saved it)
* If the block file does not exist then we lock the block folder to save the file.
* It can be possible that immediately after checking the existence of the file and before the lock, other task creates the file so, we have to check for the file again inside the lock. If the file is not there then we can save the block safely. 