### PR TITLE
Fix null warning

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -322,7 +322,7 @@ namespace WalletWasabi.Tests.RegressionTests
 				// Spend the inputs of the tx so we know
 				var success = bitcoinStore.TransactionStore.TryGetTransaction(fundingTxId, out var invalidSmartTransaction);
 				Assert.True(success);
-				var invalidCoin = Assert.Single(((CoinsRegistry)wallet.Coins).AsAllCoinsView().CreatedBy(invalidSmartTransaction.GetHash()));
+				var invalidCoin = Assert.Single(((CoinsRegistry)wallet.Coins).AsAllCoinsView().CreatedBy(invalidSmartTransaction!.GetHash()));
 				Assert.NotNull(invalidCoin.SpenderTransaction);
 				Assert.True(invalidCoin.Confirmed);
 


### PR DESCRIPTION
`invalidSmartTransaction` is not null when `TryGetTransaction` returns true.