### PR TITLE
Move SSL authentication from TorHttpClient to TorSocks5Client.

### DIFF
--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -1,12 +1,9 @@
 using Nito.AsyncEx;
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Security;
 using System.Net.Sockets;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -207,16 +204,12 @@ namespace WalletWasabi.Tor.Http
 				await TorSocks5Client.HandshakeAsync(IsolateStream, cancel).ConfigureAwait(false);
 				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port, cancel).ConfigureAwait(false);
 
-				Stream stream = TorSocks5Client.TcpClient.GetStream();
 				if (request.RequestUri.Scheme == "https")
 				{
-					SslStream sslStream = new SslStream(stream, leaveInnerStreamOpen: true);
-					await sslStream.AuthenticateAsClientAsync(host, new X509CertificateCollection(), IHttpClient.SupportedSslProtocols, true).ConfigureAwait(false);
-					stream = sslStream;
+					await TorSocks5Client.UpgradeToSslAsync(host).ConfigureAwait(false);
 				}
-
-				TorSocks5Client.Stream = stream;
 			}
+
 			cancel.ThrowIfCancellationRequested();
 
 			// https://tools.ietf.org/html/rfc7230#section-3.3.2

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -2,13 +2,16 @@ using Nito.AsyncEx;
 using System;
 using System.IO;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Exceptions;
+using WalletWasabi.Tor.Http;
 using WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields;
 using WalletWasabi.Tor.Socks5.Models.Fields.OctetFields;
 using WalletWasabi.Tor.Socks5.Models.Messages;
@@ -32,10 +35,13 @@ namespace WalletWasabi.Tor.Socks5
 
 		#region PropertiesAndMembers
 
+		/// <summary>TCP connection to Tor's SOCKS5 server.</summary>
 		public TcpClient TcpClient { get; private set; }
 
 		private EndPoint TorSocks5EndPoint { get; }
 
+		/// <summary>Transport stream for sending  HTTP/HTTPS requests through Tor's SOCKS5 server.</summary>
+		/// <remarks>This stream is not to be used to send commands to Tor's SOCKS5 server.</remarks>
 		public Stream Stream { get; internal set; }
 
 		private EndPoint RemoteEndPoint { get; set; }
@@ -169,6 +175,13 @@ namespace WalletWasabi.Tor.Socks5
 			}
 
 			Logger.LogDebug("<");
+		}
+
+		public async Task UpgradeToSslAsync(string host)
+		{
+			SslStream sslStream = new SslStream(TcpClient.GetStream(), leaveInnerStreamOpen: true);
+			await sslStream.AuthenticateAsClientAsync(host, new X509CertificateCollection(), IHttpClient.SupportedSslProtocols, true).ConfigureAwait(false);
+			Stream = sslStream;
 		}
 
 		private async Task ConnectToDestinationAsync(EndPoint destination, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This PR is quite simple. 

I attempt to use `TorSocks5Client.Stream` property to be implementation detail of `TorSocks5Client` and not to be exposed publicly. This helps with decoupling of `TorHttpClient` and `TorSocks5Client` classes.