### PR TITLE
Improve fee estimation

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
 using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Backend.Controllers
@@ -80,7 +81,14 @@ namespace WalletWasabi.Backend.Controllers
 
 			if (estimateSmartFee)
 			{
-				response.AllFeeEstimate = await BlockchainController.GetAllFeeEstimateAsync(mode);
+				try
+				{
+					response.AllFeeEstimate = await BlockchainController.GetAllFeeEstimateAsync(mode);
+				}
+				catch (Exception ex)
+				{
+					Logger.LogError(ex);
+				}
 			}
 
 			response.ExchangeRates = await OffchainController.GetExchangeRatesCollectionAsync();

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -78,7 +78,7 @@ namespace WalletWasabi.Backend.Controllers
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => RpcClient.EstimateAllFeeAsync(mode, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true));
+				() => RpcClient.EstimateAllFeeAsync(mode, simulateIfRegTest: true));
 		}
 
 		/// <summary>

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -42,74 +42,6 @@ namespace WalletWasabi.Backend.Controllers
 		public Global Global { get; }
 
 		/// <summary>
-		/// Get fees for the requested confirmation targets based on Bitcoin Core's estimatesmartfee output.
-		/// </summary>
-		/// <remarks>
-		/// Sample request:
-		///
-		///     GET /fees/2,144,1008
-		///
-		/// </remarks>
-		/// <param name="confirmationTargets">Confirmation targets in blocks wit comma separation. (2 - 1008)</param>
-		/// <returns>Array of fee estimations for the requested confirmation targets. A fee estimation contains estimation mode (Conservative/Economical) and byte per satoshi pairs.</returns>
-		/// <response code="200">Returns array of fee estimations for the requested confirmation targets.</response>
-		/// <response code="400">If invalid conformation targets were provided. (2 - 1008 integers)</response>
-		[HttpGet("fees/{confirmationTargets}")]
-		[ProducesResponseType(200)] // Note: If you add typeof(SortedDictionary<int, FeeEstimationPair>) then swagger UI will visualize incorrectly.
-		[ProducesResponseType(400)]
-		[ResponseCache(Duration = 300, Location = ResponseCacheLocation.Client)]
-		public async Task<IActionResult> GetFeesAsync(string confirmationTargets)
-		{
-			if (string.IsNullOrWhiteSpace(confirmationTargets) || !ModelState.IsValid)
-			{
-				return BadRequest($"Invalid {nameof(confirmationTargets)} are provided.");
-			}
-
-			var confirmationTargetsInts = new HashSet<int>();
-			foreach (var targetParam in confirmationTargets.Split(',', StringSplitOptions.RemoveEmptyEntries))
-			{
-				if (int.TryParse(targetParam, out var target))
-				{
-					if (target < 2 || target > Constants.SevenDaysConfirmationTarget)
-					{
-						return BadRequest($"All requested confirmation target must be >= 2 AND <= {Constants.SevenDaysConfirmationTarget}.");
-					}
-
-					if (confirmationTargetsInts.Contains(target))
-					{
-						continue;
-					}
-
-					confirmationTargetsInts.Add(target);
-				}
-				else
-				{
-					return BadRequest($"Invalid {nameof(confirmationTargets)} are provided.");
-				}
-			}
-
-			var feeEstimations = new SortedDictionary<int, FeeEstimationPair>();
-
-			foreach (int target in confirmationTargetsInts)
-			{
-				// 1. Use the sanity check that under 2 satoshi per byte should not be displayed. To correct possible rounding errors.
-				// 2. Use the RPCResponse.Blocks output to avoid redundant RPC queries.
-				// 3. Use caching.
-				var conservativeResponse = await GetEstimateSmartFeeAsync(target, EstimateSmartFeeMode.Conservative);
-				var economicalResponse = await GetEstimateSmartFeeAsync(target, EstimateSmartFeeMode.Economical);
-				var conservativeFee = conservativeResponse.FeeRate.FeePerK.Satoshi / 1000;
-				var economicalFee = economicalResponse.FeeRate.FeePerK.Satoshi / 1000;
-
-				conservativeFee = Math.Max(conservativeFee, 2);
-				economicalFee = Math.Max(economicalFee, 2);
-
-				feeEstimations.Add(target, new FeeEstimationPair() { Conservative = conservativeFee, Economical = economicalFee });
-			}
-
-			return Ok(feeEstimations);
-		}
-
-		/// <summary>
 		/// Get all fees.
 		/// </summary>
 		/// <remarks>
@@ -397,17 +329,6 @@ namespace WalletWasabi.Backend.Controllers
 			};
 
 			return Ok(response);
-		}
-
-		private async Task<EstimateSmartFeeResponse> GetEstimateSmartFeeAsync(int target, EstimateSmartFeeMode mode)
-		{
-			var cacheKey = $"{nameof(GetEstimateSmartFeeAsync)}_{target}_{mode}";
-			var cacheOptions = new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(60) };
-
-			return await Cache.AtomicGetOrCreateAsync(
-				cacheKey,
-				cacheOptions,
-				() => RpcClient.EstimateSmartFeeAsync(target, mode, simulateIfRegTest: true, tryOtherFeeRates: true));
 		}
 
 		[HttpGet("status")]

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -131,14 +131,6 @@ namespace WalletWasabi.Backend
 
 				Logger.LogInfo($"{Constants.BuiltinBitcoinNodeName} is fully synchronized.");
 
-				var estimateSmartFeeResponse = await RpcClient.TryEstimateSmartFeeAsync(2, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true);
-				if (estimateSmartFeeResponse is null)
-				{
-					throw new NotSupportedException($"{Constants.BuiltinBitcoinNodeName} cannot estimate network fees yet.");
-				}
-
-				Logger.LogInfo($"{Constants.BuiltinBitcoinNodeName} fee estimation is working.");
-
 				if (Config.Network == Network.RegTest) // Make sure there's at least 101 block, if not generate it
 				{
 					if (blocks < 101)

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -44,17 +44,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Theory]
 		[InlineData(NetworkType.Mainnet)]
 		[InlineData(NetworkType.Testnet)]
-		public async Task GetFeesAsync(NetworkType networkType)
-		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Global.Instance.TorSocks5Endpoint);
-			var feeEstimationPairs = await client.GetFeesAsync(1000);
-
-			Assert.True(feeEstimationPairs.NotNullAndNotEmpty());
-		}
-
-		[Theory]
-		[InlineData(NetworkType.Mainnet)]
-		[InlineData(NetworkType.Testnet)]
 		public async Task GetFiltersAsync(NetworkType networkType)
 		{
 			Network network = (networkType == NetworkType.Mainnet) ? Network.Main : Network.TestNet;

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1050,7 +1050,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			}
 
 			FeeRate feeRateTx = finalCoinjoin.GetFeeRate(coins.ToArray());
-			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true);
+			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
 			FeeRate feeRateReal = esr.FeeRate;
 
 			Assert.True(feeRateReal.FeePerK - feeRateReal.FeePerK / 2 < feeRateTx.FeePerK); // Max 50% mistake.

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -158,17 +158,12 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			try
 			{
 				var rpc = coreNode.RpcClient;
-				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true);
+				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
 				Assert.Equal(WalletWasabi.Helpers.Constants.OneDayConfirmationTarget, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
-				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: true);
-				Assert.Equal(145, estimations.Estimations.Count);
-				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
-				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
-				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);
-				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true, tolerateBitcoinCoreBrainfuck: false);
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
 				Assert.Equal(145, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 		{
 			try
 			{
-				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, true).ConfigureAwait(false);
+				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true).ConfigureAwait(false);
 				AllFeeEstimate = allFeeEstimate;
 			}
 			catch

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -810,7 +810,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				}
 
 				// 7.2. Get the most optimal FeeRate.
-				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true).ConfigureAwait(false);
+				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 				if (estimateSmartFeeResponse is null)
 				{
 					throw new InvalidOperationException($"{nameof(FeeRate)} is not yet initialized.");
@@ -893,7 +893,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			var outputSizeInBytes = Constants.OutputSizeInBytes;
 			try
 			{
-				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true).ConfigureAwait(false);
+				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 
 				var feeRate = estimateSmartFeeResponse.FeeRate;
 				Money feePerBytes = feeRate.FeePerK / 1000;

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -894,10 +894,6 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			try
 			{
 				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, tryOtherFeeRates: true).ConfigureAwait(false);
-				if (estimateSmartFeeResponse is null)
-				{
-					throw new InvalidOperationException($"{nameof(FeeRate)} is not yet initialized.");
-				}
 
 				var feeRate = estimateSmartFeeResponse.FeeRate;
 				Money feePerBytes = feeRate.FeePerK / 1000;

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -142,21 +142,6 @@ namespace WalletWasabi.WebClients.Wasabi
 			return allTxs.ToDependencyGraph().OrderByDependency();
 		}
 
-		public async Task<IDictionary<int, FeeEstimationPair>> GetFeesAsync(params int[] confirmationTargets)
-		{
-			var confirmationTargetsString = string.Join(",", confirmationTargets);
-
-			using var response = await TorClient.SendAndRetryAsync(HttpMethod.Get, HttpStatusCode.OK, $"/api/v{ApiVersion}/btc/blockchain/fees/{confirmationTargetsString}");
-			if (response.StatusCode != HttpStatusCode.OK)
-			{
-				await response.ThrowRequestExceptionFromContentAsync();
-			}
-
-			using HttpContent content = response.Content;
-			var ret = await content.ReadAsJsonAsync<IDictionary<int, FeeEstimationPair>>();
-			return ret;
-		}
-
 		public async Task BroadcastAsync(string hex)
 		{
 			using var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json");


### PR DESCRIPTION
- Remove a bunch of dead code.
- Handle fee estimation fail gracefully on the backend.
- Don't prevent running of the backend if fee estimation isn't available.
- This was freezing the UI with Core when estimation wasn't available.