### PR TITLE
Allow stalebot to act on priority issues and PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,7 +16,6 @@ exemptLabels:
   - feature/enhancement
   - "waiting for dependency"
   - "good first issue"
-  - priority
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
IMO we should let stale bot act on priority issues/PRs, so I think we should remove it from `exemptLabels`.
If we have an issue or a PR with the label priority but it is inactive for 60 days, this means either we should fix it or it is not really a priority.