### PR TITLE
update avalonia to 0.9.11

### DIFF
--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />    
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.11" />    
     <PackageReference Include="AvalonStudio.Shell" Version="0.9.9" />
     <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.9" />
     <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.9" />


### PR DESCRIPTION
- Fixes OSX crash
  OSX you can crash by putting in fullscreen mode then closing the program.

https://github.com/AvaloniaUI/Avalonia/releases/tag/0.9.11

should be tested on linux, windows and osx