### PR TITLE
[draft] BlockstreamInfoClient with HttpClientFactory

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoTests.cs
@@ -1,0 +1,96 @@
+using NBitcoin;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.Tor;
+using WalletWasabi.WebClients.BlockstreamInfo;
+using WalletWasabi.WebClients.Wasabi;
+using Xunit;
+
+namespace WalletWasabi.Tests.IntegrationTests
+{
+	public class BlockstreamInfoTests : IAsyncLifetime
+	{
+		public BlockstreamInfoTests()
+		{			
+			ClearnetHttpClientFactory = new(torEndPoint: null, backendUriGetter: null);
+			TorHttpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: null);
+
+			TorManager = new(Common.TorSettings, Common.TorSocks5Endpoint);
+		}
+
+		private HttpClientFactory ClearnetHttpClientFactory { get; }
+		private HttpClientFactory TorHttpClientFactory { get; }
+		private TorProcessManager TorManager { get; }
+
+		public async Task InitializeAsync()
+		{
+			bool started = await TorManager.StartAsync(ensureRunning: true);
+			Assert.True(started, "Tor failed to start.");
+		}
+
+		public Task DisposeAsync()
+		{
+			return Task.CompletedTask;
+		}
+
+		[Fact]
+		public async Task GetFeeEstimatesClearnetMainnetAsync()
+		{
+			BlockstreamInfoClient client = new(Network.Main, ClearnetHttpClientFactory);
+			AllFeeEstimate estimates = await client.GetFeeEstimatesAsync(CancellationToken.None);
+			Assert.NotNull(estimates);
+			Assert.NotEmpty(estimates.Estimations);
+		}
+
+		[Fact]
+		public async Task GetFeeEstimatesTorMainnetAsync()
+		{
+			Common.GetWorkDir();
+			Logging.Logger.SetMinimumLevel(Logging.LogLevel.Trace);
+
+			BlockstreamInfoClient client = new(Network.Main, TorHttpClientFactory);
+			AllFeeEstimate estimates = await client.GetFeeEstimatesAsync(CancellationToken.None);
+			Assert.NotNull(estimates);
+			Assert.NotEmpty(estimates.Estimations);
+		}
+
+		[Fact]
+		public async Task GetFeeEstimatesClearnetTestnetAsync()
+		{
+			BlockstreamInfoClient client = new(Network.TestNet, ClearnetHttpClientFactory);
+			AllFeeEstimate estimates = await client.GetFeeEstimatesAsync(CancellationToken.None);
+			Assert.NotNull(estimates);
+			Assert.NotEmpty(estimates.Estimations);
+		}
+
+		[Fact]
+		public async Task GetFeeEstimatesTorTestnetAsync()
+		{
+			BlockstreamInfoClient client = new(Network.TestNet, TorHttpClientFactory);
+			AllFeeEstimate estimates = await client.GetFeeEstimatesAsync(CancellationToken.None);
+			Assert.NotNull(estimates);
+			Assert.NotEmpty(estimates.Estimations);
+		}
+
+		[Fact]
+		public async Task SimulatesFeeEstimatesClearnetRegtestAsync()
+		{
+			BlockstreamInfoClient client = new(Network.RegTest, ClearnetHttpClientFactory);
+			AllFeeEstimate estimates = await client.GetFeeEstimatesAsync(CancellationToken.None);
+			Assert.NotNull(estimates);
+			Assert.NotEmpty(estimates.Estimations);
+		}
+
+		[Fact]
+		public async Task SimulatesFeeEstimatesTorRegtestAsync()
+		{
+			BlockstreamInfoClient client = new(Network.RegTest, TorHttpClientFactory);
+			AllFeeEstimate estimates = await client.GetFeeEstimatesAsync(CancellationToken.None);
+			Assert.NotNull(estimates);
+			Assert.NotEmpty(estimates.Estimations);
+		}
+	}
+}

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
@@ -1,0 +1,60 @@
+using NBitcoin;
+using NBitcoin.RPC;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Tor.Http;
+using WalletWasabi.Tor.Http.Extensions;
+using WalletWasabi.WebClients.Wasabi;
+
+namespace WalletWasabi.WebClients.BlockstreamInfo
+{
+	public class BlockstreamInfoClient
+	{
+		public BlockstreamInfoClient(Network network, HttpClientFactory httpClientFactory)
+		{
+			string uriString;
+
+			if (httpClientFactory.IsTorEnabled)
+			{
+				uriString = network == Network.TestNet
+					? "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion/testnet"
+					: "http://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion";				
+			}
+			else
+			{
+				uriString = network == Network.TestNet
+					? "https://blockstream.info/testnet"
+					: "https://blockstream.info";
+			}
+
+			HttpClient = httpClientFactory.NewHttpClient(() => new Uri(uriString), isolateStream: false);
+		}
+
+		private IHttpClient HttpClient { get; }
+
+		public async Task<AllFeeEstimate> GetFeeEstimatesAsync(CancellationToken cancel)
+		{
+			using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, "api/fee-estimates", null, cancel).ConfigureAwait(false);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+			}
+
+			var responseString = await response.Content.ReadAsStringAsync(cancel).ConfigureAwait(false);
+			var parsed = JsonDocument.Parse(responseString).RootElement;
+			var myDic = new Dictionary<int, int>();
+			foreach (var elem in parsed.EnumerateObject())
+			{
+				myDic.Add(int.Parse(elem.Name), (int)Math.Ceiling(elem.Value.GetDouble()));
+			}
+
+			return new AllFeeEstimate(EstimateSmartFeeMode.Conservative, myDic, isAccurate: true);
+		}
+	}
+}


### PR DESCRIPTION
@nopara73 Is this what you wanted to achieve?

PS: An alternative and nicer (imo) way would be to pass `IHttpClient` to `BlockstreamInfoClient` but then 

```csharp
using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, "api/fee-estimates", null, cancel).ConfigureAwait(false);
```

would be something like:

```csharp
using HttpRequestMessage request = new(HttpMethod.Get, new Uri(baseUri, "api/fee-estimates"));
using HttpResponseMessage response = await HttpClient.SendAsync(request, cancel).ConfigureAwait(false);
```

I'm not sure if you would like to use absolute URIs.

Related to #5591
