### PR TITLE
[WabiSabi] Only allow standard outputs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -69,6 +69,26 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		}
 
 		[Fact]
+		public async Task NonStandardOutputAsync()
+		{
+			WabiSabiConfig cfg = new();
+			var round = WabiSabiFactory.CreateRound(cfg);
+			round.SetPhase(Phase.OutputRegistration);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+			using Key key = new();
+
+			var sha256Bounty = Script.FromHex("aa20000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f87");
+			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, sha256Bounty);
+			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterOutputAsync(req));
+
+			// The following assertion requires standardness to be checked before allowed script types
+			Assert.Equal(WabiSabiProtocolErrorCode.NonStandardOutput, ex.ErrorCode);
+
+			await arena.StopAsync(CancellationToken.None);
+		}
+
+		[Fact]
 		public async Task NotEnoughFundsAsync()
 		{
 			WabiSabiConfig cfg = new() { MinRegistrableAmount = Money.Coins(2) };

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -26,6 +26,7 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 		ScriptNotAllowed,
 		IncorrectRequestedAmountCredentials,
 		WrongCoinjoinSignature,
-		AliceAlreadyRegistered
+		AliceAlreadyRegistered,
+		NonStandardOutput
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
@@ -72,11 +72,6 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			DisposeGuard();
 			using (RunningTasks.RememberWith(RunningRequests))
 			{
-				if (!request.Script.IsScriptType(ScriptType.P2WPKH))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
-				}
-
 				return await Arena.RegisterOutputAsync(request).ConfigureAwait(false);
 			}
 		}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -366,6 +366,11 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 				var credentialAmount = -request.AmountCredentialRequests.Delta;
 
+				if (!request.Script.IsScriptType(ScriptType.P2WPKH))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, $"Round ({request.RoundId}): Script not allowed.");
+				}
+
 				Bob bob = new(request.Script, credentialAmount);
 
 				var outputValue = bob.CalculateOutputAmount(round.FeeRate);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -366,6 +366,11 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 				var credentialAmount = -request.AmountCredentialRequests.Delta;
 
+				if (!StandardScripts.IsStandardScriptPubKey(request.Script))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardOutput, $"Round ({request.RoundId}): Non standard output.");
+				}
+
 				if (!request.Script.IsScriptType(ScriptType.P2WPKH))
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, $"Round ({request.RoundId}): Script not allowed.");


### PR DESCRIPTION
This is redundant with the allowed script check because that allows
a strict subset of standard outputs (only p2wpkh), but that check can be
parameterized in the round metadata later in order to allow payment from
CoinJoins to other address types.