### PR TITLE
Clean bin directory before publish on backend

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -15,7 +15,7 @@ bitcoind
 bitcoin-cli getblockchaininfo
 tor
 sudo service nginx start
-rm WalletWasabi/WalletWasabi.Backend/bin/ -r ; dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
+rm -rf WalletWasabi/WalletWasabi.Backend/bin/ ; dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
 pgrep -ilfa tor && pgrep -ilfa bitcoin && pgrep -ilfa wasabi && pgrep -ilfa nginx
 tail -10000 ~/.walletwasabi/backend/Logs.txt

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -15,7 +15,7 @@ bitcoind
 bitcoin-cli getblockchaininfo
 tor
 sudo service nginx start
-dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
+rm WalletWasabi/WalletWasabi.Backend/bin/ -r ; dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
 pgrep -ilfa tor && pgrep -ilfa bitcoin && pgrep -ilfa wasabi && pgrep -ilfa nginx
 tail -10000 ~/.walletwasabi/backend/Logs.txt

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -15,7 +15,7 @@ bitcoind
 bitcoin-cli getblockchaininfo
 tor
 sudo service nginx start
-rm -rf WalletWasabi/WalletWasabi.Backend/bin/ ; dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
+rm -rf WalletWasabi/WalletWasabi.Backend/bin ; dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
 pgrep -ilfa tor && pgrep -ilfa bitcoin && pgrep -ilfa wasabi && pgrep -ilfa nginx
 tail -10000 ~/.walletwasabi/backend/Logs.txt

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -15,7 +15,7 @@ bitcoind
 bitcoin-cli getblockchaininfo
 tor
 sudo service nginx start
-rm -rf WalletWasabi/WalletWasabi.Backend/bin ; dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
+rm -rf WalletWasabi/WalletWasabi.Backend/bin && dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
 pgrep -ilfa tor && pgrep -ilfa bitcoin && pgrep -ilfa wasabi && pgrep -ilfa nginx
 tail -10000 ~/.walletwasabi/backend/Logs.txt


### PR DESCRIPTION
With every dotnet major release, the publish directory changes. In this case, the old published directory remains there and can cause problems, recently I bumped into a problem where the backend was using old code because I forget to update the service file and because the files were still there I did not notice anything about this. 

Unfortunately `dotnet clean` does not delete the bin directory so I used `rm`. `;` denotes to run both commands sequentially independent of the failure or success of running of the first command. 