### PR TITLE
Make P2pBasedTests serial.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/SerialP2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/SerialP2pBasedTests.cs
@@ -18,7 +18,13 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 {
-	public class P2pBasedTests
+	/// <summary>
+	/// The tests in this collection are time-sensitive, therefore this test collection is run in a special way:
+	/// Parallel-capable test collections will be run first (in parallel), followed by parallel-disabled test collections (run sequentially) like this one.
+	/// </summary>
+	/// <seealso href="https://xunit.net/docs/running-tests-in-parallel.html#parallelism-in-test-frameworks"/>
+	[Collection("Serial unit tests collection")]
+	public class SerialP2pBasedTests
 	{
 		[Fact]
 		public async Task MempoolNotifiesAsync()


### PR DESCRIPTION
This PR is part of #4152 project. It converts `P2pBasedTests` to `SerialP2pBasedTests` as the tests are time-sensitive and prone to be flaky.

I'm aware of the Lucas' suggestion which I have added as an issue here: https://github.com/zkSNACKs/WalletWasabi/issues/4260 but I find it better to make tests as stable as possible as soon as possible. 