### PR TITLE
Tor control: Support for async Tor events

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -4,6 +4,7 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
+using WalletWasabi.Tests.Helpers;
 using WalletWasabi.Tor.Control;
 using WalletWasabi.Tor.Control.Messages;
 using Xunit;
@@ -16,6 +17,9 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 		[Fact]
 		public async Task ReceiveTorAsyncEventsUsingForeachAsync()
 		{
+			Common.GetWorkDir();
+			Logger.SetMinimumLevel(LogLevel.Trace);
+
 			using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(120));
 
 			// Test parameters.
@@ -57,9 +61,15 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 
 				if (counter == ExpectedEventsNo)
 				{
+					Assert.Equal(1, client.SubscriberCount);
 					break;
 				}
 			}
+
+			// Verifies that "break" in "await foreach" actually removes the internal Channel<T> (subscription).
+			Assert.Equal(0, client.SubscriberCount);
+
+			Logger.LogTrace("Client: Done.");
 		}
 
 		/// <summary>Verifies a correct result of a mix of sync and async messages from Tor.</summary>

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control;
+using WalletWasabi.Tor.Control.Messages;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control
+{
+	public class TorControlClientTests
+	{
+		/// <summary>Verifies that client receives correct async events from Tor.</summary>
+		[Fact]
+		public async Task ReceiveTorAsyncEventsUsingForeachAsync()
+		{
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(120));
+
+			// Test parameters.
+			const int ExpectedEventsNo = 5;
+			const string AsyncEventContent = "CIRC 1000 EXTENDED moria1,moria2";
+
+			Pipe toServer = new();
+			Pipe toClient = new();
+
+			// Set up Tor control client.
+			await using TorControlClient client = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
+
+			// Subscribe to Tor events.
+			IAsyncEnumerable<TorControlReply> events = client.ReadEventsAsync(timeoutCts.Token);
+
+			// Send a Tor event to all subscribed clients (only one here).
+			// This must happen after a client is subscribed.
+			Task serverTask = Task.Run(async () =>
+			{
+				for (int i = 0; i < ExpectedEventsNo; i++)
+				{
+					Logger.LogTrace($"Server: Send async Tor event (#{i}): '650 {AsyncEventContent}'.");
+					await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+				}
+			});
+
+			// Iterate received events.
+			int counter = 0;
+
+			// Client should get all the events.
+			await foreach (TorControlReply receivedEvent in events)
+			{
+				counter++;
+
+				Logger.LogTrace($"Client: Received event (#{counter}): '{receivedEvent}'.");
+				Assert.Equal(StatusCode.AsynchronousEventNotify, receivedEvent.StatusCode);
+				string line = Assert.Single(receivedEvent.ResponseLines);
+				Assert.Equal(AsyncEventContent, line);
+
+				if (counter == ExpectedEventsNo)
+				{
+					break;
+				}
+			}
+		}
+
+		/// <summary>Verifies a correct result of a mix of sync and async messages from Tor.</summary>
+		[Fact]
+		public async Task ReceivingMixOfSyncAndAsyncMessageFromTorControlAsync()
+		{
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(120));
+
+			// Test parameters.
+			const string AsyncEventContent = "CIRC 1000 EXTENDED moria1,moria2";
+
+			Pipe toServer = new();
+			Pipe toClient = new();
+
+			// Set up Tor control client.
+			await using TorControlClient client = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
+
+			// Subscribe to Tor events.
+			IAsyncEnumerable<TorControlReply> events = client.ReadEventsAsync(timeoutCts.Token);
+			IAsyncEnumerator<TorControlReply> eventsEnumerator = events.GetAsyncEnumerator();
+			ValueTask<bool> firstReplyTask = eventsEnumerator.MoveNextAsync();
+
+			Task serverTask = Task.Run(async () =>
+			{
+				Logger.LogTrace($"Server: Send msg #1 (async) to client: '650 {AsyncEventContent}'.");
+				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+
+				Logger.LogTrace($"Server: Send msg #2 (async) to client: '650 {AsyncEventContent}'.");
+				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+
+				Logger.LogTrace("Server: Wait for TAKEOWNERSHIP command.");
+				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+				Assert.Equal("TAKEOWNERSHIP", command);
+
+				Logger.LogTrace("Server: Send msg #3 (sync) to client in response to TAKEOWNERSHIP command.");
+				await toClient.Writer.WriteAsciiAsync($"250 OK\r\n", timeoutCts.Token);
+
+				Logger.LogTrace($"Server: Send msg #4 (async) to client: '650 {AsyncEventContent}'.");
+				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+			});
+
+			Logger.LogTrace("Client: Receive msg #1 (async).");
+			{
+				await firstReplyTask.AsTask().WithAwaitCancellationAsync(timeoutCts.Token);
+				TorControlReply receivedEvent1 = eventsEnumerator.Current;
+				Assert.Equal(StatusCode.AsynchronousEventNotify, receivedEvent1.StatusCode);
+				string line = Assert.Single(receivedEvent1.ResponseLines);
+				Assert.Equal(AsyncEventContent, line);
+			}
+
+			// Msg #2 is sent before expected reply (msg #3).
+			TorControlReply takeOwnershipReply = await client.TakeOwnershipAsync(timeoutCts.Token);
+			Assert.True(takeOwnershipReply.Success);
+
+			Logger.LogTrace("Client: Receive msg #2 (async).");
+			{
+				Assert.True(await eventsEnumerator.MoveNextAsync());
+				TorControlReply receivedEvent2 = eventsEnumerator.Current;
+				Assert.Equal(StatusCode.AsynchronousEventNotify, receivedEvent2.StatusCode);
+				string line = Assert.Single(receivedEvent2.ResponseLines);
+				Assert.Equal(AsyncEventContent, line);
+			}
+
+			Logger.LogTrace("Client: Receive msg #4 (async) - i.e. third async event.");
+			{
+				Assert.True(await eventsEnumerator.MoveNextAsync());
+				TorControlReply receivedEvent3 = eventsEnumerator.Current;
+				Assert.Equal(StatusCode.AsynchronousEventNotify, receivedEvent3.StatusCode);
+				string line = Assert.Single(receivedEvent3.ResponseLines);
+				Assert.Equal(AsyncEventContent, line);
+			}
+
+			// Client decided to stop reading Tor async events.
+			timeoutCts.Cancel();
+
+			// No more async events.
+			_ = Assert.ThrowsAsync<OperationCanceledException>(async () => await eventsEnumerator.MoveNextAsync());
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlFactoryTests.cs
@@ -37,7 +37,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Pipe toServer = new();
 			Pipe toClient = new();
 
-			using TorControlClient testClient = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
+			await using TorControlClient testClient = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
 
 			Logger.LogTrace("Client: Start authentication task.");
 			Task<TorControlClient> authenticationTask = clientFactory.AuthSafeCookieOrThrowAsync(testClient, cookieString, timeoutCts.Token);
@@ -45,7 +45,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Logger.LogTrace("Server: Read 'AUTHCHALLENGE SAFECOOKIE' command from the client.");
 			string authChallengeCommand = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
 
-			Logger.LogTrace($"Server: Received authchallenge line: '{authChallengeCommand}'.");
+			Logger.LogTrace($"Server: Received AUTHCHALLENGE line: '{authChallengeCommand}'.");
 			Assert.Equal("AUTHCHALLENGE SAFECOOKIE 6F14C18D5B00BF54E16E4728A4BFC81B1FF469F0B012CD71D9724BFBE14DB5E6", authChallengeCommand);
 
 			Logger.LogTrace("Server: Respond to client's AUTHCHALLENGE request.");

--- a/WalletWasabi/Tor/Control/ReplyCode.cs
+++ b/WalletWasabi/Tor/Control/ReplyCode.cs
@@ -55,6 +55,7 @@ namespace WalletWasabi.Tor.Control
 		UnmanagedEntity = 555,
 
 		/// <summary>A notification sent following an asynchronous operation.</summary>
+		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">4.1. Asynchronous events</seealso>
 		AsynchronousEventNotify = 650,
 	}
 }

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -242,6 +242,7 @@ namespace WalletWasabi.Tor.Control
 			// Wait until the reader loop stops.
 			await ReaderLoopTask.ConfigureAwait(false);
 
+			ReaderCts.Dispose();
 			TcpClient?.Dispose();
 		}
 	}

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -12,10 +12,8 @@ namespace WalletWasabi.Tor.Control
 	/// <summary>
 	/// Client already authenticated to Tor Control.
 	/// </summary>
-	public class TorControlClient : IDisposable
+	public class TorControlClient : IAsyncDisposable
 	{
-		private volatile bool _disposedValue = false; // To detect redundant calls
-
 		public TorControlClient(TcpClient tcpClient)
 		{
 			TcpClient = tcpClient;
@@ -99,22 +97,11 @@ namespace WalletWasabi.Tor.Control
 			return reply;
 		}
 
-		protected virtual void Dispose(bool disposing)
+		public ValueTask DisposeAsync()
 		{
-			if (!_disposedValue)
-			{
-				if (disposing)
-				{
-					TcpClient?.Dispose();
-				}
+			TcpClient?.Dispose();
 
-				_disposedValue = true;
-			}
-		}
-
-		public void Dispose()
-		{
-			Dispose(true);
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -67,6 +67,19 @@ namespace WalletWasabi.Tor.Control
 		/// <remarks>Tor control protocol does not provide a foolproof way to recognize that a response belongs to a request.</remarks>
 		private AsyncLock MessageLock { get; }
 
+		/// <summary>Number of subscribers that currently listen to Tor's async events using <see cref="ReadEventsAsync"/>.</summary>
+		/// <remarks>Mainly for tests.</remarks>
+		internal int SubscriberCount
+		{
+			get
+			{
+				lock (AsyncChannelsLock)
+				{
+					return AsyncChannels.Count;
+				}
+			}
+		}
+
 		/// <summary>
 		/// Gets protocol info (for version 1).
 		/// </summary>

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.Tor.Control
 			Random = random ?? new InsecureRandom();
 		}
 
-		/// <summary>Helps generate nonces for auth challenges.</summary>
+		/// <summary>Helps generate nonces for AUTH challenges.</summary>
 		private IRandom Random { get; }
 
 		/// <summary>Connects to Tor Control endpoint and authenticates using safe-cookie mechanism.</summary>
@@ -55,7 +55,9 @@ namespace WalletWasabi.Tor.Control
 			}
 			finally
 			{
-				if (clientToDispose is not null)
+				// `!=` instead `is not null` to avoid CA2000. The analyzer should be fixed over time.
+				// https://github.com/dotnet/roslyn-analyzers/issues/4981
+				if (clientToDispose != null)
 				{
 					await clientToDispose.DisposeAsync().ConfigureAwait(false);
 				}

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -55,7 +55,10 @@ namespace WalletWasabi.Tor.Control
 			}
 			finally
 			{
-				clientToDispose?.Dispose();
+				if (clientToDispose is not null)
+				{
+					await clientToDispose.DisposeAsync().ConfigureAwait(false);
+				}
 			}
 		}
 

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -186,7 +186,7 @@ namespace WalletWasabi.Tor
 				}
 
 				// Leads to Tor termination because we sent TAKEOWNERSHIP command.
-				torControlClient.Dispose();
+				await torControlClient.DisposeAsync().ConfigureAwait(false);
 			}
 
 			// Dispose Tor process resources (does not stop/kill Tor process).


### PR DESCRIPTION
This PR adds support for subscribing of [Tor async events](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt) (see *4.1. Asynchronous events*).

This PR is heavily inspired by Tor Stem project [implementation](https://github.com/torproject/stem/blob/faab143a3ebe6dddc9c7bed08bfd00eed14ae0f0/stem/control.py#L632) and Lucas's [Torino](https://github.com/lontivero/Torino/blob/05b5bb7282750209909d768a4afee85a96b075f0/src/TorController.cs#L434). My implementation is still slightly different though.

## Using the API

From the API client perspective, there is only one new method:

```csharp
// TorControlClient
public async IAsyncEnumerable<TorControlReply> ReadEventsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
```

and nothing changes (from the user perspective) wrt calls like `TakeOwnershipAsync`, `SendCommandAsync`, etc.

## Example

The intended use of this API method:

```csharp
class TorMonitor 
{
    public Task MonitorAsync() 
    {
        // Subscribes you to Tor async events
        // Note: You won't get old Tor events. Only the newly emitted events from the time of `ReadEventsAsync` calling.
        await foreach (TorControlReply reply in TorControlClient.ReadEventsAsync(cancellationToken))
        {
            // Do whatever you want with the event.
        }
        // Here your subscription to Tor's async events ends.
    }
}
```

## API design

1. Why `IAsyncEnumerable` was used for `ReadEventsAsync`? It seems easier to work with Tor async messages in a loop. Other solution would be to pass a callback to `ReadEventsAsync` which would be called on a different thread, so some locking may be needed. C# events require unsubscription. `IAsyncEnumerable` seemed very easy in comparison. 
2. `System.Threading.Channels.Channel` was used in the implementation. Great intro by Stephen Toub is available [here](https://devblogs.microsoft.com/dotnet/an-introduction-to-system-threading-channels/). Knowing that `Channel` is basically a thread-safe async queue (designed for producer-consumer scenarios) is sufficient to understand this PR.

## Future work

`TorControlClient.ReadEventsAsync(cancellationToken))` return only `TorControlReply`. This will be improved. 