### PR TITLE
Add missing command to deterministic build guide

### DIFF
--- a/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md
+++ b/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md
@@ -10,6 +10,7 @@ In order to reproduce Wasabi's builds you need Git, Windows 10 and the version o
 
 ```sh
 git clone https://github.com/zkSNACKs/WalletWasabi.git
+cd WalletWasabi
 git checkout {hash of the release} # This works from 1.1.3 release, https://github.com/zkSNACKs/WalletWasabi/releases
 cd WalletWasabi/WalletWasabi.Packager/
 dotnet restore

--- a/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md
+++ b/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md
@@ -18,7 +18,7 @@ dotnet build
 dotnet run -- --onlybinaries
 ```
 
-This will build our binaries for Windows, OSX and Linux from source code and open them in a file explorer for you.
+This will build our binaries for Windows, OSX and Linux from source code in `WalletWasabi/WalletWasabi.Gui/bin/dist` and open them in a file explorer for you.
 
 ![](https://i.imgur.com/8XAQzz4.png)
 
@@ -31,7 +31,7 @@ In order to end-to-end verify all the downloaded packages you need a Windows, a 
 
 ## Windows
 
-After you installed Wasabi from the `.msi`, it will be in `C:\Program Files\WasabiWallet` folder. You can compare it with your build:
+After you installed Wasabi from the `.msi`, it will be in `C:\Program Files\WasabiWallet` folder. Open a terminal, move to `WalletWasabi/WalletWasabi.Gui/bin/dist` and compare it with your build with the following command:
 
 ```sh
 git diff --no-index win7-x64 "C:\Program Files\WasabiWallet"


### PR DESCRIPTION
User must move to `WalletWasabi` folder before he can issue the `git checkout XXX` command