### PR TITLE
Gracefully handle corrupt transaction store

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -172,10 +172,19 @@ namespace WalletWasabi.Gui
 
 				#region BitcoinStoreInitialization
 
-				await bstoreInitTask.ConfigureAwait(false);
+				try
+				{
+					await bstoreInitTask.ConfigureAwait(false);
 
-				// Make sure that the height of the wallets will not be better than the current height of the filters.
-				WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+					// Make sure that the height of the wallets will not be better than the current height of the filters.
+					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+				}
+				catch (Exception ex)
+				{
+					//WalletManager.SetMaxBestHeight(0);
+
+					throw;
+				}
 
 				#endregion BitcoinStoreInitialization
 


### PR DESCRIPTION
When the confirmed transactions file corrupts we delete it, but then we must also set back the height of the wallet. This PR is an illustration only.

Note that you can ruin the transaction file by adding a random character.  

Note that if the mempool file is ruined, then this fallback should not happen. Very important!

