### PR TITLE
[Fluent] Add delay for EnableCancelOnPressed dialog feature

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -100,17 +100,24 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void UpdateDelay(bool isDialogOpen)
 		{
-			_canCancelOnPointerPressed = false;
-			CancelPointerPressedDelay?.Cancel();
-
-			if (isDialogOpen)
+			try
 			{
-				CancelPointerPressedDelay = new CancellationTokenSource();
+				_canCancelOnPointerPressed = false;
+				CancelPointerPressedDelay?.Cancel();
 
-				Task.Delay(TimeSpan.FromSeconds(1), CancelPointerPressedDelay.Token).ContinueWith(_ =>
+				if (isDialogOpen)
 				{
-					_canCancelOnPointerPressed = true;
-				});
+					CancelPointerPressedDelay = new CancellationTokenSource();
+
+					Task.Delay(TimeSpan.FromSeconds(1), CancelPointerPressedDelay.Token).ContinueWith(_ =>
+					{
+						_canCancelOnPointerPressed = true;
+					});
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				// ignored
 			}
 		}
 

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.Fluent.Controls
 	public class Dialog : ContentControl
 	{
 		private Panel? _dismissPanel;
-		private bool _canCancelOnPointerPressed = false;
+		private bool _canCancelOnPointerPressed;
 
 		public static readonly StyledProperty<bool> IsDialogOpenProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(IsDialogOpen));

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -95,7 +95,7 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(MaxContentWidthProperty, value);
 		}
 
-		private CancellationTokenSource CancelPointerPressedDelay { get; set; }
+		private CancellationTokenSource? CancelPointerPressedDelay { get; set; }
 
 		private void UpdateDelay(bool isDialogOpen)
 		{

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -42,6 +42,11 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<double> MaxContentWidthProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(MaxContentWidth), double.PositiveInfinity);
 
+		public Dialog()
+		{
+			this.GetObservable(IsDialogOpenProperty).Subscribe(UpdateDelay);
+		}
+
 		public bool IsDialogOpen
 		{
 			get => GetValue(IsDialogOpenProperty);
@@ -91,11 +96,6 @@ namespace WalletWasabi.Fluent.Controls
 		}
 
 		private CancellationTokenSource CancelPointerPressedDelay { get; set; }
-
-		public Dialog()
-		{
-			this.GetObservable(IsDialogOpenProperty).Subscribe(UpdateDelay);
-		}
 
 		private void UpdateDelay(bool isDialogOpen)
 		{

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;


### PR DESCRIPTION
This adds delay for dialog EnableCancelOnPressed  feature to eliminate accidental dialog closing on double-click event.