### PR TITLE
Fix IndexBuilderService  Access to the path is denied

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				}),
 			};
 			using var blockNotifier = new BlockNotifier(TimeSpan.MaxValue, rpc);
-			var indexer = new IndexBuilderService(rpc, blockNotifier, ".");
+			var indexer = new IndexBuilderService(rpc, blockNotifier, "filters.txt");
 
 			indexer.Synchronize();
 
@@ -57,7 +57,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				}
 			};
 			using var blockNotifier = new BlockNotifier(TimeSpan.MaxValue, rpc);
-			var indexer = new IndexBuilderService(rpc, blockNotifier, ".");
+			var indexer = new IndexBuilderService(rpc, blockNotifier, "filters.txt");
 
 			indexer.Synchronize();
 
@@ -88,7 +88,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				OnGetVerboseBlockAsync = (hash) => Task.FromResult(blockchain.Single(x => x.Hash == hash))
 			};
 			using var blockNotifier = new BlockNotifier(TimeSpan.MaxValue, rpc);
-			var indexer = new IndexBuilderService(rpc, blockNotifier, ".");
+			var indexer = new IndexBuilderService(rpc, blockNotifier, "filters.txt");
 
 			indexer.Synchronize();
 

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -94,7 +94,9 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 
 			await Task.Delay(TimeSpan.FromSeconds(10));
 			Assert.True(indexer.IsRunning);  // It is still working
-			Assert.Throws<ArgumentOutOfRangeException>(() => indexer.GetLastFilter());  // There are no filters
+
+			var lastFilter = indexer.GetLastFilter();
+			Assert.Equal(9, (int)lastFilter.Header.Height);
 			Assert.True(called > 1);
 		}
 

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -208,6 +208,9 @@ namespace WalletWasabi.Blockchain.BlockFilters
 							catch (Exception ex)
 							{
 								Logger.LogDebug(ex);
+
+								// Pause the while loop for a while to not flood logs in case of permanent error.
+								await Task.Delay(1000).ConfigureAwait(false);
 							}
 						}
 					}

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -87,6 +87,9 @@ namespace WalletWasabi.Blockchain.BlockFilters
 
 		public void Synchronize()
 		{
+			// Check permissions.
+			using var _ = File.Open(IndexFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+
 			Task.Run(async () =>
 			{
 				try


### PR DESCRIPTION
CI tests were slowed down for a long time, thousands of these messages were created in CI logs. It can be noticed only in LogLevel.Debug and only in CI. The error was unnoticeable as `IndexBuilderService` was failing inside, in an infinite loop. 

```
2021-05-28 05:49:29 [26] DEBUG	IndexBuilderService (207)	System.UnauthorizedAccessException: Access to the path 'D:\a\1\s\WalletWasabi.Tests\bin\Debug\net5.0' is denied.
   at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
   at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.File.AsyncStreamWriter(String path, Encoding encoding, Boolean append)
   at System.IO.File.AppendAllLinesAsync(String path, IEnumerable`1 contents, Encoding encoding, CancellationToken cancellationToken)
   at System.IO.File.AppendAllLinesAsync(String path, IEnumerable`1 contents, CancellationToken cancellationToken)
   at WalletWasabi.Blockchain.BlockFilters.IndexBuilderService.<Synchronize>b__37_0() in WalletWasabi\Blockchain\BlockFilters\IndexBuilderService.cs:line 187
```

Related https://github.com/zkSNACKs/WalletWasabi/pull/5874