### PR TITLE
[Fluent] Fix dialog closing when changing window state

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -16,6 +16,7 @@ namespace WalletWasabi.Fluent.Controls
 	public class Dialog : ContentControl
 	{
 		private Panel? _dismissPanel;
+		private Panel? _overlayPanel;
 		private bool _canCancelOnPointerPressed;
 
 		public static readonly StyledProperty<bool> IsDialogOpenProperty =
@@ -140,6 +141,7 @@ namespace WalletWasabi.Fluent.Controls
 			base.OnApplyTemplate(e);
 
 			_dismissPanel = e.NameScope.Find<Panel>("PART_Dismiss");
+			_overlayPanel = e.NameScope.Find<Panel>("PART_Overlay");
 
 			if (this.GetVisualRoot() is TopLevel topLevel)
 			{
@@ -155,10 +157,12 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void CancelPointerPressed(object? sender, PointerPressedEventArgs e)
 		{
-			if (IsDialogOpen && EnableCancelOnPressed && !IsBusy && _dismissPanel is not null && _canCancelOnPointerPressed)
+			if (IsDialogOpen && EnableCancelOnPressed && !IsBusy && _dismissPanel is { } && _overlayPanel is { } && _canCancelOnPointerPressed)
 			{
 				var point = e.GetPosition(_dismissPanel);
-				if (!_dismissPanel.Bounds.Contains(point))
+				var isPressedOnTitleBar = e.GetPosition(_overlayPanel).Y < 30;
+
+				if (!_dismissPanel.Bounds.Contains(point) && !isPressedOnTitleBar)
 				{
 					Close();
 				}


### PR DESCRIPTION
Before this, when a dialog was opened and I clicked on the maximized/minimized button on the top right, the window state has changed and the dialog got closed.

The dialog won't close from now.