### PR TITLE
[3/3] Simplify Grid col/row definitions declarations

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabView.xaml
@@ -19,14 +19,13 @@
     <converters:TimeSpanVisibilityConverter x:Key="TimeSpanVisibilityConverter" />
   </UserControl.Resources>
   <DockPanel LastChildFill="True" Margin="10">
-    <Grid DockPanel.Dock="Bottom">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="*" />
-      </Grid.RowDefinitions>
+    <Grid DockPanel.Dock="Bottom" RowDefinitions="*" >
       <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="150" />
-        <ColumnDefinition Width="*" MinWidth="460" />
+        <ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="150" />
+          <ColumnDefinition Width="*" MinWidth="460" />
+        </ColumnDefinitions>
       </Grid.ColumnDefinitions>
       <controls:GroupBox Grid.Row="0" Grid.Column="2" Title="Status" Padding="5" Margin="5 5 0 0">
         <ScrollViewer>
@@ -84,14 +83,7 @@
         </ScrollViewer>
       </controls:GroupBox>
       <controls:GroupBox Grid.Row="0" Grid.Column="0" Title="CoinJoin" Padding="5" Margin="0 5 5 0">
-        <Grid Grid.Row="0" Grid.Column="0" Classes="content">
-          <Grid.RowDefinitions>
-            <RowDefinition Height="150" />
-          </Grid.RowDefinitions>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-          </Grid.ColumnDefinitions>
+        <Grid Grid.Row="0" Grid.Column="0" Classes="content" RowDefinitions="150" ColumnDefinitions="*,Auto">
           <StackPanel Grid.Column="0" Spacing="10">
             <controls:TogglePasswordBox Text="{Binding Password}" Margin="0 20 0 0" MinWidth="200">
               <i:Interaction.Behaviors>
@@ -119,11 +111,7 @@
       </controls:GroupBox>
       <controls:GroupBox Grid.Column="1" Title="Target" Padding="5" Margin="5 0">
         <Button Command="{Binding TargetButtonCommand}">
-          <Grid Background="Transparent" DataContext="{Binding CoinJoinUntilAnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}">
-            <Grid.RowDefinitions>
-              <RowDefinition Height="2*"></RowDefinition>
-              <RowDefinition Height="*"></RowDefinition>
-            </Grid.RowDefinitions>
+          <Grid RowDefinitions="2*,*" Background="Transparent" DataContext="{Binding CoinJoinUntilAnonymitySet, Converter={StaticResource PrivacyLevelValueConverter}}">
             <DrawingPresenter Grid.Row="0" Drawing="{Binding Icon}" VerticalAlignment="Top" Height="100" Width="75" />
             <TextBlock Margin="0 5 0 0" Grid.Row="1" Text="{Binding ToolTip}" TextAlignment="Center" TextWrapping="Wrap" />
           </Grid>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -102,12 +102,14 @@
                   </ContextMenu>
                 </Grid.ContextMenu>
                 <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="24" />
-                  <ColumnDefinition Width="30" />
-                  <ColumnDefinition SharedSizeGroup="A" />
-                  <ColumnDefinition Width="150" />
-                  <ColumnDefinition Width="80" />
-                  <ColumnDefinition Width="*" />
+                  <ColumnDefinitions>
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="30" />
+                    <ColumnDefinition SharedSizeGroup="A" />
+                    <ColumnDefinition Width="150" />
+                    <ColumnDefinition Width="80" />
+                    <ColumnDefinition Width="*" />
+                  </ColumnDefinitions>
                 </Grid.ColumnDefinitions>
                 <Border>
                   <CheckBox HorizontalAlignment="Center" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListView.xaml
@@ -102,14 +102,12 @@
                   </ContextMenu>
                 </Grid.ContextMenu>
                 <Grid.ColumnDefinitions>
-                  <ColumnDefinitions>
-                    <ColumnDefinition Width="24" />
-                    <ColumnDefinition Width="30" />
-                    <ColumnDefinition SharedSizeGroup="A" />
-                    <ColumnDefinition Width="150" />
-                    <ColumnDefinition Width="80" />
-                    <ColumnDefinition Width="*" />
-                  </ColumnDefinitions>
+                  <ColumnDefinition Width="24" />
+                  <ColumnDefinition Width="30" />
+                  <ColumnDefinition SharedSizeGroup="A" />
+                  <ColumnDefinition Width="150" />
+                  <ColumnDefinition Width="80" />
+                  <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Border>
                   <CheckBox HorizontalAlignment="Center" IsChecked="{Binding IsSelected}" Background="{DynamicResource ThemeBackgroundBrush}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/PinPadView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/PinPadView.xaml
@@ -11,22 +11,12 @@
       <StackPanel DockPanel.Dock="Bottom">
         <Button Margin="4 20" Content="Send PIN to Device" Command="{Binding SendPinCommand}" />
       </StackPanel>
-      <Grid>
+      <Grid RowDefinitions="*,*,*"  ColumnDefinitions="*,*,*">
         <Grid.Styles>
           <Style Selector="Button">
             <Setter Property="Margin" Value="4" />
           </Style>
         </Grid.Styles>
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition />
-          <ColumnDefinition />
-          <ColumnDefinition />
-        </Grid.ColumnDefinitions>
         <Button Grid.Row="0" Grid.Column="0" Content="." Command="{Binding KeyPadCommand}" CommandParameter="7" />
         <Button Grid.Row="0" Grid.Column="1" Content="." Command="{Binding KeyPadCommand}" CommandParameter="8" />
         <Button Grid.Row="0" Grid.Column="2" Content="." Command="{Binding KeyPadCommand}" CommandParameter="9" />

--- a/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/CannotCloseDialogView.xaml
@@ -9,11 +9,7 @@
         <Button Width="100" Content="Ok" Command="{Binding OKCommand}" IsVisible="{Binding !IsBusy}" />
         <Button Width="100" Content="Cancel" Command="{Binding CancelCommand}" IsVisible="{Binding IsBusy}" />
       </StackPanel>
-      <Grid Classes="content">
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
+      <Grid Classes="content" RowDefinitions="*,*">
         <Panel Grid.Row="0" Margin="10">
           <TextBlock FontSize="15" Text="You have coins registered for CoinJoin. Wasabi is dequeing them. If a coin is currently being coinjoined Wasabi will wait for the mix to finish, so you do not disrupt the mixing round. This could take a few minutes, please be patient." TextWrapping="Wrap" />
         </Panel>

--- a/WalletWasabi.Gui/Dialogs/TextInputDialogView.xaml
+++ b/WalletWasabi.Gui/Dialogs/TextInputDialogView.xaml
@@ -13,11 +13,7 @@
         <Button Width="100" Content="Ok" Command="{Binding OKCommand}" IsVisible="{Binding !IsBusy}" />
         <Button Width="100" Content="Cancel" Command="{Binding CancelCommand}" IsVisible="{Binding IsBusy}" />
       </StackPanel>
-      <Grid Classes="content">
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
+      <Grid Classes="content" RowDefinitions="*,*">
         <Panel Grid.Row="0" Margin="10">
           <TextBlock FontSize="15" Text="{Binding Instructions}" TextWrapping="Wrap" />
         </Panel>


### PR DESCRIPTION
Closes #4104

Finish the work that i started on #4104 by simplifying some of the old row/col defs. Also added wrappers for non trivial columndefinitions in case https://github.com/AvaloniaUI/Avalonia/pull/4397 is merged into 0.10 final

cc: @lontivero @molnard 