### PR TITLE
[WabiSabi] Pre-GetStatus endpoint

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -165,8 +165,8 @@ namespace WalletWasabi.Tests.Helpers
 			var (zeroVsizeCredentialRequest, _) = vsClient.CreateRequestForZeroAmount();
 
 			return new ConnectionConfirmationRequest(
-				round?.Id ?? new uint256(12345),
-				alice?.Id ?? new uint256(98765),
+				round?.Id ?? BitcoinFactory.CreateUint256(),
+				alice?.Id ?? BitcoinFactory.CreateUint256(),
 				zeroAmountCredentialRequest,
 				realAmountCredentialRequest,
 				zeroVsizeCredentialRequest,

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -79,11 +79,11 @@ namespace WalletWasabi.Tests.Helpers
 		}
 
 		public static InputRegistrationRequest CreateInputRegistrationRequest(Key? key = null, Round? round = null, OutPoint? prevout = null)
-			=> CreateInputRegistrationRequest(prevout ?? BitcoinFactory.CreateOutPoint(), CreateOwnershipProof(key, round?.Hash), round);
+			=> CreateInputRegistrationRequest(prevout ?? BitcoinFactory.CreateOutPoint(), CreateOwnershipProof(key, round?.Id), round);
 
 		public static InputRegistrationRequest CreateInputRegistrationRequest(OutPoint prevout, OwnershipProof ownershipProof, Round? round = null)
 		{
-			var roundId = round?.Id ?? Guid.NewGuid();
+			var roundId = round?.Id ?? uint256.Zero;
 
 			(var amClient, var vsClient, _, _) = CreateWabiSabiClientsAndIssuers(round);
 			var (zeroAmountCredentialRequest, _) = amClient.CreateRequestForZeroAmount();
@@ -165,8 +165,8 @@ namespace WalletWasabi.Tests.Helpers
 			var (zeroVsizeCredentialRequest, _) = vsClient.CreateRequestForZeroAmount();
 
 			return new ConnectionConfirmationRequest(
-				round?.Id ?? Guid.NewGuid(),
-				alice?.Id ?? Guid.NewGuid(),
+				round?.Id ?? new uint256(12345),
+				alice?.Id ?? new uint256(98765),
 				zeroAmountCredentialRequest,
 				realAmountCredentialRequest,
 				zeroVsizeCredentialRequest,
@@ -252,13 +252,13 @@ namespace WalletWasabi.Tests.Helpers
 				vsClient.Credentials.Valuable);
 
 			return new OutputRegistrationRequest(
-				round?.Id ?? Guid.NewGuid(),
+				round?.Id ?? uint256.Zero,
 				script,
 				realAmountCredentialRequest,
 				realVsizeCredentialRequest);
 		}
 
-		public static IEnumerable<OutputRegistrationRequest> CreateOutputRegistrationRequests(Round round, IEnumerable<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)> ccresps)
+		public static IEnumerable<OutputRegistrationRequest> CreateOutputRegistrationRequests(Round round, IEnumerable<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)> ccresps)
 		{
 			var ret = new List<OutputRegistrationRequest>();
 
@@ -280,7 +280,7 @@ namespace WalletWasabi.Tests.Helpers
 
 		public static Round CreateBlameRound(Round round, WabiSabiConfig cfg)
 		{
-			RoundParameters parameters = new(cfg, round.Network, round.Random, round.FeeRate, blameOf: round);
+			RoundParameters parameters = new(cfg, round.Network, new InsecureRandom(), round.FeeRate, blameOf: round);
 			return new(parameters);
 		}
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/TestTranscript.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/TestTranscript.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.StrobeProtocol;
+using WalletWasabi.WabiSabi;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto
 {
@@ -14,9 +15,11 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 
 		public TestTranscript(byte[] label)
 		{
-			_strobe = new Strobe128("WabiSabi_v1.0");
+			_strobe = new Strobe128(ProtocolConstants.WabiSabiProtocolIdentifier);
 
-			var metadata = Enumerable.Concat(Encoding.UTF8.GetBytes("domain-separator"), BitConverter.GetBytes(label.Length)).ToArray();
+			var metadata = Enumerable.Concat(
+				Encoding.UTF8.GetBytes(ProtocolConstants.DomainStrobeSeparator), 
+				BitConverter.GetBytes(label.Length)).ToArray();
 			_strobe.AddAssociatedMetaData(metadata, false);
 			_strobe.AddAssociatedData(label, false);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -52,7 +52,7 @@ irreq2.OwnershipProof,
 			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
@@ -119,7 +119,7 @@ irreq1.OwnershipProof,
 			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
@@ -185,7 +185,7 @@ irreq1.OwnershipProof,
 			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
@@ -261,7 +261,7 @@ irreq1.OwnershipProof,
 			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -54,7 +54,7 @@ irreq2.OwnershipProof,
 			var alice2 = round.Alices.Single(x => x.Id == irres2.AliceId);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
 			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.vsizeClient, irres2.AliceId));
@@ -136,7 +136,7 @@ irreq2.OwnershipProof,
 			var alice2 = round.Alices.Single(x => x.Id == irres2.AliceId);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
 			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.vsizeClient, irres2.AliceId));
@@ -220,7 +220,7 @@ irreq1.OwnershipProof,
 			var alice2 = round.Alices.Single(x => x.Id == irres2.AliceId);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
 			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.vsizeClient, irres2.AliceId));
@@ -308,7 +308,7 @@ irreq1.OwnershipProof,
 			var alice2 = round.Alices.Single(x => x.Id == irres2.AliceId);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
 			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.vsizeClient, irres2.AliceId));
@@ -388,7 +388,7 @@ irreq1.OwnershipProof,
 			var alice2 = round.Alices.Single(x => x.Id == irres2.AliceId);
 
 			// Confirm connections.
-			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, Guid aliceId)>();
+			var ccresps = new List<(ConnectionConfirmationResponse resp, WabiSabiClient amountClient, WabiSabiClient vsizeClient, uint256 aliceId)>();
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
 			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.vsizeClient, irres2.AliceId));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -152,7 +152,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Prison prison = new();
 			using var key = new Key();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Banned, Guid.NewGuid());
+			prison.Punish(outpoint, Punishment.Banned, uint256.One);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
@@ -169,7 +169,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			Prison prison = new();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Noted, Guid.NewGuid());
+			prison.Punish(outpoint, Punishment.Noted, uint256.One);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
@@ -190,7 +190,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			Prison prison = new();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Noted, Guid.NewGuid());
+			prison.Punish(outpoint, Punishment.Noted, uint256.One);
 			WabiSabiConfig cfg = new() { AllowNotedInputRegistration = false };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			Prison prison = new();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Banned, Guid.NewGuid());
+			prison.Punish(outpoint, Punishment.Banned, uint256.Zero);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.Alices.Add(WabiSabiFactory.CreateAlice(prevout: outpoint));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -32,7 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
 			// There's no such alice yet, so success.
-			var req = new InputsRemovalRequest(round.Id, Guid.NewGuid());
+			var req = new InputsRemovalRequest(round.Id, new uint256(123456));
 			await handler.RemoveInputAsync(req);
 
 			// There was the alice we want to remove so success.
@@ -52,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
 
 			await using ArenaRequestHandler handler = new(new WabiSabiConfig(), new Prison(), arena, new MockRpcClient());
-			var req = new InputsRemovalRequest(Guid.NewGuid(), Guid.NewGuid());
+			var req = new InputsRemovalRequest(uint256.Zero, new uint256(123456));
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RemoveInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
@@ -67,7 +68,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21)).ConfigureAwait(false);
 			var round = arena.Rounds.First().Value;
 
-			var req = new InputsRemovalRequest(round.Id, Guid.NewGuid());
+			var req = new InputsRemovalRequest(round.Id, new uint256(123456));
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 			{
 				if (phase != Phase.InputRegistration)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
 			// There's no such alice yet, so success.
-			var req = new InputsRemovalRequest(round.Id, new uint256(123456));
+			var req = new InputsRemovalRequest(round.Id, BitcoinFactory.CreateUint256());
 			await handler.RemoveInputAsync(req);
 
 			// There was the alice we want to remove so success.
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
 
 			await using ArenaRequestHandler handler = new(new WabiSabiConfig(), new Prison(), arena, new MockRpcClient());
-			var req = new InputsRemovalRequest(uint256.Zero, new uint256(123456));
+			var req = new InputsRemovalRequest(uint256.Zero, BitcoinFactory.CreateUint256());
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RemoveInputAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
@@ -68,7 +68,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21)).ConfigureAwait(false);
 			var round = arena.Rounds.First().Value;
 
-			var req = new InputsRemovalRequest(round.Id, new uint256(123456));
+			var req = new InputsRemovalRequest(round.Id, BitcoinFactory.CreateUint256());
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 			{
 				if (phase != Phase.InputRegistration)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
 			await using ArenaRequestHandler handler = new(new WabiSabiConfig(), new Prison(), arena, new MockRpcClient());
-			var req = new TransactionSignaturesRequest(Guid.NewGuid(), null!);
+			var req = new TransactionSignaturesRequest(uint256.Zero, null!);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.SignTransactionAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 			await arena.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.Banning;
 using Xunit;
@@ -30,22 +31,22 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			// Make sure we set them to the past so the release method that looks at the time evaluates to true.
 			var past = DateTimeOffset.UtcNow - TimeSpan.FromMilliseconds(2);
 
-			var guid1 = Guid.NewGuid();
-			p.Punish(new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, past, guid1));
+			var id1 = new uint256(1234);
+			p.Punish(new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, past, id1));
 			Assert.NotEqual(currentChangeId, p.ChangeId);
 			currentChangeId = p.ChangeId;
 
-			p.Punish(new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, past, guid1));
+			p.Punish(new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, past, id1));
 			Assert.NotEqual(currentChangeId, p.ChangeId);
 			currentChangeId = p.ChangeId;
 
 			var op = BitcoinFactory.CreateOutPoint();
-			var guid2 = Guid.NewGuid();
-			p.Punish(new Inmate(op, Punishment.Noted, past, guid2));
+			var id2 = new uint256(5555);
+			p.Punish(new Inmate(op, Punishment.Noted, past, id2));
 			Assert.NotEqual(currentChangeId, p.ChangeId);
 			currentChangeId = p.ChangeId;
 
-			p.Punish(new Inmate(op, Punishment.Noted, past, guid1));
+			p.Punish(new Inmate(op, Punishment.Noted, past, id1));
 			Assert.NotEqual(currentChangeId, p.ChangeId);
 			currentChangeId = p.ChangeId;
 
@@ -62,17 +63,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		{
 			var p = new Prison();
 
-			var guid1 = Guid.NewGuid();
+			var id1 = new uint256(88888);
 
 			var utxo = BitcoinFactory.CreateOutPoint();
-			p.Punish(utxo, Punishment.Noted, guid1);
+			p.Punish(utxo, Punishment.Noted, id1);
 			Assert.Single(p.GetInmates());
 			Assert.Equal(1, p.CountInmates().noted);
 			Assert.Equal(0, p.CountInmates().banned);
 			Assert.True(p.TryGet(utxo, out _));
 
 			// Updates to banned.
-			p.Punish(utxo, Punishment.Banned, guid1);
+			p.Punish(utxo, Punishment.Banned, id1);
 			Assert.Single(p.GetInmates());
 			Assert.Equal(0, p.CountInmates().noted);
 			Assert.Equal(1, p.CountInmates().banned);
@@ -83,8 +84,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			Assert.Empty(p.GetInmates());
 
 			// Noting twice flips to banned.
-			p.Punish(utxo, Punishment.Noted, guid1);
-			p.Punish(utxo, Punishment.Noted, guid1);
+			p.Punish(utxo, Punishment.Noted, id1);
+			p.Punish(utxo, Punishment.Noted, id1);
 			Assert.Single(p.GetInmates());
 			Assert.Equal(0, p.CountInmates().noted);
 			Assert.Equal(1, p.CountInmates().banned);
@@ -92,12 +93,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			Assert.True(p.TryRelease(utxo, out _));
 
 			// Updates round.
-			var guid2 = Guid.NewGuid();
-			p.Punish(utxo, Punishment.Banned, guid1);
-			p.Punish(utxo, Punishment.Banned, guid2);
+			var id2 = new NBitcoin.uint256(1234);
+			p.Punish(utxo, Punishment.Banned, id1);
+			p.Punish(utxo, Punishment.Banned, id2);
 			Assert.Single(p.GetInmates());
 			Assert.True(p.TryGet(utxo, out var inmate));
-			Assert.Equal(guid2, inmate!.LastDisruptedRoundId);
+			Assert.Equal(id2, inmate!.LastDisruptedRoundId);
 			Assert.True(p.TryRelease(utxo, out _));
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonTests.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			// Make sure we set them to the past so the release method that looks at the time evaluates to true.
 			var past = DateTimeOffset.UtcNow - TimeSpan.FromMilliseconds(2);
 
-			var id1 = new uint256(1234);
+			var id1 = BitcoinFactory.CreateUint256();
 			p.Punish(new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, past, id1));
 			Assert.NotEqual(currentChangeId, p.ChangeId);
 			currentChangeId = p.ChangeId;
@@ -41,7 +41,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			currentChangeId = p.ChangeId;
 
 			var op = BitcoinFactory.CreateOutPoint();
-			var id2 = new uint256(5555);
+			var id2 = BitcoinFactory.CreateUint256();
 			p.Punish(new Inmate(op, Punishment.Noted, past, id2));
 			Assert.NotEqual(currentChangeId, p.ChangeId);
 			currentChangeId = p.ChangeId;
@@ -63,7 +63,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		{
 			var p = new Prison();
 
-			var id1 = new uint256(88888);
+			var id1 = BitcoinFactory.CreateUint256();
 
 			var utxo = BitcoinFactory.CreateOutPoint();
 			p.Punish(utxo, Punishment.Noted, id1);
@@ -93,7 +93,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			Assert.True(p.TryRelease(utxo, out _));
 
 			// Updates round.
-			var id2 = new NBitcoin.uint256(1234);
+			var id2 = BitcoinFactory.CreateUint256();
 			p.Punish(utxo, Punishment.Banned, id1);
 			p.Punish(utxo, Punishment.Banned, id2);
 			Assert.Single(p.GetInmates());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -35,8 +36,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			CoordinatorParameters coordinatorParameters = new(workDir);
 			using var w = new Warden(coordinatorParameters.UtxoWardenPeriod, coordinatorParameters.PrisonFilePath, coordinatorParameters.RuntimeCoordinatorConfig);
 			await w.StartAsync(CancellationToken.None);
-			var i1 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), Guid.NewGuid());
-			var i2 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), Guid.NewGuid());
+			var i1 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), uint256.Zero);
+			var i2 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), uint256.Zero);
 			w.Prison.Punish(i1);
 			w.Prison.Punish(i2);
 
@@ -72,8 +73,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			CoordinatorParameters coordinatorParameters = new(workDir);
 			using var w = new Warden(coordinatorParameters.UtxoWardenPeriod, coordinatorParameters.PrisonFilePath, coordinatorParameters.RuntimeCoordinatorConfig);
 			await w.StartAsync(CancellationToken.None);
-			var i1 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), Guid.NewGuid());
-			var i2 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), Guid.NewGuid());
+			var i1 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), uint256.Zero);
+			var i2 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), uint256.Zero);
 			w.Prison.Punish(i1);
 			w.Prison.Punish(i2);
 
@@ -99,8 +100,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 
 			using var w = new Warden(coordinatorParameters.UtxoWardenPeriod, coordinatorParameters.PrisonFilePath, coordinatorParameters.RuntimeCoordinatorConfig);
 			await w.StartAsync(CancellationToken.None);
-			var i1 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), Guid.NewGuid());
-			var i2 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), Guid.NewGuid());
+			var i1 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Noted, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), uint256.Zero);
+			var i2 = new Inmate(BitcoinFactory.CreateOutPoint(), Punishment.Banned, DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds()), uint256.Zero);
 			var p = w.Prison;
 			p.Punish(i1);
 			p.Punish(i2);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			Assert.Equal(Phase.InputRegistration, arena.Rounds.First().Value.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
-			var aliceClient = await AliceClient.CreateNewAsync(arenaClient, coin1.Coin, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
+			var aliceClient = await AliceClient.CreateNewAsync(arenaClient, coin1.Coin, bitcoinSecret, round.Id, round.FeeRate);
 
 			Task confirmationTask = aliceClient.ConfirmConnectionAsync(TimeSpan.FromSeconds(3), CancellationToken.None);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -50,9 +50,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			CredentialPool vsizeCredentials = new();
 			var aliceArenaClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.VsizeCredentialIssuerParameters, amountCredentials, vsizeCredentials, coordinator, new InsecureRandom());
 
-			var aliceId = await aliceArenaClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id, round.Hash);
+			var aliceId = await aliceArenaClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id);
 
-			Assert.NotEqual(Guid.Empty, aliceId);
+			Assert.NotEqual(uint256.Zero, aliceId);
 			Assert.Empty(amountCredentials.Valuable);
 
 			var reissuanceAmounts = new[]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
-			var aliceClient = await AliceClient.CreateNewAsync(aliceArenaClient, coin1.Coin, bitcoinSecret, round.Id, round.Hash, round.FeeRate);
+			var aliceClient = await AliceClient.CreateNewAsync(aliceArenaClient, coin1.Coin, bitcoinSecret, round.Id, round.FeeRate);
 
 			Task confirmationTask = aliceClient.ConfirmConnectionAsync(TimeSpan.FromSeconds(3), CancellationToken.None);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InputRegistrationRequestMessageSerialization()
 		{
 			var message = new InputRegistrationRequest(
-					Guid.NewGuid(),
+					new uint256(1234567),
 					BitcoinFactory.CreateOutPoint(),
 					new OwnershipProof(),
 					CreateZeroCredentialsRequest(),
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InputRegistrationResponseMessageSerialization()
 		{
 			var message = new InputRegistrationResponse(
-				Guid.NewGuid(),
+				new uint256(67432),
 				CreateCredentialsResponse(),
 				CreateCredentialsResponse());
 
@@ -64,8 +64,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void ConnectionConfirmationRequestMessageSerialization()
 		{
 			var message = new ConnectionConfirmationRequest(
-				Guid.NewGuid(),
-				Guid.NewGuid(),
+				new uint256(123456),
+				new uint256(456123),
 				CreateZeroCredentialsRequest(),
 				CreateRealCredentialsRequest(),
 				CreateZeroCredentialsRequest(),
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void OutputRegistrationRequestMessageSerialization()
 		{
 			var message = new OutputRegistrationRequest(
-				Guid.NewGuid(),
+				new uint256(1234567),
 				BitcoinFactory.CreateScript(),
 				CreateRealCredentialsRequest(),
 				CreateRealCredentialsRequest());
@@ -112,7 +112,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void ReissueCredentialRequestMessageSerialization()
 		{
 			var message = new ReissueCredentialRequest(
-				Guid.NewGuid(),
+				new uint256(1234567),
 				CreateRealCredentialsRequest(),
 				CreateRealCredentialsRequest(),
 				CreateZeroCredentialsRequest(),
@@ -137,8 +137,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InpuRemovalRequestMessageSerialization()
 		{
 			var message = new InputsRemovalRequest(
-				Guid.NewGuid(),
-				Guid.NewGuid());
+				new uint256(3456543),
+				new uint256(9998877));
 
 			AssertSerialization(message);
 		}
@@ -149,7 +149,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			using var key1 = new Key();
 			using var key2 = new Key();
 			var message = new TransactionSignaturesRequest(
-				Guid.NewGuid(),
+				new uint256(1234567),
 				new[]
 				{
 					new InputWitnessPair(1, new WitScript(Op.GetPushOp(key1.PubKey.ToBytes())) ),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InputRegistrationRequestMessageSerialization()
 		{
 			var message = new InputRegistrationRequest(
-					new uint256(1234567),
+					BitcoinFactory.CreateUint256(),
 					BitcoinFactory.CreateOutPoint(),
 					new OwnershipProof(),
 					CreateZeroCredentialsRequest(),
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InputRegistrationResponseMessageSerialization()
 		{
 			var message = new InputRegistrationResponse(
-				new uint256(67432),
+				BitcoinFactory.CreateUint256(),
 				CreateCredentialsResponse(),
 				CreateCredentialsResponse());
 
@@ -64,8 +64,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void ConnectionConfirmationRequestMessageSerialization()
 		{
 			var message = new ConnectionConfirmationRequest(
-				new uint256(123456),
-				new uint256(456123),
+				BitcoinFactory.CreateUint256(),
+				BitcoinFactory.CreateUint256(),
 				CreateZeroCredentialsRequest(),
 				CreateRealCredentialsRequest(),
 				CreateZeroCredentialsRequest(),
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void OutputRegistrationRequestMessageSerialization()
 		{
 			var message = new OutputRegistrationRequest(
-				new uint256(1234567),
+				BitcoinFactory.CreateUint256(),
 				BitcoinFactory.CreateScript(),
 				CreateRealCredentialsRequest(),
 				CreateRealCredentialsRequest());
@@ -112,7 +112,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void ReissueCredentialRequestMessageSerialization()
 		{
 			var message = new ReissueCredentialRequest(
-				new uint256(1234567),
+				BitcoinFactory.CreateUint256(),
 				CreateRealCredentialsRequest(),
 				CreateRealCredentialsRequest(),
 				CreateZeroCredentialsRequest(),
@@ -137,8 +137,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InpuRemovalRequestMessageSerialization()
 		{
 			var message = new InputsRemovalRequest(
-				new uint256(3456543),
-				new uint256(9998877));
+				BitcoinFactory.CreateUint256(),
+				BitcoinFactory.CreateUint256());
 
 			AssertSerialization(message);
 		}
@@ -149,7 +149,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			using var key1 = new Key();
 			using var key2 = new Key();
 			var message = new TransactionSignaturesRequest(
-				new uint256(1234567),
+				BitcoinFactory.CreateUint256(),
 				new[]
 				{
 					new InputWitnessPair(1, new WitScript(Op.GetPushOp(key1.PubKey.ToBytes())) ),

--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Globalization;
 using System.Text;
 using NBitcoin;
+using WalletWasabi.WabiSabi;
 
 namespace WalletWasabi.Crypto.StrobeProtocol
 {
@@ -10,18 +11,30 @@ namespace WalletWasabi.Crypto.StrobeProtocol
 	{
 		private Strobe128 strobe;
 
-		private StrobeHasher()
+		private StrobeHasher(string domain)
 		{
-			strobe = new Strobe128("WabiSabi_v1.0");
-			Append("domain-separator", "round-parameters");
+			strobe = new Strobe128(ProtocolConstants.WabiSabiProtocolIdentifier);
+			Append(ProtocolConstants.DomainStrobeSeparator, domain);
 		}
 
+		public void Append(string fieldName, object fieldValue)
+			=> Append(fieldName, fieldValue switch
+			{
+				IBitcoinSerializable serializable => serializable.ToHex(),
+				Money money => money.Satoshi.ToString(CultureInfo.InvariantCulture),
+				string str => str,
+				uint numUint => numUint.ToString(CultureInfo.InvariantCulture),
+				ulong numUlong => numUlong.ToString(CultureInfo.InvariantCulture),
+				decimal numDecimal => numDecimal.ToString(CultureInfo.InvariantCulture),
+				CredentialIssuerParameters issuerParameters => issuerParameters.ToString(),
+				_ => throw new ArgumentException($"{fieldValue.GetType().Name} doesn't have a string representation for strobe hasher.")
+			});
 
-		public void Append<T>(string fieldName, T fieldValue) where T : notnull
+		public void Append(string fieldName, string fieldValue)
 		{
 			strobe.AddAssociatedMetaData(Encoding.UTF8.GetBytes(fieldName), false);
 
-			var serializedValue = Encoding.UTF8.GetBytes($"{fieldValue}");
+			var serializedValue = Encoding.UTF8.GetBytes(fieldValue);
 			strobe.AddAssociatedMetaData(BitConverter.GetBytes(serializedValue.Length), true);
 			strobe.AddAssociatedData(serializedValue, false);
 		}
@@ -31,10 +44,10 @@ namespace WalletWasabi.Crypto.StrobeProtocol
 			return new uint256(strobe.Prf(32, false));
 		}
 
-		public static uint256 Combine(Dictionary<string, object> elements)
+		public static uint256 Combine(string domain, Dictionary<string, object> elements)
 		{
-			var hasher = new StrobeHasher(); 
-			foreach(var element in elements)
+			var hasher = new StrobeHasher(domain);
+			foreach (var element in elements)
 			{
 				hasher.Append(element.Key, element.Value);
 			}

--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using NBitcoin;
+
+namespace WalletWasabi.Crypto.StrobeProtocol
+{
+	public sealed class StrobeHasher
+	{
+		private Strobe128 strobe;
+
+		private StrobeHasher()
+		{
+			strobe = new Strobe128("WabiSabi_v1.0");
+			Append("domain-separator", "round-parameters");
+		}
+
+
+		public void Append<T>(string fieldName, T fieldValue) where T : notnull
+		{
+			strobe.AddAssociatedMetaData(Encoding.UTF8.GetBytes(fieldName), false);
+
+			var serializedValue = Encoding.UTF8.GetBytes($"{fieldValue}");
+			strobe.AddAssociatedMetaData(BitConverter.GetBytes(serializedValue.Length), true);
+			strobe.AddAssociatedData(serializedValue, false);
+		}
+
+		public uint256 GetHash()
+		{
+			return new uint256(strobe.Prf(32, false));
+		}
+
+		public static uint256 Combine(Dictionary<string, object> elements)
+		{
+			var hasher = new StrobeHasher(); 
+			foreach(var element in elements)
+			{
+				hasher.Append(element.Key, element.Value);
+			}
+			return hasher.GetHash();
+		}
+	}
+}

--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
@@ -16,42 +16,42 @@ namespace WalletWasabi.Crypto.StrobeProtocol
 			strobe = new Strobe128(ProtocolConstants.WabiSabiProtocolIdentifier);
 			Append(ProtocolConstants.DomainStrobeSeparator, domain);
 		}
+		public static StrobeHasher Create(string domain)
+			=> new (domain);
 
-		public void Append(string fieldName, object fieldValue)
-			=> Append(fieldName, fieldValue switch
-			{
-				IBitcoinSerializable serializable => serializable.ToHex(),
-				Money money => money.Satoshi.ToString(CultureInfo.InvariantCulture),
-				string str => str,
-				uint numUint => numUint.ToString(CultureInfo.InvariantCulture),
-				ulong numUlong => numUlong.ToString(CultureInfo.InvariantCulture),
-				decimal numDecimal => numDecimal.ToString(CultureInfo.InvariantCulture),
-				CredentialIssuerParameters issuerParameters => issuerParameters.ToString(),
-				_ => throw new ArgumentException($"{fieldValue.GetType().Name} doesn't have a string representation for strobe hasher.")
-			});
+		public StrobeHasher Append(string fieldName, IBitcoinSerializable serializable)
+			=> Append(fieldName, serializable.ToBytes());
 
-		public void Append(string fieldName, string fieldValue)
+		public StrobeHasher Append(string fieldName, Money money)
+			=> Append(fieldName, money.Satoshi);
+
+		public StrobeHasher Append(string fieldName, uint num)
+			=> Append(fieldName, BitConverter.GetBytes(num));
+
+		public StrobeHasher Append(string fieldName, long num)
+			=> Append(fieldName, BitConverter.GetBytes(num));
+
+		public StrobeHasher Append(string fieldName, ulong num)
+			=> Append(fieldName, BitConverter.GetBytes(num));
+
+		public StrobeHasher Append(string fieldName, CredentialIssuerParameters issuerParameters)
+			=> Append($"{fieldName}.Cw", issuerParameters.Cw.ToBytes())
+			.Append($"{fieldName}.I", issuerParameters.I.ToBytes());
+
+		public StrobeHasher Append(string fieldName, string str)
+			=> Append($"{fieldName}.Cw", Encoding.UTF8.GetBytes(str));
+
+		public StrobeHasher Append(string fieldName, byte[] serializedValue)
 		{
 			strobe.AddAssociatedMetaData(Encoding.UTF8.GetBytes(fieldName), false);
-
-			var serializedValue = Encoding.UTF8.GetBytes(fieldValue);
 			strobe.AddAssociatedMetaData(BitConverter.GetBytes(serializedValue.Length), true);
 			strobe.AddAssociatedData(serializedValue, false);
+			return this;
 		}
 
 		public uint256 GetHash()
 		{
 			return new uint256(strobe.Prf(32, false));
-		}
-
-		public static uint256 Combine(string domain, Dictionary<string, object> elements)
-		{
-			var hasher = new StrobeHasher(domain);
-			foreach (var element in elements)
-			{
-				hasher.Append(element.Key, element.Value);
-			}
-			return hasher.GetHash();
 		}
 	}
 }

--- a/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
@@ -8,6 +8,7 @@ using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.StrobeProtocol;
 using WalletWasabi.Crypto.ZeroKnowledge.LinearRelation;
 using WalletWasabi.Helpers;
+using WalletWasabi.WabiSabi;
 
 namespace WalletWasabi.Crypto.ZeroKnowledge
 {
@@ -36,7 +37,7 @@ namespace WalletWasabi.Crypto.ZeroKnowledge
 		/// the Merlin website for more details on why.
 		/// </remarks>
 		public Transcript(byte[] label)
-			: this(new Strobe128("WabiSabi_v1.0"))
+			: this(new Strobe128(ProtocolConstants.WabiSabiProtocolIdentifier))
 		{
 			AddMessage(DomainSeparatorTag, label);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.WabiSabi.Backend.Banning
 		OutPoint Utxo,
 		Punishment Punishment,
 		DateTimeOffset Started,
-		Guid LastDisruptedRoundId)
+		uint256 LastDisruptedRoundId)
 	{
 		public TimeSpan TimeSpent => DateTimeOffset.UtcNow - Started;
 
@@ -32,7 +32,7 @@ namespace WalletWasabi.WabiSabi.Backend.Banning
 			var started = DateTimeOffset.FromUnixTimeSeconds(long.Parse(startedString));
 			var punishment = Enum.Parse<Punishment>(punishmentString);
 			var utxo = new OutPoint(new uint256(utxoHashString), int.Parse(utxoIndexString));
-			var lastDisruptedRoundId = Guid.Parse(disruptedRoundIdString);
+			var lastDisruptedRoundId = uint256.Parse(disruptedRoundIdString);
 
 			return new(utxo, punishment, started, lastDisruptedRoundId);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
@@ -37,12 +37,12 @@ namespace WalletWasabi.WabiSabi.Backend.Banning
 			}
 		}
 
-		public void Note(Alice alice, Guid lastDisruptedRoundId)
+		public void Note(Alice alice, uint256 lastDisruptedRoundId)
 		{
 			Punish(alice.Coin.Outpoint, Punishment.Noted, lastDisruptedRoundId);
 		}
 
-		public void Punish(OutPoint utxo, Punishment punishment, Guid lastDisruptedRoundId)
+		public void Punish(OutPoint utxo, Punishment punishment, uint256 lastDisruptedRoundId)
 			=> Punish(new Inmate(utxo, punishment, DateTimeOffset.UtcNow, lastDisruptedRoundId));
 
 		public void Punish(Inmate inmate)

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -35,13 +35,10 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 		}
 
 		private uint256 CalculateHash()
-			=> StrobeHasher.Combine(
-				ProtocolConstants.AliceStrobeDomain,
-				new()
-				{
-					{ ProtocolConstants.AliceCoinTxOutStrobeLabel, Coin.TxOut },
-					{ ProtocolConstants.AliceCoinOutpointStrobeLabel, Coin.Outpoint },
-					{ ProtocolConstants.AliceOwnershipProofStrobeLabel, OwnershipProof },
-				});
+			=> StrobeHasher.Create(ProtocolConstants.AliceStrobeDomain)
+				.Append(ProtocolConstants.AliceCoinTxOutStrobeLabel, Coin.TxOut)
+				.Append(ProtocolConstants.AliceCoinOutpointStrobeLabel, Coin.Outpoint)
+				.Append(ProtocolConstants.AliceOwnershipProofStrobeLabel, OwnershipProof)
+				.GetHash();
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using System;
 using WalletWasabi.Crypto;
+using WalletWasabi.Crypto.StrobeProtocol;
 
 namespace WalletWasabi.WabiSabi.Backend.Models
 {
@@ -11,9 +12,10 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 			// TODO init syntax?
 			Coin = coin;
 			OwnershipProof = ownershipProof;
+			Id = CalculateHash();
 		}
 
-		public Guid Id { get; } = Guid.NewGuid();
+		public uint256 Id { get; }
 		public DateTimeOffset Deadline { get; set; } = DateTimeOffset.UtcNow;
 		public Coin Coin { get; }
 		public OwnershipProof OwnershipProof { get; }
@@ -31,5 +33,13 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 			// Have alice timeouts a bit sooner than the timeout of connection confirmation phase.
 			Deadline = DateTimeOffset.UtcNow + (connectionConfirmationTimeout * 0.9);
 		}
+
+		private uint256 CalculateHash()
+			=> StrobeHasher.Combine(new()
+			{
+				{ nameof(Coin.TxOut), Coin.TxOut.ToHex() },
+				{ nameof(Coin.Outpoint), Coin.Outpoint.ToHex() },
+				{ nameof(OwnershipProof), OwnershipProof.ToHex() },
+			});
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -35,11 +35,13 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 		}
 
 		private uint256 CalculateHash()
-			=> StrobeHasher.Combine(new()
-			{
-				{ nameof(Coin.TxOut), Coin.TxOut.ToHex() },
-				{ nameof(Coin.Outpoint), Coin.Outpoint.ToHex() },
-				{ nameof(OwnershipProof), OwnershipProof.ToHex() },
-			});
+			=> StrobeHasher.Combine(
+				ProtocolConstants.AliceStrobeDomain,
+				new()
+				{
+					{ ProtocolConstants.AliceCoinTxOutStrobeLabel, Coin.TxOut },
+					{ ProtocolConstants.AliceCoinOutpointStrobeLabel, Coin.Outpoint },
+					{ ProtocolConstants.AliceOwnershipProofStrobeLabel, OwnershipProof },
+				});
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -49,12 +49,12 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 
 		public static InputRegistrationResponse RegisterInput(
 			WabiSabiConfig config,
-			Guid roundId,
+			uint256 roundId,
 			Coin coin,
 			OwnershipProof ownershipProof,
 			ZeroCredentialsRequest zeroAmountCredentialRequests,
 			ZeroCredentialsRequest zeroVsizeCredentialRequests,
-			IDictionary<Guid, Round> rounds,
+			IDictionary<uint256, Round> rounds,
 			Network network)
 		{
 			if (!rounds.TryGetValue(roundId, out var round))
@@ -77,7 +77,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			// for validation purposes.
 			round.CoinjoinState.AssertConstruction().AddInput(coin);
 
-			var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", round.Hash);
+			var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", round.Id);
 			if (!OwnershipProof.VerifyCoinJoinInputProof(ownershipProof, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
@@ -116,7 +116,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				commitVsizeCredentialResponse.Commit());
 		}
 
-		private static void RemoveDuplicateAlices(IDictionary<Guid, Round> roundsWithId, Alice alice)
+		private static void RemoveDuplicateAlices(IDictionary<uint256, Round> roundsWithId, Alice alice)
 		{
 			var rounds = roundsWithId.Values;
 			if (rounds.Any(x => x.Phase != Phase.InputRegistration))

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			Random = new SecureRandom();
 		}
 
-		public Dictionary<Guid, Round> Rounds { get; } = new();
+		public Dictionary<uint256, Round> Rounds { get; } = new();
 		private AsyncLock AsyncLock { get; } = new();
 		public Network Network { get; }
 		public WabiSabiConfig Config { get; }
@@ -156,7 +156,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 						round.LogInfo("Trying to broadcast coinjoin.");
 						Coin[]? spentCoins = round.Alices.Select(x => x.Coin).ToArray();
 						Money networkFee = coinjoin.GetFee(spentCoins);
-						Guid roundId = round.Id;
+						uint256 roundId = round.Id;
 						FeeRate feeRate = coinjoin.GetFeeRate(spentCoins);
 						round.LogInfo($"Network Fee: {networkFee.ToString(false, false)} BTC.");
 						round.LogInfo($"Network Fee Rate: {feeRate.FeePerK.ToDecimal(MoneyUnit.Satoshi) / 1000} sat/vByte.");
@@ -247,7 +247,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		}
 
 		public async Task<InputRegistrationResponse> RegisterInputAsync(
-			Guid roundId,
+			uint256 roundId,
 			Coin coin,
 			OwnershipProof ownershipProof,
 			ZeroCredentialsRequest zeroAmountCredentialRequests,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -1,8 +1,10 @@
 using NBitcoin;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Crypto.StrobeProtocol;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Models;
@@ -25,24 +27,21 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			var txParams = new MultipartyTransactionParameters(roundParameters.FeeRate, allowedAmounts, allowedAmounts, roundParameters.Network);
 			CoinjoinState = new ConstructionState(txParams);
 
-			Hash = new(HashHelpers.GenerateSha256Hash($"{Id}{MaxInputCountByAlice}{MinRegistrableAmount}{MaxRegistrableAmount}{PerAliceVsizeAllocation}{AmountCredentialIssuerParameters}{VsizeCredentialIssuerParameters}{FeeRate.SatoshiPerByte}"));
+			Id = CalculateHash();
 		}
 
 		public IState CoinjoinState { get; set; }
-
-		public uint256 Hash { get; }
+		public uint256 Id { get; }
 		public Network Network => RoundParameters.Network;
 		public uint MaxInputCountByAlice => RoundParameters.MaxInputCountByAlice;
 		public Money MinRegistrableAmount => RoundParameters.MinRegistrableAmount;
 		public Money MaxRegistrableAmount => RoundParameters.MaxRegistrableAmount;
 		public uint PerAliceVsizeAllocation => RoundParameters.PerAliceVsizeAllocation;
 		public FeeRate FeeRate => RoundParameters.FeeRate;
-		public WasabiRandom Random => RoundParameters.Random;
 		public CredentialIssuer AmountCredentialIssuer { get; }
 		public CredentialIssuer VsizeCredentialIssuer { get; }
 		public CredentialIssuerParameters AmountCredentialIssuerParameters { get; }
 		public CredentialIssuerParameters VsizeCredentialIssuerParameters { get; }
-		public Guid Id { get; } = Guid.NewGuid();
 		public List<Alice> Alices { get; } = new();
 		public int InputCount => Alices.Count;
 		public List<Bob> Bobs { get; } = new();
@@ -55,7 +54,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public TimeSpan OutputRegistrationTimeout => RoundParameters.OutputRegistrationTimeout;
 		public TimeSpan TransactionSigningTimeout => RoundParameters.TransactionSigningTimeout;
 
-		private RoundParameters RoundParameters { get; }
 		public Phase Phase { get; private set; } = Phase.InputRegistration;
 		public DateTimeOffset InputRegistrationStart { get; } = DateTimeOffset.UtcNow;
 		public DateTimeOffset ConnectionConfirmationStart { get; private set; }
@@ -64,6 +62,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public DateTimeOffset TransactionBroadcastingStart { get; private set; }
 		public int InitialInputVsizeAllocation { get; set; } = 99954; // TODO compute as CoinjoinState.Parameters.MaxWeight - CoinjoinState.Parameters.SharedOverhead, mutable for testing until then
 		public int RemainingInputVsizeAllocation => InitialInputVsizeAllocation - Alices.Count * (int)PerAliceVsizeAllocation;
+
+		private RoundParameters RoundParameters { get; }
+		private WasabiRandom Random => RoundParameters.Random;
 
 		public void SetPhase(Phase phase)
 		{
@@ -128,5 +129,17 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		public SigningState AddWitness(int index, WitScript witness)
 			=> CoinjoinState.AssertSigning().AddWitness(index, witness);
+
+		private uint256 CalculateHash()
+			=> StrobeHasher.Combine(new()
+			{
+				{ nameof(MaxInputCountByAlice), MaxInputCountByAlice },
+				{ nameof(MinRegistrableAmount), MinRegistrableAmount },
+				{ nameof(MaxRegistrableAmount), MaxRegistrableAmount },
+				{ nameof(PerAliceVsizeAllocation), PerAliceVsizeAllocation },
+				{ nameof(AmountCredentialIssuerParameters), AmountCredentialIssuerParameters },
+				{ nameof(VsizeCredentialIssuerParameters), VsizeCredentialIssuerParameters },
+				{ nameof(FeeRate), FeeRate.SatoshiPerByte }
+			});
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -130,17 +130,14 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			=> CoinjoinState.AssertSigning().AddWitness(index, witness);
 
 		private uint256 CalculateHash()
-			=> StrobeHasher.Combine(
-				ProtocolConstants.RoundStrobeDomain,
-				new()
-				{
-					{ ProtocolConstants.RoundMaxInputCountByAliceStrobeLabel, MaxInputCountByAlice },
-					{ ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, MinRegistrableAmount },
-					{ ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, MaxRegistrableAmount },
-					{ ProtocolConstants.RoundPerAliceVsizeAllocationStrobeLabel, PerAliceVsizeAllocation },
-					{ ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, AmountCredentialIssuerParameters },
-					{ ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, VsizeCredentialIssuerParameters },
-					{ ProtocolConstants.RoundFeeRateStrobeLabel, FeeRate.SatoshiPerByte }
-				});
+			=> StrobeHasher.Create(ProtocolConstants.RoundStrobeDomain)
+				.Append(ProtocolConstants.RoundMaxInputCountByAliceStrobeLabel, MaxInputCountByAlice)
+				.Append(ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, MinRegistrableAmount)
+				.Append(ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, MaxRegistrableAmount)
+				.Append(ProtocolConstants.RoundPerAliceVsizeAllocationStrobeLabel, PerAliceVsizeAllocation)
+				.Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, AmountCredentialIssuerParameters)
+				.Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, VsizeCredentialIssuerParameters)
+				.Append(ProtocolConstants.RoundFeeRateStrobeLabel, FeeRate.FeePerK)
+				.GetHash();
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -18,8 +18,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			RoundParameters = roundParameters;
 
-			AmountCredentialIssuer = new(new(Random), Random, MaxRegistrableAmount);
-			VsizeCredentialIssuer = new(new(Random), Random, PerAliceVsizeAllocation);
+			AmountCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, MaxRegistrableAmount);
+			VsizeCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, PerAliceVsizeAllocation);
 			AmountCredentialIssuerParameters = AmountCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 			VsizeCredentialIssuerParameters = VsizeCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 
@@ -64,7 +64,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public int RemainingInputVsizeAllocation => InitialInputVsizeAllocation - Alices.Count * (int)PerAliceVsizeAllocation;
 
 		private RoundParameters RoundParameters { get; }
-		private WasabiRandom Random => RoundParameters.Random;
 
 		public void SetPhase(Phase phase)
 		{
@@ -131,15 +130,17 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			=> CoinjoinState.AssertSigning().AddWitness(index, witness);
 
 		private uint256 CalculateHash()
-			=> StrobeHasher.Combine(new()
-			{
-				{ nameof(MaxInputCountByAlice), MaxInputCountByAlice },
-				{ nameof(MinRegistrableAmount), MinRegistrableAmount },
-				{ nameof(MaxRegistrableAmount), MaxRegistrableAmount },
-				{ nameof(PerAliceVsizeAllocation), PerAliceVsizeAllocation },
-				{ nameof(AmountCredentialIssuerParameters), AmountCredentialIssuerParameters },
-				{ nameof(VsizeCredentialIssuerParameters), VsizeCredentialIssuerParameters },
-				{ nameof(FeeRate), FeeRate.SatoshiPerByte }
-			});
+			=> StrobeHasher.Combine(
+				ProtocolConstants.RoundStrobeDomain,
+				new()
+				{
+					{ ProtocolConstants.RoundMaxInputCountByAliceStrobeLabel, MaxInputCountByAlice },
+					{ ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, MinRegistrableAmount },
+					{ ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, MaxRegistrableAmount },
+					{ ProtocolConstants.RoundPerAliceVsizeAllocationStrobeLabel, PerAliceVsizeAllocation },
+					{ ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, AmountCredentialIssuerParameters },
+					{ ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, VsizeCredentialIssuerParameters },
+					{ ProtocolConstants.RoundFeeRateStrobeLabel, FeeRate.SatoshiPerByte }
+				});
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -11,7 +11,7 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class AliceClient
 	{
-		public AliceClient(Guid aliceId, Guid roundId, ArenaClient arenaClient, Coin coin, FeeRate feeRate)
+		public AliceClient(uint256 aliceId, uint256 roundId, ArenaClient arenaClient, Coin coin, FeeRate feeRate)
 		{
 			AliceId = aliceId;
 			RoundId = roundId;
@@ -20,8 +20,8 @@ namespace WalletWasabi.WabiSabi.Client
 			FeeRate = feeRate;
 		}
 
-		public Guid AliceId { get; }
-		public Guid RoundId { get; }
+		public uint256 AliceId { get; }
+		public uint256 RoundId { get; }
 		private ArenaClient ArenaClient { get; }
 		private Coin Coin { get; }
 		private FeeRate FeeRate { get; }
@@ -79,11 +79,10 @@ namespace WalletWasabi.WabiSabi.Client
 			ArenaClient arenaClient,
 			Coin coin,
 			BitcoinSecret bitcoinSecret,
-			Guid roundId,
-			uint256 roundHash,
+			uint256 roundId,
 			FeeRate feeRate)
 		{
-			Guid aliceId = await arenaClient.RegisterInputAsync(coin.Amount, coin.Outpoint, bitcoinSecret.PrivateKey, roundId, roundHash).ConfigureAwait(false);
+			uint256 aliceId = await arenaClient.RegisterInputAsync(coin.Amount, coin.Outpoint, bitcoinSecret.PrivateKey, roundId).ConfigureAwait(false);
 
 			AliceClient client = new(aliceId, roundId, arenaClient, coin, feeRate);
 

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -39,16 +39,15 @@ namespace WalletWasabi.WabiSabi.Client
 		public WabiSabiClient VsizeCredentialClient { get; }
 		public IArenaRequestHandler RequestHandler { get; }
 
-		public async ValueTask<Guid> RegisterInputAsync(
+		public async Task<uint256> RegisterInputAsync(
 			Money amount,
 			OutPoint outPoint,
 			Key key,
-			Guid roundId,
-			uint256 roundHash)
+			uint256 roundId)
 		{
 			var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
 				key,
-				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash));
+				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundId));
 
 			var zeroAmountCredentialRequestData = AmountCredentialClient.CreateRequestForZeroAmount();
 			var zeroVsizeCredentialRequestData = VsizeCredentialClient.CreateRequestForZeroAmount();
@@ -67,12 +66,12 @@ namespace WalletWasabi.WabiSabi.Client
 			return inputRegistrationResponse.AliceId;
 		}
 
-		public async Task RemoveInputAsync(Guid roundId, Guid aliceId)
+		public async Task RemoveInputAsync(uint256 roundId, uint256 aliceId)
 		{
 			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceId)).ConfigureAwait(false);
 		}
 
-		public async Task RegisterOutputAsync(Guid roundId, long value, Script scriptPubKey, IEnumerable<Credential> amountCredentialsToPresent, IEnumerable<Credential> vsizeCredentialsToPresent)
+		public async Task RegisterOutputAsync(uint256 roundId, long value, Script scriptPubKey, IEnumerable<Credential> amountCredentialsToPresent, IEnumerable<Credential> vsizeCredentialsToPresent)
 		{
 			Guard.InRange(nameof(amountCredentialsToPresent), amountCredentialsToPresent, 0, AmountCredentialClient.NumberOfCredentials);
 			Guard.InRange(nameof(vsizeCredentialsToPresent), vsizeCredentialsToPresent, 0, VsizeCredentialClient.NumberOfCredentials);
@@ -99,7 +98,7 @@ namespace WalletWasabi.WabiSabi.Client
 		}
 
 		public async Task<(IEnumerable<Credential> RealAmountCredentials, IEnumerable<Credential> RealVsizeCredentials)> ReissueCredentialAsync(
-			Guid roundId,
+			uint256 roundId,
 			long value1,
 			Script scriptPubKey1,
 			long value2,
@@ -143,7 +142,7 @@ namespace WalletWasabi.WabiSabi.Client
 			return (realAmountCredentials, realVsizeCredentials);
 		}
 
-		public async Task<bool> ConfirmConnectionAsync(Guid roundId, Guid aliceId, IEnumerable<long> inputsRegistrationVsize, IEnumerable<Credential> amountCredentialsToPresent, IEnumerable<Money> newAmount)
+		public async Task<bool> ConfirmConnectionAsync(uint256 roundId, uint256 aliceId, IEnumerable<long> inputsRegistrationVsize, IEnumerable<Credential> amountCredentialsToPresent, IEnumerable<Money> newAmount)
 		{
 			Guard.InRange(nameof(newAmount), newAmount, 1, AmountCredentialClient.NumberOfCredentials);
 			Guard.InRange(nameof(amountCredentialsToPresent), amountCredentialsToPresent, 1, AmountCredentialClient.NumberOfCredentials);
@@ -182,7 +181,7 @@ namespace WalletWasabi.WabiSabi.Client
 			return false;
 		}
 
-		public async Task SignTransactionAsync(Guid roundId, Coin coin, BitcoinSecret bitcoinSecret, Transaction unsignedCoinJoin)
+		public async Task SignTransactionAsync(uint256 roundId, Coin coin, BitcoinSecret bitcoinSecret, Transaction unsignedCoinJoin)
 		{
 			if (unsignedCoinJoin.Inputs.Count == 0)
 			{

--- a/WalletWasabi/WabiSabi/Client/BobClient.cs
+++ b/WalletWasabi/WabiSabi/Client/BobClient.cs
@@ -9,13 +9,13 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class BobClient
 	{
-		public BobClient(Guid roundId, ArenaClient arenaClient)
+		public BobClient(uint256 roundId, ArenaClient arenaClient)
 		{
 			RoundId = roundId;
 			ArenaClient = arenaClient;
 		}
 
-		private Guid RoundId { get; }
+		private uint256 RoundId { get; }
 		private ArenaClient ArenaClient { get; }
 
 		public async Task RegisterOutputAsync(Money amount, Script scriptPubKey)

--- a/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
@@ -1,11 +1,12 @@
 using System;
+using NBitcoin;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record ConnectionConfirmationRequest(
-		Guid RoundId,
-		Guid AliceId, 
+		uint256 RoundId,
+		uint256 AliceId, 
 		ZeroCredentialsRequest ZeroAmountCredentialRequests, 
 		RealCredentialsRequest RealAmountCredentialRequests, 
 		ZeroCredentialsRequest ZeroVsizeCredentialRequests, 

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationRequest.cs
@@ -6,7 +6,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputRegistrationRequest(
-		Guid RoundId,
+		uint256 RoundId,
 		OutPoint Input,
 		OwnershipProof OwnershipProof,
 		ZeroCredentialsRequest ZeroAmountCredentialRequests,

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -1,10 +1,11 @@
 using System;
+using NBitcoin;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputRegistrationResponse(
-		Guid AliceId,
+		uint256 AliceId,
 		CredentialsResponse AmountCredentials,
 		CredentialsResponse VsizeCredentials
 	);

--- a/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
@@ -1,9 +1,10 @@
 using System;
+using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputsRemovalRequest(
-		Guid RoundId,
-		Guid AliceId
+		uint256 RoundId,
+		uint256 AliceId
 	);
 }

--- a/WalletWasabi/WabiSabi/Models/OutputRegistrationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/OutputRegistrationRequest.cs
@@ -5,7 +5,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record OutputRegistrationRequest(
-		Guid RoundId,
+		uint256 RoundId,
 		Script Script,
 		RealCredentialsRequest AmountCredentialRequests,
 		RealCredentialsRequest VsizeCredentialRequests

--- a/WalletWasabi/WabiSabi/Models/ReissueCredentialRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ReissueCredentialRequest.cs
@@ -1,10 +1,11 @@
 using System;
+using NBitcoin;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record ReissueCredentialRequest(
-		Guid RoundId,
+		uint256 RoundId,
 		RealCredentialsRequest RealAmountCredentialRequests,
 		RealCredentialsRequest RealVsizeCredentialRequests,
 		ZeroCredentialsRequest ZeroAmountCredentialRequests,

--- a/WalletWasabi/WabiSabi/Models/TransactionSignaturesRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/TransactionSignaturesRequest.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record TransactionSignaturesRequest(
-		Guid RoundId,
+		uint256 RoundId,
 		IEnumerable<InputWitnessPair> InputWitnessPairs
 	);
 }

--- a/WalletWasabi/WabiSabi/ProtocolContants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolContants.cs
@@ -5,5 +5,24 @@ namespace WalletWasabi.WabiSabi
 		public const int CredentialNumber = 2;
 		public const ulong MaxAmountPerAlice = 4_300_000_000_000ul;
 		public const uint MaxVsizePerAlice = 255;
+
+		public const string WabiSabiProtocolIdentifier = "WabiSabi_v1.0";
+		public const string DomainStrobeSeparator = "domain-separator";
+
+		// Round hashing labels
+		public const string RoundStrobeDomain = "round-parameters";
+		public const string RoundMaxInputCountByAliceStrobeLabel = "maximum-input-count-by-alice";
+		public const string RoundMinRegistrableAmountStrobeLabel = "minimum-registrable-amount";
+		public const string RoundMaxRegistrableAmountStrobeLabel = "maximum-registrable-amount";
+		public const string RoundPerAliceVsizeAllocationStrobeLabel = "per-alice-vsize-allocation";
+		public const string RoundAmountCredentialIssuerParametersStrobeLabel = "amount-credential-issuer-parameters";
+		public const string RoundVsizeCredentialIssuerParametersStrobeLabel = "vsize-credential-issuer-parameters";
+		public const string RoundFeeRateStrobeLabel = "fee-rate";
+
+		// Alice hashing labels
+		public const string AliceStrobeDomain = "alice-parameters";
+		public const string AliceCoinTxOutStrobeLabel = "coin-txout";
+		public const string AliceCoinOutpointStrobeLabel = "coin-outpoint";
+		public const string AliceOwnershipProofStrobeLabel = "ownership-proof";
 	}
 }


### PR DESCRIPTION
Creates a  `StrobeHasher` class to simplify the computation of hashes using `strobe128` and use those hashes to identify `Alice` and `Round`. This removes the need for having and passing `RoundHash` and it allows the clients to compute the `AliceId` without requiring the coordinator.  
