### PR TITLE
Use standard HttpClient for WasabiClient

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -29,6 +29,8 @@ using WalletWasabi.Legal;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
+using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 
@@ -339,7 +341,15 @@ namespace WalletWasabi.Gui.ViewModels
 						{
 							if (Global.LegalDocuments is null || Global.LegalDocuments.Version < x.LegalDocumentsVersion)
 							{
-								using var client = new WasabiClient(() => Global.Config.UseTor ? Global.Config.GetCurrentBackendUri() : Global.Config.GetFallbackBackendUri(), Global.Config.UseTor ? Global.Config.TorSocks5EndPoint : null);
+								using var torClient = new TorHttpClient(
+									() => Global.Config.UseTor 
+										? Global.Config.GetCurrentBackendUri()
+										: Global.Config.GetFallbackBackendUri(), 
+									Global.Config.UseTor 
+										? Global.Config.TorSocks5EndPoint 
+										: null
+								);
+								using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 								var versions = await client.GetVersionsAsync(CancellationToken.None);
 								var version = versions.LegalDocumentsVersion;
 								var legalFolderPath = Path.Combine(Global.DataDir, LegalDocuments.LegalFolderName);

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Models;
 using WalletWasabi.Services;
 using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 
@@ -39,7 +40,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetFeesAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 			var feeEstimationPairs = await client.GetFeesAsync(1000);
 
 			Assert.True(feeEstimationPairs.NotNullAndNotEmpty());
@@ -50,7 +52,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetFiltersAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 			var filterModel = StartingFilters.GetStartingFilter(Network.GetNetwork(networkType.ToString()));
 
 			FiltersResponse filtersResponse = await client.GetFiltersAsync(filterModel.Header.BlockHash, 2);
@@ -75,7 +78,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetTransactionsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 			var randomTxIds = Enumerable.Range(0, 20).Select(_ => RandomUtils.GetUInt256());
 			var network = networkType == NetworkType.Mainnet ? Network.Main : Network.TestNet;
 
@@ -99,7 +103,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetExchangeRateAsync(NetworkType networkType) // xunit wtf: If this function is called GetExchangeRatesAsync, it'll stuck on 1 CPU VMs (Manjuro, Fedora)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 			var exchangeRates = await client.GetExchangeRatesAsync();
 
 			Assert.True(exchangeRates.NotNullAndNotEmpty());
@@ -114,7 +119,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetVersionsTestsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 
 			var versions = await client.GetVersionsAsync(CancellationToken.None);
 			Assert.InRange(versions.ClientVersion, new Version(1, 1, 10), new Version(1, 2));
@@ -128,7 +134,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task CheckUpdatesTestsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 
 			var updateStatus = await client.CheckUpdatesAsync(CancellationToken.None);
 
@@ -151,7 +158,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetLegalDocumentsTestsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var torClient = new TorHttpClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
+			using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 
 			var content = await client.GetLegalDocumentsAsync(CancellationToken.None);
 

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -44,6 +44,7 @@ using WalletWasabi.Services;
 using WalletWasabi.Stores;
 using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
@@ -635,7 +636,8 @@ namespace WalletWasabi.Tests.RegressionTests
 				uint256[] mempooltxs = await rpc.GetRawMempoolAsync();
 				Assert.Contains(unsignedCoinJoin.GetHash(), mempooltxs);
 
-				var wasabiClient = new WasabiClient(baseUri, null);
+				using var wasabiClient = new WasabiClient(new SocksHttpClientHandler(new TorHttpClient(baseUri, null)));
+
 				var syncInfo = await wasabiClient.GetSynchronizeAsync(blockHashed[0], 1);
 				Assert.Contains(unsignedCoinJoin.GetHash(), syncInfo.UnconfirmedCoinJoins);
 				var txs = await wasabiClient.GetTransactionsAsync(network, new[] { unsignedCoinJoin.GetHash() }, CancellationToken.None);

--- a/WalletWasabi.Tests/RegressionTests/Common.cs
+++ b/WalletWasabi.Tests/RegressionTests/Common.cs
@@ -14,6 +14,8 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Stores;
 using WalletWasabi.Tests.XunitConfiguration;
+using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
@@ -53,7 +55,9 @@ namespace WalletWasabi.Tests.RegressionTests
 			var firstHash = await global.RpcClient.GetBlockHashAsync(0);
 			while (true)
 			{
-				using var client = new WasabiClient(new Uri(regTestFixture.BackendEndPoint), null);
+				using var torClient = new TorHttpClient(new Uri(regTestFixture.BackendEndPoint), null);
+				using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
+
 				FiltersResponse filtersResponse = await client.GetFiltersAsync(firstHash, 1000);
 				Assert.NotNull(filtersResponse);
 

--- a/WalletWasabi.Tests/UnitTests/Clients/MockTorHttpClient.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/MockTorHttpClient.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 {
 	public class MockTorHttpClient : ITorHttpClient
 	{
-		public Uri DestinationUri => new Uri("DestinationUri");
+		public Uri DestinationUri => new Uri("https://destination.com", UriKind.Absolute);
 
 		public Func<Uri> DestinationUriAction => () => DestinationUri;
 

--- a/WalletWasabi.Tests/UnitTests/Clients/WasabiClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/WasabiClientTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Models;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 
@@ -32,7 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 
 			var torHttpClient = new MockTorHttpClient();
 			torHttpClient.OnSendAsync_Method = FakeServerCode;
-			var client = new WasabiClient(torHttpClient);
+			var client = new WasabiClient(new SocksHttpClientHandler(torHttpClient));
 			Assert.Empty(WasabiClient.TransactionCache);
 
 			// Requests one transaction

--- a/WalletWasabi/Blockchain/Mempool/MempoolService.cs
+++ b/WalletWasabi/Blockchain/Mempool/MempoolService.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
+using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Blockchain.Mempool
@@ -117,7 +119,8 @@ namespace WalletWasabi.Blockchain.Mempool
 				}
 
 				Logger.LogInfo("Start cleaning out mempool...");
-				using (var client = new WasabiClient(destAction, torSocks))
+				using var torClient = new TorHttpClient(destAction, torSocks);
+				using (var client = new WasabiClient(new SocksHttpClientHandler(torClient)))
 				{
 					var compactness = 10;
 					var allMempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -17,6 +17,8 @@ using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
 using WalletWasabi.Stores;
+using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 
@@ -90,7 +92,9 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 		private async Task BroadcastTransactionToBackendAsync(SmartTransaction transaction)
 		{
 			Logger.LogInfo("Broadcasting with backend...");
-			using (var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint))
+
+			using var torClient = new TorHttpClient(Synchronizer.ServerUriAction, Synchronizer.TorSocks5EndPoint); 
+			using (var client = new WasabiClient(new SocksHttpClientHandler(torClient)))
 			{
 				try
 				{

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -47,8 +47,8 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
 			DestinationKeyManager = KeyManager;
 			Synchronizer = Guard.NotNull(nameof(synchronizer), synchronizer);
-			CcjHostUriAction = Synchronizer.WasabiClient.TorClient.DestinationUriAction;
-			TorSocks5EndPoint = Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint;
+			CcjHostUriAction = Synchronizer.ServerUriAction;
+			TorSocks5EndPoint = Synchronizer.TorSocks5EndPoint;
 			CoordinatorFeepercentToCheck = null;
 
 			ExposedLinks = new ConcurrentDictionary<OutPoint, IEnumerable<HdPubKeyBlindedPair>>();

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -16,6 +16,8 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
+using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 
@@ -53,7 +55,8 @@ namespace WalletWasabi.CoinJoin.Client
 
 					var txsNotKnownByAWallet = WalletManager.FilterUnknownCoinjoins(unconfirmedCoinJoinHashes);
 
-					using var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint);
+					using var torClient = new TorHttpClient(Synchronizer.ServerUriAction,	Synchronizer.TorSocks5EndPoint);
+					using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 
 					var unconfirmedCoinJoins = await client.GetTransactionsAsync(Synchronizer.Network, txsNotKnownByAWallet, CancellationToken.None).ConfigureAwait(false);
 

--- a/WalletWasabi/Extensions/TorHttpClientExtensions.cs
+++ b/WalletWasabi/Extensions/TorHttpClientExtensions.cs
@@ -3,21 +3,24 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.TorSocks5;
 
-public static class TorHttpClientExtensions
+public static class HttpClientExtensions
 {
 	/// <remarks>
 	/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
 	/// </remarks>
-	public static async Task<HttpResponseMessage> SendAndRetryAsync(this ITorHttpClient client, HttpMethod method, HttpStatusCode expectedCode, string relativeUri, int retry = 2, HttpContent content = null, CancellationToken cancel = default)
+	public static async Task<HttpResponseMessage> SendAndRetryAsync(this HttpClient client, HttpMethod method, HttpStatusCode expectedCode, string relativeUri, int retry = 2, HttpContent content = null, CancellationToken cancel = default)
 	{
 		HttpResponseMessage response = null;
 		while (retry-- > 0)
 		{
 			response?.Dispose();
 			cancel.ThrowIfCancellationRequested();
-			response = await client.SendAsync(method, relativeUri, content, cancel: cancel);
+			var request = new HttpRequestMessage(method, relativeUri)
+			{
+				Content = content
+			};
+			response = await client.SendAsync(request, cancel);
 			if (response.StatusCode == expectedCode)
 			{
 				break;

--- a/WalletWasabi/TorSocks5/Socks/Socks5HttpClientHandler.cs
+++ b/WalletWasabi/TorSocks5/Socks/Socks5HttpClientHandler.cs
@@ -1,0 +1,43 @@
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.TorSocks5.Socks
+{
+	public class SocksHttpClientHandler : HttpClientHandler
+	{
+		public SocksHttpClientHandler(ITorHttpClient client)
+		{
+			Client = client;
+		}
+
+		public ITorHttpClient Client { get; }
+
+		public override bool Equals(object obj)
+		{
+			return base.Equals(obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
+
+		public override string ToString()
+		{
+			return base.ToString();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+		}
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			return Client.SendAsync(request, cancellationToken);
+		}
+	}
+}
+

--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -174,9 +174,9 @@ namespace WalletWasabi.Wallets
 
 						// If an onion was added must try to use Tor.
 						// onlyForOnionHosts should connect to it if it's an onion endpoint automatically and non-Tor endpoints through clearnet/localhost
-						if (Synchronizer.WasabiClient.TorClient.IsTorUsed)
+						if (true) //Synchronizer.WasabiClient.TorClient.IsTorUsed)
 						{
-							nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
+							nodeConnectionParameters.TemplateBehaviors.Add(new SocksSettingsBehavior(Synchronizer.TorSocks5EndPoint, onlyForOnionHosts: true, networkCredential: null, streamIsolation: false));
 						}
 
 						var localEndPoint = ServiceConfiguration.BitcoinCoreEndPoint;

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -31,6 +31,8 @@ using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
 using WalletWasabi.Stores;
+using WalletWasabi.TorSocks5;
+using WalletWasabi.TorSocks5.Socks;
 using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Wallets
@@ -421,7 +423,7 @@ namespace WalletWasabi.Wallets
 					}
 				} while (Synchronizer.AreRequestsBlocked()); // If requests are blocked, delay mempool cleanup, because coinjoin answers are always priority.
 
-				var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer?.WasabiClient?.TorClient?.DestinationUriAction, Synchronizer?.WasabiClient?.TorClient?.TorSocks5EndPoint);
+				var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer.ServerUriAction, Synchronizer.TorSocks5EndPoint);
 
 				if (task is { })
 				{
@@ -464,7 +466,8 @@ namespace WalletWasabi.Wallets
 			{
 				try
 				{
-					using var client = new WasabiClient(Synchronizer.WasabiClient.TorClient.DestinationUriAction, Synchronizer.WasabiClient.TorClient.TorSocks5EndPoint);
+					using var torClient = new TorHttpClient(Synchronizer.ServerUriAction,	Synchronizer.TorSocks5EndPoint);
+					using var client = new WasabiClient(new SocksHttpClientHandler(torClient));
 					var compactness = 10;
 
 					var mempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);


### PR DESCRIPTION
This PR is for evaluating the convenience of using the standard `HttpClient` class for communicating with the remote http servers. The advantages are:

* It is a well-known class that can dispose the handler automatically
* it allow us to use .GetAsync, PostAsync, etc and have a cleaner code
* we can remove away the `TorDisposableBase`, it doesn't look good
* using a handler makes easier for us to unit test interaction with remote servers

This is a very raw PR that displays a lot of the plumbing but that's not the idea, the idea is make it easier to use, it is just that the PR is pushed as it is. 