### PR TITLE
[WabiSabi] Prevent DoS attacks

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -84,33 +84,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		}
 
 		[Fact]
-		public async Task InputRegistrationFullVsizeAsync()
-		{
-			WabiSabiConfig cfg = new();
-			var round = WabiSabiFactory.CreateRound(cfg);
-			using Key key = new();
-			var coin = WabiSabiFactory.CreateCoin(key);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
-
-			// TODO add configuration parameter
-			round.InitialInputVsizeAllocation = (int)round.MaxVsizeAllocationPerAlice;
-
-			// Add an alice
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-
-			Assert.Equal(0, round.RemainingInputVsizeAllocation);
-
-			// try to add an additional input
-			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
-			Assert.Equal(WabiSabiProtocolErrorCode.VsizeQuotaExceeded, ex.ErrorCode);
-
-			await arena.StopAsync(CancellationToken.None);
-		}
-
-		[Fact]
 		public async Task InputRegistrationTimedoutAsync()
 		{
 			WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.Zero };
@@ -400,7 +373,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
 				async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None));
-			Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.AliceAlreadyRegistered, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using Xunit;
@@ -53,38 +54,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
 			round.Alices.Add(preAlice);
 
-			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-			var resp = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None).ConfigureAwait(false);
-			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
-
-			await arena.StopAsync(CancellationToken.None);
-		}
-
-		[Fact]
-		public async Task SuccessWithAliceUpdateCrossRoundAsync()
-		{
-			WabiSabiConfig cfg = new();
-			var round = WabiSabiFactory.CreateRound(cfg);
-			var anotherRound = WabiSabiFactory.CreateRound(cfg);
-
-			using Key key = new();
-			var coin = WabiSabiFactory.CreateCoin(key);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round, anotherRound);
-
-			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
-
-			var initialRemaining = anotherRound.RemainingInputVsizeAllocation;
-			anotherRound.Alices.Add(preAlice);
-
-			var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
-			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-			var resp = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None).ConfigureAwait(false);
-
-			AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
-			Assert.Empty(anotherRound.Alices);
-			Assert.Equal(initialRemaining, anotherRound.RemainingInputVsizeAllocation);
+			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None).ConfigureAwait(false));
+			Assert.Equal(WabiSabiProtocolErrorCode.AliceAlreadyRegistered, ex.ErrorCode);
 
 			await arena.StopAsync(CancellationToken.None);
 		}

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -105,34 +105,12 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			var commitAmountCredentialResponse = round.AmountCredentialIssuer.PrepareResponse(zeroAmountCredentialRequests);
 			var commitVsizeCredentialResponse = round.VsizeCredentialIssuer.PrepareResponse(zeroVsizeCredentialRequests);
 
-			RemoveDuplicateAlices(rounds, alice);
-
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeout);
 			round.Alices.Add(alice);
 
 			return new(alice.Id,
 				commitAmountCredentialResponse.Commit(),
 				commitVsizeCredentialResponse.Commit());
-		}
-
-		private static void RemoveDuplicateAlices(IDictionary<uint256, Round> roundsWithId, Alice alice)
-		{
-			var rounds = roundsWithId.Values;
-			if (rounds.Any(x => x.Phase != Phase.InputRegistration))
-			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyRegistered);
-			}
-
-			var aliceOutPoint = alice.Coin.Outpoint;
-			var flattenTable = rounds.SelectMany(x => x.Alices.Select(y => (Round: x, Alice: y, Outpoint: y.Coin.Outpoint)));
-
-			foreach (var (round, aliceInRound, _) in flattenTable.Where(x => x.Outpoint == aliceOutPoint).ToArray())
-			{
-				if (round.Alices.Remove(aliceInRound))
-				{
-					Logger.LogInfo("Updated Alice registration.");
-				}
-			}
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -249,6 +249,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			var coin = await InputRegistrationHandler.OutpointToCoinAsync(request, Prison, Rpc, Config).ConfigureAwait(false);
 			using (await AsyncLock.LockAsync().ConfigureAwait(false))
 			{
+				var registeredCoins = Rounds.SelectMany(r => r.Value.Alices.Select(a => a.Coin));
+
+				if (registeredCoins.Any(x => x.Outpoint == coin.Outpoint))
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyRegistered);
+				}
 				return InputRegistrationHandler.RegisterInput(
 					Config,
 					request.RoundId,


### PR DESCRIPTION
Currently a client can use a coin to repeatedly request an Alice registration and forcing the coordinator to verify the ownership proof (what requires to hit the Bitcoin full node) and verify the credentials' range proofs before detecting the coin was already used. This is imo a security bug that can facilitate DoS attacks.

This mechanism could have made sense in earlier versions of WabiSabi coordinator implementation that allowed the registration of multiple coins by the same Alice but that is not the case anymore. 