### PR TITLE
[PoC] Networkify wallets

### DIFF
--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Gui
 			var config = new Config(Path.Combine(dataDir, "Config.json"));
 			config.LoadOrCreateDefaultFile();
 			config.CorrectMixUntilAnonymitySet();
-			var walletManager = new WalletManager(config.Network, new WalletDirectories(dataDir));
+			var walletManager = new WalletManager(config.Network, new WalletDirectories(Path.Combine(dataDir, "BitcoinStore", config.Network.ToString())));
 
 			return new Global(dataDir, torLogsFile, config, uiConfig, walletManager);
 		}


### PR DESCRIPTION
My preferred concept instead of: https://github.com/zkSNACKs/WalletWasabi/pull/4947

The trick is that we can change the folder and that'd lead to quick code.

- [ ] Same code must be added to the fluent project.
- [ ] Add backwards compatibility ensurement: copy the wallets and the wallet backup folders to the mainnet wallet and devs can manually move them.