### PR TITLE
[Fluent] Transaction Broadcaster - Load transaction layout fix

### DIFF
--- a/WalletWasabi.Fluent/Views/TransactionBroadcasting/LoadTransactionView.axaml
+++ b/WalletWasabi.Fluent/Views/TransactionBroadcasting/LoadTransactionView.axaml
@@ -12,13 +12,13 @@
                  Caption="Paste or import the transaction and broadcast it to the network."
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}">
-    <WrapPanel Orientation="Horizontal" Margin="0 0 0 20" HorizontalAlignment="Center">
+    <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
       <WrapPanel.Styles>
         <Style Selector="c|TileButton">
-          <Setter Property="Margin" Value="20" />
-          <Setter Property="Height" Value="250" />
-          <Setter Property="Width" Value="250" />
-          <Setter Property="IconSize" Value="80" />
+          <Setter Property="Margin" Value="20 0" />
+          <Setter Property="Height" Value="170" />
+          <Setter Property="Width" Value="170" />
+          <Setter Property="IconSize" Value="60" />
         </Style>
       </WrapPanel.Styles>
       <c:TileButton Text="Import transaction"

--- a/WalletWasabi.Fluent/Views/TransactionBroadcasting/LoadTransactionView.axaml
+++ b/WalletWasabi.Fluent/Views/TransactionBroadcasting/LoadTransactionView.axaml
@@ -8,24 +8,25 @@
              x:DataType="transactionBroadcasting:LoadTransactionViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.TransactionBroadcasting.LoadTransactionView">
-<c:ContentArea Title="{Binding Title}"
-               Caption="Paste or import the transaction and broadcast it to the network."
-               EnableCancel="{Binding EnableCancel}"
-               EnableBack="{Binding EnableBack}">
-    <StackPanel Orientation="Horizontal" Spacing="50" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <StackPanel.Styles>
-            <Style Selector="c|TileButton">
-                <Setter Property="Height" Value="250"/>
-                <Setter Property="Width" Value="250"/>
-                <Setter Property="IconSize" Value="80"/>
-            </Style>
-        </StackPanel.Styles>
-        <c:TileButton Text="Import transaction"
-                      Icon="{StaticResource folder_move_regular}"
-                      Command="{Binding ImportTransactionCommand}"/>
-        <c:TileButton Text="Paste from clipboard"
-                      Icon="{StaticResource clipboard_text_regular}"
-                      Command="{Binding PasteCommand}"/>
-    </StackPanel>
-</c:ContentArea>
+  <c:ContentArea Title="{Binding Title}"
+                 Caption="Paste or import the transaction and broadcast it to the network."
+                 EnableCancel="{Binding EnableCancel}"
+                 EnableBack="{Binding EnableBack}">
+    <WrapPanel Orientation="Horizontal" Margin="0 0 0 20" HorizontalAlignment="Center">
+      <WrapPanel.Styles>
+        <Style Selector="c|TileButton">
+          <Setter Property="Margin" Value="20" />
+          <Setter Property="Height" Value="250" />
+          <Setter Property="Width" Value="250" />
+          <Setter Property="IconSize" Value="80" />
+        </Style>
+      </WrapPanel.Styles>
+      <c:TileButton Text="Import transaction"
+                    Icon="{StaticResource folder_move_regular}"
+                    Command="{Binding ImportTransactionCommand}" />
+      <c:TileButton Text="Paste from clipboard"
+                    Icon="{StaticResource clipboard_text_regular}"
+                    Command="{Binding PasteCommand}" />
+    </WrapPanel>
+  </c:ContentArea>
 </UserControl>


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/issues/5974

```
[3] Transaction Broadcaster
- Load transaction page - completely broken
```

On the smallest size, the buttons were not fully visible, now they are.