### PR TITLE
Restore "About Wasabi Wallet" OSX appmenu item

### DIFF
--- a/WalletWasabi.Gui/App.xaml.cs
+++ b/WalletWasabi.Gui/App.xaml.cs
@@ -9,9 +9,7 @@ namespace WalletWasabi.Gui
 	{
 		public App()
 		{
-			Name = "Wasabi Wallet";
-
-			DataContext = new ApplicationViewModel();
+			Name = "Wasabi Wallet";			
 		}
 
 		public override void Initialize()
@@ -27,6 +25,8 @@ namespace WalletWasabi.Gui
 				{
 					DataContext = MainWindowViewModel.Instance
 				};
+
+				DataContext = new ApplicationViewModel();
 			}
 
 			base.OnFrameworkInitializationCompleted();


### PR DESCRIPTION
All OSX apps are supposed to implement this "About AppName"... we removed it because it was crashing before the release and there was no time to debug.

It was happening because the bindings to the command were being set before ReactiveUI was configured... the next version of Avalonia will ensure this wont happen, however for now we can set the App.DataContext in the framework initialised callback.