### PR TITLE
Fix null warnings

### DIFF
--- a/WalletWasabi/JsonConverters/FilterModelJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/FilterModelJsonConverter.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var value = Guard.Correct((string)reader.Value);
 

--- a/WalletWasabi/JsonConverters/KeyJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/KeyJsonConverter.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var keyString = reader.Value as string;
 			if (string.IsNullOrWhiteSpace(keyString))

--- a/WalletWasabi/JsonConverters/NetworkJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/NetworkJsonConverter.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			// check additional strings that are not checked by GetNetwork
 			string networkString = ((string)reader.Value).Trim();

--- a/WalletWasabi/JsonConverters/Uint256JsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Uint256JsonConverter.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
 			var value = Guard.Correct((string)reader.Value);
 


### PR DESCRIPTION
Similar to #5781, these methods might return `default` which in case of an `object` it is null, so the return type should be `object?`.