### PR TITLE
Auto close wallet manager in a better place.

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
@@ -208,16 +208,8 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.LoadWallets
 
 			try
 			{
-				var firstWalletToLoad = !Global.WalletManager.AnyWallet();
-
-				var wallet = await Task.Run(async () => await Global.WalletManager.StartWalletAsync(keyManager));
-
+				await Task.Run(async () => await Global.WalletManager.StartWalletAsync(keyManager));
 				ResortTrigger.OnNext(new Unit());
-				// Successfully initialized.
-				if (firstWalletToLoad && !Owner.IsClosed && Owner.SelectedCategory == this)
-				{
-					Owner.OnClose();
-				}
 			}
 			catch (OperationCanceledException ex)
 			{


### PR DESCRIPTION
This PR should not change anything from the UI side. I moved the auto close logic into Wallet Manager, so now it is closing itself instead of closed by an external object. 
