### PR TITLE
[easy] Add missing "using"s and fix nullability issue.

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			var utxos = await rpc.ListUnspentAsync();
 			var utxo = utxos[0];
 			var tx = await rpc.GetRawTransactionAsync(utxo.OutPoint.Hash);
-			var content = new StringContent($"'{tx.ToHex()}'", Encoding.UTF8, "application/json");
+			using StringContent content = new($"'{tx.ToHex()}'", Encoding.UTF8, "application/json");
 
 			Logger.TurnOff();
 
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.RegressionTests
 		{
 			await Common.InitializeTestEnvironmentAsync(RegTestFixture, 1);
 
-			var content = new StringContent($"''", Encoding.UTF8, "application/json");
+			using StringContent content = new($"''", Encoding.UTF8, "application/json");
 
 			Logger.TurnOff();
 
@@ -220,7 +220,7 @@ namespace WalletWasabi.Tests.RegressionTests
 
 					await rpc.GenerateAsync(1);
 
-					var blockchainController = (BlockchainController)RegTestFixture.BackendHost.Services.GetService(typeof(BlockchainController));
+					var blockchainController = (BlockchainController)RegTestFixture.BackendHost.Services.GetService(typeof(BlockchainController))!;
 					blockchainController.Cache.Remove($"{nameof(BlockchainController.GetStatusAsync)}");
 
 					// Set back the time to trigger timeout in BlockchainController.GetStatusAsync.


### PR DESCRIPTION
`StringContent` is non-controversial.

I'm not sure whether you guys are ok with this change: https://github.com/zkSNACKs/WalletWasabi/compare/master...kiminuo:feature/2021-mising-usings?expand=1#diff-e988bb08724158f8009106903466a8b24156ae86036ea939337f7b84199b9770R223 It seems reasonable to me. I would prefer `BlockchainController service = Assert.NotNull(RegTestFixture.BackendHost.Services.GetService(typeof(BlockchainController)))` but `Assert.NotNull` does not return any object.