### PR TITLE
Update to NBitcoin 5.0.43

### DIFF
--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-	  <PackageReference Include="NBitcoin" Version="5.0.40" />
+	  <PackageReference Include="NBitcoin" Version="5.0.43" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.1" />
+    <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.3" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Update NBitcoin that has the sanity check for NonWitnessUTXO removed.

This PR contributes for #3734 