### PR TITLE
Add status badge for continuous delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![](https://i.imgur.com/4GO7nnY.png)
 
-| Code Quality           | Windows Tests           | Linux Tests             | macOS Tests             | License                   |
-| :----------------------| :-----------------------| :-----------------------| :-----------------------| :-------------------------|
-| [![CodeFactor][9]][10] | [![Build Status][1]][2] | [![Build Status][3]][4] | [![Build Status][5]][6] | [![GitHub license][7]][8] |
+| Code Quality           | Windows Tests           | Linux Tests             | macOS Tests             | Continuous Delivery     | License                   |
+| :----------------------| :-----------------------| :-----------------------| :-----------------------| :-----------------------| :-------------------------|
+| [![CodeFactor][9]][10] | [![Build Status][1]][2] | [![Build Status][3]][4] | [![Build Status][5]][6] | [![Build Status][11]][12] | [![GitHub license][7]][8] |
 
 [1]: https://dev.azure.com/zkSNACKs/Wasabi/_apis/build/status/Wasabi.Windows?branchName=master
 [2]: https://dev.azure.com/zkSNACKs/Wasabi/_build?definitionId=3
@@ -14,6 +14,8 @@
 [8]: https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md
 [9]: https://www.codefactor.io/repository/github/zksnacks/walletwasabi/badge
 [10]: https://www.codefactor.io/repository/github/zksnacks/walletwasabi
+[11]: https://dev.azure.com/zkSNACKs/Wasabi/_apis/build/status/Wasabi.ContinuousDelivery?branchName=master
+[12]: https://dev.azure.com/zkSNACKs/Wasabi/_build/latest?definitionId=12&branchName=master
 
 [Wasabi Wallet](https://wasabiwallet.io) is an open-source, non-custodial, privacy-focused Bitcoin wallet for desktop, that implements [Chaumian CoinJoin](https://github.com/nopara73/ZeroLink/#ii-chaumian-coinjoin).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://i.imgur.com/4GO7nnY.png)
 
-| Code Quality           | Windows Tests           | Linux Tests             | macOS Tests             | Continuous Delivery     | License                   |
-| :----------------------| :-----------------------| :-----------------------| :-----------------------| :-----------------------| :-------------------------|
+| Code Quality           | Windows Tests           | Linux Tests             | macOS Tests             | Continuous Delivery       | License                   |
+| :----------------------| :-----------------------| :-----------------------| :-----------------------| :-------------------------| :-------------------------|
 | [![CodeFactor][9]][10] | [![Build Status][1]][2] | [![Build Status][3]][4] | [![Build Status][5]][6] | [![Build Status][11]][12] | [![GitHub license][7]][8] |
 
 [1]: https://dev.azure.com/zkSNACKs/Wasabi/_apis/build/status/Wasabi.Windows?branchName=master


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9844978/92608830-1b0c9300-f2b6-11ea-87a3-db77b4afffcb.png)

Users can click on the badge and download the latest binaries from here. 

![image](https://user-images.githubusercontent.com/9844978/92608953-442d2380-f2b6-11ea-8ed8-946bf5eb7f56.png)

