### PR TITLE
Reduce published size with App Trimming

### DIFF
--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -18,6 +18,8 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Fluent.Desktop</PathMap>
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode>CopyUsed</TrimMode>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
+++ b/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
@@ -5,6 +5,8 @@
 		<AnalysisLevel>latest</AnalysisLevel>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode>CopyUsed</TrimMode>
     </PropertyGroup>
 
 	<ItemGroup>

--- a/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
+++ b/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
@@ -11,6 +11,8 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Fluent</PathMap>
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode>CopyUsed</TrimMode>
 	</PropertyGroup>
 	<ItemGroup>
 		<AvaloniaResource Include="Assets\**" />

--- a/WalletWasabi.Gui/WalletWasabi.Gui.csproj
+++ b/WalletWasabi.Gui/WalletWasabi.Gui.csproj
@@ -11,6 +11,8 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Gui</PathMap>
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode>CopyUsed</TrimMode>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -294,9 +294,7 @@ namespace WalletWasabi.Packager
 						$"/p:ErrorReport=none",
 						$"/p:DocumentationFile=\"\"",
 						$"/p:Deterministic=true",
-						$"/p:RestoreLockedMode=true",
-						$"/p:PublishTrimmed=true",
-						$"/p:TrimMode=CopyUsed"),
+						$"/p:RestoreLockedMode=true"),
 					redirectStandardOutput: true);
 
 				Tools.ClearSha512Tags(currentBinDistDirectory);

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -294,7 +294,9 @@ namespace WalletWasabi.Packager
 						$"/p:ErrorReport=none",
 						$"/p:DocumentationFile=\"\"",
 						$"/p:Deterministic=true",
-						$"/p:RestoreLockedMode=true"),
+						$"/p:RestoreLockedMode=true",
+						$"/p:PublishTrimmed=true",
+						$"/p:TrimMode=CopyUsed"),
 					redirectStandardOutput: true);
 
 				Tools.ClearSha512Tags(currentBinDistDirectory);

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -12,6 +12,8 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi</PathMap>
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode>CopyUsed</TrimMode>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Optionally during the publish process, a trim phase occurs which does an exhaustive walk of the code paths identifying the assemblies that are used by the code. It will then only package those assemblies into the app, thereby reducing the size of the application.

## Results

I published Wasabi with the --onlybinaries option.

**No Trim - current**

linux 201 Mb
osx 178 Mb
win 186 Mb

**Assembly-level trimming - this PR**

linux 162
osx 139
win 147

**Member-Level Trimming - experimental feature**

linux 152 Mb
osx 129 Mb
win 136 Mb

## Be aware

> Trimming sounds great, but as with most good things, there is a catch. The trimming does a static analysis of the code and therefore can only identify types and members when they are referenced from code. However .NET offers a great deal of dynamism, typically depending on reflection. For example, Dependency Injection in ASP.NET Core uses reflection to select appropriate constructors. This is largely transparent to the static analysis, so it needs to either be told about the required types or be able to detect common dynamism patterns – otherwise it will trim away code that is needed by the application which will result in runtime crashes..

## Todo: 
- Investigate places in the code where reflection is used, for example, dependency Injection in ASP.NET Core uses reflection.
According to my investigation, this is the only place where we are using reflection and it cannot create the problem mentioned above. https://github.com/molnard/WalletWasabi/blob/a241d4eaee629f1fa91ac84dab1cfce685d76b7c/WalletWasabi/Extensions/ReflectionExtensions.cs#L7

- Preserve reflection-based libraries from trimming. https://devblogs.microsoft.com/dotnet/customizing-trimming-in-net-core-5/#using-xml-files-to-control-trimming

https://devblogs.microsoft.com/dotnet/app-trimming-in-net-5/