### PR TITLE
[Backport 1.1.12.9] Cherry-picking

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -203,7 +203,7 @@ namespace WalletWasabi.Gui
 					// Make sure that the height of the wallets will not be better than the current height of the filters.
 					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
 				}
-				catch
+				catch (Exception ex) when (ex is not OperationCanceledException)
 				{
 					// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
 					WalletManager.SetMaxBestHeight(SmartHeader.GetStartingHeader(Network).Height);

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -196,10 +196,19 @@ namespace WalletWasabi.Gui
 
 				#region BitcoinStoreInitialization
 
-				await bstoreInitTask.ConfigureAwait(false);
+				try
+				{
+					await bstoreInitTask.ConfigureAwait(false);
 
-				// Make sure that the height of the wallets will not be better than the current height of the filters.
-				WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+					// Make sure that the height of the wallets will not be better than the current height of the filters.
+					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+				}
+				catch
+				{
+					// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
+					WalletManager.SetMaxBestHeight(SmartHeader.GetStartingHeader(Network).Height);
+					throw;
+				}
 
 				#endregion BitcoinStoreInitialization
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -203,7 +203,7 @@ namespace WalletWasabi.Gui
 					// Make sure that the height of the wallets will not be better than the current height of the filters.
 					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
 				}
-				catch (Exception ex) when (ex is not OperationCanceledException)
+				catch (Exception ex) when (!(ex is OperationCanceledException))
 				{
 					// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
 					WalletManager.SetMaxBestHeight(SmartHeader.GetStartingHeader(Network).Height);

--- a/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Gui/Tabs/WalletManager/RecoverWallets/RecoverWalletViewModel.cs
@@ -38,7 +38,7 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 
 			this.ValidateProperty(x => x.Password, ValidatePassword);
 			this.ValidateProperty(x => x.MinGapLimit, ValidateMinGapLimit);
-			this.ValidateProperty(x => x.AccountKeyPath, ValidateKeyPath);
+			this.ValidateProperty(x => x.AccountKeyPath, ValidateAccountKeyPath);
 
 			MnemonicWords = "";
 
@@ -223,13 +223,21 @@ namespace WalletWasabi.Gui.Tabs.WalletManager.RecoverWallets
 			}
 		}
 
-		private void ValidateKeyPath(IValidationErrors errors)
+		private void ValidateAccountKeyPath(IValidationErrors errors)
 		{
 			if (string.IsNullOrWhiteSpace(AccountKeyPath))
 			{
 				errors.Add(ErrorSeverity.Error, "Path is not valid.");
 			}
-			else if (!KeyPath.TryParse(AccountKeyPath, out _))
+			else if (KeyPath.TryParse(AccountKeyPath, out var keyPath))
+			{
+				var accountKeyPath = keyPath.GetAccountKeyPath();
+				if (keyPath.Length != accountKeyPath.Length || accountKeyPath.Length != KeyManager.DefaultAccountKeyPath.Length)
+				{
+					errors.Add(ErrorSeverity.Error, "Path is not a compatible account derivation path.");
+				}
+			}
+			else
 			{
 				errors.Add(ErrorSeverity.Error, "Path is not a valid derivation path.");
 			}

--- a/WalletWasabi.Gui/packages.lock.json
+++ b/WalletWasabi.Gui/packages.lock.json
@@ -552,8 +552,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "5.0.73",
-        "contentHash": "Vre+l+Hx8uo+5Eq2T2uvq5kY+7YeccfvvUpfIj9YJrXI0j89gxsobfKfDhCw35gOIfSwIEDGv2N7LVbSA8w6HQ==",
+        "resolved": "5.0.81",
+        "contentHash": "sBOvupELGlaw5mr4sNW0q8kwc6ALlYaG6telvebDLU7+9DYYYaPiHS1L8gPIa4BKpSO/9STQkMRbKmW7DcAUfQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"
@@ -2272,7 +2272,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "3.1.1",
           "Microsoft.Win32.Registry": "4.7.0",
-          "NBitcoin": "5.0.73",
+          "NBitcoin": "5.0.81",
           "NBitcoin.Secp256k1": "1.0.10"
         }
       }

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -63,8 +63,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "5.0.73",
-        "contentHash": "Vre+l+Hx8uo+5Eq2T2uvq5kY+7YeccfvvUpfIj9YJrXI0j89gxsobfKfDhCw35gOIfSwIEDGv2N7LVbSA8w6HQ==",
+        "resolved": "5.0.81",
+        "contentHash": "sBOvupELGlaw5mr4sNW0q8kwc6ALlYaG6telvebDLU7+9DYYYaPiHS1L8gPIa4BKpSO/9STQkMRbKmW7DcAUfQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"
@@ -293,7 +293,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "3.1.1",
           "Microsoft.Win32.Registry": "4.7.0",
-          "NBitcoin": "5.0.73",
+          "NBitcoin": "5.0.81",
           "NBitcoin.Secp256k1": "1.0.10"
         }
       }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -56,7 +56,7 @@ namespace WalletWasabi.Helpers
 
 		public const long MaxSatoshisSupply = 2_100_000_000_000_000L;
 
-		public static readonly Version ClientVersion = new Version(1, 1, 12, 8);
+		public static readonly Version ClientVersion = new Version(1, 1, 12, 9);
 		public static readonly Version HwiVersion = new Version("2.0.2");
 		public static readonly Version BitcoinCoreVersion = new Version("0.21.0");
 		public static readonly Version LegalDocumentsVersion = new Version(2, 0);

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-	  <PackageReference Include="NBitcoin" Version="5.0.73" />
+	  <PackageReference Include="NBitcoin" Version="5.0.81" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="NBitcoin.Secp256k1" Version="1.0.10" />
   </ItemGroup>

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[5.0.73, )",
-        "resolved": "5.0.73",
-        "contentHash": "Vre+l+Hx8uo+5Eq2T2uvq5kY+7YeccfvvUpfIj9YJrXI0j89gxsobfKfDhCw35gOIfSwIEDGv2N7LVbSA8w6HQ==",
+        "requested": "[5.0.81, )",
+        "resolved": "5.0.81",
+        "contentHash": "sBOvupELGlaw5mr4sNW0q8kwc6ALlYaG6telvebDLU7+9DYYYaPiHS1L8gPIa4BKpSO/9STQkMRbKmW7DcAUfQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core 3'


### PR DESCRIPTION
This commit also belongs here: 
https://github.com/zkSNACKs/WalletWasabi/commit/70a393e5437dba705e11e8f88b621be737b47b8f

Project board https://github.com/zkSNACKs/WalletWasabi/projects/26

Release note draft: https://github.com/molnard/WalletWasabi/releases/tag/v1.1.12.9

## Quick testing instructions

- Recover a wallet with an invalid keypath.
- Try to use Wasabi on Whonix (only Tor).
- Make the txstore file corrupt and check if wallet rescan. 
