### PR TITLE
Ensure `ExposedKeys` are properly cleaned up before usage

### DIFF
--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -691,10 +691,17 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			// Remove non-locked exposed keys.
 			foreach (var key in ExposedLinks.Keys.ToArray())
 			{
-				ExposedLinks[key] = ExposedLinks[key].Where(x => x.Key.KeyState == KeyState.Locked).ToArray();
-				if (!ExposedLinks[key].Any())
+				if (ExposedLinks.TryGetValue(key, out var links))
 				{
-					ExposedLinks.TryRemove(key, out _);
+					var lockedKeys = links.Where(x => x.Key.KeyState == KeyState.Locked).ToArray();
+					if (lockedKeys.Any())
+					{
+						ExposedLinks.AddOrReplace(key, lockedKeys);
+					}
+					else
+					{
+						ExposedLinks.TryRemove(key, out _);
+					}
 				}
 			}
 		}

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -608,6 +608,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 				}
 			}
 
+			CleanNonLockedExposedKeys();
 			var keysToSurelyRegister = ExposedLinks.Where(x => coinsToRegister.Contains(x.Key)).SelectMany(x => x.Value).Select(x => x.Key).ToArray();
 			var keysTryNotToRegister = ExposedLinks.SelectMany(x => x.Value).Select(x => x.Key).Except(keysToSurelyRegister).ToArray();
 
@@ -683,6 +684,19 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			// Save our modifications in the keymanager before we give back the selected keys.
 			DestinationKeyManager.ToFile();
 			return (change, actives);
+		}
+
+		private void CleanNonLockedExposedKeys()
+		{
+			// Remove non-locked exposed keys.
+			foreach (var key in ExposedLinks.Keys.ToArray())
+			{
+				ExposedLinks[key] = ExposedLinks[key].Where(x => x.Key.KeyState == KeyState.Locked).ToArray();
+				if (!ExposedLinks[key].Any())
+				{
+					ExposedLinks.TryRemove(key, out _);
+				}
+			}
 		}
 
 		public async Task QueueCoinsToMixAsync(params SmartCoin[] coins)

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -620,7 +620,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			allLockedInternalKeys = keysToSurelyRegister.Concat(allLockedInternalKeys).Distinct();
 
 			// Prefer not to bloat the wallet:
-			if (allLockedInternalKeys.Count() <= maximumMixingLevelCount)
+			if (keysTryNotToRegister.Length >= DestinationKeyManager.MinGapLimit / 2)
 			{
 				allLockedInternalKeys = allLockedInternalKeys.Concat(keysTryNotToRegister).Distinct();
 			}


### PR DESCRIPTION
I've got a report by @lukechilds on input and output side address reuse in a coinjoin. I investigated it and came to the conclusion that it can only happen if the `ExposedKeys` contain non-`Locked` `HdPubKey`s.

Considering that there's no privacy issue here, only efficiency issue, since address reuse is handled with anonset calculations and that wabisabi will obsolate this code, I think this simple sanity check is more reasonable to do instead of a more intrusive refactoring.