### PR TITLE
Upgrade Windows CI vmImage

### DIFF
--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET'


### PR DESCRIPTION
Trying to find out why windows CI is the weakest point now. We are using an older vmImage. 