### PR TITLE
Replace Grids without Row/Col Definitions with Panel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,3 +188,7 @@ Some pointers on how to recognise if we are breaking MVVM:
 * Views that depend on more than 1 viewmodel class.
 
 If it seems not possible to implement something without breaking some of this advice please consult with @danwalmsley.
+
+
+## Avoid using Grid as much as possible, Use Panel instead 
+If you dont need any row or column splitting for your child controls, just use `Panel` as your default container control instead of `Grid` since it is a moderately memory-intensive control.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,5 +189,5 @@ Some pointers on how to recognise if we are breaking MVVM:
 
 If it seems not possible to implement something without breaking some of this advice please consult with @danwalmsley.
 
-## Avoid using Grid as much as possible, Use Panel instead 
-If you dont need any row or column splitting for your child controls, just use `Panel` as your default container control instead of `Grid` since it is a moderately memory-intensive control.
+## Avoid using Grid as much as possible, use Panel instead 
+If you don't need any row or column splitting for your child controls, just use `Panel` as your default container control instead of `Grid` since it is a moderately memory-intensive control.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,5 @@ Some pointers on how to recognise if we are breaking MVVM:
 
 If it seems not possible to implement something without breaking some of this advice please consult with @danwalmsley.
 
-
 ## Avoid using Grid as much as possible, Use Panel instead 
 If you dont need any row or column splitting for your child controls, just use `Panel` as your default container control instead of `Grid` since it is a moderately memory-intensive control.

--- a/WalletWasabi.Gui/App.xaml
+++ b/WalletWasabi.Gui/App.xaml
@@ -27,9 +27,9 @@
   </Application.Styles>
   <Application.DataTemplates>
     <DataTemplate DataType="Views:MainView">
-      <Grid>
+      <Panel>
         <ContentControl Content="{Binding ActiveDockable}" />
-      </Grid>
+      </Panel>
     </DataTemplate>
     <DataTemplate DataType="id:IDockable">
       <cont:ViewModelViewHost DataContext="{Binding Context}" />

--- a/WalletWasabi.Gui/Controls/BusyIndicator.xaml
+++ b/WalletWasabi.Gui/Controls/BusyIndicator.xaml
@@ -7,7 +7,7 @@
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Grid>
+        <Panel>
           <StackPanel ZIndex="2" Orientation="Horizontal" VerticalAlignment="Top" IsVisible="{TemplateBinding IsBusy}">
             <controls:Spinner Height="20" Width="20" IsVisible="True" Margin="8" />
             <TextBlock Text="{TemplateBinding Text}" VerticalAlignment="Center" />
@@ -22,7 +22,7 @@
               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
           </Border>
-        </Grid>
+        </Panel>
       </ControlTemplate>
     </Setter>
   </Style>

--- a/WalletWasabi.Gui/Controls/EditableTextBlock.xaml
+++ b/WalletWasabi.Gui/Controls/EditableTextBlock.xaml
@@ -7,7 +7,7 @@
     <Setter Property="Focusable" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Grid>
+        <Panel>
           <TextBlock Text="{TemplateBinding Text}" IsVisible="{TemplateBinding ReadMode}" VerticalAlignment="Center" Name="PART_TextBlock" Margin="1 0 0 0" />
           <TextBox
             Text="{TemplateBinding EditText, Mode=TwoWay}"
@@ -20,7 +20,7 @@
             Padding="1 0 4 0"
             ScrollViewer.VerticalScrollBarVisibility="Hidden"
             ScrollViewer.HorizontalScrollBarVisibility="Hidden" />
-        </Grid>
+        </Panel>
       </ControlTemplate>
     </Setter>
   </Style>

--- a/WalletWasabi.Gui/Controls/LockScreen/PinLockScreenView.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/PinLockScreenView.xaml
@@ -5,7 +5,7 @@
                           xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
                           xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
                           x:Class="WalletWasabi.Gui.Controls.LockScreen.PinLockScreenView">
-  <Grid Background="{DynamicResource ThemeBackgroundBrush}">
+  <Panel Background="{DynamicResource ThemeBackgroundBrush}">
     <controls:GroupBox VerticalAlignment="Center" HorizontalAlignment="Center" TextBlock.FontSize="25" Padding="20" Margin="10">
       <DockPanel LastChildFill="True">
         <controls:TogglePasswordBox x:Name="InputField" Text="{Binding PinInput}" Width="300" DockPanel.Dock="Top" Margin="4 0 4 20" Watermark="PIN">
@@ -35,5 +35,5 @@
         </Grid>
       </DockPanel>
     </controls:GroupBox>
-  </Grid>
+  </Panel>
 </lockscreen:PinLockScreenView>

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLock.cs
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLock.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.Gui.Controls.LockScreen
 			AvaloniaProperty.Register<SlideLock, double>(nameof(Value));
 
 		private Thumb _thumb;
-		private Grid _container;
+		private Panel _container;
 		private bool _isLocked;
 		private bool _isAnimationRunning;
 		private Animation _closeAnimation;
@@ -153,7 +153,7 @@ namespace WalletWasabi.Gui.Controls.LockScreen
 			base.OnTemplateApplied(e);
 
 			_thumb = e.NameScope.Find<Thumb>("PART_Thumb");
-			_container = e.NameScope.Find<Grid>("PART_Container");
+			_container = e.NameScope.Find<Panel>("PART_Container");
 
 			this.GetObservable(CanSlideProperty)
 				.Subscribe(x => _thumb.IsHitTestVisible = x);

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLock.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLock.xaml
@@ -4,7 +4,7 @@
     <Setter Property="Threshold" Value="75" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Grid Name="PART_Container">
+        <Panel Name="PART_Container">
           <ContentPresenter Name="PART_ContentPresenter"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
@@ -21,7 +21,7 @@
               </ControlTemplate>
             </Thumb.Template>
           </Thumb>
-        </Grid>
+        </Panel>
       </ControlTemplate>
     </Setter>
   </Style>

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreenView.xaml
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreenView.xaml
@@ -2,7 +2,7 @@
                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                             xmlns:lockscreen="clr-namespace:WalletWasabi.Gui.Controls.LockScreen;assembly=WalletWasabi.Gui"
                             x:Class="WalletWasabi.Gui.Controls.LockScreen.SlideLockScreenView">
-  <Grid Background="{DynamicResource ThemeBackgroundBrush}">
+  <Panel Background="{DynamicResource ThemeBackgroundBrush}">
     <DrawingPresenter Width="300" Height="300" Opacity="0.25" VerticalAlignment="Center" HorizontalAlignment="Center" 
                       Drawing="{DynamicResource WasabiLogo}" />
     <TextBlock Text="Click and Drag upwards to unlock."
@@ -10,5 +10,5 @@
                  HorizontalAlignment="Center"
                  Margin="20"
                  Opacity="0.5" />
-  </Grid>
+  </Panel>
 </lockscreen:SlideLockScreenView>

--- a/WalletWasabi.Gui/Controls/ModalDialog.xaml
+++ b/WalletWasabi.Gui/Controls/ModalDialog.xaml
@@ -2,8 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility"
              x:Class="WalletWasabi.Gui.Controls.ModalDialog">
-  <Grid Background="#EF2D2D2D" IsVisible="{Binding IsVisible, FallbackValue=False}">
-    <Grid Height="500" Background="{DynamicResource ThemeControlBackgroundBrush}" Margin="10 0">
+  <Panel Background="#EF2D2D2D" IsVisible="{Binding IsVisible, FallbackValue=False}">
+    <Panel Height="500" Background="{DynamicResource ThemeControlBackgroundBrush}" Margin="10 0">
       <DockPanel LastChildFill="True" Margin="200 0 200 100">
         <StackPanel Orientation="Horizontal" Spacing="20" HorizontalAlignment="Right" DockPanel.Dock="Bottom" Margin="8 0 8 8" TextBlock.FontSize="15">
           <Button Command="{Binding CancelCommand}" IsVisible="{Binding CancelButtonVisible}" Content="Cancel" Width="160" Height="50" />
@@ -11,6 +11,6 @@
         </StackPanel>
         <cont:ViewModelViewHost DataContext="{Binding }" />
       </DockPanel>
-    </Grid>
-  </Grid>
+    </Panel>
+  </Panel>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/MultiTextBox.xaml
+++ b/WalletWasabi.Gui/Controls/MultiTextBox.xaml
@@ -14,15 +14,15 @@
       <ControlTemplate>
         <Border Name="border" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
           <DockPanel Margin="{TemplateBinding Padding}">
-            <Grid>
-              <Grid IsVisible="{TemplateBinding ClipboardNotificationVisible}">
-                <Grid Opacity="{TemplateBinding ClipboardNotificationOpacity}">
-                  <Grid.Transitions>
+            <Panel>
+              <Panel IsVisible="{TemplateBinding ClipboardNotificationVisible}">
+                <Panel Opacity="{TemplateBinding ClipboardNotificationOpacity}">
+                  <Panel.Transitions>
                     <DoubleTransition Property="Opacity" Easing="CircularEaseIn" Duration="0:0:0.5" />
-                  </Grid.Transitions>
+                  </Panel.Transitions>
                   <TextBlock Text="Copied" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" FontWeight="Bold" />
-                </Grid>
-              </Grid>
+                </Panel>
+              </Panel>
               <TextBlock Name="floatingWatermark" Foreground="{DynamicResource ThemeAccentBrush}" FontSize="{DynamicResource FontSizeSmall}" Text="{TemplateBinding Watermark}" DockPanel.Dock="Top">
                 <TextBlock.IsVisible>
                   <MultiBinding Converter="{x:Static BoolConverters.And}">
@@ -54,7 +54,7 @@
                   </Panel>
                 </ScrollViewer>
               </DataValidationErrors>
-            </Grid>
+            </Panel>
           </DockPanel>
         </Border>
       </ControlTemplate>

--- a/WalletWasabi.Gui/Controls/Spinner.xaml
+++ b/WalletWasabi.Gui/Controls/Spinner.xaml
@@ -1,8 +1,8 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="WalletWasabi.Gui.Controls.Spinner">
-  <Grid>
-    <Grid.Styles>
+  <Panel>
+    <Panel.Styles>
       <Style Selector="DrawingPresenter">
         <Style.Animations>
           <Animation Duration="0:0:2.5" IterationCount="Infinite">
@@ -12,8 +12,8 @@
           </Animation>
         </Style.Animations>
       </Style>
-    </Grid.Styles>
+    </Panel.Styles>
     <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" 
                       Drawing="{DynamicResource Spinner_Gear}" />
-  </Grid>
+  </Panel>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/StatusBar.xaml
+++ b/WalletWasabi.Gui/Controls/StatusBar.xaml
@@ -12,13 +12,13 @@
     <converters:PascalToPhraseConverter x:Key="PascalToPhraseConverter" />
     <converters:RpcStatusStringConverter x:Key="RpcStatusStringConverter" />
   </UserControl.Resources>
-  <Grid Cursor="{Binding UpdateAvailable, Converter={StaticResource ShowCursorConverter}}"
+  <Panel Cursor="{Binding UpdateAvailable, Converter={StaticResource ShowCursorConverter}}"
         Background="{DynamicResource ApplicationAccentBrushLow}">
     <i:Interaction.Behaviors>
       <behaviors:CommandOnClickBehavior Command="{Binding UpdateCommand}" />
     </i:Interaction.Behaviors>
 
-    <Grid Background="IndianRed" IsVisible="{Binding CriticalUpdateAvailable}" />
+    <Panel Background="IndianRed" IsVisible="{Binding CriticalUpdateAvailable}" />
 
     <DockPanel LastChildFill="True" Margin="10 0" VerticalAlignment="Center">
       <StackPanel Orientation="Horizontal" Spacing="20" DockPanel.Dock="Right" IsVisible="{Binding !CriticalUpdateAvailable}">
@@ -27,45 +27,45 @@
         </StackPanel>
         <Panel IsVisible="{Binding DownloadingBlock}">
           <StackPanel Orientation="Horizontal" Spacing="4">
-            <Grid Height="10" Width="10">
+            <Panel Height="10" Width="10">
               <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_DownloadingBlock}" />
-            </Grid>
+            </Panel>
             <TextBlock Text="Downloading a block..." Foreground="{Binding DownloadingBlock, ConverterParameter=DownloadingBlock, Converter={StaticResource StatusColorConverter}}" />
           </StackPanel>
         </Panel>
         <Panel IsVisible="{Binding FiltersLeft, Converter={StaticResource ShouldDisplayValueConverter}}">
           <StackPanel Orientation="Horizontal" Spacing="4">
-            <Grid Height="10" Width="10">
+            <Panel Height="10" Width="10">
               <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_Filter}" />
-            </Grid>
+            </Panel>
             <TextBlock Text="{Binding FiltersLeft, Converter={StaticResource FilterLeftStatusConverter}}" Foreground="{Binding FiltersLeft, ConverterParameter=FiltersLeft, Converter={StaticResource StatusColorConverter}}" />
           </StackPanel>
         </Panel>
         <StackPanel Orientation="Horizontal" Spacing="4">
-          <Grid Height="10" Width="10">
+          <Panel Height="10" Width="10">
             <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_GlobeCheckedShield}" />
-          </Grid>
+          </Panel>
           <TextBlock Text="{Binding Tor, StringFormat=Tor is \{0\}, Converter={StaticResource PascalToPhraseConverter}}" Foreground="{Binding Tor, ConverterParameter=Tor, Converter={StaticResource StatusColorConverter}}" />
         </StackPanel>
         <Panel IsVisible="{Binding UseBitcoinCore}">
           <StackPanel Orientation="Horizontal" Spacing="4">
-            <Grid Height="10" Width="10">
+            <Panel Height="10" Width="10">
               <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_ServerGlobe}" />
-            </Grid>
+            </Panel>
             <TextBlock Text="{Binding BitcoinCoreStatus, Converter={StaticResource RpcStatusStringConverter}}" Foreground="{Binding BitcoinCoreStatus, ConverterParameter=BitcoinCoreStatus, Converter={StaticResource StatusColorConverter}}" />
           </StackPanel>
         </Panel>
         <StackPanel Orientation="Horizontal" Spacing="4">
-          <Grid Height="10" Width="10">
+          <Panel Height="10" Width="10">
             <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_ServerGlobe}" />
-          </Grid>
+          </Panel>
           <TextBlock Text="{Binding Backend, StringFormat=Backend is \{0\}, Converter={StaticResource PascalToPhraseConverter}}" Foreground="{Binding Backend, ConverterParameter=Backend, Converter={StaticResource StatusColorConverter}}" />
         </StackPanel>
         <Panel IsVisible="{Binding !UseBitcoinCore}">
           <StackPanel Orientation="Horizontal" Spacing="4">
-            <Grid Height="10" Width="10">
+            <Panel Height="10" Width="10">
               <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_Peer}" />
-            </Grid>
+            </Panel>
             <TextBlock Text="{Binding Peers, StringFormat=Peers: \{0\}}" Foreground="{Binding Peers, ConverterParameter=Peers, Converter={StaticResource StatusColorConverter}}" />
           </StackPanel>
         </Panel>
@@ -76,16 +76,16 @@
       </StackPanel>
 
       <StackPanel Orientation="Horizontal" Spacing="4">
-        <Grid IsVisible="{Binding !CriticalUpdateAvailable}">
-          <Grid Height="10" Width="10" IsVisible="{Binding UpdateAvailable}">
+        <Panel IsVisible="{Binding !CriticalUpdateAvailable}">
+          <Panel Height="10" Width="10" IsVisible="{Binding UpdateAvailable}">
             <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_GreenFlag}" />
-          </Grid>
-        </Grid>
-        <Grid Height="10" Width="10" IsVisible="{Binding CriticalUpdateAvailable}">
+          </Panel>
+        </Panel>
+        <Panel Height="10" Width="10" IsVisible="{Binding CriticalUpdateAvailable}">
           <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource StatusBar_YellowFlag}" />
-        </Grid>
+        </Panel>
         <TextBlock Text="{Binding Status}" />
       </StackPanel>
     </DockPanel>
-  </Grid>
+  </Panel>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/TogglePasswordBox.xaml
+++ b/WalletWasabi.Gui/Controls/TogglePasswordBox.xaml
@@ -40,11 +40,11 @@
 
             <Button Name="PART_MaskedButton" Focusable="False" DockPanel.Dock="Right" Padding="5 0 5 0" Margin="0" Background="Transparent" BorderThickness="0"
                     ToolTip.Tip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPasswordVisible, StringFormat=\{0\} characters, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Hide:Show}">
-              <Grid Height="15" Width="15">
+              <Panel Height="15" Width="15">
                 <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource EyesShow}" />
                 <DrawingPresenter IsVisible="{TemplateBinding IsPasswordVisible}"
                                   VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource EyesHide}" />
-              </Grid>
+              </Panel>
               <Button.IsVisible>
                 <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text" Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
               </Button.IsVisible>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -19,10 +19,7 @@
     <converters:TimeSpanVisibilityConverter x:Key="TimeSpanVisibilityConverter" />
   </UserControl.Resources>
   <DockPanel LastChildFill="True" Margin="10">
-    <Grid DockPanel.Dock="Bottom">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="*" />
-      </Grid.RowDefinitions>
+    <Grid DockPanel.Dock="Bottom" RowDefinitions="*">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="150" />
@@ -84,14 +81,7 @@
         </ScrollViewer>
       </controls:GroupBox>
       <controls:GroupBox Grid.Row="0" Grid.Column="0" Title="CoinJoin" Padding="5" Margin="0 5 5 0">
-        <Grid Grid.Row="0" Grid.Column="0" Classes="content">
-          <Grid.RowDefinitions>
-            <RowDefinition Height="150" />
-          </Grid.RowDefinitions>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-          </Grid.ColumnDefinitions>
+        <Grid Grid.Row="0" Grid.Column="0" Classes="content" RowDefinitions="150" ColumnDefinitions="*,Auto">
           <StackPanel Grid.Column="0" Spacing="10">
             <controls:TogglePasswordBox Text="{Binding Password}" Margin="0 20 0 0" MinWidth="200">
               <i:Interaction.Behaviors>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -119,11 +119,7 @@
       </controls:GroupBox>
       <controls:GroupBox Grid.Column="1" Title="Target" Padding="5" Margin="5 0">
         <Button Command="{Binding TargetButtonCommand}">
-          <Grid Background="Transparent" DataContext="{Binding CoinJoinUntilAnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}">
-            <Grid.RowDefinitions>
-              <RowDefinition Height="2*"></RowDefinition>
-              <RowDefinition Height="*"></RowDefinition>
-            </Grid.RowDefinitions>
+          <Grid RowDefinitions="2*,*" Background="Transparent" DataContext="{Binding CoinJoinUntilAnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}">
             <DrawingPresenter Grid.Row="0" Drawing="{Binding Icon}" VerticalAlignment="Top" Height="100" Width="75" />
             <TextBlock Margin="0 5 0 0" Grid.Row="1" Text="{Binding ToolTip}" TextAlignment="Center" TextWrapping="Wrap" />
           </Grid>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/HistoryTabView.xaml
@@ -17,7 +17,7 @@
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
       </Style>
     </controls:GroupBox.Styles>
-    <Grid Classes="content">
+    <Panel Classes="content">
       <DockPanel LastChildFill="True">
         <DockPanel LastChildFill="True" DockPanel.Dock="Bottom">
           <Grid ColumnDefinitions="40, 160, 150, *" Margin="10 0 0 0" DockPanel.Dock="Top">
@@ -72,6 +72,6 @@
           </controls:ExtendedListBox>
         </DockPanel>
       </DockPanel>
-    </Grid>
+    </Panel>
   </controls:GroupBox>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/PinPadView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/PinPadView.xaml
@@ -11,22 +11,12 @@
       <StackPanel DockPanel.Dock="Bottom">
         <Button Margin="4 20" Content="Send PIN to Device" Command="{Binding SendPinCommand}" />
       </StackPanel>
-      <Grid>
+      <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,Auto,Auto">
         <Grid.Styles>
           <Style Selector="Button">
             <Setter Property="Margin" Value="4" />
           </Style>
         </Grid.Styles>
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition />
-          <ColumnDefinition />
-          <ColumnDefinition />
-        </Grid.ColumnDefinitions>
         <Button Grid.Row="0" Grid.Column="0" Content="." Command="{Binding KeyPadCommand}" CommandParameter="7" />
         <Button Grid.Row="0" Grid.Column="1" Content="." Command="{Binding KeyPadCommand}" CommandParameter="8" />
         <Button Grid.Row="0" Grid.Column="2" Content="." Command="{Binding KeyPadCommand}" CommandParameter="9" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml
@@ -20,7 +20,7 @@
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
       </Style>
     </controls:GroupBox.Styles>
-    <Grid Classes="content">
+    <Panel Classes="content">
       <Grid RowDefinitions="Auto,*" DockPanel.Dock="Top">
         <DockPanel LastChildFill="True">
           <Grid ColumnDefinitions="*,300" DockPanel.Dock="Top" Margin="0 0 0 10">
@@ -42,8 +42,8 @@
           </controls:ExtendedListBox.Styles>
           <controls:ExtendedListBox.ItemTemplate>
             <DataTemplate>
-              <Grid>
-                <Grid.ContextMenu>
+              <Panel>
+                <Panel.ContextMenu>
                   <ContextMenu>
                     <MenuItem Header="{Binding ExpandMenuCaption}" Command="{Binding ToggleQrCode}">
                       <MenuItem.Icon>
@@ -81,7 +81,7 @@
                       </MenuItem.Icon>
                     </MenuItem>
                   </ContextMenu>
-                </Grid.ContextMenu>
+                </Panel.ContextMenu>
                 <Expander Name="coinExpander" ExpandDirection="Down" IsExpanded="{Binding IsExpanded}" Classes="coloredExpander" Background="{Binding ElementName=coinExpander, Path=IsExpanded, Converter={StaticResource CoinItemExpanderColorConverter}}">
                   <StackPanel Orientation="Horizontal" Spacing="16" Margin="35 10 0 5">
                     <controls:QrCode Height="220" Matrix="{Binding QrCode}" SaveCommand="{Binding ExecuteSaveQRCodeCommand, Mode=OneWayToSource}" HorizontalAlignment="Left" />
@@ -105,11 +105,11 @@
                   </Grid>
                   <controls:EditableTextBlock VerticalAlignment="Top" Text="{Binding Label, ConverterParameter=27, Converter={StaticResource LurkingWifeModeStringConverter}}" InEditMode="{Binding InEditMode}" ReadOnlyMode="{Binding IsLurkingWifeMode}" Grid.Column="1" />
                 </Grid>
-              </Grid>
+              </Panel>
             </DataTemplate>
           </controls:ExtendedListBox.ItemTemplate>
         </controls:ExtendedListBox>
       </Grid>
-    </Grid>
+    </Panel>
   </controls:GroupBox>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -26,7 +26,7 @@
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
       </Style>
     </DockPanel.Styles>
-    <Grid Classes="content">
+    <Panel Classes="content">
       <DockPanel LastChildFill="True" Margin="20">
         <StackPanel DockPanel.Dock="Bottom" Margin="0 10" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Select coins you want to spend.</TextBlock>
@@ -110,13 +110,13 @@
                   <TextBlock Text="{Binding BuildTransactionButtonText}" />
                 </StackPanel>
               </Button>
-              <Grid></Grid>
+              <Panel/>
             </DockPanel>
           </StackPanel>
           <Grid ColumnDefinitions="60,100,100,600,100,Auto"></Grid>
         </StackPanel>
         <local:CoinListView SelectAllNonPrivateVisible="False" DataContext="{Binding CoinList}" />
       </DockPanel>
-    </Grid>
+    </Panel>
   </DockPanel>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionBroadcasterView.xaml
@@ -12,7 +12,7 @@
              x:Class="WalletWasabi.Gui.Controls.WalletExplorer.TransactionBroadcasterView"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450">
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
-    <Grid Classes="content">
+    <Panel Classes="content">
       <DockPanel LastChildFill="True">
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
           <Button Command="{Binding PasteCommand}" Content="Paste Signed Transaction" />
@@ -24,10 +24,10 @@
             </StackPanel>
           </Button>
         </StackPanel>
-        <Grid>
+        <Panel>
           <txndetail:TransactionDetails Grid.Row="1" DataContext="{Binding TransactionDetails}" DockPanel.Dock="Top" Margin="0 8 0 0" />
-        </Grid>
+        </Panel>
       </DockPanel>
-    </Grid>
+    </Panel>
   </controls:GroupBox>
 </UserControl>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/TransactionViewerView.xaml
@@ -13,7 +13,7 @@
     <converters:LurkingWifeModeStringConverter x:Key="LurkingWifeModeStringConverter" />
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" Margin="10">
-    <Grid Classes="content">
+    <Panel Classes="content">
       <DockPanel LastChildFill="True">
         <Panel DockPanel.Dock="Bottom" Height="64" Margin="0 0 0 -20">
           <StackPanel HorizontalAlignment="Right" VerticalAlignment="Center" Orientation="Horizontal" Spacing="10">
@@ -28,6 +28,6 @@
           <txndetail:TransactionDetails Grid.Row="1" DataContext="{Binding TransactionDetails}" DockPanel.Dock="Top" Margin="0 8 0 0" />
         </Grid>
       </DockPanel>
-    </Grid>
+    </Panel>
   </controls:GroupBox>
 </UserControl>

--- a/WalletWasabi.Gui/CrashReport/Views/CrashReportWindow.xaml
+++ b/WalletWasabi.Gui/CrashReport/Views/CrashReportWindow.xaml
@@ -17,7 +17,7 @@
   <i:Interaction.Behaviors>
     <behaviors:CloseWindowCommandBehavior Command="{Binding OkCommand}" />
   </i:Interaction.Behaviors>
-  <Grid>
+  <Panel>
     <Grid ColumnDefinitions="*,*,*" RowDefinitions="*,*,*" Opacity="0.05">
       <DrawingPresenter Grid.Column="2" Width="200" Height="200" Grid.ColumnSpan="1" Grid.Row="2" Grid.RowSpan="1" Drawing="{DynamicResource WasabiLogo}" />
     </Grid>
@@ -29,5 +29,5 @@
       <TextBox DockPanel.Dock="Top" Text="{Binding Message}" Classes="selectableTextBlock largeHeader" />
       <TextBlock Text="{Binding Details}" Margin="0 8" TextWrapping="Wrap" />
     </DockPanel>
-  </Grid>
+  </Panel>
 </cont:WasabiWindow>

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
@@ -9,11 +9,7 @@
         <Button Width="100" Content="Ok" Command="{Binding OKCommand}" IsVisible="{Binding !IsBusy}" />
         <Button Width="100" Content="Cancel" Command="{Binding CancelCommand}" IsVisible="{Binding IsBusy}" />
       </StackPanel>
-      <Grid Classes="content">
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
+      <Grid Classes="content" RowDefinitions="Auto,Auto">
         <Panel Grid.Row="0" Margin="10">
           <TextBlock FontSize="15" Text="You have coins registered for CoinJoin. Wasabi is dequeing them. If a coin is currently being coinjoined Wasabi will wait for the mix to finish, so you do not disrupt the mixing round. This could take a few minutes, please be patient." TextWrapping="Wrap" />
         </Panel>

--- a/WalletWasabi.Gui/Dialogs/GenSocksServFailDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/GenSocksServFailDialogView.xaml
@@ -3,10 +3,8 @@
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui" Design.Width="800" Design.Height="400"
              x:Class="WalletWasabi.Gui.Dialogs.GenSocksServFailDialogView">
   <controls:GroupBox Title="Tor: General SOCKS Server Failure" Background="{DynamicResource ThemeControlBackgroundBrush}" TextBlock.FontSize="30" BorderThickness="0" Margin="0 80">
-    <Grid Classes="content">
-      <Panel Margin="10">
-        <TextBlock FontSize="15" Text="The Tor daemon you are running responded with General SOCKS Server Failure. This can happen for many reasons, but Wasabi will attempt to autocorrect Tor, so this dialog should disappear within a few minutes. If that does not happen your Tor may be out of date. Please upgrade your Tor version to at least v0.3.2.2, or shut down your Tor process and restart Wasabi. This will make sure Wasabi is using its built-in Tor." TextWrapping="Wrap" />
-      </Panel>
-    </Grid>
+    <Panel Margin="10" Classes="content">
+      <TextBlock FontSize="15" Text="The Tor daemon you are running responded with General SOCKS Server Failure. This can happen for many reasons, but Wasabi will attempt to autocorrect Tor, so this dialog should disappear within a few minutes. If that does not happen your Tor may be out of date. Please upgrade your Tor version to at least v0.3.2.2, or shut down your Tor process and restart Wasabi. This will make sure Wasabi is using its built-in Tor." TextWrapping="Wrap" />     
+    </Panel>
   </controls:GroupBox>
 </UserControl>

--- a/WalletWasabi.Gui/Dialogs/TextInputDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/TextInputDialogView.xaml
@@ -13,11 +13,7 @@
         <Button Width="100" Content="Ok" Command="{Binding OKCommand}" IsVisible="{Binding !IsBusy}" />
         <Button Width="100" Content="Cancel" Command="{Binding CancelCommand}" IsVisible="{Binding IsBusy}" />
       </StackPanel>
-      <Grid Classes="content">
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
+      <Grid Classes="content" RowDefinitions="Auto,Auto">
         <Panel Grid.Row="0" Margin="10">
           <TextBlock FontSize="15" Text="{Binding Instructions}" TextWrapping="Wrap" />
         </Panel>

--- a/WalletWasabi.Gui/MainWindow.xaml
+++ b/WalletWasabi.Gui/MainWindow.xaml
@@ -23,12 +23,12 @@
     </StackPanel>
   </cont:MetroWindow.TitleBarContent>
 
-  <Grid  id:DockProperties.IsDragEnabled="False" id:DockProperties.IsDropEnabled="False">
+  <Panel  id:DockProperties.IsDragEnabled="False" id:DockProperties.IsDropEnabled="False">
     <DockPanel LastChildFill="True">
       <wasabi:StatusBar DockPanel.Dock="Bottom" DataContext="{Binding StatusBar}" />
       <shell:ShellView DataContext="{Binding Shell}" />
     </DockPanel>
     <wasabi:ModalDialog DataContext="{Binding ModalDialog}" />
     <lockscreen:LockScreen DataContext="{Binding LockScreen}" />
-  </Grid>
+  </Panel>
 </cont:MetroWindow>

--- a/WalletWasabi.Gui/Styles/Styles.xaml
+++ b/WalletWasabi.Gui/Styles/Styles.xaml
@@ -134,7 +134,7 @@
     <Setter Property="TextBlock.FontSize" Value="40" />
     <Setter Property="Margin" Value="10" />
   </Style>
-  <Style Selector="Grid.content">
+  <Style Selector="Panel.content">
     <Setter Property="TextBlock.FontSize" Value="14" />
   </Style>
   <Style Selector="TextBlock.hyperLink">

--- a/WalletWasabi.Gui/Tabs/AboutView.xaml
+++ b/WalletWasabi.Gui/Tabs/AboutView.xaml
@@ -8,7 +8,7 @@
   </UserControl.Resources>
   <controls:GroupBox Title="{Binding Title}" BorderThickness="0" Classes="docTabContainer">
     <StackPanel>
-      <Grid Classes="content" Margin="0 10 0 0">
+      <Panel Classes="content" Margin="0 10 0 0">
         <StackPanel Orientation="Vertical">
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="Current Version: " />
@@ -63,7 +63,7 @@
             <Button Content="{Binding DocsLink}" Classes="activeHyperLink" Command="{Binding OpenBrowserCommand}" CommandParameter="{Binding DocsLink}" />
           </StackPanel>
         </StackPanel>
-      </Grid>
+      </Panel>
     </StackPanel>
   </controls:GroupBox>
 </UserControl>

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -17,7 +17,7 @@
     </StackPanel>
     <ScrollViewer>
       <StackPanel Margin="30" Spacing="10">
-        <Grid Classes="content">
+        <Panel Classes="content">
           <StackPanel Orientation="Vertical" Spacing="30">
             <controls:GroupBox Title="Bitcoin" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">
               <StackPanel Orientation="Vertical" Spacing="5">
@@ -158,7 +158,7 @@
             </controls:GroupBox>
             <Button Content="Open Config File" Command="{Binding OpenConfigFileCommand}" />
           </StackPanel>
-        </Grid>
+        </Panel>
       </StackPanel>
     </ScrollViewer>
   </DockPanel>

--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWallets/GenerateWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWallets/GenerateWalletView.xaml
@@ -6,7 +6,7 @@
              xmlns:behaviors="clr-namespace:WalletWasabi.Gui.Behaviors;assembly=WalletWasabi.Gui">
   <StackPanel Margin="10" Spacing="10">
     <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="30">
-      <Grid Classes="content">
+      <Panel Classes="content">
         <StackPanel Spacing="8">
           <StackPanel>
             <TextBlock Text="Heads Up!" FontWeight="Bold" />
@@ -19,11 +19,11 @@
             </i:Interaction.Behaviors>
           </controls:TogglePasswordBox>
         </StackPanel>
-      </Grid>
+      </Panel>
     </controls:GroupBox>
     <DockPanel LastChildFill="True">
       <Button Content="Next" Command="{Binding NextCommand}" DockPanel.Dock="Right" />
-      <Grid></Grid>
+      <Panel/>
     </DockPanel>
   </StackPanel>
 </UserControl>

--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletView.xaml
@@ -7,7 +7,7 @@
   <DockPanel LastChildFill="True">
     <StackPanel DockPanel.Dock="Bottom" Spacing="10">
       <controls:GroupBox TextBlock.FontSize="30" Padding="30" Margin="20 0">
-        <Grid Classes="content">
+        <Panel Classes="content">
           <StackPanel Spacing="8">
             <StackPanel>
               <TextBlock Text="Limitations?" FontWeight="Bold" />
@@ -20,7 +20,7 @@
               <TextBlock Text="- While other hardware wallets may work, they were not tested by Wasabi developers." TextWrapping="Wrap" />
             </StackPanel>
           </StackPanel>
-        </Grid>
+        </Panel>
       </controls:GroupBox>
       <DockPanel LastChildFill="True" Margin="20 10">
         <Button Command="{Binding LoadCommand}" DockPanel.Dock="Right">
@@ -31,12 +31,12 @@
         </Button>
         <Button Content="Search Hardware Wallets" Command="{Binding EnumerateHardwareWalletsCommand}" DockPanel.Dock="Right" Margin="0 0 10 0" />
         <Button Content="Import Coldcard" Command="{Binding ImportColdcardCommand}" DockPanel.Dock="Right" Margin="0 0 10 0" />
-        <Grid></Grid>
+        <Panel/>
       </DockPanel>
     </StackPanel>
     <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" BorderThickness="0">
       <DockPanel LastChildFill="True">
-        <Grid Classes="content" DockPanel.Dock="Top" IsVisible="{Binding IsHwWalletSearchTextVisible}" Margin="10">
+        <Panel Classes="content" DockPanel.Dock="Top" IsVisible="{Binding IsHwWalletSearchTextVisible}" Margin="10">
           <StackPanel Spacing="8">
             <StackPanel Orientation="Horizontal">
               <controls:Spinner Height="15" Width="15" Margin="0 0 8 0" />
@@ -49,8 +49,8 @@
               <Button Content="{Binding UDevRulesLink}" Classes="activeHyperLink" Command="{Binding OpenBrowserCommand}" CommandParameter="{Binding UDevRulesLink}" />
             </StackPanel>
           </StackPanel>
-        </Grid>
-        <Grid Classes="content">
+        </Panel>
+        <Panel Classes="content">
           <controls:ExtendedListBox Items="{Binding Wallets}" SelectedItem="{Binding SelectedWallet, Mode=TwoWay}">
             <controls:ExtendedListBox.ItemTemplate>
               <DataTemplate>
@@ -62,7 +62,7 @@
               </DataTemplate>
             </controls:ExtendedListBox.ItemTemplate>
           </controls:ExtendedListBox>
-        </Grid>
+        </Panel>
       </DockPanel>
     </controls:GroupBox>
   </DockPanel>

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletView.xaml
@@ -7,7 +7,7 @@
   <DockPanel LastChildFill="True">
     <StackPanel DockPanel.Dock="Bottom" Spacing="10">
       <controls:GroupBox IsVisible="{Binding !IsDesktopWallet}" TextBlock.FontSize="30" Padding="30" Margin="20 0">
-        <Grid Classes="content">
+        <Panel Classes="content">
           <StackPanel IsVisible="{Binding IsPasswordRequired}" Spacing="8">
             <StackPanel>
               <TextBlock Text="Select a wallet to test its password!" FontWeight="Bold" />
@@ -18,7 +18,7 @@
               </i:Interaction.Behaviors>
             </controls:TogglePasswordBox>
           </StackPanel>
-        </Grid>
+        </Panel>
       </controls:GroupBox>
       <DockPanel LastChildFill="True" Margin="20 10">
         <Button IsVisible="{Binding IsPasswordRequired}" Content="Test Password" Command="{Binding TestPasswordCommand}" DockPanel.Dock="Right" Margin="10 0 0 0" />
@@ -29,12 +29,12 @@
             <TextBlock Text="Open Wallets Folder" />
           </StackPanel>
         </Button>
-        <Grid></Grid>
+        <Panel/>
       </DockPanel>
     </StackPanel>
     <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="20" BorderThickness="0">
       <DockPanel LastChildFill="True">
-        <Grid Classes="content">
+        <Panel Classes="content">
           <controls:ExtendedListBox Items="{Binding Wallets}" SelectedItem="{Binding SelectedWallet, Mode=TwoWay}">
             <controls:ExtendedListBox.ItemTemplate>
               <DataTemplate>
@@ -46,7 +46,7 @@
               </DataTemplate>
             </controls:ExtendedListBox.ItemTemplate>
           </controls:ExtendedListBox>
-        </Grid>
+        </Panel>
       </DockPanel>
     </controls:GroupBox>
   </DockPanel>

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletView.xaml
@@ -14,7 +14,7 @@
           </Style>
         </StackPanel.Styles>
         <controls:GroupBox Title="{Binding Title}" TextBlock.FontSize="30" Padding="15 0">
-          <Grid Classes="content">
+          <Panel Classes="content">
             <StackPanel Spacing="8">
               <StackPanel>
                 <TextBlock Text="Heads Up!" FontWeight="Bold" />
@@ -61,7 +61,7 @@
                 </StackPanel>
               </Expander>
             </StackPanel>
-          </Grid>
+          </Panel>
         </controls:GroupBox>
         <Button Content="Recover" Command="{Binding RecoverCommand}" HorizontalAlignment="Right" />
       </StackPanel>

--- a/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/WalletManagerView.xaml
@@ -3,9 +3,9 @@
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Shell.Extensibility"
              x:Class="WalletWasabi.Gui.Tabs.WalletManager.WalletManagerView">
-  <Grid Classes="content">
+  <Panel Classes="content">
     <DockPanel>
-      <Grid DockPanel.Dock="Left" Width="200">
+      <Panel DockPanel.Dock="Left" Width="200">
         <controls:ExtendedListBox Items="{Binding Categories}" SelectedItem="{Binding SelectedCategory, Mode=TwoWay}" BorderThickness="0 0 1 0">
           <controls:ExtendedListBox.ItemTemplate>
             <DataTemplate>
@@ -13,10 +13,10 @@
             </DataTemplate>
           </controls:ExtendedListBox.ItemTemplate>
         </controls:ExtendedListBox>
-      </Grid>
-      <Grid>
+      </Panel>
+      <Panel>
         <cont:ViewModelViewHost DataContext="{Binding CurrentView}" Margin="4" />
-      </Grid>
+      </Panel>
     </DockPanel>
-  </Grid>
+  </Panel>
 </UserControl>


### PR DESCRIPTION
We don't need to use `Grid` if we dont use its row/col definition features. It is a moderately heavy control CPU and Memory wise. We should use `Panel`s instead. Also added a guideline for future contributors. 

I also snuck in changes to replace old verbose row/coldefinitions with the shorthand ones if possible.

@MaxHillebrand @yahiheb @kiminuo please check all the UI features you can check and report any anomalies you can see in this PR.