### PR TITLE
trivial: Remove unused constructor from WasabiSynchronizer.

### DIFF
--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -36,11 +36,6 @@ namespace WalletWasabi.Services
 
 		private long _blockRequests; // There are priority requests in queue.
 
-		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, WasabiClient client)
-		{
-			CreateNew(network, bitcoinStore, client);
-		}
-
 		public WasabiSynchronizer(Network network, BitcoinStore bitcoinStore, Func<Uri> baseUriAction, EndPoint torSocks5EndPoint)
 		{
 			var client = new WasabiClient(baseUriAction, torSocks5EndPoint);


### PR DESCRIPTION
This PR only removes unused constructor and makes easier to review my next PR which removes `CreateNew` method.