### PR TITLE
Use ControllerBase on backend

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.Backend.Controllers
 	/// </summary>
 	[Produces("application/json")]
 	[Route("api/v" + Constants.BackendMajorVersion + "/btc/[controller]")]
-	public class BatchController : Controller
+	public class BatchController : ControllerBase
 	{
 		public BatchController(BlockchainController blockchainController, ChaumianCoinJoinController chaumianCoinJoinController, HomeController homeController, OffchainController offchainController, Global global)
 		{

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -22,7 +22,7 @@ namespace WalletWasabi.Backend.Controllers
 	/// </summary>
 	[Produces("application/json")]
 	[Route("api/v" + Constants.BackendMajorVersion + "/btc/[controller]")]
-	public class BlockchainController : Controller
+	public class BlockchainController : ControllerBase
 	{
 		public static readonly TimeSpan FilterTimeout = TimeSpan.FromMinutes(20);
 

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Backend.Controllers
 	/// </summary>
 	[Produces("application/json")]
 	[Route("api/v" + Constants.BackendMajorVersion + "/btc/[controller]")]
-	public class ChaumianCoinJoinController : Controller
+	public class ChaumianCoinJoinController : ControllerBase
 	{
 		public ChaumianCoinJoinController(IMemoryCache memoryCache, Global global)
 		{

--- a/WalletWasabi.Backend/Controllers/HomeController.cs
+++ b/WalletWasabi.Backend/Controllers/HomeController.cs
@@ -4,7 +4,7 @@ using System;
 namespace WalletWasabi.Backend.Controllers
 {
 	[Route("")]
-	public class HomeController : Controller
+	public class HomeController : ControllerBase
 	{
 		[HttpGet("")]
 		public IActionResult Index()

--- a/WalletWasabi.Backend/Controllers/OffchainController.cs
+++ b/WalletWasabi.Backend/Controllers/OffchainController.cs
@@ -13,9 +13,10 @@ namespace WalletWasabi.Backend.Controllers
 	/// <summary>
 	/// To acquire offchain data.
 	/// </summary>
+	///
 	[Produces("application/json")]
 	[Route("api/v" + Constants.BackendMajorVersion + "/btc/[controller]")]
-	public class OffchainController : Controller
+	public class OffchainController : ControllerBase
 	{
 		public OffchainController(IMemoryCache memoryCache, IExchangeRateProvider exchangeRateProvider)
 		{

--- a/WalletWasabi.Backend/Controllers/SoftwareController.cs
+++ b/WalletWasabi.Backend/Controllers/SoftwareController.cs
@@ -7,9 +7,10 @@ namespace WalletWasabi.Backend.Controllers
 	/// <summary>
 	/// To acquire administrative data about the software.
 	/// </summary>
+	///
 	[Produces("application/json")]
 	[Route("api/[controller]")]
-	public class SoftwareController : Controller
+	public class SoftwareController : ControllerBase
 	{
 		private readonly VersionsResponse VersionsResponse = new VersionsResponse
 		{

--- a/WalletWasabi.Backend/Controllers/WasabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WasabiController.cs
@@ -10,7 +10,7 @@ namespace WalletWasabi.Backend.Controllers
 	/// </summary>
 	[Produces("application/json")]
 	[Route("api/v" + Constants.BackendMajorVersion + "/[controller]")]
-	public class WasabiController : Controller
+	public class WasabiController : ControllerBase
 	{
 		/// <summary>
 		/// Gets the latest legal documents.

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,6 +17,8 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Interfaces;
 using WalletWasabi.Logging;
 using WalletWasabi.WebClients;
+
+[assembly: ApiController]
 
 namespace WalletWasabi.Backend
 {


### PR DESCRIPTION
# ControllerBase instead of Controller

> Don't create a web API controller by deriving from the Controller class. Controller derives from ControllerBase and adds support for views, so it's for handling web pages, not web API requests.

https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-3.1#controllerbase-class

# Add APIController attribute

- Define ApiController attribute on assembly level - https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-3.1#attribute-on-an-assembly

- Remove all ModelState.IsValid check https://docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-3.1#automatic-http-400-responses

