### PR TITLE
Prevent 0 peers and increase max connections

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -279,7 +279,7 @@ namespace WalletWasabi.Gui
 						await AddKnownBitcoinFullNodeAsHiddenServiceAsync(AddressManager);
 					}
 					Nodes = new NodesGroup(Network, connectionParameters, requirements: Constants.NodeRequirements);
-
+					Nodes.MaximumNodeConnection = 12;
 					RegTestMempoolServingNode = null;
 				}
 

--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -108,30 +108,27 @@ namespace WalletWasabi.Wallets
 							// Validate block
 							if (!block.Check())
 							{
-								Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.");
-								DisconnectNode(node, "Invalid block received.", force: true);
+								DisconnectNode(node, $"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.", force: true);
 								continue;
 							}
 
-							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
-							DisconnectNode(node, "Thank you!");
+							DisconnectNode(node, $"Disconnected node: {node.RemoteSocketAddress}. Block downloaded: {block.GetHash()}.");
 
 							await NodeTimeoutsAsync(false).ConfigureAwait(false);
 						}
 						catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException || ex is TimeoutException)
 						{
-							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download took too long.");
-
 							await NodeTimeoutsAsync(true).ConfigureAwait(false);
 
-							DisconnectNode(node, "Block download took too long."); // it could be a slow connection and not a misbehaving node
+							DisconnectNode(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download took too long."); // it could be a slow connection and not a misbehaving node
 							continue;
 						}
 						catch (Exception ex)
 						{
 							Logger.LogDebug(ex);
-							Logger.LogInfo($"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.");
-							DisconnectNode(node, "Block download failed.", force: true);
+							DisconnectNode(node, 
+								$"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.",
+								force: true);
 							continue;
 						}
 
@@ -286,11 +283,12 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		private void DisconnectNode(Node node, string reason, bool force = false)
+		private void DisconnectNode(Node node, string logIfDisconnect, bool force = false)
 		{
 			if (Nodes.ConnectedNodes.Count > 2 || force)
 			{
-				node.DisconnectAsync(reason);
+				Logger.LogInfo(logIfDisconnect);
+				node.DisconnectAsync(logIfDisconnect);
 			}
 		}
 		

--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -292,7 +292,6 @@ namespace WalletWasabi.Wallets
 			}
 		}
 		
-
 		/// <summary>
 		/// Current timeout used when downloading a block from the remote node. It is defined in seconds.
 		/// </summary>

--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -285,7 +285,7 @@ namespace WalletWasabi.Wallets
 
 		private void DisconnectNode(Node node, string logIfDisconnect, bool force = false)
 		{
-			if (Nodes.ConnectedNodes.Count > 2 || force)
+			if (Nodes.ConnectedNodes.Count > 3 || force)
 			{
 				Logger.LogInfo(logIfDisconnect);
 				node.DisconnectAsync(logIfDisconnect);


### PR DESCRIPTION
### Backgound

Sometimes when a user has an ugly internet connection or has to synchronize with the network by downloading tens of blocks the process fails and the nodes are disconnected until we reach zero peers. 

### Changes

This PR is to prevent peers going back to 0 by do not disconnect nodes when there are less than 2 connected peers. We only disconnect peers when there are more than two or when the node misbehaves by providing invalid blocks

Additionally the maximum number of peers connected is increase from 8 to 12.

### Note

NBitcoin makes its best to prevent sybil attacks at a network level, that can be change if needed for TestNet.
