### PR TITLE
Update hash of SkiaSharp in nuget lock file

### DIFF
--- a/WalletWasabi.Gui/packages.lock.json
+++ b/WalletWasabi.Gui/packages.lock.json
@@ -860,7 +860,7 @@
       "SkiaSharp": {
         "type": "Transitive",
         "resolved": "1.68.0",
-        "contentHash": "F8Nh6ws9WGVCddQb509Xl4lCIOu786Oc27t9LxPbuPZU7Olw6jVO2X6iqmHrwY+MZQXQXD4DeK5LU8vfiNwTCg=="
+        "contentHash": "ptuxAKk9FiClNnAgWM8hVMCYw/B0hUJWZ8W6efnIAtJmJn/Xl4jvxxDF5WOqfQYCLVzxXw5gvBPVxvTLblFp0g=="
       },
       "Splat": {
         "type": "Transitive",

--- a/WalletWasabi.Tests/packages.lock.json
+++ b/WalletWasabi.Tests/packages.lock.json
@@ -919,7 +919,7 @@
       "SkiaSharp": {
         "type": "Transitive",
         "resolved": "1.68.0",
-        "contentHash": "F8Nh6ws9WGVCddQb509Xl4lCIOu786Oc27t9LxPbuPZU7Olw6jVO2X6iqmHrwY+MZQXQXD4DeK5LU8vfiNwTCg=="
+        "contentHash": "ptuxAKk9FiClNnAgWM8hVMCYw/B0hUJWZ8W6efnIAtJmJn/Xl4jvxxDF5WOqfQYCLVzxXw5gvBPVxvTLblFp0g=="
       },
       "Splat": {
         "type": "Transitive",


### PR DESCRIPTION
After a running dotnet restore I get this

![image](https://user-images.githubusercontent.com/9844978/88811455-dec61d00-d1b6-11ea-9308-b24ca19e6c81.png)

Deleted the lock file so it was regenerated and there was a difference in the hash of SkiSharp.
