### PR TITLE
Prevent building CJ with fee lower than minMemPoolFee

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1048,7 +1048,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			}
 
 			FeeRate feeRateTx = finalCoinjoin.GetFeeRate(coins.ToArray());
-			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
+			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, new FeeRate(2m), EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
 			FeeRate feeRateReal = esr.FeeRate;
 
 			Assert.True(feeRateReal.FeePerK - feeRateReal.FeePerK / 2 < feeRateTx.FeePerK); // Max 50% mistake.

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -159,12 +159,12 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			{
 				var rpc = coreNode.RpcClient;
 				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
-				Assert.Equal(WalletWasabi.Helpers.Constants.OneDayConfirmationTarget, estimations.Estimations.Count);
+				Assert.Equal(143, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
 				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
-				Assert.Equal(145, estimations.Estimations.Count);
+				Assert.Equal(143, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.Tests.UnitTests
 				await round.TryOptimizeFeesAsync(tx1, spentCoins);
 				var txFeeAfterOptimization = tx1.GetFee(spentCoins.ToArray());
 
-				Assert.True(txFeeAfterOptimization == txFeeBeforeOptimization);
+				Assert.Equal(txFeeAfterOptimization, txFeeBeforeOptimization);
 			}
 		}
 
@@ -92,8 +92,8 @@ namespace WalletWasabi.Tests.UnitTests
 				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
 
 				var highestMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighestMinMemPoolFee));
-				Assert.True(feePerInputs == highestMinMemPoolFeeRate.GetFee(InputSizeInBytes));
-				Assert.True(feePerOutputs == highestMinMemPoolFeeRate.GetFee(OutputSizeInBytes));
+				Assert.Equal(highestMinMemPoolFeeRate.GetFee(InputSizeInBytes), feePerInputs);
+				Assert.Equal(highestMinMemPoolFeeRate.GetFee(OutputSizeInBytes), feePerOutputs);
 			}
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.CoinJoin.Coordinator.Banning;
+using WalletWasabi.CoinJoin.Coordinator.Rounds;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests
+{
+	public class CoordinatorRoundTests
+	{
+		[Fact]
+		public async Task ssAsync()
+		{
+			var rpc = new MockRpcClient();
+			var roundConfig = new CoordinatorRoundConfig();
+			var utxoReferee = new UtxoReferee(Network.Main, "./", rpc, roundConfig);
+			var confirmationTarget = 12;
+			var round = new CoordinatorRound(rpc, utxoReferee, roundConfig, adjustedConfirmationTarget: confirmationTarget, confirmationTarget, roundConfig.ConfirmationTargetReductionRate);
+
+			static OutPoint GetRandomOutPoint() => new OutPoint(RandomUtils.GetUInt256(), 0);
+			var tx = Network.Main.CreateTransaction();
+			tx.Version = 1;
+			tx.LockTime = LockTime.Zero;
+			tx.Inputs.Add(GetRandomOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
+			tx.Inputs.Add(GetRandomOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
+			tx.Outputs.Add(Money.Coins(1.9995m), new Key().ScriptPubKey);
+
+			// Under normal circunstances
+			{
+				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
+				});
+
+				var tx0 = tx.Clone();
+				var spentCoins = tx0.Inputs.Select(x => new Coin(x.PrevOut, new TxOut(Money.Coins(1), new Key().ScriptPubKey)));
+				var txFeeBeforeOptimization = tx0.GetFee(spentCoins.ToArray());
+				await round.TryOptimizeFeesAsync(tx0, spentCoins );
+				var txFeeAfterOptimization = tx0.GetFee(spentCoins.ToArray());
+				Assert.True(txFeeAfterOptimization < txFeeBeforeOptimization);
+			}
+
+			// Under heavy mempool pressure
+			{
+				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = 0.0028 // 280 s/b
+				});
+
+				var tx1 = tx.Clone();
+				var spentCoins = tx1.Inputs.Select(x => new Coin(x.PrevOut, new TxOut(Money.Coins(1), new Key().ScriptPubKey)));
+				var txFeeBeforeOptimization = tx1.GetFee(spentCoins.ToArray());
+				await round.TryOptimizeFeesAsync(tx1, spentCoins );
+				var txFeeAfterOptimization = tx1.GetFee(spentCoins.ToArray());
+
+				Assert.True(txFeeAfterOptimization == txFeeBeforeOptimization);
+			}
+		}
+
+		[Fact]
+		public async Task xxAsync()
+		{
+			const double DefaultMinMemPoolFee = 0.00001000; // 1 s/b (default value)
+			const double HighertMinMemPoolFee = 0.00200000; // 200 s/b 
+			const int InputSizeInBytes = 67;
+			const int OutputSizeInBytes = 33;
+
+			var rpc = new MockRpcClient();
+			{
+				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = DefaultMinMemPoolFee 
+				});
+
+				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
+
+				var defaultMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)DefaultMinMemPoolFee));
+				Assert.True(feePerInputs > defaultMinMemPoolFeeRate.GetFee(InputSizeInBytes));
+				Assert.True(feePerOutputs > defaultMinMemPoolFeeRate.GetFee(OutputSizeInBytes));
+			}
+
+			{
+				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				{
+					MemPoolMinFee = HighertMinMemPoolFee 
+				});
+
+				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
+
+				var higherMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighertMinMemPoolFee));
+				Assert.True(feePerInputs == higherMinMemPoolFeeRate.GetFee(InputSizeInBytes));
+				Assert.True(feePerOutputs == higherMinMemPoolFeeRate.GetFee(OutputSizeInBytes));
+			}
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Tests.UnitTests
 	public class CoordinatorRoundTests
 	{
 		[Fact]
-		public async Task ssAsync()
+		public async Task SsAsync()
 		{
 			var rpc = new MockRpcClient();
 			var roundConfig = new CoordinatorRoundConfig();
@@ -62,7 +62,7 @@ namespace WalletWasabi.Tests.UnitTests
 		}
 
 		[Fact]
-		public async Task xxAsync()
+		public async Task XxAsync()
 		{
 			const double DefaultMinMemPoolFee = 0.00001000; // 1 s/b (default value)
 			const double HighertMinMemPoolFee = 0.00200000; // 200 s/b

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -91,9 +91,9 @@ namespace WalletWasabi.Tests.UnitTests
 
 				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
 
-				var higherMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighestMinMemPoolFee));
-				Assert.True(feePerInputs == higherMinMemPoolFeeRate.GetFee(InputSizeInBytes));
-				Assert.True(feePerOutputs == higherMinMemPoolFeeRate.GetFee(OutputSizeInBytes));
+				var highestMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighestMinMemPoolFee));
+				Assert.True(feePerInputs == highestMinMemPoolFeeRate.GetFee(InputSizeInBytes));
+				Assert.True(feePerOutputs == highestMinMemPoolFeeRate.GetFee(OutputSizeInBytes));
 			}
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -91,7 +91,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
 
-				var highestMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighestMinMemPoolFee));
+				var highestMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighestMinMemPoolFee * 1.5m));
 				Assert.Equal(highestMinMemPoolFeeRate.GetFee(InputSizeInBytes), feePerInputs);
 				Assert.Equal(highestMinMemPoolFeeRate.GetFee(OutputSizeInBytes), feePerOutputs);
 			}

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.Tests.UnitTests
 				var tx0 = tx.Clone();
 				var spentCoins = tx0.Inputs.Select(x => new Coin(x.PrevOut, new TxOut(Money.Coins(1), new Key().ScriptPubKey)));
 				var txFeeBeforeOptimization = tx0.GetFee(spentCoins.ToArray());
-				await round.TryOptimizeFeesAsync(tx0, spentCoins );
+				await round.TryOptimizeFeesAsync(tx0, spentCoins);
 				var txFeeAfterOptimization = tx0.GetFee(spentCoins.ToArray());
 				Assert.True(txFeeAfterOptimization < txFeeBeforeOptimization);
 			}
@@ -54,7 +54,7 @@ namespace WalletWasabi.Tests.UnitTests
 				var tx1 = tx.Clone();
 				var spentCoins = tx1.Inputs.Select(x => new Coin(x.PrevOut, new TxOut(Money.Coins(1), new Key().ScriptPubKey)));
 				var txFeeBeforeOptimization = tx1.GetFee(spentCoins.ToArray());
-				await round.TryOptimizeFeesAsync(tx1, spentCoins );
+				await round.TryOptimizeFeesAsync(tx1, spentCoins);
 				var txFeeAfterOptimization = tx1.GetFee(spentCoins.ToArray());
 
 				Assert.True(txFeeAfterOptimization == txFeeBeforeOptimization);
@@ -65,7 +65,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public async Task xxAsync()
 		{
 			const double DefaultMinMemPoolFee = 0.00001000; // 1 s/b (default value)
-			const double HighertMinMemPoolFee = 0.00200000; // 200 s/b 
+			const double HighertMinMemPoolFee = 0.00200000; // 200 s/b
 			const int InputSizeInBytes = 67;
 			const int OutputSizeInBytes = 33;
 
@@ -73,7 +73,7 @@ namespace WalletWasabi.Tests.UnitTests
 			{
 				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
 				{
-					MemPoolMinFee = DefaultMinMemPoolFee 
+					MemPoolMinFee = DefaultMinMemPoolFee
 				});
 
 				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
@@ -86,7 +86,7 @@ namespace WalletWasabi.Tests.UnitTests
 			{
 				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
 				{
-					MemPoolMinFee = HighertMinMemPoolFee 
+					MemPoolMinFee = HighertMinMemPoolFee
 				});
 
 				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 			// Under normal circunstances
 			{
-				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				rpc.OnGetMempoolInfoAsync = () => Task.FromResult(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
 				});
@@ -46,7 +46,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 			// Under heavy mempool pressure
 			{
-				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				rpc.OnGetMempoolInfoAsync = () => Task.FromResult(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.0028 // 280 s/b
 				});
@@ -71,7 +71,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 			var rpc = new MockRpcClient();
 			{
-				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				rpc.OnGetMempoolInfoAsync = () => Task.FromResult(new MemPoolInfo
 				{
 					MemPoolMinFee = DefaultMinMemPoolFee
 				});
@@ -84,7 +84,7 @@ namespace WalletWasabi.Tests.UnitTests
 			}
 
 			{
-				rpc.OnGetMempoolAsync = () => Task.FromResult(new MemPoolInfo
+				rpc.OnGetMempoolInfoAsync = () => Task.FromResult(new MemPoolInfo
 				{
 					MemPoolMinFee = HighertMinMemPoolFee
 				});

--- a/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoordinatorRoundTests.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public async Task XxAsync()
 		{
 			const double DefaultMinMemPoolFee = 0.00001000; // 1 s/b (default value)
-			const double HighertMinMemPoolFee = 0.00200000; // 200 s/b
+			const double HighestMinMemPoolFee = 0.00200000; // 200 s/b
 			const int InputSizeInBytes = 67;
 			const int OutputSizeInBytes = 33;
 
@@ -86,12 +86,12 @@ namespace WalletWasabi.Tests.UnitTests
 			{
 				rpc.OnGetMempoolInfoAsync = () => Task.FromResult(new MemPoolInfo
 				{
-					MemPoolMinFee = HighertMinMemPoolFee
+					MemPoolMinFee = HighestMinMemPoolFee
 				});
 
 				var (feePerInputs, feePerOutputs) = await CoordinatorRound.CalculateFeesAsync(rpc, 12);
 
-				var higherMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighertMinMemPoolFee));
+				var higherMinMemPoolFeeRate = new FeeRate(Money.Coins((decimal)HighestMinMemPoolFee));
 				Assert.True(feePerInputs == higherMinMemPoolFeeRate.GetFee(InputSizeInBytes));
 				Assert.True(feePerOutputs == higherMinMemPoolFeeRate.GetFee(OutputSizeInBytes));
 			}

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Tests.UnitTests
 			throw new NotImplementedException();
 		}
 
-		public Task<MemPoolInfo> GetMempoolAsync()
+		public Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
 			return OnGetMempoolAsync();
 		}

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public Func<uint256, Task<BlockHeader>> OnGetBlockHeaderAsync { get; set; }
 		public Func<Task<BlockchainInfo>> OnGetBlockchainInfoAsync { get; set; }
 		public Func<uint256, Task<VerboseBlockInfo>> OnGetVerboseBlockAsync { get; set; }
-		public Func<Task<MemPoolInfo>> OnGetMempoolAsync { get; set; }
+		public Func<Task<MemPoolInfo>> OnGetMempoolInfoAsync { get; set; }
 
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new RPCCredentialString();
@@ -62,7 +62,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
-			return OnGetMempoolAsync();
+			return OnGetMempoolInfoAsync();
 		}
 
 		public Task<BitcoinAddress> GetNewAddressAsync()

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -15,6 +15,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public Func<uint256, Task<BlockHeader>> OnGetBlockHeaderAsync { get; set; }
 		public Func<Task<BlockchainInfo>> OnGetBlockchainInfoAsync { get; set; }
 		public Func<uint256, Task<VerboseBlockInfo>> OnGetVerboseBlockAsync { get; set; }
+		public Func<Task<MemPoolInfo>> OnGetMempoolAsync { get; set; }
 
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new RPCCredentialString();
@@ -57,6 +58,11 @@ namespace WalletWasabi.Tests.UnitTests
 		public Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true)
 		{
 			throw new NotImplementedException();
+		}
+
+		public Task<MemPoolInfo> GetMempoolAsync()
+		{
+			return OnGetMempoolAsync();
 		}
 
 		public Task<BitcoinAddress> GetNewAddressAsync()

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -145,6 +145,21 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				() => base.GetMempoolEntryAsync(txid, throwIfNotFound)).ConfigureAwait(false);
 		}
 
+		public override async Task<MemPoolInfo> GetMempoolAsync()
+		{
+			string cacheKey = nameof(GetMempoolAsync);
+			var cacheOptions = new MemoryCacheEntryOptions
+			{
+				Size = 1,
+				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(10)
+			};
+
+			return await Cache.AtomicGetOrCreateAsync(
+				cacheKey,
+				cacheOptions,
+				() => base.GetMempoolAsync()).ConfigureAwait(false);
+		}
+
 		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
 		{
 			string cacheKey = $"{nameof(EstimateSmartFeeAsync)}:{confirmationTarget}:{estimateMode}";

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -145,9 +145,9 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				() => base.GetMempoolEntryAsync(txid, throwIfNotFound)).ConfigureAwait(false);
 		}
 
-		public override async Task<MemPoolInfo> GetMempoolAsync()
+		public override async Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
-			string cacheKey = nameof(GetMempoolAsync);
+			string cacheKey = nameof(GetMempoolInfoAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
 			{
 				Size = 1,
@@ -157,7 +157,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetMempoolAsync()).ConfigureAwait(false);
+				() => base.GetMempoolInfoAsync()).ConfigureAwait(false);
 		}
 
 		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -35,6 +35,8 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 		Task<uint256[]> GetRawMempoolAsync();
 
+		Task<MemPoolInfo> GetMempoolAsync();
+
 		Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, bool allowHighFees = false);
 
 		Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative);

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 		Task<uint256[]> GetRawMempoolAsync();
 
-		Task<MemPoolInfo> GetMempoolAsync();
+		Task<MemPoolInfo> GetMempoolInfoAsync();
 
 		Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, bool allowHighFees = false);
 

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -55,6 +55,11 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound).ConfigureAwait(false);
 		}
 
+		public virtual async Task<MemPoolInfo> GetMempoolAsync()
+		{
+			return await Rpc.GetMemPoolAsync();
+		}
+
 		public virtual async Task<uint256[]> GetRawMempoolAsync()
 		{
 			return await Rpc.GetRawMempoolAsync().ConfigureAwait(false);

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -55,7 +55,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound).ConfigureAwait(false);
 		}
 
-		public virtual async Task<MemPoolInfo> GetMempoolAsync()
+		public virtual async Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
 			return await Rpc.GetMemPoolAsync().ConfigureAwait(false);
 		}

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 		public virtual async Task<MemPoolInfo> GetMempoolAsync()
 		{
-			return await Rpc.GetMemPoolAsync();
+			return await Rpc.GetMemPoolAsync().ConfigureAwait(false);
 		}
 
 		public virtual async Task<uint256[]> GetRawMempoolAsync()

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -822,7 +822,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 
 				if (optimalFeeRate is { } && optimalFeeRate != FeeRate.Zero && currentFeeRate is { } && currentFeeRate != FeeRate.Zero) // This would be really strange if it'd happen.
 				{
-					MemPoolInfo mempoolInfo = await RpcClient.GetMempoolAsync().ConfigureAwait(false);
+					MemPoolInfo mempoolInfo = await RpcClient.GetMempoolInfoAsync().ConfigureAwait(false);
 					FeeRate minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee));
 
 					var sanityFeeRate = FeeRate.Max(minMempoolFee, new FeeRate(2m)); // 2 s/b
@@ -899,7 +899,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			var outputSizeInBytes = Constants.OutputSizeInBytes;
 			try
 			{
-				var mempoolInfo = await rpc.GetMempoolAsync().ConfigureAwait(false);
+				var mempoolInfo = await rpc.GetMempoolInfoAsync().ConfigureAwait(false);
 				var minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee));
 				var sanityFeeRate = FeeRate.Max(minMempoolFee, new FeeRate(2m));
 

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -823,9 +823,8 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				if (optimalFeeRate is { } && optimalFeeRate != FeeRate.Zero && currentFeeRate is { } && currentFeeRate != FeeRate.Zero) // This would be really strange if it'd happen.
 				{
 					MemPoolInfo mempoolInfo = await RpcClient.GetMempoolInfoAsync().ConfigureAwait(false);
-					FeeRate minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee));
 
-					var sanityFeeRate = FeeRate.Max(minMempoolFee, new FeeRate(2m)); // 2 s/b
+					var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
 					optimalFeeRate = optimalFeeRate < sanityFeeRate ? sanityFeeRate : optimalFeeRate;
 					if (optimalFeeRate < currentFeeRate)
 					{
@@ -900,8 +899,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			try
 			{
 				var mempoolInfo = await rpc.GetMempoolInfoAsync().ConfigureAwait(false);
-				var minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee));
-				var sanityFeeRate = FeeRate.Max(minMempoolFee, new FeeRate(2m));
+				var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
 
 				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -822,7 +822,11 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 
 				FeeRate optimalFeeRate = estimateSmartFeeResponse.FeeRate;
 
-				if (optimalFeeRate is { } && optimalFeeRate != FeeRate.Zero && currentFeeRate is { } && currentFeeRate != FeeRate.Zero && optimalFeeRate < currentFeeRate) // This would be really strange if it'd happen.
+				if (optimalFeeRate is null || optimalFeeRate == FeeRate.Zero || currentFeeRate is null || currentFeeRate == FeeRate.Zero) // This would be really strange if it'd happen.
+				{
+					Logger.LogError($"Round ({RoundId}): This is impossible. {nameof(optimalFeeRate)}: {optimalFeeRate}, {nameof(currentFeeRate)}: {currentFeeRate}.");
+				}
+				else if (optimalFeeRate < currentFeeRate)
 				{
 					// 7.2 If the fee can be lowered, lower it.
 					// 7.2.1. How much fee can we save?
@@ -846,10 +850,6 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 							output.Value += toSavePerBestMixOutputs;
 						}
 					}
-				}
-				else
-				{
-					Logger.LogError($"Round ({RoundId}): This is impossible. {nameof(optimalFeeRate)}: {optimalFeeRate}, {nameof(currentFeeRate)}: {currentFeeRate}.");
 				}
 			}
 			catch (Exception ex)

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -812,18 +812,18 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 
 				// 7.2. Get the most optimal FeeRate.
 				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
-				
+
 				if (estimateSmartFeeResponse is null)
 				{
 					throw new InvalidOperationException($"{nameof(FeeRate)} is not yet initialized.");
 				}
 
-				FeeRate optimalFeeRate =  estimateSmartFeeResponse.FeeRate;
+				FeeRate optimalFeeRate = estimateSmartFeeResponse.FeeRate;
 
 				if (optimalFeeRate is { } && optimalFeeRate != FeeRate.Zero && currentFeeRate is { } && currentFeeRate != FeeRate.Zero) // This would be really strange if it'd happen.
 				{
 					MemPoolInfo mempoolInfo = await RpcClient.GetMempoolAsync().ConfigureAwait(false);
-					FeeRate minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee)); 
+					FeeRate minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee));
 
 					var sanityFeeRate = FeeRate.Max(minMempoolFee, new FeeRate(2m)); // 2 s/b
 					optimalFeeRate = optimalFeeRate < sanityFeeRate ? sanityFeeRate : optimalFeeRate;
@@ -900,7 +900,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			try
 			{
 				var mempoolInfo = await rpc.GetMempoolAsync().ConfigureAwait(false);
-				var minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee)); 
+				var minMempoolFee = new FeeRate(Money.Coins((decimal)mempoolInfo.MemPoolMinFee));
 				var sanityFeeRate = FeeRate.Max(minMempoolFee, new FeeRate(2m));
 
 				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -898,8 +898,9 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, sanityFeeRate, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 				var feeRate = estimateSmartFeeResponse.FeeRate;
 
-				feePerInputs = feeRate.GetFee(inputSizeInBytes);
-				feePerOutputs = feeRate.GetFee(outputSizeInBytes);
+				// Make sure min relay fee (1000 sat) is hit.
+				feePerInputs = Math.Max(feeRate.GetFee(inputSizeInBytes), Money.Satoshis(500));
+				feePerOutputs = Math.Max(feeRate.GetFee(outputSizeInBytes), Money.Satoshis(250));
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -461,5 +461,16 @@ namespace NBitcoin
 				}
 			}
 		}
+
+		public static FeeRate GetSanityFeeRate(this MemPoolInfo me)
+		{
+			var mempoolMinFee = (decimal)me.MemPoolMinFee;
+
+			// Make sure to be prepare for mempool spikes.
+			var spikeSanity = mempoolMinFee * 1.5m;
+
+			var sanityFee = FeeRate.Max(new FeeRate(Money.Coins(spikeSanity)), new FeeRate(2m));
+			return sanityFee;
+		}
 	}
 }

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -22,7 +22,7 @@ namespace NBitcoin.RPC
 			}
 			else
 			{
-				result = await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode);
+				result = await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode).ConfigureAwait(false);
 			}
 
 			result.FeeRate = FeeRate.Max(sanityFeeRate, result.FeeRate);


### PR DESCRIPTION
Bitcoin Core/Knots smart fee estimations get smaller as we increase the confirmation target at the point that we can see always a 1 sat/vbyte at the extreme. However, even when 1 sat/byte is valid and the estimation could be correct, in circumstances when there is a big pressure on the mempool (full mempools) transaction paying 1 sat/vbyte are not relayed.   

For a transaction to be relayed it has to pay at least the `MinRelayTxFee` but this doesn't guarantee the tx will be accepted in the mempool, the minimum fee to pay is provided by the node (rpc interface) asn it is called `MinMemPoolFee` that is the maximum of `MinRelayTxFee` and `MinMemPoolFee`.

This is important because Wsabi coinjoin transactions are built using the estimated fee for targets far in the time that can be under the `MinMemPoolFee` meaning that even if they are accepted by our node (wasabi is whitelisted/whitebinded so, the tx are accepted by sure) they could be no relayed and/or not accepted in other nodes' mempools.

We have to take into account that nodes drop low fee transaction from their mempool when they are full in order to make space for those that pay more so, it is not guaranteed that a low fee wasabi coinjoin transaction can survive in high fee environment.  