### PR TITLE
Remove TorSocks5Client.Connected property

### DIFF
--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -202,10 +202,19 @@ namespace WalletWasabi.Tor.Http
 
 			Stream transportStream = TorSocks5Client.GetTransportStream();
 
-			await transportStream.WriteAsync(bytes.AsMemory(0, bytes.Length), token).ConfigureAwait(false);
-			await transportStream.FlushAsync(token).ConfigureAwait(false);
+			try
+			{
+				await transportStream.WriteAsync(bytes.AsMemory(0, bytes.Length), token).ConfigureAwait(false);
+				await transportStream.FlushAsync(token).ConfigureAwait(false);
 
-			return await HttpResponseMessageExtensions.CreateNewAsync(transportStream, request.Method).ConfigureAwait(false);
+				return await HttpResponseMessageExtensions.CreateNewAsync(transportStream, request.Method).ConfigureAwait(false);
+			}
+			catch
+			{
+				TorSocks5Client?.Dispose();
+				TorSocks5Client = null;
+				throw;
+			}
 		}
 
 		#region IDisposable Support

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -84,7 +84,6 @@ namespace WalletWasabi.Tor.Http
 				request.Content = content;
 			}
 
-
 			try
 			{
 				using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
@@ -99,9 +98,6 @@ namespace WalletWasabi.Tor.Http
 					{
 						Logger.LogTrace(ex);
 
-						TorSocks5Client?.Dispose(); // rebuild the connection and retry
-						TorSocks5Client = null;
-
 						cancel.ThrowIfCancellationRequested();
 						try
 						{
@@ -113,9 +109,6 @@ namespace WalletWasabi.Tor.Http
 						catch (TorConnectCommandFailedException ex2) when (ex2.RepField == RepField.TtlExpired)
 						{
 							Logger.LogTrace(ex);
-
-							TorSocks5Client?.Dispose(); // rebuild the connection and retry
-							TorSocks5Client = null;
 
 							try
 							{

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -193,6 +193,7 @@ namespace WalletWasabi.Tor.Http
 				}
 			}
 
+			// At this point Tor SOCKS5 client is always non-null.
 			token.ThrowIfCancellationRequested();
 
 			string requestString = await request.ToHttpStringAsync(token).ConfigureAwait(false);

--- a/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
+++ b/WalletWasabi/Tor/Socks5/TorSocks5Client.cs
@@ -46,8 +46,6 @@ namespace WalletWasabi.Tor.Socks5
 
 		private EndPoint RemoteEndPoint { get; set; }
 
-		public bool IsConnected => TcpClient?.Connected is true;
-
 		internal AsyncLock AsyncLock { get; }
 
 		#endregion PropertiesAndMembers


### PR DESCRIPTION
[Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.connected?view=net-5.0) specifies that `TcpClient.Connected` behaves as follows:

> true if the Client socket was connected to a remote resource as of the most recent operation; otherwise, false.

Code led me to think that the original code relies on `TcpClient.Connected` meaning "Is connection up or not?" That would be a bug. But that's not what the code does. It checks whether the TCP connection was successfully connected. However, I find the new code is easier to follow, to understand and to argue about its behavior.

Review is easier with whitespace off: https://github.com/zkSNACKs/WalletWasabi/pull/5178/files?diff=split&w=1

Note: I have been chopping off bits of #4738 and we have been merging these smaller PRs. The small PRs were typically always a little bit better than what I did originally in #4738 because I understand the problem/design better over time. However, this PR, even though it is very small, is interesting because it seems like it will allow us to get the functionality of #4738 with less classes. So this is a boring PR with exciting possibilities ;)