### PR TITLE
[WEBSITE] Make presskit link the direct download

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -546,7 +546,7 @@
                     <div itemscope itemtype="http://schema.org/Organization">
                     <a href="https://zksnacks.com/" class="text-light p-1 mr-xl-3" target="_blank" itemprop="name">company (zkSNACKs)</a>
                     </div>
-                    <a href="https://github.com/zkSNACKs/Meta/blob/master/WasabiPressKit.zip" class="text-light p-1 mr-xl-3" target="_blank" rel="external nofollow">press kit</a>
+                    <a href="https://github.com/zkSNACKs/Meta/raw/master/WasabiPressKit.zip" class="text-light p-1 mr-xl-3" target="_blank" rel="external nofollow">press kit</a>
 					<div>
 					<a href="https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Legal/Assets/LegalDocuments.txt" class="text-light p-1 mr-xl-3" target="_blank">privacy policy / t&c</a>
 					</div>


### PR DESCRIPTION
This makes the link of `press kit` the direct download link. when this is clicked, the download starts immediately. 

https://github.com/zkSNACKs/Meta/raw/master/WasabiPressKit.zip