### PR TITLE
Fix duplicate item exception in GetFeeEstimations

### DIFF
--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -193,10 +193,5 @@ namespace System.Linq
 			}
 			return source.Zip(otherCollection);
 		}
-
-		public static IEnumerable<T> DistinctBy<T, TKey>(this IEnumerable<T> enumerable, Func<T, TKey> keySelector)
-		{
-			return enumerable.GroupBy(keySelector).Select(grp => grp.First());
-		}
 	}
 }

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -193,5 +193,10 @@ namespace System.Linq
 			}
 			return source.Zip(otherCollection);
 		}
+
+		public static IEnumerable<T> DistinctBy<T, TKey>(this IEnumerable<T> enumerable, Func<T, TKey> keySelector)
+		{
+			return enumerable.GroupBy(keySelector).Select(grp => grp.First());
+		}
 	}
 }

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -106,6 +106,7 @@ namespace NBitcoin.RPC
 				}
 			}
 
+			// EstimateSmartFeeAsync returns the block number where estimate was found - not always what the requested one.
 			return rpcFeeEstimationTasks
 				.Zip(Constants.ConfirmationTargets, (task, target) => (task, target))
 				.Where(x => x.task.IsCompletedSuccessfully)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -109,6 +109,7 @@ namespace NBitcoin.RPC
 			return rpcFeeEstimationTasks
 				.Where(x => x.IsCompletedSuccessfully)
 				.Select(x => x.Result)
+				.DistinctBy(x => x.Blocks)
 				.ToDictionary(x => x.Blocks, x => (int)Math.Ceiling(x.FeeRate.SatoshiPerByte));
 		}
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -107,10 +107,10 @@ namespace NBitcoin.RPC
 			}
 
 			return rpcFeeEstimationTasks
-				.Where(x => x.IsCompletedSuccessfully)
-				.Select(x => x.Result)
-				.DistinctBy(x => x.Blocks)
-				.ToDictionary(x => x.Blocks, x => (int)Math.Ceiling(x.FeeRate.SatoshiPerByte));
+				.Zip(Constants.ConfirmationTargets, (task, target) => (task, target))
+				.Where(x => x.task.IsCompletedSuccessfully)
+				.Select(x => (x.target, feeRate: x.task.Result.FeeRate))
+				.ToDictionary(x => x.target, x => (int)Math.Ceiling(x.feeRate.SatoshiPerByte));
 		}
 
 		public static async Task<RpcStatus> GetRpcStatusAsync(this IRPCClient rpc, CancellationToken cancel)


### PR DESCRIPTION
My local full node is returning the same target for more estimation requests. I think if it does not have enough data it will return the closest one. For example, if the node has only one estimation then it will return the exact same one on each request not matter what was the request target. 

![image](https://user-images.githubusercontent.com/9844978/108849738-cef2a800-75e2-11eb-83b3-babf301999f7.png)

