### PR TITLE
Document rpcthread setting

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -190,6 +190,7 @@ pico ~/.bitcoin/bitcoin.conf
 testnet=[0/1]
 
 [main/test].rpcworkqueue=256
+[main/test].rpcthreads=8
 
 [main/test].txindex=1
 


### PR DESCRIPTION
Documents the change in the number of threads used to process the rpc requests queue (from 4 to 8) 