### PR TITLE
ChecksConfigChangesAsync: Make it more robust wrt to detecting a conf…

### DIFF
--- a/WalletWasabi/Services/ConfigWatcher.cs
+++ b/WalletWasabi/Services/ConfigWatcher.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Bases;
 using WalletWasabi.Helpers;
 using WalletWasabi.Interfaces;
+using WalletWasabi.WabiSabi;
 
 namespace WalletWasabi.Services
 {
@@ -14,6 +15,11 @@ namespace WalletWasabi.Services
 			Config = Guard.NotNull(nameof(config), config);
 			ExecuteWhenChanged = Guard.NotNull(nameof(executeWhenChanged), executeWhenChanged);
 			config.AssertFilePathSet();
+		}
+
+		public static ConfigWatcher FromParameters(CoordinatorParameters parameters, Action executeWhenChanged)
+		{
+			return new(parameters.ConfigChangeMonitoringPeriod, parameters.RuntimeCoordinatorConfig, executeWhenChanged);
 		}
 
 		public IConfig Config { get; }

--- a/WalletWasabi/Services/ConfigWatcher.cs
+++ b/WalletWasabi/Services/ConfigWatcher.cs
@@ -17,13 +17,13 @@ namespace WalletWasabi.Services
 			config.AssertFilePathSet();
 		}
 
+		public IConfig Config { get; }
+		public Action ExecuteWhenChanged { get; }
+
 		public static ConfigWatcher FromParameters(CoordinatorParameters parameters, Action executeWhenChanged)
 		{
 			return new(parameters.ConfigChangeMonitoringPeriod, parameters.RuntimeCoordinatorConfig, executeWhenChanged);
 		}
-
-		public IConfig Config { get; }
-		public Action ExecuteWhenChanged { get; }
 
 		protected override Task ActionAsync(CancellationToken cancel)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Banning/Warden.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Warden.cs
@@ -23,16 +23,16 @@ namespace WalletWasabi.WabiSabi.Backend.Banning
 			LastKnownChange = Prison.ChangeId;
 		}
 
-		public static Warden FromParameters(CoordinatorParameters parameters)
-		{
-			return new(parameters.UtxoWardenPeriod, parameters.PrisonFilePath, parameters.RuntimeCoordinatorConfig);
-		}
-
 		public Prison Prison { get; }
 		public Guid LastKnownChange { get; private set; }
 
 		public string PrisonFilePath { get; }
 		public WabiSabiConfig Config { get; }
+
+		public static Warden FromParameters(CoordinatorParameters parameters)
+		{
+			return new(parameters.UtxoWardenPeriod, parameters.PrisonFilePath, parameters.RuntimeCoordinatorConfig);
+		}
 
 		private static Prison DeserializePrison(string prisonFilePath)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Banning/Warden.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Warden.cs
@@ -23,6 +23,11 @@ namespace WalletWasabi.WabiSabi.Backend.Banning
 			LastKnownChange = Prison.ChangeId;
 		}
 
+		public static Warden FromParameters(CoordinatorParameters parameters)
+		{
+			return new(parameters.UtxoWardenPeriod, parameters.PrisonFilePath, parameters.RuntimeCoordinatorConfig);
+		}
+
 		public Prison Prison { get; }
 		public Guid LastKnownChange { get; private set; }
 

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -18,9 +18,15 @@ namespace WalletWasabi.WabiSabi
 		public WabiSabiCoordinator(CoordinatorParameters parameters)
 		{
 			Parameters = parameters;
+			Warden = Warden.FromParameters(parameters);
+			ConfigWatcher = ConfigWatcher.FromParameters(parameters, () => Logger.LogInfo("WabiSabi configuration has changed."));
+		}
 
-			Warden = new(parameters.UtxoWardenPeriod, parameters.PrisonFilePath, Config);
-			ConfigWatcher = new(parameters.ConfigChangeMonitoringPeriod, Config, () => Logger.LogInfo("WabiSabi configuration has changed."));
+		public WabiSabiCoordinator(CoordinatorParameters parameters, Warden warden, ConfigWatcher configWatcher)
+		{
+			Parameters = parameters;
+			Warden = warden;
+			ConfigWatcher = configWatcher;
 		}
 
 		public ConfigWatcher ConfigWatcher { get; }


### PR DESCRIPTION
…ig change.

This is an idea how to make `ConfigTests.ChecksConfigChangesAsync` more robust to avoid failures like this one https://github.com/zkSNACKs/WalletWasabi/runs/1777920208. It's a little bit more code but one has more control over the process. Leaving it up for consideration here.