### PR TITLE
Improve HWI tests.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Hwi/SerialDefaultResponseTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/SerialDefaultResponseTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Hwi.ProcessBridge;
 using WalletWasabi.Microservices;
 using Xunit;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Tests.UnitTests.Hwi
 {
@@ -17,19 +18,36 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 	{
 		public TimeSpan ReasonableRequestTimeout { get; } = TimeSpan.FromMinutes(1);
 
+		/// <summary>Verify that <c>--version</c> argument returns output as expected.</summary>
 		[Fact]
-		public async Task HwiProcessBridgeTestAsync()
+		public async Task HwiVersionTestAsync()
 		{
+			using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+
 			var pb = new HwiProcessBridge(new ProcessInvoker());
 
-			using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
-			var res = await pb.SendCommandAsync("version", false, cts.Token);
-			Assert.NotEmpty(res.response);
+			// Start HWI with "version" argument and test that we get non-empty response.
+			(string response, int exitCode) result = await pb.SendCommandAsync("--version", openConsole: false, cts.Token);
+			Assert.Contains(Constants.HwiVersion.ToString(), result.response);
 
+			// Start HWI with "version" argument and test that we get non-empty response + verify that "standardInputWriter" is actually called.
 			bool stdInputActionCalled = false;
-			res = await pb.SendCommandAsync("version", false, cts.Token, (sw) => stdInputActionCalled = true);
-			Assert.NotEmpty(res.response);
+			result = await pb.SendCommandAsync("--version", openConsole: false, cts.Token, (sw) => stdInputActionCalled = true);
+			Assert.Contains(Constants.HwiVersion.ToString(), result.response);
 			Assert.True(stdInputActionCalled);
+		}
+
+		/// <summary>Verify that <c>--help</c> returns output as expected.</summary>
+		[Fact]
+		public async void HwiHelpTestAsync()
+		{
+			using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+
+			var processBridge = new HwiProcessBridge(new ProcessInvoker());
+			(string response, int exitCode) result = await processBridge.SendCommandAsync("--help", openConsole: false, cts.Token);
+
+			Assert.Equal(0, result.exitCode);
+			Assert.Equal(@"{""error"": ""Help text requested"", ""code"": -17}" + Environment.NewLine, result.response);
 		}
 	}
 }


### PR DESCRIPTION
This is part of #3863 project.

* Fixes `HwiProcessBridgeTestAsync` as it uses:

    ```csharp
    var res = await pb.SendCommandAsync("version", false, cts.Token);
    ```
   which is incorrect because `--version` should be passed instead of `version`. Previous behavior was that an error message (string) in JSON was returned (on my Windows 10 machine). `Constants.HwiVersion` is used to verify the actual version.

* New test `HwiHelpTestAsync` asserts JSON response format.
