### PR TITLE
ByteHelpers: Do not allow "null" value.

### DIFF
--- a/WalletWasabi/Helpers/ByteHelpers.cs
+++ b/WalletWasabi/Helpers/ByteHelpers.cs
@@ -137,13 +137,8 @@ namespace System
 		/// <summary>
 		/// Fastest hex to byte array implementation in C#
 		/// </summary>
-		public static byte[]? FromHex(string hex)
+		public static byte[] FromHex(string hex)
 		{
-			if (hex is null)
-			{
-				return null;
-			}
-
 			if (string.IsNullOrWhiteSpace(hex))
 			{
 				return Array.Empty<byte>();


### PR DESCRIPTION
This PR proposes to change behavior of `ByteHelpers.FromHex(string hex)` which currently can return `null` value. 

I couldn't find any caller who would actually pass `null` and all the callers I have found does not handle null-case. 