### PR TITLE
Optimize FeeRate estimation query

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -146,7 +146,7 @@ namespace WalletWasabi.Backend.Controllers
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => RpcClient.EstimateAllFeeAsync(mode, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true));
+				() => RpcClient.EstimateAllFeeAsync(mode, simulateIfRegTest: true));
 		}
 
 		/// <summary>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -694,7 +694,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						{
 							var target = feeEstimate.Key;
 							var fee = feeEstimate.Value;
-							if (FeeRate.SatoshiPerByte > fee)
+							if (FeeRate > fee)
 							{
 								feeTarget = target;
 								break;

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -157,7 +157,6 @@ namespace WalletWasabi.Tests.UnitTests
 				});
 
 			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
-			Assert.False(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
 			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
 			Assert.False(allFee.Estimations.ContainsKey(3));
@@ -178,7 +177,7 @@ namespace WalletWasabi.Tests.UnitTests
 					Headers = 2  // the node is not synchronized.
 				});
 			rpc.OnGetPeersInfoAsync = async () =>
-				await Task.FromResult(new PeerInfo[0]);
+				await Task.FromResult(new[] { new PeerInfo() });
 
 			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
 				await Task.FromResult(new EstimateSmartFeeResponse
@@ -195,7 +194,7 @@ namespace WalletWasabi.Tests.UnitTests
 					}
 				});
 
-			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical);
 			Assert.False(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
 			Assert.False(allFee.Estimations.ContainsKey(3));
@@ -216,7 +215,7 @@ namespace WalletWasabi.Tests.UnitTests
 					Headers = 600_000
 				});
 			rpc.OnGetPeersInfoAsync = async () =>
-				await Task.FromResult(new PeerInfo[0]);
+				await Task.FromResult(new[] { new PeerInfo() });
 
 			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
 				await Task.FromResult(new EstimateSmartFeeResponse
@@ -238,7 +237,7 @@ namespace WalletWasabi.Tests.UnitTests
 				});
 
 			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
-			Assert.False(allFee.IsAccurate);
+			Assert.True(allFee.IsAccurate);
 			Assert.False(allFee.Estimations.ContainsKey(13));
 			Assert.False(allFee.Estimations.ContainsKey(1008));
 			Assert.Equal(30, allFee.Estimations[8].SatoshiPerByte);

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -160,7 +160,9 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.False(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
 			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
+			Assert.False(allFee.Estimations.ContainsKey(3));
 			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
+			Assert.False(allFee.Estimations.ContainsKey(6));
 			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
 		}
 
@@ -196,9 +198,11 @@ namespace WalletWasabi.Tests.UnitTests
 			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.False(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
+			Assert.False(allFee.Estimations.ContainsKey(3));
 			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
 			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
 			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
+			Assert.False(allFee.Estimations.ContainsKey(13));
 		}
 
 		[Fact]
@@ -224,9 +228,9 @@ namespace WalletWasabi.Tests.UnitTests
 						3 => new FeeRate(100m),
 						5 => new FeeRate(89m),
 						6 => new FeeRate(75m),
-						8 => new FeeRate(70m),
+						8 => new FeeRate(30m),
 						11 => new FeeRate(30m),
-						12 => new FeeRate(30m),
+						13 => new FeeRate(30m),
 						15 => new FeeRate(30m),
 						1008  => new FeeRate(35m),
 						_ => throw new NoEstimationException(target)
@@ -235,11 +239,9 @@ namespace WalletWasabi.Tests.UnitTests
 
 			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.False(allFee.IsAccurate);
-			Assert.Equal(4, allFee.Estimations.Count);
-			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
-			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
-			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
-			Assert.Equal(35, allFee.Estimations[1008].SatoshiPerByte);
+			Assert.False(allFee.Estimations.ContainsKey(13));
+			Assert.False(allFee.Estimations.ContainsKey(1008));
+			Assert.Equal(30, allFee.Estimations[8].SatoshiPerByte);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -3,9 +3,12 @@ using NBitcoin.RPC;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
 using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.JsonConverters;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests
@@ -15,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateSerialization()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 2, 102 },
-				{ 3, 20 },
-				{ 19, 1 }
+				{ 2, new FeeRate(102m) },
+				{ 3, new FeeRate(20m) },
+				{ 19, new FeeRate(1m) }
 			};
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
 			var serialized = JsonConvert.SerializeObject(allFee);
-			var deserialized = JsonConvert.DeserializeObject<AllFeeEstimate>(serialized);
+			var deserialized = JsonConvert.DeserializeObject<AllFeeEstimate>(serialized, new FeeRatePerKbJsonConverter());
 
 			Assert.Equal(estimations[2], deserialized.Estimations[2]);
 			Assert.Equal(estimations[3], deserialized.Estimations[3]);
@@ -34,11 +37,11 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateOrdersByTarget()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 3, 20 },
-				{ 2, 102 },
-				{ 19, 1 }
+				{ 3, new FeeRate(20m) },
+				{ 2, new FeeRate(102m) },
+				{ 19, new FeeRate(1m) }
 			};
 
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
@@ -50,10 +53,10 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateHandlesDuplicate()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 2, 20 },
-				{ 3, 20 }
+				{ 2, new FeeRate(20m) },
+				{ 3, new FeeRate(20m) },
 			};
 
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
@@ -64,29 +67,179 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateHandlesInconsistentData()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 2, 20 },
-				{ 3, 21 }
+				{ 2, new FeeRate(20m) },
+				{ 3, new FeeRate(21m) },
 			};
 
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
 			Assert.Single(allFee.Estimations);
 			Assert.Equal(estimations[2], allFee.Estimations[2]);
 
-			estimations = new Dictionary<int, int>
+			estimations = new Dictionary<int, FeeRate>
 			{
-				{ 5, 1000 },
-				{ 3, 21 },
-				{ 2, 20 },
-				{ 100, 100 },
-				{ 4, 4 },
+				{ 5, new FeeRate(1_000m) },
+				{ 3, new FeeRate(21m) },
+				{ 2, new FeeRate(20m) },
+				{ 100, new FeeRate(100m) },
+				{ 4, new FeeRate(4m) },
 			};
 
 			allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
 			Assert.Equal(2, allFee.Estimations.Count);
 			Assert.Equal(estimations[2], allFee.Estimations[2]);
 			Assert.Equal(estimations[4], allFee.Estimations[4]);
+		}
+
+
+		[Fact]
+		public async Task RpcNoEnoughEstimations()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 100,
+					Headers = 100
+				});
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new PeerInfo[0]);
+
+			rpc.OnEstimateSmartFeeAsync = (target, _) =>
+				throw new NoEstimationException(target);
+
+			await Assert.ThrowsAsync<NoEstimationException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
+		}
+
+
+		[Fact]
+		public async Task RpcFailures()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = () =>
+				throw new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error", null);
+
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				throw new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error", null);
+
+			var ex = await Assert.ThrowsAsync<RPCException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
+			Assert.Equal(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, ex.RPCCode);
+			Assert.Equal("Error", ex.Message);
+		}
+
+		[Fact]
+		public async Task ToleratesRpcFailures()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 100,
+					Headers = 100
+				});
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new PeerInfo[0]);
+
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				await Task.FromResult(new EstimateSmartFeeResponse
+				{
+					Blocks = target,
+					FeeRate= target switch
+					{
+						2 => new FeeRate(100m),
+						3 => throw new RPCException(RPCErrorCode.RPC_INTERNAL_ERROR, "Error", null),
+						5 => new FeeRate(89m),
+						6 => new FeeRate(75m),
+						8 => new FeeRate(70m),
+						_ => throw new NoEstimationException(target)
+					}
+				});
+
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+			Assert.False(allFee.IsAccurate);
+			Assert.Equal(3, allFee.Estimations.Count);
+			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
+			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
+			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
+		}
+
+
+		[Fact]
+		public async Task InaccurateEstimations()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 1,
+					Headers = 2  // the node is not synchronized.
+				});
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new PeerInfo[0]);
+
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				await Task.FromResult(new EstimateSmartFeeResponse
+				{
+					Blocks = target,
+					FeeRate= target switch
+					{
+						2 => new FeeRate(100m),
+						3 => new FeeRate(100m),
+						5 => new FeeRate(89m),
+						6 => new FeeRate(75m),
+						8 => new FeeRate(70m),
+						_ => throw new NoEstimationException(target)
+					}
+				});
+
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+			Assert.False(allFee.IsAccurate);
+			Assert.Equal(3, allFee.Estimations.Count);
+			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
+			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
+			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
+		}
+
+		[Fact]
+		public async Task AccurateEstimations()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 600_000,
+					Headers = 600_000
+				});
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new PeerInfo[0]);
+
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				await Task.FromResult(new EstimateSmartFeeResponse
+				{
+					Blocks = target,
+					FeeRate= target switch
+					{
+						2 => new FeeRate(100m),
+						3 => new FeeRate(100m),
+						5 => new FeeRate(89m),
+						6 => new FeeRate(75m),
+						8 => new FeeRate(70m),
+						11 => new FeeRate(30m),
+						12 => new FeeRate(30m),
+						15 => new FeeRate(30m),
+						1008  => new FeeRate(35m),
+						_ => throw new NoEstimationException(target)
+					}
+				});
+
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+			Assert.False(allFee.IsAccurate);
+			Assert.Equal(4, allFee.Estimations.Count);
+			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
+			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
+			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
+			Assert.Equal(35, allFee.Estimations[1008].SatoshiPerByte);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -158,11 +158,8 @@ namespace WalletWasabi.Tests.UnitTests
 
 			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(3, allFee.Estimations.Count);
-			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
 			Assert.False(allFee.Estimations.ContainsKey(3));
-			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
 			Assert.False(allFee.Estimations.ContainsKey(6));
-			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
 		}
 
 
@@ -197,7 +194,6 @@ namespace WalletWasabi.Tests.UnitTests
 			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical);
 			Assert.False(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
-			Assert.False(allFee.Estimations.ContainsKey(3));
 			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
 			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
 			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -158,18 +158,18 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			try
 			{
 				var rpc = coreNode.RpcClient;
-				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true);
-				Assert.Equal(WalletWasabi.Helpers.Constants.OneDayConfirmationTarget, estimations.Estimations.Count);
+				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
+				Assert.Equal(11, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
-				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true);
-				Assert.Equal(145, estimations.Estimations.Count);
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
+				Assert.Equal(11, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);
-				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: false);
-				Assert.Equal(145, estimations.Estimations.Count);
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
+				Assert.Equal(11, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -15,6 +15,8 @@ namespace WalletWasabi.Tests.UnitTests
 		public Func<uint256, Task<BlockHeader>> OnGetBlockHeaderAsync { get; set; }
 		public Func<Task<BlockchainInfo>> OnGetBlockchainInfoAsync { get; set; }
 		public Func<uint256, Task<VerboseBlockInfo>> OnGetVerboseBlockAsync { get; set; }
+		public Func<int, EstimateSmartFeeMode, Task<EstimateSmartFeeResponse>> OnEstimateSmartFeeAsync { get; set; }
+		public Func<Task<PeerInfo[]>> OnGetPeersInfoAsync { get; set; }
 
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new RPCCredentialString();
@@ -66,7 +68,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<PeerInfo[]> GetPeersInfoAsync()
 		{
-			throw new NotImplementedException();
+			return OnGetPeersInfoAsync();
 		}
 
 		public Task<uint256[]> GetRawMempoolAsync()
@@ -101,12 +103,13 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public IRPCClient PrepareBatch()
 		{
-			throw new NotImplementedException();
+			return this;
 		}
 
 		public Task SendBatchAsync()
 		{
-			throw new NotImplementedException();
+			// do nothing here
+			return Task.CompletedTask;
 		}
 
 		public Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
@@ -166,7 +169,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
 		{
-			throw new NotImplementedException();
+			return OnEstimateSmartFeeAsync(confirmationTarget, estimateMode);
 		}
 
 		public Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address)

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 		{
 			try
 			{
-				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, true).ConfigureAwait(false);
+				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true).ConfigureAwait(false);
 				AllFeeEstimate = allFeeEstimate;
 			}
 			catch

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -806,7 +806,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				}
 
 				// 7.2. Get the most optimal FeeRate.
-				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true).ConfigureAwait(false);
+				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 				if (estimateSmartFeeResponse is null)
 				{
 					throw new InvalidOperationException($"{nameof(FeeRate)} is not yet initialized.");

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -123,7 +123,7 @@ namespace NBitcoin.RPC
 		}
 
 		private static Dictionary<int, FeeRate> SimulateRegTestFeeEstimation(EstimateSmartFeeMode estimateMode) =>
-			new[]{ 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget }
+			new[] { 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget }
 			.Select(target => SimulateRegTestFeeEstimation(target, estimateMode))
 			.ToDictionary(x => x.Blocks, x => x.FeeRate);
 
@@ -162,7 +162,7 @@ namespace NBitcoin.RPC
 		{
 			var batchClient = rpc.PrepareBatch();
 
-			var rpcFeeEstimationTasks = new[]{ 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget }
+			var rpcFeeEstimationTasks = new[] { 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget }
 				.Select(target => batchClient.EstimateSmartFeeAsync(target, estimateMode))
 				.ToList();
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -123,7 +123,7 @@ namespace NBitcoin.RPC
 		}
 
 		private static Dictionary<int, FeeRate> SimulateRegTestFeeEstimation(EstimateSmartFeeMode estimateMode) =>
-			new []{2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget}
+			new[]{ 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget }
 			.Select(target => SimulateRegTestFeeEstimation(target, estimateMode))
 			.ToDictionary(x => x.Blocks, x => x.FeeRate);
 
@@ -144,7 +144,6 @@ namespace NBitcoin.RPC
 			return null;
 		}
 
-
 		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this IRPCClient rpc, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
 		{
 			var rpcStatus = await rpc.GetRpcStatusAsync(CancellationToken.None).ConfigureAwait(false);
@@ -153,19 +152,17 @@ namespace NBitcoin.RPC
 				? SimulateRegTestFeeEstimation(estimateMode)
 				: await GetFeeEstimationsAsync(rpc, estimateMode);
 
-			return new AllFeeEstimate
-			(
+			return new AllFeeEstimate(
 				estimateMode,
 				estmimations,
-				rpcStatus.Synchronized
-			);
+				rpcStatus.Synchronized);
 		}
 
 		private static async Task<Dictionary<int, FeeRate>> GetFeeEstimationsAsync(IRPCClient rpc, EstimateSmartFeeMode estimateMode)
 		{
 			var batchClient = rpc.PrepareBatch();
 
-			var rpcFeeEstimationTasks = new []{2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget}
+			var rpcFeeEstimationTasks = new[]{ 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, Constants.SevenDaysConfirmationTarget }
 				.Select(target => batchClient.EstimateSmartFeeAsync(target, estimateMode))
 				.ToList();
 
@@ -188,7 +185,7 @@ namespace NBitcoin.RPC
 			return rpcFeeEstimationTasks
 					.Where(x => x.IsCompletedSuccessfully)
 					.Select(x => x.Result)
-					.ToDictionary(x=>x.Blocks, x=>x.FeeRate);
+					.ToDictionary(x => x.Blocks, x => x.FeeRate);
 		}
 
 		public static async Task<RpcStatus> GetRpcStatusAsync(this IRPCClient rpc, CancellationToken cancel)
@@ -207,7 +204,6 @@ namespace NBitcoin.RPC
 				return RpcStatus.Unresponsive;
 			}
 		}
-
 
 		public static async Task<(bool accept, string rejectReason)> TestMempoolAcceptAsync(this IRPCClient rpc, IEnumerable<Coin> coins, int fakeOutputCount, Money feePerInputs, Money feePerOutputs)
 		{

--- a/WalletWasabi/JsonConverters/FeeRatePerKbJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/FeeRatePerKbJsonConverter.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
-			var value = ((long)reader.Value);
+			var value = long.Parse(reader.Value.ToString());
 			return new FeeRate(new Money(value));
 		}
 


### PR DESCRIPTION
This PR simplifies the fetching of fee rates for confirmation targets in order to make advance in the integration of fee rates histograms into the fee rate estimations.

* Minimizes the number of queries to the node rpc by sending only one batch request with 14 target with fibonacci distance
* Makes the query failure resistant and ignores missing fee rate buckets (brainfarts)
* Creates new unit tests to verify the approach/implementation correctness
* Improves the serialization/deserialization of fee rates (uses FeeRate instances instead of more primitive type)
   