### PR TITLE
Remove PSBT output if KeyPath added to both inputs and outputs

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -360,7 +360,7 @@ namespace WalletWasabi.Blockchain.Transactions
 					var coinPubkey = coin.HdPubKey.PubKey;
 					psbt.AddKeyPath(coinPubkey, rootKeyPath, coin.ScriptPubKey);
 
-					// In case of multisig address the keyPath is added to both inputs and outputs which is a bug. The following code removes the output in that case. https://github.com/zkSNACKs/WalletWasabi/pull/4600
+					// In case of multisig address the keyPath is added to both inputs and outputs which is a bug. The following code removes the output in that case. https://github.com/MetacoSA/NBitcoin/issues/927
 					if (psbt.Outputs.SelectMany(output => output.HDKeyPaths.Keys).Contains(coinPubkey) && psbt.Inputs.SelectMany(input => input.HDKeyPaths.Keys).Contains(coinPubkey))
 					{
 						foreach (var output in psbt.Outputs)

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -357,8 +357,19 @@ namespace WalletWasabi.Blockchain.Transactions
 				foreach (var coin in spentCoins)
 				{
 					var rootKeyPath = new RootedKeyPath(fp, coin.HdPubKey.FullKeyPath);
-					psbt.AddKeyPath(coin.HdPubKey.PubKey, rootKeyPath, coin.ScriptPubKey);
+					var coinPubkey = coin.HdPubKey.PubKey;
+					psbt.AddKeyPath(coinPubkey, rootKeyPath, coin.ScriptPubKey);
+
+					// In case of multisig address the keyPath is added to both inputs and outputs which is a bug. The following code removes the output in that case. https://github.com/zkSNACKs/WalletWasabi/pull/4600
+					if (psbt.Outputs.SelectMany(output => output.HDKeyPaths.Keys).Contains(coinPubkey) && psbt.Inputs.SelectMany(input => input.HDKeyPaths.Keys).Contains(coinPubkey))
+					{
+						foreach (var output in psbt.Outputs)
+						{
+							output.HDKeyPaths.Remove(coinPubkey);
+						}
+					}
 				}
+
 				if (changeHdPubKey is { })
 				{
 					var rootKeyPath = new RootedKeyPath(fp, changeHdPubKey.FullKeyPath);


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/4460

Another solution to this closes https://github.com/zkSNACKs/WalletWasabi/pull/4600

After adding KeyPath to the PSBT here: 

https://github.com/molnard/WalletWasabi/blob/2acf63c420ad24b78b89b5cd44c8c48da2e623b1/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs#L361

It is added to both Inputs and Outputs and CC cannot sign the tx.

This code will remove it from the outputs. 