### PR TITLE
More node parameters

### DIFF
--- a/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
@@ -17,8 +17,7 @@ namespace WalletWasabi.Tests.Helpers
 		public static async Task<CoreNode> CreateAsync(HostedServices hostedServices, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", string additionalFolder = "", MempoolService? mempoolService = null)
 		{
 			var network = Network.RegTest;
-			return await CoreNode.CreateAsync(
-				new CoreNodeParams(
+			var nodeParameters = new CoreNodeParams(
 					network,
 					mempoolService ?? new MempoolService(),
 					hostedServices,
@@ -32,7 +31,16 @@ namespace WalletWasabi.Tests.Helpers
 					mempoolReplacement: "fee,optin",
 					userAgent: $"/WasabiClient:{Constants.ClientVersion}/",
 					fallbackFee: Money.Coins(0.0002m), // https://github.com/bitcoin/bitcoin/pull/16524
-					new MemoryCache(new MemoryCacheOptions())),
+					new MemoryCache(new MemoryCacheOptions()));
+			nodeParameters.ListenOnion = 0;
+			nodeParameters.Discover = 0;
+			nodeParameters.DnsSeed = 0;
+			nodeParameters.FixedSeeds = 0;
+			nodeParameters.Upnp = 0;
+			nodeParameters.NatPmp = 0;
+			nodeParameters.PersistMempool = 0;
+			return await CoreNode.CreateAsync(
+				nodeParameters,
 				CancellationToken.None);
 		}
 	}

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -163,6 +163,46 @@ namespace WalletWasabi.BitcoinCore
 					desiredConfigLines.Add($"{configPrefix}.fallbackfee = {coreNodeParams.FallbackFee.ToString(fplus: false, trimExcessZero: true)}");
 				}
 
+				if (coreNodeParams.ListenOnion is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.listenonion = {coreNodeParams.ListenOnion}");
+				}
+
+				if (coreNodeParams.Listen is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.listen = {coreNodeParams.Listen}");
+				}
+
+				if (coreNodeParams.Discover is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.discover = {coreNodeParams.Discover}");
+				}
+
+				if (coreNodeParams.DnsSeed is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.dnsseed = {coreNodeParams.DnsSeed}");
+				}
+
+				if (coreNodeParams.FixedSeeds is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.fixedseeds = {coreNodeParams.FixedSeeds}");
+				}
+
+				if (coreNodeParams.Upnp is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.upnp = {coreNodeParams.Upnp}");
+				}
+
+				if (coreNodeParams.NatPmp is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.natpmp = {coreNodeParams.NatPmp}");
+				}
+
+				if (coreNodeParams.PersistMempool is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.persistmempool = {coreNodeParams.PersistMempool}");
+				}
+
 				var sectionComment = $"# The following configuration options were added or modified by Wasabi Wallet.";
 				// If the comment is not already present.
 				// And there would be new config entries added.

--- a/WalletWasabi/BitcoinCore/CoreNodeParams.cs
+++ b/WalletWasabi/BitcoinCore/CoreNodeParams.cs
@@ -52,6 +52,14 @@ namespace WalletWasabi.BitcoinCore
 		public string MempoolReplacement { get; }
 		public string UserAgent { get; }
 		public Money FallbackFee { get; }
+		public int? Listen { get; set; }
+		public int? ListenOnion { get; set; }
+		public int? Discover { get; set; }
+		public int? DnsSeed { get; set; }
+		public int? FixedSeeds { get; set; }
+		public int? Upnp { get; set; }
+		public int? NatPmp { get; set; }
+		public int? PersistMempool { get; set; }
 		public EndPointStrategy P2pEndPointStrategy { get; }
 		public EndPointStrategy RpcEndPointStrategy { get; }
 		public IMemoryCache Cache { get; }


### PR DESCRIPTION
Try to increase the regression test performance by reducing the number of thread used by the bitcoin node and its workload. In this case we make sure to not create/publish a new onion service and listen on it, we do not try to discover new peers and do not try to open/save mempool file during initialization and shutdown. 