### PR TITLE
Resolving VersionsResponse.cs warnings

### DIFF
--- a/WalletWasabi.Backend/Controllers/SoftwareController.cs
+++ b/WalletWasabi.Backend/Controllers/SoftwareController.cs
@@ -11,12 +11,11 @@ namespace WalletWasabi.Backend.Controllers
 	[Route("api/[controller]")]
 	public class SoftwareController : ControllerBase
 	{
-		private readonly VersionsResponse _versionsResponse = new()
-		{
-			ClientVersion = Constants.ClientVersion.ToString(3),
-			BackendMajorVersion = Constants.BackendMajorVersion,
-			LegalDocumentsVersion = Constants.LegalDocumentsVersion.ToString()
-		};
+		private readonly VersionsResponse _versionsResponse = new(
+			Constants.ClientVersion.ToString(3),
+			Constants.BackendMajorVersion,
+			Constants.LegalDocumentsVersion.ToString()
+			);
 
 		/// <summary>
 		/// Gets the latest versions of the client and backend.

--- a/WalletWasabi/Backend/Models/Responses/VersionsResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/VersionsResponse.cs
@@ -4,6 +4,13 @@ namespace WalletWasabi.Backend.Models.Responses
 {
 	public class VersionsResponse
 	{
+		public VersionsResponse(string clientVersion, string backendMajorVersion, string legalDocumentsVersion)
+		{
+			ClientVersion = clientVersion;
+			BackendMajorVersion = backendMajorVersion;
+			LegalDocumentsVersion = legalDocumentsVersion;
+		}
+
 		public string ClientVersion { get; set; }
 
 		// KEEP THE TYPO IN IT! Otherwise the response would not be backwards compatible.


### PR DESCRIPTION
In `SoftwareController.cs` when we create a new instance, we just set the values next to an empty constructor, therefore a warning appears, as the fields are leaving the constructor with values of `null`. This is simply solved via a constructor that waits for the values to assign to the fields.