### PR TITLE
Disposing new Key in AsyncLock Dequeue

### DIFF
--- a/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
+++ b/WalletWasabi/Nito/AsyncEx/AsyncLock.cs
@@ -163,7 +163,8 @@ namespace Nito.AsyncEx
 				}
 				else
 				{
-					_queue.Dequeue(new Key(this));
+					using Key key = new(this);
+					_queue.Dequeue(key);
 				}
 			}
 		}


### PR DESCRIPTION
The ```new Key(this)``` variable has ```SingleDisposable``` implemented, tough it was not Disposed.
With this small change we make sure it is disposed at the end of scope.