### PR TITLE
RPC optional parameters and batching capability

### DIFF
--- a/WalletWasabi.Gui/Rpc/JsonRpcMethodMetadata.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcMethodMetadata.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.Gui.Rpc
 	/// </summary>
 	public class JsonRpcMethodMetadata
 	{
-		public JsonRpcMethodMetadata(string name, MethodInfo mi, List<(string name, Type type)> parameters)
+		public JsonRpcMethodMetadata(string name, MethodInfo mi, List<(string name, Type type, bool isOptional, object defaultValue)> parameters)
 		{
 			Name = name;
 			MethodInfo = mi;
@@ -20,6 +20,6 @@ namespace WalletWasabi.Gui.Rpc
 		public string Name { get; }
 
 		public MethodInfo MethodInfo { get; }
-		public List<(string name, Type type)> Parameters { get; }
+		public List<(string name, Type type, bool isOptional, object defaultValue)> Parameters { get; }
 	}
 }

--- a/WalletWasabi.Gui/Rpc/JsonRpcRequest.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcRequest.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.Gui.Rpc
 		/// <summary>
 		/// Gets the version of the JSON-RPC protocol. MUST be exactly "2.0".
 		/// </summary>
-		[JsonProperty("jsonrpc", Required = Required.Always)]
+		[JsonProperty("jsonrpc", Required = Required.Default)]
 		public string JsonRPC { get; }
 
 		/// <summary>

--- a/WalletWasabi.Gui/Rpc/JsonRpcRequest.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcRequest.cs
@@ -78,16 +78,19 @@ namespace WalletWasabi.Gui.Rpc
 		/// Parses the json rpc request giving back the deserialized JsonRpcRequest instance.
 		/// Return true if the deserialization was successful, otherwise false.
 		/// </summary>
-		public static bool TryParse(string rawJson, out JsonRpcRequest request)
+		public static bool TryParse(string rawJson, out JsonRpcRequest[] requests, out bool isBatch)
 		{
 			try
 			{
-				request = JsonConvert.DeserializeObject<JsonRpcRequest>(rawJson);
+				isBatch = rawJson.TrimStart().StartsWith("[");
+				rawJson = isBatch ? rawJson : $"[{rawJson}]";
+				requests = JsonConvert.DeserializeObject<JsonRpcRequest[]>(rawJson);
 				return true;
 			}
 			catch (JsonException)
 			{
-				request = null;
+				requests = null;
+				isBatch = false;
 				return false;
 			}
 		}

--- a/WalletWasabi.Gui/Rpc/JsonRpcRequestHandler.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcRequestHandler.cs
@@ -107,14 +107,14 @@ namespace WalletWasabi.Gui.Rpc
 						parameters.Insert(position, cancellationToken);
 					}
 				}
-				if (parameters.Count < methodParameters.Count( x => !x.isOptional ))
+				if (parameters.Count < methodParameters.Count(x => !x.isOptional))
 				{
 					return Error(JsonRpcErrorCodes.InvalidParams,
 						$"{methodParameters.Count} parameters were expected but {parameters.Count} were received.", jsonRpcRequest.Id);
 				}
 
 				var missingParameters = methodParameters.Count() - parameters.Count(); 
-				parameters.AddRange( methodParameters.TakeLast(missingParameters).Select(x => x.defaultValue) );
+				parameters.AddRange(methodParameters.TakeLast(missingParameters).Select(x => x.defaultValue));
 				var result = prodecureMetadata.MethodInfo.Invoke(Service, parameters.ToArray());
 
 				if (jsonRpcRequest.IsNotification) // the client is not interested in getting a response

--- a/WalletWasabi.Gui/Rpc/JsonRpcRequestHandler.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcRequestHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,11 +96,14 @@ namespace WalletWasabi.Gui.Rpc
 						parameters.Insert(position, cancellationToken);
 					}
 				}
-				if (parameters.Count != methodParameters.Count)
+				if (parameters.Count < methodParameters.Count( x => !x.isOptional ))
 				{
 					return Error(JsonRpcErrorCodes.InvalidParams,
 						$"{methodParameters.Count} parameters were expected but {parameters.Count} were received.", jsonRpcRequest.Id);
 				}
+
+				var missingParameters = methodParameters.Count() - parameters.Count(); 
+				parameters.AddRange( methodParameters.TakeLast(missingParameters).Select(x => x.defaultValue) );
 				var result = prodecureMetadata.MethodInfo.Invoke(Service, parameters.ToArray());
 
 				if (jsonRpcRequest.IsNotification) // the client is not interested in getting a response

--- a/WalletWasabi.Gui/Rpc/JsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcService.cs
@@ -63,10 +63,10 @@ namespace WalletWasabi.Gui.Rpc
 				{
 					if (attr is JsonRpcMethodAttribute)
 					{
-						var parameters = new List<(string name, Type type)>();
+						var parameters = new List<(string name, Type type, bool isOptional, object defaultValue)>();
 						foreach (var p in methodInfo.GetParameters())
 						{
-							parameters.Add((p.Name, p.ParameterType));
+							parameters.Add((p.Name, p.ParameterType, p.IsOptional, p.DefaultValue));
 						}
 						var jsonRpcMethodAttr = (JsonRpcMethodAttribute)attr;
 						yield return new JsonRpcMethodMetadata(jsonRpcMethodAttr.Name, methodInfo, parameters);

--- a/WalletWasabi.Tests/RpcTests.cs
+++ b/WalletWasabi.Tests/RpcTests.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tests
 				{
 					"Invalid (missing jsonrpc) request",
 					Request("1", "substract", 42, 23).Replace("\"jsonrpc\":\"2.0\",", ""),
-					Error(null, -32700, "Parse error")
+					Ok("1", 19)
 				},
 				new[]
 				{


### PR DESCRIPTION
Current rpc methods' optional parameters are settled to `null` ignoring the default value assigned by the developer, for that reason optional parameters only work for reference values.

This PR sets the optional parameters correctly. Additionally it supports batching requests. This is good in many situations, for example: You can select the wallet to use and perform the desired operation in an atomic operation. You can also simplify repetitive request.

This PR should be review commit by commit.