### PR TITLE
Use IHttpClient in CoinJoinClient.

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1558,8 +1558,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				request.ChangeOutputAddress,
 				request.BlindedOutputScripts,
 				request.Inputs,
-				() => BaseUri,
-				null);
+				BackendClearnetHttpClient);
 		}
 	}
 }

--- a/WalletWasabi.Tests/RegressionTests/DosTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/DosTests.cs
@@ -26,12 +26,13 @@ namespace WalletWasabi.Tests.RegressionTests
 		{
 			RegTestFixture = regTestFixture;
 
-			var httpClient = new ClearnetHttpClient(() => new Uri(RegTestFixture.BackendEndPoint));
-			SatoshiClient = new SatoshiClient(httpClient);
+			BackendHttpClient = new ClearnetHttpClient(() => new Uri(RegTestFixture.BackendEndPoint));
+			SatoshiClient = new SatoshiClient(BackendHttpClient);
 		}
 
 		private RegTestFixture RegTestFixture { get; }
 		public SatoshiClient SatoshiClient { get; }
+		public IHttpClient BackendHttpClient { get; }
 
 		private async Task WaitForTimeoutAsync()
 		{
@@ -125,7 +126,7 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			foreach (var user in inputRegistrationUsers)
 			{
-				aliceClients.Add(AliceClientBase.CreateNewAsync(round.RoundId, new[] { user.activeOutputAddress }, new[] { round.MixingLevels.GetBaseLevel().SignerKey.PubKey }, new[] { user.requester }, network, user.changeOutputAddress, new[] { user.blinded }, user.inputProofModels, () => baseUri, null));
+				aliceClients.Add(AliceClientBase.CreateNewAsync(round.RoundId, new[] { user.activeOutputAddress }, new[] { round.MixingLevels.GetBaseLevel().SignerKey.PubKey }, new[] { user.requester }, network, user.changeOutputAddress, new[] { user.blinded }, user.inputProofModels, BackendHttpClient));
 			}
 
 			long roundId = 0;
@@ -197,7 +198,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			round = coordinator.GetCurrentInputRegisterableRoundOrDefault();
 			foreach (var user in inputRegistrationUsers)
 			{
-				aliceClients.Add(AliceClientBase.CreateNewAsync(round.RoundId, new[] { user.activeOutputAddress }, new[] { round.MixingLevels.GetBaseLevel().SignerKey.PubKey }, new[] { user.requester }, network, user.changeOutputAddress, new[] { user.blinded }, user.inputProofModels, () => baseUri, null));
+				aliceClients.Add(AliceClientBase.CreateNewAsync(round.RoundId, new[] { user.activeOutputAddress }, new[] { round.MixingLevels.GetBaseLevel().SignerKey.PubKey }, new[] { user.requester }, network, user.changeOutputAddress, new[] { user.blinded }, user.inputProofModels, BackendHttpClient));
 			}
 
 			roundId = 0;
@@ -293,7 +294,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				InputProofModel inputProof = new InputProofModel { Input = input, Proof = inputKey.SignCompact(blindedOutputScriptsHash) };
 				InputProofModel[] inputsProofs = new InputProofModel[] { inputProof };
 				registerRequests.Add((changeOutputAddress, blinded, inputsProofs));
-				aliceClientBackup = await AliceClientBase.CreateNewAsync(round.RoundId, new[] { activeOutputAddress }, new[] { round.MixingLevels.GetBaseLevel().SignerKey.PubKey }, new[] { requester }, network, changeOutputAddress, new[] { blinded }, inputsProofs, () => baseUri, null);
+				aliceClientBackup = await AliceClientBase.CreateNewAsync(round.RoundId, new[] { activeOutputAddress }, new[] { round.MixingLevels.GetBaseLevel().SignerKey.PubKey }, new[] { requester }, network, changeOutputAddress, new[] { blinded }, inputsProofs, BackendHttpClient);
 			}
 
 			await WaitForTimeoutAsync();
@@ -307,7 +308,7 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			foreach (var registerRequest in registerRequests)
 			{
-				await AliceClientBase.CreateNewAsync(round.RoundId, aliceClientBackup.RegisteredAddresses, round.MixingLevels.GetAllLevels().Select(x => x.SignerKey.PubKey), aliceClientBackup.Requesters, network, registerRequest.changeOutputAddress, new[] { registerRequest.blindedData }, registerRequest.inputsProofs, () => baseUri, null);
+				await AliceClientBase.CreateNewAsync(round.RoundId, aliceClientBackup.RegisteredAddresses, round.MixingLevels.GetAllLevels().Select(x => x.SignerKey.PubKey), aliceClientBackup.Requesters, network, registerRequest.changeOutputAddress, new[] { registerRequest.blindedData }, registerRequest.inputsProofs, BackendHttpClient);
 			}
 
 			await WaitForTimeoutAsync();

--- a/WalletWasabi/CoinJoin/Client/Clients/AliceClient4.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/AliceClient4.cs
@@ -2,7 +2,7 @@ using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
+using WalletWasabi.Tor.Http;
 using static WalletWasabi.Crypto.SchnorrBlinding;
 
 namespace WalletWasabi.CoinJoin.Client.Clients
@@ -15,9 +15,8 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			IEnumerable<PubKey> signerPubKeys,
 			IEnumerable<Requester> requesters,
 			Network network,
-			Func<Uri> baseUriAction,
-			EndPoint torSocks5EndPoint)
-			: base(roundId, registeredAddresses, requesters, network, baseUriAction, torSocks5EndPoint)
+			IHttpClient httpClient)
+			: base(roundId, registeredAddresses, requesters, network, httpClient)
 		{
 			SignerPubKeys = signerPubKeys.ToArray();
 		}

--- a/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
@@ -28,10 +28,9 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			IEnumerable<BitcoinAddress> registeredAddresses,
 			IEnumerable<Requester> requesters,
 			Network network,
-			Func<Uri> baseUriAction,
-			EndPoint torSocks5EndPoint)
+			IHttpClient httpClient)
 		{
-			TorClient = new TorHttpClient(baseUriAction, torSocks5EndPoint, isolateStream: true);
+			TorClient = httpClient;
 			RoundId = roundId;
 			RegisteredAddresses = registeredAddresses.ToArray();
 			Requesters = requesters.ToArray();
@@ -57,8 +56,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 			BitcoinAddress changeOutput,
 			IEnumerable<BlindedOutputWithNonceIndex> blindedOutputScriptHashes,
 			IEnumerable<InputProofModel> inputs,
-			Func<Uri> baseUriAction,
-			EndPoint torSocks5EndPoint)
+			IHttpClient httpClient)
 		{
 			var request = new InputsRequest4
 			{
@@ -67,7 +65,7 @@ namespace WalletWasabi.CoinJoin.Client.Clients
 				ChangeOutputAddress = changeOutput,
 				Inputs = inputs
 			};
-			var client = new AliceClient4(roundId, registeredAddresses, signerPubKeys, requesters, network, baseUriAction, torSocks5EndPoint);
+			var client = new AliceClient4(roundId, registeredAddresses, signerPubKeys, requesters, network, httpClient);
 			try
 			{
 				// Correct it if forgot to set.

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.Tor
 							Uri baseUri = new Uri($"{FallBackTestRequestUri.Scheme}://{FallBackTestRequestUri.DnsSafeHost}");
 							using (var client = new TorHttpClient(baseUri, TorSocks5EndPoint))
 							{
-								var message = new HttpRequestMessage(HttpMethod.Get, FallBackTestRequestUri);
+								using var message = new HttpRequestMessage(HttpMethod.Get, FallBackTestRequestUri);
 								await client.SendAsync(message, token).ConfigureAwait(false);
 							}
 

--- a/WalletWasabi/WebClients/Wasabi/WasabiClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClientFactory.cs
@@ -52,14 +52,6 @@ namespace WalletWasabi.WebClients.Wasabi
 		public WasabiClient SharedWasabiClient { get; }
 
 		/// <summary>
-		/// Creates new <see cref="TorHttpClient"/> instance with correctly set backend URL.
-		/// </summary>
-		public TorHttpClient NewTorHttpClient(bool isolateStream = true)
-		{
-			return new TorHttpClient(BackendUriGetter.Invoke(), TorEndpoint, isolateStream: isolateStream);
-		}
-
-		/// <summary>
 		/// Creates new <see cref="TorHttpClient"/> or <see cref="ClearnetHttpClient"/> based on user settings.
 		/// </summary>
 		public IHttpClient NewHttpClient(Func<Uri> baseUriFn, bool isolateStream)


### PR DESCRIPTION
Goal of this PR is to make sure that all `IHttpClient` instances are obtained via `WasabiClientFactory` (would be great to find a better name for this).

With this change, it should be possible in a next PR to actually make `TorHttpClient` non-disposable which would simplify more code and this would open path to make it easy to add the TCP pool for `TorHttpClient`.

Please review commit by commit.