### PR TITLE
Enable DeclarationKeywordsMustFollowOrder

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -521,7 +521,7 @@
         </Rule>
         <Rule Name="DeclarationKeywordsMustFollowOrder">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ProtectedMustComeBeforeInternal">


### PR DESCRIPTION
https://documentation.help/StyleCop/SA1206.html

IMO this rule is good to add.