### PR TITLE
Fix RegTest

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -150,7 +150,7 @@ namespace WalletWasabi.Gui
 
 				#region TorProcessInitialization
 
-				if (Config.UseTor)
+				if (Config.UseTor && Network != Network.RegTest)
 				{
 					using (BenchmarkLogger.Measure(operationName: "TorProcessManager.Start"))
 					{


### PR DESCRIPTION
RegTest didn't work since https://github.com/zkSNACKs/WalletWasabi/pull/5393, because 

```
2021-04-05 15:02:45 [1] CRITICAL	Program (87)	System.InvalidCastException: Unable to cast object of type 'WalletWasabi.Tor.Http.ClearnetHttpClient' to type 'WalletWasabi.Tor.Http.TorHttpClient'.
   at WalletWasabi.WebClients.Wasabi.HttpClientFactory.NewTorHttpClient(Boolean isolateStream, Func`1 baseUriFn) in WalletWasabi\WebClients\Wasabi\HttpClientFactory.cs:line 104
   at WalletWasabi.Gui.Global.InitializeNoWalletAsync(TerminateService terminateService) in WalletWasabi.Gui\Global.cs:line 161
   at WalletWasabi.Fluent.Desktop.Program.<>c.<<BuildAvaloniaApp>b__9_1>d.MoveNext() in WalletWasabi.Fluent.Desktop\Program.cs:line 199
--- End of stack trace from previous location ---
   at WalletWasabi.Fluent.App.<OnFrameworkInitializationCompleted>b__5_0() in WalletWasabi.Fluent\App.axaml.cs:line 55
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__140_0(Object state)
   at Avalonia.Threading.AvaloniaSynchronizationContext.<>c__DisplayClass5_0.<Post>b__0() in /_/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs:line 33
   at Avalonia.Threading.JobRunner.Job.Avalonia.Threading.JobRunner.IJob.Run() in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 166
   at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
   at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 208
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32Platform.RunLoop(CancellationToken cancellationToken) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 157
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 61
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 107
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 134
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop\Program.cs:line 76
   ```