### PR TITLE
Pass parameter via constructor to AuthStatusField

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthStatusField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthStatusField.cs
@@ -4,12 +4,12 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class AuthStatusField : OctetSerializableBase
 	{
+		public static AuthStatusField Success = new AuthStatusField(0x00);
+
 		public AuthStatusField(byte value)
 		{
 			ByteValue = value;
 		}
-
-		public static AuthStatusField Success = new AuthStatusField(0x00);
 
 		public bool IsSuccess() => ByteValue == Success.ByteValue;
 	}

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthStatusField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthStatusField.cs
@@ -1,4 +1,3 @@
-using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Bases;
 
 namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
@@ -10,15 +9,8 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 			ByteValue = value;
 		}
 
-		public AuthStatusField(int value)
-		{
-			ByteValue = (byte)Guard.InRangeAndNotNull(nameof(value), value, 0, 255);
-		}
+		public static AuthStatusField Success = new AuthStatusField(0x00);
 
-		public static AuthStatusField Success => new AuthStatusField(0);
-
-		public int Value => ByteValue;
-
-		public bool IsSuccess() => Value == 0;
+		public bool IsSuccess() => ByteValue == Success.ByteValue;
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthStatusField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthStatusField.cs
@@ -5,10 +5,9 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class AuthStatusField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public AuthStatusField()
+		public AuthStatusField(byte value)
 		{
+			ByteValue = value;
 		}
 
 		public AuthStatusField(int value)
@@ -16,24 +15,10 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 			ByteValue = (byte)Guard.InRangeAndNotNull(nameof(value), value, 0, 255);
 		}
 
-		#endregion Constructors
-
-		#region Statics
-
 		public static AuthStatusField Success => new AuthStatusField(0);
-
-		#endregion Statics
-
-		#region PropertiesAndMembers
 
 		public int Value => ByteValue;
 
-		#endregion PropertiesAndMembers
-
-		#region
-
 		public bool IsSuccess() => Value == 0;
-
-		#endregion
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
@@ -22,8 +22,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Ver = new AuthVerField();
 			Ver.FromByte(bytes[0]);
 
-			Status = new AuthStatusField();
-			Status.FromByte(bytes[1]);
+			Status = new AuthStatusField(bytes[1]);
 		}
 
 		public override byte[] ToBytes() => new byte[]


### PR DESCRIPTION
This PR disallows to create `AuthStatusField` without passing a byte.