### PR TITLE
[Backport] Fix recovery recovery word bug

### DIFF
--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -42,13 +42,15 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 
 			MnemonicWords = "";
 
-			var numberOfWords = MnemonicWords.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-
 			var canExecute = Observable
 				.Merge(Observable.FromEventPattern(this, nameof(ErrorsChanged)).Select(_ => Unit.Default))
 				.Merge(this.WhenAnyValue(x => x.MnemonicWords).Select(_ => Unit.Default))
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Select(_ => !Validations.AnyErrors && (numberOfWords == 12 || numberOfWords == 15 || numberOfWords == 18 || numberOfWords == 21 || numberOfWords == 24));
+				.Select(_ =>
+				{
+					var numberOfWords = MnemonicWords.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+					return !Validations.AnyErrors && (numberOfWords == 12 || numberOfWords == 15 || numberOfWords == 18 || numberOfWords == 21 || numberOfWords == 24);
+				});
 
 			RecoverCommand = ReactiveCommand.Create(() => RecoverWallet(owner), canExecute);
 


### PR DESCRIPTION
The new backport introduced a silly bug. Users cannot recover their wallets entirely. 

The bug was made by me. It is getting hard to cherry-pick the changes from the master, the diff is too big. I did it manually on the last 3 releases because cherry-pick was impossible caused the number of conflicts. The backport is still on .NET Core 3.1.

Next week there will be another backport release with this fix. 