### PR TITLE
Add PathMap to solve deterministic build on  CallerFilePath

### DIFF
--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -12,6 +12,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/zkSNACKs/WalletWasabi/</RepositoryUrl>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Backend</PathMap>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -9,6 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Gui</PathMap>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/WalletWasabi.Packager/WalletWasabi.Packager.csproj
+++ b/WalletWasabi.Packager/WalletWasabi.Packager.csproj
@@ -10,6 +10,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Packager</PathMap>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -11,6 +11,7 @@
     <StartupObject />
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Tests</PathMap>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -10,6 +10,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi</PathMap>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/4090

Some places we use the `[CallerFilePath]` that will hardcode the file path into the binaries in compile time. This ruining deterministic build, if the user tries to build Wasabi from a different repository path that I used on my own machine when creating the release. 

`[CallerFilePath] string callerFilePath = ""`

We are using it in the logger, here:
https://github.com/molnard/WalletWasabi/blob/87275a988334b16baf8fca536d807ac15972c782/WalletWasabi/Logging/Logger.cs#L126

Without PathMap

![image](https://user-images.githubusercontent.com/9844978/89051054-f4247e00-d353-11ea-8926-87153a9add69.png)

By adding this to csproj file

`<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Gui</PathMap>`

![image](https://user-images.githubusercontent.com/9844978/89051208-2cc45780-d354-11ea-8dfb-a14d0c28b2c3.png)

Refs:
https://blog.paranoidcoding.com/2016/04/05/deterministic-builds-in-roslyn.html
https://gist.github.com/aelij/b20271f4bd0ab1298e49068b388b54ae
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/pathmap-compiler-option
https://www.tabsoverspaces.com/233662-changing-paths-in-pdb-files-for-source-files-and-pdb-file-path-in-dll-as-well

