### PR TITLE
Remove misleading statement from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 The main privacy features on the network level:
 - Tor-only by default.
 - BIP 158 block filters for private light client.
-- Opt-in connection to user full node.
 
 and on the blockchain level:
 - Intuitive ZeroLink CoinJoin integration.


### PR DESCRIPTION
We don't have a proper full node integration, one would associate from this that we do.