### PR TITLE
CA2219: Do not raise exceptions in exception clauses

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1158,7 +1158,8 @@ namespace WalletWasabi.Tests.RegressionTests
 					{
 						if (timeout.IsCompletedSuccessfully)
 						{
-							throw new TimeoutException("CoinJoin was not noticed.");
+							Logger.LogWarning("CoinJoin was not noticed.");
+							break;
 						}
 						await Task.Delay(1000);
 					}


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2219

I am not sure if this is the right way to fix this warning, but the test passes.