### PR TITLE
Add thread ID to logging messages.

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -136,7 +136,7 @@ namespace WalletWasabi.Logging
 				var category = string.IsNullOrWhiteSpace(callerFilePath) ? "" : $"{EnvironmentHelpers.ExtractFileName(callerFilePath)} ({callerLineNumber})";
 
 				var messageBuilder = new StringBuilder();
-				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} {level.ToString().ToUpperInvariant()}\t");
+				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} [{Thread.CurrentThread.ManagedThreadId}] {level.ToString().ToUpperInvariant()}\t");
 
 				if (message.Length == 0)
 				{


### PR DESCRIPTION
This PR is a proposal to add thread IDs to logging messages. The result would be: 

```
2021-01-04 08:49:58 [1] INFO    FileSystemBlockRepository (24)  .ctor finished in 12 milliseconds.
2021-01-04 08:49:58 [1] INFO    Global (81)     .ctor finished in 58 milliseconds.
2021-01-04 08:50:00 [1] INFO    Program (53)    Wasabi GUI started (4944e1ef-38f6-4b12-a805-a91ed32f0ac5).
2021-01-04 08:50:59 [5] INFO    TransactionStore (34)   MempoolStore.InitializeAsync finished in 57 milliseconds.
2021-01-04 08:50:59 [8] INFO    TransactionStore (34)   ConfirmedStore.InitializeAsync finished in 44 milliseconds.
2021-01-04 08:50:59 [8] INFO    AllTransactionStore (40)        InitializeAsync finished in 84 milliseconds.
```

The reasons why that may be a good thing are:

* I find it useful in general for debugging when there are two or more procedures running in parallel.
  * Maybe this issue would be slightly easier to debug too: https://github.com/zkSNACKs/WalletWasabi/issues/4955#issuecomment-753541626 
* David mentioned that logs won't be visible to users via console so they won't mind anyway.