### PR TITLE
Add IsTrimable() to string extension

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWalletPageViewModel.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Fluent.ViewModels
 				return;
 			}
 
-			if (PasswordHelper.IsTrimable(walletName, out _))
+			if (walletName.IsTrimable())
 			{
 				errors.Add(ErrorSeverity.Error, "Leading and trailing white spaces are not allowed!");
 				return;

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace System
 {
 	public static class StringExtensions
@@ -63,17 +65,12 @@ namespace System
 
 		public static bool IsTrimable(this string? me)
 		{
-			if (me is null)
+			if (string.IsNullOrEmpty(me))
 			{
 				return false;
 			}
 
-			if (me.Length != me.Trim().Length)
-			{
-				return true;
-			}
-
-			return false;
+			return char.IsWhiteSpace(me.First()) || char.IsWhiteSpace(me.Last());
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Microsoft.AspNetCore.Builder;
 
 namespace System
 {

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.AspNetCore.Builder;
 
 namespace System
 {
@@ -65,7 +66,12 @@ namespace System
 
 		public static bool IsTrimable(this string me)
 		{
-			return me.Any() && (char.IsWhiteSpace(me.First()) || char.IsWhiteSpace(me.Last()));
+			if (!me.Any())
+			{
+				return false;
+			}
+
+			return char.IsWhiteSpace(me.First()) || char.IsWhiteSpace(me.Last());
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -73,7 +73,7 @@ namespace System
 				return false;
 			}
 
-			return char.IsWhiteSpace(me.First()) || char.IsWhiteSpace(me.Last());
+			return char.IsWhiteSpace(me[0]) || char.IsWhiteSpace(me[^0]);
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -65,7 +65,7 @@ namespace System
 
 		public static bool IsTrimable(this string me)
 		{
-			if (!me.Any())
+			if (me.Length == 0)
 			{
 				return false;
 			}

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -71,7 +71,7 @@ namespace System
 				return false;
 			}
 
-			return char.IsWhiteSpace(me[0]) || char.IsWhiteSpace(me[^0]);
+			return char.IsWhiteSpace(me[0]) || char.IsWhiteSpace(me[^1]);
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -63,6 +63,9 @@ namespace System
 			return me;
 		}
 
+		/// <summary>
+		/// Returns true if the string contains leading or trailing whitespace, otherwise returns false.
+		/// </summary>
 		public static bool IsTrimable(this string me)
 		{
 			if (me.Length == 0)

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -63,14 +63,9 @@ namespace System
 			return me;
 		}
 
-		public static bool IsTrimable(this string? me)
+		public static bool IsTrimable(this string me)
 		{
-			if (string.IsNullOrEmpty(me))
-			{
-				return false;
-			}
-
-			return char.IsWhiteSpace(me.First()) || char.IsWhiteSpace(me.Last());
+			return me.Any() && (char.IsWhiteSpace(me.First()) || char.IsWhiteSpace(me.Last()));
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -60,5 +60,20 @@ namespace System
 			}
 			return me;
 		}
+
+		public static bool IsTrimable(this string? me)
+		{
+			if (me is null)
+			{
+				return false;
+			}
+
+			if (me.Length != me.Trim().Length)
+			{
+				return true;
+			}
+
+			return false;
+		}
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace System
 {
 	public static class StringExtensions

--- a/WalletWasabi/Userfacing/PasswordHelper.cs
+++ b/WalletWasabi/Userfacing/PasswordHelper.cs
@@ -72,9 +72,9 @@ namespace WalletWasabi.Userfacing
 		{
 			trimmedPassword = password;
 
-			if (password.IsTrimable())
+			if (password is {} && password.IsTrimable())
 			{
-				trimmedPassword = password!.Trim(); // IsTrimable() returns false if string is null
+				trimmedPassword = password.Trim();
 				return true;
 			}
 

--- a/WalletWasabi/Userfacing/PasswordHelper.cs
+++ b/WalletWasabi/Userfacing/PasswordHelper.cs
@@ -72,12 +72,7 @@ namespace WalletWasabi.Userfacing
 		{
 			trimmedPassword = password;
 
-			if (password is null)
-			{
-				return false;
-			}
-
-			if (password.IsTrimable())
+			if (password is {} && password.IsTrimable())
 			{
 				trimmedPassword = password.Trim();
 				return true;

--- a/WalletWasabi/Userfacing/PasswordHelper.cs
+++ b/WalletWasabi/Userfacing/PasswordHelper.cs
@@ -71,17 +71,15 @@ namespace WalletWasabi.Userfacing
 		public static bool IsTrimable(string? password, out string? trimmedPassword)
 		{
 			trimmedPassword = password;
+
 			if (password is null)
 			{
 				return false;
 			}
 
-			var beforeTrim = password.Length;
-
-			trimmedPassword = password.Trim();
-
-			if (beforeTrim != trimmedPassword.Length)
+			if (password.IsTrimable())
 			{
+				trimmedPassword = password.Trim();
 				return true;
 			}
 

--- a/WalletWasabi/Userfacing/PasswordHelper.cs
+++ b/WalletWasabi/Userfacing/PasswordHelper.cs
@@ -70,14 +70,13 @@ namespace WalletWasabi.Userfacing
 
 		public static bool IsTrimable(string? password, out string? trimmedPassword)
 		{
-			trimmedPassword = password;
-
 			if (password is {} && password.IsTrimable())
 			{
 				trimmedPassword = password.Trim();
 				return true;
 			}
 
+			trimmedPassword = password;
 			return false;
 		}
 

--- a/WalletWasabi/Userfacing/PasswordHelper.cs
+++ b/WalletWasabi/Userfacing/PasswordHelper.cs
@@ -72,9 +72,9 @@ namespace WalletWasabi.Userfacing
 		{
 			trimmedPassword = password;
 
-			if (password is {} && password.IsTrimable())
+			if (password.IsTrimable())
 			{
-				trimmedPassword = password.Trim();
+				trimmedPassword = password!.Trim(); // IsTrimable() returns false if string is null
 				return true;
 			}
 


### PR DESCRIPTION
This PR about that to increase readability in a way to not use `PasswordHelper` class in a wallet name validation.

- `IsTrimable()` added to `StringExtenstion.cs`
- Use this extension methdon in `PasswordHelper`

cc @molnard 