### PR TITLE
Fix FeePercentage when amount is 0

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -768,6 +768,10 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					{
 						FeePercentage = 100 * (decimal)EstimatedBtcFee.Satoshi / amount.Satoshi;
 					}
+					else
+					{
+						FeePercentage = 0;
+					}
 				}
 
 				if (UsdExchangeRate != 0)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -751,11 +751,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 
 				long all = selectedCoins.Sum(x => x.Amount);
-				long theAmount = IsMax
-					? all
-					: Money.TryParse(AmountText.TrimStart('~', ' '), out Money value)
-						? value.Satoshi
-						: 0;
+				long theAmount = (IsMax, Money.TryParse(AmountText.TrimStart('~', ' '), out Money value)) switch
+				{
+					(true, _) => all,
+					(false, true) => value.Satoshi,
+					(false, false) => 0
+				};
 
 				FeePercentage = theAmount != 0
 					? 100 * (decimal)EstimatedBtcFee.Satoshi / theAmount

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -751,28 +751,15 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 
 				long all = selectedCoins.Sum(x => x.Amount);
-				if (IsMax)
-				{
-					if (all != 0)
-					{
-						FeePercentage = 100 * (decimal)EstimatedBtcFee.Satoshi / all;
-					}
-					else
-					{
-						FeePercentage = 0;
-					}
-				}
-				else
-				{
-					if (Money.TryParse(AmountText.TrimStart('~', ' '), out Money amount) && amount.Satoshi != 0)
-					{
-						FeePercentage = 100 * (decimal)EstimatedBtcFee.Satoshi / amount.Satoshi;
-					}
-					else
-					{
-						FeePercentage = 0;
-					}
-				}
+				long theAmount = IsMax
+					? all
+					: Money.TryParse(AmountText.TrimStart('~', ' '), out Money value)
+						? value.Satoshi
+						: 0;
+
+				FeePercentage = theAmount != 0
+					? 100 * (decimal)EstimatedBtcFee.Satoshi / theAmount
+					: 0;
 
 				if (UsdExchangeRate != 0)
 				{


### PR DESCRIPTION
- Go to Send tab
- Change fee display format to %
- Edit the fee manually to something like 10000
- Change the amount to 1 (the expected percentage should change)
- Change the amount back to 0

The expected percentage didn't change but it should.