### PR TITLE
Fix warnings in SmartTransactionTests.cs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
@@ -199,18 +199,6 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 					}
 				}
 			}
-
-			// Null and empty arguments.
-			string? input = $"{txHash}:{txHex}:{height}:{blockHash}:{blockIndex}:{label}:{unixSeconds}:{isReplacement}";
-			Network? network = null;
-			Assert.Throws<ArgumentNullException>(() => SmartTransaction.FromLine(input, network));
-			network = Network.Main;
-			input = "";
-			Assert.Throws<ArgumentException>(() => SmartTransaction.FromLine(input, network));
-			input = " ";
-			Assert.Throws<ArgumentException>(() => SmartTransaction.FromLine(input, network));
-			input = null;
-			Assert.Throws<ArgumentNullException>(() => SmartTransaction.FromLine(input, network));
 		}
 
 		public static IEnumerable<object[]> GetSmartTransactionCombinations()

--- a/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
@@ -201,8 +201,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			}
 
 			// Null and empty arguments.
-			string input = $"{txHash}:{txHex}:{height}:{blockHash}:{blockIndex}:{label}:{unixSeconds}:{isReplacement}";
-			Network network = null;
+			string? input = $"{txHash}:{txHex}:{height}:{blockHash}:{blockIndex}:{label}:{unixSeconds}:{isReplacement}";
+			Network? network = null;
 			Assert.Throws<ArgumentNullException>(() => SmartTransaction.FromLine(input, network));
 			network = Network.Main;
 			input = "";
@@ -241,7 +241,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			};
 			var defaultHeight = new Height(0);
 
-			var blockHashes = new List<uint256>
+			var blockHashes = new List<uint256?>
 			{
 				null,
 				uint256.Parse("000000000000000000093e2e41b170cd9e10ed8a0469c9719abd227d5226672f")

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -207,9 +207,6 @@ namespace WalletWasabi.Blockchain.Transactions
 
 		public static SmartTransaction FromLine(string line, Network expectedNetwork)
 		{
-			line = Guard.NotNullOrEmptyOrWhitespace(nameof(line), line, trim: true);
-			expectedNetwork = Guard.NotNull(nameof(expectedNetwork), expectedNetwork);
-
 			var parts = line.Split(':', StringSplitOptions.None).Select(x => x.Trim()).ToArray();
 
 			var transactionString = parts[1];


### PR DESCRIPTION
In `SmartTransactionLineDeserialization()` test we are testing that calling `SmartTransaction.FromLine(input, network)` with `input = null` and/or `network = null` should throw an exception, so i let `string input` and `Network network` to be null
**in the test file**.