### PR TITLE
Modify .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,82 +7,88 @@ root = true
 
 charset = utf-8
 
-#Core editorconfig formatting - indentation
+# Core editorconfig formatting - indentation
 
-#use hard tabs for indentation
+# use hard tabs for indentation
 indent_style = tab
 
-#Formatting - new line options
+# Formatting - new line options
 
 #require braces to be on a new line for all
 csharp_new_line_before_open_brace = all
 
-#Formatting - organize using options
+# Formatting - organize using options
 
-#do not place System.* using directives before other using directives
+# do not place System.* using directives before other using directives
 dotnet_sort_system_directives_first = true:error
 
-#Formatting - spacing options
+# Formatting - remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
 
-#require NO space between a cast and the value
+# Formatting - set preferred newline characters
+end_of_line = lf
+
+# Formatting - spacing options
+
+# require NO space between a cast and the value
 csharp_space_after_cast = false:error
-#require a space before the colon for bases or interfaces in a type declaration
+# require a space before the colon for bases or interfaces in a type declaration
 csharp_space_after_colon_in_inheritance_clause = true:error
-#require a space after a keyword in a control flow statement such as a for loop
+# require a space after a keyword in a control flow statement such as a for loop
 csharp_space_after_keywords_in_control_flow_statements = true:error
-#require a space before the colon for bases or interfaces in a type declaration
+# require a space before the colon for bases or interfaces in a type declaration
 csharp_space_before_colon_in_inheritance_clause = true:error
-#remove space within empty argument list parentheses
+# remove space within empty argument list parentheses
 csharp_space_between_method_call_empty_parameter_list_parentheses = false:error
-#remove space between method call name and opening parenthesis
+# remove space between method call name and opening parenthesis
 csharp_space_between_method_call_name_and_opening_parenthesis = false:error
-#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+# do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
 csharp_space_between_method_call_parameter_list_parentheses = false:error
-#remove space within empty parameter list parentheses for a method declaration
+# remove space within empty parameter list parentheses for a method declaration
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:error
-#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+# place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
 csharp_space_between_method_declaration_parameter_list_parentheses = false:error
 
-#Formatting - wrapping options
+# Formatting - wrapping options
 
-#leave code block on single line
+# leave code block on single line
 csharp_preserve_single_line_blocks = true:error
-#leave statements and member declarations on the same line
+# leave statements and member declarations on the same line
 csharp_preserve_single_line_statements = true:error
 
-#Style - expression bodied member options
+# Style - expression bodied member options
 
-#prefer expression-bodied members for accessors
+# prefer expression-bodied members for accessors
 csharp_style_expression_bodied_accessors = true:suggestion
-#prefer block bodies for constructors
+# prefer block bodies for constructors
 csharp_style_expression_bodied_constructors = false:suggestion
-#prefer expression-bodied members for operators
+# prefer expression-bodied members for operators
 csharp_style_expression_bodied_operators = true:suggestion
-#prefer expression-bodied members for properties
+# prefer expression-bodied members for properties
 csharp_style_expression_bodied_properties = true:suggestion
 
-#Style - expression level options
+# Style - expression level options
 
-#prefer out variables to be declared inline in the argument list of a method call when possible
+# prefer out variables to be declared inline in the argument list of a method call when possible
 csharp_style_inlined_variable_declaration = true:error
 csharp_style_deconstructed_variable_declaration = false:warning
-#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+# prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
 dotnet_style_predefined_type_for_member_access = true:error
 
-#Style - language keyword and framework type options
+# Style - language keyword and framework type options
 
-#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+# prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
 dotnet_style_predefined_type_for_locals_parameters_members = true:error
 
-#Style - qualification options
+# Style - qualification options
 
-#prefer events not to be prefaced with this. or Me. in Visual Basic
+# prefer events not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_event = false:error
-#prefer fields not to be prefaced with this. or Me. in Visual Basic
+# prefer fields not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_field = false:error
-#prefer methods not to be prefaced with this. or Me. in Visual Basic
+# prefer methods not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_method = false:error
-#prefer properties not to be prefaced with this. or Me. in Visual Basic
+# prefer properties not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_property = false:error
 
 dotnet_style_object_initializer = false:warning
@@ -94,13 +100,13 @@ csharp_prefer_simple_default_expression = true:error
 csharp_indent_case_contents = true:warning
 csharp_indent_switch_labels = true:warning
 
-#prefer 'is null' for reference equality checks
+# prefer 'is null' for reference equality checks
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error
 
-#prefer braces
+# prefer braces
 csharp_prefer_braces = true:error
 
-#do not suggest readonly fields
+# do not suggest readonly fields
 dotnet_style_readonly_field = false:error
 
 # use expression body for lambdas


### PR DESCRIPTION
Hi,

this PR sets two .editorconfig properties:

* `trim_trailing_whitespace=true` 
* `end_of_line=lf`.

I'm not sure whether these changes are somewhat radical or not but the truth is that at the moment I can see that newlines are mixed in the source code. For example, Visual Studio takes incremental approach. Meaning: when you save a file, line endings won't change in the whole file, only for touched lines so git diffs won't be excessive.

Cheers!

fixes #3794