### PR TITLE
Override Object.Equals(object o)

### DIFF
--- a/WalletWasabi.Gui/Models/Sorting/SortingPreference.cs
+++ b/WalletWasabi.Gui/Models/Sorting/SortingPreference.cs
@@ -21,6 +21,8 @@ namespace WalletWasabi.Gui.Models.Sorting
 
 		#region EqualityAndComparison
 
+		public override bool Equals(object obj) => Equals(obj as SortingPreference?);
+
 		public bool Equals(SortingPreference other) => this == other;
 
 		public override int GetHashCode() => (SortOrder, ColumnTarget).GetHashCode();


### PR DESCRIPTION
There is this warning in the `SortingPreference` class

![Capture](https://user-images.githubusercontent.com/52379387/83566536-76452180-a520-11ea-9f0b-9340090c9f86.PNG)