### PR TITLE
Remove WalletWasabi.Community

### DIFF
--- a/WalletWasabi.Community/Dojo.md
+++ b/WalletWasabi.Community/Dojo.md
@@ -1,1 +1,0 @@
-The dojo can be found in the [documentation](https://docs.wasabiwallet.io/building-wasabi/Dojo.html).


### PR DESCRIPTION
This folder contained the Dojo a long time ago. We left it here and redirected to the docs as it was moved, but we didn't want to break links. I think sufficient amount of time passed by now so we can remove this root level directory.