### PR TITLE
Dispose TorHttpPool in HttpClientFactory.

### DIFF
--- a/WalletWasabi/WebClients/Wasabi/HttpClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/HttpClientFactory.cs
@@ -129,6 +129,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 				HttpClient.Dispose();
 				SocketHandler.Dispose();
+				TorHttpPool?.Dispose();
 			}
 
 			_disposed = true;


### PR DESCRIPTION
This PR adds missing dispose call for `TorHttpPool`. 

This is part of #5681 where I noticed that.