### PR TITLE
[Trivial] Use StringBuilder.Append(char) for single character strings

### DIFF
--- a/WalletWasabi.Gui/Converters/PascalToPhraseConverter.cs
+++ b/WalletWasabi.Gui/Converters/PascalToPhraseConverter.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.Gui.Converters
 				{
 					if (pos > 0)
 					{
-						builder.Append(" ");
+						builder.Append(' ');
 					}
 
 					builder.Append(char.ToLower(c));

--- a/WalletWasabi/Backend/Models/FilterModel.cs
+++ b/WalletWasabi/Backend/Models/FilterModel.cs
@@ -48,13 +48,13 @@ namespace WalletWasabi.Backend.Models
 		{
 			var builder = new StringBuilder();
 			builder.Append(Header.Height);
-			builder.Append(":");
+			builder.Append(':');
 			builder.Append(Header.BlockHash);
-			builder.Append(":");
+			builder.Append(':');
 			builder.Append(Filter);
-			builder.Append(":");
+			builder.Append(':');
 			builder.Append(Header.PrevHash);
-			builder.Append(":");
+			builder.Append(':');
 			builder.Append(Header.BlockTime.ToUnixTimeSeconds());
 
 			return builder.ToString();

--- a/WalletWasabi/Mono/OptionSet.cs
+++ b/WalletWasabi/Mono/OptionSet.cs
@@ -919,7 +919,7 @@ namespace Mono.Options
 							}
 
 							++i;
-							sb.Append("}");
+							sb.Append('}');
 						}
 						else
 						{


### PR DESCRIPTION
> When calling `StringBuilder.Append` with a unit length string, consider using a `const char` rather than a unit length `const string` to improve performance.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1834