### PR TITLE
Produce coverage reports in Linux & OSX Azure pipelines

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -30,9 +30,22 @@ jobs:
     inputs:
       command: build
       arguments: --no-restore --configuration Release
+  - task: CmdLine@2
+    inputs:
+      # Remove PathMap properties which ensure deterministic builds, since this
+      # interferes with the coverage analysis.
+      script: 'sed -i "/PathMap/d" $(System.DefaultWorkingDirectory)/*/*.csproj'
   - task: DotNetCoreCLI@2
     displayName: 'Test Debug'
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed"
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage"
+      publishTestResults: true
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish code coverage report'
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+      pathToSources: '$(System.DefaultWorkingDirectory)/'
+      failIfCoverageEmpty: true

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -30,9 +30,23 @@ jobs:
     inputs:
       command: build
       arguments: --no-restore --configuration Release
+  - task: CmdLine@2
+    inputs:
+      # Remove PathMap properties which ensure deterministic builds, since this
+      # interferes with the coverage analysis. sed -i seems unhappy with the
+      # shell glob but perl doesn't mind.
+      script: 'perl -ni -e "print unless /PathMap/" $(System.DefaultWorkingDirectory)/*/*.csproj'
   - task: DotNetCoreCLI@2
     displayName: 'Test Debug'
     inputs:
       command: test
       projects: 'WalletWasabi.Tests/WalletWasabi.Tests.csproj'
-      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed"
+      arguments: --configuration $(testConfiguration) --filter "UnitTests" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage"
+      publishTestResults: true
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish code coverage report'
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+      pathToSources: '$(System.DefaultWorkingDirectory)/'
+      failIfCoverageEmpty: true


### PR DESCRIPTION
This uses the native cobertura output as described in
WalletWasabi.Documentation/CodeCoverage.md.

The `PublishCodeCoverageResults` azure pipeline task is able to generate HTML
from cobertura reports, which can be viewed in the pipeline task. For the report
generation to work `PathMap` needs to be disabled when generating the coverage
outputs.

On Windows coverage data is generated and can be downloaded for use with visual
studio, but I haven't found a way of generating HTML reports easily, so this is
not included for now.