### PR TITLE
Get mempool of blockstream every hour

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/BlockstreamTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/BlockstreamTests.cs
@@ -1,0 +1,56 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.WebClients.BlockstreamInfo;
+using Xunit;
+
+namespace WalletWasabi.Tests.IntegrationTests
+{
+	public class BlockstreamTests
+	{
+		[Fact]
+		public void NoRegTest()
+		{
+			Assert.ThrowsAny<NotSupportedException>(() => new BlockstreamInfoClient(Network.RegTest));
+		}
+
+		[Fact]
+		public async Task GetMempoolTransactionIdsAsync()
+		{
+			using var mainClient = new BlockstreamInfoClient(Network.Main);
+			var mainIds = await mainClient.GetMempoolTransactionIdsAsync(CancellationToken.None);
+			Assert.NotEmpty(mainIds);
+
+			// Do it for testnet too, but don't assert, we have no idea.
+			using var testClient = new BlockstreamInfoClient(Network.TestNet);
+			var testIds = await testClient.GetMempoolTransactionIdsAsync(CancellationToken.None);
+		}
+
+		[Fact]
+		public async Task GetTransactionAsync()
+		{
+			using var mainClient = new BlockstreamInfoClient(Network.Main);
+			var mainTxId = new uint256("a841f7e4c2838ca945f20dcf43d22e78ea4cc8005302fde06c5d0b8f51ff11bd");
+			var mainTx = await mainClient.GetTransactionAsync(mainTxId, CancellationToken.None);
+			Assert.Equal(mainTxId, mainTx.GetHash());
+
+			// Do it for testnet too, but don't assert, we have no idea.
+			using var testClient = new BlockstreamInfoClient(Network.TestNet);
+			var testTxId = new uint256("1e47c2d74b2e013fbabcb9d00b4eda4fd34c327d677431f9518f66d92ca3e7e5");
+			var testTx = await testClient.GetTransactionAsync(testTxId, CancellationToken.None);
+			Assert.Equal(testTxId, testTx.GetHash());
+		}
+
+		[Fact]
+		public async Task GetTransactionFailsAsync()
+		{
+			using var client = new BlockstreamInfoClient(Network.Main);
+			await Assert.ThrowsAnyAsync<HttpRequestException>(async () => await client.GetTransactionAsync(uint256.One, CancellationToken.None));
+		}
+	}
+}

--- a/WalletWasabi.Tests/IntegrationTests/MempoolConsistencyTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/MempoolConsistencyTests.cs
@@ -1,0 +1,29 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Mempool;
+using WalletWasabi.Tests.UnitTests;
+using Xunit;
+
+namespace WalletWasabi.Tests.IntegrationTests
+{
+	public class MempoolConsistencyTests
+	{
+		[Fact]
+		public async Task SyncsMempoolAsync()
+		{
+			var rpc = new MockRpcClient();
+			rpc.OnSendRawTransactionAsync = (tx) => Task.FromResult(tx.GetHash());
+			rpc.OnGetRawMempoolAsync = () => Task.FromResult(Array.Empty<uint256>());
+			using var bs = new MempoolConsistency(TimeSpan.FromHours(1), rpc, Network.TestNet);
+			await bs.StartAsync(CancellationToken.None);
+			await bs.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
+
+			await bs.StopAsync(CancellationToken.None);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -16,6 +16,8 @@ namespace WalletWasabi.Tests.UnitTests
 		public Func<Task<BlockchainInfo>> OnGetBlockchainInfoAsync { get; set; }
 		public Func<uint256, Task<VerboseBlockInfo>> OnGetVerboseBlockAsync { get; set; }
 		public Func<Task<MemPoolInfo>> OnGetMempoolInfoAsync { get; set; }
+		public Func<Transaction, Task<uint256>> OnSendRawTransactionAsync { get; set; }
+		public Func<Task<uint256[]>> OnGetRawMempoolAsync { get; set; }
 
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new RPCCredentialString();
@@ -77,7 +79,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<uint256[]> GetRawMempoolAsync()
 		{
-			throw new NotImplementedException();
+			return OnGetRawMempoolAsync();
 		}
 
 		public Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true)
@@ -122,7 +124,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<uint256> SendRawTransactionAsync(Transaction transaction)
 		{
-			throw new NotImplementedException();
+			return OnSendRawTransactionAsync(transaction);
 		}
 
 		public Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string? commentTx = null, string? commentDest = null, bool subtractFeeFromAmount = false, bool replaceable = false)

--- a/WalletWasabi/Blockchain/Mempool/IMempoolSyncer.cs
+++ b/WalletWasabi/Blockchain/Mempool/IMempoolSyncer.cs
@@ -1,0 +1,17 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Blockchain.Mempool
+{
+	public interface IMempoolSyncer : IDisposable
+	{
+		public Task<IEnumerable<uint256>> GetMempoolTransactionIdsAsync(CancellationToken cancel);
+
+		public Task<Transaction> GetTransactionAsync(uint256 txid, CancellationToken cancel);
+	}
+}

--- a/WalletWasabi/Blockchain/Mempool/MempoolConsistency.cs
+++ b/WalletWasabi/Blockchain/Mempool/MempoolConsistency.cs
@@ -1,0 +1,88 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Bases;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Logging;
+using WalletWasabi.WebClients.BlockstreamInfo;
+
+namespace WalletWasabi.Blockchain.Mempool
+{
+	public class MempoolConsistency : PeriodicRunner
+	{
+		public MempoolConsistency(TimeSpan period, IRPCClient rpcClient, Network network) : base(period)
+		{
+			RpcClient = rpcClient;
+			Network = network;
+
+			// We only have blockstream info for now. I didn't find any other reliable block explorer.
+			// blockchain.info -> doesn't work for mempool txs (returns empty string)
+			// smartbit is a catastrophe in reliability
+			// coinbase have no endpoints we need
+			Syncers = new[] { new BlockstreamInfoClient(Network) };
+		}
+
+		public IMempoolSyncer[] Syncers { get; }
+		public IRPCClient RpcClient { get; }
+		public Network Network { get; }
+
+		protected override async Task ActionAsync(CancellationToken cancel)
+		{
+			using (BenchmarkLogger.Measure(LogLevel.Info, "Mempool Synchronization"))
+			{
+				var remoteMempoolIdsTasks = Syncers.Select(x => x.GetMempoolTransactionIdsAsync(cancel)).ToArray();
+				var localMempoolIds = (await RpcClient.GetRawMempoolAsync().ConfigureAwait(false)).ToHashSet();
+				cancel.ThrowIfCancellationRequested();
+
+				var remoteMempoolIds = await Task.WhenAll(remoteMempoolIdsTasks).ConfigureAwait(false);
+				cancel.ThrowIfCancellationRequested();
+
+				// Let's try to acquire transactions those have consensus of all syncers to be in mempool
+				// except in ours of course.
+				HashSet<uint256> txsToAcquire = new();
+				foreach (var txid in remoteMempoolIds.IntersectAll().Where(x => !localMempoolIds.Contains(x)))
+				{
+					txsToAcquire.Add(txid);
+				}
+
+				Logger.LogInfo($"{nameof(localMempoolIds)}: {localMempoolIds.Count}, {nameof(remoteMempoolIds)}{remoteMempoolIds.Length}, {nameof(txsToAcquire)}: {txsToAcquire.Count}.");
+
+				// Don't send out too many requests at once.
+				foreach (var txids in txsToAcquire.ChunkBy(7))
+				{
+					var txTasks = txids.Select(x => Syncers.RandomElement()?.GetTransactionAsync(x, cancel));
+
+					foreach (var txTask in txTasks)
+					{
+						if (txTask is not null)
+						{
+							try
+							{
+								var tx = await txTask.ConfigureAwait(false);
+								await RpcClient.SendRawTransactionAsync(tx).ConfigureAwait(false);
+								cancel.ThrowIfCancellationRequested();
+							}
+							catch (Exception ex)
+							{
+								Logger.LogDebug(ex);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		public override void Dispose()
+		{
+			foreach (var syncer in Syncers)
+			{
+				syncer?.Dispose();
+			}
+			base.Dispose();
+		}
+	}
+}

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 
@@ -192,6 +193,26 @@ namespace System.Linq
 				throw new InvalidOperationException($"{nameof(source)} and {nameof(otherCollection)} collections must have the same number of elements. {nameof(source)}:{source.Count()}, {nameof(otherCollection)}:{otherCollection.Count()}.");
 			}
 			return source.Zip(otherCollection);
+		}
+
+		/// <summary>
+		/// https://stackoverflow.com/a/1674779/2061103
+		/// </summary>
+		public static ISet<T> IntersectAll<T>(this IEnumerable<IEnumerable<T>> collections)
+		{
+			HashSet<T>? hashSet = null;
+			foreach (var list in collections)
+			{
+				if (hashSet is null)
+				{
+					hashSet = new HashSet<T>(list);
+				}
+				else
+				{
+					hashSet.IntersectWith(list);
+				}
+			}
+			return hashSet ?? new HashSet<T>();
 		}
 	}
 }

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
@@ -1,0 +1,88 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Mempool;
+using WalletWasabi.Tor.Http.Extensions;
+
+namespace WalletWasabi.WebClients.BlockstreamInfo
+{
+	public class BlockstreamInfoClient : IMempoolSyncer
+	{
+		private bool _disposedValue;
+
+		public BlockstreamInfoClient(Network network)
+		{
+			var baseUrl = "https://blockstream.info/";
+			if (network == Network.Main)
+			{
+				baseUrl += "api/";
+			}
+			else if (network == Network.TestNet)
+			{
+				baseUrl += "testnet/api/";
+			}
+			else
+			{
+				throw new NotSupportedException("Specified network not supported.");
+			}
+
+			HttpClient = new HttpClient
+			{
+				BaseAddress = new Uri(baseUrl)
+			};
+			Network = network;
+		}
+
+		public HttpClient HttpClient { get; }
+		public Network Network { get; }
+
+		public async Task<Transaction> GetTransactionAsync(uint256 txid, CancellationToken cancel)
+		{
+			using var response = await HttpClient.GetAsync($"tx/{txid}/hex", cancel).ConfigureAwait(false);
+			if (!response.IsSuccessStatusCode)
+			{
+				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+			}
+			using var content = response.Content;
+			var hex = await content.ReadAsStringAsync(cancel).ConfigureAwait(false);
+			return Transaction.Parse(hex, Network);
+		}
+
+		public async Task<IEnumerable<uint256>> GetMempoolTransactionIdsAsync(CancellationToken cancel)
+		{
+			using var response = await HttpClient.GetAsync("mempool/txids", cancel).ConfigureAwait(false);
+			if (!response.IsSuccessStatusCode)
+			{
+				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+			}
+			using var content = response.Content;
+			var stringIds = await content.ReadAsJsonAsync<IEnumerable<string>>().ConfigureAwait(false);
+			return stringIds.Select(x => new uint256(x)).ToArray();
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					HttpClient?.Dispose();
+				}
+
+				_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+	}
+}


### PR DESCRIPTION
The other day when I restarted Bitcoin Knots on the server it did not succeed to deserialize the mempool, which lead to our backend's mempool starting at a clean state, which lead to an increased support requests due to inconsistent mempool state. To mitigate similar issues this PR introduces a new service that tries to keep Wasabi's node's knowledge in sync with Blockstream.info's knowledge.  

According to this PR, we'd query blockstream's explorer every hour for transactions we don't have and try to feed them to our node.