### PR TITLE
[Fluent] Dialog min size

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -60,6 +60,10 @@
     <Setter Property="CornerRadius" Value="4"/>
     <Setter Property="BoxShadow" Value="{DynamicResource DialogBoxShadow}"/>
   </Style>
+  <Style Selector="c|Dialog /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="MinWidth" Value="382" />
+    <Setter Property="MinHeight" Value="284" />
+  </Style>
 
   <!-- Dialog Opened State -->
   <Style Selector="c|Dialog:open /template/ Panel#PART_DialogHost">

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
@@ -18,9 +18,8 @@
                  EnableCancel="True" CancelContent="Cancel"
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}"
-                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                 Height="300">
-    <Viewbox>
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
+    <Viewbox MaxHeight="150">
       <Image>
         <Image.Source>
           <MultiBinding Converter="{x:Static conv:WalletIconConverter.TypesToImage}">

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
@@ -14,7 +14,6 @@
   </UserControl.KeyBindings>
   <c:ContentArea Title="{Binding Title}"
                  Caption="Connect your hardware wallet, then press Continue to sign your transaction."
-                 EnableBack="True"
                  EnableCancel="True" CancelContent="Cancel"
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}"

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -7,7 +7,6 @@
              xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:authorization="clr-namespace:WalletWasabi.Fluent.ViewModels.Dialogs.Authorization"
              mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="270"
-             Width="480" Height="270"
              x:DataType="authorization:PasswordAuthDialogViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Dialogs.Authorization.PasswordAuthDialogView">


### PR DESCRIPTION
This PR adds minimum height and width to the dialog content, thus the CompactDialog will not look weird when only a progress ring is visible.

This PR also fixes the layout issue described here https://github.com/zkSNACKs/WalletWasabi/pull/5369.