### PR TITLE
Update .editorconfig for *.axaml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,11 @@ end_of_line = lf
 indent_style = space
 indent_size = 2
 
+[*.axaml]
+
+indent_style = space
+indent_size = 4
+
 [*.cs]
 
 # require braces to be on a new line for all

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,15 +18,10 @@ indent_size = 4
 # Formatting - set preferred newline characters
 end_of_line = lf
 
-[*.xaml]
+[*.{xaml,axaml}]
 
 indent_style = space
 indent_size = 2
-
-[*.axaml]
-
-indent_style = space
-indent_size = 4
 
 [*.cs]
 


### PR DESCRIPTION
Currently if you edit .axaml files using Visual Studio and you save your changes the files will be mixed with tabs and spaces.
This PR fixes that (kinda like bitcoin fixes everything).

Maybe the `indent_size` should be `2` instead of `4` like with `.xaml` files.