### PR TITLE
Open Wasabi in normal size by default.

### DIFF
--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.Gui
 
 		[JsonProperty(PropertyName = "WindowState")]
 		[JsonConverter(typeof(WindowStateAfterStartJsonConverter))]
-		public WindowState WindowState { get; internal set; } = WindowState.Maximized;
+		public WindowState WindowState { get; internal set; } = WindowState.Normal;
 
 		[DefaultValue(2)]
 		[JsonProperty(PropertyName = "FeeTarget", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
We have way too much space in the general wallet already and the distracting legal window looks much better in normal size, too.

![image](https://user-images.githubusercontent.com/9156103/92101744-daa4a500-eddd-11ea-9179-ab1da348fe0c.png)
