### PR TITLE
Fix CI tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
@@ -87,7 +87,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 		[Fact]
 		public async Task GetVersionTestsAsync()
 		{
-			using var cts = new CancellationTokenSource(7000);
+			using var cts = new CancellationTokenSource(14000);
 			Version version = await CoreNode.GetVersionAsync(cts.Token);
 			Assert.Equal(WalletWasabi.Helpers.Constants.BitcoinCoreVersion, version);
 		}

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -7,12 +7,12 @@ variables:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.1.x
+      version: 3.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -7,12 +7,12 @@ variables:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'vs2017-win2016'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'
     inputs:
-      version: 3.x
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     displayName: 'Build Debug'
     inputs:


### PR DESCRIPTION
```
[xUnit.net 00:03:12.55]     GetVersionTestsAsync [FAIL]
  X GetVersionTestsAsync [7s 203ms]
  Error Message:
   System.Threading.Tasks.TaskCanceledException : Waiting for process exiting was canceled.
---- System.OperationCanceledException : The operation was canceled.
  Stack Trace:
     at System.Diagnostics.ProcessExtensions.WaitForExitAsync(Process process, CancellationToken cancel) in D:\a\1\s\WalletWasabi\Extensions\ProcessExtensions.cs:line 46
   at WalletWasabi.Microservices.ProcessBridge.SendCommandAsync(String arguments, Boolean openConsole, CancellationToken cancel) in D:\a\1\s\WalletWasabi\Microservices\ProcessBridge.cs:line 85
   at WalletWasabi.BitcoinCore.CoreNode.GetVersionAsync(CancellationToken cancel) in D:\a\1\s\WalletWasabi\BitcoinCore\CoreNode.cs:line 191
   at WalletWasabi.Tests.UnitTests.BitcoinCore.NodeBuildingTests.GetVersionTestsAsync() in D:\a\1\s\WalletWasabi.Tests\UnitTests\BitcoinCore\NodeBuildingTests.cs:line 91
--- End of stack trace from previous location where exception was thrown ---
----- Inner Stack Trace -----
   at System.Threading.Tasks.TaskExtensions.WithAwaitCancellationAsync[T](Task`1 me, CancellationToken cancel, Int32 waitForGracefulTerminationMilliseconds) in D:\a\1\s\WalletWasabi\Extensions\TaskExtensions.cs:line 25
   at System.Diagnostics.ProcessExtensions.WaitForExitAsync(Process process, CancellationToken cancel) in D:\a\1\s\WalletWasabi\Extensions\ProcessExtensions.cs:line 37
```


