### PR TITLE
Avoid using the same DNS records for good in ClearnetHttpClient

### DIFF
--- a/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
+++ b/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
@@ -17,7 +17,8 @@ namespace WalletWasabi.Tor.Http
 		{
 			var socketHandler = new SocketsHttpHandler()
 			{
-				AutomaticDecompression = DecompressionMethods.All,
+				// Only GZip is currently used by Wasabi Backend.
+				AutomaticDecompression = DecompressionMethods.GZip,
 				PooledConnectionLifetime = TimeSpan.FromMinutes(5)
 			};
 

--- a/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
+++ b/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
@@ -15,11 +15,15 @@ namespace WalletWasabi.Tor.Http
 	{
 		static ClearnetHttpClient()
 		{
-			HttpClient = new HttpClient(new HttpClientHandler()
+			var socketHandler = new SocketsHttpHandler()
 			{
-				AutomaticDecompression = DecompressionMethods.GZip,
-				SslProtocols = IHttpClient.SupportedSslProtocols
-			});
+				AutomaticDecompression = DecompressionMethods.All,
+				PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+			};
+
+			socketHandler.SslOptions.EnabledSslProtocols = IHttpClient.SupportedSslProtocols;
+
+			HttpClient = new HttpClient(socketHandler);
 		}
 
 		public ClearnetHttpClient(Func<Uri> destinationUriAction)


### PR DESCRIPTION
This PR solves one issue that is far from being clear from [HttpClient ](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-5.0) documentation. The documentation mentions

> HttpClient is intended to be instantiated once and re-used throughout the life of an application. Instantiating an HttpClient class for every request will exhaust the number of sockets available under heavy loads. This will result in SocketException errors. Below is an example using HttpClient correctly.

However, one [gotcha](https://github.com/dotnet/extensions/issues/1345#issuecomment-480548175) of that is that DNS records won't get refreshed *at all*. This PR fixes that by setting [SocketsHttpHandler.PooledConnectionLifetime](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.pooledconnectionlifetime?view=net-5.0#remarks).

The interval of 5 minutes may or may not be reasonable. It depends on what HTTP(s) requests are being made and I don't know that answer really. It may be aggressive or it may be too slow. So I hope that somebody will weigh in and decide that.

Notes:

* `AutomaticDecompression = DecompressionMethods.GZip` was changed to `AutomaticDecompression = DecompressionMethods.All` ([link](https://docs.microsoft.com/en-us/dotnet/api/system.net.decompressionmethods?f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(System.Net.DecompressionMethods.All);k(DevLang-csharp)%26rd%3Dtrue&view=net-5.0)) as it looks like there is no downside in doing that. Can you see any?