### PR TITLE
[StyleCop] Enable UseStringEmptyForEmptyStrings

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -611,7 +611,7 @@
         </Rule>
         <Rule Name="UseStringEmptyForEmptyStrings">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="ParameterMustFollowComma">


### PR DESCRIPTION
https://documentation.help/StyleCop/SA1122.html

I think this rule is not necessary, so this PR is to see what the other devs think.