### PR TITLE
Move a part of `TorMonitor` functionality to `TorProcessManager`.

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -487,7 +487,7 @@ namespace WalletWasabi.Gui
 
 				if (TorManager is { } torManager)
 				{
-					await torManager.StopAsync().ConfigureAwait(false);
+					await torManager.DisposeAsync().ConfigureAwait(false);
 					Logger.LogInfo($"{nameof(TorManager)} is stopped.");
 				}
 

--- a/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoTests.cs
@@ -27,8 +27,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 		public async Task InitializeAsync()
 		{
-			bool started = await TorManager.StartAsync();
-			Assert.True(started, "Tor failed to start.");
+			await TorManager.StartAsync();
 		}
 
 		public async Task DisposeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoTests.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		{
 			ClearnetHttpClientFactory.Dispose();
 			TorHttpClientFactory.Dispose();
-			await TorManager.StopAsync();
+			await TorManager.DisposeAsync();
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -37,8 +37,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 		public async Task InitializeAsync()
 		{
-			bool started = await TorManager.StartAsync();
-			Assert.True(started, "Tor failed to start.");
+			await TorManager.StartAsync();
 		}
 
 		public async Task DisposeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task DisposeAsync()
 		{
 			TorHttpPool.Dispose();
-			await TorManager.StopAsync();
+			await TorManager.DisposeAsync();
 		}
 
 		#region Blockchain

--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -27,8 +27,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 		public async Task InitializeAsync()
 		{
-			bool started = await TorManager.StartAsync();
-			Assert.True(started, "Tor failed to start.");
+			await TorManager.StartAsync();
 		}
 
 		public async Task DisposeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/TorTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/TorTests.cs
@@ -34,7 +34,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 		public async Task DisposeAsync()
 		{
 			TorHttpPool.Dispose();
-			await TorManager.StopAsync();
+			await TorManager.DisposeAsync();
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/Tor/CancellationTokenExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/CancellationTokenExtensions.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Tests.UnitTests.Tor
+{
+	public static class CancellationTokenExtensions
+	{
+		/// <seealso href="https://github.com/dotnet/runtime/issues/14991#issuecomment-131221355"/>
+		public static Task WhenCanceled(this CancellationToken cancellationToken)
+		{
+			TaskCompletionSource<bool> tcs = new();
+			cancellationToken.Register(s => ((TaskCompletionSource<bool>)s!).SetResult(true), tcs);
+			return tcs.Task;
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -187,12 +187,12 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Control
 				Task task = client.SubscribeEventsAsync(new string[] { "CIRC", "STATUS_CLIENT" }, timeoutCts.Token);
 
 				// CIRC is already subscribed.
-				Logger.LogTrace("Server: Wait for 'SETEVENTS CIRC,STATUS_CLIENT' command.");
+				Logger.LogTrace("Server: Wait for 'SETEVENTS CIRC STATUS_CLIENT' command.");
 				string command = await toServer.Reader.ReadLineAsync(timeoutCts.Token);
 
 				// This means that BOTH 'CIRC' and 'STATUS_CLIENT' must be subscribed now.
 				// Note: Given we count logical event subscriptions, 'CIRC' is now (logically) subscribed twice!
-				Assert.Equal("SETEVENTS CIRC,STATUS_CLIENT", command);
+				Assert.Equal("SETEVENTS CIRC STATUS_CLIENT", command);
 
 				Logger.LogTrace("Server: Reply with OK code.");
 				await toClient.Writer.WriteAsciiAndFlushAsync("250 OK\r\n", timeoutCts.Token);

--- a/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
@@ -20,45 +20,58 @@ namespace WalletWasabi.Tests.UnitTests.Tor
 		private static readonly IPEndPoint DummyTorControlEndpoint = new(IPAddress.Loopback, 7777);
 
 		/// <summary>
-		/// Verifies that in case Tor process is successfully started and Tor Control is set up,
-		/// <see cref="TorProcessManager.StartAsync(CancellationToken)"/> returns <c>true</c>.
+		/// Simulates: Tor OS process is fully started. The process crashes after 2 seconds.
+		/// Then we simulate then user asked to cancel TorProcessManager as the application shuts down.
 		/// </summary>
 		[Fact]
 		public async Task StartProcessAsync()
 		{
 			using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(2));
 
+			// Test parameter: Simulate that Tor process crashes after two seconds.
+			TimeSpan torProcessCrashPeriod = TimeSpan.FromSeconds(2);
+
 			// Tor settings.
 			string dataDir = Path.Combine("temp", "tempDataDir");
 			string distributionFolder = "tempDistributionDir";
 			TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
-			// Dummy Tor process.
+			// Mock Tor process.
 			Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
 			mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>(), It.IsAny<bool>()))
-				.Returns(async (CancellationToken cancellationToken, bool killOnCancel) => await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false));
-
-			// Set up Tor control client.
-			Pipe toServer = new();
-			Pipe toClient = new();
-			await using TorControlClient controlClient = new(pipeReader: toClient.Reader, pipeWriter: toServer.Writer);
+				.Returns((CancellationToken cancellationToken, bool killOnCancel) => Task.Delay(torProcessCrashPeriod, cancellationToken));
+			mockProcess.Setup(p => p.Dispose());
 
 			// Set up Tor process manager.			
 			Mock<TorTcpConnectionFactory> mockTcpConnectionFactory = new(MockBehavior.Strict, DummyTorControlEndpoint);
 			mockTcpConnectionFactory.Setup(c => c.IsTorRunningAsync())
 				.ReturnsAsync(false);
 
+			// Mock TorProcessManager.
 			Mock<TorProcessManager> mockTorProcessManager = new(MockBehavior.Strict, settings, mockTcpConnectionFactory.Object) { CallBase = true };
 			mockTorProcessManager.Setup(c => c.StartProcess(It.IsAny<string>()))
 				.Returns(mockProcess.Object);
 			mockTorProcessManager.Setup(c => c.EnsureRunningAsync(It.IsAny<ProcessAsync>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(true);
-			mockTorProcessManager.Setup(c => c.InitTorControlAsync(It.IsAny<CancellationToken>()))
-				.ReturnsAsync(controlClient);
+			mockTorProcessManager.SetupSequence(c => c.InitTorControlAsync(It.IsAny<CancellationToken>()))
+				.ReturnsAsync(() => new TorControlClient(pipeReader: new Pipe().Reader, pipeWriter: new Pipe().Writer)) // (1)
+				.ThrowsAsync(new OperationCanceledException()); // (2)
 
-			TorProcessManager manager = mockTorProcessManager.Object;
-			bool result = await manager.StartAsync(timeoutCts.Token);
-			Assert.True(result);
+			await using (TorProcessManager manager = mockTorProcessManager.Object)
+			{
+				// No exception is expected here.
+				CancellationToken ct1 = await manager.StartAsync(timeoutCts.Token);
+
+				// Wait for the Tor process crash (see (1)).
+				await ct1.WhenCanceled().WithAwaitCancellationAsync(timeoutCts.Token);
+
+				// Wait until TorProcessManager is stopped (see (2)).
+				CancellationToken ct2 = await manager.WaitForNextAttemptAsync(timeoutCts.Token);
+				await ct2.WhenCanceled().WithAwaitCancellationAsync(timeoutCts.Token);
+			}
+
+			mockTorProcessManager.Verify(c => c.StartProcess(It.IsAny<string>()), Times.Exactly(2));
+			mockTorProcessManager.VerifyAll();
 		}
 	}
 }

--- a/WalletWasabi/Microservices/ProcessAsync.cs
+++ b/WalletWasabi/Microservices/ProcessAsync.cs
@@ -90,8 +90,7 @@ namespace WalletWasabi.Microservices
 
 			try
 			{
-				Logger.LogTrace($"Wait for the process to exit: '{Process.StartInfo.FileName}'");
-
+				Logger.LogTrace($"Wait for the process to exit: '{Process.Id}'");
 				await Process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
 				Logger.LogTrace("Process has exited.");
@@ -137,7 +136,7 @@ namespace WalletWasabi.Microservices
 			_disposed = true;
 		}
 
-		public void Dispose()
+		public virtual void Dispose()
 		{
 			// Dispose of unmanaged resources.
 			Dispose(true);

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -1,6 +1,7 @@
 using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net.Sockets;
@@ -417,6 +418,10 @@ namespace WalletWasabi.Tor.Control
 			catch (OperationCanceledException)
 			{
 				Logger.LogTrace("Reader loop was stopped.");
+			}
+			catch (IOException e)
+			{
+				Logger.LogError("Reply reader failed to read from pipe. Internal stream was most likely forcefully closed.", e);
 			}
 			catch (Exception e)
 			{

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -259,7 +259,7 @@ namespace WalletWasabi.Tor.Control
 				}
 
 				// Get all event names that must be subscribed.
-				subscribedEventNames = string.Join(',', SubscribedEvents.Keys);
+				subscribedEventNames = string.Join(' ', SubscribedEvents.Keys);
 			}
 
 			if (sendCommand)
@@ -307,7 +307,7 @@ namespace WalletWasabi.Tor.Control
 				}
 
 				// Get all event names that remained.
-				subscribedEventNames = string.Join(',', SubscribedEvents.Keys);
+				subscribedEventNames = string.Join(' ', SubscribedEvents.Keys);
 			}
 
 			if (sendCommand)

--- a/WalletWasabi/Tor/Control/TorControlReplyReader.cs
+++ b/WalletWasabi/Tor/Control/TorControlReplyReader.cs
@@ -18,6 +18,7 @@ namespace WalletWasabi.Tor.Control
 		/// <para>However, such implementation is available <see href="https://github.com/zcash/zcash/pull/2251">here</see>.</para>
 		/// </remarks>
 		/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
+		/// <exception cref="IOException">When reading fails because the internal stream is forcibly closed, etc.</exception>
 		/// <exception cref="TorControlReplyParseException">When received message does not follow Tor Control reply grammar.</exception>
 		/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4. Replies".</seealso>
 		/// <seealso href="https://github.com/lontivero/Torino/blob/d891616777ed596ef54dbf1d86c9b4771e45e8f3/src/Reply.cs#L72"/>

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -62,16 +62,7 @@ namespace WalletWasabi.Tor
 					{
 						bool isRunning = await HttpClient.IsTorRunningAsync().ConfigureAwait(false);
 
-						if (!isRunning)
-						{
-							Logger.LogInfo($"Tor did not work properly for {(int)torMisbehavedFor.TotalSeconds} seconds. Maybe it crashed. Attempting to start it...");
-
-							// Try starting Tor, if it does not work it'll be another issue.
-							bool started = await TorProcessManager.StartAsync(token).ConfigureAwait(false);
-
-							Logger.LogInfo($"Tor re-starting attempt {(started ? "succeeded." : "FAILED. Will try again later.")}");
-						}
-						else
+						if (isRunning)
 						{
 							Logger.LogInfo("Tor is running. Waiting for a confirmation that HTTP requests can pass through.");
 						}

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -17,7 +17,8 @@ namespace WalletWasabi.Tor
 	/// <seealso href="https://2019.www.torproject.org/docs/tor-manual.html.en"/>
 	public class TorProcessManager : IAsyncDisposable
 	{
-		private bool _disposed = false;
+		/// <summary>Task competion source returning a cancellation token which is canceled when Tor process is terminated.</summary>
+		private volatile TaskCompletionSource<CancellationToken> _tcs = new();
 
 		public TorProcessManager(TorSettings settings) :
 			this(settings, new(settings.SocksEndpoint))
@@ -29,78 +30,147 @@ namespace WalletWasabi.Tor
 		{
 			TorProcess = null;
 			TorControlClient = null;
+			LoopCts = new();
+			LoopTask = null;
 			Settings = settings;
 			TcpConnectionFactory = tcpConnectionFactory;
 		}
 
-		private ProcessAsync? TorProcess { get; set; }
+		/// <summary>Guards <see cref="TorProcess"/> and <see cref="TorControlClient"/>.</summary>
+		private object StateLock { get; } = new();
+
+		private Task? LoopTask { get; set; }
+
+		/// <summary>To stop the loop that keeps starting Tor process.</summary>
+		private CancellationTokenSource LoopCts { get; }
 		private TorSettings Settings { get; }
 		private TorTcpConnectionFactory TcpConnectionFactory { get; }
 
+		/// <remarks>Guarded by <see cref="StateLock"/>.</remarks>
+		private ProcessAsync? TorProcess { get; set; }
+
+		/// <remarks>Guarded by <see cref="StateLock"/>.</remarks>
 		private TorControlClient? TorControlClient { get; set; }
 
-		/// <summary>Starts Tor process if it is not running already.</summary>
+		/// <summary>Starts loop which makes sure that Tor process is started.</summary>
+		/// <param name="cancellationToken">Application lifetime cancellation token.</param>
+		/// <returns>Cancellation token which is canceled once Tor process terminates (either forcefully or gracefully).</returns>
+		/// <remarks>This method must be called exactly once.</remarks>		
 		/// <exception cref="OperationCanceledException"/>
-		public async Task<bool> StartAsync(CancellationToken token = default)
+		public async Task<CancellationToken> StartAsync(CancellationToken cancellationToken = default)
 		{
-			ThrowIfDisposed();
+			LoopTask = RestartingLoopAsync(cancellationToken);
 
-			ProcessAsync? process = null;
-			TorControlClient? controlClient = null;
+			return await WaitForNextAttemptAsync(cancellationToken).ConfigureAwait(false);
+		}
 
-			try
+		/// <summary>Waits until Tor process is fully started or until it is stopped for some reason.</summary>
+		/// <returns>Cancellation token which is canceled once Tor process terminates.</returns>
+		/// <remarks>This is useful to set up Tor control monitors that need to be restarted once Tor process is started again.</remarks>
+		public Task<CancellationToken> WaitForNextAttemptAsync(CancellationToken cancellationToken = default)
+		{
+			return _tcs.Task.WithAwaitCancellationAsync(cancellationToken);
+		}
+
+		/// <summary>Keeps starting Tor OS process.</summary>
+		/// <param name="globalCancellationToken">Application lifetime cancellation token.</param>
+		private async Task RestartingLoopAsync(CancellationToken globalCancellationToken)
+		{
+			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(globalCancellationToken, LoopCts.Token);
+			CancellationToken cancellationToken = linkedCts.Token;
+
+			while (!cancellationToken.IsCancellationRequested)
 			{
-				// Is Tor already running? Either our Tor process from previous Wasabi Wallet run or possibly user's own Tor.
-				bool isAlreadyRunning = await TcpConnectionFactory.IsTorRunningAsync().ConfigureAwait(false);
+				ProcessAsync? process = null;
+				TorControlClient? controlClient = null;
+				bool setNewTcs = true;
 
-				if (isAlreadyRunning)
+				// Use CancellationTokenSource to signal that Tor process terminated.
+				using CancellationTokenSource cts = new();
+
+				try
 				{
-					Logger.LogInfo($"Tor is already running on {Settings.SocksEndpoint.Address}:{Settings.SocksEndpoint.Port}.");
-					TorControlClient = await InitTorControlAsync(token).ConfigureAwait(false);
-					return true;
+					// Is Tor already running? Either our Tor process from previous Wasabi Wallet run or possibly user's own Tor.
+					bool isAlreadyRunning = await TcpConnectionFactory.IsTorRunningAsync().ConfigureAwait(false);
+
+					if (isAlreadyRunning)
+					{
+						Logger.LogInfo($"Tor is already running on {Settings.SocksEndpoint.Address}:{Settings.SocksEndpoint.Port}.");
+						controlClient = await InitTorControlAsync(cancellationToken).ConfigureAwait(false);
+
+						// Tor process can crash even between these two commands too.
+						int processId = await controlClient.GetTorProcessIdAsync(cancellationToken).ConfigureAwait(false);
+						process = new ProcessAsync(Process.GetProcessById(processId));
+					}
+					else
+					{
+						string arguments = Settings.GetCmdArguments();
+						process = StartProcess(arguments);
+
+						bool isRunning = await EnsureRunningAsync(process, cancellationToken).ConfigureAwait(false);
+
+						if (!isRunning)
+						{
+							Logger.LogTrace("Failed to start Tor process. Trying again.");
+							continue;
+						}
+
+						controlClient = await InitTorControlAsync(cancellationToken).ConfigureAwait(false);
+					}
+
+					Logger.LogInfo("Tor is running.");
+					_tcs.SetResult(cts.Token);
+
+					// Only now we know that Tor process is fully started.
+					lock (StateLock)
+					{
+						TorProcess = process;
+						TorControlClient = controlClient;
+					}
+
+					await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 				}
-
-				string arguments = Settings.GetCmdArguments();
-				process = StartProcess(arguments);
-
-				bool isRunning = await EnsureRunningAsync(process, token).ConfigureAwait(false);
-
-				if (!isRunning)
+				catch (OperationCanceledException ex)
 				{
-					return false;
+					Logger.LogDebug("User canceled operation.", ex);
+					setNewTcs = false;
+					break;
 				}
-
-				controlClient = await InitTorControlAsync(token).ConfigureAwait(false);
-				Logger.LogInfo("Tor is running.");
-
-				// Only now we know that Tor process is fully started.
-				TorProcess = process;
-				TorControlClient = controlClient;
-				controlClient = null;
-				process = null;
-
-				return true;
-			}
-			catch (OperationCanceledException ex)
-			{
-				Logger.LogDebug("User canceled operation.", ex);
-				throw;
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError("Could not automatically start Tor. Try running Tor manually.", ex);
-			}
-			finally
-			{
-				if (controlClient is not null)
+				catch (Exception ex)
 				{
-					await controlClient.DisposeAsync().ConfigureAwait(false);
+					Logger.LogError("Unexpected problem in starting Tor.", ex);
+					setNewTcs = false;
+					throw;
 				}
+				finally
+				{
+					TaskCompletionSource<CancellationToken> originalTcs = _tcs;
 
-				process?.Dispose();
+					if (setNewTcs)
+					{
+						// (1) and (2) must be in this order. Otherwise, there is a race condition risk of getting invalid CT by clients.
+						TaskCompletionSource<CancellationToken> newTcs = new();
+						originalTcs = Interlocked.Exchange(ref _tcs, newTcs); // (1)
+					}
+
+					cts.Cancel(); // (2)
+					originalTcs.TrySetResult(cts.Token);
+					cts.Dispose();
+
+					if (controlClient is not null)
+					{
+						await controlClient.DisposeAsync().ConfigureAwait(false);
+					}
+
+					process?.Dispose();
+
+					lock (StateLock)
+					{
+						TorProcess = null;
+						TorControlClient = null;
+					}
+				}
 			}
-
-			return false;
 		}
 
 		/// <summary>Ensure <paramref name="process"/> is actually running.</summary>
@@ -203,9 +273,25 @@ namespace WalletWasabi.Tor
 
 		public async ValueTask DisposeAsync()
 		{
-			_disposed = true;
+			LoopCts.Cancel();
 
-			if (TorControlClient is TorControlClient torControlClient)
+			if (LoopTask is Task t)
+			{
+				await t.ConfigureAwait(false);
+			}
+
+			LoopCts.Dispose();
+
+			ProcessAsync? process;
+			TorControlClient? torControlClient;
+
+			lock (StateLock)
+			{
+				process = TorProcess;
+				torControlClient = TorControlClient;
+			}
+
+			if (torControlClient is TorControlClient)
 			{
 				// Even though terminating the TCP connection with Tor would shut down Tor,
 				// the spec is quite clear:
@@ -223,15 +309,7 @@ namespace WalletWasabi.Tor
 			}
 
 			// Dispose Tor process resources (does not stop/kill Tor process).
-			TorProcess?.Dispose();
-		}
-
-		private void ThrowIfDisposed()
-		{
-			if (_disposed)
-			{
-				throw new ObjectDisposedException(GetType().FullName);
-			}
+			process?.Dispose();
 		}
 	}
 }

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.Tor
 {
 	/// <summary>Manages lifetime of Tor process.</summary>
 	/// <seealso href="https://2019.www.torproject.org/docs/tor-manual.html.en"/>
-	public class TorProcessManager
+	public class TorProcessManager : IAsyncDisposable
 	{
 		private bool _disposed = false;
 
@@ -201,7 +201,7 @@ namespace WalletWasabi.Tor
 			return client;
 		}
 
-		public async Task StopAsync()
+		public async ValueTask DisposeAsync()
 		{
 			_disposed = true;
 


### PR DESCRIPTION
## Currently

The code in the current master branch works as follows: `TorProcessManager` starts the Tor program and `TorMonitor` checks whether HTTP requests pass through and when they don't it calls `TorProcessManager.StartAsync()` to start Tor again. However, `TorMonitor` does not know whether Tor process was actually killed/terminated/etc. It's a somewhat heuristic approach.

## Proposed change

This PR attempts to change this behavior in the following way: `TorProcessManager` starts the Tor program and when Tor is killed/stopped/etc. `TorProcessManager` starts it again. 

## Why is the proposed behavior better?

The main reason why this change makes sense is because we need a reliable way to work with Tor control. @nopara73 mentioned that we want to be able to recover from Tor process terminations (crashes, killed by user, etc.). So when Tor process terminates and it is started again, we need to make sure that any code that relies on Tor Control gets this information and has a way to restart/adapt. 

An example to make it easier to grasp what I talk about: Suppose you monitor Tor circuits using Tor async events and you get information like one circuit was created and that one was extended, the third one was removed. When Tor process dies and your Tor circuit monitor is not restarted in some way, you will rely on old data and the monitor will get corrupted. 

## Future

This PR is a prerequisite for the Tor bootstrap monitoring feature.

Additional notes:

* bugfix: `SETEVENTS` parameters were delimited by `,` and not ` ` (space).
* `TorProcessManager` is newly `IAsyncDisposable`.

Can be reviewed commit-by-commit.