### PR TITLE
Add IRelativeHttpClient.

### DIFF
--- a/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
+++ b/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -9,12 +10,10 @@ namespace WalletWasabi.Tor.Http
 	/// HTTP client implementation based on .NET's <see cref="HttpClient"/> which provides least privacy for Wasabi users,
 	/// as HTTP requests are being sent over clearnet.
 	/// </summary>
-	public class ClearnetHttpClient : IHttpClient
+	/// <remarks>Inner <see cref="HttpClient"/> instance is thread-safe.</remarks>
+	public class ClearnetHttpClient : IRelativeHttpClient
 	{
-		/// <summary>This field is temporary and should be ultimately removed.</summary>
-		public static ClearnetHttpClient Instance = new ClearnetHttpClient();
-
-		private ClearnetHttpClient()
+		static ClearnetHttpClient()
 		{
 			HttpClient = new HttpClient(new HttpClientHandler()
 			{
@@ -23,13 +22,20 @@ namespace WalletWasabi.Tor.Http
 			});
 		}
 
+		public ClearnetHttpClient(Func<Uri> destinationUriAction)
+		{
+			DestinationUriAction = destinationUriAction;
+		}
+
+		public Func<Uri> DestinationUriAction { get; }
+
 		/// <summary>Predefined HTTP client that handles HTTP requests when Tor is disabled.</summary>
-		private HttpClient HttpClient { get; }
+		private static HttpClient HttpClient { get; }
 
 		/// <inheritdoc cref="HttpClient.SendAsync(HttpRequestMessage, CancellationToken)"/>
-		public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
+		public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
 		{
-			return await HttpClient.SendAsync(request, token).ConfigureAwait(false);
+			return HttpClient.SendAsync(request, token);
 		}
 	}
 }

--- a/WalletWasabi/Tor/Http/IRelativeHttpClient.cs
+++ b/WalletWasabi/Tor/Http/IRelativeHttpClient.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Tor.Http
+{
+	/// <summary>
+	/// Interface defining HTTP client capable of sending HTTP requests that are relative to some base URI.
+	/// <para>This is useful to send requests to Wasabi Backend server, for example.</para>
+	/// </summary>
+	public interface IRelativeHttpClient : IHttpClient
+	{
+		Func<Uri> DestinationUriAction { get; }
+
+		async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent? content = null, CancellationToken cancel = default)
+		{
+			var requestUri = new Uri(DestinationUriAction.Invoke(), relativeUri);
+			using var httpRequestMessage = new HttpRequestMessage(method, requestUri);
+			httpRequestMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+			if (content is { })
+			{
+				httpRequestMessage.Content = content;
+			}
+
+			return await SendAsync(httpRequestMessage, cancel).ConfigureAwait(false);
+		}
+	}
+}

--- a/WalletWasabi/Tor/Http/Interfaces/ITorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/Interfaces/ITorHttpClient.cs
@@ -1,14 +1,7 @@
-using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace WalletWasabi.Tor.Http.Interfaces
 {
-	public interface ITorHttpClient : IHttpClient
+	public interface ITorHttpClient : IRelativeHttpClient
 	{
 		bool IsTorUsed { get; }
-
-		Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent? content = null, CancellationToken cancel = default);
 	}
 }

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -69,9 +69,9 @@ namespace WalletWasabi.Tor.Http
 
 		private static AsyncLock AsyncLock { get; } = new AsyncLock(); // We make everything synchronous, so slow, but at least stable.
 
-		private static async Task<HttpResponseMessage> ClearnetRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+		private Task<HttpResponseMessage> ClearnetRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
 		{
-			return await ClearnetHttpClient.Instance.SendAsync(request, cancellationToken).ConfigureAwait(false);
+			return new ClearnetHttpClient(DestinationUriAction).SendAsync(request, cancellationToken);
 		}
 
 		/// <remarks>
@@ -95,7 +95,14 @@ namespace WalletWasabi.Tor.Http
 			{
 				return await ClearnetRequestAsync(request, cancel).ConfigureAwait(false);
 			}
+			else
+			{
+				return await TorRequestAsync(request, cancel).ConfigureAwait(false);
+			}
+		}
 
+		private async Task<HttpResponseMessage> TorRequestAsync(HttpRequestMessage request, CancellationToken cancel)
+		{
 			try
 			{
 				using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
@@ -171,14 +178,19 @@ namespace WalletWasabi.Tor.Http
 		/// <exception cref="OperationCanceledException">If <paramref name="cancel"/> is set.</exception>
 		public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancel = default)
 		{
-			Guard.NotNull(nameof(request), request);
-
 			// Use clearnet HTTP client when Tor is disabled.
 			if (TorSocks5EndPoint is null)
 			{
 				return await ClearnetRequestAsync(request, cancel).ConfigureAwait(false);
 			}
+			else
+			{
+				return await TorRequestCoreAsync(request, cancel).ConfigureAwait(false);
+			}
+		}
 
+		private async Task<HttpResponseMessage> TorRequestCoreAsync(HttpRequestMessage request, CancellationToken cancel)
+		{
 			// https://tools.ietf.org/html/rfc7230#section-2.7.1
 			// A sender MUST NOT generate an "http" URI with an empty host identifier.
 			string host = Guard.NotNullOrEmptyOrWhitespace($"{nameof(request)}.{nameof(request.RequestUri)}.{nameof(request.RequestUri.DnsSafeHost)}", request.RequestUri.DnsSafeHost, trim: true);
@@ -197,7 +209,7 @@ namespace WalletWasabi.Tor.Http
 
 			if (TorSocks5Client is null || !TorSocks5Client.IsConnected)
 			{
-				TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint);
+				TorSocks5Client = new TorSocks5Client(TorSocks5EndPoint!);
 				await TorSocks5Client.ConnectAsync().ConfigureAwait(false);
 				await TorSocks5Client.HandshakeAsync(IsolateStream, cancel).ConfigureAwait(false);
 				await TorSocks5Client.ConnectToDestinationAsync(host, request.RequestUri.Port, cancel).ConfigureAwait(false);


### PR DESCRIPTION
This PR adds `IRelativeHttpClient` interface on top of `IHttpClient` to allow me to continue with my refactorings.

`ClearnetHttpClient` newly implements `IRelativeHttpClient`.