### PR TITLE
[WabiSabi] Fix NRE in UTs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
@@ -132,6 +132,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			rpcMock.SetupGet(rpc => rpc.Network).Returns(Network.Main);
 			rpcMock.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { FeeRate = new FeeRate(10m) });
+			rpcMock.Setup(rpc => rpc.GetMempoolInfoAsync())
+				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 			return rpcMock.Object;
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -72,9 +72,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		private static IRPCClient NewMockRpcClient()
 		{
 			var mockRpcClient = new Mock<IRPCClient>();
-			mockRpcClient.Setup(c => c.Network).Returns(Network.Main);
-			mockRpcClient.Setup(c => c.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			mockRpcClient.Setup(rpc => rpc.Network).Returns(Network.Main);
+			mockRpcClient.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { Blocks = 5, FeeRate = new FeeRate(100m) });
+			mockRpcClient.Setup(rpc => rpc.GetMempoolInfoAsync())
+				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 			return mockRpcClient.Object;
 		}
 	}


### PR DESCRIPTION
There is a NRE when you run WabiSabi UTs. This is the third time I fix this exact same error in less than a month so, we should find a way to make the UT to fail when something bad happens inside a PeriodicRunner instead of continue silently (even when that's what we want in production). See also:

- https://github.com/zkSNACKs/WalletWasabi/pull/5519
- https://github.com/zkSNACKs/WalletWasabi/pull/5366

Any idea?