### PR TITLE
Tor parallel bits - part 1

### DIFF
--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -28,6 +28,7 @@ namespace WalletWasabi.Helpers
 			return (bool)value;
 		}
 
+		[return: NotNull]
 		public static T NotNull<T>(string parameterName, T value)
 		{
 			AssertCorrectParameterName(parameterName);

--- a/WalletWasabi/Tor/Socks5/Models/Bases/OctetSerializableBase.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Bases/OctetSerializableBase.cs
@@ -1,12 +1,11 @@
 using System;
-using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Interfaces;
 
 namespace WalletWasabi.Tor.Socks5.Models.Bases
 {
 	public abstract class OctetSerializableBase : IByteSerializable, IEquatable<OctetSerializableBase>, IEquatable<byte>
 	{
-		protected byte ByteValue { get; set; }
+		protected byte ByteValue { get; init; }
 
 		#region Serialization
 
@@ -19,19 +18,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Bases
 				return $"X'{ByteHelpers.ToHex(ToByte())}'";
 			}
 			return ByteHelpers.ToHex(ToByte());
-		}
-
-		public void FromHex(string hex)
-		{
-			hex = Guard.NotNullOrEmptyOrWhitespace(nameof(hex), hex, true);
-
-			byte[] bytes = ByteHelpers.FromHex(hex);
-			if (bytes.Length != 1)
-			{
-				throw new FormatException($"{nameof(hex)} must be exactly one byte. Actual: {bytes.Length} bytes. Value: {hex}.");
-			}
-
-			ByteValue = bytes[0];
 		}
 
 		public override string ToString()

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/MethodsField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/MethodsField.cs
@@ -8,8 +8,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 {
 	public class MethodsField : ByteArraySerializableBase
 	{
-		#region Constructors
-
 		public MethodsField(byte[] bytes)
 		{
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
@@ -37,10 +35,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 			}
 		}
 
-		#endregion Constructors
-
-		#region PropertiesAndMembers
-
 		private byte[] Bytes { get; }
 
 		public IEnumerable<MethodField> Methods
@@ -55,12 +49,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 			}
 		}
 
-		#endregion PropertiesAndMembers
-
-		#region Serialization
-
 		public override byte[] ToBytes() => Bytes;
-
-		#endregion Serialization
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PasswdField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PasswdField.cs
@@ -11,14 +11,12 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
 		}
 
-		public PasswdField(string passwd)
-			: this(Encoding.UTF8.GetBytes(passwd))
+		public PasswdField(string password)
+			: this(Encoding.UTF8.GetBytes(password))
 		{
 		}
 
 		private byte[] Bytes { get; }
-
-		public string Passwd => Encoding.UTF8.GetString(Bytes); // Tor accepts UTF8 encoded passwd
 
 		public override byte[] ToBytes() => Bytes;
 	}

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PortField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/PortField.cs
@@ -7,8 +7,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 {
 	public class PortField : ByteArraySerializableBase
 	{
-		#region Constructors
-
 		public PortField(byte[] bytes)
 		{
 			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
@@ -29,22 +27,12 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 			Bytes = bytes.Take(2).Reverse().ToArray();
 		}
 
-		#endregion Constructors
-
-		#region PropertiesAndMembers
-
 		private byte[] Bytes { get; }
 
 		public int DstPort => BitConverter.ToInt16(Bytes.Reverse().ToArray(), 0);
 
-		#endregion PropertiesAndMembers
-
-		#region Serialization
-
 		public override byte[] ToBytes() => Bytes;
 
 		public override string ToString() => DstPort.ToString();
-
-		#endregion Serialization
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/UNameField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/ByteArrayFields/UNameField.cs
@@ -6,8 +6,6 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 {
 	public class UNameField : ByteArraySerializableBase
 	{
-		#region Constructors
-
 		public UNameField(byte[] bytes)
 		{
 			Bytes = Guard.NotNullOrEmpty(nameof(bytes), bytes);
@@ -18,20 +16,8 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields
 		{
 		}
 
-		#endregion Constructors
-
-		#region PropertiesAndMembers
-
 		private byte[] Bytes { get; }
 
-		public string UName => Encoding.UTF8.GetString(Bytes); // Tor accepts UTF8 encoded passwd
-
-		#endregion PropertiesAndMembers
-
-		#region Serialization
-
 		public override byte[] ToBytes() => Bytes;
-
-		#endregion Serialization
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AtypField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/AtypField.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 		{
 			dstAddr = Guard.NotNullOrEmptyOrWhitespace(nameof(dstAddr), dstAddr, true);
 
-			if (IPAddress.TryParse(dstAddr, out IPAddress address))
+			if (IPAddress.TryParse(dstAddr, out IPAddress? address))
 			{
 				Guard.Same($"{nameof(address)}.{nameof(address.AddressFamily)}", AddressFamily.InterNetwork, address.AddressFamily);
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/CmdField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/CmdField.cs
@@ -4,16 +4,11 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class CmdField : OctetSerializableBase
 	{
-		public CmdField(byte byteValue)
-		{
-			ByteValue = byteValue;
-		}
-
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt
 		// The BIND command is not supported.
 		// The (SOCKS5) "UDP ASSOCIATE" command is not supported.
 
-		public static CmdField Connect => new CmdField(0x01);
+		public static readonly CmdField Connect = new CmdField(0x01);
 
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n46
 		// As an extension to SOCKS4A and SOCKS5, Tor implements a new command value,
@@ -22,7 +17,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 		// request.The reply is either an error(if the address could not be
 		// resolved) or a success response.In the case of success, the address is
 		// stored in the portion of the SOCKS response reserved for remote IP address.
-		public static CmdField Resolve => new CmdField(0xF0);
+		public static readonly CmdField Resolve = new CmdField(0xF0);
 
 		// https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt#n55
 		// For SOCKS5 only, we support reverse resolution with a new command value,
@@ -30,6 +25,11 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 		// an IPv4 address as its target, Tor attempts to find the canonical
 		// hostname for that IPv4 record, and returns it in the "server bound
 		// address" portion of the reply.
-		public static CmdField ResolvePtr => new CmdField(0xF1);
+		public static readonly CmdField ResolvePtr = new CmdField(0xF1);
+
+		public CmdField(byte byteValue)
+		{
+			ByteValue = byteValue;
+		}
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/NMethodsField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/NMethodsField.cs
@@ -1,4 +1,3 @@
-using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Bases;
 using WalletWasabi.Tor.Socks5.Models.Fields.ByteArrayFields;
 

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RepField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RepField.cs
@@ -21,32 +21,28 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 	/// <seealso href="https://www.ietf.org/rfc/rfc1928.txt"/>
 	public class RepField : OctetSerializableBase
 	{
+		public static readonly RepField Succeeded = new RepField((byte)ReplyType.Succeeded);
+
+		public static readonly RepField GeneralSocksServerFailure = new RepField((byte)ReplyType.GeneralSocksServerFailure);
+
+		public static readonly RepField CconnectionNotAllowedByRuleset = new RepField((byte)ReplyType.ConnectionNotAllowedByRuleset);
+
+		public static readonly RepField NetworkUnreachable = new RepField((byte)ReplyType.NetworkUnreachable);
+
+		public static readonly RepField HostUnreachable = new RepField((byte)ReplyType.HostUnreachable);
+
+		public static readonly RepField ConnectionRefused = new RepField((byte)ReplyType.ConnectionRefused);
+
+		public static readonly RepField TtlExpired = new RepField((byte)ReplyType.TtlExpired);
+
+		public static readonly RepField CommandNoSupported = new RepField((byte)ReplyType.CommandNotSupported);
+
+		public static readonly RepField AddressTypeNotSupported = new RepField((byte)ReplyType.AddressTypeNotSupported);
+
 		public RepField(byte byteValue)
 		{
 			ByteValue = byteValue;
 		}
-
-		#region Statics
-
-		public static RepField Succeeded => new RepField((byte)ReplyType.Succeeded);
-
-		public static RepField GeneralSocksServerFailure => new RepField((byte)ReplyType.GeneralSocksServerFailure);
-
-		public static RepField CconnectionNotAllowedByRuleset => new RepField((byte)ReplyType.ConnectionNotAllowedByRuleset);
-
-		public static RepField NetworkUnreachable => new RepField((byte)ReplyType.NetworkUnreachable);
-
-		public static RepField HostUnreachable => new RepField((byte)ReplyType.HostUnreachable);
-
-		public static RepField ConnectionRefused => new RepField((byte)ReplyType.ConnectionRefused);
-
-		public static RepField TtlExpired => new RepField((byte)ReplyType.TtlExpired);
-
-		public static RepField CommandNoSupported => new RepField((byte)ReplyType.CommandNotSupported);
-
-		public static RepField AddressTypeNotSupported => new RepField((byte)ReplyType.AddressTypeNotSupported);
-
-		#endregion Statics
 
 		public override string ToString()
 		{

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RsvField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RsvField.cs
@@ -4,11 +4,11 @@ namespace WalletWasabi.Tor.Socks5.Models.Fields.OctetFields
 {
 	public class RsvField : OctetSerializableBase
 	{
+		public static readonly RsvField X00 = new RsvField(0x00);
+
 		public RsvField(byte byteValue)
 		{
 			ByteValue = byteValue;
 		}
-
-		public static RsvField X00 => new RsvField(0x00);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Interfaces/IByteSerializable.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Interfaces/IByteSerializable.cs
@@ -5,7 +5,5 @@ namespace WalletWasabi.Tor.Socks5.Models.Interfaces
 		byte ToByte();
 
 		string ToHex(bool xhhSyntax);
-
-		void FromHex(string hex);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Messages/TorSocks5Response.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.Tor.Socks5.Models.Messages
 		public TorSocks5Response(byte[] bytes)
 		{
 			Guard.NotNullOrEmpty(nameof(bytes), bytes);
-			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, 6);
+			Guard.MinimumAndNotNull($"{nameof(bytes)}.{nameof(bytes.Length)}", bytes.Length, smallest: 6);
 
 			Ver = new VerField(bytes[0]);
 			Rep = new RepField(bytes[1]);

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -152,7 +152,7 @@ namespace WalletWasabi.Tor.Socks5
 				// Username / Password request:
 				var identity = RandomString.CapitalAlphaNumeric(21);
 				var uName = new UNameField(uName: identity);
-				var passwd = new PasswdField(passwd: identity);
+				var passwd = new PasswdField(password: identity);
 				var usernamePasswordRequest = new UsernamePasswordRequest(uName, passwd);
 				sendBuffer = usernamePasswordRequest.ToBytes();
 


### PR DESCRIPTION
This PR contains some changes from #4738 that can be reviewed. 

This work mostly finishes the job of converting Tor SOCKS5 classes to be immutable and as such they can be used as "constants" so that many allocations are not needed. It won't have any significant perf outcome but the code is more clear after the change and I guess it's more in line with the rest of the source code.

The PR can be reviewed commit by commit too.