### PR TITLE
Return IsLikelyCoinJoin as part of gethistory

### DIFF
--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -180,6 +180,7 @@ namespace WalletWasabi.Gui.Rpc
 				amount = x.Amount.Satoshi,
 				label = x.Label,
 				tx = x.TransactionId,
+				islikelycoinjoin = x.IsLikelyCoinJoinOutput
 			}).ToArray();
 		}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -114,7 +114,8 @@ namespace WalletWasabi.Blockchain.Transactions
 							Amount = Money.Zero - coin.Amount,
 							Label = "",
 							TransactionId = coin.SpenderTransactionId,
-							BlockIndex = foundSpenderTransaction.BlockIndex
+							BlockIndex = foundSpenderTransaction.BlockIndex,
+							IsLikelyCoinJoinOutput = coin.IsLikelyCoinJoinOutput is true
 						});
 					}
 				}

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -71,7 +71,8 @@ namespace WalletWasabi.Blockchain.Transactions
 						Amount = coin.Amount,
 						Label = coin.Label,
 						TransactionId = coin.TransactionId,
-						BlockIndex = foundTransaction.BlockIndex
+						BlockIndex = foundTransaction.BlockIndex,
+						IsLikelyCoinJoinOutput = coin.IsLikelyCoinJoinOutput is true
 					});
 				}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -12,5 +12,6 @@ namespace WalletWasabi.Blockchain.Transactions
 		public string Label { get; set; }
 		public uint256 TransactionId { get; set; }
 		public int BlockIndex { get; set; }
+		public bool IsLikelyCoinJoinOutput { get; set; }
 	}
 }


### PR DESCRIPTION
This PR adds a new boolean fields `islikelycoinjoin` to the result of RPC `gethistory` method.

```
$ curl -s --data-binary '{"jsonrpc":"2.0","id":"1","method":"gethistory"}' http:/127.0.0.1:37128 | jq '.result[0]'
{
  "datetime": "2019-01-15T21:27:36+00:00",
  "height": 102,
  "amount": 5000000000,
  "label": "Walter",
  "tx": "bb51003b65642a31337b28ad1bb118ebd923c6f8a972209805d10bcfd0b9210a",
  "islikelycoinjoin": false
}
```