### PR TITLE
TorProcessManager.IsTorRunningAsync no longer accepts NULL.

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -184,7 +184,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task TorRunningAsync()
 		{
-			Assert.True(await TorProcessManager.IsTorRunningAsync(null));
 			Assert.True(await TorProcessManager.IsTorRunningAsync(new IPEndPoint(IPAddress.Loopback, 9050)));
 			Assert.False(await TorProcessManager.IsTorRunningAsync(new IPEndPoint(IPAddress.Loopback, 9054)));
 		}

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -160,7 +160,7 @@ namespace WalletWasabi.Tor
 			return false;
 		}
 
-		/// <param name="torSocks5EndPoint">Opt out Tor with null.</param>
+		/// <param name="torSocks5EndPoint">Valid Tor end point.</param>
 		public static async Task<bool> IsTorRunningAsync(EndPoint torSocks5EndPoint)
 		{
 			using var client = new TorSocks5Client(torSocks5EndPoint);


### PR DESCRIPTION
This is part of work on #4421 where I try to simplify the code first.

My plan is to continue with cleaning up of `TorSocks5Client`. I have some plan for that.