### PR TITLE
Mark keys with dust as used

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -646,6 +646,23 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		}
 
 		[Fact]
+		public async Task ReceiveManyConsecutiveTransactionWithDustForWalletAsync()
+		{
+			var transactionProcessor = await CreateTransactionProcessorAsync();
+			var keys = transactionProcessor.KeyManager.GetKeys();
+
+			foreach (var key in keys.Take(5))
+			{
+				transactionProcessor.Process(
+					CreateCreditingTransaction(key.P2wpkhScript, Money.Coins(0.000099m)));
+			}
+
+			// It is relevant even when all the coins can be dust.
+			Assert.All(keys.Take(5), key => Assert.Equal( KeyState.Used, key.KeyState));
+			Assert.All(keys.Skip(5), key => Assert.Equal( KeyState.Clean, key.KeyState));
+		}
+
+		[Fact]
 		public async Task ReceiveCoinJoinTransactionAsync()
 		{
 			var transactionProcessor = await CreateTransactionProcessorAsync();

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -172,13 +172,13 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 					HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
 					if (foundKey != default)
 					{
+						foundKey.SetKeyState(KeyState.Used, KeyManager);
 						if (output.Value <= DustThreshold)
 						{
 							result.ReceivedDusts.Add(output);
 							continue;
 						}
 
-						foundKey.SetKeyState(KeyState.Used, KeyManager);
 						spentOwnCoins ??= Coins.OutPoints(tx.Transaction.Inputs).ToList();
 						var anonset = tx.Transaction.GetAnonymitySet(i);
 						if (spentOwnCoins.Count != 0)


### PR DESCRIPTION
During the transaction processing those keys that received dust were not marked as `Used` (they remained as `Clean`), for this reason the address is not removed from the `Receive` tab what make it possible to reuse.  