### PR TITLE
[Fluent] Fix normal dialog visibility when fullscreen dialog is visible

### DIFF
--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -48,17 +48,6 @@
       </Panel>
     </SplitView>
     <c:Dialog x:CompileBindings="False"
-              DataContext="{Binding DialogScreen}"
-              IsDialogOpen="{Binding IsDialogOpen, Mode=TwoWay}"
-              EnableCancelOnPressed="False"
-              EnableCancelOnEscape="True"
-              IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
-              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-              HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
-              MaxContentWidth="800" MaxContentHeight="700">
-      <ContentControl Content="{Binding CurrentPage}" />
-    </c:Dialog>
-    <c:Dialog x:CompileBindings="False"
               DataContext="{Binding FullScreen}"
               IsDialogOpen="{Binding IsDialogOpen, Mode=TwoWay}"
               EnableCancelOnPressed="False"
@@ -83,6 +72,17 @@
           <Setter Property="Opacity" Value="1"/>
         </Style>
       </c:Dialog.Styles>
+      <ContentControl Content="{Binding CurrentPage}" />
+    </c:Dialog>
+    <c:Dialog x:CompileBindings="False"
+              DataContext="{Binding DialogScreen}"
+              IsDialogOpen="{Binding IsDialogOpen, Mode=TwoWay}"
+              EnableCancelOnPressed="False"
+              EnableCancelOnEscape="True"
+              IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
+              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+              HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
+              MaxContentWidth="800" MaxContentHeight="700">
       <ContentControl Content="{Binding CurrentPage}" />
     </c:Dialog>
     <c:Dialog x:CompileBindings="False"


### PR DESCRIPTION
The normal dialog was not visible when the fullscreen dialog is visible. This because the fullscreen dialog covered the normal one.

How to test:
1. Click on Add Wallet.
2. Import a wallet that is already added.
3. See error dialog.

(Before this fix, the dialog was not visible until the fullscreen dialog was not closed)