### PR TITLE
[Fluent] QuestionControl fixes

### DIFF
--- a/WalletWasabi.Fluent/Controls/QuestionControl.axaml
+++ b/WalletWasabi.Fluent/Controls/QuestionControl.axaml
@@ -17,10 +17,12 @@
                           FontSize="{TemplateBinding FontSize}"
                           DockPanel.Dock="Bottom"
                           Margin="0 10 0 50" />
-          <Viewbox MaxHeight="150" DockPanel.Dock="Top">
-            <Image Height="100" Source="{TemplateBinding Icon}" />
-          </Viewbox>
-          <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" DockPanel.Dock="Top"/>
+            <Panel DockPanel.Dock="Top">
+              <Viewbox MaxHeight="150">
+                <Image Height="100" Source="{TemplateBinding Icon}" />
+              </Viewbox>
+              <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" DockPanel.Dock="Top"/>
+            </Panel>
         </DockPanel>
       </ControlTemplate>
     </Setter>

--- a/WalletWasabi.Fluent/Controls/QuestionControl.axaml
+++ b/WalletWasabi.Fluent/Controls/QuestionControl.axaml
@@ -12,16 +12,17 @@
             <Button Name="PART_NoButton" HorizontalAlignment="Left" Content="No" Classes="yesNo" Command="{TemplateBinding NoCommand}" />
             <Button Name="PART_YesButton" HorizontalAlignment="Right" Content="Yes" Classes="yesNo" IsDefault="True" Command="{TemplateBinding YesCommand}" />
           </DockPanel>
-          <ContentControl Content="{TemplateBinding QuestionContent}"
-                          HorizontalContentAlignment="Center"
-                          FontSize="{TemplateBinding FontSize}"
-                          DockPanel.Dock="Bottom"
-                          Margin="0 10 0 50" />
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalContentAlignment="Center"
+                            TextBlock.FontSize="{TemplateBinding FontSize}"
+                            DockPanel.Dock="Bottom"
+                            Margin="0 10 0 50" />
             <Panel DockPanel.Dock="Top">
               <Viewbox MaxHeight="150">
-                <Image Height="100" Source="{TemplateBinding Icon}" />
+                <Image Height="100" Source="{TemplateBinding ImageIcon}" />
               </Viewbox>
-              <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" DockPanel.Dock="Top"/>
+              <ContentControl Content="{TemplateBinding IconContent}" DockPanel.Dock="Top"/>
             </Panel>
         </DockPanel>
       </ControlTemplate>

--- a/WalletWasabi.Fluent/Controls/QuestionControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/QuestionControl.axaml.cs
@@ -21,11 +21,11 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<ICommand> NoCommandProperty =
 			AvaloniaProperty.Register<QuestionControl, ICommand>(nameof(NoCommand));
 
-		public static readonly StyledProperty<IImage> IconProperty =
-			AvaloniaProperty.Register<QuestionControl, IImage>(nameof(Icon));
+		public static readonly StyledProperty<IImage> ImageIconProperty =
+			AvaloniaProperty.Register<QuestionControl, IImage>(nameof(ImageIcon));
 
-		public static readonly StyledProperty<object?> QuestionContentProperty =
-			AvaloniaProperty.Register<QuestionControl, object?>(nameof(QuestionContent));
+		public static readonly StyledProperty<object?> IconContentProperty =
+			AvaloniaProperty.Register<QuestionControl, object?>(nameof(IconContent));
 
 		public static readonly StyledProperty<HighlightedButton> HighlightButtonProperty =
 			AvaloniaProperty.Register<QuestionControl, HighlightedButton>(nameof(HighlightButton));
@@ -42,16 +42,16 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(NoCommandProperty, value);
 		}
 
-		public IImage Icon
+		public IImage ImageIcon
 		{
-			get => GetValue(IconProperty);
-			set => SetValue(IconProperty, value);
+			get => GetValue(ImageIconProperty);
+			set => SetValue(ImageIconProperty, value);
 		}
 
-		public object? QuestionContent
+		public object? IconContent
 		{
-			get => GetValue(QuestionContentProperty);
-			set => SetValue(QuestionContentProperty, value);
+			get => GetValue(IconContentProperty);
+			set => SetValue(IconContentProperty, value);
 		}
 
 		public HighlightedButton HighlightButton

--- a/WalletWasabi.Fluent/Views/AddWallet/HardwareWallet/DetectedHardwareWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/HardwareWallet/DetectedHardwareWalletView.axaml
@@ -16,10 +16,10 @@
                  EnableNext="False"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
 
-    <c:QuestionControl QuestionContent="{Binding TypeName, StringFormat={}{0}  was detected. Is this correct?}"
+    <c:QuestionControl Content="{Binding TypeName, StringFormat={}{0}  was detected. Is this correct?}"
                        YesCommand="{Binding NextCommand}"
                        NoCommand="{Binding NoCommand}"
-                       Icon="{Binding Type, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}"
+                       ImageIcon="{Binding Type, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}"
                        HighlightButton="YesButton"/>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/ConfirmHideAddressView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ConfirmHideAddressView.axaml
@@ -13,16 +13,16 @@
     <c:QuestionControl YesCommand="{Binding NextCommand}"
                        NoCommand="{Binding CancelCommand}"
                        HighlightButton="YesButton">
-      <c:QuestionControl.QuestionContent>
+      <c:QuestionControl.IconContent>
+        <Viewbox MaxHeight="150" Margin="40">
+          <PathIcon Data="{StaticResource delete_regular}" Opacity="0.6" />
+        </Viewbox>
+      </c:QuestionControl.IconContent>
         <StackPanel Spacing="10">
           <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" Text="Do you wish to hide the address with the following labels?" />
           <c:TagsBox IsReadOnly="True" HorizontalAlignment="Center" Items="{Binding Label}" />
           <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" Text="This can not be undone." />
         </StackPanel>
-      </c:QuestionControl.QuestionContent>
-      <Viewbox MaxHeight="150" Margin="40">
-        <PathIcon Data="{StaticResource delete_regular}" Opacity="0.6" />
-      </Viewbox>
     </c:QuestionControl>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/InsufficientBalanceDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/InsufficientBalanceDialogView.axaml
@@ -10,19 +10,21 @@
              x:Class="WalletWasabi.Fluent.Views.Dialogs.InsufficientBalanceDialogView">
   <c:ContentArea Title="{Binding Title}"
                  Caption="{Binding Caption}">
-    <c:QuestionControl QuestionContent="Would you like to do this instead?"
+    <c:QuestionControl Content="Would you like to do this instead?"
                        YesCommand="{Binding NextCommand}"
                        NoCommand="{Binding CancelCommand}"
                        HighlightButton="YesButton">
-      <StackPanel Spacing="20">
-        <c:PreviewItem Icon="{StaticResource btc_logo}"
-                       Text="Send a total of"
-                       Content="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
-        <Separator />
-        <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
-                       Text="for an additional fee of"
-                       Content="{Binding FeeText, FallbackValue=235 satoshis (≈55.34 USD)}" />
-      </StackPanel>
+      <c:QuestionControl.IconContent>
+        <StackPanel Spacing="20">
+          <c:PreviewItem Icon="{StaticResource btc_logo}"
+                         Text="Send a total of"
+                         Content="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
+          <Separator />
+          <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
+                         Text="for an additional fee of"
+                         Content="{Binding FeeText, FallbackValue=235 satoshis (≈55.34 USD)}" />
+        </StackPanel>
+      </c:QuestionControl.IconContent>
     </c:QuestionControl>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Login/PasswordFinder/ContainsNumbersView.axaml
+++ b/WalletWasabi.Fluent/Views/Login/PasswordFinder/ContainsNumbersView.axaml
@@ -14,10 +14,10 @@
                  EnableBack="{Binding EnableBack}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
 
-    <c:QuestionControl QuestionContent="Does your password contains numbers?"
+    <c:QuestionControl Content="Does your password contains numbers?"
                        YesCommand="{Binding YesCommand}"
                        NoCommand="{Binding NoCommand}"
-                       Icon="{Binding Icon}"
+                       ImageIcon="{Binding Icon}"
                        HighlightButton="Both"/>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Login/PasswordFinder/ContainsSymbolsView.axaml
+++ b/WalletWasabi.Fluent/Views/Login/PasswordFinder/ContainsSymbolsView.axaml
@@ -14,10 +14,10 @@
                  EnableBack="{Binding EnableBack}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
 
-    <c:QuestionControl QuestionContent="Does your password contains special characters?"
+    <c:QuestionControl Content="Does your password contains special characters?"
                        YesCommand="{Binding YesCommand}"
                        NoCommand="{Binding NoCommand}"
-                       Icon="{Binding Icon}"
+                       ImageIcon="{Binding Icon}"
                        HighlightButton="Both"/>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Login/PasswordFinder/PasswordNotFoundView.axaml
+++ b/WalletWasabi.Fluent/Views/Login/PasswordFinder/PasswordNotFoundView.axaml
@@ -11,13 +11,15 @@
   <c:ContentArea Title="{Binding Title}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
 
-    <c:QuestionControl QuestionContent="We have not found your password, would you like to try again? "
+    <c:QuestionControl Content="We have not found your password, would you like to try again? "
                        YesCommand="{Binding NextCommand}"
                        NoCommand="{Binding CancelCommand}"
                        HighlightButton="YesButton">
-      <Viewbox MaxHeight="150" Margin="40">
-        <PathIcon Data="{StaticResource search_info_regular}" Opacity="0.6"/>
-      </Viewbox>
+      <c:QuestionControl.IconContent>
+        <Viewbox MaxHeight="150" Margin="40">
+          <PathIcon Data="{StaticResource search_info_regular}" Opacity="0.6"/>
+        </Viewbox>
+      </c:QuestionControl.IconContent>
     </c:QuestionControl>
   </c:ContentArea>
 </UserControl>


### PR DESCRIPTION
I refactored the control a bit to make the usage more obvious.

Before:
- `QuestionContent` was the question.
- `Content` was the custom icon.
- `Icon` was the image icon.

Now:
- The `Content` is the question.
- `ImageIcon` -> obviously an image that will show up as the icon.
- `IconContent` -> Any other custom icon can be set here.

Also fixed a layout issue:

Before:
![image](https://user-images.githubusercontent.com/16364053/118109846-fd15a600-b3e1-11eb-9cc8-3babd0f00a96.png)

After:
![image](https://user-images.githubusercontent.com/16364053/118109755-e1120480-b3e1-11eb-95bb-6c0a6bfd69b1.png)
