### PR TITLE
Use MSBuild instead of C# code for copying resources to "dist" folder.

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -422,7 +422,6 @@ namespace WalletWasabi.Packager
 						$"--runtime \"{target}\"",
 						$"--disable-parallel",
 						$"--no-cache",
-						$"/p:WasabiPackagerRuntimeIdentifier=\"{target}\"",
 						$"/p:VersionPrefix={VersionPrefix}",
 						$"/p:DebugType=none",
 						$"/p:DebugSymbols=false",

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -337,12 +337,12 @@ namespace WalletWasabi.Packager
 
 			using (var process = Process.Start(new ProcessStartInfo
 			{
-				FileName = "cmd",
+				FileName = "dotnet",
+				Arguments = "clean --configuration Release",
 				RedirectStandardInput = true,
 				WorkingDirectory = GuiProjectDirectory
 			}))
 			{
-				process.StandardInput.WriteLine("dotnet clean --configuration Release && exit");
 				process.WaitForExit();
 			}
 

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -422,6 +422,7 @@ namespace WalletWasabi.Packager
 						$"--runtime \"{target}\"",
 						$"--disable-parallel",
 						$"--no-cache",
+						$"/p:WasabiPackagerRuntimeIdentifier=\"{target}\"",
 						$"/p:VersionPrefix={VersionPrefix}",
 						$"/p:DebugType=none",
 						$"/p:DebugSymbols=false",
@@ -442,41 +443,6 @@ namespace WalletWasabi.Packager
 				}
 
 				Tools.ClearSha512Tags(currentBinDistDirectory);
-
-				// Remove Tor binaries that are not relevant to the platform.
-				var torFolder = new DirectoryInfo(Path.Combine(currentBinDistDirectory, "TorDaemons"));
-				var toNotRemove = "";
-				if (target.StartsWith("win"))
-				{
-					toNotRemove = "win";
-				}
-				else if (target.StartsWith("linux"))
-				{
-					toNotRemove = "lin";
-				}
-				else if (target.StartsWith("osx"))
-				{
-					toNotRemove = "osx";
-				}
-
-				foreach (var file in torFolder.EnumerateFiles())
-				{
-					if (!file.Name.Contains("data", StringComparison.OrdinalIgnoreCase) && !file.Name.Contains(toNotRemove, StringComparison.OrdinalIgnoreCase))
-					{
-						File.Delete(file.FullName);
-					}
-				}
-
-				// Remove binaries that are not relevant to the platform.
-				var binaryFolder = new DirectoryInfo(Path.Combine(currentBinDistDirectory, "Microservices", "Binaries"));
-
-				foreach (var dir in binaryFolder.EnumerateDirectories())
-				{
-					if (!dir.Name.Contains(toNotRemove, StringComparison.OrdinalIgnoreCase))
-					{
-						IoHelpers.TryDeleteDirectoryAsync(dir.FullName).GetAwaiter().GetResult();
-					}
-				}
 
 				// Rename the final exe.
 				string oldExecutablePath;

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -53,7 +53,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="$(WasabiPackagerRuntimeIdentifier.StartsWith('linux')) Or $(WasabiPackagerRuntimeIdentifier) == ''">
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux')) Or $(RuntimeIdentifier) == ''">
     <None Update="Microservices\Binaries\lin64\bitcoind">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -65,7 +65,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="$(WasabiPackagerRuntimeIdentifier.StartsWith('osx')) Or $(WasabiPackagerRuntimeIdentifier) == ''">
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('osx')) Or $(RuntimeIdentifier) == ''">
     <None Update="Microservices\Binaries\osx64\bitcoind">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -77,7 +77,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="$(WasabiPackagerRuntimeIdentifier.StartsWith('win')) Or $(WasabiPackagerRuntimeIdentifier) == ''">
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('win')) Or $(RuntimeIdentifier) == ''">
     <None Update="Microservices\Binaries\win64\bitcoind.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PlatformTarget>x64</PlatformTarget>
@@ -36,24 +36,6 @@
     <None Update="Legal\Assets\LegalDocuments.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Microservices\Binaries\lin64\bitcoind">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Microservices\Binaries\osx64\bitcoind">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Microservices\Binaries\win64\bitcoind.exe">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Microservices\Binaries\lin64\hwi">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Microservices\Binaries\osx64\hwi">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Microservices\Binaries\win64\hwi.exe">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="OnionSeeds\MainOnionSeeds.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -69,10 +51,37 @@
     <None Update="TorDaemons\Data.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(WasabiPackagerRuntimeIdentifier.StartsWith('linux')) Or $(WasabiPackagerRuntimeIdentifier) == ''">
+    <None Update="Microservices\Binaries\lin64\bitcoind">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Microservices\Binaries\lin64\hwi">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TorDaemons\tor-linux64.zip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(WasabiPackagerRuntimeIdentifier.StartsWith('osx')) Or $(WasabiPackagerRuntimeIdentifier) == ''">
+    <None Update="Microservices\Binaries\osx64\bitcoind">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Microservices\Binaries\osx64\hwi">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TorDaemons\tor-osx64.zip">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(WasabiPackagerRuntimeIdentifier.StartsWith('win')) Or $(WasabiPackagerRuntimeIdentifier) == ''">
+    <None Update="Microservices\Binaries\win64\bitcoind.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Microservices\Binaries\win64\hwi.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="TorDaemons\tor-win64.zip">


### PR DESCRIPTION
This PR attempts to clean up Packager. I find it better to deploy only needed files rather than deploy everything and remove not-needed files.

**Notes:**

* I did not change content of `<CopyToOutputDirectory>XXX</CopyToOutputDirectory>` occurrences. Sometimes it is set to "always" sometimes it is set to "PreserveNewest". Does anyone know why it is like that?