### PR TITLE
[PoF] Wrong balance after first rescan

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -48,6 +48,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 			BlockchainState = blockchainState ?? new BlockchainState();
 			AccountKeyPath = accountKeyPath ?? DefaultAccountKeyPath;
+			Init();
 
 			SetFilePath(filePath);
 			ToFileLock = new object();
@@ -76,6 +77,7 @@ namespace WalletWasabi.Blockchain.Keys
 			MasterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
 			AccountKeyPath = accountKeyPath ?? DefaultAccountKeyPath;
 			ExtPubKey = extKey.Derive(AccountKeyPath).Neuter();
+			Init();
 
 			SetFilePath(filePath);
 			ToFileLock = new object();
@@ -206,7 +208,18 @@ namespace WalletWasabi.Blockchain.Keys
 			// Backwards compatibility:
 			km.PasswordVerified ??= true;
 
+			km.Init();
+
 			return km;
+		}
+
+		public AddressDeriver InternalAddressDeriver { get; private set; }
+		public AddressDeriver ExternalAddressDeriver { get; private set; }
+
+		public void Init()
+		{
+			InternalAddressDeriver = new AddressDeriver(ExtPubKey, AccountKeyPath, true, GetKeys(isInternal: true).Count(), 500);
+			ExternalAddressDeriver = new AddressDeriver(ExtPubKey, AccountKeyPath, false, GetKeys(isInternal: false).Count(), 500);
 		}
 
 		public void SetFilePath(string filePath)

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -80,7 +80,6 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 		public IEnumerable<ProcessedResult> Process(params SmartTransaction[] txs)
 			=> Process(txs as IEnumerable<SmartTransaction>);
 
-
 		/// <summary>
 		/// Was the transaction already processed by the transaction processor?
 		/// </summary>
@@ -205,7 +204,22 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 			{
 				// If transaction received to any of the wallet keys:
 				var output = tx.Transaction.Outputs[i];
+
+				bool relevant = KeyManager.InternalAddressDeriver.IsMyScript(output.ScriptPubKey);
+
 				HdPubKey foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
+
+				if (foundKey is null && relevant)
+				{
+					do
+					{
+						KeyManager.GenerateNewKey("", KeyState.Clean, true);
+						foundKey = KeyManager.GetKeyForScriptPubKey(output.ScriptPubKey);
+					}
+					while (foundKey is null);
+					KeyManager.ToFile();
+				}
+
 				if (foundKey is { })
 				{
 					if (!foundKey.IsInternal)

--- a/WalletWasabi/Wallets/AddressDeriver.cs
+++ b/WalletWasabi/Wallets/AddressDeriver.cs
@@ -1,0 +1,47 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Wallets
+{
+	public class AddressDeriver
+	{
+		public KeyPath AccountKeyPath { get; }
+		public bool IsInternal { get; }
+		public ExtPubKey ExtPubKey { get; }
+		private int AdditionalGap { get; set; }
+		private Dictionary<Script, int> Script { get; } = new Dictionary<Script, int>();
+
+		public AddressDeriver(ExtPubKey extPubKey, KeyPath accountKeyPath, bool isInternal, int lastIndex, int additionalGap)
+		{
+			ExtPubKey = extPubKey;
+			AccountKeyPath = accountKeyPath;
+			AdditionalGap = additionalGap;
+			IsInternal = isInternal;
+			EnsureAdditionalGap(lastIndex);
+		}
+
+		public bool IsMyScript(Script scriptPubKey)
+		{
+			if (Script.TryGetValue(scriptPubKey, out var index))
+			{
+				EnsureAdditionalGap(index);
+				return true;
+			}
+
+			return false;
+		}
+
+		private void EnsureAdditionalGap(int fromIndex)
+		{
+			while (Script.Count < (fromIndex + AdditionalGap))
+			{
+				int nextIndex = Script.Count == 0 ? 0 : Script.Last().Value + 1;
+				Script.Add(ExtPubKey.Derive(IsInternal ? 1 : 0, false).Derive(nextIndex, false).PubKey.WitHash.ScriptPubKey, nextIndex);
+			}
+		}
+	}
+}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -429,6 +429,8 @@ namespace WalletWasabi.Wallets
 				TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
 			}
 
+			Logger.LogInfo($"GapLimit: {KeyManager.CountConsecutiveUnusedKeys(true)}");
+
 			// Go through the filters and queue to download the matches.
 			await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) =>
 			{


### PR DESCRIPTION
### Problem

We got several reports with balance problems, those can be solved by rescanning the wallet => set the height to zero in the wallet file. After the scan, the balance got fixed. 

### Status

I was able to reproduce it. I have a TestNet wallet where I made several CoinJoins. The issue is hard because it is hard to reproduce it because of the following: after the second load of the same wallet the balance changes then after 2 more loads the balance got fixed without touching anything - thus the issues cannot be reproduced and detected.

### What does this PR do

This PR is to provide a dirty solution, just to demonstrate the problem. I created a class called `AddressDeriver` as a secondary validator if a `ScriptPubKey` is relevant to the wallet or not. The result shows there are undetected addresses. The GapLimit of the wallet is 50 but for some reason, at a point(s) it has the GapLimit of 70. Because `AddressDeriver` scanning more addresses in advance than the GapLimit and ensure to generate more keys to reach that specific key. 

### Next step

I am afraid that without pointing out the real bug (why the wallet exceeds the GapLimit in some cases) this is just a hacky solution. Also if the unknown bug is related to the GapLimit then, automatically fixing the Gap limit could get into a loop where the Gap limit is increased to infinity. 

The light solution can be to somehow scan more addresses than the Gap limit just to make sure and adjust the keys according to that. This PR is doing something like this. 

Just for the record do not check it, here is my experiment reproducing the bug https://github.com/molnard/WalletWasabi/tree/balacebug

Related https://github.com/zkSNACKs/WalletWasabi/issues/3552
