### PR TITLE
Fixes/dialogs not sizing

### DIFF
--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.6" />    
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />    
     <PackageReference Include="AvalonStudio.Shell" Version="0.9.6" />
     <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.6" />
     <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.6" />

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -57,9 +57,9 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />    
-    <PackageReference Include="AvalonStudio.Shell" Version="0.9.6" />
-    <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.6" />
-    <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.6" />
+    <PackageReference Include="AvalonStudio.Shell" Version="0.9.7" />
+    <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.7" />
+    <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.7" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 

--- a/WalletWasabi.Gui/WasabiWindow.xaml
+++ b/WalletWasabi.Gui/WasabiWindow.xaml
@@ -7,5 +7,6 @@
                   FontFamily="{DynamicResource UiFont}" FontSize="14"
                   Foreground="{DynamicResource ThemeForegroundBrush}"                  
                   UseLayoutRounding="True"
+                  WindowStartupLocation="CenterOwner"
                   RenderOptions.BitmapInterpolationMode="HighQuality" />
 


### PR DESCRIPTION
fixes #3443 
also ensures dialogs open in the center of the mainwindow...

This only affects linux, because we use native file dialogs on both osx and windows.