### PR TITLE
Fix PathMaps and add prebuilt launch.json to allow debugging on VSCode again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@
 
 #Visual Studio Code
 .vscode/
-!.vscode/settings.json
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # Build results
 [Dd]ebug/

--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,6 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
-#Visual Studio Code
-.vscode/
-!.vscode/launch.json
-!.vscode/tasks.json
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to find out which attributes exist for C# debugging
+    // Use hover for the description of the existing attributes
+    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+    "version": "0.2.0",
+    "configurations": [
+         {
+             "name": ".NET Core Launch (console)",
+             "type": "coreclr",
+             "request": "launch",
+             "preLaunchTask": "build",
+             // If you have changed target frameworks, make sure to update the program path.
+             "program": "${workspaceFolder}/WalletWasabi.Gui/bin/Debug/netcoreapp3.1/WalletWasabi.Gui.dll",
+             "args": [],
+             "cwd": "${workspaceFolder}",
+             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+             "console": "internalConsole",
+             "stopAtEntry": false,
+             "sourceFileMap": {
+                 "/src/": "${workspaceFolder}"
+             }
+         },
+         {
+             "name": ".NET Core Attach",
+             "type": "coreclr",
+             "request": "attach",
+             "processId": "${command:pickProcess}"
+         }
+     ]
+ }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/WalletWasabi.Gui/WalletWasabi.Gui.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/WalletWasabi.Gui/WalletWasabi.Gui.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/WalletWasabi.Gui/WalletWasabi.Gui.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -12,7 +12,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/zkSNACKs/WalletWasabi/</RepositoryUrl>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Backend</PathMap>
+    <PathMap>$(MSBuildProjectDirectory)\=/src/WalletWasabi.Backend</PathMap>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -9,7 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Gui</PathMap>
+    <PathMap>$(MSBuildProjectDirectory)\=/src/WalletWasabi.Gui</PathMap>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/WalletWasabi.Packager/WalletWasabi.Packager.csproj
+++ b/WalletWasabi.Packager/WalletWasabi.Packager.csproj
@@ -10,7 +10,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Packager</PathMap>
+    <PathMap>$(MSBuildProjectDirectory)\=/src/WalletWasabi.Packager</PathMap>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -11,7 +11,7 @@
     <StartupObject />
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Tests</PathMap>
+    <PathMap>$(MSBuildProjectDirectory)\=/src/WalletWasabi.Tests</PathMap>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -10,7 +10,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <PathMap>$(MSBuildProjectDirectory)\=WalletWasabi</PathMap>
+    <PathMap>$(MSBuildProjectDirectory)\=/src/WalletWasabi</PathMap>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Fixes #4118 by appending `/src/` as a hook in the `<PathMap>`s so that `sourceFileMap` in `launch.json` can replace it with user's current working directory in VSCode.

inspiration for the this: https://github.com/OmniSharp/omnisharp-vscode/issues/1543

cc @molnard @lontivero 