### PR TITLE
Hide block height if the transaction is not confirmed

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionInfoTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionInfoTabView.xaml
@@ -25,7 +25,7 @@
           <TextBlock Classes="monospaceFont" Text="Transaction Date:" />
           <controls:ExtendedTextBox Grid.Column="1" Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding Path=DateTime, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" />
         </Grid>
-        <Grid ColumnDefinitions="170, *">
+        <Grid ColumnDefinitions="170, *" IsVisible="{Binding Confirmed}">
           <TextBlock Classes="monospaceFont" Text="Block Height:" />
           <controls:ExtendedTextBox Grid.Column="1" Classes="selectableTextBlock monospaceFont Transparent" Text="{Binding BlockHeight}" />
         </Grid>


### PR DESCRIPTION
Fixes #3878

https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs#L145
Should we also change that to
`BlockHeight = txr.Height.Type == HeightType.Chain ? txr.Height.Value : int.MaxValue,`
or
`BlockHeight = txr.Height.Type == HeightType.Chain ? txr.Height.Value : int.MinValue,`