### PR TITLE
[Fluent] fix PW auth dialog layout on smallest size

### DIFF
--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -9,6 +9,7 @@
              mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="270"
              x:DataType="authorization:PasswordAuthDialogViewModel"
              x:CompileBindings="True"
+             Width="400"
              x:Class="WalletWasabi.Fluent.Views.Dialogs.Authorization.PasswordAuthDialogView">
   <UserControl.KeyBindings>
     <KeyBinding Gesture="Enter" Command="{Binding NextCommand}" />
@@ -19,7 +20,7 @@
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}">
 
-        <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton" Width="350">
+        <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton">
             <i:Interaction.Behaviors>
                 <behaviors:FocusOnAttachedBehavior />
             </i:Interaction.Behaviors>

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -7,9 +7,9 @@
              xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:authorization="clr-namespace:WalletWasabi.Fluent.ViewModels.Dialogs.Authorization"
              mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="270"
-             Width="480" Height="270"
              x:DataType="authorization:PasswordAuthDialogViewModel"
              x:CompileBindings="True"
+             Width="400"
              x:Class="WalletWasabi.Fluent.Views.Dialogs.Authorization.PasswordAuthDialogView">
   <UserControl.KeyBindings>
     <KeyBinding Gesture="Enter" Command="{Binding NextCommand}" />
@@ -20,7 +20,7 @@
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}">
 
-        <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton" VerticalAlignment="Top" HorizontalAlignment="Stretch">
+        <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton">
             <i:Interaction.Behaviors>
                 <behaviors:FocusOnAttachedBehavior />
             </i:Interaction.Behaviors>

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -9,7 +9,6 @@
              mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="270"
              x:DataType="authorization:PasswordAuthDialogViewModel"
              x:CompileBindings="True"
-             Width="400"
              x:Class="WalletWasabi.Fluent.Views.Dialogs.Authorization.PasswordAuthDialogView">
   <UserControl.KeyBindings>
     <KeyBinding Gesture="Enter" Command="{Binding NextCommand}" />
@@ -20,7 +19,7 @@
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}">
 
-        <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton">
+        <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton" Width="350">
             <i:Interaction.Behaviors>
                 <behaviors:FocusOnAttachedBehavior />
             </i:Interaction.Behaviors>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/16364053/111286293-52cc0d00-8642-11eb-947b-f22d7f6830c3.png)

after:
![image](https://user-images.githubusercontent.com/16364053/111286105-21534180-8642-11eb-9bf6-10dc2df7189c.png)
