### PR TITLE
Add back CLI functionality to Fluent

### DIFF
--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
+		<OutputType>Exe</OutputType>
 		<TargetFramework>net5.0</TargetFramework>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
`<OutputType>WinExe</OutputType>` won't open a console window when you start the application, in this way we could dismiss NSubsys. However no log messages, neither any `Console.Write` messages appear on the console. We need the console because of our CLI interface which is used by the daemon or version check, etc. 

https://docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/5.0/automatically-infer-winexe-output-type

## Non- solutions

The alternative non-solution is to add `AllocConsole()` and run it in the code. The problem here is that this pops up a Console window when running. 
https://stackoverflow.com/questions/4362111/how-do-i-show-a-console-output-window-in-a-forms-application
```C#
		[DllImport("kernel32.dll", SetLastError = true)]
		[return: MarshalAs(UnmanagedType.Bool)]
		private static extern bool AllocConsole();
```
