### PR TITLE
Rename GetAsync related to IRepository

### DIFF
--- a/WalletWasabi/Wallets/CachedBlockProvider.cs
+++ b/WalletWasabi/Wallets/CachedBlockProvider.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Wallets
 		/// <returns>The requested bitcoin block.</returns>
 		public async Task<Block> GetBlockAsync(uint256 hash, CancellationToken cancellationToken)
 		{
-			Block? block = await BlockRepository.GetAsync(hash, cancellationToken).ConfigureAwait(false);
+			Block? block = await BlockRepository.TryGetAsync(hash, cancellationToken).ConfigureAwait(false);
 			if (block is null)
 			{
 				block = await BlockSourceProvider.GetBlockAsync(hash, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Wallets/FileSystemBlockRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlockRepository.cs
@@ -206,7 +206,7 @@ namespace WalletWasabi.Wallets
 		/// <param name="hash">The block's hash that identifies the requested block.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>The requested bitcoin block.</returns>
-		public async Task<Block?> GetAsync(uint256 hash, CancellationToken cancellationToken)
+		public async Task<Block?> TryGetAsync(uint256 hash, CancellationToken cancellationToken)
 		{
 			// Try get the block.
 			Block? block = null;

--- a/WalletWasabi/Wallets/IRepository.cs
+++ b/WalletWasabi/Wallets/IRepository.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.Wallets
 	/// </summary>
 	public interface IRepository<TID, TElement>
 	{
-		Task<TElement?> GetAsync(TID id, CancellationToken cancel);
+		Task<TElement?> TryGetAsync(TID id, CancellationToken cancel);
 
 		Task SaveAsync(TElement element, CancellationToken cancel);
 


### PR DESCRIPTION
As @nopara73 mentioned [here](https://github.com/zkSNACKs/WalletWasabi/pull/5744/files#r626394991), ```TryGetAsync``` would be a better name, as it reflects that it returns null in case the block was not found.