### PR TITLE
Fix Break anonymity set calculation at address reuse

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -147,12 +147,16 @@ namespace WalletWasabi.Blockchain.Analysis
 					// If it's a reuse of another output' pubkey, then intersection punishment can only go as low as the inherited anonset.
 					hdPubKey.SetAnonymitySet(Math.Max(newInputAnonset, Intersect(new[] { anonset, hdPubKey.AnonymitySet }, 1)), txid);
 				}
-				else if (hdPubKey.AnonymitySetReasons.Contains(txid))
+				else if (hdPubKey.AnonymitySets.ContainsKey(txid))
 				{
 					// If we already processed this transaction for this script
-					// then we'll go with normal processing, it's not an address reuse,
-					// it's just we're processing the transaction twice.
-					hdPubKey.SetAnonymitySet(anonset, txid);
+					// then we'll go with normal processing.
+					// It may be a duplicated processing or new information arrived (like other wallet loaded)
+					if (hdPubKey.AnonymitySets.Count == 1)
+					{
+						// If there are more anonsets already then it's address reuse so leave it alone.
+						hdPubKey.SetAnonymitySet(anonset, txid);
+					}
 				}
 				else
 				{

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Blockchain.Keys
 			set => RaiseAndSetIfChanged(ref _cluster, value);
 		}
 
-		public HashSet<uint256> AnonymitySetReasons { get; } = new();
+		public Dictionary<uint256, int> AnonymitySets { get; } = new();
 
 		public int AnonymitySet
 		{
@@ -100,7 +100,7 @@ namespace WalletWasabi.Blockchain.Keys
 		public void SetAnonymitySet(int anonset, uint256 reason)
 		{
 			AnonymitySet = anonset;
-			AnonymitySetReasons.Add(reason);
+			AnonymitySets.AddOrReplace(reason, anonset);
 		}
 
 		public void SetLabel(SmartLabel label, KeyManager? kmToFile = null)


### PR DESCRIPTION
Satisfies the test at https://github.com/zkSNACKs/WalletWasabi/pull/5329, but there are still edge cases where it doesn't work perfectly.

closes https://github.com/zkSNACKs/WalletWasabi/pull/5329