### PR TITLE
Wallet has a fixed network settings

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/HardwareWalletOperations.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/HardwareWalletOperations.cs
@@ -143,7 +143,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 					var detectedHardwareWallets =
 						(await Client.EnumerateAsync(timeoutCts.Token)
 							.ConfigureAwait(false))
-							.Where(wallet => !WalletManager.WalletExists(wallet.Fingerprint, WalletManager.Network))
+							.Where(wallet => !WalletManager.WalletExists(wallet.Fingerprint))
 							.ToArray();
 
 					detectionCts.Token.ThrowIfCancellationRequested();

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/HardwareWalletOperations.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/HardwareWalletOperations.cs
@@ -16,6 +16,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 	public class HardwareWalletOperations : IDisposable
 	{
 		public event EventHandler<HwiEnumerateEntry[]>? HardwareWalletsFound;
+
 		public event EventHandler? NoHardwareWalletFound;
 
 		public HardwareWalletOperations(WalletManager walletManager, Network network)
@@ -26,7 +27,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 			DisposeCts = new CancellationTokenSource();
 			Stopwatch = new Stopwatch();
 
-			PassphraseTimer = new Timer(8000) {AutoReset = false};
+			PassphraseTimer = new Timer(8000) { AutoReset = false };
 
 			StartDetection();
 		}
@@ -57,7 +58,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 			}
 			else
 			{
-				HardwareWalletsFound?.Invoke(this,wallets);
+				HardwareWalletsFound?.Invoke(this, wallets);
 			}
 		}
 
@@ -74,7 +75,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 
 				await StopDetectionAsync();
 
-				var fingerPrint = (HDFingerprint) selectedDevice.Fingerprint;
+				var fingerPrint = (HDFingerprint)selectedDevice.Fingerprint;
 				using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
 				var extPubKey = await Client.GetXpubAsync(
 					selectedDevice.Model,
@@ -83,8 +84,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 					cts.Token).ConfigureAwait(false);
 				var path = WalletManager.WalletDirectories.GetWalletFilePaths(walletName).walletFilePath;
 
-				return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, extPubKey, path);
-
+				return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, extPubKey, WalletManager.Network, path);
 			}
 			catch (Exception)
 			{
@@ -143,7 +143,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet
 					var detectedHardwareWallets =
 						(await Client.EnumerateAsync(timeoutCts.Token)
 							.ConfigureAwait(false))
-							.Where(wallet => !WalletManager.WalletExists(wallet.Fingerprint))
+							.Where(wallet => !WalletManager.WalletExists(wallet.Fingerprint, WalletManager.Network))
 							.ToArray();
 
 					detectionCts.Token.ThrowIfCancellationRequested();

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
@@ -98,11 +98,10 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 							var result = KeyManager.Recover(
 								CurrentMnemonics!,
 								password!,
+								network,
 								walletFilePath,
 								AccountKeyPath,
 								MinGapLimit);
-
-							result.SetNetwork(network);
 
 							return result;
 						});

--- a/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/HardwareWallets/ConnectHardwareWalletViewModel.cs
@@ -122,7 +122,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 					Logger.LogInfo("Creating a new wallet file.");
 					var walletName = WalletManager.WalletDirectories.GetNextWalletName("Coldcard");
 					var walletFullPath = WalletManager.WalletDirectories.GetWalletFilePaths(walletName).walletFilePath;
-					var keyManager = KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, walletFullPath);
+					var keyManager = KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, WalletManager.Network, walletFullPath);
 					WalletManager.AddWallet(keyManager);
 					owner.SelectLoadWallet(keyManager);
 				}
@@ -340,7 +340,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.HardwareWallets
 					{
 						throw new InvalidOperationException("Hardware wallet did not provide fingerprint.");
 					}
-					WalletManager.AddWallet(KeyManager.CreateNewHardwareWalletWatchOnly(selectedWallet.HardwareWalletInfo.Fingerprint.Value, extPubKey, path));
+					WalletManager.AddWallet(KeyManager.CreateNewHardwareWalletWatchOnly(selectedWallet.HardwareWalletInfo.Fingerprint.Value, extPubKey, WalletManager.Network, path));
 				}
 
 				KeyManager keyManager = WalletManager.GetWalletByName(walletName).KeyManager;

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -86,8 +86,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 				try
 				{
 					var mnemonic = new Mnemonic(MnemonicWords);
-					var km = KeyManager.Recover(mnemonic, Password, filePath: null, keyPath, minGapLimit);
-					km.SetNetwork(Global.Network);
+					var km = KeyManager.Recover(mnemonic, Password, Global.Network, filePath: null, keyPath, minGapLimit);
 					km.SetFilePath(walletFilePath);
 					WalletManager.AddWallet(km);
 

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -102,7 +102,6 @@ namespace WalletWasabi.Tests.IntegrationTests
 				bitcoinStore.BlockRepository);
 
 			using Wallet wallet = Wallet.CreateAndRegisterServices(
-				network,
 				bitcoinStore,
 				keyManager,
 				syncer,

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -93,7 +93,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 			using var nodes = new NodesGroup(network, connectionParameters, requirements: Constants.NodeRequirements);
 
-			KeyManager keyManager = KeyManager.CreateNew(out _, "password");
+			KeyManager keyManager = KeyManager.CreateNew(out _, "password", network);
 			WasabiClientFactory wasabiClientFactory = new WasabiClientFactory(Common.TorSocks5Endpoint, backendUriGetter: () => new Uri("http://localhost:12345"));
 			WasabiSynchronizer syncer = new WasabiSynchronizer(network, bitcoinStore, wasabiClientFactory);
 			ServiceConfiguration serviceConfig = new ServiceConfiguration(MixUntilAnonymitySet.PrivacyLevelStrong.ToString(), 2, 21, 50, new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold));

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -64,7 +64,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				new P2pBlockProvider(nodes, null, synchronizer, serviceConfiguration, network),
 				bitcoinStore.BlockRepository);
 
-			using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
+			using var wallet = Wallet.CreateAndRegisterServices(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
 			wallet.NewFilterProcessed += Common.Wallet_NewFilterProcessed;
 
 			var scp = new Key().ScriptPubKey;

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -56,7 +56,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer = new WasabiSynchronizer(rpc.Network, bitcoinStore, wasabiClientFactory);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();
@@ -220,7 +220,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer = new WasabiSynchronizer(rpc.Network, bitcoinStore, wasabiClientFactory);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1399,11 +1399,11 @@ namespace WalletWasabi.Tests.RegressionTests
 				new P2pBlockProvider(nodes2, null, synchronizer, serviceConfiguration, network),
 				bitcoinStore.BlockRepository);
 
-			using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
+			using var wallet = Wallet.CreateAndRegisterServices(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
 			wallet.NewFilterProcessed += Common.Wallet_NewFilterProcessed;
 
 			var workDir2 = Path.Combine(Helpers.Common.GetWorkDir(), "2");
-			using var wallet2 = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager2, synchronizer2, nodes2, workDir2, serviceConfiguration, synchronizer2, blockProvider2);
+			using var wallet2 = Wallet.CreateAndRegisterServices(bitcoinStore, keyManager2, synchronizer2, nodes2, workDir2, serviceConfiguration, synchronizer2, blockProvider2);
 
 			// Get some money, make it confirm.
 			var key = keyManager.GetNextReceiveKey("fundZeroLink", out _);

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -265,7 +265,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			{
 				// Test DelayedClientRoundRegistration logic.
 				ClientRoundRegistration first = null;
-				var randomKey = KeyManager.CreateNew(out _, "").GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false);
+				var randomKey = KeyManager.CreateNew(out _, "", network).GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false);
 				var second = new ClientRoundRegistration(aliceClient,
 					new[] { BitcoinFactory.CreateSmartCoin(randomKey, 0m, anonymitySet: 2) },
 					BitcoinAddress.Create("12Rty3c8j3QiZSwLVaBtch6XUMZaja3RC7", Network.Main));
@@ -1104,7 +1104,7 @@ namespace WalletWasabi.Tests.RegressionTests
 
 				var amount = Money.Coins((decimal)damount);
 
-				var keyManager = KeyManager.CreateNew(out _, password);
+				var keyManager = KeyManager.CreateNew(out _, password, network);
 				var key = keyManager.GenerateNewKey("foo", KeyState.Clean, false);
 				var bech = key.GetP2wpkhAddress(network);
 				var txId = await rpc.SendToAddressAsync(bech, amount, replaceable: false);
@@ -1191,7 +1191,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			coordinator.RoundConfig.UpdateOrDefault(roundConfig, toFile: true);
 			coordinator.AbortAllRoundsInInputRegistration("");
 			await rpc.GenerateAsync(3); // So to make sure we have enough money.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 			var key1 = keyManager.GenerateNewKey("foo", KeyState.Clean, false);
 			var key2 = keyManager.GenerateNewKey("bar", KeyState.Clean, false);
 			var key3 = keyManager.GenerateNewKey("baz", KeyState.Clean, false);
@@ -1384,9 +1384,9 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer2 = new WasabiSynchronizer(network, bitcoinStore, wasabiClientFactory);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
-			var keyManager2 = KeyManager.CreateNew(out _, password);
+			var keyManager2 = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -716,7 +716,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				new P2pBlockProvider(nodes, null, synchronizer, serviceConfiguration, network),
 				bitcoinStore.BlockRepository);
 
-			using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
+			using var wallet = Wallet.CreateAndRegisterServices(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
 			wallet.NewFilterProcessed += Common.Wallet_NewFilterProcessed;
 
 			Assert.Empty(wallet.Coins);

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer = new WasabiSynchronizer(rpc.Network, bitcoinStore, wasabiClientFactory);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();
@@ -533,7 +533,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer = new WasabiSynchronizer(rpc.Network, bitcoinStore, wasabiClientFactory);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();
@@ -707,7 +707,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer = new WasabiSynchronizer(rpc.Network, bitcoinStore, wasabiClientFactory);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -122,7 +122,7 @@ namespace WalletWasabi.Tests.RegressionTests
 		{
 			(string password, IRPCClient rpc, Network network, _, _, BitcoinStore bitcoinStore, Backend.Global global) = await Common.InitializeTestEnvironmentAsync(RegTestFixture, 1);
 
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// Mine some coins, make a few bech32 transactions then make it confirm.
 			await rpc.GenerateAsync(1);
@@ -247,7 +247,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var synchronizer = new WasabiSynchronizer(rpc.Network, bitcoinStore, wasabiClientFactory);
 
 			// 3. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 4. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -256,7 +256,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				new P2pBlockProvider(nodes, null, synchronizer, serviceConfiguration, network),
 				bitcoinStore.BlockRepository);
 
-			using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
+			using var wallet = Wallet.CreateAndRegisterServices(bitcoinStore, keyManager, synchronizer, nodes, workDir, serviceConfiguration, synchronizer, blockProvider);
 			wallet.NewFilterProcessed += Common.Wallet_NewFilterProcessed;
 
 			// Get some money, make it confirm.

--- a/WalletWasabi/Blockchain/Keys/BlockchainState.cs
+++ b/WalletWasabi/Blockchain/Keys/BlockchainState.cs
@@ -15,15 +15,15 @@ namespace WalletWasabi.Blockchain.Keys
 			Height = height;
 		}
 
-		public BlockchainState()
+		public BlockchainState(Network network)
 		{
-			Network = Network.Main;
+			Network = network;
 			Height = 0;
 		}
 
 		[JsonProperty]
 		[JsonConverter(typeof(NetworkJsonConverter))]
-		public Network Network { get; set; }
+		public Network Network { get; private set; }
 
 		[JsonProperty]
 		[JsonConverter(typeof(HeightJsonConverter))]

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -763,26 +763,6 @@ namespace WalletWasabi.Blockchain.Keys
 			}
 		}
 
-		public void AssertNetworkOrClearBlockState(Network expectedNetwork)
-		{
-			lock (BlockchainStateLock)
-			{
-				var lastNetwork = BlockchainState.Network;
-				if (lastNetwork is null || lastNetwork != expectedNetwork)
-				{
-					BlockchainState.Network = expectedNetwork;
-					BlockchainState.Height = 0;
-					ToFileNoBlockchainStateLock();
-
-					if (lastNetwork is { })
-					{
-						Logger.LogWarning($"Wallet is opened on {expectedNetwork}. Last time it was opened on {lastNetwork}.");
-					}
-					Logger.LogInfo("Blockchain cache is cleared.");
-				}
-			}
-		}
-
 		#endregion BlockchainState
 	}
 }

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -42,8 +42,7 @@ namespace WalletWasabi.Blockchain.Keys
 			// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password because of compatibility.
 			PasswordHelper.Guard(password);
 
-			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password);
-			km.SetNetwork(Network);
+			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network);
 			km.SetBestHeight(new Height(TipHeight));
 			km.SetFilePath(walletFilePath);
 			return (km, mnemonic);

--- a/WalletWasabi/Helpers/ImportWalletHelper.cs
+++ b/WalletWasabi/Helpers/ImportWalletHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,7 +35,7 @@ namespace WalletWasabi.Helpers
 		{
 			var km = KeyManager.FromFile(filePath);
 
-			if (manager.WalletExists(km.MasterFingerprint))
+			if (manager.WalletExists(km.MasterFingerprint, manager.Network))
 			{
 				throw new InvalidOperationException(WalletExistsErrorMessage);
 			}
@@ -61,7 +61,7 @@ namespace WalletWasabi.Helpers
 			}
 			else
 			{
-				Version coldCardVersion = new (coldCardVersionString);
+				Version coldCardVersion = new(coldCardVersionString);
 
 				if (coldCardVersion == new Version("2.1.0")) // Should never happen though.
 				{
@@ -72,14 +72,14 @@ namespace WalletWasabi.Helpers
 			var bytes = ByteHelpers.FromHex(Guard.NotNullOrEmptyOrWhitespace(nameof(mfpString), mfpString, trim: true));
 			HDFingerprint mfp = reverseByteOrder ? new HDFingerprint(bytes.Reverse().ToArray()) : new HDFingerprint(bytes);
 
-			if (manager.WalletExists(mfp))
+			if (manager.WalletExists(mfp, manager.Network))
 			{
 				throw new InvalidOperationException(WalletExistsErrorMessage);
 			}
 
 			ExtPubKey extPubKey = NBitcoinHelpers.BetterParseExtPubKey(xpubString);
 
-			return KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, walletFullPath);
+			return KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, manager.Network, walletFullPath);
 		}
 	}
 }

--- a/WalletWasabi/Helpers/ImportWalletHelper.cs
+++ b/WalletWasabi/Helpers/ImportWalletHelper.cs
@@ -35,7 +35,12 @@ namespace WalletWasabi.Helpers
 		{
 			var km = KeyManager.FromFile(filePath);
 
-			if (manager.WalletExists(km.MasterFingerprint, manager.Network))
+			if (km.GetNetwork() != manager.Network)
+			{
+				throw new InvalidOperationException($"Wasabi network is currently '{manager.Network}', but wallet that you want to import is on '{km.GetNetwork()}'.");
+			}
+
+			if (manager.WalletExists(km.MasterFingerprint))
 			{
 				throw new InvalidOperationException(WalletExistsErrorMessage);
 			}
@@ -72,7 +77,7 @@ namespace WalletWasabi.Helpers
 			var bytes = ByteHelpers.FromHex(Guard.NotNullOrEmptyOrWhitespace(nameof(mfpString), mfpString, trim: true));
 			HDFingerprint mfp = reverseByteOrder ? new HDFingerprint(bytes.Reverse().ToArray()) : new HDFingerprint(bytes);
 
-			if (manager.WalletExists(mfp, manager.Network))
+			if (manager.WalletExists(mfp))
 			{
 				throw new InvalidOperationException(WalletExistsErrorMessage);
 			}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -29,14 +29,13 @@ namespace WalletWasabi.Wallets
 	{
 		private WalletState _state;
 
-		public Wallet(string dataDir, Network network, string filePath) : this(dataDir, network, KeyManager.FromFile(filePath))
+		public Wallet(string dataDir, string filePath) : this(dataDir, KeyManager.FromFile(filePath))
 		{
 		}
 
-		public Wallet(string dataDir, Network network, KeyManager keyManager)
+		public Wallet(string dataDir, KeyManager keyManager)
 		{
 			Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
-			Network = Guard.NotNull(nameof(network), network);
 			KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
 
 			RuntimeParams.SetDataDir(dataDir);
@@ -85,7 +84,7 @@ namespace WalletWasabi.Wallets
 		/// </summary>
 		public ICoinsView Coins { get; private set; }
 
-		public Network Network { get; }
+		public Network Network => KeyManager.GetNetwork();
 		public TransactionProcessor TransactionProcessor { get; private set; }
 
 		public IFeeProvider FeeProvider { get; private set; }
@@ -487,9 +486,9 @@ namespace WalletWasabi.Wallets
 			State = WalletState.WaitingForInit;
 		}
 
-		public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, NodesGroup nodes, string dataDir, ServiceConfiguration serviceConfiguration, IFeeProvider feeProvider, IBlockProvider blockProvider)
+		public static Wallet CreateAndRegisterServices(BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, NodesGroup nodes, string dataDir, ServiceConfiguration serviceConfiguration, IFeeProvider feeProvider, IBlockProvider blockProvider)
 		{
-			var wallet = new Wallet(dataDir, network, keyManager);
+			var wallet = new Wallet(dataDir, keyManager);
 			wallet.RegisterServices(bitcoinStore, synchronizer, nodes, serviceConfiguration, feeProvider, blockProvider);
 			return wallet;
 		}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -389,7 +389,6 @@ namespace WalletWasabi.Wallets
 
 		private async Task LoadWalletStateAsync(CancellationToken cancel)
 		{
-			KeyManager.AssertNetworkOrClearBlockState(Network);
 			Height bestKeyManagerHeight = KeyManager.GetBestHeight();
 
 			using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -281,6 +281,8 @@ namespace WalletWasabi.Wallets
 
 		public bool WalletExists(HDFingerprint? fingerprint, Network network) => GetWallets().Any(x => fingerprint is { } && x.KeyManager.MasterFingerprint == fingerprint && x.Network == network);
 
+		public bool WalletExists(HDFingerprint? fingerprint) => WalletExists(fingerprint, Network);
+
 		private void ChaumianClient_OnDequeue(object? sender, DequeueResult e)
 		{
 			OnDequeue?.Invoke(sender, e);

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -279,7 +279,7 @@ namespace WalletWasabi.Wallets
 			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
-		public bool WalletExists(HDFingerprint? fingerprint) => GetWallets().Any(x => fingerprint is { } && x.KeyManager.MasterFingerprint == fingerprint);
+		public bool WalletExists(HDFingerprint? fingerprint, Network network) => GetWallets().Any(x => fingerprint is { } && x.KeyManager.MasterFingerprint == fingerprint && x.Network == network);
 
 		private void ChaumianClient_OnDequeue(object? sender, DequeueResult e)
 		{

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -201,7 +201,7 @@ namespace WalletWasabi.Wallets
 
 		public Wallet AddWallet(KeyManager keyManager)
 		{
-			Wallet wallet = new Wallet(WalletDirectories.WorkDir, Network, keyManager);
+			Wallet wallet = new Wallet(WalletDirectories.WorkDir, keyManager);
 			AddWallet(wallet);
 			return wallet;
 		}
@@ -212,7 +212,7 @@ namespace WalletWasabi.Wallets
 			Wallet wallet;
 			try
 			{
-				wallet = new Wallet(WalletDirectories.WorkDir, Network, walletFullPath);
+				wallet = new Wallet(WalletDirectories.WorkDir, walletFullPath);
 			}
 			catch (Exception ex)
 			{
@@ -239,7 +239,7 @@ namespace WalletWasabi.Wallets
 				}
 				File.Copy(walletBackupFullPath, walletFullPath);
 
-				wallet = new Wallet(WalletDirectories.WorkDir, Network, walletFullPath);
+				wallet = new Wallet(WalletDirectories.WorkDir, walletFullPath);
 			}
 
 			AddWallet(wallet);

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -143,7 +143,10 @@ namespace WalletWasabi.Wallets
 			lock (Lock)
 			{
 				// Throw an exception if the wallet was not added to the WalletManager.
-				Wallets.Single(x => x.Key == wallet);
+				if (!Wallets.Any(x => x.Key == wallet))
+				{
+					throw new InvalidOperationException($"Wallet with name '{wallet.WalletName}' on network '{Network}' does not exist.");
+				}
 			}
 
 			wallet.SetWaitingForInitState();
@@ -275,7 +278,7 @@ namespace WalletWasabi.Wallets
 			}
 			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
-		
+
 		public bool WalletExists(HDFingerprint? fingerprint) => GetWallets().Any(x => fingerprint is { } && x.KeyManager.MasterFingerprint == fingerprint);
 
 		private void ChaumianClient_OnDequeue(object? sender, DequeueResult e)


### PR DESCRIPTION
This PR is about to change the current behavior that a wallet can be loaded on any network. This is required to display only the network-related wallets in the wallet list. 

- Removed the possibility to load the wallet on a different network where it was created. 
- As a consequence now it is possible to have more wallets on different networks for one HW device. So not only the fingerprint needs to be matched. when detecting HWs.