### PR TITLE
[WabiSabi] Inject CredentialPool into ArenaClient

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
@@ -48,11 +48,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			CredentialPool amountCredentialPool = new();
 			CredentialPool weightCredentialPool = new();
-			var apiClient = new ArenaClient(amountCredentialPool, weightCredentialPool, round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
+			var arenaClient = new ArenaClient(amountCredentialPool, weightCredentialPool, round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
 			Assert.Equal(Phase.InputRegistration, arena.Rounds.First().Value.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
-			var aliceClient = await AliceClient.CreateNewAsync(apiClient, new[] { coin1.Coin }, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
+			var aliceClient = await AliceClient.CreateNewAsync(arenaClient, new[] { coin1.Coin }, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
 
 			Task confirmationTask = aliceClient.ConfirmConnectionAsync(TimeSpan.FromSeconds(3), CancellationToken.None);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			CredentialPool amountCredentialPool = new();
 			CredentialPool weightCredentialPool = new();
-			var arenaClient = new ArenaClient(amountCredentialPool, weightCredentialPool, round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
+			var arenaClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, amountCredentialPool, weightCredentialPool, coordinator, new InsecureRandom());
 			Assert.Equal(Phase.InputRegistration, arena.Rounds.First().Value.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
@@ -15,6 +15,7 @@ using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Crypto;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
@@ -44,7 +45,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				});
 
 			await using var coordinator = new ArenaRequestHandler(config, new Prison(), arena, mockRpc.Object);
-			var apiClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
+
+			CredentialPool amountCredentialPool = new();
+			CredentialPool weightCredentialPool = new();
+			var apiClient = new ArenaClient(amountCredentialPool, weightCredentialPool, round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
 			Assert.Equal(Phase.InputRegistration, arena.Rounds.First().Value.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			CredentialPool amountCredentials = new();
 			CredentialPool weightCredentials = new();
-			var aliceArenaClient = new ArenaClient(amountCredentials, weightCredentials, round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
+			var aliceArenaClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, amountCredentials, weightCredentials, coordinator, new InsecureRandom());
 
 			var aliceId = await aliceArenaClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id, round.Hash);
 
@@ -89,7 +89,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(1));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
-			var bobArenaClient = new ArenaClient(amountCredentials, weightCredentials, round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, coordinator, new InsecureRandom());
+			var bobArenaClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, amountCredentials, weightCredentials, coordinator, new InsecureRandom());
 			// Phase: Output Registration
 			using var destinationKey1 = new Key();
 			using var destinationKey2 = new Key();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -90,6 +90,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
 			var bobArenaClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.WeightCredentialIssuerParameters, amountCredentials, weightCredentials, coordinator, new InsecureRandom());
+
 			// Phase: Output Registration
 			using var destinationKey1 = new Key();
 			using var destinationKey2 = new Key();

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -21,16 +21,15 @@ namespace WalletWasabi.WabiSabi.Client
 		public static readonly ulong ProtocolMaxWeightPerAlice = 1_000ul;
 
 		public ArenaClient(
+			CredentialPool amountCredentialPool,
+			CredentialPool weightCredentialPool,
 			CredentialIssuerParameters amountCredentialIssuerParameters,
 			CredentialIssuerParameters weightCredentialIssuerParameters,
 			IArenaRequestHandler requestHandler,
 			WasabiRandom random)
 		{
-			var amountCredentials = new CredentialPool();
-			var weightCredentials = new CredentialPool();
-
-			AmountCredentialClient = new WabiSabiClient(amountCredentialIssuerParameters, ProtocolCredentialNumber, random, ProtocolMaxAmountPerAlice, amountCredentials);
-			WeightCredentialClient = new WabiSabiClient(weightCredentialIssuerParameters, ProtocolCredentialNumber, random, ProtocolMaxWeightPerAlice, weightCredentials);
+			AmountCredentialClient = new WabiSabiClient(amountCredentialIssuerParameters, ProtocolCredentialNumber, random, ProtocolMaxAmountPerAlice, amountCredentialPool);
+			WeightCredentialClient = new WabiSabiClient(weightCredentialIssuerParameters, ProtocolCredentialNumber, random, ProtocolMaxWeightPerAlice, weightCredentialPool);
 			RequestHandler = requestHandler;
 		}
 

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -21,10 +21,10 @@ namespace WalletWasabi.WabiSabi.Client
 		public static readonly ulong ProtocolMaxWeightPerAlice = 1_000ul;
 
 		public ArenaClient(
-			CredentialPool amountCredentialPool,
-			CredentialPool weightCredentialPool,
 			CredentialIssuerParameters amountCredentialIssuerParameters,
 			CredentialIssuerParameters weightCredentialIssuerParameters,
+			CredentialPool amountCredentialPool,
+			CredentialPool weightCredentialPool,
 			IArenaRequestHandler requestHandler,
 			WasabiRandom random)
 		{


### PR DESCRIPTION
> `ArenaClient` has to be private as in `AliceClient`. Anyway, clients have to create their own `ArenaClient` instances because the `IRequestHandler` is different for Alice, Bod and Satoshi. What the all share is the `CredentialPool`.