### PR TITLE
trivial: Remove superfluous condition.

### DIFF
--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -228,11 +228,6 @@ namespace WalletWasabi.Tor
 		{
 			Interlocked.CompareExchange(ref _monitorState, StateStopping, StateRunning); // If running, make it stopping.
 
-			if (TorSocks5EndPoint is null)
-			{
-				Interlocked.Exchange(ref _monitorState, StateStopped);
-			}
-
 			Stop?.Cancel();
 			while (Interlocked.CompareExchange(ref _monitorState, StateStopped, StateNotStarted) == StateStopping)
 			{


### PR DESCRIPTION
Remove condition that is no longer useful since `TorSocks5EndPoint` is never null.