### PR TITLE
Use EnumExtension's FriendlyName on DequeueReason enum

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -30,6 +30,7 @@ using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Client;
 using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
+using WalletWasabi.Extensions;
 using WalletWasabi.Gui.CrashReport;
 using WalletWasabi.Gui.Helpers;
 using WalletWasabi.Gui.Models;
@@ -486,7 +487,7 @@ namespace WalletWasabi.Gui
 					if (reason != DequeueReason.Spent)
 					{
 						var type = reason == DequeueReason.UserRequested ? NotificationType.Information : NotificationType.Warning;
-						var message = reason == DequeueReason.UserRequested ? "" : reason.ToFriendlyString();
+						var message = reason == DequeueReason.UserRequested ? "" : reason.FriendlyName();
 						var title = success.Value.Count() == 1 ? $"Coin ({success.Value.First().Amount.ToString(false, true)}) Dequeued" : $"{success.Value.Count()} Coins Dequeued";
 						NotificationHelpers.Notify(message, title, type, sender: sender);
 					}
@@ -496,7 +497,7 @@ namespace WalletWasabi.Gui
 				{
 					DequeueReason reason = failure.Key;
 					var type = NotificationType.Warning;
-					var message = reason.ToFriendlyString();
+					var message = reason.FriendlyName();
 					var title = failure.Value.Count() == 1 ? $"Couldn't Dequeue Coin ({failure.Value.First().Amount.ToString(false, true)})" : $"Couldn't Dequeue {failure.Value.Count()} Coins";
 					NotificationHelpers.Notify(message, title, type, sender: sender);
 				}

--- a/WalletWasabi/CoinJoin/Client/Clients/Queuing/DequeueReason.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/Queuing/DequeueReason.cs
@@ -1,37 +1,34 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 
 namespace WalletWasabi.CoinJoin.Client.Clients.Queuing
 {
 	public enum DequeueReason
 	{
+		[Description("User requested.")]
 		UserRequested, // Success, user requested the dequeue.
-		TransactionBuilding, // Success, transaction is being built with the coins.
-		Banned, // Success
-		NotEnoughFundsEnqueued, // Success
-		CoordinatorFeeChanged, // Success
-		ApplicationExit, // Success, application is exiting.
-		Spent, // Success, coin is spent.
-		Mixing // Failure, the coin's mixing status is > registration.
-	}
 
-	public static class DequeueReasonExtensions
-	{
-		public static string ToFriendlyString(this DequeueReason me)
-		{
-			return me switch
-			{
-				DequeueReason.UserRequested => "User requested.",
-				DequeueReason.TransactionBuilding => "Using coin for transaction building.",
-				DequeueReason.Banned => "Coin is banned.",
-				DequeueReason.NotEnoughFundsEnqueued => "Not enough funds enqueued.",
-				DequeueReason.CoordinatorFeeChanged => "Coordinator fee changed.",
-				DequeueReason.ApplicationExit => "Application is exiting.",
-				DequeueReason.Spent => "Coin is spent.",
-				DequeueReason.Mixing => "Coin is being mixed.",
-				_ => me.ToString()
-			};
-		}
+		[Description("Using coin for transaction building.")]
+		TransactionBuilding, // Success, transaction is being built with the coins.
+
+		[Description("Coin is banned.")]
+		Banned, // Success
+
+		[Description("Not enough funds enqueued.")]
+		NotEnoughFundsEnqueued, // Success
+
+		[Description("Coordinator fee changed.")]
+		CoordinatorFeeChanged, // Success
+
+		[Description("Application is exiting.")]
+		ApplicationExit, // Success, application is exiting.
+
+		[Description("Coin is spent.")]
+		Spent, // Success, coin is spent.
+
+		[Description("Coin is being mixed.")]
+		Mixing // Failure, the coin's mixing status is > registration.
 	}
 }


### PR DESCRIPTION
Similar to here #4388.

Since now we have an `EnumExtension` to get a `FriendlyName()` I think it is better to use it here too.