### PR TITLE
[Fluent] [Trivial] Fix naming rule violation in ResponsivePanel

### DIFF
--- a/WalletWasabi.Fluent/Controls/ResponsivePanel.cs
+++ b/WalletWasabi.Fluent/Controls/ResponsivePanel.cs
@@ -122,10 +122,10 @@ namespace WalletWasabi.Fluent.Controls
 
 		private struct Item
 		{
-			public int Column;
-			public int Row;
-			public int ColumnSpan;
-			public int RowSpan;
+			internal int Column;
+			internal int Row;
+			internal int ColumnSpan;
+			internal int RowSpan;
 		}
 
 		private Size MeasureArrange(Size panelSize, bool isMeasure)


### PR DESCRIPTION
Fixes IDE1006 (Naming rule violation) error/warning for Item struct used in ResponsivePanel