### PR TITLE
Add status checks to BackendDeployment.md

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -32,7 +32,7 @@ sudo service nginx start
 # Start Wasabi
 rm -rf WalletWasabi/WalletWasabi.Backend/bin && dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
-systemctl is-active tor && systemctl is-active walletwasabi && systemctl is-active nginx && ps -C bitcoind >/dev/null && echo "active" || echo "incative"
+systemctl is-active tor && systemctl is-active walletwasabi && systemctl is-active nginx && ps -C bitcoind >/dev/null && echo "active" || echo "inactive"
 tail -10000 ~/.walletwasabi/backend/Logs.txt
 
 # Advanced status checks

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -12,7 +12,7 @@ sudo killall tor
 bitcoin-cli stop
 
 # Status checks
-systemctl is-active tor && systemctl is-active walletwasabi && systemctl is-active nginx && ps -C bitcoind >/dev/null && echo "active" || echo "incative"
+echo -n 'Tor: '; systemctl is-active tor; echo -n 'Wasabi: '; systemctl is-active walletwasabi; echo -n 'Bitcoind: '; ps -C bitcoind >/dev/null && echo "active" || echo "incative";
 
 # Upgrade and reboot
 sudo apt-get upgrade -y && sudo apt-get autoremove -y

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -4,21 +4,43 @@ Consider updating the versions in `WalletWasabi.Helpers.Constants`. If the versi
 
 ```sh
 sudo apt-get update && cd ~/WalletWasabi && git pull && cd ~/WalletWasabi/WalletWasabi.Backend && dotnet restore && cd ~
+
+# Stop
 sudo service nginx stop
 sudo systemctl stop walletwasabi.service
 sudo killall tor
 bitcoin-cli stop
+
+# Status checks
+systemctl is-active tor && systemctl is-active walletwasabi && systemctl is-active nginx && ps -C bitcoind >/dev/null && echo "active" || echo "incative"
+
+# Upgrade and reboot
 sudo apt-get upgrade -y && sudo apt-get autoremove -y
 sudo reboot
 set DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# Start Bitcoind
 bitcoind
 bitcoin-cli getblockchaininfo
+
+# Start Tor
 tor
+
+# Start Nginx
 sudo service nginx start
+
+# Start Wasabi
 rm -rf WalletWasabi/WalletWasabi.Backend/bin && dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
-pgrep -ilfa tor && pgrep -ilfa bitcoin && pgrep -ilfa wasabi && pgrep -ilfa nginx
+systemctl is-active tor && systemctl is-active walletwasabi && systemctl is-active nginx && ps -C bitcoind >/dev/null && echo "active" || echo "incative"
 tail -10000 ~/.walletwasabi/backend/Logs.txt
+
+# Advanced status checks
+systemctl status nginx
+systemctl status walletwasabi
+systemctl status tor
+pgrep -ilfa bitcoin
+
 ```
 
 # 1. Create Remote Server

--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -32,7 +32,7 @@ sudo service nginx start
 # Start Wasabi
 rm -rf WalletWasabi/WalletWasabi.Backend/bin && dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
-systemctl is-active tor && systemctl is-active walletwasabi && systemctl is-active nginx && ps -C bitcoind >/dev/null && echo "active" || echo "inactive"
+echo -n 'Tor: '; systemctl is-active tor; echo -n 'Wasabi: '; systemctl is-active walletwasabi; echo -n 'Bitcoind: '; ps -C bitcoind >/dev/null && echo "active" || echo "incative";
 tail -10000 ~/.walletwasabi/backend/Logs.txt
 
 # Advanced status checks


### PR DESCRIPTION
The last time we restarted the server Knots [lost mempool with an error message about serialization](https://github.com/zkSNACKs/WalletWasabi/pull/5118). The goal of this PR is to add status check commands to make us able to verify the status of the services before we move forward, for example with a shutdown. 

Based on this https://github.com/zkSNACKs/WalletWasabi/pull/4644

P.S. this command might seem to be scary but this is how it works. The goals were the following one-liner and easy to check. 

![image](https://user-images.githubusercontent.com/9844978/107032815-b0a04600-67b4-11eb-939a-25a1d83ece0a.png)
