### PR TITLE
CA2200: Rethrow to preserve stack details

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -257,3 +257,6 @@ dotnet_diagnostic.CA1829.severity = warning
 
 # CA1816: Dispose methods should call SuppressFinalize
 dotnet_diagnostic.CA1816.severity = none
+
+# CA2200: Rethrow to preserve stack details
+dotnet_diagnostic.CA2200.severity = warning

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -332,7 +332,7 @@ namespace WalletWasabi.Backend.Controllers
 			catch (Exception ex)
 			{
 				Logger.LogDebug(ex);
-				throw ex;
+				throw;
 			}
 		}
 

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -320,7 +320,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				{
 					if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					{
-						throw ex;
+						throw;
 					}
 					return; // Occassionally this fails on Linux or OSX, I have no idea why.
 				}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -219,7 +219,7 @@ namespace WalletWasabi.Services
 									}
 									else
 									{
-										throw ex;
+										throw;
 									}
 								}
 								catch (Exception x)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200

> Once an exception is thrown, part of the information it carries is the stack trace. The stack trace is a list of the method call hierarchy that starts with the method that throws the exception and ends with the method that catches the exception. If an exception is re-thrown by specifying the exception in the throw statement, the stack trace is restarted at the current method and the list of method calls between the original method that threw the exception and the current method is lost. To keep the original stack trace information with the exception, use the throw statement without specifying the exception.