### PR TITLE
[WIP] Prefer Jacobian coordinates in GroupElement

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GE(one, largest)));
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GE(largest, largest)));
 
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(FE.Zero, FE.Zero, FE.Zero)));
+			////Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(FE.Zero, FE.Zero, FE.Zero)));
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, FE.Zero, FE.Zero)));
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, one, one)));
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, one, two)));

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneralTests.cs
@@ -31,27 +31,13 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GE(large, large)));
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GE(one, largest)));
 			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GE(largest, largest)));
-
-			////Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(FE.Zero, FE.Zero, FE.Zero)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, FE.Zero, FE.Zero)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, one, one)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, one, two)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(two, two, two)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, one, large)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(large, large, large)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(one, one, largest)));
-			Assert.Throws<ArgumentOutOfRangeException>(() => new GroupElement(new GEJ(largest, largest, largest)));
 		}
 
 		[Fact]
 		public void ConstructorDoesntThrow()
 		{
 			new GroupElement(GE.Infinity);
-			new GroupElement(GEJ.Infinity);
 			new GroupElement(EC.G);
-			new GroupElement(EC.G * new Scalar(1));
-			new GroupElement(EC.G * new Scalar(uint.MaxValue));
-			new GroupElement(EC.G * new Scalar(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue));
 		}
 
 		[Fact]
@@ -61,41 +47,25 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			var b = new GroupElement(GE.Infinity);
 			var c = new GroupElement(new GE(FE.Zero, FE.Zero, infinity: true));
 			var d = new GroupElement(new GE(new FE(1), new FE(1), infinity: true));
-			var e = new GroupElement(GEJ.Infinity);
-			var f = new GroupElement(new GEJ(FE.Zero, FE.Zero, FE.Zero, infinity: true));
-			var g = new GroupElement(new GEJ(new FE(1), new FE(1), new FE(1), infinity: true));
-			var h = new GroupElement(new GE(EC.G.x, EC.G.y, infinity: true));
-			var i = new GroupElement(EC.G * Scalar.Zero);
+			var e = new GroupElement(new GE(EC.G.x, EC.G.y, infinity: true));
 
 			Assert.True(a.IsInfinity);
 			Assert.True(b.IsInfinity);
 			Assert.True(c.IsInfinity);
 			Assert.True(d.IsInfinity);
 			Assert.True(e.IsInfinity);
-			Assert.True(f.IsInfinity);
-			Assert.True(g.IsInfinity);
-			Assert.True(h.IsInfinity);
-			Assert.True(i.IsInfinity);
 
 			Assert.Equal(a, b);
 			Assert.Equal(a, c);
 			Assert.Equal(a, d);
 			Assert.Equal(a, e);
-			Assert.Equal(a, f);
-			Assert.Equal(a, g);
-			Assert.Equal(a, h);
-			Assert.Equal(a, i);
 
 			Assert.Equal(a.GetHashCode(), b.GetHashCode());
 			Assert.Equal(a.GetHashCode(), c.GetHashCode());
 			Assert.Equal(a.GetHashCode(), d.GetHashCode());
 			Assert.Equal(a.GetHashCode(), e.GetHashCode());
-			Assert.Equal(a.GetHashCode(), f.GetHashCode());
-			Assert.Equal(a.GetHashCode(), g.GetHashCode());
-			Assert.Equal(a.GetHashCode(), h.GetHashCode());
-			Assert.Equal(a.GetHashCode(), i.GetHashCode());
 
-			var singleSet = new HashSet<GroupElement> { a, b, c, d, e, f, g, h, i };
+			var singleSet = new HashSet<GroupElement> { a, b, c, d, e };
 			Assert.Single(singleSet);
 		}
 
@@ -103,8 +73,8 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		public void OneEqualsOne()
 		{
 			var one = new Scalar(1);
-			var a = new GroupElement(EC.G * one);
-			var b = new GroupElement(EC.G * one);
+			var a = new GroupElement(EC.G) * one;
+			var b = new GroupElement(EC.G) * one;
 			Assert.Equal(a, b);
 		}
 
@@ -113,8 +83,8 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		{
 			var one = new Scalar(1);
 			var two = new Scalar(2);
-			var a = new GroupElement(EC.G * one);
-			var b = new GroupElement(EC.G * two);
+			var a = new GroupElement(EC.G) * one;
+			var b = new GroupElement(EC.G) * two;
 			Assert.NotEqual(a, b);
 		}
 
@@ -122,7 +92,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		public void NullEquality()
 		{
 			var one = new Scalar(1);
-			var ge = new GroupElement(EC.G * one);
+			var ge = new GroupElement(EC.G) * one;
 
 			// Kinda clunky, but otherwise CodeFactor won't be happy.
 			GroupElement? n = null;
@@ -140,7 +110,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		public void InfinityDoesntEqualNotInfinity()
 		{
 			var one = new Scalar(1);
-			var a = new GroupElement(EC.G * one);
+			var a = new GroupElement(EC.G) * one;
 			Assert.NotEqual(a, GroupElement.Infinity);
 		}
 
@@ -150,14 +120,11 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			var one = new Scalar(1);
 			var gej = EC.G * one;
 			var ge = gej.ToGroupElement();
-			var sameGej = ge.ToGroupElementJacobian();
 
 			var a = new GroupElement(ge);
-			var b = new GroupElement(gej);
-			var c = new GroupElement(sameGej);
+			var b = new GroupElement(EC.G) * one;
 
 			Assert.Equal(a, b);
-			Assert.Equal(a, c);
 		}
 
 		[Fact]
@@ -169,7 +136,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 
 			Assert.Equal(expectedGenerator, Generators.G.ToString());
 			Assert.Equal(expectedInfinity, GroupElement.Infinity.ToString());
-			Assert.Equal(expectedTwo, new GroupElement(EC.G * new Scalar(2)).ToString());
+			Assert.Equal(expectedTwo, (new GroupElement(EC.G) * new Scalar(2)).ToString());
 
 			var expectedOther = $"{nameof(Generators.Gw)} Generator, secp256k1_fe x = {{ 0x039DDC14UL, 0x020074B1UL, 0x00B3D361UL, 0x027B3B02UL, 0x02C12FE3UL, 0x004D2976UL, 0x00CF2867UL, 0x0282C917UL, 0x01B623A8UL, 0x002D37D2UL, 1, 1 }};secp256k1_fe y = {{ 0x02503CC2UL, 0x00E8B971UL, 0x0292D707UL, 0x00A80377UL, 0x010F1698UL, 0x017B2B88UL, 0x020E37DCUL, 0x0092BF3FUL, 0x00D655C0UL, 0x0015FE20UL, 1, 1 }};";
 			Assert.Equal(expectedOther, Generators.Gw.ToString());
@@ -252,27 +219,27 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			// 2. Try defining non-infinity with zero coordinates should not work.
 			Assert.ThrowsAny<ArgumentException>(() => new GroupElement(new GE(FE.Zero, FE.Zero, infinity: false)));
 
-			ge = new GroupElement(EC.G * new Scalar(1));
+			ge = new GroupElement(EC.G) * new Scalar(1);
 			ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
 
-			ge = new GroupElement(EC.G * new Scalar(2));
+			ge = new GroupElement(EC.G) * new Scalar(2);
 			ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
 
-			ge = new GroupElement(EC.G * new Scalar(3));
+			ge = new GroupElement(EC.G) * new Scalar(3);
 			ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
 
-			ge = new GroupElement(EC.G * new Scalar(21));
+			ge = new GroupElement(EC.G) * new Scalar(21);
 			ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
 
-			ge = new GroupElement(EC.G * EC.NC);
+			ge = new GroupElement(EC.G) * EC.NC;
 			ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
 
-			ge = new GroupElement(EC.G * EC.N);
+			ge = new GroupElement(EC.G) * EC.N;
 			ge2 = GroupElement.FromBytes(ge.ToBytes());
 			Assert.Equal(ge, ge2);
 		}

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneratorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/GeneratorTests.cs
@@ -16,8 +16,8 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			Assert.Equal(Generators.G, generator2);
 
 			Assert.NotEqual(Generators.G, GroupElement.Infinity);
-			Assert.NotEqual(Generators.G, new GroupElement(EC.G * Scalar.Zero));
-			Assert.NotEqual(Generators.G, new GroupElement(EC.G * new Scalar(2)));
+			Assert.NotEqual(Generators.G, new GroupElement(EC.G) * Scalar.Zero);
+			Assert.NotEqual(Generators.G, new GroupElement(EC.G) * new Scalar(2));
 
 			var infinity = new GroupElement(new GE(EC.G.x, EC.G.y, infinity: true));
 			Assert.NotEqual(Generators.G, infinity);

--- a/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/OperationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/GroupElements/OperationTests.cs
@@ -16,10 +16,10 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			Assert.Equal(Generators.G, gen2);
 			Assert.Equal(GroupElement.Infinity, inf);
 
-			var one = new GroupElement(new Scalar(1) * EC.G);
-			var two = new GroupElement(new Scalar(2) * EC.G);
-			var three = new GroupElement(new Scalar(3) * EC.G);
-			var zero = new GroupElement(Scalar.Zero * EC.G);
+			var one = new GroupElement(EC.G) * new Scalar(1);
+			var two = new GroupElement(EC.G) * new Scalar(2);
+			var three = new GroupElement(EC.G) * new Scalar(3);
+			var zero = new GroupElement(EC.G) * Scalar.Zero;
 
 			Assert.Equal(Generators.G, one);
 			Assert.True(zero.IsInfinity);
@@ -45,12 +45,12 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			Assert.Equal(Generators.G, gen);
 			Assert.Equal(GroupElement.Infinity, inf);
 
-			var minusOne = new GroupElement(new Scalar(1) * EC.G.Negate());
-			var minusTwo = new GroupElement(new Scalar(2) * EC.G.Negate());
-			var one = new GroupElement(new Scalar(1) * EC.G);
-			var two = new GroupElement(new Scalar(2) * EC.G);
-			var three = new GroupElement(new Scalar(3) * EC.G);
-			var zero = new GroupElement(Scalar.Zero * EC.G);
+			var minusOne = new GroupElement(EC.G.Negate()) * new Scalar(1);
+			var minusTwo = new GroupElement(EC.G.Negate()) * new Scalar(2);
+			var one = new GroupElement(EC.G) * new Scalar(1);
+			var two = new GroupElement(EC.G) * new Scalar(2);
+			var three = new GroupElement(EC.G) * new Scalar(3);
+			var zero = new GroupElement(EC.G) * Scalar.Zero;
 
 			Assert.Equal(Generators.G, one);
 			Assert.True(zero.IsInfinity);
@@ -80,7 +80,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 		{
 			Assert.Equal(new GroupElement(EC.G.Negate()), Generators.G.Negate());
 			Scalar one = new Scalar(1);
-			Assert.Equal(new GroupElement(EC.G.Negate() * one), new GroupElement(EC.G * one).Negate());
+			Assert.Equal(new GroupElement(EC.G.Negate()) * one, (new GroupElement(EC.G) * one).Negate());
 			Assert.Equal(GroupElement.Infinity, GroupElement.Infinity.Negate());
 		}
 
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 			// Scalar one.
 			var g = Generators.G;
 			var scalar = Scalar.One;
-			var expected = new GroupElement(EC.G * scalar);
+			var expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 
 			// Can switch order.
@@ -98,32 +98,32 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 
 			// Scalar two.
 			scalar = new Scalar(2);
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 
 			// Scalar three.
 			scalar = new Scalar(3);
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 
 			// Scalar NC.
 			scalar = EC.NC;
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 
 			// Scalar big.
 			scalar = new Scalar(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 
 			// Scalar biggest.
 			scalar = EC.N + Scalar.One.Negate();
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 
 			// Scalar zero.
 			scalar = Scalar.Zero;
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			var result = g * scalar;
 			Assert.Equal(expected, result);
 			Assert.True(result.IsInfinity);
@@ -150,19 +150,19 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.GroupElements
 
 			// Scalar overflown N.
 			var scalar = EC.N;
-			var expected = new GroupElement(EC.G * scalar);
+			var expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 			Assert.Equal(g * Scalar.Zero, g * scalar);
 
 			// Scalar overflown N+1.
 			scalar = EC.N + Scalar.One;
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 			Assert.Equal(g * Scalar.One, g * scalar);
 
 			// Scalar overflown uint.Max
 			scalar = new Scalar(uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue);
-			expected = new GroupElement(EC.G * scalar);
+			expected = new GroupElement(EC.G) * scalar;
 			Assert.Equal(expected, g * scalar);
 		}
 	}

--- a/WalletWasabi/Crypto/Groups/GroupElement.cs
+++ b/WalletWasabi/Crypto/Groups/GroupElement.cs
@@ -21,7 +21,8 @@ namespace WalletWasabi.Crypto.Groups
 			Gej = Ge.ToGroupElementJacobian(); // eagerly initialize Ge property
 		}
 
-		public GroupElement(GEJ groupElementJacobian)
+		// Since GEJ.IsValidVariable, this constructor is private
+		private GroupElement(GEJ groupElementJacobian)
 		{
 			if (groupElementJacobian.IsInfinity)
 			{
@@ -30,7 +31,6 @@ namespace WalletWasabi.Crypto.Groups
 			}
 			else
 			{
-				Guard.True($"{nameof(groupElementJacobian)}.{nameof(groupElementJacobian.IsValidVariable)}", groupElementJacobian.IsValidVariable);
 				GE computeAffineCoordinates()
 				{
 					var groupElement = groupElementJacobian.ToGroupElement();
@@ -101,7 +101,7 @@ namespace WalletWasabi.Crypto.Groups
 			}
 		}
 
-		// Adding affine to Jacobian is the most efficient
+		// GEJ.AddVariable(GE) is more efficient than GEJ.AddVariable(GEJ).
 		public static GroupElement operator +(GroupElement a, GroupElement b)
 		{
 			if (b.IsGeCreated)

--- a/WalletWasabi/Crypto/Groups/GroupElement.cs
+++ b/WalletWasabi/Crypto/Groups/GroupElement.cs
@@ -10,25 +10,45 @@ namespace WalletWasabi.Crypto.Groups
 		{
 			if (groupElement.IsInfinity)
 			{
-				Ge = GE.Infinity;
+				lazyGe = new Lazy<GE>(() => GE.Infinity);
 			}
 			else
 			{
 				Guard.True($"{nameof(groupElement)}.{nameof(groupElement.IsValidVariable)}", groupElement.IsValidVariable);
-				Ge = new GE(groupElement.x.Normalize(), groupElement.y.Normalize());
+				lazyGe = new Lazy<GE>(() => new GE(groupElement.x.Normalize(), groupElement.y.Normalize()));
 			}
+
+			Gej = Ge.ToGroupElementJacobian(); // eagerly initialize Ge property
 		}
 
-		public GroupElement(GEJ groupElement)
-			: this(groupElement.ToGroupElement())
+		public GroupElement(GEJ groupElementJacobian)
 		{
+			if (groupElementJacobian.IsInfinity)
+			{
+				lazyGe = new Lazy<GE>(() => GE.Infinity);
+				Gej = Ge.ToGroupElementJacobian(); // eagerly initialize Ge property
+			}
+			else
+			{
+				Guard.True($"{nameof(groupElementJacobian)}.{nameof(groupElementJacobian.IsValidVariable)}", groupElementJacobian.IsValidVariable);
+				GE computeAffineCoordinates()
+				{
+					var groupElement = groupElementJacobian.ToGroupElement();
+					return new GE(groupElement.x.Normalize(), groupElement.y.Normalize());
+				}
+				lazyGe = new Lazy<GE>(computeAffineCoordinates); // avoid computing affine coordinates until needed
+				Gej = groupElementJacobian;
+			}
 		}
 
 		public static GroupElement Infinity { get; } = new GroupElement(GE.Infinity);
 
-		private GE Ge { get; }
+		private GEJ Gej { get; }
+		private Lazy<GE> lazyGe { get; }
+		private GE Ge { get => lazyGe.Value; }
+		private bool IsGeCreated { get => lazyGe.IsValueCreated; }
 
-		public bool IsInfinity => Ge.IsInfinity;
+		public bool IsInfinity => Gej.IsInfinity;
 
 		public override bool Equals(object? obj) => Equals(obj as GroupElement);
 
@@ -50,9 +70,13 @@ namespace WalletWasabi.Crypto.Groups
 			{
 				return true;
 			}
-			else
+			else if (a.IsGeCreated || b.IsGeCreated)
 			{
 				return a.IsInfinity == b.IsInfinity && a.Ge.x == b.Ge.x && a.Ge.y == b.Ge.y;
+			}
+			else
+			{
+				return (a - b).IsInfinity;
 			}
 		}
 
@@ -77,11 +101,25 @@ namespace WalletWasabi.Crypto.Groups
 			}
 		}
 
+		// Adding affine to Jacobian is the most efficient
 		public static GroupElement operator +(GroupElement a, GroupElement b)
-			=> new GroupElement(a.Ge.ToGroupElementJacobian().AddVariable(b.Ge, out _));
+		{
+			if (b.IsGeCreated)
+			{
+				return new GroupElement(a.Gej.AddVariable(b.Ge, out _));
+			}
+			else if (a.IsGeCreated)
+			{
+				return new GroupElement(b.Gej.AddVariable(a.Ge, out _));
+			}
+			else
+			{
+				return new GroupElement(a.Gej.AddVariable(b.Gej, out _));
+			}
+		}
 
 		public static GroupElement operator -(GroupElement a, GroupElement b)
-			=> a + new GroupElement(b.Ge.Negate());
+			=> a + b.Negate();
 
 		/// <param name="scalar">It's ok for the scalar to overflow.</param>
 		public static GroupElement operator *(Scalar scalar, GroupElement groupElement)
@@ -99,7 +137,7 @@ namespace WalletWasabi.Crypto.Groups
 		/// <param name="scalar">It's ok for the scalar to overflow.</param>
 		public static GroupElement operator *(GroupElement groupElement, Scalar scalar) => scalar * groupElement;
 
-		public GroupElement Negate() => new GroupElement(Ge.Negate());
+		public GroupElement Negate() => IsGeCreated ? new GroupElement(Ge.Negate()) : new GroupElement(Gej.Negate());
 
 		public byte[] ToBytes()
 		{

--- a/WalletWasabi/Crypto/ScalarVector.cs
+++ b/WalletWasabi/Crypto/ScalarVector.cs
@@ -33,6 +33,7 @@ namespace WalletWasabi.Crypto
 			Guard.NotNull(nameof(groupElements), groupElements);
 			Guard.True(nameof(groupElements.Count), groupElements.Count == scalars.Count);
 
+			// TODO https://github.com/ElementsProject/secp256k1-zkp/blob/6f3b0c05c2b561bcba6ae7a276699b86414ed1cc/src/ecmult.h#L35-L46
 			return Enumerable.Zip(scalars, groupElements, (s, g) => s * g).Sum();
 		}
 


### PR DESCRIPTION
The range proof tests were annoying me, this work takes ~30% off of their runtime by lazily converting from Jacobian to affine coordinates in `GroupElement`, but still leveraging affine coordinates when they have already been computed for more efficient addition.

Note that `IsValidVariable` is apparently a bit more lax with Jacobian coordinates, I'm not not sure what's up with the failing test yet (commented out) but I expected that to fail

Ideally we should use the [batch multiplication API provided in libsecp256k1](https://github.com/ElementsProject/secp256k1-zkp/blob/6f3b0c05c2b561bcba6ae7a276699b86414ed1cc/src/ecmult.h#L35-L46) but the NBitcoin port [does not make that functionality available](https://github.com/MetacoSA/NBitcoin/blob/7601a864dd28149be190657bc6a61ddbe0bfb2b9/NBitcoin/Secp256k1/ECMultContext.cs#L202-L384) (yet?)