### PR TITLE
Fix Possible DoS Attack Vector

### DIFF
--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRoundConfig.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRoundConfig.cs
@@ -87,6 +87,8 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 
 		public Script GetNextCleanCoordinatorScript() => CoordinatorExtPubKey.Derive(0, false).Derive(CoordinatorExtPubKeyCurrentDepth, false).PubKey.WitHash.ScriptPubKey;
 
+		public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;
+
 		public void MakeNextCoordinatorScriptDirty()
 		{
 			CoordinatorExtPubKeyCurrentDepth++;

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRoundConfig.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRoundConfig.cs
@@ -85,7 +85,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 		[JsonProperty(PropertyName = "CoordinatorExtPubKeyCurrentDepth", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public int CoordinatorExtPubKeyCurrentDepth { get; private set; }
 
-		public Script GetNextCleanCoordinatorScript() => CoordinatorExtPubKey.Derive(0, false).Derive(CoordinatorExtPubKeyCurrentDepth, false).PubKey.WitHash.ScriptPubKey;
+		public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 		public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;
 


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/3815

If someone does not register a Bob, we couldn't just send out the incomplete transaction with the large mining fee for signing, because the attacker could just sign, knowing well that that he won't lose money as the tx would be invalid. For this we were adding the coordinator output to fill up the gap of the missing Bob.

However as @onvej-sl pointed out, it is not enough to make sure that the tx will be valid in a naive way. We also have to make sure that the Wasabi tx structure is valid otherwise the tx can still be invalid due to tx building logic later on.

There are 2 changes I made here:

- First I made sure the coordinator fills up the gap with new addresses, because filling up the gap with the coordinator address would result in optimizing it out and not having anyone on a mixing level, which can cause issues later.
- Then I made sure the coordinator fillup happens before any decision would've been made on further transaction structure, so the coordinator address on a mixing level will actually signal to Wasabi that mixing level exists.