### PR TITLE
Remove Ubuntu 16.04 from compatibility list

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -6,7 +6,7 @@ This document lists all the officially supported software and devices by Wasabi 
 
 - Windows 10 1607+ (except 1703)
 - macOs 10.13+
-- Ubuntu 20.10, 20.04 (LTS), 18.04 (LTS), 16.04 (LTS)
+- Ubuntu 20.10, 20.04 (LTS), 18.04 (LTS)
 - Fedora 32+
 - Debian 9+
 


### PR DESCRIPTION
**Ubuntu Linux 16.04 LTS is no longer supported**

> Ubuntu Linux 16.04 LTS reached the end of its five-year LTS window on April 30th 2021 and is no longer supported by its vendor, Canonical except through a paid annual Extended Security Maintenance (ESM). At that time, Ubuntu 16.04 LTS stopped receiving security patches or other software updates through our standard software support.

https://computing.cs.cmu.edu/news/2020/eol-ubuntu-1604