### PR TITLE
Dismiss false alarms on Backend about filter generation

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -433,13 +433,21 @@ namespace WalletWasabi.Backend.Controllers
 					status = new StatusResponse();
 
 					// Updating the status of the filters.
-					var lastFilter = Global.IndexBuilderService.GetLastFilter();
-					var lastFilterHash = lastFilter.Header.BlockHash;
-					var bestHash = await RpcClient.GetBestBlockHashAsync();
-					var lastBlockHeader = await RpcClient.GetBlockHeaderAsync(bestHash);
-					var prevHash = lastBlockHeader.HashPrevBlock;
+					if (DateTimeOffset.UtcNow - Global.IndexBuilderService.LastFilterBuildTime > TimeSpan.FromMinutes(20))
+					{
+						// Checking if the last generated filter is created for one of the last two blocks on the blockchain.
+						var lastFilter = Global.IndexBuilderService.GetLastFilter();
+						var lastFilterHash = lastFilter.Header.BlockHash;
+						var bestHash = await RpcClient.GetBestBlockHashAsync();
+						var lastBlockHeader = await RpcClient.GetBlockHeaderAsync(bestHash);
+						var prevHash = lastBlockHeader.HashPrevBlock;
 
-					if (bestHash == lastFilterHash || prevHash == lastFilterHash)
+						if (bestHash == lastFilterHash || prevHash == lastFilterHash)
+						{
+							status.FilterCreationActive = true;
+						}
+					}
+					else
 					{
 						status.FilterCreationActive = true;
 					}

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -74,6 +74,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 		public uint StartingHeight { get; }
 		public bool IsRunning => Interlocked.Read(ref _serviceStatus) == Running;
 		public bool IsStopping => Interlocked.Read(ref _serviceStatus) >= Stopping;
+		public DateTimeOffset LastFilterBuildTime { get; private set; }
 
 		public static GolombRiceFilter CreateDummyEmptyFilter(uint256 blockHash)
 		{
@@ -222,6 +223,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 								{
 									Logger.LogDebug($"Created filter for block: {nextHeight}.");
 								}
+								LastFilterBuildTime = DateTimeOffset.UtcNow;
 							}
 							catch (Exception ex)
 							{


### PR DESCRIPTION
Currently, we are getting false alarms in our monitoring system, about filter generation. Now the monitor checks if the last filter is created for one of the last two blocks on the blockchain. This is not always true especially on TestNet where the backend is slower and there are mining bursts. 

Adding a time frame for the filter creation would solve this. 

So basically the monitor will fail only if both conditions fail:

- The last filter was generated more than 20 minutes ago.
- The last filter was not generated either of the last two blocks on the blockchain.

This will also slightly optimize the RPC usage. 

I checked on slack and the longest false filter downtime was 15 minutes. 