### PR TITLE
Fix randomly changing anonymity set

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -28,6 +28,21 @@ namespace WalletWasabi.Tests.UnitTests.BlockchainAnalysis
 		}
 
 		[Fact]
+		public void DoubleProcessing()
+		{
+			var analyser = ServiceFactory.CreateBlockchainAnalyzer();
+			var tx = BitcoinFactory.CreateSmartTransaction(9, Enumerable.Repeat(Money.Coins(1m), 9), new[] { (Money.Coins(1.1m), 1) }, new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) });
+
+			analyser.Analyze(tx);
+			analyser.Analyze(tx);
+
+			Assert.Equal(1, tx.WalletInputs.First().HdPubKey.AnonymitySet);
+
+			// 10 participants, 1 is you, your anonset is 10.
+			Assert.Equal(10, tx.WalletOutputs.First().HdPubKey.AnonymitySet);
+		}
+
+		[Fact]
 		public void Inheritance()
 		{
 			var analyser = ServiceFactory.CreateBlockchainAnalyzer();

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Blockchain.Analysis
 		/// </summary>
 		public void Analyze(SmartTransaction tx)
 		{
-			if(!CheckedTxs.Add(tx.GetHash()))
+			if (!CheckedTxs.Add(tx.GetHash()))
 			{
 				return;
 			}
@@ -34,8 +34,6 @@ namespace WalletWasabi.Blockchain.Analysis
 
 			var ownInputCount = tx.WalletInputs.Count;
 			var ownOutputCount = tx.WalletOutputs.Count;
-
-
 
 			if (ownInputCount == 0)
 			{

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -17,16 +17,25 @@ namespace WalletWasabi.Blockchain.Analysis
 
 		public int PrivacyLevelThreshold { get; }
 
+		public HashSet<uint256> CheckedTxs { get; } = new();
+
 		/// <summary>
 		/// Sets clusters and anonymity sets for related HD public keys.
 		/// </summary>
 		public void Analyze(SmartTransaction tx)
 		{
+			if(!CheckedTxs.Add(tx.GetHash()))
+			{
+				return;
+			}
+
 			var inputCount = tx.Transaction.Inputs.Count;
 			var outputCount = tx.Transaction.Outputs.Count;
 
 			var ownInputCount = tx.WalletInputs.Count;
 			var ownOutputCount = tx.WalletOutputs.Count;
+
+
 
 			if (ownInputCount == 0)
 			{


### PR DESCRIPTION
Probably we found a fixes #5287 Issue, where anonymity set changed back to 1 after CoinJoin or Opening a wallet with unconfirmed coins, where those coins changed to 1.