### PR TITLE
The estimation fee doesnt show anymore in Regtest

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1052,8 +1052,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			}
 
 			FeeRate feeRateTx = finalCoinjoin.GetFeeRate(coins.ToArray());
-			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
-			FeeRate feeRateReal = esr.FeeRate;
+			FeeRate feeRateReal = (await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true)).FeeRate;
 
 			Assert.True(feeRateReal.FeePerK - feeRateReal.FeePerK / 2 < feeRateTx.FeePerK); // Max 50% mistake.
 			Assert.True(2 * feeRateReal.FeePerK > feeRateTx.FeePerK); // Max 200% mistake.

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1052,7 +1052,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			}
 
 			FeeRate feeRateTx = finalCoinjoin.GetFeeRate(coins.ToArray());
-			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, new FeeRate(2m), EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
+			var esr = await rpc.EstimateSmartFeeAsync(roundConfig.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
 			FeeRate feeRateReal = esr.FeeRate;
 
 			Assert.True(feeRateReal.FeePerK - feeRateReal.FeePerK / 2 < feeRateTx.FeePerK); // Max 50% mistake.

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -819,9 +819,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				}
 
 				// 7.2. Get the most optimal FeeRate.
-				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
-
-				FeeRate optimalFeeRate = estimateSmartFeeResponse.FeeRate;
+				FeeRate optimalFeeRate = (await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false)).FeeRate;
 
 				if (optimalFeeRate is null || optimalFeeRate == FeeRate.Zero || currentFeeRate is null || currentFeeRate == FeeRate.Zero) // This would be really strange if it'd happen.
 				{
@@ -894,8 +892,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			var outputSizeInBytes = Constants.OutputSizeInBytes;
 			try
 			{
-				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
-				var feeRate = estimateSmartFeeResponse.FeeRate;
+				var feeRate = (await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false)).FeeRate;
 
 				// Make sure min relay fee (1000 sat) is hit.
 				feePerInputs = Math.Max(feeRate.GetFee(inputSizeInBytes), Money.Satoshis(500));

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -819,14 +819,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				}
 
 				// 7.2. Get the most optimal FeeRate.
-				MemPoolInfo mempoolInfo = await RpcClient.GetMempoolInfoAsync().ConfigureAwait(false);
-				var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
-				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, sanityFeeRate, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
-
-				if (estimateSmartFeeResponse is null)
-				{
-					throw new InvalidOperationException($"{nameof(FeeRate)} is not yet initialized.");
-				}
+				EstimateSmartFeeResponse estimateSmartFeeResponse = await RpcClient.EstimateSmartFeeAsync(AdjustedConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 
 				FeeRate optimalFeeRate = estimateSmartFeeResponse.FeeRate;
 
@@ -901,9 +894,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			var outputSizeInBytes = Constants.OutputSizeInBytes;
 			try
 			{
-				var mempoolInfo = await rpc.GetMempoolInfoAsync().ConfigureAwait(false);
-				var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
-				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, sanityFeeRate, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
+				var estimateSmartFeeResponse = await rpc.EstimateSmartFeeAsync(confirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 				var feeRate = estimateSmartFeeResponse.FeeRate;
 
 				// Make sure min relay fee (1000 sat) is hit.

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -13,7 +13,7 @@ namespace NBitcoin.RPC
 {
 	public static class RPCClientExtensions
 	{
-		public static async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(this IRPCClient rpc, int confirmationTarget, FeeRate sanityFeeRate, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
+		public static async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(this IRPCClient rpc, int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
 		{
 			EstimateSmartFeeResponse result;
 			if (simulateIfRegTest && rpc.Network == Network.RegTest)
@@ -25,7 +25,8 @@ namespace NBitcoin.RPC
 				result = await rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode).ConfigureAwait(false);
 			}
 
-			result.FeeRate = FeeRate.Max(sanityFeeRate, result.FeeRate);
+			var mempoolInfo = await rpc.GetMempoolInfoAsync().ConfigureAwait(false);
+			result.FeeRate = FeeRate.Max(mempoolInfo.GetSanityFeeRate(), result.FeeRate);
 
 			return result;
 		}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -242,9 +242,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			if (!Rounds.Values.Any(x => !x.IsBlameRound && x.Phase == Phase.InputRegistration))
 			{
-				var estimateSmartFeeResponse = await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
+				var feeRate = (await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false)).FeeRate;
 
-				RoundParameters roundParams = new(Config, Network, Random, estimateSmartFeeResponse.FeeRate);
+				RoundParameters roundParams = new(Config, Network, Random, feeRate);
 				Round r = new(roundParams);
 				Rounds.Add(r.Id, r);
 			}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -240,13 +240,16 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		private async Task CreateRoundsAsync()
 		{
-			if (!Rounds.Values.Any(x => !x.IsBlameRound && x.Phase == Phase.InputRegistration))
+			if(!(Rpc.Network == Network.RegTest))
 			{
-				var feeRate = (await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative).ConfigureAwait(false)).FeeRate;
+				if (!Rounds.Values.Any(x => !x.IsBlameRound && x.Phase == Phase.InputRegistration))
+				{
+					var feeRate = (await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative).ConfigureAwait(false)).FeeRate;
 
-				RoundParameters roundParams = new(Config, Network, Random, feeRate);
-				Round r = new(roundParams);
-				Rounds.Add(r.Id, r);
+					RoundParameters roundParams = new(Config, Network, Random, feeRate);
+					Round r = new(roundParams);
+					Rounds.Add(r.Id, r);
+				}
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -242,9 +242,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			if (!Rounds.Values.Any(x => !x.IsBlameRound && x.Phase == Phase.InputRegistration))
 			{
-				var mempoolInfo = await Rpc.GetMempoolInfoAsync().ConfigureAwait(false);
-				var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
-				var estimateSmartFeeResponse = await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, sanityFeeRate, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
+				var estimateSmartFeeResponse = await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 
 				RoundParameters roundParams = new(Config, Network, Random, estimateSmartFeeResponse.FeeRate);
 				Round r = new(roundParams);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -240,18 +240,16 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		private async Task CreateRoundsAsync()
 		{
-			
 			if (!Rounds.Values.Any(x => !x.IsBlameRound && x.Phase == Phase.InputRegistration))
 			{
 				var mempoolInfo = await Rpc.GetMempoolInfoAsync().ConfigureAwait(false);
 				var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
 				var estimateSmartFeeResponse = await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, sanityFeeRate, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true).ConfigureAwait(false);
 
-				RoundParameters roundParams = new(Config, Network, Random,estimateSmartFeeResponse.FeeRate);
+				RoundParameters roundParams = new(Config, Network, Random, estimateSmartFeeResponse.FeeRate);
 				Round r = new(roundParams);
 				Rounds.Add(r.Id, r);
 			}
-			
 		}
 
 		private void TimeoutAlices()


### PR DESCRIPTION
When the developer is in regtest mode and runnign the bitcoin core, there was an exception showing up continiously, saying the estimationfee cannot be calculated. I just added an if expression in CreateRoundAsync, and it seems it solved this issue

closes https://github.com/zkSNACKs/WalletWasabi/issues/5494