### PR TITLE
Bump Linux CI from Ubuntu 16.04 to 20.04.

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET'


### PR DESCRIPTION
This makes it possible to run HWI in CI again to avoid:

```
Error loading Python lib '/tmp/_MEIwuJ4Gx/libpython3.6m.so.1.0': dlopen: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /tmp/_MEIwuJ4Gx/libpython3.6m.so.1.0)
```