### PR TITLE
Do not process transactions that are not received from the network

### DIFF
--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -114,19 +114,7 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 				}
 			}
 
-			BelieveTransaction(transaction);
-
 			Logger.LogInfo($"Transaction is successfully broadcasted to backend: {transaction.GetHash()}.");
-		}
-
-		private void BelieveTransaction(SmartTransaction transaction)
-		{
-			if (transaction.Height == Height.Unknown)
-			{
-				transaction.SetUnconfirmed();
-			}
-
-			WalletManager.Process(transaction);
 		}
 
 		public async Task SendTransactionAsync(SmartTransaction transaction)
@@ -189,7 +177,6 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 		private async Task BroadcastTransactionWithRpcAsync(SmartTransaction transaction)
 		{
 			await RpcClient.SendRawTransactionAsync(transaction.Transaction).ConfigureAwait(false);
-			BelieveTransaction(transaction);
 			Logger.LogInfo($"Transaction is successfully broadcasted with RPC: {transaction.GetHash()}.");
 		}
 	}


### PR DESCRIPTION
This is for discussing the issue https://github.com/zkSNACKs/WalletWasabi/issues/3699. Basically we are trusting the RPC will broadcast the transaction to the network and that the network will accept it but that seems to not be true, and if that were true then why not wait to receive the tx from the network as an eco.