### PR TITLE
[WabiSabi] Fix range proof tests in Release builds

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfRepTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfRepTests.cs
@@ -62,12 +62,12 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 			var three = new Scalar(3);
 
 			// Public point must be sum(generator * secret).
-			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G, Generators.G, Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.Ga, Generators.G), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.G, Generators.Gg), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(Generators.G + three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
-			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)));
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)).AssertSoundness());
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G, Generators.G, Generators.Ga), new ScalarVector(two, three)).AssertSoundness());
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.Ga, Generators.G), new ScalarVector(two, three)).AssertSoundness());
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.G, Generators.Gg), new ScalarVector(two, three)).AssertSoundness());
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(Generators.G + three * Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)).AssertSoundness());
+			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + Generators.Ga, Generators.G, Generators.Ga), new ScalarVector(two, three)).AssertSoundness());
 
 			// Generators and secrets must be equal.
 			Assert.ThrowsAny<ArgumentException>(() => new Knowledge(new Statement(two * Generators.G + three * Generators.Ga, Generators.Gg, Generators.Ga), new ScalarVector(two)));

--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/LinearRelationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/LinearRelationTests.cs
@@ -170,7 +170,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 			Assert.Contains("size does not match", ex.Message);
 
 			// Incorrect witness (multiplying by generators does not produce the public point)
-			ex = Assert.ThrowsAny<ArgumentException>(() => new Knowledge(statement, new ScalarVector(Scalar.One)));
+			ex = Assert.ThrowsAny<ArgumentException>(() => new Knowledge(statement, new ScalarVector(Scalar.One)).AssertSoundness());
 			Assert.Contains("witness is not solution of the equation", ex.Message);
 
 			// Incorrect statement generators (effectively incorrect witness)
@@ -179,7 +179,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto.ZeroKnowledge
 				{ a, Generators.Gh },
 				{ b, Generators.Gg },
 			});
-			ex = Assert.ThrowsAny<ArgumentException>(() => new Knowledge(badStatement, new ScalarVector(Scalar.One)));
+			ex = Assert.ThrowsAny<ArgumentException>(() => new Knowledge(badStatement, new ScalarVector(Scalar.One)).AssertSoundness());
 			Assert.Contains("witness is not solution of the equation", ex.Message);
 		}
 	}

--- a/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Equation.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Equation.cs
@@ -72,7 +72,6 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 			return secretNonces + challenge * witness;
 		}
 
-		[Conditional("DEBUG")]
 		internal void CheckSolution(ScalarVector witness)
 		{
 			if (PublicPoint != witness * Generators)

--- a/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Knowledge.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Knowledge.cs
@@ -20,6 +20,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 		internal ScalarVector RespondToChallenge(Scalar challenge, ScalarVector secretNonces) =>
 			Equation.Respond(Witness, secretNonces, challenge);
 
+		/// <summary>For testing purposes.</summary>
 		internal void AssertSoundness()
 		{
 			foreach (var equation in Statement.Equations)

--- a/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Knowledge.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/LinearRelation/Knowledge.cs
@@ -10,12 +10,6 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 		{
 			Guard.True(nameof(witness), witness.Count == statement.Equations.First().Generators.Count, $"{nameof(witness)} size does not match {nameof(statement)}.{nameof(statement.Equations)}");
 
-			// don't try to prove something which isn't true
-			foreach (var equation in statement.Equations)
-			{
-				equation.CheckSolution(witness);
-			}
-
 			Statement = statement;
 			Witness = witness;
 		}
@@ -25,5 +19,13 @@ namespace WalletWasabi.Crypto.ZeroKnowledge.LinearRelation
 
 		internal ScalarVector RespondToChallenge(Scalar challenge, ScalarVector secretNonces) =>
 			Equation.Respond(Witness, secretNonces, challenge);
+
+		internal void AssertSoundness()
+		{
+			foreach (var equation in Statement.Equations)
+			{
+				equation.CheckSolution(Witness);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Commit 5ba9b54c0971c264aa0160c8401c15db5fab417c changed the prover side
to only verify its own proofs in debug builds, since these checks are
very expensive for range proofs.

This means that the tests fail in release builds, since an exception is
not thrown (reported by @kiminuo).

This change removes the automatic self checking altogether and makes the
check method unconditional so that it can be called explicitly in tests
or in code that uses the prover.

Allowing the prover to create invalid proofs is perhaps not as misuse
resistant as it could be, but this makes it possible for the tests to
confirm that the verifier rejects such invalid proofs without
duplicating the prover code or manually constructing invalid range
proofs in the tests, and it is more important for the security of the
protocol that the verifier rejects invalid proofs than that the prover
refuses to create them.