### PR TITLE
`Synchronizer` must be stopped after `HostedServices`.

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -696,18 +696,18 @@ namespace WalletWasabi.Gui
 					Logger.LogInfo($"{nameof(CoinJoinProcessor)} is disposed.");
 				}
 
-				if (Synchronizer is { } synchronizer)
-				{
-					await synchronizer.StopAsync().ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
-				}
-
 				if (HostedServices is { } backgroundServices)
 				{
 					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
 					await backgroundServices.StopAllAsync(cts.Token).ConfigureAwait(false);
 					backgroundServices.Dispose();
 					Logger.LogInfo("Stopped background services.");
+				}
+
+				if (Synchronizer is { } synchronizer)
+				{
+					await synchronizer.StopAsync().ConfigureAwait(false);
+					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
 				}
 
 				if (AddressManagerFilePath is { } addressManagerFilePath)


### PR DESCRIPTION
@yahiheb sent me the following log when he tested #4507:

```
2020-10-14 22:19:35 WARNING     Global (643)    Process is exiting.
2020-10-14 22:19:35 DEBUG       Global (654)    Step #1: Wait for initialization to complete.
2020-10-14 22:19:35 DEBUG       Global (666)    Step #2: WalletManager.
2020-10-14 22:19:35 INFO        WalletManager (331)     KeyManager backup saved to `C:\Users\RESEAU\AppData\Roaming\WalletWasabi\Client\WalletBackups\Testnet Wallet.json`.
2020-10-14 22:19:35 INFO        Wallet (258)    ChaumianClient is stopped.
2020-10-14 22:19:35 INFO        WalletManager (333)     Wallet is stopped.
2020-10-14 22:19:35 DEBUG       Global (678)    Step #2: Application's MainWindow.
2020-10-14 22:19:35 DEBUG       Global (689)    Step #3: RpcServer.
2020-10-14 22:19:35 DEBUG       Global (698)    Step #4: FeeProviders.
2020-10-14 22:19:35 INFO        Global (703)    Disposed FeeProviders.
2020-10-14 22:19:35 DEBUG       Global (706)    Step #5: CoinJoinProcessor.
2020-10-14 22:19:36 INFO        Global (711)    CoinJoinProcessor is disposed.
2020-10-14 22:19:36 DEBUG       Global (714)    Step #6: Synchronizer.
2020-10-14 22:19:36 INFO        Global (719)    Synchronizer is stopped.
2020-10-14 22:19:36 DEBUG       Global (722)    Step #7: HostedServices.
2020-10-14 22:19:36 INFO        HostedServices (78)     Stopped System Awake Checker.
2020-10-14 22:19:36 INFO        HostedServices (78)     Stopped Software Update Checker.
2020-10-14 22:19:36 ERROR       TorSocks5Client (229)   Exception was thrown when connecting to destination. Exception: WalletWasabi.Tor.Exceptions.ConnectionException: TorSocks5Client is not connected to 127.0.0.1:9050.
 ---> System.IO.IOException: Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
--- End of stack trace from previous location where exception was thrown ---
   at WalletWasabi.Tor.Socks5.TorSocks5Client.SendAsync(Byte[] sendBuffer, Nullable`1 receiveBufferSize) in WalletWasabi\Tor\Socks5\TorSocks5Client.cs:line 331
   --- End of inner exception stack trace ---
   at WalletWasabi.Tor.Socks5.TorSocks5Client.SendAsync(Byte[] sendBuffer, Nullable`1 receiveBufferSize) in WalletWasabi\Tor\Socks5\TorSocks5Client.cs:line 362
   at WalletWasabi.Tor.Socks5.TorSocks5Client.ConnectToDestinationAsync(String host, Int32 port) in WalletWasabi\Tor\Socks5\TorSocks5Client.cs:line 198
2020-10-14 22:19:36 DEBUG       TorSocks5Client (234)   <
2020-10-14 22:19:36 INFO        HostedServices (128)    Disposed Software Update Checker.
2020-10-14 22:19:36 INFO        HostedServices (128)    Disposed System Awake Checker.
2020-10-14 22:19:36 INFO        Global (729)    Stopped background services.
2020-10-14 22:19:36 DEBUG       Global (732)    Step #8: AddressManagerFilePath.
2020-10-14 22:19:36 INFO        Global (741)    AddressManager is saved to `C:\Users\RESEAU\AppData\Roaming\WalletWasabi\Client\AddressManager\AddressManagerTestNet.dat`.
2020-10-14 22:19:36 DEBUG       Global (745)    Step #9: Nodes.
2020-10-14 22:19:37 INFO        Global (755)    Nodes are disposed.
2020-10-14 22:19:37 DEBUG       Global (758)    Step #10: RegTestMempoolServingNode.
2020-10-14 22:19:37 DEBUG       Global (766)    Step #11: BitcoinCoreNode.
2020-10-14 22:19:37 DEBUG       Global (778)    Step #12: TorManager.
```

The exception (bug) seems to be unrelated to #4507 as the order of disposing calls seems to be not correct. 

`UpdateChecker` (running as a `HostedService`) relies on `WasabiSynchronizer`. However, on the current master, `WasabiSynchronizer` is stopped before `HostedServices`.