### PR TITLE
[WabiSabi] Simplify `RemoveDuplicatedAlices` method

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -151,7 +151,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			var aliceOutPoints = alice.Coins.Select(x => x.Outpoint).ToList();
 			var flattenTable = rounds.SelectMany(x => x.Alices.SelectMany(y => y.Coins.Select(z => (Round: x, Alice: y, Output: z.Outpoint))));
 
-			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => aliceOutPoints.Contains(x.Output))
+			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => aliceOutPoints.Contains(x.Output)))
 			{
 				if (round.Alices.Remove(aliceInRound))
 				{

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -148,7 +148,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyRegistered);
 			}
 			
-			var aliceOutPoints = alice.Coins.Select(x => x.Outpoint).ToList();
+			var aliceOutPoints = alice.Coins.Select(x => x.Outpoint).ToHashSet();
 			var flattenTable = rounds.SelectMany(x => x.Alices.SelectMany(y => y.Coins.Select(z => (Round: x, Alice: y, Output: z.Outpoint))));
 
 			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => aliceOutPoints.Contains(x.Output)))

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -151,7 +151,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			var aliceOutPoints = alice.Coins.Select(x => x.Outpoint).ToHashSet();
 			var flattenTable = rounds.SelectMany(x => x.Alices.SelectMany(y => y.Coins.Select(z => (Round: x, Alice: y, Output: z.Outpoint))));
 
-			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => aliceOutPoints.Contains(x.Output)))
+			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => aliceOutPoints.Contains(x.Output)).ToArray())
 			{
 				if (round.Alices.Remove(aliceInRound))
 				{


### PR DESCRIPTION
This method simplifies code that removes the duplicated alices by flattering the hierarchical structure as:

| Round | Alice | Outpoint |
|----------|--------|-------------|
| r1        | a1    | o1  |
| r1        | a1    | o2  |
| r1        | a2    | ox  |
| r1        | a2    | oy  |

After that it filters the table by outpoint that belong to the specified alice.