### PR TITLE
HWI: Add CommandName attribute and use it.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiCommandsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiCommandsTests.cs
@@ -1,0 +1,17 @@
+using WalletWasabi.Extensions;
+using WalletWasabi.Hwi.Models;
+using WalletWasabi.Hwi.Parsers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Hwi
+{
+	public class HwiCommandsTests
+	{
+		[Fact]
+		public void TestCommandNameAsync()
+		{
+			Assert.Equal("getmasterxpub", HwiCommands.GetMasterXpub.ToCommandName());
+			Assert.Equal("sendpin", HwiCommands.SendPin.ToCommandName());
+		}
+	}
+}

--- a/WalletWasabi/Hwi/Models/CommandNameAttribute.cs
+++ b/WalletWasabi/Hwi/Models/CommandNameAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace WalletWasabi.Hwi.Models
+{
+	/// <summary>
+	/// This attribute is used to represent command names as expected to be received by HWI.
+	/// </summary>
+	/// <example>For <see cref="HwiCommands.GetMasterXpub"/>, we want to send <c>getmasterxpub</c> to HWI.</example>
+	public class CommandNameAttribute : Attribute
+	{
+		public CommandNameAttribute(string value)
+		{
+			CommandName = value;
+		}
+
+		public string CommandName { get; }
+	}
+}

--- a/WalletWasabi/Hwi/Models/HwiCommands.cs
+++ b/WalletWasabi/Hwi/Models/HwiCommands.cs
@@ -10,6 +10,7 @@ namespace WalletWasabi.Hwi.Models
 	public enum HwiCommands
 	{
 		/// <summary>Get a list of all available hardware wallets.</summary>
+		[CommandName("enumerate")]
 		Enumerate,
 
 		/// <summary>
@@ -20,6 +21,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"xpub": &lt;xpub string&gt;"}</code>.
 		/// </remarks>
+		[CommandName("getmasterxpub")]
 		GetMasterXpub,
 
 		/// <summary>
@@ -28,6 +30,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"psbt": &lt;base64 psbt string&gt;}</code>.
 		/// </remarks>
+		[CommandName("signtx")]
 		SignTx,
 
 		/// <summary>
@@ -37,6 +40,7 @@ namespace WalletWasabi.Hwi.Models
 		/// Return <code>{"xpub": &lt;xpub string&gt;}</code>.
 		/// </remarks>
 		/// </summary>
+		[CommandName("getxpub")]
 		GetXpub,
 
 		/// <summary>
@@ -48,6 +52,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"signature": &lt;base64 signature string&gt;}</code>.
 		/// </remarks>
+		[CommandName("signmessage")]
 		SignMessage,
 
 		/// <summary>
@@ -61,6 +66,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <item><c>end</c>    - The index to end at.</item>
 		/// </list>
 		/// </remarks>
+		[CommandName("getkeypool")]
 		GetKeypool,
 
 		/// <summary>
@@ -72,6 +78,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"address": &lt;base58 or bech32 address string&gt;}</code>.
 		/// </remarks>
+		[CommandName("displayaddress")]
 		DisplayAddress,
 
 		/// <summary>
@@ -82,6 +89,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"success": bool, "error": str, "code": int}</code>.
 		/// </remarks>
+		[CommandName("setup")]
 		Setup,
 
 		/// <summary>
@@ -92,6 +100,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"success": bool, "error": srt, "code": int}</code>.
 		/// </remarks>
+		[CommandName("wipe")]
 		Wipe,
 
 		/// <summary>
@@ -102,6 +111,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"success": bool, "error": srt, "code": int}</code>.
 		/// </remarks>
+		[CommandName("restore")]
 		Restore,
 
 		/// <summary>
@@ -112,6 +122,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"success": bool, "error": srt, "code": int}</code>.
 		/// </remarks>
+		[CommandName("backup")]
 		Backup,
 
 		/// <summary>
@@ -122,6 +133,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"success": bool, "error": srt, "code": int}</code>.
 		/// </remarks>
+		[CommandName("promptpin")]
 		PromptPin,
 
 		/// <summary>
@@ -132,6 +144,7 @@ namespace WalletWasabi.Hwi.Models
 		/// <remarks>
 		/// Return <code>{"success": bool, "error": srt, "code": int}</code>.
 		/// </remarks>
+		[CommandName("sendpin")]
 		SendPin
 	}
 }

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
@@ -371,7 +372,9 @@ namespace WalletWasabi.Hwi.Parsers
 				{
 					argumentBuilder.Append(' ');
 				}
-				argumentBuilder.Append(command.ToString().ToLowerInvariant());
+
+				string commandName = command.GetFirstAttribute<CommandNameAttribute>()!.CommandName;
+				argumentBuilder.Append(commandName);
 			}
 
 			commandArguments = Guard.Correct(commandArguments);

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -373,8 +373,7 @@ namespace WalletWasabi.Hwi.Parsers
 					argumentBuilder.Append(' ');
 				}
 
-				string commandName = command.GetFirstAttribute<CommandNameAttribute>()!.CommandName;
-				argumentBuilder.Append(commandName);
+				argumentBuilder.Append(command.Value.ToCommandName());
 			}
 
 			commandArguments = Guard.Correct(commandArguments);
@@ -391,6 +390,11 @@ namespace WalletWasabi.Hwi.Parsers
 		public static string ToHwiFriendlyString(this HardwareWalletModels me)
 		{
 			return me.ToString().ToLowerInvariant();
+		}
+
+		public static string ToCommandName(this HwiCommands command)
+		{
+			return command.GetFirstAttribute<CommandNameAttribute>()!.CommandName;
 		}
 	}
 }


### PR DESCRIPTION
This PR is meant to make it clear what the commands are actually being sent to HWI. 

There are a few advantages for this:

* You can rename enum values as you like and it does not matter. So if you find `HwiCommands.Enumerate` not-sufficiently-descriptive name then you can rename it and it's OK.
* Adding new commands seems subjectively easier with this approach than with the current one.