### PR TITLE
[PoC] Proper dispose on Shutdown, Restart, Logout on Win10

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -168,6 +168,11 @@ namespace WalletWasabi.Gui
 					await DisposeAsync().ConfigureAwait(false);
 				};
 
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				{
+					Microsoft.Win32.SystemEvents.SessionEnding += (s, e) => DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+				}
+
 				#endregion ProcessKillSubscription
 
 				cancel.ThrowIfCancellationRequested();
@@ -642,6 +647,8 @@ namespace WalletWasabi.Gui
 			try
 			{
 				StoppingCts?.Cancel();
+
+				await Task.Delay(30000).ConfigureAwait(false);
 
 				if (!InitializationStarted)
 				{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore;
@@ -648,7 +649,11 @@ namespace WalletWasabi.Gui
 			{
 				StoppingCts?.Cancel();
 
-				await Task.Delay(30000).ConfigureAwait(false);
+				while (true)
+				{
+					Logger.LogInfo("I am still alive!");
+					await Task.Delay(500).ConfigureAwait(false);
+				}
 
 				if (!InitializationStarted)
 				{

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -69,6 +69,7 @@
     <PackageReference Include="AvalonStudio.Shell" Version="0.9.9" />
     <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.9.9" />
     <PackageReference Include="Dock.Avalonia.Themes.Metro" Version="0.9.9" />
+	  <PackageReference Include="Microsoft.Win32.SystemEvents" Version="4.7.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 

--- a/WalletWasabi.Gui/packages.lock.json
+++ b/WalletWasabi.Gui/packages.lock.json
@@ -63,6 +63,15 @@
           "Dock.Model": "0.9.9"
         }
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        }
+      },
       "System.Runtime": {
         "type": "Direct",
         "requested": "[4.3.1, )",
@@ -540,14 +549,6 @@
         "dependencies": {
           "System.Security.AccessControl": "4.7.0",
           "System.Security.Principal.Windows": "4.7.0"
-        }
-      },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "LuI1oG+24TUj1ZRQQjM5Ew73BKnZE5NZ/7eAdh1o8ST5dPhUnJvIkiIn2re3MwnkRy6ELRnvEbBxHP8uALKhJw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.0.0"
         }
       },
       "NBitcoin": {
@@ -2278,6 +2279,15 @@
       }
     },
     ".NETCoreApp,Version=v3.1/linux-x64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        }
+      },
       "System.Runtime": {
         "type": "Direct",
         "requested": "[4.3.1, )",
@@ -2339,14 +2349,6 @@
         "dependencies": {
           "System.Security.AccessControl": "4.7.0",
           "System.Security.Principal.Windows": "4.7.0"
-        }
-      },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "LuI1oG+24TUj1ZRQQjM5Ew73BKnZE5NZ/7eAdh1o8ST5dPhUnJvIkiIn2re3MwnkRy6ELRnvEbBxHP8uALKhJw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.0.0"
         }
       },
       "runtime.any.System.Collections": {
@@ -3350,6 +3352,15 @@
       }
     },
     ".NETCoreApp,Version=v3.1/osx-x64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        }
+      },
       "System.Runtime": {
         "type": "Direct",
         "requested": "[4.3.1, )",
@@ -3411,14 +3422,6 @@
         "dependencies": {
           "System.Security.AccessControl": "4.7.0",
           "System.Security.Principal.Windows": "4.7.0"
-        }
-      },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "LuI1oG+24TUj1ZRQQjM5Ew73BKnZE5NZ/7eAdh1o8ST5dPhUnJvIkiIn2re3MwnkRy6ELRnvEbBxHP8uALKhJw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.0.0"
         }
       },
       "runtime.any.System.Collections": {
@@ -4422,6 +4425,15 @@
       }
     },
     ".NETCoreApp,Version=v3.1/win7-x64": {
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        }
+      },
       "System.Runtime": {
         "type": "Direct",
         "requested": "[4.3.1, )",
@@ -4535,14 +4547,6 @@
         "dependencies": {
           "System.Security.AccessControl": "4.7.0",
           "System.Security.Principal.Windows": "4.7.0"
-        }
-      },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "LuI1oG+24TUj1ZRQQjM5Ew73BKnZE5NZ/7eAdh1o8ST5dPhUnJvIkiIn2re3MwnkRy6ELRnvEbBxHP8uALKhJw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.0.0"
         }
       },
       "runtime.any.System.Collections": {


### PR DESCRIPTION
`ProcessExit` not signaled when the user shuts down the OS. This leads to the immediate termination of Wasabi - which can lead to file corruption. 

This PR detects the shutdown, restart, and logout events and observe the behavior of the OS. 

For detection, I am using `SessionEnding`.
https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents?view=dotnet-plat-ext-3.1

Seemingly we have 5 seconds before the OS terminate the application: 
```
2020-10-13 16:47:27 WARNING	Global (646)	Process is exiting.
2020-10-13 16:47:27 INFO	Global (654)	I am still alive!
2020-10-13 16:47:27 INFO	Global (654)	I am still alive!
2020-10-13 16:47:28 INFO	Global (654)	I am still alive!
2020-10-13 16:47:28 INFO	Global (654)	I am still alive!
2020-10-13 16:47:29 INFO	Global (654)	I am still alive!
2020-10-13 16:47:29 INFO	Global (654)	I am still alive!
2020-10-13 16:47:30 INFO	Global (654)	I am still alive!
2020-10-13 16:47:30 INFO	Global (654)	I am still alive!
2020-10-13 16:47:31 INFO	Global (654)	I am still alive!
2020-10-13 16:47:31 INFO	Global (654)	I am still alive!
```
 
### TODO:

- [ ] Unsubscribe
- [ ] Test it with packaged software

Do not forget, for daemon mode we will have a problem, I have to deal with this. 

![image](https://user-images.githubusercontent.com/9844978/95879292-7c70c780-0d76-11eb-82b8-0bfeefd773a9.png)

### Next step, prevent shutdown until proper disposal: 

https://www.meziantou.net/prevent-windows-shutdown-or-session-ending-in-dotnet.htm