### PR TITLE
Refactor VerField.

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Bases/OctetSerializableBase.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Bases/OctetSerializableBase.cs
@@ -6,19 +6,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Bases
 {
 	public abstract class OctetSerializableBase : IByteSerializable, IEquatable<OctetSerializableBase>, IEquatable<byte>
 	{
-		#region ConstructorsAndInitializers
-
-		protected OctetSerializableBase()
-		{
-		}
-
-		#endregion ConstructorsAndInitializers
-
-		#region PropertiesAndMembers
-
 		protected byte ByteValue { get; set; }
-
-		#endregion PropertiesAndMembers
 
 		#region Serialization
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/VerField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/VerField.cs
@@ -5,29 +5,13 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class VerField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public VerField()
-		{
-		}
-
-		public VerField(int value)
-		{
-			ByteValue = (byte)Guard.InRangeAndNotNull(nameof(value), value, 0, 255);
-		}
-
-		#endregion Constructors
-
-		#region Statics
-
 		public static VerField Socks5 => new VerField(5);
 
-		#endregion Statics
+		public VerField(byte value)
+		{
+			ByteValue = value;
+		}
 
-		#region PropertiesAndMembers
-
-		public int Value => ByteValue;
-
-		#endregion PropertiesAndMembers
+		public byte Value => ByteValue;
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/VerField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/VerField.cs
@@ -5,7 +5,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class VerField : OctetSerializableBase
 	{
-		public static VerField Socks5 => new VerField(5);
+		public static readonly VerField Socks5 = new VerField(5);
 
 		public VerField(byte value)
 		{

--- a/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
@@ -35,8 +35,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.Same($"{nameof(bytes)}.{nameof(bytes.Length)}", 2, bytes.Length);
 
-			Ver = new VerField();
-			Ver.FromByte(bytes[0]);
+			Ver = new VerField(bytes[0]);
 
 			Method = new MethodField();
 			Method.FromByte(bytes[1]);

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
@@ -49,8 +49,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
 
-			Ver = new VerField();
-			Ver.FromByte(bytes[0]);
+			Ver = new VerField(bytes[0]);
 
 			Cmd = new CmdField();
 			Cmd.FromByte(bytes[1]);

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
@@ -49,8 +49,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
 
-			Ver = new VerField();
-			Ver.FromByte(bytes[0]);
+			Ver = new VerField(bytes[0]);
 
 			Rep = new RepField();
 			Rep.FromByte(bytes[1]);

--- a/WalletWasabi/Tor/Socks5/Models/Messages/VersionMethodRequest.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/VersionMethodRequest.cs
@@ -46,8 +46,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 3, 257);
 
-			Ver = new VerField();
-			Ver.FromByte(bytes[0]);
+			Ver = new VerField(bytes[0]);
 
 			NMethods = new NMethodsField();
 			NMethods.FromByte(bytes[1]);


### PR DESCRIPTION
Do not allow to create `VerField` without getting some byte - make it harder to make a mistake.