### PR TITLE
[Fluent] Keep NavBarItem height when login inicator is visible

### DIFF
--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -146,7 +146,7 @@
                     <Binding Path="IconName" Converter="{x:Static conv:NavBarIconConverter.Instance}" />
                   </PathIcon.Data>
                 </PathIcon>
-                <Ellipse IsVisible="{Binding IsLoggedIn, Mode=OneWay}" Width="9" Height="9" Margin="15,13,0,0" Fill="#F2994A"/>
+                <Ellipse IsVisible="{Binding IsLoggedIn, Mode=OneWay}" Width="9" Height="9" Margin="15,0,0,-13" Fill="#F2994A"/>
               </Panel>
               <TextBlock Text="{Binding Title}" Margin="55 0 0 0" />
             </Panel>
@@ -300,7 +300,7 @@
                   <Binding Path="IconName" Converter="{x:Static conv:NavBarIconConverter.Instance}" />
                 </PathIcon.Data>
               </PathIcon>
-              <Ellipse IsVisible="{Binding IsLoggedIn, Mode=OneWay}" Width="9" Height="9" Margin="15,13,0,0" Fill="#F2994A"/>
+              <Ellipse IsVisible="{Binding IsLoggedIn, Mode=OneWay}" Width="9" Height="9" Margin="15,0,0,-13" Fill="#F2994A"/>
             </Panel>
             <TextBlock Text="{Binding Title}" Margin="55 0 0 0" />
           </Panel>


### PR DESCRIPTION
When the login indicator appeared the button's height increased a bit. This fixes it.

Before:
![image](https://user-images.githubusercontent.com/16364053/108834791-e32caa00-75ce-11eb-82dd-a49618f79fdf.png)
![image](https://user-images.githubusercontent.com/16364053/108834965-18d19300-75cf-11eb-921f-379d192ed049.png)

After:
![image](https://user-images.githubusercontent.com/16364053/108834802-e6279a80-75ce-11eb-8b59-c355d70f8093.png)
![image](https://user-images.githubusercontent.com/16364053/108834859-f5a6e380-75ce-11eb-8986-d258df6e00a6.png)

