### PR TITLE
[Fluent] Fix up CurrencyEntryBox

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -290,7 +290,7 @@ namespace WalletWasabi.Fluent.Controls
 
 			if (ValidateEntryText(text))
 			{
-				base.OnTextInput(new TextInputEventArgs {Text = text});
+				OnTextInput(new TextInputEventArgs {Text = text});
 			}
 		}
 

--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -202,8 +202,8 @@ namespace WalletWasabi.Fluent.Controls
 			var wholeStr = match.Groups["Whole"].ToString();
 			var whole = _regexGroupAndDecimal.Replace(wholeStr, "").Length;
 
-			var fracStr = match.Groups["Frac"].ToString();
-			var frac = fracStr.Length;
+			var fracStr = match.Groups["Frac"].ToString().Replace($"{_groupSeparator}", "");
+			var frac = _regexGroupAndDecimal.Replace(fracStr, "").Length;
 
 			// Check for consecutive spaces (2 or more) and leading spaces.
 			var rule1 = preComposedText.Length > 1 && (preComposedText[0] == _groupSeparator ||

--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -258,12 +258,7 @@ namespace WalletWasabi.Fluent.Controls
 
 			if (Match(keymap.Paste))
 			{
-				var text = await AvaloniaLocator.Current.GetService<IClipboard>().GetTextAsync();
-
-				if (!string.IsNullOrEmpty(text) && ValidateEntryText(text))
-				{
-					base.OnTextInput(new TextInputEventArgs { Text = text});
-				}
+				ModifiedPaste();
 			}
 			else
 			{
@@ -273,7 +268,7 @@ namespace WalletWasabi.Fluent.Controls
 
 		public async void ModifiedPaste()
 		{
-			var text = (await AvaloniaLocator.Current.GetService<IClipboard>().GetTextAsync()).Replace("\r", "").Replace("\n", "");
+			var text = (await AvaloniaLocator.Current.GetService<IClipboard>().GetTextAsync()).Replace("\r", "").Replace("\n", "").Trim();
 
 			if (!string.IsNullOrEmpty(text) || ValidateEntryText(text))
 			{

--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -235,7 +235,7 @@ namespace WalletWasabi.Fluent.Controls
 
 			if (IsConversionReversed)
 			{
-				// Fiat input restriction is is to only allow 2 decimal places max
+				// Fiat input restriction is to only allow 2 decimal places max
 				// and also 16 whole number places.
 				if ((whole > 16 && !trailingDecimal) || frac > 2)
 				{

--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -177,14 +177,23 @@ namespace WalletWasabi.Fluent.Controls
 				return;
 			}
 
-			e.Handled = !ValidateEntryText(e.Text);
+			var preComposedText = PreComposeText(e.Text);
+
+			decimal fiatValue = 0;
+
+			e.Handled = !(ValidateEntryText(preComposedText) &&
+			            decimal.TryParse(preComposedText, NumberStyles.Number, _customCultureInfo, out fiatValue));
+
+			if (IsConversionReversed & !e.Handled)
+			{
+				e.Handled = FiatToBitcoin(fiatValue) >= Constants.MaximumNumberOfBitcoins;
+			}
+
 			base.OnTextInput(e);
 		}
 
-		private bool ValidateEntryText(string input)
+		private bool ValidateEntryText(string preComposedText)
 		{
-			var preComposedText = PreComposeText(input);
-
 			// Check if it has a decimal separator.
 			var trailingDecimal = preComposedText.Length > 0 && preComposedText[^1] == _decimalSeparator;
 			var match = _regexBTCFormat.Match(preComposedText);


### PR DESCRIPTION
Fixes:
- [x] Type a btc value to get this form -> x.xxxy xxxx; Delete y; It is not possible to type a number to that position.
- [x] USD input chars are unlimited, it can break the look.
- [x] BTC input number limit can be exceeded by entering a big USD value then switch.

cc @danwalmsley @soosr 
@MaxHillebrand please test this thoroughly