### PR TITLE
Add a shebang line to the top of .coverage.sh file

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 COLLECT_COVERAGE="//p:CollectCoverage=true"
 OUTPUT_FORMAT="//p:CoverletOutputFormat=lcov"
 FILE_NAME="//p:CoverletOutputName=lcov"


### PR DESCRIPTION
https://www.codefactor.io/repository/github/zksnacks/walletwasabi/issues?category=Maintainability&groupId=2412

It is the first time I see that, maybe adding `#!/bin/bash` will fix that.

https://github.com/koalaman/shellcheck/wiki/SC2148