### PR TITLE
TorProcessManager.Start - async version

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -176,7 +176,7 @@ namespace WalletWasabi.Gui
 				if (Config.UseTor)
 				{
 					TorManager = new TorProcessManager(TorSettings, Config.TorSocks5EndPoint);
-					TorManager.Start(ensureRunning: false);
+					await TorManager.StartAsync(ensureRunning: false).ConfigureAwait(false);
 
 					var fallbackRequestTestUri = new Uri(Config.GetFallbackBackendUri(), "/api/software/versions");
 					TorManager.StartMonitor(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(7), fallbackRequestTestUri);

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -175,8 +175,11 @@ namespace WalletWasabi.Gui
 
 				if (Config.UseTor)
 				{
-					TorManager = new TorProcessManager(TorSettings, Config.TorSocks5EndPoint);
-					await TorManager.StartAsync(ensureRunning: false).ConfigureAwait(false);
+					using (BenchmarkLogger.Measure(operationName: "TorProcessManager.Start"))
+					{
+						TorManager = new TorProcessManager(TorSettings, Config.TorSocks5EndPoint);
+						await TorManager.StartAsync(ensureRunning: false).ConfigureAwait(false);
+					}
 
 					var fallbackRequestTestUri = new Uri(Config.GetFallbackBackendUri(), "/api/software/versions");
 					TorManager.StartMonitor(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(7), fallbackRequestTestUri);

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -178,7 +178,7 @@ namespace WalletWasabi.Gui
 					using (BenchmarkLogger.Measure(operationName: "TorProcessManager.Start"))
 					{
 						TorManager = new TorProcessManager(TorSettings, Config.TorSocks5EndPoint);
-						await TorManager.StartAsync(ensureRunning: false).ConfigureAwait(false);
+						await TorManager.StartAsync(ensureRunning: true).ConfigureAwait(false);
 					}
 
 					var fallbackRequestTestUri = new Uri(Config.GetFallbackBackendUri(), "/api/software/versions");

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -28,8 +28,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task InitializeAsync()
 		{
 			var torManager = new TorProcessManager(Global.Instance.TorSettings, Global.Instance.TorSocks5Endpoint);
-			torManager.Start(ensureRunning: true);
-			await Task.Delay(3000);
+			await torManager.StartAsync(ensureRunning: true);
 		}
 
 		public Task DisposeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -28,7 +28,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task InitializeAsync()
 		{
 			var torManager = new TorProcessManager(Global.Instance.TorSettings, Global.Instance.TorSocks5Endpoint);
-			await torManager.StartAsync(ensureRunning: true);
+			bool started = await torManager.StartAsync(ensureRunning: true);
+			Assert.True(started, "Tor failed to start.");
 		}
 
 		public Task DisposeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -17,8 +17,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task InitializeAsync()
 		{
 			var torManager = new TorProcessManager(Global.Instance.TorSettings, Global.Instance.TorSocks5Endpoint);
-			torManager.Start(ensureRunning: true);
-			await Task.Delay(3000);
+			await torManager.StartAsync(ensureRunning: true);
 		}
 
 		public Task DisposeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;

--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -16,7 +16,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task InitializeAsync()
 		{
 			var torManager = new TorProcessManager(Global.Instance.TorSettings, Global.Instance.TorSocks5Endpoint);
-			await torManager.StartAsync(ensureRunning: true);
+			bool started = await torManager.StartAsync(ensureRunning: true);
+			Assert.True(started, "Tor failed to start.");
 		}
 
 		public Task DisposeAsync()

--- a/WalletWasabi/Logging/BenchmarkLogger.cs
+++ b/WalletWasabi/Logging/BenchmarkLogger.cs
@@ -45,16 +45,16 @@ namespace WalletWasabi.Logging
 				{
 					Stopwatch.Stop();
 
-					var min = Stopwatch.Elapsed.TotalMinutes;
-					var sec = Stopwatch.Elapsed.TotalSeconds;
+					double min = Stopwatch.Elapsed.TotalMinutes;
+					double sec = Stopwatch.Elapsed.TotalSeconds;
 					string message;
 					if (min > 1)
 					{
-						message = $"{OperationName} finished in {(int)min} minutes.";
+						message = $"{OperationName} finished in {min:#.##} minutes.";
 					}
 					else if (sec > 1)
 					{
-						message = $"{OperationName} finished in {(int)sec} seconds.";
+						message = $"{OperationName} finished in {sec:#.##} seconds.";
 					}
 					else
 					{

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -136,7 +136,7 @@ namespace WalletWasabi.Tor
 							break;
 						}
 
-						const int MaxAttempts = 15;
+						const int MaxAttempts = 25;
 
 						if (i >= MaxAttempts)
 						{
@@ -144,8 +144,8 @@ namespace WalletWasabi.Tor
 							return false;
 						}
 
-						// Wait 750 milliseconds between attempts.
-						await Task.Delay(500).ConfigureAwait(false);
+						// Wait 250 milliseconds between attempts.
+						await Task.Delay(250).ConfigureAwait(false);
 					}
 
 					Logger.LogInfo("Tor is running.");

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Tor
 		/// </summary>
 		/// <param name="ensureRunning">
 		/// If <c>false</c>, Tor is started but no attempt to verify that it actually runs is made.
-		/// <para>If <c>true</c>, we start Tor and attempt to connect to it to verify it is running (at most 10 attempts).</para>
+		/// <para>If <c>true</c>, we start Tor and attempt to connect to it to verify it is running (at most 25 attempts).</para>
 		/// </param>
 		public async Task<bool> StartAsync(bool ensureRunning)
 		{


### PR DESCRIPTION
This is part of #4244 project where I would actually like to get rid of those await `Task.Delay(3000);` delays in `TorTests` and enforce that when you start Tor and you ask for `ensureRunning` it will be started or an exception will be thrown. This PR paves the path to that goal.

<s>**Depends on #4403.**</s>

**Notes;**

* Review with whitespace changes [disabled](https://github.com/zkSNACKs/WalletWasabi/pull/4405/files?diff=split&w=1).
* Major change (up to discussion here) is [waiting until Wasabi Wallet can connect to Tor process](https://github.com/zkSNACKs/WalletWasabi/pull/4405/files?diff=split&w=1#diff-4d4ddd30769b96fecd018a04b266a850R181) (note that this is not the same as to prove that Tor really works because to prove that you need to access some URL via Tor).
  * On my machine with VMs, it takes around 1.3 second to do that. So Wasabi Wallet startup would be **slower**. Note that it's one thing: when you close and start Wasabi Wallet again, it will be much faster.
  * Why does this make sense to me even when it's slower? There is no coordination of starting of various services. So for example, there is `UpdateChecker` which needs Tor (suppose user wants to use Tor) to function correctly. But Tor may not be connected just yet, so it will throw an exception on startup. I think this may confuse users. And also it's noisy when user reports issues back to Wasabi devs. 
  * Why not just start services in correct order to avoid that delay? I agree that that would be the best approach here. I have actually tried that for `UpdateChecker` locally but it got out-of-hand quite quickly as it lead me to make big changes I was not happy with. 
* `BenchmarkLogger was modified to be more [precise](https://github.com/zkSNACKs/WalletWasabi/pull/4405/files#diff-468cd65c69794967ca9f8dd5ab5f2257R53). 
* `TorProcessManager.StartAsync(ensureRunning:true)` uses a [new algorithm](https://github.com/zkSNACKs/WalletWasabi/pull/4405/files#diff-ecde5e50ff2abc89fa9ac3db58ca7d5fR139) which attempts (at most 10 times) to make a connection to Tor or it gives up. This makes the method nicer to use as you know whether Tor was started or not.
* `Settings.LogFilePath` is already non-null, so the condition was superfluous.