### PR TITLE
Call GC.SuppressFinalize correctly

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/CoinViewModel.cs
@@ -279,6 +279,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		public void Dispose()
 		{
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModelBase.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModelBase.cs
@@ -101,6 +101,8 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModelBase.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/WalletViewModelBase.cs
@@ -101,6 +101,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
 		}

--- a/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/LoadWallets/LoadWalletViewModel.cs
@@ -251,6 +251,8 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.LoadWallets
 		public void Dispose()
 		{
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -275,6 +275,8 @@ namespace WalletWasabi.Gui.ViewModels
 		public void Dispose()
 		{
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/MainWindowViewModel.cs
@@ -188,6 +188,8 @@ namespace WalletWasabi.Gui.ViewModels
 		public void Dispose()
 		{
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -144,6 +144,8 @@ namespace WalletWasabi.Tests.XunitConfiguration
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -144,6 +144,7 @@ namespace WalletWasabi.Tests.XunitConfiguration
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
 		}

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/FeeProviders.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/FeeProviders.cs
@@ -86,6 +86,8 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -225,6 +225,8 @@ namespace WalletWasabi.Blockchain.Blocks
 				P2pNode.BlockInv -= P2pNode_BlockInv;
 			}
 			base.Dispose();
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
@@ -233,6 +233,8 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -102,6 +102,8 @@ namespace WalletWasabi.CoinJoin.Client
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/CoinJoin/Client/Rounds/ClientRoundRegistration.cs
+++ b/WalletWasabi/CoinJoin/Client/Rounds/ClientRoundRegistration.cs
@@ -65,6 +65,8 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/CoinJoin/Client/Rounds/ClientRoundRegistration.cs
+++ b/WalletWasabi/CoinJoin/Client/Rounds/ClientRoundRegistration.cs
@@ -65,6 +65,7 @@ namespace WalletWasabi.CoinJoin.Client.Rounds
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
 		}

--- a/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Coordinator.cs
@@ -524,7 +524,8 @@ namespace WalletWasabi.CoinJoin.Coordinator
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
-			//// GC.SuppressFinalize(this);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/Logging/BenchmarkLogger.cs
+++ b/WalletWasabi/Logging/BenchmarkLogger.cs
@@ -73,6 +73,8 @@ namespace WalletWasabi.Logging
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/Logging/BenchmarkLogger.cs
+++ b/WalletWasabi/Logging/BenchmarkLogger.cs
@@ -73,6 +73,7 @@ namespace WalletWasabi.Logging
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
 		}

--- a/WalletWasabi/Services/HostedServices.cs
+++ b/WalletWasabi/Services/HostedServices.cs
@@ -139,6 +139,8 @@ namespace WalletWasabi.Services
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/Services/HostedServices.cs
+++ b/WalletWasabi/Services/HostedServices.cs
@@ -139,6 +139,7 @@ namespace WalletWasabi.Services
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
+
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
 		}

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -48,6 +48,7 @@ namespace WalletWasabi.Services
 		{
 			Synchronizer.PropertyChanged -= Synchronizer_PropertyChanged;
 			base.Dispose();
+
 			// Suppress finalization.
 			GC.SuppressFinalize(this);
 		}

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -19,6 +19,7 @@ namespace WalletWasabi.Services
 		}
 
 		public event EventHandler<UpdateStatus>? UpdateStatusChanged;
+
 		private WasabiSynchronizer Synchronizer { get; }
 		public UpdateStatus UpdateStatus { get; private set; }
 		public WasabiClient WasabiClient { get; }
@@ -47,6 +48,8 @@ namespace WalletWasabi.Services
 		{
 			Synchronizer.PropertyChanged -= Synchronizer_PropertyChanged;
 			base.Dispose();
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -289,7 +289,8 @@ namespace WalletWasabi.Tor.Http
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
-			// GC.SuppressFinalize(this);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		#endregion IDisposable Support

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.Tor.Socks5
 
 		private EndPoint TorSocks5EndPoint { get; }
 
-		/// <summary>Transport stream for sending  HTTP/HTTPS requests through Tor's SOCKS5 server.</summary>
+		/// <summary>Transport stream for sending HTTP/HTTPS requests through Tor's SOCKS5 server.</summary>
 		/// <remarks>This stream is not to be used to send commands to Tor's SOCKS5 server.</remarks>
 		private Stream Stream { get; set; }
 
@@ -425,7 +425,8 @@ namespace WalletWasabi.Tor.Socks5
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
-			// GC.SuppressFinalize(this);
+			// Suppress finalization.
+			GC.SuppressFinalize(this);
 		}
 
 		private void DisposeTcpClient()


### PR DESCRIPTION
> The `IDisposable.Dispose` method lets users release resources at any time before the object becoming available for garbage collection. If the `IDisposable.Dispose` method is called, it frees resources of the object. This makes finalization unnecessary. `IDisposable.Dispose` should call `GC.SuppressFinalize` so the garbage collector doesn't call the finalizer of the object.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1816