### PR TITLE
[WabiSabi] Remove Fully Qualified identifiers

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfDlogTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfDlogTests.cs
@@ -1,11 +1,10 @@
 using NBitcoin.Secp256k1;
-using System;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge;
+using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
-using LR = WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 {
@@ -24,7 +23,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 			var secret = new Scalar(scalarSeed);
 			var generator = Generators.G;
 			var publicPoint = secret * generator;
-			var statement = new LR.Statement(publicPoint, generator);
+			var statement = new Statement(publicPoint, generator);
 			var random = new MockRandom();
 			random.GetBytesResults.Add(new byte[32]);
 			var proof = ProofSystem.Prove(statement, secret, random);
@@ -38,7 +37,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 			{
 				var generator = Generators.G;
 				var publicPoint = secret * generator;
-				var statement = new LR.Statement(publicPoint, Generators.G);
+				var statement = new Statement(publicPoint, Generators.G);
 				var proof = ProofSystem.Prove(statement, secret, new SecureRandom());
 				Assert.True(ProofSystem.Verify(statement, proof));
 			}
@@ -53,31 +52,31 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 
 			var secret = new Scalar(val, val, val, val, val, val, val, val);
 			var p = secret * gen;
-			var statement = new LR.Statement(p, gen);
+			var statement = new Statement(p, gen);
 			var proof = ProofSystem.Prove(statement, secret, random);
 			Assert.True(ProofSystem.Verify(statement, proof));
 
 			secret = EC.N + Scalar.One.Negate();
 			p = secret * gen;
-			statement = new LR.Statement(p, gen);
+			statement = new Statement(p, gen);
 			proof = ProofSystem.Prove(statement, secret, random);
 			Assert.True(ProofSystem.Verify(statement, proof));
 
 			secret = EC.NC;
 			p = secret * gen;
-			statement = new LR.Statement(p, gen);
+			statement = new Statement(p, gen);
 			proof = ProofSystem.Prove(statement, secret, random);
 			Assert.True(ProofSystem.Verify(statement, proof));
 
 			secret = EC.NC + Scalar.One;
 			p = secret * gen;
-			statement = new LR.Statement(p, gen);
+			statement = new Statement(p, gen);
 			proof = ProofSystem.Prove(statement, secret, random);
 			Assert.True(ProofSystem.Verify(statement, proof));
 
 			secret = EC.NC + Scalar.One.Negate();
 			p = secret * gen;
-			statement = new LR.Statement(p, gen);
+			statement = new Statement(p, gen);
 			proof = ProofSystem.Prove(statement, secret, random);
 			Assert.True(ProofSystem.Verify(statement, proof));
 		}

--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfRepTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfRepTests.cs
@@ -5,9 +5,9 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge;
+using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
-using LR = WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 {
@@ -28,7 +28,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 			var generators = new GroupElementVector(Generators.G, Generators.Ga);
 			var publicPoint = secrets * generators;
 
-			var statement = new LR.Statement(publicPoint, generators);
+			var statement = new Statement(publicPoint, generators);
 			var random = new MockRandom();
 			random.GetBytesResults.Add(new byte[32]);
 			var proof = ProofSystem.Prove(statement, secrets, random);
@@ -46,7 +46,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 					var secrets = new ScalarVector(secret1, secret2);
 					var generators = new GroupElementVector(Generators.G, Generators.Ga);
 					var publicPoint = secrets * generators;
-					var statement = new LR.Statement(publicPoint, generators);
+					var statement = new Statement(publicPoint, generators);
 					var proof = ProofSystem.Prove(statement, secrets, new SecureRandom());
 					Assert.True(ProofSystem.Verify(statement, proof));
 				}
@@ -60,18 +60,18 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 			var three = new Scalar(3);
 
 			// Public point must be sum(generator * secret).
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G, Generators.G, Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + three * Generators.Ga, Generators.Ga, Generators.G), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + three * Generators.Ga, Generators.G, Generators.Gg), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(Generators.G + three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G, Generators.G, Generators.Ga), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.Ga, Generators.G), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.G, Generators.Gg), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(Generators.G + three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
 
 			// Generators and secrets must be equal.
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + three * Generators.Ga, Generators.Gg, Generators.Ga), new ScalarVector(two)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + three * Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + three * Generators.Ga, Generators.Gg), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new LR.Knowledge(new LR.Statement(two * Generators.G + three * Generators.Ga, Generators.G, Generators.Ga, Generators.Gg), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.Gg, Generators.Ga), new ScalarVector(two)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.Gg), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.G, Generators.Ga, Generators.Gg), new ScalarVector(two, three)));
 		}
 	}
 }

--- a/WalletWasabi/Crypto/ZeroKnowledge/NonInteractive/Verifier.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/NonInteractive/Verifier.cs
@@ -1,12 +1,13 @@
 using System.Linq;
 using System.Collections.Generic;
+using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge.NonInteractive
 {
 	public static class Verifier
 	{
-		public static bool Verify(Transcript transcript, IEnumerable<LinearRelation.Statement> statements, IEnumerable<Proof> proofs)
+		public static bool Verify(Transcript transcript, IEnumerable<Statement> statements, IEnumerable<Proof> proofs)
 		{
 			Guard.Same(nameof(proofs), proofs.Count(), statements.Count());
 

--- a/WalletWasabi/Crypto/ZeroKnowledge/ProofSystem.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/ProofSystem.cs
@@ -1,11 +1,9 @@
 using NBitcoin.Secp256k1;
 using System.Linq;
-using System.Collections.Generic;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Crypto.ZeroKnowledge.NonInteractive;
-using System.Diagnostics.CodeAnalysis;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge
 {
@@ -15,26 +13,26 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 
 		public static bool Verify(LinearRelation.Statement statement, Proof proof)
 		{
-			return NonInteractive.Verifier.Verify(new Transcript(new byte[0]), new[] { statement }, new[] { proof });
+			return Verifier.Verify(new Transcript(new byte[0]), new[] { statement }, new[] { proof });
 		}
 
 		public static Proof Prove(Knowledge knowledge, WasabiRandom random)
 		{
-			return NonInteractive.Prover.Prove(new Transcript(new byte[0]), new[] { knowledge }, random).First();
+			return Prover.Prove(new Transcript(new byte[0]), new[] { knowledge }, random).First();
 		}
 
 		// Syntactic sugar used in tests
-		public static Proof Prove(LinearRelation.Statement statement, Scalar witness, WasabiRandom random)
+		public static Proof Prove(Statement statement, Scalar witness, WasabiRandom random)
 			=> Prove(statement, new ScalarVector(witness), random);
 
-		public static Proof Prove(LinearRelation.Statement statement, ScalarVector witness, WasabiRandom random)
+		public static Proof Prove(Statement statement, ScalarVector witness, WasabiRandom random)
 			=> Prove(new Knowledge(statement, witness), random);
 
 		public static Knowledge IssuerParameters(MAC mac, GroupElement ma, CoordinatorSecretKey sk)
 			=> new Knowledge(IssuerParameters(sk.ComputeCoordinatorParameters(), mac, ma), new ScalarVector(sk.W, sk.Wp, sk.X0, sk.X1, sk.Ya));
 
-		public static LinearRelation.Statement IssuerParameters(CoordinatorParameters iparams, MAC mac, GroupElement ma)
-			=> new LinearRelation.Statement(new GroupElement[,]
+		public static Statement IssuerParameters(CoordinatorParameters iparams, MAC mac, GroupElement ma)
+			=> new Statement(new GroupElement[,]
 			{
 				// public                                             Witness terms:
 				// point                     w,             wp,             x0,             x1,             ya

--- a/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
@@ -6,6 +6,7 @@ using System.Text;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.StrobeProtocol;
+using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge
@@ -56,7 +57,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 			AddMessages(PublicNonceTag, publicNonces.Select(x => x.ToBytes()));
 		}
 
-		public void CommitStatement(LinearRelation.Statement statement)
+		public void CommitStatement(Statement statement)
 		{
 			Guard.NotNull(nameof(statement.Generators), statement.Generators);
 			CryptoGuard.NotNullOrInfinity(nameof(statement.PublicPoints), statement.PublicPoints);


### PR DESCRIPTION
Trivial PR that simplifies the code simply by removing the FQs from everywhere. These identifiers were there in order to be able to have a previous version and a new version separated by namespaces.