### PR TITLE
Adjust GetDefaultBitcoinCoreDataDirOrEmptyString.

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -84,7 +84,7 @@ namespace WalletWasabi.Gui
 		public bool StopLocalBitcoinCoreOnShutdown { get; internal set; }
 
 		[JsonProperty(PropertyName = "LocalBitcoinCoreDataDir")]
-		public string LocalBitcoinCoreDataDir { get; internal set; } = EnvironmentHelpers.TryGetDefaultBitcoinCoreDataDir() ?? "";
+		public string LocalBitcoinCoreDataDir { get; internal set; } = EnvironmentHelpers.GetDefaultBitcoinCoreDataDirOrEmptyString();
 
 		[JsonProperty(PropertyName = "TorSocks5EndPoint")]
 		[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTorSocksPort)]

--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -43,7 +43,7 @@ namespace WalletWasabi.Helpers
 		// Do not change the output of this function. Backwards compatibility depends on it.
 		public static string GetDataDir(string appName)
 		{
-			if (DataDirDict.TryGetValue(appName, out string dataDir))
+			if (DataDirDict.TryGetValue(appName, out string? dataDir))
 			{
 				return dataDir;
 			}
@@ -90,45 +90,44 @@ namespace WalletWasabi.Helpers
 			return directory;
 		}
 
-		public static string TryGetDefaultBitcoinCoreDataDir()
+		/// <summary>
+		/// Gets Bitcoin <c>datadir</c> parameter from:
+		/// <list type="bullet">
+		/// <item><c>APPDATA</c> environment variable on Windows, and</item>
+		/// <item><c>HOME</c> environment variable on other platforms.</item>
+		/// </list>
+		/// </summary>
+		/// <returns><c>datadir</c> or empty string.</returns>
+		/// <seealso href="https://en.bitcoin.it/wiki/Data_directory"/>
+		public static string GetDefaultBitcoinCoreDataDirOrEmptyString()
 		{
-			string directory = null;
+			string directory = "";
 
-			// https://en.bitcoin.it/wiki/Data_directory
-			try
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				var localAppData = Environment.GetEnvironmentVariable("APPDATA");
+				if (!string.IsNullOrEmpty(localAppData))
 				{
-					var localAppData = Environment.GetEnvironmentVariable("APPDATA");
-					if (!string.IsNullOrEmpty(localAppData))
-					{
-						directory = Path.Combine(localAppData, "Bitcoin");
-					}
-					else
-					{
-						throw new DirectoryNotFoundException($"Could not find suitable default {Constants.BuiltinBitcoinNodeName} datadir.");
-					}
+					directory = Path.Combine(localAppData, "Bitcoin");
 				}
 				else
 				{
-					var home = Environment.GetEnvironmentVariable("HOME");
-					if (!string.IsNullOrEmpty(home))
-					{
-						directory = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-							? Path.Combine(home, "Library", "Application Support", "Bitcoin")
-							: Path.Combine(home, ".bitcoin"); // Linux
-					}
-					else
-					{
-						throw new DirectoryNotFoundException($"Could not find suitable default {Constants.BuiltinBitcoinNodeName} datadir.");
-					}
+					Logger.LogDebug($"Could not find suitable default {Constants.BuiltinBitcoinNodeName} datadir.");
 				}
-
-				return directory;
 			}
-			catch (Exception ex)
+			else
 			{
-				Logger.LogDebug(ex);
+				var home = Environment.GetEnvironmentVariable("HOME");
+				if (!string.IsNullOrEmpty(home))
+				{
+					directory = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+						? Path.Combine(home, "Library", "Application Support", "Bitcoin")
+						: Path.Combine(home, ".bitcoin"); // Linux
+				}
+				else
+				{
+					Logger.LogDebug($"Could not find suitable default {Constants.BuiltinBitcoinNodeName} datadir.");
+				}
 			}
 
 			return directory;


### PR DESCRIPTION
Notes:

* This PR should be reviewed with disabled whitespace changes.
* It fixes nullable warning for `string directory`.
* It removes exception throwing for the sake of cathing it later. I'm not sure what the intent behind this was but I kind of think that you wanted stacktrace. If you don't like this part, I can revert it.
* EnvironmentHelpers.cs is now without a nullable warning.