### PR TITLE
[Fluent] Fix Wasabi process never ends

### DIFF
--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -391,7 +391,7 @@ namespace WalletWasabi.Services
 			Cancel?.Cancel();
 			while (Interlocked.CompareExchange(ref _running, 3, 0) == 2)
 			{
-				await Task.Delay(50);
+				await Task.Delay(50).ConfigureAwait(false);
 			}
 
 			Cancel?.Dispose();


### PR DESCRIPTION
This fixes the issue when the wasabi process never ends when running the Fluent project.