### PR TITLE
Hwi/Models: add BitBox02 support

### DIFF
--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -20,6 +20,8 @@ namespace WalletWasabi.Hwi.Models
 		Trezor_1,
 		Trezor_1_Simulator,
 		Trezor_T,
-		Trezor_T_Simulator
+		Trezor_T_Simulator,
+		BitBox02_BTCOnly,
+		BitBox02_Multi,
 	}
 }


### PR DESCRIPTION
With HWI 1.2, the BitBox02 hardware wallets are supported. This commit
adds those to the list of enabled wallets for Wasabi.

See also https://github.com/bitcoin-core/HWI/milestone/4?closed=1

HWI 1.2 can be vendored once it is released. Until then, this commit is a no-op, but once HWI 1.2 is vendored, it will automatically work with the BitBox02.