### PR TITLE
[Fluent] Fix action center box shadow clipping for items

### DIFF
--- a/WalletWasabi.Fluent/Views/Search/SearchPageView.axaml
+++ b/WalletWasabi.Fluent/Views/Search/SearchPageView.axaml
@@ -39,7 +39,10 @@
           <DataTemplate x:DataType="search:SearchResult">
             <DockPanel Margin="0,0,0,30">
               <Panel Margin="8 0"  DockPanel.Dock="Top">
-                <Label Classes="h6 bold" DataContext="{Binding Category}" Content="{Binding Title}" />
+                <Label Classes="h6 bold"
+                       Margin="-6,0,0,0"
+                       DataContext="{Binding Category}"
+                       Content="{Binding Title}" />
               </Panel>
               <ItemsControl HorizontalAlignment="Left"
                             Items="{Binding Items}"

--- a/WalletWasabi.Fluent/Views/Search/SearchPageView.axaml
+++ b/WalletWasabi.Fluent/Views/Search/SearchPageView.axaml
@@ -26,7 +26,10 @@
       </c:ConcatenatingWrapPanel>
     </c:ContentArea.Caption>
     <Panel>
-      <ItemsControl HorizontalAlignment="Left" Items="{Binding SearchResults}">
+      <ItemsControl HorizontalAlignment="Left"
+                    Items="{Binding SearchResults}"
+                    Margin="6,0,20,0"
+                    ClipToBounds="False">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>
             <WrapPanel Orientation="Vertical" Margin="-8 0" />
@@ -38,7 +41,9 @@
               <Panel Margin="8 0"  DockPanel.Dock="Top">
                 <Label Classes="h6 bold" DataContext="{Binding Category}" Content="{Binding Title}" />
               </Panel>
-              <ItemsControl HorizontalAlignment="Left" Items="{Binding Items}">
+              <ItemsControl HorizontalAlignment="Left"
+                            Items="{Binding Items}"
+                            ClipToBounds="False">
                 <ItemsControl.ItemsPanel>
                   <ItemsPanelTemplate>
                     <WrapPanel Orientation="Horizontal" />


### PR DESCRIPTION
The box shadow for items of left side has been clipped.

![WalletWasabi Fluent Desktop_8IYMoCFViG](https://user-images.githubusercontent.com/2297442/124303349-a1a2a180-db62-11eb-9ca9-24839d45164b.png)
