### PR TITLE
[Fluent] Don't take up space on Textbox without errors

### DIFF
--- a/WalletWasabi.Fluent/Styles/TextBox.axaml
+++ b/WalletWasabi.Fluent/Styles/TextBox.axaml
@@ -123,4 +123,8 @@
       </ControlTemplate>
     </Setter>
   </Style>
+
+  <Style Selector="TextBox:not(:error) /template/ DataValidationErrors">
+    <Setter Property="IsVisible" Value="False"/>
+  </Style>
 </Styles>


### PR DESCRIPTION
This change is gonna be a bit painful since we relied on this extra padding from `TextBox`, which is incorrect.

@soosr @wieslawsoltes please help on identifying which controls/views are affected by this change. 