### PR TITLE
Create CreateHostBuilder method

### DIFF
--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -15,11 +15,7 @@ namespace WalletWasabi.Backend
 		{
 			try
 			{
-				using var host = Host.CreateDefaultBuilder(args)
-					.ConfigureWebHostDefaults(webBuilder => webBuilder
-							.UseStartup<Startup>())
-					.Build();
-
+				using var host = CreateHostBuilder(args).Build();
 				await host.RunWithTasksAsync();
 			}
 			catch (Exception ex)
@@ -27,5 +23,8 @@ namespace WalletWasabi.Backend
 				Logger.LogCritical(ex);
 			}
 		}
+
+		public static IHostBuilder CreateHostBuilder(string[] args) =>
+			Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
 	}
 }


### PR DESCRIPTION
No behavior change here. However some ASP.NET boilerplate apps rely on this function being in the `Program.cs`. For example the MVC test framework only works if it's here, which we should start using for testing eventually instead of the large dirty code of RegTests.