### PR TITLE
Turn on RBF by default for every transaction

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -152,7 +152,7 @@ namespace WalletWasabi.Blockchain.Transactions
 				builder.SetChange(changeHdPubKey.P2wpkhScript);
 			}
 
-			builder.OptInRBF = new Random().NextDouble() < Constants.TransactionRBFSignalRate;
+			builder.OptInRBF = true;
 
 			FeeRate feeRate = feeRateFetcher();
 			builder.SendEstimatedFees(feeRate);

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -45,7 +45,7 @@ namespace WalletWasabi.Helpers
 		public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
 		public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
 
-		public const double TransactionRBFSignalRate = 0.02; // 2% RBF transactions
+		public const double TransactionRBFSignalRate = 1; // 100% RBF transactions.
 
 		public const decimal DefaultDustThreshold = 0.00005m;
 

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -45,8 +45,6 @@ namespace WalletWasabi.Helpers
 		public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
 		public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
 
-		public const double TransactionRBFSignalRate = 1; // 100% RBF transactions.
-
 		public const decimal DefaultDustThreshold = 0.00005m;
 
 		public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/1543

RBF may have some privacy issues with it, but as transaction fees are raising it's getting inevitable to have it.

In the future we can have a "Speed Up" context menu item in the Transaction History, which would work as follows:

1. If normal TX, then RBF it.
2. If receiving TX, then CPFP it.
3. If coinjoin, then CPFP it - but MAKE SURE THE USER KNOWS THE COSTS.