### PR TITLE
Add config option to close Tor instance on quit

### DIFF
--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -71,6 +71,10 @@ namespace WalletWasabi.Gui
 		public bool UseTor { get; internal set; }
 
 		[DefaultValue(false)]
+		[JsonProperty(PropertyName = "CloseTor", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public bool CloseTor { get; internal set; }
+
+		[DefaultValue(false)]
 		[JsonProperty(PropertyName = "StartLocalBitcoinCoreOnStartup", DefaultValueHandling = DefaultValueHandling.Populate)]
 		public bool StartLocalBitcoinCoreOnStartup { get; internal set; }
 

--- a/WalletWasabi.Gui/Config.cs
+++ b/WalletWasabi.Gui/Config.cs
@@ -71,8 +71,8 @@ namespace WalletWasabi.Gui
 		public bool UseTor { get; internal set; }
 
 		[DefaultValue(false)]
-		[JsonProperty(PropertyName = "CloseTor", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public bool CloseTor { get; internal set; }
+		[JsonProperty(PropertyName = "TerminateTorOnExit", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public bool TerminateTorOnExit { get; internal set; }
 
 		[DefaultValue(false)]
 		[JsonProperty(PropertyName = "StartLocalBitcoinCoreOnStartup", DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -759,7 +759,7 @@ namespace WalletWasabi.Gui
 				var torManager = TorManager;
 				if (torManager is { })
 				{
-					await torManager.StopAsync().ConfigureAwait(false);
+					await torManager.StopAsync(Config.CloseTor).ConfigureAwait(false);
 					Logger.LogInfo($"{nameof(TorManager)} is stopped.");
 				}
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -759,7 +759,7 @@ namespace WalletWasabi.Gui
 				var torManager = TorManager;
 				if (torManager is { })
 				{
-					await torManager.StopAsync(Config.CloseTor).ConfigureAwait(false);
+					await torManager.StopAsync(Config.TerminateTorOnExit).ConfigureAwait(false);
 					Logger.LogInfo($"{nameof(TorManager)} is stopped.");
 				}
 

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -84,7 +84,7 @@
                     </i:Interaction.Behaviors>
                   </TextBox>
                 </StackPanel>
-                <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
+                <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5" IsVisible="{Binding UseTor}">
                   <ToggleButton IsChecked="{Binding CloseTor}" Content="{Binding CloseTor, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" />
                   <TextBlock VerticalAlignment="Center">Close Tor instance after quit.</TextBlock>
                 </StackPanel>

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -84,6 +84,10 @@
                     </i:Interaction.Behaviors>
                   </TextBox>
                 </StackPanel>
+                <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5">
+                  <ToggleButton IsChecked="{Binding CloseTor}" Content="{Binding CloseTor, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" />
+                  <TextBlock VerticalAlignment="Center">Close Tor instance after quit.</TextBlock>
+                </StackPanel>
               </StackPanel>
             </controls:GroupBox>
             <controls:GroupBox Title="UI" TextBlock.FontSize="16" Padding="10" Margin="0 5 10 5">

--- a/WalletWasabi.Gui/Tabs/SettingsView.xaml
+++ b/WalletWasabi.Gui/Tabs/SettingsView.xaml
@@ -85,8 +85,8 @@
                   </TextBox>
                 </StackPanel>
                 <StackPanel Margin="0 10" Orientation="Horizontal" Spacing="5" IsVisible="{Binding UseTor}">
-                  <ToggleButton IsChecked="{Binding CloseTor}" Content="{Binding CloseTor, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" />
-                  <TextBlock VerticalAlignment="Center">Close Tor instance after quit.</TextBlock>
+                  <ToggleButton IsChecked="{Binding TerminateTorOnExit}" Content="{Binding TerminateTorOnExit, Converter={StaticResource BooleanStringConverter}, ConverterParameter=On:Off}" Margin="0 0 10 0" />
+                  <TextBlock VerticalAlignment="Center">Terminate Tor process on exit.</TextBlock>
                 </StackPanel>
               </StackPanel>
             </controls:GroupBox>

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.Gui.Tabs
 		private bool _startLocalBitcoinCoreOnStartup;
 		private bool _stopLocalBitcoinCoreOnShutdown;
 		private bool _isModified;
-		private bool _closeTor;
+		private bool _terminateTorOnExit;
 		private string _somePrivacyLevel;
 		private string _finePrivacyLevel;
 		private string _strongPrivacyLevel;
@@ -65,7 +65,7 @@ namespace WalletWasabi.Gui.Tabs
 			Network = config.Network;
 			TorSocks5EndPoint = config.TorSocks5EndPoint.ToString(-1);
 			UseTor = config.UseTor;
-			CloseTor = config.CloseTor;
+			TerminateTorOnExit = config.TerminateTorOnExit;
 			StartLocalBitcoinCoreOnStartup = config.StartLocalBitcoinCoreOnStartup;
 			StopLocalBitcoinCoreOnShutdown = config.StopLocalBitcoinCoreOnShutdown;
 
@@ -83,7 +83,7 @@ namespace WalletWasabi.Gui.Tabs
 			this.WhenAnyValue(
 				x => x.Network,
 				x => x.UseTor,
-				x => x.CloseTor,
+				x => x.TerminateTorOnExit,
 				x => x.StartLocalBitcoinCoreOnStartup,
 				x => x.StopLocalBitcoinCoreOnShutdown)
 				.ObserveOn(RxApp.TaskpoolScheduler)
@@ -254,10 +254,10 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _useTor, value);
 		}
 
-		public bool CloseTor
+		public bool TerminateTorOnExit
 		{
-			get => _closeTor;
-			set => this.RaiseAndSetIfChanged(ref _closeTor, value);
+			get => _terminateTorOnExit;
+			set => this.RaiseAndSetIfChanged(ref _terminateTorOnExit, value);
 		}
 
 		public string SomePrivacyLevel
@@ -372,7 +372,7 @@ namespace WalletWasabi.Gui.Tabs
 							config.SetP2PEndpoint(p2pEp);
 						}
 						config.UseTor = UseTor;
-						config.CloseTor = CloseTor;
+						config.TerminateTorOnExit = TerminateTorOnExit;
 						config.StartLocalBitcoinCoreOnStartup = StartLocalBitcoinCoreOnStartup;
 						config.StopLocalBitcoinCoreOnShutdown = StopLocalBitcoinCoreOnShutdown;
 						config.LocalBitcoinCoreDataDir = Guard.Correct(LocalBitcoinCoreDataDir);

--- a/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/SettingsViewModel.cs
@@ -35,6 +35,7 @@ namespace WalletWasabi.Gui.Tabs
 		private bool _startLocalBitcoinCoreOnStartup;
 		private bool _stopLocalBitcoinCoreOnShutdown;
 		private bool _isModified;
+		private bool _closeTor;
 		private string _somePrivacyLevel;
 		private string _finePrivacyLevel;
 		private string _strongPrivacyLevel;
@@ -64,6 +65,7 @@ namespace WalletWasabi.Gui.Tabs
 			Network = config.Network;
 			TorSocks5EndPoint = config.TorSocks5EndPoint.ToString(-1);
 			UseTor = config.UseTor;
+			CloseTor = config.CloseTor;
 			StartLocalBitcoinCoreOnStartup = config.StartLocalBitcoinCoreOnStartup;
 			StopLocalBitcoinCoreOnShutdown = config.StopLocalBitcoinCoreOnShutdown;
 
@@ -81,6 +83,7 @@ namespace WalletWasabi.Gui.Tabs
 			this.WhenAnyValue(
 				x => x.Network,
 				x => x.UseTor,
+				x => x.CloseTor,
 				x => x.StartLocalBitcoinCoreOnStartup,
 				x => x.StopLocalBitcoinCoreOnShutdown)
 				.ObserveOn(RxApp.TaskpoolScheduler)
@@ -251,6 +254,12 @@ namespace WalletWasabi.Gui.Tabs
 			set => this.RaiseAndSetIfChanged(ref _useTor, value);
 		}
 
+		public bool CloseTor
+		{
+			get => _closeTor;
+			set => this.RaiseAndSetIfChanged(ref _closeTor, value);
+		}
+
 		public string SomePrivacyLevel
 		{
 			get => _somePrivacyLevel;
@@ -363,6 +372,7 @@ namespace WalletWasabi.Gui.Tabs
 							config.SetP2PEndpoint(p2pEp);
 						}
 						config.UseTor = UseTor;
+						config.CloseTor = CloseTor;
 						config.StartLocalBitcoinCoreOnStartup = StartLocalBitcoinCoreOnStartup;
 						config.StopLocalBitcoinCoreOnShutdown = StopLocalBitcoinCoreOnShutdown;
 						config.LocalBitcoinCoreDataDir = Guard.Correct(LocalBitcoinCoreDataDir);

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -257,10 +257,10 @@ namespace WalletWasabi.Tor
 				TorProcess.Kill();
 				using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 				await TorProcess.WaitForExitAsync(cts.Token, true).ConfigureAwait(false);
-
-				TorProcess.Dispose();
-				TorProcess = null;
 			}
+
+			TorProcess?.Dispose();
+			TorProcess = null;
 		}
 
 		#endregion Monitor

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -256,7 +256,7 @@ namespace WalletWasabi.Tor
 
 				TorProcess.Kill();
 				using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-				await TorProcess.WaitForExitAsync(cts.Token, true).ConfigureAwait(false);
+				await TorProcess.WaitForExitAsync(cts.Token, killOnCancel: true).ConfigureAwait(false);
 			}
 
 			TorProcess?.Dispose();

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -254,9 +254,18 @@ namespace WalletWasabi.Tor
 			{
 				Logger.LogInfo($"Killing Tor process.");
 
-				TorProcess.Kill();
-				using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-				await TorProcess.WaitForExitAsync(cts.Token, killOnCancel: true).ConfigureAwait(false);
+				try
+				{
+					TorProcess.Kill();
+					using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+					await TorProcess.WaitForExitAsync(cts.Token, killOnCancel: true).ConfigureAwait(false);
+
+					Logger.LogInfo($"Tor process killed successfully.");
+				}
+				catch (Exception ex)
+				{
+					Logger.LogError($"Could not kill Tor process: {ex.Message}.");
+				}
 			}
 
 			TorProcess?.Dispose();


### PR DESCRIPTION
If the Tor process was started by Wasabi then it will kill it on quit. The default value for this option is false - by default Wasabi is not closing the Tor process after quit - this is intentional and for privacy reasons. 