### PR TITLE
[Fluent] Add Wallet - Layout fixes

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/DynamicHeightBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/DynamicHeightBehavior.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using ReactiveUI;
+
+namespace WalletWasabi.Fluent.Behaviors
+{
+	public class DynamicHeightBehavior : DisposingBehavior<Control>
+	{
+		public static readonly StyledProperty<double> HeightMultiplierProperty =
+			AvaloniaProperty.Register<DynamicHeightBehavior, double>(nameof(HeightMultiplier));
+
+		public static readonly StyledProperty<double> HideThresholdHeightProperty =
+			AvaloniaProperty.Register<DynamicHeightBehavior, double>(nameof(HideThresholdHeight));
+
+		public double HeightMultiplier
+		{
+			get => GetValue(HeightMultiplierProperty);
+			set => SetValue(HeightMultiplierProperty, value);
+		}
+
+		public double HideThresholdHeight
+		{
+			get => GetValue(HideThresholdHeightProperty);
+			set => SetValue(HideThresholdHeightProperty, value);
+		}
+
+		protected override void OnAttached(CompositeDisposable disposables)
+		{
+			AssociatedObject?.Parent?.WhenAnyValue(x => x.Bounds)
+				.Subscribe(bounds =>
+				{
+					var newHeight = bounds.Height * HeightMultiplier;
+
+					if (newHeight < HideThresholdHeight)
+					{
+						AssociatedObject.IsVisible = false;
+					}
+					else
+					{
+						AssociatedObject.IsVisible = true;
+						AssociatedObject.Height = newHeight;
+					}
+				})
+				.DisposeWith(disposables);
+		}
+	}
+}

--- a/WalletWasabi.Fluent/Views/AddWallet/Create/ConfirmRecoveryWordsView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/Create/ConfirmRecoveryWordsView.axaml
@@ -20,16 +20,16 @@
                  EnableBack="{Binding EnableBack}"
                  EnableNext="True" NextContent="Continue"
                  EnableSkip="{Binding IsSkipEnable}">
-    <ScrollViewer>
-      <ItemsControl HorizontalAlignment="Center" VerticalAlignment="Center" Items="{Binding ConfirmationWords}">
+    <ScrollViewer HorizontalAlignment="Stretch" VerticalAlignment="Center" MaxWidth="350">
+      <ItemsControl Items="{Binding ConfirmationWords}">
         <i:Interaction.Behaviors>
           <behaviors:FocusFirstTextBoxInItemsControlBehavior />
         </i:Interaction.Behaviors>
         <ItemsControl.ItemTemplate>
           <DataTemplate>
-            <DockPanel HorizontalAlignment="Left">
+            <DockPanel>
               <Label Content="{Binding Index, StringFormat=Recovery word {0}}" DockPanel.Dock="Top" />
-              <TextBox Watermark="Type the word here..." Classes="hasCheckMarkBoolean" validation:CheckMarkStatus.IsEnabled="{Binding IsConfirmed}" Text="{Binding Input}" IsEnabled="{Binding !IsConfirmed}" DockPanel.Dock="Top" Width="350">
+              <TextBox Watermark="Type the word here..." Classes="hasCheckMarkBoolean" validation:CheckMarkStatus.IsEnabled="{Binding IsConfirmed}" Text="{Binding Input}" IsEnabled="{Binding !IsConfirmed}" DockPanel.Dock="Top">
                 <i:Interaction.Behaviors>
                   <behaviors:FocusNextItemBehavior IsFocused="{Binding !IsConfirmed}" />
                 </i:Interaction.Behaviors>

--- a/WalletWasabi.Fluent/Views/AddWallet/Create/RecoveryWordsView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/Create/RecoveryWordsView.axaml
@@ -13,7 +13,8 @@
                  CancelContent="Cancel"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"
-                 EnableNext="True" NextContent="Continue" FocusNext="True">
+                 EnableNext="True" NextContent="Continue" FocusNext="True"
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto">
     <ItemsControl Items="{Binding MnemonicWords}" VerticalAlignment="Center" HorizontalAlignment="Center">
       <ItemsControl.Styles>
         <Style Selector="TextBlock">

--- a/WalletWasabi.Fluent/Views/AddWallet/HardwareWallet/ConnectHardwareWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/HardwareWallet/ConnectHardwareWalletView.axaml
@@ -3,6 +3,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="using:WalletWasabi.Fluent.Behaviors"
              xmlns:hardwareWallet="using:WalletWasabi.Fluent.ViewModels.AddWallet.HardwareWallet"
              xmlns:conv="clr-namespace:WalletWasabi.Fluent.Converters"
              mc:Ignorable="d" d:DesignWidth="428" d:DesignHeight="371"
@@ -17,23 +19,28 @@
                  EnableBack="{Binding EnableBack}"
                  EnableNext="{Binding ConfirmationRequired}" NextContent="Continue"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
-    <Grid RowDefinitions="*,3*,Auto">
-      <Viewbox MaxHeight="150" Grid.Row="0" DockPanel.Dock="Top" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0 30 0 0">
-        <StackPanel Spacing="40" Orientation="Horizontal">
+    <DockPanel>
+      <Viewbox MaxHeight="150" DockPanel.Dock="Top" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0 30 0 0">
+        <i:Interaction.Behaviors>
+          <behaviors:DynamicHeightBehavior HeightMultiplier="0.3" HideThresholdHeight="50"/>
+        </i:Interaction.Behaviors>
+        <StackPanel Orientation="Horizontal">
           <Image Height="100" Source="{Binding Ledger, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
           <Image Height="100" Source="{Binding Coldcard, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
           <Image Height="100" Source="{Binding Trezor, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
           <Image Height="100" Source="{Binding Generic, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
         </StackPanel>
       </Viewbox>
-      <Panel HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1">
+      <Button Command="{Binding OpenBrowserCommand}" Content="More information and help with Hardware Wallets" Classes="h8 plain activeHyperLink" HorizontalAlignment="Center" DockPanel.Dock="Bottom" VerticalAlignment="Bottom"/>
+      <Panel HorizontalAlignment="Center" VerticalAlignment="Center">
         <DockPanel>
           <TextBlock Text="{Binding Message}" TextWrapping="Wrap" TextAlignment="Center" DockPanel.Dock="Top"/>
-          <Button IsVisible="{Binding ExistingWalletFound}" Margin="0 15 0 0" Command="{Binding NavigateToExistingWalletLoginCommand}" Content="Open wallet" Classes="h7 plain activeHyperLink" HorizontalAlignment="Center" VerticalAlignment="Bottom" DockPanel.Dock="Bottom"/>
+          <Button IsVisible="{Binding ExistingWalletFound}" Margin="0 5 0 0" Command="{Binding NavigateToExistingWalletLoginCommand}" Content="Open wallet" Classes="h7 plain activeHyperLink" HorizontalAlignment="Center" VerticalAlignment="Bottom" DockPanel.Dock="Bottom"/>
         </DockPanel>
-        <c:ProgressRing IsVisible="{Binding !ConfirmationRequired}" Margin="15" IsIndeterminate="True" Height="100" Width="100" />
+        <Viewbox IsVisible="{Binding !ConfirmationRequired}" MaxHeight="100" Margin="15">
+          <c:ProgressRing IsIndeterminate="True" Height="100" Width="100" />
+        </Viewbox>
       </Panel>
-      <Button Command="{Binding OpenBrowserCommand}" Content="More information and help with Hardware Wallets" Classes="h8 plain activeHyperLink" HorizontalAlignment="Center" Grid.Row="2"/>
-    </Grid>
+    </DockPanel>
   </c:ContentArea>
 </UserControl>


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/issues/5974

```
[1] Add Wallet
- Recovery words are not fully visible on the smallest size.
- Textbox padding is different on the smallest size on the Confirm rec words page
- Too big progress ring (while searching) on add HW wallet page
```

Note:
- The HW wallet fix was required more changes to get it to work in every case.
  - During searching
  - When an error message is visible
  - When an already added wallet found