### PR TITLE
TorProcessManager: Report that Tor process has exited when waiting fo…

### DIFF
--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -109,6 +109,12 @@ namespace WalletWasabi.Tor
 							break;
 						}
 
+						if (TorProcess.HasExited)
+						{
+							Logger.LogError("Tor process failed to start!");
+							return false;
+						}
+
 						const int MaxAttempts = 25;
 
 						if (i >= MaxAttempts)


### PR DESCRIPTION
…r its start.

It does not make sense to wait for Tor process to be running when it has already exited. This is a very minor improvement but it is useful for debugging.