### PR TITLE
Wallet: Remove always-true if statement

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -432,10 +432,7 @@ namespace WalletWasabi.Wallets
 			// Go through the filters and queue to download the matches.
 			await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>
 			{
-				if (filterModel.Filter is { }) // Filter can be null if there is no bech32 tx.
-				{
-					await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false);
-				}
+				await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false);
 			},
 			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
 		}


### PR DESCRIPTION
As far as I can understand the code, it looks to me that `filterModel.Filter` cannot be `null` thanks to:

https://github.com/zkSNACKs/WalletWasabi/blob/5a6d80f14b63b6dbb247489293c9f80de3361d0d/WalletWasabi/Backend/Models/FilterModel.cs#L15

(I have found this when trying to understand #5418 better.)