### PR TITLE
Replace `hidden service` with `onion service`

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -107,13 +107,13 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					if (payjoinEndPointUri.DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 					{
-						Logger.LogWarning("Payjoin server is a hidden service but Tor is disabled. Ignoring...");
+						Logger.LogWarning("Payjoin server is a onion service but Tor is disabled. Ignoring...");
 						return null;
 					}
 
 					if (Global.Config.Network == Network.Main && payjoinEndPointUri.Scheme != Uri.UriSchemeHttps)
 					{
-						Logger.LogWarning("Payjoin server is not exposed as onion hidden service nor https. Ignoring...");
+						Logger.LogWarning("Payjoin server is not exposed as onion service nor https. Ignoring...");
 						return null;
 					}
 				}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -107,7 +107,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					if (payjoinEndPointUri.DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 					{
-						Logger.LogWarning("Payjoin server is a onion service but Tor is disabled. Ignoring...");
+						Logger.LogWarning("Payjoin server is an onion service but Tor is disabled. Ignoring...");
 						return null;
 					}
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -113,7 +113,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 					if (Global.Config.Network == Network.Main && payjoinEndPointUri.Scheme != Uri.UriSchemeHttps)
 					{
-						Logger.LogWarning("Payjoin server is not exposed as onion service nor https. Ignoring...");
+						Logger.LogWarning("Payjoin server is not exposed as an onion service nor https. Ignoring...");
 						return null;
 					}
 				}


### PR DESCRIPTION
For a couple of years, Tor documentation has made the term `hidden service` obsolete, in favor of `onion service`: [Tor Project | Onion Services](https://community.torproject.org/onion-services/)

This PR updates references for Payjoin alerts.