### PR TITLE
Fixes/3909 tooltip stuck on screen

### DIFF
--- a/WalletWasabi.Gui/Behaviors/PreventTooltipStuckBehavior.cs
+++ b/WalletWasabi.Gui/Behaviors/PreventTooltipStuckBehavior.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace WalletWasabi.Gui.Behaviors
+{
+	/// <summary>
+	/// Ensures Tooltips are closed when parent control is removed from visual tree.
+	/// This is a workaround and should be removed when Avalonia 0.10.0 upgrade is complete. TODO
+	/// </summary>
+	public class PreventTooltipStuckBehavior : Behavior<Control>
+	{
+		protected override void OnDetaching()
+		{
+			base.OnDetaching();
+
+			ToolTip.SetIsOpen(AssociatedObject, false);
+		}
+	}
+}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletExplorerView.xaml
@@ -56,6 +56,7 @@
             <StackPanel Classes="TreeViewRoot">
               <i:Interaction.Behaviors>
                 <behaviors:CommandOnDoubleClickBehavior Command="{Binding OpenWalletCommand}" />
+                <behaviors:PreventTooltipStuckBehavior />
               </i:Interaction.Behaviors>
               <StackPanel.ContextMenu>
                 <ContextMenu>
@@ -84,6 +85,9 @@
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletViewModel" ItemsSource="{Binding Actions}">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <StackPanel.DataTemplates>
                 <DataTemplate DataType="ViewModels:HardwareWalletViewModel">
                   <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorer_HardwareWalletOpen}" />
@@ -101,42 +105,63 @@
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:SendTabViewModel">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Send}" />
               <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:BuildTabViewModel">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Builder}" />
               <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:ReceiveTabViewModel">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Receive}" />
               <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:CoinJoinTabViewModel">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_CoinJoin}" />
               <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:HistoryTabViewModel">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_History}" />
               <TextBlock Text="{Binding Title}" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletInfoViewModel">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Info}" />
               <TextBlock Text="Wallet Info" />
             </StackPanel>
           </TreeDataTemplate>
           <TreeDataTemplate DataType="ViewModels:WalletAdvancedViewModel" ItemsSource="{Binding Items}">
             <StackPanel Classes="TreeViewRoot">
+              <i:Interaction.Behaviors>
+                <behaviors:PreventTooltipStuckBehavior />
+              </i:Interaction.Behaviors>
               <DrawingPresenter Width="16" Height="16" Drawing="{DynamicResource WalletExplorerView_Advanced}" />
               <TextBlock Text="Advanced" />
             </StackPanel>


### PR DESCRIPTION
This is a workaround for the tooltip getting stuck on the screen.

It should be removed once Avalonia 0.10.0 upgrade is completed...

this is fixed in avalonia here:
https://github.com/AvaloniaUI/Avalonia/pull/4296