### PR TITLE
[Trivial] Remove Async prefix from method

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -179,7 +179,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		}
 
 		[Fact]
-		public void SelectSameClusterCoinsAsync()
+		public void SelectSameClusterCoins()
 		{
 			var password = "foo";
 			var keyManager = ServiceFactory.CreateKeyManager(password);


### PR DESCRIPTION
#5784 made `SelectSameClusterCoinsAsync()` synchronous, so the Async suffix should be removed.