### PR TITLE
Enable LWM button (Wallet Explorer)

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerViewModel.cs
@@ -64,7 +64,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				});
 
 			Observable
-				.FromEventPattern<Wallet>(WalletManager, nameof(WalletManager.WalletAdded))				
+				.FromEventPattern<Wallet>(WalletManager, nameof(WalletManager.WalletAdded))
 				.Select(x => x.EventArgs)
 				.Where(x => x is { })
 				.ObserveOn(RxApp.MainThreadScheduler)
@@ -79,7 +79,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			CollapseAllCommand = ReactiveCommand.Create(CollapseWallets, this.WhenAnyValue(x => x.AnyWalletStarted));
 
-			LurkingWifeModeCommand = ReactiveCommand.Create(ToggleLurkingWifeMode, this.WhenAnyValue(x => x.AnyWalletStarted));
+			LurkingWifeModeCommand = ReactiveCommand.Create(ToggleLurkingWifeMode);
 
 			_isLurkingWifeMode = UiConfig
 				.WhenAnyValue(x => x.LurkingWifeMode)


### PR DESCRIPTION
Fixes #3405

This would allow the user to enable LWM before loading the wallet. https://github.com/zkSNACKs/WalletWasabi/issues/3405#issuecomment-608413045