### PR TITLE
[WabiSabi] Enforce range proof constraints in dependency graph

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CredentialDependencies/DependencyGraph.cs
+++ b/WalletWasabi/WabiSabi/Client/CredentialDependencies/DependencyGraph.cs
@@ -24,8 +24,8 @@ namespace WalletWasabi.WabiSabi.Client.CredentialDependencies
 
 		// Internal properties used to keep track of effective values and edges
 		public ImmutableSortedDictionary<CredentialType, CredentialEdgeSet> EdgeSets { get; init; } = ImmutableSortedDictionary<CredentialType, CredentialEdgeSet>.Empty
-			.Add(CredentialType.Amount, new() { CredentialType = CredentialType.Amount })
-			.Add(CredentialType.Vsize, new() { CredentialType = CredentialType.Vsize });
+			.Add(CredentialType.Amount, new() { CredentialType = CredentialType.Amount, MaxCredentialValue = ProtocolConstants.MaxAmountPerAlice })
+			.Add(CredentialType.Vsize, new() { CredentialType = CredentialType.Vsize, MaxCredentialValue = ProtocolConstants.MaxVsizeCredentialValue });
 
 		public long Balance(RequestNode node, CredentialType credentialType) => EdgeSets[credentialType].Balance(node);
 

--- a/WalletWasabi/WabiSabi/ProtocolContants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolContants.cs
@@ -4,6 +4,7 @@ namespace WalletWasabi.WabiSabi
 	{
 		public const int CredentialNumber = 2;
 		public const long MaxAmountPerAlice = 4_300_000_000_000L;
+		public const long MaxVsizeCredentialValue = 255;
 
 		public const string WabiSabiProtocolIdentifier = "WabiSabi_v1.0";
 		public const string DomainStrobeSeparator = "domain-separator";


### PR DESCRIPTION
This is a proper fix for the issue with the dependency graph that 498de7a0ba615cb432c193e9803b9f491af72e62 is a workaround for.

I gave up trying to clean up the way that `ProtocolConstants.MaxAmountPerAlice`, `MaxRegistrableVsize`, `MaxRegistrableAmount`, and (new for this PR) `ProtocolConstants.MaxVsizeCredentialValue` work, or make the test agnostic of these values and just added another constant, and did not make this configurable in the dependency graph construction. Arguably it should be, but these values are used somewhat inconsistently and I didn't want to compound that, and I don't think it should be made configurable until we clean that up.