### PR TITLE
Encode PSBT using base64 instead of base16

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -122,7 +122,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 				}
 
-				return new PayjoinClient(payjoinEndPointUri, Global.TorSocks5EndPoint);
+				return new PayjoinClient(payjoinEndPointUri, Global.Config.TorSocks5EndPoint);
 			}
 
 			return null;

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -231,12 +231,14 @@ namespace WalletWasabi.Blockchain.Transactions
 
 				UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
 
+				var isPayjoin = false;
 				if (!KeyManager.IsWatchOnly)
 				{
 					// Try to pay using payjoin
 					if (payjoinClient is { })
 					{
 						psbt = TryNegotiatePayjoin(payjoinClient, builder, psbt, changeHdPubKey);
+						isPayjoin = true;
 					}
 				}
 				psbt.Finalize();
@@ -248,13 +250,16 @@ namespace WalletWasabi.Blockchain.Transactions
 					throw new InvalidOperationException("Impossible to get the fee rate of the PSBT, this should never happen.");
 				}
 
-				// Manually check the feerate, because some inaccuracy is possible.
-				var sb1 = feeRate.SatoshiPerByte;
-				var sb2 = actualFeeRate.SatoshiPerByte;
-				if (Math.Abs(sb1 - sb2) > 2) // 2s/b inaccuracy ok.
+				if (!isPayjoin)
 				{
-					// So it'll generate a transactionpolicy error thrown below.
-					checkResults.Add(new NotEnoughFundsPolicyError("Fees different than expected"));
+					// Manually check the feerate, because some inaccuracy is possible.
+					var sb1 = feeRate.SatoshiPerByte;
+					var sb2 = actualFeeRate.SatoshiPerByte;
+					if (Math.Abs(sb1 - sb2) > 2) // 2s/b inaccuracy ok.
+					{
+						// So it'll generate a transactionpolicy error thrown below.
+						checkResults.Add(new NotEnoughFundsPolicyError("Fees different than expected"));
+					}
 				}
 				if (checkResults.Count > 0)
 				{

--- a/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
@@ -93,7 +93,7 @@ namespace WalletWasabi.WebClients.PayJoin
 
 			var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
 			{
-				Content = new StringContent(cloned.ToHex(), Encoding.UTF8, "text/plain")
+				Content = new StringContent(cloned.ToBase64(), Encoding.UTF8, "text/plain")
 			};
 
 			HttpResponseMessage bpuResponse = await TorHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #4426
Encode the PSBT with base64 in the PayJoin client in order to make it work with JM. BTCPayServer uses base16 but the bip says base64 only so.
@MaxHillebrand would you like to try this?