### PR TITLE
Use FriendlyName attribute instead of Description attribute

### DIFF
--- a/WalletWasabi/CoinJoin/Client/Clients/Queuing/DequeueReason.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/Queuing/DequeueReason.cs
@@ -1,31 +1,31 @@
-using System.ComponentModel;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.CoinJoin.Client.Clients.Queuing
 {
 	public enum DequeueReason
 	{
-		[Description("User requested.")]
+		[FriendlyName("User requested.")]
 		UserRequested, // Success, user requested the dequeue.
 
-		[Description("Using coin for transaction building.")]
+		[FriendlyName("Using coin for transaction building.")]
 		TransactionBuilding, // Success, transaction is being built with the coins.
 
-		[Description("Coin is banned.")]
+		[FriendlyName("Coin is banned.")]
 		Banned, // Success
 
-		[Description("Not enough funds enqueued.")]
+		[FriendlyName("Not enough funds enqueued.")]
 		NotEnoughFundsEnqueued, // Success
 
-		[Description("Coordinator fee changed.")]
+		[FriendlyName("Coordinator fee changed.")]
 		CoordinatorFeeChanged, // Success
 
-		[Description("Application is exiting.")]
+		[FriendlyName("Application is exiting.")]
 		ApplicationExit, // Success, application is exiting.
 
-		[Description("Coin is spent.")]
+		[FriendlyName("Coin is spent.")]
 		Spent, // Success, coin is spent.
 
-		[Description("Coin is being mixed.")]
+		[FriendlyName("Coin is being mixed.")]
 		Mixing // Failure, the coin's mixing status is > registration.
 	}
 }

--- a/WalletWasabi/Extensions/EnumExtension.cs
+++ b/WalletWasabi/Extensions/EnumExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Extensions
 {
@@ -17,9 +18,9 @@ namespace WalletWasabi.Extensions
 
 		public static string FriendlyName(this Enum value)
 		{
-			var attribute = value.GetFirstAttribute<DescriptionAttribute>();
+			var attribute = value.GetFirstAttribute<FriendlyNameAttribute>();
 
-			return attribute is { } ? attribute.Description : value.ToString();
+			return attribute is { } ? attribute.FriendlyName : value.ToString();
 		}
 	}
 }

--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Hwi.Models
 {
@@ -7,46 +8,46 @@ namespace WalletWasabi.Hwi.Models
 	/// </summary>
 	public enum HardwareWalletModels
 	{
-		[Description("Hardware Wallet")]
+		[FriendlyName("Hardware Wallet")]
 		Unknown,
 
-		[Description("Coldcard")]
+		[FriendlyName("Coldcard")]
 		Coldcard,
 
-		[Description("Coldcard Simulator")]
+		[FriendlyName("Coldcard Simulator")]
 		Coldcard_Simulator,
 
-		[Description("BitBox")]
+		[FriendlyName("BitBox")]
 		DigitalBitBox_01,
 
-		[Description("BitBox Simulator")]
+		[FriendlyName("BitBox Simulator")]
 		DigitalBitBox_01_Simulator,
 
-		[Description("KeepKey")]
+		[FriendlyName("KeepKey")]
 		KeepKey,
 
-		[Description("KeepKey Simulator")]
+		[FriendlyName("KeepKey Simulator")]
 		KeepKey_Simulator,
 
-		[Description("Ledger Nano S")]
+		[FriendlyName("Ledger Nano S")]
 		Ledger_Nano_S,
 
-		[Description("Trezor One")]
+		[FriendlyName("Trezor One")]
 		Trezor_1,
 
-		[Description("Trezor One Simulator")]
+		[FriendlyName("Trezor One Simulator")]
 		Trezor_1_Simulator,
 
-		[Description("Trezor T")]
+		[FriendlyName("Trezor T")]
 		Trezor_T,
 
-		[Description("Trezor T Simulator")]
+		[FriendlyName("Trezor T Simulator")]
 		Trezor_T_Simulator,
 
-		[Description("BitBox")]
+		[FriendlyName("BitBox")]
 		BitBox02_BTCOnly,
 
-		[Description("BitBox")]
+		[FriendlyName("BitBox")]
 		BitBox02_Multi,
 	}
 }

--- a/WalletWasabi/Models/FriendlyNameAttribute.cs
+++ b/WalletWasabi/Models/FriendlyNameAttribute.cs
@@ -5,11 +5,11 @@ namespace WalletWasabi.Models
 	[AttributeUsage(AttributeTargets.Field)]
 	public class FriendlyNameAttribute : Attribute
 	{
-		public string FriendlyName { get; }
-
 		public FriendlyNameAttribute(string friendlyName)
 		{
 			FriendlyName = friendlyName;
 		}
+
+		public string FriendlyName { get; }
 	}
 }

--- a/WalletWasabi/Models/FriendlyNameAttribute.cs
+++ b/WalletWasabi/Models/FriendlyNameAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace WalletWasabi.Models
+{
+	[AttributeUsage(AttributeTargets.Field)]
+	public class FriendlyNameAttribute : Attribute
+	{
+		public string FriendlyName { get; }
+
+		public FriendlyNameAttribute(string friendlyName)
+		{
+			FriendlyName = friendlyName;
+		}
+	}
+}

--- a/WalletWasabi/Wallets/PasswordFinder/PasswordFinderCharset.cs
+++ b/WalletWasabi/Wallets/PasswordFinder/PasswordFinderCharset.cs
@@ -1,22 +1,23 @@
 using System.ComponentModel;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Wallets.PasswordFinder
 {
 	public enum Charset
 	{
-		[Description("English")]
+		[FriendlyName("English")]
 		en,
 
-		[Description("Spanish")]
+		[FriendlyName("Spanish")]
 		es,
 
-		[Description("Italian")]
+		[FriendlyName("Italian")]
 		it,
 
-		[Description("French")]
+		[FriendlyName("French")]
 		fr,
 
-		[Description("Portuguese")]
+		[FriendlyName("Portuguese")]
 		pt
 	}
 }

--- a/WalletWasabi/Wallets/PasswordFinder/PasswordFinderCharset.cs
+++ b/WalletWasabi/Wallets/PasswordFinder/PasswordFinderCharset.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Wallets.PasswordFinder


### PR DESCRIPTION
This PR creates a custom attribute called `FriendlyName` and uses this instead of the `Description` attribute.
This improves readability. FriendlyName attribute is more meaningful, if someone looks at it, will know immediately what does it mean.