### PR TITLE
Reduce RPC calls in coinjoins

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -321,12 +321,7 @@ namespace WalletWasabi.Backend.Controllers
 					// Progress round if needed.
 					if (round.CountAlices() >= round.AnonymitySet)
 					{
-						await round.RemoveAlicesIfAnInputRefusedByMempoolAsync();
-
-						if (round.CountAlices() >= round.AnonymitySet)
-						{
-							await round.ExecuteNextPhaseAsync(RoundPhase.ConnectionConfirmation);
-						}
+						await round.ExecuteNextPhaseAsync(RoundPhase.ConnectionConfirmation);
 					}
 
 					var resp = new InputsResponse


### PR DESCRIPTION
I think `RemoveAlicesIfAnInputRefusedByMempoolAsync` is called twice, but please check me. I think `ExecuteNextPhaseAsync` will call `MoveToConnectionConfirmationAsync` and that also calls `RemoveAlicesIfAnInputRefusedByMempoolAsync`. @yahiheb @kiminuo you guys are good at spotting off by ones. May I ask one of you to make sure I'm right or wrong?

