### PR TITLE
[Fluent] Do not store default labels

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -60,17 +60,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 					EnoughSelected = StillNeeded <= 0;
 				});
 
-			_pocketSource
-				.Connect()
-				.WhenValueChanged(x => x.IsSelected)
-				.Subscribe(_ =>
-				{
-					var selectedPocketLabels = Pockets.Where(x => x.IsSelected)
-													  .Select(x => x.Labels)
-													  .Where(label => label != CoinPocketHelper.PrivateFundsText && label != CoinPocketHelper.UnlabelledFundsText);
-					transactionInfo.PocketLabels = SmartLabel.Merge(selectedPocketLabels);
-				});
-
 			StillNeeded = transactionInfo.Amount.ToDecimal(MoneyUnit.BTC);
 
 			EnableBack = true;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -65,7 +65,9 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				.WhenValueChanged(x => x.IsSelected)
 				.Subscribe(_ =>
 				{
-					var selectedPocketLabels = Pockets.Where(x => x.IsSelected).Select(x => x.Labels);
+					var selectedPocketLabels = Pockets.Where(x => x.IsSelected)
+													  .Select(x => x.Labels)
+													  .Where(label => label != CoinPocketHelper.PrivateFundsText && label != CoinPocketHelper.UnlabelledFundsText);
 					transactionInfo.PocketLabels = SmartLabel.Merge(selectedPocketLabels);
 				});
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -120,7 +120,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 					}
 				});
 
-			Labels.ToObservableChangeSet().Subscribe(x => _transactionInfo.SendLabels = new SmartLabel(_labels.ToArray()));
+			Labels.ToObservableChangeSet().Subscribe(x => _transactionInfo.UserLabels = new SmartLabel(_labels.ToArray()));
 
 			EnableBack = true;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 	{
 		public SmartLabel UserLabels { private get; set; }
 
-		public SmartLabel Labels => SmartLabel.Merge(UserLabels, SmartLabel.Merge(Coins.Select(x => x.HdPubKey.Cluster.Labels)));
+		public SmartLabel Labels => SmartLabel.Merge(UserLabels, SmartLabel.Merge(Coins?.Select(x => x.HdPubKey.Cluster.Labels)));
 
 		public BitcoinAddress Address { get; set; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -11,9 +12,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 	{
 		public SmartLabel SendLabels { private get; set; }
 
-		public SmartLabel? PocketLabels { private get; set; }
-
-		public SmartLabel Labels => SmartLabel.Merge(SendLabels, PocketLabels);
+		public SmartLabel Labels => SmartLabel.Merge(SendLabels, SmartLabel.Merge(Coins.Select(x => x.HdPubKey.Cluster.Labels)));
 
 		public BitcoinAddress Address { get; set; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
@@ -10,9 +10,9 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 {
 	public class TransactionInfo
 	{
-		public SmartLabel SendLabels { private get; set; }
+		public SmartLabel UserLabels { private get; set; }
 
-		public SmartLabel Labels => SmartLabel.Merge(SendLabels, SmartLabel.Merge(Coins.Select(x => x.HdPubKey.Cluster.Labels)));
+		public SmartLabel Labels => SmartLabel.Merge(UserLabels, SmartLabel.Merge(Coins.Select(x => x.HdPubKey.Cluster.Labels)));
 
 		public BitcoinAddress Address { get; set; }
 


### PR DESCRIPTION
Do not store the default `Unlabelled Funds` and `Private Funds` as if the user was typed them in when selecting a pocket.