### PR TITLE
Remove extra space in LegalDocuments.txt

### DIFF
--- a/WalletWasabi/Legal/Assets/LegalDocuments.txt
+++ b/WalletWasabi/Legal/Assets/LegalDocuments.txt
@@ -170,7 +170,6 @@ I. TERMS AND CONDITIONS
     Any failure or delay by us to exercise or enforce any right or remedy provided under these Terms or by law will not constitute a waiver of that or any other right or remedy, nor will it preclude any further exercise of that or any other right or remedy. No single or partial right exercise of any right or remedy shall preclude or restrict the further exercise of that or any other right or remedy.
 
 9.5 ASSIGNMENT
-
     The Service Provider may assign these Terms to its parent company, affiliate or subsidiary, or in connection with a merger, consolidation, or sale or other disposition of all or substantially all of its assets. You may not assign these Terms or Your use of or access to the Services at any time.
 
 9.6 ENTIRE AGREEMENT


### PR DESCRIPTION
There was an extra space. Now the 9.5 chapter follows the design of the rest of the document.