### PR TITLE
Fix label and FirstSeen show in history for >1 & <100 confirmations

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -484,7 +484,14 @@ namespace WalletWasabi.Wallets
 				for (int i = 0; i < currentBlock.Transactions.Count; i++)
 				{
 					Transaction tx = currentBlock.Transactions[i];
-					txsToProcess.Add(new SmartTransaction(tx, height, currentBlock.GetHash(), i, firstSeen: currentBlock.Header.BlockTime));
+					SmartTransaction stx = new(tx, height, currentBlock.GetHash(), i, firstSeen: currentBlock.Header.BlockTime);
+					if (BitcoinStore.TransactionStore.TryGetTransaction(stx.GetHash(), out var foundTx))
+					{
+						foundTx.TryUpdate(stx);
+						stx = foundTx;
+					}
+
+					txsToProcess.Add(stx);
 				}
 				TransactionProcessor.Process(txsToProcess);
 				KeyManager.SetBestHeight(height);


### PR DESCRIPTION
I noticed labels only show up properly in the history tab if the txs are unconfirmed or over 100 confirmation. The same is true for the Date Time entry (FirstSeen). The reason is because we load txs from transaction store only for current height - 100 blocks and mempool transactions. Here I ensure that if we have the transactions already, then we use that instead of creating a new one.

This isn't the cleanest fix. I think it'd be cleaner to make sure in the transaction processor itself that smartcoins aren't pointing to different smarttransactions, so the inconsistencies should be sorted out there.