### PR TITLE
Add batch acquiring txs from RPC

### DIFF
--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
@@ -86,6 +87,11 @@ namespace WalletWasabi.Tests.UnitTests
 		}
 
 		public Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
 		{
 			throw new NotImplementedException();
 		}

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -1,6 +1,8 @@
 using NBitcoin;
 using NBitcoin.RPC;
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc.Models;
@@ -57,6 +59,8 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		Task<BumpResponse> BumpFeeAsync(uint256 txid);
 
 		Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true);
+
+		Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel);
 
 		Task<int> GetBlockCountAsync();
 

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc.Models;
@@ -187,6 +188,34 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		public virtual async Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true)
 		{
 			return await Rpc.GetRawTransactionAsync(txid, throwIfNotFound).ConfigureAwait(false);
+		}
+
+		public virtual async Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
+		{
+			// 8 is half of the default rpcworkqueue
+			List<Transaction> retList = new();
+			foreach (var txidsChunk in txids.ChunkBy(8))
+			{
+				IRPCClient batchingRpc = PrepareBatch();
+				List<Task<Transaction>> tasks = new();
+				foreach (var txid in txidsChunk)
+				{
+					tasks.Add(batchingRpc.GetRawTransactionAsync(txid, throwIfNotFound: false));
+				}
+
+				await batchingRpc.SendBatchAsync().ConfigureAwait(false);
+
+				foreach (var tx in await Task.WhenAll(tasks).ConfigureAwait(false))
+				{
+					if (tx is not null)
+					{
+						retList.Add(tx);
+					}
+					cancel.ThrowIfCancellationRequested();
+				}
+			}
+
+			return retList;
 		}
 
 		public virtual async Task<int> GetBlockCountAsync()

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -193,7 +193,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		public virtual async Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
 		{
 			// 8 is half of the default rpcworkqueue
-			List<Transaction> retList = new();
+			List<Transaction> acquiredTransactions = new();
 			foreach (var txidsChunk in txids.ChunkBy(8))
 			{
 				IRPCClient batchingRpc = PrepareBatch();
@@ -209,13 +209,13 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				{
 					if (tx is not null)
 					{
-						retList.Add(tx);
+						acquiredTransactions.Add(tx);
 					}
 					cancel.ThrowIfCancellationRequested();
 				}
 			}
 
-			return retList;
+			return acquiredTransactions;
 		}
 
 		public virtual async Task<int> GetBlockCountAsync()


### PR DESCRIPTION
Prerequisite for the mempool mirror: https://github.com/zkSNACKs/WalletWasabi/pull/5765

The idea is to forget P2P and get txs through RPC instead.