### PR TITLE
Check if IsCoinBase first when checking if utxo is immature

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -222,6 +222,12 @@ namespace WalletWasabi.Backend.Controllers
 						// Check if unconfirmed.
 						if (getTxOutResponse.Confirmations <= 0)
 						{
+							// Check if immature.
+							if (getTxOutResponse.IsCoinBase)
+							{
+								return BadRequest("Provided input is immature.");
+							}
+
 							// If it spends a CJ then it may be acceptable to register.
 							if (!await Coordinator.ContainsUnconfirmedCoinJoinAsync(inputProof.Input.Hash))
 							{

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -222,12 +222,6 @@ namespace WalletWasabi.Backend.Controllers
 						// Check if unconfirmed.
 						if (getTxOutResponse.Confirmations <= 0)
 						{
-							// Check if immature.
-							if (getTxOutResponse.IsCoinBase)
-							{
-								return BadRequest("Provided input is immature.");
-							}
-
 							// If it spends a CJ then it may be acceptable to register.
 							if (!await Coordinator.ContainsUnconfirmedCoinJoinAsync(inputProof.Input.Hash))
 							{

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -238,12 +238,9 @@ namespace WalletWasabi.Backend.Controllers
 						}
 
 						// Check if immature.
-						if (getTxOutResponse.IsCoinBase)
+						if (getTxOutResponse.IsCoinBase && getTxOutResponse.Confirmations <= 100)
 						{
-							if (getTxOutResponse.Confirmations <= 100)
-							{
-								return BadRequest("Provided input is immature.");
-							}
+							return BadRequest("Provided input is immature.");
 						}
 
 						// Check if inputs are native segwit.

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -238,9 +238,9 @@ namespace WalletWasabi.Backend.Controllers
 						}
 
 						// Check if immature.
-						if (getTxOutResponse.Confirmations <= 100)
+						if (getTxOutResponse.IsCoinBase)
 						{
-							if (getTxOutResponse.IsCoinBase)
+							if (getTxOutResponse.Confirmations <= 100)
 							{
 								return BadRequest("Provided input is immature.");
 							}


### PR DESCRIPTION
- There is less coinbase utxos than utxos with confirmations <= 100, and more importantly there is very few coinbase utxos that are coinjoined, so it makes sense to check if IsCoinBase first when checking if utxo is immature.

This is to slightly optimize the code.