### PR TITLE
Handle exceptions from avalonia's data error subsystem in ErrorDescriptorToBorderColorConverter.cs

### DIFF
--- a/WalletWasabi.Gui/Converters/ErrorDescriptorToBorderColorConverter.cs
+++ b/WalletWasabi.Gui/Converters/ErrorDescriptorToBorderColorConverter.cs
@@ -11,6 +11,12 @@ namespace WalletWasabi.Gui.Converters
 {
 	public class ErrorDescriptorToBorderColorConverter : IValueConverter
 	{
+		private ErrorDescriptor UndefinedExceptionToErrorDescriptor(Exception ex)
+		{
+			var newErrDescMessage = ExceptionExtensions.ToTypeMessageString(ex);
+			return new ErrorDescriptor(ErrorSeverity.Warning, newErrDescMessage);
+		}
+
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
 			var descriptors = ErrorDescriptors.Create();
@@ -21,6 +27,15 @@ namespace WalletWasabi.Gui.Converters
 				{
 					descriptors.Add(error);
 				}
+
+				foreach (var ex in rawObj.OfType<Exception>())
+				{
+					descriptors.Add(UndefinedExceptionToErrorDescriptor(ex));
+				}
+			}
+			else if (value is Exception ex)
+			{
+				descriptors.Add(UndefinedExceptionToErrorDescriptor(ex));
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #3914 by handling the exception that is thrown by avalonia bindings system when the textbox string value doesnt match the target property's type.

@danwalmsley the issue was fixed before but then it was reintroduced by https://github.com/zkSNACKs/WalletWasabi/commit/3f87d20f4cdd916cef3b9a3e7e9e0a9e0e6af66c#diff-ac677b2018688e0543b1e4c97549229f
Is this solution valid?