### PR TITLE
Mark members as static (CA1822)

### DIFF
--- a/WalletWasabi.Fluent.Generators/AutoNotifyGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/AutoNotifyGenerator.cs
@@ -183,7 +183,7 @@ namespace {namespaceName}
 			return source.ToString();
 		}
 
-		private void ProcessField(StringBuilder source, IFieldSymbol fieldSymbol, ISymbol attributeSymbol)
+		private static void ProcessField(StringBuilder source, IFieldSymbol fieldSymbol, ISymbol attributeSymbol)
 		{
 			var fieldName = fieldSymbol.Name;
 			var fieldType = fieldSymbol.Type;

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
@@ -142,7 +142,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 			}
 		}
 
-		private void ValidateWalletName(IValidationErrors errors, WalletManager walletManager, string walletName)
+		private static void ValidateWalletName(IValidationErrors errors, WalletManager walletManager, string walletName)
 		{
 			string walletFilePath = Path.Combine(walletManager.WalletDirectories.WalletsDir, $"{walletName}.json");
 

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/AboutAdvancedInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/AboutAdvancedInfoViewModel.cs
@@ -12,13 +12,13 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 			NextCommand = CancelCommand;
 		}
 
-		public Version BitcoinCoreVersion => Constants.BitcoinCoreVersion;
+		public static Version BitcoinCoreVersion => Constants.BitcoinCoreVersion;
 
-		public Version HwiVersion => Constants.HwiVersion;
+		public static Version HwiVersion => Constants.HwiVersion;
 
-		public string BackendCompatibleVersions => Constants.ClientSupportBackendVersionText;
+		public static string BackendCompatibleVersions => Constants.ClientSupportBackendVersionText;
 
-		public string CurrentBackendMajorVersion => WasabiClient.ApiVersion.ToString();
+		public static string CurrentBackendMajorVersion => WasabiClient.ApiVersion.ToString();
 
 		protected override void OnDialogClosed()
 		{

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/DialogScreenViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/DialogScreenViewModel.cs
@@ -38,7 +38,7 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 			IsDialogOpen = CurrentPage is { };
 		}
 
-		private void CloseDialogs(IEnumerable<RoutableViewModel> navigationStack)
+		private static void CloseDialogs(IEnumerable<RoutableViewModel> navigationStack)
 		{
 			// Close all dialogs so the awaited tasks can complete.
 			// - DialogViewModelBase.ShowDialogAsync()

--- a/WalletWasabi.Fluent/ViewModels/HelpAndSupport/AboutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/HelpAndSupport/AboutViewModel.cs
@@ -55,7 +55,7 @@ namespace WalletWasabi.Fluent.ViewModels.HelpAndSupport
 
 		public ICommand CopyLinkCommand { get; }
 
-		public Version ClientVersion => Constants.ClientVersion;
+		public static Version ClientVersion => Constants.ClientVersion;
 
 		public static string ClearnetLink => "https://wasabiwallet.io/";
 

--- a/WalletWasabi.Fluent/ViewModels/Navigation/RoutableViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/RoutableViewModel.cs
@@ -69,7 +69,7 @@ namespace WalletWasabi.Fluent.ViewModels.Navigation
 			return Navigate(currentTarget);
 		}
 
-		public INavigationStack<RoutableViewModel> Navigate(NavigationTarget currentTarget)
+		public static INavigationStack<RoutableViewModel> Navigate(NavigationTarget currentTarget)
 		{
 			switch (currentTarget)
 			{

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -56,14 +56,14 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 				.Subscribe(_ => Save());
 		}
 
-		public Version BitcoinCoreVersion => Constants.BitcoinCoreVersion;
+		public static Version BitcoinCoreVersion => Constants.BitcoinCoreVersion;
 
-		public IEnumerable<Network> Networks => Network.GetNetworks();
+		public static IEnumerable<Network> Networks => Network.GetNetworks();
 
 		private void ValidateBitcoinP2PEndPoint(IValidationErrors errors)
 			=> ValidateEndPoint(errors, BitcoinP2PEndPoint, Network.DefaultPort, whiteSpaceOk: true);
 
-		private void ValidateEndPoint(IValidationErrors errors, string endPoint, int defaultPort, bool whiteSpaceOk)
+		private static void ValidateEndPoint(IValidationErrors errors, string endPoint, int defaultPort, bool whiteSpaceOk)
 		{
 			if (!whiteSpaceOk || !string.IsNullOrWhiteSpace(endPoint))
 			{
@@ -77,7 +77,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 		private void ValidateDustThreshold(IValidationErrors errors) =>
 			ValidateDustThreshold(errors, DustThreshold, whiteSpaceOk: true);
 
-		private void ValidateDustThreshold(IValidationErrors errors, string dustThreshold, bool whiteSpaceOk)
+		private static void ValidateDustThreshold(IValidationErrors errors, string dustThreshold, bool whiteSpaceOk)
 		{
 			if (!whiteSpaceOk || !string.IsNullOrWhiteSpace(dustThreshold))
 			{

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 				.Subscribe(x => uiConfig.FeeDisplayFormat = (int) x);
 		}
 
-		public IEnumerable<FeeDisplayFormat> FeeDisplayFormats =>
+		public static IEnumerable<FeeDisplayFormat> FeeDisplayFormats =>
 			Enum.GetValues(typeof(FeeDisplayFormat)).Cast<FeeDisplayFormat>();
 
 		protected override void EditConfigOnSave(Config config)

--- a/WalletWasabi.Fluent/ViewModels/Settings/NetworkSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/NetworkSettingsTabViewModel.cs
@@ -47,7 +47,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 		private void ValidateTorSocks5EndPoint(IValidationErrors errors)
 			=> ValidateEndPoint(errors, TorSocks5EndPoint, Constants.DefaultTorSocksPort, whiteSpaceOk: true);
 
-		private void ValidateEndPoint(IValidationErrors errors, string endPoint, int defaultPort, bool whiteSpaceOk)
+		private static void ValidateEndPoint(IValidationErrors errors, string endPoint, int defaultPort, bool whiteSpaceOk)
 		{
 			if (!whiteSpaceOk || !string.IsNullOrWhiteSpace(endPoint))
 			{

--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -94,7 +94,7 @@ namespace WalletWasabi.Fluent.ViewModels
 
 			if (!walletManager.AnyWallet(x => x.State >= WalletState.Started && x != walletViewModel.Wallet))
 			{
-				walletViewModel.OpenWalletTabs();
+				WalletViewModel.OpenWalletTabs();
 			}
 
 			walletViewModel.IsExpanded = true;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 					: new WalletViewModel(uiConfig, wallet);
 		}
 
-		public void OpenWalletTabs()
+		public static void OpenWalletTabs()
 		{
 			// TODO: Implement.
 		}


### PR DESCRIPTION
> Members that do not access instance data or call instance methods can be marked as static (Shared in Visual Basic). After you mark the methods as static, the compiler will emit nonvirtual call sites to these members. Emitting nonvirtual call sites will prevent a check at run time for each call that makes sure that the current object pointer is non-null. This can achieve a measurable performance gain for performance-sensitive code. In some cases, the failure to access the current object instance represents a correctness issue.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822