### PR TITLE
Possible NREs in WasabiClient 

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/Common.cs
+++ b/WalletWasabi.Tests/RegressionTests/Common.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			while (true)
 			{
 				using var client = new WasabiClient(new Uri(regTestFixture.BackendEndPoint), torSocks5EndPoint: null);
-				FiltersResponse filtersResponse = await client.GetFiltersAsync(firstHash, 1000);
+				FiltersResponse? filtersResponse = await client.GetFiltersAsync(firstHash, 1000);
 				Assert.NotNull(filtersResponse);
 
 				var filterCount = filtersResponse.Filters.Count();


### PR DESCRIPTION
`TorClient.SendAndRetryAsync` can return `null` when all attempts fails. This was not handled in `WasabiClient` code.