### PR TITLE
BlockNotifierTests: Make `NotifyBlocksAsync` test more robust

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -111,7 +111,7 @@ namespace WalletWasabi.Tests.UnitTests
 			notifier.TriggerRound();
 
 			// Wait at most 1500 ms or until cts is canceled
-			await WaitForCancelSignalAsync(TimeSpan.FromMilliseconds(1500), cts.Token).ConfigureAwait(false);
+			await WaitForCancelSignalAsync(TimeSpan.FromSeconds(1.5), cts.Token).ConfigureAwait(false);
 
 			Assert.True(string.IsNullOrEmpty(message), message);
 

--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -65,9 +65,11 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public async Task NotifyBlocksAsync()
 		{
+			const int BlockCount = 3;
+
+			var cts = new CancellationTokenSource();
 			var chain = new ConcurrentChain(Network.RegTest);
 			using var notifier = CreateNotifier(chain);
-			var blockCount = 3;
 
 			var reorgAwaiter = new EventAwaiter<uint256>(
 				h => notifier.OnReorg += h,
@@ -77,16 +79,41 @@ namespace WalletWasabi.Tests.UnitTests
 
 			// Assert that the blocks come in the right order
 			var height = 0;
-			void OnBlockInv(object s, Block b) => Assert.Equal(b.GetHash(), chain.GetBlock(height++).HashBlock);
+			string message = string.Empty;
+
+			void OnBlockInv(object blockNotifier, Block b)
+			{
+				uint256 h1 = b.GetHash();
+				uint256 h2 = chain.GetBlock(height + 1).HashBlock;
+
+				if (h1 != h2)
+				{
+					message = string.Format("height={0}, [h1] {1} != [h2] {2}", height, h1, h2);
+					cts.Cancel();
+					return;
+				}
+
+				height++;
+
+				if (height == BlockCount)
+				{
+					cts.Cancel();
+				}
+			}
+
 			notifier.OnBlock += OnBlockInv;
 
-			foreach (var n in Enumerable.Range(0, blockCount))
+			foreach (var n in Enumerable.Range(0, BlockCount))
 			{
 				await AddBlockAsync(chain);
 			}
 
 			notifier.TriggerRound();
-			await Task.Delay(TimeSpan.FromMilliseconds(100)); // give it time to process the blocks
+
+			// Wait at most 1500 ms or until cts is canceled
+			await WaitForCancelSignalAsync(TimeSpan.FromMilliseconds(1500), cts.Token);
+
+			Assert.True(string.IsNullOrEmpty(message), message);
 
 			// Three blocks notifications
 			Assert.Equal(chain.Height, height);
@@ -97,6 +124,17 @@ namespace WalletWasabi.Tests.UnitTests
 
 			notifier.OnBlock -= OnBlockInv;
 			await notifier.StopAsync(CancellationToken.None);
+		}
+
+		private async Task WaitForCancelSignalAsync(TimeSpan timeSpan, CancellationToken token)
+		{
+			try
+			{
+				await Task.Delay(timeSpan, token).ConfigureAwait(false);
+			}
+			catch (TaskCanceledException)
+			{
+			}
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -111,7 +111,7 @@ namespace WalletWasabi.Tests.UnitTests
 			notifier.TriggerRound();
 
 			// Wait at most 1500 ms or until cts is canceled
-			await WaitForCancelSignalAsync(TimeSpan.FromMilliseconds(1500), cts.Token);
+			await WaitForCancelSignalAsync(TimeSpan.FromMilliseconds(1500), cts.Token).ConfigureAwait(false);
 
 			Assert.True(string.IsNullOrEmpty(message), message);
 

--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Tests.UnitTests
 		{
 			const int BlockCount = 3;
 
-			var cts = new CancellationTokenSource();
+			using var cts = new CancellationTokenSource();
 			var chain = new ConcurrentChain(Network.RegTest);
 			using var notifier = CreateNotifier(chain);
 


### PR DESCRIPTION
Hi,

this PR tackles several things:

1) `Assert.Equal(b.GetHash(), chain.GetBlock(height++).HashBlock);` - this assert does actually nothing because any exception thrown by `Assert.Equal` is caught by `PeriodicRunner` and it is not propagated. The solution, I have chosen, is to make the delay long (10s) and add a CTS that is canceled when the work is done, so in ideal case the test will be fast and when it fails, it may take up to 10 seconds (which is fine imo).

2) `await Task.Delay(TimeSpan.FromMilliseconds(100)); // give it time to process the blocks` makes the test (potentially) unstable and prone to failing when a machine is under heavier load.

Cheers