### PR TITLE
Add back Confirmed property

### DIFF
--- a/WalletWasabi.Gui/Controls/TransactionDetails/ViewModels/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Gui/Controls/TransactionDetails/ViewModels/TransactionDetailsViewModel.cs
@@ -26,6 +26,8 @@ namespace WalletWasabi.Gui.Controls.TransactionDetails.ViewModels
 			set => this.RaiseAndSetIfChanged(ref _dateTime, value);
 		}
 
+		public bool Confirmed => Confirmations > 0;
+
 		public int Confirmations
 		{
 			get => _confirmations;


### PR DESCRIPTION
#3880 didn't really fix the block height issue because https://github.com/zkSNACKs/WalletWasabi/commit/0e62cf81c7d12643abb85933a8be26ae64b38840#diff-995774607e811ee67f9687572ce5b3c9 removed the `Confirmed` property which is necessary [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Gui/Controls/WalletExplorer/TransactionInfoTabView.xaml#L28)