### PR TITLE
Tor parallel bits - part 5: Remove IHttpClient.SupportedSslProtocols.

### DIFF
--- a/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
+++ b/WalletWasabi/Tor/Http/ClearnetHttpClient.cs
@@ -22,8 +22,6 @@ namespace WalletWasabi.Tor.Http
 				PooledConnectionLifetime = TimeSpan.FromMinutes(5)
 			};
 
-			socketHandler.SslOptions.EnabledSslProtocols = IHttpClient.SupportedSslProtocols;
-
 			HttpClient = new HttpClient(socketHandler);
 		}
 

--- a/WalletWasabi/Tor/Http/IHttpClient.cs
+++ b/WalletWasabi/Tor/Http/IHttpClient.cs
@@ -11,9 +11,6 @@ namespace WalletWasabi.Tor.Http
 	/// </summary>
 	public interface IHttpClient
 	{
-		/// <summary>TLS protocols we support for both clearnet and Tor proxy.</summary>
-		static readonly SslProtocols SupportedSslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
-
 		/// <summary>Sends an HTTP(s) request.</summary>
 		/// <param name="request">HTTP request message to send.</param>
 		/// <param name="isolateStream"><c>true</c> value is only available for Tor HTTP client to use a new Tor circuit

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -183,7 +183,7 @@ namespace WalletWasabi.Tor.Socks5
 		public async Task UpgradeToSslAsync(string host)
 		{
 			SslStream sslStream = new SslStream(TcpClient.GetStream(), leaveInnerStreamOpen: true);
-			await sslStream.AuthenticateAsClientAsync(host, new X509CertificateCollection(), IHttpClient.SupportedSslProtocols, true).ConfigureAwait(false);
+			await sslStream.AuthenticateAsClientAsync(host, new X509CertificateCollection(), true).ConfigureAwait(false);
 			Stream = sslStream;
 		}
 


### PR DESCRIPTION
This PR extracts @lontivero commit from #4738. 

Explanation from the commit:

> According to the documentation (https://docs.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-5.0) by default (None) is the recommended one because let the OS to negotiate the most secure connection.
>
> Side note: TLS is only for backward compatibility and TLS1.1 is being deprecated and it is disabled in most recent browsers and servers.

Cherry-picked from: https://github.com/zkSNACKs/WalletWasabi/pull/4738/commits/e54ea8922b63c2861dec62d366686c7e4618dd33