### PR TITLE
Resolve null warning in BitcoinAddressJsonConverter.cs

### DIFF
--- a/WalletWasabi/JsonConverters/BitcoinAddressJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/BitcoinAddressJsonConverter.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var bitcoinAddressString = reader.Value as string;
 			if (string.IsNullOrWhiteSpace(bitcoinAddressString))


### PR DESCRIPTION
If `string.IsNullOrWhiteSpace(bitcoinAddressString)` gives back true, we return `default`, which in case of an object is null, so this should be nullable as well.