### PR TITLE
Disable CD build for PR-s

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -4,6 +4,8 @@ trigger:
     include:
       - master
 
+pr: none
+
 jobs:
 - job: CDelivery
   pool:


### PR DESCRIPTION
We only want to have a CD if something merged into the master - not when creating a PR. 