### PR TITLE
Fix nullability for events and its `object sender` parameter.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ IoHelpers.DeleteRecursivelyWithMagicDustAsync(Folder).GetAwaiter().GetResult();
 }
 
 // GOOD
-private async void Synchronizer_ResponseArrivedAsync(object sender, EventArgs e)
+private async void Synchronizer_ResponseArrivedAsync(object? sender, EventArgs e)
 {
 	try
 	{

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -62,12 +62,12 @@ namespace WalletWasabi.Backend
 			}
 		}
 
-		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
 			Logger.LogWarning(e?.Exception);
 		}
 
-		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 		{
 			Logger.LogWarning(e?.ExceptionObject as Exception);
 		}

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLock.cs
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLock.cs
@@ -163,7 +163,7 @@ namespace WalletWasabi.Gui.Controls.LockScreen
 			_thumb.DragCompleted += OnThumb_DragCompletedAsync;
 		}
 
-		private async void OnThumb_DragCompletedAsync(object sender, VectorEventArgs e)
+		private async void OnThumb_DragCompletedAsync(object? sender, VectorEventArgs e)
 		{
 			if (CanSlide)
 			{
@@ -189,7 +189,7 @@ namespace WalletWasabi.Gui.Controls.LockScreen
 			return (Bounds.Height / 100) * value;
 		}
 
-		private void OnThumb_DragDelta(object sender, VectorEventArgs e)
+		private void OnThumb_DragDelta(object? sender, VectorEventArgs e)
 		{
 			if (CanSlide && Bounds.Height > 0)
 			{

--- a/WalletWasabi.Gui/Controls/SortingArrow.cs
+++ b/WalletWasabi.Gui/Controls/SortingArrow.cs
@@ -100,7 +100,7 @@ namespace WalletWasabi.Gui.Controls
 			Click += SortingArrow_Click;
 		}
 
-		private void SortingArrow_Click(object sender, RoutedEventArgs e)
+		private void SortingArrow_Click(object? sender, RoutedEventArgs e)
 		{
 			switch (SortDirection)
 			{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinListViewModel.cs
@@ -175,11 +175,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				.Subscribe(ex => Logger.LogError(ex));
 		}
 
-		public event EventHandler<SmartCoin> DequeueCoinsPressed;
+		public event EventHandler<SmartCoin>? DequeueCoinsPressed;
 
-		public event EventHandler CoinListShown;
+		public event EventHandler? CoinListShown;
 
-		public event EventHandler SelectionChanged;
+		public event EventHandler? SelectionChanged;
 
 		private CompositeDisposable Disposables { get; set; }
 

--- a/WalletWasabi.Gui/MainWindow.xaml.cs
+++ b/WalletWasabi.Gui/MainWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace WalletWasabi.Gui
 
 		private int _closingState;
 
-		private async void MainWindow_ClosingAsync(object sender, CancelEventArgs e)
+		private async void MainWindow_ClosingAsync(object? sender, CancelEventArgs e)
 		{
 			try
 			{

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -157,12 +157,12 @@ namespace WalletWasabi.Gui
 			}
 		}
 
-		private static void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
 			Logger.LogWarning(e?.Exception);
 		}
 
-		private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 		{
 			Logger.LogWarning(e?.ExceptionObject as Exception);
 		}

--- a/WalletWasabi.Gui/ViewModels/ViewModelBase.cs
+++ b/WalletWasabi.Gui/ViewModels/ViewModelBase.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Gui.ViewModels
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(e.PropertyName));
 		}
 
-		private void ViewModelBase_PropertyChanged(object sender, PropertyChangedEventArgs e)
+		private void ViewModelBase_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (string.IsNullOrWhiteSpace(e.PropertyName))
 			{

--- a/WalletWasabi.Tests/RegressionTests/Common.cs
+++ b/WalletWasabi.Tests/RegressionTests/Common.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Tests.RegressionTests
 		}
 
 		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Must match delegate")]
-		public static void Wallet_NewFilterProcessed(object sender, FilterModel e)
+		public static void Wallet_NewFilterProcessed(object? sender, FilterModel e)
 		{
 			Interlocked.Increment(ref FiltersProcessedByWalletCount);
 		}

--- a/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
+++ b/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.Bases
 	{
 		#region Events
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 			RpcClient = Guard.NotNull(nameof(rpcClient), rpcClient);
 		}
 
-		public event EventHandler<AllFeeEstimate> AllFeeEstimateChanged;
+		public event EventHandler<AllFeeEstimate>? AllFeeEstimateChanged;
 
 		public AllFeeEstimate AllFeeEstimate
 		{

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcMonitor.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcMonitor.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 			RpcClient = Guard.NotNull(nameof(rpcClient), rpcClient);
 		}
 
-		public event EventHandler<RpcStatus> RpcStatusChanged;
+		public event EventHandler<RpcStatus>? RpcStatusChanged;
 
 		public IRPCClient RpcClient { get; set; }
 

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.BitcoinCore
 			ReconnectorLock = new AsyncLock();
 		}
 
-		public event EventHandler<uint256> BlockInv;
+		public event EventHandler<uint256>? BlockInv;
 
 		private Node Node { get; set; }
 		private TrustedP2pBehavior TrustedP2pBehavior { get; set; }
@@ -110,7 +110,7 @@ namespace WalletWasabi.BitcoinCore
 			}
 		}
 
-		private void TrustedP2pBehavior_BlockInv(object sender, uint256 e)
+		private void TrustedP2pBehavior_BlockInv(object? sender, uint256 e)
 		{
 			BlockInv?.Invoke(this, e);
 		}

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/FeeProviders.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/FeeProviders.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 			SetAllFeeEstimate();
 		}
 
-		public event EventHandler<AllFeeEstimate> AllFeeEstimateChanged;
+		public event EventHandler<AllFeeEstimate>? AllFeeEstimateChanged;
 
 		public AllFeeEstimate AllFeeEstimate { get; private set; }
 
@@ -36,7 +36,7 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 
 		private object Lock { get; }
 
-		private void Provider_AllFeeEstimateChanged(object sender, AllFeeEstimate e)
+		private void Provider_AllFeeEstimateChanged(object? sender, AllFeeEstimate e)
 		{
 			SetAllFeeEstimate();
 		}

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/IFeeProvider.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/IFeeProvider.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 {
 	public interface IFeeProvider
 	{
-		public event EventHandler<AllFeeEstimate> AllFeeEstimateChanged;
+		public event EventHandler<AllFeeEstimate>? AllFeeEstimateChanged;
 
 		public AllFeeEstimate AllFeeEstimate { get; }
 	}

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -287,7 +287,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			return pbcinfo;
 		}
 
-		private void BlockNotifier_OnBlock(object sender, Block e)
+		private void BlockNotifier_OnBlock(object? sender, Block e)
 		{
 			try
 			{

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -24,9 +24,9 @@ namespace WalletWasabi.Blockchain.Blocks
 			}
 		}
 
-		public event EventHandler<Block> OnBlock;
+		public event EventHandler<Block>? OnBlock;
 
-		public event EventHandler<uint256> OnReorg;
+		public event EventHandler<uint256>? OnReorg;
 
 		public IRPCClient RpcClient { get; set; }
 		public Network Network => RpcClient.Network;
@@ -39,7 +39,7 @@ namespace WalletWasabi.Blockchain.Blocks
 		private uint256 LastInv { get; set; } = null;
 		private object LastInvLock { get; } = new object();
 
-		private void P2pNode_BlockInv(object sender, uint256 blockHash)
+		private void P2pNode_BlockInv(object? sender, uint256 blockHash)
 		{
 			lock (LastInvLock)
 			{

--- a/WalletWasabi/Blockchain/P2p/TrustedP2pBehavior.cs
+++ b/WalletWasabi/Blockchain/P2p/TrustedP2pBehavior.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Blockchain.P2p
 		{
 		}
 
-		public event EventHandler<uint256> BlockInv;
+		public event EventHandler<uint256>? BlockInv;
 
 		protected override bool ProcessInventoryVector(InventoryVector inv, EndPoint remoteSocketEndpoint)
 		{

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -25,7 +25,7 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 			Coins = new CoinsRegistry(privacyLevelThreshold);
 		}
 
-		public event EventHandler<ProcessedResult> WalletRelevantTransactionProcessed;
+		public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
 
 		private static object Lock { get; } = new object();
 		public AllTransactionStore TransactionStore { get; }

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -69,11 +69,11 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			}
 		}
 
-		public event EventHandler StateUpdated;
+		public event EventHandler? StateUpdated;
 
-		public event EventHandler<SmartCoin> CoinQueued;
+		public event EventHandler<SmartCoin>? CoinQueued;
 
-		public event EventHandler<DequeueResult> OnDequeue;
+		public event EventHandler<DequeueResult>? OnDequeue;
 
 		public Network Network { get; private set; }
 		public KeyManager KeyManager { get; }
@@ -106,7 +106,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 
 		public bool IsDestinationSame => KeyManager.ExtPubKey == DestinationKeyManager.ExtPubKey;
 
-		private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse e)
+		private async void Synchronizer_ResponseArrivedAsync(object? sender, SynchronizeResponse e)
 		{
 			await TryProcessStatusAsync(e?.CcjRoundStates).ConfigureAwait(false);
 		}

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.CoinJoin.Client
 		public IRPCClient RpcClient { get; private set; }
 		private AsyncLock ProcessLock { get; }
 
-		private async void Synchronizer_ResponseArrivedAsync(object sender, SynchronizeResponse response)
+		private async void Synchronizer_ResponseArrivedAsync(object? sender, SynchronizeResponse response)
 		{
 			try
 			{

--- a/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
@@ -130,7 +130,7 @@ namespace WalletWasabi.CoinJoin.Coordinator
 			BlockNotifier.OnBlock += BlockNotifier_OnBlockAsync;
 		}
 
-		public event EventHandler<Transaction> CoinJoinBroadcasted;
+		public event EventHandler<Transaction>? CoinJoinBroadcasted;
 
 		public DateTimeOffset LastSuccessfulCoinJoinTime { get; private set; }
 
@@ -155,7 +155,7 @@ namespace WalletWasabi.CoinJoin.Coordinator
 
 		public UtxoReferee UtxoReferee { get; }
 
-		private async void BlockNotifier_OnBlockAsync(object sender, Block block)
+		private async void BlockNotifier_OnBlockAsync(object? sender, Block block)
 		{
 			try
 			{
@@ -279,12 +279,12 @@ namespace WalletWasabi.CoinJoin.Coordinator
 			}
 		}
 
-		private void Round_CoinJoinBroadcasted(object sender, Transaction transaction)
+		private void Round_CoinJoinBroadcasted(object? sender, Transaction transaction)
 		{
 			CoinJoinBroadcasted?.Invoke(sender, transaction);
 		}
 
-		private async void Round_StatusChangedAsync(object sender, CoordinatorRoundStatus status)
+		private async void Round_StatusChangedAsync(object? sender, CoordinatorRoundStatus status)
 		{
 			try
 			{

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -82,11 +82,11 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			}
 		}
 
-		public event EventHandler<RoundPhase> PhaseChanged;
+		public event EventHandler<RoundPhase>? PhaseChanged;
 
-		public event EventHandler<CoordinatorRoundStatus> StatusChanged;
+		public event EventHandler<CoordinatorRoundStatus>? StatusChanged;
 
-		public event EventHandler<Transaction> CoinJoinBroadcasted;
+		public event EventHandler<Transaction>? CoinJoinBroadcasted;
 
 		public long RoundId { get; }
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -22,7 +22,7 @@ namespace WalletWasabi.Services
 			Synchronizer.PropertyChanged += Synchronizer_PropertyChanged;
 		}
 
-		public event EventHandler<UpdateStatus> UpdateStatusChanged;
+		public event EventHandler<UpdateStatus>? UpdateStatusChanged;
 
 		public WasabiClient WasabiClient { get; }
 
@@ -41,7 +41,7 @@ namespace WalletWasabi.Services
 			}
 		}
 
-		private void Synchronizer_PropertyChanged(object sender, PropertyChangedEventArgs e)
+		private void Synchronizer_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(WasabiSynchronizer.BackendStatus) &&
 				Synchronizer.BackendStatus == BackendStatus.Connected)

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -53,11 +53,11 @@ namespace WalletWasabi.Services
 
 		#region EventsPropertiesMembers
 
-		public event EventHandler<AllFeeEstimate> AllFeeEstimateChanged;
+		public event EventHandler<AllFeeEstimate>? AllFeeEstimateChanged;
 
-		public event EventHandler<bool> ResponseArrivedIsGenSocksServFail;
+		public event EventHandler<bool>? ResponseArrivedIsGenSocksServFail;
 
-		public event EventHandler<SynchronizeResponse> ResponseArrived;
+		public event EventHandler<SynchronizeResponse>? ResponseArrived;
 
 		public SynchronizeResponse LastResponse { get; private set; }
 

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -32,9 +32,9 @@ namespace WalletWasabi.Stores
 
 		private int _throttleId;
 
-		public event EventHandler<FilterModel> Reorged;
+		public event EventHandler<FilterModel>? Reorged;
 
-		public event EventHandler<FilterModel> NewFilter;
+		public event EventHandler<FilterModel>? NewFilter;
 
 		private string WorkFolderPath { get; set; }
 		private Network Network { get; }

--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.Wallets
 			Network = network;
 		}
 
-		public static event EventHandler<bool> DownloadingBlockChanged;
+		public static event EventHandler<bool>? DownloadingBlockChanged;
 
 		public NodesGroup Nodes { get; }
 		public CoreNode CoreNode { get; }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -47,17 +47,17 @@ namespace WalletWasabi.Wallets
 			KeyManager.AssertLockedInternalKeysIndexed(14);
 		}
 
-		public event EventHandler<ProcessedResult> WalletRelevantTransactionProcessed;
+		public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
 
-		public event EventHandler<DequeueResult> OnDequeue;
+		public event EventHandler<DequeueResult>? OnDequeue;
 
-		public static event EventHandler<bool> InitializingChanged;
+		public static event EventHandler<bool>? InitializingChanged;
 
-		public event EventHandler<FilterModel> NewFilterProcessed;
+		public event EventHandler<FilterModel>? NewFilterProcessed;
 
-		public event EventHandler<Block> NewBlockProcessed;
+		public event EventHandler<Block>? NewBlockProcessed;
 
-		public event EventHandler<WalletState> StateChanged;
+		public event EventHandler<WalletState>? StateChanged;
 
 		public WalletState State
 		{
@@ -264,7 +264,7 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		private async void TransactionProcessor_WalletRelevantTransactionProcessedAsync(object sender, ProcessedResult e)
+		private async void TransactionProcessor_WalletRelevantTransactionProcessedAsync(object? sender, ProcessedResult e)
 		{
 			try
 			{
@@ -308,12 +308,12 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		private void ChaumianClient_OnDequeue(object sender, DequeueResult e)
+		private void ChaumianClient_OnDequeue(object? sender, DequeueResult e)
 		{
 			OnDequeue?.Invoke(this, e);
 		}
 
-		private void Mempool_TransactionReceived(object sender, SmartTransaction tx)
+		private void Mempool_TransactionReceived(object? sender, SmartTransaction tx)
 		{
 			try
 			{
@@ -325,7 +325,7 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		private async void IndexDownloader_ReorgedAsync(object sender, FilterModel invalidFilter)
+		private async void IndexDownloader_ReorgedAsync(object? sender, FilterModel invalidFilter)
 		{
 			try
 			{
@@ -348,7 +348,7 @@ namespace WalletWasabi.Wallets
 			}
 		}
 
-		private async void IndexDownloader_NewFilterAsync(object sender, FilterModel filterModel)
+		private async void IndexDownloader_NewFilterAsync(object? sender, FilterModel filterModel)
 		{
 			try
 			{

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -41,22 +41,22 @@ namespace WalletWasabi.Wallets
 		/// <summary>
 		/// Triggered if any of the Wallets processes a transaction. The sender of the event will be the Wallet.
 		/// </summary>
-		public event EventHandler<ProcessedResult> WalletRelevantTransactionProcessed;
+		public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
 
 		/// <summary>
 		/// Triggered if any of the Wallets dequeues one or more coins. The sender of the event will be the Wallet.
 		/// </summary>
-		public event EventHandler<DequeueResult> OnDequeue;
+		public event EventHandler<DequeueResult>? OnDequeue;
 
 		/// <summary>
 		/// Triggered if any of the Wallets changes its state. The sender of the event will be the Wallet.
 		/// </summary>
-		public event EventHandler<WalletState> WalletStateChanged;
+		public event EventHandler<WalletState>? WalletStateChanged;
 
 		/// <summary>
 		/// Triggered if a wallet added to the Wallet collection. The sender of the event will be the WalletManager and the argument is the added Wallet.
 		/// </summary>
-		public event EventHandler<Wallet> WalletAdded;
+		public event EventHandler<Wallet>? WalletAdded;
 
 		private CancellationTokenSource CancelAllInitialization { get; }
 
@@ -276,17 +276,17 @@ namespace WalletWasabi.Wallets
 			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
-		private void ChaumianClient_OnDequeue(object sender, DequeueResult e)
+		private void ChaumianClient_OnDequeue(object? sender, DequeueResult e)
 		{
 			OnDequeue?.Invoke(sender, e);
 		}
 
-		private void TransactionProcessor_WalletRelevantTransactionProcessed(object sender, ProcessedResult e)
+		private void TransactionProcessor_WalletRelevantTransactionProcessed(object? sender, ProcessedResult e)
 		{
 			WalletRelevantTransactionProcessed?.Invoke(sender, e);
 		}
 
-		private void Wallet_StateChanged(object sender, WalletState e)
+		private void Wallet_StateChanged(object? sender, WalletState e)
 		{
 			WalletStateChanged?.Invoke(sender, e);
 		}


### PR DESCRIPTION
This PR changes 

```csharp
public event EventHandler Name; // ditto for its generic variant: public event EventHandler<T> Name; 
```

to

```csharp
public event EventHandler? Name; // ditto for its generic variant: public event EventHandler<T>? Name; 
```

because

> You should make the event nullable, because it is indeed nullable. It may look a bit strange but that's the correct way of expressing your intent. 
(see https://stackoverflow.com/a/62536248)

Resources:

* https://stackoverflow.com/questions/58376972/guidelines-for-events-since-non-nullable-references
* https://source.dot.net/#System.Private.CoreLib/EventHandler.cs,3b79d2b06c15f250
* https://source.dot.net/#System.ObjectModel/System/ComponentModel/PropertyChangedEventHandler.cs,670754815f6804ff

PS: This PR removes about 130 nullability warnings. When NRT was deployed (see https://github.com/zkSNACKs/WalletWasabi/pull/3873) we had 2,981 warnings, with this PR we are at 2,411 warnings. So good progress.