### PR TITLE
Provide useful info about invalid transactions

### DIFF
--- a/WalletWasabi.Tests/UnitTests/InvalidTxExceptionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/InvalidTxExceptionTests.cs
@@ -16,17 +16,17 @@ namespace WalletWasabi.Tests.UnitTests
 		public void ExceptionMessageContainsUsefulInformation()
 		{
 			var crazyInvalidTx = BitcoinFactory.CreateSmartTransaction(
-				9, 
-				Enumerable.Repeat(Money.Coins(1m), 9), 
-				new[] { (Money.Coins(1.1m), 1) }, 
-				new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) }
-			);
+				9,
+				Enumerable.Repeat(Money.Coins(1m), 9),
+				new[] { (Money.Coins(1.1m), 1) },
+				new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) });
 
-			TransactionPolicyError[] crazyInvalidTxErrors = {
-				new NotEnoughFundsPolicyError("Fees different than expected"),
-				new OutputPolicyError("Output value should not be less than zero", (int)-10),
-				new CoinNotFoundPolicyError(new IndexedTxIn { TxIn = new TxIn { PrevOut = OutPoint.Zero }})
-			};
+			TransactionPolicyError[] crazyInvalidTxErrors =
+				{
+					new NotEnoughFundsPolicyError("Fees different than expected"),
+					new OutputPolicyError("Output value should not be less than zero", -10),
+					new CoinNotFoundPolicyError(new IndexedTxIn { TxIn = new TxIn { PrevOut = OutPoint.Zero } })
+				};
 
 			var ex = new InvalidTxException(crazyInvalidTx.Transaction, crazyInvalidTxErrors);
 			Assert.Contains(crazyInvalidTxErrors[0].ToString(), ex.Message);

--- a/WalletWasabi.Tests/UnitTests/InvalidTxExceptionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/InvalidTxExceptionTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.Policy;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Exceptions;
+using WalletWasabi.Helpers;
+using WalletWasabi.Tests.Helpers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests
+{
+	public class InvalidTxExceptionTests
+	{
+		[Fact]
+		public void ExceptionMessageContainsUsefulInformation()
+		{
+			var crazyInvalidTx = BitcoinFactory.CreateSmartTransaction(
+				9, 
+				Enumerable.Repeat(Money.Coins(1m), 9), 
+				new[] { (Money.Coins(1.1m), 1) }, 
+				new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) }
+			);
+
+			TransactionPolicyError[] crazyInvalidTxErrors = {
+				new NotEnoughFundsPolicyError("Fees different than expected"),
+				new OutputPolicyError("Output value should not be less than zero", (int)-10),
+				new CoinNotFoundPolicyError(new IndexedTxIn { TxIn = new TxIn { PrevOut = OutPoint.Zero }})
+			};
+
+			var ex = new InvalidTxException(crazyInvalidTx.Transaction, crazyInvalidTxErrors);
+			Assert.Contains(crazyInvalidTxErrors[0].ToString(), ex.Message);
+			Assert.Contains(crazyInvalidTxErrors[1].ToString(), ex.Message);
+			Assert.Contains(crazyInvalidTxErrors[2].ToString(), ex.Message);
+		}
+	}
+}

--- a/WalletWasabi/Exceptions/InvalidTxException.cs
+++ b/WalletWasabi/Exceptions/InvalidTxException.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Exceptions
 
 		public override string Message
 		{
-			get 
+			get
 			{
 				var errors = string.Join(Environment.NewLine, Errors.Select((error, i) => $"#{i}: {error}."));
 				var txHex = string.Join(Environment.NewLine, Transaction.ToHex().ChunkBy(200).Select(x => new string(x.ToArray())));

--- a/WalletWasabi/Exceptions/InvalidTxException.cs
+++ b/WalletWasabi/Exceptions/InvalidTxException.cs
@@ -2,19 +2,30 @@ using NBitcoin;
 using NBitcoin.Policy;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Exceptions
 {
 	public class InvalidTxException : Exception
 	{
-		public InvalidTxException(Transaction invalidTx, IEnumerable<TransactionPolicyError>? errors = null)
+		public InvalidTxException(Transaction invalidTx, IEnumerable<TransactionPolicyError> errors)
 		{
-			Transaction = Guard.NotNull(nameof(invalidTx), invalidTx);
+			Transaction = invalidTx;
 			Errors = errors;
 		}
 
 		public Transaction Transaction { get; }
-		public IEnumerable<TransactionPolicyError>? Errors { get; }
+		public IEnumerable<TransactionPolicyError> Errors { get; }
+
+		public override string Message
+		{
+			get 
+			{
+				var errors = string.Join(Environment.NewLine, Errors.Select((error, i) => $"#{i}: {error}."));
+				var txHex = string.Join(Environment.NewLine, Transaction.ToHex().ChunkBy(200).Select(x => new string(x.ToArray())));
+				return string.Join(Environment.NewLine, "Invalid transaction:", txHex, "Policy errors:", errors);
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR overrides the default `InvalidTxException.Message` to provide better information about invalid transactions created by Wasabi as in #5259
 
 The exception message, contains the serialized invalid transaction and all the collected reason why it is invalid:
 ```
 Invalid transaction:
010000000aabe301115d20f1061b9f60fdd8bc3e8d8861cb98d317b2655ccee982356bda285000000000ffffffff5b8cfe1b2e169f6cedf366ace365ab007aadd5314f13fefa4c29a402379605466000000000ffffffff6a32b604e93bdf81975d4ad09f
04a2a40aeba2fb4b5aad72e14c911c81fa49b04c00000000ffffffff21e8c966e190c11332a83fbb43773c5be528551b4dd829e9283ca2510e107c584600000000ffffffff323f400b4f038bc6f36c1243c31856999cfe6962732bbe0eb4fc50452931b6
0b4000000000ffffffff3cb3b5f132909a6add1406285527e34951e90f57e584364204531078119177b66300000000ffffffff74e08d6ada5b3a167098ae3c3fae7db839aa45bd2b064d67813bf04f0fb11b332100000000ffffffff391e8fa622064e20
739ccae59685b64a5bc212606789e2fa4f2b1a56d5335cce5300000000ffffffffa379c699ba4911be3ec2b68f100ee7c552c6ccce36f6e66697fcc3f2006a5a034c00000000ffffffff8e8ad2f0fe327dafef4f0c5fe1e5543daeed369966ac0ce15a5e
da03e81349390900000000ffffffff0a00e1f505000000001976a914d09c05315c52ebca98b97ee8f2bb151664a047a188ac00e1f505000000001976a914584f5e93faf6221f00f47d5f4d8e03557cabc7d888ac00e1f505000000001976a914391ce6ca
5dff80ca4d121180d83961a0f5becb3488ac00e1f505000000001976a91400ee3bc517aa3f32be5ae55ce83f563d19cfb95488ac00e1f505000000001976a914a96aeca10646ea9149174dab56c934f6364e6e9288ac00e1f505000000001976a9140d95
c7c895e7382e247a9fdaee1a4de8b751c5e388ac00e1f505000000001976a9147be9dedd552a8f5476a89552fe77f47dc718c78288ac00e1f505000000001976a914cbe2d39f3675df2b765131078a4b8edd2cbab01f88ac00e1f505000000001976a914
a9ee98a52c09bf0542ae39998e457c84100f356288ac00e1f5050000000016001454b8f5f43c2f1e92e857e0e7fefc0793111e5bae00000000
Policy errors:
#0: Fees different than expected.
#1: Output value should not be less than zero.
#2: No coin matching 0000000000000000000000000000000000000000000000000000000000000000-0 was found.

 ```