### PR TITLE
[WabiSabi] Split `CredentialIssuer.HandleRequest` into two phases

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
@@ -12,6 +12,7 @@ using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Crypto;
+using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 using WalletWasabi.WabiSabi.Models;
 using Xunit;
 
@@ -179,34 +180,24 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		}
 
 		[Fact]
-		public async Task InvalidRequestedWeightCredentialsAsync()
+		public async Task InvalidRequestedAmountCredentialsAsync()
 		{
-			WabiSabiConfig cfg = new();
-			var round = WabiSabiFactory.CreateRound(cfg);
-			round.SetPhase(Phase.ConnectionConfirmation);
-			var alice = WabiSabiFactory.CreateAlice();
-			round.Alices.Add(alice);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-
-			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
-
-			// invalidate serial numbers
-			round.WeightCredentialIssuer.HandleRequest(req.RealWeightCredentialRequests);
-			Assert.Equal(0, round.AmountCredentialIssuer.Balance);
-			Assert.Equal(req.RealWeightCredentialRequests.Delta, round.WeightCredentialIssuer.Balance);
-
-			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
-			var ex = await Assert.ThrowsAsync<WabiSabiCryptoException>(async () => await handler.ConfirmConnectionAsync(req));
-			Assert.Equal(WabiSabiCryptoErrorCode.SerialNumberAlreadyUsed, ex.ErrorCode);
-			Assert.False(alice.ConfirmedConnetion);
-			Assert.Equal(0, round.AmountCredentialIssuer.Balance);
-			Assert.Equal(req.RealWeightCredentialRequests.Delta, round.WeightCredentialIssuer.Balance);
-
-			await arena.StopAsync(CancellationToken.None);
+			await InvalidRequestedCredentialsAsync(
+				(round) => (round.AmountCredentialIssuer, round.WeightCredentialIssuer),
+				(request) => request.RealAmountCredentialRequests);
 		}
 
 		[Fact]
-		public async Task InvalidRequestedAmountCredentialsAsync()
+		public async Task InvalidRequestedWeightCredentialsAsync()
+		{
+			await InvalidRequestedCredentialsAsync(
+				(round) => (round.WeightCredentialIssuer, round.AmountCredentialIssuer),
+				(request) => request.RealWeightCredentialRequests);
+		}
+
+		private async Task InvalidRequestedCredentialsAsync(
+			Func<Round, (CredentialIssuer, CredentialIssuer)> credentialIssuerSelector,
+			Func<ConnectionConfirmationRequest, RealCredentialsRequest> credentialsRequestSelector)
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
@@ -216,19 +207,20 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
+			var (issuer, issuer2) = credentialIssuerSelector(round);
+			var credentialsRequest = credentialsRequestSelector(req);
 
 			// invalidate serial numbers
-			round.AmountCredentialIssuer.HandleRequest(req.RealAmountCredentialRequests);
-			Assert.Equal(req.RealAmountCredentialRequests.Delta, round.AmountCredentialIssuer.Balance);
-			Assert.Equal(0, round.WeightCredentialIssuer.Balance);
+			issuer.HandleRequest(credentialsRequest);
+			Assert.Equal(0, issuer2.Balance);
+			Assert.Equal(credentialsRequest.Delta, issuer.Balance);
 
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			var ex = await Assert.ThrowsAsync<WabiSabiCryptoException>(async () => await handler.ConfirmConnectionAsync(req));
 			Assert.Equal(WabiSabiCryptoErrorCode.SerialNumberAlreadyUsed, ex.ErrorCode);
 			Assert.False(alice.ConfirmedConnetion);
-			Assert.Equal(req.RealAmountCredentialRequests.Delta, round.AmountCredentialIssuer.Balance);
-			Assert.Equal(0, round.WeightCredentialIssuer.Balance);
-
+			Assert.Equal(0, issuer2.Balance);
+			Assert.Equal(credentialsRequest.Delta, issuer.Balance);
 			await arena.StopAsync(CancellationToken.None);
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
@@ -218,7 +218,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 					validCredentialRequest.Requested,
 					validCredentialRequest.Proofs);
 
-				var ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(invalidCredentialRequest));
+				var ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(invalidCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.InvalidNumberOfPresentedCredentials, ex.ErrorCode);
 				Assert.Equal("3 credential presentations were expected but 1 were received.", ex.Message);
 
@@ -230,7 +230,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 					validCredentialRequest.Requested,
 					validCredentialRequest.Proofs);
 
-				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(invalidCredentialRequest));
+				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(invalidCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.InvalidNumberOfPresentedCredentials, ex.ErrorCode);
 				Assert.Equal("3 credential presentations were expected but 0 were received.", ex.Message);
 
@@ -243,7 +243,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 					validCredentialRequest.Requested.Take(1),
 					validCredentialRequest.Proofs);
 
-				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(invalidCredentialRequest));
+				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(invalidCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.InvalidNumberOfRequestedCredentials, ex.ErrorCode);
 				Assert.Equal("3 credential requests were expected but 1 were received.", ex.Message);
 
@@ -254,7 +254,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 					validCredentialRequest.Requested.Take(1),
 					validCredentialRequest.Proofs);
 
-				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(invalidCredentialRequest));
+				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(invalidCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.InvalidNumberOfRequestedCredentials, ex.ErrorCode);
 				Assert.Equal("3 credential requests were expected but 1 were received.", ex.Message);
 
@@ -267,7 +267,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 					new[] { requested[0], requested[1], new IssuanceRequest(requested[2].Ma, new[] { GroupElement.Infinity }) },
 					validCredentialRequest.Proofs);
 
-				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(invalidCredentialRequest));
+				ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(invalidCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.InvalidBitCommitment, ex.ErrorCode);
 			}
 
@@ -282,7 +282,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 					validCredentialRequest.Requested,
 					proofs);
 
-				var ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(invalidCredentialRequest));
+				var ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(invalidCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.CoordinatorReceivedInvalidProofs, ex.ErrorCode);
 			}
 
@@ -296,7 +296,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 				(validCredentialRequest, validationData) = client.CreateRequest(Enumerable.Empty<long>(), client.Credentials.All);
 
 				issuer.HandleRequest(validCredentialRequest);
-				var ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.HandleRequest(validCredentialRequest));
+				var ex = Assert.Throws<WabiSabiCryptoException>(() => issuer.PrepareResponse(validCredentialRequest));
 				Assert.Equal(WabiSabiCryptoErrorCode.SerialNumberAlreadyUsed, ex.ErrorCode);
 			}
 		}

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -128,15 +128,15 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
 			}
 
-			var amountCredentialResponse = round.AmountCredentialIssuer.HandleRequest(zeroAmountCredentialRequests);
-			var weightCredentialResponse = round.WeightCredentialIssuer.HandleRequest(zeroWeightCredentialRequests);
+			var commitAmountCredentialResponse = round.AmountCredentialIssuer.PrepareResponse(zeroAmountCredentialRequests);
+			var commitWeightCredentialResponse = round.WeightCredentialIssuer.PrepareResponse(zeroWeightCredentialRequests);
 
 			RemoveDuplicateAlices(rounds, alice);
 
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
 			round.Alices.Add(alice);
 
-			return new(alice.Id, amountCredentialResponse, weightCredentialResponse);
+			return new(alice.Id, commitAmountCredentialResponse(), commitWeightCredentialResponse());
 		}
 
 		private static void RemoveDuplicateAlices(IDictionary<Guid, Round> rounds, Alice alice)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -312,9 +312,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({request.RoundId}): Alice ({request.AliceId}) not found.");
 				}
 
-				var amountZeroCredentialResponse = round.AmountCredentialIssuer.HandleRequest(request.ZeroAmountCredentialRequests);
-				var weightZeroCredentialResponse = round.WeightCredentialIssuer.HandleRequest(request.ZeroWeightCredentialRequests);
-
 				var realAmountCredentialRequests = request.RealAmountCredentialRequests;
 				var realWeightCredentialRequests = request.RealWeightCredentialRequests;
 
@@ -327,24 +324,27 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedAmountCredentials, $"Round ({request.RoundId}): Incorrect requested amount credentials.");
 				}
 
+				var commitAmountZeroCredentialResponse = round.AmountCredentialIssuer.PrepareResponse(request.ZeroAmountCredentialRequests);
+				var commitWeightZeroCredentialResponse = round.WeightCredentialIssuer.PrepareResponse(request.ZeroWeightCredentialRequests);
+
 				if (round.Phase == Phase.InputRegistration)
 				{
 					alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
 					return new(
-						amountZeroCredentialResponse,
-						weightZeroCredentialResponse);
+						commitAmountZeroCredentialResponse(),
+						commitWeightZeroCredentialResponse());
 				}
 				else if (round.Phase == Phase.ConnectionConfirmation)
 				{
-					var amountRealCredentialResponse = round.AmountCredentialIssuer.HandleRequest(realAmountCredentialRequests);
-					var weightRealCredentialResponse = round.WeightCredentialIssuer.HandleRequest(realWeightCredentialRequests);
+					var commitAmountRealCredentialResponse = round.AmountCredentialIssuer.PrepareResponse(realAmountCredentialRequests);
+					var commitWeightRealCredentialResponse = round.WeightCredentialIssuer.PrepareResponse(realWeightCredentialRequests);
 					alice.ConfirmedConnetion = true;
 
 					return new(
-						amountZeroCredentialResponse,
-						weightZeroCredentialResponse,
-						amountRealCredentialResponse,
-						weightRealCredentialResponse);
+						commitAmountZeroCredentialResponse(),
+						commitWeightZeroCredentialResponse(),
+						commitAmountRealCredentialResponse(),
+						commitWeightRealCredentialResponse());
 				}
 				else
 				{
@@ -397,14 +397,14 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({request.RoundId}): Wrong phase ({round.Phase}).");
 				}
 
-				var amountCredentialResponse = round.AmountCredentialIssuer.HandleRequest(request.AmountCredentialRequests);
-				var weightCredentialResponse = round.WeightCredentialIssuer.HandleRequest(weightCredentialRequests);
+				var commitAmountCredentialResponse = round.AmountCredentialIssuer.PrepareResponse(request.AmountCredentialRequests);
+				var commitWeightCredentialResponse = round.WeightCredentialIssuer.PrepareResponse(weightCredentialRequests);
 
 				round.Bobs.Add(bob);
 
 				return new(
-					amountCredentialResponse,
-					weightCredentialResponse);
+					commitAmountCredentialResponse(),
+					commitWeightCredentialResponse());
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
+++ b/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 		private HashSet<GroupElement> SerialNumbers { get; } = new HashSet<GroupElement>();
 
 		// Canary test check to ensure credential balance is never negative
-		private long Balance { get; set; } = 0;
+		public long Balance { get; private set; } = 0;
 
 		private WasabiRandom RandomNumberGenerator { get; }
 

--- a/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
+++ b/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
@@ -212,7 +212,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 			var macs = credentials.Select(x => x.Mac);
 			var response = new CredentialsResponse(macs, proofs);
 
-			return delegate
+			return () =>
 			{
 				// Register the serial numbers to prevent credential reuse.
 				foreach (var presentation in presented)


### PR DESCRIPTION
Because we are now using two credential issuers, `HandleRequest` means the effects of one credential request will be applied before the other is validated.

This PR modifies the arena request flow to first prepare handling of both kinds of credential requests, and then commit them after both have been validated by splitting `HandleRequest` into `PrepareRequest` and a delegate with no arguments, `CommitRequest`.