### PR TITLE
SmartTransaction and HdPubKey to know all the SmartCoins it is connected to

### DIFF
--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -1,8 +1,10 @@
 using NBitcoin;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Helpers;
 using WalletWasabi.JsonConverters;
 
@@ -43,6 +45,8 @@ namespace WalletWasabi.Blockchain.Keys
 				throw new ArgumentException(nameof(FullKeyPath));
 			}
 		}
+
+		public HashSet<SmartCoin> Coins { get; } = new HashSet<SmartCoin>();
 
 		[JsonProperty(Order = 1)]
 		[JsonConverter(typeof(PubKeyJsonConverter))]

--- a/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -9,27 +10,39 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 {
 	public class BuildTransactionResult
 	{
-		public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool spendsUnconfirmed, bool signed, Money fee, decimal feePercentOfSent, IEnumerable<Coin> outerWalletOutputs, IEnumerable<SmartCoin> innerWalletOutputs, IEnumerable<SmartCoin> spentCoins)
+		public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent)
 		{
 			Transaction = Guard.NotNull(nameof(transaction), transaction);
 			Psbt = Guard.NotNull(nameof(psbt), psbt);
-			SpendsUnconfirmed = spendsUnconfirmed;
 			Signed = signed;
 			Fee = fee ?? Money.Zero;
 			FeePercentOfSent = feePercentOfSent;
-			OuterWalletOutputs = outerWalletOutputs;
-			InnerWalletOutputs = innerWalletOutputs;
-			SpentCoins = spentCoins;
 		}
 
 		public SmartTransaction Transaction { get; }
 		public PSBT Psbt { get; }
-		public bool SpendsUnconfirmed { get; }
 		public bool Signed { get; }
 		public Money Fee { get; }
 		public decimal FeePercentOfSent { get; }
-		public IEnumerable<Coin> OuterWalletOutputs { get; }
-		public IEnumerable<SmartCoin> InnerWalletOutputs { get; }
-		public IEnumerable<SmartCoin> SpentCoins { get; }
+		public bool SpendsUnconfirmed => Transaction.WalletInputs.Any(c => !c.Confirmed);
+
+		public IEnumerable<SmartCoin> InnerWalletOutputs => Transaction.WalletOutputs;
+		public IEnumerable<SmartCoin> SpentCoins => Transaction.WalletInputs;
+
+		public IEnumerable<Coin> OuterWalletOutputs
+		{
+			get
+			{
+				var outputs = Transaction.Transaction.Outputs;
+				var ownOutputIndexes = Transaction.WalletOutputs.Select(x => x.Index).ToHashSet();
+				for (uint i = 0; i < outputs.Count; i++)
+				{
+					if (!ownOutputIndexes.Contains(i))
+					{
+						yield return new Coin(Transaction.Transaction, i);
+					}
+				}
+			}
+		}
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -84,6 +84,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 				if (!SpentCoins.Contains(coin))
 				{
 					added = Coins.Add(coin);
+					coin.RegisterToHdPubKey();
 					if (added)
 					{
 						if (ClustersByScriptPubKey.TryGetValue(coin.ScriptPubKey, out var cluster))
@@ -141,6 +142,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 				{
 					SpentCoins.Remove(toRemove);
 				}
+				toRemove.UnregisterFromHdPubKey();
 
 				var removedCoinOutPoint = toRemove.OutPoint;
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -38,7 +38,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 		public SmartCoin(SmartTransaction transaction, uint outputIndex, HdPubKey pubKey, int anonymitySet)
 		{
 			Transaction = transaction;
-			Transaction.WalletInputs.Add(this);
 			Index = outputIndex;
 			_transactionId = new Lazy<uint256>(() => Transaction.GetHash(), true);
 
@@ -54,6 +53,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			HdPubKey = pubKey;
 
 			_cluster = new Cluster(this);
+			Transaction.WalletInputs.Add(this);
 		}
 
 		public SmartTransaction Transaction { get; }
@@ -66,8 +66,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 
 		public Script ScriptPubKey => TxOut.ScriptPubKey;
 		public Money Amount => TxOut.Value;
-
-		private int HashCode => _hashCode.Value;
 
 		public Height Height
 		{
@@ -177,7 +175,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 
 		public bool Equals(SmartCoin? other) => this == other;
 
-		public override int GetHashCode() => HashCode;
+		public override int GetHashCode() => _hashCode.Value;
 
 		public static bool operator ==(SmartCoin? x, SmartCoin? y)
 		{
@@ -191,7 +189,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			}
 			else
 			{
-				var hashEquals = x.HashCode == y.HashCode;
+				var hashEquals = x.GetHashCode() == y.GetHashCode();
 				return hashEquals && y.TransactionId == x.TransactionId && y.Index == x.Index;
 			}
 		}

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -54,7 +54,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 
 			_cluster = new Cluster(this);
 
-			HdPubKey.Coins.Add(this);
 			Transaction.WalletOutputs.Add(this);
 		}
 
@@ -98,6 +97,12 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 				}
 			}
 		}
+
+		public bool RegisterToHdPubKey()
+			=> HdPubKey.Coins.Add(this);
+
+		public bool UnregisterFromHdPubKey()
+			=> HdPubKey.Coins.Remove(this);
 
 		public bool CoinJoinInProgress
 		{

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			HdPubKey = pubKey;
 
 			_cluster = new Cluster(this);
-			Transaction.WalletInputs.Add(this);
+			Transaction.WalletOutputs.Add(this);
 		}
 
 		public SmartTransaction Transaction { get; }
@@ -92,7 +92,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			{
 				if (RaiseAndSetIfChanged(ref _spenderTransaction, value))
 				{
-					value?.WalletOutputs.Add(this);
+					value?.WalletInputs.Add(this);
 				}
 			}
 		}

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -53,6 +53,8 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			HdPubKey = pubKey;
 
 			_cluster = new Cluster(this);
+
+			HdPubKey.Coins.Add(this);
 			Transaction.WalletOutputs.Add(this);
 		}
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -38,6 +38,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 		public SmartCoin(SmartTransaction transaction, uint outputIndex, HdPubKey pubKey, int anonymitySet)
 		{
 			Transaction = transaction;
+			Transaction.WalletInputs.Add(this);
 			Index = outputIndex;
 			_transactionId = new Lazy<uint256>(() => Transaction.GetHash(), true);
 
@@ -89,7 +90,13 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 		public SmartTransaction? SpenderTransaction
 		{
 			get => _spenderTransaction;
-			set => RaiseAndSetIfChanged(ref _spenderTransaction, value);
+			set
+			{
+				if (RaiseAndSetIfChanged(ref _spenderTransaction, value))
+				{
+					value?.WalletOutputs.Add(this);
+				}
+			}
 		}
 
 		public bool CoinJoinInProgress

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -34,14 +34,16 @@ namespace WalletWasabi.Blockchain.Transactions
 			FirstSeen = firstSeen == default ? DateTimeOffset.UtcNow : firstSeen;
 
 			IsReplacement = isReplacement;
+			WalletInputs = new HashSet<SmartCoin>(Transaction.Inputs.Count);
+			WalletOutputs = new HashSet<SmartCoin>(Transaction.Outputs.Count);
 		}
 
 		#endregion Constructors
 
 		#region Members
 
-		public HashSet<SmartCoin> WalletInputs { get; } = new HashSet<SmartCoin>();
-		public HashSet<SmartCoin> WalletOutputs { get; } = new HashSet<SmartCoin>();
+		public HashSet<SmartCoin> WalletInputs { get; }
+		public HashSet<SmartCoin> WalletOutputs { get; }
 
 		[JsonProperty]
 		[JsonConverter(typeof(TransactionJsonConverter))]

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Helpers;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.Logging;
@@ -38,6 +39,9 @@ namespace WalletWasabi.Blockchain.Transactions
 		#endregion Constructors
 
 		#region Members
+
+		public HashSet<SmartCoin> WalletInputs { get; } = new HashSet<SmartCoin>();
+		public HashSet<SmartCoin> WalletOutputs { get; } = new HashSet<SmartCoin>();
 
 		[JsonProperty]
 		[JsonConverter(typeof(TransactionJsonConverter))]


### PR DESCRIPTION
- this cannot be used in tx processor, nor in tx factory because that's where it's set.  
- these are set for all loaded wallets -> question arises if it enables cross-wallet anonset calculation?
- there are sadly some circular references here (smartcoin knows its smarttransactions and smarttransaction knows its smartcoins)