### PR TITLE
Add locktime distribution test

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -571,7 +571,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		public void RespectLockTimeProbabilityDistribution()
 		{
 			var lockTimeZero = uint.MaxValue;
-			var samplingSize = 2_000;
+			var samplingSize = 4_000;
 
 			var dict = Enumerable.Range(-99, 101).ToDictionary(x => (uint)x, x => 0);
 			dict[lockTimeZero] = 0;


### PR DESCRIPTION
@lontivero asked me to add a test to verify that the `TransactionFactory` builds the transactions following the same locktime distribution. https://github.com/zkSNACKs/WalletWasabi/issues/3625#issuecomment-625331421

Note that the test doesn't pass for me because the samplingSize is small (100), and if you increase it to a big number like 10000 it will take a long time to run.