### PR TITLE
Reword error message

### DIFF
--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -66,7 +66,7 @@ namespace WalletWasabi.BitcoinCore
 
 			if (!Node.PeerVersion.Services.HasFlag(NodeServices.Network))
 			{
-				throw new InvalidOperationException("We are unable to use the local node because it does not provide blocks.");
+				throw new InvalidOperationException("Unable to use the local node because it does not provide blocks.");
 			}
 
 			if (!Node.IsConnected)

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -66,7 +66,7 @@ namespace WalletWasabi.BitcoinCore
 
 			if (!Node.PeerVersion.Services.HasFlag(NodeServices.Network))
 			{
-				throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
+				throw new InvalidOperationException("We are unable to use the local node because it does not provide blocks.");
 			}
 
 			if (!Node.IsConnected)


### PR DESCRIPTION
- Avoid wallet's name in the error Message
because it has already been written clearly
to the Console using LogSoftwareStarted().

This reduces the diff against Forks with
different names or even future name changes.

- ' Cannot ' was slighly dubious because it
could indicate permission but also ability.

- Add subject ' We ' for readability