### PR TITLE
Fix some null warnings

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Userfacing/ParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/ParserTests.cs
@@ -163,10 +163,10 @@ namespace WalletWasabi.Tests.UnitTests
 				Assert.False(AddressStringParser.TryParseBitcoinAddress(null, test.network, out _));
 
 				Assert.True(AddressStringParser.TryParseBitcoinAddress(test.address, test.network, out BitcoinUrlBuilder? result));
-				Assert.Equal(test.address, result.Address.ToString());
+				Assert.Equal(test.address, result!.Address.ToString());
 
 				Assert.True(AddressStringParser.TryParseBitcoinAddress(test.address.Insert(0, "   "), test.network, out result));
-				Assert.Equal(test.address.Trim(), result.Address.ToString());
+				Assert.Equal(test.address.Trim(), result!.Address.ToString());
 			}
 		}
 
@@ -194,10 +194,10 @@ namespace WalletWasabi.Tests.UnitTests
 				Assert.False(AddressStringParser.TryParseBitcoinUrl(null, test.network, out _));
 
 				Assert.True(AddressStringParser.TryParseBitcoinUrl(test.url, test.network, out BitcoinUrlBuilder? result));
-				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result.Address.ToString());
+				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result!.Address.ToString());
 
 				Assert.True(AddressStringParser.TryParseBitcoinUrl(test.url.Insert(0, "   "), test.network, out result));
-				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result.Address.ToString());
+				Assert.Equal(test.url.Split(new[] { ':', '?' })[1], result!.Address.ToString());
 				Assert.Equal("Luke-Jr", result.Label);
 				Assert.Equal(Money.Coins(50m), result.Amount);
 			}


### PR DESCRIPTION
`result` is not null when `TryParseBitcoinUrl` returns true.