### PR TITLE
LiveServerTests: Use factory method to instantiate TorHttpClient.

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -10,6 +10,7 @@ using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.Models;
 using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.Tor;
+using WalletWasabi.Tor.Http;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 
@@ -46,7 +47,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 		{
 			Network network = (networkType == NetworkType.Mainnet) ? Network.Main : Network.TestNet;
 
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Common.TorSocks5Endpoint);
+			using var torHttpClient = MakeTorHttpClient(networkType);
+			using var client = new WasabiClient(torHttpClient);
+
 			var filterModel = StartingFilters.GetStartingFilter(network);
 
 			FiltersResponse filtersResponse = await client.GetFiltersAsync(filterModel.Header.BlockHash, 2);
@@ -71,7 +74,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetTransactionsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Common.TorSocks5Endpoint);
+			using var torHttpClient = MakeTorHttpClient(networkType);
+			using var client = new WasabiClient(torHttpClient);
+
 			var randomTxIds = Enumerable.Range(0, 20).Select(_ => RandomUtils.GetUInt256());
 			var network = networkType == NetworkType.Mainnet ? Network.Main : Network.TestNet;
 
@@ -95,7 +100,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetExchangeRateAsync(NetworkType networkType) // xunit wtf: If this function is called GetExchangeRatesAsync, it'll stuck on 1 CPU VMs (Manjuro, Fedora)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Common.TorSocks5Endpoint);
+			using var torHttpClient = MakeTorHttpClient(networkType);
+			using var client = new WasabiClient(torHttpClient);
+
 			var exchangeRates = await client.GetExchangeRatesAsync();
 
 			Assert.True(exchangeRates.NotNullAndNotEmpty());
@@ -110,7 +117,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetVersionsTestsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Common.TorSocks5Endpoint);
+			using var torHttpClient = MakeTorHttpClient(networkType);
+			using var client = new WasabiClient(torHttpClient);
 
 			var versions = await client.GetVersionsAsync(CancellationToken.None);
 			Assert.InRange(versions.ClientVersion, new Version(1, 1, 10), new Version(1, 2));
@@ -124,7 +132,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task CheckUpdatesTestsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Common.TorSocks5Endpoint);
+			using var torHttpClient = MakeTorHttpClient(networkType);
+			using var client = new WasabiClient(torHttpClient);
 
 			var updateStatus = await client.CheckUpdatesAsync(CancellationToken.None);
 
@@ -149,7 +158,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[InlineData(NetworkType.Testnet)]
 		public async Task GetLegalDocumentsTestsAsync(NetworkType networkType)
 		{
-			using var client = new WasabiClient(LiveServerTestsFixture.UriMappings[networkType], Common.TorSocks5Endpoint);
+			using var torHttpClient = MakeTorHttpClient(networkType);
+			using var client = new WasabiClient(torHttpClient);
 
 			var content = await client.GetLegalDocumentsAsync(CancellationToken.None);
 
@@ -160,5 +170,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 		}
 
 		#endregion Wasabi
+
+		private TorHttpClient MakeTorHttpClient(NetworkType networkType)
+		{
+			Uri baseUri = LiveServerTestsFixture.UriMappings[networkType];
+			return new TorHttpClient(baseUri, Common.TorSocks5Endpoint, isolateStream: true);
+		}
 	}
 }

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -174,7 +174,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		private TorHttpClient MakeTorHttpClient(NetworkType networkType)
 		{
 			Uri baseUri = LiveServerTestsFixture.UriMappings[networkType];
-			return new TorHttpClient(baseUri, Common.TorSocks5Endpoint, isolateStream: true);
+			return new TorHttpClient(baseUri, Common.TorSocks5Endpoint, isolateStream: false);
 		}
 	}
 }


### PR DESCRIPTION
This PR is paves the way to remove the following two constructors:

```csharp
public WasabiClient(Func<Uri> baseUriAction, EndPoint? torSocks5EndPoint)
{
  TorClient = new TorHttpClient(baseUriAction, torSocks5EndPoint, isolateStream: true);
}

public WasabiClient(Uri baseUri, EndPoint? torSocks5EndPoint) : this(() => baseUri, torSocks5EndPoint)
{
}
```

from `WasabiClient` class. 

Notes:

* `isolateStream: true` was set in the original code too, I have not changed it.