### PR TITLE
Replace L with UL in AllFeeEstimateTests.cs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -213,8 +213,8 @@ namespace WalletWasabi.Tests.UnitTests
 				OnGetBlockchainInfoAsync = async () =>
 					await Task.FromResult(new BlockchainInfo
 					{
-						Blocks = isSynchronized ? 100_000L : 89_765L,
-						Headers = 100_000L
+						Blocks = isSynchronized ? 100_000UL : 89_765UL,
+						Headers = 100_000UL
 					}),
 				OnGetPeersInfoAsync = async () =>
 					await Task.FromResult(hasPeersInfo ? new[] { new PeerInfo() } : Array.Empty<PeerInfo>()),


### PR DESCRIPTION
```
##[error]WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs(216,16): Error CS0266: Cannot implicitly convert type 'long' to 'ulong'. An explicit conversion exists (are you missing a cast?)
```
Error during build debug, trying to see if this occurs again.