### PR TITLE
Improve Fee Estimation both in privacy and accuracy

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -58,7 +58,7 @@ namespace WalletWasabi.Gui
 
 		public NodesGroup Nodes { get; private set; }
 		public WasabiSynchronizer Synchronizer { get; private set; }
-		public FeeProviders FeeProviders { get; private set; }
+		public PrivacyFeeProvider FeeProviders { get; private set; }
 		public WalletManager WalletManager { get; }
 		public TransactionBroadcaster TransactionBroadcaster { get; set; }
 		public CoinJoinProcessor CoinJoinProcessor { get; set; }
@@ -215,7 +215,7 @@ namespace WalletWasabi.Gui
 
 				var rpcFeeProvider = HostedServices.FirstOrDefault<RpcFeeProvider>();
 
-				FeeProviders = new FeeProviders(Synchronizer, rpcFeeProvider);
+				FeeProviders = new PrivacyFeeProvider(Synchronizer, rpcFeeProvider);
 
 				#endregion BitcoinCoreInitialization
 

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -54,7 +54,7 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 		public Dictionary<int, int> Estimations { get; }
 
 		/// <returns>
-		/// An estimate based on these estimates, but randomizes each estimation between
+		/// An estimates based on these estimates, but randomizes each estimation between
 		/// the value of its larger estimation sibling - or 50% more if the largest
 		/// with a probabilistic bias towards the estimate.
 		/// </returns>

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -47,6 +47,12 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 		[JsonProperty]
 		public bool IsAccurate { get; }
 
+		/// <summary>
+		/// Gets the fee estimations: int: fee target, int: satoshi/vByte
+		/// </summary>
+		[JsonProperty]
+		public Dictionary<int, int> Estimations { get; }
+
 		/// <returns>
 		/// An estimate based on these estimates, but randomizes each estimation between
 		/// the value of its larger estimation sibling - or 50% more if the largest
@@ -88,12 +94,6 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 			}
 			return new AllFeeEstimate(Type, fingerprintless, IsAccurate);
 		}
-
-		/// <summary>
-		/// Gets the fee estimations: int: fee target, int: satoshi/vByte
-		/// </summary>
-		[JsonProperty]
-		public Dictionary<int, int> Estimations { get; }
 
 		public FeeRate GetFeeRate(int feeTarget)
 		{

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation
 		public bool IsAccurate { get; }
 
 		/// <returns>
-		/// An estimates based on these estimates, but randomizes each estimation between
+		/// An estimate based on these estimates, but randomizes each estimation between
 		/// the value of its larger estimation sibling - or 50% more if the largest
 		/// with a probabilistic bias towards the estimate.
 		/// </returns>


### PR DESCRIPTION
There's a privacy issue with getting fee estimation from a public fee service (Wasabi backend and to some extent even local Bitcoin Core is fingerprintable based on fees.)

This PR randomizes fees to improve their privacy, but also improves their accuracy as in practice it turns out the fee estimation we're getting from Bitcoin Core isn't aggressive enough for our users.

In this PR, every client changes the fees it receives from its Core or its backend as follows:

Assume we get all fee entries like this:

- target 1 : 100 s/b
- target 3: 50 s/b

This PR changes the target 1 estimation to be somewhere between 100 and 150 s/b (150%) and target 3 estimation to be between target 1's estimation: 100 and itself: 50.  

This isn't fully random though as I also introduce a bias towards the real estimation.

This PR both improves Wasabi's fee estimation and fixes a theoretical privacy issue all at once.