### PR TITLE
Hide CoinJoin tab if watch only wallet

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -92,12 +92,7 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <StackPanel IsVisible="{Binding IsWatchOnly}" Grid.Column="0" Spacing="8">
-            <StackPanel IsVisible="{Binding IsHardwareWallet}" VerticalAlignment="Center">
-              <TextBlock Text="Hardware wallets cannot coinjoin :(" />
-            </StackPanel>
-          </StackPanel>
-          <StackPanel IsVisible="{Binding !IsWatchOnly}" Grid.Column="0" Spacing="10">
+          <StackPanel Grid.Column="0" Spacing="10">
             <controls:TogglePasswordBox Text="{Binding Password}" Margin="0 20 0 0" MinWidth="200">
               <i:Interaction.Behaviors>
                 <behaviors:CommandOnEnterBehavior Command="{Binding EnqueueCommand}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModel.cs
@@ -57,7 +57,6 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 
 			ReceiveTab = new ReceiveTabViewModel(Wallet);
-			CoinjoinTab = new CoinJoinTabViewModel(Wallet);
 			HistoryTab = new HistoryTabViewModel(Wallet);
 
 			var advancedAction = new WalletAdvancedViewModel();
@@ -65,7 +64,14 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			BuildTab = new BuildTabViewModel(Wallet);
 
 			Actions.Add(ReceiveTab);
-			Actions.Add(CoinjoinTab);
+
+			// If not watch only wallet (not hww) then we need the CoinJoin tab.
+			if (!Wallet.KeyManager.IsWatchOnly)
+			{
+				CoinjoinTab = new CoinJoinTabViewModel(Wallet);
+				Actions.Add(CoinjoinTab);
+			}
+
 			Actions.Add(HistoryTab);
 
 			Actions.Add(advancedAction);
@@ -107,7 +113,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			}
 
 			shell.AddOrSelectDocument(ReceiveTab);
-			shell.AddOrSelectDocument(CoinjoinTab);
+
+			if (CoinjoinTab is { })
+			{
+				shell.AddOrSelectDocument(CoinjoinTab);
+			}
+
 			shell.AddOrSelectDocument(HistoryTab);
 
 			SelectTab(shell);


### PR DESCRIPTION
Partially addresses #3653

> 1. It is not hidden because, at that time when we integrated the HWWs, we believed that at some point it will be supported. Now I am more on the site it will be never supported. So your suggestion makes sense.