### PR TITLE
Better exception handling on SendTab

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -368,7 +368,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 				catch (Exception ex)
 				{
-					NotificationHelpers.Error(ex.ToUserFriendlyString());
+					NotificationHelpers.Error(ex.ToUserFriendlyString(), sender: Wallet);
 					Logger.LogError(ex);
 				}
 				finally

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -48,11 +48,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 					signedTransaction = signedPsbt.ExtractSmartTransaction(result.Transaction);
 				}
-				catch (Exception ex)
-				{
-					NotificationHelpers.Error(ex.ToUserFriendlyString());
-					return;
-				}
 				finally
 				{
 					MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusType.AcquiringSignatureFromHardwareWallet);

--- a/WalletWasabi.Gui/Helpers/NotificationHelpers.cs
+++ b/WalletWasabi.Gui/Helpers/NotificationHelpers.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls.Notifications;
 using ReactiveUI;
 using Splat;
 using System;
+using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using WalletWasabi.Gui.Controls.WalletExplorer;
 using WalletWasabi.Wallets;
@@ -21,6 +22,13 @@ namespace WalletWasabi.Gui.Helpers
 
 		public static void Notify(string message, string title, NotificationType type, Action onClick = null, object sender = null)
 		{
+			List<string> titles = new List<string>();
+
+			if (!string.IsNullOrEmpty(title))
+			{
+				titles.Add(title);
+			}
+
 			string walletname = sender switch
 			{
 				Wallet wallet => wallet.WalletName,
@@ -28,13 +36,18 @@ namespace WalletWasabi.Gui.Helpers
 				_ => ""
 			};
 
-			title = $"{(string.IsNullOrEmpty(title) ? "" : $"{title} - ")}{walletname}";
+			if (!string.IsNullOrEmpty(walletname))
+			{
+				titles.Add(walletname);
+			}
 
-			title = title.Substring(0, Math.Min(title.Length, MaxTitleLength));
+			var fullTitle = string.Join(" - ", titles);
+
+			fullTitle = fullTitle.Substring(0, Math.Min(fullTitle.Length, MaxTitleLength));
 
 			RxApp.MainThreadScheduler
 				.Schedule(() => GetNotificationManager()
-				.Show(new Notification(title, message, type, TimeSpan.FromSeconds(DefaultNotificationTimeout), onClick)));
+				.Show(new Notification(fullTitle, message, type, TimeSpan.FromSeconds(DefaultNotificationTimeout), onClick)));
 		}
 
 		public static void Success(string message, string title = "Success!", object sender = null)


### PR DESCRIPTION
- I removed one extra catch clause.
- I fixed the notification title, sometimes it displayed: "Error - " Now it will be only "Error"
- Added WalletName to the error notification when sending. Sometimes it takes several seconds to get the error and the user can navigate elsewhere meanwhile. Better to clarify which send was erroneous. 