### PR TITLE
Update .editorconfig for *.csproj files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,19 @@
 # You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 root = true
 
+[*.csproj]
+
+charset = utf-8
+
+# use hard tabs for indentation
+indent_style = tab
+
+# Formatting - set preferred newline characters
+end_of_line = lf
+
+# Formatting - remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+
 [*.cs]
 
 charset = utf-8
@@ -14,7 +27,7 @@ indent_style = tab
 
 # Formatting - new line options
 
-#require braces to be on a new line for all
+# require braces to be on a new line for all
 csharp_new_line_before_open_brace = all
 
 # Formatting - organize using options

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,20 +3,7 @@
 # You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 root = true
 
-[*.csproj]
-
-charset = utf-8
-
-# use hard tabs for indentation
-indent_style = tab
-
-# Formatting - set preferred newline characters
-end_of_line = lf
-
-# Formatting - remove any whitespace characters preceding newline characters
-trim_trailing_whitespace = true
-
-[*.cs]
+[*.{cs,csproj}]
 
 charset = utf-8
 
@@ -25,7 +12,18 @@ charset = utf-8
 # use hard tabs for indentation
 indent_style = tab
 
-# Formatting - new line options
+# Formatting - set preferred newline characters
+end_of_line = lf
+
+# Formatting - remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+
+[*.xaml]
+
+indent_style = space
+indent_size = 2
+
+[*.cs]
 
 # require braces to be on a new line for all
 csharp_new_line_before_open_brace = all
@@ -34,12 +32,6 @@ csharp_new_line_before_open_brace = all
 
 # do not place System.* using directives before other using directives
 dotnet_sort_system_directives_first = true:error
-
-# Formatting - remove any whitespace characters preceding newline characters
-trim_trailing_whitespace = true
-
-# Formatting - set preferred newline characters
-end_of_line = lf
 
 # Formatting - spacing options
 
@@ -258,7 +250,3 @@ dotnet_diagnostic.IDE0004.severity = error
 
 # IDE0019: Use pattern matching
 csharp_style_pattern_matching_over_as_with_null_check = true:error
-
-[*.xaml]
-indent_style = space
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,20 +3,21 @@
 # You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 root = true
 
-[*.{cs,csproj}]
+# For all files.
+[*]
 
 charset = utf-8
 
-# Core editorconfig formatting - indentation
+# Formatting - remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+
+[*.{cs,csproj}]
 
 # use hard tabs for indentation
 indent_style = tab
 
 # Formatting - set preferred newline characters
 end_of_line = lf
-
-# Formatting - remove any whitespace characters preceding newline characters
-trim_trailing_whitespace = true
 
 [*.xaml]
 


### PR DESCRIPTION
Currently, the rules apply to `*.cs` files. `*.csproj` should follow similar rules.