### PR TITLE
Add verbose console logging for CI tests

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -28,4 +28,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --blame
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed"

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -28,4 +28,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests"
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --blame

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -28,4 +28,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --blame
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed"

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -28,4 +28,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests"
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --blame

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -28,4 +28,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --blame
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed"

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -28,4 +28,4 @@ jobs:
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests"
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --blame


### PR DESCRIPTION
This improves logging for CI tests in Azure Pipelines by adding two options to the 'Test Debug' task. 

1. `--logger "console;verbosity=detailed"` Currently, our logs only show failed tests. Adding this option shows successful tests, how long they took to complete, and at what time they completed:

![image](https://user-images.githubusercontent.com/4956763/82932625-b91e5c80-9f56-11ea-8fa3-72a8cc556673.png)

2. `--blame` 

> Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates an sequence file in TestResults/<Guid>/<Guid>_Sequence.xml that captures the order of tests that were run before the crash.

These two options may be helpful in providing clues for solving some of the more difficult CI issues like #3660, without adding much complexity or causing the tests to run much slower.