### PR TITLE
Increase test timeouts

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			w.Prison.Punish(i2);
 
 			// Wait until serializes.
-			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(3));
+			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 			await w.StopAsync(CancellationToken.None);
 
 			// See if prev UTXOs are loaded.
@@ -78,11 +78,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			w.Prison.Punish(i2);
 
 			// Wait until serializes.
-			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(3));
+			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 
 			// Make sure it does not serialize again as there was no change.
 			File.Delete(w.PrisonFilePath);
-			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(3));
+			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 			Assert.False(File.Exists(w.PrisonFilePath));
 			await w.StopAsync(CancellationToken.None);
 		}
@@ -107,7 +107,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			Assert.NotEmpty(p.GetInmates());
 
 			// Wait until releases from prison.
-			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(3));
+			await w.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 			Assert.Empty(p.GetInmates());
 			await w.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi.Tests/UnitTests/Wabisabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wabisabi/Backend/ConfigTests.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			Assert.NotEqual(newTarget, coordinator.Config.ConfirmationTarget);
 			configChanger.ToFile();
 			var configWatcher = coordinator.ConfigWatcher;
-			await configWatcher.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(3));
+			await configWatcher.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 			Assert.Equal(newTarget, coordinator.Config.ConfirmationTarget);
 
 			// Do it one more time.
@@ -116,7 +116,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			configChanger.ConfirmationTarget = newTarget;
 			Assert.NotEqual(newTarget, coordinator.Config.ConfirmationTarget);
 			configChanger.ToFile();
-			await configWatcher.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(3));
+			await configWatcher.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 			Assert.Equal(newTarget, coordinator.Config.ConfirmationTarget);
 
 			await coordinator.StopAsync(CancellationToken.None);


### PR DESCRIPTION
One of these tests were randomly failing as pointed out by @kiminuo so I'll default them to 7 sec instead of 3, even though 3 should be more than sufficient, it's an xunit synchronization issue and the tests aren't testing these times anyway.