### PR TITLE
TorSocks5Client: Remove unused constructor.

### DIFF
--- a/WalletWasabi/TorSocks5/TorProcessManager.cs
+++ b/WalletWasabi/TorSocks5/TorProcessManager.cs
@@ -13,6 +13,10 @@ using WalletWasabi.TorSocks5.Models.Fields.OctetFields;
 
 namespace WalletWasabi.TorSocks5
 {
+	/// <summary>
+	/// Installs, starts and monitors Tor program.
+	/// </summary>
+	/// <seealso href="https://2019.www.torproject.org/docs/tor-manual.html.en"/>
 	public class TorProcessManager
 	{
 		/// <summary>

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -32,23 +32,6 @@ namespace WalletWasabi.TorSocks5
 			AsyncLock = new AsyncLock();
 		}
 
-		/// <param name="tcpClient">Must be already connected.</param>
-		internal TorSocks5Client(TcpClient tcpClient)
-		{
-			Guard.NotNull(nameof(tcpClient), tcpClient);
-			TcpClient = tcpClient;
-			AsyncLock = new AsyncLock();
-			Stream = tcpClient.GetStream();
-			TorSocks5EndPoint = null;
-			DestinationHost = tcpClient.Client.RemoteEndPoint.GetHostOrDefault();
-			DestinationPort = tcpClient.Client.RemoteEndPoint.GetPortOrDefault().Value;
-			RemoteEndPoint = tcpClient.Client.RemoteEndPoint;
-			if (!IsConnected)
-			{
-				throw new ConnectionException($"{nameof(TorSocks5Client)} is not connected to {RemoteEndPoint}.");
-			}
-		}
-
 		#endregion Constructors
 
 		#region PropertiesAndMembers


### PR DESCRIPTION
This is part of my attempt to clean Tor-related classes a bit.