### PR TITLE
Pass byte via constructor to MethodField.

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/MethodsField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/MethodsField.cs
@@ -38,8 +38,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 			{
 				foreach (var b in Bytes)
 				{
-					var method = new MethodField();
-					method.FromByte(b);
+					var method = new MethodField(b);
 					yield return method;
 				}
 			}

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/MethodField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/MethodField.cs
@@ -4,14 +4,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class MethodField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public MethodField()
-		{
-		}
-
-		#endregion Constructors
-
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
 		// The "NO AUTHENTICATION REQUIRED" (SOCKS5) authentication method[00] is
 		// supported; and as of Tor 0.2.3.2-alpha, the "USERNAME/PASSWORD" (SOCKS5)
@@ -20,34 +12,15 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 		// we allow clients to pass "USERNAME/PASSWORD" authentication to us even if
 		// no authentication was selected.
 
-		public static MethodField NoAuthenticationRequired
-		{
-			get
-			{
-				var method = new MethodField();
-				method.FromHex("00");
-				return method;
-			}
-		}
+		public static readonly MethodField NoAuthenticationRequired = new MethodField(0x00);
 
-		public static MethodField UsernamePassword
-		{
-			get
-			{
-				var method = new MethodField();
-				method.FromHex("02");
-				return method;
-			}
-		}
+		public static readonly MethodField UsernamePassword = new MethodField(0x02);
 
-		public static MethodField NoAcceptableMethods
+		public static readonly MethodField NoAcceptableMethods = new MethodField(0xFF);
+
+		public MethodField(byte value)
 		{
-			get
-			{
-				var method = new MethodField();
-				method.FromHex("FF");
-				return method;
-			}
+			ByteValue = value;
 		}
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/VerField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/VerField.cs
@@ -1,4 +1,3 @@
-using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Bases;
 
 namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields

--- a/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
@@ -6,29 +6,13 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 {
 	public class MethodSelectionResponse : ByteArraySerializableBase
 	{
-		#region Constructors
-
 		public MethodSelectionResponse()
 		{
 		}
 
-		public MethodSelectionResponse(MethodField method)
-		{
-			Method = Guard.NotNull(nameof(method), method);
-			Ver = VerField.Socks5;
-		}
-
-		#endregion Constructors
-
-		#region PropertiesAndMembers
-
 		public VerField Ver { get; set; }
 
 		public MethodField Method { get; set; }
-
-		#endregion PropertiesAndMembers
-
-		#region Serialization
 
 		public override void FromBytes(byte[] bytes)
 		{
@@ -36,17 +20,13 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.Same($"{nameof(bytes)}.{nameof(bytes.Length)}", 2, bytes.Length);
 
 			Ver = new VerField(bytes[0]);
-
-			Method = new MethodField();
-			Method.FromByte(bytes[1]);
+			Method = new MethodField(bytes[1]);
 		}
 
 		public override byte[] ToBytes() => new byte[]
-			{
-				Ver.ToByte(),
-				Method.ToByte()
-			};
-
-		#endregion Serialization
+		{
+			Ver.ToByte(),
+			Method.ToByte()
+		};
 	}
 }


### PR DESCRIPTION
This PR disallows to create `MethodField` without passing a byte.

Notes:

* `MethodField.NoAuthenticationRequired` no longer allocates when accessing needlessly.
* `MethodSelectionResponse` constructor was not in use.