### PR TITLE
Disable Load button if hww is already loaded

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
@@ -25,6 +25,7 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Hwi;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Logging;
+using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 {
@@ -51,6 +52,13 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 				.Subscribe(_ =>
 				{
 					SelectedWallet = Wallets.FirstOrDefault();
+
+					if (SelectedWallet is { })
+					{
+						Wallet wallet = WalletManager.GetWalletByName(SelectedWallet.WalletName);
+						SelectedWallet.IsHardwareWalletLoaded = wallet.State == WalletState.Started;
+					}
+
 					SetLoadButtonText();
 				});
 
@@ -66,7 +74,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => SetLoadButtonText());
 
-			LoadCommand = ReactiveCommand.CreateFromTask(LoadWalletAsync, this.WhenAnyValue(x => x.SelectedWallet, x => x.IsBusy).Select(x => x.Item1 is { } && !x.Item2));
+			LoadCommand = ReactiveCommand.CreateFromTask(LoadWalletAsync, this.WhenAnyValue(x => x.SelectedWallet.IsHardwareWalletLoaded).Select(x => !x));
 			ImportColdcardCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
 				var ofd = new OpenFileDialog

--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/HardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/HardwareWalletViewModel.cs
@@ -37,6 +37,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 
 		public string WalletName { get; }
 		public HwiEnumerateEntry HardwareWalletInfo { get; }
+		public bool IsHardwareWalletLoaded { get; set; }
 
 		public override string ToString()
 		{


### PR DESCRIPTION
Fixes #3464, and fixes #3930

I am not sure if this is the correct way to implement this, but it works.

I tested it with only one hardware wallet connected, so please someone with multiple hardware wallets test this.