### PR TITLE
[Fluent] Transaction History - blink newly received txn's row

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -101,6 +101,11 @@ namespace WalletWasabi.Fluent.ViewModels
 
 					if (_walletDictionary.TryGetValue(wallet, out var walletViewModel) && walletViewModel is WalletViewModel wvm)
 					{
+						if (wvm.IsSelected && (e.NewlyReceivedCoins.Any() || e.NewlyConfirmedReceivedCoins.Any()))
+						{
+							wvm.History.SelectTransaction(e.Transaction.GetHash());
+						}
+
 						NotificationHelpers.Show(e, onClick: () => wvm.NavigateAndHighlight(e.Transaction.GetHash()));
 					}
 				});

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -60,12 +60,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 				.Filter(coinJoinFilter)
 				.Bind(_transactions)
 				.Subscribe();
-
-			this.WhenAnyValue(x => x.SelectedItem)
-				.Buffer(2, 1)
-				.Select(buf => buf[0])
-				.WhereNotNull()
-				.Subscribe(x => x.IsSelected = false);
 		}
 
 		public DataGridCollectionView CollectionView { get; }
@@ -141,7 +135,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 						_transactionSourceList.Add(new HistoryItemViewModel(i, transactionSummary, _walletViewModel, balance, _updateTrigger));
 					}
 
-					if (_txidsToSelect.FirstOrDefault() is { } txid)
+					// Flashing animation on the new items
+					foreach (var txid in _txidsToSelect.ToList())
 					{
 						SelectTransaction(txid);
 					}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -29,6 +29,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 		[AutoNotify] private bool _showCoinJoin;
 		[AutoNotify] private HistoryItemViewModel? _selectedItem;
 
+		private uint256? _txidToSelectWhenAppears;
+
 		public HistoryViewModel(WalletViewModel walletViewModel, IObservable<Unit> updateTrigger)
 		{
 			_walletViewModel = walletViewModel;
@@ -77,6 +79,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 			if (txnItem is { })
 			{
 				SelectedItem = txnItem;
+				_txidToSelectWhenAppears = null;
 				SelectedItem.IsSelected = true;
 
 				RxApp.MainThreadScheduler.Schedule(async () =>
@@ -84,6 +87,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 					await Task.Delay(1260);
 					SelectedItem.IsSelected = false;
 				});
+			}
+			else
+			{
+				_txidToSelectWhenAppears = txid;
 			}
 		}
 
@@ -130,6 +137,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 						var transactionSummary = txRecordList[i];
 						balance += transactionSummary.Amount;
 						_transactionSourceList.Add(new HistoryItemViewModel(i, transactionSummary, _walletViewModel, balance, _updateTrigger));
+					}
+
+					if (_txidToSelectWhenAppears is { } txid)
+					{
+						SelectTransaction(txid);
 					}
 				}
 			}


### PR DESCRIPTION
It turned out in some cases the `SelectTransaction` couldn't select the row despite it was received.

I have tried `Post`, `Throttle`, `Task.Delay` but they were not deterministic at all...
So this solution's logic is:
- Try to select the transaction
- If not exists in the list yet, store the ID in a temp variable
- Next time when the list gets updated, select the row if the temp variable is not null.

https://user-images.githubusercontent.com/16364053/118973592-213d2e00-b972-11eb-88fe-047604b09b34.mp4

