### PR TITLE
Fix Trezor display address cmd on TestNet

### DIFF
--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -86,7 +86,10 @@ namespace WalletWasabi.Hwi
 				var newOptions = BuildOptions(firstNoFingerprintEntry.Model, firstNoFingerprintEntry.Path, fingerprint: null, options.Where(x => x.Type != HwiOptions.Fingerprint).ToArray());
 				return await SendCommandAsync(newOptions, command, arguments, openConsole, cancel, isRecursion: true);
 			}
-			catch (HwiException ex) when (Network != Network.Main && ex.ErrorCode == HwiErrorCode.UnknownError && ex.Message?.Contains("DataError: Forbidden key path") is true)
+			catch (HwiException ex)
+			when (Network != Network.Main
+				&& ((ex.ErrorCode == HwiErrorCode.UnknownError && ex.Message?.Contains("DataError: Forbidden key path") is true)
+				|| (ex.ErrorCode == HwiErrorCode.BadArgument && ex.Message?.Contains("No path supplied matched device keys") is true)))
 			{
 				// Trezor only accepts KeyPath 84'/1' on TestNet from v2.3.1. We fake that we are on MainNet to ensure compatibility.
 				string fixedArguments = HwiParser.ToArgumentString(Network.Main, options, command, commandArguments);


### PR DESCRIPTION
Trezor won't display the address on the device if the path is not correct according to BIP44. With this hack, the address will be displayed but on the device but on MainNet so the user cannot verify that the address is correct, and in the end, Wasabi will throw an exception because the network is not matching with the current one.

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/3937
Related: https://github.com/zkSNACKs/WalletWasabi/issues/3982

Maybe this sounds strange but I am against merging this fix as it makes no sense fix this just to make it work but the address still unverifiable, so the main goal of the function is not working. 
In that case this is a wontfix.