### PR TITLE
Fix spent rbf

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -395,7 +395,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			//                  |
 			//                  +--tx3 (replacement)---> (E)   { after this tx1 is confirmed }
 			//
-			var transactionProcessor = await CreateTransactionProcessorAsync();
+			await using var txStore = await CreateTransactionStoreAsync();
+			var transactionProcessor = CreateTransactionProcessor(txStore);
 
 			// A confirmed segwit transaction for us
 			var tx0 = CreateCreditingTransaction(transactionProcessor.NewKey("A").P2wpkhScript, Money.Coins(1.0m), height: 54321);
@@ -448,7 +449,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			//                                     |
 			//                                     +--> (C)
 			//
-			var transactionProcessor = await CreateTransactionProcessorAsync();
+			await using var txStore = await CreateTransactionStoreAsync();
+			var transactionProcessor = CreateTransactionProcessor(txStore);
 
 			// A confirmed segwit transaction for us
 			var tx0 = CreateCreditingTransaction(transactionProcessor.NewKey("A").P2wpkhScript, Money.Coins(1.0m));

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -437,7 +437,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.DoesNotContain(transactionProcessor.Coins, coin => coin.HdPubKey.Label == "E");
 			Assert.DoesNotContain(transactionProcessor.Coins, coin => coin.HdPubKey.Label == "D"); // Wasabi forgot about it but that's not a problem.
 
-			// Replacement transactions tx2 and tx3 have to be removed because tx1 confirmed and then they are invalid.
+			// Replacement transaction tx3 have to be removed because tx1 confirmed and then they are invalid.
 			var mempool = transactionProcessor.TransactionStore.MempoolStore.GetTransactions();
 			Assert.DoesNotContain(tx3, mempool);
 		}

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Bases;
 using WalletWasabi.Blockchain.Keys;
@@ -11,6 +12,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 	/// <summary>
 	/// An UTXO that knows more.
 	/// </summary>
+	[DebuggerDisplay("{Amount}BTC {Confirmed} {HdPubKey.Label} OutPoint={Coin.Outpoint}")]
 	public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>
 	{
 		private Height _height;

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -172,7 +172,6 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 						}
 						else
 						{
-							/////////////////
 							// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
 							foreach (SmartCoin doubleSpentCoin in doubleSpends)
 							{

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -99,7 +99,7 @@ namespace WalletWasabi.Blockchain.Transactions
 		/// * Explicitly by using a nSequence &lt; (0xffffffff - 1) or,
 		/// * Implicitly in case one of its unconfirmed ancestors are replaceable
 		/// </summary>
-		public bool IsRBF => !Confirmed && (Transaction.RBF || IsReplacement);
+		public bool IsRBF => !Confirmed && (Transaction.RBF || IsReplacement || WalletInputs.Any(x => x.IsReplaceable()));
 
 		#endregion Members
 


### PR DESCRIPTION
I was reviewing the RBF logic because I suspected (still) that the transaction stores are inconsistent after RBF (true) is the default value and I found two problems:

1. In a long chain of transactions where only the first one signals RBF, that one and the next one are recognized as replaceable while the rest are not.
2. In some (rare) cases when the user broadcast a replacement transaction but the original is mined first the wallet state is broken.

These are not the final solutions, I am uploading them here for discussion and because the tests are okay (the code is not).  