### PR TITLE
Lower max coord fee from 0.7% to 0.3%

### DIFF
--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -366,7 +366,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 							if (changeAmount > Money.Zero) // If the coordinator fee would make change amount to be negative or zero then no need to pay it.
 							{
 								Money minimumOutputAmount = Money.Coins(0.0001m); // If the change would be less than about $1 then add it to the coordinator.
-								Money somePercentOfDenomination = newDenomination.Percentage(0.7m); // If the change is less than about 0.7% of the newDenomination then add it to the coordinator fee.
+								Money somePercentOfDenomination = newDenomination.Percentage(0.3m); // If the change is less than about 0.3% of the newDenomination then add it to the coordinator fee.
 								Money minimumChangeAmount = Math.Max(minimumOutputAmount, somePercentOfDenomination);
 								if (changeAmount < minimumChangeAmount)
 								{


### PR DESCRIPTION
As a test we are lowering the fees. As discussed in the management meeting. This avoids overpaying. It's a bit worse for privacy, but prevents edge cases when user would overpay.  

For the record we officially advertise 1%.