### PR TITLE
Add code quality rule (CA1829: Use Length/Count property instead of Enumerable.Count method)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -245,3 +245,6 @@ csharp_style_pattern_matching_over_as_with_null_check = true:error
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
 dotnet_diagnostic.CA2016.severity = warning
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = warning

--- a/WalletWasabi.Gui/Rpc/JsonRpcRequestHandler.cs
+++ b/WalletWasabi.Gui/Rpc/JsonRpcRequestHandler.cs
@@ -113,7 +113,7 @@ namespace WalletWasabi.Gui.Rpc
 						$"{methodParameters.Count} parameters were expected but {parameters.Count} were received.", jsonRpcRequest.Id);
 				}
 
-				var missingParameters = methodParameters.Count() - parameters.Count();
+				var missingParameters = methodParameters.Count - parameters.Count;
 				parameters.AddRange(methodParameters.TakeLast(missingParameters).Select(x => x.defaultValue));
 				var result = prodecureMetadata.MethodInfo.Invoke(Service, parameters.ToArray());
 

--- a/WalletWasabi.Tests/UnitTests/Clients/WasabiClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/WasabiClientTests.cs
@@ -54,7 +54,7 @@ namespace WalletWasabi.Tests.UnitTests.Clients
 			searchedTxIds = mempool.Select(x => x.GetHash());
 			txs = await client.GetTransactionsAsync(Network.Main, searchedTxIds, CancellationToken.None);
 			Assert.Equal(1_100, txs.Count());
-			Assert.Equal(1_000, WasabiClient.TransactionCache.Count());
+			Assert.Equal(1_000, WasabiClient.TransactionCache.Count);
 
 			Assert.Subset(WasabiClient.TransactionCache.Keys.ToHashSet(), txs.TakeLast(1_000).Select(x => x.GetHash()).ToHashSet());
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/TranscriptTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/TranscriptTests.cs
@@ -160,7 +160,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 
 			var secretNonce = secretNonceProvider.GetScalarVector();
 
-			Assert.Equal(secretNonce.Count(), witness.Length);
+			Assert.Equal(secretNonce.Count, witness.Length);
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/NBitcoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/NBitcoinTests.cs
@@ -43,13 +43,13 @@ namespace WalletWasabi.Tests.UnitTests
 			var graph = new[] { tx0, tx1, tx2, tx7, tx5, tx3, tx4, tx6 }.ToDependencyGraph();
 
 			Assert.Equal(3, graph.Count());  // tx0, tx1 and tx2
-			Assert.Equal(2, graph.First().Children.Count());  // tx0 has two children tx3 and tx4
-			Assert.Equal(2, graph.Skip(1).First().Children.Count());  // tx1 has two children tx3 and tx4
+			Assert.Equal(2, graph.First().Children.Count);  // tx0 has two children tx3 and tx4
+			Assert.Equal(2, graph.Skip(1).First().Children.Count);  // tx1 has two children tx3 and tx4
 			Assert.Single(graph.Last().Children);  // tx2 has only one children tx7
-			Assert.Equal(2, graph.Last().Children.Single().Parents.Count());  // tx7 has two parents tx2 and tx6
+			Assert.Equal(2, graph.Last().Children.Single().Parents.Count);  // tx7 has two parents tx2 and tx6
 
 			var txs = graph.OrderByDependency().ToArray();
-			Assert.Equal(8, txs.Count());
+			Assert.Equal(8, txs.Length);
 			Assert.Equal(tx0, txs[0]);
 			Assert.Equal(tx1, txs[1]);
 			Assert.Equal(tx2, txs[2]);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -76,7 +76,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Equal(200, spentCoin.HdPubKey.AnonymitySet);
 			Assert.False(result.SpendsUnconfirmed);
 			var tx = result.Transaction.Transaction;
-			Assert.Equal(2, tx.Outputs.Count());
+			Assert.Equal(2, tx.Outputs.Count);
 
 			var changeCoin = Assert.Single(result.InnerWalletOutputs);
 			Assert.True(changeCoin.HdPubKey.IsInternal);
@@ -104,7 +104,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Equal(200, spentCoin.HdPubKey.AnonymitySet);
 			Assert.False(result.SpendsUnconfirmed);
 			var tx = result.Transaction.Transaction;
-			Assert.Equal(2, tx.Outputs.Count());
+			Assert.Equal(2, tx.Outputs.Count);
 
 			var changeCoin = Assert.Single(result.InnerWalletOutputs);
 			Assert.True(changeCoin.HdPubKey.IsInternal);
@@ -139,7 +139,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.False(result.SpendsUnconfirmed);
 
 			var tx = result.Transaction.Transaction;
-			Assert.Equal(2, tx.Outputs.Count());
+			Assert.Equal(2, tx.Outputs.Count);
 		}
 
 		[Fact]
@@ -170,7 +170,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// it must select the unconfirm coin even when the anonymity set is lower
 			Assert.True(result.SpendsUnconfirmed);
-			Assert.Equal(2, tx.Outputs.Count());
+			Assert.Equal(2, tx.Outputs.Count);
 		}
 
 		[Fact]
@@ -283,7 +283,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Equal(Money.Coins(1m), result.SpentCoins.Select(x => x.Amount).Sum());
 
 			var tx = result.Transaction.Transaction;
-			Assert.Equal(2, tx.Outputs.Count());
+			Assert.Equal(2, tx.Outputs.Count);
 
 			var changeOutput = Assert.Single(tx.Outputs, x => x.ScriptPubKey == changeDestination);
 			Assert.Null(transactionFactory.KeyManager.GetKeyForScriptPubKey(changeOutput.ScriptPubKey));
@@ -315,7 +315,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Equal(Money.Coins(1m), spentCoin.Amount);
 
 			var tx = result.Transaction.Transaction;
-			Assert.Equal(4, tx.Outputs.Count());
+			Assert.Equal(4, tx.Outputs.Count);
 
 			var destination2Output = Assert.Single(tx.Outputs, x => x.ScriptPubKey == destination2);
 			Assert.Equal(Money.Coins(0.3m), destination2Output.Value + result.Fee);
@@ -370,7 +370,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Equal(Money.Coins(1m), spentCoin.Amount);
 
 			var tx = result.Transaction.Transaction;
-			Assert.Equal(2, tx.Outputs.Count()); // consolidates same address payment
+			Assert.Equal(2, tx.Outputs.Count); // consolidates same address payment
 
 			var destinationOutput = Assert.Single(result.OuterWalletOutputs);
 			Assert.Equal(destination, destinationOutput.ScriptPubKey);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -315,7 +315,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 					Assert.Equal(Money.Coins(1.0m), originalCoin.Amount);
 
 					// Remove the created coin by the transaction.
-					Assert.Equal(3, e.ReplacedCoins.Count());
+					Assert.Equal(3, e.ReplacedCoins.Count);
 					Assert.Single(e.ReplacedCoins, coin => coin.HdPubKey.Label == "B");
 					Assert.Single(e.ReplacedCoins, coin => coin.HdPubKey.Label == "C");
 					Assert.Single(e.ReplacedCoins, coin => coin.HdPubKey.Label == "D");

--- a/WalletWasabi.Tests/UnitTests/Wabisabi/CredentialTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wabisabi/CredentialTests.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Tests.UnitTests.Wabisabi
 
 				Assert.False(credentialRequest.IsNullRequest);
 				var credentialRequested = credentialRequest.Requested.ToArray();
-				Assert.Equal(numberOfCredentials, credentialRequested.Count());
+				Assert.Equal(numberOfCredentials, credentialRequested.Length);
 				Assert.NotEmpty(credentialRequested[0].BitCommitments);
 				Assert.NotEmpty(credentialRequested[1].BitCommitments);
 
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.Wabisabi
 
 				Assert.False(credentialRequest.IsNullRequest);
 				var requested = credentialRequest.Requested.ToArray();
-				Assert.Equal(numberOfCredentials, requested.Count());
+				Assert.Equal(numberOfCredentials, requested.Length);
 				Assert.NotEmpty(requested[0].BitCommitments);
 				Assert.NotEmpty(requested[1].BitCommitments);
 				Assert.Equal(Money.Zero, credentialRequest.DeltaAmount);
@@ -86,7 +86,7 @@ namespace WalletWasabi.Tests.UnitTests.Wabisabi
 				client.HandleResponse(credentialResponse, validationData);
 				var credentials = client.Credentials.All.ToArray();
 				Assert.NotEmpty(credentials);
-				Assert.Equal(3, credentials.Count());
+				Assert.Equal(3, credentials.Length);
 
 				var valuableCredentials = client.Credentials.Valuable.ToArray();
 				Assert.Equal(new Scalar(50_000_000), valuableCredentials[0].Amount);

--- a/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Knowledge.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Knowledge.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 	{
 		internal Knowledge(Statement statement, ScalarVector witness)
 		{
-			Guard.True(nameof(witness), witness.Count() == statement.Equations.First().Generators.Count(), $"{nameof(witness)} size does not match {nameof(statement)}.{nameof(statement.Equations)}");
+			Guard.True(nameof(witness), witness.Count == statement.Equations.First().Generators.Count, $"{nameof(witness)} size does not match {nameof(statement)}.{nameof(statement.Equations)}");
 
 			// don't try to prove something which isn't true
 			foreach (var equation in statement.Equations)

--- a/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Statement.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Statement.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 		{
 			// The responses matrix should match the generators in the equations and
 			// there should be once nonce per equation.
-			Guard.True(nameof(publicNonces), Equations.Count() == publicNonces.Count());
+			Guard.True(nameof(publicNonces), Equations.Count() == publicNonces.Count);
 
 			return Equations.Zip(publicNonces, (equation, r) => equation.Verify(r, challenge, responses)).All(x => x);
 		}

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -358,7 +358,7 @@ namespace NBitcoin
 			{
 				if (!parentCounter.ContainsKey(node))
 				{
-					parentCounter.Add(node, node.Parents.Count());
+					parentCounter.Add(node, node.Parents.Count);
 					foreach (var child in node.Children)
 					{
 						Walk(child);


### PR DESCRIPTION
> This rule flags the `Count` LINQ method calls on collections of types that have equivalent, but more efficient `Length` or `Count` property to fetch the same data. `Length` or `Count` property does not enumerate the collection, hence is more efficient.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1829