### PR TITLE
Fix backend log message "two rounds"

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,7 +94,7 @@ namespace WalletWasabi.Backend
 			Logger.LogInfo($"{nameof(IndexBuilderService)} is successfully initialized and started synchronization.");
 
 			await Coordinator.MakeSureInputregistrableRoundRunningAsync();
-			Logger.LogInfo("Chaumian CoinJoin Coordinator is successfully initialized and started two new rounds.");
+			Logger.LogInfo($"Chaumian CoinJoin Coordinator is successfully initialized and started '{Coordinator.GetRunningRounds().Count()}' new round(s).");
 		}
 
 		private async Task InitializeP2pAsync(Network network, EndPoint endPoint, CancellationToken cancel)


### PR DESCRIPTION
Fixing this log message when starting the backend:

`2021-03-31 10:20:42 [13] INFO   Global (96)     Chaumian CoinJoin Coordinator is successfully initialized and started two new rounds.`