### PR TITLE
[PoC] Add git clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,5 @@ Run Wasabi with `dotnet run` from the `WalletWasabi.Gui` folder.
 
 ```sh
 git pull
+git clean -xdf
 ```


### PR DESCRIPTION
Avalonia sometimes do not clean properly when rebuilding Wasabi. As a result, objects, that are deleted from the project could not be linked when building Wasabi from the source. 

`Avalonia error XAMLIL: Unable to find type WalletWasabi.Gui.Tabs.LegalDocumentsView`

**This has been asked at least 10 times so far.** 

As a solution this git command can be used:

`git clean -xdf`

### Question

Shall we add this command somewhere? 
