### PR TITLE
Nitpicking on log wording.

### DIFF
--- a/WalletWasabi/BestEffortEndpointConnector.cs
+++ b/WalletWasabi/BestEffortEndpointConnector.cs
@@ -112,7 +112,7 @@ namespace WalletWasabi
 
 			public override string ToString()
 			{
-				return $"Connections: {ConnectedNodesCount}, Currently allow only onions: {!_allowAnyConnetionType}.";
+				return $"Connections: {ConnectedNodesCount}, Allow only Tor endpoints: {!_allowAnyConnetionType}.";
 			}
 		}
 	}


### PR DESCRIPTION
Current log message might give the impression that some connections wouldn't go through Tor.
![image](https://user-images.githubusercontent.com/51679301/118180498-45af7c80-b43f-11eb-9119-463c6df32624.png)

Tried to make it more clear it's about Tor/.onion endpoints.