### PR TITLE
Pass parameter via constructor to AuthVerField

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthVerField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthVerField.cs
@@ -1,21 +1,15 @@
-using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Bases;
 
 namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class AuthVerField : OctetSerializableBase
 	{
+		public static AuthVerField Version1 = new AuthVerField(0x01);
+
 		public AuthVerField(byte value)
 		{
 			ByteValue = value;
 		}
-
-		public AuthVerField(int value)
-		{
-			ByteValue = (byte)Guard.InRangeAndNotNull(nameof(value), value, 0, 255);
-		}
-
-		public static AuthVerField Version1 => new AuthVerField(1);
 
 		public int Value => ByteValue;
 	}

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthVerField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AuthVerField.cs
@@ -5,10 +5,9 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class AuthVerField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public AuthVerField()
+		public AuthVerField(byte value)
 		{
+			ByteValue = value;
 		}
 
 		public AuthVerField(int value)
@@ -16,18 +15,8 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 			ByteValue = (byte)Guard.InRangeAndNotNull(nameof(value), value, 0, 255);
 		}
 
-		#endregion Constructors
-
-		#region Statics
-
 		public static AuthVerField Version1 => new AuthVerField(1);
 
-		#endregion Statics
-
-		#region PropertiesAndMembers
-
 		public int Value => ByteValue;
-
-		#endregion PropertiesAndMembers
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordRequest.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordRequest.cs
@@ -37,8 +37,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6, 513);
 
-			Ver = new AuthVerField();
-			Ver.FromByte(bytes[0]);
+			Ver = new AuthVerField(bytes[0]);
 
 			ULen = new ULenField();
 			ULen.FromByte(bytes[1]);

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
@@ -19,8 +19,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.Same($"{nameof(bytes)}.{nameof(bytes.Length)}", 2, bytes.Length);
 
-			Ver = new AuthVerField();
-			Ver.FromByte(bytes[0]);
+			Ver = new AuthVerField(bytes[0]);
 
 			Status = new AuthStatusField();
 			Status.FromByte(bytes[1]);


### PR DESCRIPTION
This PR disallows to create `AuthVerField` without passing a byte.