### PR TITLE
Resolving WasabiSynchronizer warning

### DIFF
--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.WebClients.Wasabi
 		/// <remarks>
 		/// Throws OperationCancelledException if <paramref name="cancel"/> is set.
 		/// </remarks>
-		public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
+		public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256? bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
 		{
 			string relativeUri = $"/api/v{ApiVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
 			if (estimateMode is { })


### PR DESCRIPTION
```WasabiSynchronizer``` calls 
```WasabiClient.GetSynchronizeAsync(BitcoinStore.SmartHeaderChain.TipHash, maxFiltersToSyncAtInitialization, EstimateSmartFeeMode.Conservative, StopCts.Token)```
where **TipHash** may be null on purpose, we handle this as well, therefore making ```bestKnownBlockHash``` nullable is fine.