### PR TITLE
Tor parallel bits - part 3: StreamExtensions: Fix "ReadBlockAsync" method and use it in TorSock…

### DIFF
--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -1,6 +1,6 @@
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
-using System;
 
 namespace System.IO
 {
@@ -8,25 +8,59 @@ namespace System.IO
 	{
 		public static async Task<int> ReadByteAsync(this Stream stream, CancellationToken ctsToken = default)
 		{
-			var buf = new byte[1];
-			var len = await stream.ReadAsync(buf.AsMemory(0, 1), ctsToken).ConfigureAwait(false);
-			if (len == 0)
+			ArrayPool<byte> pool = ArrayPool<byte>.Shared;
+			byte[] buffer = pool.Rent(1);
+			try
 			{
-				return -1;
-			}
+				int len = await stream.ReadAsync(buffer.AsMemory(0, 1), ctsToken).ConfigureAwait(false);
 
-			return buf[0];
+				// End of stream.
+				if (len == 0)
+				{
+					return -1;
+				}
+
+				return buffer[0];
+			}
+			finally
+			{
+				pool.Return(buffer);
+			}
 		}
 
 		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken ctsToken = default)
 		{
-			var left = count;
+			int left = count;
 			while (left != 0)
 			{
-				var read = await stream.ReadAsync(buffer.AsMemory(count - left, left), ctsToken).ConfigureAwait(false);
+				int read = await stream.ReadAsync(buffer.AsMemory(count - left, left), ctsToken).ConfigureAwait(false);
 				left -= read;
 			}
 			return count - left;
+		}
+
+		/// <summary>
+		/// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/>.
+		/// </summary>
+		/// <param name="stream">Stream to read from.</param>
+		/// <param name="buffer">Buffer whose length must be at least <paramref name="count"/> elements.</param>
+		/// <param name="count">Number of bytes to read.</param>
+		/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
+		/// <returns><c>true</c> if we could read exactly <paramref name="count"/> bytes from stream (stream may contain more bytes though).</returns>
+		public static async Task<bool> ReadExactlyAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
+		{
+			int offset = 0;
+			while (offset < count)
+			{
+				int read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset), cancellationToken).ConfigureAwait(false);
+				if (read == 0)
+				{
+					return false;
+				}
+				offset += read;
+			}
+
+			return true;
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -35,7 +35,7 @@ namespace System.IO
 		/// <param name="buffer">Buffer whose length must be at least <paramref name="count"/> elements.</param>
 		/// <param name="count">Number of bytes to read.</param>
 		/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
-		/// <returns><paramref name="count"/> when all <paramref name="count"/> bytes were read from the stream. Otherwise, a number of remaining bytes that were not transmitted.</returns>
+		/// <returns>Number of read bytes. At most <paramref name="count"/>.</returns>
 		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
 		{
 			int left = count;

--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -35,7 +35,7 @@ namespace System.IO
 		/// <param name="buffer">Buffer whose length must be at least <paramref name="count"/> elements.</param>
 		/// <param name="count">Number of bytes to read.</param>
 		/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
-		/// <returns><c>0</c> when all <paramref name="count"/> bytes were read from the stream. Otherwise, a number of remaining bytes that were not transmitted.</returns>
+		/// <returns><paramref name="count"/> when all <paramref name="count"/> bytes were read from the stream. Otherwise, a number of remaining bytes that were not transmitted.</returns>
 		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
 		{
 			int left = count;

--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -28,39 +28,30 @@ namespace System.IO
 			}
 		}
 
-		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken ctsToken = default)
-		{
-			int left = count;
-			while (left != 0)
-			{
-				int read = await stream.ReadAsync(buffer.AsMemory(count - left, left), ctsToken).ConfigureAwait(false);
-				left -= read;
-			}
-			return count - left;
-		}
-
 		/// <summary>
-		/// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/>.
+		/// Attempts to read <paramref name="count"/> bytes from <paramref name="stream"/>.
 		/// </summary>
 		/// <param name="stream">Stream to read from.</param>
 		/// <param name="buffer">Buffer whose length must be at least <paramref name="count"/> elements.</param>
 		/// <param name="count">Number of bytes to read.</param>
 		/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
-		/// <returns><c>true</c> if we could read exactly <paramref name="count"/> bytes from stream (stream may contain more bytes though).</returns>
-		public static async Task<bool> ReadExactlyAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
+		/// <returns><c>0</c> when all <paramref name="count"/> bytes were read from the stream. Otherwise, a number of remaining bytes that were not transmitted.</returns>
+		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
 		{
-			int offset = 0;
-			while (offset < count)
+			int left = count;
+			while (left != 0)
 			{
-				int read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset), cancellationToken).ConfigureAwait(false);
+				int read = await stream.ReadAsync(buffer.AsMemory(count - left, left), cancellationToken).ConfigureAwait(false);
+
+				// End of stream.
 				if (read == 0)
 				{
-					return false;
+					break;
 				}
-				offset += read;
-			}
 
-			return true;
+				left -= read;
+			}
+			return count - left;
 		}
 	}
 }

--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -38,10 +38,10 @@ namespace System.IO
 		/// <returns>Number of read bytes. At most <paramref name="count"/>.</returns>
 		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
 		{
-			int left = count;
-			while (left != 0)
+			int remaining = count;
+			while (remaining != 0)
 			{
-				int read = await stream.ReadAsync(buffer.AsMemory(count - left, left), cancellationToken).ConfigureAwait(false);
+				int read = await stream.ReadAsync(buffer.AsMemory(count - remaining, remaining), cancellationToken).ConfigureAwait(false);
 
 				// End of stream.
 				if (read == 0)
@@ -49,9 +49,9 @@ namespace System.IO
 					break;
 				}
 
-				left -= read;
+				remaining -= read;
 			}
-			return count - left;
+			return count - remaining;
 		}
 	}
 }

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -367,7 +367,9 @@ namespace WalletWasabi.Tor.Socks5
 					// Read exactly "receiveBufferSize" bytes.
 					if (receiveBufferSize != null)
 					{
-						if (await stream.ReadExactlyAsync(receiveBuffer, receiveBufferSize.Value, cancellationToken).ConfigureAwait(false))
+						int unreadBytes = await stream.ReadBlockAsync(receiveBuffer, receiveBufferSize.Value, cancellationToken).ConfigureAwait(false);
+
+						if (unreadBytes == 0)
 						{
 							return receiveBuffer;
 						}

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -369,7 +369,7 @@ namespace WalletWasabi.Tor.Socks5
 					{
 						int unreadBytes = await stream.ReadBlockAsync(receiveBuffer, receiveBufferSize.Value, cancellationToken).ConfigureAwait(false);
 
-						if (unreadBytes == 0)
+						if (unreadBytes == receiveBufferSize.Value)
 						{
 							return receiveBuffer;
 						}


### PR DESCRIPTION
…s5Client.

Notes:

* `ArrayPool` is useful to avoid a lot of allocations here.
* `ReadExactlyAsync` reads correctly n bytes from a (network) stream which represents a single logical message. Currently, it's possible that the received message was not read correctly (it is still possibly in one case, this will be addressed in a follow-up PR).