### PR TITLE
Create officially supported OSs and devices document

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -2,7 +2,7 @@
 
 This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we not give support for them. There are a lot of systems out there and more to come we have to focus our priorities.
 
-# Officially Supported Operating systems
+# Officially Supported Operating Systems
 
 - Windows 10
 - macOs 10.13+

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -4,15 +4,12 @@ This document lists all the officially supported software and devices by Wasabi 
 
 # Officially Supported Operating systems
 
-MacOs 10.13+
 Windows 10
+macOs 10.13+
 Ubuntu 16.04+
 Fedora 30+
 Debian 9+
 CentOS 7+
-Oracle Linux 7+
-Linux Mint 18+
-openSUSE 15+
 
 # Officially Supported Hardware wallets
 
@@ -25,7 +22,7 @@ openSUSE 15+
 
 ## Operating systems
 
-Wasabi might work on OSs those support these:
+Wasabi might work on OSs those support these dependencies:
 - .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md)
 - Avalonia [reqs](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements)
 - NBitcoin dependencies and requirements are the same as .NET Core. 
@@ -33,4 +30,4 @@ Wasabi might work on OSs those support these:
 
 ## Hardware wallets
 
-Wasabi is using [HWI](https://github.com/bitcoin-core/HWI) as a bridge between the wallet and the hardware. Unfortunately, some hardware wallets supported by HWI implemented custom workflows that are not compatible with the Wallet.
+Wasabi is using [HWI](https://github.com/bitcoin-core/HWI) as a bridge between the wallet and the hardware. Check the compatibility list there, but some hardware wallets supported by HWI still not compatible with the Wallet because they implemented custom workflows that are not compatible.

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -22,7 +22,7 @@ This document lists all the officially supported software and devices by Wasabi 
 
 ## Operating systems
 
-Wasabi might work on OSs those support these dependencies:
+Wasabi dependencies are:
 - .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md).
 - Avalonia [reqs](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements).
 - NBitcoin dependencies and requirements are the same as .NET Core.

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -1,6 +1,6 @@
 # Abstract
 
-This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break user-space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we will not give any support for them. There are a lot of potentially supported systems out there and more to come, but we can only promise support and stability on platforms that our dependencies support, too.
+This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi is tested on those systems and we put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user-space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we do not officially support them. There are a lot of potentially supported systems out there and more to come, but we can only promise support and stability on platforms that our dependencies support, too.
 
 # Officially Supported Operating Systems
 

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -30,4 +30,5 @@ Wasabi dependencies are:
 
 ## Hardware wallets
 
-Wasabi is using [HWI](https://github.com/bitcoin-core/HWI) as a bridge between the wallet and the hardware. Check the compatibility list there, but some hardware wallets supported by HWI still not compatible with the Wallet because they implemented custom workflows that are not compatible.
+Wasabi dependencies are:
+- [HWI](https://github.com/bitcoin-core/HWI), check the [device support](https://github.com/bitcoin-core/HWI#device-support) list there. Some hardware wallets supported by HWI still not compatible with the Wallet because they implemented custom workflows.

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -29,20 +29,20 @@ Wasabi dependencies are:
 - .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md).
 - Avalonia [reqs](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements).
 - NBitcoin dependencies and requirements are the same as .NET Core.
-- Bitcoin Knots (same requirement as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements).
+- Bitcoin Knots (same requirements as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements).
 
-## What are the bottlenecks of officially supporting Hardware Wallets
+## What are the bottlenecks of officially supporting Hardware Wallets?
 
 Wasabi dependencies are:
-- [HWI](https://github.com/bitcoin-core/HWI), check the [device support](https://github.com/bitcoin-core/HWI#device-support) list there. Some hardware wallets supported by HWI still not compatible with the Wallet because they implemented custom workflows.
+- [HWI](https://github.com/bitcoin-core/HWI), check the [device support](https://github.com/bitcoin-core/HWI#device-support) list there. Some hardware wallets supported by HWI are still not compatible with the Wallet because they implemented custom workflows.
 
 ## What about Whonix and Tails?
 
-Whonix and Tails are privacy-oriented OSs so it makes sense to use them with Wasabi Wallet. At the moment Wasabi is working properly on these platforms but our dependencies do not officially support them, we are not able to make promises regarding future stability. 
+Whonix and Tails are privacy-oriented OSs so it makes sense to use them with Wasabi Wallet. At the moment Wasabi is working properly on these platforms but our dependencies do not officially support them, so we cannot make promises regarding future stability.
 
 ## What about Trezor?
 
-Trezor One and Trezor T are popular hardware wallets Wasabi officially supported in the past. However, from 2020 April to 2020 June Trezor's new firmware releases introduced 3 backward-incompatible changes, which made us reassess our official support for the hardware wallet.
+Trezor One and Trezor T are popular hardware wallets that Wasabi officially supported in the past. However, from April 2020 to June 2020 Trezor's new firmware releases introduced 3 backward-incompatible changes, which made us reassess our official support for the hardware wallet.
 - https://github.com/bitcoin-core/HWI/pull/319
 - https://github.com/zkSNACKs/WalletWasabi/issues/3734
 - https://github.com/trezor/trezor-firmware/issues/1044

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -1,0 +1,32 @@
+# Abstract
+
+This document lists all the officially supported softwares and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user space so we have to set up boundaries that we can responsible maintain. This does not neccesary mean that systems those are not listed will not work - they might work but we not give support for them. There are a lot of systems out there and more to come we have focus our priorities.
+
+# Offcially Supported Operating systems
+
+MacOs 10.13+
+Windows 10
+Ubuntu
+
+
+# Officially Supported Hardware wallets
+
+- ColdCard MK1
+- ColdCard MK2
+- ColdCard MK3
+- Ledger Nano S
+
+# FAQ
+
+## Operating systems
+
+Wasabi dependencies and requirements
+- .NET Core dependencies and requirements can be found [here](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md)
+- Avalonia dependencies and requirements can be found [here](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements)
+- NBitcoin dependencies and requirements are the same with .NET Core. 
+- Bitcoin Knots (same requirement as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements)
+
+## Hardware wallets
+
+Wasabi is using [HWI](https://github.com/bitcoin-core/HWI) as a bridge between the wallet and the hardware. Unfortunately some hardware wallets that supported by HWI, implemented custom workflows those are not compatible with the Wallet.
+

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -9,7 +9,6 @@ This document lists all the officially supported software and devices by Wasabi 
 - Ubuntu 16.04+
 - Fedora 30+
 - Debian 9+
-- CentOS 7+
 
 # Officially Supported Hardware wallets
 

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -23,7 +23,7 @@ This document lists all the officially supported software and devices by Wasabi 
 
 # FAQ
 
-## Operating systems
+## What are the bottlenecks of officially supporting Operating Systems?
 
 Wasabi dependencies are:
 - .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md).
@@ -31,7 +31,20 @@ Wasabi dependencies are:
 - NBitcoin dependencies and requirements are the same as .NET Core.
 - Bitcoin Knots (same requirement as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements).
 
-## Hardware wallets
+## What are the bottlenecks of officially supporting Hardware Wallets
 
 Wasabi dependencies are:
 - [HWI](https://github.com/bitcoin-core/HWI), check the [device support](https://github.com/bitcoin-core/HWI#device-support) list there. Some hardware wallets supported by HWI still not compatible with the Wallet because they implemented custom workflows.
+
+## What about Whonix and Tails?
+
+Whonix and Tails are privacy-oriented OSs so it makes sense to use them with Wasabi Wallet. At the moment Wasabi is working properly on these platforms but our dependencies do not officially support them, we are not able to make promises regarding future stability. 
+
+## What about Trezor?
+
+Trezor One and Trezor T are popular hardware wallets Wasabi officially supported in the past. However, from 2020 April to 2020 June Trezor's new firmware releases introduced 3 backward-incompatible changes, which made us reassess our official support for the hardware wallet.
+- https://github.com/bitcoin-core/HWI/pull/319
+- https://github.com/zkSNACKs/WalletWasabi/issues/3734
+- https://github.com/trezor/trezor-firmware/issues/1044
+
+At the moment Wasabi is working properly with Trezor One and Trezor T, but after resolving these issues, we must concede guaranteeing future stability is beyond our control, hence we shan't promise to continue official support forthwith.

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -1,6 +1,6 @@
 # Abstract
 
-This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we not give support for them. There are a lot of systems out there and more to come we have to focus our priorities.
+This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break user-space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we will not give any support for them. There are a lot of potentially supported systems out there and more to come we have to focus our priorities.
 
 # Officially Supported Operating Systems
 

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -1,6 +1,6 @@
 # Abstract
 
-This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break user-space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we will not give any support for them. There are a lot of potentially supported systems out there and more to come we have to focus our priorities.
+This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break user-space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we will not give any support for them. There are a lot of potentially supported systems out there and more to come, but we can only promise support and stability on platforms that our dependencies support, too.
 
 # Officially Supported Operating Systems
 

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -17,6 +17,10 @@ This document lists all the officially supported software and devices by Wasabi 
 - ColdCard MK3
 - Ledger Nano S
 
+# Officially Supported Architectures
+
+- x64
+
 # FAQ
 
 ## Operating systems

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -23,10 +23,10 @@ This document lists all the officially supported software and devices by Wasabi 
 ## Operating systems
 
 Wasabi might work on OSs those support these dependencies:
-- .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md)
-- Avalonia [reqs](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements)
-- NBitcoin dependencies and requirements are the same as .NET Core. 
-- Bitcoin Knots (same requirement as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements)
+- .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md).
+- Avalonia [reqs](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements).
+- NBitcoin dependencies and requirements are the same as .NET Core.
+- Bitcoin Knots (same requirement as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements).
 
 ## Hardware wallets
 

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -1,13 +1,18 @@
 # Abstract
 
-This document lists all the officially supported softwares and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user space so we have to set up boundaries that we can responsible maintain. This does not neccesary mean that systems those are not listed will not work - they might work but we not give support for them. There are a lot of systems out there and more to come we have focus our priorities.
+This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we not give support for them. There are a lot of systems out there and more to come we have to focus our priorities.
 
-# Offcially Supported Operating systems
+# Officially Supported Operating systems
 
 MacOs 10.13+
 Windows 10
-Ubuntu
-
+Ubuntu 16.04+
+Fedora 30+
+Debian 9+
+CentOS 7+
+Oracle Linux 7+
+Linux Mint 18+
+openSUSE 15+
 
 # Officially Supported Hardware wallets
 
@@ -20,13 +25,12 @@ Ubuntu
 
 ## Operating systems
 
-Wasabi dependencies and requirements
-- .NET Core dependencies and requirements can be found [here](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md)
-- Avalonia dependencies and requirements can be found [here](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements)
-- NBitcoin dependencies and requirements are the same with .NET Core. 
+Wasabi might work on OSs those support these:
+- .NET Core [reqs](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md)
+- Avalonia [reqs](https://github.com/AvaloniaUI/Avalonia/wiki/Runtime-Requirements)
+- NBitcoin dependencies and requirements are the same as .NET Core. 
 - Bitcoin Knots (same requirement as Bitcoin Core) [reqs](https://bitcoin.org/en/bitcoin-core/features/requirements#system-requirements)
 
 ## Hardware wallets
 
-Wasabi is using [HWI](https://github.com/bitcoin-core/HWI) as a bridge between the wallet and the hardware. Unfortunately some hardware wallets that supported by HWI, implemented custom workflows those are not compatible with the Wallet.
-
+Wasabi is using [HWI](https://github.com/bitcoin-core/HWI) as a bridge between the wallet and the hardware. Unfortunately, some hardware wallets supported by HWI implemented custom workflows that are not compatible with the Wallet.

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -4,12 +4,12 @@ This document lists all the officially supported software and devices by Wasabi 
 
 # Officially Supported Operating systems
 
-Windows 10
-macOs 10.13+
-Ubuntu 16.04+
-Fedora 30+
-Debian 9+
-CentOS 7+
+- Windows 10
+- macOs 10.13+
+- Ubuntu 16.04+
+- Fedora 30+
+- Debian 9+
+- CentOS 7+
 
 # Officially Supported Hardware wallets
 


### PR DESCRIPTION
This document lists all the officially supported software and devices by Wasabi Wallet. This means that Wasabi makes tests on those systems and put all the efforts to make it work and maintain compatibility. One of our main goals is to not break the user space so we have to set up boundaries that we can responsibly maintain. This does not necessarily mean that systems that are not listed will not work - they might work but we not give support for them. There are a lot of systems out there and more to come we have to focus our priorities.