### PR TITLE
Use 'AsSpan' instead of the 'System.Range'-based indexer on 'byte[]' to avoid creating unnecessary data copies

### DIFF
--- a/WalletWasabi/Crypto/Groups/GroupElement.cs
+++ b/WalletWasabi/Crypto/Groups/GroupElement.cs
@@ -173,8 +173,8 @@ namespace WalletWasabi.Crypto.Groups
 			return bytes[0] switch
 			{
 				0 => Infinity,
-				GE.SECP256K1_TAG_PUBKEY_ODD => Parse(bytes[1..], isOdd: true),
-				GE.SECP256K1_TAG_PUBKEY_EVEN => Parse(bytes[1..], isOdd: false),
+				GE.SECP256K1_TAG_PUBKEY_ODD => Parse(bytes.AsSpan()[1..], isOdd: true),
+				GE.SECP256K1_TAG_PUBKEY_EVEN => Parse(bytes.AsSpan()[1..], isOdd: false),
 				_ => throw new ArgumentException($"Argument is not a well-formatted group element.", nameof(bytes))
 			};
 		}


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1833

> Using a range-indexer on array and assigning to a memory or span type: The range indexer on a Span<T> is a non-copying Slice operation, but for the range indexer on array the method GetSubArray will be used instead of Slice, which produces a copy of requested portion of the array. This copy is usually unnecessary when it is implicitly used as a Span<T> or Memory<T> value. If a copy isn't intended, use the AsSpan or AsMemory method to avoid the unnecessary copy.