### PR TITLE
Add Logging in Signing and Broadcasting phase

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -192,7 +192,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					}
 					else if (round.TransactionSigningStart + round.TransactionSigningTimeout < DateTimeOffset.UtcNow)
 					{
-						throw new TimeoutException($"Signing phase timed out after {round.TransactionSigningTimeout.TotalSeconds} seconds");
+						throw new TimeoutException($"Signing phase timed out after {round.TransactionSigningTimeout.TotalSeconds} seconds.");
 					}
 				}
 				catch (Exception ex)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -162,7 +162,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				var coinjoin = round.Coinjoin;
 				var isFullySigned = coinjoin.Inputs.All(x => x.HasWitScript());
-				bool timeout = round.TransactionSigningStart + round.TransactionSigningTimeout < DateTimeOffset.UtcNow;
 
 				try
 				{
@@ -191,7 +190,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 						round.LogInfo($"Successfully broadcast the CoinJoin: {coinjoin.GetHash()}.");
 					}
-					else if (timeout)
+					else if (round.TransactionSigningStart + round.TransactionSigningTimeout < DateTimeOffset.UtcNow)
 					{
 						throw new TimeoutException($"Signing phase timed out after {round.TransactionSigningTimeout.TotalSeconds} seconds");
 					}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -162,21 +162,43 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				var coinjoin = round.Coinjoin;
 				var isFullySigned = coinjoin.Inputs.All(x => x.HasWitScript());
-				if (isFullySigned)
+				bool timeout = round.TransactionSigningStart + round.TransactionSigningTimeout < DateTimeOffset.UtcNow;
+
+				try
 				{
-					try
+					if (isFullySigned)
 					{
+						// Logging.
+						round.LogInfo("Trying to broadcast coinjoin.");
+						Coin[]? spentCoins = round.Alices.SelectMany(x => x.Coins).ToArray();
+						Money networkFee = coinjoin.GetFee(spentCoins);
+						Guid roundId = round.Id;
+						FeeRate feeRate = coinjoin.GetFeeRate(spentCoins);
+						round.LogInfo($"Network Fee: {networkFee.ToString(false, false)} BTC.");
+						round.LogInfo($"Network Fee Rate: {feeRate.FeePerK.ToDecimal(MoneyUnit.Satoshi) / 1000} sat/vByte.");
+						round.LogInfo($"Number of inputs: {coinjoin.Inputs.Count}.");
+						round.LogInfo($"Number of outputs: {coinjoin.Outputs.Count}.");
+						round.LogInfo($"Serialized Size: {coinjoin.GetSerializedSize() / 1024} KB.");
+						round.LogInfo($"VSize: {coinjoin.GetVirtualSize() / 1024} KB.");
+						foreach (var (value, count) in coinjoin.GetIndistinguishableOutputs(includeSingle: false))
+						{
+							round.LogInfo($"There are {count} occurrences of {value.ToString(true, false)} BTC output.");
+						}
+
+						// Broadcasting.
 						await Rpc.SendRawTransactionAsync(coinjoin).ConfigureAwait(false);
 						round.SetPhase(Phase.TransactionBroadcasting);
+
+						round.LogInfo($"Successfully broadcast the CoinJoin: {coinjoin.GetHash()}.");
 					}
-					catch (Exception ex)
+					else if (timeout)
 					{
-						Logger.LogWarning(ex);
-						await FailTransactionSigningPhaseAsync(round).ConfigureAwait(false);
+						throw new TimeoutException($"Signing phase timed out after {round.TransactionSigningTimeout.TotalSeconds} seconds");
 					}
 				}
-				else if (round.TransactionSigningStart + round.TransactionSigningTimeout < DateTimeOffset.UtcNow)
+				catch (Exception ex)
 				{
+					round.LogWarning($"Signing phase failed, reason: '{ex}'.");
 					await FailTransactionSigningPhaseAsync(round).ConfigureAwait(false);
 				}
 			}

--- a/WalletWasabi/WabiSabi/LoggerTools.cs
+++ b/WalletWasabi/WabiSabi/LoggerTools.cs
@@ -1,0 +1,30 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+
+namespace WalletWasabi.WabiSabi
+{
+	public static class LoggerTools
+	{
+		public static void Log(this Round round, LogLevel logLevel, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		{
+			Logger.Log(logLevel, $"Round ({round.Id}): {logMessage}", callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		}
+
+		public static void LogInfo(this Round round, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		{
+			Log(round, LogLevel.Info, logMessage, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		}
+
+		public static void LogWarning(this Round round, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		{
+			Log(round, LogLevel.Warning, logMessage, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		}
+	}
+}


### PR DESCRIPTION
Basically, the PR is as the title. I also simplified the logic to have only one failure path, better for logging and error handling. 

Oh and one more thing, I tried to create something to not forget the round Id every time we have to log something related to the round like `$"Round ({round.Id}):`. So I ended up having `LoggerTools.cs`. This can be done in a various way but IMO the less SPAM in the code the better. I can even move that huge logging part about the CoinJoin transaction details into `LoggerTools.cs `.

I know this is a new concept, so we can N/ACK it. 

### Alternatives

- Create an extension method into `Round` like `string ToLog(string message)` and call `Logger.Log(round.ToLog("tx broadcast"))`