### PR TITLE
PipeWriterExtensions: Add missing `.ConfigureAwait(false)`.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/Control/PipeWriterExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/PipeWriterExtensions.cs
@@ -13,12 +13,10 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			return writer.WriteAsync(new ReadOnlyMemory<byte>(encoding.GetBytes(data)), cancellationToken);
 		}
 
-		public static ValueTask WriteAsciiAndFlushAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
+		public static async ValueTask WriteAsciiAndFlushAsync(this PipeWriter writer, string data, CancellationToken cancellationToken = default)
 		{
-			_ = writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken);
-			_ = writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-
-			return ValueTask.CompletedTask;
+			await writer.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(data)), cancellationToken).ConfigureAwait(false);
+			await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 		[Fact]
 		public async Task ReceiveTorAsyncEventsUsingForeachAsync()
 		{
-			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(4));
+			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(3));
 
 			// Test parameters.
 			const int ExpectedEventsNo = 3;
@@ -35,6 +35,17 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 			// This must happen after a client is subscribed.
 			Task serverTask = Task.Run(async () =>
 			{
+				// We do not want to send the data until the client is really subscribed.
+				while (!timeoutCts.IsCancellationRequested)
+				{
+					if (client.SubscriberCount == 1)
+					{
+						break;
+					}
+
+					await Task.Delay(200).ConfigureAwait(false);
+				}
+
 				for (int i = 0; i < ExpectedEventsNo; i++)
 				{
 					Logger.LogTrace($"Server: Send async Tor event (#{i}): '650 {AsyncEventContent}'.");

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -168,8 +168,8 @@ namespace WalletWasabi.Tor.Control
 			using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ReaderCts.Token, cancellationToken);
 
 			Logger.LogTrace($"Client: About to send command: '{command.TrimEnd()}'");
-			_ = await PipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(command)), linkedCts.Token).ConfigureAwait(false);
-			_ = await PipeWriter.FlushAsync(linkedCts.Token).ConfigureAwait(false);
+			await PipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(command)), linkedCts.Token).ConfigureAwait(false);
+			await PipeWriter.FlushAsync(linkedCts.Token).ConfigureAwait(false);
 
 			TorControlReply reply = await SyncChannel.Reader.ReadAsync(linkedCts.Token).ConfigureAwait(false);
 			Logger.LogTrace($"Client: Reply: '{reply}'");
@@ -203,7 +203,6 @@ namespace WalletWasabi.Tor.Control
 				}
 
 				Logger.LogTrace($"ReadEventsAsync: subscribers: {newList.Count}.");
-
 				await foreach (TorControlReply item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
 				{
 					yield return item;


### PR DESCRIPTION
🤦‍♂️ 

This PR should, finally, make `ReceiveTorAsyncEventsUsingForeachAsync` non-flaky.