### PR TITLE
Increase timeout for SingleInstanceChecker.

### DIFF
--- a/WalletWasabi/Services/SingleInstanceChecker.cs
+++ b/WalletWasabi/Services/SingleInstanceChecker.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Services
 			var mutex = new AsyncMutex($"{MutexString}-{Network}");
 			try
 			{
-				using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.Zero);
+				using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
 				SingleApplicationLockHolder = await mutex.LockAsync(cts.Token).ConfigureAwait(false);
 			}
 			catch (IOException ex)


### PR DESCRIPTION
This PR attempts to fix `SingleInstanceCheckerTest` as it appears the test is flaky:

![image](https://user-images.githubusercontent.com/58662979/95019625-ad5e4780-0666-11eb-9927-90784d643ed3.png)

@molnard Could you say why `TimeSpan.Zero` was used in the first place?