### PR TITLE
[WabiSabi] Constrain registration vsize

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -365,7 +365,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task TooMuchWeightAsync()
 		{
-			WabiSabiConfig cfg = new() { RegistrableWeightCredentials = 1 };
+			WabiSabiConfig cfg = new() { PerAliceVsizeAllocation = 1 };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -83,6 +83,33 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		}
 
 		[Fact]
+		public async Task InputRegistrationFullWeightAsync()
+		{
+			WabiSabiConfig cfg = new();
+			var round = WabiSabiFactory.CreateRound(cfg);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+			using Key key = new();
+
+			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
+
+			// TODO add configuration parameter
+			round.InitialInputVsizeAllocation = (int)round.PerAliceVsizeAllocation;
+
+			// Add an alice
+			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+			round.Alices.Add(WabiSabiFactory.CreateAlice());
+
+			Assert.Equal(0, round.RemainingInputVsizeAllocation);
+
+			// try to add an additional input
+			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
+			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchTotalWeight, ex.ErrorCode);
+
+			await arena.StopAsync(CancellationToken.None);
+		}
+
+		[Fact]
 		public async Task InputRegistrationTimedoutAsync()
 		{
 			WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.Zero };

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -81,6 +81,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 
 			// Make sure an Alice have already been registered with the same input.
 			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+
+			var initialRemaining = anotherRound.RemainingInputVsizeAllocation;
 			anotherRound.Alices.Add(preAlice);
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
@@ -88,6 +90,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var resp = await handler.RegisterInputAsync(req);
 			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 			Assert.Empty(anotherRound.Alices);
+			Assert.Equal(initialRemaining, anotherRound.RemainingInputVsizeAllocation);
 
 			await arena.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -33,6 +33,7 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 		InsufficientFees,
 		SizeLimitExceeded,
 		DustOutput,
-		UneconomicalInput
+		UneconomicalInput,
+		TooMuchTotalWeight
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -113,7 +113,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
 			}
 
-			if (alice.TotalInputVsize > round.RegistrableWeightCredentials)
+			if (alice.TotalInputVsize > round.PerAliceVsizeAllocation)
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchWeight);
 			}
@@ -123,7 +123,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
 			}
 
-			if (round.RemainingInputVsizeAllocation < (round.RegistrableWeightCredentials+3)/4) // TODO standardize on vsize
+			if (round.RemainingInputVsizeAllocation < round.PerAliceVsizeAllocation)
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchTotalWeight);
 			}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -65,6 +65,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public DateTimeOffset OutputRegistrationStart { get; private set; }
 		public DateTimeOffset TransactionSigningStart { get; private set; }
 		public DateTimeOffset TransactionBroadcastingStart { get; private set; }
+		public int InitialInputVsizeAllocation { get; set; } = 99954; // TODO compute as CoinjoinState.Parameters.MaxWeight - CoinjoinState.Parameters.SharedOverhead, mutable for testing until then
+		public int RemainingInputVsizeAllocation => InitialInputVsizeAllocation - Alices.Count() * (int)((RegistrableWeightCredentials+3)/4); // TODO remove weight
 
 		public void SetPhase(Phase phase)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 			Coinjoin = Transaction.Create(Network);
 
-			Hash = new(HashHelpers.GenerateSha256Hash($"{Id}{MaxInputCountByAlice}{MinRegistrableAmount}{MaxRegistrableAmount}{RegistrableWeightCredentials}{AmountCredentialIssuerParameters}{WeightCredentialIssuerParameters}{FeeRate.SatoshiPerByte}"));
+			Hash = new(HashHelpers.GenerateSha256Hash($"{Id}{MaxInputCountByAlice}{MinRegistrableAmount}{MaxRegistrableAmount}{PerAliceVsizeAllocation}{AmountCredentialIssuerParameters}{WeightCredentialIssuerParameters}{FeeRate.SatoshiPerByte}"));
 		}
 
 		public uint256 Hash { get; }
@@ -37,7 +37,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public uint MaxInputCountByAlice => RoundParameters.MaxInputCountByAlice;
 		public Money MinRegistrableAmount => RoundParameters.MinRegistrableAmount;
 		public Money MaxRegistrableAmount => RoundParameters.MaxRegistrableAmount;
-		public uint RegistrableWeightCredentials => RoundParameters.RegistrableWeightCredentials;
+		public uint PerAliceVsizeAllocation => RoundParameters.PerAliceVsizeAllocation;
+		public uint RegistrableWeightCredentials => 4 * PerAliceVsizeAllocation; // TODO remove weight
 		public FeeRate FeeRate => RoundParameters.FeeRate;
 		public WasabiRandom Random => RoundParameters.Random;
 		public CredentialIssuer AmountCredentialIssuer { get; }
@@ -66,7 +67,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public DateTimeOffset TransactionSigningStart { get; private set; }
 		public DateTimeOffset TransactionBroadcastingStart { get; private set; }
 		public int InitialInputVsizeAllocation { get; set; } = 99954; // TODO compute as CoinjoinState.Parameters.MaxWeight - CoinjoinState.Parameters.SharedOverhead, mutable for testing until then
-		public int RemainingInputVsizeAllocation => InitialInputVsizeAllocation - Alices.Count() * (int)((RegistrableWeightCredentials+3)/4); // TODO remove weight
+		public int RemainingInputVsizeAllocation => InitialInputVsizeAllocation - Alices.Count * (int)PerAliceVsizeAllocation;
 
 		public void SetPhase(Phase phase)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			MaxInputCountByAlice = wabiSabiConfig.MaxInputCountByAlice;
 			MinRegistrableAmount = wabiSabiConfig.MinRegistrableAmount;
 			MaxRegistrableAmount = wabiSabiConfig.MaxRegistrableAmount;
-			RegistrableWeightCredentials = wabiSabiConfig.RegistrableWeightCredentials;
+			PerAliceVsizeAllocation = wabiSabiConfig.PerAliceVsizeAllocation;
 
 			// Note that input registration timeouts can be modified runtime.
 			ConnectionConfirmationTimeout = wabiSabiConfig.ConnectionConfirmationTimeout;
@@ -47,7 +47,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public uint MaxInputCountByAlice { get; }
 		public Money MinRegistrableAmount { get; }
 		public Money MaxRegistrableAmount { get; }
-		public uint RegistrableWeightCredentials { get; }
+		public uint PerAliceVsizeAllocation { get; }
 		public Round? BlameOf { get; }
 		public bool IsBlameRound { get; }
 		public ISet<OutPoint> BlameWhitelist { get; }

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -53,14 +53,14 @@ namespace WalletWasabi.WabiSabi.Backend
 		public Money MaxRegistrableAmount { get; set; } = Money.Coins(43_000m);
 
 		/// <summary>
-		/// How much weight units the server gives to alices per registrations.
-		/// If it's 1000, then about 400 alices can participate.
+		/// How many virtual bytes the server gives to alices per registrations.
+		/// If it's 250, then about 400 alices can participate.
 		/// The width of the rangeproofs are calculated from this, so don't choose stupid numbers.
 		/// Consider that it applies to registrations, not for inputs. This usually consists one input, but can be more.
 		/// </summary>
-		[DefaultValue(1000)]
-		[JsonProperty(PropertyName = "RegistrableWeightCredentials", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public uint RegistrableWeightCredentials { get; set; } = 1_000;
+		[DefaultValue(250)]
+		[JsonProperty(PropertyName = "PerAliceVsizeAllocation", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public uint PerAliceVsizeAllocation { get; set; } = 250;
 
 		[DefaultValue(true)]
 		[JsonProperty(PropertyName = "AllowNotedInputRegistration", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
I decided to leave the `AddAlice` refactor for a later since keeping track of the allocated weight as a computed property based on `Alices.Count` resolved the tension of keeping the integer in sync with the collection, it's best done as part of #5531, which can also address a TODO comment this PR introduces.

Continuation of #5487.

Fixes #5438.