### PR TITLE
Fix label show in history for >1 & <100 confirmations

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -806,6 +806,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			// Spend the received coin
 			var tx1 = CreateSpendingTransaction(createdCoin, BitcoinFactory.CreateScript());
 			tx1.Label = "foo";
+
 			// Add the transaction to the tx store manually and don't process it.
 			transactionProcessor.TransactionStore.AddOrUpdate(tx1);
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -792,7 +792,6 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			Assert.Empty(matureTxs);
 
 			Assert.Contains(spentCoin, tx1.WalletInputs);
-			Assert.Contains(spentCoin, tx2.WalletInputs);
 		}
 
 		[Fact]

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -126,6 +126,14 @@ namespace WalletWasabi.Blockchain.TransactionProcessing
 
 			uint256 txId = tx.GetHash();
 
+			// If we already have the transaction, then let's work on that.
+			if (TransactionStore.TryGetTransaction(txId, out var foundTx))
+			{
+				foundTx.TryUpdate(tx);
+				tx = foundTx;
+				result = new ProcessedResult(tx);
+			}
+
 			// Performance ToDo: txids could be cached in a hashset here by the AllCoinsView and then the contains would be fast.
 			if (!tx.Transaction.IsCoinBase && !Coins.AsAllCoinsView().CreatedBy(txId).Any()) // Transactions we already have and processed would be "double spends" but they shouldn't.
 			{


### PR DESCRIPTION
Cleaner solution to closes https://github.com/zkSNACKs/WalletWasabi/pull/5981

I noticed labels only show up properly in the history tab if the txs are unconfirmed or over 100 confirmation. The same is true for the Date Time entry (FirstSeen). The reason is because we load txs from transaction store only for current height - 100 blocks and mempool transactions. Here I ensure that if we have the transaction already, then we use that instead of working with a new one.