### PR TITLE
Enable PropertySummaryDocumentationMustMatchAccessors

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -226,7 +226,7 @@
         </Rule>
         <Rule Name="PropertySummaryDocumentationMustMatchAccessors">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="PropertySummaryDocumentationMustOmitSetAccessorWithRestrictedAccess">

--- a/WalletWasabi.Gui/Rpc/JsonRpcRequest.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcRequest.cs
@@ -31,19 +31,19 @@ namespace WalletWasabi.Gui.Rpc
 		}
 
 		/// <summary>
-		/// Requests with null Id are called notification requests and indicate the
-		/// client is not interested in receiving a response.
+		/// Gets a value indicating whether the JsonRpcRequest is a notification request
+		/// which means the client is not interested in receiving a response.
 		/// </summary>
 		public bool IsNotification => Id == null;
 
 		/// <summary>
-		/// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
+		/// Gets the version of the JSON-RPC protocol. MUST be exactly "2.0".
 		/// </summary>
 		[JsonProperty("jsonrpc", Required = Required.Always)]
 		public string JsonRPC { get; }
 
 		/// <summary>
-		/// An identifier established by the Client that MUST contain a String,
+		/// Gets the identifier established by the Client that MUST contain a String,
 		/// Number, or NULL value if included. If it is not included it is assumed
 		/// to be a notification.
 		/// The value SHOULD normally not be Null and Numbers SHOULD NOT contain
@@ -59,7 +59,7 @@ namespace WalletWasabi.Gui.Rpc
 		public string Id { get; }
 
 		/// <summary>
-		/// A String containing the name of the method to be invoked. Method names that
+		/// Gets the name of the method to be invoked. Method names that
 		/// begin with the word rpc followed by a period character (U+002E or ASCII 46)
 		/// are reserved for rpc-internal methods and extensions and MUST NOT be used
 		/// for anything else.
@@ -68,7 +68,7 @@ namespace WalletWasabi.Gui.Rpc
 		public string Method { get; }
 
 		/// <summary>
-		/// A Structured value that holds the parameter values to be used during the
+		/// Gets a structured value that holds the parameter values to be used during the
 		/// invocation of the method. This member MAY be omitted.
 		/// </summary>
 		[JsonProperty("params")]

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -27,13 +27,13 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 		public EstimateSmartFeeMode Type { get; private set; }
 
 		/// <summary>
-		/// If it's been fetched from a fully synced node.
+		/// Gets a value indicating whether the fee has been fetched from a fully synced node.
 		/// </summary>
 		[JsonProperty]
 		public bool IsAccurate { get; private set; }
 
 		/// <summary>
-		/// Dictionary: int: fee target, int: satoshi/vByte
+		/// Gets the fee estimations: int: fee target, int: satoshi/vByte
 		/// </summary>
 		[JsonProperty]
 		public Dictionary<int, int> Estimations { get; private set; }

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -31,55 +31,55 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 		public bool IsLikelyOwnCoinJoin { get; set; } = false;
 
 		/// <summary>
-		/// Dust outputs we received in this transaction. We may or may not have known about
+		/// Gets the dust outputs we received in this transaction. We may or may not have known about
 		/// them previously. They aren't SmartCoins, because they aren't fully processed.
 		/// </summary>
 		public List<TxOut> ReceivedDusts { get; } = new List<TxOut>();
 
 		/// <summary>
-		/// Coins we received in this transaction.
+		/// Gets the coins we received in this transaction.
 		/// </summary>
 		public List<SmartCoin> ReceivedCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins we received in this transaction and we did not previously know about.
+		/// Gets the coins we received in this transaction and we did not previously know about.
 		/// </summary>
 		public List<SmartCoin> NewlyReceivedCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins we received in this transaction, we have known already about, but they just got confirmed.
+		/// Gets the coins we received in this transaction, we have known already about, but they just got confirmed.
 		/// </summary>
 		public List<SmartCoin> NewlyConfirmedReceivedCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins we spent in this transaction.
+		/// Gets the coins we spent in this transaction.
 		/// </summary>
 		public List<SmartCoin> SpentCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins we spent in this transaction and we did not previously know about.
+		/// Gets the coins we spent in this transaction and we did not previously know about.
 		/// </summary>
 		public List<SmartCoin> NewlySpentCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins we spent in this transaction, we have known already about, but they just got confirmed.
+		/// Gets the coins we spent in this transaction, we have known already about, but they just got confirmed.
 		/// </summary>
 		public List<SmartCoin> NewlyConfirmedSpentCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins those we previously had in the mempool, but this confirmed
+		/// Gets the coins that we previously had in the mempool, but this confirmed
 		/// transaction has successfully invalidated them, because it spends
 		/// some of the same inputs.
 		/// </summary>
 		public List<SmartCoin> SuccessfullyDoubleSpentCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Unconfirmed coins those were replaced by the coins of the transaction.
+		/// Gets the unconfirmed coins that were replaced by the coins of the transaction.
 		/// </summary>
 		public List<SmartCoin> ReplacedCoins { get; } = new List<SmartCoin>();
 
 		/// <summary>
-		/// Coins those were made unspent again by this double spend transaction.
+		/// Gets the coins that were made unspent again by this double spend transaction.
 		/// </summary>
 		public List<SmartCoin> RestoredCoins { get; } = new List<SmartCoin>();
 	}

--- a/WalletWasabi/CoinJoin/Client/Rounds/ClientRoundRegistration.cs
+++ b/WalletWasabi/CoinJoin/Client/Rounds/ClientRoundRegistration.cs
@@ -26,7 +26,7 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 		}
 
 		/// <summary>
-		/// Completed all the necessary actions in the phase.
+		/// Gets or sets the RoundPhase that completed all the necessary actions in the phase.
 		/// </summary>
 		public RoundPhase CompletedPhase { get; set; }
 

--- a/WalletWasabi/CoinJoin/Common/Models/RoundStateResponse.cs
+++ b/WalletWasabi/CoinJoin/Common/Models/RoundStateResponse.cs
@@ -41,6 +41,7 @@ namespace WalletWasabi.CoinJoin.Common.Models
 		public long RoundId { get; set; }
 
 		/// <summary>
+		/// Gets or sets the number of successful rounds.
 		/// This is round independent, it is only here because of backward compatibility.
 		/// </summary>
 		public int SuccessfulRoundCount { get; set; }

--- a/WalletWasabi/Interfaces/IConfig.cs
+++ b/WalletWasabi/Interfaces/IConfig.cs
@@ -6,7 +6,7 @@ namespace WalletWasabi.Interfaces
 	public interface IConfig
 	{
 		/// <summary>
-		/// The path of the config file.
+		/// Gets the path of the config file.
 		/// </summary>
 		string FilePath { get; }
 

--- a/WalletWasabi/Io/DigestableSafeMutexIoManager.cs
+++ b/WalletWasabi/Io/DigestableSafeMutexIoManager.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.Io
 		public string DigestFilePath { get; }
 
 		/// <summary>
-		/// Use the random index of the line to create digest faster. -1 is special value, it means the last character. If null then hash whole file.
+		/// Gets a random index of the line to create digest faster. -1 is special value, it means the last character. If null then hash whole file.
 		/// </summary>
 		private int? DigestRandomIndex { get; }
 

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.Logging
 		public static Guid InstanceGuid { get; } = Guid.NewGuid();
 
 		/// <summary>
-		/// KB
+		/// Gets the maximum log file size in KB
 		/// </summary>
 		public static long MaximumLogFileSize { get; private set; } = 10_000; // approx 10 MB
 

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -29,6 +29,7 @@ namespace WalletWasabi.Logging
 		public static string EntrySeparator { get; private set; } = Environment.NewLine;
 
 		/// <summary>
+		/// Gets the Guid instance.
 		/// You can use it to identify which software instance created a log entry.
 		/// It gets created automatically, but you have to use it manually.
 		/// </summary>

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -65,34 +65,34 @@ namespace Nito.AsyncEx
 		public bool IsQuitPending { get; set; }
 
 		/// <summary>
-		/// Short name of the mutex. This string added to the end of the mutex name.
+		/// Gets or sets the short name of the mutex. This string added to the end of the mutex name.
 		/// </summary>
 		private string ShortName { get; set; }
 
 		/// <summary>
-		/// The full name of the named mutex. Global\ included in the string.
+		/// Gets or sets the full name of the named mutex. Global\ included in the string.
 		/// </summary>
 		private string FullName { get; set; }
 
 		/// <summary>
-		/// Mutex for interprocess synchronization.
+		/// Gets or sets the Mutex for interprocess synchronization.
 		/// </summary>
 		private Mutex Mutex { get; set; }
 
 		/// <summary>
-		/// AsyncLock for local thread synchronization.
+		/// Gets or sets the AsyncLock for local thread synchronization.
 		/// </summary>
 		private AsyncLock AsyncLock { get; set; }
 
 		/// <summary>
-		/// Separate thread for the mutex where it is created and released.
+		/// Gets or sets a separate thread for the mutex where it is created and released.
 		/// </summary>
 		private Thread MutexThread { get; set; }
 
 		private bool IsAlive => MutexThread?.IsAlive is true;
 
 		/// <summary>
-		/// Static storage for local mutexes. It can be used to get an already existing AsyncLock by name of the mutex.
+		/// Gets the static storage for local mutexes. It can be used to get an already existing AsyncLock by name of the mutex.
 		/// </summary>
 		private static Dictionary<string, AsyncMutex> AsyncMutexes { get; } = new Dictionary<string, AsyncMutex>();
 

--- a/WalletWasabi/Nito/AsyncEx/IAsyncWaitQueue.cs
+++ b/WalletWasabi/Nito/AsyncEx/IAsyncWaitQueue.cs
@@ -13,7 +13,7 @@ namespace Nito.AsyncEx
 	public interface IAsyncWaitQueue<T>
 	{
 		/// <summary>
-		/// Gets whether the queue is empty.
+		/// Gets a value indicating whether the queue is empty.
 		/// </summary>
 		bool IsEmpty { get; }
 

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Services
 		public Network Network { get; private set; }
 
 		/// <summary>
-		/// The Bitcoin price in USD.
+		/// Gets the Bitcoin price in USD.
 		/// </summary>
 		public decimal UsdExchangeRate
 		{


### PR DESCRIPTION
https://documentation.help/StyleCop/SA1623.html

> The property’s summary text must begin with wording describing the types of accessors exposed within the property. If the property contains only a get accessor, the summary must begin with the word “Gets”. If the property contains only a set accessor, the summary must begin with the word “Sets”. If the property exposes both a get and set accessor, the summary text must begin with “Gets or sets”.