### PR TITLE
TorProcessManager & ProcessAsync API.

### DIFF
--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -162,7 +162,7 @@ namespace WalletWasabi.Helpers
 		}
 
 		/// <summary>
-		/// Executes a command with Bash.
+		/// Executes a command with Bourne shell.
 		/// https://stackoverflow.com/a/47918132/2061103
 		/// </summary>
 		public static async Task ShellExecAsync(string cmd, bool waitForExit = true)

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -17,29 +17,34 @@ namespace WalletWasabi.Tor
 		public TorSettings(string dataDir, string logFilePath)
 		{
 			TorDir = Path.Combine(dataDir, "tor");
+			TorBinaryDir = Path.Combine(TorDir, "Tor");
 			TorDataDir = Path.Combine(dataDir, "tordata");
 			LogFilePath = logFilePath;
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
-				TorPath = $@"{TorDir}\Tor\tor.exe";
-				HashSourcePath = $@"{TorDir}\Tor\tor.exe";
+				TorPath = $@"{TorBinaryDir}\tor.exe";
+				HashSourcePath = $@"{TorBinaryDir}\tor.exe";
 				GeoIpPath = $@"{TorDir}\Data\Tor\geoip";
 				GeoIp6Path = $@"{TorDir}\Data\Tor\geoip6";
 			}
 			else
 			{
-				TorPath = $@"{TorDir}/Tor/tor";
+				TorPath = $@"{TorBinaryDir}/tor";
 				HashSourcePath = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-					? $@"{TorDir}/Tor/tor.real"
-					: $@"{TorDir}/Tor/tor";
+					? $@"{TorBinaryDir}/tor.real"
+					: $@"{TorBinaryDir}/tor";
 				GeoIpPath = $@"{TorDir}/Data/Tor/geoip";
 				GeoIp6Path = $@"{TorDir}/Data/Tor/geoip6";
 			}
 		}
 
 		/// <summary>Full directory path where Tor is installed (or supposed to be installed).</summary>
+		/// <remarks>Folder contains <c>Data</c> and <c>Tor</c> (see <see cref="TorBinaryDir"/>) sub-folders.</remarks>
 		public string TorDir { get; }
+
+		/// <summary>Full directory path where Tor binaries are placed.</summary>
+		public string TorBinaryDir { get; }
 
 		/// <summary>Full directory path where Tor stores its data.</summary>
 		public string TorDataDir { get; }


### PR DESCRIPTION
This is part of #4244 project where I would actually like to get rid of those `await Task.Delay(3000);` delays in `TorTests` and enforce that when you start Tor and you ask for `ensureRunning` it will be started or an exception will be thrown. This PR paves the path to that goal.

**Notes:**

* This PR adds a convenience `TorBinaryDir` property to `TorSettings`. I will remove those `Tor` prefixes later on. But now it's for consistency reasons.
* Main change of this PR is to use `ProcessAsync` API for Linux & macOS to start Tor process.

**Testing:** I have tested on the following platforms

* Windows 10 
* Ubuntu 20.04
* Ubuntu 18.04
* Ubuntu 16.04
* Fedora 32

Can anyone help with testing this on not covered OSes?

PS: I don't have mac. Does anyone know how to install mac in a virtual machine to test it?