### PR TITLE
Remove BIP21 "bpu" payjoin detection

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -101,7 +101,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			base.OnAddressPaste(url);
 
-			if (url.UnknowParameters.TryGetValue("bpu", out var endPoint) || url.UnknowParameters.TryGetValue("pj", out endPoint))
+			if (url.UnknowParameters.TryGetValue("pj", out var endPoint))
 			{
 				if (!Wallet.KeyManager.IsWatchOnly)
 				{


### PR DESCRIPTION
The new Payjoin spec is not guaranteed to work with BIP79 so I would remove its BIP21 key as a signal for payjoin.