### PR TITLE
Tests: Set higher timeout for GetNodeVersionTestsAsync.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
@@ -89,7 +89,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 		[Fact]
 		public async Task GetNodeVersionTestsAsync()
 		{
-			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
 			Version version = await CoreNode.GetVersionAsync(cts.Token);
 			Assert.Equal(WalletWasabi.Helpers.Constants.BitcoinCoreVersion, version);
 		}

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/NodeBuildingTests.cs
@@ -89,6 +89,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 		[Fact]
 		public async Task GetNodeVersionTestsAsync()
 		{
+			// CI was failing a lot, the timeout was increased. 
 			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
 			Version version = await CoreNode.GetVersionAsync(cts.Token);
 			Assert.Equal(WalletWasabi.Helpers.Constants.BitcoinCoreVersion, version);


### PR DESCRIPTION
`GetNodeVersionTestsAsync` appears to be flaky. I would give it more time. 

Part of #4880.