### PR TITLE
Add KeyPaths first to PSBT

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -218,8 +218,8 @@ namespace WalletWasabi.Blockchain.Transactions
 			Logger.LogInfo("Signing transaction...");
 			// It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
 
-			psbt.AddPrevTxs(TransactionStore);
 			psbt.AddKeyPaths(KeyManager);
+			psbt.AddPrevTxs(TransactionStore);
 
 			Transaction tx;
 			if (KeyManager.IsWatchOnly)
@@ -238,8 +238,8 @@ namespace WalletWasabi.Blockchain.Transactions
 				{
 					psbt = TryNegotiatePayjoin(payjoinClient, builder, psbt, changeHdPubKey);
 					isPayjoin = true;
-					psbt.AddPrevTxs(TransactionStore);
 					psbt.AddKeyPaths(KeyManager);
+					psbt.AddPrevTxs(TransactionStore);
 				}
 
 				psbt.Finalize();

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -446,7 +446,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Tries to equip the PSBT with previous transactions with best effort. Always <see cref="AddKeyPath"/> first otherwise the prev tx won't be added.
+		/// Tries to equip the PSBT with previous transactions with best effort. Always <see cref="AddKeyPaths"/> first otherwise the prev tx won't be added.
 		/// </summary>
 		public static void AddPrevTxs(this PSBT psbt, AllTransactionStore transactionStore)
 		{

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -446,7 +446,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Tries to equip the PSBT with previous transactions with best effort.
+		/// Tries to equip the PSBT with previous transactions with best effort. Always <see cref="AddKeyPath"/> first otherwise the prev tx won't be added.
 		/// </summary>
 		public static void AddPrevTxs(this PSBT psbt, AllTransactionStore transactionStore)
 		{


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/4689

The feature was broken by https://github.com/zkSNACKs/WalletWasabi/pull/4608 when the order of adding more information to PSBT was changed. 