### PR TITLE
PeriodicRunner: Fix possible NullPointerException

### DIFF
--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -101,10 +101,9 @@ namespace WalletWasabi.Bases
 					{
 						lock (TriggerLock)
 						{
-							if (TriggeringCts.IsCancellationRequested)
+							if (TriggeringCts?.IsCancellationRequested ?? false)
 							{
 								TriggeringCts?.Dispose();
-								TriggeringCts = null;
 								TriggeringCts = new CancellationTokenSource();
 							}
 						}

--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -101,7 +101,7 @@ namespace WalletWasabi.Bases
 					{
 						lock (TriggerLock)
 						{
-							if (TriggeringCts?.IsCancellationRequested ?? false)
+							if (TriggeringCts?.IsCancellationRequested is true)
 							{
 								TriggeringCts?.Dispose();
 								TriggeringCts = new CancellationTokenSource();


### PR DESCRIPTION
When I run WasabiWallet in my Visual Studio 2019 in debug mode and then close it, often I can see an NPE as a result. This PR fixes that.

**Notes:**

1. https://github.com/zkSNACKs/WalletWasabi/compare/master...kiminuo:feature/2020-06-periodic-runner?expand=1#diff-289b5b3f1a6c7a552e98f4cc7e6cd666L107 - This line is superfluous. I don't see any value for a reader to set `TriggeringCts` explicitly to null and garbage collector is fine with just `TriggeringCts = new CancellationTokenSource();`

2. https://github.com/zkSNACKs/WalletWasabi/compare/master...kiminuo:feature/2020-06-periodic-runner?expand=1#diff-289b5b3f1a6c7a552e98f4cc7e6cd666R104 - This line can throw the mentioned NullPointerException

3. `IDisposable` in .NET has its rules one should follow, so my understanding is that the issue here is more complex - basically, `Dispose` should be called after you know there is nothing going on with the object. It's not meant to be some mechanism to control behavior of its class. So I think the issue is that the correct state would be:

* Guarantee that `ExecuteAsync()` method finish
* Call `Dispose()`

I would go now with the proposed fix and we can later research whether the `PeriodicRunner` instances are correctly stopped.

Cheers!

Feedback is more than welcome.