### PR TITLE
Refactor EncodationStruct

### DIFF
--- a/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/DataEncode.cs
+++ b/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/DataEncode.cs
@@ -51,10 +51,7 @@ namespace Gma.QrCodeNet.Encoding.DataEncodation
 				throw new ArgumentException($"{nameof(dataCodewords)} num of bytes not equal to {nameof(vcStruct.VersionDetail.NumDataBytes)} for current version");
 			}
 
-			var encStruct = new EncodationStruct(vcStruct)
-			{
-				DataCodewords = dataCodewords
-			};
+			var encStruct = new EncodationStruct(vcStruct, dataCodewords);
 			return encStruct;
 		}
 

--- a/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/EncodationStruct.cs
+++ b/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/EncodationStruct.cs
@@ -4,9 +4,10 @@ namespace Gma.QrCodeNet.Encoding.DataEncodation
 {
 	internal struct EncodationStruct
 	{
-		internal EncodationStruct(VersionControlStruct vcStruct) : this()
+		internal EncodationStruct(VersionControlStruct vcStruct, BitList dataCodewords) : this()
 		{
 			VersionDetail = vcStruct.VersionDetail;
+			DataCodewords = dataCodewords;
 		}
 
 		internal VersionDetail VersionDetail { get; set; }

--- a/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/EncodationStruct.cs
+++ b/WalletWasabi/Gma/QrCodeNet/Encoding/DataEncodation/EncodationStruct.cs
@@ -4,7 +4,7 @@ namespace Gma.QrCodeNet.Encoding.DataEncodation
 {
 	internal struct EncodationStruct
 	{
-		internal EncodationStruct(VersionControlStruct vcStruct, BitList dataCodewords) : this()
+		internal EncodationStruct(VersionControlStruct vcStruct, BitList dataCodewords)
 		{
 			VersionDetail = vcStruct.VersionDetail;
 			DataCodewords = dataCodewords;


### PR DESCRIPTION
The ```BitList DataCodewords``` could be easily added in the constructor of ```EncodationStruct```, and thus lets us remove the ```this()``` call, as all fields are declared in the constructor already.