### PR TITLE
Change access modifier & rename fields to fix name violation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -151,12 +151,12 @@ dotnet_naming_symbols.readonly_fields.applicable_kinds   = field
 dotnet_naming_symbols.readonly_fields.required_modifiers = readonly
 
 # internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = error
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_rule.camel_case_for_private_fields.severity = error
+dotnet_naming_rule.camel_case_for_private_fields.symbols  = private_fields
+dotnet_naming_rule.camel_case_for_private_fields.style    = camel_case_underscore_style
 
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case

--- a/WalletWasabi.Packager/NSubsys/NSubsysUtil.cs
+++ b/WalletWasabi.Packager/NSubsys/NSubsysUtil.cs
@@ -19,8 +19,8 @@ namespace NSubsys
 			SubSystemType subsysVal;
 			var subsysOffset = peFile.MainHeaderOffset;
 
-			subsysVal = (SubSystemType)peFile.OptionalHeader.Subsystem;
-			subsysOffset += Marshal.OffsetOf<ImageOptionalHeader>(nameof(ImageOptionalHeader.Subsystem)).ToInt32();
+			subsysVal = (SubSystemType)peFile.OptionalHeader._subsystem;
+			subsysOffset += Marshal.OffsetOf<ImageOptionalHeader>(nameof(ImageOptionalHeader._subsystem)).ToInt32();
 
 			switch (subsysVal)
 			{

--- a/WalletWasabi.Packager/NSubsys/PeUtility.cs
+++ b/WalletWasabi.Packager/NSubsys/PeUtility.cs
@@ -17,7 +17,7 @@ namespace NSubsys
 			var dosHeader = FromBinaryReader<ImageDosHeader>(reader);
 
 			// Seek the new PE Header and skip NtHeadersSignature (4 bytes) & IMAGE_FILE_HEADER struct (20bytes).
-			Stream.Seek(dosHeader.FileAddressNew + 4 + 20, SeekOrigin.Begin);
+			Stream.Seek(dosHeader._fileAddressNew + 4 + 20, SeekOrigin.Begin);
 
 			MainHeaderOffset = Stream.Position;
 
@@ -67,22 +67,18 @@ namespace NSubsys
 			InternalBinReader?.Dispose();
 		}
 
-#pragma warning disable IDE1006 // Naming Styles
-
 		[StructLayout(LayoutKind.Explicit)]
 		public struct ImageDosHeader
 		{
 			[FieldOffset(60)]
-			public uint FileAddressNew;
+			internal uint _fileAddressNew;
 		}
 
 		[StructLayout(LayoutKind.Explicit)]
 		public struct ImageOptionalHeader
 		{
 			[FieldOffset(68)]
-			public ushort Subsystem;
+			internal ushort _subsystem;
 		}
-
-#pragma warning restore IDE1006 // Naming Styles
 	}
 }


### PR DESCRIPTION
I changed the access modifiers from public to internal (fields) to be able to remove the pragma warning and to fix the name violation.

I changed them before but to public (properties) not to internal fields https://github.com/zkSNACKs/WalletWasabi/commit/f3b77ae1a2422fa30aa279879f6d33d8e6683af3#diff-62b3e00b350f62d9adee789be2a8a3c8, but then @nopara73 had to change them back to public fields https://github.com/zkSNACKs/WalletWasabi/commit/8f6bef0fd8c2c4f0e1203916b7d0643a55bcd8e7#diff-62b3e00b350f62d9adee789be2a8a3c8 because it caused an issue.

@nopara73 please make sure that this doesn't introduce any issue.