### PR TITLE
Enable DocumentationTextMustNotBeEmpty

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -246,7 +246,7 @@
         </Rule>
         <Rule Name="DocumentationTextMustNotBeEmpty">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="DocumentationTextMustBeginWithACapitalLetter">


### PR DESCRIPTION
https://documentation.help/StyleCop/SA1627.html

> A violation of this rule occurs when the documentation header for an element contains an empty tag.