### PR TITLE
Force wallet rescan after import

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -607,6 +607,11 @@ namespace WalletWasabi.Blockchain.Keys
 			}
 		}
 
+		public void ResetHeight()
+		{
+			BlockchainState.Height = 0;
+		}
+
 		#region BlockchainState
 
 		public Height GetBestHeight()

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -607,14 +607,6 @@ namespace WalletWasabi.Blockchain.Keys
 			}
 		}
 
-		public void ResetHeight()
-		{
-			lock (BlockchainStateLock)
-			{
-				BlockchainState.Height = new Height(0);
-			}
-		}
-
 		#region BlockchainState
 
 		public Height GetBestHeight()

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -609,7 +609,10 @@ namespace WalletWasabi.Blockchain.Keys
 
 		public void ResetHeight()
 		{
-			BlockchainState.Height = 0;
+			lock (BlockchainStateLock)
+			{
+				BlockchainState.Height = new Height(0);
+			}
 		}
 
 		#region BlockchainState

--- a/WalletWasabi/Helpers/ImportWalletHelper.cs
+++ b/WalletWasabi/Helpers/ImportWalletHelper.cs
@@ -32,6 +32,8 @@ namespace WalletWasabi.Helpers
 				km.SetIcon(WalletType.Coldcard);
 			}
 
+			km.ResetHeight();
+
 			return km;
 		}
 

--- a/WalletWasabi/Helpers/ImportWalletHelper.cs
+++ b/WalletWasabi/Helpers/ImportWalletHelper.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Helpers
 				km.SetIcon(WalletType.Coldcard);
 			}
 
-			km.ResetHeight();
+			km.SetBestHeight(0);
 
 			return km;
 		}


### PR DESCRIPTION
When a wallet gets imported the `BlockchainState.Height` should be 0, thus the wallet will be rescanned.