### PR TITLE
[PoC] Tor parallelization suggestion 3 - BackendHttpClient 

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -15,6 +15,7 @@ using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Logging;
+using WalletWasabi.Tests.UnitTests.Clients;
 using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.Tor.Http;
 using WalletWasabi.Tor.Http.Extensions;

--- a/WalletWasabi.Tests/UnitTests/Clients/BackendHttpClient.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/BackendHttpClient.cs
@@ -2,8 +2,9 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Tor.Http;
 
-namespace WalletWasabi.Tor.Http
+namespace WalletWasabi.Tests.UnitTests.Clients
 {
 	/// <summary>
 	/// Convenience class that allows sending HTTP request to Wasabi Backend using relative URIs.


### PR DESCRIPTION
Move BackendHttpClient to the test project

Goal
- Reduce the number of *Clients