### PR TITLE
Validate Account keypath

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -38,7 +38,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 
 			this.ValidateProperty(x => x.Password, ValidatePassword);
 			this.ValidateProperty(x => x.MinGapLimit, ValidateMinGapLimit);
-			this.ValidateProperty(x => x.AccountKeyPath, ValidateKeyPath);
+			this.ValidateProperty(x => x.AccountKeyPath, ValidateAccountKeyPath);
 
 			MnemonicWords = "";
 
@@ -220,15 +220,23 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 			}
 		}
 
-		private void ValidateKeyPath(IValidationErrors errors)
+		private void ValidateAccountKeyPath(IValidationErrors errors)
 		{
 			if (string.IsNullOrWhiteSpace(AccountKeyPath))
 			{
 				errors.Add(ErrorSeverity.Error, "Path is not valid.");
 			}
-			else if (!KeyPath.TryParse(AccountKeyPath, out _))
+			else if (!KeyPath.TryParse(AccountKeyPath, out var keyPath))
 			{
 				errors.Add(ErrorSeverity.Error, "Path is not a valid derivation path.");
+			}
+			else
+			{
+				var accountKeyPath = keyPath.GetAccountKeyPath();
+				if (keyPath.Length != accountKeyPath.Length || accountKeyPath.Length != KeyManager.DefaultAccountKeyPath.Length)
+				{
+					errors.Add(ErrorSeverity.Error, "Path is a full account derivation path.");
+				}
 			}
 		}
 	}

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -235,7 +235,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 				var accountKeyPath = keyPath.GetAccountKeyPath();
 				if (keyPath.Length != accountKeyPath.Length || accountKeyPath.Length != KeyManager.DefaultAccountKeyPath.Length)
 				{
-					errors.Add(ErrorSeverity.Error, "Path is a full account derivation path.");
+					errors.Add(ErrorSeverity.Error, "Path is not a compatible account derivation path.");
 				}
 			}
 		}

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -226,17 +226,17 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 			{
 				errors.Add(ErrorSeverity.Error, "Path is not valid.");
 			}
-			else if (!KeyPath.TryParse(AccountKeyPath, out var keyPath))
-			{
-				errors.Add(ErrorSeverity.Error, "Path is not a valid derivation path.");
-			}
-			else
+			else if (KeyPath.TryParse(AccountKeyPath, out var keyPath))
 			{
 				var accountKeyPath = keyPath.GetAccountKeyPath();
 				if (keyPath.Length != accountKeyPath.Length || accountKeyPath.Length != KeyManager.DefaultAccountKeyPath.Length)
 				{
 					errors.Add(ErrorSeverity.Error, "Path is not a compatible account derivation path.");
 				}
+			}
+			else
+			{
+				errors.Add(ErrorSeverity.Error, "Path is not a valid derivation path.");
 			}
 		}
 	}


### PR DESCRIPTION
In the Recovery Wallet page Wasabi allows users to specify the `Account Key Path` but it never validates that the entered keypath is really an account key path compatible with Wasabi.

Closes https://github.com/zkSNACKs/WalletWasabi/issues/3916