### PR TITLE
Build transaction without the backend

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
@@ -63,8 +63,8 @@
                 </StackPanel>
               </ToolTip.Tip>
             </controls:ExtendedTextBox>
-            <StackPanel Opacity="{Binding FeeControlOpacity}">
-              <StackPanel IsVisible="{Binding !MinMaxFeeTargetsEqual}" Orientation="Horizontal" Spacing="10">
+            <StackPanel IsEnabled ="{Binding IsEstimateAvailable}" Opacity="{Binding FeeControlOpacity}">
+              <StackPanel Orientation="Horizontal" Spacing="10">
                 <TextBlock Text="Fee:" />
                 <Panel Height="10" Width="10">
                   <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource SendTabView_Lightning}" />

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -64,7 +64,7 @@
               </ToolTip.Tip>
             </controls:ExtendedTextBox>
             <StackPanel IsEnabled ="{Binding IsEstimateAvailable}" Opacity="{Binding FeeControlOpacity}">
-              <StackPanel Orientation="Horizontal" Spacing="10">
+              <StackPanel IsVisible="{Binding !MinMaxFeeTargetsEqual}" Orientation="Horizontal" Spacing="10">
                 <TextBlock Text="Fee:" />
                 <Panel Height="10" Width="10">
                   <DrawingPresenter VerticalAlignment="Center" HorizontalAlignment="Center" Drawing="{DynamicResource SendTabView_Lightning}" />
@@ -112,10 +112,10 @@
                   <TextBlock Text="{Binding BuildTransactionButtonText}" />
                 </StackPanel>
               </Button>
-              <Panel/>
+              <Panel />
             </DockPanel>
           </StackPanel>
-          <Grid ColumnDefinitions="60,100,100,600,100,Auto"/>
+          <Grid ColumnDefinitions="60,100,100,600,100,Auto" />
         </StackPanel>
         <local:CoinListView SelectAllNonPrivateVisible="False" DataContext="{Binding CoinList}" />
       </DockPanel>

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -68,6 +68,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private FeeDisplayFormat _feeDisplayFormat;
 		private bool _isSliderFeeUsed = true;
 		private double _feeControlOpacity;
+		private bool _isEstimateAvailable;
 
 		protected SendControlViewModel(Wallet wallet, string title)
 			: base(title)
@@ -209,6 +210,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					this.RaisePropertyChanged(nameof(CustomChangeAddress));
 				});
 
+			Observable
+				.FromEventPattern<AllFeeEstimate>(Global.FeeProviders, nameof(Global.FeeProviders.AllFeeEstimateChanged))
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ => IsEstimateAvailable = true );
+				
 			FeeRateCommand = ReactiveCommand.Create(ChangeFeeRateDisplay, outputScheduler: RxApp.MainThreadScheduler);
 
 			OnAddressPasteCommand = ReactiveCommand.Create((BitcoinUrlBuilder url) => OnAddressPaste(url));
@@ -407,6 +413,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					NotificationHelpers.Error(ex.ToUserFriendlyString());
 					Logger.LogError(ex);
 				});
+
+			IsEstimateAvailable = Global.FeeProviders.AllFeeEstimate != null;
 		}
 
 		protected Global Global { get; }
@@ -580,6 +588,12 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			private set => this.RaiseAndSetIfChanged(ref _isCustomFee, value);
 		}
 
+		public bool IsEstimateAvailable
+		{
+			get => _isEstimateAvailable;
+			set => this.RaiseAndSetIfChanged(ref _isEstimateAvailable, value);
+		}
+
 		public string AmountTip
 		{
 			get => _amountTip;
@@ -637,149 +651,147 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			AllFeeEstimate allFeeEstimate = Global.FeeProviders?.AllFeeEstimate;
 
-			if (allFeeEstimate is { })
+			int feeTarget = -1; // 1 => 10 minutes
+			if (IsSliderFeeUsed && IsEstimateAvailable)
 			{
-				int feeTarget = -1; // 1 => 10 minutes
-				if (IsSliderFeeUsed)
-				{
-					feeTarget = FeeTarget;
+				feeTarget = FeeTarget;
 
-					int prevKey = allFeeEstimate.Estimations.Keys.First();
-					foreach (int target in allFeeEstimate.Estimations.Keys)
+				int prevKey = allFeeEstimate.Estimations.Keys.First();
+				foreach (int target in allFeeEstimate.Estimations.Keys)
+				{
+					if (feeTarget == target)
 					{
-						if (feeTarget == target)
+						break;
+					}
+					else if (feeTarget < target)
+					{
+						feeTarget = prevKey;
+						break;
+					}
+					prevKey = target;
+				}
+
+				FeeRate = allFeeEstimate.GetFeeRate(feeTarget);
+				UserFeeText = FeeRate.SatoshiPerByte.ToString();
+			}
+			else
+			{
+				FeeRate = null;
+
+				// In decimal ',' means order of magnitude.
+				// User could think it is decimal point but 3,5 means 35 Satoshi.
+				// For this reason we treat ',' as an invalid character.
+				if (TryParseUserFee(UserFeeText, out decimal userFee) && IsSliderFeeUsed)
+				{
+					FeeRate = new FeeRate(userFee);
+					feeTarget = Constants.SevenDaysConfirmationTarget;
+					foreach (var feeEstimate in allFeeEstimate.Estimations)
+					{
+						var target = feeEstimate.Key;
+						var fee = feeEstimate.Value;
+						if (FeeRate.SatoshiPerByte > fee)
 						{
+							feeTarget = target;
 							break;
 						}
-						else if (feeTarget < target)
-						{
-							feeTarget = prevKey;
-							break;
-						}
-						prevKey = target;
 					}
 				}
 				else
 				{
-					FeeRate = null;
+					FeeRate = new FeeRate(userFee);
+				}
+			}
 
-					// In decimal ',' means order of magnitude.
-					// User could think it is decimal point but 3,5 means 35 Satoshi.
-					// For this reason we treat ',' as an invalid character.
-					if (TryParseUserFee(UserFeeText, out decimal userFee))
+			IEnumerable<SmartCoin> selectedCoins = CoinList.Coins.Where(cvm => cvm.IsSelected).Select(x => x.Model);
+
+			int vsize = 150;
+			if (selectedCoins.Any())
+			{
+				if (IsMax)
+				{
+					vsize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(selectedCoins.Count(), 1);
+				}
+				else
+				{
+					if (Money.TryParse(AmountText.TrimStart('~', ' '), out Money amount))
 					{
-						FeeRate = new FeeRate(userFee);
-						feeTarget = Constants.SevenDaysConfirmationTarget;
-						foreach (var feeEstimate in allFeeEstimate.Estimations)
+						var inNum = 0;
+						var amountSoFar = Money.Zero;
+						foreach (SmartCoin coin in selectedCoins.OrderByDescending(x => x.Amount))
 						{
-							var target = feeEstimate.Key;
-							var fee = feeEstimate.Value;
-							if (FeeRate.SatoshiPerByte > fee)
+							amountSoFar += coin.Amount;
+							inNum++;
+							if (amountSoFar > amount)
 							{
-								feeTarget = target;
 								break;
 							}
 						}
+						vsize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(inNum, 2);
 					}
+					// Else whatever, do not change.
 				}
+			}
 
-				if (IsSliderFeeUsed)
+			if (FeeRate != null)
+			{
+				EstimatedBtcFee = FeeRate.GetTotalFee(vsize);
+			}
+			else
+			{
+				// This should not happen. Never.
+				// If FeeRate is null we will have problems when building the tx.
+				EstimatedBtcFee = Money.Zero;
+			}
+
+			long all = selectedCoins.Sum(x => x.Amount);
+			long theAmount = (IsMax, Money.TryParse(AmountText.TrimStart('~', ' '), out Money value)) switch
+			{
+				(true, _) => all,
+				(false, true) => value.Satoshi,
+				(false, false) => 0
+			};
+
+			FeePercentage = theAmount != 0
+				? 100 * (decimal)EstimatedBtcFee.Satoshi / theAmount
+				: 0;
+
+			if (UsdExchangeRate != 0)
+			{
+				UsdFee = EstimatedBtcFee.ToUsd(UsdExchangeRate);
+			}
+
+			AllSelectedAmount = Math.Max(Money.Zero, all - EstimatedBtcFee);
+			if (FeeRate is null)
+			{
+				FeeText = "";
+				FeeToolTip = "";
+			}
+			else
+			{
+				switch (FeeDisplayFormat)
 				{
-					FeeRate = allFeeEstimate.GetFeeRate(feeTarget);
-					UserFeeText = FeeRate.SatoshiPerByte.ToString();
-				}
+					case FeeDisplayFormat.SatoshiPerByte:
+						FeeText = $"(~ {FeeRate.SatoshiPerByte} sat/vByte)";
+						FeeToolTip = "Expected fee rate in satoshi/vByte.";
+						break;
 
-				IEnumerable<SmartCoin> selectedCoins = CoinList.Coins.Where(cvm => cvm.IsSelected).Select(x => x.Model);
+					case FeeDisplayFormat.USD:
+						FeeText = $"(~ ${UsdFee:0.##})";
+						FeeToolTip = $"Estimated total fees in USD. Exchange Rate: {(long)UsdExchangeRate} USD/BTC.";
+						break;
 
-				int vsize = 150;
-				if (selectedCoins.Any())
-				{
-					if (IsMax)
-					{
-						vsize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(selectedCoins.Count(), 1);
-					}
-					else
-					{
-						if (Money.TryParse(AmountText.TrimStart('~', ' '), out Money amount))
-						{
-							var inNum = 0;
-							var amountSoFar = Money.Zero;
-							foreach (SmartCoin coin in selectedCoins.OrderByDescending(x => x.Amount))
-							{
-								amountSoFar += coin.Amount;
-								inNum++;
-								if (amountSoFar > amount)
-								{
-									break;
-								}
-							}
-							vsize = NBitcoinHelpers.CalculateVsizeAssumeSegwit(inNum, 2);
-						}
-						// Else whatever, do not change.
-					}
-				}
+					case FeeDisplayFormat.BTC:
+						FeeText = $"(~ {EstimatedBtcFee.ToString(false, false)} BTC)";
+						FeeToolTip = "Estimated total fees in BTC.";
+						break;
 
-				if (FeeRate != null)
-				{
-					EstimatedBtcFee = FeeRate.GetTotalFee(vsize);
-				}
-				else
-				{
-					// This should not happen. Never.
-					// If FeeRate is null we will have problems when building the tx.
-					EstimatedBtcFee = Money.Zero;
-				}
+					case FeeDisplayFormat.Percentage:
+						FeeText = $"(~ {FeePercentage:0.#} %)";
+						FeeToolTip = "Expected percentage of fees against the amount to be sent.";
+						break;
 
-				long all = selectedCoins.Sum(x => x.Amount);
-				long theAmount = (IsMax, Money.TryParse(AmountText.TrimStart('~', ' '), out Money value)) switch
-				{
-					(true, _) => all,
-					(false, true) => value.Satoshi,
-					(false, false) => 0
-				};
-
-				FeePercentage = theAmount != 0
-					? 100 * (decimal)EstimatedBtcFee.Satoshi / theAmount
-					: 0;
-
-				if (UsdExchangeRate != 0)
-				{
-					UsdFee = EstimatedBtcFee.ToUsd(UsdExchangeRate);
-				}
-
-				AllSelectedAmount = Math.Max(Money.Zero, all - EstimatedBtcFee);
-				if (FeeRate is null)
-				{
-					FeeText = "";
-					FeeToolTip = "";
-				}
-				else
-				{
-					switch (FeeDisplayFormat)
-					{
-						case FeeDisplayFormat.SatoshiPerByte:
-							FeeText = $"(~ {FeeRate.SatoshiPerByte} sat/vByte)";
-							FeeToolTip = "Expected fee rate in satoshi/vByte.";
-							break;
-
-						case FeeDisplayFormat.USD:
-							FeeText = $"(~ ${UsdFee:0.##})";
-							FeeToolTip = $"Estimated total fees in USD. Exchange Rate: {(long)UsdExchangeRate} USD/BTC.";
-							break;
-
-						case FeeDisplayFormat.BTC:
-							FeeText = $"(~ {EstimatedBtcFee.ToString(false, false)} BTC)";
-							FeeToolTip = "Estimated total fees in BTC.";
-							break;
-
-						case FeeDisplayFormat.Percentage:
-							FeeText = $"(~ {FeePercentage:0.#} %)";
-							FeeToolTip = "Expected percentage of fees against the amount to be sent.";
-							break;
-
-						default:
-							throw new NotSupportedException("This is impossible.");
-					}
+					default:
+						throw new NotSupportedException("This is impossible.");
 				}
 			}
 		}
@@ -911,8 +923,27 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 			Global.UiConfig.WhenAnyValue(x => x.IsCustomFee)
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(x => IsCustomFee = x)
+				.Subscribe(x => IsCustomFee = x || Global.FeeProviders.AllFeeEstimate == null)
 				.DisposeWith(disposables);
+
+			Global.FeeProviders.WhenAnyValue(x => x.AllFeeEstimate)
+				.Where(x => x == null)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ => IsEstimateAvailable = false);
+
+			this.WhenAnyValue(x => x.IsEstimateAvailable)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(_ =>
+				{
+					if (_isEstimateAvailable)
+					{
+						IsCustomFee = Global.UiConfig.IsCustomFee;
+					}
+					else
+					{
+						IsCustomFee = true;
+					}
+				});
 
 			this.WhenAnyValue(x => x.IsCustomFee)
 				.Where(x => !x)


### PR DESCRIPTION
fixes #3520 
closes #3551 

I talked with @molnard what would be the best to fix #3520 and the solution is:

- If the backend is not available then set the slider to unavailable, if it is available then set it back
- Show manual set fee textbox if there is no backend connection no matter what is in the settings, if the connection is built up then set the textbox visibility by the settings  

To store the last EstimationFee is not a good option because what if the user opens Wasabi a week later...