### PR TITLE
Update NBitcoin and NBitcoin.Secp256k1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,4 @@ lcov.info
 # WindowsInstaller generated files
 /WalletWasabi.WindowsInstaller/ComponentsGenerated.wxs
 /WalletWasabi.WindowsInstaller/*.wixobj
+.ionide/symbolCache.db

--- a/WalletWasabi.Gui/packages.lock.json
+++ b/WalletWasabi.Gui/packages.lock.json
@@ -552,8 +552,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "5.0.47",
-        "contentHash": "fjEOFg2syu1AC2Q6NCeZ8GmwpDGtUeRTvbgiRyVQflm8NVSR/6X2mrFRu+KG/Q+77eq9c5K5ip081cnpuK9d4w==",
+        "resolved": "5.0.57",
+        "contentHash": "KPSXwlUAcsysp27ygpO/dQDqu1R2kKUDfloDovTRwajFIpKJ/QY6vWrhR0d4IDMh9A3HBCiN3yc6oFUpYj/NYw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.1"
@@ -561,8 +561,8 @@
       },
       "NBitcoin.Secp256k1": {
         "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "TCRUf7C44H/Hy42Ad1g0Dt83EfEH0l+4OuDhnWrzVsPBNiM6s6YRHnHYT+0dxGZKxD0CgdCTZ5f9Z2Ml1RRGbw=="
+        "resolved": "1.0.8",
+        "contentHash": "X96liPg7Xr3qUMq3Js/+Ochq/aCR0DnwkXwzS63rlkL6w2YkYH7V88ngGQe3qNv7HAr9pe+v6Qkn/GF2ggEzsQ=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -2272,8 +2272,8 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "3.1.1",
           "Microsoft.Win32.Registry": "4.7.0",
-          "NBitcoin": "5.0.47",
-          "NBitcoin.Secp256k1": "1.0.3"
+          "NBitcoin": "5.0.57",
+          "NBitcoin.Secp256k1": "1.0.8"
         }
       }
     },

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -63,8 +63,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "5.0.47",
-        "contentHash": "fjEOFg2syu1AC2Q6NCeZ8GmwpDGtUeRTvbgiRyVQflm8NVSR/6X2mrFRu+KG/Q+77eq9c5K5ip081cnpuK9d4w==",
+        "resolved": "5.0.57",
+        "contentHash": "KPSXwlUAcsysp27ygpO/dQDqu1R2kKUDfloDovTRwajFIpKJ/QY6vWrhR0d4IDMh9A3HBCiN3yc6oFUpYj/NYw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.1"
@@ -72,8 +72,8 @@
       },
       "NBitcoin.Secp256k1": {
         "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "TCRUf7C44H/Hy42Ad1g0Dt83EfEH0l+4OuDhnWrzVsPBNiM6s6YRHnHYT+0dxGZKxD0CgdCTZ5f9Z2Ml1RRGbw=="
+        "resolved": "1.0.8",
+        "contentHash": "X96liPg7Xr3qUMq3Js/+Ochq/aCR0DnwkXwzS63rlkL6w2YkYH7V88ngGQe3qNv7HAr9pe+v6Qkn/GF2ggEzsQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
@@ -293,8 +293,8 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "3.1.1",
           "Microsoft.Win32.Registry": "4.7.0",
-          "NBitcoin": "5.0.47",
-          "NBitcoin.Secp256k1": "1.0.3"
+          "NBitcoin": "5.0.57",
+          "NBitcoin.Secp256k1": "1.0.8"
         }
       }
     },

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -27,9 +27,9 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-	  <PackageReference Include="NBitcoin" Version="5.0.47" />
+	  <PackageReference Include="NBitcoin" Version="5.0.57" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.3" />
+    <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[5.0.47, )",
-        "resolved": "5.0.47",
-        "contentHash": "fjEOFg2syu1AC2Q6NCeZ8GmwpDGtUeRTvbgiRyVQflm8NVSR/6X2mrFRu+KG/Q+77eq9c5K5ip081cnpuK9d4w==",
+        "requested": "[5.0.57, )",
+        "resolved": "5.0.57",
+        "contentHash": "KPSXwlUAcsysp27ygpO/dQDqu1R2kKUDfloDovTRwajFIpKJ/QY6vWrhR0d4IDMh9A3HBCiN3yc6oFUpYj/NYw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.1"
@@ -35,9 +35,9 @@
       },
       "NBitcoin.Secp256k1": {
         "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "TCRUf7C44H/Hy42Ad1g0Dt83EfEH0l+4OuDhnWrzVsPBNiM6s6YRHnHYT+0dxGZKxD0CgdCTZ5f9Z2Ml1RRGbw=="
+        "requested": "[1.0.8, )",
+        "resolved": "1.0.8",
+        "contentHash": "X96liPg7Xr3qUMq3Js/+Ochq/aCR0DnwkXwzS63rlkL6w2YkYH7V88ngGQe3qNv7HAr9pe+v6Qkn/GF2ggEzsQ=="
       },
       "Microsoft.AspNetCore.JsonPatch": {
         "type": "Transitive",


### PR DESCRIPTION
NBitcoin.Secp256k1 contains a new ctor for Scalar that we need to use. I took the opportunity to update NBitcoin too (this is not absolutely necessary but we use to work with the latest version).