### PR TITLE
Remove warnings related to FileSystemBlockRepository

### DIFF
--- a/WalletWasabi/Wallets/CachedBlockProvider.cs
+++ b/WalletWasabi/Wallets/CachedBlockProvider.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Wallets
 		/// <returns>The requested bitcoin block.</returns>
 		public async Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancellationToken)
 		{
-			Block block = await BlockRepository.GetAsync(hash, cancellationToken).ConfigureAwait(false);
+			Block? block = await BlockRepository.GetAsync(hash, cancellationToken).ConfigureAwait(false);
 			if (block is null)
 			{
 				block = await BlockSourceProvider.GetBlockAsync(hash, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Wallets/FileSystemBlockRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlockRepository.cs
@@ -206,7 +206,7 @@ namespace WalletWasabi.Wallets
 		/// <param name="hash">The block's hash that identifies the requested block.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>The requested bitcoin block.</returns>
-		public async Task<Block> GetAsync(uint256 hash, CancellationToken cancellationToken)
+		public async Task<Block?> GetAsync(uint256 hash, CancellationToken cancellationToken)
 		{
 			// Try get the block.
 			Block? block = null;
@@ -221,7 +221,7 @@ namespace WalletWasabi.Wallets
 						byte[] blockBytes = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
 						block = Block.Load(blockBytes, Network);
 
-						new FileInfo(filePath)
+						_ = new FileInfo(filePath)
 						{
 							LastAccessTimeUtc = DateTime.UtcNow
 						};

--- a/WalletWasabi/Wallets/IRepository.cs
+++ b/WalletWasabi/Wallets/IRepository.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.Wallets
 	/// </summary>
 	public interface IRepository<TID, TElement>
 	{
-		Task<TElement> GetAsync(TID id, CancellationToken cancel);
+		Task<TElement?> GetAsync(TID id, CancellationToken cancel);
 
 		Task SaveAsync(TElement element, CancellationToken cancel);
 


### PR DESCRIPTION
- In ```CachedBlockProvider``` we had to make sure that the ```Block``` is nullable, as it is okay if it gets back null, we make sure to have an acceptable value in the next line anyhow.
- In ```FileSystemBlockRepository``` we had to make the Block in ```Task<Block>``` nullable for the same reason before. (To achive that correctly, we had to change the original interface's function in ```IRepository``` to accept null)
- Also at line 224 we gave ```FilePath``` a discard variable to remove the warning "it is not used anywhere".