### PR TITLE
PayjoinClient accepts HttpClient only through IRelativeHttpClient now.

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -17,6 +17,7 @@ using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.PayJoin;
 using WalletWasabi.Gui.Validation;
 using WalletWasabi.Logging;
+using WalletWasabi.Tor.Http;
 
 namespace WalletWasabi.Gui.Controls.WalletExplorer
 {
@@ -122,7 +123,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 					}
 				}
 
-				return new PayjoinClient(payjoinEndPointUri, Global.Config.TorSocks5EndPoint);
+				IRelativeHttpClient httpClient = Global.Synchronizer.WasabiClientFactory.NewHttpClient(() => payjoinEndPointUri, isolateStream: false);
+				return new PayjoinClient(payjoinEndPointUri, httpClient);
 			}
 
 			return null;

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -64,7 +64,6 @@ namespace WalletWasabi.Gui
 		public TransactionBroadcaster TransactionBroadcaster { get; set; }
 		public CoinJoinProcessor CoinJoinProcessor { get; set; }
 		public Node RegTestMempoolServingNode { get; private set; }
-		public EndPoint? TorSocks5EndPoint { get; private set; }
 		private TorProcessManager? TorManager { get; set; }
 		public CoreNode BitcoinCoreNode { get; private set; }
 
@@ -170,10 +169,6 @@ namespace WalletWasabi.Gui
 					var fallbackRequestTestUri = new Uri(Config.GetFallbackBackendUri(), "/api/software/versions");
 
 					HostedServices.Register(new TorMonitor(period: TimeSpan.FromSeconds(3), fallbackRequestTestUri, Config.TorSocks5EndPoint, TorManager), nameof(TorMonitor));
-				}
-				else
-				{
-					TorSocks5EndPoint = null;
 				}
 
 				Logger.LogInfo($"{nameof(TorProcessManager)} is initialized.");

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -86,7 +86,7 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 		private async Task BroadcastTransactionToBackendAsync(SmartTransaction transaction)
 		{
 			Logger.LogInfo("Broadcasting with backend...");
-			using (TorHttpClient torHttpClient = Synchronizer.WasabiClientFactory.NewTorHttpClient(isolateStream: true))
+			using (TorHttpClient torHttpClient = Synchronizer.WasabiClientFactory.NewBackendTorHttpClient(isolateStream: true))
 			{
 				var client = new WasabiClient(torHttpClient);
 

--- a/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -19,23 +18,13 @@ namespace WalletWasabi.WebClients.PayJoin
 {
 	public class PayjoinClient : IPayjoinClient
 	{
-		public PayjoinClient(Uri paymentUrl, EndPoint torSocks5EndPoint)
-		{
-			// This can be null if Tor is turned off - and it is OK.
-			TorSocks5EndPoint = torSocks5EndPoint;
-			PaymentUrl = Guard.NotNull(nameof(paymentUrl), paymentUrl);
-			TorHttpClient = new TorHttpClient(PaymentUrl, TorSocks5EndPoint);
-		}
-
-		// For testing only
-		internal PayjoinClient(Uri paymentUrl, IRelativeHttpClient httpClient)
+		public PayjoinClient(Uri paymentUrl, IRelativeHttpClient httpClient)
 		{
 			PaymentUrl = paymentUrl;
-			TorHttpClient = Guard.NotNull(nameof(httpClient), httpClient);
+			TorHttpClient = httpClient;
 		}
 
 		public Uri PaymentUrl { get; }
-		private EndPoint TorSocks5EndPoint { get; }
 		private IRelativeHttpClient TorHttpClient { get; }
 
 		public async Task<PSBT> RequestPayjoin(PSBT originalTx, IHDKey accountKey, RootedKeyPath rootedKeyPath, HdPubKey changeHdPubKey, CancellationToken cancellationToken)

--- a/WalletWasabi/WebClients/Wasabi/WasabiClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClientFactory.cs
@@ -74,7 +74,6 @@ namespace WalletWasabi.WebClients.Wasabi
 			return new TorHttpClient(BackendUriGetter, TorEndpoint, isolateStream);
 		}
 
-
 		// Protected implementation of Dispose pattern.
 		protected virtual void Dispose(bool disposing)
 		{

--- a/WalletWasabi/WebClients/Wasabi/WasabiClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClientFactory.cs
@@ -51,6 +51,30 @@ namespace WalletWasabi.WebClients.Wasabi
 			return new TorHttpClient(BackendUriGetter.Invoke(), TorEndpoint, isolateStream: isolateStream);
 		}
 
+		/// <summary>
+		/// Creates new <see cref="TorHttpClient"/> or <see cref="ClearnetHttpClient"/> based on user settings.
+		/// </summary>
+		public IRelativeHttpClient NewHttpClient(Func<Uri> baseUriFn, bool isolateStream)
+		{
+			if (TorEndpoint is { })
+			{
+				return new TorHttpClient(baseUriFn, TorEndpoint, isolateStream);
+			}
+			else
+			{
+				return new ClearnetHttpClient(baseUriFn);
+			}
+		}
+
+		/// <summary>
+		/// Creates new <see cref="TorHttpClient"/> instance with correctly set backend URL.
+		/// </summary>
+		public TorHttpClient NewBackendTorHttpClient(bool isolateStream)
+		{
+			return new TorHttpClient(BackendUriGetter, TorEndpoint, isolateStream);
+		}
+
+
 		// Protected implementation of Dispose pattern.
 		protected virtual void Dispose(bool disposing)
 		{
@@ -75,14 +99,6 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
-		}
-
-		/// <summary>
-		/// Creates new <see cref="TorHttpClient"/>.
-		/// </summary>
-		public TorHttpClient NewBackendTorHttpClient(bool isolateStream)
-		{
-			return new TorHttpClient(BackendUriGetter, TorEndpoint, isolateStream);
 		}
 	}
 }


### PR DESCRIPTION
PR notes:

* Removes one property from `Global` - namely `TorSocks5EndPoint`.
* `PayjoinClient` accepts an HttpClient only through `IRelativeHttpClient` now.
* `NewBackendTorHttpClient` and `NewTorHttpClient` did basically the same. That was a mistake.
* New method was added `WasabiClientFactory.NewHttpClient` to get `IRelativeHttpClient` that is correctly created.