### PR TITLE
[Fluent] Reset navigation when Dialog is using IScreen

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
@@ -52,16 +52,7 @@ namespace WalletWasabi.Fluent.Controls
 			base.OnApplyTemplate(e);
 
 			var overlayButton = e.NameScope.Find<Panel>("PART_Overlay");
-			overlayButton.PointerPressed += (_, __) =>
-			{
-				if (DataContext is IScreen screen)
-				{
-					// Reset navigation when Dialog is using IScreen for navigation instead of the default IDialogHost.
-					screen.Router.NavigationStack.Clear();
-				}
-
-				IsDialogOpen = false;
-			};
+			overlayButton.PointerPressed += (_, __) => IsDialogOpen = false;
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using ReactiveUI;
 
 namespace WalletWasabi.Fluent.Controls
 {

--- a/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using ReactiveUI;
 
 namespace WalletWasabi.Fluent.Controls
 {
@@ -51,7 +52,16 @@ namespace WalletWasabi.Fluent.Controls
 			base.OnApplyTemplate(e);
 
 			var overlayButton = e.NameScope.Find<Panel>("PART_Overlay");
-			overlayButton.PointerPressed += (_, __) => IsDialogOpen = false;
+			overlayButton.PointerPressed += (_, __) =>
+			{
+				if (DataContext is IScreen screen)
+				{
+					// Reset navigation when Dialog is using IScreen for navigation instead of the default IDialogHost.
+					screen.Router.NavigationStack.Clear();
+				}
+
+				IsDialogOpen = false;
+			};
 		}
 	}
 }


### PR DESCRIPTION
Fixes:

> bottom left click Settings -  click Add Wallet - click outside the dialog screen - notice the focus is still on Add Wallet, but the Settings content is shown in tab - now click Add Wallet again, notice it does not open the dialog screen again - click Settings, notice tab content refreshes - now click Add Wallet and see it opens the dialog screen again.
