### PR TITLE
TorHttpClient: SslStream is supposed to support SNI since .NET Core 2.1.

### DIFF
--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -173,7 +173,7 @@ namespace WalletWasabi.Tor.Http
 
 			// https://tools.ietf.org/html/rfc7230#section-2.7.1
 			// A sender MUST NOT generate an "http" URI with an empty host identifier.
-			var host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
+			string host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
 
 			// https://tools.ietf.org/html/rfc7230#section-2.6
 			// Intermediaries that process HTTP messages (i.e., all intermediaries
@@ -197,25 +197,7 @@ namespace WalletWasabi.Tor.Http
 				Stream stream = TorSocks5Client.TcpClient.GetStream();
 				if (request.RequestUri.Scheme == "https")
 				{
-					SslStream sslStream;
-					// On Linux and OSX ignore certificate, because of a .NET Core bug
-					// This is a security vulnerability, has to be fixed as soon as the bug get fixed
-					// Details:
-					// https://github.com/dotnet/corefx/issues/21761
-					// https://github.com/nopara73/DotNetTor/issues/4
-					if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-					{
-						sslStream = new SslStream(
-							stream,
-							leaveInnerStreamOpen: true);
-					}
-					else
-					{
-						sslStream = new SslStream(
-							stream,
-							leaveInnerStreamOpen: true,
-							userCertificateValidationCallback: (a, b, c, d) => true);
-					}
+					SslStream sslStream = new SslStream(stream, leaveInnerStreamOpen: true);
 
 					await sslStream
 						.AuthenticateAsClientAsync(


### PR DESCRIPTION
I have noticed this TODO in code when looking at #4421.

Depends on #4405. (For correct path where to install Tor when running tests with: `~/work/WalletWasabi$ dotnet test --configuration Debug --filter "IntegrationTests" --logger "console;verbosity=detailed"`).

Relevant resources:

* https://github.com/dotnet/corefx/issues/21761
* https://github.com/dotnet/runtime/issues/17677
* https://github.com/dotnet/corefx/pull/28278 - PR fixing the issue
* https://devblogs.microsoft.com/dotnet/announcing-net-core-2-1-preview-1/#sockets-performance-and-http-managed-handler - relevant release notes for .NET Core 2.1

@nopara73 Do you agree with the concept here? Do you possibly remember how to test this?