### PR TITLE
Clear custom change address when Max button is clicked

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -184,6 +184,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						SetFeesAndTexts();
 
 						LabelToolTip = "Spending whole coins does not generate change, thus labeling is unnecessary.";
+
+						CustomChangeAddress = "";
 					}
 					else
 					{


### PR DESCRIPTION
If you set the address and the custom change address to the same value and then you click the max button, the custom change address is not cleared and therefor the error message is not removed which looks ugly:

![Capture0](https://user-images.githubusercontent.com/52379387/79087491-b4536f80-7d3f-11ea-9e07-cb0774d7bd62.PNG)

and you can send the transaction even with those errors displayed which is not a good UX.

With this PR it looks more clean:
![Capture](https://user-images.githubusercontent.com/52379387/79087566-fa103800-7d3f-11ea-9445-9affc0017820.PNG)

In https://github.com/zkSNACKs/WalletWasabi/pull/3198/commits/08718a7153e01a56444672865f5a6ef3a998042c @nopara73 removed the clearing option.