### PR TITLE
Remove unused const

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -52,8 +52,6 @@ namespace WalletWasabi.Helpers
 
 		public const decimal DefaultDustThreshold = 0.00005m;
 
-		public const long MaxSatoshisSupply = 2_100_000_000_000_000L;
-
 		public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 		public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 


### PR DESCRIPTION
As pointed out twice https://github.com/zkSNACKs/WalletWasabi/pull/4036#issuecomment-663082174 & https://github.com/zkSNACKs/WalletWasabi/pull/4036#pullrequestreview-464687067 `MaxSatoshisSupply` is no longer used.

There are other constants that are not used, should those also get removed?
https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Helpers/Constants.cs#L39-L41
https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Helpers/Constants.cs#L81-L94