### PR TITLE
Set indent_size to 4 for C# Files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ trim_trailing_whitespace = true
 
 # use hard tabs for indentation
 indent_style = tab
+indent_size = 4
 
 # Formatting - set preferred newline characters
 end_of_line = lf


### PR DESCRIPTION
This PR sets `indent_size` to 4 for this repository by updating the `.editorconfig` file. Currently, there is no preconfigured default for this, and a tab character on GitHub is equivalent to 8 spaces. That hurts the readability of the source code when one decides to browse the code online. Currently, the source files look like this:

![image](https://user-images.githubusercontent.com/6759207/98950694-620f4280-250a-11eb-9027-499c92d43dbe.png)

With the updated `indent_size` setting, the source files should look like this:

![image](https://user-images.githubusercontent.com/6759207/98950783-7f441100-250a-11eb-9a5a-6e1525b1f8d1.png)

This way we get shorter lines of code when browsing source files online. Also, we get better formatting for `WhenAny` chains. Probably worth noting that WasabiWallet uses `indent_size = 2` for XAML files.

The solution is taken from https://stackoverflow.com/a/33831598/11351183