### PR TITLE
[Tor] Deserialize Byte Arrays from Constructors

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Bases/ByteArraySerializableBase.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Bases/ByteArraySerializableBase.cs
@@ -9,8 +9,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Bases
 	{
 		public abstract byte[] ToBytes();
 
-		public abstract void FromBytes(byte[] bytes);
-
 		public string ToHex(bool xhhSyntax = false)
 		{
 			if (xhhSyntax)
@@ -18,14 +16,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Bases
 				return $"X'{ByteHelpers.ToHex(ToBytes())}'";
 			}
 			return ByteHelpers.ToHex(ToBytes());
-		}
-
-		public void FromHex(string hex)
-		{
-			hex = Guard.NotNullOrEmptyOrWhitespace(nameof(hex), hex, true);
-
-			var bytes = ByteHelpers.FromHex(hex);
-			FromBytes(bytes);
 		}
 
 		public string ToString(Encoding encoding)

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/AddrField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/AddrField.cs
@@ -11,8 +11,25 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 	{
 		#region Constructors
 
-		public AddrField()
+		public AddrField(byte[] bytes)
 		{
+			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
+
+			AtypField atyp;
+			if (bytes.First() == bytes.Length - 1 && bytes.Length != 4)
+			{
+				atyp = AtypField.DomainName;
+			}
+			else if (bytes.Length == 4)
+			{
+				atyp = AtypField.IPv4;
+			}
+			else
+			{
+				throw new FormatException($"Could not read IPv4 or domain name from {nameof(bytes)}. Value: {bytes}.");
+			}
+
+			Atyp = atyp;
 		}
 
 		/// <param name="dstAddr">Domain or IPv4</param>
@@ -78,9 +95,9 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 
 		#region PropertiesAndMembers
 
-		private byte[] Bytes { get; set; }
+		private byte[] Bytes { get; }
 
-		public AtypField Atyp { get; set; }
+		public AtypField Atyp { get; }
 
 		public string DomainOrIPv4
 		{
@@ -108,27 +125,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 		#endregion PropertiesAndMembers
 
 		#region Serialization
-
-		public override void FromBytes(byte[] bytes)
-		{
-			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
-
-			AtypField atyp;
-			if (bytes.First() == bytes.Length - 1 && bytes.Length != 4)
-			{
-				atyp = AtypField.DomainName;
-			}
-			else if (bytes.Length == 4)
-			{
-				atyp = AtypField.IPv4;
-			}
-			else
-			{
-				throw new FormatException($"Could not read IPv4 or domain name from {nameof(bytes)}. Value: {bytes}.");
-			}
-
-			Atyp = atyp;
-		}
 
 		public override byte[] ToBytes() => Bytes;
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/MethodsField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/MethodsField.cs
@@ -10,8 +10,19 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 	{
 		#region Constructors
 
-		public MethodsField()
+		public MethodsField(byte[] bytes)
 		{
+			Guard.NotNullOrEmpty(nameof(bytes), bytes);
+
+			foreach (var b in bytes)
+			{
+				if (b != MethodField.NoAuthenticationRequired && b != MethodField.UsernamePassword)
+				{
+					throw new FormatException($"Unrecognized authentication method: {ByteHelpers.ToHex(b)}.");
+				}
+			}
+
+			Bytes = bytes;
 		}
 
 		public MethodsField(params MethodField[] methods)
@@ -30,7 +41,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 
 		#region PropertiesAndMembers
 
-		private byte[] Bytes { get; set; }
+		private byte[] Bytes { get; }
 
 		public IEnumerable<MethodField> Methods
 		{
@@ -47,21 +58,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 		#endregion PropertiesAndMembers
 
 		#region Serialization
-
-		public override void FromBytes(byte[] bytes)
-		{
-			Guard.NotNullOrEmpty(nameof(bytes), bytes);
-
-			foreach (var b in bytes)
-			{
-				if (b != MethodField.NoAuthenticationRequired && b != MethodField.UsernamePassword)
-				{
-					throw new FormatException($"Unrecognized authentication method: {ByteHelpers.ToHex(b)}.");
-				}
-			}
-
-			Bytes = bytes;
-		}
 
 		public override byte[] ToBytes() => Bytes;
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PasswdField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PasswdField.cs
@@ -6,17 +6,19 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 {
 	public class PasswdField : ByteArraySerializableBase
 	{
-		public PasswdField(string passwd)
+		public PasswdField(byte[] bytes)
 		{
-			Guard.NotNullOrEmpty(nameof(passwd), passwd);
-			Bytes = Encoding.UTF8.GetBytes(passwd);
+			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 		}
 
-		private byte[] Bytes { get; set; }
+		public PasswdField(string passwd)
+			: this(Encoding.UTF8.GetBytes(passwd))
+		{
+		}
+
+		private byte[] Bytes { get; }
 
 		public string Passwd => Encoding.UTF8.GetString(Bytes); // Tor accepts UTF8 encoded passwd
-
-		public override void FromBytes(byte[] bytes) => Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 
 		public override byte[] ToBytes() => Bytes;
 	}

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PortField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PortField.cs
@@ -9,8 +9,9 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 	{
 		#region Constructors
 
-		public PortField()
+		public PortField(byte[] bytes)
 		{
+			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 		}
 
 		public PortField(int dstPort)
@@ -32,15 +33,13 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 
 		#region PropertiesAndMembers
 
-		private byte[] Bytes { get; set; }
+		private byte[] Bytes { get; }
 
 		public int DstPort => BitConverter.ToInt16(Bytes.Reverse().ToArray(), 0);
 
 		#endregion PropertiesAndMembers
 
 		#region Serialization
-
-		public override void FromBytes(byte[] bytes) => Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 
 		public override byte[] ToBytes() => Bytes;
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/UNameField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/UNameField.cs
@@ -8,29 +8,27 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 	{
 		#region Constructors
 
-		public UNameField()
+		public UNameField(byte[] bytes)
 		{
+			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 		}
 
 		public UNameField(string uName)
+			: this(Encoding.UTF8.GetBytes(uName))
 		{
-			Guard.NotNullOrEmpty(nameof(uName), uName);
-			Bytes = Encoding.UTF8.GetBytes(uName);
 		}
 
 		#endregion Constructors
 
 		#region PropertiesAndMembers
 
-		private byte[] Bytes { get; set; }
+		private byte[] Bytes { get; }
 
 		public string UName => Encoding.UTF8.GetString(Bytes); // Tor accepts UTF8 encoded passwd
 
 		#endregion PropertiesAndMembers
 
 		#region Serialization
-
-		public override void FromBytes(byte[] bytes) => Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 
 		public override byte[] ToBytes() => Bytes;
 

--- a/WalletWasabi/Tor/Socks5/Models/Interfaces/IByteArraySerializable.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Interfaces/IByteArraySerializable.cs
@@ -4,10 +4,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Interfaces
 	{
 		byte[] ToBytes();
 
-		void FromBytes(params byte[] bytes);
-
 		string ToHex(bool xhhSyntax);
-
-		void FromHex(string hex);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Bases;
 using WalletWasabi.Tor.Socks5.Models.Fields.OctetFields;
@@ -6,21 +7,22 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 {
 	public class MethodSelectionResponse : ByteArraySerializableBase
 	{
-		public MethodSelectionResponse()
+		/// <param name="bytes">2 bytes are required to be passed in.</param>
+		public MethodSelectionResponse(byte[] bytes)
 		{
-		}
-
-		public VerField Ver { get; set; }
-
-		public MethodField Method { get; set; }
-
-		public override void FromBytes(byte[] bytes)
-		{
-			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.Same($"{nameof(bytes)}.{nameof(bytes.Length)}", 2, bytes.Length);
 
 			Ver = new VerField(bytes[0]);
 			Method = new MethodField(bytes[1]);
+		}
+
+		public VerField Ver { get; }
+
+		public MethodField Method { get; }
+
+		public override void FromBytes(byte[] bytes)
+		{
+			throw new NotSupportedException("This method is no longer supported.");
 		}
 
 		public override byte[] ToBytes() => new byte[]

--- a/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
@@ -21,6 +21,10 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 		public MethodField Method { get; }
 
 		public override byte[] ToBytes()
-			=> new byte[] { Ver.ToByte(), Method.ToByte() };
+			=> new byte[]
+			{
+				Ver.ToByte(),
+				Method.ToByte()
+			};
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
@@ -20,15 +20,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 		public MethodField Method { get; }
 
-		public override void FromBytes(byte[] bytes)
-		{
-			throw new NotSupportedException("This method is no longer supported.");
-		}
-
-		public override byte[] ToBytes() => new byte[]
-		{
-			Ver.ToByte(),
-			Method.ToByte()
-		};
+		public override byte[] ToBytes() => new byte[] { Ver.ToByte(), Method.ToByte() };
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/MethodSelectionResponse.cs
@@ -20,6 +20,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 		public MethodField Method { get; }
 
-		public override byte[] ToBytes() => new byte[] { Ver.ToByte(), Method.ToByte() };
+		public override byte[] ToBytes()
+			=> new byte[] { Ver.ToByte(), Method.ToByte() };
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
@@ -8,35 +8,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 {
 	public class TorSocks5Request : ByteArraySerializableBase
 	{
-		public TorSocks5Request(CmdField cmd, AddrField dstAddr, PortField dstPort)
-		{
-			Cmd = Guard.NotNull(nameof(cmd), cmd);
-			DstAddr = Guard.NotNull(nameof(dstAddr), dstAddr);
-			DstPort = Guard.NotNull(nameof(dstPort), dstPort);
-			Ver = VerField.Socks5;
-			Rsv = RsvField.X00;
-			Atyp = dstAddr.Atyp;
-		}
-
-		#region PropertiesAndMembers
-
-		public VerField Ver { get; set; }
-
-		public CmdField Cmd { get; set; }
-
-		public RsvField Rsv { get; set; }
-
-		public AtypField Atyp { get; set; }
-
-		public AddrField DstAddr { get; set; }
-
-		public PortField DstPort { get; set; }
-
-		#endregion PropertiesAndMembers
-
-		#region Serialization
-
-		public override void FromBytes(byte[] bytes)
+		public TorSocks5Request(byte[] bytes)
 		{
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
@@ -51,12 +23,38 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 			Atyp = new AtypField(bytes[3]);
 
-			DstAddr = new AddrField();
-			DstAddr.FromBytes(bytes[4..^2]);
+			DstAddr = new AddrField(bytes[4..^2]);
 
-			DstPort = new PortField();
-			DstPort.FromBytes(bytes[^2..]);
+			DstPort = new PortField(bytes[^2..]);
 		}
+
+		public TorSocks5Request(CmdField cmd, AddrField dstAddr, PortField dstPort)
+		{
+			Cmd = Guard.NotNull(nameof(cmd), cmd);
+			DstAddr = Guard.NotNull(nameof(dstAddr), dstAddr);
+			DstPort = Guard.NotNull(nameof(dstPort), dstPort);
+			Ver = VerField.Socks5;
+			Rsv = RsvField.X00;
+			Atyp = dstAddr.Atyp;
+		}
+
+		#region PropertiesAndMembers
+
+		public VerField Ver { get; }
+
+		public CmdField Cmd { get; }
+
+		public RsvField Rsv { get; }
+
+		public AtypField Atyp { get; }
+
+		public AddrField DstAddr { get; }
+
+		public PortField DstPort { get; }
+
+		#endregion PropertiesAndMembers
+
+		#region Serialization
 
 		public override byte[] ToBytes() => ByteHelpers.Combine(new byte[] { Ver.ToByte(), Cmd.ToByte(), Rsv.ToByte(), Atyp.ToByte() }, DstAddr.ToBytes(), DstPort.ToBytes());
 

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
@@ -8,23 +8,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 {
 	public class TorSocks5Response : ByteArraySerializableBase
 	{
-		public TorSocks5Response()
-		{
-		}
-
-		public VerField Ver { get; set; }
-
-		public RepField Rep { get; set; }
-
-		public RsvField Rsv { get; set; }
-
-		public AtypField Atyp { get; set; }
-
-		public AddrField BndAddr { get; set; }
-
-		public PortField BndPort { get; set; }
-
-		public override void FromBytes(byte[] bytes)
+		public TorSocks5Response(byte[] bytes)
 		{
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
@@ -39,12 +23,22 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 			Atyp = new AtypField(bytes[3]);
 
-			BndAddr = new AddrField();
-			BndAddr.FromBytes(bytes[4..^2]);
+			BndAddr = new AddrField(bytes[4..^2]);
 
-			BndPort = new PortField();
-			BndPort.FromBytes(bytes[^2..]);
+			BndPort = new PortField(bytes[^2..]);
 		}
+
+		public VerField Ver { get; }
+
+		public RepField Rep { get; }
+
+		public RsvField Rsv { get; }
+
+		public AtypField Atyp { get; }
+
+		public AddrField BndAddr { get; }
+
+		public PortField BndPort { get; }
 
 		public override byte[] ToBytes() => ByteHelpers.Combine(new byte[] { Ver.ToByte(), Rep.ToByte(), Rsv.ToByte(), Atyp.ToByte() }, BndAddr.ToBytes(), BndPort.ToBytes());
 	}

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordRequest.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordRequest.cs
@@ -8,6 +8,28 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 {
 	public class UsernamePasswordRequest : ByteArraySerializableBase
 	{
+		public UsernamePasswordRequest(byte[] bytes)
+		{
+			Guard.NotNullOrEmpty(nameof(bytes), bytes);
+			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6, 513);
+
+			Ver = new AuthVerField(bytes[0]);
+
+			ULen = new ULenField();
+			ULen.FromByte(bytes[1]);
+
+			UName = new UNameField(bytes[2..(2 + ULen.Value)]);
+
+			PLen = new PLenField();
+			PLen.FromByte(bytes[1 + ULen.Value]);
+			int expectedPlenValue = bytes.Length - 3 + ULen.Value;
+			if (PLen.Value != expectedPlenValue)
+			{
+				throw new FormatException($"{nameof(PLen)}.{nameof(PLen.Value)} must be {nameof(bytes)}.{nameof(bytes.Length)} - 3 + {nameof(ULen)}.{nameof(ULen.Value)} = {expectedPlenValue}. Actual: {PLen.Value}.");
+			}
+			Passwd = new PasswdField(bytes[(3 + ULen.Value)..]);
+		}
+
 		public UsernamePasswordRequest(UNameField uName, PasswdField passwd)
 		{
 			Ver = AuthVerField.Version1;
@@ -22,38 +44,15 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			ULen = uLen;
 		}
 
-		public AuthVerField Ver { get; set; }
+		public AuthVerField Ver { get; }
 
-		public ULenField ULen { get; set; }
+		public ULenField ULen { get; }
 
-		public UNameField UName { get; set; }
+		public UNameField UName { get; }
 
-		public PLenField PLen { get; set; }
+		public PLenField PLen { get; }
 
-		public PasswdField Passwd { get; set; }
-
-		public override void FromBytes(byte[] bytes)
-		{
-			Guard.NotNullOrEmpty(nameof(bytes), bytes);
-			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6, 513);
-
-			Ver = new AuthVerField(bytes[0]);
-
-			ULen = new ULenField();
-			ULen.FromByte(bytes[1]);
-
-			UName = new UNameField();
-			UName.FromBytes(bytes[2..(2 + ULen.Value)]);
-
-			PLen = new PLenField();
-			PLen.FromByte(bytes[1 + ULen.Value]);
-			int expectedPlenValue = bytes.Length - 3 + ULen.Value;
-			if (PLen.Value != expectedPlenValue)
-			{
-				throw new FormatException($"{nameof(PLen)}.{nameof(PLen.Value)} must be {nameof(bytes)}.{nameof(bytes.Length)} - 3 + {nameof(ULen)}.{nameof(ULen.Value)} = {expectedPlenValue}. Actual: {PLen.Value}.");
-			}
-			Passwd.FromBytes(bytes[(3 + ULen.Value)..]);
-		}
+		public PasswdField Passwd { get; }
 
 		public override byte[] ToBytes() => ByteHelpers.Combine(new byte[] { Ver.ToByte(), ULen.ToByte() }, UName.ToBytes(), new byte[] { PLen.ToByte() }, Passwd.ToBytes());
 	}

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Bases;
 using WalletWasabi.Tor.Socks5.Models.Fields.OctetFields;
@@ -6,22 +7,22 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 {
 	public class UsernamePasswordResponse : ByteArraySerializableBase
 	{
-		public UsernamePasswordResponse()
+		/// <param name="bytes">2 bytes are required to be passed in.</param>
+		public UsernamePasswordResponse(byte[] bytes)
 		{
-		}
-
-		public AuthVerField Ver { get; set; }
-
-		public AuthStatusField Status { get; set; }
-
-		public override void FromBytes(byte[] bytes)
-		{
-			Guard.NotNullOrEmpty(nameof(bytes), bytes);
 			Guard.Same($"{nameof(bytes)}.{nameof(bytes.Length)}", 2, bytes.Length);
 
 			Ver = new AuthVerField(bytes[0]);
-
 			Status = new AuthStatusField(bytes[1]);
+		}
+
+		public AuthVerField Ver { get; }
+
+		public AuthStatusField Status { get; }
+
+		public override void FromBytes(byte[] bytes)
+		{
+			throw new NotSupportedException("This method is no longer supported.");
 		}
 
 		public override byte[] ToBytes() => new byte[]

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
@@ -20,15 +20,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 		public AuthStatusField Status { get; }
 
-		public override void FromBytes(byte[] bytes)
-		{
-			throw new NotSupportedException("This method is no longer supported.");
-		}
-
-		public override byte[] ToBytes() => new byte[]
-			{
-				Ver.ToByte(),
-				Status.ToByte()
-			};
+		public override byte[] ToBytes() => new byte[] { Ver.ToByte(), Status.ToByte() };
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
@@ -21,6 +21,10 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 		public AuthStatusField Status { get; }
 
 		public override byte[] ToBytes()
-			=> new byte[] { Ver.ToByte(), Status.ToByte() };
+			=> new byte[]
+			{
+				Ver.ToByte(),
+				Status.ToByte()
+			};
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordResponse.cs
@@ -20,6 +20,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 		public AuthStatusField Status { get; }
 
-		public override byte[] ToBytes() => new byte[] { Ver.ToByte(), Status.ToByte() };
+		public override byte[] ToBytes()
+			=> new byte[] { Ver.ToByte(), Status.ToByte() };
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/VersionMethodRequest.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/VersionMethodRequest.cs
@@ -11,6 +11,22 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 	{
 		#region Constructors
 
+		public VersionMethodRequest(byte[] bytes)
+		{
+			Guard.NotNullOrEmpty(nameof(bytes), bytes);
+			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 3, 257);
+
+			Ver = new VerField(bytes[0]);
+			NMethods = new NMethodsField(bytes[1]);
+
+			if (NMethods.Value != bytes.Length - 2)
+			{
+				throw new FormatException($"{nameof(NMethods)}.{nameof(NMethods.Value)} must be {nameof(bytes)}.{nameof(bytes.Length)} - 2 = {bytes.Length - 2}. Actual: {NMethods.Value}.");
+			}
+
+			Methods = new MethodsField(bytes.Skip(2).ToArray());
+		}
+
 		public VersionMethodRequest(MethodsField methods)
 		{
 			Methods = Guard.NotNull(nameof(methods), methods);
@@ -25,32 +41,15 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 
 		#region PropertiesAndMembers
 
-		public VerField Ver { get; set; }
+		public VerField Ver { get; }
 
-		public NMethodsField NMethods { get; set; }
+		public NMethodsField NMethods { get; }
 
-		public MethodsField Methods { get; set; }
+		public MethodsField Methods { get; }
 
 		#endregion PropertiesAndMembers
 
 		#region Serialization
-
-		public override void FromBytes(byte[] bytes)
-		{
-			Guard.NotNullOrEmpty(nameof(bytes), bytes);
-			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 3, 257);
-
-			Ver = new VerField(bytes[0]);
-			NMethods = new NMethodsField(bytes[1]);
-
-			if (NMethods.Value != bytes.Length - 2)
-			{
-				throw new FormatException($"{nameof(NMethods)}.{nameof(NMethods.Value)} must be {nameof(bytes)}.{nameof(bytes.Length)} - 2 = {bytes.Length - 2}. Actual: {NMethods.Value}.");
-			}
-
-			Methods = new MethodsField();
-			Methods.FromBytes(bytes.Skip(2).ToArray());
-		}
 
 		public override byte[] ToBytes() => ByteHelpers.Combine(
 			new byte[]

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -100,6 +100,8 @@ namespace WalletWasabi.Tor.Socks5
 		/// </summary>
 		public async Task HandshakeAsync(bool isolateStream = false, CancellationToken cancellationToken = default)
 		{
+			Logger.LogDebug($"> {nameof(isolateStream)}={isolateStream}");
+
 			// https://github.com/torproject/torspec/blob/master/socks-extensions.txt
 			// The "NO AUTHENTICATION REQUIRED" (SOCKS5) authentication method [00] is
 			// supported; and as of Tor 0.2.3.2 - alpha, the "USERNAME/PASSWORD"(SOCKS5)
@@ -111,18 +113,6 @@ namespace WalletWasabi.Tor.Socks5
 			// violates RFC1929[4], but ensures interoperability with somewhat broken
 			// SOCKS5 client implementations.
 			string identity = isolateStream ? RandomString.CapitalAlphaNumeric(21) : "default";
-			await HandshakeAsync(identity, cancellationToken).ConfigureAwait(false);
-		}
-
-		/// <summary>
-		/// IsolateSOCKSAuth must be on (on by default)
-		/// https://www.torproject.org/docs/tor-manual.html.en
-		/// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n35
-		/// </summary>
-		/// <param name="identity">Isolates streams by identity. If identity is empty string, it won't isolate stream.</param>
-		private async Task HandshakeAsync(string identity, CancellationToken cancellationToken = default)
-		{
-			Logger.LogDebug($"> {nameof(identity)}={identity}");
 
 			MethodsField methods = string.IsNullOrWhiteSpace(identity)
 				? new MethodsField(MethodField.NoAuthenticationRequired)

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -196,8 +196,7 @@ namespace WalletWasabi.Tor.Socks5
 
 				var receiveBuffer = await SendAsync(sendBuffer, receiveBufferSize: null, cancellationToken).ConfigureAwait(false);
 
-				var connectionResponse = new TorSocks5Response();
-				connectionResponse.FromBytes(receiveBuffer);
+				var connectionResponse = new TorSocks5Response(receiveBuffer);
 
 				if (connectionResponse.Rep != RepField.Succeeded)
 				{


### PR DESCRIPTION
Notes:

* No change in behavior.
* Pass bytes via constructors in `UsernamePasswordResponse` and `MethodSelectionResponse`.
* Merge two `HandshakeAsync` methods in TorSocks5Client.