### PR TITLE
Remove Trezor from supported hardwarewallets

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletView.xaml
@@ -16,7 +16,7 @@
             </StackPanel>
             <StackPanel>
               <TextBlock Text="Which hardware wallets are supported?" FontWeight="Bold" />
-              <TextBlock Text="- Coldcard, Ledger Nano S, Trezor One, and Trezor T." TextWrapping="Wrap" />
+              <TextBlock Text="- Coldcard and Ledger Nano S." TextWrapping="Wrap" />
               <TextBlock Text="- While other hardware wallets may work, they were not tested by Wasabi developers." TextWrapping="Wrap" />
             </StackPanel>
           </StackPanel>


### PR DESCRIPTION
Trezor broke HWI / Wasabi compatibility twice within one month, without warning us before hand that the new firmware would be unusable.
I don't think we can still claim that it is supported hardware wallet, if it might stop working at any time...