### PR TITLE
Process argument length Tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Hwi/DefaultResponseTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/DefaultResponseTests.cs
@@ -143,6 +143,19 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			}
 		}
 
+		[Fact]
+		public async Task HwiProcessBridgeArgumentLengthTestAsync()
+		{
+			HwiProcessBridge pb = new HwiProcessBridge();
+
+			using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+
+			string myString = new string('a', 4000);
+
+			var res = await pb.SendCommandAsync(myString, false, cts.Token);
+			Assert.NotEmpty(res.response);
+		}
+
 		#endregion Tests
 
 		#region HelperMethods

--- a/WalletWasabi.Tests/UnitTests/Hwi/DefaultResponseTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/DefaultResponseTests.cs
@@ -2,13 +2,12 @@ using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Hwi;
-using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Hwi.ProcessBridge;
+using WalletWasabi.Microservices;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Hwi
@@ -150,7 +149,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 
 			using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
 
-			string myString = new string('a', 4000);
+			string myString = new string('a', ProcessBridge.MaxArgumentLength);
 
 			var res = await pb.SendCommandAsync(myString, false, cts.Token);
 			Assert.NotEmpty(res.response);

--- a/WalletWasabi.Tests/UnitTests/ProcessBridgeTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ProcessBridgeTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Microservices;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests
+{
+	public class ProcessBridgeTests
+	{
+		public TimeSpan ReasonableRequestTimeout { get; } = TimeSpan.FromMinutes(1);
+
+		[Fact]
+		public async Task ProcessBridgeArgumentLengthTestAsync()
+		{
+			ProcessBridge pb = new ProcessBridge("dotnet", false);
+
+			using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+
+			string myString = new string('a', ProcessBridge.MaxArgumentLength);
+
+			var res = await pb.SendCommandAsync(myString, false, cts.Token);
+		}
+	}
+}

--- a/WalletWasabi/Microservices/ProcessBridge.cs
+++ b/WalletWasabi/Microservices/ProcessBridge.cs
@@ -13,10 +13,12 @@ namespace WalletWasabi.Microservices
 {
 	public class ProcessBridge : IProcessBridge
 	{
-		public ProcessBridge(string processPath)
+		public const int MaxArgumentLength = 32_698;
+
+		public ProcessBridge(string processPath, bool ensureExists = true)
 		{
 			ProcessPath = Guard.NotNullOrEmptyOrWhitespace(nameof(processPath), processPath);
-			if (!File.Exists(ProcessPath))
+			if (ensureExists && !File.Exists(ProcessPath))
 			{
 				var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(ProcessPath);
 				throw new FileNotFoundException($"{fileNameWithoutExtension} is not found.", ProcessPath);


### PR DESCRIPTION
This goal of this PR is to determine the limitation and open a discussion. 

I noticed there is no argument length limitation in the ProcessBridge. Neither we are testing the capability of different microservices. This question came to my mind regarding the [PSBT changes](https://github.com/zkSNACKs/WalletWasabi/issues/3734), we will surely need longer command-line arguments. It would be good to determine the maximum length of the arguments. 

According to [Microsoft](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.arguments?view=netcore-3.1#remarks), the limit is 32,698.


