### PR TITLE
Use friendly wallet names

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
@@ -154,39 +154,38 @@ namespace WalletWasabi.Tests.UnitTests
 		}
 
 		[Fact]
-		public async Task GetNextWalletTestAsync()
+		public async Task GetNextWalletAsync()
 		{
 			var baseDir = Path.Combine(Global.Instance.DataDir, EnvironmentHelpers.GetCallerFileName(), EnvironmentHelpers.GetMethodName());
 			await CleanupWalletDirectoriesAsync(baseDir);
 			var walletDirectories = new WalletDirectories(baseDir);
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 3.json"));
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 3.json"));
 
-			Assert.Equal("Random Wallet", walletDirectories.GetNextWalletName());
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet.json"));
-			Assert.Equal("Random Wallet 2", walletDirectories.GetNextWalletName());
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 2.json"));
-			Assert.Equal("Random Wallet 4", walletDirectories.GetNextWalletName());
+			Assert.Equal("Wallet 1", walletDirectories.GetNextWalletName());
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 1.json"));
+			Assert.Equal("Wallet 2", walletDirectories.GetNextWalletName());
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 2.json"));
+			Assert.Equal("Wallet 4", walletDirectories.GetNextWalletName());
 
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 4.dat"));
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 4"));
-			Assert.Equal("Random Wallet 4", walletDirectories.GetNextWalletName());
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 4.dat"));
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 4"));
+			Assert.Equal("Wallet 4", walletDirectories.GetNextWalletName());
 
-			File.Delete(Path.Combine(walletDirectories.WalletsDir, "Random Wallet.json"));
-			File.Delete(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 3.json"));
-			Assert.Equal("Random Wallet", walletDirectories.GetNextWalletName());
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet.json"));
-			Assert.Equal("Random Wallet 3", walletDirectories.GetNextWalletName());
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 3.json"));
-			File.Delete(Path.Combine(walletDirectories.WalletsDir, "Random Wallet 3.json"));
+			File.Delete(Path.Combine(walletDirectories.WalletsDir, "Wallet 1.json"));
+			File.Delete(Path.Combine(walletDirectories.WalletsDir, "Wallet 3.json"));
+			Assert.Equal("Wallet 1", walletDirectories.GetNextWalletName());
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 1.json"));
+			Assert.Equal("Wallet 3", walletDirectories.GetNextWalletName());
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Wallet 3.json"));
+			File.Delete(Path.Combine(walletDirectories.WalletsDir, "Wallet 3.json"));
 
-			Assert.Equal("Foo", walletDirectories.GetNextWalletName("Foo"));
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Foo.json"));
+			Assert.Equal("Foo 1", walletDirectories.GetNextWalletName("Foo"));
+			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Foo 1.json"));
 			Assert.Equal("Foo 2", walletDirectories.GetNextWalletName("Foo"));
-			IoHelpers.CreateOrOverwriteFile(Path.Combine(walletDirectories.WalletsDir, "Foo 2.json"));
 		}
 
 		[Fact]
-		public async Task GetFriendlyNameTestAsync()
+		public void GetFriendlyName()
 		{
 			Assert.Equal("Hardware Wallet", HardwareWalletModels.Unknown.FriendlyName());
 			Assert.Equal("Coldcard", HardwareWalletModels.Coldcard.FriendlyName());

--- a/WalletWasabi/Wallets/WalletDirectories.cs
+++ b/WalletWasabi/Wallets/WalletDirectories.cs
@@ -68,14 +68,13 @@ namespace WalletWasabi.Wallets
 			return result.OrderByDescending(t => t.LastAccessTimeUtc);
 		}
 
-		public string GetNextWalletName(string prefix = "Random Wallet")
+		public string GetNextWalletName(string prefix = "Wallet")
 		{
 			int i = 1;
 			var walletNames = EnumerateWalletFiles().Select(x => Path.GetFileNameWithoutExtension(x.Name));
 			while (true)
 			{
-				var walletName = i == 1 ? prefix : $"{prefix} {i}";
-
+				var walletName = $"{prefix} {i}";
 				if (!walletNames.Contains(walletName))
 				{
 					return walletName;


### PR DESCRIPTION
This PR removes the word `random` from the suggested wallet names when generating a new wallet.

I don't think using the word `random` helps make the wallet names more friendly.
I prefer `Wallet 1`, `Wallet 2` rather than `Random Wallet 1` `Random Wallet 2`