### PR TITLE
trivial: Remove unused `DataDir` property from Wallet.

### DIFF
--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -89,7 +89,8 @@ namespace WalletWasabi.Tor.Http.Extensions
 		public static async Task ThrowRequestExceptionFromContentAsync(this HttpResponseMessage me)
 		{
 			var errorMessage = "";
-			if (me?.Content is { })
+
+			if (me.Content is { })
 			{
 				var contentString = await me.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.Wallets
 
 		public Wallet(string dataDir, Network network, KeyManager keyManager)
 		{
-			DataDir = Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
+			Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
 			Network = Guard.NotNull(nameof(network), network);
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
 
@@ -73,7 +73,6 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		public string DataDir { get; }
 		public BitcoinStore BitcoinStore { get; private set; }
 		public KeyManager KeyManager { get; }
 		public WasabiSynchronizer Synchronizer { get; private set; }


### PR DESCRIPTION
This PR removes `DataDir` property from `Wallet` class + fixes nullability issue in `ThrowRequestExceptionFromContentAsync`.