### PR TITLE
NodeBuildingTests.GetVersionTestsAsync: Increase timeout significantl…

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore;
 using WalletWasabi.Services;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 
@@ -84,12 +85,19 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			}
 		}
 
+		/// <summary>
+		/// Tests that Bitcoin Node reports correct <see cref="Constants.BitcoinCoreVersion" /> version.
+		/// </summary>
+		/// <remarks>
+		/// A few seconds may be enough for this test to run on a personal computer. However,
+		/// CI using parallelization and all available threads has hard time to finish it in a few seconds.
+		/// </remarks>
 		[Fact]
 		public async Task GetVersionTestsAsync()
 		{
-			using var cts = new CancellationTokenSource(7000);
+			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 			Version version = await CoreNode.GetVersionAsync(cts.Token);
-			Assert.Equal(WalletWasabi.Helpers.Constants.BitcoinCoreVersion, version);
+			Assert.Equal(Constants.BitcoinCoreVersion, version);
 		}
 	}
 }


### PR DESCRIPTION
…y to allow it finish on CI.

This is a temporary fix. The long term solution is, in my opinion, to move this test to integration tests which should run in serial order so that time-sensitive operations will finish in expected time.

This PR is part of #4152 project.