### PR TITLE
Remove text-decoration and color from social hyperlinks

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -628,12 +628,12 @@
 
                     <!-- Social Links -->
                     <div itemscope itemtype="http://schema.org/Organization" class="col-sm-6 text-right text-center-xs mt-2 mt-sm-0">
-                        <a href="https://twitter.com/wasabiwallet" title="Wasabi Wallet Twitter profile" itemprop="sameAs" class="p-1" target="_blank" rel="external nofollow">
+                        <a href="https://twitter.com/wasabiwallet" title="Wasabi Wallet Twitter profile" itemprop="sameAs" class="p-1" target="_blank" rel="external nofollow" style="color:inherit; text-decoration:none">
                             <svg width="31" height="25" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M11.37 24.943a26.15 26.15 0 0 1-4.04-.32c-2.403-.378-4.836-1.635-5.524-2.011L0 21.624l1.955-.643c2.137-.702 3.437-1.138 5.046-1.82-1.611-.781-2.853-2.185-3.45-4l-.456-1.38.373.057a6.782 6.782 0 0 1-.849-1.047c-.77-1.17-1.177-2.598-1.09-3.823l.085-1.205.721.28a6.745 6.745 0 0 1-.653-1.833c-.315-1.569-.052-3.235.742-4.693L3.053.363l.84 1.01C6.552 4.566 9.92 6.46 13.915 7.015c-.163-1.125-.04-2.211.364-3.184.471-1.134 1.31-2.095 2.424-2.78A7.28 7.28 0 0 1 20.928.014c1.579.097 3.011.688 4.15 1.71.555-.144.964-.298 1.518-.506.333-.125.71-.268 1.183-.43l1.74-.6-1.135 3.242c.075-.006.153-.011.233-.015l1.86-.084-1.1 1.502c-.062.086-.078.11-.1.144-.09.133-.2.3-1.708 2.314-.378.504-.566 1.16-.531 1.85.134 2.617-.187 4.985-.955 7.037-.726 1.942-1.85 3.608-3.343 4.952-1.847 1.663-4.201 2.802-6.999 3.384a21.546 21.546 0 0 1-4.371.429z" fill="#C8C2CB" fill-rule="nonzero" />
                             </svg>
                         </a>
-                        <a href="https://www.reddit.com/r/WasabiWallet/" title="Wasabi Wallet subreddit" itemprop="sameAs" class="p-1" target="_blank" rel="external nofollow">
+                        <a href="https://www.reddit.com/r/WasabiWallet/" title="Wasabi Wallet subreddit" itemprop="sameAs" class="p-1" target="_blank" rel="external nofollow" style="color:inherit; text-decoration:none">
                             <svg width="30" height="25" xmlns="http://www.w3.org/2000/svg">
                                 <g fill="#C8C2CB" fill-rule="nonzero">
                                     <path d="M11.132 13.91a.99.99 0 0 0-1.979 0 .99.99 0 0 0 1.979 0zM18.43 13.91a.99.99 0 0 0 1.978 0 .99.99 0 0 0-1.978 0z" />
@@ -641,7 +641,7 @@
                                 </g>
                             </svg>
                         </a>
-                        <a href="https://github.com/zkSNACKs/WalletWasabi/" title="Wasabi Wallet GitHub repository" itemprop="sameAs" class="p-1" target="_blank" rel="external nofollow">
+                        <a href="https://github.com/zkSNACKs/WalletWasabi/" title="Wasabi Wallet GitHub repository" itemprop="sameAs" class="p-1" target="_blank" rel="external nofollow" style="color:inherit; text-decoration:none">
                             <svg width="26" height="25" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M23.842 6.385a12.723 12.723 0 0 0-4.65-4.65C17.234.592 15.097.021 12.778.021c-2.318 0-4.456.572-6.414 1.714a12.721 12.721 0 0 0-4.65 4.65C.57 8.343 0 10.481 0 12.8c0 2.784.812 5.288 2.437 7.512 1.625 2.224 3.725 3.763 6.298 4.617.3.056.521.016.665-.116a.65.65 0 0 0 .217-.5l-.009-.898a148.59 148.59 0 0 1-.008-1.48L9.217 22a4.882 4.882 0 0 1-.923.058 7.036 7.036 0 0 1-1.157-.116c-.4-.072-.77-.238-1.114-.5a2.111 2.111 0 0 1-.732-1.022l-.167-.383a4.157 4.157 0 0 0-.524-.848c-.238-.311-.48-.522-.723-.633l-.117-.083a1.221 1.221 0 0 1-.216-.2.913.913 0 0 1-.15-.233c-.033-.078-.006-.141.083-.191.09-.05.25-.075.483-.075l.332.05c.222.044.497.177.824.4.327.22.596.51.807.864.255.455.563.802.923 1.04.36.239.724.358 1.09.358.366 0 .682-.028.948-.083a3.31 3.31 0 0 0 .749-.25c.1-.743.372-1.315.815-1.714-.632-.066-1.2-.166-1.705-.3a6.79 6.79 0 0 1-1.564-.649 4.48 4.48 0 0 1-1.34-1.114c-.354-.444-.646-1.026-.873-1.747-.227-.721-.34-1.553-.34-2.496 0-1.342.437-2.485 1.314-3.427-.41-1.01-.372-2.141.116-3.394.322-.1.799-.025 1.43.224.633.25 1.096.464 1.39.64.294.178.53.328.707.45a11.814 11.814 0 0 1 3.195-.432c1.098 0 2.163.144 3.195.432l.632-.4c.432-.265.943-.51 1.53-.731.588-.222 1.038-.283 1.349-.183.498 1.253.543 2.385.132 3.394.877.943 1.315 2.085 1.315 3.427 0 .943-.114 1.778-.341 2.504-.227.727-.521 1.309-.882 1.747-.36.438-.81.807-1.348 1.107-.538.3-1.06.515-1.564.649a11.38 11.38 0 0 1-1.705.3c.577.498.865 1.286.865 2.362v3.51c0 .2.07.366.208.5.139.132.358.171.657.115 2.574-.854 4.673-2.393 6.298-4.617 1.625-2.223 2.437-4.727 2.437-7.512 0-2.317-.572-4.455-1.714-6.413z" fill="#C8C2CB" fill-rule="nonzero" />
                             </svg>


### PR DESCRIPTION
Removed underlines from social media links in the footer (website). There was a small graphical issue when pointing with the cursor.

![image](https://user-images.githubusercontent.com/46527252/107955787-7f86f900-6f9e-11eb-83b0-b372ca0a225a.png)
