### PR TITLE
Make RPC EstimateAllFee cancellable

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Backend.Controllers
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => RpcClient.EstimateAllFeeAsync(new CancellationToken(), mode, simulateIfRegTest: true));
+				() => RpcClient.EstimateAllFeeAsync(mode, simulateIfRegTest: true));
 		}
 
 		/// <summary>

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
@@ -72,7 +73,7 @@ namespace WalletWasabi.Backend.Controllers
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => RpcClient.EstimateAllFeeAsync(mode, simulateIfRegTest: true));
+				() => RpcClient.EstimateAllFeeAsync(new CancellationToken(), mode, simulateIfRegTest: true));
 		}
 
 		/// <summary>

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -156,7 +156,7 @@ namespace WalletWasabi.Tests.UnitTests
 				.ThrowsAsync(new NoEstimationException(1));
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 
-			await Assert.ThrowsAsync<NoEstimationException>(async () => await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative));
+			await Assert.ThrowsAsync<NoEstimationException>(async () => await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
 		}
 
 		[Fact]
@@ -177,7 +177,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 
-			var ex = await Assert.ThrowsAsync<RPCException>(async () => await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative));
+			var ex = await Assert.ThrowsAsync<RPCException>(async () => await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
 			Assert.Equal(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, ex.RPCCode);
 			Assert.Equal("Error-EstimateSmartFee", ex.Message);
 		}
@@ -194,7 +194,7 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(8, any)).ReturnsAsync(FeeRateResponse(8, 70m));
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8), any)).ThrowsAsync(new NoEstimationException(0));
 
-			var allFee = await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative);
+			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(2, allFee.Estimations.Count);
 			Assert.False(allFee.Estimations.ContainsKey(3));
 			Assert.False(allFee.Estimations.ContainsKey(5));
@@ -218,7 +218,7 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any)).ReturnsAsync(FeeRateResponse(1008, 31m));
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any)).ThrowsAsync(new NoEstimationException(0));
 
-			var allFee = await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative);
+			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.True(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
 			Assert.Equal(99, allFee.Estimations[2]);
@@ -254,7 +254,7 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any)).ReturnsAsync(FeeRateResponse(1008, 1m));
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any)).ThrowsAsync(new NoEstimationException(0));
 
-			var allFee = await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative);
+			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(3_500, allFee.Estimations[2]);
 			Assert.True(allFee.Estimations[3] > 500);
 			Assert.True(allFee.Estimations[1008] > 1);
@@ -270,7 +270,7 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2), any)).ThrowsAsync(new NoEstimationException(0));
 
 			// Do not throw exception
-			await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative);
+			await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 		}
 
 		[Fact]
@@ -282,7 +282,7 @@ namespace WalletWasabi.Tests.UnitTests
 				var mempoolInfo = MempoolInfoGenerator.GenerateMempoolInfo();
 				mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(mempoolInfo);
 				mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative)).ReturnsAsync(FeeRateResponse(2, 120m));
-				var feeRates = await mockRpc.Object.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative);
+				var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 				var estimations = feeRates.Estimations;
 
 				Assert.Subset(Constants.ConfirmationTargets.ToHashSet(), estimations.Keys.ToHashSet());

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 using Moq;
+using System.Threading;
 
 namespace WalletWasabi.Tests.UnitTests
 {
@@ -146,7 +147,7 @@ namespace WalletWasabi.Tests.UnitTests
 				});
 			mockRpc.Setup(rpc => rpc.GetPeersInfoAsync())
 				.ReturnsAsync(Array.Empty<PeerInfo>());
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync())
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
@@ -168,7 +169,7 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error-EstimateSmartFee", null));
 
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync())
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
@@ -231,7 +232,7 @@ namespace WalletWasabi.Tests.UnitTests
 			var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 			var any = EstimateSmartFeeMode.Conservative;
 
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(
 				new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000, // 1 s/b (default value)
@@ -279,7 +280,7 @@ namespace WalletWasabi.Tests.UnitTests
 			{
 				var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 				var mempoolInfo = MempoolInfoGenerator.GenerateMempoolInfo();
-				mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(mempoolInfo);
+				mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(mempoolInfo);
 				mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative)).ReturnsAsync(FeeRateResponse(2, 120m));
 				var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 				var estimations = feeRates.Estimations;
@@ -304,7 +305,7 @@ namespace WalletWasabi.Tests.UnitTests
 				hasPeersInfo
 					? new[] { new PeerInfo() }
 					: Array.Empty<PeerInfo>());
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(
 				new MemPoolInfo
 				{
 					MemPoolMinFee = memPoolMinFee, // 1 s/b (default value)

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -13,7 +13,6 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 using Moq;
-using System.Threading;
 
 namespace WalletWasabi.Tests.UnitTests
 {

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using NBitcoin.RPC;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -166,6 +167,23 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Economical, estimations.Type);
+			}
+			finally
+			{
+				await coreNode.TryStopAsync();
+			}
+		}
+
+		[Fact]
+		public async Task FeeEstimationCanCancelAsync()
+		{
+			var coreNode = await TestNodeBuilder.CreateAsync();
+			try
+			{
+				var rpc = coreNode.RpcClient;
+				using CancellationTokenSource cts = new();
+				cts.Cancel();
+				await Assert.ThrowsAsync<OperationCanceledException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, cts.Token));
 			}
 			finally
 			{

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -156,12 +156,12 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			try
 			{
 				var rpc = coreNode.RpcClient;
-				var estimations = await rpc.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
+				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
 				Assert.Equal(7, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
-				estimations = await rpc.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
+				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
 				Assert.Equal(7, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -156,12 +156,12 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			try
 			{
 				var rpc = coreNode.RpcClient;
-				var estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
+				var estimations = await rpc.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Conservative, simulateIfRegTest: true);
 				Assert.Equal(7, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
 				Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
-				estimations = await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
+				estimations = await rpc.EstimateAllFeeAsync(new CancellationToken(), EstimateSmartFeeMode.Economical, simulateIfRegTest: true);
 				Assert.Equal(7, estimations.Estimations.Count);
 				Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 				Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -181,8 +181,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			try
 			{
 				var rpc = coreNode.RpcClient;
-				using CancellationTokenSource cts = new();
-				cts.Cancel();
+				using CancellationTokenSource cts = new(TimeSpan.Zero);
 				await Assert.ThrowsAsync<OperationCanceledException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, cts.Token));
 			}
 			finally

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
 using NBitcoin.RPC;
@@ -64,7 +65,7 @@ namespace WalletWasabi.Tests.UnitTests
 			throw new NotImplementedException();
 		}
 
-		public Task<MemPoolInfo> GetMempoolInfoAsync()
+		public Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
 		{
 			return OnGetMempoolInfoAsync();
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
@@ -132,7 +132,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			rpcMock.SetupGet(rpc => rpc.Network).Returns(Network.Main);
 			rpcMock.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { FeeRate = new FeeRate(10m) });
-			rpcMock.Setup(rpc => rpc.GetMempoolInfoAsync())
+			rpcMock.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 			return rpcMock.Object;
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -75,7 +75,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			mockRpcClient.Setup(rpc => rpc.Network).Returns(Network.Main);
 			mockRpcClient.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { Blocks = 5, FeeRate = new FeeRate(100m) });
-			mockRpcClient.Setup(rpc => rpc.GetMempoolInfoAsync())
+			mockRpcClient.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 			return mockRpcClient.Object;
 		}

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 		{
 			try
 			{
-				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(cancel, EstimateSmartFeeMode.Conservative, true).ConfigureAwait(false);
+				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, cancel).ConfigureAwait(false);
 
 				// If Core was running for a day already && it's synchronized, then we can be pretty sure that the estimate is accurate.
 				// It could also be accurate if Core was only shut down for a few minutes, but that's hard to figure out.

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 		{
 			try
 			{
-				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true).ConfigureAwait(false);
+				var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(cancel, EstimateSmartFeeMode.Conservative, true).ConfigureAwait(false);
 
 				// If Core was running for a day already && it's synchronized, then we can be pretty sure that the estimate is accurate.
 				// It could also be accurate if Core was only shut down for a few minutes, but that's hard to figure out.

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -145,7 +145,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				() => base.GetMempoolEntryAsync(txid, throwIfNotFound)).ConfigureAwait(false);
 		}
 
-		public override async Task<MemPoolInfo> GetMempoolInfoAsync()
+		public override async Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
 		{
 			string cacheKey = nameof(GetMempoolInfoAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -157,7 +157,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetMempoolInfoAsync()).ConfigureAwait(false);
+				() => base.GetMempoolInfoAsync(cancel)).ConfigureAwait(false);
 		}
 
 		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using NBitcoin.RPC;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc.Models;
 
@@ -35,7 +36,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 		Task<uint256[]> GetRawMempoolAsync();
 
-		Task<MemPoolInfo> GetMempoolInfoAsync();
+		Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default);
 
 		Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, bool allowHighFees = false);
 

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc.Models;
 using WalletWasabi.Helpers;
@@ -59,12 +60,11 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound).ConfigureAwait(false);
 		}
 
-		public virtual async Task<MemPoolInfo> GetMempoolInfoAsync()
+		public virtual async Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
 		{
 			try
 			{
 				var response = await Rpc.SendCommandAsync(RPCOperations.getmempoolinfo, true).ConfigureAwait(false);
-
 				static IEnumerable<FeeRateGroup> ExtractFeeRateGroups(JToken jt) =>
 					jt switch
 					{
@@ -95,6 +95,8 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			}
 			catch (RPCException ex) when (ex.RPCCode == RPCErrorCode.RPC_MISC_ERROR)
 			{
+				cancel.ThrowIfCancellationRequested();
+
 				return await Rpc.GetMemPoolAsync().ConfigureAwait(false);
 			}
 		}

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -68,7 +68,7 @@ namespace NBitcoin.RPC
 		/// <summary>
 		/// Estimates fees for 1w, 3d, 1d, 12h, 6h, 3h, 1h, 30m, 20m.
 		/// </summary>
-		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this IRPCClient rpc, CancellationToken cancel, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
+		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this IRPCClient rpc, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false, CancellationToken cancel = default)
 		{
 			var smartEstimations = (simulateIfRegTest && rpc.Network == Network.RegTest)
 				? SimulateRegTestFeeEstimation(estimateMode)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -100,7 +100,7 @@ namespace NBitcoin.RPC
 				rpcStatus.Synchronized);
 		}
 
-		private static async Task<Dictionary<int, int>> GetFeeEstimationsAsync(IRPCClient rpc, EstimateSmartFeeMode estimateMode, CancellationToken cancel)
+		private static async Task<Dictionary<int, int>> GetFeeEstimationsAsync(IRPCClient rpc, EstimateSmartFeeMode estimateMode, CancellationToken cancel = default)
 		{
 			var batchClient = rpc.PrepareBatch();
 
@@ -109,11 +109,11 @@ namespace NBitcoin.RPC
 				.ToList();
 
 			await batchClient.SendBatchAsync().ConfigureAwait(false);
+			cancel.ThrowIfCancellationRequested();
 
 			try
 			{
 				await Task.WhenAll(rpcFeeEstimationTasks).ConfigureAwait(false);
-				cancel.ThrowIfCancellationRequested();
 			}
 			catch
 			{
@@ -121,11 +121,6 @@ namespace NBitcoin.RPC
 				{
 					throw rpcFeeEstimationTasks[0].Exception?.InnerExceptions[0]
 						?? new Exception($"{nameof(GetFeeEstimationsAsync)} failed to fetch fee estimations.");
-				}
-				if (cancel.IsCancellationRequested)
-				{
-					Logger.LogInfo($"{nameof(GetFeeEstimationsAsync)} has been cancelled.");
-					throw new OperationCanceledException();
 				}
 			}
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -68,7 +68,7 @@ namespace NBitcoin.RPC
 		/// <summary>
 		/// Estimates fees for 1w, 3d, 1d, 12h, 6h, 3h, 1h, 30m, 20m.
 		/// </summary>
-		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this IRPCClient rpc, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
+		public static async Task<AllFeeEstimate> EstimateAllFeeAsync(this IRPCClient rpc, CancellationToken cancel, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, bool simulateIfRegTest = false)
 		{
 			var smartEstimations = (simulateIfRegTest && rpc.Network == Network.RegTest)
 				? SimulateRegTestFeeEstimation(estimateMode)


### PR DESCRIPTION
This PR makes the EstimateAllFee method cancellable with CancelationToken.

**Note:** 
I did not use this CancelationToken so far, so please tell me if the token should go deeper into the separate functions or if the token should be an optional  parameter for the method or this is completely wrong and this is not the way it should be used.