### PR TITLE
[draft] Tor control with safe cookie authentication

### DIFF
--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -22,7 +22,7 @@ namespace WalletWasabi.Tests.Helpers
 		static Common()
 		{
 			Logger.SetFilePath(Path.Combine(DataDir, "Logs.txt"));
-			Logger.SetMinimumLevel(LogLevel.Info);
+			Logger.SetMinimumLevel(LogLevel.Debug);
 			Logger.SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
 		}
 

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/Messages/ProtocolInfoReplyTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/Messages/ProtocolInfoReplyTests.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System;
 using System.Threading.Tasks;
 using WalletWasabi.Tor.Control.Messages;
 using Xunit;

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/Messages/ProtocolInfoReplyTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/Messages/ProtocolInfoReplyTests.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System;
+using System.Threading.Tasks;
+using WalletWasabi.Tor.Control.Messages;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control
+{
+	/// <summary>
+	/// Tests for <see cref="ProtocolInfoReply"/> class.
+	/// </summary>
+	public class ProtocolInfoReplyTests
+	{
+		[Fact]
+		public async Task AuthMethodHashedPasswordAsync()
+		{
+			string data = "250-PROTOCOLINFO 1\r\n250-AUTH METHODS=HASHEDPASSWORD\r\n250-VERSION Tor=\"0.4.3.5\"\r\n250 OK\r\n";
+
+			TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+			ProtocolInfoReply reply = ProtocolInfoReply.FromReply(rawReply);
+
+			Assert.Equal(1, reply.ProtocolVersion);
+			Assert.Equal("0.4.3.5", reply.TorVersion);
+			Assert.Single(reply.AuthMethods);
+			Assert.Contains("HASHEDPASSWORD", reply.AuthMethods);
+		}
+
+		[Fact]
+		public async Task AuthMethodCookieAsync()
+		{
+			// Yes, Tor really returns: "C:\\Users\\Wasabi\\AppData\\Roaming\\WalletWasabi\\Client\\control_auth_cookie" path on Windows.
+			string data = "250-PROTOCOLINFO 1\r\n250-AUTH METHODS=COOKIE,SAFECOOKIE COOKIEFILE=\"C:\\\\Users\\\\Wasabi\\\\AppData\\\\Roaming\\\\WalletWasabi\\\\Client\\\\control_auth_cookie\"\r\n250-VERSION Tor=\"0.4.5.7\"\r\n250 OK\r\n";
+
+			TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+			ProtocolInfoReply reply = ProtocolInfoReply.FromReply(rawReply);
+
+			Assert.Equal(1, reply.ProtocolVersion);
+			Assert.Equal("0.4.5.7", reply.TorVersion);
+			Assert.Equal(2, reply.AuthMethods.Length);
+			Assert.Equal("COOKIE", reply.AuthMethods[0]);
+			Assert.Equal("SAFECOOKIE", reply.AuthMethods[1]);
+			Assert.Equal(@"C:\Users\Wasabi\AppData\Roaming\WalletWasabi\Client\control_auth_cookie", reply.CookieFilePath);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/PipeWriterExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/PipeWriterExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control
+{
+	public static class PipeWriterExtensions
+	{
+		public static ValueTask<FlushResult> WriteAsync(this PipeWriter writer, string data, Encoding encoding, CancellationToken cancellationToken = default)
+		{
+			return writer.WriteAsync(new ReadOnlyMemory<byte>(encoding.GetBytes(data)), cancellationToken);
+		}
+
+		public static ValueTask<FlushResult> WriteAsciiAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
+		{
+			return writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlFactoryTests.cs
@@ -1,0 +1,79 @@
+using Moq;
+using NBitcoin;
+using System;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.Tor.Control;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control
+{
+	/// <seealso cref="XunitConfiguration.SerialCollectionDefinition"/>
+	[Collection("Serial unit tests collection")]
+	public class TorControlFactoryTests
+	{
+		/// <summary>
+		/// TODO.
+		/// </summary>
+		[Fact]
+		public async Task SafeCookieAuthenticationAsync()
+		{
+			// TODO: Remove.
+			Common.GetWorkDir();
+			Logger.SetMinimumLevel(LogLevel.Trace);
+
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(2));
+
+			// Setup.
+			string cookieString = "200339DD9897265DF859C6578DFB51E2E867AA8966C9112349262F5398DEFC3D";
+			string clientNonce = "6F14C18D5B00BF54E16E4728A4BFC81B1FF469F0B012CD71D9724BFBE14DB5E6";
+			string serverHash = "E3C00FB4A14AF48B43CE8A13E4BB01F8C72796352072B1994EE21D35148931C1";
+			string serverNonce = "1650507A46A2979974DA72A833523B72789A65F6E24EAA59C5DF1D3DC294228D";
+
+			Mock<IRandom> mockRandom = new(MockBehavior.Strict);
+			mockRandom.Setup(c => c.GetBytes(It.IsAny<byte[]>()))
+				.Callback((byte[] dest) =>
+				{
+					byte[] src = ByteHelpers.FromHex(clientNonce);
+					Array.Copy(src, dest, 32);
+				});
+
+			TorControlClientFactory clientFactory = new(mockRandom.Object);
+
+			Pipe toServer = new();
+			Pipe toClient = new();
+
+			using TorControlClient testClient = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
+
+			Logger.LogTrace("Client: AuthenticateAsync.");
+			Task<TorControlClient> authenticationTask = clientFactory.AuthSafeCookieOrThrowAsync(testClient, cookieString, timeoutCts.Token);
+
+			Logger.LogTrace("Server: Read 'AUTHCHALLENGE SAFECOOKIE' command from the client.");
+			string? authChallengeCommand = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+
+			Logger.LogTrace($"Server: Received authchallenge line: '{authChallengeCommand}'.");
+			Assert.Equal("AUTHCHALLENGE SAFECOOKIE 6F14C18D5B00BF54E16E4728A4BFC81B1FF469F0B012CD71D9724BFBE14DB5E6", authChallengeCommand);
+
+			Logger.LogTrace("Server: Respond to AUTHCHALLENGE request.");
+			string challengeResponse = $"250 AUTHCHALLENGE SERVERHASH={serverHash} SERVERNONCE={serverNonce}\r\n";
+			await toClient.Writer.WriteAsciiAsync(challengeResponse, timeoutCts.Token);
+
+			Logger.LogTrace("Server: Read 'AUTHENTICATE' command from the client.");
+			string? authCommand = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+
+			Logger.LogTrace($"Server: Received auth line: '{authCommand}'.");
+			Assert.Equal("AUTHENTICATE 6013EA09D4E36B6CF01C18A707D350C1B5AFF8C1A21527266B9FC40C89BDCB4A", authCommand);
+
+			Logger.LogTrace("Server: Respond to AUTHENTICATION request.");
+			await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+
+			Logger.LogTrace("Server: End.");
+
+			TorControlClient authenticatedClient = await authenticationTask;
+			Assert.NotNull(authenticatedClient);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
@@ -1,9 +1,9 @@
 using System;
 using System.IO.Pipelines;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tor.Control;
+using WalletWasabi.Tor.Control.Exceptions;
 using WalletWasabi.Tor.Control.Messages;
 using Xunit;
 
@@ -14,21 +14,14 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 	/// </summary>
 	public class TorControlReplyReaderTest
 	{
-		/// <summary>
-		/// TODO.
-		/// </summary>
 		[Theory]
 		[InlineData(StatusCode.OK, 1, "250 OK\r\n")]
 		[InlineData(StatusCode.OK, 2, "250-SOCKSPORT=9050\r\n250 ORPORT=0\r\n")]
 		[InlineData(StatusCode.OK, 4, "250-PROTOCOLINFO 1\r\n250-AUTH METHODS=HASHEDPASSWORD\r\n250-VERSION Tor=\"0.4.3.5\"\r\n250 OK\r\n")]
 		[InlineData(StatusCode.AsynchronousEventNotify, 1, "650 CIRC 1000 EXTENDED moria1,moria2\r\n")]
-		public async Task ReplyParsingTestsAsync(StatusCode expectedStatusCode, int expectedReplyLines, string data)
-		{		
-			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(1));
-
-			Pipe pipe = new();
-			await pipe.Writer.WriteAsync(data, Encoding.ASCII, timeoutCts.Token);
-			TorControlReply reply = await TorControlReplyReader.ReadReplyAsync(pipe.Reader, timeoutCts.Token);
+		public async Task WellformedTestsAsync(StatusCode expectedStatusCode, int expectedReplyLines, string data)
+		{
+			TorControlReply reply = await ParseAsync(data);
 
 			if (expectedStatusCode == StatusCode.OK)
 			{
@@ -36,7 +29,50 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			}
 
 			Assert.Equal(expectedStatusCode, reply.StatusCode);
-			Assert.Equal(expectedReplyLines, reply.ResponseLines.Count);			
+			Assert.Equal(expectedReplyLines, reply.ResponseLines.Count);
+		}
+
+		/// <summary>Makes sure we don't normalize <c>\n</c>, <c>\t</c>, <c>\r</c> of Tor reply.</summary>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">2.1.1. Notes on an escaping bug</seealso>
+		[Fact]
+		public async Task EscapingQuotesTestAsync()
+		{
+			TorControlReply reply = await ParseAsync("250-PROTOCOLINFO 1\r\n250-VERSION Tor=\\\"0.4.3.5\\\"\r\n250 OK\r\n");
+
+			Assert.True(reply.Success);
+			Assert.Equal(3, reply.ResponseLines.Count);
+
+			// We are expected to read: 'VERSION Tor=\"0.4.3.5\"' (with the backslashes).
+			Assert.Equal(@"VERSION Tor=\""0.4.3.5\""", reply.ResponseLines[1]);
+		}
+
+		[Fact]
+		public async Task InvalidStatusCodeAsync()
+		{
+			var ex = await Assert.ThrowsAsync<TorControlReplyParseException>(async () => await ParseAsync("2 OK\r\n").ConfigureAwait(false));
+			Assert.StartsWith("Unknown status code: '2 O'", ex.Message, StringComparison.Ordinal);
+		}
+
+		[Theory]
+		[InlineData("No reply line was received.", "\r" /* no input line */)]
+		[InlineData("Status code requires at least 3 characters.", "OK\r\n")]
+		[InlineData("Unknown status code: 'xx '.", "xx OK\r\n")]
+		[InlineData("Unknown status code: '2 O'.", "2 OK\r\n")]
+		public async Task InvalidRepliesAsync(string expectedExceptionMsg, string data)
+		{
+			var ex = await Assert.ThrowsAsync<TorControlReplyParseException>(async () => await ParseAsync(data).ConfigureAwait(false));
+			Assert.Equal(expectedExceptionMsg, ex.Message);
+		}
+
+		private async Task<TorControlReply> ParseAsync(string data)
+		{
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(1));
+
+			Pipe pipe = new();
+			await pipe.Writer.WriteAsciiAsync(data, timeoutCts.Token);
+			await pipe.Writer.FlushAsync(timeoutCts.Token);
+			await pipe.Writer.CompleteAsync();
+			return await TorControlReplyReader.ReadReplyAsync(pipe.Reader, timeoutCts.Token);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Tor.Control;
+using WalletWasabi.Tor.Control.Messages;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control
+{
+	/// <summary>
+	/// Tests for <see cref="TorControlReplyReader"/> class.
+	/// </summary>
+	public class TorControlReplyReaderTest
+	{
+		/// <summary>
+		/// TODO.
+		/// </summary>
+		[Theory]
+		[InlineData(StatusCode.OK, 1, "250 OK\r\n")]
+		[InlineData(StatusCode.OK, 2, "250-SOCKSPORT=9050\r\n250 ORPORT=0\r\n")]
+		[InlineData(StatusCode.OK, 4, "250-PROTOCOLINFO 1\r\n250-AUTH METHODS=HASHEDPASSWORD\r\n250-VERSION Tor=\"0.4.3.5\"\r\n250 OK\r\n")]
+		[InlineData(StatusCode.AsynchronousEventNotify, 1, "650 CIRC 1000 EXTENDED moria1,moria2\r\n")]
+		public async Task ReplyParsingTestsAsync(StatusCode expectedStatusCode, int expectedReplyLines, string data)
+		{		
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(1));
+
+			Pipe pipe = new();
+			await pipe.Writer.WriteAsync(data, Encoding.ASCII, timeoutCts.Token);
+			TorControlReply reply = await TorControlReplyReader.ReadReplyAsync(pipe.Reader, timeoutCts.Token);
+
+			if (expectedStatusCode == StatusCode.OK)
+			{
+				Assert.True(reply.Success);
+			}
+
+			Assert.Equal(expectedStatusCode, reply.StatusCode);
+			Assert.Equal(expectedReplyLines, reply.ResponseLines.Count);			
+		}
+	}
+
+	public static class PipeWriterExtensions
+	{
+		public static ValueTask<FlushResult> WriteAsync(this PipeWriter writer, string data, Encoding encoding, CancellationToken cancellationToken = default)
+		{
+			return writer.WriteAsync(new ReadOnlyMemory<byte>(encoding.GetBytes(data)), cancellationToken);
+		}
+
+		public static ValueTask<FlushResult> WriteAsciiAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
+		{
+			return writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
@@ -39,17 +39,4 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Assert.Equal(expectedReplyLines, reply.ResponseLines.Count);			
 		}
 	}
-
-	public static class PipeWriterExtensions
-	{
-		public static ValueTask<FlushResult> WriteAsync(this PipeWriter writer, string data, Encoding encoding, CancellationToken cancellationToken = default)
-		{
-			return writer.WriteAsync(new ReadOnlyMemory<byte>(encoding.GetBytes(data)), cancellationToken);
-		}
-
-		public static ValueTask<FlushResult> WriteAsciiAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
-		{
-			return writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken);
-		}
-	}
 }

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
@@ -64,7 +64,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Assert.Equal(expectedExceptionMsg, ex.Message);
 		}
 
-		private async Task<TorControlReply> ParseAsync(string data)
+		public static async Task<TorControlReply> ParseAsync(string data)
 		{
 			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(1));
 

--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using System.Net;
 using WalletWasabi.Tor;
 using Xunit;
-using System.IO;
 
 namespace WalletWasabi.Tests.UnitTests.Tor
 {
@@ -25,6 +25,9 @@ namespace WalletWasabi.Tests.UnitTests.Tor
 			string expected = string.Join(
 				" ",
 				$"--SOCKSPort 127.0.0.1:9050",
+				$"--ControlPort 29051",
+				$"--CookieAuthentication 1",
+				$"--CookieAuthFile \"{Path.Combine("temp", "tempDataDir", "control_auth_cookie")}\"",
 				$"--DataDirectory \"{Path.Combine("temp", "tempDataDir", "tordata")}\"",
 				$"--GeoIPFile \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip")}\"",
 				$"--GeoIPv6File \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip6")}\"",

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Logging
 
 		private static int LoggingFailedCount = 0;
 
-		private static LogLevel MinimumLevel { get; set; } = LogLevel.Critical;
+		private static LogLevel MinimumLevel { get; set; } = LogLevel.Trace;
 
 		private static HashSet<LogMode> Modes { get; } = new HashSet<LogMode>();
 
@@ -73,7 +73,7 @@ namespace WalletWasabi.Logging
 			SetModes(LogMode.Console, LogMode.File);
 
 #else
-			SetMinimumLevel(logLevel ??= LogLevel.Debug);
+			SetMinimumLevel(logLevel ??= LogLevel.Trace);
 			SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
 #endif
 		}

--- a/WalletWasabi/Tor/Control/Exceptions/TorControlException.cs
+++ b/WalletWasabi/Tor/Control/Exceptions/TorControlException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace WalletWasabi.Tor.Control.Exceptions
+{
+	public class TorControlException : Exception
+	{
+		public TorControlException(string message) : base(message)
+		{
+		}
+
+		public TorControlException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/Exceptions/TorControlReplyParseException.cs
+++ b/WalletWasabi/Tor/Control/Exceptions/TorControlReplyParseException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace WalletWasabi.Tor.Control.Exceptions
+{
+	public class TorControlReplyParseException : TorControlException
+	{
+		public TorControlReplyParseException(string message) : base(message)
+		{
+		}
+
+		public TorControlReplyParseException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/Messages/ProtocolInfoReply.cs
+++ b/WalletWasabi/Tor/Control/Messages/ProtocolInfoReply.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Exceptions;
+
+namespace WalletWasabi.Tor.Control.Messages
+{
+	/// <remarks>
+	/// Note that the protocol_version is the only mandatory data for a valid PROTOCOLINFO response.
+	/// </remarks>
+	public class ProtocolInfoReply
+	{
+		private const string ProtocolInfoLinePrefix = "PROTOCOLINFO ";
+
+		private const string VersionLinePrefix = "VERSION ";
+
+		public int? ProtocolVersion { get; init; }
+		public string? TorVersion { get; init; }
+		public string? CookieFile { get; init; }
+
+		// public AuthMethod[] AuthMethods { get; init; }
+
+		public static ProtocolInfoReply FromReply(TorControlReply reply)
+		{
+			if (!reply.Success || reply.ResponseLines.Last() != "250 OK")
+			{
+				throw new TorControlReplyParseException("PROTOCOLINFO: Expected reply with OK status.");
+			}
+
+			int protocolVersion = ParseProtocolVersionLine(reply.ResponseLines[0]);
+
+			foreach (string line in reply.ResponseLines.Skip(1).SkipLast(1))
+			{
+				if (line.StartsWith(VersionLinePrefix, StringComparison.Ordinal))
+				{
+
+				}
+			}
+
+			return new ProtocolInfoReply()
+			{
+				ProtocolVersion = protocolVersion
+			};
+		}
+
+		private static int ParseProtocolVersionLine(string line)
+		{
+			if (line.StartsWith(ProtocolInfoLinePrefix, StringComparison.Ordinal))
+			{
+				if (int.TryParse(line.AsSpan(ProtocolInfoLinePrefix.Length), out int parsedVersion))
+				{
+					if (parsedVersion != 1)
+					{
+						Logger.LogWarning($"Version {parsedVersion} may not work expected.");
+					}
+
+					return parsedVersion;
+				}
+				else
+				{
+					Logger.LogError("Failed to parse PROTOCOLINFO version.");
+				}
+			}
+
+			throw new TorControlReplyParseException("PROTOCOLINFO: Version is not specified.");
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/Messages/TorControlReply.cs
+++ b/WalletWasabi/Tor/Control/Messages/TorControlReply.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace WalletWasabi.Tor.Control.Messages
+{
+	/// <summary>
+	/// A class containing information regarding a response received back from a Tor control connection.
+	/// </summary>
+	/// <remarks>
+	/// Tor replies follow the following grammar:
+	/// <code>
+	///   Reply = SyncReply / AsyncReply
+	///   SyncReply = *(MidReplyLine / DataReplyLine) EndReplyLine
+	///   AsyncReply = *(MidReplyLine / DataReplyLine) EndReplyLine
+	///
+	///   MidReplyLine = StatusCode "-" ReplyLine
+	///   DataReplyLine = StatusCode "+" ReplyLine CmdData
+	///   EndReplyLine = StatusCode SP ReplyLine
+	///   ReplyLine = [ReplyText] CRLF
+	///   ReplyText = XXXX
+	///   StatusCode = 3DIGIT
+	/// </code>
+	/// </remarks>
+	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Section 2.3</seealso>
+	public class TorControlReply
+	{
+		public TorControlReply(StatusCode statusCode)
+		{
+			StatusCode = statusCode;
+			ResponseLines = new List<string>().AsReadOnly();
+		}
+
+		public TorControlReply(StatusCode statusCode, IList<string> responseLines)
+		{
+			StatusCode = statusCode;
+			ResponseLines = new ReadOnlyCollection<string>(responseLines);
+		}
+
+		public ReadOnlyCollection<string> ResponseLines { get; }
+
+		public StatusCode StatusCode { get; }
+
+		/// <summary>Gets a value indicating whether the reply indicated success.</summary>
+		public bool Success => StatusCode == StatusCode.OK;
+
+		public static implicit operator bool(TorControlReply r) => r.Success;
+
+		/// <inheritdoc/>
+		public override string ToString()
+		{
+			return string.Format("[{0}: '{1}']", StatusCode, string.Join("<CRLF>", ResponseLines));
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/NetworkReplyParser.cs
+++ b/WalletWasabi/Tor/Control/NetworkReplyParser.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Tor.Control
+{
+	/// <summary>
+	/// This class employs <c>System.IO.Pipelines</c> to correctly read incoming streamed data.
+	/// </summary>
+	/// <remarks>Please read the link below to understand common gotchas of that task.</remarks>
+	/// <seealso href="https://docs.microsoft.com/en-us/dotnet/standard/io/pipelines#what-problem-does-systemiopipelines-solve"/>
+	public static class NetworkReplyParser
+	{
+		/// <summary>
+		/// Parses a single message and updates the consumed SequencePosition and examined <see cref="SequencePosition"/> to point
+		/// to the start of the trimmed input buffer.
+		/// <para>
+		/// The two SequencePosition arguments are updated because <see cref="TryParseLine"/> removes the parsed message
+		/// from the input buffer. Generally, when parsing a single message from the buffer, the examined position should be
+		/// one of the following:
+		/// <list item="bullet">
+		/// <item>The end of the message.</item>
+		/// <item>The end of the received buffer if no message was found.</item>
+		/// </list>
+		/// </para>
+		/// <para>
+		/// The single message case has the most potential for errors. Passing the wrong values to examined can result
+		/// in an out of memory exception or an infinite loop. For more information, see the
+		/// <see href="https://docs.microsoft.com/en-us/dotnet/standard/io/pipelines#gotchas">gotchas article</see>
+		/// </para>
+		/// </summary>
+		/// <seealso href="https://docs.microsoft.com/en-us/dotnet/standard/io/pipelines#read-a-single-message"/>
+		/// <remarks>The following code reads a single message from a PipeReader and returns it to the caller.</remarks>
+		public static async ValueTask<string?> ReadLineAsync(this PipeReader reader, CancellationToken cancellationToken = default)
+		{
+			while (true)
+			{
+				ReadResult result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+				ReadOnlySequence<byte> buffer = result.Buffer;
+
+				// In the event that no message is parsed successfully, mark consumed
+				// as nothing and examined as the entire buffer.
+				SequencePosition consumed = buffer.Start;
+				SequencePosition examined = buffer.End;
+
+				try
+				{
+					if (TryParseLine(ref buffer, out ReadOnlySequence<byte> messageBytes))
+					{
+						string message = messageBytes.GetString(Encoding.ASCII);
+						Logger.LogTrace($"Read message: '{message}'");
+
+						// A single message was successfully parsed so mark the start as the
+						// parsed buffer as consumed. TryParseMessage trims the buffer to
+						// point to the data after the message was parsed.
+						consumed = buffer.Start;
+
+						// Examined is marked the same as consumed here, so the next call
+						// to ReadSingleMessageAsync will process the next message if there's
+						// one.
+						examined = consumed;
+
+						return message;
+					}
+
+					// There's no more data to be processed.
+					if (result.IsCompleted)
+					{
+						if (buffer.Length > 0)
+						{
+							// The message is incomplete and there's no more data to process.
+							throw new InvalidDataException("Incomplete message.");
+						}
+
+						break;
+					}
+				}
+				finally
+				{
+					reader.AdvanceTo(consumed, examined);
+				}
+			}
+
+			return null;
+		}
+
+		/// <seealso href="https://docs.microsoft.com/en-us/dotnet/standard/io/buffers#process-text-data"/>
+		private static bool TryParseLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> line)
+		{
+			SequencePosition position = buffer.Start;
+			SequencePosition previous = position;
+			var index = -1;
+			line = default;
+
+			while (buffer.TryGet(ref position, out ReadOnlyMemory<byte> segment))
+			{
+				ReadOnlySpan<byte> span = segment.Span;
+
+				// Look for \r in the current segment.
+				index = span.IndexOf((byte)'\r');
+
+				if (index != -1)
+				{
+					// Check next segment for \n.
+					if (index + 1 >= span.Length)
+					{
+						SequencePosition next = position;
+						if (!buffer.TryGet(ref next, out ReadOnlyMemory<byte> nextSegment))
+						{
+							// You're at the end of the sequence.
+							return false;
+						}
+						else if (nextSegment.Span[0] == (byte)'\n')
+						{
+							//  A match was found.
+							break;
+						}
+					}
+					// Check the current segment of \n.
+					else if (span[index + 1] == (byte)'\n')
+					{
+						// It was found.
+						break;
+					}
+				}
+
+				previous = position;
+			}
+
+			if (index != -1)
+			{
+				// Get the position just before the \r\n.
+				SequencePosition delimeter = buffer.GetPosition(index, previous);
+
+				// Slice the line (excluding \r\n).
+				line = buffer.Slice(buffer.Start, delimeter);
+
+				// Slice the buffer to get the remaining data after the line.
+				buffer = buffer.Slice(buffer.GetPosition(2, delimeter));
+				return true;
+			}
+
+			return false;
+		}
+
+		private static string GetString(in this ReadOnlySequence<byte> payload, Encoding? encoding = null)
+		{
+			encoding ??= Encoding.UTF8;
+
+			return payload.IsSingleSegment
+				? encoding.GetString(payload.FirstSpan)
+				: GetStringSlow(payload, encoding);
+
+			static string GetStringSlow(in ReadOnlySequence<byte> payload, Encoding encoding)
+			{
+				// linearize
+				int length = checked((int)payload.Length);
+				var oversized = ArrayPool<byte>.Shared.Rent(length);
+				try
+				{
+					payload.CopyTo(oversized);
+					return encoding.GetString(oversized, 0, length);
+				}
+				finally
+				{
+					ArrayPool<byte>.Shared.Return(oversized);
+				}
+			}
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/NetworkReplyParser.cs
+++ b/WalletWasabi/Tor/Control/NetworkReplyParser.cs
@@ -36,7 +36,8 @@ namespace WalletWasabi.Tor.Control
 		/// </summary>
 		/// <seealso href="https://docs.microsoft.com/en-us/dotnet/standard/io/pipelines#read-a-single-message"/>
 		/// <remarks>The following code reads a single message from a PipeReader and returns it to the caller.</remarks>
-		public static async ValueTask<string?> ReadLineAsync(this PipeReader reader, CancellationToken cancellationToken = default)
+		/// <exception cref="InvalidDataException">The message is incomplete and there's no more data to process.</exception>
+		public static async ValueTask<string> ReadLineAsync(this PipeReader reader, CancellationToken cancellationToken = default)
 		{
 			while (true)
 			{
@@ -86,9 +87,11 @@ namespace WalletWasabi.Tor.Control
 				}
 			}
 
-			return null;
+			throw new InvalidDataException("This should never happen.");
 		}
 
+		/// <summary>Finds the first newline (<c>\r\n</c>) in the buffer.</summary>
+		/// <param name="line">Trims that line, excluding the <c>\r\n</c> from the input buffer.</param>
 		/// <seealso href="https://docs.microsoft.com/en-us/dotnet/standard/io/buffers#process-text-data"/>
 		private static bool TryParseLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> line)
 		{

--- a/WalletWasabi/Tor/Control/ReplyCode.cs
+++ b/WalletWasabi/Tor/Control/ReplyCode.cs
@@ -1,0 +1,63 @@
+namespace WalletWasabi.Tor.Control
+{
+	/// <summary>
+	/// An enumerator containing the status codes sent in response to commands.
+	/// </summary>
+	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4. Replies".</seealso>
+	public enum StatusCode : int
+	{
+		/// <summary>This should never occur ideally, unless a response was malformed or incomplete.</summary>
+		Unknown = 0,
+
+		/// <summary>The command was processed.</summary>
+		OK = 250,
+
+		/// <summary>The operation was unnecessary.</summary>
+		OperationUnnecessary = 251,
+
+		/// <summary>The resources were exhausted.</summary>
+		ResourceExhausted = 451,
+
+		/// <summary>There was a syntax error in the protocol.</summary>
+		SyntaxErrorProtocol = 500,
+
+		/// <summary>The command was unrecognized.</summary>
+		UnrecognizedCommand = 510,
+
+		/// <summary>The command is unimplemented.</summary>
+		UnimplementedCommand = 511,
+
+		/// <summary>There was a syntax error in a command argument.</summary>
+		SyntaxErrorArgument = 512,
+
+		/// <summary>The command argument was unrecognized.</summary>
+		UnrecognizedCommandArgument = 513,
+
+		/// <summary>The command could not execute because authentication is required.</summary>
+		AuthenticationRequired = 514,
+
+		/// <summary>The command to authenticate returned an invalid authentication response.</summary>
+		BadAuthentication = 515,
+
+		/// <summary>The command generated a non-specific error response.</summary>
+		Unspecified = 550,
+
+		/// <summary>An error occurred within Tor leading to the command failing to execute.</summary>
+		InternalError = 551,
+
+		/// <summary>The command contained a configuration key, stream ID, circuit ID, or event which did not exist.</summary>
+		UnrecognizedEntity = 552,
+
+		/// <summary>The command sent a configuration value incompatible with the configuration.</summary>
+		InvalidConfigurationValue = 553,
+
+		/// <summary>The command contained an invalid descriptor.</summary>
+		InvalidDescriptor = 554,
+
+		/// <summary>The command contained a reference to an unmanaged entity.</summary>
+		UnmanagedEntity = 555,
+
+		/// <summary>A notification sent following an asynchronous operation.</summary>
+		AsynchronousEventNotify = 650,
+	}
+}

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -2,10 +2,10 @@ using System;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
 using System.Threading;
-using WalletWasabi.Tor.Control.Messages;
+using System.Threading.Tasks;
 using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Messages;
 
 namespace WalletWasabi.Tor.Control
 {
@@ -31,6 +31,19 @@ namespace WalletWasabi.Tor.Control
 		private TcpClient? TcpClient { get; }
 		private PipeReader PipeReader { get; }
 		private PipeWriter PipeWriter { get; }
+
+		/// <summary>
+		/// Gets protocol info (for version 1).
+		/// </summary>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">3.21. PROTOCOLINFO</seealso>
+		public async Task<ProtocolInfoReply> GetProtocolInfoAsync(CancellationToken cancellationToken = default)
+		{
+			// Grammar: "PROTOCOLINFO" *(SP PIVERSION) CRLF
+			// Note: PIVERSION is there in case we drastically change the syntax one day. For now it should always be "1".
+			TorControlReply reply = await SendCommandAsync("PROTOCOLINFO 1\r\n", cancellationToken).ConfigureAwait(false);
+
+			return ProtocolInfoReply.FromReply(reply);
+		}
 
 		/// <summary>
 		/// Sends a control command to Tor.

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO.Pipelines;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading;
+using WalletWasabi.Tor.Control.Messages;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Tor.Control
+{
+	public class TorControlClient : IDisposable
+	{
+		private volatile bool _disposedValue = false; // To detect redundant calls
+
+		public TorControlClient(TcpClient tcpClient)
+		{
+			TcpClient = tcpClient;
+
+			PipeReader = PipeReader.Create(tcpClient.GetStream());
+			PipeWriter = PipeWriter.Create(tcpClient.GetStream());
+		}
+
+		internal TorControlClient(PipeReader pipeReader, PipeWriter pipeWriter)
+		{
+			TcpClient = null;
+			PipeReader = pipeReader;
+			PipeWriter = pipeWriter;
+		}
+
+		private TcpClient? TcpClient { get; }
+		private PipeReader PipeReader { get; }
+		private PipeWriter PipeWriter { get; }
+
+		/// <summary>
+		/// Sends a control command to Tor.
+		/// </summary>
+		/// <param name="command">A Tor control command which must end with <c>\r\n</c>.</param>
+		public async Task<TorControlReply> SendCommandAsync(string command, CancellationToken cancellationToken = default)
+		{
+			Logger.LogDebug($"Client: About to send command: '{command.TrimEnd()}'");
+			await PipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(command)), cancellationToken).ConfigureAwait(false);
+			await PipeWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+			Logger.LogTrace($"Client: Flushed write.");
+
+			TorControlReply reply = await TorControlReplyReader.ReadReplyAsync(PipeReader, cancellationToken).ConfigureAwait(false);
+
+			return reply;
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposedValue)
+			{
+				if (disposing)
+				{
+					TcpClient?.Dispose();
+				}
+
+				_disposedValue = true;
+			}
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -21,14 +21,14 @@ namespace WalletWasabi.Tor.Control
 	/// <seealso href="https://tools.ietf.org/html/rfc5234"/>
 	public class TorControlClientFactory
 	{
+		private static readonly Regex AuthChallengeRegex = new($"^AUTHCHALLENGE SERVERHASH=([a-fA-F0-9]+) SERVERNONCE=([a-fA-F0-9]+)$", RegexOptions.Compiled);
+
 		/// <summary>Client HMAC-SHA256 key for AUTHCHALLENGE.</summary>
 		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Section 3.24. AUTHCHALLENGE</seealso>
 		private static byte[] ClientHmacKey = Encoding.ASCII.GetBytes("Tor safe cookie authentication controller-to-server hash");
 
 		/// <summary></summary>
 		private static byte[] ServerHmacKey = Encoding.ASCII.GetBytes("Tor safe cookie authentication server-to-controller hash");
-
-		private static readonly Regex AuthChallengeRegex = new($"^AUTHCHALLENGE SERVERHASH=([a-fA-F0-9]+) SERVERNONCE=([a-fA-F0-9]+)$", RegexOptions.Compiled);
 
 		public TorControlClientFactory(IRandom? random = null)
 		{
@@ -40,7 +40,6 @@ namespace WalletWasabi.Tor.Control
 		/// <summary>
 		/// Sends <c>AUTHENTICATE</c> command.
 		/// </summary>
-		/// <returns>TODO.</returns>
 		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.5</seealso>
 		/// <exception cref="TorControlException">If TCP connection cannot be established OR if authentication fails for some reason.</exception>
 		public async Task<TorControlClient> ConnectAndAuthenticateAsync(IPEndPoint endPoint, string cookieString, CancellationToken cancellationToken = default)
@@ -119,7 +118,6 @@ namespace WalletWasabi.Tor.Control
 		/// <summary>
 		/// Connects to Tor control using a TCP client.
 		/// </summary>
-		/// <exception cref="TorControlException"/>
 		private TcpClient Connect(IPEndPoint endPoint)
 		{
 			try

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -1,0 +1,138 @@
+using NBitcoin;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Messages;
+
+namespace WalletWasabi.Tor.Control
+{
+	/// <summary>
+	/// Class to authenticate to Tor Control.
+	/// </summary>
+	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt"/>
+	/// <seealso href="https://tools.ietf.org/html/rfc5234"/>
+	public class TorControlClientFactory
+	{
+		/// <summary>Client HMAC-SHA256 key for AUTHCHALLENGE.</summary>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Section 3.24. AUTHCHALLENGE</seealso>
+		private static byte[] ClientHmacKey = Encoding.ASCII.GetBytes("Tor safe cookie authentication controller-to-server hash");
+
+		/// <summary></summary>
+		private static byte[] ServerHmacKey = Encoding.ASCII.GetBytes("Tor safe cookie authentication server-to-controller hash");
+
+		private static readonly Regex AuthChallengeRegex = new($"^AUTHCHALLENGE SERVERHASH=([a-fA-F0-9]+) SERVERNONCE=([a-fA-F0-9]+)$", RegexOptions.Compiled);
+
+		public TorControlClientFactory(IRandom? random = null)
+		{
+			Random = random ?? new InsecureRandom();
+		}
+
+		private IRandom Random { get; }
+
+		/// <summary>
+		/// Sends <c>AUTHENTICATE</c> command.
+		/// </summary>
+		/// <returns>TODO.</returns>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.5</seealso>
+		/// <exception cref="TorControlException">If TCP connection cannot be established OR if authentication fails for some reason.</exception>
+		public async Task<TorControlClient> ConnectAndAuthenticateAsync(IPEndPoint endPoint, string cookieString, CancellationToken cancellationToken = default)
+		{
+			TcpClient tcpClient = Connect(endPoint);
+			TorControlClient? clientToDispose = null;
+
+			try
+			{
+				TorControlClient controlClient = clientToDispose = new(tcpClient);
+
+				await AuthSafeCookieOrThrowAsync(controlClient, cookieString, cancellationToken).ConfigureAwait(false);
+
+				// All good, do not dispose.
+				clientToDispose = null;
+
+				return controlClient;
+			}
+			finally
+			{
+				clientToDispose?.Dispose();
+			}
+		}
+
+		/// <summary>Authenticates client using SAFE-COOKIE.</summary>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.24 for SAFECOOKIE authentication.</seealso>
+		/// <seealso href="https://github.com/torproject/stem/blob/63a476056017dda5ede35efc4e4f7acfcc1d7d1a/stem/connection.py#L893">Python implementation.</seealso>
+		/// <exception cref="TorControlException">If TCP connection cannot be established OR if authentication fails for some reason.</exception>
+		internal async Task<TorControlClient> AuthSafeCookieOrThrowAsync(TorControlClient controlClient, string cookieString, CancellationToken cancellationToken = default)
+		{
+			byte[] nonceBytes = new byte[32];
+			Random.GetBytes(nonceBytes);
+			string clientNonce = ByteHelpers.ToHex(nonceBytes);
+
+			TorControlReply authChallengeReply = await controlClient.SendCommandAsync($"AUTHCHALLENGE SAFECOOKIE {clientNonce}\r\n", cancellationToken).ConfigureAwait(false);
+
+			if (authChallengeReply)
+			{
+				if (authChallengeReply.ResponseLines.Count != 1)
+				{
+					Logger.LogError($"Invalid reply: '{authChallengeReply}'");
+					throw new TorControlException("Invalid AUTHCHALLENGE reply.");
+				}
+
+				string reply = authChallengeReply.ResponseLines[0];
+				Match match = AuthChallengeRegex.Match(reply);
+
+				if (!match.Success)
+				{
+					Logger.LogError($"Invalid reply: '{reply}'");
+					throw new TorControlException("Invalid AUTHCHALLENGE reply.");
+				}
+
+				string serverNonce = match.Groups[2].Value;
+				string toHash = $"{cookieString}{clientNonce}{serverNonce}";
+
+				using HMACSHA256 hmacSha256 = new(ClientHmacKey);
+				byte[] serverHash = hmacSha256.ComputeHash(ByteHelpers.FromHex(toHash));
+				string serverHashStr = ByteHelpers.ToHex(serverHash);
+
+				Logger.LogTrace($"Authenticate using server hash: '{serverHashStr}'.");
+				TorControlReply authenticationReply = await controlClient.SendCommandAsync($"AUTHENTICATE {serverHashStr}\r\n", cancellationToken).ConfigureAwait(false);
+
+				if (!authenticationReply)
+				{
+					Logger.LogError($"Invalid reply: '{authenticationReply}'");
+					throw new TorControlException("Invalid AUTHENTICATE reply.");
+				}
+
+				Logger.LogTrace("Success!");
+			}
+
+			return controlClient;
+		}
+
+		/// <summary>
+		/// Connects to Tor control using a TCP client.
+		/// </summary>
+		/// <exception cref="TorControlException"/>
+		private TcpClient Connect(IPEndPoint endPoint)
+		{
+			try
+			{
+				TcpClient tcpClient = new();
+				tcpClient.Connect(endPoint);
+				return tcpClient;
+			}
+			catch (Exception e)
+			{
+				Logger.LogError($"Failed to connect to the Tor control: '{endPoint}'.", e);
+				throw new TorControlException($"Failed to connect to the Tor control: '{endPoint}'.", e);
+			}
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/TorControlReplyReader.cs
+++ b/WalletWasabi/Tor/Control/TorControlReplyReader.cs
@@ -1,105 +1,106 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Exceptions;
 using WalletWasabi.Tor.Control.Messages;
 
 namespace WalletWasabi.Tor.Control
 {
-	/// <summary>
-	/// TODO.
-	/// </summary>
 	public class TorControlReplyReader
 	{
+		/// <remarks>
+		/// <see href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Notes on an escaping bug</see> mentions that
+		/// it is possible to implement a workaround so that a controller is compatible with buggy Tor implementations. This
+		/// implementation DOES NOT do that.
+		/// <para>However, such implementation is available <see href="https://github.com/zcash/zcash/pull/2251">here</see>.</para>
+		/// </remarks>
 		/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
+		/// <exception cref="TorControlReplyParseException">When received message does not follow Tor Control reply grammar.</exception>
 		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4. Replies".</seealso>
 		/// <seealso href="https://github.com/lontivero/Torino/blob/d891616777ed596ef54dbf1d86c9b4771e45e8f3/src/Reply.cs#L72"/>
+		/// <seealso href="https://github.com/torproject/stem/blob/master/stem/response/__init__.py"/>
 		public static async Task<TorControlReply> ReadReplyAsync(PipeReader reader, CancellationToken cancellationToken = default)
 		{
-			Logger.LogTrace(">");
+			string line;
 
 			try
 			{
-				string? line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+				line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+			}
+			catch (InvalidDataException e)
+			{
+				throw new TorControlReplyParseException("No reply line was received.", e);
+			}
 
-				if (line == null)
+			if (line.Length < 3)
+			{
+				throw new TorControlReplyParseException("Status code requires at least 3 characters.");
+			}
+
+			if (!int.TryParse(line.AsSpan(0, 3), out int code))
+			{
+				throw new TorControlReplyParseException($"Unknown status code: '{line.Substring(0, 3)}'.");
+			}
+
+			line = line[3..];
+
+			if (line.Length == 0)
+			{
+				return new TorControlReply((StatusCode)code, responseLines: new List<string>() { string.Empty });
+			}
+
+			char id = line[0];
+
+			if (id != '+' && id != '-')
+			{
+				if (id == ' ')
 				{
-					return new TorControlReply(StatusCode.Unknown);
+					line = line[1..];
 				}
 
-				if (line.Length < 3)
-				{
-					return new TorControlReply(StatusCode.Unknown);
-				}
+				return new TorControlReply((StatusCode)code, responseLines: new List<string>() { line });
+			}
 
-				if (!int.TryParse(line.AsSpan(0, 3), out int code))
-				{
-					return new TorControlReply(StatusCode.Unknown);
-				}
+			List<string> responses = new();
+			responses.Add(line[1..]);
 
-				line = line[3..];
+			while (true)
+			{
+				line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+
+				if (line is null)
+				{
+					break;
+				}
 
 				if (line.Length == 0)
 				{
-					return new TorControlReply((StatusCode)code, responseLines: new List<string>() { string.Empty });
+					continue;
 				}
 
-				char id = line[0];
-
-				if (id != '+' && id != '-')
+				if (id == '-' && line.Length > 3 && line[3] == ' ')
 				{
-					if (id == ' ')
-					{
-						line = line[1..];
-					}
-
-					return new TorControlReply((StatusCode)code, responseLines: new List<string>() { line });
-				}				
-
-				List<string> responses = new();
-				responses.Add(line[1..]);
-
-				while (true)
-				{
-					line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
-
-					if (line is null)
-					{
-						break;
-					}
-
-					if (line.Length == 0)
-					{
-						continue;
-					}
-
-					if (id == '-' && line.Length > 3 && line[3] == ' ')
-					{
-						responses.Add(line);
-						break;
-					}
-
-					if (line.Length > 3 && id != '+')
-					{
-						line = line[4..];
-					}
-
 					responses.Add(line);
-
-					if (id == '+' && ".".Equals(line))
-					{
-						break;
-					}
+					break;
 				}
 
-				return new TorControlReply((StatusCode)code, responses);
+				if (line.Length > 3 && id != '+')
+				{
+					line = line[4..];
+				}
+
+				responses.Add(line);
+
+				if (id == '+' && ".".Equals(line))
+				{
+					break;
+				}
 			}
-			catch
-			{
-				return new TorControlReply(StatusCode.Unknown);
-			}
+
+			return new TorControlReply((StatusCode)code, responseLines: responses);
 		}
 	}
 }

--- a/WalletWasabi/Tor/Control/TorControlReplyReader.cs
+++ b/WalletWasabi/Tor/Control/TorControlReplyReader.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Tor.Control
 	/// </summary>
 	public class TorControlReplyReader
 	{
-		/// <exception cref="OperationCanceledException"/>
+		/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
 		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4. Replies".</seealso>
 		/// <seealso href="https://github.com/lontivero/Torino/blob/d891616777ed596ef54dbf1d86c9b4771e45e8f3/src/Reply.cs#L72"/>
 		public static async Task<TorControlReply> ReadReplyAsync(PipeReader reader, CancellationToken cancellationToken = default)

--- a/WalletWasabi/Tor/Control/TorControlReplyReader.cs
+++ b/WalletWasabi/Tor/Control/TorControlReplyReader.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Messages;
+
+namespace WalletWasabi.Tor.Control
+{
+	/// <summary>
+	/// TODO.
+	/// </summary>
+	public class TorControlReplyReader
+	{
+		/// <exception cref="OperationCanceledException"/>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4. Replies".</seealso>
+		/// <seealso href="https://github.com/lontivero/Torino/blob/d891616777ed596ef54dbf1d86c9b4771e45e8f3/src/Reply.cs#L72"/>
+		public static async Task<TorControlReply> ReadReplyAsync(PipeReader reader, CancellationToken cancellationToken = default)
+		{
+			Logger.LogTrace(">");
+
+			try
+			{
+				string? line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+
+				if (line == null)
+				{
+					return new TorControlReply(StatusCode.Unknown);
+				}
+
+				if (line.Length < 3)
+				{
+					return new TorControlReply(StatusCode.Unknown);
+				}
+
+				if (!int.TryParse(line.AsSpan(0, 3), out int code))
+				{
+					return new TorControlReply(StatusCode.Unknown);
+				}
+
+				line = line[3..];
+
+				if (line.Length == 0)
+				{
+					return new TorControlReply((StatusCode)code, responseLines: new List<string>() { string.Empty });
+				}
+
+				char id = line[0];
+
+				if (id != '+' && id != '-')
+				{
+					if (id == ' ')
+					{
+						line = line[1..];
+					}
+
+					return new TorControlReply((StatusCode)code, responseLines: new List<string>() { line });
+				}				
+
+				List<string> responses = new();
+				responses.Add(line[1..]);
+
+				while (true)
+				{
+					line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+
+					if (line is null)
+					{
+						break;
+					}
+
+					if (line.Length == 0)
+					{
+						continue;
+					}
+
+					if (id == '-' && line.Length > 3 && line[3] == ' ')
+					{
+						responses.Add(line);
+						break;
+					}
+
+					if (line.Length > 3 && id != '+')
+					{
+						line = line[4..];
+					}
+
+					responses.Add(line);
+
+					if (id == '+' && ".".Equals(line))
+					{
+						break;
+					}
+				}
+
+				return new TorControlReply((StatusCode)code, responses);
+			}
+			catch
+			{
+				return new TorControlReply(StatusCode.Unknown);
+			}
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
+++ b/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
@@ -1,0 +1,88 @@
+using System;
+using WalletWasabi.Tor.Control.Exceptions;
+
+namespace WalletWasabi.Tor.Control.Utils
+{
+	public class Tokenizer
+	{
+		public static (string token, string remainder) ReadUntilSeparator(string input)
+		{
+			if (input == "")
+			{
+				throw new TorControlReplyParseException("Expected a token.");
+			}
+
+			string[] parts = input.Split(separator: ' ', count: 2);
+
+			if (parts.Length == 2)
+			{
+				return (parts[0], parts[1]);
+			}
+			else
+			{
+				return (parts[0], "");
+			}
+		}
+
+		/// <summary>
+		/// Reads "&lt;KEY&gt;=QuotedString".
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="input"></param>
+		/// <returns>Quoted string content.</returns>
+		public static (string value, string remainder) ReadKeyValueAssignment(string key, string input)
+		{
+			input = ReadExactString(key, input);
+
+			int startAt = input.IndexOf('"');
+
+			if (startAt == -1)
+			{
+				throw new TorControlReplyParseException("Missing opening quote character.");
+			}
+
+			startAt++;
+			int endAt = startAt;
+
+			if (endAt >= input.Length)
+			{
+				throw new TorControlReplyParseException("Unexpected end of string.");
+			}
+
+			// Do not stop at escaped quotes (").
+			while ((endAt = input.IndexOf('"', endAt)) != -1)
+			{
+				if (input[endAt - 1] != '\\')
+				{
+					break;
+				}
+			}
+
+			if (endAt == -1)
+			{
+				throw new TorControlReplyParseException($"Missing closing quote character.");
+			}
+
+			string value = input[startAt..endAt];
+			string remainder = (endAt == input.Length) ? "" : input[(endAt + 1)..];
+
+			// Unescape: \\ -> '
+			value = value.Replace(@"\\", @"\");
+
+			// Unescape: \" -> "
+			value = value.Replace("\\\"", "\"");
+
+			return (value, remainder);
+		}
+
+		public static string ReadExactString(string expectedStart, string input)
+		{
+			if (!input.StartsWith(expectedStart, StringComparison.Ordinal))
+			{
+				throw new TorControlReplyParseException($"Expected input to start with '{expectedStart}'.");
+			}
+
+			return input[expectedStart.Length..];
+		}
+	}
+}

--- a/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
+++ b/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
@@ -3,8 +3,14 @@ using WalletWasabi.Tor.Control.Exceptions;
 
 namespace WalletWasabi.Tor.Control.Utils
 {
-	public class Tokenizer
+	/// <summary>
+	/// Helper functions for parsing Tor control protocol replies.
+	/// </summary>
+	public static class Tokenizer
 	{
+		/// <summary>
+		/// Splits input string using space separator into at most two parts - token and remainder.
+		/// </summary>
 		public static (string token, string remainder) ReadUntilSeparator(string input)
 		{
 			if (input == "")
@@ -25,10 +31,8 @@ namespace WalletWasabi.Tor.Control.Utils
 		}
 
 		/// <summary>
-		/// Reads "&lt;KEY&gt;=QuotedString".
+		/// Reads "&lt;KEY&gt;=QuotedString" string.
 		/// </summary>
-		/// <param name="key"></param>
-		/// <param name="input"></param>
 		/// <returns>Quoted string content.</returns>
 		public static (string value, string remainder) ReadKeyValueAssignment(string key, string input)
 		{
@@ -75,6 +79,9 @@ namespace WalletWasabi.Tor.Control.Utils
 			return (value, remainder);
 		}
 
+		/// <summary>
+		/// Makes sure that <paramref name="input"/> starts with <paramref name="expectedStart"/>.
+		/// </summary>
 		public static string ReadExactString(string expectedStart, string input)
 		{
 			if (!input.StartsWith(expectedStart, StringComparison.Ordinal))

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -167,6 +167,11 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					}
 				} while (i < attemptsNo);
 			}
+			catch (OperationCanceledException)
+			{
+				Logger.LogTrace($"[{connection}] Request was canceled: '{request.RequestUri}'.");
+				throw;
+			}
 			catch (Exception e)
 			{
 				Logger.LogTrace($"[{connection}] Request failed with exception", e);
@@ -227,6 +232,11 @@ namespace WalletWasabi.Tor.Socks5.Pool
 			catch (TorException e)
 			{
 				Logger.LogDebug($"['{host}'][ERROR] Failed to create a new pool connection.", e);
+				throw;
+			}
+			catch (OperationCanceledException)
+			{
+				Logger.LogTrace($"['{host}'] Operation was canceled.");
 				throw;
 			}
 			catch (Exception e)

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -36,6 +36,9 @@ namespace WalletWasabi.Tor
 		/// <inheritdoc/>
 		protected override async Task ActionAsync(CancellationToken token)
 		{
+			// TODO: Return something.
+			await TorProcessManager.CheckStatusAsync().ConfigureAwait(false);
+
 			if (TorHttpPool.TorDoesntWorkSince is { }) // If Tor misbehaves.
 			{
 				TimeSpan torMisbehavedFor = DateTimeOffset.UtcNow - TorHttpPool.TorDoesntWorkSince ?? TimeSpan.Zero;

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -1,10 +1,8 @@
-using Microsoft.VisualBasic.CompilerServices;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -1,8 +1,10 @@
+using Microsoft.VisualBasic.CompilerServices;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
@@ -188,6 +190,14 @@ namespace WalletWasabi.Tor
 				Logger.LogInfo("**Circuit status**");
 				TorControlReply statusReply = await client.SendCommandAsync("GETINFO circuit-status\r\n").ConfigureAwait(false);
 				Logger.LogInfo($"Status reply: {statusReply}");
+
+				Logger.LogInfo("**Circuit status**");
+
+				TorControlReply protocolInfoReply = await client.SendCommandAsync("PROTOCOLINFO\r\n").ConfigureAwait(false);
+				Logger.LogInfo($"Protocol info reply: {protocolInfoReply}");
+
+				ProtocolInfoReply protocolInfoReply2 = await client.GetProtocolInfoAsync().ConfigureAwait(false);
+				Logger.LogInfo($"Protocol info reply: {protocolInfoReply2}");
 			}
 
 			Logger.LogTrace($"Checking Tor status: {(result ? "UP" : "DOWN")}");

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -183,6 +183,11 @@ namespace WalletWasabi.Tor
 				{
 					result = true;
 				}
+
+
+				Logger.LogInfo("**Circuit status**");
+				TorControlReply statusReply = await client.SendCommandAsync("GETINFO circuit-status\r\n").ConfigureAwait(false);
+				Logger.LogInfo($"Status reply: {statusReply}");
 			}
 
 			Logger.LogTrace($"Checking Tor status: {(result ? "UP" : "DOWN")}");

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -22,6 +22,7 @@ namespace WalletWasabi.Tor
 			TorBinaryDir = Path.Combine(MicroserviceHelpers.GetBinaryFolder(), "Tor");
 
 			TorDataDir = Path.Combine(dataDir, "tordata");
+			CookieAuthFilePath = Path.Combine(dataDir, "control_auth_cookie");
 			LogFilePath = logFilePath;
 			IoHelpers.EnsureContainingDirectoryExists(LogFilePath);
 			DistributionFolder = distributionFolderPath;
@@ -48,6 +49,13 @@ namespace WalletWasabi.Tor
 		/// <summary>Full path to executable file that is used to start Tor process.</summary>
 		public string TorBinaryFilePath { get; }
 
+		/// <summary>Full path to Tor cookie file.</summary>
+		public string CookieAuthFilePath { get; }
+
+		/// <summary>Tor control IP address.</summary>
+		/// <seealso href="https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Ports.md">TODO</seealso>
+		public IPEndPoint ControlEndpoint { get; } = new(IPAddress.Loopback, 29051);
+
 		private string GeoIpPath { get; }
 		private string GeoIp6Path { get; }
 
@@ -65,6 +73,9 @@ namespace WalletWasabi.Tor
 			return string.Join(
 				" ",
 				$"--SOCKSPort {torSocks5EndPoint}",
+				$"--ControlPort {ControlEndpoint.Port}",
+				$"--CookieAuthentication 1",
+				$"--CookieAuthFile \"{CookieAuthFilePath}\"",
 				$"--DataDirectory \"{TorDataDir}\"",
 				$"--GeoIPFile \"{GeoIpPath}\"",
 				$"--GeoIPv6File \"{GeoIp6Path}\"",


### PR DESCRIPTION
This PR starts Tor with `--ControlPort 29051 --CookieAuthFile "<PATH-IN-WASABI-TOR-FOLDER>"`. 

* `TorProcessMonitor` starts Tor, initiates a connection with Tor Control and authenticates using safe-cookie mechanism.
* `TAKEOWNERSHIP` command is sent to Tor Control when WW user has enabled the option to terminate Tor when WW is terminated. This means that once WW is closed, Tor is closed too (gracefully).
* [WIP] `TorMonitor` sends periodically `GETINFO network-liveness` command to check whether Tor is working or not. (Is there a better way or better approach?)

PS: I'm aware of Lucas's [comment](https://github.com/zkSNACKs/WalletWasabi/issues/4501#issuecomment-809734117).

Related to #4501.
______

### What Tor Control authentication method is correct to use?

There are the following choices (see "3.5. AUTHENTICATE" in [spec](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt#n369)):

1. No authentication
    * If no authentication is used, then in some scenarios an adversory may change Tor settings for you and de-anonymize you probably. Better be safe than sorry holds.
1. Cookie-based authentication. 
    * *Cookie authentication simply means that your credential is the content of a file in Tor's **DataDirectory**.* The idea of this authentication is simply that Tor writes some random content to a cookie file and you (as a Tor client) can authenticate based on read-access to that cookie file.
1. Safe-cookie-based authentication
    * This authentication method relies on `AUTHCHALLENGE` + `AUTHENTICATION` commands and it's prefered over cookie-based authentication.
1. Password authentication (`HashedControlPassword` option, see [spec: 3.5 AUTHENTICATE](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt))
    * See example below.

See "5.1. Authentication [implementation notes]" in [spec](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt) which marks the first two choices as "not good".

The important question: Should we choose safe-cookie authentication or password authentication? I went with safe-cookie as it's safer when TCP communication is eavesdropped and it's not that harders than password authentication.

Feedback on this welcome.

The following text is useful for understanding Tor Control authentication methods. It's not necessary to read it.

#### Details: Cookie authentication

##### Why to avoid cookie-based authentication?

[[1](https://gitlab.torproject.org/legacy/trac/-/issues/28295#note_2303641)] and [[2](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt)] says:

> The COOKIE authentication method exposes the user running a
> controller to an unintended information disclosure attack whenever
> the controller has greater filesystem read access than the process
> that it has connected to.  (Note that a controller may connect to a
> process other than Tor.)  It is almost never safe to use, even if
> the controller's user has explicitly specified which filename to
> read an authentication cookie from.  For this reason, the COOKIE
> authentication method has been deprecated and will be removed from
> a future version of Tor.

##### Cookie authentication example

<details>
  <summary>Cookie authentication example</summary>

(From https://stem.torproject.org/faq.html)

To get the credential for your `AUTHENTICATE` command we will use `hexdump`...

```
% hexdump -e '32/1 "%02x""\n"' /home/atagar/.tor/control_auth_cookie
be9c9e18364e33d5eb8ba820d456aa2bc03444c0420f089ba4569b6aeecc6254

% telnet localhost 9051
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
AUTHENTICATE be9c9e18364e33d5eb8ba820d456aa2bc03444c0420f089ba4569b6aeecc6254
250 OK
GETINFO version
250-version=0.2.5.1-alpha-dev (git-245ecfff36c0cecc)
250 OK
QUIT
250 closing connection
Connection closed by foreign host.
```
</details>

#### Details: Password authentication

<details>
  <summary>Password authentication example</summary>

(From https://stem.torproject.org/faq.html)

```
% tor --hash-password "my_password"
16:E600ADC1B52C80BB6022A0E999A7734571A451EB6AE50FED489B72E3DF
```

Authenticating with this simply involves giving Tor the credential...

```
% cat ~/.tor/torrc
ControlPort 9051
HashedControlPassword 16:E600ADC1B52C80BB6022A0E999A7734571A451EB6AE50FED489B72E3DF

% telnet localhost 9051
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
AUTHENTICATE "my_password"
250 OK
GETINFO version
250-version=0.2.5.1-alpha-dev (git-245ecfff36c0cecc)
250 OK
QUIT
250 closing connection
Connection closed by foreign host.
```
</details>