### PR TITLE
Fix exception warning while using rpc

### DIFF
--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -227,7 +227,10 @@ namespace WalletWasabi.Gui.Rpc
 				var wallet = Global.WalletManager.GetWalletByName(walletName);
 
 				ActiveWallet = wallet;
-				Global.WalletManager.StartWalletAsync(wallet).ConfigureAwait(false);
+				if (wallet.State == WalletState.Uninitialized)
+				{
+					Global.WalletManager.StartWalletAsync(wallet).ConfigureAwait(false);
+				}
 			}
 			catch (InvalidOperationException) // wallet not found
 			{

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -147,14 +147,6 @@ namespace WalletWasabi.Wallets
 			return labels;
 		}
 
-		public Wallet GetFirstOrDefaultWallet()
-		{
-			lock (Lock)
-			{
-				return Wallets.Keys.FirstOrDefault(x => x.State == WalletState.Started);
-			}
-		}
-
 		public bool AnyWallet()
 		{
 			return AnyWallet(x => x.State >= WalletState.Starting);


### PR DESCRIPTION
Fixes an ugly warning that happens when you select a wallet using the rpc method. It also deletes a unused method.