### PR TITLE
Remove FromByte from OctetSerializableBase.

### DIFF
--- a/WalletWasabi/Tor/Socks5/Models/Bases/OctetSerializableBase.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Bases/OctetSerializableBase.cs
@@ -12,8 +12,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Bases
 
 		public byte ToByte() => ByteValue;
 
-		public void FromByte(byte b) => ByteValue = b;
-
 		public string ToHex(bool xhhSyntax = false)
 		{
 			if (xhhSyntax)

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/CmdField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/CmdField.cs
@@ -4,29 +4,16 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class CmdField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public CmdField()
+		public CmdField(byte byteValue)
 		{
+			ByteValue = byteValue;
 		}
-
-		#endregion Constructors
-
-		#region Statics
 
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
 		// The BIND command is not supported.
 		// The (SOCKS5) "UDP ASSOCIATE" command is not supported.
 
-		public static CmdField Connect
-		{
-			get
-			{
-				var cmd = new CmdField();
-				cmd.FromHex("01");
-				return cmd;
-			}
-		}
+		public static CmdField Connect => new CmdField(0x01);
 
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n46
 		// As an extension to SOCKS4A and SOCKS5, Tor implements a new command value,
@@ -35,15 +22,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 		// request.The reply is either an error(if the address could not be
 		// resolved) or a success response.In the case of success, the address is
 		// stored in the portion of the SOCKS response reserved for remote IP address.
-		public static CmdField Resolve
-		{
-			get
-			{
-				var cmd = new CmdField();
-				cmd.FromHex("F0");
-				return cmd;
-			}
-		}
+		public static CmdField Resolve => new CmdField(0xF0);
 
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n55
 		// For SOCKS5 only, we support reverse resolution with a new command value,
@@ -51,16 +30,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 		// an IPv4 address as its target, Tor attempts to find the canonical
 		// hostname for that IPv4 record, and returns it in the "server bound
 		// address" portion of the reply.
-		public static CmdField ResolvePtr
-		{
-			get
-			{
-				var cmd = new CmdField();
-				cmd.FromHex("F1");
-				return cmd;
-			}
-		}
-
-		#endregion Statics
+		public static CmdField ResolvePtr => new CmdField(0xF1);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/PLenField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/PLenField.cs
@@ -6,17 +6,18 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class PLenField : OctetSerializableBase
 	{
-		public PLenField()
+		public PLenField(byte byteValue)
 		{
+			ByteValue = byteValue;
 		}
 
-		public int Value => ByteValue;
-
-		public void FromPasswdField(PasswdField passwd)
+		public PLenField(PasswdField passwd)
 		{
 			Guard.NotNull(nameof(passwd), passwd);
 
 			ByteValue = (byte)passwd.ToBytes().Length;
 		}
+
+		public int Value => ByteValue;
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RepField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RepField.cs
@@ -3,128 +3,54 @@ using WalletWasabi.Tor.Socks5.Models.Bases;
 
 namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
+	/// <summary>
+	/// Possible values of "reply field" are:
+	/// <list type="bullet">
+	///   <item>X'00' succeeded</item>
+	///   <item>X'01' general SOCKS server failure</item>
+	///   <item>X'02' connection not allowed by ruleset</item>
+	///   <item>X'03' Network unreachable</item>
+	///   <item>X'04' Host unreachable</item>
+	///   <item>X'05' Connection refused</item>
+	///   <item>X'06' TTL expired</item>
+	///   <item>X'07' Command not supported</item>
+	///   <item>X'08' Address type not supported</item>
+	///   <item>X'09' to X'FF' unassigned</item>
+	/// </list>
+	/// </summary>
+	/// <seealso href="https://www.ietf.org/rfc/rfc1928.txt"/>
 	public class RepField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public RepField()
+		public RepField(byte byteValue)
 		{
+			ByteValue = byteValue;
 		}
-
-		#endregion Constructors
 
 		#region Statics
 
-		// https://www.ietf.org/rfc/rfc1928.txt
-		// REP    Reply field:
-		// o X'00' succeeded
-		// o X'01' general SOCKS server failure
-		// o X'02' connection not allowed by ruleset
-		// o X'03' Network unreachable
-		// o X'04' Host unreachable
-		// o X'05' Connection refused
-		// o X'06' TTL expired
-		// o X'07' Command not supported
-		// o X'08' Address type not supported
-		// o X'09' to X'FF' unassigned
+		public static RepField Succeeded => new RepField((byte)ReplyType.Succeeded);
 
-		public static RepField Succeeded
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.Succeeded);
-				return cmd;
-			}
-		}
+		public static RepField GeneralSocksServerFailure => new RepField((byte)ReplyType.GeneralSocksServerFailure);
 
-		public static RepField GeneralSocksServerFailure
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.GeneralSocksServerFailure);
-				return cmd;
-			}
-		}
+		public static RepField CconnectionNotAllowedByRuleset => new RepField((byte)ReplyType.ConnectionNotAllowedByRuleset);
 
-		public static RepField CconnectionNotAllowedByRuleset
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.ConnectionNotAllowedByRuleset);
-				return cmd;
-			}
-		}
+		public static RepField NetworkUnreachable => new RepField((byte)ReplyType.NetworkUnreachable);
 
-		public static RepField NetworkUnreachable
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.NetworkUnreachable);
-				return cmd;
-			}
-		}
+		public static RepField HostUnreachable => new RepField((byte)ReplyType.HostUnreachable);
 
-		public static RepField HostUnreachable
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.HostUnreachable);
-				return cmd;
-			}
-		}
+		public static RepField ConnectionRefused => new RepField((byte)ReplyType.ConnectionRefused);
 
-		public static RepField ConnectionRefused
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.ConnectionRefused);
-				return cmd;
-			}
-		}
+		public static RepField TtlExpired => new RepField((byte)ReplyType.TtlExpired);
 
-		public static RepField TtlExpired
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.TtlExpired);
-				return cmd;
-			}
-		}
+		public static RepField CommandNoSupported => new RepField((byte)ReplyType.CommandNotSupported);
 
-		public static RepField CommandNoSupported
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.CommandNotSupported);
-				return cmd;
-			}
-		}
-
-		public static RepField AddressTypeNotSupported
-		{
-			get
-			{
-				var cmd = new RepField();
-				cmd.FromByte((byte)ReplyType.AddressTypeNotSupported);
-				return cmd;
-			}
-		}
+		public static RepField AddressTypeNotSupported => new RepField((byte)ReplyType.AddressTypeNotSupported);
 
 		#endregion Statics
 
-		#region Serialization
-
 		public override string ToString()
 		{
-			foreach (ReplyType rt in Enum.GetValues(typeof(ReplyType)))
+			foreach (ReplyType rt in (ReplyType[])Enum.GetValues(typeof(ReplyType)))
 			{
 				if (ByteValue == (byte)rt)
 				{
@@ -133,7 +59,5 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 			}
 			return $"Unassigned ({ToHex()})";
 		}
-
-		#endregion Serialization
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RsvField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RsvField.cs
@@ -4,26 +4,11 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class RsvField : OctetSerializableBase
 	{
-		#region Constructors
-
-		public RsvField()
+		public RsvField(byte byteValue)
 		{
+			ByteValue = byteValue;
 		}
 
-		#endregion Constructors
-
-		#region Statics
-
-		public static RsvField X00
-		{
-			get
-			{
-				var rsv = new RsvField();
-				rsv.FromHex("00");
-				return rsv;
-			}
-		}
-
-		#endregion Statics
+		public static RsvField X00 => new RsvField(0x00);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/ULenField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/ULenField.cs
@@ -5,15 +5,16 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class ULenField : OctetSerializableBase
 	{
-		public ULenField()
+		public ULenField(byte byteValue)
 		{
+			ByteValue = byteValue;
 		}
 
-		public int Value => ByteValue;
-
-		public void FromUNameField(UNameField uName)
+		public ULenField(UNameField uName)
 		{
 			ByteValue = (byte)uName.ToBytes().Length;
 		}
+
+		public int Value => ByteValue;
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Interfaces/IByteSerializable.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Interfaces/IByteSerializable.cs
@@ -4,8 +4,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Interfaces
 	{
 		byte ToByte();
 
-		void FromByte(byte b);
-
 		string ToHex(bool xhhSyntax);
 
 		void FromHex(string hex);

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Request.cs
@@ -14,17 +14,10 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
 
 			Ver = new VerField(bytes[0]);
-
-			Cmd = new CmdField();
-			Cmd.FromByte(bytes[1]);
-
-			Rsv = new RsvField();
-			Rsv.FromByte(bytes[2]);
-
+			Cmd = new CmdField(bytes[1]);
+			Rsv = new RsvField(bytes[2]);
 			Atyp = new AtypField(bytes[3]);
-
 			DstAddr = new AddrField(bytes[4..^2]);
-
 			DstPort = new PortField(bytes[^2..]);
 		}
 

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
@@ -14,17 +14,10 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
 
 			Ver = new VerField(bytes[0]);
-
-			Rep = new RepField();
-			Rep.FromByte(bytes[1]);
-
-			Rsv = new RsvField();
-			Rsv.FromByte(bytes[2]);
-
+			Rep = new RepField(bytes[1]);
+			Rsv = new RsvField(bytes[2]);
 			Atyp = new AtypField(bytes[3]);
-
 			BndAddr = new AddrField(bytes[4..^2]);
-
 			BndPort = new PortField(bytes[^2..]);
 		}
 

--- a/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordRequest.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/UsernamePasswordRequest.cs
@@ -14,14 +14,10 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Guard.InRangeAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6, 513);
 
 			Ver = new AuthVerField(bytes[0]);
-
-			ULen = new ULenField();
-			ULen.FromByte(bytes[1]);
-
+			ULen = new ULenField(bytes[1]);
 			UName = new UNameField(bytes[2..(2 + ULen.Value)]);
 
-			PLen = new PLenField();
-			PLen.FromByte(bytes[1 + ULen.Value]);
+			PLen = new PLenField(bytes[1 + ULen.Value]);
 			int expectedPlenValue = bytes.Length - 3 + ULen.Value;
 			if (PLen.Value != expectedPlenValue)
 			{
@@ -35,13 +31,8 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 			Ver = AuthVerField.Version1;
 			UName = Guard.NotNull(nameof(uName), uName);
 			Passwd = Guard.NotNull(nameof(passwd), passwd);
-
-			var pLen = new PLenField();
-			var uLen = new ULenField();
-			pLen.FromPasswdField(passwd);
-			uLen.FromUNameField(uName);
-			PLen = pLen;
-			ULen = uLen;
+			PLen = new PLenField(passwd);
+			ULen = new ULenField(uName);
 		}
 
 		public AuthVerField Ver { get; }


### PR DESCRIPTION
This PR only removes `OctetSerializableBase.FromByte` so that all classes are properly constructed using their respective constructors.