### PR TITLE
Check for existence of gedit before trying to launch it

### DIFF
--- a/WalletWasabi.Gui/Helpers/FileHelpers.cs
+++ b/WalletWasabi.Gui/Helpers/FileHelpers.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.Gui.Helpers
 				{
 					// If no associated application/json MimeType is found xdg-open opens retrun error
 					// but it tries to open it anyway using the console editor (nano, vim, other..)
-					await EnvironmentHelpers.ShellExecAsync($"gedit {filePath} || xdg-open {filePath}", waitForExit: false).ConfigureAwait(false);
+					await EnvironmentHelpers.ShellExecAsync($"which gedit &> /dev/null && gedit {filePath} || xdg-open {filePath}", waitForExit: false).ConfigureAwait(false);
 				}
 				else
 				{


### PR DESCRIPTION
Noticed this while [testing v1.1.12](https://github.com/zkSNACKs/WalletWasabi/issues/3782).

Without this change on a Linux systems without gedit installed (like mine), each time you try to open some log file, confusing `/bin/sh: gedit: command not found` error is printed to stdout. This fixes that.

Of course, this is fairly minor and likely should not be merged before next release.