### PR TITLE
[Fluent] Disable dismiss dialogs by clicking outside

### DIFF
--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -36,7 +36,7 @@
               <ContentPresenter Name="PART_CaptionPresenter" Content="{TemplateBinding Caption}" />
             </StackPanel>
             <Panel DockPanel.Dock="Bottom">
-              <Button Name="PART_CancelButton" Classes="invisible" IsVisible="{TemplateBinding EnableCancel}" Content="{TemplateBinding CancelContent}" Margin="0,10,10,10" HorizontalAlignment="Left" Command="{Binding CancelCommand}">
+              <Button Name="PART_CancelButton" IsCancel="{TemplateBinding EnableCancel}" Classes="invisible" IsVisible="{TemplateBinding EnableCancel}" Content="{TemplateBinding CancelContent}" Margin="0,10,10,10" HorizontalAlignment="Left" Command="{Binding CancelCommand}">
                 <i:Interaction.Behaviors>
                   <behaviors:FocusOnAttachedBehavior IsEnabled="{Binding FocusCancel, RelativeSource={RelativeSource TemplatedParent}}" />
                 </i:Interaction.Behaviors>

--- a/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
@@ -1,6 +1,9 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace WalletWasabi.Fluent.Controls
 {
@@ -12,8 +15,11 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<bool> IsDialogOpenProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(IsDialogOpen));
 
-		public static readonly StyledProperty<bool> EnableOverlayCancelProperty =
+		public static readonly StyledProperty<bool> EnableCancelOnPressedProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(EnableCancelOnPressed));
+
+		public static readonly StyledProperty<bool> EnableCancelOnEscapeProperty =
+			AvaloniaProperty.Register<Dialog, bool>(nameof(EnableCancelOnEscape));
 
 		public static readonly StyledProperty<double> MaxContentHeightProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(MaxContentHeight), double.PositiveInfinity);
@@ -29,8 +35,14 @@ namespace WalletWasabi.Fluent.Controls
 
 		public bool EnableCancelOnPressed
 		{
-			get => GetValue(EnableOverlayCancelProperty);
-			set => SetValue(EnableOverlayCancelProperty, value);
+			get => GetValue(EnableCancelOnPressedProperty);
+			set => SetValue(EnableCancelOnPressedProperty, value);
+		}
+
+		public bool EnableCancelOnEscape
+		{
+			get => GetValue(EnableCancelOnEscapeProperty);
+			set => SetValue(EnableCancelOnEscapeProperty, value);
 		}
 
 		public double MaxContentHeight
@@ -64,9 +76,27 @@ namespace WalletWasabi.Fluent.Controls
 			{
 				if (EnableCancelOnPressed)
 				{
-					IsDialogOpen = false;
+					Close();
 				}
 			};
+
+			if (this.GetVisualRoot() is TopLevel topLevel)
+			{
+				topLevel.AddHandler(KeyDownEvent, CancelKeyDown, RoutingStrategies.Tunnel);
+			}
+		}
+
+		private void Close()
+		{
+			IsDialogOpen = false;
+		}
+
+		private void CancelKeyDown(object? sender, KeyEventArgs e)
+		{
+			if (e.Key == Key.Escape && EnableCancelOnEscape)
+			{
+				Close();
+			}
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Fluent.Controls
 			AvaloniaProperty.Register<Dialog, bool>(nameof(IsDialogOpen));
 
 		public static readonly StyledProperty<bool> EnableOverlayCancelProperty =
-			AvaloniaProperty.Register<Dialog, bool>(nameof(EnableOverlayCancel));
+			AvaloniaProperty.Register<Dialog, bool>(nameof(EnableCancelOnPressed));
 
 		public static readonly StyledProperty<double> MaxContentHeightProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(MaxContentHeight), double.PositiveInfinity);
@@ -27,7 +27,7 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(IsDialogOpenProperty, value);
 		}
 
-		public bool EnableOverlayCancel
+		public bool EnableCancelOnPressed
 		{
 			get => GetValue(EnableOverlayCancelProperty);
 			set => SetValue(EnableOverlayCancelProperty, value);
@@ -62,7 +62,7 @@ namespace WalletWasabi.Fluent.Controls
 			var overlayButton = e.NameScope.Find<Panel>("PART_Overlay");
 			overlayButton.PointerPressed += (_, __) =>
 			{
-				if (EnableOverlayCancel)
+				if (EnableCancelOnPressed)
 				{
 					IsDialogOpen = false;
 				}

--- a/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.xaml.cs
@@ -12,6 +12,9 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<bool> IsDialogOpenProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(IsDialogOpen));
 
+		public static readonly StyledProperty<bool> EnableOverlayCancelProperty =
+			AvaloniaProperty.Register<Dialog, bool>(nameof(EnableOverlayCancel));
+
 		public static readonly StyledProperty<double> MaxContentHeightProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(MaxContentHeight), double.PositiveInfinity);
 
@@ -22,6 +25,12 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			get => GetValue(IsDialogOpenProperty);
 			set => SetValue(IsDialogOpenProperty, value);
+		}
+
+		public bool EnableOverlayCancel
+		{
+			get => GetValue(EnableOverlayCancelProperty);
+			set => SetValue(EnableOverlayCancelProperty, value);
 		}
 
 		public double MaxContentHeight
@@ -51,7 +60,13 @@ namespace WalletWasabi.Fluent.Controls
 			base.OnApplyTemplate(e);
 
 			var overlayButton = e.NameScope.Find<Panel>("PART_Overlay");
-			overlayButton.PointerPressed += (_, __) => IsDialogOpen = false;
+			overlayButton.PointerPressed += (_, __) =>
+			{
+				if (EnableOverlayCancel)
+				{
+					IsDialogOpen = false;
+				}
+			};
 		}
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/AboutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AboutViewModel.cs
@@ -42,6 +42,8 @@ namespace WalletWasabi.Fluent.ViewModels
 			OpenBrowserCommand.ThrownExceptions
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Subscribe(ex => Logger.LogError(ex));
+
+			NextCommand = ReactiveCommand.Create(() => Navigate().Clear());
 		}
 
 		public ICommand AboutAdvancedInfoDialogCommand { get; }

--- a/WalletWasabi.Fluent/Views/AboutView.axaml
+++ b/WalletWasabi.Fluent/Views/AboutView.axaml
@@ -71,7 +71,7 @@
     </Style>
   </UserControl.Styles>
   <Panel>
-    <controls:ContentArea>
+    <controls:ContentArea EnableNext="True" NextContent="Close">
       <controls:ContentArea.Title>
         <StackPanel Orientation="Horizontal">
           <TextBlock Name="LogoText1" Classes="h1 semibold">Wasabi</TextBlock>

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -50,6 +50,8 @@
     <c:Dialog x:CompileBindings="False"
               DataContext="{Binding DialogScreen}"
               IsDialogOpen="{Binding IsDialogOpen, Mode=TwoWay}"
+              EnableCancelOnPressed="False"
+              EnableCancelOnEscape="True"
               IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
               MaxContentWidth="800" MaxContentHeight="700">
@@ -57,6 +59,8 @@
     </c:Dialog>
     <c:Dialog DataContext="{Binding CurrentDialog}"
               IsDialogOpen="{Binding IsDialogOpen, Mode=TwoWay}"
+              EnableCancelOnPressed="False"
+              EnableCancelOnEscape="True"
               Content="{Binding }"
               HorizontalContentAlignment="Center" VerticalContentAlignment="Center" />
   </Panel>


### PR DESCRIPTION
- [x] Add EnableCancelOnPressed property to Dialog control to enable dismiss dialog by clicking outside (default is disabled)
- [x] Add EnableCancelOnEscape property for Esc key support to dismiss dialog anytime (default is enabled)
- [x] When Cancel button is active add support for Esc key (executes CancelCommand)
- [x] Enable Next/Cancel buttons to dialogs without those (e.g. About...)