### PR TITLE
TorSettings: Compute Tor logs file path from data dir.

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -154,10 +154,9 @@ namespace WalletWasabi.Fluent.Desktop
 
 		private static Global CreateGlobal(string dataDir, UiConfig uiConfig, Config config)
 		{
-			string torLogsFile = Path.Combine(dataDir, "TorLogs.txt");
 			var walletManager = new WalletManager(config.Network, dataDir, new WalletDirectories(config.Network, dataDir));
 
-			return new Global(dataDir, torLogsFile, config, uiConfig, walletManager);
+			return new Global(dataDir, config, uiConfig, walletManager);
 		}
 
 		/// <summary>

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -78,7 +78,7 @@ namespace WalletWasabi.Gui
 
 		public JsonRpcServer? RpcServer { get; private set; }
 
-		public Global(string dataDir, string torLogsFile, Config config, UiConfig uiConfig, WalletManager walletManager)
+		public Global(string dataDir, Config config, UiConfig uiConfig, WalletManager walletManager)
 		{
 			using (BenchmarkLogger.Measure())
 			{
@@ -86,7 +86,7 @@ namespace WalletWasabi.Gui
 				DataDir = dataDir;
 				Config = config;
 				UiConfig = uiConfig;
-				TorSettings = new TorSettings(DataDir, torLogsFile, distributionFolderPath: EnvironmentHelpers.GetFullBaseDirectory(), Config.TerminateTorOnExit, Environment.ProcessId);
+				TorSettings = new TorSettings(DataDir, distributionFolderPath: EnvironmentHelpers.GetFullBaseDirectory(), Config.TerminateTorOnExit, Environment.ProcessId);
 
 				HostedServices = new HostedServices();
 				WalletManager = walletManager;

--- a/WalletWasabi.Gui/Program.cs
+++ b/WalletWasabi.Gui/Program.cs
@@ -60,7 +60,6 @@ namespace WalletWasabi.Gui
 		{
 			string dataDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client"));
 			Directory.CreateDirectory(dataDir);
-			string torLogsFile = Path.Combine(dataDir, "TorLogs.txt");
 
 			var uiConfig = new UiConfig(Path.Combine(dataDir, "UiConfig.json"));
 			uiConfig.LoadOrCreateDefaultFile();
@@ -71,7 +70,7 @@ namespace WalletWasabi.Gui
 
 			Logger.InitializeDefaults(Path.Combine(dataDir, "Logs.txt"));
 
-			return new Global(dataDir, torLogsFile, config, uiConfig, walletManager);
+			return new Global(dataDir, config, uiConfig, walletManager);
 		}
 
 		private static void SetTheme() => AvalonStudio.Extensibility.Theme.ColorTheme.LoadTheme(AvalonStudio.Extensibility.Theme.ColorTheme.VisualStudioDark);

--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -27,9 +27,8 @@ namespace WalletWasabi.Tests.Helpers
 		}
 
 		public static EndPoint TorSocks5Endpoint => new IPEndPoint(IPAddress.Loopback, 37150);
-		public static string TorLogsFile => Path.Combine(DataDir, "TorLogs.txt");
 		public static string TorDistributionFolder => Path.Combine(EnvironmentHelpers.GetFullBaseDirectory(), "TorDaemons");
-		public static TorSettings TorSettings => new(DataDir, TorLogsFile, TorDistributionFolder, terminateOnExit: false);
+		public static TorSettings TorSettings => new(DataDir, TorDistributionFolder, terminateOnExit: false);
 
 		public static string DataDir => EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Tests"));
 

--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -14,10 +14,9 @@ namespace WalletWasabi.Tests.UnitTests.Tor
 		public void GetCmdArgumentsTest()
 		{
 			string dataDir = Path.Combine("temp", "tempDataDir");
-			string logFilePath = Path.Combine("temp", "Tor.log");
 			string distributionFolder = "tempDistributionDir";
 
-			TorSettings settings = new(dataDir, logFilePath, distributionFolder, terminateOnExit: true, owningProcessId: 7);
+			TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
 			string arguments = settings.GetCmdArguments();
 
@@ -30,7 +29,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor
 				$"--DataDirectory \"{Path.Combine("temp", "tempDataDir", "tordata2")}\"",
 				$"--GeoIPFile \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip")}\"",
 				$"--GeoIPv6File \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip6")}\"",
-				$"--Log \"notice file {Path.Combine("temp", "Tor.log")}\"",
+				$"--Log \"notice file {Path.Combine("temp", "tempDataDir", "TorLogs.txt")}\"",
 				$"__OwningControllerProcess 7");
 
 			Assert.Equal(expected, arguments);

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -11,20 +11,16 @@ namespace WalletWasabi.Tor
 	/// </summary>
 	public class TorSettings
 	{
-		/// <summary>
-		/// Creates a new instance.
-		/// </summary>
 		/// <param name="dataDir">Application data directory.</param>
-		/// <param name="logFilePath">Full Tor log file path.</param>
 		/// <param name="distributionFolderPath">Full path to folder containing Tor installation files.</param>
-		public TorSettings(string dataDir, string logFilePath, string distributionFolderPath, bool terminateOnExit, int? owningProcessId = null)
+		public TorSettings(string dataDir, string distributionFolderPath, bool terminateOnExit, int? owningProcessId = null)
 		{
 			TorBinaryFilePath = GetTorBinaryFilePath();
 			TorBinaryDir = Path.Combine(MicroserviceHelpers.GetBinaryFolder(), "Tor");
 
 			TorDataDir = Path.Combine(dataDir, "tordata2");
 			CookieAuthFilePath = Path.Combine(dataDir, "control_auth_cookie");
-			LogFilePath = logFilePath;
+			LogFilePath = Path.Combine(dataDir, "TorLogs.txt");
 			IoHelpers.EnsureContainingDirectoryExists(LogFilePath);
 			DistributionFolder = distributionFolderPath;
 			TerminateOnExit = terminateOnExit;


### PR DESCRIPTION
This PR simplifies instantiating of `TorSettings` class by not setting Tor log file path directly but by letting it to be computed from already provided data directory.