### PR TITLE
bugfix HwiClient.SendCommandAsync() recursive call

### DIFF
--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -79,7 +79,7 @@ namespace WalletWasabi.Hwi
 
 				// Build options without fingerprint with device model and device path.
 				var newOptions = BuildOptions(firstNoFingerprintEntry.Model, firstNoFingerprintEntry.Path, fingerprint: null, options.Where(x => x.Type != HwiOptions.Fingerprint).ToArray());
-				return await SendCommandAsync(newOptions, command, arguments, openConsole, cancel, isRecursion: true);
+				return await SendCommandAsync(newOptions, command, commandArguments, openConsole, cancel, isRecursion: true);
 			}
 			catch (HwiException ex) when (Network != Network.Main && ex.ErrorCode == HwiErrorCode.UnknownError && ex.Message?.Contains("DataError: Forbidden key path") is true)
 			{


### PR DESCRIPTION
`commandArguments` from argument should be just passed through to recursive call but instead local variable `arguments` has been mistakenly used (it already included options and command)

(cherry picked from commit 5aae4e5a7ada2a00d6077df54e2cfbf8737b0e84)