### PR TITLE
Make button height same as textbox height

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletInfoView.xaml
@@ -28,7 +28,7 @@
                 </i:Interaction.Behaviors>
               </controls:TogglePasswordBox>
 
-              <Button VerticalAlignment="Top" Content="{Binding ShowSensitiveKeys, StringFormat=\{0\} Sensitive Keys, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Hide:Show}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right" />
+              <Button Content="{Binding ShowSensitiveKeys, StringFormat=\{0\} Sensitive Keys, Converter={StaticResource BooleanStringConverter}, ConverterParameter=Hide:Show}" Command="{Binding ToggleSensitiveKeysCommand}" DockPanel.Dock="Right" />
             </StackPanel>
 
             <StackPanel IsVisible="{Binding !IsWatchOnly}" Spacing="4">


### PR DESCRIPTION
Similar to https://github.com/zkSNACKs/WalletWasabi/pull/4321#issuecomment-693298309

> If password box has any text in it, the height of the button next to it grows to the same as the password box height.

![Capture](https://user-images.githubusercontent.com/52379387/93719429-c228de80-fb82-11ea-9007-92aca88b9a79.PNG)


There is still one place in the Receive tab where this can be changed but I don't know how to do that (@jmacato can you take a look at that):
https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Gui/Controls/WalletExplorer/ReceiveTabView.xaml#L30

![Capture3](https://user-images.githubusercontent.com/52379387/93719507-509d6000-fb83-11ea-8e6d-1ef34755dae5.PNG)
