### PR TITLE
Remove ConfigureAwait(false) from tests.

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1487,7 +1487,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				request.BlindedOutputScripts,
 				request.Inputs,
 				() => BaseUri,
-				null).ConfigureAwait(false);
+				null);
 		}
 	}
 }

--- a/WalletWasabi.Tests/RpcTests.cs
+++ b/WalletWasabi.Tests/RpcTests.cs
@@ -94,7 +94,7 @@ namespace WalletWasabi.Tests
 		{
 			var handler = new JsonRpcRequestHandler<TestableRpcService>(new TestableRpcService());
 
-			var response = await handler.HandleAsync(request, CancellationToken.None).ConfigureAwait(false);
+			var response = await handler.HandleAsync(request, CancellationToken.None);
 			Assert.Equal(expectedResponse, response);
 		}
 

--- a/WalletWasabi.Tests/TestableRpcService.cs
+++ b/WalletWasabi.Tests/TestableRpcService.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.Tests
 		public int Substract(int minuend, int subtrahend) => minuend - subtrahend;
 
 		[JsonRpcMethod("substractasync")]
-		public async Task<int> SubstractAsync(int minuend, int subtrahend) => await Task.FromResult(minuend - subtrahend).ConfigureAwait(false);
+		public async Task<int> SubstractAsync(int minuend, int subtrahend) => await Task.FromResult(minuend - subtrahend);
 
 		[JsonRpcMethod("writelog")]
 		public void Log(string logEntry)
@@ -34,7 +34,7 @@ namespace WalletWasabi.Tests
 		{
 			Unused(unit);
 			Unused(ct);
-			await Task.FromResult((JsonRpcResponse)null).ConfigureAwait(false);
+			await Task.FromResult((JsonRpcResponse)null);
 		}
 
 #pragma warning disable IDE0060 // unused parameter

--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -111,7 +111,7 @@ namespace WalletWasabi.Tests.UnitTests
 			notifier.TriggerRound();
 
 			// Waits at most 1.5s given CancellationTokenSource definition
-			await Task.WhenAny(Task.Delay(Timeout.InfiniteTimeSpan, cts.Token)).ConfigureAwait(false);
+			await Task.WhenAny(Task.Delay(Timeout.InfiniteTimeSpan, cts.Token));
 
 			Assert.True(string.IsNullOrEmpty(message), message);
 
@@ -280,7 +280,7 @@ namespace WalletWasabi.Tests.UnitTests
 			var block = chain.GetBlock(header.GetHash());
 			if (wait)
 			{
-				await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+				await Task.Delay(TimeSpan.FromSeconds(1));
 			}
 			return block;
 		}

--- a/WalletWasabi.Tests/UnitTests/Clients/WasabiClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/WasabiClientTests.cs
@@ -112,25 +112,25 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 			// Disposal test.
 			using (SingleInstanceChecker sic = new SingleInstanceChecker(Network.Main))
 			{
-				await sic.CheckAsync().ConfigureAwait(false);
+				await sic.CheckAsync();
 			}
 
 			// Check different networks.
 			using (SingleInstanceChecker sic = new SingleInstanceChecker(Network.Main))
 			{
-				await sic.CheckAsync().ConfigureAwait(false);
-				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sic.CheckAsync().ConfigureAwait(false));
+				await sic.CheckAsync();
+				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sic.CheckAsync());
 
 				using SingleInstanceChecker sic2 = new SingleInstanceChecker(Network.Main);
-				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sic2.CheckAsync().ConfigureAwait(false));
+				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sic2.CheckAsync());
 
 				using SingleInstanceChecker sicTest = new SingleInstanceChecker(Network.TestNet);
-				await sicTest.CheckAsync().ConfigureAwait(false);
-				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicTest.CheckAsync().ConfigureAwait(false));
+				await sicTest.CheckAsync();
+				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicTest.CheckAsync());
 
 				using SingleInstanceChecker sicReg = new SingleInstanceChecker(Network.RegTest);
-				await sicReg.CheckAsync().ConfigureAwait(false);
-				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicReg.CheckAsync().ConfigureAwait(false));
+				await sicReg.CheckAsync();
+				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicReg.CheckAsync());
 			}
 		}
 	}


### PR DESCRIPTION
See #4147 issue and comment https://github.com/zkSNACKs/WalletWasabi/issues/4147#issuecomment-671798346 for details why xunit tests should not contain DIRECTLY ConfigureAwait(false) method calls.

This is a part of work on #4152 too.