### PR TITLE
Adds `#nullable enable` to a few unit tests to demonstrate incrementa…

### DIFF
--- a/WalletWasabi.Tests/UnitTests/SerializableExceptionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SerializableExceptionTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -16,7 +18,7 @@ namespace WalletWasabi.Tests.UnitTests
 			var innerStackTrace = "";
 
 			Exception ex;
-			string stackTrace;
+			string? stackTrace;
 			try
 			{
 				try

--- a/WalletWasabi.Tests/UnitTests/SmartBlockProviderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartBlockProviderTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -18,21 +20,21 @@ namespace WalletWasabi.Tests.UnitTests
 			var blocks = new Dictionary<uint256, Block>
 			{
 				[uint256.Zero] = Block.CreateBlock(Network.Main),
-				[uint256.One]  = Block.CreateBlock(Network.Main)
+				[uint256.One] = Block.CreateBlock(Network.Main)
 			};
-			
-			var source = new MockProvider();
-			source.OnGetBlockAsync = async (hash, cancel) => 
-			{
-				await Task.Delay(TimeSpan.FromSeconds(0.5));
-				var block = Block.CreateBlock(Network.Main);
-				return block;
-			};
+
+			var source = new MockProvider(onGetBlockAsync: async (hash, cancel) =>
+				{
+					await Task.Delay(TimeSpan.FromSeconds(0.5));
+					var block = Block.CreateBlock(Network.Main);
+					return block;
+				});
+
 			using var cache = new MemoryCache(new MemoryCacheOptions());
 			var blockProvider = new SmartBlockProvider(source, cache);
 
 			var b1 = blockProvider.GetBlockAsync(uint256.Zero, CancellationToken.None);
-			var b2 = blockProvider.GetBlockAsync(uint256.One,  CancellationToken.None);
+			var b2 = blockProvider.GetBlockAsync(uint256.One, CancellationToken.None);
 			var b3 = blockProvider.GetBlockAsync(uint256.Zero, CancellationToken.None);
 
 			await Task.WhenAll(b1, b2, b3);
@@ -42,7 +44,12 @@ namespace WalletWasabi.Tests.UnitTests
 
 		private class MockProvider : IBlockProvider
 		{
-			public Func<uint256, CancellationToken, Task<Block>> OnGetBlockAsync { get; set; }
+			public Func<uint256, CancellationToken, Task<Block>> OnGetBlockAsync { get; }
+
+			public MockProvider(Func<uint256, CancellationToken, Task<Block>> onGetBlockAsync)
+			{
+				OnGetBlockAsync = onGetBlockAsync;
+			}
 
 			public Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancel)
 			{

--- a/WalletWasabi.Tests/UnitTests/SmartBlockProviderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartBlockProviderTests.cs
@@ -44,12 +44,12 @@ namespace WalletWasabi.Tests.UnitTests
 
 		private class MockProvider : IBlockProvider
 		{
-			public Func<uint256, CancellationToken, Task<Block>> OnGetBlockAsync { get; }
-
 			public MockProvider(Func<uint256, CancellationToken, Task<Block>> onGetBlockAsync)
 			{
 				OnGetBlockAsync = onGetBlockAsync;
 			}
+
+			public Func<uint256, CancellationToken, Task<Block>> OnGetBlockAsync { get; }
 
 			public Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancel)
 			{

--- a/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using NBitcoin;
 using System;
 using System.Collections.Generic;

--- a/WalletWasabi.Tests/UnitTests/SmartHeaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartHeaderTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using System;

--- a/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -57,7 +59,7 @@ namespace WalletWasabi.Tests.UnitTests
 			label = new SmartLabel(new List<string>() { "   foo   ", "   bar    " });
 			Assert.Equal("bar, foo", label);
 
-			label = new SmartLabel(new List<string>() { "foo:", ":bar", null, ":buz:", ",", ": , :", "qux:quux", "corge,grault", "", "  ", " , garply, waldo,", " : ,  :  ,  fred  , : , :   plugh, : , : ," });
+			label = new SmartLabel(new List<string>() { "foo:", ":bar", null!, ":buz:", ",", ": , :", "qux:quux", "corge,grault", "", "  ", " , garply, waldo,", " : ,  :  ,  fred  , : , :   plugh, : , : ," });
 			Assert.Equal("bar, buz, corge, foo, fred, garply, grault, plugh, quux, qux, waldo", label);
 
 			label = new SmartLabel(",: foo::bar :buz:,: , :qux:quux, corge,grault  , garply, waldo, : ,  :  ,  fred  , : , :   plugh, : , : ,");
@@ -81,8 +83,10 @@ namespace WalletWasabi.Tests.UnitTests
 			var label3 = new SmartLabel("bar, buz");
 			Assert.NotEqual(label, label3);
 
-			SmartLabel label4 = null;
-			SmartLabel label5 = null;
+			SmartLabel? label4 = null;
+			SmartLabel? label5 = null;
+
+			// Tests equality operators in SmartLabel class.
 			Assert.Equal(label4, label5);
 			Assert.NotEqual(label, label4);
 			Assert.False(label.Equals(label4));

--- a/WalletWasabi.Tests/UnitTests/StringNoWhiteSpaceEqualityComparerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StringNoWhiteSpaceEqualityComparerTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/WalletWasabi.Tests/UnitTests/UpdateStatusTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UpdateStatusTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/WalletWasabi.Tests/UnitTests/UtxoRefereeTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UtxoRefereeTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using NBitcoin;
 using System;
 using System.Collections.Generic;

--- a/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
…l approach of adding Nullable reference types to Wasabi.

Notes:

* Test files were chosen because they are simple.
* These `#nullable enable` pragmas work on file level. You can actually use a combination of `#nullable enable` & `#nullable restore` to annotate smaller part of a file.

Resources:

* https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references - introduction
* https://docs.microsoft.com/en-us/dotnet/csharp/nullable-migration-strategies#choose-a-strategy-for-nullable-reference-types - see Second strategy - strategies to introducing Nullable reference types to existing projects.

Fixes #3860.