### PR TITLE
[WabiSabi] Remove delegate from `CredentialIssuer`

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -136,7 +136,9 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
 			round.Alices.Add(alice);
 
-			return new(alice.Id, commitAmountCredentialResponse(), commitWeightCredentialResponse());
+			return new(alice.Id, 
+				commitAmountCredentialResponse.Commit(), 
+				commitWeightCredentialResponse.Commit());
 		}
 
 		private static void RemoveDuplicateAlices(IDictionary<Guid, Round> rounds, Alice alice)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -331,8 +331,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				{
 					alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
 					return new(
-						commitAmountZeroCredentialResponse(),
-						commitWeightZeroCredentialResponse());
+						commitAmountZeroCredentialResponse.Commit(),
+						commitWeightZeroCredentialResponse.Commit());
 				}
 				else if (round.Phase == Phase.ConnectionConfirmation)
 				{
@@ -341,10 +341,10 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					alice.ConfirmedConnetion = true;
 
 					return new(
-						commitAmountZeroCredentialResponse(),
-						commitWeightZeroCredentialResponse(),
-						commitAmountRealCredentialResponse(),
-						commitWeightRealCredentialResponse());
+						commitAmountZeroCredentialResponse.Commit(),
+						commitWeightZeroCredentialResponse.Commit(),
+						commitAmountRealCredentialResponse.Commit(),
+						commitWeightRealCredentialResponse.Commit());
 				}
 				else
 				{
@@ -403,8 +403,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				round.Bobs.Add(bob);
 
 				return new(
-					commitAmountCredentialResponse(),
-					commitWeightCredentialResponse());
+					commitAmountCredentialResponse.Commit(),
+					commitWeightCredentialResponse.Commit());
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
+++ b/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
@@ -237,6 +237,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 			private readonly CredentialsResponse _response;
 			private readonly long _delta;
 			private readonly IEnumerable<GroupElement> _serialNumbers;
+			private bool _committed;
 
 			public PreparedCredentialsResponse(CredentialIssuer issuer, CredentialsResponse response, long delta, IEnumerable<GroupElement> serialNumbers)
 			{
@@ -244,10 +245,16 @@ namespace WalletWasabi.WabiSabi.Crypto
 				_response = response;
 				_delta = delta;
 				_serialNumbers = serialNumbers;
+				_committed = false;
 			}
 
 			public CredentialsResponse Commit()
 			{
+				if (_committed)
+				{
+					throw new InvalidOperationException("The instance was already committed.");
+				}
+				_committed = true;
 				return _issuer.Commit(_response, _delta, _serialNumbers);
 			}
 		}

--- a/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
+++ b/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 	/// used as a key, in this way using a standard solution it is possible to respond with the exact
 	/// same valid credentials to the client without performance penalties.
 	/// </remarks>
-	public partial class CredentialIssuer
+	public class CredentialIssuer
 	{
 		/// <summary>
 		/// Initializes a new instance of the CredentialIssuer class.

--- a/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
+++ b/WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs
@@ -63,8 +63,6 @@ namespace WalletWasabi.WabiSabi.Crypto
 			RandomNumberGenerator = Guard.NotNull(nameof(randomNumberGenerator), randomNumberGenerator);
 		}
 
-		public delegate CredentialsResponse CommitResponse();
-
 		public ulong MaxAmount { get; }
 
 		public int RangeProofWidth { get; }
@@ -96,16 +94,16 @@ namespace WalletWasabi.WabiSabi.Crypto
 		/// <returns>The <see cref="CredentialsResponse">registration response</see> containing the issued credentials and the proofs.</returns>
 		/// <exception cref="WabiSabiCryptoException">Error code: <see cref="WabiSabiCryptoErrorCode">WabiSabiErrorCode</see></exception>
 		public CredentialsResponse HandleRequest(CredentialsRequest registrationRequest)
-			=> PrepareResponse(registrationRequest)();
+			=> PrepareResponse(registrationRequest).Commit();
 
 		/// <summary>
 		/// Validate the <see cref="CredentialsRequest">credentials registration requests</see> and
 		/// prepare to mark the serial numbers as used and issue the credentials.
 		/// </summary>
 		/// <param name="registrationRequest">The request containing the credentials presentations, credential requests and the proofs.</param>
-		/// <returns>The <see cref="CommitResponse">delegate</see> which returns the <see cref="CredentialsResponse">response</see> with the issued credentials and the proofs.</returns>
+		/// <returns>The <see cref="ICommitableCredentialsResponse">The response ready to be committed to</see> which returns the <see cref="ICommitableCredentialsResponse">response</see> with the issued credentials and the proofs.</returns>
 		/// <exception cref="WabiSabiCryptoException">Error code: <see cref="WabiSabiCryptoErrorCode">WabiSabiErrorCode</see></exception>
-		public CommitResponse PrepareResponse(CredentialsRequest registrationRequest)
+		public ICommitableCredentialsResponse PrepareResponse(CredentialsRequest registrationRequest)
 		{
 			Guard.NotNull(nameof(registrationRequest), registrationRequest);
 
@@ -212,17 +210,46 @@ namespace WalletWasabi.WabiSabi.Crypto
 			var macs = credentials.Select(x => x.Mac);
 			var response = new CredentialsResponse(macs, proofs);
 
-			return () =>
-			{
-				// Register the serial numbers to prevent credential reuse.
-				foreach (var presentation in presented)
-				{
-					SerialNumbers.Add(presentation.S);
-				}
-				Balance += registrationRequest.Delta;
+			var serialNumbers = presented.Select(x => x.S);
+			return new PreparedCredentialsResponse(this, response, registrationRequest.Delta, serialNumbers);
+		}
 
-				return response;
-			};
+		private CredentialsResponse Commit(CredentialsResponse response, long delta, IEnumerable<GroupElement> serialNumbers)
+		{
+			// Register the serial numbers to prevent credential reuse.
+			foreach (var serialNumber in serialNumbers)
+			{
+				SerialNumbers.Add(serialNumber);
+			}
+			Balance += delta;
+
+			return response;
+		}
+
+		public interface ICommitableCredentialsResponse
+		{
+			CredentialsResponse Commit();
+		}
+
+		private class PreparedCredentialsResponse : ICommitableCredentialsResponse 
+		{
+			private readonly CredentialIssuer _issuer;
+			private readonly CredentialsResponse _response;
+			private readonly long _delta;
+			private readonly IEnumerable<GroupElement> _serialNumbers;
+
+			public PreparedCredentialsResponse(CredentialIssuer issuer, CredentialsResponse response, long delta, IEnumerable<GroupElement> serialNumbers)
+			{
+				_issuer = issuer;
+				_response = response;
+				_delta = delta;
+				_serialNumbers = serialNumbers;
+			}
+
+			public CredentialsResponse Commit()
+			{
+				return _issuer.Commit(_response, _delta, _serialNumbers);
+			}
 		}
 
 		private (MAC Mac, Knowledge Knowledge) IssueCredential(GroupElement ma, Scalar t)

--- a/WalletWasabi/WabiSabi/Crypto/ICommitableCredentialsResponse.cs
+++ b/WalletWasabi/WabiSabi/Crypto/ICommitableCredentialsResponse.cs
@@ -1,0 +1,12 @@
+using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
+
+namespace WalletWasabi.WabiSabi.Crypto
+{
+	public partial class CredentialIssuer
+	{
+		public interface ICommitableCredentialsResponse
+		{
+			CredentialsResponse Commit();
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Crypto/ICommitableCredentialsResponse.cs
+++ b/WalletWasabi/WabiSabi/Crypto/ICommitableCredentialsResponse.cs
@@ -2,11 +2,8 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Crypto
 {
-	public partial class CredentialIssuer
+	public interface ICommitableCredentialsResponse
 	{
-		public interface ICommitableCredentialsResponse
-		{
-			CredentialsResponse Commit();
-		}
+		CredentialsResponse Commit();
 	}
 }


### PR DESCRIPTION
This is the first attempt to eliminate the use of a `delegate` in `CredentialIssuer` by a more OOP approach: https://github.com/zkSNACKs/WalletWasabi/pull/5504#issuecomment-811957428

