### PR TITLE
Disable CodeMaid's Build Progress Tool Window

### DIFF
--- a/CodeMaid.config
+++ b/CodeMaid.config
@@ -27,6 +27,9 @@
             <setting name="Cleaning_PerformPartialCleanupOnExternal" serializeAs="String">
                 <value>2</value>
             </setting>
+            <setting name="Feature_BuildProgressToolWindow" serializeAs="String">
+                <value>False</value>
+            </setting>
         </SteveCadwallader.CodeMaid.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
If you use Visual Studio whenever you build the solution you get an extra build window which is annoying, this disables that.