### PR TITLE
Replace `h` with `'` in keypath strings

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -210,7 +210,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 					response = $"{{\"xpub\": \"{xpub}\"}}\r\n";
 				}
 			}
-			else if (CompareArguments(out bool t1, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/0h/0h --addr-type wit", false))
+			else if (CompareArguments(out bool t1, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84'/0'/0' --addr-type wit", false))
 			{
 				if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
 				{
@@ -219,7 +219,7 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 						: "{\"address\": \"bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah\"}\r\n";
 				}
 			}
-			else if (CompareArguments(out bool t2, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/0h/0h/1 --addr-type wit", false))
+			else if (CompareArguments(out bool t2, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84'/0'/0'/1 --addr-type wit", false))
 			{
 				if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
 				{
@@ -282,11 +282,11 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			{
 				// The +1 is the space.
 				var keyPath = arguments[(arguments.IndexOf(command) + command.Length + 1)..];
-				if (keyPath == "m/84h/0h/0h")
+				if (keyPath == "m/84'/0'/0'")
 				{
 					extPubKey = "xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M";
 				}
-				else if (keyPath == "m/84h/0h/0h/1")
+				else if (keyPath == "m/84'/0'/0'/1")
 				{
 					extPubKey = "xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu";
 				}

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -123,7 +123,7 @@ namespace WalletWasabi.Hwi
 
 		private async Task<ExtPubKey> GetXpubImplAsync(HardwareWalletModels? deviceType, string? devicePath, HDFingerprint? fingerprint, KeyPath keyPath, CancellationToken cancel)
 		{
-			string keyPathString = keyPath.ToString(true, "h");
+			string keyPathString = keyPath.ToString(true, "'");
 			var response = await SendCommandAsync(
 				options: BuildOptions(deviceType, devicePath, fingerprint),
 				command: HwiCommands.GetXpub,
@@ -147,7 +147,7 @@ namespace WalletWasabi.Hwi
 			var response = await SendCommandAsync(
 				options: BuildOptions(deviceType, devicePath, fingerprint),
 				command: HwiCommands.DisplayAddress,
-				commandArguments: $"--path {keyPath.ToString(true, "h")} --addr-type wit",
+				commandArguments: $"--path {keyPath.ToString(true, "'")} --addr-type wit",
 				openConsole: false,
 				cancel).ConfigureAwait(false);
 


### PR DESCRIPTION
Based on https://github.com/zkSNACKs/WalletWasabi/pull/5465#issuecomment-809415948

@adamPetho @yahiheb can you confirm if the Trezor Kata works with this?