### PR TITLE
WalletManager: Nits

### DIFF
--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -121,8 +121,7 @@ namespace WalletWasabi.Wallets
 
 			lock (Lock)
 			{
-				return Wallets.Keys
-					.ToList();
+				return Wallets.Keys.ToList();
 			}
 		}
 

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -206,7 +206,7 @@ namespace WalletWasabi.Wallets
 			return wallet;
 		}
 
-		private Wallet AddWallet(string walletName)
+		private void AddWallet(string walletName)
 		{
 			(string walletFullPath, string walletBackupFullPath) = WalletDirectories.GetWalletFilePaths(walletName);
 			Wallet wallet;
@@ -243,7 +243,6 @@ namespace WalletWasabi.Wallets
 			}
 
 			AddWallet(wallet);
-			return wallet;
 		}
 
 		private void AddWallet(Wallet wallet)

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -271,7 +271,7 @@ namespace WalletWasabi.Wallets
 
 		public async Task DequeueAllCoinsGracefullyAsync(DequeueReason reason, CancellationToken token)
 		{
-			IEnumerable<Task> tasks = null;
+			IEnumerable<Task> tasks;
 			lock (Lock)
 			{
 				tasks = Wallets.Keys.Where(x => x.ChaumianClient is { }).Select(x => x.ChaumianClient.DequeueAllCoinsFromMixGracefullyAsync(reason, token)).ToArray();

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -62,6 +62,7 @@ namespace WalletWasabi.Wallets
 
 		private CancellationTokenSource CancelAllInitialization { get; }
 
+		/// <remarks>All access must be guarded by <see cref="Lock"/> object.</remarks>
 		private Dictionary<Wallet, HashSet<uint256>> Wallets { get; }
 		private object Lock { get; }
 		private AsyncLock StartStopWalletLock { get; }


### PR DESCRIPTION
Please review commit by commit.

I have also noticed how `IsInitialized` property is used:

```csharp
while (!IsInitialized)
{
	await Task.Delay(100, CancelAllInitialization.Token).ConfigureAwait(false);
}
```

where `IsInitialized` not synchronized and it is used in multiple threads (at least it seems so). `Task.Delay` is a workaround here, it would be nicer to use Cleary's [AsyncManualResetEvent](https://github.com/StephenCleary/AsyncEx/blob/master/src/Nito.AsyncEx.Coordination/AsyncManualResetEvent.cs) or `SemaphoreSlim`