### PR TITLE
Revert cancellable `Rpc::GetMempoolInfoAsync`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -147,7 +147,7 @@ namespace WalletWasabi.Tests.UnitTests
 				});
 			mockRpc.Setup(rpc => rpc.GetPeersInfoAsync())
 				.ReturnsAsync(Array.Empty<PeerInfo>());
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync())
 				.ReturnsAsync(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
@@ -169,7 +169,7 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error-EstimateSmartFee", null));
 
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync())
 				.ReturnsAsync(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
@@ -232,7 +232,7 @@ namespace WalletWasabi.Tests.UnitTests
 			var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 			var any = EstimateSmartFeeMode.Conservative;
 
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(
 				new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000, // 1 s/b (default value)
@@ -280,7 +280,7 @@ namespace WalletWasabi.Tests.UnitTests
 			{
 				var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 				var mempoolInfo = MempoolInfoGenerator.GenerateMempoolInfo();
-				mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(mempoolInfo);
+				mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(mempoolInfo);
 				mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative)).ReturnsAsync(FeeRateResponse(2, 120m));
 				var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 				var estimations = feeRates.Estimations;
@@ -305,7 +305,7 @@ namespace WalletWasabi.Tests.UnitTests
 				hasPeersInfo
 					? new[] { new PeerInfo() }
 					: Array.Empty<PeerInfo>());
-			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(
+			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync()).ReturnsAsync(
 				new MemPoolInfo
 				{
 					MemPoolMinFee = memPoolMinFee, // 1 s/b (default value)

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.Tests.UnitTests
 			throw new NotImplementedException();
 		}
 
-		public Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
+		public Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
 			return OnGetMempoolInfoAsync();
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
@@ -132,7 +132,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			rpcMock.SetupGet(rpc => rpc.Network).Returns(Network.Main);
 			rpcMock.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { FeeRate = new FeeRate(10m) });
-			rpcMock.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
+			rpcMock.Setup(rpc => rpc.GetMempoolInfoAsync())
 				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 			return rpcMock.Object;
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -75,7 +75,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			mockRpcClient.Setup(rpc => rpc.Network).Returns(Network.Main);
 			mockRpcClient.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { Blocks = 5, FeeRate = new FeeRate(100m) });
-			mockRpcClient.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
+			mockRpcClient.Setup(rpc => rpc.GetMempoolInfoAsync())
 				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 			return mockRpcClient.Object;
 		}

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -145,7 +145,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				() => base.GetMempoolEntryAsync(txid, throwIfNotFound)).ConfigureAwait(false);
 		}
 
-		public override async Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
+		public override async Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
 			string cacheKey = nameof(GetMempoolInfoAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -157,7 +157,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetMempoolInfoAsync(cancel)).ConfigureAwait(false);
+				() => base.GetMempoolInfoAsync()).ConfigureAwait(false);
 		}
 
 		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 		Task<uint256[]> GetRawMempoolAsync();
 
-		Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default);
+		Task<MemPoolInfo> GetMempoolInfoAsync();
 
 		Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, bool allowHighFees = false);
 

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound).ConfigureAwait(false);
 		}
 
-		public virtual async Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
+		public virtual async Task<MemPoolInfo> GetMempoolInfoAsync()
 		{
 			try
 			{
@@ -95,8 +95,6 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			}
 			catch (RPCException ex) when (ex.RPCCode == RPCErrorCode.RPC_MISC_ERROR)
 			{
-				cancel.ThrowIfCancellationRequested();
-
 				return await Rpc.GetMemPoolAsync().ConfigureAwait(false);
 			}
 		}

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -74,7 +74,7 @@ namespace NBitcoin.RPC
 				? SimulateRegTestFeeEstimation(estimateMode)
 				: await GetFeeEstimationsAsync(rpc, estimateMode, cancel).ConfigureAwait(false);
 
-			var mempoolInfo = await rpc.GetMempoolInfoAsync(cancel).ConfigureAwait(false);
+			var mempoolInfo = await rpc.GetMempoolInfoAsync().ConfigureAwait(false);
 
 			var sanityFeeRate = mempoolInfo.GetSanityFeeRate();
 			var rpcStatus = await rpc.GetRpcStatusAsync(cancel).ConfigureAwait(false);


### PR DESCRIPTION
Making the `GetMempoolInfoAsync` cancellable in https://github.com/zkSNACKs/WalletWasabi/pull/5670 was unnecessary. The action was never cancelled nor cancelleable.

By their own nature the rpc calls are not cancellable but abandomables, this means that in case one day we decide to make the `IRCPClient` methods "cancellable" we can only achieve it by abandom the tasks with something like `Task.WhenAny(cancellableTask, theRpcCall)`.

In any case this PR reverts the parts of #5670 that are not necessary, leaving those changes that make `GetFeeEstimationsAsync` cancellable and the tests that verify that.    