### PR TITLE
[Fleunt] Fix Optimise Privacy layout

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/OptimisePrivacyView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/OptimisePrivacyView.axaml
@@ -29,6 +29,7 @@
                     </Style>
                     <Style Selector="ListBoxItem /template/ ContentPresenter#PART_ContentPresenter">
                         <Setter Property="CornerRadius" Value="4" />
+                        <Setter Property="Margin" Value="5" />
                     </Style>
                     <Style Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
                         <Setter Property="Background" Value="#353535" />
@@ -36,12 +37,12 @@
                 </ListBox.Styles>
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <StackPanel Orientation="Horizontal" Spacing="10" />
+                        <WrapPanel Orientation="Horizontal" />
                     </ItemsPanelTemplate>
                 </ListBox.ItemsPanel>
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <local:PrivacySuggestionControl HorizontalAlignment="Stretch" />
+                        <local:PrivacySuggestionControl />
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacySuggestionControl.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacySuggestionControl.axaml
@@ -3,16 +3,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:conv="using:WalletWasabi.Fluent.Converters"
-             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:behaviors="using:WalletWasabi.Fluent.Behaviors"
-             xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:vm="using:WalletWasabi.Fluent.ViewModels.Wallets.Send"
              mc:Ignorable="d"
              x:DataType="vm:PrivacySuggestionControlViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Send.PrivacySuggestionControl">
     <StackPanel Spacing="20">
-        <Panel MinHeight="150" MinWidth="200">
+        <Panel MinHeight="150" MinWidth="150">
             <StackPanel Spacing="10" VerticalAlignment="Top" TextBlock.Foreground="{Binding OptimisationLevel, Converter={x:Static conv:PrivacyOptimisationLevelConverters.OptimisationLevelToBrushConverter}}">
                 <Panel>
                     <Ellipse Stroke="{Binding OptimisationLevel, Converter={x:Static conv:PrivacyOptimisationLevelConverters.OptimisationLevelToBrushConverter}, FallbackValue=White}" StrokeThickness="4" Height="115" Width="115" />


### PR DESCRIPTION
This PR fixes the layout issue and also handles when the dialog is on the smallest size.

before:
![image](https://user-images.githubusercontent.com/16364053/111326084-8cb20900-866c-11eb-8a0e-38f8e981011d.png)

after:
![image](https://user-images.githubusercontent.com/16364053/111325888-68eec300-866c-11eb-9268-8a2598e8cb83.png)
