### PR TITLE
Nit - Fix typo

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/GenerateWallets/GenerateWalletSuccessView.xaml
+++ b/WalletWasabi.Gui/Tabs/WalletManager/GenerateWallets/GenerateWalletSuccessView.xaml
@@ -23,7 +23,7 @@
     <TextBlock Text="You can recover your wallet on any computer with" />
     <TextBlock Text="- your Recovery Words AND" />
     <TextBlock Text="- your Password." />
-    <CheckBox Margin="0 10 0 0" HorizontalAlignment="Center" IsChecked="{Binding IsConfirmed}" Content="I have written down my recovery words and memorized my my password." />
+    <CheckBox Margin="0 10 0 0" HorizontalAlignment="Center" IsChecked="{Binding IsConfirmed}" Content="I have written down my recovery words and memorized my password." />
     <Button Margin="0 10 0 0" HorizontalAlignment="Center" Content="Generate Wallet" Command="{Binding ConfirmCommand}" />
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
FWIW, I agree with @yahiheb [comment](https://github.com/zkSNACKs/WalletWasabi/pull/4257#pullrequestreview-478069277).

If the goal is to encourage users to keep mnemonic and password separate, then why not to tell them exactly that? Telling them to memorize the password does not tell them to keep them separate; e.g., I can imagine users that memorize the password because so the wallet says, but they also write it down next to the mnemonic for good measure (since no one is telling them to keep them separate).