### PR TITLE
Call Environment.Exit at a better place

### DIFF
--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -124,8 +124,6 @@ namespace WalletWasabi.Gui.CommandLine
 				}
 				// Keep this loop alive as long as a coin is enqueued or keepalive was specified.
 				while (keepMixAlive || AnyCoinsQueued());
-
-				await Global.DisposeAsync();
 			}
 			catch
 			{
@@ -136,6 +134,7 @@ namespace WalletWasabi.Gui.CommandLine
 			}
 			finally
 			{
+				await Global.DisposeAsync().ConfigureAwait(false);
 				Logger.LogInfo($"{nameof(Daemon)} stopped.");
 			}
 		}

--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -134,7 +134,7 @@ namespace WalletWasabi.Gui.CommandLine
 			}
 			finally
 			{
-				await Global.DisposeAsync().ConfigureAwait(false);
+				await Global.DisposeAsync().ConfigureAwait(false); 
 				Logger.LogInfo($"{nameof(Daemon)} stopped.");
 			}
 		}

--- a/WalletWasabi.Gui/CommandLine/MixerCommand.cs
+++ b/WalletWasabi.Gui/CommandLine/MixerCommand.cs
@@ -49,6 +49,11 @@ namespace WalletWasabi.Gui.CommandLine
 			}
 			catch (Exception ex)
 			{
+				if (!(ex is OperationCanceledException))
+				{
+					Logger.LogCritical(ex);
+				}
+
 				Console.WriteLine($"commands: There was a problem interpreting the command, please review it.");
 				Logger.LogDebug(ex);
 				error = true;

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Gui
 
 		public Network Network => Config.Network;
 
-		public MemoryCache Cache  { get; private set; }
+		public MemoryCache Cache { get; private set; }
 
 		public static JsonRpcServer RpcServer { get; private set; }
 
@@ -119,10 +119,10 @@ namespace WalletWasabi.Gui
 
 			try
 			{
-				Cache = new MemoryCache(new MemoryCacheOptions 
-				{ 
-					SizeLimit = 1_000, 
-					ExpirationScanFrequency = TimeSpan.FromSeconds(30) 
+				Cache = new MemoryCache(new MemoryCacheOptions
+				{
+					SizeLimit = 1_000,
+					ExpirationScanFrequency = TimeSpan.FromSeconds(30)
 				});
 				BitcoinStore = new BitcoinStore();
 				var bstoreInitTask = BitcoinStore.InitializeAsync(Path.Combine(DataDir, "BitcoinStore"), Network);
@@ -360,17 +360,6 @@ namespace WalletWasabi.Gui
 				#endregion Blocks provider
 
 				WalletManager.RegisterServices(BitcoinStore, Synchronizer, Nodes, Config.ServiceConfiguration, FeeProviders, blockProvider);
-			}
-			catch (Exception ex)
-			{
-				if (!cancel.IsCancellationRequested)
-				{
-					Logger.LogCritical(ex);
-				}
-
-				InitializationCompleted = true;
-				await DisposeAsync().ConfigureAwait(false);
-				Environment.Exit(1);
 			}
 			finally
 			{

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -65,14 +65,27 @@ namespace WalletWasabi.Gui
 
 		private static async void AppMainAsync(string[] args)
 		{
-			AvalonStudio.Extensibility.Theme.ColorTheme.LoadTheme(AvalonStudio.Extensibility.Theme.ColorTheme.VisualStudioDark);
-			MainWindowViewModel.Instance = new MainWindowViewModel();
+			try
+			{
+				AvalonStudio.Extensibility.Theme.ColorTheme.LoadTheme(AvalonStudio.Extensibility.Theme.ColorTheme.VisualStudioDark);
+				MainWindowViewModel.Instance = new MainWindowViewModel();
 
-			await Global.InitializeNoWalletAsync();
+				await Global.InitializeNoWalletAsync();
 
-			MainWindowViewModel.Instance.Initialize();
+				MainWindowViewModel.Instance.Initialize();
 
-			Dispatcher.UIThread.Post(GC.Collect);
+				Dispatcher.UIThread.Post(GC.Collect);
+			}
+			catch (Exception ex)
+			{
+				if (!(ex is OperationCanceledException))
+				{
+					Logger.LogCritical(ex);
+				}
+
+				await Global.DisposeAsync().ConfigureAwait(false);
+				Environment.Exit(1);
+			}
 		}
 
 		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)


### PR DESCRIPTION
This PR is moving the "dirty" `Environment.Exit` to the topmost position where it is required. 

The `Environment.Exit` is a walkaround fix because the AppMainAsync method cannot throw exceptions as it is crashing Avalonia. With this, I could clean out the daemon code too - so the goal to call `Environment.Exit` only if required is reached. 