### PR TITLE
Do NOT advise to write down the password

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWallets/GenerateWalletSuccessView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWallets/GenerateWalletSuccessView.xaml
@@ -3,7 +3,7 @@
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              x:Class="WalletWasabi.Gui.Tabs.WalletManager.GenerateWallets.GenerateWalletSuccessView">
   <StackPanel Margin="10" Spacing="5">
-    <TextBlock Text="Write down these Recovery Words and Your Password" FontWeight="Bold" />
+    <TextBlock Text="Write down these Recovery Words and memorize Your Password" FontWeight="Bold" />
     <Border Padding="10" Margin="10 0" HorizontalAlignment="Center">
       <ItemsControl Items="{Binding MnemonicWords}">
         <ItemsControl.Styles>
@@ -23,7 +23,7 @@
     <TextBlock Text="You can recover your wallet on any computer with" />
     <TextBlock Text="- your Recovery Words AND" />
     <TextBlock Text="- your Password." />
-    <CheckBox Margin="0 10 0 0" HorizontalAlignment="Center" IsChecked="{Binding IsConfirmed}" Content="I have written down my password and recovery words." />
+    <CheckBox Margin="0 10 0 0" HorizontalAlignment="Center" IsChecked="{Binding IsConfirmed}" Content="I have written down my recovery words and memorized my my password." />
     <Button Margin="0 10 0 0" HorizontalAlignment="Center" Content="Generate Wallet" Command="{Binding ConfirmCommand}" />
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
The reason why we salt the recovery words with the password is for those two to not be in the same place physically, thus both has to be hacked in order to gain access to the user's wallet. Or more specifically an attacker would have to break into

- the user's mind (to get the password/passphrase)

AND to one of the following places:

- the user's house (to get the mnemonics)
- the user's computer (to get the wallet file)