### PR TITLE
[Fluent] Fix CurrencyEntryBox layout issue on pasting

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -273,7 +273,7 @@ namespace WalletWasabi.Fluent.Controls
 
 		public async void ModifiedPaste()
 		{
-			var text = await AvaloniaLocator.Current.GetService<IClipboard>().GetTextAsync();
+			var text = (await AvaloniaLocator.Current.GetService<IClipboard>().GetTextAsync()).Replace("\r\n", "");
 
 			if (!string.IsNullOrEmpty(text) || ValidateEntryText(text))
 			{


### PR DESCRIPTION
This PR removes the newlines from the string that the user wants to paste.

Before:
![image](https://user-images.githubusercontent.com/16364053/110338040-d8d6cb00-8026-11eb-861a-4851d54bfb30.png)

After:
![image](https://user-images.githubusercontent.com/16364053/110338334-2bb08280-8027-11eb-814f-f27f954de407.png)
