### PR TITLE
[WabiSabi] Improve Unit Test

### DIFF
--- a/WalletWasabi.Tests/Helpers/ArenaRequestHandlerAdapter.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaRequestHandlerAdapter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.WabiSabi.Backend.PostRequests;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Models;
+
+namespace WalletWasabi.Tests.Helpers
+{
+	class ArenaRequestHandlerAdapter : IWabiSabiApiRequestHandler
+	{
+		private readonly Arena arena;
+
+		public ArenaRequestHandlerAdapter(Arena arena)
+		{
+			this.arena = arena;
+		}
+
+		public Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request, CancellationToken cancellationToken)
+			=> arena.ConfirmConnectionAsync(request);
+
+		public Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+			=> throw new NotImplementedException();
+
+		public Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request, CancellationToken cancellationToken)
+			=> arena.RegisterInputAsync((request));
+
+		public Task<OutputRegistrationResponse> RegisterOutputAsync(OutputRegistrationRequest request, CancellationToken cancellationToken)
+			=> arena.RegisterOutputAsync(request);
+
+		public Task<ReissueCredentialResponse> ReissueCredentialAsync(ReissueCredentialRequest request, CancellationToken cancellationToken)
+			=> arena.ReissuanceAsync(request);
+
+		public Task RemoveInputAsync(InputsRemovalRequest request, CancellationToken cancellationToken)
+			=> arena.RemoveInputAsync(request);
+
+		public Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken)
+			=> arena.SignTransactionAsync(request);
+	}
+}

--- a/WalletWasabi.Tests/Helpers/ArenaRequestHandlerAdapter.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaRequestHandlerAdapter.cs
@@ -7,7 +7,7 @@ using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.Tests.Helpers
 {
-	class ArenaRequestHandlerAdapter : IWabiSabiApiRequestHandler
+	public class ArenaRequestHandlerAdapter : IWabiSabiApiRequestHandler
 	{
 		private readonly Arena arena;
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
@@ -1,8 +1,6 @@
 using NBitcoin;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
@@ -75,10 +73,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task RoundNotFoundAsync()
 		{
+			var cfg = new WabiSabiConfig();
+			var nonExistingRound = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
-			await using ArenaRequestHandler handler = new(new WabiSabiConfig(), new Prison(), arena, new MockRpcClient());
-			var req = WabiSabiFactory.CreateConnectionConfirmationRequest();
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.ConfirmConnectionAsync(req, CancellationToken.None));
+			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
+			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(nonExistingRound);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await handler.ConfirmConnectionAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -96,13 +98,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			round.Alices.Add(alice);
 
 			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
+			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 			{
 				if (phase != Phase.InputRegistration && phase != Phase.ConnectionConfirmation)
 				{
 					round.SetPhase(phase);
-					await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
-					var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.ConfirmConnectionAsync(req, CancellationToken.None));
+					var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+						async () => await handler.ConfirmConnectionAsync(req, CancellationToken.None));
+
 					Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 				}
 			}
@@ -137,14 +141,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
-			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
-			req = new(
-				req.RoundId,
-				req.AliceId,
-				req.ZeroAmountCredentialRequests,
-				req.RealAmountCredentialRequests,
-				req.ZeroVsizeCredentialRequests,
-				WabiSabiFactory.CreateRealCredentialRequests(round, null, 234).vsizeReq);
+			var incorrectVsizeCredentials = WabiSabiFactory.CreateRealCredentialRequests(round, null, 234).vsizeRequest;
+			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round) with { RealVsizeCredentialRequests = incorrectVsizeCredentials };
+
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.ConfirmConnectionAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.IncorrectRequestedVsizeCredentials, ex.ErrorCode);
@@ -163,14 +162,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
-			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
-			req = new(
-				req.RoundId,
-				req.AliceId,
-				req.ZeroAmountCredentialRequests,
-				WabiSabiFactory.CreateRealCredentialRequests(round, Money.Coins(3), null).amountReq,
-				req.ZeroVsizeCredentialRequests,
-				req.RealVsizeCredentialRequests);
+			var incorrectAmountCredentials = WabiSabiFactory.CreateRealCredentialRequests(round, Money.Coins(3), null).amountRequest;
+			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round) with { RealAmountCredentialRequests = incorrectAmountCredentials };
+
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.ConfirmConnectionAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.IncorrectRequestedAmountCredentials, ex.ErrorCode);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -1,8 +1,10 @@
+using Moq;
 using NBitcoin;
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -25,12 +27,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task RoundNotFoundAsync()
 		{
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
 			using Key key = new();
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(new(), WabiSabiFactory.CreatePreconfiguredRpcClient());
 
-			await using ArenaRequestHandler handler = new(new(), new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputRegistrationRequest();
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(uint256.Zero, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -44,8 +46,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21)).ConfigureAwait(false);
 			var round = arena.Rounds.First().Value;
 			using Key key = new();
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(round, key: key);
+			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreatePreconfiguredRpcClient().Object);
 
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 			{
@@ -64,17 +66,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
-
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(), round);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			round.Alices.Add(WabiSabiFactory.CreateAlice());
 			round.Alices.Add(WabiSabiFactory.CreateAlice());
 			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			await RegisterAndAssertWrongPhaseAsync(req, handler);
+
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -85,10 +88,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
-
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
+			var coin = WabiSabiFactory.CreateCoin(key);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
 			// TODO add configuration parameter
 			round.InitialInputVsizeAllocation = (int)round.MaxVsizeAllocationPerAlice;
@@ -100,8 +102,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Assert.Equal(0, round.RemainingInputVsizeAllocation);
 
 			// try to add an additional input
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.VsizeQuotaExceeded, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -112,15 +115,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.Zero };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
 			using Key key = new();
+			var coin = WabiSabiFactory.CreateCoin(key);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin));
 
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
 			arena.Rounds.Add(round.Id, round);
-			await RegisterAndAssertWrongPhaseAsync(req, handler);
+
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -130,17 +136,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		public async Task InputRegistrationTimeoutCanBeModifiedRuntimeAsync()
 		{
 			WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.FromHours(1) };
-
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
 			using Key key = new();
+			var coin = WabiSabiFactory.CreateCoin(key);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin));
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			var round = arena.Rounds.First().Value;
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
 
 			cfg.StandardInputRegistrationTimeout = TimeSpan.Zero;
-			await RegisterAndAssertWrongPhaseAsync(req, handler);
+
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -149,16 +157,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputBannedAsync()
 		{
-			Prison prison = new();
-			using var key = new Key();
+			using Key key = new();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Banned, uint256.One);
+
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: outpoint, round: round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			arena.Prison.Punish(outpoint, Punishment.Banned, uint256.One);
+
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, key, CancellationToken.None));
+
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -167,20 +178,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputCanBeNotedAsync()
 		{
-			Prison prison = new();
+			using Key key = new();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Noted, uint256.One);
+
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+			arena.Prison.Punish(outpoint, Punishment.Noted, uint256.One);
 
-			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: outpoint, round: round);
-			var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
-			if (ex is WabiSabiProtocolException wspex)
-			{
-				Assert.NotEqual(WabiSabiProtocolErrorCode.InputBanned, wspex.ErrorCode);
-			}
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, key, CancellationToken.None));
+			Assert.NotEqual(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -188,16 +198,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputCantBeNotedAsync()
 		{
-			Prison prison = new();
+			using Key key = new();
 			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Noted, uint256.One);
+
 			WabiSabiConfig cfg = new() { AllowNotedInputRegistration = false };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+			arena.Prison.Punish(outpoint, Punishment.Noted, uint256.One);
 
-			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: outpoint, round: round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -206,15 +218,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputSpentAsync()
 		{
+			using Key key = new();
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			MockRpcClient rpc = new();
-			rpc.OnGetTxOutAsync = (_, _, _) => null;
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var mockRpc = new Mock<IRPCClient>();
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+				.ReturnsAsync((NBitcoin.RPC.GetTxOutResponse?)null);
+
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputSpent, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -223,15 +239,19 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputUnconfirmedAsync()
 		{
+			using Key key = new();
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			MockRpcClient rpc = new();
-			rpc.OnGetTxOutAsync = (_, _, _) => new() { Confirmations = 0 };
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var mockRpc = new Mock<IRPCClient>();
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse { Confirmations = 0 });
+
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputUnconfirmed, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -240,18 +260,24 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputImmatureAsync()
 		{
+			using Key key = new();
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			MockRpcClient rpc = new();
+			var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient();
+			var rpcCfg = rpc.SetupSequence(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()));
+			foreach (var i in Enumerable.Range(1, 100))
+			{
+				rpcCfg = rpcCfg.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse { Confirmations = i, IsCoinBase = true });
+			}
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, rpc, round);
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: round);
-			for (int i = 1; i <= 100; i++)
+			foreach (var i in Enumerable.Range(1, 100))
 			{
-				rpc.OnGetTxOutAsync = (_, _, _) => new() { Confirmations = i, IsCoinBase = true };
+				var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+					async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
 
-				await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-				var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
 				Assert.Equal(WabiSabiProtocolErrorCode.InputImmature, ex.ErrorCode);
 			}
 
@@ -263,19 +289,23 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			MockRpcClient rpc = new();
 			using Key key = new();
 
-			rpc.OnGetTxOutAsync = (_, _, _) => new()
-			{
-				Confirmations = 1,
-				TxOut = new(Money.Coins(1), key.PubKey.GetScriptAddress(Network.Main))
-			};
+			var mockRpc = new Mock<IRPCClient>();
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
+				{
+					Confirmations = 1,
+					TxOut = new(Money.Coins(1), key.PubKey.GetScriptAddress(Network.Main))
+				});
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, rpc);
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
+
 			Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -284,14 +314,16 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task WrongOwnershipProofAsync()
 		{
+			using Key key = new();
+			var coin = WabiSabiFactory.CreateCoin(key);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			using Key key = new();
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			using Key nonOwnerKey = new();
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, nonOwnerKey, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.WrongOwnershipProof, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -300,14 +332,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task NotEnoughFundsAsync()
 		{
+			using Key key = new();
 			WabiSabiConfig cfg = new() { MinRegistrableAmount = Money.Coins(2) };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			using Key key = new();
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.NotEnoughFunds, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -316,14 +348,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task TooMuchFundsAsync()
 		{
+			using Key key = new();
 			WabiSabiConfig cfg = new() { MaxRegistrableAmount = Money.Coins(0.9m) };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			using Key key = new();
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(), round);
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchFunds, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -335,16 +367,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			// Configures a round that allows so many inputs (Alices) that
 			// the virtual size each of they have available is not enought
 			// to register anything.
+			using Key key = new();
+			var coin = WabiSabiFactory.CreateCoin(key);
 			WabiSabiConfig cfg = new() { MaxInputCountByRound = 100_000 };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			Assert.Equal(0, round.MaxVsizeAllocationPerAlice);
 
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			using Key key = new();
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchVsize, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
@@ -353,20 +386,21 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task AliceAlreadyRegisteredIntraRoundAsync()
 		{
+			using Key key = new();
+			var coin = WabiSabiFactory.CreateCoin(key);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
-			using Key key = new();
-
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var anotherAlice = WabiSabiFactory.CreateAlice(prevout: req.Input, ownershipProof: req.OwnershipProof);
+			var anotherAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
 			round.Alices.Add(anotherAlice);
 			round.SetPhase(Phase.ConnectionConfirmation);
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			await RegisterAndAssertWrongPhaseAsync(req, handler);
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -374,21 +408,21 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task AliceAlreadyRegisteredCrossRoundAsync()
 		{
+			using Key key = new();
+			var coin = WabiSabiFactory.CreateCoin(key);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var anotherRound = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, anotherRound);
-			using Key key = new();
-
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(key, round);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round, anotherRound);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(prevout: req.Input, ownershipProof: req.OwnershipProof);
+			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
 			anotherRound.Alices.Add(preAlice);
 			anotherRound.SetPhase(Phase.ConnectionConfirmation);
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.AliceAlreadyRegistered, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -23,8 +23,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 			using Key key = new();
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient();
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc(key));
+			await using ArenaRequestHandler handler = new(cfg, new(), arena, mockRpc.Object);
 			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: blameRound);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputNotWhitelisted, ex.ErrorCode);
@@ -35,15 +36,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputWhitelistedAsync()
 		{
-			var outpoint = BitcoinFactory.CreateOutPoint();
+			var alice = WabiSabiFactory.CreateAlice();
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(prevout: outpoint));
+			round.Alices.Add(alice);
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 
-			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: outpoint, round: blameRound);
+			await using ArenaRequestHandler handler = new(cfg, new(), arena, WabiSabiFactory.CreatePreconfiguredRpcClient().Object);
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: alice.Coin.Outpoint, round: blameRound);
 
 			var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
 			if (ex is WabiSabiProtocolException wspex)
@@ -57,17 +58,21 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputWhitelistedButBannedAsync()
 		{
-			Prison prison = new();
-			var outpoint = BitcoinFactory.CreateOutPoint();
-			prison.Punish(outpoint, Punishment.Banned, uint256.Zero);
+			using Key key = new();
+			var alice = WabiSabiFactory.CreateAlice(key);
+			var bannedCoin = alice.Coin.Outpoint;
+
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(prevout: outpoint));
+			round.Alices.Add(alice);
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(alice.Coin);
 
-			await using ArenaRequestHandler handler = new(cfg, prison, arena, WabiSabiFactory.CreateMockRpc());
-			var req = WabiSabiFactory.CreateInputRegistrationRequest(round: blameRound, prevout: outpoint);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round, blameRound);
+			arena.Prison.Punish(bannedCoin, Punishment.Banned, uint256.Zero);
+			await using ArenaRequestHandler handler = new(cfg, arena.Prison, arena, mockRpc.Object);
+
+			var req = WabiSabiFactory.CreateInputRegistrationRequest(key: key, round: blameRound, prevout: bannedCoin);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -38,9 +38,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task RoundNotFoundAsync()
 		{
+			var cfg = new WabiSabiConfig();
+			var nonExistingRound = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
-			await using ArenaRequestHandler handler = new(new WabiSabiConfig(), new Prison(), arena, new MockRpcClient());
-			var req = WabiSabiFactory.CreateOutputRegistrationRequest();
+			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
+			var req = WabiSabiFactory.CreateOutputRegistrationRequest(nonExistingRound);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterOutputAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
@@ -56,7 +58,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(value: Money.Coins(1)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1)));
 
 			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, key.PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.Main).ScriptPubKey);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
@@ -74,7 +76,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(value: Money.Coins(1)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1)));
 
 			var sha256Bounty = Script.FromHex("aa20000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f87");
 			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, sha256Bounty);
@@ -93,7 +95,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new() { MinRegistrableAmount = Money.Coins(2) };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(value: Money.Coins(1)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1)));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
@@ -111,7 +113,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new() { MaxRegistrableAmount = Money.Coins(1.999m) }; // TODO migrate to MultipartyTransactionParameters
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(value: Money.Coins(2)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(2)));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -27,22 +27,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 		{
 			var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
 			var round = WabiSabiFactory.CreateRound(config);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
-
 			var km = ServiceFactory.CreateKeyManager("");
 			var key = BitcoinFactory.CreateHdPubKey(km);
 			SmartCoin coin1 = BitcoinFactory.CreateSmartCoin(key, Money.Coins(2m));
 			var outpoint = coin1.OutPoint;
 
-			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true))
-				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
-				{
-					IsCoinBase = false,
-					Confirmations = coin1.Height,
-					TxOut = coin1.TxOut,
-				});
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin);
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, mockRpc, round);
+			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 
 			ZeroCredentialPool zeroAmountCredential = new();
 			ZeroCredentialPool zeroVsizeCredential = new();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -265,10 +265,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		[Fact]
 		public void UneconomicalInputs()
 		{
-			var alice1 = WabiSabiFactory.CreateAlice(value: new Money(1000L));
+			var alice1 = WabiSabiFactory.CreateAlice(new Money(1000L));
 			var alice1Coin = alice1.Coin;
 
-			var alice2 = WabiSabiFactory.CreateAlice(value: new Money(1001L));
+			var alice2 = WabiSabiFactory.CreateAlice(new Money(1001L));
 			var alice2Coin = alice2.Coin;
 
 			// requires 1k sats per input in sat/vKB

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
@@ -35,14 +35,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			DisposeGuard();
 			using (RunningTasks.RememberWith(RunningRequests))
 			{
-				var coin = await InputRegistrationHandler.OutpointToCoinAsync(request, Prison, Rpc, Config).ConfigureAwait(false);
-
-				return await Arena.RegisterInputAsync(
-					request.RoundId,
-					coin,
-					request.OwnershipProof,
-					request.ZeroAmountCredentialRequests,
-					request.ZeroVsizeCredentialRequests).ConfigureAwait(false);
+				return await Arena.RegisterInputAsync(request).ConfigureAwait(false);
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -8,12 +8,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
 using WalletWasabi.BitcoinCore.Rpc;
-using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
-using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
@@ -246,22 +244,18 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			}
 		}
 
-		public async Task<InputRegistrationResponse> RegisterInputAsync(
-			uint256 roundId,
-			Coin coin,
-			OwnershipProof ownershipProof,
-			ZeroCredentialsRequest zeroAmountCredentialRequests,
-			ZeroCredentialsRequest zeroVsizeCredentialRequests)
+		public async Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request)
 		{
+			var coin = await InputRegistrationHandler.OutpointToCoinAsync(request, Prison, Rpc, Config).ConfigureAwait(false);
 			using (await AsyncLock.LockAsync().ConfigureAwait(false))
 			{
 				return InputRegistrationHandler.RegisterInput(
 					Config,
-					roundId,
+					request.RoundId,
 					coin,
-					ownershipProof,
-					zeroAmountCredentialRequests,
-					zeroVsizeCredentialRequests,
+					request.OwnershipProof,
+					request.ZeroAmountCredentialRequests,
+					request.ZeroVsizeCredentialRequests,
 					Rounds);
 			}
 		}


### PR DESCRIPTION
This PR contains improvements and clean ups for existing WabiSabi unit tests.

Given the coordinator code was written first, at the time there were no clients available to abstract away the complexities for the creation of credentials and keep tract of the amounts, etc. For that reason the `WabiSabiFactory` was created but now we have the `ArenaClient`, a much higher-level component that can do just that, in fact we also have the `AliceClient` and `BobClient` too so, these are better (in most of the cases) than the `WabiSabiFactory`.

There are other important changes:

* `MockRpcClient` is not used anymore (we have to use `Moq`) and,
* The `output -> coin` conversion was moved to a better place what forced us to configure the RPC for all the tests (before this that code was bypassed)
