### PR TITLE
Move SingleInstanceChecker to program.cs from global

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -105,8 +105,6 @@ namespace WalletWasabi.Gui
 
 				BitcoinStore = new BitcoinStore(indexStore, transactionStore, mempoolService, blocks);
 
-				SingleInstanceChecker = new SingleInstanceChecker(Network);
-
 				WasabiClientFactory wasabiClientFactory = Config.UseTor
 					? new WasabiClientFactory(Config.TorSocks5EndPoint, backendUriGetter: () => Config.GetCurrentBackendUri())
 					: new WasabiClientFactory(torEndPoint: null, backendUriGetter: () => Config.GetFallbackBackendUri());
@@ -121,8 +119,6 @@ namespace WalletWasabi.Gui
 
 		private CancellationTokenSource StoppingCts { get; }
 
-		private SingleInstanceChecker SingleInstanceChecker { get; }
-
 		public async Task InitializeNoWalletAsync(TerminateService terminateService)
 		{
 			InitializationStarted = true;
@@ -130,8 +126,6 @@ namespace WalletWasabi.Gui
 
 			try
 			{
-				await SingleInstanceChecker.EnsureSingleOrThrowAsync().ConfigureAwait(false);
-
 				cancel.ThrowIfCancellationRequested();
 
 				Cache = new MemoryCache(new MemoryCacheOptions
@@ -753,15 +747,6 @@ namespace WalletWasabi.Gui
 				}
 
 				Logger.LogDebug($"Step: {nameof(SingleInstanceChecker)}.", nameof(Global));
-
-				try
-				{
-					await SingleInstanceChecker.DisposeAsync().ConfigureAwait(false);
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError($"Error during the disposal of {nameof(SingleInstanceChecker)}: {ex}");
-				}
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -7,7 +7,6 @@ using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.Protocol.Behaviors;
 using NBitcoin.Protocol.Connectors;
-using Nito.AsyncEx;
 using System;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
`Global.InitializeNoWalletAsync` running in parallel with the creation of the window. We can detect multiple instances earlier and in case we can prevent the further execution of the software. I moved the check before `Global.InitializeNoWalletAsync` into program.cs.

Note that this will prevent running some CLI command as well like --version. To fix that further refactoring has to be done - not the goal of this PR.

Based on https://github.com/zkSNACKs/WalletWasabi/pull/4896