### PR TITLE
Prevent the tor to warn bc missing torrc file

### DIFF
--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -117,7 +117,7 @@ namespace WalletWasabi.TorSocks5
 							Logger.LogInfo($"Tor instance found at {torPath}.");
 						}
 
-						string torArguments = $"--SOCKSPort {TorSocks5EndPoint} --DataDirectory {torDataDir}";
+						string torArguments = $"--SOCKSPort {TorSocks5EndPoint} --DataDirectory {torDataDir} --allow-missing-torrc";
 						if (!string.IsNullOrEmpty(LogFile))
 						{
 							IoHelpers.EnsureContainingDirectoryExists(LogFile);


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/3436

Tor doesn't find the torrc file and then uses default values for its settings and then it complains about those setting to be using relative paths instead of absolute paths. 