### PR TITLE
[WabiSabi] Uses Vsize capacity instead of InputCount

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -98,7 +99,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		{
 			// Alice does not time out if input reg is full with alices,
 			// even though the deadline is reached and still in input reg.
-			WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
+			WabiSabiConfig cfg = new() { MaxVsizeCapacityByRound = 3 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var alice = WabiSabiFactory.CreateAlice();
 			round.Alices.Add(alice);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -13,7 +14,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		[Fact]
 		public async Task AllConfirmedStepsAsync()
 		{
-			WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinInputCountByRoundMultiplier = 0.5 };
+			WabiSabiConfig cfg = new() { MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var a1 = WabiSabiFactory.CreateAlice();
 			var a2 = WabiSabiFactory.CreateAlice();
@@ -39,7 +40,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		[Fact]
 		public async Task NotAllConfirmedStaysAsync()
 		{
-			WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinInputCountByRoundMultiplier = 0.5 };
+			WabiSabiConfig cfg = new() { MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var a1 = WabiSabiFactory.CreateAlice();
 			var a2 = WabiSabiFactory.CreateAlice();
@@ -69,8 +70,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5,
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize,
 				ConnectionConfirmationTimeout = TimeSpan.Zero
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
@@ -103,8 +103,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5,
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize,
 				ConnectionConfirmationTimeout = TimeSpan.Zero
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -13,7 +14,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		[Fact]
 		public async Task RoundFullAsync()
 		{
-			WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
+			WabiSabiConfig cfg = new() { MaxVsizeCapacityByRound = 3 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
@@ -35,11 +36,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		[Fact]
 		public async Task BlameRoundFullAsync()
 		{
-			WabiSabiConfig cfg = new()
-			{
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5
-			};
+			WabiSabiConfig cfg = new() { MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var alice1 = WabiSabiFactory.CreateAlice();
 			var alice2 = WabiSabiFactory.CreateAlice();
@@ -72,8 +69,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			WabiSabiConfig cfg = new()
 			{
 				StandardInputRegistrationTimeout = TimeSpan.Zero,
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.Alices.Add(WabiSabiFactory.CreateAlice());
@@ -93,8 +89,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			{
 				BlameInputRegistrationTimeout = TimeSpan.Zero,
 				StandardInputRegistrationTimeout = TimeSpan.FromHours(1), // Test that this is disregarded.
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var alice1 = WabiSabiFactory.CreateAlice();
@@ -120,8 +115,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			WabiSabiConfig cfg = new()
 			{
 				StandardInputRegistrationTimeout = TimeSpan.Zero,
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
@@ -144,8 +138,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			{
 				BlameInputRegistrationTimeout = TimeSpan.Zero,
 				StandardInputRegistrationTimeout = TimeSpan.FromHours(1), // Test that this is disregarded.
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var alice1 = WabiSabiFactory.CreateAlice();
@@ -169,8 +162,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			WabiSabiConfig cfg = new()
 			{
 				StandardInputRegistrationTimeout = TimeSpan.FromHours(1),
-				MaxInputCountByRound = 4,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 4 * Constants.P2wpkhInputVirtualSize
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -23,8 +23,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize
 			};
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
 
@@ -89,8 +88,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5,
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize,
 				OutputRegistrationTimeout = TimeSpan.Zero
 			};
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
@@ -154,8 +152,7 @@ irreq1.OwnershipProof,
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5,
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize,
 				OutputRegistrationTimeout = TimeSpan.Zero
 			};
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
@@ -232,8 +229,7 @@ irreq1.OwnershipProof,
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize
 			};
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Crypto.ZeroKnowledge;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -23,8 +24,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize
 			};
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
 
@@ -102,8 +102,7 @@ irreq2.OwnershipProof,
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize
 			};
 			var mockRpc = new MockRpcClient();
 			mockRpc.OnSendRawTransactionAsync = _ => throw new RPCException(RPCErrorCode.RPC_TRANSACTION_REJECTED, "", null);
@@ -186,8 +185,7 @@ irreq2.OwnershipProof,
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 0.5
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize
 			};
 			var mockRpc = new MockRpcClient();
 			mockRpc.OnSendRawTransactionAsync = _ => throw new RPCException(RPCErrorCode.RPC_TRANSACTION_REJECTED, "", null);
@@ -274,8 +272,8 @@ irreq2.OwnershipProof,
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 1,
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize,
+				MinVsizeByRoundMultiplier = 1,
 				TransactionSigningTimeout = TimeSpan.Zero
 			};
 			var mockRpc = new MockRpcClient();
@@ -353,8 +351,8 @@ irreq2.OwnershipProof,
 		{
 			WabiSabiConfig cfg = new()
 			{
-				MaxInputCountByRound = 2,
-				MinInputCountByRoundMultiplier = 1,
+				MaxVsizeCapacityByRound = 2 * Constants.P2wpkhInputVirtualSize,
+				MinVsizeByRoundMultiplier = 1,
 				TransactionSigningTimeout = TimeSpan.Zero,
 				OutputRegistrationTimeout = TimeSpan.Zero
 			};

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AliceClientTests.cs
@@ -8,6 +8,7 @@ using WalletWasabi.Backend.Controllers;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -24,7 +25,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 		[Fact]
 		public async Task CreateNewAsync()
 		{
-			var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
+			var config = new WabiSabiConfig { MaxVsizeCapacityByRound = 1 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(config);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 		[Fact]
 		public async Task FullCoinjoinAsyncTestAsync()
 		{
-			var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
+			var config = new WabiSabiConfig { MaxVsizeCapacityByRound = 1 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(config);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -8,6 +8,7 @@ using WalletWasabi.Backend.Controllers;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -24,7 +25,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 		[Fact]
 		public async Task RegisterOutputTestAsync()
 		{
-			var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
+			var config = new WabiSabiConfig { MaxVsizeCapacityByRound = 1 * Constants.P2wpkhInputVirtualSize };
 			var round = WabiSabiFactory.CreateRound(config);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NBitcoin;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -98,7 +99,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 					// Instruct the coodinator DI container to use these two scoped
 					// services to build everything (wabisabi controller, arena, etc)
 					services.AddScoped<IRPCClient>(s => rpc);
-					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig { MaxInputCountByRound = InputCount });
+					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig { MaxVsizeCapacityByRound = InputCount * Constants.P2wpkhInputVirtualSize });
 				});
 			}).CreateClient();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 	public class MultipartyTransactionTests
 	{
 		private static MoneyRange DefaultAllowedAmounts = new(Money.Zero, Money.Coins(1));
-		private static MultipartyTransactionParameters DefaultParameters = new(FeeRate.Zero, DefaultAllowedAmounts, DefaultAllowedAmounts, Network.Main, TimeSpan.FromSeconds(10));
+		private static MultipartyTransactionParameters DefaultParameters = new(FeeRate.Zero, DefaultAllowedAmounts, DefaultAllowedAmounts, 99954, Network.Main, TimeSpan.FromSeconds(10));
 
 		private static void ThrowsProtocolException(WabiSabiProtocolErrorCode expectedError, Action action) =>
 			Assert.Equal(expectedError, Assert.Throws<WabiSabiProtocolException>(action).ErrorCode);

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -62,7 +61,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound);
 			}
 
-			if (round.IsInputRegistrationEnded(config.MaxInputCountByRound, config.GetInputRegistrationTimeout(round)))
+			if (round.IsInputRegistrationEnded(config.MaxVsizeCapacityByRound, config.GetInputRegistrationTimeout(round)))
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
 			}
@@ -99,10 +98,6 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchVsize);
 			}
 
-			if (round.RemainingInputVsizeAllocation < round.PerAliceVsizeAllocation)
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.VsizeQuotaExceeded);
-			}
 			var commitAmountCredentialResponse = round.AmountCredentialIssuer.PrepareResponse(zeroAmountCredentialRequests);
 			var commitVsizeCredentialResponse = round.VsizeCredentialIssuer.PrepareResponse(zeroVsizeCredentialRequests);
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -64,10 +64,10 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			foreach (var round in Rounds.Values.Where(x =>
 				x.Phase == Phase.InputRegistration
-				&& x.IsInputRegistrationEnded(Config.MaxInputCountByRound, Config.GetInputRegistrationTimeout(x)))
+				&& x.IsInputRegistrationEnded(Config.MaxVsizeCapacityByRound, Config.GetInputRegistrationTimeout(x)))
 				.ToArray())
 			{
-				if (round.InputCount < Config.MinInputCountByRound)
+				if (round.TotalVsizeUsedByAlices < Config.MinVsizeCapacityByRound)
 				{
 					Rounds.Remove(round.Id);
 					round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.InputRegistration)} phase.");
@@ -97,7 +97,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					var removedAliceCount = round.Alices.RemoveAll(x => alicesDidntConfirm.Contains(x));
 					round.LogInfo($"{removedAliceCount} alices removed because they didn't confirm.");
 
-					if (round.InputCount < Config.MinInputCountByRound)
+					if (round.TotalVsizeUsedByAlices < Config.MinVsizeCapacityByRound)
 					{
 						Rounds.Remove(round.Id);
 						round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.ConnectionConfirmation)} phase.");
@@ -208,7 +208,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			round.Alices.RemoveAll(x => alicesWhoDidntSign.Contains(x));
 			Rounds.Remove(round.Id);
 
-			if (round.InputCount >= Config.MinInputCountByRound)
+			if (round.TotalVsizeUsedByAlices >= Config.MinVsizeCapacityByRound)
 			{
 				await CreateBlameRoundAsync(round).ConfigureAwait(false);
 			}
@@ -236,7 +236,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		private void TimeoutAlices()
 		{
-			foreach (var round in Rounds.Values.Where(x => !x.IsInputRegistrationEnded(Config.MaxInputCountByRound, Config.GetInputRegistrationTimeout(x))).ToArray())
+			foreach (var round in Rounds.Values.Where(x => !x.IsInputRegistrationEnded(Config.MaxVsizeCapacityByRound, Config.GetInputRegistrationTimeout(x))).ToArray())
 			{
 				var removedAliceCount = round.Alices.RemoveAll(x => x.Deadline < DateTimeOffset.UtcNow);
 				if (removedAliceCount > 0)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -19,8 +19,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			Random = random;
 			FeeRate = feeRate;
 
-			MaxInputCountByRound = wabiSabiConfig.MaxInputCountByRound;
-			MinInputCountByRound = wabiSabiConfig.MinInputCountByRound;
+			MaxVsizeCapacityByRound = wabiSabiConfig.MaxVsizeCapacityByRound;
+			MinVsizeCapacityByRound = wabiSabiConfig.MinVsizeCapacityByRound;
 			MinRegistrableAmount = wabiSabiConfig.MinRegistrableAmount;
 			MaxRegistrableAmount = wabiSabiConfig.MaxRegistrableAmount;
 			PerAliceVsizeAllocation = wabiSabiConfig.PerAliceVsizeAllocation;
@@ -44,8 +44,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public WasabiRandom Random { get; }
 		public FeeRate FeeRate { get; }
 		public Network Network { get; }
-		public uint MinInputCountByRound { get; }
-		public uint MaxInputCountByRound { get; }
+		public int MinVsizeCapacityByRound { get; }
+		public int MaxVsizeCapacityByRound { get; }
 		public Money MinRegistrableAmount { get; }
 		public Money MaxRegistrableAmount { get; }
 		public uint PerAliceVsizeAllocation { get; }

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -81,15 +81,15 @@ namespace WalletWasabi.WabiSabi.Backend
 		[JsonConverter(typeof(TimeSpanJsonConverter))]
 		public TimeSpan TransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
-		[DefaultValue(100)]
-		[JsonProperty(PropertyName = "MaxInputCountByRound", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public uint MaxInputCountByRound { get; set; } = 100;
+		[DefaultValue(99954)]
+		[JsonProperty(PropertyName = "MaxVsizeCapacityByRound", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public int MaxVsizeCapacityByRound { get; set; } = 99954;
 
 		[DefaultValue(0.5)]
-		[JsonProperty(PropertyName = "MinInputCountByRoundMultiplier", DefaultValueHandling = DefaultValueHandling.Populate)]
-		public double MinInputCountByRoundMultiplier { get; set; } = 0.5;
+		[JsonProperty(PropertyName = "MinVsizeByRoundMultiplier", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public double MinVsizeByRoundMultiplier { get; set; } = 0.5;
 
-		public uint MinInputCountByRound => (uint)(MaxInputCountByRound * MinInputCountByRoundMultiplier);
+		public int MinVsizeCapacityByRound => (int)(MaxVsizeCapacityByRound * MinVsizeByRoundMultiplier);
 
 		/// <summary>
 		/// If money comes to the blame script, then either an attacker lost money or there's a client bug.

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
@@ -18,12 +18,14 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 			FeeRate feeRate,
 			MoneyRange allowedInputAmounts,
 			MoneyRange allowedOutputAmounts,
+			int maxVsizeCapacityByRound,
 			Network network,
 			TimeSpan connectionConfirmationTimeout)
 		{
 			FeeRate = feeRate;
 			AllowedInputAmounts = allowedInputAmounts;
 			AllowedOutputAmounts = allowedOutputAmounts;
+			MaxVsizeCapacityByRound = maxVsizeCapacityByRound;
 			Network = network;
 			ConnectionConfirmationTimeout = connectionConfirmationTimeout;
 		}
@@ -42,6 +44,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 		public MoneyRange AllowedOutputAmounts { get; init; }
 		public Network Network { get; }
 		public TimeSpan ConnectionConfirmationTimeout { get; }
+		public int MaxVsizeCapacityByRound { get; init; }
 
 		// implied:
 		// segwit transaction

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -21,6 +21,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 		public int OutputsVsize => Outputs.Sum(x => x.ScriptPubKey.EstimateOutputVsize());
 
 		public int EstimatedVsize => MultipartyTransactionParameters.SharedOverhead + EstimatedInputsVsize + OutputsVsize;
+		public int MaxVsizeCapacityByRound => Parameters.MaxVsizeCapacityByRound;
 
 		// With no coordinator fees we can't ensure that the shared overhead
 		// of the transaction also pays at the nominal feerate so this will have


### PR DESCRIPTION
This PR replaces the transaction capacity control from `InputCount` to `VsizeCapacity`. 