### PR TITLE
StatusBarViewModel: Remove Ubuntu 16.04 specific code.

### DIFF
--- a/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
+++ b/WalletWasabi.Gui/ViewModels/StatusBarViewModel.cs
@@ -10,22 +10,15 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
 using WalletWasabi.BitcoinCore.Monitoring;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Gui.Dialogs;
-using WalletWasabi.Gui.Helpers;
 using WalletWasabi.Gui.Models.StatusBarStatuses;
 using WalletWasabi.Gui.Tabs;
-using WalletWasabi.Helpers;
-using WalletWasabi.Legal;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
-using WalletWasabi.Tor.Socks5.Exceptions;
 using WalletWasabi.Wallets;
-using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Gui.ViewModels
 {
@@ -382,16 +375,6 @@ namespace WalletWasabi.Gui.ViewModels
 				if (MainWindowViewModel.Instance.ModalDialog is { })
 				{
 					// Do nothing.
-				}
-				else
-				{
-					// Show GenSocksServFail dialog on OS-es we suspect Tor is outdated.
-					var osDesc = RuntimeInformation.OSDescription;
-					if (osDesc.Contains("16.04.1-Ubuntu", StringComparison.InvariantCultureIgnoreCase)
-						|| osDesc.Contains("16.04.0-Ubuntu", StringComparison.InvariantCultureIgnoreCase))
-					{
-						MainWindowViewModel.Instance.ShowDialogAsync(new GenSocksServFailDialogViewModel()).GetAwaiter().GetResult();
-					}
 				}
 			}
 			else


### PR DESCRIPTION
Ubuntu 16.04 is no longer supported and as such the removed code should be no longer needed.

A follow-up question: I have noticed that there is `GenSocksServFailDialogViewModel` and this https://github.com/zkSNACKs/WalletWasabi/issues/640  and the commit that added the change https://github.com/zkSNACKs/WalletWasabi/commit/3338a7c762d8c13c2802abaf435be91d6a0623fe. Is that still relevant given that we use a bundled Tor now?