### PR TITLE
Fix null warnings for `out`s

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -247,7 +247,7 @@ namespace WalletWasabi.Backend.Controllers
 				{
 					foreach (var txid in parsedIds)
 					{
-						if (TransactionHexCache.TryGetValue(txid, out string hex))
+						if (TransactionHexCache.TryGetValue(txid, out var hex))
 						{
 							hexes.Add(txid, hex);
 						}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -345,7 +345,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				}
 				try
 				{
-					PasswordHelper.GetMasterExtKey(Wallet.KeyManager, Password, out string compatiblityPassword); // If the password is not correct we throw.
+					PasswordHelper.GetMasterExtKey(Wallet.KeyManager, Password, out var compatiblityPassword); // If the password is not correct we throw.
 
 					if (compatiblityPassword != null)
 					{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -323,7 +323,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					{
 						try
 						{
-							PasswordHelper.GetMasterExtKey(Wallet.KeyManager, Password, out string compatiblityPasswordUsed); // We could use TryPassword but we need the exception.
+							PasswordHelper.GetMasterExtKey(Wallet.KeyManager, Password, out var compatiblityPasswordUsed); // We could use TryPassword but we need the exception.
 							if (compatiblityPasswordUsed != null)
 							{
 								Password = compatiblityPasswordUsed; // Overwrite the password for BuildTransaction function.

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoViewModel.cs
@@ -45,7 +45,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 					else
 					{
-						var secret = PasswordHelper.GetMasterExtKey(Wallet.KeyManager, Password, out string isCompatibilityPasswordUsed);
+						var secret = PasswordHelper.GetMasterExtKey(Wallet.KeyManager, Password, out var isCompatibilityPasswordUsed);
 						Password = "";
 
 						if (isCompatibilityPasswordUsed != null)

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
@@ -161,7 +161,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.LoadWallets
 				// Only check requirepassword here, because the above checks are applicable to loadwallet, too and we are using this function from load wallet.
 				if (IsPasswordRequired)
 				{
-					if (PasswordHelper.TryPassword(keyManager, password, out string compatibilityPasswordUsed))
+					if (PasswordHelper.TryPassword(keyManager, password, out var compatibilityPasswordUsed))
 					{
 						NotificationHelpers.Success("Correct password.");
 						if (compatibilityPasswordUsed != null)

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTests.cs
@@ -62,11 +62,11 @@ bar
 
 			var configDic = coreConfig.ToDictionary();
 
-			Assert.True(configDic.TryGetValue("foo", out string v1));
-			Assert.True(configDic.TryGetValue("too", out string v2));
+			Assert.True(configDic.TryGetValue("foo", out var v1));
+			Assert.True(configDic.TryGetValue("too", out var v2));
 			Assert.False(configDic.TryGetValue("qoo", out _));
 			Assert.False(configDic.TryGetValue("bar", out _));
-			Assert.True(configDic.TryGetValue("foo bar", out string v3));
+			Assert.True(configDic.TryGetValue("foo bar", out var v3));
 
 			Assert.Equal("bar", v1);
 			Assert.Equal("1", v2);
@@ -77,11 +77,11 @@ bar
 
 			var configDic2 = coreConfig2.ToDictionary();
 
-			Assert.True(configDic2.TryGetValue("foo", out string v1_2));
-			Assert.True(configDic2.TryGetValue("too", out string v2_2));
+			Assert.True(configDic2.TryGetValue("foo", out var v1_2));
+			Assert.True(configDic2.TryGetValue("too", out var v2_2));
 			Assert.False(configDic2.TryGetValue("qoo", out _));
 			Assert.False(configDic2.TryGetValue("bar", out _));
-			Assert.True(configDic2.TryGetValue("foo bar", out string v3_3));
+			Assert.True(configDic2.TryGetValue("foo bar", out var v3_3));
 
 			Assert.Equal("bar", v1_2);
 			Assert.Equal("1", v2_2);
@@ -101,9 +101,9 @@ bar
 			configDic = coreConfig.ToDictionary();
 			configDic2 = coreConfig2.ToDictionary();
 
-			Assert.True(configDic.TryGetValue("moo", out string mooValue));
-			Assert.True(configDic.TryGetValue("foo", out string fooValue));
-			Assert.True(configDic.TryGetValue("too", out string tooValue));
+			Assert.True(configDic.TryGetValue("moo", out var mooValue));
+			Assert.True(configDic.TryGetValue("foo", out var fooValue));
+			Assert.True(configDic.TryGetValue("too", out var tooValue));
 			Assert.Equal("1", mooValue);
 			Assert.Equal("bar", fooValue);
 			Assert.Equal("0", tooValue);

--- a/WalletWasabi.Tests/UnitTests/PasswordTests.cs
+++ b/WalletWasabi.Tests/UnitTests/PasswordTests.cs
@@ -104,10 +104,10 @@ namespace WalletWasabi.Tests.UnitTests
 			// This should pass
 			Assert.NotNull(PasswordHelper.GetMasterExtKey(keyManager, original, out _));
 
-			Assert.True(PasswordHelper.TryPassword(keyManager, buggy, out string compatiblePasswordNotUsed));
+			Assert.True(PasswordHelper.TryPassword(keyManager, buggy, out var compatiblePasswordNotUsed));
 			Assert.Null(compatiblePasswordNotUsed);
 
-			Assert.True(PasswordHelper.TryPassword(keyManager, original, out string compatiblePassword));
+			Assert.True(PasswordHelper.TryPassword(keyManager, original, out var compatiblePassword));
 			Assert.Equal(buggy, compatiblePassword);
 			Logger.TurnOn();
 		}

--- a/WalletWasabi/Blockchain/Blocks/SmartHeaderChain.cs
+++ b/WalletWasabi/Blockchain/Blocks/SmartHeaderChain.cs
@@ -71,7 +71,7 @@ namespace WalletWasabi.Blockchain.Blocks
 		{
 			lock (Lock)
 			{
-				if (Chain.TryGetValue(TipHeight, out SmartHeader lastHeader))
+				if (Chain.TryGetValue(TipHeight, out var lastHeader))
 				{
 					if (lastHeader.BlockHash != header.PrevHash)
 					{

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -238,7 +238,7 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 				foreach (var coin in Coins.AsAllCoinsView())
 				{
 					// If spends any of our coin
-					if (prevOutSet.TryGetValue(coin.OutPoint, out OutPoint input))
+					if (prevOutSet.TryGetValue(coin.OutPoint, out var input))
 					{
 						var alreadyKnown = coin.SpenderTransactionId == txId;
 						coin.SpenderTransactionId = txId;

--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -164,7 +164,7 @@ namespace WalletWasabi.Blockchain.Transactions
 		{
 			var hash = tx.GetHash();
 
-			if (Transactions.TryGetValue(hash, out SmartTransaction found))
+			if (Transactions.TryGetValue(hash, out var found))
 			{
 				return found.TryUpdate(tx);
 			}

--- a/WalletWasabi/CoinJoin/Coordinator/Banning/UtxoReferee.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Banning/UtxoReferee.cs
@@ -93,7 +93,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Banning
 			foreach (var utxo in toBan)
 			{
 				BannedUtxo foundElem = null;
-				if (BannedUtxos.TryGetValue(utxo, out BannedUtxo fe))
+				if (BannedUtxos.TryGetValue(utxo, out var fe))
 				{
 					foundElem = fe;
 					bool bannedForTheSameRound = foundElem.BannedForRound == bannedForRound;
@@ -161,7 +161,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Banning
 
 		public async Task<BannedUtxo> TryGetBannedAsync(OutPoint outpoint, bool notedToo)
 		{
-			if (BannedUtxos.TryGetValue(outpoint, out BannedUtxo bannedElem))
+			if (BannedUtxos.TryGetValue(outpoint, out var bannedElem))
 			{
 				int maxBan = (int)TimeSpan.FromHours(RoundConfig.DosDurationHours).TotalMinutes;
 				int banLeftMinutes = maxBan - (int)bannedElem.BannedRemaining.TotalMinutes;

--- a/WalletWasabi/Extensions/MemoryExtensions.cs
+++ b/WalletWasabi/Extensions/MemoryExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Caching.Memory
 			lock (AsyncLocksLock)
 			{
 				// If we have no dic for the cache yet then create one.
-				if (!AsyncLocks.TryGetValue(cache, out Dictionary<object, AsyncLock> cacheDic))
+				if (!AsyncLocks.TryGetValue(cache, out var cacheDic))
 				{
 					cacheDic = new Dictionary<object, AsyncLock>();
 					AsyncLocks.Add(cache, cacheDic);

--- a/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/ECISet.cs
+++ b/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/ECISet.cs
@@ -168,7 +168,7 @@ namespace Gma.QrCodeNet.Encoding.DataEncodation
 				Initialize(AppendOption.ValueToName);
 			}
 
-			if (_valueToName.TryGetValue(eCIValue, out string eCIName))
+			if (_valueToName.TryGetValue(eCIValue, out var eCIName))
 			{
 				return eCIName;
 			}

--- a/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncMutex.cs
@@ -34,7 +34,7 @@ namespace Nito.AsyncEx
 			// If we already have an asynclock with this fullname then just use it and do not create a new one.
 			lock (AsyncMutexesLock)
 			{
-				if (AsyncMutexes.TryGetValue(FullName, out AsyncMutex asyncMutex))
+				if (AsyncMutexes.TryGetValue(FullName, out var asyncMutex))
 				{
 					// Use the already existing lock.
 					AsyncLock = asyncMutex.AsyncLock;


### PR DESCRIPTION
Using `var`s for `out`s is fine, a better solution could be to start using `[NotNullWhen(true)]` annotation for the `out` parameter when we implement the TryGet/TryParse pattern and not just using it from a library.

https://www.meziantou.net/csharp-8-nullable-reference-types.htm

This can be a PR in itself or if you agree then go ahead and do the annotations, too.