### PR TITLE
Navigation fixes

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/NavBar/NavBarItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/NavBar/NavBarItemViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using ReactiveUI;
 using System.Windows.Input;
 using WalletWasabi.Fluent.ViewModels.Navigation;
@@ -33,18 +32,7 @@ namespace WalletWasabi.Fluent.ViewModels.NavBar
 						Navigate().To(this, NavigationMode.Clear);
 					}
 				});
-
-			this.WhenAnyValue(x => x.IsExpanded)
-				.Subscribe(x =>
-				{
-					if (Parent != null)
-					{
-						Parent.IsExpanded = x;
-					}
-				});
 		}
-
-		public NavBarItemViewModel? Parent { get; set; }
 
 		public NavBarItemSelectionMode SelectionMode { get; protected set; }
 

--- a/WalletWasabi.Fluent/ViewModels/NavBar/NavBarItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/NavBar/NavBarItemViewModel.cs
@@ -17,9 +17,10 @@ namespace WalletWasabi.Fluent.ViewModels.NavBar
 		[AutoNotify] private bool _isExpanded;
 		[AutoNotify] private bool _isEnabled = true;
 
-		protected NavBarItemViewModel()
+		protected NavBarItemViewModel(NavigationMode defaultNavigationMode = NavigationMode.Clear)
 		{
 			SelectionMode = NavBarItemSelectionMode.Selected;
+
 			OpenCommand = ReactiveCommand.Create(
 				() =>
 				{
@@ -29,7 +30,7 @@ namespace WalletWasabi.Fluent.ViewModels.NavBar
 					}
 					else
 					{
-						Navigate().To(this, NavigationMode.Clear);
+						Navigate().To(this, defaultNavigationMode);
 					}
 				});
 		}

--- a/WalletWasabi.Fluent/ViewModels/NavBar/NavBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/NavBar/NavBarViewModel.cs
@@ -152,12 +152,6 @@ namespace WalletWasabi.Fluent.ViewModels.NavBar
 			{
 				_selectedItem.IsSelected = false;
 				_selectedItem.IsExpanded = false;
-
-				if (_selectedItem.Parent is { })
-				{
-					_selectedItem.Parent.IsSelected = false;
-					_selectedItem.Parent.IsExpanded = false;
-				}
 			}
 
 			RaiseAndChangeSelectedItem(null);
@@ -167,12 +161,6 @@ namespace WalletWasabi.Fluent.ViewModels.NavBar
 			{
 				_selectedItem.IsSelected = true;
 				_selectedItem.IsExpanded = IsOpen;
-
-				if (_selectedItem.Parent is { })
-				{
-					_selectedItem.Parent.IsSelected = true;
-					_selectedItem.Parent.IsExpanded = true;
-				}
 			}
 		}
 

--- a/WalletWasabi.Fluent/ViewModels/Navigation/NavigationStack.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/NavigationStack.cs
@@ -146,11 +146,6 @@ namespace WalletWasabi.Fluent.ViewModels.Navigation
 					_operationsEnabled = false;
 					Clear();
 					_operationsEnabled = true;
-
-					if (CurrentPage is { })
-					{
-						_backStack.Push(CurrentPage);
-					}
 					break;
 
 				case NavigationMode.Skip:

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Actions/AdvancedWalletActionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Actions/AdvancedWalletActionViewModel.cs
@@ -1,4 +1,5 @@
 using WalletWasabi.Fluent.ViewModels.NavBar;
+using WalletWasabi.Fluent.ViewModels.Navigation;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Actions
 {
@@ -11,7 +12,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Actions
 		NavigationTarget = NavigationTarget.HomeScreen)]
 	public partial class AdvancedWalletActionViewModel : NavBarItemViewModel
 	{
-		public AdvancedWalletActionViewModel(WalletViewModelBase wallet)
+		public AdvancedWalletActionViewModel(WalletViewModelBase wallet) : base(NavigationMode.Normal)
 		{
 			Title = "Advanced";
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Actions/CoinJoinWalletActionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Actions/CoinJoinWalletActionViewModel.cs
@@ -1,4 +1,5 @@
 using WalletWasabi.Fluent.ViewModels.NavBar;
+using WalletWasabi.Fluent.ViewModels.Navigation;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Actions
 {
@@ -11,7 +12,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Actions
 		NavigationTarget = NavigationTarget.HomeScreen)]
 	public partial class CoinJoinWalletActionViewModel : NavBarItemViewModel
 	{
-		public CoinJoinWalletActionViewModel(WalletViewModelBase wallet)
+		public CoinJoinWalletActionViewModel(WalletViewModelBase wallet) : base(NavigationMode.Normal)
 		{
 			Title = "CoinJoin";
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/ClosedWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/ClosedWalletViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using ReactiveUI;
 using WalletWasabi.Fluent.ViewModels.Login;
 using WalletWasabi.Fluent.ViewModels.NavBar;
+using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Fluent.ViewModels.Wallets.HardwareWallet;
 using WalletWasabi.Fluent.ViewModels.Wallets.WatchOnlyWallet;
 using WalletWasabi.Wallets;
@@ -21,11 +22,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 			{
 				if (!Wallet.IsLoggedIn)
 				{
-					Navigate().To(new LoginViewModel(walletManagerViewModel, this));
+					Navigate().To(new LoginViewModel(walletManagerViewModel, this), NavigationMode.Clear);
 				}
 				else
 				{
-					Navigate().To(this);
+					Navigate().To(this, NavigationMode.Clear);
 				}
 			});
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveViewModel.cs
@@ -7,6 +7,7 @@ using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.ViewModels.NavBar;
+using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Stores;
 using WalletWasabi.Wallets;
 
@@ -25,7 +26,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Receive
 		[AutoNotify] private HashSet<string> _suggestions;
 		[AutoNotify] private bool _isExistingAddressesButtonVisible;
 
-		public ReceiveViewModel(WalletViewModelBase wallet, WalletManager walletManager, BitcoinStore bitcoinStore)
+		public ReceiveViewModel(WalletViewModelBase wallet, WalletManager walletManager, BitcoinStore bitcoinStore) : base(NavigationMode.Normal)
 		{
 			SelectionMode = NavBarItemSelectionMode.Button;
 			WasabiWallet = wallet.Wallet;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -22,6 +22,7 @@ using WalletWasabi.Fluent.Model;
 using WalletWasabi.Fluent.Validation;
 using WalletWasabi.Fluent.ViewModels.Dialogs;
 using WalletWasabi.Fluent.ViewModels.NavBar;
+using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Gui.Converters;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -61,7 +62,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		private bool _updatingCurrentValue;
 		private double _lastXAxisCurrentValue;
 
-		public SendViewModel(WalletViewModel walletVm, TransactionBroadcaster broadcaster)
+		public SendViewModel(WalletViewModel walletVm, TransactionBroadcaster broadcaster) : base(NavigationMode.Normal)
 		{
 			_to = "";
 			_owner = walletVm;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModelBase.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using WalletWasabi.Fluent.ViewModels.NavBar;
+using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Helpers;
 using WalletWasabi.Wallets;
 
@@ -35,7 +36,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 				.Subscribe(x => WalletState = x.EventArgs)
 				.DisposeWith(_disposables);
 
-			OpenCommand = ReactiveCommand.Create(() => Navigate().To(this));
+			OpenCommand = ReactiveCommand.Create(() => Navigate().To(this,  NavigationMode.Clear));
 		}
 
 		public override string Title


### PR DESCRIPTION
- Removes the unused NavBarItem.Parent Property
- Fixes Clear implementation which was keeping the page you navigated away from on the stack.
- Root navbar items, clear the stack when navigated to, children dont.