### PR TITLE
BobClient without being disposable.

### DIFF
--- a/WalletWasabi/CoinJoin/Client/Clients/BobClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/BobClient.cs
@@ -1,26 +1,23 @@
-using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using WalletWasabi.CoinJoin.Common.Models;
 using WalletWasabi.Helpers;
-using WalletWasabi.Tor.Http.Bases;
+using WalletWasabi.Tor.Http;
 using WalletWasabi.Tor.Http.Extensions;
 using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.CoinJoin.Client.Clients
 {
-	public class BobClient : TorDisposableBase
+	public class BobClient
 	{
 		/// <inheritdoc/>
-		public BobClient(Func<Uri> baseUriAction, EndPoint torSocks5EndPoint) : base(baseUriAction, torSocks5EndPoint)
+		public BobClient(IRelativeHttpClient httpClient)
 		{
+			HttpClient = httpClient;
 		}
 
-		/// <inheritdoc/>
-		public BobClient(Uri baseUri, EndPoint torSocks5EndPoint) : base(baseUri, torSocks5EndPoint)
-		{
-		}
+		private IRelativeHttpClient HttpClient { get; }
 
 		/// <returns>If the phase is still in OutputRegistration.</returns>
 		public async Task<bool> PostOutputAsync(long roundId, ActiveOutput activeOutput)
@@ -29,7 +26,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			Guard.NotNull(nameof(activeOutput), activeOutput);
 
 			var request = new OutputRequest { OutputAddress = activeOutput.Address, UnblindedSignature = activeOutput.Signature, Level = activeOutput.MixingLevel };
-			using var response = await TorClient.SendAsync(HttpMethod.Post, $"/api/v{WasabiClient.ApiVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()).ConfigureAwait(false);
+			using var response = await HttpClient.SendAsync(HttpMethod.Post, $"/api/v{WasabiClient.ApiVersion}/btc/chaumiancoinjoin/output?roundId={roundId}", request.ToHttpStringContent()).ConfigureAwait(false);
 			if (response.StatusCode == HttpStatusCode.Conflict)
 			{
 				return false;

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -427,11 +427,14 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			shuffledOutputs.Shuffle();
 			foreach (var activeOutput in shuffledOutputs)
 			{
-				using var bobClient = new BobClient(CcjHostUriAction, TorSocks5EndPoint);
-				if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput).ConfigureAwait(false))
+				using (TorHttpClient torHttpClient = Synchronizer.WasabiClientFactory.NewBackendTorHttpClient(isolateStream: true))
 				{
-					Logger.LogWarning($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.");
-					break;
+					var bobClient = new BobClient(torHttpClient);
+					if (!await bobClient.PostOutputAsync(ongoingRound.RoundId, activeOutput).ConfigureAwait(false))
+					{
+						Logger.LogWarning($"Round ({ongoingRound.State.RoundId}) Bobs did not have enough time to post outputs before timeout. If you see this message, contact nopara73, so he can optimize the phase timeout periods to the worst Internet/Tor connections, which may be yours.");
+						break;
+					}
 				}
 
 				// Unblind our exposed links.


### PR DESCRIPTION
Please review with hidden whitespace changes: https://github.com/zkSNACKs/WalletWasabi/pull/4757/files?diff=split&w=1

The goal here is to remove dependency on `TorDisposable` as was done for `SatoshiClient` already.

I'm not sure how to correctly run `CoinJoinTests`. Does anyone know? Hm, looks like one by one. 