### PR TITLE
BitcoinStore: Improve DI

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.Gui
 
 		public string DataDir { get; }
 		public string TorLogsFile { get; }
-		public BitcoinStore BitcoinStore { get; private set; }
+		public BitcoinStore BitcoinStore { get; }
 		public LegalDocuments LegalDocuments { get; set; }
 		public Config Config { get; }
 
@@ -101,6 +101,8 @@ namespace WalletWasabi.Gui
 
 				WalletManager.OnDequeue += WalletManager_OnDequeue;
 				WalletManager.WalletRelevantTransactionProcessed += WalletManager_WalletRelevantTransactionProcessed;
+
+				BitcoinStore = new BitcoinStore(Path.Combine(DataDir, "BitcoinStore"), Network);
 			}
 		}
 
@@ -124,8 +126,7 @@ namespace WalletWasabi.Gui
 					SizeLimit = 1_000,
 					ExpirationScanFrequency = TimeSpan.FromSeconds(30)
 				});
-				BitcoinStore = new BitcoinStore();
-				var bstoreInitTask = BitcoinStore.InitializeAsync(Path.Combine(DataDir, "BitcoinStore"), Network);
+				var bstoreInitTask = BitcoinStore.InitializeAsync();
 				var addressManagerFolderPath = Path.Combine(DataDir, "AddressManager");
 
 				AddressManagerFilePath = Path.Combine(addressManagerFolderPath, $"AddressManager{Network}.dat");

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -107,10 +107,7 @@ namespace WalletWasabi.Gui
 
 				BitcoinStore = new BitcoinStore(
 					Path.Combine(DataDir, "BitcoinStore"), Network,
-					new IndexStore(),
-					new AllTransactionStore(),
-					new SmartHeaderChain(),
-					new MempoolService()
+					new IndexStore(), new AllTransactionStore(), new SmartHeaderChain(), new MempoolService()
 				);
 			}
 		}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -20,10 +20,13 @@ using WalletWasabi.BitcoinCore;
 using WalletWasabi.BitcoinCore.Endpointing;
 using WalletWasabi.BitcoinCore.Monitoring;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.TransactionBroadcasting;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.TransactionProcessing;
+using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Client;
 using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
@@ -102,7 +105,13 @@ namespace WalletWasabi.Gui
 				WalletManager.OnDequeue += WalletManager_OnDequeue;
 				WalletManager.WalletRelevantTransactionProcessed += WalletManager_WalletRelevantTransactionProcessed;
 
-				BitcoinStore = new BitcoinStore(Path.Combine(DataDir, "BitcoinStore"), Network);
+				BitcoinStore = new BitcoinStore(
+					Path.Combine(DataDir, "BitcoinStore"), Network,
+					new IndexStore(),
+					new AllTransactionStore(),
+					new SmartHeaderChain(),
+					new MempoolService()
+				);
 			}
 		}
 

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -11,7 +11,9 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.Crypto;
@@ -55,8 +57,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 			var dataDir = Path.Combine(Global.Instance.DataDir, EnvironmentHelpers.GetCallerFileName());
 
-			BitcoinStore bitcoinStore = new BitcoinStore();
-			await bitcoinStore.InitializeAsync(Path.Combine(dataDir, EnvironmentHelpers.GetMethodName()), network);
+			BitcoinStore bitcoinStore = new BitcoinStore(Path.Combine(dataDir, EnvironmentHelpers.GetMethodName()), network,
+				new IndexStore(), new AllTransactionStore(), new SmartHeaderChain(), new MempoolService());
+			await bitcoinStore.InitializeAsync();
 
 			var addressManagerFolderPath = Path.Combine(dataDir, "AddressManager");
 			var addressManagerFilePath = Path.Combine(addressManagerFolderPath, $"AddressManager{network}.dat");

--- a/WalletWasabi.Tests/RegressionTests/Common.cs
+++ b/WalletWasabi.Tests/RegressionTests/Common.cs
@@ -9,6 +9,9 @@ using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.BitcoinCore;
+using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.Blockchain.Mempool;
+using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Coordinator;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
@@ -85,9 +88,10 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			var network = global.RpcClient.Network;
 			var serviceConfiguration = new ServiceConfiguration(MixUntilAnonymitySet.PrivacyLevelSome.ToString(), 2, 21, 50, regTestFixture.BackendRegTestNode.P2pEndPoint, Money.Coins(Constants.DefaultDustThreshold));
-			var bitcoinStore = new BitcoinStore();
+
 			var dir = GetWorkDir(callerFilePath, callerMemberName);
-			await bitcoinStore.InitializeAsync(dir, network);
+			var bitcoinStore = new BitcoinStore(dir, network, new IndexStore(), new AllTransactionStore(), new SmartHeaderChain(), new MempoolService());
+			await bitcoinStore.InitializeAsync();
 			return ("password", global.RpcClient, network, global.Coordinator, serviceConfiguration, bitcoinStore, global);
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore;
 using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Services;
@@ -30,9 +31,9 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			{
 				var network = coreNode.Network;
 				var rpc = coreNode.RpcClient;
-				var bitcoinStore = new BitcoinStore();
 				var dir = Path.Combine(Global.Instance.DataDir, EnvironmentHelpers.GetCallerFileName(), EnvironmentHelpers.GetMethodName());
-				await bitcoinStore.InitializeAsync(dir, network);
+				var bitcoinStore = new BitcoinStore(dir, network, new IndexStore(), new AllTransactionStore(), new SmartHeaderChain(), new MempoolService());
+				await bitcoinStore.InitializeAsync();
 
 				await rpc.GenerateAsync(101);
 

--- a/WalletWasabi/Stores/BitcoinStore.cs
+++ b/WalletWasabi/Stores/BitcoinStore.cs
@@ -20,8 +20,8 @@ namespace WalletWasabi.Stores
 	public class BitcoinStore
 	{
 		public bool IsInitialized { get; private set; }
-		private string WorkFolderPath { get;}
-		public Network Network { get;}
+		private string WorkFolderPath { get; }
+		public Network Network { get; }
 
 		public IndexStore IndexStore { get; }
 		public AllTransactionStore TransactionStore { get; }
@@ -34,17 +34,22 @@ namespace WalletWasabi.Stores
 		/// </summary>
 		public UntrustedP2pBehavior CreateUntrustedP2pBehavior() => new UntrustedP2pBehavior(MempoolService);
 
-		public BitcoinStore(string workFolderPath, Network network)
+		public BitcoinStore(
+			string workFolderPath,
+			Network network,
+			IndexStore indexStore,
+			AllTransactionStore transactionStore,
+			SmartHeaderChain smartHeaderChain,
+			MempoolService mempoolService)
 		{
 			WorkFolderPath = Guard.NotNullOrEmptyOrWhitespace(nameof(workFolderPath), workFolderPath, trim: true);
 			IoHelpers.EnsureDirectoryExists(WorkFolderPath);
 
 			Network = Guard.NotNull(nameof(network), network);
-
-			IndexStore = new IndexStore();
-			TransactionStore = new AllTransactionStore();
-			SmartHeaderChain = new SmartHeaderChain();
-			MempoolService = new MempoolService();
+			IndexStore = indexStore;
+			TransactionStore = transactionStore;
+			SmartHeaderChain = smartHeaderChain;
+			MempoolService = mempoolService;
 		}
 
 		public async Task InitializeAsync()

--- a/WalletWasabi/Stores/BitcoinStore.cs
+++ b/WalletWasabi/Stores/BitcoinStore.cs
@@ -19,21 +19,6 @@ namespace WalletWasabi.Stores
 	/// </summary>
 	public class BitcoinStore
 	{
-		public bool IsInitialized { get; private set; }
-		private string WorkFolderPath { get; }
-		public Network Network { get; }
-
-		public IndexStore IndexStore { get; }
-		public AllTransactionStore TransactionStore { get; }
-		public SmartHeaderChain SmartHeaderChain { get; }
-		public MempoolService MempoolService { get; }
-
-		/// <summary>
-		/// This should not be a property, but a creator function, because it'll be cloned left and right by NBitcoin later.
-		/// So it should not be assumed it's some singleton.
-		/// </summary>
-		public UntrustedP2pBehavior CreateUntrustedP2pBehavior() => new UntrustedP2pBehavior(MempoolService);
-
 		public BitcoinStore(
 			string workFolderPath,
 			Network network,
@@ -51,6 +36,21 @@ namespace WalletWasabi.Stores
 			SmartHeaderChain = smartHeaderChain;
 			MempoolService = mempoolService;
 		}
+
+		public bool IsInitialized { get; private set; }
+		private string WorkFolderPath { get; }
+		public Network Network { get; }
+
+		public IndexStore IndexStore { get; }
+		public AllTransactionStore TransactionStore { get; }
+		public SmartHeaderChain SmartHeaderChain { get; }
+		public MempoolService MempoolService { get; }
+
+		/// <summary>
+		/// This should not be a property, but a creator function, because it'll be cloned left and right by NBitcoin later.
+		/// So it should not be assumed it's some singleton.
+		/// </summary>
+		public UntrustedP2pBehavior CreateUntrustedP2pBehavior() => new UntrustedP2pBehavior(MempoolService);
 
 		public async Task InitializeAsync()
 		{


### PR DESCRIPTION
This PR moves dependencies of `BitcoinStore` class to its constructor. It paves the path for #3372, for example.

Review is very easy when reviewing commits separately. It's only moving of code basically.

You may not like how many parameters the new `BitcoinStore` has. I don't like it either. The point of this refactoring is actually to show that the class depends on *too much* dependencies. Over time it will go down again with more refactoring PRs. Unfortunately, it's not possible to solve this in one go..