### PR TITLE
[Fluent] [Trivial] Set SelectedWallet after it is added to SelectedWallets collection

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -161,8 +161,8 @@ namespace WalletWasabi.Fluent.ViewModels
 
 			if (_currentSelection == closedWalletViewModel)
 			{
-				SelectedWallet = walletViewModelItem;
 				InsertActions(walletViewModelItem, actions);
+				SelectedWallet = walletViewModelItem;
 			}
 
 			IsLoadingWallet = false;


### PR DESCRIPTION
This fixed bug that resurfaced after updated to Avalonia 0.10.2 (it is actually present in 0.10.0 if you strip down the xaml in NavBar, but for some reason was mitigated by something else).