### PR TITLE
Payjoin Improvements

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public override string DoButtonText => "Send Transaction";
 		public override string DoingButtonText => "Sending Transaction...";
 
-		private Func<PSBT, CancellationToken, Task<(PSBT PSBT, bool Signed)>> GetSigner()
+		private Func<PSBT, CancellationToken, Task<PSBT>> GetSigner()
 		{
 			if (!Wallet.KeyManager.IsHardwareWallet)
 			{
@@ -51,19 +51,19 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						.AcquiringSignatureFromHardwareWallet);
 					try
 					{
-						return (await hwiClient.SignTxAsync(Wallet.KeyManager.MasterFingerprint.Value, psbt, false,
-							cancellationToken), true);
+						return await hwiClient.SignTxAsync(Wallet.KeyManager.MasterFingerprint.Value, psbt, false,
+							cancellationToken);
 					}
 					catch (HwiException)
 					{
 						await PinPadViewModel.UnlockAsync();
-						return (await hwiClient.SignTxAsync(Wallet.KeyManager.MasterFingerprint.Value, psbt, false,
-							cancellationToken), true);
+						return await hwiClient.SignTxAsync(Wallet.KeyManager.MasterFingerprint.Value, psbt, false,
+							cancellationToken);
 					}
 				}
 				catch
 				{
-					return (psbt, false);
+					return null;
 				}
 				finally
 				{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -101,7 +101,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			base.OnAddressPaste(url);
 
-			if (url.UnknowParameters.TryGetValue("bpu", out var endPoint) || url.UnknowParameters.TryGetValue("pj", out endPoint))
+			if (url.UnknowParameters.TryGetValue("pj", out var endPoint))
 			{
 				if (!Wallet.KeyManager.IsWatchOnly)
 				{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -67,13 +67,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					PSBT signedPsbt = await SignWithHWW(result.Psbt);
 					if (pjClient != null)
 					{
-						var signedPayjoinPsbt = await pjClient.TryNegotiatePayjoin(SignWithHWW, signedPsbt,
-							Wallet.KeyManager);
-						if (signedPayjoinPsbt != null)
-						{
-							//TODO: Schedule signedPsbt to be broadcast in 2 mins
-							signedPsbt = signedPayjoinPsbt;
-						}
+							var signedPayjoinPsbt = await pjClient.TryNegotiatePayjoin(SignWithHWW, signedPsbt,
+								Wallet.KeyManager);
+							if (signedPayjoinPsbt != null)
+							{
+								//TODO: Schedule signedPsbt to be broadcast in 2 mins
+								signedPsbt = signedPayjoinPsbt;
+							}
 					}
 					if (!signedPsbt.IsAllFinalized())
 					{
@@ -115,7 +115,16 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					return null;
 				}
 				//TODO: Use an IHttpClientFactory to construct the HttpClient
+				if (Global.Config.Network == Network.RegTest)
+				{
+					HttpClientHandler clientHandler = new HttpClientHandler();
+					clientHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+					
+					return new PayjoinClient(payjoinEndPointUri, new HttpClient(clientHandler));
+				}
+				
 				return new PayjoinClient(payjoinEndPointUri, new HttpClient());
+
 			}
 
 			return null;

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.AcceptanceTests
 
 			// USER: CONFIRM
 			PSBT psbt = BuildPsbt(network, fingerprint, xpub1, keyPath1);
-			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token);
+			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token);
 
 			Transaction signedTx = signedPsbt.GetOriginalTransaction();
 			Assert.Equal(psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
@@ -209,11 +209,11 @@ namespace WalletWasabi.Tests.AcceptanceTests
 			PSBT psbt = BuildPsbt(network, fingerprint, xpub1, keyPath1);
 
 			// USER: REFUSE
-			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token));
+			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token));
 			Assert.Equal(HwiErrorCode.ActionCanceled, ex.ErrorCode);
 
 			// USER: CONFIRM
-			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token);
+			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token);
 
 			Transaction signedTx = signedPsbt.GetOriginalTransaction();
 			Assert.Equal(psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
@@ -300,11 +300,11 @@ namespace WalletWasabi.Tests.AcceptanceTests
 
 			// USER: REFUSE
 			PSBT psbt = BuildPsbt(network, fingerprint, xpub1, keyPath1);
-			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token));
+			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token));
 			Assert.Equal(HwiErrorCode.BadArgument, ex.ErrorCode);
 
 			// USER: CONFIRM
-			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token);
+			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token);
 
 			Transaction signedTx = signedPsbt.GetOriginalTransaction();
 			Assert.Equal(psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -235,9 +235,9 @@ namespace WalletWasabi.Blockchain.Transactions
 				return Task.FromResult(psbt);
 			};
 
+			UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
 			var signedPSBT = psbtSigner(psbt, CancellationToken.None).GetAwaiter().GetResult();
 			
-			UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
 			if (signedPSBT == null)
 			{
 				tx = psbt.GetGlobalTransaction();
@@ -251,6 +251,8 @@ namespace WalletWasabi.Blockchain.Transactions
 				{
 					//TODO: Schedule signedPsbt to be broadcast in 2 mins
 					psbt = signedPayjoinPsbt;
+					
+					UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
 				}
 				
 				psbt.Finalize();
@@ -276,7 +278,6 @@ namespace WalletWasabi.Blockchain.Transactions
 				}
 			}
 
-			UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
 
 			var label = SmartLabel.Merge(payments.Requests.Select(x => x.Label).Concat(spentCoins.Select(x => x.Label)));
 			var outerWalletOutputs = new List<SmartCoin>();

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -223,7 +223,7 @@ namespace WalletWasabi.Blockchain.Transactions
 			{
 				if (KeyManager.IsWatchOnly)
 				{
-					return null;
+					return Task.FromResult((PSBT)null);
 				}
 
 				var psbt = psbt1.Clone();

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -162,13 +162,13 @@ namespace WalletWasabi.Hwi
 			return address;
 		}
 
-		public async Task<PSBT> SignTxAsync(HardwareWalletModels deviceType, string devicePath, PSBT psbt, CancellationToken cancel)
-			=> await SignTxImplAsync(deviceType, devicePath, null, psbt, cancel);
+		public async Task<PSBT> SignTxAsync(HardwareWalletModels deviceType, string devicePath, PSBT psbt, bool finalize, CancellationToken cancel)
+			=> await SignTxImplAsync(deviceType, devicePath, null, psbt, finalize, cancel);
 
-		public async Task<PSBT> SignTxAsync(HDFingerprint fingerprint, PSBT psbt, CancellationToken cancel)
-			=> await SignTxImplAsync(null, null, fingerprint, psbt, cancel);
+		public async Task<PSBT> SignTxAsync(HDFingerprint fingerprint, PSBT psbt, bool finalize, CancellationToken cancel)
+			=> await SignTxImplAsync(null, null, fingerprint, psbt, finalize, cancel);
 
-		private async Task<PSBT> SignTxImplAsync(HardwareWalletModels? deviceType, string devicePath, HDFingerprint? fingerprint, PSBT psbt, CancellationToken cancel)
+		private async Task<PSBT> SignTxImplAsync(HardwareWalletModels? deviceType, string devicePath, HDFingerprint? fingerprint, PSBT psbt, bool finalize, CancellationToken cancel)
 		{
 			var psbtString = psbt.ToBase64();
 
@@ -181,7 +181,7 @@ namespace WalletWasabi.Hwi
 
 			PSBT signedPsbt = HwiParser.ParsePsbt(response, Network);
 
-			if (!signedPsbt.IsAllFinalized())
+			if (finalize && !signedPsbt.IsAllFinalized())
 			{
 				signedPsbt.Finalize();
 			}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -220,7 +220,7 @@ namespace WalletWasabi.Wallets
 			bool allowUnconfirmed = false,
 			IEnumerable<OutPoint> allowedInputs = null,
 			IPayjoinClient payjoinClient = null,
-			Func<PSBT, CancellationToken, Task<(PSBT PSBT, bool Signed)>> psbtSigner = null)
+			Func<PSBT, CancellationToken, Task<PSBT>> psbtSigner = null)
 		{
 			var builder = new TransactionFactory(Network, KeyManager, Coins, password, allowUnconfirmed);
 			return builder.BuildTransaction(

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -219,7 +219,8 @@ namespace WalletWasabi.Wallets
 			FeeStrategy feeStrategy,
 			bool allowUnconfirmed = false,
 			IEnumerable<OutPoint> allowedInputs = null,
-			IPayjoinClient payjoinClient = null)
+			IPayjoinClient payjoinClient = null,
+			Func<PSBT, CancellationToken, Task<(PSBT PSBT, bool Signed)>> psbtSigner = null)
 		{
 			var builder = new TransactionFactory(Network, KeyManager, Coins, password, allowUnconfirmed);
 			return builder.BuildTransaction(
@@ -241,7 +242,8 @@ namespace WalletWasabi.Wallets
 				},
 				allowedInputs,
 				SelectLockTimeForTransaction,
-				payjoinClient);
+				payjoinClient,
+				psbtSigner);
 		}
 
 		public void RenameLabel(SmartCoin coin, SmartLabel newLabel)

--- a/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
@@ -8,9 +8,6 @@ namespace WalletWasabi.WebClients.PayJoin
 	public interface IPayjoinClient
 	{
 		Uri PaymentUrl { get; }
-
-		// Task<PSBT> RequestPayjoin(PSBT originalTx, IHDKey accountKey, RootedKeyPath rootedKeyPath, CancellationToken cancellationToken);
 		Task<PSBT> TryNegotiatePayjoin(Func<PSBT, Task<PSBT>> sign, PSBT psbt, KeyManager keyManager);
-
 	}
 }

--- a/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
 using WalletWasabi.Blockchain.Keys;
@@ -8,6 +9,7 @@ namespace WalletWasabi.WebClients.PayJoin
 	public interface IPayjoinClient
 	{
 		Uri PaymentUrl { get; }
-		Task<PSBT> TryNegotiatePayjoin(Func<PSBT, Task<PSBT>> sign, PSBT psbt, KeyManager keyManager);
+		Task<PSBT> TryNegotiatePayjoin(Func<PSBT, CancellationToken, Task<(PSBT PSBT, bool Signed)>> sign, PSBT psbt,
+			KeyManager keyManager, CancellationToken cancellationToken);
 	}
 }

--- a/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
 
 namespace WalletWasabi.WebClients.PayJoin
 {
@@ -9,6 +9,8 @@ namespace WalletWasabi.WebClients.PayJoin
 	{
 		Uri PaymentUrl { get; }
 
-		Task<PSBT> RequestPayjoin(PSBT originalTx, IHDKey accountKey, RootedKeyPath rootedKeyPath, CancellationToken cancellationToken);
+		// Task<PSBT> RequestPayjoin(PSBT originalTx, IHDKey accountKey, RootedKeyPath rootedKeyPath, CancellationToken cancellationToken);
+		Task<PSBT> TryNegotiatePayjoin(Func<PSBT, Task<PSBT>> sign, PSBT psbt, KeyManager keyManager);
+
 	}
 }

--- a/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/IPayjoinClient.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.WebClients.PayJoin
 	public interface IPayjoinClient
 	{
 		Uri PaymentUrl { get; }
-		Task<PSBT> TryNegotiatePayjoin(Func<PSBT, CancellationToken, Task<(PSBT PSBT, bool Signed)>> sign, PSBT psbt,
+		Task<PSBT> TryNegotiatePayjoin(Func<PSBT, CancellationToken, Task<PSBT>> sign, PSBT psbt,
 			KeyManager keyManager, CancellationToken cancellationToken);
 	}
 }

--- a/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
@@ -265,7 +265,7 @@ namespace WalletWasabi.WebClients.PayJoin
 			return newPSBT;
 		}
 		
-		public async Task<PSBT> TryNegotiatePayjoin(Func<PSBT, CancellationToken, Task<(PSBT PSBT, bool Signed)>> sign, PSBT psbt, KeyManager keyManager, CancellationToken cancellationToken)
+		public async Task<PSBT> TryNegotiatePayjoin(Func<PSBT, CancellationToken, Task<PSBT>> sign, PSBT psbt, KeyManager keyManager, CancellationToken cancellationToken)
 		{
 			try
 			{
@@ -281,13 +281,13 @@ namespace WalletWasabi.WebClients.PayJoin
 				}
 
 				var signedPayjoinPsbt = await sign.Invoke(psbt, cancellationToken);
-				if (!signedPayjoinPsbt.Signed)
+				if (signedPayjoinPsbt == null)
 				{
 					Logger.LogWarning($"Payjoin PSBT could not be signed. Ignoring...");
 					return null;
 				}
 				Logger.LogInfo($"Payjoin payment was negotiated successfully.");
-				return signedPayjoinPsbt.PSBT;
+				return signedPayjoinPsbt;
 			}
 			catch (TorSocks5FailureResponseException e)
 			{


### PR DESCRIPTION
* Removes the BIP21 check for the `bpu` key. This is not guaranteed to be compatible
* When Tor is disabled and you paste a PJ enabled BIP21, it threw the following error:
![dotnet_pA7fyQ6txw](https://user-images.githubusercontent.com/1818366/81171433-b0141e00-8f9c-11ea-9db2-4604cd0d8bbb.png)
Now, when Tor is disabled:
  * If the endpoint is an onion url, shows a warning and ignores
  * Create an `HttpClient` (which I've also added a TODO alongside it to eventually use `IHttpClientFactory` to create)
* Moved the `TryNegotiatePayjoin` from `TransactionFactory` to `PayjoinClient` so that I could reuse it in the Send ViewModel
* Enabled payjoin for hardware wallets
* Added todos as we should schedule broadcasting the original transaction after some time in any case 
