### PR TITLE
[Fluent] Add copy button to `PreviewItem`

### DIFF
--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -11,8 +11,19 @@
                               DockPanel.Dock="Left" />
                     <DockPanel DockPanel.Dock="Right" Margin="30 0 0 0">
                         <TextBlock Name="PART_Text" Text="{TemplateBinding Text}" DockPanel.Dock="Top" Margin="0 0 0 5" Opacity="0.6" />
-                        <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}" DockPanel.Dock="Bottom" />
+                        <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
+                            <c:AnimatedButton Margin="5 0 0 0"
+                                              Command="{TemplateBinding CopyCommand}"
+                                              CommandParameter="{TemplateBinding CopyParameter}"
+                                              ToolTip.Tip="Copy"
+                                              NormalIcon="{StaticResource copy_regular}"
+                                              ClickIcon="{StaticResource copy_confirmed}"
+                                              InitialOpacity="0.6"
+                                              DockPanel.Dock="Right"
+                                              IsVisible="{TemplateBinding CopyButtonVisibility}"/>
+                            <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}" />
+                        </DockPanel>
                     </DockPanel>
                 </DockPanel>
             </ControlTemplate>

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -5,7 +5,7 @@
     <Style Selector="c|PreviewItem">
         <Setter Property="Template">
             <ControlTemplate>
-                <DockPanel>
+                <DockPanel Background="Transparent">
                     <PathIcon Width="{TemplateBinding IconSize}" Height="{TemplateBinding IconSize}"
                               Data="{TemplateBinding Icon}" Opacity="0.6" Foreground="{DynamicResource SystemAccentColor}"
                               DockPanel.Dock="Left" />

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -1,7 +1,10 @@
+using System;
+using System.Reactive.Linq;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using ReactiveUI;
 
 namespace WalletWasabi.Fluent.Controls
 {
@@ -15,6 +18,30 @@ namespace WalletWasabi.Fluent.Controls
 
 		public static readonly StyledProperty<double> IconSizeProperty =
 			AvaloniaProperty.Register<PreviewItem, double>(nameof(IconSize), 24);
+
+		public static readonly StyledProperty<object?> CopyParameterProperty =
+			AvaloniaProperty.Register<PreviewItem, object?>(nameof(CopyParameter));
+
+		public static readonly StyledProperty<ICommand> CopyCommandProperty =
+			AvaloniaProperty.Register<PreviewItem, ICommand>(nameof(CopyCommand));
+
+		public static readonly StyledProperty<bool> CopyButtonVisibilityProperty =
+			AvaloniaProperty.Register<PreviewItem, bool>(nameof(CopyButtonVisibility));
+
+		public PreviewItem()
+		{
+			CopyCommand = ReactiveCommand.CreateFromTask<object>(async obj =>
+			{
+				if (obj.ToString() is { } text)
+				{
+					await Application.Current.Clipboard.SetTextAsync(text);
+				}
+			});
+
+			this.WhenAnyValue(x => x.CopyParameter)
+				.Select(x => !string.IsNullOrEmpty(x?.ToString()))
+				.Subscribe(x => CopyButtonVisibility = x);
+		}
 
 		public string Text
 		{
@@ -32,6 +59,24 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			get => GetValue(IconSizeProperty);
 			set => SetValue(IconSizeProperty, value);
+		}
+
+		public object? CopyParameter
+		{
+			get => GetValue(CopyParameterProperty);
+			set => SetValue(CopyParameterProperty, value);
+		}
+
+		public ICommand CopyCommand
+		{
+			get => GetValue(CopyCommandProperty);
+			set => SetValue(CopyCommandProperty, value);
+		}
+
+		public bool CopyButtonVisibility
+		{
+			get => GetValue(CopyButtonVisibilityProperty);
+			set => SetValue(CopyButtonVisibilityProperty, value);
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Fluent.Controls
 				}
 			});
 
-			this.WhenAnyValue(x => x.CopyParameter, x => x.IsPointerOver, (cp, apo) => !string.IsNullOrEmpty(cp?.ToString()) && apo)
+			this.WhenAnyValue(x => x.CopyParameter, x => x.IsPointerOver, (copyParameter, isPointerOver) => !string.IsNullOrEmpty(copyParameter?.ToString()) && isPointerOver)
 				.Subscribe(async value =>
 				{
 					if (_copyButtonPressedStopwatch is { } sw)

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.Fluent.Controls
 					{
 						var elapsedMilliseconds = sw.ElapsedMilliseconds;
 
-						var millisecondsToWait = 1400 - (int)elapsedMilliseconds;
+						var millisecondsToWait = 1050 - (int)elapsedMilliseconds;
 
 						if (millisecondsToWait > 0)
 						{

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reactive.Linq;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
@@ -38,9 +37,8 @@ namespace WalletWasabi.Fluent.Controls
 				}
 			});
 
-			this.WhenAnyValue(x => x.CopyParameter)
-				.Select(x => !string.IsNullOrEmpty(x?.ToString()))
-				.Subscribe(x => CopyButtonVisibility = x);
+			this.WhenAnyValue(x => x.CopyParameter, x => x.IsPointerOver, (cp, apo) => !string.IsNullOrEmpty(cp?.ToString()) && apo)
+				.Subscribe(value => CopyButtonVisibility = value);
 		}
 
 		public string Text

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -17,7 +17,7 @@
       <c:PreviewItem Icon="{StaticResource timer_regular}"
                      Text="Date / Time"
                      Content="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}'}"
-                     CopyParameter="{Binding Date}" />
+                     CopyParameter="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}'}" />
 
       <Separator />
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -16,7 +16,8 @@
       <!-- Date -->
       <c:PreviewItem Icon="{StaticResource timer_regular}"
                      Text="Date / Time"
-                     Content="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}'}" />
+                     Content="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}'}"
+                     CopyParameter="{Binding Date}" />
 
       <Separator />
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -22,18 +22,9 @@
 
       <!-- Transaction ID -->
       <c:PreviewItem Icon="{StaticResource transaction_id}"
-                     Text="Transaction ID">
-        <DockPanel HorizontalAlignment="Left">
-          <c:AnimatedButton Margin="5 0 0 0"
-                            Command="{Binding CopyTransactionIdCommand}"
-                            ToolTip.Tip="Copy"
-                            NormalIcon="{StaticResource copy_regular}"
-                            ClickIcon="{StaticResource copy_confirmed}"
-                            InitialOpacity="0.6"
-                            DockPanel.Dock="Right"/>
-          <TextBlock Text="{Binding TransactionId}"/>
-        </DockPanel>
-      </c:PreviewItem>
+                     Text="Transaction ID"
+                     Content="{Binding TransactionId}"
+                     CopyParameter="{Binding TransactionId}"/>
 
       <Separator />
 
@@ -51,26 +42,30 @@
       <!-- Incoming amount  -->
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Text="Amount"
-                     Content="{Binding Amount, StringFormat={}{0} BTC}"/>
+                     Content="{Binding Amount, StringFormat={}{0} BTC}"
+                     CopyParameter="{Binding Amount}" />
 
       <Separator />
 
       <!-- Block height -->
       <c:PreviewItem Icon="{StaticResource block_height}"
                      Text="Block height"
-                     Content="{Binding BlockHeight}" />
+                     Content="{Binding BlockHeight}"
+                     CopyParameter="{Binding BlockHeight}" />
       <Separator />
 
       <!-- Confirmations -->
       <c:PreviewItem Icon="{StaticResource copy_confirmed}"
                      Text="Confirmations"
-                     Content="{Binding Confirmations}" />
+                     Content="{Binding Confirmations}"
+                     CopyParameter="{Binding Confirmations}" />
 
       <Separator />
 
       <!-- Labels -->
       <c:PreviewItem Icon="{StaticResource entities_regular}"
-                     Text="Labels">
+                     Text="Labels"
+                     CopyParameter="{Binding Labels}">
         <c:TagsBox Padding="0" IsReadOnly="True" Items="{Binding Labels}" />
       </c:PreviewItem>
 


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/pull/5599#pullrequestreview-637698621

This PR adds a copy button to the `PreviewItem` control, thus if the control's `CopyParameter` is set to something, the user will be able to copy that.

https://user-images.githubusercontent.com/16364053/115374163-dc847280-a1cc-11eb-815a-251b8a542cd3.mp4