### PR TITLE
Tor parallel bits - part 2: Improve performance by not allocating for every single byte of an HTT…

### DIFF
--- a/WalletWasabi/Tor/Http/Constants.cs
+++ b/WalletWasabi/Tor/Http/Constants.cs
@@ -4,8 +4,7 @@ namespace WalletWasabi.Tor.Http
 	{
 		public const string SP = " ";
 		public const string HTAB = "\t";
-		public const string CR = "\r";
-		public const string LF = "\n";
+		public const byte LF = (byte)'\n';
 		public const string CRLF = "\r\n";
 	}
 }

--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.Tor.Http.Helpers
 			{
 				read = await stream.ReadByteAsync(ctsToken).ConfigureAwait(false);
 				bab.Append((byte)read);
-				if (Encoding.ASCII.GetBytes(LF)[0] == (byte)read)
+				if (LF == (byte)read)
 				{
 					break;
 				}


### PR DESCRIPTION
…P response.

This PR contains some changes from #4738 that can be reviewed. 

Notes:

* `CR` was unused constant.
* Conversion of LF char to byte can be double checked here: https://source.dot.net/#System.Private.CoreLib/Convert.cs,0f4b42b329e2067f 