### PR TITLE
Remove ugliSolution var from tests

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -233,35 +233,40 @@ namespace WalletWasabi.Tests.Helpers
 			var requests = new List<(ConnectionConfirmationRequest request, WabiSabiClient amountClient, WabiSabiClient weightClient, CredentialsResponseValidation amountValidation, CredentialsResponseValidation weightValidation)>();
 			foreach (var resp in responses)
 			{
-				(var amClient, var weClient, _, _) = CreateWabiSabiClientsAndIssuers(round);
-
-				var zeroPresentables = CreateZeroCredentials(round);
-				var alice = round.Alices.First(x => x.Id == resp.AliceId);
-				var (realAmountCredentialRequest, amVal) = amClient.CreateRequest(
-					new[] { alice.CalculateRemainingAmountCredentials(round.FeeRate).Satoshi },
-					zeroPresentables.amountCredentials);
-				var (realWeightCredentialRequest, weVal) = weClient.CreateRequest(
-					new[] { alice.CalculateRemainingWeightCredentials(round.RegistrableWeightCredentials) },
-					zeroPresentables.weightCredentials);
-
-				var (zeroAmountCredentialRequest, _) = amClient.CreateRequestForZeroAmount();
-				var (zeroWeightCredentialRequest, _) = weClient.CreateRequestForZeroAmount();
-
-				requests.Add((
-					new ConnectionConfirmationRequest(
-						round.Id,
-						resp.AliceId,
-						zeroAmountCredentialRequest,
-						realAmountCredentialRequest,
-						zeroWeightCredentialRequest,
-						realWeightCredentialRequest),
-					amClient,
-					weClient,
-					amVal,
-					weVal));
+				requests.Add(CreateConnectionConfirmationRequest(round, resp));
 			}
 
 			return requests.ToArray();
+		}
+
+		public static (ConnectionConfirmationRequest request, WabiSabiClient amountClient, WabiSabiClient weightClient, CredentialsResponseValidation amountValidation, CredentialsResponseValidation weightValidation) CreateConnectionConfirmationRequest(Round round, InputsRegistrationResponse response)
+		{
+			(var amClient, var weClient, _, _) = CreateWabiSabiClientsAndIssuers(round);
+
+			var zeroPresentables = CreateZeroCredentials(round);
+			var alice = round.Alices.First(x => x.Id == response.AliceId);
+			var (realAmountCredentialRequest, amVal) = amClient.CreateRequest(
+				new[] { alice.CalculateRemainingAmountCredentials(round.FeeRate).Satoshi },
+				zeroPresentables.amountCredentials);
+			var (realWeightCredentialRequest, weVal) = weClient.CreateRequest(
+				new[] { alice.CalculateRemainingWeightCredentials(round.RegistrableWeightCredentials) },
+				zeroPresentables.weightCredentials);
+
+			var (zeroAmountCredentialRequest, _) = amClient.CreateRequestForZeroAmount();
+			var (zeroWeightCredentialRequest, _) = weClient.CreateRequestForZeroAmount();
+
+			return (
+				new ConnectionConfirmationRequest(
+					round.Id,
+					response.AliceId,
+					zeroAmountCredentialRequest,
+					realAmountCredentialRequest,
+					zeroWeightCredentialRequest,
+					realWeightCredentialRequest),
+				amClient,
+				weClient,
+				amVal,
+				weVal);
 		}
 
 		public static OutputRegistrationRequest CreateOutputRegistrationRequest(Round? round = null, Script? script = null, int? weight = null)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -52,15 +52,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
+
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -112,15 +116,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
+
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -170,15 +178,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
+
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -231,15 +243,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
+
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -55,15 +55,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -133,15 +135,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -213,15 +217,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -297,15 +303,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
@@ -373,15 +381,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Confirm connections.
 			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient weightClient, Guid aliceId)>();
-			var ugliSolution = false;
-			foreach (var ccreq in WabiSabiFactory.CreateConnectionConfirmationRequests(round, irres1, irres2))
-			{
-				var ccresp = await arena.ConfirmConnectionAsync(ccreq.request);
-				ccresps.Add((ccresp, ccreq.amountClient, ccreq.weightClient, ugliSolution ? irres1.AliceId : irres2.AliceId));
-				ugliSolution = true;
-				ccreq.amountClient.HandleResponse(ccresp.RealAmountCredentials!, ccreq.amountValidation);
-				ccreq.weightClient.HandleResponse(ccresp.RealWeightCredentials!, ccreq.weightValidation);
-			}
+			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
+			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
+			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.weightClient, irres2.AliceId));
+			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.weightClient.HandleResponse(ccresp1.RealWeightCredentials!, ccreq1.weightValidation);
+
+			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
+			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
+			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.weightClient, irres1.AliceId));
+			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.weightClient.HandleResponse(ccresp2.RealWeightCredentials!, ccreq2.weightValidation);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 


### PR DESCRIPTION
Basically as the title. The cleanest way to do this was to dismiss the foreach and duplicate the code. 