### PR TITLE
Add more logging to TorSocks5Client.

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -365,7 +365,9 @@ namespace WalletWasabi.Logging
 		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
 		/// Example log message: "Cannot insert record due to duplicate key violation."
 		/// </summary>
-		public static void LogError(string message, Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(message, ex, LogLevel.Error, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogError(string message, Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(message, ex, LogLevel.Error, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Error level.
 		///

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -233,14 +233,22 @@ namespace WalletWasabi.Logging
 
 		#region ExceptionLoggingMethods
 
-		private static void Log(Exception ex, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		/// <summary>
+		/// Logs user message concatenated with exception string.
+		/// </summary>
+		private static void Log(string message, Exception ex, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
-			Log(level, ExceptionToStringHandleNull(ex), callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+			string formattedMessage = message + " Exception: " + (ex?.ToString() ?? "Exception was null.");
+			Log(level, formattedMessage, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 		}
 
-		private static string ExceptionToStringHandleNull(Exception ex)
+		/// <summary>
+		/// Logs exception string without any user message.
+		/// </summary>
+		private static void Log(Exception ex, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
-			return ex?.ToString() ?? "Exception was null.";
+			string message = ex?.ToString() ?? "Exception was null.";
+			Log(level, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 		}
 
 		#endregion ExceptionLoggingMethods
@@ -350,6 +358,14 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		public static void LogError(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Error, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 
+		/// <summary>
+		/// Logs user message with exception concatenated to it at Error level.
+		///
+		/// For errors and exceptions that cannot be handled.
+		/// These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.
+		/// Example log message: "Cannot insert record due to duplicate key violation."
+		/// </summary>
+		public static void LogError(string message, Exception ex, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(message, ex, LogLevel.Error, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 		/// <summary>
 		/// Logs the <paramref name="ex"/>.ToString() at Error level.
 		///

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -271,6 +271,7 @@ namespace WalletWasabi.TorSocks5
 			catch (Exception e)
 			{
 				Logger.LogError("Exception was thrown when connecting to destination.", e);
+				throw;
 			}
 			finally
 			{

--- a/WalletWasabi/TorSocks5/TorSocks5Client.cs
+++ b/WalletWasabi/TorSocks5/TorSocks5Client.cs
@@ -205,61 +205,77 @@ namespace WalletWasabi.TorSocks5
 		/// <param name="host">IPv4 or domain</param>
 		internal async Task ConnectToDestinationAsync(string host, int port, bool isRecursiveCall = false)
 		{
+			Logger.LogDebug($"> {nameof(host)}={host}, {nameof(port)}={port}, {nameof(isRecursiveCall)}={isRecursiveCall}");
+
 			host = Guard.NotNullOrEmptyOrWhitespace(nameof(host), host, true);
 			Guard.MinimumAndNotNull(nameof(port), port, 0);
 
-			if (TorSocks5EndPoint is null)
+			try
 			{
-				using (await AsyncLock.LockAsync().ConfigureAwait(false))
+				if (TorSocks5EndPoint is null)
 				{
-					TcpClient?.Dispose();
-					TcpClient = IPAddress.TryParse(host, out IPAddress ip) ? new TcpClient(ip.AddressFamily) : new TcpClient();
-					await TcpClient.ConnectAsync(host, port).ConfigureAwait(false);
-					Stream = TcpClient.GetStream();
-					RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
+					Logger.LogDebug($"Tor is NOT enabled.");
+
+					using (await AsyncLock.LockAsync().ConfigureAwait(false))
+					{
+						TcpClient?.Dispose();
+						TcpClient = IPAddress.TryParse(host, out IPAddress ip) ? new TcpClient(ip.AddressFamily) : new TcpClient();
+						await TcpClient.ConnectAsync(host, port).ConfigureAwait(false);
+						Stream = TcpClient.GetStream();
+						RemoteEndPoint = TcpClient.Client.RemoteEndPoint;
+					}
 				}
+				else
+				{
+					Logger.LogDebug($"Tor is enabled.");
 
-				return;
+					var dstAddr = new AddrField(host);
+					DestinationHost = dstAddr.DomainOrIPv4;
+
+					var dstPort = new PortField(port);
+					DestinationPort = dstPort.DstPort;
+
+					var connectionRequest = new TorSocks5Request(cmd: CmdField.Connect, dstAddr, dstPort);
+					var sendBuffer = connectionRequest.ToBytes();
+
+					var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall).ConfigureAwait(false);
+
+					var connectionResponse = new TorSocks5Response();
+					connectionResponse.FromBytes(receiveBuffer);
+
+					if (connectionResponse.Rep != RepField.Succeeded)
+					{
+						// https://www.ietf.org/rfc/rfc1928.txt
+						// When a reply(REP value other than X'00') indicates a failure, the
+						// SOCKS server MUST terminate the TCP connection shortly after sending
+						// the reply.This must be no more than 10 seconds after detecting the
+						// condition that caused a failure.
+						DisposeTcpClient();
+						Logger.LogWarning($"Connection response indicates a failure. Actual response is: '{connectionResponse.Rep}'.");
+						throw new TorSocks5FailureResponseException(connectionResponse.Rep);
+					}
+
+					// Do not check the Bnd. Address and Bnd. Port. because Tor does not seem to return any, ever. It returns zeros instead.
+					// Generally also do not check anything but the success response, according to Socks5 RFC
+
+					// If the reply code(REP value of X'00') indicates a success, and the
+					// request was either a BIND or a CONNECT, the client may now start
+					// passing data. If the selected authentication method supports
+					// encapsulation for the purposes of integrity, authentication and / or
+					// confidentiality, the data are encapsulated using the method-dependent
+					// encapsulation.Similarly, when data arrives at the SOCKS server for
+					// the client, the server MUST encapsulate the data as appropriate for
+					// the authentication method in use.
+				}
 			}
-
-			var cmd = CmdField.Connect;
-
-			var dstAddr = new AddrField(host);
-			DestinationHost = dstAddr.DomainOrIPv4;
-
-			var dstPort = new PortField(port);
-			DestinationPort = dstPort.DstPort;
-
-			var connectionRequest = new TorSocks5Request(cmd, dstAddr, dstPort);
-			var sendBuffer = connectionRequest.ToBytes();
-
-			var receiveBuffer = await SendAsync(sendBuffer, isRecursiveCall: isRecursiveCall).ConfigureAwait(false);
-
-			var connectionResponse = new TorSocks5Response();
-			connectionResponse.FromBytes(receiveBuffer);
-
-			if (connectionResponse.Rep != RepField.Succeeded)
+			catch (Exception e)
 			{
-				// https://www.ietf.org/rfc/rfc1928.txt
-				// When a reply(REP value other than X'00') indicates a failure, the
-				// SOCKS server MUST terminate the TCP connection shortly after sending
-				// the reply.This must be no more than 10 seconds after detecting the
-				// condition that caused a failure.
-				DisposeTcpClient();
-				throw new TorSocks5FailureResponseException(connectionResponse.Rep);
+				Logger.LogError("Exception was thrown when connecting to destination.", e);
 			}
-
-			// Do not check the Bnd. Address and Bnd. Port. because Tor does not seem to return any, ever. It returns zeros instead.
-			// Generally also do not check anything but the success response, according to Socks5 RFC
-
-			// If the reply code(REP value of X'00') indicates a success, and the
-			// request was either a BIND or a CONNECT, the client may now start
-			// passing data. If the selected authentication method supports
-			// encapsulation for the purposes of integrity, authentication and / or
-			// confidentiality, the data are encapsulated using the method-dependent
-			// encapsulation.Similarly, when data arrives at the SOCKS server for
-			// the client, the server MUST encapsulate the data as appropriate for
-			// the authentication method in use.
+			finally
+			{
+				Logger.LogDebug("<");
+			}
 		}
 
 		public async Task AssertConnectedAsync(bool isRecursiveCall = false)


### PR DESCRIPTION
This PR adds more logs to `TorSocks5Client` class as Tor issues are important to diagnose correctly.

Notes:

* Review should be done with whitespace changes disabled (https://github.com/zkSNACKs/WalletWasabi/pull/4131/files/?w=1).
* The PR just wraps code in try-catch and adds logging statements. There should be no change in behavior.
* I have used `Logger.LogDebug($"> {nameof(host)}={host}, {nameof(port)}={port}, {nameof(isRecursiveCall)}={isRecursiveCall}");` where `>` is a convention for saying "we are entering `ConnectToDestinationAsync` method. It can be any character/string. If you like something better, it can be changed. However, by itself it's very useful to know "that code went into the method and that it left the method (denoted by `>` sign)". 
* I would add more log statements but I'm testing the ground here what you guys will accept. The point here is that you just need to know what has happened. If you don't know, you go through the "run application, simulate it, debug it, fix it". If you have logs, you may save hours of your time. So I find it extremely useful and I don't see a drawback except that the code may be a little bit longer (I don't find it that off putting though).

This PR is meant to help with issue #4122.