### PR TITLE
[WabiSabi] Allow only one input per alice for now

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -1,8 +1,5 @@
 using NBitcoin;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
@@ -34,7 +31,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 				TxOut = new TxOut(Money.Coins(1), key.PubKey.GetSegwitAddress(Network.Main))
 			};
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, rpc);
 			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 			await handler.RegisterInputAsync(req);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -1,14 +1,8 @@
-using NBitcoin;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
-using WalletWasabi.WabiSabi.Backend.Banning;
-using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using Xunit;
 
@@ -68,24 +62,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			blameRound.Alices.Add(alice3);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.ConnectionConfirmation, blameRound.Phase);
-
-			await arena.StopAsync(CancellationToken.None);
-		}
-
-		[Fact]
-		public async Task RoundFullAliceMultiInputAsync()
-		{
-			WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
-			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-
-			round.Alices.Add(WabiSabiFactory.CreateAlice(WabiSabiFactory.CreateInputRoundSignaturePairs(2)));
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
-			Assert.Equal(Phase.InputRegistration, round.Phase);
-
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
-			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 			await arena.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -33,17 +33,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Register Alices.
 			using Key key1 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
 			using Key key2 = new();
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -98,17 +100,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Register Alices.
 			using Key key1 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
 			using Key key2 = new();
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+				irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -159,19 +163,22 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			var round = Assert.Single(arena.Rounds).Value;
 
+			// TODO maybe refactor to use arena client?
 			// Register Alices.
 			using Key key1 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+				irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
 			using Key key2 = new();
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+				irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -205,9 +212,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// the remaining amount after deducting the fees needs to be less
 			// than the minimum.
 			var txParams = round.CoinjoinState.AssertConstruction().Parameters;
-			var extraAlice = WabiSabiFactory.CreateAlice(value: txParams.FeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParams.AllowedOutputAmounts.Min - new Money(1));
+			var extraAlice = WabiSabiFactory.CreateAlice(value: txParams.FeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParams.AllowedOutputAmounts.Min - new Money(1L));
 			round.Alices.Add(extraAlice);
-			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(extraAlice.Coins.First());
+			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(extraAlice.Coin);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -235,17 +242,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 
 			// Register Alices.
 			using Key key1 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+				irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
 			using Key key2 = new();
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+				irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -34,16 +34,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// Register Alices.
 			using Key key1 = new();
 			using Key key2 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -76,8 +78,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 			var signedCoinJoin = round.CoinjoinState.AssertSigning().CreateTransaction();
-			var coin1 = alice1.Coins.First();
-			var coin2 = alice2.Coins.First();
+			var coin1 = alice1.Coin;
+			var coin2 = alice2.Coin;
 			var idx1 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin1.Outpoint));
 			var idx2 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin2.Outpoint));
 			signedCoinJoin.Sign(key1.GetBitcoinSecret(Network.Main), coin1);
@@ -114,16 +116,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// Register Alices.
 			using Key key1 = new();
 			using Key key2 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -156,8 +160,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 			var signedCoinJoin = round.CoinjoinState.AssertSigning().CreateTransaction();
-			var coin1 = alice1.Coins.First();
-			var coin2 = alice2.Coins.First();
+			var coin1 = alice1.Coin;
+			var coin2 = alice2.Coin;
 			var idx1 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin1.Outpoint));
 			var idx2 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin2.Outpoint));
 			signedCoinJoin.Sign(key1.GetBitcoinSecret(Network.Main), coin1);
@@ -196,16 +200,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// Register Alices.
 			using Key key1 = new();
 			using Key key2 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+				irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -238,8 +244,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 			var signedCoinJoin = round.CoinjoinState.AssertSigning().CreateTransaction();
-			var coin1 = alice1.Coins.First();
-			var coin2 = alice2.Coins.First();
+			var coin1 = alice1.Coin;
+			var coin2 = alice2.Coin;
 			var idx1 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin1.Outpoint));
 			var idx2 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin2.Outpoint));
 			signedCoinJoin.Sign(key1.GetBitcoinSecret(Network.Main), coin1);
@@ -282,16 +288,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// Register Alices.
 			using Key key1 = new();
 			using Key key2 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+				irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+				irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -324,7 +332,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 			var signedCoinJoin = round.CoinjoinState.AssertSigning().CreateTransaction();
-			var coin1 = alice1.Coins.First();
+			var coin1 = alice1.Coin;
 			var idx1 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin1.Outpoint));
 			signedCoinJoin.Sign(key1.GetBitcoinSecret(Network.Main), coin1);
 			var txsigreq1 = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair((uint)idx1, signedCoinJoin.Inputs[idx1].WitScript) });
@@ -333,7 +341,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.DoesNotContain(round.Id, arena.Rounds.Keys);
 			Assert.Empty(arena.Rounds.Where(x => x.Value.IsBlameRound));
-			Assert.Contains(alice2.Coins.Select(x => x.Outpoint).First(), arena.Prison.GetInmates().Select(x => x.Utxo));
+			Assert.Contains(alice2.Coin.Outpoint, arena.Prison.GetInmates().Select(x => x.Utxo));
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -360,16 +368,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// Register Alices.
 			using Key key1 = new();
 			using Key key2 = new();
-			var irreq1 = WabiSabiFactory.CreateInputsRegistrationRequest(key1, round);
+			var irreq1 = WabiSabiFactory.CreateInputRegistrationRequest(key1, round);
 			var irres1 = await arena.RegisterInputAsync(
 				irreq1.RoundId,
-				irreq1.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq1.Input, new TxOut(Money.Coins(1), key1.PubKey.GetSegwitAddress(Network.Main))),
+				irreq1.RoundSignature,
 				irreq1.ZeroAmountCredentialRequests,
 				irreq1.ZeroVsizeCredentialRequests);
-			var irreq2 = WabiSabiFactory.CreateInputsRegistrationRequest(key2, round);
+			var irreq2 = WabiSabiFactory.CreateInputRegistrationRequest(key2, round);
 			var irres2 = await arena.RegisterInputAsync(
 				irreq2.RoundId,
-				irreq2.InputRoundSignaturePairs.ToDictionary(x => new Coin(x.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))), x => x.RoundSignature),
+				new Coin(irreq2.Input, new TxOut(Money.Coins(1), key2.PubKey.GetSegwitAddress(Network.Main))),
+				irreq2.RoundSignature,
 				irreq2.ZeroAmountCredentialRequests,
 				irreq2.ZeroVsizeCredentialRequests);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -403,13 +413,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var alice3 = WabiSabiFactory.CreateAlice();
 			alice3.ConfirmedConnection = true;
 			round.Alices.Add(alice3);
-			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(alice3.Coins.First());
+			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(alice3.Coin);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 			var signedCoinJoin = round.CoinjoinState.AssertSigning().CreateTransaction();
-			var coin1 = alice1.Coins.First();
-			var coin2 = alice2.Coins.First();
+			var coin1 = alice1.Coin;
+			var coin2 = alice2.Coin;
 			var idx1 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin1.Outpoint));
 			var idx2 = signedCoinJoin.Inputs.IndexOf(signedCoinJoin.Inputs.Single(x => x.PrevOut == coin2.Outpoint));
 			signedCoinJoin.Sign(key1.GetBitcoinSecret(Network.Main), coin1);
@@ -423,7 +433,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.DoesNotContain(round.Id, arena.Rounds.Keys);
 			Assert.Single(arena.Rounds.Where(x => x.Value.IsBlameRound));
-			var badOutpoint = alice3.Coins.Select(x => x.Outpoint).First();
+			var badOutpoint = alice3.Coin.Outpoint;
 			Assert.Contains(badOutpoint, arena.Prison.GetInmates().Select(x => x.Utxo));
 
 			var blameRound = arena.Rounds.Single(x => x.Value.IsBlameRound).Value;
@@ -432,8 +442,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(round.Id, blameRound.BlameOf?.Id);
 
 			var whitelist = blameRound.BlameWhitelist;
-			Assert.Contains(alice1.Coins.Select(x => x.Outpoint).First(), whitelist);
-			Assert.Contains(alice2.Coins.Select(x => x.Outpoint).First(), whitelist);
+			Assert.Contains(alice1.Coin.Outpoint, whitelist);
+			Assert.Contains(alice2.Coin.Outpoint, whitelist);
 			Assert.DoesNotContain(badOutpoint, whitelist);
 
 			await arena.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -1,9 +1,6 @@
 using NBitcoin;
-using NBitcoin.RPC;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
@@ -19,7 +16,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 {
 	public class RegisterInputFailureTests
 	{
-		private static async Task RegisterAndAssertWrongPhaseAsync(InputsRegistrationRequest req, ArenaRequestHandler handler)
+		private static async Task RegisterAndAssertWrongPhaseAsync(InputRegistrationRequest req, ArenaRequestHandler handler)
 		{
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
@@ -32,7 +29,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(new(), new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest();
+			var req = WabiSabiFactory.CreateInputRegistrationRequest();
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
@@ -47,7 +44,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21)).ConfigureAwait(false);
 			var round = arena.Rounds.First().Value;
 			using Key key = new();
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
@@ -70,12 +67,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			round.Alices.Add(WabiSabiFactory.CreateAlice(WabiSabiFactory.CreateInputRoundSignaturePairs(2)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice());
 			await RegisterAndAssertWrongPhaseAsync(req, handler);
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
@@ -102,7 +100,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Assert.Equal(0, round.RemainingInputVsizeAllocation);
 
 			// try to add an additional input
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.VsizeQuotaExceeded, ex.ErrorCode);
 
@@ -117,7 +115,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
 			using Key key = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
@@ -139,43 +137,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			var round = arena.Rounds.First().Value;
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			cfg.StandardInputRegistrationTimeout = TimeSpan.Zero;
 			await RegisterAndAssertWrongPhaseAsync(req, handler);
 			Assert.Equal(Phase.InputRegistration, round.Phase);
-
-			await arena.StopAsync(CancellationToken.None);
-		}
-
-		[Fact]
-		public async Task NonUniqueInputsAsync()
-		{
-			WabiSabiConfig cfg = new();
-			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			var inputSigPair = WabiSabiFactory.CreateInputRoundSignaturePair();
-
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(new[] { inputSigPair, inputSigPair }, round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
-			Assert.Equal(WabiSabiProtocolErrorCode.NonUniqueInputs, ex.ErrorCode);
-
-			await arena.StopAsync(CancellationToken.None);
-		}
-
-		[Fact]
-		public async Task TooManyInputsAsync()
-		{
-			WabiSabiConfig cfg = new() { MaxInputCountByAlice = 3 };
-			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			using Key key = new();
-
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(WabiSabiFactory.CreateInputRoundSignaturePairs(4), round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
-			Assert.Equal(WabiSabiProtocolErrorCode.TooManyInputs, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -190,7 +156,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(pair, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 
@@ -208,7 +174,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(pair, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, round);
 			var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await handler.RegisterInputAsync(req));
 			if (ex is WabiSabiProtocolException wspex)
 			{
@@ -229,7 +195,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(pair, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 
@@ -246,7 +212,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			rpc.OnGetTxOutAsync = (_, _, _) => null;
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputSpent, ex.ErrorCode);
 
@@ -263,7 +229,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			rpc.OnGetTxOutAsync = (_, _, _) => new() { Confirmations = 0 };
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputUnconfirmed, ex.ErrorCode);
 
@@ -278,7 +244,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			MockRpcClient rpc = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round);
 			for (int i = 1; i <= 100; i++)
 			{
 				rpc.OnGetTxOutAsync = (_, _, _) => new() { Confirmations = i, IsCoinBase = true };
@@ -307,7 +273,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			};
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, ex.ErrorCode);
 
@@ -323,7 +289,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.WrongRoundSignature, ex.ErrorCode);
 
@@ -339,7 +305,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.NotEnoughFunds, ex.ErrorCode);
 
@@ -355,7 +321,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchFunds, ex.ErrorCode);
 
@@ -371,7 +337,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchVsize, ex.ErrorCode);
 
@@ -386,10 +352,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var anotherAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			var anotherAlice = WabiSabiFactory.CreateAlice(new InputRoundSignaturePair(req.Input, req.RoundSignature)); // FIXME fugly
 			round.Alices.Add(anotherAlice);
 			round.SetPhase(Phase.ConnectionConfirmation);
 
@@ -408,10 +374,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, anotherRound);
 			using Key key = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			var preAlice = WabiSabiFactory.CreateAlice(new (req.Input, req.RoundSignature)); // FIXME fugly
 			anotherRound.Alices.Add(preAlice);
 			anotherRound.SetPhase(Phase.ConnectionConfirmation);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(new (req.Input, req.RoundSignature)); // FIXME fugly
+			var preAlice = WabiSabiFactory.CreateAlice(prevout: req.Input, roundSignature: req.RoundSignature);
 			round.Alices.Add(preAlice);
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(new InputRoundSignaturePair(req.Input, req.RoundSignature)); // FIXME fugly
+			var preAlice = WabiSabiFactory.CreateAlice(prevout: req.Input, roundSignature: req.RoundSignature);
 
 			var initialRemaining = anotherRound.RemainingInputVsizeAllocation;
 			anotherRound.Alices.Add(preAlice);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -1,15 +1,9 @@
 using NBitcoin;
-using NBitcoin.RPC;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
-using WalletWasabi.WabiSabi.Backend.Banning;
-using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Models;
@@ -19,7 +13,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 {
 	public class RegisterInputSuccessTests
 	{
-		private static void AssertSingleAliceSuccessfullyRegistered(Round round, DateTimeOffset minAliceDeadline, InputsRegistrationResponse resp)
+		private static void AssertSingleAliceSuccessfullyRegistered(Round round, DateTimeOffset minAliceDeadline, InputRegistrationResponse resp)
 		{
 			var alice = Assert.Single(round.Alices);
 			Assert.NotNull(resp);
@@ -38,7 +32,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 			var resp = await handler.RegisterInputAsync(req);
 			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
@@ -54,10 +48,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			var preAlice = WabiSabiFactory.CreateAlice(new (req.Input, req.RoundSignature)); // FIXME fugly
 			round.Alices.Add(preAlice);
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
@@ -77,10 +71,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, anotherRound);
 			using Key key = new();
 
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(key, round);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(req.InputRoundSignaturePairs);
+			var preAlice = WabiSabiFactory.CreateAlice(new InputRoundSignaturePair(req.Input, req.RoundSignature)); // FIXME fugly
 
 			var initialRemaining = anotherRound.RemainingInputVsizeAllocation;
 			anotherRound.Alices.Add(preAlice);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -25,7 +25,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(blameRound);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: blameRound);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputNotWhitelisted, ex.ErrorCode);
 
@@ -35,15 +35,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputWhitelistedAsync()
 		{
-			var pair = WabiSabiFactory.CreateInputRoundSignaturePair();
+			var outpoint = BitcoinFactory.CreateOutPoint();
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(pair));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(prevout: outpoint));
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, blameRound);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: outpoint, round: blameRound);
 
 			var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await handler.RegisterInputAsync(req));
 			if (ex is WabiSabiProtocolException wspex)
@@ -58,16 +58,16 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		public async Task InputWhitelistedButBannedAsync()
 		{
 			Prison prison = new();
-			var pair = WabiSabiFactory.CreateInputRoundSignaturePair();
-			prison.Punish(pair.Input, Punishment.Banned, Guid.NewGuid());
+			var outpoint = BitcoinFactory.CreateOutPoint();
+			prison.Punish(outpoint, Punishment.Banned, Guid.NewGuid());
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(pair));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(prevout: outpoint));
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 
 			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, blameRound);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: blameRound, prevout: outpoint);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -1,9 +1,5 @@
 using NBitcoin;
-using NBitcoin.RPC;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
@@ -12,7 +8,6 @@ using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
-using WalletWasabi.WabiSabi.Models;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
@@ -30,7 +25,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(blameRound);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(blameRound);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputNotWhitelisted, ex.ErrorCode);
 
@@ -48,7 +43,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 
 			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(pair, blameRound);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, blameRound);
 
 			var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await handler.RegisterInputAsync(req));
 			if (ex is WabiSabiProtocolException wspex)
@@ -72,7 +67,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 
 			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputsRegistrationRequest(pair, blameRound);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(pair, blameRound);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -108,7 +108,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task TooMuchFundsAsync()
 		{
-			WabiSabiConfig cfg = new() { MaxRegistrableAmount = Money.Coins(1.999m) };
+			WabiSabiConfig cfg = new() { MaxRegistrableAmount = Money.Coins(1.999m) }; // TODO migrate to MultipartyTransactionParameters
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
 			round.Alices.Add(WabiSabiFactory.CreateAlice(value: Money.Coins(2)));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -25,12 +25,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 			Alice alice = WabiSabiFactory.CreateAlice(key: key);
 			round.Alices.Add(alice);
-			round.CoinjoinState = round.AddInput(alice.Coins.First()).Finalize();
+			round.CoinjoinState = round.AddInput(alice.Coin).Finalize();
 			round.SetPhase(Phase.TransactionSigning);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			var aliceSignedCoinJoin = round.CoinjoinState.AssertSigning().CreateUnsignedTransaction();
-			aliceSignedCoinJoin.Sign(key.GetBitcoinSecret(Network.Main), alice.Coins.First());
+			aliceSignedCoinJoin.Sign(key.GetBitcoinSecret(Network.Main), alice.Coin);
 
 			var req = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair(0, aliceSignedCoinJoin.Inputs[0].WitScript) });
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
@@ -83,13 +83,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Alice alice2 = WabiSabiFactory.CreateAlice(key: key2);
 			round.Alices.Add(alice1);
 			round.Alices.Add(alice2);
-			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(alice1.Coins.First()).AddInput(alice2.Coins.First()).Finalize();
+			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(alice1.Coin).AddInput(alice2.Coin).Finalize();
 			round.SetPhase(Phase.TransactionSigning);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			// Submit the signature for the second alice to the first alice's input.
 			var alice2signedCoinJoin = round.CoinjoinState.AssertSigning().CreateUnsignedTransaction();
-			alice2signedCoinJoin.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coins.First());
+			alice2signedCoinJoin.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coin);
 
 			var req = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair(0, alice2signedCoinJoin.Inputs[0].WitScript) });
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
@@ -1,9 +1,7 @@
 using Moq;
 using NBitcoin;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
@@ -52,7 +50,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			Assert.Equal(Phase.InputRegistration, arena.Rounds.First().Value.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
-			var aliceClient = await AliceClient.CreateNewAsync(arenaClient, new[] { coin1.Coin }, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
+			var aliceClient = await AliceClient.CreateNewAsync(arenaClient, coin1.Coin, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
 
 			Task confirmationTask = aliceClient.ConfirmConnectionAsync(TimeSpan.FromSeconds(3), CancellationToken.None);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -1,9 +1,7 @@
 using Moq;
 using NBitcoin;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
@@ -53,7 +51,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
-			var aliceClient = await AliceClient.CreateNewAsync(aliceArenaClient, new[] { coin1.Coin }, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
+			var aliceClient = await AliceClient.CreateNewAsync(aliceArenaClient, coin1.Coin, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
 
 			Task confirmationTask = aliceClient.ConfirmConnectionAsync(TimeSpan.FromSeconds(3), CancellationToken.None);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -2,7 +2,6 @@ using NBitcoin;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
@@ -28,8 +27,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			var alice1 = WabiSabiFactory.CreateAlice(key: key1);
 			var alice2 = WabiSabiFactory.CreateAlice(key: key2);
 
-			var alice1Coin = alice1.Coins.First();
-			var alice2Coin = alice2.Coins.First();
+			var alice1Coin = alice1.Coin;
+			var alice2Coin = alice2.Coin;
 
 			var state = new ConstructionState(DefaultParameters);
 
@@ -104,17 +103,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		{
 			var alice = WabiSabiFactory.CreateAlice();
 
-			var state = new ConstructionState(DefaultParameters).AddInput(alice.Coins.First());
+			var state = new ConstructionState(DefaultParameters).AddInput(alice.Coin);
 
 			var script = BitcoinFactory.CreateScript();
-			var bob = new TxOut(alice.Coins.First().Amount/2, script);
+			var bob = new TxOut(alice.Coin.Amount/2, script);
 			var withOutput = state.AddOutput(bob);
 			var duplicateOutputNoFee = withOutput.AddOutput(bob).Finalize();
 
 			var tx2 = duplicateOutputNoFee.CreateUnsignedTransaction();
 			var output = Assert.Single(tx2.Outputs);
 			Assert.Equal(script, output.ScriptPubKey);
-			Assert.Equal(alice.Coins.First().Amount, output.Value);
+			Assert.Equal(alice.Coin.Amount, output.Value);
 		}
 
 		[Fact]
@@ -126,8 +125,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			var alice1 = WabiSabiFactory.CreateAlice(key: key1);
 			var alice2 = WabiSabiFactory.CreateAlice(key: key2);
 
-			var alice1Coin = alice1.Coins.First();
-			var alice2Coin = alice2.Coins.First();
+			var alice1Coin = alice1.Coin;
+			var alice2Coin = alice2.Coin;
 
 			var state = new ConstructionState(DefaultParameters).AddInput(alice1Coin).AddInput(alice2Coin);
 
@@ -172,8 +171,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			var alice1 = WabiSabiFactory.CreateAlice(key: key1);
 			var alice2 = WabiSabiFactory.CreateAlice(key: key2);
 
-			var alice1Coin = alice1.Coins.First();
-			var alice2Coin = alice2.Coins.First();
+			var alice1Coin = alice1.Coin;
+			var alice2Coin = alice2.Coin;
 
 			var state = new ConstructionState(DefaultParameters with { FeeRate = feeRate })
 				.AddInput(alice1Coin)
@@ -231,8 +230,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void NoDuplicateInputs()
 		{
 			var alice = WabiSabiFactory.CreateAlice();
-			var state = new ConstructionState(DefaultParameters).AddInput(alice.Coins.First());
-			ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(alice.Coins.First()));
+			var state = new ConstructionState(DefaultParameters).AddInput(alice.Coin);
+			ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(alice.Coin));
 			Assert.Single(state.Inputs);
 		}
 
@@ -243,14 +242,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		{
 			var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
 			var alice = WabiSabiFactory.CreateAlice();
-			ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(alice.Coins.First()));
+			ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(alice.Coin));
 		}
 
 		[Fact]
 		public void InputAmountRanges()
 		{
 			var alice = WabiSabiFactory.CreateAlice();
-			var coin = alice.Coins.First();
+			var coin = alice.Coin;
 
 			var exact = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(coin.Amount, coin.Amount) });
 			var above = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(2 * coin.Amount, 3 * coin.Amount) });
@@ -267,10 +266,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void UneconomicalInputs()
 		{
 			var alice1 = WabiSabiFactory.CreateAlice(value: new Money(1000L));
-			var alice1Coin = alice1.Coins.First();
+			var alice1Coin = alice1.Coin;
 
 			var alice2 = WabiSabiFactory.CreateAlice(value: new Money(1001L));
-			var alice2Coin = alice2.Coins.First();
+			var alice2Coin = alice2.Coin;
 
 			// requires 1k sats per input in sat/vKB
 			var inputVsize = alice1Coin.ScriptPubKey.EstimateInputVsize();

--- a/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
@@ -39,10 +39,7 @@ namespace WalletWasabi.WabiSabi.Backend.Banning
 
 		public void Note(Alice alice, Guid lastDisruptedRoundId)
 		{
-			foreach (var input in alice.Coins.Select(x => x.Outpoint))
-			{
-				Punish(input, Punishment.Noted, lastDisruptedRoundId);
-			}
+			Punish(alice.Coin.Outpoint, Punishment.Noted, lastDisruptedRoundId);
 		}
 
 		public void Punish(OutPoint utxo, Punishment punishment, Guid lastDisruptedRoundId)

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -1,27 +1,23 @@
 using NBitcoin;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.WabiSabi.Backend.Models
 {
 	public class Alice
 	{
-		public Alice(IDictionary<Coin, byte[]> coinRoundSignaturePairs)
+		public Alice(Coin coin, byte[] signature)
 		{
-			Coins = coinRoundSignaturePairs.Keys;
-			CoinRoundSignaturePairs = coinRoundSignaturePairs;
+			// TODO init syntax?
+			Coin = coin;
+			Signature = signature;
 		}
 
 		public Guid Id { get; } = Guid.NewGuid();
 		public DateTimeOffset Deadline { get; set; } = DateTimeOffset.UtcNow;
-		public IEnumerable<Coin> Coins { get; }
-		public IDictionary<Coin, byte[]> CoinRoundSignaturePairs { get; }
-		public Money TotalInputAmount => Coins.Sum(x => x.Amount);
-		public int TotalInputVsize => Coins.Sum(x => x.ScriptPubKey.EstimateInputVsize());
+		public Coin Coin { get; }
+		public byte[] Signature { get; }
+		public Money TotalInputAmount => Coin.Amount;
+		public int TotalInputVsize => Coin.ScriptPubKey.EstimateInputVsize();
 
 		public bool ConfirmedConnection { get; set; } = false;
 

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
@@ -1,14 +1,9 @@
 using NBitcoin;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
-using WalletWasabi.Helpers;
 using WalletWasabi.Nito.AsyncEx;
 using WalletWasabi.WabiSabi.Backend.Banning;
-using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Models;
 
@@ -34,16 +29,17 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 		public IRPCClient Rpc { get; }
 		public Network Network { get; }
 
-		public async Task<InputsRegistrationResponse> RegisterInputAsync(InputsRegistrationRequest request)
+		public async Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request)
 		{
 			DisposeGuard();
 			using (RunningTasks.RememberWith(RunningRequests))
 			{
-				var coinRoundSignaturePairs = await InputRegistrationHandler.PreProcessAsync(request, Prison, Rpc, Config).ConfigureAwait(false);
+				var coin = await InputRegistrationHandler.OutpointToCoinAsync(request, Prison, Rpc, Config).ConfigureAwait(false);
 
 				return await Arena.RegisterInputAsync(
 					request.RoundId,
-					coinRoundSignaturePairs,
+					coin,
+					request.RoundSignature,
 					request.ZeroAmountCredentialRequests,
 					request.ZeroVsizeCredentialRequests).ConfigureAwait(false);
 			}

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/IArenaRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/IArenaRequestHandler.cs
@@ -5,7 +5,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
 	public interface IArenaRequestHandler
 	{
-		Task<InputsRegistrationResponse> RegisterInputAsync(InputsRegistrationRequest request);
+		Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request);
 
 		Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request);
 

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -17,53 +17,41 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
 	public static class InputRegistrationHandler
 	{
-		public static async Task<IDictionary<Coin, byte[]>> PreProcessAsync(
-			InputsRegistrationRequest request,
+		public static async Task<Coin> OutpointToCoinAsync(
+			InputRegistrationRequest request,
 			Prison prison,
 			IRPCClient rpc,
 			WabiSabiConfig config)
 		{
-			var inputRoundSignaturePairs = request.InputRoundSignaturePairs;
-			var inputs = inputRoundSignaturePairs.Select(x => x.Input);
+			OutPoint input = request.Input;
 
-			int inputCount = inputs.Count();
-			if (inputCount != inputs.Distinct().Count())
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
-			}
-			if (inputs.Any(x => prison.TryGet(x, out var inmate) && (!config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)))
+			if (prison.TryGet(input, out var inmate) && (!config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted))
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned);
 			}
 
-			Dictionary<Coin, byte[]> coinRoundSignaturePairs = new();
-			foreach (var inputRoundSignaturePair in inputRoundSignaturePairs)
+			var txOutResponse = await rpc.GetTxOutAsync(input.Hash, (int)input.N, includeMempool: true).ConfigureAwait(false);
+			if (txOutResponse is null)
 			{
-				OutPoint input = inputRoundSignaturePair.Input;
-				var txOutResponse = await rpc.GetTxOutAsync(input.Hash, (int)input.N, includeMempool: true).ConfigureAwait(false);
-				if (txOutResponse is null)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputSpent);
-				}
-				if (txOutResponse.Confirmations == 0)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputUnconfirmed);
-				}
-				if (txOutResponse.IsCoinBase && txOutResponse.Confirmations <= 100)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputImmature);
-				}
-
-				coinRoundSignaturePairs.Add(new Coin(input, txOutResponse.TxOut), inputRoundSignaturePair.RoundSignature);
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputSpent);
+			}
+			if (txOutResponse.Confirmations == 0)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputUnconfirmed);
+			}
+			if (txOutResponse.IsCoinBase && txOutResponse.Confirmations <= 100)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputImmature);
 			}
 
-			return coinRoundSignaturePairs;
+			return new Coin(input, txOutResponse.TxOut);
 		}
 
-		public static InputsRegistrationResponse RegisterInput(
+		public static InputRegistrationResponse RegisterInput(
 			WabiSabiConfig config,
 			Guid roundId,
-			IDictionary<Coin, byte[]> coinRoundSignaturePairs,
+			Coin coin,
+			byte[] signature,
 			ZeroCredentialsRequest zeroAmountCredentialRequests,
 			ZeroCredentialsRequest zeroVsizeCredentialRequests,
 			IDictionary<Guid, Round> rounds,
@@ -74,18 +62,12 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
 			}
 
-			var coins = coinRoundSignaturePairs.Select(x => x.Key);
-
 			if (round.IsInputRegistrationEnded(config.MaxInputCountByRound, config.GetInputRegistrationTimeout(round)))
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
 			}
 
-			if (round.MaxInputCountByAlice < coins.Count())
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooManyInputs);
-			}
-			if (round.IsBlameRound && coins.Select(x => x.Outpoint).Any(x => !round.BlameWhitelist.Contains(x)))
+			if (round.IsBlameRound && !round.BlameWhitelist.Contains(coin.Outpoint))
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputNotWhitelisted);
 			}
@@ -93,25 +75,15 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			// Compute but don't commit updated CoinJoin to round state, it will
 			// be re-calculated on input confirmation. This is computed it here
 			// for validation purposes.
-			var state = round.CoinjoinState.AssertConstruction();
-			foreach (var coin in coins)
+			round.CoinjoinState.AssertConstruction().AddInput(coin);
+
+			var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", round.Hash);
+			if (!OwnershipProof.VerifyCoinJoinInputProof(signature, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
 			{
-				state = state.AddInput(coin);
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongRoundSignature);
 			}
 
-			foreach (var coinRoundSignaturePair in coinRoundSignaturePairs)
-			{
-				var coin = coinRoundSignaturePair.Key;
-				var signature = coinRoundSignaturePair.Value;
-
-				var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", round.Hash);
-				if (!OwnershipProof.VerifyCoinJoinInputProof(signature, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongRoundSignature);
-				}
-			}
-
-			var alice = new Alice(coinRoundSignaturePairs);
+			var alice = new Alice(coin, signature);
 
 			if (alice.TotalInputAmount < round.MinRegistrableAmount)
 			{
@@ -152,10 +124,10 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyRegistered);
 			}
 
-			var aliceOutPoints = alice.Coins.Select(x => x.Outpoint).ToHashSet();
-			var flattenTable = rounds.SelectMany(x => x.Alices.SelectMany(y => y.Coins.Select(z => (Round: x, Alice: y, Output: z.Outpoint))));
+			var aliceOutPoint = alice.Coin.Outpoint;
+			var flattenTable = rounds.SelectMany(x => x.Alices.Select(y => (Round: x, Alice: y, Outpoint: y.Coin.Outpoint)));
 
-			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => aliceOutPoints.Contains(x.Output)).ToArray())
+			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => x.Outpoint == aliceOutPoint).ToArray())
 			{
 				if (round.Alices.Remove(aliceInRound))
 				{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -1,7 +1,6 @@
 using NBitcoin;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -45,7 +44,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public CredentialIssuerParameters VsizeCredentialIssuerParameters { get; }
 		public Guid Id { get; } = Guid.NewGuid();
 		public List<Alice> Alices { get; } = new();
-		public int InputCount => Alices.Sum(x => x.Coins.Count());
+		public int InputCount => Alices.Count;
 		public List<Bob> Bobs { get; } = new();
 
 		public Round? BlameOf => RoundParameters.BlameOf;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -2,8 +2,6 @@ using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using WalletWasabi.Crypto.Randomness;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds
@@ -35,8 +33,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			IsBlameRound = BlameOf is not null;
 			BlameWhitelist = BlameOf
 				?.Alices
-				.SelectMany(x => x.Coins)
-				.Select(x => x.Outpoint)
+				.Select(x => x.Coin.Outpoint)
 				.ToHashSet()
 			?? new HashSet<OutPoint>();
 		}

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationRequest.cs
@@ -1,12 +1,13 @@
 using System;
-using System.Collections.Generic;
+using NBitcoin;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-	public record InputsRegistrationRequest(
+	public record InputRegistrationRequest(
 		Guid RoundId,
-		IEnumerable<InputRoundSignaturePair> InputRoundSignaturePairs,
+		OutPoint Input,
+		byte[] RoundSignature,
 		ZeroCredentialsRequest ZeroAmountCredentialRequests,
 		ZeroCredentialsRequest ZeroVsizeCredentialRequests
 	);

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -3,7 +3,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-	public record InputsRegistrationResponse(
+	public record InputRegistrationResponse(
 		Guid AliceId,
 		CredentialsResponse AmountCredentials,
 		CredentialsResponse VsizeCredentials

--- a/WalletWasabi/WabiSabi/Models/InputRoundSignaturePair.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRoundSignaturePair.cs
@@ -1,9 +1,0 @@
-using NBitcoin;
-
-namespace WalletWasabi.WabiSabi.Models
-{
-	public record InputRoundSignaturePair(
-		OutPoint Input,
-		byte[] RoundSignature
-	);
-}


### PR DESCRIPTION
As discussed in last week's call, this PR removes support for multiple inputs because it is a premature optimization that is slowing down progress.

TODO

- [x] finish removing `InputRoundSignaturePair` (last commit breaks things)
- [ ] index alices by outpoint to simplify removal of duplicates
- [ ] some additional cleanups of tests & factory code? lots of low hanging fruit