### PR TITLE
Improves fee rate estimations fetching

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -677,7 +677,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 						{
 							var target = feeEstimate.Key;
 							var fee = feeEstimate.Value;
-							if (FeeRate.SatoshiPerByte > fee)
+							if (FeeRate > fee)
 							{
 								feeTarget = target;
 								break;

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -1,3 +1,4 @@
+using NBitcoin;
 using NBitcoin.RPC;
 using Newtonsoft.Json;
 using System.Collections.Generic;
@@ -40,7 +41,6 @@ namespace WalletWasabi.Tests.UnitTests
 			JsonConvert.SerializeObject(deserialized,  new FeeRatePerKbJsonConverter());
 
 		}
-
 
 		[Fact]
 		public void AllFeeEstimateSerialization()
@@ -117,6 +117,181 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.Equal(2, allFee.Estimations.Count);
 			Assert.Equal(estimations[2], allFee.Estimations[2]);
 			Assert.Equal(estimations[4], allFee.Estimations[4]);
+		}
+
+		[Fact]
+		public async Task RpcNoEnoughEstimationsAsync()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 100,
+					Headers = 100
+				});
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new PeerInfo[0]);
+			rpc.OnGetMempoolInfoAsync = async () =>
+				await Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.00001000 // 1 s/b (default value) 
+				});
+			rpc.OnEstimateSmartFeeAsync = (target, _) =>
+				throw new NoEstimationException(target);
+
+			await Assert.ThrowsAsync<NoEstimationException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
+		}
+
+		[Fact]
+		public async Task RpcFailures()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = () =>
+				throw new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error", null);
+
+			rpc.OnEstimateSmartFeeAsync = (target, _) =>
+				throw new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error", null);
+
+			rpc.OnGetMempoolInfoAsync = async () =>
+				await Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.00001000 // 1 s/b (default value) 
+				});
+
+			var ex = await Assert.ThrowsAsync<RPCException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
+			Assert.Equal(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, ex.RPCCode);
+			Assert.Equal("Error", ex.Message);
+		}
+
+		[Fact]
+		public async Task ToleratesRpcFailures()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 100,
+					Headers = 100
+				});
+
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new PeerInfo[0]);
+			
+			rpc.OnGetMempoolInfoAsync = async () =>
+				await Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.00001000 // 1 s/b (default value) 
+				});
+			
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				await Task.FromResult(new EstimateSmartFeeResponse
+				{
+					Blocks = target,
+					FeeRate= target switch
+					{
+						2 => new FeeRate(100m),
+						3 => throw new RPCException(RPCErrorCode.RPC_INTERNAL_ERROR, "Error", null),
+						5 => new FeeRate(89m),
+						6 => new FeeRate(75m),
+						8 => new FeeRate(70m),
+						_ => throw new NoEstimationException(target)
+					}
+				});
+
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+			Assert.Equal(4, allFee.Estimations.Count);
+			Assert.False(allFee.Estimations.ContainsKey(3));
+			Assert.False(allFee.Estimations.ContainsKey(7));
+		}
+
+		[Fact]
+		public async Task InaccurateEstimations()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 1,
+					Headers = 2  // the node is not synchronized.
+				});
+
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new[] { new PeerInfo() });
+
+			rpc.OnGetMempoolInfoAsync = async () =>
+				await Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.00001000 // 1 s/b (default value) 
+				});
+
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				await Task.FromResult(new EstimateSmartFeeResponse
+				{
+					Blocks = target,
+					FeeRate= target switch
+					{
+						2 => new FeeRate(100m),
+						3 => new FeeRate(100m),
+						5 => new FeeRate(89m),
+						6 => new FeeRate(75m),
+						8 => new FeeRate(70m),
+						_ => throw new NoEstimationException(target)
+					}
+				});
+
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical);
+			Assert.False(allFee.IsAccurate);
+			Assert.Equal(4, allFee.Estimations.Count);
+			Assert.Equal(100, allFee.Estimations[2].SatoshiPerByte);
+			Assert.Equal(89, allFee.Estimations[5].SatoshiPerByte);
+			Assert.Equal(70, allFee.Estimations[8].SatoshiPerByte);
+			Assert.False(allFee.Estimations.ContainsKey(13));
+		}
+
+		[Fact]
+		public async Task AccurateEstimations()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnGetBlockchainInfoAsync = async () =>
+				await Task.FromResult(new BlockchainInfo
+				{
+					Blocks = 600_000,
+					Headers = 600_000
+				});
+
+			rpc.OnGetPeersInfoAsync = async () =>
+				await Task.FromResult(new[] { new PeerInfo() });
+
+			rpc.OnGetMempoolInfoAsync = async () =>
+				await Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.00001000 // 1 s/b (default value) 
+				});
+
+			rpc.OnEstimateSmartFeeAsync = async (target, _) =>
+				await Task.FromResult(new EstimateSmartFeeResponse
+				{
+					Blocks = target,
+					FeeRate= target switch
+					{
+						2 => new FeeRate(100m),
+						3 => new FeeRate(100m),
+						5 => new FeeRate(89m),
+						6 => new FeeRate(75m),
+						8 => new FeeRate(30m),
+						11 => new FeeRate(30m),
+						13 => new FeeRate(30m),
+						15 => new FeeRate(30m),
+						1008  => new FeeRate(35m),
+						_ => throw new NoEstimationException(target)
+					}
+				});
+
+			var allFee = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+			Assert.True(allFee.IsAccurate);
+			Assert.False(allFee.Estimations.ContainsKey(13));
+			Assert.False(allFee.Estimations.ContainsKey(1008));
+			Assert.Equal(30, allFee.Estimations[8].SatoshiPerByte);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -1,7 +1,13 @@
 using NBitcoin.RPC;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.JsonConverters;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests
@@ -9,17 +15,45 @@ namespace WalletWasabi.Tests.UnitTests
 	public class AllFeeEstimateTests
 	{
 		[Fact]
+		public void AllFeeEstimateDeserialization()
+		{
+			var serialized =
+				"{"
+				+ "\"allFeeEstimate\": {"
+					+ "\"type\": 0,"
+					+ "\"isAccurate\": true,"
+					+ "\"estimations\": {"
+						+ "\"2\": 32,"
+						+ "\"3\": 30,"
+						+ "\"4\": 28,"
+						+ "\"6\": 24,"
+						+ "\"8\": 5,"
+						+ "\"10\": 4,"
+						+ "\"73\": 3,"
+						+ "\"145\": 2,"
+						+ "\"505\": 1"
+						+ "}"
+					+ "}"
+				+ "}";
+
+			var deserialized = JsonConvert.DeserializeObject<SynchronizeResponse>(serialized, new FeeRatePerKbJsonConverter());
+			JsonConvert.SerializeObject(deserialized,  new FeeRatePerKbJsonConverter());
+
+		}
+
+
+		[Fact]
 		public void AllFeeEstimateSerialization()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 2, 102 },
-				{ 3, 20 },
-				{ 19, 1 }
+				{ 2, new FeeRate(102m) },
+				{ 3, new FeeRate(20m) },
+				{ 19, new FeeRate(1m) }
 			};
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
 			var serialized = JsonConvert.SerializeObject(allFee);
-			var deserialized = JsonConvert.DeserializeObject<AllFeeEstimate>(serialized);
+			var deserialized = JsonConvert.DeserializeObject<AllFeeEstimate>(serialized, new FeeRatePerKbJsonConverter());
 
 			Assert.Equal(estimations[2], deserialized.Estimations[2]);
 			Assert.Equal(estimations[3], deserialized.Estimations[3]);
@@ -30,11 +64,11 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateOrdersByTarget()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 3, 20 },
-				{ 2, 102 },
-				{ 19, 1 }
+				{ 3, new FeeRate(20m) },
+				{ 2, new FeeRate(102m) },
+				{ 19, new FeeRate(1m) }
 			};
 
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
@@ -46,10 +80,10 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateHandlesDuplicate()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 2, 20 },
-				{ 3, 20 }
+				{ 2, new FeeRate(20m) },
+				{ 3, new FeeRate(20m) },
 			};
 
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
@@ -60,23 +94,23 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void AllFeeEstimateHandlesInconsistentData()
 		{
-			var estimations = new Dictionary<int, int>
+			var estimations = new Dictionary<int, FeeRate>
 			{
-				{ 2, 20 },
-				{ 3, 21 }
+				{ 2, new FeeRate(20m) },
+				{ 3, new FeeRate(21m) },
 			};
 
 			var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
 			Assert.Single(allFee.Estimations);
 			Assert.Equal(estimations[2], allFee.Estimations[2]);
 
-			estimations = new Dictionary<int, int>
+			estimations = new Dictionary<int, FeeRate>
 			{
-				{ 5, 1000 },
-				{ 3, 21 },
-				{ 2, 20 },
-				{ 100, 100 },
-				{ 4, 4 },
+				{ 5, new FeeRate(1_000m) },
+				{ 3, new FeeRate(21m) },
+				{ 2, new FeeRate(20m) },
+				{ 100, new FeeRate(100m) },
+				{ 4, new FeeRate(4m) },
 			};
 
 			allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -159,12 +159,17 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			{
 				var rpc = coreNode.RpcClient;
 				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
-				Assert.Equal(143, estimations.Estimations.Count);
+				Assert.Equal(23, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
 				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
-				Assert.Equal(143, estimations.Estimations.Count);
+				Assert.Equal(23, estimations.Estimations.Count);
+				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
+				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
+				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
+				Assert.Equal(23, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -16,6 +16,8 @@ namespace WalletWasabi.Tests.UnitTests
 		public Func<Task<BlockchainInfo>> OnGetBlockchainInfoAsync { get; set; }
 		public Func<uint256, Task<VerboseBlockInfo>> OnGetVerboseBlockAsync { get; set; }
 		public Func<Task<MemPoolInfo>> OnGetMempoolInfoAsync { get; set; }
+		public Func<int, EstimateSmartFeeMode, Task<EstimateSmartFeeResponse>> OnEstimateSmartFeeAsync { get; set; }
+		public Func<Task<PeerInfo[]>> OnGetPeersInfoAsync { get; set; }
 
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new RPCCredentialString();
@@ -72,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<PeerInfo[]> GetPeersInfoAsync()
 		{
-			throw new NotImplementedException();
+			return OnGetPeersInfoAsync();
 		}
 
 		public Task<uint256[]> GetRawMempoolAsync()
@@ -102,12 +104,13 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public IRPCClient PrepareBatch()
 		{
-			throw new NotImplementedException();
+			return this;
 		}
 
 		public Task SendBatchAsync()
 		{
-			throw new NotImplementedException();
+			// do nothing here
+			return Task.CompletedTask;
 		}
 
 		public Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
@@ -167,7 +170,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
 		{
-			throw new NotImplementedException();
+			return OnEstimateSmartFeeAsync(confirmationTarget, estimateMode);
 		}
 
 		public Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Monitoring;
@@ -42,6 +44,11 @@ namespace NBitcoin.RPC
 			return resp;
 		}
 
+		private static Dictionary<int, FeeRate> SimulateRegTestFeeEstimation(EstimateSmartFeeMode estimateMode) =>
+			Constants.FeeTargets
+			.Select(target => SimulateRegTestFeeEstimation(target, estimateMode))
+			.ToDictionary(x => x.Blocks, x => x.FeeRate);
+
 		/// <summary>
 		/// If null is returned, no exception is thrown, so the test was successful.
 		/// </summary>
@@ -64,9 +71,46 @@ namespace NBitcoin.RPC
 			var rpcStatus = await rpc.GetRpcStatusAsync(CancellationToken.None).ConfigureAwait(false);
 			var mempoolInfo = await rpc.GetMempoolInfoAsync().ConfigureAwait(false);
 			var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
-			var estimations = await rpc.EstimateHalfFeesAsync(new Dictionary<int, int>(), 2, 0, Constants.SevenDaysConfirmationTarget, 0, sanityFeeRate, estimateMode, simulateIfRegTest).ConfigureAwait(false);
-			var allFeeEstimate = new AllFeeEstimate(estimateMode, estimations, rpcStatus.Synchronized);
-			return allFeeEstimate;
+
+			var estmimations = (simulateIfRegTest && rpc.Network == Network.RegTest)
+				? SimulateRegTestFeeEstimation(estimateMode)
+				: await GetFeeEstimationsAsync(rpc, estimateMode);
+
+			return new AllFeeEstimate(
+				estimateMode,
+				estmimations,
+				rpcStatus.Synchronized);
+		}
+
+		private static async Task<Dictionary<int, FeeRate>> GetFeeEstimationsAsync(IRPCClient rpc, EstimateSmartFeeMode estimateMode)
+		{
+			var batchClient = rpc.PrepareBatch();
+
+			var rpcFeeEstimationTasks = Constants.FeeTargets
+				.Select(target => batchClient.EstimateSmartFeeAsync(target, estimateMode))
+				.ToList();
+
+			await batchClient.SendBatchAsync().ConfigureAwait(false);
+
+			var allTask = Task.WhenAll(rpcFeeEstimationTasks);
+
+			try
+			{
+				await allTask;
+			}
+			catch
+			{
+				if (rpcFeeEstimationTasks.All(x => x.IsFaulted))
+				{
+					throw rpcFeeEstimationTasks[0].Exception?.InnerExceptions[0] 
+						?? new Exception($"{nameof(GetFeeEstimationsAsync)} failed to fetch fee estimations.");
+				}
+			}
+
+			return rpcFeeEstimationTasks
+				.Where(x => x.IsCompletedSuccessfully)
+				.Select(x => x.Result)
+				.ToDictionary(x => x.Blocks, x => x.FeeRate);
 		}
 
 		public static async Task<RpcStatus> GetRpcStatusAsync(this IRPCClient rpc, CancellationToken cancel)
@@ -79,69 +123,11 @@ namespace NBitcoin.RPC
 
 				return RpcStatus.Responsive(bci.Headers, bci.Blocks, pi.Length);
 			}
-			catch (Exception ex) when (ex is not OperationCanceledException and not TimeoutException)
+			catch (Exception ex) when (!(ex is OperationCanceledException || ex is TaskCanceledException || ex is TimeoutException))
 			{
 				Logger.LogTrace(ex);
 				return RpcStatus.Unresponsive;
 			}
-		}
-
-		private static async Task<Dictionary<int, int>> EstimateHalfFeesAsync(this IRPCClient rpc, IDictionary<int, int> estimations, int smallTarget, int smallTargetFee, int largeTarget, int largeTargetFee, FeeRate sanityFeeRate, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
-		{
-			var newEstimations = new Dictionary<int, int>();
-			foreach (var est in estimations)
-			{
-				newEstimations.TryAdd(est.Key, est.Value);
-			}
-
-			if (Math.Abs(smallTarget - largeTarget) <= 1)
-			{
-				return newEstimations;
-			}
-
-			if (smallTargetFee == 0)
-			{
-				var smallTargetFeeResult = await rpc.EstimateSmartFeeAsync(smallTarget, sanityFeeRate, estimateMode, simulateIfRegTest).ConfigureAwait(false);
-				smallTargetFee = (int)Math.Ceiling(smallTargetFeeResult.FeeRate.SatoshiPerByte);
-				newEstimations.TryAdd(smallTarget, smallTargetFee);
-			}
-
-			if (largeTargetFee == 0)
-			{
-				var largeTargetFeeResult = await rpc.EstimateSmartFeeAsync(largeTarget, sanityFeeRate, estimateMode, simulateIfRegTest).ConfigureAwait(false);
-				largeTargetFee = (int)Math.Ceiling(largeTargetFeeResult.FeeRate.SatoshiPerByte);
-
-				// Blocks should never be larger than the target that we asked for, so it's just a sanity check.
-				largeTarget = Math.Min(largeTarget, largeTargetFeeResult.Blocks);
-				newEstimations.TryAdd(largeTarget, largeTargetFee);
-			}
-
-			int halfTarget = (smallTarget + largeTarget) / 2;
-			var halfFeeResult = await rpc.EstimateSmartFeeAsync(halfTarget, sanityFeeRate, estimateMode, simulateIfRegTest).ConfigureAwait(false);
-			int halfTargetFee = (int)Math.Ceiling(halfFeeResult.FeeRate.SatoshiPerByte);
-
-			// Blocks should never be larger than the target that we asked for, so it's just a sanity check.
-			halfTarget = Math.Min(halfTarget, halfFeeResult.Blocks);
-			newEstimations.TryAdd(halfTarget, halfTargetFee);
-
-			if (smallTargetFee > halfTargetFee)
-			{
-				var smallEstimations = await rpc.EstimateHalfFeesAsync(newEstimations, smallTarget, smallTargetFee, halfTarget, halfTargetFee, sanityFeeRate, estimateMode, simulateIfRegTest).ConfigureAwait(false);
-				foreach (var est in smallEstimations)
-				{
-					newEstimations.TryAdd(est.Key, est.Value);
-				}
-			}
-			if (largeTargetFee < halfTargetFee)
-			{
-				var largeEstimations = await rpc.EstimateHalfFeesAsync(newEstimations, halfTarget, halfTargetFee, largeTarget, largeTargetFee, sanityFeeRate, estimateMode, simulateIfRegTest).ConfigureAwait(false);
-				foreach (var est in largeEstimations)
-				{
-					newEstimations.TryAdd(est.Key, est.Value);
-				}
-			}
-
-			return newEstimations;
 		}
 
 		public static async Task<(bool accept, string rejectReason)> TestMempoolAcceptAsync(this IRPCClient rpc, IEnumerable<Coin> coins, int fakeOutputCount, Money feePerInputs, Money feePerOutputs)

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -92,6 +92,12 @@ namespace WalletWasabi.Helpers
 
 		public static readonly int RangeProofWidth = (int)Math.Log2(MaximumNumberOfSatoshis);
 
+		public static readonly int[] FeeTargets = new int[]
+		{
+			2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 17, 20, 25, 30, 40, 50, 60, 70, 80,
+			100, 120, 140, 170, 200, 250, 300, 400, 500, 600, 700, 800, 1000
+		};
+
 		public static Money MinimumCredentailAmount = Money.Satoshis(10_000);
 
 		public static Money MaximumCredentailAmount = Money.Satoshis(MaximumNumberOfSatoshis);

--- a/WalletWasabi/JsonConverters/FeeRatePerKbJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/FeeRatePerKbJsonConverter.cs
@@ -1,0 +1,28 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using System;
+
+namespace WalletWasabi.JsonConverters
+{
+	public class FeeRatePerKbJsonConverter : JsonConverter
+	{
+		/// <inheritdoc />
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(FeeRate);
+		}
+
+		/// <inheritdoc />
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var value = long.Parse(reader.Value.ToString());
+			return new FeeRate(new Money(value));
+		}
+
+		/// <inheritdoc />
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(((FeeRate)value).FeePerK.Satoshi.ToString());
+		}
+	}
+}

--- a/WalletWasabi/Tor/Http/Extensions/HttpContentExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpContentExtensions.cs
@@ -17,7 +17,11 @@ namespace WalletWasabi.Tor.Http.Extensions
 
 			var settings = new JsonSerializerSettings
 			{
-				Converters = new[] { new RoundStateResponseJsonConverter(WasabiClient.ApiVersion) }
+				Converters = new JsonConverter[]
+				{ 
+					new RoundStateResponseJsonConverter(WasabiClient.ApiVersion),
+					new FeeRatePerKbJsonConverter()
+				}
 			};
 			var jsonString = await me.ReadAsStringAsync().ConfigureAwait(false);
 			return JsonConvert.DeserializeObject<T>(jsonString, settings);


### PR DESCRIPTION
Currently Wasabi uses the estimated fee rates provided by the backend's bitcoin full node which are the result of observing of how long it took to transactions to confirm based on how much they paid. This means that those estimations use data fee rates paid by transactions on the past to predict how much a transaction has to pay to confirm in a given future.

However, advanced human users do something completely different, they check how much other users are currently paying and how strong is the pressure over the mempool. For example, if there is a lot of transactions in a growing mempool where there are a few people paying 600 sats/vbyte, it doesn't matter than 2 hours ago transactions confirmed in 3 blocks by paying 5 sats/vbytes, the past is somehow irrelevant in these cases.

Bitcoin Knots provides that information in the `getmempoolinfo`and allows us to see how much other are paying and how many they are (transactions) so, we can include this info to improve our estimations.

---------------------------
    
This PR simplifies the fetching of _fee rates_ for confirmation targets in order to make progress in the integration of _fee rates histograms_ into the fee rate estimations.

* Minimizes the number of queries to the node rpc by sending only one batch request with targets in a logarithmic scale  distance.
* Makes the query failure resistant and ignores missing fee rate buckets (brainfarts)
* Creates new unit tests to verify the approach/implementation correctness
* Improves the serialization/deserialization of fee rates (uses FeeRate instances instead of more primitive type)

------------------------------------------

The best way to review this PR is commit by commit.   

This is part of the https://github.com/zkSNACKs/WalletWasabi/issues/4154 project.