### PR TITLE
Fix null warning

### DIFF
--- a/WalletWasabi.Gui/Controls/WalletExplorer/BuildTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/BuildTabViewModel.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 		// Must be here, it is bound at SendControlView.xaml.
 		public string PayjoinEndPoint => null;
 
-		protected override async Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint> allowedInputs = null)
+		protected override async Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint>? allowedInputs = null)
 		{
 			BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, payments, feeStrategy, allowUnconfirmed: true, allowedInputs: allowedInputs));
 

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendControlViewModel.cs
@@ -940,7 +940,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			base.OnOpen(disposables);
 		}
 
-		protected abstract Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint> allowedInputs = null);
+		protected abstract Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint>? allowedInputs = null);
 
 		protected virtual void OnAddressPaste(BitcoinUrlBuilder url)
 		{

--- a/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
+++ b/WalletWasabi.Gui/Controls/WalletExplorer/SendTabViewModel.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.Gui.Controls.WalletExplorer
 			set => this.RaiseAndSetIfChanged(ref _payjoinEndPoint, value);
 		}
 
-		protected override async Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint> allowedInputs = null)
+		protected override async Task BuildTransaction(string password, PaymentIntent payments, FeeStrategy feeStrategy, bool allowUnconfirmed = false, IEnumerable<OutPoint>? allowedInputs = null)
 		{
 			BuildTransactionResult result = await Task.Run(() => Wallet.BuildTransaction(Password, payments, feeStrategy, allowUnconfirmed: true, allowedInputs: allowedInputs, GetPayjoinClient()));
 


### PR DESCRIPTION
If `allowedInputs` is not passed it is assigned the value `null`, that is why it should be nullable.