### PR TITLE
Make HdPubKey have Anonset and not SmartCoin

### DIFF
--- a/WalletWasabi.Gui/CommandLine/Daemon.cs
+++ b/WalletWasabi.Gui/CommandLine/Daemon.cs
@@ -145,13 +145,13 @@ namespace WalletWasabi.Gui.CommandLine
 		{
 			try
 			{
-				var coinsToMix = Wallet.Coins.Available().FilterBy(x => x.AnonymitySet <= maxAnonset && minAnonset <= x.AnonymitySet);
+				var coinsToMix = Wallet.Coins.Available().FilterBy(x => x.HdPubKey.AnonymitySet <= maxAnonset && minAnonset <= x.HdPubKey.AnonymitySet);
 
 				var enqueuedCoins = await Wallet.ChaumianClient.QueueCoinsToMixAsync(password, coinsToMix.ToArray());
 
 				if (enqueuedCoins.Any())
 				{
-					Logger.LogInfo($"Enqueued {Money.Satoshis(enqueuedCoins.Sum(x => x.Amount)).ToString(false, true)} BTC, {enqueuedCoins.Count()} coins with smallest anonset {enqueuedCoins.Min(x => x.AnonymitySet)} and largest anonset {enqueuedCoins.Max(x => x.AnonymitySet)}.");
+					Logger.LogInfo($"Enqueued {Money.Satoshis(enqueuedCoins.Sum(x => x.Amount)).ToString(false, true)} BTC, {enqueuedCoins.Count()} coins with smallest anonset {enqueuedCoins.Min(x => x.HdPubKey.AnonymitySet)} and largest anonset {enqueuedCoins.Max(x => x.HdPubKey.AnonymitySet)}.");
 				}
 			}
 			catch (Exception ex)

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinJoinTabViewModel.cs
@@ -441,7 +441,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 				{
 					var available = coins.Confirmed().Available();
 					RequiredBTC = available.Any()
-						? registrableRound.State.CalculateRequiredAmount(available.Where(x => x.AnonymitySet < Global.Config.PrivacyLevelStrong).Select(x => x.Amount).ToArray())
+						? registrableRound.State.CalculateRequiredAmount(available.Where(x => x.HdPubKey.AnonymitySet < Global.Config.PrivacyLevelStrong).Select(x => x.Amount).ToArray())
 						: registrableRound.State.CalculateRequiredAmount();
 				}
 			}

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -28,6 +28,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		private ObservableAsPropertyHelper<bool> _coinJoinInProgress;
 		private ObservableAsPropertyHelper<bool> _confirmed;
 		private ObservableAsPropertyHelper<string> _cluster;
+		private ObservableAsPropertyHelper<int> _anonymitySet;
 
 		private volatile bool _disposedValue = false;
 
@@ -51,6 +52,11 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			_confirmed = Model
 				.WhenAnyValue(x => x.Confirmed)
 				.ToProperty(this, x => x.Confirmed, scheduler: RxApp.MainThreadScheduler)
+				.DisposeWith(Disposables);
+
+			_anonymitySet = Model
+				.WhenAnyValue(x => x.HdPubKey.AnonymitySet)
+				.ToProperty(this, x => x.AnonymitySet, scheduler: RxApp.MainThreadScheduler)
 				.DisposeWith(Disposables);
 
 			_cluster = Model
@@ -167,7 +173,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public uint OutputIndex => Model.Index;
 
-		public int AnonymitySet => Model.HdPubKey.AnonymitySet;
+		public int AnonymitySet => _anonymitySet?.Value ?? 1;
 
 		public string InCoinJoin => Model.CoinJoinInProgress ? "Yes" : "No";
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -167,7 +167,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 
 		public uint OutputIndex => Model.Index;
 
-		public int AnonymitySet => Model.AnonymitySet;
+		public int AnonymitySet => Model.HdPubKey.AnonymitySet;
 
 		public string InCoinJoin => Model.CoinJoinInProgress ? "Yes" : "No";
 

--- a/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Gui/Rpc/WasabiJsonRpcService.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.Gui.Rpc
 				txid = x.TransactionId.ToString(),
 				index = x.Index,
 				amount = x.Amount.Satoshi,
-				anonymitySet = x.AnonymitySet,
+				anonymitySet = x.HdPubKey.AnonymitySet,
 				confirmed = x.Confirmed,
 				confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
 				label = x.HdPubKey.Label.ToString(),

--- a/WalletWasabi.Tests/Common.cs
+++ b/WalletWasabi.Tests/Common.cs
@@ -47,7 +47,8 @@ namespace WalletWasabi.Tests
 			var tx = Transaction.Create(Network.Main);
 			tx.Outputs.Add(new TxOut(Money.Coins(amount), pubKey.P2wpkhScript));
 			var stx = new SmartTransaction(tx, height);
-			return new SmartCoin(stx, 0, pubKey, anonymitySet);
+			pubKey.AnonymitySet = anonymitySet;
+			return new SmartCoin(stx, 0, pubKey);
 		}
 
 		public static TransactionFactory CreateTransactionFactory(

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1113,7 +1113,8 @@ namespace WalletWasabi.Tests.RegressionTests
 				var stx = new SmartTransaction(tx, height + 1);
 				var bechCoin = tx.Outputs.GetCoins(bech.ScriptPubKey).Single();
 
-				var smartCoin = new SmartCoin(stx, bechCoin.Outpoint.N, key, anonymitySet: tx.GetAnonymitySet(bechCoin.Outpoint.N));
+				var smartCoin = new SmartCoin(stx, bechCoin.Outpoint.N, key);
+				key.AnonymitySet = tx.GetAnonymitySet(bechCoin.Outpoint.N);
 
 				var chaumianClient = new CoinJoinClient(synchronizer, rpc.Network, keyManager);
 
@@ -1226,10 +1227,14 @@ namespace WalletWasabi.Tests.RegressionTests
 			var bech3Coin = tx3.Outputs.GetCoins(bech3.ScriptPubKey).Single();
 			var bech4Coin = tx4.Outputs.GetCoins(bech4.ScriptPubKey).Single();
 
-			var smartCoin1 = new SmartCoin(stx1, bech1Coin.Outpoint.N, key1, anonymitySet: tx1.GetAnonymitySet(bech1Coin.Outpoint.N));
-			var smartCoin2 = new SmartCoin(stx2, bech2Coin.Outpoint.N, key2, anonymitySet: tx2.GetAnonymitySet(bech2Coin.Outpoint.N));
-			var smartCoin3 = new SmartCoin(stx3, bech3Coin.Outpoint.N, key3, anonymitySet: tx3.GetAnonymitySet(bech3Coin.Outpoint.N));
-			var smartCoin4 = new SmartCoin(stx4, bech4Coin.Outpoint.N, key4, anonymitySet: tx4.GetAnonymitySet(bech4Coin.Outpoint.N));
+			var smartCoin1 = new SmartCoin(stx1, bech1Coin.Outpoint.N, key1);
+			var smartCoin2 = new SmartCoin(stx2, bech2Coin.Outpoint.N, key2);
+			var smartCoin3 = new SmartCoin(stx3, bech3Coin.Outpoint.N, key3);
+			var smartCoin4 = new SmartCoin(stx4, bech4Coin.Outpoint.N, key4);
+			key1.AnonymitySet = tx1.GetAnonymitySet(bech1Coin.Outpoint.N);
+			key2.AnonymitySet = tx2.GetAnonymitySet(bech2Coin.Outpoint.N);
+			key3.AnonymitySet = tx3.GetAnonymitySet(bech3Coin.Outpoint.N);
+			key4.AnonymitySet = tx4.GetAnonymitySet(bech4Coin.Outpoint.N);
 
 			var chaumianClient1 = new CoinJoinClient(synchronizer, rpc.Network, keyManager);
 			var chaumianClient2 = new CoinJoinClient(synchronizer, rpc.Network, keyManager);
@@ -1256,7 +1261,8 @@ namespace WalletWasabi.Tests.RegressionTests
 				var randomTx = network.Consensus.ConsensusFactory.CreateTransaction();
 				randomTx.Outputs.Add(new TxOut(Money.Coins(3m), randomKey.P2wpkhScript));
 				var randomStx = new SmartTransaction(randomTx, Height.Mempool);
-				await chaumianClient1.DequeueCoinsFromMixAsync(new SmartCoin(randomStx, 0, randomKey, anonymitySet: 1), DequeueReason.UserRequested);
+				await chaumianClient1.DequeueCoinsFromMixAsync(new SmartCoin(randomStx, 0, randomKey), DequeueReason.UserRequested);
+				randomKey.AnonymitySet = 1;
 
 				Assert.True(2 == (await chaumianClient1.QueueCoinsToMixAsync(password, smartCoin1, smartCoin2)).Count());
 				await chaumianClient1.DequeueCoinsFromMixAsync(smartCoin1, DequeueReason.UserRequested);

--- a/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
@@ -24,15 +24,14 @@ namespace WalletWasabi.Tests.UnitTests
 
 			var height = Height.Mempool;
 			var stx = new SmartTransaction(tx, height);
-			var label = "foo";
 
-			var coin = new SmartCoin(stx, index, hdpk1, tx.GetAnonymitySet(index));
+			var coin = new SmartCoin(stx, index, hdpk1);
 
 			// If the txId or the index differ, equality should think it's a different coin.
-			var differentCoin = new SmartCoin(stx, index + 1, hdpk2, tx.GetAnonymitySet(index + 1));
+			var differentCoin = new SmartCoin(stx, index + 1, hdpk2);
 
 			// If the txId and the index are the same, equality should think it's the same coin.
-			var sameCoin = new SmartCoin(stx, index, hdpk1, tx.GetAnonymitySet(index));
+			var sameCoin = new SmartCoin(stx, index, hdpk1);
 
 			Assert.Equal(coin, sameCoin);
 			Assert.NotEqual(coin, differentCoin);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.True(result.Signed);
 			var spentCoin = Assert.Single(result.SpentCoins);
 			Assert.Equal(Money.Coins(0.16m), spentCoin.Amount);
-			Assert.Equal(200, spentCoin.AnonymitySet);
+			Assert.Equal(200, spentCoin.HdPubKey.AnonymitySet);
 			Assert.False(result.SpendsUnconfirmed);
 			var tx = result.Transaction.Transaction;
 			Assert.Equal(2, tx.Outputs.Count());
@@ -100,7 +100,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.True(result.Signed);
 			var spentCoin = Assert.Single(result.SpentCoins);
 			Assert.Equal(Money.Coins(0.16m), spentCoin.Amount);
-			Assert.Equal(200, spentCoin.AnonymitySet);
+			Assert.Equal(200, spentCoin.HdPubKey.AnonymitySet);
 			Assert.False(result.SpendsUnconfirmed);
 			var tx = result.Transaction.Transaction;
 			Assert.Equal(2, tx.Outputs.Count());
@@ -129,8 +129,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			Assert.True(result.Signed);
 			Assert.Equal(2, result.SpentCoins.Count());
-			var spentCoin200 = Assert.Single(result.SpentCoins, x => x.AnonymitySet == 200);
-			var spentCoin100 = Assert.Single(result.SpentCoins, x => x.AnonymitySet == 100);
+			var spentCoin200 = Assert.Single(result.SpentCoins, x => x.HdPubKey.AnonymitySet == 200);
+			var spentCoin100 = Assert.Single(result.SpentCoins, x => x.HdPubKey.AnonymitySet == 100);
 
 			Assert.Equal(Money.Coins(0.16m), spentCoin200.Amount);
 			Assert.Equal(Money.Coins(0.04m), spentCoin100.Amount);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -1100,7 +1100,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			return new OutPoint(RandomUtils.GetUInt256(), 0);
 		}
 
-		private async Task<TransactionProcessor> CreateTransactionProcessorAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "")
+		private async Task<TransactionProcessor> CreateTransactionProcessorAsync(int privacyLevelThreshold = 100, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "")
 		{
 			var keyManager = KeyManager.CreateNew(out _, "password");
 			keyManager.AssertCleanKeysIndexed();
@@ -1113,7 +1113,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			return new TransactionProcessor(
 				txStore,
 				keyManager,
-				Money.Coins(0.0001m));
+				Money.Coins(0.0001m),
+				privacyLevelThreshold);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -681,7 +681,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var tx = Network.RegTest.CreateTransaction();
 			tx.Version = 1;
 			tx.LockTime = LockTime.Zero;
-			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
+			tx.Outputs.Add(amount, keys.Skip(1).First().P2wpkhScript);
 			var txOut = new TxOut(amount, new Key().PubKey.WitHash.ScriptPubKey);
 			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts
 			tx.Inputs.AddRange(Enumerable.Repeat(new TxIn(GetRandomOutPoint(), Script.Empty), 4));
@@ -691,7 +691,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			// It is relevant even when all the coins can be dust.
 			Assert.True(relevant.IsNews);
 			var coin = Assert.Single(transactionProcessor.Coins);
-			Assert.Equal(4, coin.AnonymitySet);
+			Assert.Equal(4, coin.HdPubKey.AnonymitySet);
 			Assert.Equal(amount, coin.Amount);
 		}
 
@@ -710,7 +710,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var tx = Network.RegTest.CreateTransaction();
 			tx.Version = 1;
 			tx.LockTime = LockTime.Zero;
-			tx.Outputs.Add(amount, keys.First().P2wpkhScript);
+			tx.Outputs.Add(amount, keys.Skip(1).First().P2wpkhScript);
 			var txOut = new TxOut(Money.Coins(0.1m), new Key().PubKey.WitHash.ScriptPubKey);
 			tx.Outputs.AddRange(Enumerable.Repeat(txOut, 5)); // 6 indistinguishable txouts
 			tx.Inputs.Add(createdCoin.Outpoint, Script.Empty, WitScript.Empty);
@@ -720,8 +720,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// It is relevant even when all the coins can be dust.
 			Assert.True(relevant.IsNews);
-			var coin = Assert.Single(transactionProcessor.Coins, c => c.AnonymitySet > 1);
-			Assert.Equal(5, coin.AnonymitySet);
+			var coin = Assert.Single(transactionProcessor.Coins, c => c.HdPubKey.AnonymitySet > 1);
+			Assert.Equal(5, coin.HdPubKey.AnonymitySet);
 			Assert.Equal(amount, coin.Amount);
 		}
 

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -1,0 +1,61 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WalletWasabi.Blockchain.Transactions;
+
+namespace WalletWasabi.Blockchain.Analysis
+{
+	public class BlockchainAnalyzer
+	{
+		public BlockchainAnalyzer(int privacyLevelThreshold, Money dustThreshold)
+		{
+			PrivacyLevelThreshold = privacyLevelThreshold;
+			DustThreshold = dustThreshold;
+		}
+
+		public int PrivacyLevelThreshold { get; }
+		public Money DustThreshold { get; }
+
+		/// <summary>
+		/// Sets clusters and anonymity sets for related HD public keys.
+		/// </summary>
+		public void Analyze(SmartTransaction tx)
+		{
+			// Dust attack could ruin the analysis, so it's better not to incorporate this.
+			// For example if someone would dust a mixed coin of ours, its anon score would end up being 1,
+			// even though the duster does not know who it sent the money.
+			// FTR at the time of writing this comment the transaction processor doesn't even let dust to come this far,
+			// but it's better to be prepared for future changes if it's not too computationally expensive.
+			foreach (var newCoin in tx.WalletOutputs.Where(x => x.Amount > DustThreshold))
+			{
+				// Calculate anonymity sets.
+				// Get the anonymity set of i-th output in the transaction.
+				var anonset = tx.Transaction.GetAnonymitySet(newCoin.Index);
+				// If we provided inputs to the transaction.
+				if (tx.WalletInputs.Any())
+				{
+					// Take the input that we provided with the smallest anonset.
+					// And add that to the base anonset from the tx.
+					// Our smallest anonset input is the relevant here, because this way the common input ownership heuristic is considered.
+					// Take minus 1, because we do not want to count own into the anonset, so...
+					// If the anonset of our UTXO would be 1, and the smallest anonset of our inputs would be 1, too, then we don't make...
+					// The new UTXO's anonset 2, but only 1.
+					anonset += tx.WalletInputs.Select(x => x.HdPubKey).Min(x => x.AnonymitySet) - 1;
+				}
+
+				newCoin.HdPubKey.AnonymitySet = Math.Min(anonset, newCoin.HdPubKey.AnonymitySet);
+
+				// Set clusters.
+				if (newCoin.HdPubKey.AnonymitySet < PrivacyLevelThreshold)
+				{
+					foreach (var spentCoin in tx.WalletInputs)
+					{
+						newCoin.HdPubKey.Cluster.Merge(spentCoin.HdPubKey.Cluster);
+					}
+				}
+			}
+		}
+	}
+}

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -33,6 +33,7 @@ namespace WalletWasabi.Blockchain.Analysis
 				// Calculate anonymity sets.
 				// Get the anonymity set of i-th output in the transaction.
 				var anonset = tx.Transaction.GetAnonymitySet(newCoin.Index);
+
 				// If we provided inputs to the transaction.
 				if (tx.WalletInputs.Any())
 				{

--- a/WalletWasabi/Blockchain/Analysis/Clustering/Cluster.cs
+++ b/WalletWasabi/Blockchain/Analysis/Clustering/Cluster.cs
@@ -29,8 +29,6 @@ namespace WalletWasabi.Blockchain.Analysis.Clustering
 			private set => RaiseAndSetIfChanged(ref _labels, value);
 		}
 
-		public int Size => Keys.Count;
-
 		private object Lock { get; }
 		private List<HdPubKey> Keys { get; set; }
 		private HashSet<HdPubKey> KeysSet { get; set; }
@@ -69,6 +67,8 @@ namespace WalletWasabi.Blockchain.Analysis.Clustering
 		{
 			Labels = SmartLabel.Merge(Keys.Select(x => x.Label));
 		}
+
+		public override string ToString() => Labels;
 
 		#region EqualityAndComparison
 

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using WalletWasabi.Bases;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Helpers;
@@ -11,8 +12,10 @@ using WalletWasabi.JsonConverters;
 namespace WalletWasabi.Blockchain.Keys
 {
 	[JsonObject(MemberSerialization.OptIn)]
-	public class HdPubKey : IEquatable<HdPubKey>
+	public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 	{
+		private int _anonymitySet = int.MaxValue;
+
 		public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, SmartLabel label, KeyState keyState)
 		{
 			PubKey = Guard.NotNull(nameof(pubKey), pubKey);
@@ -44,6 +47,12 @@ namespace WalletWasabi.Blockchain.Keys
 			{
 				throw new ArgumentException(nameof(FullKeyPath));
 			}
+		}
+
+		public int AnonymitySet
+		{
+			get => _anonymitySet;
+			set => RaiseAndSetIfChanged(ref _anonymitySet, value);
 		}
 
 		public HashSet<SmartCoin> Coins { get; } = new HashSet<SmartCoin>();

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -16,6 +16,7 @@ namespace WalletWasabi.Blockchain.Keys
 	{
 		private Cluster _cluster;
 		private int _anonymitySet = int.MaxValue;
+
 		public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, SmartLabel label, KeyState keyState)
 		{
 			PubKey = Guard.NotNull(nameof(pubKey), pubKey);
@@ -56,11 +57,12 @@ namespace WalletWasabi.Blockchain.Keys
 			set => RaiseAndSetIfChanged(ref _cluster, value);
 		}
 
-				public int AnonymitySet
+		public int AnonymitySet
 		{
 			get => _anonymitySet;
 			set => RaiseAndSetIfChanged(ref _anonymitySet, value);
 		}
+
 		public HashSet<SmartCoin> Coins { get; } = new HashSet<SmartCoin>();
 
 		[JsonProperty(Order = 1)]

--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 				{
 					group.Coins,
 					Unconfirmed = group.Coins.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
-					AnonymitySet = group.Coins.Min(x => x.AnonymitySet), // The group is as anonymous as its weakest member.
+					AnonymitySet = group.Coins.Min(x => x.HdPubKey.AnonymitySet), // The group is as anonymous as its weakest member.
 					ClusterPrivacy = group.Privacy, // The number people/entities that know the cluster.
 					Amount = group.Coins.Sum(x => x.Amount)
 				});

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 {
 	public class CoinsRegistry : ICoinsView
 	{
-		public CoinsRegistry(int privacyLevelThreshold)
+		public CoinsRegistry()
 		{
 			Coins = new HashSet<SmartCoin>();
 			SpentCoins = new HashSet<SmartCoin>();
@@ -19,7 +19,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			LatestSpentCoinsSnapshot = new HashSet<SmartCoin>();
 			InvalidateSnapshot = false;
 			CoinsByOutPoint = new Dictionary<OutPoint, HashSet<SmartCoin>>();
-			PrivacyLevelThreshold = privacyLevelThreshold;
 			Lock = new object();
 		}
 
@@ -30,7 +29,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 		private HashSet<SmartCoin> SpentCoins { get; }
 		private HashSet<SmartCoin> LatestSpentCoinsSnapshot { get; set; }
 		private Dictionary<OutPoint, HashSet<SmartCoin>> CoinsByOutPoint { get; }
-		private int PrivacyLevelThreshold { get; }
 
 		public bool IsEmpty => !AsCoinsView().Any();
 
@@ -162,15 +160,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 				{
 					InvalidateSnapshot = true;
 					SpentCoins.Add(spentCoin);
-					var createdCoins = CreatedByNoLock(spentCoin.SpenderTransaction.GetHash());
-					foreach (var newCoin in createdCoins)
-					{
-						if (newCoin.HdPubKey.AnonymitySet < PrivacyLevelThreshold)
-						{
-							spentCoin.HdPubKey.Cluster.Merge(newCoin.HdPubKey.Cluster);
-							newCoin.HdPubKey.Cluster = spentCoin.HdPubKey.Cluster;
-						}
-					}
 				}
 			}
 		}

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -250,7 +250,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 
 		public IEnumerator<SmartCoin> GetEnumerator() => AsCoinsView().GetEnumerator();
 
-		public ICoinsView OutPoints(IEnumerable<OutPoint> outPoints) => AsCoinsView().OutPoints(outPoints);
+		public ICoinsView OutPoints(ISet<OutPoint> outPoints) => AsCoinsView().OutPoints(outPoints);
 
 		public ICoinsView OutPoints(TxInList txIns) => AsCoinsView().OutPoints(txIns);
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -176,7 +176,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 					var createdCoins = CreatedByNoLock(spentCoin.SpenderTransaction.GetHash());
 					foreach (var newCoin in createdCoins)
 					{
-						if (newCoin.AnonymitySet < PrivacyLevelThreshold)
+						if (newCoin.HdPubKey.AnonymitySet < PrivacyLevelThreshold)
 						{
 							spentCoin.Cluster.Merge(newCoin.Cluster);
 							newCoin.Cluster = spentCoin.Cluster;

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
@@ -61,7 +61,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 
 		public ICoinsView FilterBy(Func<SmartCoin, bool> expression) => new CoinsView(Coins.Where(expression));
 
-		public ICoinsView OutPoints(IEnumerable<OutPoint> outPoints) => new CoinsView(Coins.Where(x => outPoints.Any(y => y == x.OutPoint)));
+		public ICoinsView OutPoints(ISet<OutPoint> outPoints) => new CoinsView(Coins.Where(x => outPoints.Contains(x.OutPoint)));
 
 		public ICoinsView OutPoints(TxInList txIns)
 		{

--- a/WalletWasabi/Blockchain/TransactionOutputs/ICoinsView.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/ICoinsView.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 
 		ICoinsView FilterBy(Func<SmartCoin, bool> expression);
 
-		ICoinsView OutPoints(IEnumerable<OutPoint> outPoints);
+		ICoinsView OutPoints(ISet<OutPoint> outPoints);
 
 		ICoinsView CreatedBy(uint256 txid);
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -16,7 +16,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 	public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>
 	{
 		private Height _height;
-		private int _anonymitySet;
 		private SmartTransaction? _spenderTransaction;
 		private bool _coinJoinInProgress;
 		private DateTimeOffset? _bannedUntilUtc;
@@ -35,7 +34,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 		private Lazy<Coin> _coin;
 		private Lazy<int> _hashCode;
 
-		public SmartCoin(SmartTransaction transaction, uint outputIndex, HdPubKey pubKey, int anonymitySet)
+		public SmartCoin(SmartTransaction transaction, uint outputIndex, HdPubKey pubKey)
 		{
 			Transaction = transaction;
 			Index = outputIndex;
@@ -48,7 +47,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			_hashCode = new Lazy<int>(() => OutPoint.GetHashCode(), true);
 
 			Height = transaction.Height;
-			AnonymitySet = Guard.InRangeAndNotNull(nameof(anonymitySet), anonymitySet, 1, int.MaxValue);
 
 			HdPubKey = pubKey;
 
@@ -78,12 +76,6 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 					Confirmed = _height.Type == HeightType.Chain;
 				}
 			}
-		}
-
-		public int AnonymitySet
-		{
-			get => _anonymitySet;
-			set => RaiseAndSetIfChanged(ref _anonymitySet, value);
 		}
 
 		public SmartTransaction? SpenderTransaction

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -9,9 +10,12 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 {
 	public class ProcessedResult
 	{
+		private Lazy<bool> _isLikelyOwnCoinJoin;
+
 		public ProcessedResult(SmartTransaction transaction)
 		{
 			Transaction = Guard.NotNull(nameof(transaction), transaction);
+			_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.WalletInputs.Any() && Transaction.Transaction.IsLikelyCoinjoin(), true);
 		}
 
 		public SmartTransaction Transaction { get; }
@@ -26,7 +30,7 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 			|| NewlyConfirmedSpentCoins.Any()
 			|| ReceivedDusts.Any(); // To be fair it isn't necessarily news, the algorithm of the processor can be improved for that. Not sure it is worth it though.
 
-		public bool IsLikelyOwnCoinJoin { get; set; } = false;
+		public bool IsLikelyOwnCoinJoin => _isLikelyOwnCoinJoin.Value;
 
 		/// <summary>
 		/// Gets the dust outputs we received in this transaction. We may or may not have known about

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -221,7 +221,6 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 				}
 			}
 
-			bool? isLikelyCj = null;
 			// If spends any of our coin
 			foreach (var coin in Coins.AsAllCoinsView().OutPoints(tx.Transaction.Inputs.Select(x => x.PrevOut).ToHashSet()))
 			{
@@ -238,9 +237,6 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 				{
 					result.NewlyConfirmedSpentCoins.Add(coin);
 				}
-
-				isLikelyCj ??= tx.Transaction.IsLikelyCoinjoin();
-				result.IsLikelyOwnCoinJoin = isLikelyCj is true;
 			}
 
 			if (result.IsNews)

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -281,8 +281,7 @@ namespace WalletWasabi.Blockchain.Transactions
 				var foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
 				if (foundKey is { })
 				{
-					var anonset = tx.GetAnonymitySet(i) + smartTransaction.WalletInputs.Min(x => x.AnonymitySet) - 1; // Minus 1, because count own only once.
-					var smartCoin = new SmartCoin(smartTransaction, i, foundKey, anonset);
+					var smartCoin = new SmartCoin(smartTransaction, i, foundKey);
 					label = SmartLabel.Merge(label, smartCoin.HdPubKey.Label); // foundKey's label is already added to the coinlabel.
 					smartTransaction.WalletOutputs.Add(smartCoin);
 				}

--- a/WalletWasabi/CoinJoin/Client/Rounds/ClientState.cs
+++ b/WalletWasabi/CoinJoin/Client/Rounds/ClientState.cs
@@ -217,7 +217,7 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 						coinGroups = coinGroups.OrderByDescending(x => x.Sum(y => y.Amount)).ToList();
 
 						// Try to register with the smallest anonymity set, so new unmixed coins come to the mix.
-						coinGroups = coinGroups.OrderBy(x => x.Sum(y => y.AnonymitySet)).ToList();
+						coinGroups = coinGroups.OrderBy(x => x.Sum(y => y.HdPubKey.AnonymitySet)).ToList();
 					}
 					else // Else coin merging will happen.
 					{
@@ -225,7 +225,7 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 						coinGroups = coinGroups.OrderBy(x => x.Sum(y => y.Amount)).ToList();
 
 						// Try to register the largest anonymity set, so red and green coins input merging should be less likely.
-						coinGroups = coinGroups.OrderByDescending(x => x.Sum(y => y.AnonymitySet)).ToList();
+						coinGroups = coinGroups.OrderByDescending(x => x.Sum(y => y.HdPubKey.AnonymitySet)).ToList();
 					}
 
 					coinGroups = coinGroups.OrderBy(x => x.Count(y => y.Confirmed == false)).ToList(); // Where the lowest amount of unconfirmed coins there are.
@@ -242,7 +242,7 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 						{
 							// Generating toxic change leads to mass merging so it's better to merge sooner in coinjoin than the user do it himself in a non-CJ.
 							// The best selection's anonset should not be lowered by this merge.
-							int bestMinAnonset = bestSet.Min(x => x.AnonymitySet);
+							int bestMinAnonset = bestSet.Min(x => x.HdPubKey.AnonymitySet);
 							var bestSum = Money.Satoshis(bestSet.Sum(x => x.Amount));
 
 							if (!bestSum.Almost(amountNeeded, Money.Coins(0.0001m)) // Otherwise it wouldn't generate change so consolidation would make no sense.
@@ -251,8 +251,8 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 								IEnumerable<SmartCoin> coinsThatCanBeConsolidated = coins
 									.Except(bestSet) // Get all the registrable coins, except the already chosen ones.
 									.Where(x =>
-										x.AnonymitySet >= bestMinAnonset // The anonset must be at least equal to the bestSet's anonset so we do not ruin the change's after mix anonset.
-										&& x.AnonymitySet > 1 // Red coins should never be merged.
+										x.HdPubKey.AnonymitySet >= bestMinAnonset // The anonset must be at least equal to the bestSet's anonset so we do not ruin the change's after mix anonset.
+										&& x.HdPubKey.AnonymitySet > 1 // Red coins should never be merged.
 										&& x.Amount < amountNeeded // The amount needs to be smaller than the amountNeeded (so to make sure this is toxic change.)
 										&& bestSum + x.Amount > amountNeeded) // Sanity check that the amount added do not ruin the registration.
 									.OrderBy(x => x.Amount); // Choose the smallest ones.

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -393,7 +393,10 @@ namespace WalletWasabi.Wallets
 			KeyManager.AssertNetworkOrClearBlockState(Network);
 			Height bestKeyManagerHeight = KeyManager.GetBestHeight();
 
-			TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
+			using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))
+			{
+				TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
+			}
 
 			// Go through the filters and queue to download the matches.
 			await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -290,7 +290,7 @@ namespace WalletWasabi.Wallets
 						{
 							// If it's being mixed and anonset is not sufficient, then queue it.
 							if (!newCoin.IsSpent() && ChaumianClient.HasIngredients
-								&& newCoin.AnonymitySet < ServiceConfiguration.GetMixUntilAnonymitySetValue())
+								&& newCoin.HdPubKey.AnonymitySet < ServiceConfiguration.GetMixUntilAnonymitySetValue())
 							{
 								coinsToQueue.Add(newCoin);
 							}


### PR DESCRIPTION
Recently we removed the `Label` from `SmartCoin` because it was coming from the `SmartCoin`'s `HdPubKey` anyway.  
Previous PR moved Cluster to `HdPubKey` from `SmartCoin`: https://github.com/zkSNACKs/WalletWasabi/pull/4717

This PR moves anonymity set to `HdPubKey` from `SmartCoin`.
This PR is the final preparation for https://github.com/zkSNACKs/WalletWasabi/pull/4678

This PR accidentally also results in a 50% performance gain in transaction processing on top of the 30% increase in https://github.com/zkSNACKs/WalletWasabi/pull/4717.