### PR TITLE
Potentially fix anonySet decrease bug

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -669,8 +669,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var matureTxs = transactionProcessor.TransactionStore.ConfirmedStore.GetTransactions().ToArray();
 			Assert.Empty(matureTxs);
 
-			Assert.True(Object.ReferenceEquals(tx2, spentCoin?.SpenderTransaction));
-			Assert.False(Object.ReferenceEquals(tx1, spentCoin?.SpenderTransaction));
+			Assert.True(ReferenceEquals(tx2, spentCoin?.SpenderTransaction));
+			Assert.False(ReferenceEquals(tx1, spentCoin?.SpenderTransaction));
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -630,6 +630,50 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		}
 
 		[Fact]
+		public async Task CorrectSpenderAsync()
+		{
+			var transactionProcessor = await CreateTransactionProcessorAsync();
+			SmartCoin? spentCoin = null;
+			transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
+			{
+				if (e.NewlySpentCoins.Any())
+				{
+					spentCoin = e.NewlySpentCoins.Single();
+				}
+			};
+			var keys = transactionProcessor.KeyManager.GetKeys();
+			var tx0 = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(1.0m));
+			transactionProcessor.Process(tx0);
+
+			var createdCoin = tx0.Transaction.Outputs.AsCoins().First();
+
+			// Spend the received coin
+			using Key key = new();
+			var tx1 = CreateSpendingTransaction(createdCoin, key.PubKey.ScriptPubKey);
+
+			transactionProcessor.Process(tx1);
+
+			var tx2 = new SmartTransaction(tx1.Transaction, tx1.Height, tx1.BlockHash, tx1.BlockIndex, tx1.Label, tx1.IsReplacement, tx1.FirstSeen);
+			var relevant = transactionProcessor.Process(tx2);
+
+			Assert.False(relevant.IsNews);
+			var coin = Assert.Single(transactionProcessor.Coins.AsAllCoinsView());
+			Assert.True(coin.IsSpent());
+			Assert.NotNull(spentCoin);
+			Assert.Equal(coin, spentCoin);
+
+			// Transaction store assertions
+			var mempool = transactionProcessor.TransactionStore.MempoolStore.GetTransactions();
+			Assert.Equal(2, mempool.Count());
+
+			var matureTxs = transactionProcessor.TransactionStore.ConfirmedStore.GetTransactions().ToArray();
+			Assert.Empty(matureTxs);
+
+			Assert.True(Object.ReferenceEquals(tx2, spentCoin?.SpenderTransaction));
+			Assert.False(Object.ReferenceEquals(tx1, spentCoin?.SpenderTransaction));
+		}
+
+		[Fact]
 		public async Task ReceiveTransactionWithDustForWalletAsync()
 		{
 			var transactionProcessor = await CreateTransactionProcessorAsync();

--- a/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
+++ b/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
@@ -27,6 +27,18 @@ namespace WalletWasabi.Bases
 			return true;
 		}
 
+		protected bool RaiseAndSetIfRefChanged<T>(ref T field, ref T value, [CallerMemberName] string propertyName = null)
+		{
+			if (ReferenceEquals(field, value))
+			{
+				return false;
+			}
+
+			field = value;
+			OnPropertyChanged(propertyName);
+			return true;
+		}
+
 		#endregion Events
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -78,8 +78,10 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			get => _spenderTransaction;
 			set
 			{
-				if (RaiseAndSetIfChanged(ref _spenderTransaction, value))
+				if (!Object.ReferenceEquals(value, _spenderTransaction))
 				{
+					_spenderTransaction = value;
+					OnPropertyChanged(nameof(SpenderTransaction));
 					value?.WalletInputs.Add(this);
 				}
 			}

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -78,10 +78,8 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			get => _spenderTransaction;
 			set
 			{
-				if (!Object.ReferenceEquals(value, _spenderTransaction))
+				if (RaiseAndSetIfRefChanged(ref _spenderTransaction, ref value))
 				{
-					_spenderTransaction = value;
-					OnPropertyChanged(nameof(SpenderTransaction));
 					value?.WalletInputs.Add(this);
 				}
 			}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -227,10 +227,10 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 			{
 				var alreadyKnown = coin.SpenderTransaction == tx;
 				result.SpentCoins.Add(coin);
+				Coins.Spend(coin, tx);
 
 				if (!alreadyKnown)
 				{
-					Coins.Spend(coin, tx);
 					result.NewlySpentCoins.Add(coin);
 				}
 


### PR DESCRIPTION
After CoinJoin, your new coin's anonimity set would decrease back to 1 until confirmation, altough it should have a new, increased anonimitySet value.
Also, after opening your wallet, all unconfirmed coin's anonimity set would decrease back to 1 after several seconds of opening.
This PR should fix both.