### PR TITLE
Fix the update of confirmations on History Tab

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabViewModel.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			base.OnOpen(disposables);
 
-			Observable.FromEventPattern(Wallet, nameof(Wallet.NewBlockProcessed))
+			Observable.FromEventPattern(Wallet, nameof(Wallet.NewFilterProcessed))
 				.Merge(Observable.FromEventPattern(Wallet.TransactionProcessor, nameof(Wallet.TransactionProcessor.WalletRelevantTransactionProcessed)))
 				.Throttle(TimeSpan.FromSeconds(3))
 				.ObserveOn(RxApp.MainThreadScheduler)


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/3877

NewBlockProcessed was only called when there was at least one relevant tx in the block

https://github.com/molnard/WalletWasabi/blob/f7397ece96fe448ab908659122056f1fb238dfeb/WalletWasabi/Wallets/Wallet.cs#L523

The confirmations need to be updated every time if there is a new block. So change this to be triggered by NewFilterProcessed

https://github.com/molnard/WalletWasabi/blob/f7397ece96fe448ab908659122056f1fb238dfeb/WalletWasabi/Wallets/Wallet.cs#L411 

It gets called every time and after the wallet processed a new filter/block. 