### PR TITLE
Update NBitcoin to 5.0.28

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -48,7 +48,6 @@ using WalletWasabi.TorSocks5;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
-using static NBitcoin.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.Tests.RegressionTests
 {

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -48,7 +48,6 @@ using WalletWasabi.TorSocks5;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
-using static NBitcoin.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.Tests.RegressionTests
 {

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-	  <PackageReference Include="NBitcoin" Version="5.0.18" />
+	  <PackageReference Include="NBitcoin" Version="5.0.28" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.1" />
   </ItemGroup>


### PR DESCRIPTION
NBitcoin doesn't have the Schnorr Blinding Signature algorithms we use in Wasabi. Those algorithms were move to Wasabi and it was removed from NBitcoin.

Note this version allows us to create transactions with smaller amounts (greater than dust) than before and the dust protection mechanism is aware of the fact that the transaction input is segwit.  