### PR TITLE
[WabiSabi] Range proof

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/ProofSystemTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ProofSystemTests.cs
@@ -178,5 +178,45 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			var badStatement = ProofSystem.BalanceProof(Ca + (delta + Scalar.One) * Generators.Gg - Ma);
 			Assert.False(ProofSystem.Verify(badStatement, proofOfBalance));
 		}
+
+		[Theory]
+		[InlineData(0, 0, true)]
+		[InlineData(0, 1, true)]
+		[InlineData(1, 0, false)]
+		[InlineData(1, 1, true)]
+		[InlineData(1, 2, true)]
+		[InlineData(2, 0, false)]
+		[InlineData(2, 1, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(3, 1, false)]
+		[InlineData(3, 2, true)]
+		[InlineData(4, 2, false)]
+		[InlineData(4, 3, true)]
+		[InlineData(7, 2, false)]
+		[InlineData(7, 3, true)]
+		[InlineData((ulong)uint.MaxValue + 1, 32, false)]
+		[InlineData((ulong)uint.MaxValue + 1, 33, true)]
+		[InlineData(2099999997690000ul, 50, false)]
+		[InlineData(2099999997690000ul, 51, true)]
+		public void CanProveAndVerifyCommitmentRange(ulong amount, int width, bool pass)
+		{
+			var rnd = new SecureRandom();
+
+			var amountScalar = new Scalar(amount);
+			var randomness = rnd.GetScalar();
+			var commitment = amountScalar * Generators.Gg + randomness * Generators.Gh;
+
+			var maskedScalar = new Scalar(amount & ((1ul << width) - 1));
+			var (knowledge, bitCommitments) = ProofSystem.RangeProof(maskedScalar, randomness, width, rnd);
+
+			var rangeProof = ProofSystem.Prove(knowledge, rnd);
+
+			Assert.Equal(pass, ProofSystem.Verify(ProofSystem.RangeProof(commitment, bitCommitments), rangeProof));
+
+			if (!pass)
+			{
+				Assert.Throws<ArgumentOutOfRangeException>(() => ProofSystem.RangeProof(amountScalar, randomness, width, rnd));
+			}
+		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/LinearRelationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/LinearRelationTests.cs
@@ -153,17 +153,6 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 		}
 
 		[Fact]
-		public void StatementThrows()
-		{
-			// Null generators are not allowed
-			Assert.ThrowsAny<ArgumentException>(() => new Statement(new GroupElement[,]
-			{
-				{ GroupElement.Infinity, Generators.Gg, Generators.Gh },
-				{ GroupElement.Infinity, Generators.G, null! },
-			}));
-		}
-
-		[Fact]
 		public void KnowledgeThrows()
 		{
 			var x = new Scalar(42);

--- a/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Statement.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Statement.cs
@@ -8,6 +8,8 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 {
 	public class Statement
 	{
+		private static GroupElement O = GroupElement.Infinity;
+
 		public Statement(GroupElement publicPoint, IEnumerable<GroupElement> generators)
 			: this(ToTable(generators.Prepend(publicPoint)))
 		{
@@ -22,15 +24,11 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 		{
 			var terms = equations.GetLength(1);
 			Guard.True(nameof(terms), terms >= 2, $"Invalid {nameof(terms)}. It needs to have at least one generator and one public point.");
-			foreach (var generator in equations)
-			{
-				Guard.NotNull(nameof(generator), generator);
-			}
 
 			// make an equation out of each row taking the first element of each row as the public point
 			var rows = Enumerable.Range(0, equations.GetLength(0));
 			var cols = Enumerable.Range(1, terms - 1);
-			Equations = rows.Select(i => new Equation(equations[i, 0], new GroupElementVector(cols.Select(j => equations[i, j]))));
+			Equations = rows.Select(i => new Equation(equations[i, 0] ?? O, new GroupElementVector(cols.Select(j => equations[i, j] ?? O))));
 		}
 
 		public IEnumerable<Equation> Equations { get; }

--- a/WalletWasabi/Crypto/ZeroKnowledge/ProofSystem.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/ProofSystem.cs
@@ -1,9 +1,11 @@
 using NBitcoin.Secp256k1;
+using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Crypto.ZeroKnowledge.NonInteractive;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge
 {
@@ -65,5 +67,123 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 		// using generator Ga. Witness terms: (\sum z, \sum r_i - r'_i)
 		public static Statement BalanceProof(GroupElement balanceCommitment)
 			=> new Statement(balanceCommitment, Generators.Ga, Generators.Gh);
+
+		// overload for bootstrap credential request proofs.
+		// this is just a range proof with width=0
+		// equivalent to proof of representation w/ Gh
+		public static Knowledge ZeroProof(GroupElement ma, Scalar r)
+			=> new Knowledge(ZeroProof(ma), new ScalarVector(r));
+
+		// TODO swap return value order, remove GroupElement argument
+		// expect nonce provider instead of WasabiRandom?
+		public static (Knowledge knowledge, IEnumerable<GroupElement> bitCommitments) RangeProof(Scalar a, Scalar r, int width, WasabiRandom rnd)
+		{
+			var ma = a * Generators.Gg + r * Generators.Gh;
+			var bits = Enumerable.Range(0, width).Select(i => a.GetBits(i, 1) == 0 ? Scalar.Zero : Scalar.One);
+
+			// Generate bit commitments.
+			// FIXME
+			// - derive r_i from a, r, and additional randomness (like synthetic nonces)?
+			// - maybe derive without randomness for idempotent requests?
+			//   (deterministic blinding terms)? probably simpler to just save
+			//   randomly generated credentials in memory or persistent storage, and
+			//   re-request by loading and re-sending.
+			// - long term fee credentials will definitely need deterministic
+			//   randomness because the server can only give idempotent responses with
+			//   its own records.
+			var randomness = Enumerable.Repeat(0, width).Select(_ => rnd.GetScalar()).ToArray();
+			var bitCommitments = bits.Zip(randomness, (b, r) => b * Generators.Gg + r * Generators.Gh);
+
+			var columns = width * 3 + 1; // three witness terms per bit and one for the commitment
+			int bitColumn(int i) => 3 * i + 1;
+			int rndColumn(int i) => bitColumn(i) + 1;
+			int productColumn(int i) => bitColumn(i) + 2;
+
+			// Construct witness vector. First term is r from Ma = a*Gg + r*Gh. This
+			// is followed by 3 witness terms per bit commitment, the bit b_i, the
+			// randomness in its bit commitment r_i, and their product rb_i (0 or r).
+			var witness = new Scalar[columns];
+			witness[0] = r;
+			foreach ((Scalar b_i, Scalar r_i, int i) in bits.Zip(randomness, Enumerable.Range(0, width), (x, y, z) => (x, y, z)))
+			{
+				witness[bitColumn(i)] = b_i;
+				witness[rndColumn(i)] = r_i;
+				witness[productColumn(i)] = r_i * b_i;
+			}
+
+			return (new Knowledge(RangeProof(ma, bitCommitments), new ScalarVector(witness)), bitCommitments);
+		}
+
+		// overload for bootstrap credential request proofs.
+		// this is just a range proof with width=0
+		// equivalent to new Statement(ma, Generators.Gh)
+		public static Statement ZeroProof(GroupElement ma)
+			=> RangeProof(ma, new GroupElement[0]);
+
+		public static Statement RangeProof(GroupElement ma, IEnumerable<GroupElement> bitCommitments)
+		{
+			var width = bitCommitments.Count();
+			Guard.True(nameof(width), width >= 0); // a width of 0 means no bits are set (commitment to 0)
+			Guard.True(nameof(width), width <= 255); // 256 is tautological for the order of secp256k1
+
+			var rows = width * 2 + 1; // two equations per bit, and one for the sum
+			var columns = width * 3 + 1 + 1; // three witness components per bit and one for the Ma randomness, plus one for the public inputs
+
+			// uninitialized values are implicitly O
+			var equations = new GroupElement[rows, columns];
+
+			// Proof of [ ( \sum 2^i * B_i ) - Ma = (\sum2^i r_i)*Gh - r*Gh ]
+			// This means that the bit commitments, if they are bits (proven in
+			// subsequent equations), are a decomposition of the amount committed in
+			// Ma, proven by showing that the public input is a commitment to 0 (only
+			// Gh term required to represent it). The per-bit witness terms of this
+			// equation are added in the loop below.
+			var bitsTotal = bitCommitments.Select((B, i) => Scalar.Zero.CAddBit((uint)i, 1) * B).Sum();
+			equations[0, 0] = ma - bitsTotal;
+			equations[0, 1] = Generators.Gh; // first witness term is r in Ma = a*Gg + r*Gh
+
+			// Some helper functions to calculate indices of witness terms.
+			// The witness structure is basically: r, zip3(b_i, r_i, rb_i)
+			// So the terms in each equation are the public input (can be thought of
+			// as a generator for a -1 term ) and the remaining are generators to
+			// be used with 1+3n terms:
+			//   ( r, b_0, r_0, rb_0, b_1, r_1, rb_1, ..., b_n, r_n, rb_n)
+			int bitColumn(int i) => 3 * i + 2; // column for b_i witness term
+			int rndColumn(int i) => bitColumn(i) + 1; // column for r_i witness term
+			int productColumn(int i) => bitColumn(i) + 2; // column for rb_i witness term
+			int bitRepresentationRow(int i) => 2 * i + 1; // row for B_i representation proof
+			int bitSquaredRow(int i) => bitRepresentationRow(i) + 1; // row for [ b*(B_i-Gg) - rb*Gh <=> b = b*b ] proof
+
+			// For each bit, add two equations and one term to the first equation.
+			var B = bitCommitments.ToArray();
+			for (int i = 0; i < bitCommitments.Count(); i++)
+			{
+				// Add [ -r_i * 2^i * Gh ] term to first equation.
+				equations[0, rndColumn(i)] = Scalar.Zero.CAddBit((uint)i, 1) * Generators.Gh.Negate();
+
+				// Add equation proving B is a Pedersen commitment to b:
+				//   [ B = b*Gg + r*Gh ]
+				equations[bitRepresentationRow(i), 0] = B[i];
+				equations[bitRepresentationRow(i), bitColumn(i)] = Generators.Gg;
+				equations[bitRepresentationRow(i), rndColumn(i)] = Generators.Gh;
+
+				// Add an equation:
+				//   [ O = b*(B - Gg) - rb*Gh ]
+				// which proves that b is a bit:
+				//   [ b = b*b  <=>  b \in {0,1} ]
+				// assuming [ B = b*Gg + r*Gh ] as proven in the previous equation.
+				//
+				// This works because the following will be a commitment to 0 if and
+				// only if b is a bit:
+				//   [ b*(B-Gg) == b*((b*Gg)-Gg) + r*Gh == b*b*Gg - b*Gg + r*b*Gh =?= rb * Gh ]
+				//
+				// in the verification equation we require that the following terms
+				// cancel out (public input point is O):
+				equations[bitSquaredRow(i), bitColumn(i)] = B[i] - Generators.Gg;
+				equations[bitSquaredRow(i), productColumn(i)] = Generators.Gh.Negate();
+			}
+
+			return new Statement(equations);
+		}
 	}
 }

--- a/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 		public void CommitStatement(Statement statement)
 		{
 			Guard.NotNull(nameof(statement.Generators), statement.Generators);
-			CryptoGuard.NotNullOrInfinity(nameof(statement.PublicPoints), statement.PublicPoints);
+			Guard.NotNull(nameof(statement.PublicPoints), statement.PublicPoints);
 			AddMessages(StatementTag, statement.PublicPoints.Select(x => x.ToBytes()).Concat(statement.Generators.Select(x => x.ToBytes())));
 		}
 


### PR DESCRIPTION
I think it's good enough for now, but this could still use some work:

- better tests
  - improve coverage of inter-equation aspects of LinearRelation, in particular range proofs rely on the fact that witness components are shared between equations, there should be tests with more maliciously constructed proofs to ensure the verifier rejects
  - tests are pretty slow, not sure what to do about this
- cleaner API
  - it's not clear whether the `Knowledge` returning variant of `RangeProof` should generate bit commitments itself or that should be done separately (e.g. in some convenience routine used before calling that, in which case the arguments would be a vector of bits, a vector of randomness, and the randomness of the amount commitment... i tried this and didn't like it)

The range proofs are not efficient for communications, having size O(n) where n is number of bits. More precisely, they require 3 group elements (1 bit commitment and 2 public nonces) and 3 scalars in the response for each bit, plus a public nonce for for the first equation and a response term for the randomness in the amount commitment. To support amounts up to 1 ᵇTBC - 1 TBCᵇ i.e. the full 32 bit unsigned int range this amounts to 6305 bytes per range proof.

The protocol is based on chapter 20 of Boneh & Shoup, https://toc.cryptobook.us/, in particular examples 20.5 and 20.11.

![image](https://user-images.githubusercontent.com/14242/94364763-44e9f600-00bb-11eb-90d3-788430154811.png)

<!--
```latex
\documentclass{article}
\usepackage{amsmath}
\usepackage{amssymb}
\usepackage[operators]{cryptocode}

\begin{document}

\pseudocode{%
\textbf{Prover} \<\< \textbf{Verifier} \\
\mathbf{b} \in \{0,1\}^n \quad
a = \sum_{i=0}^n 2^i \cdot \mathbf{b}_i  \<\< \\
(r, \mathbf{r}) \sample \mathbb{Z}_p \times {\mathbb{Z}_p}^n \<\< \\
M = a \cdot G_g + r \cdot G_h \<\<\\
\mathbf{B} = (\mathbf{b}_i \cdot G_g + \mathbf{r}_i \cdot G_h)_{i=0}^n\<\<\\
\< \sendmessageright*{M, \mathbf{B}} \< \\
(k_r, (\mathbf{k}_b, \mathbf{k}_r, \mathbf{k}_{rb})) \sample \mathbb{Z}_p \times ({\mathbb{Z}_p}^n)^3 \<\< \\
R_M = (k_r + \sum_{i=0}^n \mathbf{k}_{r_i}) \cdot G_h \<\< \\
\mathbf{R}_B = (\mathbf{k}_{b_i} \cdot G_g + \mathbf{k}_{r_i} \cdot G_h)_{i=0}^n\<\< \\
\mathbf{R}_O = (\mathbf{k}_{b_i} \cdot G_g + \mathbf{k}_{rb_i} \cdot G_h)_{i=0}^n \<\< \\
\< \sendmessageright*{R_M, \mathbf{R}_B, \mathbf{R}_O} \< \\
\<\< c \sample \mathbb{Z}_p \\
\< \sendmessageleft*{c} \< \\
s_r = k_r + c r \<\<\\
\mathbf{s}_b = \mathbf{k}_{b} + c \cdot  \mathbf{b} \<\<\\
\mathbf{s}_r = \mathbf{k}_{r} + c \cdot \mathbf{r} \<\<\\
\mathbf{s}_{rb} = \mathbf{k}_{rb_i} + c \cdot ( \mathbf{r} \circ \mathbf{b} ) \<\<\\
\< \sendmessageright*{s_r, \mathbf{s_b}, \mathbf{s_r}, \mathbf{s}_{rb}} \< \\
\<\< R_M + M - \sum_{i=0}^n 2^i \cdot \mathbf{B}_i \stackrel{?}{=} s_r \cdot G_h - \sum_{i=0}^n 2^i \mathbf{s}_{r_i} \cdot G_h \\
\<\< \mathbf{R}_{B_i} + \mathbf{B}_i \stackrel{?}{=} \mathbf{s}_{b_i} \cdot G_g + \mathbf{s}_{r_i} \cdot G_h \forall i \in [0,n) \\
\<\< \mathbf{R}_{O_i} \stackrel{?}{=} \mathbf{s}_{b_i} \cdot (\mathbf{B}_i - G_g) + \mathbf{s}_{rb_i} \cdot G_h \forall i \in [0,n) \\
}
\end{document}
```
-->