### PR TITLE
Remove readonly field naming rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,14 +142,6 @@ dotnet_naming_symbols.constant_or_static_fields.required_modifiers = static
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-# name all readonly fields using PascalCase
-dotnet_naming_rule.readonly_fields_should_be_pascal_case.severity = error
-dotnet_naming_rule.readonly_fields_should_be_pascal_case.symbols  = readonly_fields
-dotnet_naming_rule.readonly_fields_should_be_pascal_case.style    = pascal_case_style
-
-dotnet_naming_symbols.readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.readonly_fields.required_modifiers = readonly
-
 # private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_fields.severity = error
 dotnet_naming_rule.camel_case_for_private_fields.symbols  = private_fields

--- a/WalletWasabi.Backend/Controllers/SoftwareController.cs
+++ b/WalletWasabi.Backend/Controllers/SoftwareController.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Backend.Controllers
 	[Route("api/[controller]")]
 	public class SoftwareController : ControllerBase
 	{
-		private readonly VersionsResponse VersionsResponse = new VersionsResponse
+		private readonly VersionsResponse _versionsResponse = new VersionsResponse
 		{
 			ClientVersion = Constants.ClientVersion.ToString(3),
 			BackendMajorVersion = Constants.BackendMajorVersion,
@@ -27,7 +27,7 @@ namespace WalletWasabi.Backend.Controllers
 		[ProducesResponseType(typeof(VersionsResponse), 200)]
 		public VersionsResponse GetVersions()
 		{
-			return VersionsResponse;
+			return _versionsResponse;
 		}
 	}
 }

--- a/WalletWasabi.Backend/Middlewares/HeadMethodMiddleware.cs
+++ b/WalletWasabi.Backend/Middlewares/HeadMethodMiddleware.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Backend.Middlewares
 	{
 		#region Fields
 
-		private readonly RequestDelegate Next;
+		private readonly RequestDelegate _next;
 
 		#endregion Fields
 
@@ -21,7 +21,7 @@ namespace WalletWasabi.Backend.Middlewares
 
 		public HeadMethodMiddleware(RequestDelegate next)
 		{
-			Next = next ?? throw new ArgumentNullException(nameof(next));
+			_next = next ?? throw new ArgumentNullException(nameof(next));
 		}
 
 		#endregion Constructor
@@ -40,7 +40,7 @@ namespace WalletWasabi.Backend.Middlewares
 				context.Response.Body = Stream.Null;
 			}
 
-			await Next(context);
+			await _next(context);
 
 			if (methodSwitched)
 			{

--- a/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreenViewModel.cs
+++ b/WalletWasabi.Gui/Controls/LockScreen/SlideLockScreenViewModel.cs
@@ -6,8 +6,6 @@ namespace WalletWasabi.Gui.Controls.LockScreen
 {
 	public class SlideLockScreenViewModel : WasabiLockScreenViewModelBase
 	{
-		public readonly double ThresholdPercent = 1 / 6d;
-
 		public SlideLockScreenViewModel() : base()
 		{
 			CanSlide = true;

--- a/WalletWasabi.Packager/NSubsys/PeUtility.cs
+++ b/WalletWasabi.Packager/NSubsys/PeUtility.cs
@@ -7,7 +7,7 @@ namespace NSubsys
 {
 	internal class PeUtility : IDisposable
 	{
-		private readonly IDisposable InternalBinReader;
+		private readonly IDisposable _internalBinReader;
 
 		public PeUtility(string filePath)
 		{
@@ -24,7 +24,7 @@ namespace NSubsys
 
 			OptionalHeader = FromBinaryReader<ImageOptionalHeader>(reader);
 
-			InternalBinReader = reader;
+			_internalBinReader = reader;
 		}
 
 		public enum SubSystemType : ushort
@@ -65,7 +65,7 @@ namespace NSubsys
 		public void Dispose()
 		{
 			Stream?.Dispose();
-			InternalBinReader?.Dispose();
+			_internalBinReader?.Dispose();
 		}
 
 		[StructLayout(LayoutKind.Explicit)]

--- a/WalletWasabi/BitcoinCore/Processes/BitcoindRpcProcessBridge.cs
+++ b/WalletWasabi/BitcoinCore/Processes/BitcoindRpcProcessBridge.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.BitcoinCore.Processes
 		public const string PidFileName = "bitcoin.pid";
 
 		/// <summary>Experimentally found constant.</summary>
-		private readonly TimeSpan ReasonableCoreShutdownTimeout = TimeSpan.FromSeconds(21);
+		private readonly TimeSpan _reasonableCoreShutdownTimeout = TimeSpan.FromSeconds(21);
 
 		public BitcoindRpcProcessBridge(IRPCClient rpcClient, string dataDir, bool printToConsole)
 		{
@@ -128,7 +128,7 @@ namespace WalletWasabi.BitcoinCore.Processes
 
 			ProcessAsync process = Process; // process is guaranteed to be non-null at this point.
 
-			using var cts = new CancellationTokenSource(ReasonableCoreShutdownTimeout);
+			using var cts = new CancellationTokenSource(_reasonableCoreShutdownTimeout);
 			int? pid = await PidFile.TryReadAsync().ConfigureAwait(false);
 
 			// If the cached PID is PID, then we own the process.

--- a/WalletWasabi/Crypto/ZeroKnowledge/SyntheticSecretNonceProvider.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/SyntheticSecretNonceProvider.cs
@@ -9,29 +9,29 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 {
 	public class SyntheticSecretNonceProvider
 	{
-		private readonly Strobe128 Strobe;
-		private readonly int SecretCount;
+		private readonly Strobe128 _strobe;
+		private readonly int _secretCount;
 
 		public SyntheticSecretNonceProvider(Strobe128 strobe, IEnumerable<Scalar> secrets, WasabiRandom random)
 		{
 			Guard.NotNullOrEmpty(nameof(secrets), secrets);
-			Strobe = strobe;
-			SecretCount = secrets.Count();
+			_strobe = strobe;
+			_secretCount = secrets.Count();
 
 			// add secret inputs as key material
 			foreach (var secret in secrets)
 			{
-				Strobe.Key(secret.ToBytes(), false);
+				_strobe.Key(secret.ToBytes(), false);
 			}
 
-			Strobe.Key(random.GetBytes(32), false);
+			_strobe.Key(random.GetBytes(32), false);
 		}
 
 		private IEnumerable<Scalar> Sequence()
 		{
 			while (true)
 			{
-				yield return new Scalar(Strobe.Prf(32, false));
+				yield return new Scalar(_strobe.Prf(32, false));
 			}
 		}
 
@@ -39,6 +39,6 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 			Sequence().First();
 
 		internal ScalarVector GetScalarVector() =>
-			new ScalarVector(Sequence().Take(SecretCount));
+			new ScalarVector(Sequence().Take(_secretCount));
 	}
 }

--- a/WalletWasabi/Mono/OptionSet.cs
+++ b/WalletWasabi/Mono/OptionSet.cs
@@ -170,7 +170,7 @@ namespace Mono.Options
 {
 	public class OptionSet : KeyedCollection<string, Option>
 	{
-		private readonly Regex ValueOption = new Regex(@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
+		private readonly Regex _valueOption = new Regex(@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
 		private const int OptionWidth = 29;
 		private const int DescriptionFirstWidth = 140 - OptionWidth;
@@ -529,7 +529,7 @@ namespace Mono.Options
 			Guard.NotNull(nameof(argument), argument);
 
 			flag = name = sep = value = null;
-			Match m = ValueOption.Match(argument);
+			Match m = _valueOption.Match(argument);
 			if (!m.Success)
 			{
 				return false;

--- a/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
@@ -51,12 +51,12 @@ namespace Nito.AsyncEx
 		/// <summary>
 		/// The queue of TCSs that other tasks are awaiting to acquire the lock.
 		/// </summary>
-		private readonly IAsyncWaitQueue<IDisposable> Queue;
+		private readonly IAsyncWaitQueue<IDisposable> _queue;
 
 		/// <summary>
 		/// The object used for mutual exclusion.
 		/// </summary>
-		private readonly object Mutex;
+		private readonly object _mutex;
 
 		/// <summary>
 		/// Whether the lock is taken by a task.
@@ -82,8 +82,8 @@ namespace Nito.AsyncEx
 		/// <param name="queue">The wait queue used to manage waiters. This may be <c>null</c> to use a default (FIFO) queue.</param>
 		public AsyncLock(IAsyncWaitQueue<IDisposable> queue)
 		{
-			Queue = queue ?? new DefaultAsyncWaitQueue<IDisposable>();
-			Mutex = new object();
+			_queue = queue ?? new DefaultAsyncWaitQueue<IDisposable>();
+			_mutex = new object();
 		}
 
 		/// <summary>
@@ -98,7 +98,7 @@ namespace Nito.AsyncEx
 		/// <returns>A disposable that releases the lock when disposed.</returns>
 		private Task<IDisposable> RequestLockAsync(CancellationToken cancellationToken)
 		{
-			lock (Mutex)
+			lock (_mutex)
 			{
 				if (!_taken)
 				{
@@ -109,7 +109,7 @@ namespace Nito.AsyncEx
 				else
 				{
 					// Wait for the lock to become available or cancellation.
-					return Queue.Enqueue(Mutex, cancellationToken);
+					return _queue.Enqueue(_mutex, cancellationToken);
 				}
 			}
 		}
@@ -155,15 +155,15 @@ namespace Nito.AsyncEx
 		/// </summary>
 		internal void ReleaseLock()
 		{
-			lock (Mutex)
+			lock (_mutex)
 			{
-				if (Queue.IsEmpty)
+				if (_queue.IsEmpty)
 				{
 					_taken = false;
 				}
 				else
 				{
-					Queue.Dequeue(new Key(this));
+					_queue.Dequeue(new Key(this));
 				}
 			}
 		}
@@ -192,18 +192,18 @@ namespace Nito.AsyncEx
 		[DebuggerNonUserCode]
 		private sealed class DebugView
 		{
-			private readonly AsyncLock Mutex;
+			private readonly AsyncLock _mutex;
 
 			public DebugView(AsyncLock mutex)
 			{
-				Mutex = mutex;
+				_mutex = mutex;
 			}
 
-			public int Id => Mutex.Id;
+			public int Id => _mutex.Id;
 
-			public bool Taken => Mutex._taken;
+			public bool Taken => _mutex._taken;
 
-			public IAsyncWaitQueue<IDisposable> WaitQueue => Mutex.Queue;
+			public IAsyncWaitQueue<IDisposable> WaitQueue => _mutex._queue;
 		}
 
 		// ReSharper restore UnusedMember.Local

--- a/WalletWasabi/Nito/AsyncEx/AwaitableDisposable.cs
+++ b/WalletWasabi/Nito/AsyncEx/AwaitableDisposable.cs
@@ -13,7 +13,7 @@ namespace Nito.AsyncEx
 		/// <summary>
 		/// The underlying task.
 		/// </summary>
-		private readonly Task<T> Task;
+		private readonly Task<T> _task;
 
 		/// <summary>
 		/// Initializes a new awaitable wrapper around the specified task.
@@ -21,7 +21,7 @@ namespace Nito.AsyncEx
 		/// <param name="task">The underlying task to wrap. This may not be <c>null</c>.</param>
 		public AwaitableDisposable(Task<T> task)
 		{
-			Task = task ?? throw new ArgumentNullException(nameof(task));
+			_task = task ?? throw new ArgumentNullException(nameof(task));
 		}
 
 		/// <summary>
@@ -29,7 +29,7 @@ namespace Nito.AsyncEx
 		/// </summary>
 		public Task<T> AsTask()
 		{
-			return Task;
+			return _task;
 		}
 
 		/// <summary>
@@ -43,7 +43,7 @@ namespace Nito.AsyncEx
 		/// </summary>
 		public TaskAwaiter<T> GetAwaiter()
 		{
-			return Task.GetAwaiter();
+			return _task.GetAwaiter();
 		}
 
 		/// <summary>
@@ -52,7 +52,7 @@ namespace Nito.AsyncEx
 		/// <param name="continueOnCapturedContext">Whether to attempt to marshal the continuation back to the captured context.</param>
 		public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext)
 		{
-			return Task.ConfigureAwait(continueOnCapturedContext);
+			return _task.ConfigureAwait(continueOnCapturedContext);
 		}
 	}
 }

--- a/WalletWasabi/Nito/AsyncEx/DefaultAsyncWaitQueue.cs
+++ b/WalletWasabi/Nito/AsyncEx/DefaultAsyncWaitQueue.cs
@@ -14,42 +14,42 @@ namespace Nito.AsyncEx
 	[DebuggerTypeProxy(typeof(DefaultAsyncWaitQueue<>.DebugView))]
 	public sealed class DefaultAsyncWaitQueue<T> : IAsyncWaitQueue<T>
 	{
-		private readonly Deque<TaskCompletionSource<T>> Queue = new Deque<TaskCompletionSource<T>>();
+		private readonly Deque<TaskCompletionSource<T>> _queue = new Deque<TaskCompletionSource<T>>();
 
-		private int Count => Queue.Count;
+		private int Count => _queue.Count;
 
 		bool IAsyncWaitQueue<T>.IsEmpty => Count == 0;
 
 		Task<T> IAsyncWaitQueue<T>.Enqueue()
 		{
 			var tcs = TaskCompletionSourceExtensions.CreateAsyncTaskSource<T>();
-			Queue.AddToBack(tcs);
+			_queue.AddToBack(tcs);
 			return tcs.Task;
 		}
 
 		void IAsyncWaitQueue<T>.Dequeue(T result)
 		{
-			Queue.RemoveFromFront().TrySetResult(result);
+			_queue.RemoveFromFront().TrySetResult(result);
 		}
 
 		void IAsyncWaitQueue<T>.DequeueAll(T result)
 		{
-			foreach (var source in Queue)
+			foreach (var source in _queue)
 			{
 				source.TrySetResult(result);
 			}
 
-			Queue.Clear();
+			_queue.Clear();
 		}
 
 		bool IAsyncWaitQueue<T>.TryCancel(Task task, CancellationToken cancellationToken)
 		{
-			for (int i = 0; i != Queue.Count; ++i)
+			for (int i = 0; i != _queue.Count; ++i)
 			{
-				if (Queue[i].Task == task)
+				if (_queue[i].Task == task)
 				{
-					Queue[i].TrySetCanceled(cancellationToken);
-					Queue.RemoveAt(i);
+					_queue[i].TrySetCanceled(cancellationToken);
+					_queue.RemoveAt(i);
 					return true;
 				}
 			}
@@ -58,22 +58,22 @@ namespace Nito.AsyncEx
 
 		void IAsyncWaitQueue<T>.CancelAll(CancellationToken cancellationToken)
 		{
-			foreach (var source in Queue)
+			foreach (var source in _queue)
 			{
 				source.TrySetCanceled(cancellationToken);
 			}
 
-			Queue.Clear();
+			_queue.Clear();
 		}
 
 		[DebuggerNonUserCode]
 		internal sealed class DebugView
 		{
-			private readonly DefaultAsyncWaitQueue<T> Queue;
+			private readonly DefaultAsyncWaitQueue<T> _queue;
 
 			public DebugView(DefaultAsyncWaitQueue<T> queue)
 			{
-				Queue = queue;
+				_queue = queue;
 			}
 
 			[DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
@@ -81,8 +81,8 @@ namespace Nito.AsyncEx
 			{
 				get
 				{
-					var result = new List<Task<T>>(Queue.Queue.Count);
-					foreach (var entry in Queue.Queue)
+					var result = new List<Task<T>>(_queue._queue.Count);
+					foreach (var entry in _queue._queue)
 					{
 						result.Add(entry.Task);
 					}

--- a/WalletWasabi/Nito/Collections/CollectionHelpers.cs
+++ b/WalletWasabi/Nito/Collections/CollectionHelpers.cs
@@ -31,18 +31,18 @@ namespace Nito.Collections
 
 		private sealed class NongenericCollectionWrapper<T> : IReadOnlyCollection<T>
 		{
-			private readonly ICollection Collection;
+			private readonly ICollection _collection;
 
 			public NongenericCollectionWrapper(ICollection collection)
 			{
-				Collection = collection ?? throw new ArgumentNullException(nameof(collection));
+				_collection = collection ?? throw new ArgumentNullException(nameof(collection));
 			}
 
-			public int Count => Collection.Count;
+			public int Count => _collection.Count;
 
 			public IEnumerator<T> GetEnumerator()
 			{
-				foreach (T item in Collection)
+				foreach (T item in _collection)
 				{
 					yield return item;
 				}
@@ -50,29 +50,29 @@ namespace Nito.Collections
 
 			IEnumerator IEnumerable.GetEnumerator()
 			{
-				return Collection.GetEnumerator();
+				return _collection.GetEnumerator();
 			}
 		}
 
 		private sealed class CollectionWrapper<T> : IReadOnlyCollection<T>
 		{
-			private readonly ICollection<T> Collection;
+			private readonly ICollection<T> _collection;
 
 			public CollectionWrapper(ICollection<T> collection)
 			{
-				Collection = collection ?? throw new ArgumentNullException(nameof(collection));
+				_collection = collection ?? throw new ArgumentNullException(nameof(collection));
 			}
 
-			public int Count => Collection.Count;
+			public int Count => _collection.Count;
 
 			public IEnumerator<T> GetEnumerator()
 			{
-				return Collection.GetEnumerator();
+				return _collection.GetEnumerator();
 			}
 
 			IEnumerator IEnumerable.GetEnumerator()
 			{
-				return Collection.GetEnumerator();
+				return _collection.GetEnumerator();
 			}
 		}
 	}

--- a/WalletWasabi/Nito/Collections/Deque.cs
+++ b/WalletWasabi/Nito/Collections/Deque.cs
@@ -887,15 +887,15 @@ namespace Nito.Collections
 		[DebuggerNonUserCode]
 		private sealed class DebugView
 		{
-			private readonly Deque<T> Deque;
+			private readonly Deque<T> _deque;
 
 			public DebugView(Deque<T> deque)
 			{
-				Deque = deque;
+				_deque = deque;
 			}
 
 			[DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-			public T[] Items => Deque.ToArray();
+			public T[] Items => _deque.ToArray();
 		}
 	}
 }

--- a/WalletWasabi/Nito/Disposables/Internals/BoundAction.cs
+++ b/WalletWasabi/Nito/Disposables/Internals/BoundAction.cs
@@ -70,22 +70,22 @@ namespace Nito.Disposables.Internals
 
 		private sealed class BoundAction : IBoundAction
 		{
-			private readonly Action<T> Action;
-			private readonly T Context;
+			private readonly Action<T> _action;
+			private readonly T _context;
 
 			public BoundAction(Action<T> action, T context)
 			{
-				Action = action;
-				Context = context;
+				_action = action;
+				_context = context;
 			}
 
 			public BoundAction(BoundAction originalBoundAction, Func<T, T> contextUpdater)
 			{
-				Action = originalBoundAction.Action;
-				Context = contextUpdater(originalBoundAction.Context);
+				_action = originalBoundAction._action;
+				_context = contextUpdater(originalBoundAction._context);
 			}
 
-			public void Invoke() => Action?.Invoke(Context);
+			public void Invoke() => _action?.Invoke(_context);
 		}
 	}
 }

--- a/WalletWasabi/Nito/Disposables/SingleDisposable.cs
+++ b/WalletWasabi/Nito/Disposables/SingleDisposable.cs
@@ -16,9 +16,9 @@ namespace Nito.Disposables
 		/// <summary>
 		/// The context. This is never <c>null</c>. This is empty if this instance has already been disposed (or is being disposed).
 		/// </summary>
-		private readonly BoundActionField<T> Context;
+		private readonly BoundActionField<T> _context;
 
-		private readonly ManualResetEventSlim Mre = new ManualResetEventSlim();
+		private readonly ManualResetEventSlim _mre = new ManualResetEventSlim();
 
 		/// <summary>
 		/// Creates a disposable for the specified context.
@@ -26,18 +26,18 @@ namespace Nito.Disposables
 		/// <param name="context">The context passed to <see cref="Dispose(T)"/>.</param>
 		protected SingleDisposable(T context)
 		{
-			Context = new BoundActionField<T>(Dispose, context);
+			_context = new BoundActionField<T>(Dispose, context);
 		}
 
 		/// <summary>
 		/// Whether this instance is currently disposing or has been disposed.
 		/// </summary>
-		public bool IsDisposeStarted => Context.IsEmpty;
+		public bool IsDisposeStarted => _context.IsEmpty;
 
 		/// <summary>
 		/// Whether this instance is disposed (finished disposing).
 		/// </summary>
-		public bool IsDisposed => Mre.IsSet;
+		public bool IsDisposed => _mre.IsSet;
 
 		/// <summary>
 		/// Whether this instance is currently disposing, but not finished yet.
@@ -58,10 +58,10 @@ namespace Nito.Disposables
 		/// </remarks>
 		public void Dispose()
 		{
-			var context = Context.TryGetAndUnset();
+			var context = _context.TryGetAndUnset();
 			if (context is null)
 			{
-				Mre.Wait();
+				_mre.Wait();
 				return;
 			}
 			try
@@ -70,7 +70,7 @@ namespace Nito.Disposables
 			}
 			finally
 			{
-				Mre.Set();
+				_mre.Set();
 			}
 		}
 
@@ -78,6 +78,6 @@ namespace Nito.Disposables
 		/// Attempts to update the stored context. This method returns <c>false</c> if this instance has already been disposed (or is being disposed).
 		/// </summary>
 		/// <param name="contextUpdater">The function used to update an existing context. This may be called more than once if more than one thread attempts to simultanously update the context.</param>
-		protected bool TryUpdateContext(Func<T, T> contextUpdater) => Context.TryUpdateContext(contextUpdater);
+		protected bool TryUpdateContext(Func<T, T> contextUpdater) => _context.TryUpdateContext(contextUpdater);
 	}
 }

--- a/WalletWasabi/Services/SingleInstanceChecker.cs
+++ b/WalletWasabi/Services/SingleInstanceChecker.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Services
 		private const string MutexString = "WalletWasabiSingleInstance";
 
 		/// <summary>Name of system-wide mutex.</summary>
-		private readonly string LockName;
+		private readonly string _lockName;
 
 		private bool _disposedValue;
 
@@ -33,7 +33,7 @@ namespace WalletWasabi.Services
 		public SingleInstanceChecker(Network network, string lockName)
 		{
 			Network = network;
-			LockName = $"{MutexString}-{lockName}";
+			_lockName = $"{MutexString}-{lockName}";
 		}
 
 		private IDisposable? SingleApplicationLockHolder { get; set; }
@@ -47,7 +47,7 @@ namespace WalletWasabi.Services
 			}
 
 			// The disposal of this mutex handled by AsyncMutex.WaitForAllMutexToCloseAsync().
-			var mutex = new AsyncMutex(LockName);
+			var mutex = new AsyncMutex(_lockName);
 			try
 			{
 				using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));

--- a/WalletWasabi/Services/Terminate/TerminateService.cs
+++ b/WalletWasabi/Services/Terminate/TerminateService.cs
@@ -7,7 +7,7 @@ namespace WalletWasabi.Services.Terminate
 {
 	public class TerminateService
 	{
-		private readonly Func<Task> TerminateApplicationAsync;
+		private readonly Func<Task> _terminateApplicationAsync;
 
 		private const long TerminateStatusNotStarted = 0;
 		private const long TerminateStatusInProgress = 1;
@@ -17,7 +17,7 @@ namespace WalletWasabi.Services.Terminate
 
 		public TerminateService(Func<Task> terminateApplicationAsync)
 		{
-			TerminateApplicationAsync = terminateApplicationAsync;
+			_terminateApplicationAsync = terminateApplicationAsync;
 			AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
 			Console.CancelKeyPress += Console_CancelKeyPress;
 		}
@@ -67,7 +67,7 @@ namespace WalletWasabi.Services.Terminate
 			{
 				try
 				{
-					await TerminateApplicationAsync().ConfigureAwait(false);
+					await _terminateApplicationAsync().ConfigureAwait(false);
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.WebClients
 {
 	public class ExchangeRateProvider : IExchangeRateProvider
 	{
-		private readonly IExchangeRateProvider[] ExchangeRateProviders =
+		private readonly IExchangeRateProvider[] _exchangeRateProviders =
 		{
 			new BlockchainInfoExchangeRateProvider(),
 			new BitstampExchangeRateProvider(),
@@ -28,7 +28,7 @@ namespace WalletWasabi.WebClients
 
 		public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
 		{
-			foreach (var provider in ExchangeRateProviders)
+			foreach (var provider in _exchangeRateProviders)
 			{
 				try
 				{


### PR DESCRIPTION
This PR:
- Removes an editorconfig naming rule (as suggested in https://github.com/zkSNACKs/WalletWasabi/pull/4655#issuecomment-721127344)
- Fixes naming violations.
- Removes unused variable.