### PR TITLE
Refactor Randomness

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/BlindingTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/BlindingTests.cs
@@ -115,7 +115,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			// Unblind the signature.
 			UnblindedSignature unblindedSignature = requester.UnblindSignature(blindedSignature);
 
-			// verify the original data is signed
+			// Verify the original data is signed.
 			Assert.True(VerifySignature(hash, unblindedSignature, keyPubKey));
 		}
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.Crypto.Randomness;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Crypto
+{
+	public class RandomTests
+	{
+		[Fact]
+		public void GetBytesArgumentTests()
+		{
+			var randoms = new List<IWasabiRandom>
+			{
+				new SecureRandom(),
+				new PseudoRandom(),
+				new MockRandom()
+			};
+
+			foreach (var random in randoms)
+			{
+				Assert.Throws<ArgumentOutOfRangeException>(() => random.GetBytes(int.MinValue));
+				Assert.Throws<ArgumentOutOfRangeException>(() => random.GetBytes(-1));
+				Assert.Throws<ArgumentOutOfRangeException>(() => random.GetBytes(0));
+
+				if (random is MockRandom == false)
+				{
+					var r1 = random.GetBytes(1);
+					Assert.Single(r1);
+					var r2 = random.GetBytes(2);
+					Assert.Equal(2, r2.Length);
+				}
+
+				if (random is SecureRandom secureRandom)
+				{
+					secureRandom.Dispose();
+				}
+			}
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -2,12 +2,47 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Helpers;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto
 {
 	public class RandomTests
 	{
+		[Fact]
+		public void BasicTests()
+		{
+			// Make sure byte array comparision works within hashset and that the underlying API won't pull the floor out.
+			var byteArray = new byte[] { 1, 2, 3 };
+			var sameByteArray = new byte[] { 1, 2, 3 };
+			var differentByteArray = new byte[] { 4, 5, 6 };
+			var twoSet = new HashSet<byte[]>(new ByteArrayEqualityComparer())
+			{
+				byteArray,
+				sameByteArray,
+				differentByteArray
+			};
+
+			Assert.True(ByteHelpers.CompareFastUnsafe(byteArray, sameByteArray));
+			Assert.False(ByteHelpers.CompareFastUnsafe(byteArray, differentByteArray));
+			Assert.Equal(2, twoSet.Count);
+
+			// It's probabilistically ensured that it never produces the same scalar, so unit test should pass always.
+			var pseudoSet = new HashSet<byte[]>();
+			var secureSet = new HashSet<byte[]>();
+			var count = 100;
+			IWasabiRandom iPseudoRandom = new SecureRandom();
+			using var secureRandom = new SecureRandom();
+			IWasabiRandom iSecureRandom = new SecureRandom();
+			for (int i = 0; i < count; i++)
+			{
+				pseudoSet.Add(iPseudoRandom.GetBytes(10));
+				secureSet.Add(iSecureRandom.GetBytes(10));
+			}
+			Assert.Equal(count, pseudoSet.Count);
+			Assert.Equal(count, secureSet.Count);
+		}
+
 		[Fact]
 		public void GetBytesArgumentTests()
 		{

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -31,12 +31,12 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			var pseudoSet = new HashSet<byte[]>();
 			var secureSet = new HashSet<byte[]>();
 			var count = 100;
-			IWasabiRandom iPseudoRandom = new PseudoRandom();
+			IWasabiRandom iUnsecureRandom = new UnsecureRandom();
 			using var secureRandom = new SecureRandom();
 			IWasabiRandom iSecureRandom = secureRandom;
 			for (int i = 0; i < count; i++)
 			{
-				pseudoSet.Add(iPseudoRandom.GetBytes(10));
+				pseudoSet.Add(iUnsecureRandom.GetBytes(10));
 				secureSet.Add(iSecureRandom.GetBytes(10));
 			}
 			Assert.Equal(count, pseudoSet.Count);
@@ -49,7 +49,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			var randoms = new List<IWasabiRandom>
 			{
 				new SecureRandom(),
-				new PseudoRandom(),
+				new UnsecureRandom(),
 				new MockRandom()
 			};
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -31,9 +31,9 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			var pseudoSet = new HashSet<byte[]>();
 			var secureSet = new HashSet<byte[]>();
 			var count = 100;
-			IWasabiRandom iPseudoRandom = new SecureRandom();
+			IWasabiRandom iPseudoRandom = new PseudoRandom();
 			using var secureRandom = new SecureRandom();
-			IWasabiRandom iSecureRandom = new SecureRandom();
+			IWasabiRandom iSecureRandom = secureRandom;
 			for (int i = 0; i < count; i++)
 			{
 				pseudoSet.Add(iPseudoRandom.GetBytes(10));

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -31,13 +31,12 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			var pseudoSet = new HashSet<byte[]>();
 			var secureSet = new HashSet<byte[]>();
 			var count = 100;
-			IWasabiRandom iUnsecureRandom = new UnsecureRandom();
+			var unsecureRandom = new UnsecureRandom();
 			using var secureRandom = new SecureRandom();
-			IWasabiRandom iSecureRandom = secureRandom;
 			for (int i = 0; i < count; i++)
 			{
-				pseudoSet.Add(iUnsecureRandom.GetBytes(10));
-				secureSet.Add(iSecureRandom.GetBytes(10));
+				pseudoSet.Add(unsecureRandom.GetBytes(10));
+				secureSet.Add(secureRandom.GetBytes(10));
 			}
 			Assert.Equal(count, pseudoSet.Count);
 			Assert.Equal(count, secureSet.Count);

--- a/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
@@ -6,7 +6,6 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Logging;
 using WalletWasabi.Tests.XunitConfiguration;
 using Xunit;
-using static WalletWasabi.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto
 {

--- a/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
@@ -8,12 +8,5 @@ namespace WalletWasabi.Crypto.Randomness
 {
 	public interface IWasabiRandom : IRandom
 	{
-		public byte[] GetBytes(int length)
-		{
-			Guard.MinimumAndNotNull(nameof(length), length, 1);
-			var buffer = new byte[length];
-			GetBytes(buffer);
-			return buffer;
-		}
 	}
 }

--- a/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Crypto.Randomness
 {
@@ -9,6 +10,7 @@ namespace WalletWasabi.Crypto.Randomness
 	{
 		public byte[] GetBytes(int length)
 		{
+			Guard.MinimumAndNotNull(nameof(length), length, 1);
 			var buffer = new byte[length];
 			GetBytes(buffer);
 			return buffer;

--- a/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
@@ -7,5 +7,11 @@ namespace WalletWasabi.Crypto.Randomness
 {
 	public interface IWasabiRandom : IRandom
 	{
+		public byte[] GetBytes(int length)
+		{
+			var buffer = new byte[length];
+			GetBytes(buffer);
+			return buffer;
+		}
 	}
 }

--- a/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/IWasabiRandom.cs
@@ -1,0 +1,11 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Crypto.Randomness
+{
+	public interface IWasabiRandom : IRandom
+	{
+	}
+}

--- a/WalletWasabi/Crypto/Randomness/IWasabiRandomExtensions.cs
+++ b/WalletWasabi/Crypto/Randomness/IWasabiRandomExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.Crypto.Randomness
+{
+	public static class IWasabiRandomExtensions
+	{
+		public static byte[] GetBytes(this IWasabiRandom me, int length)
+		{
+			Guard.MinimumAndNotNull(nameof(length), length, 1);
+			var buffer = new byte[length];
+			me.GetBytes(buffer);
+			return buffer;
+		}
+	}
+}

--- a/WalletWasabi/Crypto/Randomness/MockRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/MockRandom.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Crypto.Randomness
+{
+	public class MockRandom : IWasabiRandom
+	{
+		public void GetBytes(byte[] output)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void GetBytes(Span<byte> output)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/WalletWasabi/Crypto/Randomness/PseudoRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/PseudoRandom.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WalletWasabi.Crypto.Randomness
+{
+	public class PseudoRandom : IWasabiRandom
+	{
+		public PseudoRandom()
+		{
+			Random = new Random();
+		}
+
+		public Random Random { get; }
+
+		public void GetBytes(byte[] buffer) => Random.NextBytes(buffer);
+
+		public void GetBytes(Span<byte> buffer) => Random.NextBytes(buffer);
+	}
+}

--- a/WalletWasabi/Crypto/Randomness/PseudoRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/PseudoRandom.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Crypto.Randomness
 			Random = new Random();
 		}
 
-		public Random Random { get; }
+		private Random Random { get; }
 
 		public void GetBytes(byte[] buffer) => Random.NextBytes(buffer);
 

--- a/WalletWasabi/Crypto/Randomness/SecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/SecureRandom.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WalletWasabi.Crypto.Randomness
+{
+	public class SecureRandom : IWasabiRandom, IDisposable
+	{
+		private bool _disposedValue;
+
+		public SecureRandom()
+		{
+			Random = RandomNumberGenerator.Create();
+		}
+
+		public RandomNumberGenerator Random { get; }
+
+		public void GetBytes(byte[] buffer) => Random.GetBytes(buffer);
+
+		public void GetBytes(Span<byte> buffer) => Random.GetBytes(buffer);
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					Random?.Dispose();
+				}
+
+				_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+	}
+}

--- a/WalletWasabi/Crypto/Randomness/SecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/SecureRandom.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.Crypto.Randomness
 			Random = RandomNumberGenerator.Create();
 		}
 
-		public RandomNumberGenerator Random { get; }
+		private RandomNumberGenerator Random { get; }
 
 		public void GetBytes(byte[] buffer) => Random.GetBytes(buffer);
 

--- a/WalletWasabi/Crypto/Randomness/UnsecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/UnsecureRandom.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace WalletWasabi.Crypto.Randomness
 {
-	public class PseudoRandom : IWasabiRandom
+	public class UnsecureRandom : IWasabiRandom
 	{
-		public PseudoRandom()
+		public UnsecureRandom()
 		{
 			Random = new Random();
 		}

--- a/WalletWasabi/Crypto/StringCipher.cs
+++ b/WalletWasabi/Crypto/StringCipher.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using WalletWasabi.Crypto.Randomness;
 
 namespace WalletWasabi.Crypto
 {
@@ -120,12 +121,8 @@ namespace WalletWasabi.Crypto
 
 		private static byte[] Generate128BitsOfRandomEntropy()
 		{
-			var randomBytes = new byte[16]; // 16 Bytes will give us 128 bits.
-			using (var rngCsp = new RNGCryptoServiceProvider())
-			{
-				// Fill the array with cryptographically secure random bytes.
-				rngCsp.GetBytes(randomBytes);
-			}
+			using var secureRandom = new SecureRandom();
+			var randomBytes = (secureRandom as IWasabiRandom).GetBytes(16); // 16 Bytes will give us 128 bits.
 			return randomBytes;
 		}
 	}

--- a/WalletWasabi/Helpers/ByteArrayEqualityComparer.cs
+++ b/WalletWasabi/Helpers/ByteArrayEqualityComparer.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace WalletWasabi.Helpers
+{
+	public class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
+	{
+		public bool Equals([AllowNull] byte[] x, [AllowNull] byte[] y) => ByteHelpers.CompareFastUnsafe(x, y);
+
+		public int GetHashCode([DisallowNull] byte[] obj) => HashHelpers.ComputeHashCode(obj);
+	}
+}

--- a/WalletWasabi/Helpers/HashHelpers.cs
+++ b/WalletWasabi/Helpers/HashHelpers.cs
@@ -21,5 +21,29 @@ namespace WalletWasabi.Helpers
 
 			return hash;
 		}
+
+		/// <summary>
+		/// https://stackoverflow.com/a/468084/2061103
+		/// </summary>
+		public static int ComputeHashCode(params byte[] data)
+		{
+			unchecked
+			{
+				const int P = 16777619;
+				int hash = (int)2166136261;
+
+				for (int i = 0; i < data.Length; i++)
+				{
+					hash = (hash ^ data[i]) * P;
+				}
+
+				hash += hash << 13;
+				hash ^= hash >> 7;
+				hash += hash << 3;
+				hash ^= hash >> 17;
+				hash += hash << 5;
+				return hash;
+			}
+		}
 	}
 }

--- a/WalletWasabi/Helpers/HashHelpers.cs
+++ b/WalletWasabi/Helpers/HashHelpers.cs
@@ -22,28 +22,14 @@ namespace WalletWasabi.Helpers
 			return hash;
 		}
 
-		/// <summary>
-		/// https://stackoverflow.com/a/468084/2061103
-		/// </summary>
 		public static int ComputeHashCode(params byte[] data)
 		{
-			unchecked
+			var hash = new HashCode();
+			foreach (var element in data)
 			{
-				const int P = 16777619;
-				int hash = (int)2166136261;
-
-				for (int i = 0; i < data.Length; i++)
-				{
-					hash = (hash ^ data[i]) * P;
-				}
-
-				hash += hash << 13;
-				hash ^= hash >> 7;
-				hash += hash << 3;
-				hash ^= hash >> 17;
-				hash += hash << 5;
-				return hash;
+				hash.Add(element);
 			}
+			return hash.ToHashCode();
 		}
 	}
 }


### PR DESCRIPTION
This is a preparation PR for WabiSabi: https://github.com/zkSNACKs/WalletWasabi/pull/3851

I refactored the randomness implementation based on @lontivero's suggestion (https://github.com/zkSNACKs/WalletWasabi/pull/3851#discussion_r449032189) and some private conversation with @lontivero and @molnard. So now we will be able to have an own custom `MockRandom` for making it easy for us to test things. The design is as follows:

`IRandom` (from NBitcoin) -> `IWasabiRandom` -> `SecureRandom`, `PseudoRandom`, `MockRandom`

It does not touch the code, except in one place. It swaps the `StringCypher`'s old school randomness implementation with our `SecureRandom` implementation.