### PR TITLE
Legal bits - part 1: Remove legal check at Add Wallet

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
@@ -39,7 +39,6 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 		[AutoNotify] private bool _enableCancel;
 
 		public AddWalletPageViewModel(
-			LegalDocuments legalDocuments,
 			WalletManager walletManager,
 			BitcoinStore store,
 			Network network)

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
@@ -38,8 +38,6 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 		[AutoNotify] private bool _enableBack;
 		[AutoNotify] private bool _enableCancel;
 
-		private readonly LegalDocuments _legalDocuments;
-
 		public AddWalletPageViewModel(
 			LegalDocuments legalDocuments,
 			WalletManager walletManager,
@@ -48,7 +46,6 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 		{
 			Title = "Add Wallet";
 			SelectionMode = NavBarItemSelectionMode.Button;
-			_legalDocuments = legalDocuments;
 
 			var enableBack = default(IDisposable);
 
@@ -135,10 +132,6 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 			if (!inStack)
 			{
 				WalletName = "";
-
-				var termsAndConditions = new TermsAndConditionsViewModel(_legalDocuments, this);
-
-				Navigate().To(termsAndConditions);
 			}
 		}
 

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -70,7 +70,6 @@ namespace WalletWasabi.Fluent.ViewModels
 			_walletManager = new WalletManagerViewModel(global.WalletManager, global.UiConfig);
 
 			_addWalletPage = new AddWalletPageViewModel(
-				global.LegalDocuments,
 				global.WalletManager,
 				global.BitcoinStore,
 				global.Network);


### PR DESCRIPTION
We decided to check and show legal agreement on wallet load. Reason - the client will have more time to download the file and loading the wallet is unavoidable for both newly generated or already existing wallets. 

Break down of https://github.com/zkSNACKs/WalletWasabi/pull/4995