### PR TITLE
Tor control: Subscription API for events.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/Control/PipeWriterExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/PipeWriterExtensions.cs
@@ -13,9 +13,12 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			return writer.WriteAsync(new ReadOnlyMemory<byte>(encoding.GetBytes(data)), cancellationToken);
 		}
 
-		public static ValueTask<FlushResult> WriteAsciiAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
+		public static ValueTask WriteAsciiAndFlushAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
 		{
-			return writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken);
+			_ = writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken);
+			_ = writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -38,7 +38,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				for (int i = 0; i < ExpectedEventsNo; i++)
 				{
 					Logger.LogTrace($"Server: Send async Tor event (#{i}): '650 {AsyncEventContent}'.");
-					await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+					await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 				}
 			});
 
@@ -91,20 +91,20 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Task serverTask = Task.Run(async () =>
 			{
 				Logger.LogTrace($"Server: Send msg #1 (async) to client: '650 {AsyncEventContent}'.");
-				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 
 				Logger.LogTrace($"Server: Send msg #2 (async) to client: '650 {AsyncEventContent}'.");
-				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 
 				Logger.LogTrace("Server: Wait for TAKEOWNERSHIP command.");
-				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token).ConfigureAwait(false);
 				Assert.Equal("TAKEOWNERSHIP", command);
 
 				Logger.LogTrace("Server: Send msg #3 (sync) to client in response to TAKEOWNERSHIP command.");
-				await toClient.Writer.WriteAsciiAsync($"250 OK\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAsync($"250 OK\r\n", timeoutCts.Token).ConfigureAwait(false);
 
 				Logger.LogTrace($"Server: Send msg #4 (async) to client: '650 {AsyncEventContent}'.");
-				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 			});
 
 			Logger.LogTrace("Client: Receive msg #1 (async).");

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -16,10 +16,10 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 		[Fact]
 		public async Task ReceiveTorAsyncEventsUsingForeachAsync()
 		{
-			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(3));
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(4));
 
 			// Test parameters.
-			const int ExpectedEventsNo = 5;
+			const int ExpectedEventsNo = 3;
 			const string AsyncEventContent = "CIRC 1000 EXTENDED moria1,moria2";
 
 			Pipe toServer = new();
@@ -38,7 +38,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				for (int i = 0; i < ExpectedEventsNo; i++)
 				{
 					Logger.LogTrace($"Server: Send async Tor event (#{i}): '650 {AsyncEventContent}'.");
-					await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
+					await toClient.Writer.WriteAsciiAndFlushAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 				}
 			});
 
@@ -91,20 +91,20 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Task serverTask = Task.Run(async () =>
 			{
 				Logger.LogTrace($"Server: Send msg #1 (async) to client: '650 {AsyncEventContent}'.");
-				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
+				await toClient.Writer.WriteAsciiAndFlushAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 
 				Logger.LogTrace($"Server: Send msg #2 (async) to client: '650 {AsyncEventContent}'.");
-				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
+				await toClient.Writer.WriteAsciiAndFlushAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 
 				Logger.LogTrace("Server: Wait for TAKEOWNERSHIP command.");
 				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token).ConfigureAwait(false);
 				Assert.Equal("TAKEOWNERSHIP", command);
 
 				Logger.LogTrace("Server: Send msg #3 (sync) to client in response to TAKEOWNERSHIP command.");
-				await toClient.Writer.WriteAsciiAsync($"250 OK\r\n", timeoutCts.Token).ConfigureAwait(false);
+				await toClient.Writer.WriteAsciiAndFlushAsync($"250 OK\r\n", timeoutCts.Token).ConfigureAwait(false);
 
 				Logger.LogTrace($"Server: Send msg #4 (async) to client: '650 {AsyncEventContent}'.");
-				await toClient.Writer.WriteAsciiAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
+				await toClient.Writer.WriteAsciiAndFlushAsync($"650 {AsyncEventContent}\r\n", timeoutCts.Token).ConfigureAwait(false);
 			});
 
 			Logger.LogTrace("Client: Receive msg #1 (async).");
@@ -166,7 +166,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				Assert.Equal("SETEVENTS CIRC", command);
 
 				Logger.LogTrace("Server: Reply with OK code.");
-				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAndFlushAsync("250 OK\r\n", timeoutCts.Token);
 
 				await task;
 			}
@@ -184,7 +184,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				Assert.Equal("SETEVENTS CIRC,STATUS_CLIENT", command);
 
 				Logger.LogTrace("Server: Reply with OK code.");
-				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAndFlushAsync("250 OK\r\n", timeoutCts.Token);
 
 				await task;
 			}
@@ -202,7 +202,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				Assert.Equal("SETEVENTS CIRC", command);
 
 				Logger.LogTrace("Server: Reply with OK code.");
-				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAndFlushAsync("250 OK\r\n", timeoutCts.Token);
 
 				await task;
 			}
@@ -219,7 +219,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				Assert.Equal("SETEVENTS", command);
 
 				Logger.LogTrace("Server: Reply with OK code.");
-				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+				await toClient.Writer.WriteAsciiAndFlushAsync("250 OK\r\n", timeoutCts.Token);
 
 				await task;
 			}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -144,5 +144,85 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			// No more async events.
 			_ = Assert.ThrowsAsync<OperationCanceledException>(async () => await eventsEnumerator.MoveNextAsync());
 		}
+
+		/// <summary>Verifies behavior of the subscription API and its logical subscription model.</summary>
+		[Fact]
+		public async Task SubscribeAndUnsubscribeAsync()
+		{
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(120));
+
+			Pipe toServer = new();
+			Pipe toClient = new();
+
+			// Set up Tor control client.
+			await using TorControlClient client = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
+
+			Logger.LogTrace("Client: Subscribe 'CIRC' events.");
+			{
+				Task task = client.SubscribeEventsAsync(new string[] { "CIRC" }, timeoutCts.Token);
+
+				Logger.LogTrace("Server: Wait for 'SETEVENTS CIRC' command.");
+				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+				Assert.Equal("SETEVENTS CIRC", command);
+
+				Logger.LogTrace("Server: Reply with OK code.");
+				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+
+				await task;
+			}
+
+			Logger.LogTrace("Client: Subscribe 'CIRC' (already subscribed) and 'STATUS_CLIENT' (not subscribed) events.");
+			{
+				Task task = client.SubscribeEventsAsync(new string[] { "CIRC", "STATUS_CLIENT" }, timeoutCts.Token);
+
+				// CIRC is already subscribed.
+				Logger.LogTrace("Server: Wait for 'SETEVENTS CIRC,STATUS_CLIENT' command.");
+				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+
+				// This means that BOTH 'CIRC' and 'STATUS_CLIENT' must be subscribed now.
+				// Note: Given we count logical event subscriptions, 'CIRC' is now (logically) subscribed twice!
+				Assert.Equal("SETEVENTS CIRC,STATUS_CLIENT", command);
+
+				Logger.LogTrace("Server: Reply with OK code.");
+				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+
+				await task;
+			}
+
+			Logger.LogTrace("Client: Unsubscribe 'CIRC' and 'STATUS_CLIENT' events.");
+			{
+				Task task = client.UnsubscribeEventsAsync(new string[] { "CIRC", "STATUS_CLIENT" }, timeoutCts.Token);
+
+				// CIRC is already subscribed.
+				Logger.LogTrace("Server: Wait for 'SETEVENTS CIRC' command.");
+				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+
+				// This means that CIRC is still subscribed (!). The reason for that is that we count logical subscriptions,
+				// so when two distinct components can work the subscription API and they don't affect each other.
+				Assert.Equal("SETEVENTS CIRC", command);
+
+				Logger.LogTrace("Server: Reply with OK code.");
+				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+
+				await task;
+			}
+
+			Logger.LogTrace("Client: Unsubscribe 'CIRC' events.");
+			{
+				Task task = client.UnsubscribeEventsAsync(new string[] { "CIRC" }, timeoutCts.Token);
+
+				// CIRC is already subscribed.
+				Logger.LogTrace("Server: Wait for 'SETEVENTS' command.");
+				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
+
+				// This means that no events are subscribed.
+				Assert.Equal("SETEVENTS", command);
+
+				Logger.LogTrace("Server: Reply with OK code.");
+				await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+
+				await task;
+			}
+		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlFactoryTests.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 
 			Logger.LogTrace("Server: Respond to client's AUTHCHALLENGE request.");
 			string challengeResponse = $"250 AUTHCHALLENGE SERVERHASH={serverHash} SERVERNONCE={serverNonce}\r\n";
-			await toClient.Writer.WriteAsciiAsync(challengeResponse, timeoutCts.Token);
+			await toClient.Writer.WriteAsciiAndFlushAsync(challengeResponse, timeoutCts.Token);
 
 			Logger.LogTrace("Server: Read 'AUTHENTICATE' command from the client.");
 			string authCommand = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
@@ -59,7 +59,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			Assert.Equal("AUTHENTICATE 6013EA09D4E36B6CF01C18A707D350C1B5AFF8C1A21527266B9FC40C89BDCB4A", authCommand);
 
 			Logger.LogTrace("Server: Respond to the client's AUTHENTICATION request.");
-			await toClient.Writer.WriteAsciiAsync("250 OK\r\n", timeoutCts.Token);
+			await toClient.Writer.WriteAsciiAndFlushAsync("250 OK\r\n", timeoutCts.Token);
 
 			Logger.LogTrace("Client: Verify the authentication task finishes correctly.");
 			TorControlClient authenticatedClient = await authenticationTask;

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlReplyReaderTests.cs
@@ -69,8 +69,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(1));
 
 			Pipe pipe = new();
-			await pipe.Writer.WriteAsciiAsync(data, timeoutCts.Token);
-			await pipe.Writer.FlushAsync(timeoutCts.Token);
+			await pipe.Writer.WriteAsciiAndFlushAsync(data, timeoutCts.Token);
 			await pipe.Writer.CompleteAsync();
 			return await TorControlReplyReader.ReadReplyAsync(pipe.Reader, timeoutCts.Token);
 		}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/Utils/AsyncEventParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/Utils/AsyncEventParserTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+using WalletWasabi.Tor.Control.Messages;
+using WalletWasabi.Tor.Control.Messages.Events;
+using WalletWasabi.Tor.Control.Messages.Events.StatusEvents;
+using WalletWasabi.Tor.Control.Utils;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control.Utils
+{
+	/// <summary>
+	/// Tests for <see cref="AsyncEventParser"/> class.
+	/// </summary>
+	public class AsyncEventParserTests
+	{
+		[Fact]
+		public async Task ParseUnknownEventAsync()
+		{
+			/// "XXX" is not a valid event name.
+			string data = "650 XXX NOTICE\r\n";
+
+			TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+			_ = Assert.Throws<NotSupportedException>(() => AsyncEventParser.Parse(rawReply));
+		}
+
+		[Fact]
+		public async Task ParseSystemClientEventAsync()
+		{
+			string data = "650 STATUS_CLIENT NOTICE BOOTSTRAP PROGRESS=14 TAG=handshake SUMMARY=\"Handshaking with a relay\"\r\n";
+
+			TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+			IAsyncEvent asyncEvent = AsyncEventParser.Parse(rawReply);
+
+			BootstrapStatusEvent @event = Assert.IsType<BootstrapStatusEvent>(asyncEvent);
+			Assert.NotNull(@event);
+		}
+
+		[Fact]
+		public async Task ParseCircEventAsync()
+		{
+			string data = "650 CIRC 16 LAUNCHED BUILD_FLAGS=NEED_CAPACITY PURPOSE=GENERAL TIME_CREATED=2021-06-10T05:42:43.808915\r\n";
+
+			TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+			IAsyncEvent asyncEvent = AsyncEventParser.Parse(rawReply);
+
+			CircEvent @event = Assert.IsType<CircEvent>(asyncEvent);
+			Assert.NotNull(@event);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/Utils/AsyncEventParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/Utils/AsyncEventParserTests.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control.Utils
 		[Fact]
 		public async Task ParseUnknownEventAsync()
 		{
-			/// "XXX" is not a valid event name.
+			// "XXX" is not a valid event name.
 			string data = "650 XXX NOTICE\r\n";
 
 			TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);

--- a/WalletWasabi/Tor/Control/Messages/Events/IAsyncEvent.cs
+++ b/WalletWasabi/Tor/Control/Messages/Events/IAsyncEvent.cs
@@ -2,6 +2,6 @@ namespace WalletWasabi.Tor.Control.Messages.Events
 {
 	/// <summary>Represents any asynchronous event that Tor control can send us.</summary>
 	public interface IAsyncEvent
-	{		
+	{
 	}
 }

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -2,6 +2,7 @@ using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -9,6 +10,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Exceptions;
 using WalletWasabi.Tor.Control.Messages;
 
 namespace WalletWasabi.Tor.Control
@@ -22,6 +24,9 @@ namespace WalletWasabi.Tor.Control
 		{
 			SingleWriter = true
 		};
+
+		/// <remarks>This helps with graceful stopping of the reader loop.</remarks>
+		private volatile bool _readLastSyncReply;
 
 		public TorControlClient(TcpClient tcpClient) :
 			this(PipeReader.Create(tcpClient.GetStream()), PipeWriter.Create(tcpClient.GetStream()))
@@ -66,6 +71,13 @@ namespace WalletWasabi.Tor.Control
 		/// <summary>Lock to when sending a request to Tor control and waiting for a reply.</summary>
 		/// <remarks>Tor control protocol does not provide a foolproof way to recognize that a response belongs to a request.</remarks>
 		private AsyncLock MessageLock { get; }
+
+		/// <summary>Key represents an event name and value represents a subscription counter.</summary>
+		private SortedDictionary<string, int> SubscribedEvents { get; } = new();
+
+		/// <summary>Lock to guard all access to <see cref="SubscribedEvents"/>.</summary>
+		/// <remarks><see cref="MessageLock"/> must be locked first if it is needed too.</remarks>
+		private object SubscriptionEventsLock { get; } = new();
 
 		/// <summary>Number of subscribers that currently listen to Tor's async events using <see cref="ReadEventsAsync"/>.</summary>
 		/// <remarks>Mainly for tests.</remarks>
@@ -116,8 +128,22 @@ namespace WalletWasabi.Tor.Control
 		/// </summary>
 		/// <remarks>If server is a client (OP), exit immediately. If it's a relay (OR), close listeners and exit after <c>ShutdownWaitLength</c> seconds.</remarks>
 		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See 3.7. SIGNAL.</seealso>
-		public Task<TorControlReply> SignalShutdownAsync(CancellationToken cancellationToken = default)
-			=> SendCommandAsync("SIGNAL SHUTDOWN\r\n", cancellationToken);
+		public async Task<TorControlReply> SignalShutdownAsync(CancellationToken cancellationToken = default)
+		{
+			using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
+
+			// This assignment must be done after MessageLock is acquired to prevent the race in calling SendCommand method by someone else.
+			_readLastSyncReply = true;
+
+			TorControlReply reply = await SendCommandNoLockAsync("SIGNAL SHUTDOWN\r\n", cancellationToken).ConfigureAwait(false);
+
+			if (reply.Success)
+			{
+				ReaderCts.Cancel();
+			}
+
+			return reply;
+		}
 
 		/// <summary>
 		/// Causes Tor to stop polling for the existence of a process with its owning controller's PID.
@@ -127,20 +153,27 @@ namespace WalletWasabi.Tor.Control
 		public Task<TorControlReply> ResetOwningControllerProcessConfAsync(CancellationToken cancellationToken = default)
 			=> SendCommandAsync("RESETCONF __OwningControllerProcess\r\n", cancellationToken);
 
-		/// <summary>
-		/// Sends a command to Tor.
-		/// </summary>
+		/// <summary>Sends a command to Tor.</summary>
 		/// <remarks>This is meant as a low-level API method, if needed for some reason.</remarks>
 		/// <param name="command">A Tor control command which must end with <c>\r\n</c>.</param>
 		public async Task<TorControlReply> SendCommandAsync(string command, CancellationToken cancellationToken = default)
 		{
-			using var _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
+			using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
+			return await SendCommandNoLockAsync(command, cancellationToken).ConfigureAwait(false);
+		}
+
+		/// <remarks>Lock <see cref="MessageLock"/> must be acquired by the caller.</remarks>
+		private async Task<TorControlReply> SendCommandNoLockAsync(string command, CancellationToken cancellationToken = default)
+		{
+			using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ReaderCts.Token, cancellationToken);
 
 			Logger.LogTrace($"Client: About to send command: '{command.TrimEnd()}'");
-			await PipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(command)), cancellationToken).ConfigureAwait(false);
-			await PipeWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+			_ = await PipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(command)), linkedCts.Token).ConfigureAwait(false);
+			_ = await PipeWriter.FlushAsync(linkedCts.Token).ConfigureAwait(false);
 
-			TorControlReply reply = await SyncChannel.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+			TorControlReply reply = await SyncChannel.Reader.ReadAsync(linkedCts.Token).ConfigureAwait(false);
+			Logger.LogTrace($"Client: Reply: '{reply}'");
+
 			return reply;
 		}
 
@@ -182,11 +215,142 @@ namespace WalletWasabi.Tor.Control
 				lock (AsyncChannelsLock)
 				{
 					newList = new(AsyncChannels);
-					newList.Remove(channel);
+					_ = newList.Remove(channel);
 
 					AsyncChannels = newList;
 				}
 			}
+		}
+
+		/// <returns>List of event names like <c>CIRC</c>, <c>STATUS_CLIENT</c>, etc.</returns>
+		public List<string> GetSubscribedEvents()
+		{
+			lock (SubscriptionEventsLock)
+			{
+				// Return a copy to avoid multi-threading issues.
+				return SubscribedEvents.Keys.ToList();
+			}
+		}
+
+		/// <summary>Subscribes Tor control events by their names.</summary>
+		/// <remarks>If an event stream is already subscribed, no command is sent to Tor control.</remarks>
+		/// <param name="cancellationToken">
+		/// Useful when the whole application stops. Otherwise, the internal state of this object may get corrupted.
+		/// </param>
+		public async Task SubscribeEventsAsync(string[] names, CancellationToken cancellationToken = default)
+		{
+			using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
+
+			bool sendCommand = false;
+			string subscribedEventNames;
+
+			lock (SubscriptionEventsLock)
+			{
+				foreach (string eventName in names)
+				{
+					if (SubscribedEvents.TryGetValue(eventName, out int counter))
+					{
+						SubscribedEvents[eventName] = counter + 1;
+					}
+					else
+					{
+						sendCommand = true;
+						SubscribedEvents.Add(eventName, 1);
+					}
+				}
+
+				// Get all event names that must be subscribed.
+				subscribedEventNames = string.Join(',', SubscribedEvents.Keys);
+			}
+
+			if (sendCommand)
+			{
+				TorControlReply reply = await SendCommandNoLockAsync($"SETEVENTS {subscribedEventNames}\r\n", cancellationToken).ConfigureAwait(false);
+
+				if (!reply.Success)
+				{
+					// This should never happen.
+					throw new TorControlException("Failed to subscribe events.");
+				}
+			}
+		}
+
+		/// <summary>Unsubscribes Tor control events by their names.</summary>
+		/// <remarks>If the event listener counter gets to zero, the event stream is actually truly unsubscribed.</remarks>
+		/// <param name="cancellationToken">
+		/// Useful when the whole application stops. Otherwise, the internal state of this object may get corrupted.
+		/// </param>
+		public async Task UnsubscribeEventsAsync(string[] names, CancellationToken cancellationToken = default)
+		{
+			using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
+
+			bool sendCommand = false;
+			string subscribedEventNames;
+
+			lock (SubscriptionEventsLock)
+			{
+				foreach (string eventName in names)
+				{
+					if (SubscribedEvents.TryGetValue(eventName, out int counter))
+					{
+						counter--;
+
+						if (counter > 0)
+						{
+							SubscribedEvents[eventName] = counter;
+						}
+						else
+						{
+							SubscribedEvents.Remove(eventName);
+							sendCommand = true;
+						}
+					}
+				}
+
+				// Get all event names that remained.
+				subscribedEventNames = string.Join(',', SubscribedEvents.Keys);
+			}
+
+			if (sendCommand)
+			{
+				string command = subscribedEventNames == "" ? "SETEVENTS\r\n" : $"SETEVENTS {subscribedEventNames}\r\n";
+				TorControlReply reply = await SendCommandNoLockAsync(command, cancellationToken).ConfigureAwait(false);
+
+				if (!reply.Success)
+				{
+					// This should never happen.
+					throw new TorControlException("Failed to unsubscribe events.");
+				}
+			}
+		}
+
+		/// <summary>Unsubscribes all Tor control events.</summary>
+		public async Task<bool> UnsubscribeAllEventsAsync()
+		{
+			// Sanity timeout.
+			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(10));
+			using IDisposable _ = await MessageLock.LockAsync(cts.Token).ConfigureAwait(false);
+
+			int count;
+
+			lock (SubscriptionEventsLock)
+			{
+				count = SubscribedEvents.Keys.Count;
+				SubscribedEvents.Clear();
+			}
+
+			if (count > 0)
+			{
+				TorControlReply reply = await SendCommandNoLockAsync($"SETEVENTS\r\n", cts.Token).ConfigureAwait(false);
+
+				if (!reply.Success)
+				{
+					// This should never happen.
+					return false;
+				}
+			}
+
+			return true;
 		}
 
 		/// <summary>
@@ -219,6 +383,12 @@ namespace WalletWasabi.Tor.Control
 					{
 						// Propagate a response back to the requester.
 						await SyncChannel.Writer.WriteAsync(reply, ReaderCts.Token).ConfigureAwait(false);
+
+						if (_readLastSyncReply)
+						{
+							Logger.LogTrace("Request to read last message was issued. No more message reading.");
+							break;
+						}
 					}
 				}
 			}
@@ -236,6 +406,13 @@ namespace WalletWasabi.Tor.Control
 
 		public async ValueTask DisposeAsync()
 		{
+			bool isOk = await UnsubscribeAllEventsAsync().ConfigureAwait(false);
+
+			if (!isOk)
+			{
+				Logger.LogWarning("Failed to unsubscribe all Tor control events.");
+			}
+
 			// Stop reader loop.
 			ReaderCts.Cancel();
 

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -204,7 +204,7 @@ namespace WalletWasabi.Tor.Control
 
 				Logger.LogTrace($"ReadEventsAsync: subscribers: {newList.Count}.");
 
-				await foreach (TorControlReply item in channel.Reader.ReadAllAsync(cancellationToken))
+				await foreach (TorControlReply item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
 				{
 					yield return item;
 				}

--- a/WalletWasabi/Tor/Control/Utils/AsyncEventParser.cs
+++ b/WalletWasabi/Tor/Control/Utils/AsyncEventParser.cs
@@ -6,6 +6,9 @@ using WalletWasabi.Tor.Control.Messages.Events.StatusEvents;
 
 namespace WalletWasabi.Tor.Control.Utils
 {
+	/// <summary>
+	/// Parses an incoming Tor control event based on its name.
+	/// </summary>
 	public static class AsyncEventParser
 	{
 		/// <exception cref="TorControlReplyParseException"/>

--- a/WalletWasabi/Tor/Control/Utils/AsyncEventParser.cs
+++ b/WalletWasabi/Tor/Control/Utils/AsyncEventParser.cs
@@ -1,0 +1,29 @@
+using System;
+using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Messages;
+using WalletWasabi.Tor.Control.Messages.Events;
+using WalletWasabi.Tor.Control.Messages.Events.StatusEvents;
+
+namespace WalletWasabi.Tor.Control.Utils
+{
+	public static class AsyncEventParser
+	{
+		/// <exception cref="TorControlReplyParseException"/>
+		public static IAsyncEvent Parse(TorControlReply reply)
+		{
+			if (reply.StatusCode != StatusCode.AsynchronousEventNotify)
+			{
+				throw new TorControlReplyParseException($"Event: Expected {StatusCode.AsynchronousEventNotify} status code.");
+			}
+
+			(string value, _) = Tokenizer.ReadUntilSeparator(reply.ResponseLines[0]);
+
+			return value switch
+			{
+				"STATUS_CLIENT" or "STATUS_SERVER" or "STATUS_GENERAL" => StatusEvent.FromReply(reply),
+				"CIRC" => CircEvent.FromReply(reply),
+				_ => throw new NotSupportedException("This should never happen."),
+			};
+		}
+	}
+}


### PR DESCRIPTION
This PR adds several improvements

* Adds several missing `.ConfigureAwait(false)` in `TorControlClientTests.cs` which should help with the test flakiness + added missing flush operations.
* It adds `AsyncEventParser` which takes an event an dispatches it to a proper parser.
* Adds `TorControlClient.{SubscribeEventsAsync|UnsubscribeEventsAsync}` methods to correctly subscribe events.
  *  One can think that you can just call `SETEVENTS some-streams-here` but that might affect other subscribers, so I added a mechanism that counts subscriptions for each particular event name and basically the (un)subscription operation is now a logical one so if you subscribe to an event, no one else will affect you.
* All Tor control streams are unsubscribed when `TorControlClient` is disposed. This is not strictly necessary but it's probably better to do it anyway.