### PR TITLE
Organize Group Element Tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
@@ -123,12 +123,18 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		public void NullEquality()
 		{
 			var one = new Scalar(1);
-			var a = new GroupElement(EC.G * one);
+			var ge = new GroupElement(EC.G * one);
 
-			Assert.False(a == null);
-			Assert.True(a != null);
+			// Kinda clunky, but otherwise CodeFactor won't be happy.
+			GroupElement n = null;
 
-			Assert.False(a.Equals(null));
+			Assert.False(ge == n);
+			Assert.True(ge != n);
+
+			Assert.False(n == ge);
+			Assert.True(n != ge);
+
+			Assert.False(ge.Equals(n));
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
@@ -5,9 +5,9 @@ using System.Text;
 using WalletWasabi.Crypto;
 using Xunit;
 
-namespace WalletWasabi.Tests.UnitTests.Crypto
+namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 {
-	public class GroupElementTests
+	public class GeneralTests
 	{
 		[Fact]
 		public void IsIEquitable()
@@ -187,94 +187,6 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			Assert.Equal(expectedTwo, new GroupElement(EC.G * new Scalar(2)).ToString());
 		}
 
-		[Fact]
-		public void Addition()
-		{
-			Assert.Throws<ArgumentNullException>(() => GroupElement.G + null);
-			Assert.Throws<ArgumentNullException>(() => null + GroupElement.G);
-			Assert.Throws<ArgumentNullException>(() => GroupElement.Infinity + null);
-			Assert.Throws<ArgumentNullException>(() => null + GroupElement.Infinity);
-
-			var gen1 = GroupElement.Infinity + GroupElement.G;
-			var gen2 = GroupElement.G + GroupElement.Infinity;
-			var inf = GroupElement.Infinity + GroupElement.Infinity;
-			Assert.Equal(GroupElement.G, gen1);
-			Assert.Equal(GroupElement.G, gen2);
-			Assert.Equal(GroupElement.Infinity, inf);
-
-			var one = new GroupElement(new Scalar(1) * EC.G);
-			var two = new GroupElement(new Scalar(2) * EC.G);
-			var three = new GroupElement(new Scalar(3) * EC.G);
-			var zero = new GroupElement(Scalar.Zero * EC.G);
-
-			Assert.Equal(GroupElement.G, one);
-			Assert.True(zero.IsInfinity);
-
-			Assert.Equal(two, one + one);
-			Assert.Equal(three, one + one + one);
-			Assert.Equal(three, two + one);
-			Assert.Equal(three, one + two);
-			Assert.Equal(one, one + zero);
-			Assert.Equal(two, one + one + zero);
-			Assert.Equal(two, two + zero);
-			Assert.Equal(three, three + zero);
-			Assert.Equal(three, two + one + zero);
-		}
-
-		[Fact]
-		public void Subtraction()
-		{
-			Assert.Throws<ArgumentNullException>(() => GroupElement.G - null);
-			Assert.Throws<ArgumentNullException>(() => null - GroupElement.G);
-			Assert.Throws<ArgumentNullException>(() => GroupElement.Infinity - null);
-			Assert.Throws<ArgumentNullException>(() => null - GroupElement.Infinity);
-
-			var minusGen = GroupElement.Infinity - GroupElement.G;
-			var gen = GroupElement.G - GroupElement.Infinity;
-			var inf = GroupElement.Infinity - GroupElement.Infinity;
-			Assert.Equal(new GroupElement(EC.G.Negate()), minusGen);
-			Assert.Equal(GroupElement.G, gen);
-			Assert.Equal(GroupElement.Infinity, inf);
-
-			var minusOne = new GroupElement(new Scalar(1) * EC.G.Negate());
-			var minusTwo = new GroupElement(new Scalar(2) * EC.G.Negate());
-			var one = new GroupElement(new Scalar(1) * EC.G);
-			var two = new GroupElement(new Scalar(2) * EC.G);
-			var three = new GroupElement(new Scalar(3) * EC.G);
-			var zero = new GroupElement(Scalar.Zero * EC.G);
-
-			Assert.Equal(GroupElement.G, one);
-			Assert.True(zero.IsInfinity);
-
-			Assert.Equal(zero, one - one);
-			Assert.Equal(minusOne, one - one - one);
-			Assert.Equal(one, one + one - one);
-			Assert.Equal(one, one - one + one);
-			Assert.Equal(one, two - one);
-			Assert.Equal(minusOne, one - two);
-			Assert.Equal(one, one - zero);
-			Assert.Equal(minusOne, zero - one);
-			Assert.Equal(zero, one - one + zero);
-			Assert.Equal(two, one + one - zero);
-			Assert.Equal(zero, one - one - zero);
-			Assert.Equal(two, two - zero);
-			Assert.Equal(minusTwo, zero - two);
-			Assert.Equal(three, three - zero);
-			Assert.Equal(two, three - one);
-			Assert.Equal(minusTwo, one - three);
-			Assert.Equal(one, two - one + zero);
-			Assert.Equal(zero, zero + zero - zero + zero);
-		}
-
-		[Fact]
-		public void Negation()
-		{
-			Assert.Equal(new GroupElement(EC.G.Negate()), GroupElement.G.Negate());
-			Scalar one = new Scalar(1);
-			Assert.Equal(new GroupElement(EC.G.Negate() * one), new GroupElement(EC.G * one).Negate());
-			Assert.Equal(GroupElement.Infinity, GroupElement.Infinity.Negate());
-		}
-
 		private byte[] FillByteArray(int length, byte character)
 		{
 			var array = new byte[length];
@@ -399,89 +311,13 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 				);
 			var x = EC.G.x;
 			x = x.Add(p);
-			var x3 = ((x * x) * x);
+			var x3 = x * x * x;
 			var y2 = x3 + new FE(EC.CURVE_B);
 			Assert.True(y2.Sqrt(out var y));
 			var ge = new GroupElement(new GE(x, y));
 
 			var ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
-		}
-
-		[Fact]
-		public void MultiplyByScalar()
-		{
-			// Scalar one.
-			var g = GroupElement.G;
-			var scalar = Scalar.One;
-			var expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-
-			// Can switch order.
-			Assert.Equal(expected, scalar * g);
-
-			// Scalar two.
-			scalar = new Scalar(2);
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-
-			// Scalar three.
-			scalar = new Scalar(3);
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-
-			// Scalar NC.
-			scalar = EC.NC;
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-
-			// Scalar big.
-			scalar = new Scalar(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-
-			// Scalar biggest.
-			scalar = EC.N + Scalar.One.Negate();
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-
-			// Scalar zero.
-			scalar = Scalar.Zero;
-			expected = new GroupElement(EC.G * scalar);
-			var result = g * scalar;
-			Assert.Equal(expected, result);
-			Assert.True(result.IsInfinity);
-
-			// Group element is infinity.
-			scalar = new Scalar(2);
-			result = GroupElement.Infinity * scalar;
-			expected = GroupElement.Infinity;
-			Assert.Equal(expected, result);
-			Assert.True(result.IsInfinity);
-
-			// Group element is infinity & Scalar is zero.
-			scalar = Scalar.Zero;
-			result = GroupElement.Infinity * scalar;
-			expected = GroupElement.Infinity;
-			Assert.Equal(expected, result);
-			Assert.True(result.IsInfinity);
-
-			// Scalar overflown N.
-			scalar = EC.N;
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-			Assert.Equal(g * Scalar.Zero, g * scalar);
-
-			// Scalar overflown N+1.
-			scalar = EC.N + Scalar.One;
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
-			Assert.Equal(g * Scalar.One, g * scalar);
-
-			// Scalar overflown uint.Max
-			scalar = new Scalar(uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue);
-			expected = new GroupElement(EC.G * scalar);
-			Assert.Equal(expected, g * scalar);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
@@ -128,9 +128,6 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			Assert.False(a == null);
 			Assert.True(a != null);
 
-			Assert.False(null == a);
-			Assert.True(null != a);
-
 			Assert.False(a.Equals(null));
 		}
 
@@ -244,6 +241,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			byte[] zeroBytes = ge.ToBytes();
 			ge2 = GroupElement.FromBytes(zeroBytes);
 			Assert.Equal(GroupElement.Infinity, ge2);
+
 			// 2. Try defining non-infinity with zero coordinates should not work.
 			Assert.ThrowsAny<ArgumentException>(() => new GroupElement(new GE(FE.Zero, FE.Zero, infinity: false)));
 
@@ -307,8 +305,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 				0xFFFFFFFFU,
 				0xFFFFFFFFU,
 				0xFFFFFFFFU,
-				0xFFFFFFFFU
-				);
+				0xFFFFFFFFU);
 			var x = EC.G.x;
 			x = x.Add(p);
 			var x3 = x * x * x;

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/OperationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/OperationTests.cs
@@ -1,0 +1,181 @@
+using NBitcoin.Secp256k1;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WalletWasabi.Crypto;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
+{
+	public class OperationTests
+	{
+		[Fact]
+		public void Addition()
+		{
+			Assert.Throws<ArgumentNullException>(() => GroupElement.G + null);
+			Assert.Throws<ArgumentNullException>(() => null + GroupElement.G);
+			Assert.Throws<ArgumentNullException>(() => GroupElement.Infinity + null);
+			Assert.Throws<ArgumentNullException>(() => null + GroupElement.Infinity);
+
+			var gen1 = GroupElement.Infinity + GroupElement.G;
+			var gen2 = GroupElement.G + GroupElement.Infinity;
+			var inf = GroupElement.Infinity + GroupElement.Infinity;
+			Assert.Equal(GroupElement.G, gen1);
+			Assert.Equal(GroupElement.G, gen2);
+			Assert.Equal(GroupElement.Infinity, inf);
+
+			var one = new GroupElement(new Scalar(1) * EC.G);
+			var two = new GroupElement(new Scalar(2) * EC.G);
+			var three = new GroupElement(new Scalar(3) * EC.G);
+			var zero = new GroupElement(Scalar.Zero * EC.G);
+
+			Assert.Equal(GroupElement.G, one);
+			Assert.True(zero.IsInfinity);
+
+			Assert.Equal(two, one + one);
+			Assert.Equal(three, one + one + one);
+			Assert.Equal(three, two + one);
+			Assert.Equal(three, one + two);
+			Assert.Equal(one, one + zero);
+			Assert.Equal(two, one + one + zero);
+			Assert.Equal(two, two + zero);
+			Assert.Equal(three, three + zero);
+			Assert.Equal(three, two + one + zero);
+		}
+
+		[Fact]
+		public void Subtraction()
+		{
+			Assert.Throws<ArgumentNullException>(() => GroupElement.G - null);
+			Assert.Throws<ArgumentNullException>(() => null - GroupElement.G);
+			Assert.Throws<ArgumentNullException>(() => GroupElement.Infinity - null);
+			Assert.Throws<ArgumentNullException>(() => null - GroupElement.Infinity);
+
+			var minusGen = GroupElement.Infinity - GroupElement.G;
+			var gen = GroupElement.G - GroupElement.Infinity;
+			var inf = GroupElement.Infinity - GroupElement.Infinity;
+			Assert.Equal(new GroupElement(EC.G.Negate()), minusGen);
+			Assert.Equal(GroupElement.G, gen);
+			Assert.Equal(GroupElement.Infinity, inf);
+
+			var minusOne = new GroupElement(new Scalar(1) * EC.G.Negate());
+			var minusTwo = new GroupElement(new Scalar(2) * EC.G.Negate());
+			var one = new GroupElement(new Scalar(1) * EC.G);
+			var two = new GroupElement(new Scalar(2) * EC.G);
+			var three = new GroupElement(new Scalar(3) * EC.G);
+			var zero = new GroupElement(Scalar.Zero * EC.G);
+
+			Assert.Equal(GroupElement.G, one);
+			Assert.True(zero.IsInfinity);
+
+			Assert.Equal(zero, one - one);
+			Assert.Equal(minusOne, one - one - one);
+			Assert.Equal(one, one + one - one);
+			Assert.Equal(one, one - one + one);
+			Assert.Equal(one, two - one);
+			Assert.Equal(minusOne, one - two);
+			Assert.Equal(one, one - zero);
+			Assert.Equal(minusOne, zero - one);
+			Assert.Equal(zero, one - one + zero);
+			Assert.Equal(two, one + one - zero);
+			Assert.Equal(zero, one - one - zero);
+			Assert.Equal(two, two - zero);
+			Assert.Equal(minusTwo, zero - two);
+			Assert.Equal(three, three - zero);
+			Assert.Equal(two, three - one);
+			Assert.Equal(minusTwo, one - three);
+			Assert.Equal(one, two - one + zero);
+			Assert.Equal(zero, zero + zero - zero + zero);
+		}
+
+		[Fact]
+		public void Negation()
+		{
+			Assert.Equal(new GroupElement(EC.G.Negate()), GroupElement.G.Negate());
+			Scalar one = new Scalar(1);
+			Assert.Equal(new GroupElement(EC.G.Negate() * one), new GroupElement(EC.G * one).Negate());
+			Assert.Equal(GroupElement.Infinity, GroupElement.Infinity.Negate());
+		}
+
+		[Fact]
+		public void MultiplyByScalar()
+		{
+			// Scalar one.
+			var g = GroupElement.G;
+			var scalar = Scalar.One;
+			var expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+
+			// Can switch order.
+			Assert.Equal(expected, scalar * g);
+
+			// Scalar two.
+			scalar = new Scalar(2);
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+
+			// Scalar three.
+			scalar = new Scalar(3);
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+
+			// Scalar NC.
+			scalar = EC.NC;
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+
+			// Scalar big.
+			scalar = new Scalar(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+
+			// Scalar biggest.
+			scalar = EC.N + Scalar.One.Negate();
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+
+			// Scalar zero.
+			scalar = Scalar.Zero;
+			expected = new GroupElement(EC.G * scalar);
+			var result = g * scalar;
+			Assert.Equal(expected, result);
+			Assert.True(result.IsInfinity);
+
+			// Group element is infinity.
+			scalar = new Scalar(2);
+			result = GroupElement.Infinity * scalar;
+			expected = GroupElement.Infinity;
+			Assert.Equal(expected, result);
+			Assert.True(result.IsInfinity);
+
+			// Group element is infinity & Scalar is zero.
+			scalar = Scalar.Zero;
+			result = GroupElement.Infinity * scalar;
+			expected = GroupElement.Infinity;
+			Assert.Equal(expected, result);
+			Assert.True(result.IsInfinity);
+		}
+
+		[Fact]
+		public void OverflownScalar()
+		{
+			var g = GroupElement.G;
+			// Scalar overflown N.
+			var scalar = EC.N;
+			var expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+			Assert.Equal(g * Scalar.Zero, g * scalar);
+
+			// Scalar overflown N+1.
+			scalar = EC.N + Scalar.One;
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+			Assert.Equal(g * Scalar.One, g * scalar);
+
+			// Scalar overflown uint.Max
+			scalar = new Scalar(uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue);
+			expected = new GroupElement(EC.G * scalar);
+			Assert.Equal(expected, g * scalar);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/OperationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/OperationTests.cs
@@ -160,6 +160,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		public void OverflownScalar()
 		{
 			var g = GroupElement.G;
+
 			// Scalar overflown N.
 			var scalar = EC.N;
 			var expected = new GroupElement(EC.G * scalar);


### PR DESCRIPTION
In https://github.com/zkSNACKs/WalletWasabi/pull/4149 CodeScene complained about the code health of Group Element tests, but it did not provide any information why. After https://github.com/zkSNACKs/WalletWasabi/pull/4149 got merged I did an X-Ray on the tests and found the `MultiplyByScalar` test to have the largest "Complexity/Size" metric.

This PR does two things:

- Created a test directory `GroupElements` and moved the `GroupElementTests` file under it. Renamed the file to `GeneralTests` and added a new file `OperationTests`, to which I copypasted operation related tests, like addition, subtraction, multiply by scalar, negation.
- I decoupled the `MultiplyByScalar` test into two tests, where the first part stayed the same, but the second part is called `OverflownScalar` as that's specifically trying to make sure that our `GroupElement` works properly when it is working with overflown scalars. (This change is copypaste, too.)