### PR TITLE
[Fluent] Clear navigation stacks on close

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -164,7 +164,11 @@ namespace WalletWasabi.Fluent.Desktop
 		private static async Task TerminateApplicationAsync()
 		{
 			var mainViewModel = MainViewModel.Instance;
-			mainViewModel?.ClearStacks();
+
+			if (mainViewModel is { })
+			{
+				mainViewModel.ClearStacks();
+			}
 
 			if (Global is { } global)
 			{

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -9,8 +9,8 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using WalletWasabi.Fluent.CrashReport;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Gui;
-using WalletWasabi.Gui.ViewModels;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
@@ -163,11 +163,8 @@ namespace WalletWasabi.Fluent.Desktop
 		/// </summary>
 		private static async Task TerminateApplicationAsync()
 		{
-			var mainViewModel = MainWindowViewModel.Instance;
-			if (mainViewModel is { })
-			{
-				mainViewModel.Dispose();
-			}
+			var mainViewModel = MainViewModel.Instance;
+			mainViewModel?.ClearStacks();
 
 			if (Global is { } global)
 			{

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -163,15 +163,15 @@ namespace WalletWasabi.Fluent.Desktop
 		/// </summary>
 		private static async Task TerminateApplicationAsync()
 		{
-			if (Global is { } global)
-			{
-				await global.DisposeAsync().ConfigureAwait(false);
-			}
-
 			if (MainViewModel.Instance is { } mainViewModel)
 			{
 				mainViewModel.ClearStacks();
 				Logger.LogSoftwareStopped("Wasabi GUI");
+			}
+
+			if (Global is { } global)
+			{
+				await global.DisposeAsync().ConfigureAwait(false);
 			}
 		}
 

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -163,20 +163,14 @@ namespace WalletWasabi.Fluent.Desktop
 		/// </summary>
 		private static async Task TerminateApplicationAsync()
 		{
-			var mainViewModel = MainViewModel.Instance;
-
-			if (mainViewModel is { })
-			{
-				mainViewModel.ClearStacks();
-			}
-
 			if (Global is { } global)
 			{
 				await global.DisposeAsync().ConfigureAwait(false);
 			}
 
-			if (mainViewModel is { })
+			if (MainViewModel.Instance is { } mainViewModel)
 			{
+				mainViewModel.ClearStacks();
 				Logger.LogSoftwareStopped("Wasabi GUI");
 			}
 		}

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -121,6 +121,13 @@ namespace WalletWasabi.Fluent.ViewModels
 
 		private Network Network { get; }
 
+		public void ClearStacks()
+		{
+			MainScreen.Clear();
+			DialogScreen.Clear();
+			FullScreen.Clear();
+		}
+
 		public void Initialize()
 		{
 			StatusBar.Initialize(_global.Nodes.ConnectedNodes);

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -617,14 +617,6 @@ namespace WalletWasabi.Gui
 					Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
 				}
 
-				Logger.LogDebug($"Step: Application's MainWindow.", nameof(Global));
-
-				Dispatcher.UIThread.PostLogException(() =>
-				{
-					var window = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).MainWindow;
-					window?.Close();
-				});
-
 				WalletManager.OnDequeue -= WalletManager_OnDequeue;
 				WalletManager.WalletRelevantTransactionProcessed -= WalletManager_WalletRelevantTransactionProcessed;
 


### PR DESCRIPTION
This PR is about improving fluent project disposing logic by clearing the navigation stacks on close. When a ViewModel is cleared from navigation stack, its `DoNavigateFrom()` is called which calls `_currentDisposable?.Dispose();`