### PR TITLE
[Fluent] Track only selectable NavBarItemViewModel in wallet manager

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -183,7 +183,10 @@ namespace WalletWasabi.Fluent.ViewModels
 
 		public NavBarItemViewModel? SelectionChanged(NavBarItemViewModel item)
 		{
-			_currentSelection = item;
+			if (item.SelectionMode == NavBarItemSelectionMode.Selected)
+			{
+				_currentSelection = item;
+			}
 
 			if (IsLoadingWallet || SelectedWallet == item)
 			{


### PR DESCRIPTION
When user clicks wallet login and after that clicks on navbar item of other type than selectable (e.g. Add Wallet) selection can get lost as tracking of selected item is wrong. This fixes that scenario.