### PR TITLE
TorProcessManager: Add cancellation token to `StartAsync`.

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -151,8 +151,7 @@ namespace WalletWasabi.Gui
 					using (BenchmarkLogger.Measure(operationName: "TorProcessManager.Start"))
 					{
 						TorManager = new TorProcessManager(TorSettings, Config.TorSocks5EndPoint);
-						await TorManager.StartAsync().ConfigureAwait(false);
-						cancel.ThrowIfCancellationRequested();
+						await TorManager.StartAsync(cancel).ConfigureAwait(false);
 					}
 
 					Tor.Http.TorHttpClient torHttpClient = BackendHttpClientFactory.NewTorHttpClient(isolateStream: false);

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Tor
 							Logger.LogInfo($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
 
 							// Try starting Tor, if it does not work it'll be another issue.
-							bool started = await TorProcessManager.StartAsync().ConfigureAwait(false);
+							bool started = await TorProcessManager.StartAsync(token).ConfigureAwait(false);
 
 							Logger.LogInfo($"Tor re-starting attempt {(started ? "succeeded." : "FAILED. Will try again later.")}");
 						}

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -37,7 +37,8 @@ namespace WalletWasabi.Tor
 		/// <summary>
 		/// Starts Tor process if it is not running already.
 		/// </summary>
-		public async Task<bool> StartAsync()
+		/// <exception cref="OperationCanceledException"/>
+		public async Task<bool> StartAsync(CancellationToken token = default)
 		{
 			ThrowIfDisposed();
 
@@ -111,11 +112,16 @@ namespace WalletWasabi.Tor
 					}
 
 					// Wait 250 milliseconds between attempts.
-					await Task.Delay(250).ConfigureAwait(false);
+					await Task.Delay(250, token).ConfigureAwait(false);
 				}
 
 				Logger.LogInfo("Tor is running.");
 				return true;
+			}
+			catch (OperationCanceledException ex)
+			{
+				Logger.LogDebug("User canceled operation.", ex);
+				throw;
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
This PR should be safe because it just makes potential waiting in `StartAsync` shorter if cancel is requested. 

This is part of #5681 where I noticed that.