### PR TITLE
5.0.40

### DIFF
--- a/WalletWasabi.Tests/UnitTests/ParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ParserTests.cs
@@ -161,7 +161,7 @@ namespace WalletWasabi.Tests.UnitTests
 			{
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Remove(0, 1), test.network, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Remove(5, 1), test.network, out _));
-				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(1, "b"), test.network, out _));
+				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(4, "b"), test.network, out _));
 
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(test.address, null, out _));
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(null, test.network, out _));

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-	  <PackageReference Include="NBitcoin" Version="5.0.29" />
+	  <PackageReference Include="NBitcoin" Version="5.0.40" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.1" />
   </ItemGroup>


### PR DESCRIPTION
The number of changes is really big, I was not able to review them all. 

We have to have in mind the followings by sure:
```
09a53a106 In the txbuilder, if locktime is set to 0, keep the tx input to uint.max (https://github.com/zkSNACKs/WalletWasabi/issues/3625)
8422ca553 If LockTime is set, put all input's sequence to max-1
61cf0011b Fix corner case in transaction builder which may have reuslted in transaction paying less than minrelayfee
```

Some changes included since 5.0.29 (shitcoins related were filtered):
```
e08512863 Add SetOptInRBF
b040cfcf5 Decrease memory consumption on some base58 parse
ea08a404e Improve performance of address parsing
befaaa7c0 Allow SigningOptions to be passed in PSBT methods
648d3b159 Remove unnecessary if statement
24bb03c6f Merge pull request #856 from MetacoSA/fixsendestimate
121e86407 Refactor TransactionBuilder
6675c215f Better uint256 write
7e508e822 Improve hex encoder by removing bound checks
4f6de1189 Improve uint256 parsing
210436eb1 Use ulong inside uint256 to improve perf
35f29edfa Improve performance of uint256 GetBytes and improve test coverage
f3d486427 Fix build on netfx
4795a84ac Improve performance of uint256 (#852)
9e7ebbca1 Allow LowR enforcement at signature time for PSBT and TransactionBuilder
ade1d4c9f Add benchmark for ECDSA sign/verify, make verify zero alloc
4e4d08897 Micro optimize XPub parsing (#849)
866ccb2de Improve parsing performance of Bech32 (#848)
330a95cdd Fix FeeRateJsonConverter parsing of integer
f6d59df6b Remove a O(n2) issue when building transaction with the builder
8cc3bfdf6 Clear for finalization after updating inputs in PSBT
7b9bbad1d Ignore UpdateFromCoin if the input is finalized, do not throw
4459e6137 Add PSBT.TryGetFinalizedHash
0a70fda3b PSBTInput.GetSignableCoin is looking at Final scripts
```

@yahiheb this is the update we were wait for. Could you please run your test and make sure this is compatible?