### PR TITLE
Receive change in the first clean change address

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -146,7 +146,7 @@ namespace WalletWasabi.Blockchain.Transactions
 			{
 				KeyManager.AssertCleanKeysIndexed(isInternal: true);
 				KeyManager.AssertLockedInternalKeysIndexed(14);
-				changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
+				changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).FirstOrDefault();
 
 				builder.SetChange(changeHdPubKey.P2wpkhScript);
 			}


### PR DESCRIPTION
Fixes #4172

Currently when you make a transaction that generates change, the change goes to a random address from the list of clean change addresses. The standard behavior is to receive the change in the first clean change address.

Used `FirstOrDefault()` because `RandomElement()` returns `default` if there is no element. https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Extensions/LinqExtensions.cs#L44-L61