### PR TITLE
IoHelpers: Remove unused "CheckExpectedHash" method.

### DIFF
--- a/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
+++ b/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
@@ -26,8 +26,3 @@ Do not delete Tor file from the original folder!
 ## Geoip files
 
 msi => Browser\TorBrowser\Data\Tor
-
-## Digest creation 
-
-WalletWasabi\WalletWasabi.Packager> dotnet run -- onlycreatedigests
-Copy hashes (SHA256) without file names into WalletWasabi\WalletWasabi\TorDaemons\digests.txt (order of the hashes doesn't matter)

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -103,28 +103,6 @@ namespace System.IO
 			return HashHelpers.GenerateSha256Hash(bytes);
 		}
 
-		public static bool CheckExpectedHash(string filePath, string sourceFolderPath)
-		{
-			var fileHash = GetHashFile(filePath);
-			try
-			{
-				var digests = File.ReadAllLines(Path.Combine(sourceFolderPath, "digests.txt"));
-				foreach (var digest in digests)
-				{
-					var expectedHash = ByteHelpers.FromHex(digest);
-					if (ByteHelpers.CompareFastUnsafe(fileHash, expectedHash))
-					{
-						return true;
-					}
-				}
-				return false;
-			}
-			catch
-			{
-				return false;
-			}
-		}
-
 		public static void OpenFolderInFileExplorer(string dirPath)
 		{
 			if (Directory.Exists(dirPath))

--- a/WalletWasabi/Helpers/IoHelpers.cs
+++ b/WalletWasabi/Helpers/IoHelpers.cs
@@ -97,12 +97,6 @@ namespace System.IO
 			}
 		}
 
-		public static byte[] GetHashFile(string filePath)
-		{
-			var bytes = File.ReadAllBytes(filePath);
-			return HashHelpers.GenerateSha256Hash(bytes);
-		}
-
 		public static void OpenFolderInFileExplorer(string dirPath)
 		{
 			if (Directory.Exists(dirPath))


### PR DESCRIPTION
This PR removes unused code.

This section https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md#digest-creation seems obsolete thanks to f6ccd89a. Should we delete it too?