### PR TITLE
Inject `CredentialPool`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -41,17 +41,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			await using var coordinator = new ArenaRequestHandler(config, new Prison(), arena, mockRpc.Object);
 
 			var rnd = new InsecureRandom();
+			var amountCredentials = new CredentialPool();
+			var weightCredentials = new CredentialPool();
 			var protocolCredentialNumber = 2;
 			var protocolMaxWeightPerAlice = 1_000L;
-			var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, protocolCredentialNumber, rnd, 4_300_000_000_000ul);
-			var weightClient = new WabiSabiClient(round.WeightCredentialIssuerParameters, protocolCredentialNumber, rnd, (ulong)protocolMaxWeightPerAlice);
+			var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, protocolCredentialNumber, rnd, 4_300_000_000_000ul, amountCredentials);
+			var weightClient = new WabiSabiClient(round.WeightCredentialIssuerParameters, protocolCredentialNumber, rnd, (ulong)protocolMaxWeightPerAlice, weightCredentials);
 
 			var apiClient = new ArenaClient(amountClient, weightClient, coordinator);
 
 			var aliceId = await apiClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id, round.Hash);
 
 			Assert.NotEqual(Guid.Empty, aliceId);
-			Assert.Empty(apiClient.AmountCredentialClient.Credentials.Valuable);
+			Assert.Empty(amountCredentials.Valuable);
 
 			var reissuanceAmounts = new[]
 			{
@@ -67,10 +69,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				round.Id,
 				aliceId,
 				inputRemainingWeights,
-				apiClient.AmountCredentialClient.Credentials.ZeroValue.Take(protocolCredentialNumber),
+				amountCredentials.ZeroValue.Take(protocolCredentialNumber),
 				reissuanceAmounts);
 
-			Assert.Empty(apiClient.AmountCredentialClient.Credentials.Valuable);
+			Assert.Empty(amountCredentials.Valuable);
 
 			// Phase: Connection Confirmation
 			round.SetPhase(Phase.ConnectionConfirmation);
@@ -78,11 +80,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				round.Id,
 				aliceId,
 				inputRemainingWeights,
-				apiClient.AmountCredentialClient.Credentials.ZeroValue.Take(protocolCredentialNumber),
+				amountCredentials.ZeroValue.Take(protocolCredentialNumber),
 				reissuanceAmounts);
 
-			Assert.Single(apiClient.AmountCredentialClient.Credentials.Valuable, x => x.Amount.ToMoney() == reissuanceAmounts.First());
-			Assert.Single(apiClient.AmountCredentialClient.Credentials.Valuable, x => x.Amount.ToMoney() == reissuanceAmounts.Last());
+			Assert.Single(amountCredentials.Valuable, x => x.Amount.ToMoney() == reissuanceAmounts.First());
+			Assert.Single(amountCredentials.Valuable, x => x.Amount.ToMoney() == reissuanceAmounts.Last());
 		}
 
 		[Fact]

--- a/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
+++ b/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
@@ -24,14 +24,15 @@ namespace WalletWasabi.WabiSabi.Crypto
 			CredentialIssuerParameters credentialIssuerParameters,
 			int numberOfCredentials,
 			WasabiRandom randomNumberGenerator,
-			ulong maxAmount)
+			ulong maxAmount,
+			CredentialPool? credentialPool = null)
 		{
 			MaxAmount = maxAmount;
 			RangeProofWidth = (int)Math.Ceiling(Math.Log2(MaxAmount));
 			RandomNumberGenerator = Guard.NotNull(nameof(randomNumberGenerator), randomNumberGenerator);
 			NumberOfCredentials = Guard.InRangeAndNotNull(nameof(numberOfCredentials), numberOfCredentials, 1, 100);
 			CredentialIssuerParameters = Guard.NotNull(nameof(credentialIssuerParameters), credentialIssuerParameters);
-			Credentials = new CredentialPool();
+			Credentials = credentialPool ?? new CredentialPool();
 		}
 
 		public ulong MaxAmount { get; }


### PR DESCRIPTION
Allow to inject the `CredentialPool` in `WabiSabiClient` to make it stateless and allow higher level clients use the credentials as they please. 