### PR TITLE
Add fee display format option in settings

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:WalletWasabi.Gui.Controls;assembly=WalletWasabi.Gui"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -914,6 +914,15 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(x => IsCustomFee = x)
 				.DisposeWith(disposables);
 
+			Global.UiConfig.WhenAnyValue(x => x.FeeDisplayFormat)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(x =>
+				{
+					FeeDisplayFormat = (FeeDisplayFormat)x;
+					SetFeesAndTexts();
+				})
+				.DisposeWith(disposables);
+
 			this.WhenAnyValue(x => x.IsCustomFee)
 				.Where(x => !x)
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Gui/Converters/FeeDisplayFormatStringConverter.cs
+++ b/WalletWasabi.Gui/Converters/FeeDisplayFormatStringConverter.cs
@@ -1,0 +1,35 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+using WalletWasabi.Gui.Models;
+using WalletWasabi.Exceptions;
+using System.Collections.Generic;
+
+namespace WalletWasabi.Gui.Converters
+{
+	public class FeeDisplayFormatStringConverter : IValueConverter
+	{
+		private Dictionary<FeeDisplayFormat, string> Texts { get; } = new Dictionary<FeeDisplayFormat, string>
+		{
+			{ FeeDisplayFormat.SatoshiPerByte, "sat/vByte" },
+			{ FeeDisplayFormat.USD, "USD" },
+			{ FeeDisplayFormat.BTC, "BTC" },
+			{ FeeDisplayFormat.Percentage, "Percentage" },
+		};
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is FeeDisplayFormat format)
+			{
+				return Texts[format];
+			}
+
+			throw new TypeArgumentException(value, typeof(FeeDisplayFormat), nameof(value));
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -9,6 +9,7 @@
     <converters:BooleanStringConverter x:Key="BooleanStringConverter" />
     <converters:NetworkStringConverter x:Key="NetworkStringConverter" />
     <converters:VersionStringConverter x:Key="VersionStringConverter" />
+    <converters:FeeDisplayFormatStringConverter x:Key="FeeDisplayFormatStringConverter" />
   </UserControl.Resources>
   <DockPanel LastChildFill="true">
     <StackPanel DockPanel.Dock="Top" IsVisible="{Binding IsModified}" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5 10 5">
@@ -102,6 +103,16 @@
                 <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
                   <ToggleButton IsChecked="{Binding LurkingWifeMode}" Content="{Binding LurkingWifeMode, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" Command="{Binding LurkingWifeModeCommand}" />
                   <TextBlock VerticalAlignment="Center">Lurking Wife Mode, hides sensitive content.</TextBlock>
+                </StackPanel>
+                <StackPanel Margin="0 10" Orientation="Vertical" Spacing="5">
+                  <TextBlock>Fee Display Format</TextBlock>
+                  <DropDown Items="{Binding FeeDisplayFormats}" SelectedItem="{Binding SelectedFeeDisplayFormat}">
+                    <DropDown.ItemTemplate>
+                      <DataTemplate>
+                        <TextBlock Text="{Binding Converter={StaticResource FeeDisplayFormatStringConverter}}" />
+                      </DataTemplate>
+                    </DropDown.ItemTemplate>
+                  </DropDown>
                 </StackPanel>
               </StackPanel>
             </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -168,9 +168,7 @@ namespace WalletWasabi.Gui.Tabs
 
 			this.WhenAnyValue(x => x.SelectedFeeDisplayFormat)
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(x =>
-				Global.UiConfig.FeeDisplayFormat = (int)x
-				);
+				.Subscribe(x => Global.UiConfig.FeeDisplayFormat = (int)x);
 		}
 
 		private bool TabOpened { get; set; }
@@ -319,6 +317,11 @@ namespace WalletWasabi.Gui.Tabs
 					.Throttle(TimeSpan.FromSeconds(1))
 					.ObserveOn(RxApp.TaskpoolScheduler)
 					.Subscribe(_ => Global.UiConfig.ToFile())
+					.DisposeWith(disposables);
+
+				Global.UiConfig.WhenAnyValue(x => x.FeeDisplayFormat)
+					.ObserveOn(RxApp.MainThreadScheduler)
+					.Subscribe(x => SelectedFeeDisplayFormat = (FeeDisplayFormat)x)
 					.DisposeWith(disposables);
 
 				base.OnOpen(disposables);

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -14,6 +14,7 @@ using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using WalletWasabi.Crypto;
 using WalletWasabi.Gui.Helpers;
+using WalletWasabi.Gui.Models;
 using WalletWasabi.Gui.Validation;
 using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Helpers;
@@ -41,6 +42,7 @@ namespace WalletWasabi.Gui.Tabs
 		private string _dustThreshold;
 		private string _pinBoxText;
 		private ObservableAsPropertyHelper<bool> _isPinSet;
+		private FeeDisplayFormat _selectedFeeDisplayFormat;
 
 		public SettingsViewModel() : base("Settings")
 		{
@@ -161,6 +163,14 @@ namespace WalletWasabi.Gui.Tabs
 				.Merge(TextBoxLostFocusCommand.ThrownExceptions)
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(ex => Logger.LogError(ex));
+
+			SelectedFeeDisplayFormat = (Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat)) ? (FeeDisplayFormat)Global.UiConfig.FeeDisplayFormat : FeeDisplayFormat.SatoshiPerByte;
+
+			this.WhenAnyValue(x => x.SelectedFeeDisplayFormat)
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(x =>
+				Global.UiConfig.FeeDisplayFormat = (int)x
+				);
 		}
 
 		private bool TabOpened { get; set; }
@@ -280,6 +290,14 @@ namespace WalletWasabi.Gui.Tabs
 		{
 			get => _pinBoxText;
 			set => this.RaiseAndSetIfChanged(ref _pinBoxText, value);
+		}
+
+		public IEnumerable<FeeDisplayFormat> FeeDisplayFormats => Enum.GetValues(typeof(FeeDisplayFormat)).Cast<FeeDisplayFormat>();
+
+		public FeeDisplayFormat SelectedFeeDisplayFormat
+		{
+			get => _selectedFeeDisplayFormat;
+			set => this.RaiseAndSetIfChanged(ref _selectedFeeDisplayFormat, value);
 		}
 
 		public override void OnOpen(CompositeDisposable disposables)

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -164,7 +164,9 @@ namespace WalletWasabi.Gui.Tabs
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(ex => Logger.LogError(ex));
 
-			SelectedFeeDisplayFormat = (Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat)) ? (FeeDisplayFormat)Global.UiConfig.FeeDisplayFormat : FeeDisplayFormat.SatoshiPerByte;
+			SelectedFeeDisplayFormat = Enum.IsDefined(typeof(FeeDisplayFormat), Global.UiConfig.FeeDisplayFormat)
+				? (FeeDisplayFormat)Global.UiConfig.FeeDisplayFormat
+				: FeeDisplayFormat.SatoshiPerByte;
 
 			this.WhenAnyValue(x => x.SelectedFeeDisplayFormat)
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -28,6 +28,7 @@ namespace WalletWasabi.Gui
 		private bool _isCustomFee;
 		private bool _isCustomChangeAddress;
 		private bool _autocopy;
+		private int _feeDisplayFormat;
 
 		public UiConfig() : base()
 		{
@@ -47,7 +48,11 @@ namespace WalletWasabi.Gui
 
 		[DefaultValue(0)]
 		[JsonProperty(PropertyName = "FeeDisplayFormat", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public int FeeDisplayFormat { get; internal set; }
+		public int FeeDisplayFormat
+		{
+			get => _feeDisplayFormat;
+			set => RaiseAndSetIfChanged(ref _feeDisplayFormat, value);
+		}
 
 		[DefaultValue("")]
 		[JsonProperty(PropertyName = "LastActiveTab", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
A simple version of #2038.
Closes #2038

- Option added in `Settings` to select the display format of the fee.
- Everything is synchronized (Send tab detects if the selected display format is changed in Settings and Settings detects if it changed in the Send tab)