### PR TITLE
Uppercase QR encoded bech32 addresses

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
@@ -100,7 +100,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Receive
 		{
 			try
 			{
-				QrCode = new QrEncoder().Encode(Address).Matrix.InternalArray;
+				QrCode = new QrEncoder().Encode(Address.ToUpperInvariant()).Matrix.InternalArray;
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/AddressViewModel.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.Gui.ViewModels
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Where(x => x)
 				.Take(1)
-				.Select(x => new QrEncoder().Encode(Address).Matrix.InternalArray)
+				.Select(x => new QrEncoder().Encode(Address.ToUpperInvariant()).Matrix.InternalArray)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(qr => QrCode = qr, onError: ex => Logger.LogError(ex)); // Catch the exceptions everywhere (e.g.: Select) except in Subscribe.
 


### PR DESCRIPTION
[BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32) subsection Uppercase/lowercase says:

> For presentation, lowercase is usually preferable, but inside QR codes
> uppercase SHOULD be used, as those permit the use of alphanumeric
> mode, which is 45% more compact than the normal byte mode.