### PR TITLE
Password finder

### DIFF
--- a/WalletWasabi.Gui/CommandLine/PasswordFinderCommand.cs
+++ b/WalletWasabi.Gui/CommandLine/PasswordFinderCommand.cs
@@ -19,16 +19,16 @@ namespace WalletWasabi.Gui.CommandLine
 
 			Options = new OptionSet()
 			{
-				"usage: findpassword --wallet:WalletName --language:lang --numbers:[TRUE|FALSE] --symbold:[TRUE|FALSE]",
+				"usage: findpassword --wallet:WalletName --language:lang --numbers:[TRUE|FALSE] --symbols:[TRUE|FALSE]",
 				"",
 				"Tries to find typing mistakes in the user password by brute forcing it char by char.",
-				"eg: ./wassabee findpassword --wallet:MyWalletName --numbers:false --symbold:true",
+				"eg: ./wassabee findpassword --wallet:MyWalletName --numbers:false --symbols:true",
 				"",
 				{ "w|wallet=", "The name of the wallet file.", x => WalletName = x },
 				{ "s|secret=", "You can specify an encrypted secret key instead of wallet. Example of encrypted secret: 6PYTMDmkxQrSv8TK4761tuKrV8yFwPyZDqjJafcGEiLBHiqBV6WviFxJV4", x => EncryptedSecret = Guard.Correct(x) },
 				{ "l|language=", "The charset to use: en, es, it, fr, pt. Default=en.", v => Language = v },
-				{ "n|numbers=", "Try passwords with numbers. Default=true.", v => UseNumbers = (v.Length == 0 || v == "1" || v.ToUpper() == "TRUE") },
-				{ "x|symbols=", "Try passwords with symbolds. Default=true.", v => UseSymbols = (v.Length == 0 || v == "1" || v.ToUpper() == "TRUE") },
+				{ "n|numbers=", "Try passwords with numbers. Default=false.", v => UseNumbers = (v.Length == 0 || v == "1" || v.ToUpper() == "TRUE") },
+				{ "x|symbols=", "Try passwords with symbols. Default=false.", v => UseSymbols = (v.Length == 0 || v == "1" || v.ToUpper() == "TRUE") },
 				{ "h|help", "Show Help", v => ShowHelp = true }
 			};
 		}


### PR DESCRIPTION
Currently if you run `wassabeed.exe findpassword --wallet:walletname` on Windows the `numbers` argument is false, it should be true by default.
Same for `symbols` argument.