### PR TITLE
IndexStore: Remove extra "IoHelpers.EnsureDirectoryExists(WorkFolderPath);".

### DIFF
--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -80,10 +80,6 @@ namespace WalletWasabi.Stores
 				using (await MatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
 				using (await ImmatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
 				{
-					IoHelpers.EnsureDirectoryExists(WorkFolderPath);
-
-					cancel.ThrowIfCancellationRequested();
-
 					await EnsureBackwardsCompatibilityAsync().ConfigureAwait(false);
 
 					if (Network == Network.RegTest)


### PR DESCRIPTION
The exactly same `IoHelpers.EnsureDirectoryExists(workFolderPath)` call is in constructor. I believe this is just an oversight.