### PR TITLE
[Fluent] Use expression body for accessors

### DIFF
--- a/WalletWasabi.Fluent/Controls/ConcatenatingWrapPanel.cs
+++ b/WalletWasabi.Fluent/Controls/ConcatenatingWrapPanel.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Fluent.Controls
 
 		public ConcatenatingWrapPanel()
 		{
-			ConcatenatedChildren.CollectionChanged += base.ChildrenChanged;
+			ConcatenatedChildren.CollectionChanged += ChildrenChanged;
 		}
 
 		public Avalonia.Controls.Controls ConcatenatedChildren { get; } = new Avalonia.Controls.Controls();

--- a/WalletWasabi.Fluent/Controls/ConcatenatingWrapPanel.cs
+++ b/WalletWasabi.Fluent/Controls/ConcatenatingWrapPanel.cs
@@ -159,7 +159,8 @@ namespace WalletWasabi.Fluent.Controls
 					child.Measure(childConstraint);
 
 					// This is the size of the child in UV space
-					var sz = new UVSize(orientation,
+					var sz = new UVSize(
+						orientation,
 						itemWidthSet ? itemWidth : child.DesiredSize.Width,
 						itemHeightSet ? itemHeight : child.DesiredSize.Height);
 
@@ -213,7 +214,8 @@ namespace WalletWasabi.Fluent.Controls
 				var child = children[i];
 				if (child != null)
 				{
-					var sz = new UVSize(orientation,
+					var sz = new UVSize(
+						orientation,
 						itemWidthSet ? itemWidth : child.DesiredSize.Width,
 						itemHeightSet ? itemHeight : child.DesiredSize.Height);
 
@@ -291,6 +293,10 @@ namespace WalletWasabi.Fluent.Controls
 
 		private struct UVSize
 		{
+			internal double U;
+			internal double V;
+			private Orientation _orientation;
+
 			internal UVSize(Orientation orientation, double width, double height)
 			{
 				U = V = 0d;
@@ -304,10 +310,6 @@ namespace WalletWasabi.Fluent.Controls
 				U = V = 0d;
 				_orientation = orientation;
 			}
-
-			internal double U;
-			internal double V;
-			private Orientation _orientation;
 
 			internal double Width
 			{

--- a/WalletWasabi.Fluent/Controls/ConcatenatingWrapPanel.cs
+++ b/WalletWasabi.Fluent/Controls/ConcatenatingWrapPanel.cs
@@ -52,8 +52,8 @@ namespace WalletWasabi.Fluent.Controls
 		/// </summary>
 		public Orientation Orientation
 		{
-			get { return GetValue(OrientationProperty); }
-			set { SetValue(OrientationProperty, value); }
+			get => GetValue(OrientationProperty);
+			set => SetValue(OrientationProperty, value);
 		}
 
 		/// <summary>
@@ -61,8 +61,8 @@ namespace WalletWasabi.Fluent.Controls
 		/// </summary>
 		public double ItemWidth
 		{
-			get { return GetValue(ItemWidthProperty); }
-			set { SetValue(ItemWidthProperty, value); }
+			get => GetValue(ItemWidthProperty);
+			set => SetValue(ItemWidthProperty, value);
 		}
 
 		/// <summary>
@@ -70,8 +70,8 @@ namespace WalletWasabi.Fluent.Controls
 		/// </summary>
 		public double ItemHeight
 		{
-			get { return GetValue(ItemHeightProperty); }
-			set { SetValue(ItemHeightProperty, value); }
+			get => GetValue(ItemHeightProperty);
+			set => SetValue(ItemHeightProperty, value);
 		}
 
 		/// <summary>
@@ -93,24 +93,31 @@ namespace WalletWasabi.Fluent.Controls
 				case NavigationDirection.First:
 					index = 0;
 					break;
+
 				case NavigationDirection.Last:
 					index = children.Count - 1;
 					break;
+
 				case NavigationDirection.Next:
 					++index;
 					break;
+
 				case NavigationDirection.Previous:
 					--index;
 					break;
+
 				case NavigationDirection.Left:
 					index = horiz ? index - 1 : -1;
 					break;
+
 				case NavigationDirection.Right:
 					index = horiz ? index + 1 : -1;
 					break;
+
 				case NavigationDirection.Up:
 					index = horiz ? -1 : index - 1;
 					break;
+
 				case NavigationDirection.Down:
 					index = horiz ? -1 : index + 1;
 					break;
@@ -304,7 +311,7 @@ namespace WalletWasabi.Fluent.Controls
 
 			internal double Width
 			{
-				get { return _orientation == Orientation.Horizontal ? U : V; }
+				get => _orientation == Orientation.Horizontal ? U : V;
 				set
 				{
 					if (_orientation == Orientation.Horizontal)
@@ -317,9 +324,10 @@ namespace WalletWasabi.Fluent.Controls
 					}
 				}
 			}
+
 			internal double Height
 			{
-				get { return _orientation == Orientation.Horizontal ? V : U; }
+				get => _orientation == Orientation.Horizontal ? V : U;
 				set
 				{
 					if (_orientation == Orientation.Horizontal)


### PR DESCRIPTION
Regarding the 3rd commit (to fix CodeFactor):

> Calls to members from a base class should not begin with base., unless a local override is implemented, and the developer wants to specifically call the base class member. When there is no local override of the base class member, the call should be prefixed with `this.` rather than `base.`.


https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md