### PR TITLE
Fix CodeFactor issues

### DIFF
--- a/WalletWasabi.Tests/UnitTests/HashChainTests.cs
+++ b/WalletWasabi.Tests/UnitTests/HashChainTests.cs
@@ -87,68 +87,47 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.PropertyChanged(
 				hashChain,
 				nameof(hashChain.ServerTipHeight),
-
-				// ASSERT FUNCTION
-				// Assert update server height raises.
-				() => hashChain.UpdateServerTipHeight(newServerHeight));
+				() => hashChain.UpdateServerTipHeight(newServerHeight)); // ASSERT FUNCTION. Assert update server height raises.
 
 			newServerHeight++;
 			Assert.PropertyChanged(
 				hashChain,
 				nameof(hashChain.HashesLeft),
-
-				// ASSERT FUNCTION
-				// Assert update server height raises.
-				() => hashChain.UpdateServerTipHeight(newServerHeight));
+				() => hashChain.UpdateServerTipHeight(newServerHeight)); // ASSERT FUNCTION. Assert update server height raises.
 
 			newServerHeight++;
-			Assert.Throws<PropertyChangedException>(() =>
-				Assert.PropertyChanged(
+			Assert.Throws<PropertyChangedException>(
+				() => Assert.PropertyChanged(
 					hashChain,
 					nameof(hashChain.HashCount),
-
-					// ASSERT FUNCTIONS
-					// Assert update server height does not raise unnecessary events.
-					() => hashChain.UpdateServerTipHeight(newServerHeight)));
+					() => hashChain.UpdateServerTipHeight(newServerHeight))); // ASSERT FUNCTION. Assert update server height does not raise unnecessary events.
 
 			newServerHeight++;
-			Assert.Throws<PropertyChangedException>(() =>
-				Assert.PropertyChanged(
+			Assert.Throws<PropertyChangedException>(
+				() => Assert.PropertyChanged(
 					hashChain,
 					nameof(hashChain.TipHash),
-
-					// ASSERT FUNCTIONS
-					// Assert update server height does not raise unnecessary events.
-					() => hashChain.UpdateServerTipHeight(newServerHeight)));
+					() => hashChain.UpdateServerTipHeight(newServerHeight))); // ASSERT FUNCTION. Assert update server height does not raise unnecessary events.
 
 			newServerHeight++;
-			Assert.Throws<PropertyChangedException>(() =>
-				Assert.PropertyChanged(
+			Assert.Throws<PropertyChangedException>(
+				() => Assert.PropertyChanged(
 					hashChain,
 					nameof(hashChain.TipHeight),
-
-					// ASSERT FUNCTIONS
-					// Assert update server height does not raise unnecessary events.
-					() => hashChain.UpdateServerTipHeight(newServerHeight)));
+					() => hashChain.UpdateServerTipHeight(newServerHeight))); // ASSERT FUNCTION. Assert update server height does not raise unnecessary events.
 
 			var sameServerheight = newServerHeight;
-			Assert.Throws<PropertyChangedException>(() =>
-				Assert.PropertyChanged(
+			Assert.Throws<PropertyChangedException>(
+				() => Assert.PropertyChanged(
 					hashChain,
 					nameof(hashChain.ServerTipHeight),
+					() => hashChain.UpdateServerTipHeight(sameServerheight))); // ASSERT FUNCTION. // Assert update server height does not raise without actually changing.
 
-					// ASSERT FUNCTIONS
-					// Assert update server height does not raise without actually changing.
-					() => hashChain.UpdateServerTipHeight(sameServerheight)));
-
-			Assert.Throws<PropertyChangedException>(() =>
-				Assert.PropertyChanged(
+			Assert.Throws<PropertyChangedException>(
+				() => Assert.PropertyChanged(
 					hashChain,
 					nameof(hashChain.HashesLeft),
-
-					// ASSERT FUNCTIONS
-					// Assert update server height does not raise without actually changing.
-					() => hashChain.UpdateServerTipHeight(sameServerheight)));
+					() => hashChain.UpdateServerTipHeight(sameServerheight))); // ASSERT FUNCTION. Assert update server height does not raise without actually changing.
 
 			// ASSERT PROPERTIES
 			Assert.Equal(0, hashChain.HashCount);


### PR DESCRIPTION
`The parameter must begin on the line after the previous parameter.`

I just moved the comments.