### PR TITLE
Tor parallel bits - part 7 [second attempt]: Add TorException base class and add a few comments. 

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -375,7 +375,7 @@ namespace WalletWasabi.Gui.ViewModels
 						catch (Exception ex)
 						{
 							Logger.LogError(ex);
-							NotificationHelpers.Error($"Could not get Legal Documents!{(ex is TorConnectionException ? " Backend not connected. Check your internet connection!" : "")}");
+							NotificationHelpers.Error($"Could not get Legal Documents!{(ex.InnerException is TorConnectionException ? " Backend not connected. Check your internet connection!" : "")}");
 						}
 						finally
 						{

--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -106,7 +106,8 @@ namespace WalletWasabi.Tests.IntegrationTests
 			using CancellationTokenSource ctsTimeout = new(TimeSpan.FromMinutes(2));
 
 			using var client = MakeTorHttpClient(new Uri("http://172.217.6.142"));
-			var content = await (await client.SendAsync(HttpMethod.Get, "")).Content.ReadAsStringAsync(ctsTimeout.Token);
+			HttpResponseMessage httpResponseMessage = await client.SendAsync(HttpMethod.Get, relativeUri: "", content: null, ctsTimeout.Token);
+			string content = await httpResponseMessage.Content.ReadAsStringAsync(ctsTimeout.Token);
 
 			Assert.NotEmpty(content);
 		}

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -323,9 +323,9 @@ namespace WalletWasabi.Blockchain.Transactions
 
 				Logger.LogInfo($"Payjoin payment was negotiated successfully.");
 			}
-			catch (TorConnectCommandFailedException e)
+			catch (HttpRequestException ex) when (ex.InnerException is TorConnectCommandFailedException innerEx)
 			{
-				if (e.Message.Contains("HostUnreachable"))
+				if (innerEx.Message.Contains("HostUnreachable"))
 				{
 					Logger.LogWarning($"Payjoin server is not reachable. Ignoring...");
 				}

--- a/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
@@ -173,11 +173,11 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 				{
 					return;
 				}
-				catch (TorConnectionException) // If some internet connection issue then it'll likely time out and take it as unconfirmed.
+				catch (HttpRequestException ex) when (ex.InnerException is TorConnectionException) // If some Internet connection issue then it'll likely time out and take it as unconfirmed.
 				{
 					return;
 				}
-				catch (TorConnectCommandFailedException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
+				catch (HttpRequestException ex) when (ex.InnerException is TorConnectCommandFailedException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
 				{
 					return;
 				}

--- a/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
@@ -173,11 +173,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 				{
 					return;
 				}
-				catch (HttpRequestException ex) when (ex.InnerException is TorConnectionException) // If some Internet connection issue then it'll likely time out and take it as unconfirmed.
-				{
-					return;
-				}
-				catch (HttpRequestException ex) when (ex.InnerException is TorConnectCommandFailedException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
+				catch (HttpRequestException ex) when (ex.InnerException is TorException) // If some Tor connection issue then it'll likely time out and take it as unconfirmed.
 				{
 					return;
 				}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -187,18 +187,18 @@ namespace WalletWasabi.Services
 								TorStatus = TorStatus.Running;
 								DoNotGenSocksServFail();
 							}
-							catch (TorConnectionException ex)
+							catch (HttpRequestException ex) when (ex.InnerException is TorConnectionException innerEx)
 							{
 								TorStatus = TorStatus.NotRunning;
 								BackendStatus = BackendStatus.NotConnected;
-								HandleIfGenSocksServFail(ex);
+								HandleIfGenSocksServFail(innerEx);
 								throw;
 							}
-							catch (TorConnectCommandFailedException ex)
+							catch (HttpRequestException ex) when (ex.InnerException is TorConnectCommandFailedException innerEx)
 							{
 								TorStatus = TorStatus.Running;
 								BackendStatus = BackendStatus.NotConnected;
-								HandleIfGenSocksServFail(ex);
+								HandleIfGenSocksServFail(innerEx);
 								throw;
 							}
 							catch (HttpRequestException ex) when (ex.Message.Contains("Not Found"))

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -252,7 +252,7 @@ namespace WalletWasabi.Services
 							}
 
 							hashChain.UpdateServerTipHeight((uint)response.BestHeight);
-							ExchangeRate exchangeRate = response.ExchangeRates.FirstOrDefault();
+							ExchangeRate? exchangeRate = response.ExchangeRates.FirstOrDefault();
 							if (exchangeRate is { } && exchangeRate.Rate != 0)
 							{
 								UsdExchangeRate = exchangeRate.Rate;

--- a/WalletWasabi/Tor/Socks5/Exceptions/TorConnectCommandFailedException.cs
+++ b/WalletWasabi/Tor/Socks5/Exceptions/TorConnectCommandFailedException.cs
@@ -1,13 +1,12 @@
-using System;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tor.Socks5.Models.Fields.OctetFields;
 
 namespace WalletWasabi.Tor.Socks5.Exceptions
 {
 	/// <summary>
-	/// Thrown when Tor SOCKS5 responds with an error to our <see cref="CmdField.Connect"/> command.
+	/// Thrown when Tor SOCKS5 responds with an error code to previously sent <see cref="CmdField.Connect"/> command.
 	/// </summary>
-	public class TorConnectCommandFailedException : Exception
+	public class TorConnectCommandFailedException : TorException
 	{
 		public TorConnectCommandFailedException(RepField rep) : base($"Tor SOCKS5 proxy responded with {rep}.")
 		{

--- a/WalletWasabi/Tor/Socks5/Exceptions/TorConnectionException.cs
+++ b/WalletWasabi/Tor/Socks5/Exceptions/TorConnectionException.cs
@@ -2,7 +2,15 @@ using System;
 
 namespace WalletWasabi.Tor.Socks5.Exceptions
 {
-	public class TorConnectionException : Exception
+	/// <summary>
+	/// Exception for the following cases:
+	/// <list type="bullet">
+	/// <item>An error in establishing a TCP connection to Tor SOCKS5 endpoint.</item>
+	/// <item>Any failure in sending data to Tor SOCKS5 endpoint.</item>
+	/// <item>Any failure in reading data from Tor SOCKS5 endpoint.</item>
+	/// </list>
+	/// </summary>
+	public class TorConnectionException : TorException
 	{
 		public TorConnectionException(string message) : base(message)
 		{

--- a/WalletWasabi/Tor/Socks5/Exceptions/TorException.cs
+++ b/WalletWasabi/Tor/Socks5/Exceptions/TorException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace WalletWasabi.Tor.Socks5.Exceptions
+{
+	/// <summary>
+	/// A base class for exceptions thrown by the Tor SOCKS5 classes.
+	/// </summary>
+	/// <remarks>This exception is abstract because it is not supposed to be instantiated.</remarks>
+	public abstract class TorException : Exception
+	{
+		public TorException(string message) : base(message)
+		{
+		}
+
+		public TorException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}


### PR DESCRIPTION
* This PR adds `TorException` class so that it will be possible to catch any Tor-related exception in Tor Parallel PR.
* This PR also unifies behavior of HTTP clients (TorHttpClient & ClearnetHttpClient) so that both throws `HttpRequestException`. For `TorHttpClient`, this `HttpRequestException` contains proper `TorException` as an inner exception of `HttpRequestException`.

This PR is based on feedback: https://github.com/zkSNACKs/WalletWasabi/pull/4986#issuecomment-761099455 and it is an alternative to #4986 which is generally not considered to be good.