### PR TITLE
[WabiSabi] Credential pool snchronization (no dead lock)

### DIFF
--- a/WalletWasabi.Tests/Helpers/CredentialPoolExtensions.cs
+++ b/WalletWasabi.Tests/Helpers/CredentialPoolExtensions.cs
@@ -1,0 +1,17 @@
+using NBitcoin;
+using NBitcoin.Secp256k1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using WalletWasabi.Crypto.ZeroKnowledge;
+using WalletWasabi.WabiSabi.Crypto;
+
+namespace WalletWasabi.Tests.Helpers
+{
+	public static class CredentialPoolExtensions
+	{
+		public static Credential[] GetCredentialsForRequester(this CredentialPool pool, uint256 requesterId)
+			=> pool.GetCredentialsForRequesterAsync(requesterId).GetAwaiter().GetResult();
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -57,14 +57,14 @@ irreq2.OwnershipProof,
 			var ccreq1 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres1);
 			var ccresp1 = await arena.ConfirmConnectionAsync(ccreq1.request);
 			ccresps.Add((ccresp1, ccreq1.amountClient, ccreq1.vsizeClient, irres2.AliceId));
-			ccreq1.amountClient.HandleResponse(ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
-			ccreq1.vsizeClient.HandleResponse(ccresp1.RealVsizeCredentials!, ccreq1.vsizeValidation);
+			ccreq1.amountClient.HandleResponse(irres1.AliceId, ccresp1.RealAmountCredentials!, ccreq1.amountValidation);
+			ccreq1.vsizeClient.HandleResponse(irres1.AliceId, ccresp1.RealVsizeCredentials!, ccreq1.vsizeValidation);
 
 			var ccreq2 = WabiSabiFactory.CreateConnectionConfirmationRequest(round, irres2);
 			var ccresp2 = await arena.ConfirmConnectionAsync(ccreq2.request);
 			ccresps.Add((ccresp2, ccreq2.amountClient, ccreq2.vsizeClient, irres1.AliceId));
-			ccreq2.amountClient.HandleResponse(ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
-			ccreq2.vsizeClient.HandleResponse(ccresp2.RealVsizeCredentials!, ccreq2.vsizeValidation);
+			ccreq2.amountClient.HandleResponse(irres2.AliceId, ccresp2.RealAmountCredentials!, ccreq2.amountValidation);
+			ccreq2.vsizeClient.HandleResponse(irres2.AliceId, ccresp2.RealVsizeCredentials!, ccreq2.vsizeValidation);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.OutputRegistration, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			using var destinationKey3 = new Key();
 			using var destinationKey4 = new Key();
 
-			var bobClient = new BobClient(round.Id, bobArenaClient);
+			var bobClient = new BobClient(BitcoinFactory.CreateUint256(), round.Id, bobArenaClient);
 			await bobClient.RegisterOutputAsync(Money.Coins(0.25m), destinationKey1.PubKey.WitHash.ScriptPubKey);
 			await bobClient.RegisterOutputAsync(Money.Coins(0.25m), destinationKey2.PubKey.WitHash.ScriptPubKey);
 			await bobClient.RegisterOutputAsync(Money.Coins(0.25m), destinationKey3.PubKey.WitHash.ScriptPubKey);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
@@ -6,7 +6,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge;
-using WalletWasabi.WabiSabi;
+using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 using Xunit;
@@ -33,6 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 			Assert.Equal(43, issuer.RangeProofWidth);
 		}
 
+#if false
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
 		public void Splitting()
@@ -60,17 +61,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 			client.HandleResponse(credentialResponse, validationData);
 
 			// Output Reg
-			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 8L }, client.Credentials.Valuable);
+			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 8L }, client.Credentials.TakeValuable());
 			credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
 			Assert.Equal(-1, credentialRequest.Delta);
 
-			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 7L }, client.Credentials.Valuable);
+			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 7L }, client.Credentials.TakeValuable());
 			credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
 			Assert.Equal(-1, credentialRequest.Delta);
 
-			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 6L }, client.Credentials.Valuable);
+			(credentialRequest, validationData) = client.CreateRequest(new[] { 1L, 6L }, client.Credentials.TakeValuable());
 			credentialResponse = issuer.HandleRequest(credentialRequest);
 			client.HandleResponse(credentialResponse, validationData);
 			Assert.Equal(-1, credentialRequest.Delta);
@@ -111,14 +112,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 
 				var credentialResponse = issuer.HandleRequest(credentialRequest);
 				client.HandleResponse(credentialResponse, validationData);
-				Assert.Equal(ProtocolConstants.CredentialNumber, client.Credentials.ZeroValue.Count());
-				Assert.Empty(client.Credentials.Valuable);
-				var issuedCredential = client.Credentials.ZeroValue.First();
+//				Assert.Equal(numberOfCredentials, client.Credentials.ZeroValue.Count());
+//				Assert.Empty(client.Credentials.Valuable);
+				var issuedCredential = client.Credentials.TakeZeroValue().First();
 				Assert.True(issuedCredential.Amount.IsZero);
 			}
 
 			{
-				var present = client.Credentials.ZeroValue.Take(ProtocolConstants.CredentialNumber);
+				var present = client.Credentials.TakeZeroValue();
 				var (credentialRequest, validationData) = client.CreateRequest(new[] { 100_000_000L }, present);
 
 				Assert.False(credentialRequest.IsNullRequest);
@@ -296,5 +297,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 				Assert.Equal(WabiSabiCryptoErrorCode.SerialNumberAlreadyUsed, ex.ErrorCode);
 			}
 		}
+#endif
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/SerializationTests.cs
@@ -8,6 +8,7 @@ using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.JsonConverters.Bitcoin;
+using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
@@ -161,8 +162,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi
 			var client = new WabiSabiClient(sk.ComputeCredentialIssuerParameters(), rnd, 4300000000000);
 			(CredentialsRequest credentialRequest, CredentialsResponseValidation validationData) = client.CreateRequestForZeroAmount();
 			var credentialResponse = issuer.HandleRequest(credentialRequest);
-			client.HandleResponse(credentialResponse, validationData);
-			var present = client.Credentials.ZeroValue.Take(ProtocolConstants.CredentialNumber);
+			client.HandleResponse(BitcoinFactory.CreateUint256(), credentialResponse, validationData);
+			var present = client.Credentials.GetCredentialsForRequester(0);
 			(credentialRequest, _) = client.CreateRequest(new[] { 1L }, present);
 
 			// Registration request message.

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -57,7 +57,7 @@ namespace WalletWasabi.WabiSabi.Client
 					RoundId,
 					AliceId,
 					inputRemainingVsizes,
-					amountCredentials.ZeroValue.Take(ProtocolConstants.CredentialNumber),
+					await amountCredentials.GetCredentialsForRequesterAsync(AliceId),
 					amountsToRequest)
 				.ConfigureAwait(false);
 		}

--- a/WalletWasabi/WabiSabi/Client/BobClient.cs
+++ b/WalletWasabi/WabiSabi/Client/BobClient.cs
@@ -9,23 +9,26 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class BobClient
 	{
-		public BobClient(uint256 roundId, ArenaClient arenaClient)
+		public BobClient(uint256 id, uint256 roundId, ArenaClient arenaClient)
 		{
+			Id = id;
 			RoundId = roundId;
 			ArenaClient = arenaClient;
 		}
 
+		public uint256 Id { get; }
 		private uint256 RoundId { get; }
 		private ArenaClient ArenaClient { get; }
 
 		public async Task RegisterOutputAsync(Money amount, Script scriptPubKey)
 		{
 			await ArenaClient.RegisterOutputAsync(
+				Id,
 				RoundId,
 				amount.Satoshi,
 				scriptPubKey,
-				ArenaClient.AmountCredentialClient.Credentials.Valuable,
-				ArenaClient.VsizeCredentialClient.Credentials.Valuable).ConfigureAwait(false);
+				await ArenaClient.AmountCredentialClient.Credentials.GetCredentialsForRequesterAsync(Id),
+				await ArenaClient.VsizeCredentialClient.Credentials.GetCredentialsForRequesterAsync(Id)).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Crypto/UnboundedChannel.cs
+++ b/WalletWasabi/WabiSabi/Crypto/UnboundedChannel.cs
@@ -1,0 +1,37 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+
+namespace WalletWasabi.WabiSabi.Crypto
+{
+	public class UnboundedChannel<T>
+	{
+		private readonly ConcurrentQueue<T> _queue = new();
+		private readonly ConcurrentQueue<TaskCompletionSource<T>> _waitingQueue = new();
+
+		public void Send(T item)
+		{
+			if (_waitingQueue.TryDequeue(out var tcs))
+			{
+				tcs.TrySetResult(item);
+				return;
+			}
+
+			_queue.Enqueue(item);
+		}
+
+		public Task<T> TakeAsync(CancellationToken cancellationToken = default(CancellationToken))
+		{
+			if (_queue.TryDequeue(out var item))
+			{
+				return Task.FromResult(item);
+			}
+
+			var tcs = new TaskCompletionSource<T>();
+			_waitingQueue.Enqueue(tcs);
+
+			using (cancellationToken.Register(() => tcs.TrySetCanceled()))
+			return tcs.Task;
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
+++ b/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
@@ -110,7 +110,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 			// Make sure we present always the same number of credentials (except for Null requests)
 			var missingCredentialPresent = NumberOfCredentials - credentialsToPresent.Count();
 
-			var alreadyPresentedZeroCredentials = credentialsToPresent.Where(x => x.Amount.IsZero);
+/*			var alreadyPresentedZeroCredentials = credentialsToPresent.Where(x => x.Amount.IsZero);
 			var availableZeroCredentials = Credentials.ZeroValue.Except(alreadyPresentedZeroCredentials);
 
 			// This should not be possible
@@ -121,8 +121,8 @@ namespace WalletWasabi.WabiSabi.Crypto
 					WabiSabiCryptoErrorCode.NotEnoughZeroCredentialToFillTheRequest,
 					$"{missingCredentialPresent} credentials are missing but there are only {availableZeroCredentialCount} zero-value credentials available.");
 			}
-
-			credentialsToPresent = credentialsToPresent.Concat(availableZeroCredentials.Take(missingCredentialPresent)).ToList();
+*/
+			credentialsToPresent = credentialsToPresent /*.Concat(availableZeroCredentials.Take(missingCredentialPresent))*/.ToList();
 			var macsToPresent = credentialsToPresent.Select(x => x.Mac);
 			if (macsToPresent.Distinct().Count() < macsToPresent.Count())
 			{
@@ -192,7 +192,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 		/// </remarks>
 		/// <param name="registrationResponse">The registration response message received from the coordinator.</param>
 		/// <param name="registrationValidationData">The state data required to validate the issued credentials and the proofs.</param>
-		public IEnumerable<Credential> HandleResponse(CredentialsResponse registrationResponse, CredentialsResponseValidation registrationValidationData)
+		public IEnumerable<Credential> HandleResponse(uint256 requesterId, CredentialsResponse registrationResponse, CredentialsResponseValidation registrationValidationData)
 		{
 			Guard.NotNull(nameof(registrationResponse), registrationResponse);
 			Guard.NotNull(nameof(registrationValidationData), registrationValidationData);
@@ -222,7 +222,7 @@ namespace WalletWasabi.WabiSabi.Crypto
 			var credentialReceived = credentials.Select(x =>
 				new Credential(new Scalar((ulong)x.Requested.Amount), x.Requested.Randomness, x.Issued));
 
-			Credentials.UpdateCredentials(credentialReceived, registrationValidationData.Presented);
+			Credentials.UpdateCredentials(requesterId, credentialReceived);
 			return credentialReceived;
 		}
 


### PR DESCRIPTION
This PR implements the mechanism that prevents deadlock in the CredentialPool as was discussed today. 

If well it is true that the `CredentialPool` code using a list of channels is much much simpler than the previous attempt (https://github.com/zkSNACKs/WalletWasabi/pull/5713), we achieve that but moving the complexity to somewhere else and poisoning all the code.

I think this solution is a good. Instead, I think the Planner (or the CoinJoinClient) is the one that knows all the Alices and Bobs and all the intermediate steps required to provide the final credentials to Bobs and then it is that same component the one that should provide the Promises to each Bob.

For this same reason I think the `CredentialPool` as a container of credentials makes no sense (except for zero credentials, perhaps). The `WabiSabiClient::HandleResponse` should not update any credential pool (except one containing the zero credentials). What we need it the planner to create the full graph of tasks without any CredentialPool.  

**Note:** this PR is only to show how this looks like, it doesn't compile because it makes no sense to continue working on this line.   