### PR TITLE
Add code quality rule (CA2000: Dispose objects before losing scope)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -245,3 +245,6 @@ csharp_style_pattern_matching_over_as_with_null_check = true:error
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
 dotnet_diagnostic.CA2016.severity = warning
+
+# CA2000: Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = warning


### PR DESCRIPTION
> If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2000