### PR TITLE
Autorescan wallets when internal data structure corrups.

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -182,7 +182,7 @@ namespace WalletWasabi.Gui
 				catch
 				{
 					// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
-					WalletManager.SetMaxBestHeight(0);
+					WalletManager.SetMaxBestHeight(SmartHeader.GetStartingHeader(Network).Height);
 					throw;
 				}
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -172,10 +172,19 @@ namespace WalletWasabi.Gui
 
 				#region BitcoinStoreInitialization
 
-				await bstoreInitTask.ConfigureAwait(false);
+				try
+				{
+					await bstoreInitTask.ConfigureAwait(false);
 
-				// Make sure that the height of the wallets will not be better than the current height of the filters.
-				WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+					// Make sure that the height of the wallets will not be better than the current height of the filters.
+					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+				}
+				catch
+				{
+					// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
+					WalletManager.SetMaxBestHeight(0);
+					throw;
+				}
 
 				#endregion BitcoinStoreInitialization
 


### PR DESCRIPTION
closes https://github.com/zkSNACKs/WalletWasabi/pull/5496

If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.