### PR TITLE
[WabiSabi] Add SignTransactionAsync 

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/WabiSabiApiClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/WabiSabiApiClientTests.cs
@@ -1,0 +1,48 @@
+using Moq;
+using NBitcoin;
+using System.Threading.Tasks;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Crypto;
+using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Banning;
+using WalletWasabi.WabiSabi.Backend.PostRequests;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Crypto;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
+{
+	public class WabiSabiApiClientTests
+	{
+		[Fact]
+		public async Task RegisterInputAsyncTest()
+		{
+			var config = new WabiSabiConfig();
+			var round = WabiSabiFactory.CreateRound(config);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
+
+			using var key = new Key(); 
+			var outpoint = BitcoinFactory.CreateOutPoint();
+
+			var mockRpc = new Mock<IRPCClient>();
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true))
+				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse{
+					IsCoinBase = false,
+					Confirmations = 200,
+					TxOut = new TxOut(Money.Coins(1m), key.PubKey.WitHash.GetAddress(Network.Main)),
+				});
+			await using var coordinator = new PostRequestHandler(config, new Prison(), arena, mockRpc.Object);
+
+			var rnd = new InsecureRandom();
+			var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, 2, rnd, 4300000000000ul);
+			var weightClient = new WabiSabiClient(round.WeightCredentialIssuerParameters, 2, rnd, 2000ul);
+
+			var apiClient = new WabiSabiApiClient(amountClient, weightClient, coordinator);
+
+			await apiClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id, round.Hash);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/WabiSabiApiClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/WabiSabiApiClientTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using NBitcoin;
+using System.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Crypto;
@@ -7,6 +8,7 @@ using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
+using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
@@ -24,12 +26,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			var round = WabiSabiFactory.CreateRound(config);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
 
-			using var key = new Key(); 
+			using var key = new Key();
 			var outpoint = BitcoinFactory.CreateOutPoint();
 
 			var mockRpc = new Mock<IRPCClient>();
 			mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true))
-				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse{
+				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
+				{
 					IsCoinBase = false,
 					Confirmations = 200,
 					TxOut = new TxOut(Money.Coins(1m), key.PubKey.WitHash.GetAddress(Network.Main)),
@@ -43,6 +46,39 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			var apiClient = new WabiSabiApiClient(amountClient, weightClient, coordinator);
 
 			await apiClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id, round.Hash);
+		}
+
+		[Fact]
+		public async Task SignTransactionAsync()
+		{
+			WabiSabiConfig config = new();
+			Round round = WabiSabiFactory.CreateRound(config);
+			using Key key1 = new();
+			Alice alice1 = WabiSabiFactory.CreateAlice(key: key1);
+
+			round.Alices.Add(alice1);
+
+			var coinjoin = round.Coinjoin;
+			coinjoin.Inputs.Add(alice1.Coins.First().Outpoint);
+
+			round.SetPhase(Phase.TransactionSigning);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
+
+			var mockRpc = new Mock<IRPCClient>();
+			await using var coordinator = new PostRequestHandler(config, new Prison(), arena, mockRpc.Object);
+
+			var signedCoinJoin = coinjoin.Clone();
+
+			var rnd = new InsecureRandom();
+			var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, 2, rnd, 4300000000000ul);
+			var weightClient = new WabiSabiClient(round.WeightCredentialIssuerParameters, 2, rnd, 2000ul);
+			var apiClient = new WabiSabiApiClient(amountClient, weightClient, coordinator);
+
+			Assert.False(round.Coinjoin.HasWitness);
+
+			await apiClient.SignTransactionAsync(round.Id, alice1.Coins.ToArray(), new BitcoinSecret(key1, Network.Main), coinjoin);
+
+			Assert.True(round.Coinjoin.HasWitness);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/IRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/IRequestHandler.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using WalletWasabi.WabiSabi.Models;
+
+namespace WalletWasabi.WabiSabi.Backend.PostRequests
+{
+	public interface IRequestHandler
+	{
+		Task<InputsRegistrationResponse> RegisterInputAsync(InputsRegistrationRequest request);
+		Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request);
+		Task<OutputRegistrationResponse> RegisterOutputAsync(OutputRegistrationRequest request);
+		Task RemoveInputAsync(InputsRemovalRequest request);
+		Task SignTransactionAsync(TransactionSignaturesRequest request);
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/PostRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/PostRequestHandler.cs
@@ -14,7 +14,7 @@ using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
-	public class PostRequestHandler : IAsyncDisposable
+	public class PostRequestHandler : IAsyncDisposable, IRequestHandler
 	{
 		public PostRequestHandler(WabiSabiConfig config, Prison prison, Arena arena, IRPCClient rpc)
 		{

--- a/WalletWasabi/WabiSabi/Client/WabiSabiApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiApiClient.cs
@@ -1,0 +1,63 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WalletWasabi.Crypto;
+using WalletWasabi.WabiSabi.Backend.PostRequests;
+using WalletWasabi.WabiSabi.Crypto;
+using WalletWasabi.WabiSabi.Models;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public class WabiSabiApiClient
+	{
+		public WabiSabiApiClient(WabiSabiClient wabiSabiClientAmount, WabiSabiClient wabiSabiClientWeight, IRequestHandler requestHandler)
+		{
+			WabiSabiClientAmount = wabiSabiClientAmount;
+			WabiSabiClientWeight = wabiSabiClientWeight;
+			RequestHandler = requestHandler;
+		}
+
+		public WabiSabiClient WabiSabiClientAmount { get; }
+		public WabiSabiClient WabiSabiClientWeight { get; }
+		public IRequestHandler RequestHandler { get; }
+
+		public Task RegisterInputAsync(Money amount, OutPoint outPoint, Key key, Guid roundId, uint256 roundHash) =>
+			RegisterInputAsync(
+				new[] { amount },
+				new[] { outPoint },
+				new[] { key },
+				roundId,
+				roundHash);
+				
+		public async Task RegisterInputAsync(
+			IEnumerable<Money> amounts, 
+			IEnumerable<OutPoint> outPoints, 
+			IEnumerable<Key> keys,
+			Guid roundId,
+			uint256 roundHash)
+		{
+			static byte[] GenerateOwnershipProof(Key key, uint256 roundHash) => OwnershipProof.GenerateCoinJoinInputProof(
+				key, 
+				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash)).ToBytes();
+
+			var registrableInputs = outPoints
+				.Zip(keys, (outPoint, key) => (outPoint, key))
+				.Select(x => new InputRoundSignaturePair(x.outPoint, GenerateOwnershipProof(x.key, roundHash)));
+
+			var (zeroAmountCredentialRequest, zeroAmountCredentialResponseValidation) = WabiSabiClientAmount.CreateRequestForZeroAmount();
+			var (zeroWeightCredentialRequest, zeroWeightCredentialResponseValidation) = WabiSabiClientWeight.CreateRequestForZeroAmount();
+
+			var inputRegistrationResponse = await RequestHandler.RegisterInputAsync(
+				new InputsRegistrationRequest(
+					roundId,
+					registrableInputs,
+					zeroAmountCredentialRequest,
+					zeroWeightCredentialRequest));
+
+			WabiSabiClientAmount.HandleResponse(inputRegistrationResponse.AmountCredentials, zeroAmountCredentialResponseValidation);
+			WabiSabiClientWeight.HandleResponse(inputRegistrationResponse.WeightCredentials, zeroWeightCredentialResponseValidation);
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/WabiSabiApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiApiClient.cs
@@ -3,8 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Crypto;
+using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Models;
 
@@ -30,16 +33,16 @@ namespace WalletWasabi.WabiSabi.Client
 				new[] { key },
 				roundId,
 				roundHash);
-				
+
 		public async Task RegisterInputAsync(
-			IEnumerable<Money> amounts, 
-			IEnumerable<OutPoint> outPoints, 
+			IEnumerable<Money> amounts,
+			IEnumerable<OutPoint> outPoints,
 			IEnumerable<Key> keys,
 			Guid roundId,
 			uint256 roundHash)
 		{
 			static byte[] GenerateOwnershipProof(Key key, uint256 roundHash) => OwnershipProof.GenerateCoinJoinInputProof(
-				key, 
+				key,
 				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash)).ToBytes();
 
 			var registrableInputs = outPoints
@@ -58,6 +61,32 @@ namespace WalletWasabi.WabiSabi.Client
 
 			WabiSabiClientAmount.HandleResponse(inputRegistrationResponse.AmountCredentials, zeroAmountCredentialResponseValidation);
 			WabiSabiClientWeight.HandleResponse(inputRegistrationResponse.WeightCredentials, zeroWeightCredentialResponseValidation);
+		}
+
+		public async Task SignTransactionAsync(Guid roundId, ICoin[] coinsToSign, BitcoinSecret bitcoinSecret, Transaction unsignedCoinJoin)
+		{
+			// TODO: Sanity check on the CoinJoin.
+
+			List<InputWitnessPair> signatures = new();
+
+			var signedCoinJoin = unsignedCoinJoin.Clone();
+			foreach (var coin in coinsToSign)
+			{
+				signedCoinJoin.Sign(bitcoinSecret, coin);
+			}
+
+			var myInputs = coinsToSign.Select(c => c.Outpoint).ToHashSet();
+
+			for (uint i = 0; i < signedCoinJoin.Inputs.Count; i++)
+			{
+				var input = signedCoinJoin.Inputs[i];
+				if (myInputs.Contains(input.PrevOut))
+				{
+					signatures.Add(new InputWitnessPair(i, signedCoinJoin.Inputs[i].WitScript));
+				}
+			}
+
+			await RequestHandler.SignTransactionAsync(new TransactionSignaturesRequest(roundId, signatures)).ConfigureAwait(false);
 		}
 	}
 }


### PR DESCRIPTION
Based on https://github.com/zkSNACKs/WalletWasabi/pull/5429

Add SignTransactionAsync to WabiSabiApiClient.

Questions:

- Should Coins be stored in WabiSabiApiClient? 

Todo,here or in next PR:

- [ ] - Add sanity check: do not sign if the transaction is malicious.
- [ ] - Handle [EncryptedUnsignedCoinJoin](https://github.com/zkSNACKs/WabiSabi/blob/master/protocol.md) transactions. The encryption/decryption code is missing. The `UnsignedTransactionSecret ` should be stored in WabiSabiApiClient.
- [ ] - Find `WabiSabiApiClient` final name. 

