### PR TITLE
Remove AsyncMutex in SingleInstanceChecker

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -754,9 +754,7 @@ namespace WalletWasabi.Gui
 
 				try
 				{
-					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
-					await SingleInstanceChecker.StopAsync(cts.Token).ConfigureAwait(false);
-					SingleInstanceChecker.Dispose();
+					await SingleInstanceChecker.DisposeAsync().ConfigureAwait(false);
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -754,7 +754,9 @@ namespace WalletWasabi.Gui
 
 				try
 				{
-					SingleInstanceChecker?.Dispose();
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
+					await SingleInstanceChecker.StopAsync(cts.Token).ConfigureAwait(false);
+					SingleInstanceChecker.Dispose();
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
@@ -16,27 +16,27 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 			string mainLockName = GenerateLockName(Network.Main);
 
 			// Disposal test.
-			using (SingleInstanceChecker sic = new SingleInstanceChecker(Network.Main, mainLockName))
+			await using (SingleInstanceChecker sic = new SingleInstanceChecker(Network.Main, mainLockName))
 			{
 				await sic.CheckAsync();
 			}
 
 			// Check different networks.
-			using (SingleInstanceChecker sic = new SingleInstanceChecker(Network.Main, mainLockName))
+			await using (SingleInstanceChecker sic = new SingleInstanceChecker(Network.Main, mainLockName))
 			{
 				await sic.CheckAsync();
 				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sic.CheckAsync());
 
-				using SingleInstanceChecker sicMainNet2 = new SingleInstanceChecker(Network.Main, mainLockName);
+				await using SingleInstanceChecker sicMainNet2 = new SingleInstanceChecker(Network.Main, mainLockName);
 				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicMainNet2.CheckAsync());
 
 				string testnetLockName = GenerateLockName(Network.TestNet);
-				using SingleInstanceChecker sicTestNet = new SingleInstanceChecker(Network.TestNet, testnetLockName);
+				await using SingleInstanceChecker sicTestNet = new SingleInstanceChecker(Network.TestNet, testnetLockName);
 				await sicTestNet.CheckAsync();
 				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicTestNet.CheckAsync());
 
 				string regtestLockName = GenerateLockName(Network.RegTest);
-				using SingleInstanceChecker sicRegTest = new SingleInstanceChecker(Network.RegTest, regtestLockName);
+				await using SingleInstanceChecker sicRegTest = new SingleInstanceChecker(Network.RegTest, regtestLockName);
 				await sicRegTest.CheckAsync();
 				await Assert.ThrowsAsync<InvalidOperationException>(async () => await sicRegTest.CheckAsync());
 			}

--- a/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Services;
 using Xunit;
+using WalletWasabi.Logging;
 
 namespace WalletWasabi.Tests.UnitTests.Clients
 {
@@ -14,6 +15,7 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 		[Fact]
 		public async Task SingleInstanceTestsAsync()
 		{
+			Logger.LogInfo("Started test 1");
 			string mainLockName = GenerateLockName(Network.Main);
 
 			// Disposal test.
@@ -46,6 +48,7 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 		[Fact]
 		public async Task OtherInstanceStartedTestsAsync()
 		{
+			Logger.LogInfo("Started test 2");
 			string mainLockName = GenerateLockName(Network.Main);
 
 			// Disposal test.

--- a/WalletWasabi/Services/SingleInstanceChecker.cs
+++ b/WalletWasabi/Services/SingleInstanceChecker.cs
@@ -106,7 +106,7 @@ namespace WalletWasabi.Services
 					server.Disconnect();
 				}
 			}
-			catch (Exception ex) when (!(ex is OperationCanceledException))
+			catch (Exception ex) when (ex is not OperationCanceledException)
 			{
 				// If something happened we are not trying to recover the NamedPipeServerStream.
 				Logger.LogError(ex);

--- a/WalletWasabi/Services/SingleInstanceChecker.cs
+++ b/WalletWasabi/Services/SingleInstanceChecker.cs
@@ -33,6 +33,8 @@ namespace WalletWasabi.Services
 			PipeName = $"{PipeNamePrefix}-{lockName}";
 		}
 
+		public event EventHandler? OtherInstanceStarted;
+
 		private Network Network { get; }
 
 		private string PipeName { get; }
@@ -90,7 +92,9 @@ namespace WalletWasabi.Services
 				while (!stoppingToken.IsCancellationRequested)
 				{
 					await server.WaitForConnectionAsync(stoppingToken).ConfigureAwait(false);
-					Logger.LogInfo("Got a connection!");
+					Logger.LogDebug("Other instance connected!");
+
+					OtherInstanceStarted?.Invoke(this, EventArgs.Empty);
 
 					// Disconnect the client to be able to wait for another connection.
 					server.Disconnect();

--- a/WalletWasabi/Services/SingleInstanceChecker.cs
+++ b/WalletWasabi/Services/SingleInstanceChecker.cs
@@ -13,7 +13,6 @@ namespace WalletWasabi.Services
 	public class SingleInstanceChecker : BackgroundService, IAsyncDisposable
 	{
 		private const string PipeNamePrefix = "WalletWasabiSingleInstance";
-		private bool _disposed;
 
 		/// <summary>
 		/// Creates a new instance of the object where lock name is based on <paramref name="network"/> name.


### PR DESCRIPTION
To be able to show up the Wasabi window when running Wasabi twice, the latter instance needs to signal the first in some way before exiting with the message: ''Wasabi is already running'. This leads to the fact that we need some kind of inter-process communication. At the first glance, I was thinking of some kind of socket server but that would involve the network, even if it is localhost and probably annoy the firewalls as well. I found NamedPipes that we haven't used yet but it seems to be the optimal solution. 

Meta goal -> we might be able to remove AsyncMutex class entirely. 

I also started to use DisposeAsync class.

https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#implement-both-dispose-and-async-dispose-patterns