### PR TITLE
Move the rest of installation stuff from TorProcessManager to TorInstallator.

### DIFF
--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Microservices;
 using WalletWasabi.Tor.Exceptions;
@@ -80,30 +79,7 @@ namespace WalletWasabi.Tor
 							return;
 						}
 
-						var fullBaseDirectory = EnvironmentHelpers.GetFullBaseDirectory();
-
-						if (!File.Exists(Settings.TorBinaryFilePath))
-						{
-							Logger.LogInfo($"Tor instance NOT found at '{Settings.TorBinaryFilePath}'. Attempting to acquire it ...");
-							new TorInstallator(Settings).InstallAsync().GetAwaiter().GetResult();
-						}
-						else if (!IoHelpers.CheckExpectedHash(Settings.HashSourcePath, Path.Combine(fullBaseDirectory, "TorDaemons")))
-						{
-							Logger.LogInfo($"Updating Tor...");
-
-							string backupTorDir = $"{Settings.TorDir}_backup";
-							if (Directory.Exists(backupTorDir))
-							{
-								Directory.Delete(backupTorDir, true);
-							}
-							Directory.Move(Settings.TorDir, backupTorDir);
-
-							new TorInstallator(Settings).InstallAsync().GetAwaiter().GetResult();
-						}
-						else
-						{
-							Logger.LogInfo($"Tor instance found at '{Settings.TorBinaryFilePath}'.");
-						}
+						new TorInstallator(Settings).VerifyInstallationAsync().GetAwaiter().GetResult();
 
 						string torArguments = Settings.GetCmdArguments(TorSocks5EndPoint);
 


### PR DESCRIPTION
This is part of #4244 project where I would actually like to get rid of those await `Task.Delay(3000);` delays in `TorTests` and enforce that when you start Tor and you ask for `ensureRunning` it will be started or an exception will be thrown. This PR paves the path to that goal.

**Notes:**

* Only moves a few conditions from `TorProcessManager` to `TorInstallator`. 
* The change is important because `TorInstallator` is supposed to do everything related to installation of Tor and `TorProcessManager` is supposed to manage Tor process: to run it and to monitor it.