### PR TITLE
Move FilterProcessor inside the Synchronizer

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -173,7 +173,6 @@ namespace WalletWasabi.Gui
 				}
 
 				HostedServices.Register<P2pNetwork>(new P2pNetwork(Network, Config.GetBitcoinP2pEndPoint(), Config.UseTor ? Config.TorSocks5EndPoint : null, Path.Combine(DataDir, "BitcoinP2pNetwork"), BitcoinStore), "Bitcoin P2P Network");
-				HostedServices.Register<FilterProcessor>(new FilterProcessor(Synchronizer, BitcoinStore), "Filter Processor");
 
 				try
 				{

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -56,7 +56,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
@@ -128,7 +127,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 10000); // Start wasabi synchronizer service.
 
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				// Wait until the filter our previous transaction is present.
@@ -188,7 +186,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			{
 				await wallet.StopAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes?.Dispose();
 				node?.Disconnect();
@@ -212,7 +209,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
@@ -244,7 +240,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 10000); // Start wasabi synchronizer service.
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				// Wait until the filter our previous transaction is present.
@@ -407,7 +402,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				bitcoinStore.IndexStore.NewFilter -= Common.Wallet_NewFilterProcessed;
 				await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes?.Dispose();
 				node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1381,7 +1381,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
@@ -1426,7 +1425,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 10000); // Start wasabi synchronizer service.
 
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				nodes2.Connect(); // Start connection service.
@@ -1534,7 +1532,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				node?.Disconnect();
 				await wallet2.StopAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes2?.Dispose();
 			}

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -53,7 +53,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
@@ -85,7 +84,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 10000); // Start wasabi synchronizer service.
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				// Wait until the filter our previous transaction is present.
@@ -509,7 +507,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				bitcoinStore.IndexStore.NewFilter -= Common.Wallet_NewFilterProcessed;
 				await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes?.Dispose();
 				node?.Disconnect();
@@ -534,7 +531,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
@@ -558,7 +554,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 10000); // Start wasabi synchronizer service.
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				// Wait until the filter our previous transaction is present.
@@ -681,7 +676,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				bitcoinStore.IndexStore.NewFilter -= Common.Wallet_NewFilterProcessed;
 				await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes?.Dispose();
 				node?.Disconnect();
@@ -706,7 +700,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 3. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
@@ -732,7 +725,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 10000); // Start wasabi synchronizer service.
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				// Wait until the filter our previous transaction is present.
@@ -782,7 +774,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			{
 				await wallet.StopAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes?.Dispose();
 				node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -55,11 +55,9 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			try
 			{
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(1), 1000);
-				await filterProcessor.StartAsync(CancellationToken.None);
 
 				var blockCount = await rpc.GetBlockCountAsync() + 1; // Plus one because of the zeroth.
 																	 // Test initial synchronization.
@@ -114,7 +112,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			finally
 			{
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 			}
 		}
 
@@ -141,12 +138,10 @@ namespace WalletWasabi.Tests.RegressionTests
 
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 
 			try
 			{
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 1000);
-				await filterProcessor.StartAsync(CancellationToken.None);
 
 				var reorgAwaiter = new EventsAwaiter<FilterModel>(
 					h => bitcoinStore.IndexStore.Reorged += h,
@@ -226,7 +221,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			finally
 			{
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 			}
 		}
 
@@ -246,7 +240,6 @@ namespace WalletWasabi.Tests.RegressionTests
 			// 2. Create wasabi synchronizer service.
 			using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
-			FilterProcessor filterProcessor = new(synchronizer, bitcoinStore);
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 3. Create key manager service.
@@ -273,7 +266,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				nodes.Connect(); // Start connection service.
 				node.VersionHandshake(); // Start mempool service.
 				synchronizer.Start(requestInterval: TimeSpan.FromSeconds(3), 1000); // Start wasabi synchronizer service.
-				await filterProcessor.StartAsync(CancellationToken.None);
 				await feeProvider.StartAsync(CancellationToken.None);
 
 				// Wait until the filter our previous transaction is present.
@@ -407,7 +399,6 @@ namespace WalletWasabi.Tests.RegressionTests
 				wallet.NewFilterProcessed -= Common.Wallet_NewFilterProcessed;
 				await wallet.StopAsync(CancellationToken.None);
 				await synchronizer.StopAsync();
-				await filterProcessor.StopAsync(CancellationToken.None);
 				await feeProvider.StopAsync(CancellationToken.None);
 				nodes?.Dispose();
 				node?.Disconnect();


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/5785

Drawback: It's slower because now we are waiting for the FilterProcessor to finish processing the filters before we'd make our next request to the synchronizer.