### PR TITLE
Remove nullable warning.

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -8,9 +8,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.CoinJoin.Client.Clients;
-using WalletWasabi.Legal;
 using WalletWasabi.Models;
-using WalletWasabi.Services;
 using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.TorSocks5;
 using WalletWasabi.WebClients.Wasabi;
@@ -50,8 +48,10 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetFiltersAsync(NetworkType networkType)
 		{
+			Network network = (networkType == NetworkType.Mainnet) ? Network.Main : Network.TestNet;
+
 			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
-			var filterModel = StartingFilters.GetStartingFilter(Network.GetNetwork(networkType.ToString()));
+			var filterModel = StartingFilters.GetStartingFilter(network);
 
 			FiltersResponse filtersResponse = await client.GetFiltersAsync(filterModel.Header.BlockHash, 2);
 


### PR DESCRIPTION
I have noticed this when researching `TorProcessManager` & #4299.

Notes:

* The PR fixes a single nullable warning. Alternatively, one can use `Network.GetNetwork(networkType.ToString())!` (i.e. with the `!` operator).