### PR TITLE
Minor refactoring in TorTests.

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using WalletWasabi.Tor;
 using WalletWasabi.Tor.Http;
@@ -35,7 +34,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task CanRequestChunkEncodedAsync()
 		{
-			using var client = new TorHttpClient(new Uri("http://anglesharp.azurewebsites.net/"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("http://anglesharp.azurewebsites.net/"));
 			var response = await client.SendAsync(HttpMethod.Get, "Chunked");
 			var content = await response.Content.ReadAsStringAsync();
 			Assert.Contains("Chunked transfer encoding test", content);
@@ -44,18 +43,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 		}
 
 		[Fact]
-		public async Task CanRequestClearnetAsync()
-		{
-			using var client = new TorHttpClient(new Uri("https://jigsaw.w3.org/"), null);
-			var response = await client.SendAsync(HttpMethod.Get, "/HTTP/ChunkedScript");
-			var content = await response.Content.ReadAsStringAsync();
-			Assert.Equal(1000, Regex.Matches(content, "01234567890123456789012345678901234567890123456789012345678901234567890").Count);
-		}
-
-		[Fact]
 		public async Task CanDoBasicPostHttpsRequestAsync()
 		{
-			using var client = new TorHttpClient(new Uri("https://postman-echo.com"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("https://postman-echo.com"));
 			HttpContent content = new StringContent("This is expected to be sent back as part of response body.");
 
 			HttpResponseMessage message = await client.SendAsync(HttpMethod.Post, "post", content);
@@ -68,8 +58,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task TorIpIsNotTheRealOneAsync()
 		{
 			var requestUri = "https://api.ipify.org/";
-			IPAddress realIp;
-			IPAddress torIp;
+			IPAddress? realIp;
+			IPAddress? torIp;
 
 			// 1. Get real IP
 			using (var httpClient = new HttpClient())
@@ -80,7 +70,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 
 			// 2. Get Tor IP
-			using (var client = new TorHttpClient(new Uri(requestUri), Common.TorSocks5Endpoint))
+			using (var client = MakeTorHttpClient(new Uri(requestUri)))
 			{
 				var content = await (await client.SendAsync(HttpMethod.Get, "")).Content.ReadAsStringAsync();
 				var gotIp = IPAddress.TryParse(content.Replace("\n", ""), out torIp);
@@ -93,7 +83,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task CanDoHttpsAsync()
 		{
-			using var client = new TorHttpClient(new Uri("https://postman-echo.com"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("https://postman-echo.com"));
 			var content = await (await client.SendAsync(HttpMethod.Get, "get?foo1=bar1&foo2=bar2")).Content.ReadAsStringAsync();
 
 			Assert.Contains("{\"args\":{\"foo1\":\"bar1\",\"foo2\":\"bar2\"}", content);
@@ -102,7 +92,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task CanDoIpAddressAsync()
 		{
-			using var client = new TorHttpClient(new Uri("http://172.217.6.142"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("http://172.217.6.142"));
 			var content = await (await client.SendAsync(HttpMethod.Get, "")).Content.ReadAsStringAsync();
 
 			Assert.NotEmpty(content);
@@ -111,7 +101,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task CanRequestInRowAsync()
 		{
-			using var client = new TorHttpClient(new Uri("http://api.qbit.ninja"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("http://api.qbit.ninja"));
 			await (await client.SendAsync(HttpMethod.Get, "/transactions/38d4cfeb57d6685753b7a3b3534c3cb576c34ca7344cd4582f9613ebf0c2b02a?format=json&headeronly=true")).Content.ReadAsStringAsync();
 			await (await client.SendAsync(HttpMethod.Get, "/balances/15sYbVpRh6dyWycZMwPdxJWD4xbfxReeHe?unspentonly=true")).Content.ReadAsStringAsync();
 			await (await client.SendAsync(HttpMethod.Get, "balances/akEBcY5k1dn2yeEdFnTMwdhVbHxtgHb6GGi?from=tip&until=336000")).Content.ReadAsStringAsync();
@@ -120,7 +110,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task CanRequestOnionV2Async()
 		{
-			using var client = new TorHttpClient(new Uri("http://expyuzz4wqqyqhjn.onion/"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("http://expyuzz4wqqyqhjn.onion/"));
 			HttpResponseMessage response = await client.SendAsync(HttpMethod.Get, "");
 			var content = await response.Content.ReadAsStringAsync();
 
@@ -132,7 +122,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task CanRequestOnionV3Async()
 		{
-			using var client = new TorHttpClient(new Uri("http://www.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion"), Common.TorSocks5Endpoint);
+			using var client = MakeTorHttpClient(new Uri("http://www.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion"));
 			HttpResponseMessage response = await client.SendAsync(HttpMethod.Get, "");
 			var content = await response.Content.ReadAsStringAsync();
 
@@ -144,9 +134,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task DoesntIsolateStreamsAsync()
 		{
-			using var c1 = new TorHttpClient(new Uri("http://api.ipify.org"), Common.TorSocks5Endpoint);
-			using var c2 = new TorHttpClient(new Uri("http://api.ipify.org"), Common.TorSocks5Endpoint);
-			using var c3 = new TorHttpClient(new Uri("http://api.ipify.org"), Common.TorSocks5Endpoint);
+			using var c1 = MakeTorHttpClient(new Uri("http://api.ipify.org"));
+			using var c2 = MakeTorHttpClient(new Uri("http://api.ipify.org"));
+			using var c3 = MakeTorHttpClient(new Uri("http://api.ipify.org"));
 			var t1 = c1.SendAsync(HttpMethod.Get, "");
 			var t2 = c2.SendAsync(HttpMethod.Get, "");
 			var t3 = c3.SendAsync(HttpMethod.Get, "");
@@ -164,9 +154,9 @@ namespace WalletWasabi.Tests.IntegrationTests
 		[Fact]
 		public async Task IsolatesStreamsAsync()
 		{
-			using var c1 = new TorHttpClient(new Uri("http://api.ipify.org"), Common.TorSocks5Endpoint, isolateStream: true);
-			using var c2 = new TorHttpClient(new Uri("http://api.ipify.org"), Common.TorSocks5Endpoint, isolateStream: true);
-			using var c3 = new TorHttpClient(new Uri("http://api.ipify.org"), Common.TorSocks5Endpoint, isolateStream: true);
+			using var c1 = MakeTorHttpClient(new Uri("http://api.ipify.org"), isolateStream: true);
+			using var c2 = MakeTorHttpClient(new Uri("http://api.ipify.org"), isolateStream: true);
+			using var c3 = MakeTorHttpClient(new Uri("http://api.ipify.org"), isolateStream: true);
 			var t1 = c1.SendAsync(HttpMethod.Get, "");
 			var t2 = c2.SendAsync(HttpMethod.Get, "");
 			var t3 = c3.SendAsync(HttpMethod.Get, "");
@@ -198,7 +188,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 				var task = client.SendAsync(HttpMethod.Get, relativetUri);
 				if (alterRequests)
 				{
-					using var ipClient = new TorHttpClient(new Uri("https://api.ipify.org/"), Common.TorSocks5Endpoint);
+					using var ipClient = MakeTorHttpClient(new Uri("https://api.ipify.org/"));
 					var task2 = ipClient.SendAsync(HttpMethod.Get, "/");
 					tasks.Add(task2);
 				}
@@ -214,6 +204,11 @@ namespace WalletWasabi.Tests.IntegrationTests
 			}
 
 			return contents;
+		}
+
+		private static TorHttpClient MakeTorHttpClient(Uri uri, bool isolateStream = false)
+		{
+			return new TorHttpClient(uri, Common.TorSocks5Endpoint, isolateStream);
 		}
 	}
 }


### PR DESCRIPTION
`TorHttpClient` is not supposed to be used for clearnet requests - `CanRequestClearnetAsync` was removed.