### PR TITLE
MempoolNotifiesAsync times out often.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore;
 using WalletWasabi.BitcoinCore.Rpc;
@@ -77,7 +76,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				Task rpcBatchTask = rpcBatch.SendBatchAsync();
 
 				// Wait until the mempool service receives all the sent transactions.
-				IEnumerable<SmartTransaction> mempoolSmartTxs = await eventAwaiter.WaitAsync(TimeSpan.FromSeconds(30));
+				IEnumerable<SmartTransaction> mempoolSmartTxs = await eventAwaiter.WaitAsync(TimeSpan.FromMinutes(2));
 
 				await rpcBatchTask;
 


### PR DESCRIPTION
Contributes to #4244.

This test fails very often and this should help to mitigate the issue. 

@molnard expressed once a concern that bumping the timeouts is not that great. The thing here is that if you have more and more tests, in the current design it is somewhat unavoidable unless there some bigger change how tests are being executed.

Just for the sake of making myself clear, there are several things we can consider to limit these timeout bumps in the long term:

* Split one test project (kind of non-standard really) to "one C# project ~ one test C# project" and run one test project after another.
    * fun fact: https://github.com/zkSNACKs/WalletWasabi/pull/5051 cannot be merged because we have only one test project. 
* Split tests in the current test project to some smaller collections/serial collections.

As the things are now, I belive that if you were to double the amount of tests, then timeouts would need to double as well (roughly). Unless something changes.