### PR TITLE
Refactor TransactionBuilder to be able to add different signers

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HwiPsbtSigner.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HwiPsbtSigner.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Gui.Models.StatusBarStatuses;
+using WalletWasabi.Gui.ViewModels;
+using WalletWasabi.Hwi;
+using WalletWasabi.Hwi.Exceptions;
+using WalletWasabi.Interfaces;
+
+namespace WalletWasabi.Gui.Controls.WalletExplorer
+{
+	internal class HwiPsbtSigner : IPsbtSigner
+	{
+		private readonly HwiClient _hwiClient;
+		private readonly Action<bool> _hardwareBusyModifier;
+
+		public HwiPsbtSigner(HwiClient hwiClient, Action<bool> hardwareBusyModifier)
+		{
+			_hwiClient = hwiClient;
+			_hardwareBusyModifier = hardwareBusyModifier;
+		}
+
+		public async Task<PSBT> TrySign(PSBT psbt, KeyManager keyManager, CancellationToken cancellationToken)
+		{
+			try
+			{
+				if (!keyManager.IsHardwareWallet)
+				{
+					return null;
+				}
+
+				_hardwareBusyModifier.Invoke(true);
+				MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusType
+					.AcquiringSignatureFromHardwareWallet);
+				try
+				{
+					return await _hwiClient.SignTxAsync(keyManager.MasterFingerprint.Value, psbt, false,
+						cancellationToken);
+				}
+				catch (HwiException)
+				{
+					await PinPadViewModel.UnlockAsync();
+					return await _hwiClient.SignTxAsync(keyManager.MasterFingerprint.Value, psbt, false,
+						cancellationToken);
+				}
+			}
+			catch
+			{
+				return null;
+			}
+			finally
+			{
+				MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusType
+					.AcquiringSignatureFromHardwareWallet);
+				_hardwareBusyModifier.Invoke(false);
+			}
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Gui.Helpers;
@@ -16,6 +17,7 @@ using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.PayJoin;
 using WalletWasabi.Gui.Validation;
+using WalletWasabi.Interfaces;
 
 namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
@@ -33,39 +35,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		protected override async Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint> allowedInputs = null)
 		{
-			BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, payments, feeStrategy, allowUnconfirmed: true, allowedInputs: allowedInputs, GetPayjoinClient()));
+			BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, payments, feeStrategy, allowUnconfirmed: true, allowedInputs: allowedInputs, GetPayjoinClient(), GetSigner()));
 
 			MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusType.SigningTransaction);
 			SmartTransaction signedTransaction = result.Transaction;
-
-			if (Wallet.KeyManager.IsHardwareWallet && !result.Signed) // If hardware but still has a privkey then it's password, then meh.
-			{
-				try
-				{
-					IsHardwareBusy = true;
-					MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusType.AcquiringSignatureFromHardwareWallet);
-					var client = new HwiClient(Global.Network);
-
-					using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
-					PSBT signedPsbt = null;
-					try
-					{
-						signedPsbt = await client.SignTxAsync(Wallet.KeyManager.MasterFingerprint.Value, result.Psbt, cts.Token);
-					}
-					catch (HwiException)
-					{
-						await PinPadViewModel.UnlockAsync();
-						signedPsbt = await client.SignTxAsync(Wallet.KeyManager.MasterFingerprint.Value, result.Psbt, cts.Token);
-					}
-					signedTransaction = signedPsbt.ExtractSmartTransaction(result.Transaction);
-				}
-				finally
-				{
-					MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusType.AcquiringSignatureFromHardwareWallet);
-					IsHardwareBusy = false;
-				}
-			}
-
 			MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusType.BroadcastingTransaction);
 			await Task.Run(async () => await Global.TransactionBroadcaster.SendTransactionAsync(signedTransaction));
 
@@ -117,6 +90,61 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			base.ResetUi();
 			PayjoinEndPoint = "";
+		}
+
+		private IPsbtSigner GetSigner()
+		{
+			return !Wallet.KeyManager.IsHardwareWallet
+				? null
+				: new HwiPsbtSigner(new HwiClient(Global.Network), b => IsHardwareBusy = b);
+		}
+
+		class HwiPsbtSigner : IPsbtSigner
+		{
+			private readonly HwiClient _hwiClient;
+			private readonly Action<bool> _hardwareBusyModifier;
+
+			public HwiPsbtSigner(HwiClient hwiClient, Action<bool> hardwareBusyModifier)
+			{
+				_hwiClient = hwiClient;
+				_hardwareBusyModifier = hardwareBusyModifier;
+			}
+
+			public async Task<PSBT> TrySign(PSBT psbt, KeyManager keyManager, CancellationToken cancellationToken)
+			{
+				try
+				{
+					if (!keyManager.IsHardwareWallet)
+					{
+						return null;
+					}
+
+					_hardwareBusyModifier.Invoke(true);
+					MainWindowViewModel.Instance.StatusBar.TryAddStatus(StatusType
+						.AcquiringSignatureFromHardwareWallet);
+					try
+					{
+						return await _hwiClient.SignTxAsync(keyManager.MasterFingerprint.Value, psbt, false,
+							cancellationToken);
+					}
+					catch (HwiException)
+					{
+						await PinPadViewModel.UnlockAsync();
+						return await _hwiClient.SignTxAsync(keyManager.MasterFingerprint.Value, psbt, false,
+							cancellationToken);
+					}
+				}
+				catch
+				{
+					return null;
+				}
+				finally
+				{
+					MainWindowViewModel.Instance.StatusBar.TryRemoveStatus(StatusType
+						.AcquiringSignatureFromHardwareWallet);
+					_hardwareBusyModifier.Invoke(false);
+				}
+			}
 		}
 	}
 }

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -32,7 +32,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public override string DoButtonText => "Send Transaction";
 		public override string DoingButtonText => "Sending Transaction...";
-
+		public string PayjoinEndPoint
+		{
+			get => _payjoinEndPoint;
+			set => this.RaiseAndSetIfChanged(ref _payjoinEndPoint, value);
+		}
 		protected override async Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint> allowedInputs = null)
 		{
 			BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, payments, feeStrategy, allowUnconfirmed: true, allowedInputs: allowedInputs, GetPayjoinClient(), GetSigner()));
@@ -43,12 +47,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			await Task.Run(async () => await Global.TransactionBroadcaster.SendTransactionAsync(signedTransaction));
 
 			ResetUi();
-		}
-
-		public string PayjoinEndPoint
-		{
-			get => _payjoinEndPoint;
-			set => this.RaiseAndSetIfChanged(ref _payjoinEndPoint, value);
 		}
 
 		private IPayjoinClient GetPayjoinClient()
@@ -99,7 +97,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				: new HwiPsbtSigner(new HwiClient(Global.Network), b => IsHardwareBusy = b);
 		}
 
-		class HwiPsbtSigner : IPsbtSigner
+		private class HwiPsbtSigner : IPsbtSigner
 		{
 			private readonly HwiClient _hwiClient;
 			private readonly Action<bool> _hardwareBusyModifier;

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.AcceptanceTests
 
 			// USER: CONFIRM
 			PSBT psbt = BuildPsbt(network, fingerprint, xpub1, keyPath1);
-			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token);
+			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token);
 
 			Transaction signedTx = signedPsbt.GetOriginalTransaction();
 			Assert.Equal(psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
@@ -209,11 +209,11 @@ namespace WalletWasabi.Tests.AcceptanceTests
 			PSBT psbt = BuildPsbt(network, fingerprint, xpub1, keyPath1);
 
 			// USER: REFUSE
-			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token));
+			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token));
 			Assert.Equal(HwiErrorCode.ActionCanceled, ex.ErrorCode);
 
 			// USER: CONFIRM
-			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token);
+			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token);
 
 			Transaction signedTx = signedPsbt.GetOriginalTransaction();
 			Assert.Equal(psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
@@ -300,11 +300,11 @@ namespace WalletWasabi.Tests.AcceptanceTests
 
 			// USER: REFUSE
 			PSBT psbt = BuildPsbt(network, fingerprint, xpub1, keyPath1);
-			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token));
+			var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token));
 			Assert.Equal(HwiErrorCode.BadArgument, ex.ErrorCode);
 
 			// USER: CONFIRM
-			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, cts.Token);
+			PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, psbt, true, cts.Token);
 
 			Transaction signedTx = signedPsbt.GetOriginalTransaction();
 			Assert.Equal(psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());

--- a/WalletWasabi/Blockchain/Transactions/DefaultPSBTSigner.cs
+++ b/WalletWasabi/Blockchain/Transactions/DefaultPSBTSigner.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Interfaces;
+
+namespace WalletWasabi.Blockchain.Transactions
+{
+	public class DefaultPSBTSigner : IPsbtSigner
+	{
+		private readonly string _password;
+		private readonly SmartCoin[] _spentCoins;
+		private readonly TransactionBuilder _transactionBuilder;
+		private readonly Func<LockTime> _lockTimeSelector;
+
+		public DefaultPSBTSigner(string password, SmartCoin[] spentCoins, TransactionBuilder transactionBuilder,
+			Func<LockTime> lockTimeSelector)
+		{
+			_password = password;
+			_spentCoins = spentCoins;
+			_transactionBuilder = transactionBuilder;
+			_lockTimeSelector = lockTimeSelector;
+		}
+
+		public Task<PSBT> TrySign(PSBT psbt, KeyManager keyManager, CancellationToken cancellationToken)
+		{
+			if (keyManager.IsWatchOnly)
+			{
+				return Task.FromResult((PSBT) null);
+			}
+
+			var workingPsbt = psbt.Clone();
+			IEnumerable<ExtKey> signingKeys =
+				keyManager.GetSecrets(_password, _spentCoins.Select(x => x.ScriptPubKey).ToArray());
+			var workingTransactionBuilder = _transactionBuilder.AddKeys(signingKeys.ToArray());
+			workingTransactionBuilder.SetLockTime(_lockTimeSelector());
+			workingTransactionBuilder.SignPSBT(workingPsbt);
+			return Task.FromResult(workingPsbt);
+		}
+	}
+}

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -221,7 +221,7 @@ namespace WalletWasabi.Blockchain.Transactions
 			psbtSigner ??= new DefaultPSBTSigner(Password, spentCoins, builder, lockTimeSelector);
 			UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
 			var signedPSBT = psbtSigner.TrySign(psbt, KeyManager, CancellationToken.None).GetAwaiter().GetResult();
-			if (signedPSBT == null)
+			if (signedPSBT is null)
 			{
 				tx = psbt.GetGlobalTransaction();
 			}
@@ -324,13 +324,13 @@ namespace WalletWasabi.Blockchain.Transactions
 					KeyManager.ExtPubKey,
 					new RootedKeyPath(KeyManager.MasterFingerprint.Value, KeyManager.AccountKeyPath),
 					cancellationToken);
-				if (psbt == null)
+				if (psbt is null)
 				{
 					return null;
 				}
 
 				var signedPayjoinPsbt = await psbtSigner.TrySign(psbt, KeyManager, cancellationToken);
-				if (signedPayjoinPsbt == null)
+				if (signedPayjoinPsbt is null)
 				{
 					Logger.LogWarning($"Payjoin PSBT could not be signed. Ignoring...");
 					return null;

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -162,13 +162,13 @@ namespace WalletWasabi.Hwi
 			return address;
 		}
 
-		public async Task<PSBT> SignTxAsync(HardwareWalletModels deviceType, string devicePath, PSBT psbt, CancellationToken cancel)
-			=> await SignTxImplAsync(deviceType, devicePath, null, psbt, cancel);
+		public async Task<PSBT> SignTxAsync(HardwareWalletModels deviceType, string devicePath, PSBT psbt, bool finalize, CancellationToken cancel)
+			=> await SignTxImplAsync(deviceType, devicePath, null, psbt, finalize, cancel);
 
-		public async Task<PSBT> SignTxAsync(HDFingerprint fingerprint, PSBT psbt, CancellationToken cancel)
-			=> await SignTxImplAsync(null, null, fingerprint, psbt, cancel);
+		public async Task<PSBT> SignTxAsync(HDFingerprint fingerprint, PSBT psbt, bool finalize, CancellationToken cancel)
+			=> await SignTxImplAsync(null, null, fingerprint, psbt, finalize, cancel);
 
-		private async Task<PSBT> SignTxImplAsync(HardwareWalletModels? deviceType, string devicePath, HDFingerprint? fingerprint, PSBT psbt, CancellationToken cancel)
+		private async Task<PSBT> SignTxImplAsync(HardwareWalletModels? deviceType, string devicePath, HDFingerprint? fingerprint, PSBT psbt, bool finalize, CancellationToken cancel)
 		{
 			var psbtString = psbt.ToBase64();
 
@@ -181,7 +181,7 @@ namespace WalletWasabi.Hwi
 
 			PSBT signedPsbt = HwiParser.ParsePsbt(response, Network);
 
-			if (!signedPsbt.IsAllFinalized())
+			if (finalize && !signedPsbt.IsAllFinalized())
 			{
 				signedPsbt.Finalize();
 			}

--- a/WalletWasabi/Interfaces/IPsbtSigner.cs
+++ b/WalletWasabi/Interfaces/IPsbtSigner.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+
+namespace WalletWasabi.Interfaces
+{
+	public interface IPsbtSigner
+	{
+		Task<PSBT> TrySign(PSBT psbt, KeyManager keyManager, CancellationToken cancellationToken);
+	}
+}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -27,6 +27,7 @@ using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
 using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
+using WalletWasabi.Interfaces;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
@@ -219,7 +220,8 @@ namespace WalletWasabi.Wallets
 			FeeStrategy feeStrategy,
 			bool allowUnconfirmed = false,
 			IEnumerable<OutPoint> allowedInputs = null,
-			IPayjoinClient payjoinClient = null)
+			IPayjoinClient payjoinClient = null,
+			IPsbtSigner psbtSigner = null)
 		{
 			var builder = new TransactionFactory(Network, KeyManager, Coins, password, allowUnconfirmed);
 			return builder.BuildTransaction(
@@ -241,7 +243,8 @@ namespace WalletWasabi.Wallets
 				},
 				allowedInputs,
 				SelectLockTimeForTransaction,
-				payjoinClient);
+				payjoinClient,
+				psbtSigner);
 		}
 
 		public void RenameLabel(SmartCoin coin, SmartLabel newLabel)


### PR DESCRIPTION
I've also got another commit on top of this that gets rid of `GetAwaiter().GetResult()` as per https://github.com/zkSNACKs/WalletWasabi/pull/3626#discussion_r422109510 but it's a bit big (https://github.com/Kukks/WalletWasabi/tree/builder-different-signers-async) 
Let me know if i should include it or open it as a separate PR after this