### PR TITLE
Unify package prefix

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -599,7 +599,7 @@ namespace WalletWasabi.Packager
 					{
 						throw new Exception($"{publishedFolder} does not exist.");
 					}
-					var newFolderName = $"WasabiLinux-{VersionPrefix}";
+					var newFolderName = $"Wasabi-{VersionPrefix}";
 					var newFolderPath = Path.Combine(BinDistDirectory, newFolderName);
 					Directory.Move(publishedFolder, newFolderPath);
 					publishedFolder = newFolderPath;


### PR DESCRIPTION
Only the package for the "other" Linux distributions has the prefix `WasabiLinux` while for Windows, macOS, Debian/Ubuntu packages they have the prefix `Wasabi`:

![Capture](https://user-images.githubusercontent.com/52379387/84792582-4dc72800-aff4-11ea-93da-29bc1f2a84f2.PNG)


I tired to check if there is a reason for that in the [code](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Packager/Program.cs) but I don't see any, but please check if I am correct or not.

This is a low priority but it is to avoid things like https://github.com/zkSNACKs/WasabiDoc/pull/886