### PR TITLE
Logger: Add `CallerMemberName` information to logs

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -123,7 +123,7 @@ namespace WalletWasabi.Logging
 
 		#region GeneralLoggingMethods
 
-		public static void Log(LogLevel level, string message, int additionalEntrySeparators = 0, bool additionalEntrySeparatorsLogFileOnlyMode = true, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		public static void Log(LogLevel level, string message, int additionalEntrySeparators = 0, bool additionalEntrySeparatorsLogFileOnlyMode = true, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
 			try
 			{
@@ -138,7 +138,7 @@ namespace WalletWasabi.Logging
 				}
 
 				message = Guard.Correct(message);
-				var category = string.IsNullOrWhiteSpace(callerFilePath) ? "" : $"{EnvironmentHelpers.ExtractFileName(callerFilePath)} ({callerLineNumber})";
+				var category = string.IsNullOrWhiteSpace(callerFilePath) ? "" : $"{EnvironmentHelpers.ExtractFileName(callerFilePath)}:{callerMemberName} ({callerLineNumber})";
 
 				var messageBuilder = new StringBuilder();
 				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss} [{Thread.CurrentThread.ManagedThreadId}] {level.ToString().ToUpperInvariant()}\t");
@@ -251,17 +251,17 @@ namespace WalletWasabi.Logging
 		/// <summary>
 		/// Logs user message concatenated with exception string.
 		/// </summary>
-		private static void Log(string message, Exception ex, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		private static void Log(string message, Exception ex, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
-			Log(level, message: $"{message} Exception: {ex}", callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+			Log(level, message: $"{message} Exception: {ex}", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 		}
 
 		/// <summary>
 		/// Logs exception string without any user message.
 		/// </summary>
-		private static void Log(Exception exception, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		private static void Log(Exception exception, LogLevel level, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 		{
-			Log(level, exception.ToString(), callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+			Log(level, exception.ToString(), callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 		}
 
 		#endregion ExceptionLoggingMethods
@@ -275,7 +275,7 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages may contain sensitive application data and so should not be enabled in a production environment.</remarks>
 		/// <example>For example: <c>Credentials: {"User":"SomeUser", "Password":"P@ssword"}</c></example>
-		public static void LogTrace(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Trace, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogTrace(string message, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Trace, message, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="exception"/> using <see cref="Exception.ToString()"/> at <see cref="LogLevel.Trace"/> level.
@@ -284,7 +284,7 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages may contain sensitive application data and so should not be enabled in a production environment.</remarks>
 		/// <example>For example: <c>Credentials: {"User":"SomeUser", "Password":"P@ssword"}</c></example>
-		public static void LogTrace(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Trace, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogTrace(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Trace, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs <paramref name="message"/> with <paramref name="exception"/> using <see cref="Exception.ToString()"/> concatenated to it at <see cref="LogLevel.Trace"/> level.
@@ -293,8 +293,8 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages may contain sensitive application data and so should not be enabled in a production environment.</remarks>
 		/// <example>For example: <c>Credentials: {"User":"SomeUser", "Password":"P@ssword"}</c></example>
-		public static void LogTrace(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-			=> Log(message, exception, LogLevel.Trace, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogTrace(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(message, exception, LogLevel.Trace, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		#endregion TraceLoggingMethods
 
@@ -307,7 +307,7 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>You typically would not enable <see cref="LogLevel.Debug"/> level in production unless you are troubleshooting, due to the high volume of generated logs.</remarks>
 		/// <example>For example: <c>Entering method Configure with flag set to true.</c></example>
-		public static void LogDebug(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Debug, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogDebug(string message, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Debug, message, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="exception"/> using <see cref="Exception.ToString()"/> at <see cref="LogLevel.Debug"/> level.
@@ -316,7 +316,7 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages may contain sensitive application data and so should not be enabled in a production environment.</remarks>
 		/// <example>For example: <c>Credentials: {"User":"SomeUser", "Password":"P@ssword"}</c></example>
-		public static void LogDebug(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Debug, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogDebug(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Debug, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs <paramref name="message"/> with <paramref name="exception"/> using <see cref="Exception.ToString()"/> concatenated to it at <see cref="LogLevel.Debug"/> level.
@@ -324,8 +324,8 @@ namespace WalletWasabi.Logging
 		/// <para>For information that has short-term usefulness during development and debugging.</para>
 		/// </summary>
 		/// <remarks>You typically would not enable <see cref="LogLevel.Debug"/> level in production unless you are troubleshooting, due to the high volume of generated logs.</remarks>
-		public static void LogDebug(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-			=> Log(message, exception, LogLevel.Debug, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogDebug(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(message, exception, LogLevel.Debug, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		#endregion DebugLoggingMethods
 
@@ -335,15 +335,15 @@ namespace WalletWasabi.Logging
 		/// Logs special event: Software has started. Add also <see cref="InstanceGuid"/> identifier and insert three newlines to increase log readability.
 		/// </summary>
 		/// <param name="appName">Name of the application.</param>
-		public static void LogSoftwareStarted(string appName, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-			=> Log(LogLevel.Info, $"{appName} started ({InstanceGuid}).", additionalEntrySeparators: 3, additionalEntrySeparatorsLogFileOnlyMode: true, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogSoftwareStarted(string appName, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(LogLevel.Info, $"{appName} started ({InstanceGuid}).", additionalEntrySeparators: 3, additionalEntrySeparatorsLogFileOnlyMode: true, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs special event: Software has stopped. Add also <see cref="InstanceGuid"/> identifier.
 		/// </summary>
 		/// <param name="appName">Name of the application.</param>
-		public static void LogSoftwareStopped(string appName, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-			=> Log(LogLevel.Info, $"{appName} stopped gracefully ({InstanceGuid}).", callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogSoftwareStopped(string appName, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(LogLevel.Info, $"{appName} stopped gracefully ({InstanceGuid}).", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs a string message at <see cref="LogLevel.Info"/> level.
@@ -352,7 +352,7 @@ namespace WalletWasabi.Logging
 		/// <remarks>These logs typically have some long-term value.</remarks>
 		/// <example>"Request received for path /api/my-controller"</example>
 		/// </summary>
-		public static void LogInfo(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Info, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogInfo(string message, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Info, message, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="exception"/> using <see cref="Exception.ToString()"/> at <see cref="LogLevel.Info"/> level.
@@ -361,7 +361,7 @@ namespace WalletWasabi.Logging
 		/// These logs typically have some long-term value.
 		/// Example: "Request received for path /api/my-controller"
 		/// </summary>
-		public static void LogInfo(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Info, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogInfo(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Info, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs <paramref name="message"/> with <paramref name="exception"/> using <see cref="Exception.ToString()"/> concatenated to it at <see cref="LogLevel.Info"/> level.
@@ -370,8 +370,8 @@ namespace WalletWasabi.Logging
 		/// These logs typically have some long-term value.
 		/// Example: "Request received for path /api/my-controller"
 		/// </summary>
-		public static void LogInfo(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-			=> Log(message, exception, LogLevel.Info, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogInfo(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(message, exception, LogLevel.Info, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		#endregion InfoLoggingMethods
 
@@ -387,7 +387,7 @@ namespace WalletWasabi.Logging
 		/// </remarks>
 		/// <example>"FileNotFoundException for file quotes.txt."</example>
 		/// </summary>
-		public static void LogWarning(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Warning, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogWarning(string message, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Warning, message, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="exception"/> using <see cref="Exception.ToString()"/> at <see cref="LogLevel.Warning"/> level.
@@ -399,7 +399,7 @@ namespace WalletWasabi.Logging
 		/// <para>Handled exceptions are a common place to use the <see cref="LogLevel.Warning"/> log level.</para>
 		/// </remarks>
 		/// <example>For example: <c>FileNotFoundException for file quotes.txt.</c></example>
-		public static void LogWarning(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Warning, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogWarning(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Warning, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		#endregion WarningLoggingMethods
 
@@ -412,7 +412,7 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.</remarks>
 		/// <example>Log message such as: "Cannot insert record due to duplicate key violation."</example>
-		public static void LogError(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Error, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogError(string message, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Error, message, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs <paramref name="message"/> with <paramref name="exception"/> using <see cref="Exception.ToString()"/> concatenated to it at <see cref="LogLevel.Error"/> level.
@@ -421,8 +421,8 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.</remarks>
 		/// <example>Log message such as: "Cannot insert record due to duplicate key violation."</example>
-		public static void LogError(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-			=> Log(message, exception, LogLevel.Error, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogError(string message, Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+			=> Log(message, exception, LogLevel.Error, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="exception"/> using <see cref="Exception.ToString()"/> at <see cref="LogLevel.Error"/> level.
@@ -431,7 +431,7 @@ namespace WalletWasabi.Logging
 		/// </summary>
 		/// <remarks>These messages indicate a failure in the current activity or operation (such as the current HTTP request), not an application-wide failure.</remarks>
 		/// <example>Log message such as: "Cannot insert record due to duplicate key violation."</example>
-		public static void LogError(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Error, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogError(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Error, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		#endregion ErrorLoggingMethods
 
@@ -443,7 +443,7 @@ namespace WalletWasabi.Logging
 		/// <para>For failures that require immediate attention.</para>
 		/// </summary>
 		/// <example>Data loss scenarios, out of disk space.</example>
-		public static void LogCritical(string message, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Critical, message, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogCritical(string message, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(LogLevel.Critical, message, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		/// <summary>
 		/// Logs the <paramref name="exception"/> using <see cref="Exception.ToString()"/> at <see cref="LogLevel.Critical"/> level.
@@ -451,7 +451,7 @@ namespace WalletWasabi.Logging
 		/// <para>For failures that require immediate attention.</para>
 		/// </summary>
 		/// <example>Examples: Data loss scenarios, out of disk space, etc.</example>
-		public static void LogCritical(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Critical, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		public static void LogCritical(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1) => Log(exception, LogLevel.Critical, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 
 		#endregion CriticalLoggingMethods
 


### PR DESCRIPTION
This PR may prove useful for debugging by developers and for cases when users supply their logs too.

The proposed change simply adds a *method name* denoting where the corresponding `Logger.Log*` call was called to each log line.

## Why?

It's easier to understand non-trivial operations when you can see method names in logs. 

## Log output comparsion

Note that I have `Trace` log level is enabled in these samples which is not default behavior.

<details>
  <summary>Log output without the patch</summary>

  ```
2021-06-03 22:13:58 [1] INFO	Program (48)	Wasabi GUI started (51f0607b-5cdc-42da-87ac-df3d3cc6aba5).
2021-06-03 22:13:59 [1] INFO	TransactionStore (34)	MempoolStore.InitializeAsync finished in 16 milliseconds.
2021-06-03 22:13:59 [1] INFO	TransactionStore (34)	ConfirmedStore.InitializeAsync finished in 0 milliseconds.
2021-06-03 22:13:59 [1] INFO	AllTransactionStore (41)	InitializeAsync finished in 25 milliseconds.
2021-06-03 22:14:01 [8] INFO	TorProcessManager (84)	Starting Tor process ...
2021-06-03 22:14:02 [9] INFO	TorProcessManager (118)	Tor is running.
2021-06-03 22:14:03 [11] INFO	Global (150)	TorProcessManager.Start finished in 3.75 seconds.
2021-06-03 22:14:03 [11] INFO	Global (160)	TorProcessManager is initialized.
2021-06-03 22:14:04 [5] INFO	IndexStore (77)	InitializeAsync finished in 5.56 seconds.
2021-06-03 22:14:04 [5] INFO	BitcoinStore (46)	InitializeAsync finished in 5.56 seconds.
2021-06-03 22:14:04 [5] INFO	P2pNetwork (57)	Loaded AddressManager from `<PATH>\WalletWasabi\Client\BitcoinP2pNetwork\AddressManagerMain.dat`.
2021-06-03 22:14:04 [5] TRACE	TorHttpPool (187)	> request='http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/software/versions', circuit=[DefaultCircuit:T8IZ6VRHZCTICNW5TGVE5]
2021-06-03 22:14:04 [4] TRACE	TorTcpConnectionFactory (229)	> host='wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion', port=80
2021-06-03 22:14:04 [6] INFO	HostedServices (57)	Started Software Update Checker.
2021-06-03 22:14:04 [6] INFO	HostedServices (57)	Started System Awake Checker.
2021-06-03 22:14:04 [5] INFO	TorProcessManager (180)	**Checking Tor status**
2021-06-03 22:14:04 [5] TRACE	TorControlClient (127)	Client: About to send command: 'GETINFO network-liveness'
2021-06-03 22:14:04 [4] INFO	HostedServices (57)	Started TorMonitor.
2021-06-03 22:14:04 [4] INFO	HostedServices (57)	Started Bitcoin P2P Network.
2021-06-03 22:14:04 [6] INFO	HostedServices (57)	Started Blockstream.info Fee Provider.
2021-06-03 22:14:04 [4] INFO	HostedServices (57)	Started Third Party Fee Provider.
2021-06-03 22:14:04 [6] INFO	HostedServices (57)	Started Hybrid Fee Provider.
2021-06-03 22:14:04 [6] TRACE	WasabiSynchronizer (131)	> requestInterval=00:00:30, maxFiltersToSyncAtInitialization=1000
2021-06-03 22:14:04 [6] TRACE	WasabiSynchronizer (296)	<
2021-06-03 22:14:04 [6] INFO	Global (221)	Start synchronizing filters...
2021-06-03 22:14:04 [5] TRACE	WasabiSynchronizer (145)	> Wasabi synchronizer thread starts.
2021-06-03 22:14:04 [5] TRACE	TorHttpPool (187)	> request='http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/v4/btc/batch/synchronize?bestKnownBlockHash=00000000000000000004182eb2c717ab32a371ff79fb50b317782c8648a7f96a&maxNumberOfFilters=1000&estimateSmartFeeMode=Conservative', circuit=[DefaultCircuit:T8IZ6VRHZCTICNW5TGVE5]
2021-06-03 22:14:04 [14] DEBUG	BestEffortEndpointConnector (104)	Connections: 0, Currently allow only onions: False.
2021-06-03 22:14:04 [13] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250-network-liveness=up'
2021-06-03 22:14:04 [13] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250 OK'
2021-06-03 22:14:04 [13] TRACE	TorControlClient (209)	ReaderLoop: Sync '[OK: 'network-liveness=up<CRLF>250 OK']'
2021-06-03 22:14:04 [10] INFO	TorProcessManager (188)	**Circuit status**
2021-06-03 22:14:04 [10] TRACE	TorControlClient (127)	Client: About to send command: 'GETINFO circuit-status'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250+circuit-status='
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension (61)	Read message: '1 BUILT $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude,$D9B91878B46BB80E6D752E876BF9D481EFEAC5BF~xx,$D24D0C28AB48768CF8B79DD762D61DB4FD015677~kukuruz BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:02.997451'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension (61)	Read message: '3 EXTENDED $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY PURPOSE=HS_CLIENT_HSDIR HS_STATE=HSCI_CONNECTING TIME_CREATED=2021-06-03T20:14:04.838757'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension (61)	Read message: '4 EXTENDED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:04.877762 SOCKS_USERNAME="4EEPOS6533D2AAPYHJBTV" SOCKS_PASSWORD="4EEPOS6533D2AAPYHJBTV"'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension (61)	Read message: '.'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250 OK'
2021-06-03 22:14:05 [9] TRACE	TorControlClient (209)	ReaderLoop: Sync '[OK: 'circuit-status=<CRLF>1 BUILT $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude,$D9B91878B46BB80E6D752E876BF9D481EFEAC5BF~xx,$D24D0C28AB48768CF8B79DD762D61DB4FD015677~kukuruz BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:02.997451<CRLF>3 EXTENDED $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY PURPOSE=HS_CLIENT_HSDIR HS_STATE=HSCI_CONNECTING TIME_CREATED=2021-06-03T20:14:04.838757<CRLF>4 EXTENDED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:04.877762 SOCKS_USERNAME="4EEPOS6533D2AAPYHJBTV" SOCKS_PASSWORD="4EEPOS6533D2AAPYHJBTV"<CRLF>.<CRLF>250 OK']'
2021-06-03 22:14:05 [6] INFO	TorProcessManager (190)	Status reply: [OK: 'circuit-status=<CRLF>1 BUILT $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude,$D9B91878B46BB80E6D752E876BF9D481EFEAC5BF~xx,$D24D0C28AB48768CF8B79DD762D61DB4FD015677~kukuruz BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:02.997451<CRLF>3 EXTENDED $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY PURPOSE=HS_CLIENT_HSDIR HS_STATE=HSCI_CONNECTING TIME_CREATED=2021-06-03T20:14:04.838757<CRLF>4 EXTENDED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:04.877762 SOCKS_USERNAME="4EEPOS6533D2AAPYHJBTV" SOCKS_PASSWORD="4EEPOS6533D2AAPYHJBTV"<CRLF>.<CRLF>250 OK']
2021-06-03 22:14:05 [6] INFO	TorProcessManager (192)	**Circuit status**
2021-06-03 22:14:05 [6] TRACE	TorControlClient (127)	Client: About to send command: 'PROTOCOLINFO 1'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250-PROTOCOLINFO 1'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250-AUTH METHODS=COOKIE,SAFECOOKIE COOKIEFILE="<PATH>\\WalletWasabi\\Client\\control_auth_cookie"'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250-VERSION Tor="0.4.5.7"'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension (61)	Read message: '250 OK'
  ```
</details>


<details>
  <summary>Log output with the patch</summary>

  ```
2021-06-03 22:13:58 [1] INFO	Program:Main (48)	Wasabi GUI started (51f0607b-5cdc-42da-87ac-df3d3cc6aba5).
2021-06-03 22:13:59 [1] INFO	TransactionStore:Dispose (34)	MempoolStore.InitializeAsync finished in 16 milliseconds.
2021-06-03 22:13:59 [1] INFO	TransactionStore:Dispose (34)	ConfirmedStore.InitializeAsync finished in 0 milliseconds.
2021-06-03 22:13:59 [1] INFO	AllTransactionStore:Dispose (41)	InitializeAsync finished in 25 milliseconds.
2021-06-03 22:14:01 [8] INFO	TorProcessManager:StartAsync (84)	Starting Tor process ...
2021-06-03 22:14:02 [9] INFO	TorProcessManager:StartAsync (118)	Tor is running.
2021-06-03 22:14:03 [11] INFO	Global:Dispose (150)	TorProcessManager.Start finished in 3.75 seconds.
2021-06-03 22:14:03 [11] INFO	Global:InitializeNoWalletAsync (160)	TorProcessManager is initialized.
2021-06-03 22:14:04 [5] INFO	IndexStore:Dispose (77)	InitializeAsync finished in 5.56 seconds.
2021-06-03 22:14:04 [5] INFO	BitcoinStore:Dispose (46)	InitializeAsync finished in 5.56 seconds.
2021-06-03 22:14:04 [5] INFO	P2pNetwork:.ctor (57)	Loaded AddressManager from `<PATH>\WalletWasabi\Client\BitcoinP2pNetwork\AddressManagerMain.dat`.
2021-06-03 22:14:04 [5] TRACE	TorHttpPool:ObtainFreeConnectionAsync (187)	> request='http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/software/versions', circuit=[DefaultCircuit:T8IZ6VRHZCTICNW5TGVE5]
2021-06-03 22:14:04 [4] TRACE	TorTcpConnectionFactory:ConnectToDestinationAsync (229)	> host='wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion', port=80
2021-06-03 22:14:04 [6] INFO	HostedServices:StartAllAsync (57)	Started Software Update Checker.
2021-06-03 22:14:04 [6] INFO	HostedServices:StartAllAsync (57)	Started System Awake Checker.
2021-06-03 22:14:04 [5] INFO	TorProcessManager:CheckStatusAsync (180)	**Checking Tor status**
2021-06-03 22:14:04 [5] TRACE	TorControlClient:SendCommandAsync (127)	Client: About to send command: 'GETINFO network-liveness'
2021-06-03 22:14:04 [4] INFO	HostedServices:StartAllAsync (57)	Started TorMonitor.
2021-06-03 22:14:04 [4] INFO	HostedServices:StartAllAsync (57)	Started Bitcoin P2P Network.
2021-06-03 22:14:04 [6] INFO	HostedServices:StartAllAsync (57)	Started Blockstream.info Fee Provider.
2021-06-03 22:14:04 [4] INFO	HostedServices:StartAllAsync (57)	Started Third Party Fee Provider.
2021-06-03 22:14:04 [6] INFO	HostedServices:StartAllAsync (57)	Started Hybrid Fee Provider.
2021-06-03 22:14:04 [6] TRACE	WasabiSynchronizer:Start (131)	> requestInterval=00:00:30, maxFiltersToSyncAtInitialization=1000
2021-06-03 22:14:04 [6] TRACE	WasabiSynchronizer:Start (296)	<
2021-06-03 22:14:04 [6] INFO	Global:InitializeNoWalletAsync (221)	Start synchronizing filters...
2021-06-03 22:14:04 [5] TRACE	WasabiSynchronizer:Start (145)	> Wasabi synchronizer thread starts.
2021-06-03 22:14:04 [5] TRACE	TorHttpPool:ObtainFreeConnectionAsync (187)	> request='http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/v4/btc/batch/synchronize?bestKnownBlockHash=00000000000000000004182eb2c717ab32a371ff79fb50b317782c8648a7f96a&maxNumberOfFilters=1000&estimateSmartFeeMode=Conservative', circuit=[DefaultCircuit:T8IZ6VRHZCTICNW5TGVE5]
2021-06-03 22:14:04 [14] DEBUG	BestEffortEndpointConnector:AllowOnlyTorEndpoints (104)	Connections: 0, Currently allow only onions: False.
2021-06-03 22:14:04 [13] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250-network-liveness=up'
2021-06-03 22:14:04 [13] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250 OK'
2021-06-03 22:14:04 [13] TRACE	TorControlClient:ReaderLoopAsync (209)	ReaderLoop: Sync '[OK: 'network-liveness=up<CRLF>250 OK']'
2021-06-03 22:14:04 [10] INFO	TorProcessManager:CheckStatusAsync (188)	**Circuit status**
2021-06-03 22:14:04 [10] TRACE	TorControlClient:SendCommandAsync (127)	Client: About to send command: 'GETINFO circuit-status'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250+circuit-status='
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '1 BUILT $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude,$D9B91878B46BB80E6D752E876BF9D481EFEAC5BF~xx,$D24D0C28AB48768CF8B79DD762D61DB4FD015677~kukuruz BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:02.997451'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '3 EXTENDED $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY PURPOSE=HS_CLIENT_HSDIR HS_STATE=HSCI_CONNECTING TIME_CREATED=2021-06-03T20:14:04.838757'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '4 EXTENDED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:04.877762 SOCKS_USERNAME="4EEPOS6533D2AAPYHJBTV" SOCKS_PASSWORD="4EEPOS6533D2AAPYHJBTV"'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '.'
2021-06-03 22:14:05 [9] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250 OK'
2021-06-03 22:14:05 [9] TRACE	TorControlClient:ReaderLoopAsync (209)	ReaderLoop: Sync '[OK: 'circuit-status=<CRLF>1 BUILT $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude,$D9B91878B46BB80E6D752E876BF9D481EFEAC5BF~xx,$D24D0C28AB48768CF8B79DD762D61DB4FD015677~kukuruz BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:02.997451<CRLF>3 EXTENDED $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY PURPOSE=HS_CLIENT_HSDIR HS_STATE=HSCI_CONNECTING TIME_CREATED=2021-06-03T20:14:04.838757<CRLF>4 EXTENDED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:04.877762 SOCKS_USERNAME="4EEPOS6533D2AAPYHJBTV" SOCKS_PASSWORD="4EEPOS6533D2AAPYHJBTV"<CRLF>.<CRLF>250 OK']'
2021-06-03 22:14:05 [6] INFO	TorProcessManager:CheckStatusAsync (190)	Status reply: [OK: 'circuit-status=<CRLF>1 BUILT $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude,$D9B91878B46BB80E6D752E876BF9D481EFEAC5BF~xx,$D24D0C28AB48768CF8B79DD762D61DB4FD015677~kukuruz BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:02.997451<CRLF>3 EXTENDED $51BD782616C3EBA543B0D4EE34D7C1CE1ED2291D~Geodude BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY PURPOSE=HS_CLIENT_HSDIR HS_STATE=HSCI_CONNECTING TIME_CREATED=2021-06-03T20:14:04.838757<CRLF>4 EXTENDED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-03T20:14:04.877762 SOCKS_USERNAME="4EEPOS6533D2AAPYHJBTV" SOCKS_PASSWORD="4EEPOS6533D2AAPYHJBTV"<CRLF>.<CRLF>250 OK']
2021-06-03 22:14:05 [6] INFO	TorProcessManager:CheckStatusAsync (192)	**Circuit status**
2021-06-03 22:14:05 [6] TRACE	TorControlClient:SendCommandAsync (127)	Client: About to send command: 'PROTOCOLINFO 1'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250-PROTOCOLINFO 1'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250-AUTH METHODS=COOKIE,SAFECOOKIE COOKIEFILE="<PATH>\\WalletWasabi\\Client\\control_auth_cookie"'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250-VERSION Tor="0.4.5.7"'
2021-06-03 22:14:05 [8] TRACE	PipeReaderLineReaderExtension:ReadLineAsync (61)	Read message: '250 OK'
  ```
</details>

## Perf

There should be [no runtime performance hit](https://stackoverflow.com/questions/16101152/is-performance-hit-by-using-caller-information-attributes) caused by `[CallerMemberName]`. Obviously, slightly more data is being logged to a disk.