### PR TITLE
[Fluent] Tweak infomessage in Settings page

### DIFF
--- a/WalletWasabi.Fluent/Controls/InfoMessage.axaml
+++ b/WalletWasabi.Fluent/Controls/InfoMessage.axaml
@@ -2,13 +2,14 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:c="using:WalletWasabi.Fluent.Controls"
         xmlns:conv="using:WalletWasabi.Fluent.Converters">
-<Design.PreviewWith>
-  <Border Padding="40" >
-    <c:InfoMessage Classes="overlay" Padding="25">This is a test message.</c:InfoMessage>
-  </Border>
-</Design.PreviewWith>
+  <Design.PreviewWith>
+    <Border Padding="40">
+      <c:InfoMessage Classes="overlay" Padding="25">This is a test message.</c:InfoMessage>
+    </Border>
+  </Design.PreviewWith>
   <Style Selector="c|InfoMessage">
-    <Setter Property="IsVisible" x:CompileBindings="False" Value="{Binding $self.Opacity, Converter={x:Static conv:BoolOpacityConverters.OpacityToBool}}" />
+    <Setter Property="IsVisible" x:CompileBindings="False"
+            Value="{Binding $self.Opacity, Converter={x:Static conv:BoolOpacityConverters.OpacityToBool}}" />
     <Setter Property="VerticalAlignment" Value="Top" />
     <Setter Property="Template">
       <ControlTemplate>
@@ -17,7 +18,7 @@
                 Padding="{TemplateBinding Padding}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
-                ClipToBounds="False" >
+                ClipToBounds="False">
           <DockPanel>
 
             <PathIcon Data="{StaticResource info_regular}"
@@ -25,12 +26,12 @@
                       DockPanel.Dock="Left"
                       VerticalAlignment="Center"
                       Width="{TemplateBinding IconSize}"
-                      Height="{TemplateBinding IconSize}"/>
+                      Height="{TemplateBinding IconSize}" />
 
             <ContentPresenter Name="PART_ContentPresenter"
                               ContentTemplate="{TemplateBinding ContentTemplate}"
                               Content="{TemplateBinding Content}"
-                              Margin="10 0 0 0"/>
+                              Margin="10 0 0 0" />
           </DockPanel>
         </Border>
       </ControlTemplate>
@@ -43,11 +44,12 @@
   </Style>
 
   <Style Selector="c|InfoMessage[IsVisible=True]">
-    <Setter Property="Opacity" Value="1"/>
+    <Setter Property="Opacity" Value="1" />
   </Style>
 
   <Style Selector="c|InfoMessage :is(TextBlock)">
     <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="VerticalAlignment" Value="Center" />
   </Style>
 
   <Style Selector="c|InfoMessage.overlay">

--- a/WalletWasabi.Fluent/Views/Settings/SettingsPageView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/SettingsPageView.axaml
@@ -26,6 +26,8 @@
   <DockPanel LastChildFill="True">
     <c:InfoMessage Content="Changes will be applied after restarting the application."
                    Foreground="{StaticResource WarningMessageForeground}"
+                   Margin="0,16"
+                   HorizontalAlignment="Center"
                    Opacity="{Binding IsModified, Converter={x:Static conv:BoolOpacityConverters.BoolToOpacity}}"
                    DockPanel.Dock="Bottom" />
 
@@ -40,7 +42,7 @@
           </TabItem>
 
           <TabItem Header="Privacy">
-             <v:PrivacySettingsTabView DataContext="{Binding PrivacySettingsTab}" />
+            <v:PrivacySettingsTabView DataContext="{Binding PrivacySettingsTab}" />
           </TabItem>
 
           <TabItem Header="Network">


### PR DESCRIPTION
before:
<img width="776" alt="Screen Shot 2021-06-17 at 4 44 32 PM" src="https://user-images.githubusercontent.com/16554748/122363150-4c279b80-cf8b-11eb-9291-f718bbffeecb.png">

after:
<img width="1005" alt="Screen Shot 2021-06-17 at 4 38 55 PM" src="https://user-images.githubusercontent.com/16554748/122362195-82b0e680-cf8a-11eb-8b5c-5383f8171ecc.png">
