### PR TITLE
Pass parameters via constructor to AtypField

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/AddrField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/AddrField.cs
@@ -20,8 +20,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 		{
 			dstAddr = Guard.NotNullOrEmptyOrWhitespace(nameof(dstAddr), dstAddr, true);
 
-			var atyp = new AtypField();
-			atyp.FromDstAddr(dstAddr);
+			var atyp = new AtypField(dstAddr);
 
 			Atyp = atyp;
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AtypField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AtypField.cs
@@ -7,44 +7,12 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class AtypField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public AtypField()
+		public AtypField(byte value)
 		{
+			ByteValue = value;
 		}
 
-		#endregion Constructors
-
-		#region Statics
-
-		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
-		// IPv6 is not supported in CONNECT commands.
-
-		public static AtypField IPv4
-		{
-			get
-			{
-				var atyp = new AtypField();
-				atyp.FromHex("01");
-				return atyp;
-			}
-		}
-
-		public static AtypField DomainName
-		{
-			get
-			{
-				var atyp = new AtypField();
-				atyp.FromHex("03");
-				return atyp;
-			}
-		}
-
-		#endregion Statics
-
-		#region Serialization
-
-		public void FromDstAddr(string dstAddr)
+		public AtypField(string dstAddr)
 		{
 			dstAddr = Guard.NotNullOrEmptyOrWhitespace(nameof(dstAddr), dstAddr, true);
 
@@ -60,6 +28,11 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 			}
 		}
 
-		#endregion Serialization
+		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
+		// IPv6 is not supported in CONNECT commands.
+
+		public static readonly AtypField IPv4 = new AtypField(0x01);
+
+		public static AtypField DomainName = new AtypField(0x03);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AtypField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AtypField.cs
@@ -7,6 +7,13 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class AtypField : OctetSerializableBase
 	{
+		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
+		// IPv6 is not supported in CONNECT commands.
+
+		public static readonly AtypField IPv4 = new AtypField(0x01);
+
+		public static readonly AtypField DomainName = new AtypField(0x03);
+
 		public AtypField(byte value)
 		{
 			ByteValue = value;
@@ -27,12 +34,5 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 				ByteValue = DomainName.ToByte();
 			}
 		}
-
-		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
-		// IPv6 is not supported in CONNECT commands.
-
-		public static readonly AtypField IPv4 = new AtypField(0x01);
-
-		public static AtypField DomainName = new AtypField(0x03);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
@@ -49,8 +49,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Rsv = new RsvField();
 			Rsv.FromByte(bytes[2]);
 
-			Atyp = new AtypField();
-			Atyp.FromByte(bytes[3]);
+			Atyp = new AtypField(bytes[3]);
 
 			DstAddr = new AddrField();
 			DstAddr.FromBytes(bytes[4..^2]);

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
@@ -37,8 +37,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Rsv = new RsvField();
 			Rsv.FromByte(bytes[2]);
 
-			Atyp = new AtypField();
-			Atyp.FromByte(bytes[3]);
+			Atyp = new AtypField(bytes[3]);
 
 			BndAddr = new AddrField();
 			BndAddr.FromBytes(bytes[4..^2]);


### PR DESCRIPTION
This PR disallows to create `AtypField` without passing a parameter (byte/string).