### PR TITLE
[WabiSabi] Credentials pool synchronization

### DIFF
--- a/WalletWasabi.Tests/Helpers/CredentialPoolExtensions.cs
+++ b/WalletWasabi.Tests/Helpers/CredentialPoolExtensions.cs
@@ -1,0 +1,16 @@
+using NBitcoin.Secp256k1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using WalletWasabi.Crypto.ZeroKnowledge;
+using WalletWasabi.WabiSabi.Crypto;
+
+namespace WalletWasabi.Tests.Helpers
+{
+	public static class CredentialPoolExtensions
+	{
+		public static Credential[] Take(this CredentialPool pool, long value)
+			=> pool.TakeAsync(value).GetAwaiter().GetResult();
+	}
+}

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -129,7 +129,7 @@ namespace WalletWasabi.Tests.Helpers
 			var vsCredResp = vsIssuer.HandleRequest(zeroVsizeCredentialRequest);
 			amClient.HandleResponse(amCredResp, amVal);
 			vsClient.HandleResponse(vsCredResp, vsVal);
-			return (amClient.Credentials.ZeroValue.Take(amIssuer.NumberOfCredentials).ToArray(), vsClient.Credentials.ZeroValue.Take(vsIssuer.NumberOfCredentials));
+			return (amClient.Credentials.Take(0), vsClient.Credentials.Take(0));
 		}
 
 		public static (RealCredentialsRequest amountReq, RealCredentialsRequest vsizeReq) CreateRealCredentialRequests(Round? round = null, Money? amount = null, long? vsize = null)
@@ -236,7 +236,7 @@ namespace WalletWasabi.Tests.Helpers
 			script ??= BitcoinFactory.CreateScript();
 			var (realAmountCredentialRequest, _) = amClient.CreateRequest(
 				Array.Empty<long>(),
-				amClient.Credentials.Valuable);
+				amClient.Credentials.Take(amCredentialRequest.Delta));
 
 			try
 			{
@@ -249,7 +249,7 @@ namespace WalletWasabi.Tests.Helpers
 
 			var (realVsizeCredentialRequest, _) = vsClient.CreateRequest(
 				new[] { startingVsizeCredentialAmount - (long)vsize },
-				vsClient.Credentials.Valuable);
+				vsClient.Credentials.Take(vsCredentialRequest.Delta));
 
 			return new OutputRegistrationRequest(
 				round?.Id ?? uint256.Zero,
@@ -271,8 +271,8 @@ namespace WalletWasabi.Tests.Helpers
 				ret.Add(new OutputRegistrationRequest(
 					round.Id,
 					script,
-					ccresp.amountClient.CreateRequest(Array.Empty<long>(), ccresp.amountClient.Credentials.Valuable).CredentialsRequest,
-					ccresp.vsizeClient.CreateRequest(new[] { startingVsizeCredentialAmount - vsize }, ccresp.vsizeClient.Credentials.Valuable).CredentialsRequest));
+					ccresp.amountClient.CreateRequest(Array.Empty<long>(), ccresp.amountClient.Credentials.Take(1)).CredentialsRequest,
+					ccresp.vsizeClient.CreateRequest(new[] { startingVsizeCredentialAmount - vsize }, ccresp.vsizeClient.Credentials.Take(1)).CredentialsRequest));
 			}
 
 			return ret;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -52,9 +52,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			var aliceId = await aliceArenaClient.RegisterInputAsync(Money.Coins(1m), outpoint, key, round.Id);
 
-			Assert.NotEqual(uint256.Zero, aliceId);
-			Assert.Empty(amountCredentials.Valuable);
-
 			var reissuanceAmounts = new[]
 			{
 				Money.Coins(.75m) - round.FeeRate.GetFee(Constants.P2wpkhInputVirtualSize),
@@ -71,10 +68,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				round.Id,
 				aliceId,
 				inputRemainingVsizes,
-				amountCredentials.ZeroValue.Take(ProtocolConstants.CredentialNumber),
+				amountCredentials.Take(0),
 				reissuanceAmounts);
-
-			Assert.Empty(amountCredentials.Valuable);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
@@ -84,18 +79,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				round.Id,
 				aliceId,
 				inputRemainingVsizes,
-				amountCredentials.ZeroValue.Take(ProtocolConstants.CredentialNumber),
+				amountCredentials.Take(0),
 				reissuanceAmounts);
 
-			Assert.Single(amountCredentials.Valuable, x => x.Amount.ToMoney() == reissuanceAmounts.First());
-			Assert.Single(amountCredentials.Valuable, x => x.Amount.ToMoney() == reissuanceAmounts.Last());
-
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
+			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(1));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 
 			var bobArenaClient = new ArenaClient(round.AmountCredentialIssuerParameters, round.VsizeCredentialIssuerParameters, amountCredentials, vsizeCredentials, coordinator, new InsecureRandom());
-
-			Assert.Equal(4, amountCredentials.ZeroValue.Count());
 
 			// Phase: Output Registration
 			using var destinationKey1 = new Key();
@@ -107,11 +97,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				destinationKey1.PubKey.WitHash.ScriptPubKey,
 				reissuanceAmounts[1],
 				destinationKey2.PubKey.WitHash.ScriptPubKey,
-				amountCredentials.Valuable,
-				vsizeCredentials.Valuable);
-
-			Assert.Equal(6, amountCredentials.ZeroValue.Count());
-			Assert.Equal(6, vsizeCredentials.ZeroValue.Count());
+				amountCredentials.Take(reissuanceAmounts.Sum()),
+				vsizeCredentials.Take(inputRemainingVsizes.Sum()));
 
 			Credential amountCred1 = result.RealAmountCredentials.ElementAt(0);
 			Credential amountCred2 = result.RealAmountCredentials.ElementAt(1);
@@ -123,15 +110,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				round.Id,
 				reissuanceAmounts[0],
 				destinationKey1.PubKey.WitHash.ScriptPubKey,
-				new[] { amountCred1 },
-				new[] { vsizeCred1 });
+				amountCredentials.Take(reissuanceAmounts[0]),
+				vsizeCredentials.Take(destinationKey1.PubKey.WitHash.ScriptPubKey.EstimateOutputVsize()));
 
 			await bobArenaClient.RegisterOutputAsync(
 				round.Id,
 				reissuanceAmounts[1],
 				destinationKey2.PubKey.WitHash.ScriptPubKey,
-				new[] { amountCred2 },
-				new[] { vsizeCred2 });
+				amountCredentials.Take(reissuanceAmounts[1]),
+				vsizeCredentials.Take(destinationKey1.PubKey.WitHash.ScriptPubKey.EstimateOutputVsize()));
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
@@ -6,7 +6,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge;
-using WalletWasabi.WabiSabi;
+using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 using Xunit;
@@ -33,6 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 			Assert.Equal(43, issuer.RangeProofWidth);
 		}
 
+#if false
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
 		public void Splitting()
@@ -60,17 +61,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 			client.HandleResponse(credentialResponse, validationData);
 
 			// Output Reg
-			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 8L }, client.Credentials.Valuable);
+			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 8L }, client.Credentials.TakeValuable());
 			credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
 			Assert.Equal(-1, credentialRequest.Delta);
 
-			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 7L }, client.Credentials.Valuable);
+			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 7L }, client.Credentials.TakeValuable());
 			credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
 			Assert.Equal(-1, credentialRequest.Delta);
 
-			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 6L }, client.Credentials.Valuable);
+			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 6L }, client.Credentials.TakeValuable());
 			credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
 			Assert.Equal(-1, credentialRequest.Delta);
@@ -111,14 +112,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 
 				var credentialResponse = issuer.HandleRequest(credentialRequest);
 				client.HandleResponse(credentialResponse, validationData);
-				Assert.Equal(ProtocolConstants.CredentialNumber, client.Credentials.ZeroValue.Count());
-				Assert.Empty(client.Credentials.Valuable);
-				var issuedCredential = client.Credentials.ZeroValue.First();
+//				Assert.Equal(numberOfCredentials, client.Credentials.ZeroValue.Count());
+//				Assert.Empty(client.Credentials.Valuable);
+				var issuedCredential = client.Credentials.TakeZeroValue().First();
 				Assert.True(issuedCredential.Amount.IsZero);
 			}
 
 			{
-				var present = client.Credentials.ZeroValue.Take(ProtocolConstants.CredentialNumber);
+				var present = client.Credentials.TakeZeroValue();
 				var (credentialRequest, validationData) = client.CreateRequest(new[] { 100_000_000L }, present);
 
 				Assert.False(credentialRequest.IsNullRequest);
@@ -296,5 +297,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 				Assert.Equal(WabiSabiCryptoErrorCode.SerialNumberAlreadyUsed, ex.ErrorCode);
 			}
 		}
+#endif
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/SerializationTests.cs
@@ -8,6 +8,7 @@ using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.JsonConverters.Bitcoin;
+using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
@@ -162,7 +163,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 			(CredentialsRequest credentialRequest, CredentialsResponseValidation validationData) = client.CreateRequestForZeroAmount();
 			var credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
-			var present = client.Credentials.ZeroValue.Take(ProtocolConstants.CredentialNumber);
+			var present = client.Credentials.Take(0);
 			(credentialRequest, _) = client.CreateRequest(new[] { 1L }, present);
 
 			// Registration request message.

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.WabiSabi.Client
 					RoundId,
 					AliceId,
 					inputRemainingVsizes,
-					amountCredentials.ZeroValue.Take(ProtocolConstants.CredentialNumber),
+					await amountCredentials.TakeAsync(0),
 					amountsToRequest)
 				.ConfigureAwait(false);
 		}

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -154,7 +154,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 			var realVsizeCredentialRequestData = VsizeCredentialClient.CreateRequest(
 				inputsRegistrationVsize,
-				Enumerable.Empty<Credential>());
+				await VsizeCredentialClient.Credentials.TakeAsync(0));
 
 			var zeroAmountCredentialRequestData = AmountCredentialClient.CreateRequestForZeroAmount();
 			var zeroVsizeCredentialRequestData = VsizeCredentialClient.CreateRequestForZeroAmount();

--- a/WalletWasabi/WabiSabi/Client/BobClient.cs
+++ b/WalletWasabi/WabiSabi/Client/BobClient.cs
@@ -24,8 +24,8 @@ namespace WalletWasabi.WabiSabi.Client
 				RoundId,
 				amount.Satoshi,
 				scriptPubKey,
-				ArenaClient.AmountCredentialClient.Credentials.Valuable,
-				ArenaClient.VsizeCredentialClient.Credentials.Valuable).ConfigureAwait(false);
+				await ArenaClient.AmountCredentialClient.Credentials.TakeAsync(amount.Satoshi),
+				await ArenaClient.VsizeCredentialClient.Credentials.TakeAsync(scriptPubKey.EstimateOutputVsize())).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
+++ b/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
@@ -110,7 +110,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 			// Make sure we present always the same number of credentials (except for Null requests)
 			var missingCredentialPresent = NumberOfCredentials - credentialsToPresent.Count();
 
-			var alreadyPresentedZeroCredentials = credentialsToPresent.Where(x => x.Amount.IsZero);
+/*			var alreadyPresentedZeroCredentials = credentialsToPresent.Where(x => x.Amount.IsZero);
 			var availableZeroCredentials = Credentials.ZeroValue.Except(alreadyPresentedZeroCredentials);
 
 			// This should not be possible
@@ -121,8 +121,8 @@ namespace WalletWasabi.WabiSabi.Crypto
 					WabiSabiCryptoErrorCode.NotEnoughZeroCredentialToFillTheRequest,
 					$"{missingCredentialPresent} credentials are missing but there are only {availableZeroCredentialCount} zero-value credentials available.");
 			}
-
-			credentialsToPresent = credentialsToPresent.Concat(availableZeroCredentials.Take(missingCredentialPresent)).ToList();
+*/
+			credentialsToPresent = credentialsToPresent /*.Concat(availableZeroCredentials.Take(missingCredentialPresent))*/.ToList();
 			var macsToPresent = credentialsToPresent.Select(x => x.Mac);
 			if (macsToPresent.Distinct().Count() < macsToPresent.Count())
 			{
@@ -222,7 +222,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 			var credentialReceived = credentials.Select(x =>
 				new Credential(new Scalar((ulong)x.Requested.Amount), x.Requested.Randomness, x.Issued));
 
-			Credentials.UpdateCredentials(credentialReceived, registrationValidationData.Presented);
+			Credentials.UpdateCredentials(credentialReceived);
 			return credentialReceived;
 		}
 


### PR DESCRIPTION
This PR contains a synchronization mechanism for the credentials pool. 

### How does it work?

`CredentialPool` maintains a list of credentials as before. When we request `k` credentials for a value `v` it checks if it has credentials for that exact amount and in case it does have then it returns the credentials, otherwise it returns a promise (task) that will be completed when it receives the needed credentials from the server.

In this way `Bob` can request the credentials needed for registering the outputs even before `Alice` register the inputs. For example, `Bob` needs to register an output with value 1btc and 31vbytes size so, he requests those credentials and wait until the are available.
