### PR TITLE
Fix warning in TransactionStoreTests.cs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionStoreTests.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		[Fact]
 		public async Task CanInitializeAsync()
 		{
-			var txStore = await CreateTransactionStoreAsync();
+			await using var txStore = await CreateTransactionStoreAsync();
 
 			Assert.Equal(Network.Main, txStore.Network);
 			Assert.Empty(txStore.GetTransactionHashes());
@@ -24,14 +24,12 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.False(txStore.TryRemove(uint256.One, out _));
 			Assert.NotEmpty(txStore.WorkFolderPath);
 			Assert.True(File.Exists(Path.Combine(txStore.WorkFolderPath, "Transactions.dat")));
-
-			await txStore.DisposeAsync();
 		}
 
 		[Fact]
 		public async Task CanDoOperationsAsync()
 		{
-			var txStore = await CreateTransactionStoreAsync();
+			await using var txStore = await CreateTransactionStoreAsync();
 
 			Assert.True(txStore.IsEmpty());
 
@@ -78,8 +76,6 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			txStore.TryAddOrUpdate(stx);
 			Assert.Single(txStore.GetTransactions());
 			Assert.Single(txStore.GetTransactionHashes());
-
-			await txStore.DisposeAsync();
 		}
 
 		private static async Task<TransactionStore> CreateTransactionStoreAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "")

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionStoreTests.cs
@@ -24,6 +24,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.False(txStore.TryRemove(uint256.One, out _));
 			Assert.NotEmpty(txStore.WorkFolderPath);
 			Assert.True(File.Exists(Path.Combine(txStore.WorkFolderPath, "Transactions.dat")));
+
+			await txStore.DisposeAsync();
 		}
 
 		[Fact]
@@ -76,6 +78,8 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			txStore.TryAddOrUpdate(stx);
 			Assert.Single(txStore.GetTransactions());
 			Assert.Single(txStore.GetTransactionHashes());
+
+			await txStore.DisposeAsync();
 		}
 
 		private static async Task<TransactionStore> CreateTransactionStoreAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "")


### PR DESCRIPTION
We didn't dispose `txStore` before all reference to it are out of scope (when the test is finished).

This PR fixes it.