### PR TITLE
Log failing attempts to start rpc server

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -323,7 +323,15 @@ namespace WalletWasabi.Gui
 				if (jsonRpcServerConfig.IsEnabled)
 				{
 					RpcServer = new JsonRpcServer(this, jsonRpcServerConfig);
-					await RpcServer.StartAsync(cancel).ConfigureAwait(false);
+					try
+					{
+						await RpcServer.StartAsync(cancel).ConfigureAwait(false);
+					}
+					catch (System.Net.HttpListenerException e)
+					{
+						Logger.LogWarning($"Failed to start JsonRpcServer with error: {e.Message}.");
+						RpcServer = null;
+					}
 				}
 
 				#endregion JsonRpcServerInitialization

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -329,7 +329,7 @@ namespace WalletWasabi.Gui
 					}
 					catch (System.Net.HttpListenerException e)
 					{
-						Logger.LogWarning($"Failed to start JsonRpcServer with error: {e.Message}.");
+						Logger.LogWarning($"Failed to start {nameof(JsonRpcServer)} with error: {e.Message}.");
 						RpcServer = null;
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/3479

It log the reason why the rpc server cannot start (most of the times is `port already in use` or `permission denied`). Also, it sets the `RpcServer` variable to `null`, in that way wasabi does not try to dispose it.