### PR TITLE
Prevent some duplicated tx processing

### DIFF
--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -80,7 +80,6 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 		public IEnumerable<ProcessedResult> Process(params SmartTransaction[] txs)
 			=> Process(txs as IEnumerable<SmartTransaction>);
 
-		private Dictionary<uint256, string> Processed { get; } = new();
 
 		/// <summary>
 		/// Was the transaction already processed by the transaction processor?
@@ -99,13 +98,6 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 			lock (Lock)
 			{
 				Aware.Add(tx.GetHash());
-				if (Processed.TryGetValue(tx.GetHash(), out var stack))
-				{
-					Logger.LogWarning(tx.GetHash().ToString());
-					Logger.LogWarning(stack);
-					Logger.LogWarning(Environment.StackTrace);
-				}
-				Processed.AddOrReplace(tx.GetHash(), Environment.StackTrace);
 				try
 				{
 					QueuedTxCount = 1;

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -345,7 +345,10 @@ namespace WalletWasabi.Wallets
 		{
 			try
 			{
-				TransactionProcessor.Process(tx);
+				if (!TransactionProcessor.IsAware(tx.GetHash()))
+				{
+					TransactionProcessor.Process(tx);
+				}
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Background: https://github.com/zkSNACKs/WalletWasabi/pull/5376#issuecomment-801425896

What does it improve?

- There was a dirty dictionary in the wallet manager that paired wallets to hashsets for the coinjoin processor. It was moved to the transaction processor so now we can be sure that all the transactions those were processed are there.
- We don't reprocess transactions when they come from mempool now. (Be much more careful with other places though.)

This PR has an effect on many things probably, but one reproducible issue is at processing unconfirmed coinjoins when Bitcoin Core is running. In that case after we received the coinjoins from the mempool we sent it to the Bitcoin Core RPC, which propagated us the transaction back and we processed it again. Now we don't do that.