### PR TITLE
[WabiSabi] Handle Alice if already registered

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -37,20 +37,25 @@ namespace WalletWasabi.Tests.Helpers
 			}
 		}
 
-		public static IEnumerable<InputRoundSignaturePair> CreateInputRoundSignaturePairs(int count, uint256? roundHash = null)
+		public static InputRoundSignaturePair[] CreateInputRoundSignaturePairs(int count, uint256? roundHash = null)
 		{
+			List<InputRoundSignaturePair> pairs = new();
 			for (int i = 0; i < count; i++)
 			{
-				yield return CreateInputRoundSignaturePair(null, roundHash);
+				pairs.Add(CreateInputRoundSignaturePair(null, roundHash));
 			}
+
+			return pairs.ToArray();
 		}
 
-		public static IEnumerable<InputRoundSignaturePair> CreateInputRoundSignaturePairs(IEnumerable<Key> keys, uint256? roundHash = null)
+		public static InputRoundSignaturePair[] CreateInputRoundSignaturePairs(IEnumerable<Key> keys, uint256? roundHash = null)
 		{
+			List<InputRoundSignaturePair> pairs = new();
 			foreach (var key in keys)
 			{
-				yield return CreateInputRoundSignaturePair(key, roundHash);
+				pairs.Add(CreateInputRoundSignaturePair(key, roundHash));
 			}
+			return pairs.ToArray();
 		}
 
 		public static Round CreateRound(WabiSabiConfig cfg)
@@ -142,13 +147,13 @@ namespace WalletWasabi.Tests.Helpers
 			return (ac, wc, ai, wi);
 		}
 
-		public static (IEnumerable<Credential> amountCredentials, IEnumerable<Credential> weightCredentials) CreateZeroCredentials(Round? round)
+		public static (Credential[] amountCredentials, IEnumerable<Credential> weightCredentials) CreateZeroCredentials(Round? round)
 		{
 			(var amClient, var weClient, var amIssuer, var weIssuer) = CreateWabiSabiClientsAndIssuers(round);
 			return CreateZeroCredentials(amClient, weClient, amIssuer, weIssuer);
 		}
 
-		private static (IEnumerable<Credential> amountCredentials, IEnumerable<Credential> weightCredentials) CreateZeroCredentials(WabiSabiClient amClient, WabiSabiClient weClient, CredentialIssuer amIssuer, CredentialIssuer weIssuer)
+		private static (Credential[] amountCredentials, IEnumerable<Credential> weightCredentials) CreateZeroCredentials(WabiSabiClient amClient, WabiSabiClient weClient, CredentialIssuer amIssuer, CredentialIssuer weIssuer)
 		{
 			var (zeroAmountCredentialRequest, amVal) = amClient.CreateRequestForZeroAmount();
 			var (zeroWeightCredentialRequest, weVal) = weClient.CreateRequestForZeroAmount();
@@ -156,7 +161,7 @@ namespace WalletWasabi.Tests.Helpers
 			var weCredResp = weIssuer.HandleRequest(zeroWeightCredentialRequest);
 			amClient.HandleResponse(amCredResp, amVal);
 			weClient.HandleResponse(weCredResp, weVal);
-			return (amClient.Credentials.ZeroValue.Take(amIssuer.NumberOfCredentials), weClient.Credentials.ZeroValue.Take(weIssuer.NumberOfCredentials));
+			return (amClient.Credentials.ZeroValue.Take(amIssuer.NumberOfCredentials).ToArray(), weClient.Credentials.ZeroValue.Take(weIssuer.NumberOfCredentials));
 		}
 
 		public static (RealCredentialsRequest amountReq, RealCredentialsRequest weightReq) CreateRealCredentialRequests(Round? round = null, Money? amount = null, long? weight = null)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RegisterInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RegisterInputTests.cs
@@ -19,6 +19,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 {
 	public class RegisterInputTests
 	{
+		private static void AssertSingleAliceSuccessfullyRegistered(Round round, DateTimeOffset minAliceDeadline, InputsRegistrationResponse resp)
+		{
+			var alice = Assert.Single(round.Alices);
+			Assert.NotNull(resp);
+			Assert.NotNull(resp.AmountCredentials);
+			Assert.NotNull(resp.WeightCredentials);
+			Assert.True(minAliceDeadline <= alice.Deadline);
+		}
+
 		[Fact]
 		public async Task SuccessAsync()
 		{
@@ -40,11 +49,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
 			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 			var resp = await handler.RegisterInputAsync(req);
-			var alice = Assert.Single(round.Alices);
-			Assert.NotNull(resp);
-			Assert.NotNull(resp.AmountCredentials);
-			Assert.NotNull(resp.WeightCredentials);
-			Assert.True(minAliceDeadline <= alice.Deadline);
+			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -75,11 +80,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
 			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 			var resp = await handler.RegisterInputAsync(req);
-			var alice = Assert.Single(round.Alices);
-			Assert.NotNull(resp);
-			Assert.NotNull(resp.AmountCredentials);
-			Assert.NotNull(resp.WeightCredentials);
-			Assert.True(minAliceDeadline <= alice.Deadline);
+			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -111,12 +112,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
 			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 			var resp = await handler.RegisterInputAsync(req);
-			var alice = Assert.Single(round.Alices);
+			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 			Assert.Empty(anotherRound.Alices);
-			Assert.NotNull(resp);
-			Assert.NotNull(resp.AmountCredentials);
-			Assert.NotNull(resp.WeightCredentials);
-			Assert.True(minAliceDeadline <= alice.Deadline);
 
 			await arena.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RegisterInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RegisterInputTests.cs
@@ -50,6 +50,78 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		}
 
 		[Fact]
+		public async Task SuccessWithAliceUpdateIntraRoundAsync()
+		{
+			WabiSabiConfig cfg = new();
+			var round = WabiSabiFactory.CreateRound(cfg);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(round);
+
+			MockRpcClient rpc = new();
+			using Key key = new();
+
+			rpc.OnGetTxOutAsync = (_, _, _) => new()
+			{
+				Confirmations = 1,
+				ScriptPubKeyType = "witness_v0_keyhash",
+				TxOut = new TxOut(Money.Coins(1), key.PubKey.GetSegwitAddress(Network.Main))
+			};
+
+			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+
+			// Make sure an Alice have already been registered with the same input.
+			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			round.Alices.Add(preAlice);
+
+			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
+			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
+			var resp = await handler.RegisterInputAsync(req);
+			var alice = Assert.Single(round.Alices);
+			Assert.NotNull(resp);
+			Assert.NotNull(resp.AmountCredentials);
+			Assert.NotNull(resp.WeightCredentials);
+			Assert.True(minAliceDeadline <= alice.Deadline);
+
+			await arena.StopAsync(CancellationToken.None);
+		}
+
+		[Fact]
+		public async Task SuccessWithAliceUpdateCrossRoundAsync()
+		{
+			WabiSabiConfig cfg = new();
+			var round = WabiSabiFactory.CreateRound(cfg);
+			var anotherRound = WabiSabiFactory.CreateRound(cfg);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(round, anotherRound);
+
+			MockRpcClient rpc = new();
+			using Key key = new();
+
+			rpc.OnGetTxOutAsync = (_, _, _) => new()
+			{
+				Confirmations = 1,
+				ScriptPubKeyType = "witness_v0_keyhash",
+				TxOut = new TxOut(Money.Coins(1), key.PubKey.GetSegwitAddress(Network.Main))
+			};
+
+			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+
+			// Make sure an Alice have already been registered with the same input.
+			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			anotherRound.Alices.Add(preAlice);
+
+			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
+			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
+			var resp = await handler.RegisterInputAsync(req);
+			var alice = Assert.Single(round.Alices);
+			Assert.Empty(anotherRound.Alices);
+			Assert.NotNull(resp);
+			Assert.NotNull(resp.AmountCredentials);
+			Assert.NotNull(resp.WeightCredentials);
+			Assert.True(minAliceDeadline <= alice.Deadline);
+
+			await arena.StopAsync(CancellationToken.None);
+		}
+
+		[Fact]
 		public async Task RoundNotFoundAsync()
 		{
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
@@ -436,6 +508,69 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchWeight, ex.ErrorCode);
+
+			await arena.StopAsync(CancellationToken.None);
+		}
+
+		[Fact]
+		public async Task AliceAlreadyRegisteredIntraRoundAsync()
+		{
+			WabiSabiConfig cfg = new();
+			var round = WabiSabiFactory.CreateRound(cfg);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(round);
+
+			MockRpcClient rpc = new();
+			using Key key = new();
+
+			rpc.OnGetTxOutAsync = (_, _, _) => new()
+			{
+				Confirmations = 1,
+				ScriptPubKeyType = "witness_v0_keyhash",
+				TxOut = new TxOut(Money.Coins(1), key.PubKey.GetSegwitAddress(Network.Main))
+			};
+
+			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+
+			// Make sure an Alice have already been registered with the same input.
+			var anotherAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			round.Alices.Add(anotherAlice);
+			round.Phase = Phase.ConnectionConfirmation;
+
+			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
+
+			await arena.StopAsync(CancellationToken.None);
+		}
+
+		[Fact]
+		public async Task AliceAlreadyRegisteredCrossRoundAsync()
+		{
+			WabiSabiConfig cfg = new();
+			var round = WabiSabiFactory.CreateRound(cfg);
+			var anotherRound = WabiSabiFactory.CreateRound(cfg);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(round, anotherRound);
+
+			MockRpcClient rpc = new();
+			using Key key = new();
+
+			rpc.OnGetTxOutAsync = (_, _, _) => new()
+			{
+				Confirmations = 1,
+				ScriptPubKeyType = "witness_v0_keyhash",
+				TxOut = new TxOut(Money.Coins(1), key.PubKey.GetSegwitAddress(Network.Main))
+			};
+
+			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+
+			// Make sure an Alice have already been registered with the same input.
+			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			anotherRound.Alices.Add(preAlice);
+			anotherRound.Phase = Phase.ConnectionConfirmation;
+
+			await using PostRequestHandler handler = new(cfg, new Prison(), arena, rpc);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
+			Assert.Equal(WabiSabiProtocolErrorCode.AliceAlreadyRegistered, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -25,6 +25,7 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 		TooMuchWeight,
 		ScriptNotAllowed,
 		IncorrectRequestedAmountCredentials,
-		WrongCoinjoinSignature
+		WrongCoinjoinSignature,
+		AliceAlreadyRegistered
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -1,0 +1,154 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Backend.Banning;
+using WalletWasabi.WabiSabi.Backend.Models;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
+using WalletWasabi.WabiSabi.Models;
+
+namespace WalletWasabi.WabiSabi.Backend.PostRequests
+{
+	public static class InputRegistrationHandler
+	{
+		public static async Task<Dictionary<Coin, byte[]>> PreProcessAsync(
+			InputsRegistrationRequest request,
+			Prison prison,
+			IRPCClient rpc,
+			WabiSabiConfig config)
+		{
+			var inputRoundSignaturePairs = request.InputRoundSignaturePairs;
+			var inputs = inputRoundSignaturePairs.Select(x => x.Input);
+
+			int inputCount = inputs.Count();
+			if (inputCount != inputs.Distinct().Count())
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
+			}
+			if (inputs.Any(x => prison.TryGet(x, out var inmate) && (!config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned);
+			}
+
+			Dictionary<Coin, byte[]> coinRoundSignaturePairs = new();
+			foreach (var inputRoundSignaturePair in inputRoundSignaturePairs)
+			{
+				OutPoint input = inputRoundSignaturePair.Input;
+				var txOutResponse = await rpc.GetTxOutAsync(input.Hash, (int)input.N, includeMempool: true).ConfigureAwait(false);
+				if (txOutResponse is null)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputSpent);
+				}
+				if (txOutResponse.Confirmations == 0)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputUnconfirmed);
+				}
+				if (txOutResponse.IsCoinBase && txOutResponse.Confirmations <= 100)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputImmature);
+				}
+				if (!txOutResponse.TxOut.ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
+				}
+
+				coinRoundSignaturePairs.Add(new Coin(input, txOutResponse.TxOut), inputRoundSignaturePair.RoundSignature);
+			}
+
+			return coinRoundSignaturePairs;
+		}
+
+		public static InputsRegistrationResponse RegisterInput(
+			Guid roundId,
+			IDictionary<Coin, byte[]> coinRoundSignaturePairs,
+			ZeroCredentialsRequest zeroAmountCredentialRequests,
+			ZeroCredentialsRequest zeroWeightCredentialRequests,
+			IDictionary<Guid, Round> rounds,
+			Network network)
+		{
+			if (!rounds.TryGetValue(roundId, out var round))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+			}
+
+			var alice = new Alice(coinRoundSignaturePairs);
+
+			var coins = alice.Coins;
+			if (round.MaxInputCountByAlice < coins.Count())
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooManyInputs);
+			}
+			if (round.IsBlameRound && coins.Select(x => x.Outpoint).Any(x => !round.BlameWhitelist.Contains(x)))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputNotWhitelisted);
+			}
+
+			var inputValueSum = Money.Zero;
+			var inputWeightSum = 0;
+			foreach (var coinRoundSignaturePair in alice.CoinRoundSignaturePairs)
+			{
+				var coin = coinRoundSignaturePair.Key;
+				var signature = coinRoundSignaturePair.Value;
+				var address = (BitcoinWitPubKeyAddress)coin.TxOut.ScriptPubKey.GetDestinationAddress(network);
+				if (!address.VerifyMessage(round.Hash, signature))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongRoundSignature);
+				}
+				inputValueSum += coin.TxOut.Value;
+
+				// Convert conservative P2WPKH size in virtual bytes to weight units.
+				inputWeightSum += coin.TxOut.ScriptPubKey.EstimateInputVsize() * 4;
+			}
+
+			if (inputValueSum < round.MinRegistrableAmount)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
+			}
+			if (inputValueSum > round.MaxRegistrableAmount)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
+			}
+
+			if (inputWeightSum > round.RegistrableWeightCredentials)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchWeight);
+			}
+
+			if (round.Phase != Phase.InputRegistration)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
+			}
+
+			var amountCredentialResponse = round.AmountCredentialIssuer.HandleRequest(zeroAmountCredentialRequests);
+			var weightCredentialResponse = round.WeightCredentialIssuer.HandleRequest(zeroWeightCredentialRequests);
+
+			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
+			foreach (var otherRound in rounds.Values)
+			{
+				foreach (var op in alice.Coins.Select(x => x.Outpoint))
+				{
+					try
+					{
+						if (otherRound.RemoveAlices(x => x.Coins.Select(x => x.Outpoint).Contains(op)) > 0)
+						{
+							Logger.LogInfo("Updated Alice registration.");
+						}
+					}
+					catch (WabiSabiProtocolException ex) when (ex.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
+					{
+						throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyRegistered);
+					}
+				}
+			}
+
+			round.Alices.Add(alice);
+
+			return new(alice.Id, amountCredentialResponse, weightCredentialResponse);
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -25,17 +25,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		private object Lock { get; } = new();
 		public Network Network { get; }
 
-		public bool TryGetRound(Guid roundId, [NotNullWhen(true)] out Round? round)
+		protected override Task ActionAsync(CancellationToken cancel)
 		{
 			lock (Lock)
 			{
-				return Rounds.TryGetValue(roundId, out round);
+				return Task.CompletedTask;
 			}
-		}
-
-		protected override Task ActionAsync(CancellationToken cancel)
-		{
-			return Task.CompletedTask;
 		}
 
 		public InputsRegistrationResponse RegisterInput(
@@ -44,62 +39,66 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			ZeroCredentialsRequest zeroAmountCredentialRequests,
 			ZeroCredentialsRequest zeroWeightCredentialRequests)
 		{
-			if (!TryGetRound(roundId, out var round))
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
-			}
-
-			var alice = new Alice(coinRoundSignaturePairs);
-
-			var coins = alice.Coins;
-			if (round.MaxInputCountByAlice < coins.Count())
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooManyInputs);
-			}
-			if (round.IsBlameRound && coins.Select(x => x.Outpoint).Any(x => !round.BlameWhitelist.Contains(x)))
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputNotWhitelisted);
-			}
-
-			var inputValueSum = Money.Zero;
-			var inputWeightSum = 0;
-			foreach (var coinRoundSignaturePair in alice.CoinRoundSignaturePairs)
-			{
-				var coin = coinRoundSignaturePair.Key;
-				var signature = coinRoundSignaturePair.Value;
-				var address = (BitcoinWitPubKeyAddress)coin.TxOut.ScriptPubKey.GetDestinationAddress(Network);
-				if (!address.VerifyMessage(round.Hash, signature))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongRoundSignature);
-				}
-				inputValueSum += coin.TxOut.Value;
-
-				// Convert conservative P2WPKH size in virtual bytes to weight units.
-				inputWeightSum += coin.TxOut.ScriptPubKey.EstimateInputVsize() * 4;
-			}
-
-			if (inputValueSum < round.MinRegistrableAmount)
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
-			}
-			if (inputValueSum > round.MaxRegistrableAmount)
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
-			}
-
-			if (inputWeightSum > round.RegistrableWeightCredentials)
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchWeight);
-			}
-
-			var resp = round.RegisterAlice(
-				alice,
-				zeroAmountCredentialRequests,
-				zeroWeightCredentialRequests);
-
 			lock (Lock)
 			{
-				foreach (var otherRound in Rounds.Where(x => x.Key != round.Id).Select(x => x.Value))
+				if (!Rounds.TryGetValue(roundId, out var round))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				}
+
+				var alice = new Alice(coinRoundSignaturePairs);
+
+				var coins = alice.Coins;
+				if (round.MaxInputCountByAlice < coins.Count())
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooManyInputs);
+				}
+				if (round.IsBlameRound && coins.Select(x => x.Outpoint).Any(x => !round.BlameWhitelist.Contains(x)))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputNotWhitelisted);
+				}
+
+				var inputValueSum = Money.Zero;
+				var inputWeightSum = 0;
+				foreach (var coinRoundSignaturePair in alice.CoinRoundSignaturePairs)
+				{
+					var coin = coinRoundSignaturePair.Key;
+					var signature = coinRoundSignaturePair.Value;
+					var address = (BitcoinWitPubKeyAddress)coin.TxOut.ScriptPubKey.GetDestinationAddress(Network);
+					if (!address.VerifyMessage(round.Hash, signature))
+					{
+						throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongRoundSignature);
+					}
+					inputValueSum += coin.TxOut.Value;
+
+					// Convert conservative P2WPKH size in virtual bytes to weight units.
+					inputWeightSum += coin.TxOut.ScriptPubKey.EstimateInputVsize() * 4;
+				}
+
+				if (inputValueSum < round.MinRegistrableAmount)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
+				}
+				if (inputValueSum > round.MaxRegistrableAmount)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
+				}
+
+				if (inputWeightSum > round.RegistrableWeightCredentials)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchWeight);
+				}
+
+				if (round.Phase != Phase.InputRegistration)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
+				}
+
+				var amountCredentialResponse = round.AmountCredentialIssuer.HandleRequest(zeroAmountCredentialRequests);
+				var weightCredentialResponse = round.WeightCredentialIssuer.HandleRequest(zeroWeightCredentialRequests);
+
+				alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
+				foreach (var otherRound in Rounds.Values)
 				{
 					foreach (var op in alice.Coins.Select(x => x.Outpoint))
 					{
@@ -116,67 +115,173 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 						}
 					}
 				}
-			}
 
-			return resp;
+				round.Alices.Add(alice);
+
+				return new(alice.Id, amountCredentialResponse, weightCredentialResponse);
+			}
 		}
 
 		public void RemoveInput(InputsRemovalRequest request)
 		{
-			if (!TryGetRound(request.RoundId, out var round))
+			lock (Lock)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				if (!Rounds.TryGetValue(request.RoundId, out var round))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				}
+				round.RemoveAlices(x => x.Id == request.AliceId);
 			}
-			round.RemoveAlices(x => x.Id == request.AliceId);
 		}
 
 		public ConnectionConfirmationResponse ConfirmConnection(ConnectionConfirmationRequest request)
 		{
-			if (!TryGetRound(request.RoundId, out var round))
+			lock (Lock)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
-			}
+				if (!Rounds.TryGetValue(request.RoundId, out var round))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				}
 
-			return round.ConfirmAlice(request);
+				var alice = round.Alices.FirstOrDefault(x => x.Id == request.AliceId);
+				if (alice is null)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound);
+				}
+
+				var amountZeroCredentialResponse = round.AmountCredentialIssuer.HandleRequest(request.ZeroAmountCredentialRequests);
+				var weightZeroCredentialResponse = round.WeightCredentialIssuer.HandleRequest(request.ZeroWeightCredentialRequests);
+
+				var realAmountCredentialRequests = request.RealAmountCredentialRequests;
+				var realWeightCredentialRequests = request.RealWeightCredentialRequests;
+
+				if (realWeightCredentialRequests.Delta != alice.CalculateRemainingWeightCredentials(round.RegistrableWeightCredentials))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedWeightCredentials);
+				}
+				if (realAmountCredentialRequests.Delta != alice.CalculateRemainingAmountCredentials(round.FeeRate))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedAmountCredentials);
+				}
+
+				if (round.Phase == Phase.InputRegistration)
+				{
+					alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
+					return new(
+						amountZeroCredentialResponse,
+						weightZeroCredentialResponse);
+				}
+				else if (round.Phase == Phase.ConnectionConfirmation)
+				{
+					var amountRealCredentialResponse = round.AmountCredentialIssuer.HandleRequest(realAmountCredentialRequests);
+					var weightRealCredentialResponse = round.WeightCredentialIssuer.HandleRequest(realWeightCredentialRequests);
+
+					return new(
+						amountZeroCredentialResponse,
+						weightZeroCredentialResponse,
+						amountRealCredentialResponse,
+						weightRealCredentialResponse);
+				}
+				else
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
+				}
+			}
 		}
 
 		public OutputRegistrationResponse RegisterOutput(OutputRegistrationRequest request)
 		{
-			if (!TryGetRound(request.RoundId, out var round))
+			lock (Lock)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				if (!Rounds.TryGetValue(request.RoundId, out var round))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				}
+
+				var credentialAmount = -request.AmountCredentialRequests.Delta;
+
+				var bob = new Bob(request.Script, credentialAmount);
+
+				var outputValue = bob.CalculateOutputAmount(round.FeeRate);
+				if (outputValue < round.MinRegistrableAmount)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
+				}
+				if (outputValue > round.MaxRegistrableAmount)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
+				}
+
+				var weightCredentialRequests = request.WeightCredentialRequests;
+				if (-weightCredentialRequests.Delta != bob.CalculateWeight())
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedWeightCredentials);
+				}
+
+				if (round.Phase != Phase.OutputRegistration)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
+				}
+
+				var amountCredentialResponse = round.AmountCredentialIssuer.HandleRequest(request.AmountCredentialRequests);
+				var weightCredentialResponse = round.WeightCredentialIssuer.HandleRequest(weightCredentialRequests);
+
+				round.Bobs.Add(bob);
+
+				return new(
+					round.UnsignedTxSecret,
+					amountCredentialResponse,
+					weightCredentialResponse);
 			}
-
-			var credentialAmount = -request.AmountCredentialRequests.Delta;
-
-			var bob = new Bob(request.Script, credentialAmount);
-
-			var outputValue = bob.CalculateOutputAmount(round.FeeRate);
-			if (outputValue < round.MinRegistrableAmount)
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
-			}
-			if (outputValue > round.MaxRegistrableAmount)
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
-			}
-
-			var weightCredentialRequests = request.WeightCredentialRequests;
-			if (-weightCredentialRequests.Delta != bob.CalculateWeight())
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedWeightCredentials);
-			}
-
-			return round.RegisterBob(bob, request.AmountCredentialRequests, weightCredentialRequests);
 		}
 
 		public void SignTransaction(TransactionSignaturesRequest request)
 		{
-			if (!TryGetRound(request.RoundId, out var round))
+			lock (Lock)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				if (!Rounds.TryGetValue(request.RoundId, out var round))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
+				}
+
+				if (round.Phase != Phase.TransactionSigning)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
+				}
+				foreach (var inputWitnessPair in request.InputWitnessPairs)
+				{
+					var index = (int)inputWitnessPair.InputIndex;
+					var witness = inputWitnessPair.Witness;
+
+					// If input is already signed, don't bother.
+					if (round.Coinjoin.Inputs[index].HasWitScript())
+					{
+						continue;
+					}
+
+					// Verify witness.
+					// 1. Copy UnsignedCoinJoin.
+					Transaction cjCopy = Transaction.Parse(round.Coinjoin.ToHex(), Network);
+
+					// 2. Sign the copy.
+					cjCopy.Inputs[index].WitScript = witness;
+
+					// 3. Convert the current input to IndexedTxIn.
+					IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
+
+					// 4. Find the corresponding registered input.
+					Coin registeredCoin = round.Alices.SelectMany(x => x.Coins).Single(x => x.Outpoint == cjCopy.Inputs[index].PrevOut);
+
+					// 5. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
+					if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
+					{
+						throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongCoinjoinSignature);
+					}
+
+					// Finally add it to our CJ.
+					round.Coinjoin.Inputs[index].WitScript = witness;
+				}
 			}
-			round.SubmitTransactionSignatures(request.InputWitnessPairs);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -65,170 +65,17 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public Round? BlameOf { get; } = null;
 		public bool IsBlameRound => BlameOf is not null;
 		public ISet<OutPoint> BlameWhitelist { get; } = new HashSet<OutPoint>();
-		private object Lock { get; } = new();
 		public byte[] UnsignedTxSecret { get; }
 		public Transaction Coinjoin { get; }
 		public RoundParameters RoundParameters { get; }
 
-		public InputsRegistrationResponse RegisterAlice(
-			Alice alice,
-			ZeroCredentialsRequest zeroAmountCredentialRequests,
-			ZeroCredentialsRequest zeroWeightCredentialRequests)
-		{
-			lock (Lock)
-			{
-				if (Phase != Phase.InputRegistration)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
-				}
-
-				var amountCredentialResponse = AmountCredentialIssuer.HandleRequest(zeroAmountCredentialRequests);
-				var weightCredentialResponse = WeightCredentialIssuer.HandleRequest(zeroWeightCredentialRequests);
-
-				alice.SetDeadlineRelativeTo(ConnectionConfirmationTimeout);
-				foreach (var op in alice.Coins.Select(x => x.Outpoint))
-				{
-					if (RemoveAlicesNoLock(x => x.Coins.Select(x => x.Outpoint).Contains(op)) > 0)
-					{
-						Logger.LogInfo("Updated Alice registration.");
-					}
-				}
-				Alices.Add(alice);
-
-				return new(alice.Id, amountCredentialResponse, weightCredentialResponse);
-			}
-		}
-
 		public int RemoveAlices(Predicate<Alice> match)
-		{
-			lock (Lock)
-			{
-				return RemoveAlicesNoLock(match);
-			}
-		}
-
-		private int RemoveAlicesNoLock(Predicate<Alice> match)
 		{
 			if (Phase != Phase.InputRegistration)
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
 			}
 			return Alices.RemoveAll(match);
-		}
-
-		public ConnectionConfirmationResponse ConfirmAlice(ConnectionConfirmationRequest request)
-		{
-			lock (Lock)
-			{
-				var alice = Alices.FirstOrDefault(x => x.Id == request.AliceId);
-				if (alice is null)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound);
-				}
-
-				var amountZeroCredentialResponse = AmountCredentialIssuer.HandleRequest(request.ZeroAmountCredentialRequests);
-				var weightZeroCredentialResponse = WeightCredentialIssuer.HandleRequest(request.ZeroWeightCredentialRequests);
-
-				var realAmountCredentialRequests = request.RealAmountCredentialRequests;
-				var realWeightCredentialRequests = request.RealWeightCredentialRequests;
-
-				if (realWeightCredentialRequests.Delta != alice.CalculateRemainingWeightCredentials(RegistrableWeightCredentials))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedWeightCredentials);
-				}
-				if (realAmountCredentialRequests.Delta != alice.CalculateRemainingAmountCredentials(FeeRate))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedAmountCredentials);
-				}
-
-				if (Phase == Phase.InputRegistration)
-				{
-					alice.SetDeadlineRelativeTo(ConnectionConfirmationTimeout);
-					return new(
-						amountZeroCredentialResponse,
-						weightZeroCredentialResponse);
-				}
-				else if (Phase == Phase.ConnectionConfirmation)
-				{
-					var amountRealCredentialResponse = AmountCredentialIssuer.HandleRequest(realAmountCredentialRequests);
-					var weightRealCredentialResponse = WeightCredentialIssuer.HandleRequest(realWeightCredentialRequests);
-
-					return new(
-						amountZeroCredentialResponse,
-						weightZeroCredentialResponse,
-						amountRealCredentialResponse,
-						weightRealCredentialResponse);
-				}
-				else
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
-				}
-			}
-		}
-
-		public OutputRegistrationResponse RegisterBob(Bob bob, RealCredentialsRequest amountCredentialRequests, RealCredentialsRequest weightCredentialRequests)
-		{
-			lock (Lock)
-			{
-				if (Phase != Phase.OutputRegistration)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
-				}
-
-				var amountCredentialResponse = AmountCredentialIssuer.HandleRequest(amountCredentialRequests);
-				var weightCredentialResponse = WeightCredentialIssuer.HandleRequest(weightCredentialRequests);
-
-				Bobs.Add(bob);
-
-				return new(
-					UnsignedTxSecret,
-					amountCredentialResponse,
-					weightCredentialResponse);
-			}
-		}
-
-		public void SubmitTransactionSignatures(IEnumerable<InputWitnessPair> inputWitnessPairs)
-		{
-			lock (Lock)
-			{
-				if (Phase != Phase.TransactionSigning)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
-				}
-				foreach (var inputWitnessPair in inputWitnessPairs)
-				{
-					var index = (int)inputWitnessPair.InputIndex;
-					var witness = inputWitnessPair.Witness;
-
-					// If input is already signed, don't bother.
-					if (Coinjoin.Inputs[index].HasWitScript())
-					{
-						continue;
-					}
-
-					// Verify witness.
-					// 1. Copy UnsignedCoinJoin.
-					Transaction cjCopy = Transaction.Parse(Coinjoin.ToHex(), Network);
-
-					// 2. Sign the copy.
-					cjCopy.Inputs[index].WitScript = witness;
-
-					// 3. Convert the current input to IndexedTxIn.
-					IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
-
-					// 4. Find the corresponding registered input.
-					Coin registeredCoin = Alices.SelectMany(x => x.Coins).Single(x => x.Outpoint == cjCopy.Inputs[index].PrevOut);
-
-					// 5. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
-					if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
-					{
-						throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongCoinjoinSignature);
-					}
-
-					// Finally add it to our CJ.
-					Coinjoin.Inputs[index].WitScript = witness;
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Behavior

If Alice was already registered

- to the same round and the phase is input registration: update Alice
- to the same round and the phase isn't input registration: throw wrong round exception
- to another round and the phase is input registration: update Alice
- to another round and the phase isn't input registration: throw Alice already registered exception

### Concern

I'm not too happy with the implementation as the logic is in two different places, it should be improved somehow.

### Edit:

Even the behavior was wrong, because of the locking all over the place. I won't be optimizing for performance now. Arena locks everything.