### PR TITLE
Support taproot script in filters

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -4,6 +4,7 @@ using NBitcoin.Crypto;
 using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
@@ -129,24 +130,22 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 		[Fact]
 		public void IncludeTaprootScriptInFilters()
 		{
-			var block = GenerateBlockchain().First();
+			var getBlockRpcRawResponse = File.ReadAllText("./UnitTests/Data/VerboseBlock.json");
+
+			var block = RpcParser.ParseVerboseBlockResponse(getBlockRpcRawResponse);
 			var filter = IndexBuilderService.BuildFilterForBlock(block);
 
-			var firstTaprootScript = block
-				.Transactions.First()
-				.Outputs.Where(x => x.PubkeyType == RpcPubkeyType.TxWitnessV1Taproot)
-				.Select(x => x.ScriptPubKey)
-				.First();
+			var txOutputs = block.Transactions.SelectMany(x => x.Outputs);
+			var prevTxOutputs = block.Transactions.SelectMany(x => x.Inputs.Where(y => y.PrevOutput is { }).Select(y => y.PrevOutput));
+			var allOutputs = txOutputs.Concat(prevTxOutputs);
 
-			var firstTaprootScript2 = block
-				.Transactions.First()
-				.Outputs.Where(x => x.PubkeyType == RpcPubkeyType.TxWitnessV1Taproot)
-				.Select(x => x.ScriptPubKey)
-				.First();
+			var indexableOutputs = allOutputs.Where(x => x.PubkeyType is RpcPubkeyType.TxWitnessV0Keyhash or RpcPubkeyType.TxWitnessV1Taproot);
+			var nonIndexableOutputs = allOutputs.Except(indexableOutputs);
 
 			static byte[] ComputeKey(uint256 blockId) => blockId.ToBytes()[0..16];
 
-			Assert.True(filter.Match(firstTaprootScript.ToCompressedBytes(), ComputeKey(block.Hash)));
+			Assert.All(indexableOutputs, x => Assert.True(filter.Match(x.ScriptPubKey.ToCompressedBytes(), ComputeKey(block.Hash))));
+			Assert.All(nonIndexableOutputs, x => Assert.False(filter.Match(x.ScriptPubKey.ToCompressedBytes(), ComputeKey(block.Hash))));
 		}
 
 		private IEnumerable<VerboseBlockInfo> GenerateBlockchain() =>
@@ -158,7 +157,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				DateTimeOffset.UtcNow.AddMinutes(height * 10),
 				height,
 				GenerateTransactions().ToList()
-				);
+			);
 
 		private IEnumerable<ulong> GenerateHeights() =>
 			Enumerable.Range(0, int.MaxValue).Select(x => (ulong)x);
@@ -171,7 +170,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				GenerateOutputs().ToList());
 
 		private IEnumerable<VerboseOutputInfo> GenerateOutputs() =>
-			from scriptType in new[]{ "witness_v0_keyhash", "witness_v1_taproot"}
+			from scriptType in new[] { "witness_v0_keyhash", "witness_v1_taproot" }
 			select new VerboseOutputInfo(Money.Coins(1), Script.FromBytesUnsafe(RandomUtils.GetBytes(40)), scriptType);
 
 		private static uint256 BlockHashFromHeight(ulong height)

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -149,29 +149,15 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 		}
 
 		private IEnumerable<VerboseBlockInfo> GenerateBlockchain() =>
-			from height in GenerateHeights()
+			from height in Enumerable.Range(0, int.MaxValue).Select(x => (ulong)x)
 			select new VerboseBlockInfo(
 				BlockHashFromHeight(height),
 				height,
 				BlockHashFromHeight(height + 1),
 				DateTimeOffset.UtcNow.AddMinutes(height * 10),
 				height,
-				GenerateTransactions().ToList()
+				Enumerable.Empty<VerboseTransactionInfo>()
 			);
-
-		private IEnumerable<ulong> GenerateHeights() =>
-			Enumerable.Range(0, int.MaxValue).Select(x => (ulong)x);
-
-		private IEnumerable<VerboseTransactionInfo> GenerateTransactions() =>
-			from i in Enumerable.Range(0, 2)
-			select new VerboseTransactionInfo(
-				RandomUtils.GetUInt256(),
-				Enumerable.Empty<VerboseInputInfo>(),
-				GenerateOutputs().ToList());
-
-		private IEnumerable<VerboseOutputInfo> GenerateOutputs() =>
-			from scriptType in new[] { "witness_v0_keyhash", "witness_v1_taproot" }
-			select new VerboseOutputInfo(Money.Coins(1), Script.FromBytesUnsafe(RandomUtils.GetBytes(40)), scriptType);
 
 		private static uint256 BlockHashFromHeight(ulong height)
 			=> height == 0 ? uint256.Zero : Hashes.DoubleSHA256(BitConverter.GetBytes(height));

--- a/WalletWasabi.Tests/UnitTests/Data/VerboseBlock.json
+++ b/WalletWasabi.Tests/UnitTests/Data/VerboseBlock.json
@@ -1,0 +1,350 @@
+{
+    "hash": "0000002f9499df68ea3eb1dbf11c0ba60b81608f3dc38ccc646c276165ab039b",
+    "confirmations": 2796,
+    "strippedsize": 773,
+    "size": 1173,
+    "weight": 3492,
+    "height": 26808,
+    "version": 536870912,
+    "versionHex": "20000000",
+    "merkleroot": "b8ec2c6326875baed01b7f59801d2ec181bf6c112d1fd7efc5630ac2fb12f0c5",
+    "tx": [
+      {
+        "txid": "727238b64755bc9bf42e9ed3a3c0f8d9836add7c9e9d394734ff689657e08b3f",
+        "hash": "31982a447aa5e310ceb6b5c647a22aea1386a2ba4166217a5d77549a51538ba2",
+        "version": 1,
+        "size": 249,
+        "vsize": 222,
+        "weight": 888,
+        "locktime": 0,
+        "vin": [
+          {
+            "coinbase": "02b868",
+            "txinwitness": [
+              "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "sequence": 4294967294
+          }
+        ],
+        "vout": [
+          {
+            "value": 50.00000722,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "0 81113cad52683679a83e76f76f84a4cfe36f7501",
+              "desc": "addr(tb1qsygnet2jdqm8n2p7wmmklp9yel3k7agpnycv4f)#05l58hyw",
+              "hex": "001481113cad52683679a83e76f76f84a4cfe36f7501",
+              "reqSigs": 1,
+              "type": "witness_v0_keyhash",
+              "addresses": [
+                "tb1qsygnet2jdqm8n2p7wmmklp9yel3k7agpnycv4f"
+              ]
+            }
+          },
+          {
+            "value": 0.00000000,
+            "n": 1,
+            "scriptPubKey": {
+              "asm": "OP_RETURN aa21a9ed304ce7afc94028e4cf524551620a665bf0efa679dc8a22a4ebe8b206b247d1bc ecc7daa24900473044022030f58f46c88d1d4995140a92bb8cf199f9af1cd676920c8fe369bc867161ca30022040c03572b24b63a6a92e144a8adc05cd31b64813d4fa41c5863cfe2d0be06a200100",
+              "desc": "raw(6a24aa21a9ed304ce7afc94028e4cf524551620a665bf0efa679dc8a22a4ebe8b206b247d1bc4c4fecc7daa24900473044022030f58f46c88d1d4995140a92bb8cf199f9af1cd676920c8fe369bc867161ca30022040c03572b24b63a6a92e144a8adc05cd31b64813d4fa41c5863cfe2d0be06a200100)#j3vk76sp",
+              "hex": "6a24aa21a9ed304ce7afc94028e4cf524551620a665bf0efa679dc8a22a4ebe8b206b247d1bc4c4fecc7daa24900473044022030f58f46c88d1d4995140a92bb8cf199f9af1cd676920c8fe369bc867161ca30022040c03572b24b63a6a92e144a8adc05cd31b64813d4fa41c5863cfe2d0be06a200100",
+              "type": "nulldata"
+            }
+          }
+        ],
+        "hex": "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0302b868feffffff02d2f4052a0100000016001481113cad52683679a83e76f76f84a4cfe36f75010000000000000000776a24aa21a9ed304ce7afc94028e4cf524551620a665bf0efa679dc8a22a4ebe8b206b247d1bc4c4fecc7daa24900473044022030f58f46c88d1d4995140a92bb8cf199f9af1cd676920c8fe369bc867161ca30022040c03572b24b63a6a92e144a8adc05cd31b64813d4fa41c5863cfe2d0be06a2001000120000000000000000000000000000000000000000000000000000000000000000000000000"
+      },
+      {
+        "txid": "8696e87fdf653f5af33048ee9f6b68fc3e1d71b404e39128fe71767715260e30",
+        "hash": "cd997d905f89e43d494edb98e9706fce0163d52380f13031db8d8113bafa9ed2",
+        "version": 2,
+        "size": 99,
+        "vsize": 96,
+        "weight": 381,
+        "locktime": 0,
+        "vin": [
+          {
+            "txid": "712a77092b4bc61d60861df37beb7374fdab5abe857b6a8f9c9b94a5da4a9029",
+            "vout": 0,
+            "scriptSig": {
+              "asm": "",
+              "hex": ""
+            },
+            "txinwitness": [
+              "51"
+            ],
+            "prevout": {
+              "height": 26807,
+              "value": 4.99696221,
+              "generated": false,
+              "scriptPubKey": {
+                "asm": "0 4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+                "desc": "addr(tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw)#gtc05zpf",
+                "hex": "00204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+                "reqSigs": 1,
+                "type": "witness_v0_scripthash",
+                "addresses": [
+                  "tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw"
+                ]
+              }
+            },
+            "sequence": 4294967295
+          }
+        ],
+        "vout": [
+          {
+            "value": 4.99696096,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "0 4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+              "desc": "addr(tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw)#gtc05zpf",
+              "hex": "00204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+              "reqSigs": 1,
+              "type": "witness_v0_scripthash",
+              "addresses": [
+                "tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw"
+              ]
+            }
+          }
+        ],
+        "fee": 0.00000125,
+        "hex": "0200000000010129904adaa5949b9c8f6a7b85be5aabfd7473eb7bf31d86601dc64b2b09772a710000000000ffffffff01e0c1c81d000000002200204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc3326001015100000000"
+      },
+      {
+        "txid": "dfb38af06d063128af9c4483bf944cc38c6608749cc145be2b9912ef7e185450",
+        "hash": "a5383052c6f1dae8f0c7f48bd7dfd7bd0c994b01529f88a5c8e56e9ddd5c98bd",
+        "version": 2,
+        "size": 99,
+        "vsize": 96,
+        "weight": 381,
+        "locktime": 0,
+        "vin": [
+          {
+            "txid": "f35481573468b5e4f4a4fce6afb2c3efb5e7f9b18ad5413e45ce07a1de315d7c",
+            "vout": 0,
+            "scriptSig": {
+              "asm": "",
+              "hex": ""
+            },
+            "txinwitness": [
+              "51"
+            ],
+            "prevout": {
+              "height": 26807,
+              "value": 0.99696002,
+              "generated": false,
+              "scriptPubKey": {
+                "asm": "0 4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+                "desc": "addr(tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw)#gtc05zpf",
+                "hex": "00204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+                "reqSigs": 1,
+                "type": "witness_v0_scripthash",
+                "addresses": [
+                  "tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw"
+                ]
+              }
+            },
+            "sequence": 4294967295
+          }
+        ],
+        "vout": [
+          {
+            "value": 0.99695877,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "0 4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+              "desc": "addr(tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw)#gtc05zpf",
+              "hex": "00204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+              "reqSigs": 1,
+              "type": "witness_v0_scripthash",
+              "addresses": [
+                "tb1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqaqh7jw"
+              ]
+            }
+          }
+        ],
+        "fee": 0.00000125,
+        "hex": "020000000001017c5d31dea107ce453e41d58ab1f9e7b5efc3b2afe6fca4f4e4b56834578154f30000000000ffffffff01053df105000000002200204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc3326001015100000000"
+      },
+      {
+        "txid": "6a8cb2d81062ef93ae5d58b5cbe78d5fc5159f609e0d06f767d2f8eae5ead907",
+        "hash": "fdb16ec301b679df5705d70c8f226eec7bc071a0577d366abc8c05085be3fcd4",
+        "version": 2,
+        "size": 234,
+        "vsize": 153,
+        "weight": 609,
+        "locktime": 26807,
+        "vin": [
+          {
+            "txid": "06d0e3ae26dc6a98da5ea16d19eb6ad2817aab3f510d91c13de2ea9457124258",
+            "vout": 1,
+            "scriptSig": {
+              "asm": "",
+              "hex": ""
+            },
+            "txinwitness": [
+              "30440220136315309acc3a2f73f3ab1e8859a6c2e2c91271079322418b1d3d82eb00834b022043f4ef434d47157a4f5c74fa65a882cc13b29f81e4a4ff101d97854728b3e41001",
+              "0341d84fbc50dddcccb3ee51abd12eca8c06ed79d764432c82f70ba6ff4b11bd56"
+            ],
+            "prevout": {
+              "height": 26807,
+              "value": 0.01000000,
+              "generated": false,
+              "scriptPubKey": {
+                "asm": "0 5f6bee927e9d025f55554601f3ebd563ee815f9e",
+                "desc": "addr(tb1qta47ayn7n5p97424gcql8674v0hgzhu7vl3rkj)#ng832xsf",
+                "hex": "00145f6bee927e9d025f55554601f3ebd563ee815f9e",
+                "reqSigs": 1,
+                "type": "witness_v0_keyhash",
+                "addresses": [
+                  "tb1qta47ayn7n5p97424gcql8674v0hgzhu7vl3rkj"
+                ]
+              }
+            },
+            "sequence": 4294967294
+          }
+        ],
+        "vout": [
+          {
+            "value": 0.00990000,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "1 3d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+              "desc": "addr(tb1p85lx6qpdvs4vlpjnhnexhqwmuetd7klc3dk4ggsmycrtc78n6nnqg2u5a8)#p7ahxxe2",
+              "hex": "51203d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+              "reqSigs": 1,
+              "type": "witness_v1_taproot",
+              "addresses": [
+                "tb1p85lx6qpdvs4vlpjnhnexhqwmuetd7klc3dk4ggsmycrtc78n6nnqg2u5a8"
+              ]
+            }
+          },
+          {
+            "value": 0.00009801,
+            "n": 1,
+            "scriptPubKey": {
+              "asm": "0 06c303262759a5bf810ffbdde3721c622ff2cd30",
+              "desc": "addr(tb1qqmpsxf38txjmlqg0l0w7xusuvghl9nfs899n6y)#wc5qnqcs",
+              "hex": "001406c303262759a5bf810ffbdde3721c622ff2cd30",
+              "reqSigs": 1,
+              "type": "witness_v0_keyhash",
+              "addresses": [
+                "tb1qqmpsxf38txjmlqg0l0w7xusuvghl9nfs899n6y"
+              ]
+            }
+          }
+        ],
+        "fee": 0.00000199,
+        "hex": "020000000001015842125794eae23dc1910d513fab7a81d26aeb196da15eda986adc26aee3d0060100000000feffffff02301b0f00000000002251203d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6492600000000000016001406c303262759a5bf810ffbdde3721c622ff2cd30024730440220136315309acc3a2f73f3ab1e8859a6c2e2c91271079322418b1d3d82eb00834b022043f4ef434d47157a4f5c74fa65a882cc13b29f81e4a4ff101d97854728b3e41001210341d84fbc50dddcccb3ee51abd12eca8c06ed79d764432c82f70ba6ff4b11bd56b7680000"
+      },
+      {
+        "txid": "dda4cb9290415952d93f52518df978d45ae1710e60e711e6786926e99d305ef9",
+        "hash": "91f58e3b04e5543865bebd44076ebcd81400b2a0dd24c46d729a75f37f7a1a94",
+        "version": 2,
+        "size": 411,
+        "vsize": 228,
+        "weight": 909,
+        "locktime": 26807,
+        "vin": [
+          {
+            "txid": "6a8cb2d81062ef93ae5d58b5cbe78d5fc5159f609e0d06f767d2f8eae5ead907",
+            "vout": 1,
+            "scriptSig": {
+              "asm": "",
+              "hex": ""
+            },
+            "txinwitness": [
+              "30440220273019dd87b3476a1db05f35908ec8dfbaa4eba4cf65884023ef13dbef5af93002201f5df87913371341c117f2591eb895765466aeeba3debb29e000cd1914fe0eb101",
+              "03ea214d99f0149c3441e47aa3bc401072ff6adc5e4d5c0102d3818bbed565bf60"
+            ],
+            "prevout": {
+              "height": 26808,
+              "value": 0.00009801,
+              "generated": false,
+              "scriptPubKey": {
+                "asm": "0 06c303262759a5bf810ffbdde3721c622ff2cd30",
+                "desc": "addr(tb1qqmpsxf38txjmlqg0l0w7xusuvghl9nfs899n6y)#wc5qnqcs",
+                "hex": "001406c303262759a5bf810ffbdde3721c622ff2cd30",
+                "reqSigs": 1,
+                "type": "witness_v0_keyhash",
+                "addresses": [
+                  "tb1qqmpsxf38txjmlqg0l0w7xusuvghl9nfs899n6y"
+                ]
+              }
+            },
+            "sequence": 4294967294
+          },
+          {
+            "txid": "6a8cb2d81062ef93ae5d58b5cbe78d5fc5159f609e0d06f767d2f8eae5ead907",
+            "vout": 0,
+            "scriptSig": {
+              "asm": "",
+              "hex": ""
+            },
+            "txinwitness": [
+              "e6e81bea57db6bed922afbc5fab65c61f546b6f467b8c3570b5478ba21851e57b00bef791cd06d58afebb883770d956afaf2a9a796fb594a85d124b6837a4c7101",
+              "20dcd9a3fdad900e39ff367823f5d683135238d04425ac8dce19d0220e5791c700ac",
+              "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+            ],
+            "prevout": {
+              "height": 26808,
+              "value": 0.00990000,
+              "generated": false,
+              "scriptPubKey": {
+                "asm": "1 3d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+                "desc": "addr(tb1p85lx6qpdvs4vlpjnhnexhqwmuetd7klc3dk4ggsmycrtc78n6nnqg2u5a8)#p7ahxxe2",
+                "hex": "51203d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+                "reqSigs": 1,
+                "type": "witness_v1_taproot",
+                "addresses": [
+                  "tb1p85lx6qpdvs4vlpjnhnexhqwmuetd7klc3dk4ggsmycrtc78n6nnqg2u5a8"
+                ]
+              }
+            },
+            "sequence": 4294967294
+          }
+        ],
+        "vout": [
+          {
+            "value": 0.00009528,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "0 f27d573e60371742343db4a711c3e2d6194c25cd",
+              "desc": "addr(tb1q7f74w0nqxut5ydpakjn3rslz6cv5cfwduev4ux)#s47fdk8x",
+              "hex": "0014f27d573e60371742343db4a711c3e2d6194c25cd",
+              "reqSigs": 1,
+              "type": "witness_v0_keyhash",
+              "addresses": [
+                "tb1q7f74w0nqxut5ydpakjn3rslz6cv5cfwduev4ux"
+              ]
+            }
+          },
+          {
+            "value": 0.00990000,
+            "n": 1,
+            "scriptPubKey": {
+              "asm": "1 3d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+              "desc": "addr(tb1p85lx6qpdvs4vlpjnhnexhqwmuetd7klc3dk4ggsmycrtc78n6nnqg2u5a8)#p7ahxxe2",
+              "hex": "51203d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+              "reqSigs": 1,
+              "type": "witness_v1_taproot",
+              "addresses": [
+                "tb1p85lx6qpdvs4vlpjnhnexhqwmuetd7klc3dk4ggsmycrtc78n6nnqg2u5a8"
+              ]
+            }
+          }
+        ],
+        "fee": 0.00000273,
+        "hex": "0200000000010207d9eae5eaf8d267f7060d9e609f15c55f8de7cbb5585dae93ef6210d8b28c6a0100000000feffffff07d9eae5eaf8d267f7060d9e609f15c55f8de7cbb5585dae93ef6210d8b28c6a0000000000feffffff023825000000000000160014f27d573e60371742343db4a711c3e2d6194c25cd301b0f00000000002251203d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6024730440220273019dd87b3476a1db05f35908ec8dfbaa4eba4cf65884023ef13dbef5af93002201f5df87913371341c117f2591eb895765466aeeba3debb29e000cd1914fe0eb1012103ea214d99f0149c3441e47aa3bc401072ff6adc5e4d5c0102d3818bbed565bf600341e6e81bea57db6bed922afbc5fab65c61f546b6f467b8c3570b5478ba21851e57b00bef791cd06d58afebb883770d956afaf2a9a796fb594a85d124b6837a4c71012220dcd9a3fdad900e39ff367823f5d683135238d04425ac8dce19d0220e5791c700ac21c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0b7680000"
+      }
+    ],
+    "time": 1614396691,
+    "mediantime": 1614393098,
+    "nonce": 4688380,
+    "bits": "1e01649f",
+    "difficulty": 0.002804053822772332,
+    "chainwork": "0000000000000000000000000000000000000000000000000000004b3a0cb057",
+    "nTx": 5,
+    "previousblockhash": "0000014f3cfbada1942e4479db880ac6bd9d7de36a1669ec4aa685e52a195a87",
+    "nextblockhash": "000000d27468ec0ea6bfc5b24e9b216b0a0b7fffa3c30cf670c81d44ffbfef09"
+  }

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -52,6 +52,9 @@
 		<None Update="./UnitTests/Data/MempoolInfoWithHistogram.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Update="./UnitTests/Data/VerboseBlock.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/WalletWasabi/BitcoinCore/Rpc/Models/RpcPubkeyType.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/Models/RpcPubkeyType.cs
@@ -11,6 +11,7 @@ namespace WalletWasabi.BitcoinCore.Rpc.Models
 		TxNullData,
 		TxWitnessV0Keyhash,
 		TxWitnessV0Scripthash,
+		TxWitnessV1Taproot,
 		TxWitnessUnknown,
 	}
 }

--- a/WalletWasabi/BitcoinCore/Rpc/RpcParser.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcParser.cs
@@ -19,6 +19,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				"nulldata" => RpcPubkeyType.TxNullData,
 				"witness_v0_keyhash" => RpcPubkeyType.TxWitnessV0Keyhash,
 				"witness_v0_scripthash" => RpcPubkeyType.TxWitnessV0Scripthash,
+				"witness_v1_taproot" => RpcPubkeyType.TxWitnessV1Taproot,
 				"witness_unknown" => RpcPubkeyType.TxWitnessUnknown,
 				_ => RpcPubkeyType.Unknown
 			};

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -246,7 +246,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			{
 				foreach (var input in tx.Inputs)
 				{
-					if (input.PrevOutput?.PubkeyType == RpcPubkeyType.TxWitnessV0Keyhash)
+					if (input.PrevOutput is { PubkeyType: RpcPubkeyType.TxWitnessV0Keyhash or RpcPubkeyType.TxWitnessV1Taproot })
 					{
 						scripts.Add(input.PrevOutput.ScriptPubKey);
 					}
@@ -254,7 +254,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 
 				foreach (var output in tx.Outputs)
 				{
-					if (output.PubkeyType == RpcPubkeyType.TxWitnessV0Keyhash)
+					if (output is { PubkeyType: RpcPubkeyType.TxWitnessV0Keyhash or RpcPubkeyType.TxWitnessV1Taproot })
 					{
 						scripts.Add(output.ScriptPubKey);
 					}

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -179,24 +179,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 									continue;
 								}
 
-								var scripts = FetchScripts(block);
-
-								GolombRiceFilter filter;
-								if (scripts.Any())
-								{
-									filter = new GolombRiceFilterBuilder()
-										.SetKey(block.Hash)
-										.SetP(20)
-										.SetM(1 << 20)
-										.AddEntries(scripts.Select(x => x.ToCompressedBytes()))
-										.Build();
-								}
-								else
-								{
-									// We cannot have empty filters, because there was a bug in GolombRiceFilterBuilder that evaluates empty filters to true.
-									// And this must be fixed in a backwards compatible way, so we create a fake filter with a random scp instead.
-									filter = CreateDummyEmptyFilter(block.Hash);
-								}
+								var filter = BuildFilterForBlock(block);
 
 								var smartHeader = new SmartHeader(block.Hash, block.PrevBlockHash, nextHeight, block.BlockTime);
 								var filterModel = new FilterModel(smartHeader, filter);
@@ -238,7 +221,28 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			});
 		}
 
-		private List<Script> FetchScripts(VerboseBlockInfo block)
+		internal static GolombRiceFilter BuildFilterForBlock(VerboseBlockInfo block)
+		{
+			var scripts = FetchScripts(block);
+
+			if (scripts.Any())
+			{
+				return new GolombRiceFilterBuilder()
+					.SetKey(block.Hash)
+					.SetP(20)
+					.SetM(1 << 20)
+					.AddEntries(scripts.Select(x => x.ToCompressedBytes()))
+					.Build();
+			}
+			else
+			{
+				// We cannot have empty filters, because there was a bug in GolombRiceFilterBuilder that evaluates empty filters to true.
+				// And this must be fixed in a backwards compatible way, so we create a fake filter with a random scp instead.
+				return CreateDummyEmptyFilter(block.Hash);
+			}
+		}
+
+		private static List<Script> FetchScripts(VerboseBlockInfo block)
 		{
 			var scripts = new List<Script>();
 


### PR DESCRIPTION
This PR includes taproot scripts in the compact filters. This is necessary for Wasabi to detect taproot payments.

**UNTESTED**