### PR TITLE
Remove exception type from ToUserFriendlyString()

### DIFF
--- a/WalletWasabi/Extensions/ExceptionExtensions.cs
+++ b/WalletWasabi/Extensions/ExceptionExtensions.cs
@@ -55,7 +55,7 @@ namespace System
 					}
 				}
 
-				return ex.ToTypeMessageString();
+				return trimmed;
 			}
 		}
 


### PR DESCRIPTION
An Exception type is everything but not user-friendly, this PR removes it from the message if there is a relevant message.