### PR TITLE
Fix name violations

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/ProofSystemTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ProofSystemTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NBitcoin.Secp256k1;
 using WalletWasabi.Crypto;
@@ -10,6 +11,7 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto
 {
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Crypto naming")]
 	public class ProofSystemTests
 	{
 		[Fact]

--- a/WalletWasabi/Crypto/ZeroKnowledge/Credential.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/Credential.cs
@@ -1,4 +1,5 @@
-﻿using NBitcoin.Secp256k1;
+using NBitcoin.Secp256k1;
+using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Crypto.Groups;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge
@@ -16,6 +17,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 		public Scalar Randomness { get; }
 		public MAC Mac { get; }
 
+		[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Crypto naming")]
 		public CredentialPresentation Present(Scalar z)
 		{
 			GroupElement Randomize(GroupElement G, GroupElement M) => M + z * G;

--- a/WalletWasabi/Crypto/ZeroKnowledge/CredentialPresentation.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/CredentialPresentation.cs
@@ -1,9 +1,11 @@
-﻿using WalletWasabi.Crypto.Groups;
+using System.Diagnostics.CodeAnalysis;
+using WalletWasabi.Crypto.Groups;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge
 {
 	public class CredentialPresentation
 	{
+		[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Crypto naming")]
 		public CredentialPresentation(GroupElement Ca, GroupElement Cx0, GroupElement Cx1, GroupElement CV, GroupElement S)
 		{
 			this.Ca = Ca;

--- a/WalletWasabi/Crypto/ZeroKnowledge/ProofSystem.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/ProofSystem.cs
@@ -1,4 +1,5 @@
 using NBitcoin.Secp256k1;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
@@ -46,6 +47,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 				ShowCredential(presentation, z * iparams.I, iparams),
 				new ScalarVector(z, (credential.Mac.T * z).Negate(), credential.Mac.T, credential.Amount, credential.Randomness));
 
+		[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Crypto naming")]
 		public static Statement ShowCredential(CredentialPresentation c, GroupElement Z, CoordinatorParameters iparams)
 			=> new Statement(new GroupElement[,]
 			{

--- a/WalletWasabi/Crypto/ZeroKnowledge/SyntheticSecretNonceProvider.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/SyntheticSecretNonceProvider.cs
@@ -9,29 +9,29 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 {
 	public class SyntheticSecretNonceProvider
 	{
-		private readonly Strobe128 _strobe;
-		private readonly int _secretCount;
+		private readonly Strobe128 Strobe;
+		private readonly int SecretCount;
 
 		public SyntheticSecretNonceProvider(Strobe128 strobe, IEnumerable<Scalar> secrets, WasabiRandom random)
 		{
 			Guard.NotNullOrEmpty(nameof(secrets), secrets);
-			_strobe = strobe;
-			_secretCount = secrets.Count();
+			Strobe = strobe;
+			SecretCount = secrets.Count();
 
 			// add secret inputs as key material
 			foreach (var secret in secrets)
 			{
-				_strobe.Key(secret.ToBytes(), false);
+				Strobe.Key(secret.ToBytes(), false);
 			}
 
-			_strobe.Key(random.GetBytes(32), false);
+			Strobe.Key(random.GetBytes(32), false);
 		}
 
 		private IEnumerable<Scalar> Sequence()
 		{
 			while (true)
 			{
-				yield return new Scalar(_strobe.Prf(32, false));
+				yield return new Scalar(Strobe.Prf(32, false));
 			}
 		}
 
@@ -39,6 +39,6 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 			Sequence().First();
 
 		public ScalarVector GetScalarVector() =>
-			new ScalarVector(Sequence().Take(_secretCount));
+			new ScalarVector(Sequence().Take(SecretCount));
 	}
 }


### PR DESCRIPTION
The reason I didn't fix the naming violations for the crypto variables https://github.com/zkSNACKs/WalletWasabi/pull/3622#pullrequestreview-408517414:

> in code handling crypto concepts it is critical important to visualize easily what is an scalar (lowercase) and what is an elliptic point (uppercase) so, if I read A2 = w * P it is obvious that this is w times the EC point P and I know the result is another EC point A2 but, if I read a2 = w * p I understand that that is a scalar multiplication.