### PR TITLE
Fix mnemonic phrase length (GUI only)

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -45,7 +45,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 					.Merge(Observable.FromEventPattern(this, nameof(ErrorsChanged)).Select(_ => Unit.Default))
 					.Merge(this.WhenAnyValue(x => x.MnemonicWords).Select(_ => Unit.Default))
 					.ObserveOn(RxApp.MainThreadScheduler)
-					.Select(_ => !Validations.AnyErrors && MnemonicWords.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length == 12);
+					.Select(_ => !Validations.AnyErrors && MnemonicWords.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length is 12 or 15 or 18 or 21 or 24 );
 
 			RecoverCommand = ReactiveCommand.Create(() => RecoverWallet(owner), canExecute);
 


### PR DESCRIPTION
Fix mnemonic phrase length (fixes https://github.com/zkSNACKs/WalletWasabi/issues/5212)
Valid lengths are 12, 15, 18, 21 and 24.

@danwalmsley this have to be fixed on Fluent too. I tag @jmacato because it seems he was involved in the implementation of this in Fluent.