### PR TITLE
Alternative solution for AnonSet bug

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -669,8 +669,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var matureTxs = transactionProcessor.TransactionStore.ConfirmedStore.GetTransactions().ToArray();
 			Assert.Empty(matureTxs);
 
-			Assert.True(ReferenceEquals(tx2, spentCoin?.SpenderTransaction));
-			Assert.False(ReferenceEquals(tx1, spentCoin?.SpenderTransaction));
+			Assert.Contains(spentCoin, tx1.WalletInputs);
+			Assert.Contains(spentCoin, tx2.WalletInputs);
 		}
 
 		[Fact]

--- a/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
+++ b/WalletWasabi/Bases/NotifyPropertyChangedBase.cs
@@ -27,18 +27,6 @@ namespace WalletWasabi.Bases
 			return true;
 		}
 
-		protected bool RaiseAndSetIfRefChanged<T>(ref T field, ref T value, [CallerMemberName] string propertyName = null)
-		{
-			if (ReferenceEquals(field, value))
-			{
-				return false;
-			}
-
-			field = value;
-			OnPropertyChanged(propertyName);
-			return true;
-		}
-
 		#endregion Events
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -78,10 +78,8 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			get => _spenderTransaction;
 			set
 			{
-				if (RaiseAndSetIfRefChanged(ref _spenderTransaction, ref value))
-				{
-					value?.WalletInputs.Add(this);
-				}
+				value?.WalletInputs.Add(this);
+				RaiseAndSetIfChanged(ref _spenderTransaction, value);
 			}
 		}
 


### PR DESCRIPTION
### Description
When an already procceded transaction comes in, we add the **SmartCoin** to the _walletInput_ regardless of the equality check.
There is no loss or harm, but still gives us the right anon set.

## Totally removed 

- RaiseAndSetIfRefChanged
(it was unnecessary)