### PR TITLE
Remove confawait check from the GUI project.

### DIFF
--- a/WalletWasabi.Gui/.editorconfig
+++ b/WalletWasabi.Gui/.editorconfig
@@ -1,0 +1,8 @@
+root = false
+
+# Code files
+[*.cs]
+
+# CA2007: Do not directly await a Task
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none 


### PR DESCRIPTION
This is wrong, because UI thread sync back is preferable. https://github.com/zkSNACKs/WalletWasabi/pull/4771