### PR TITLE
[WabiSabi] Multi client test

### DIFF
--- a/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
+++ b/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
@@ -13,7 +13,6 @@ namespace WalletWasabi.Tests.Helpers
 		public HttpClientWrapper(HttpClient httpClient)
 		{
 			_httpClient = httpClient;
-			_httpClient.Timeout = TimeSpan.FromMinutes(2);
 		}
 
 		public Func<Uri>? BaseUriGetter => ()=> _httpClient.BaseAddress;

--- a/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
+++ b/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
@@ -19,7 +19,10 @@ namespace WalletWasabi.Tests.Helpers
 
 		public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
 		{
-			return _httpClient.SendAsync(request, token);
+			// HttpCompletionOption is required here because of a bug in dotnet.
+			// without it the test fails randomly with ObjectDisposedException
+			// see: https://github.com/dotnet/runtime/issues/23870
+			return _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
 		}
 	}
 }

--- a/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
+++ b/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
@@ -13,6 +13,7 @@ namespace WalletWasabi.Tests.Helpers
 		public HttpClientWrapper(HttpClient httpClient)
 		{
 			_httpClient = httpClient;
+			_httpClient.Timeout = TimeSpan.FromMinutes(2);
 		}
 
 		public Func<Uri>? BaseUriGetter => ()=> _httpClient.BaseAddress;

--- a/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
@@ -16,11 +16,31 @@ namespace WalletWasabi.Tests.Helpers
 	{
 		public static async Task<CoreNode> CreateAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", string additionalFolder = "", MempoolService? mempoolService = null)
 		{
-			var network = Network.RegTest;
+			var dataDir = Path.Combine(Common.GetWorkDir(callerFilePath, callerMemberName), additionalFolder);
+
+			CoreNodeParams nodeParameters = CreateDefaultCoreNodeParams(mempoolService ?? new MempoolService(), dataDir);
+			return await CoreNode.CreateAsync(
+				nodeParameters,
+				CancellationToken.None);
+		}
+
+		public static async Task<CoreNode> CreateForHeavyConcurrencyAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", string additionalFolder = "", MempoolService? mempoolService = null)
+		{
+			var dataDir = Path.Combine(Common.GetWorkDir(callerFilePath, callerMemberName), additionalFolder);
+
+			CoreNodeParams nodeParameters = CreateDefaultCoreNodeParams(mempoolService ?? new MempoolService(), dataDir);
+			nodeParameters.RpcWorkQueue = 32;
+			return await CoreNode.CreateAsync(
+				nodeParameters,
+				CancellationToken.None);
+		}
+
+		private static CoreNodeParams CreateDefaultCoreNodeParams(MempoolService mempoolService, string dataDir)
+		{
 			var nodeParameters = new CoreNodeParams(
-					network,
+					Network.RegTest,
 					mempoolService ?? new MempoolService(),
-					Path.Combine(Common.GetWorkDir(callerFilePath, callerMemberName), additionalFolder),
+					dataDir,
 					tryRestart: true,
 					tryDeleteDataDir: true,
 					EndPointStrategy.Random,
@@ -38,9 +58,7 @@ namespace WalletWasabi.Tests.Helpers
 			nodeParameters.Upnp = 0;
 			nodeParameters.NatPmp = 0;
 			nodeParameters.PersistMempool = 0;
-			return await CoreNode.CreateAsync(
-				nodeParameters,
-				CancellationToken.None);
+			return nodeParameters;
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -20,9 +20,11 @@ namespace WalletWasabi.Tests.UnitTests
 		public Func<uint256, Task<VerboseBlockInfo>> OnGetVerboseBlockAsync { get; set; }
 		public Func<Transaction, uint256> OnSendRawTransactionAsync { get; set; }
 		public Func<Task<MemPoolInfo>> OnGetMempoolInfoAsync { get; set; }
+		public Func<Task<uint256[]>> OnGetRawMempoolAsync { get; set; }
+		public Func<uint256, bool, Task<Transaction>> OnGetRawTransactionAsync { get; set; }
 		public Func<int, EstimateSmartFeeMode, Task<EstimateSmartFeeResponse>> OnEstimateSmartFeeAsync { get; set; }
 		public Func<Task<PeerInfo[]>> OnGetPeersInfoAsync { get; set; }
-
+		public Func<int, BitcoinAddress, Task<uint256[]>> OnGenerateToAddressAsync { get; set; }
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new();
 
@@ -83,12 +85,12 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<uint256[]> GetRawMempoolAsync()
 		{
-			throw new NotImplementedException();
+			return OnGetRawMempoolAsync();
 		}
 
 		public Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true)
 		{
-			throw new NotImplementedException();
+			return OnGetRawTransactionAsync(txid, throwIfNotFound);
 		}
 
 		public Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
@@ -185,7 +187,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 		public Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address)
 		{
-			throw new NotImplementedException();
+			return OnGenerateToAddressAsync(nBlocks, address);
 		}
 
 		public Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		}
 
 		public KeyManager KeyManager { get; }
-		public List<Coin> Coins { get; } = new ();
+		public List<Coin> Coins { get; } = new();
 		public IRPCClient Rpc { get; }
 		public WabiSabiHttpApiClient ApiClient { get; }
 
@@ -43,7 +43,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		public async Task StartParticipatingAsync(CancellationToken cancellationToken)
 		{
 			using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(3), ApiClient);
-			await roundStateUpdater.StartAsync(cancellationToken);
+			await roundStateUpdater.StartAsync(cancellationToken).ConfigureAwait(false);
 
 			var kitchen = new Kitchen();
 			kitchen.Cook("");
@@ -51,9 +51,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var coinJoinClient = new CoinJoinClient(ApiClient, Coins, kitchen, KeyManager, roundStateUpdater);
 
 			// Run the coinjoin client task.
-			await coinJoinClient.StartCoinJoinAsync(cancellationToken);
+			await coinJoinClient.StartCoinJoinAsync(cancellationToken).ConfigureAwait(false);
 
-			await roundStateUpdater.StopAsync(cancellationToken);
+			await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -29,12 +29,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 		public async Task InitializeAsync(int numberOfCoins, CancellationToken cancellationToken)
 		{
-			var keys = KeyManager.GetKeys().Take(numberOfCoins);
+			var keys = KeyManager.GetKeys().Take(numberOfCoins).ToArray();
 			foreach (var key in keys)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				var blockIds = await Rpc.GenerateToAddressAsync(1, key.GetP2wpkhAddress(Rpc.Network));
-				var block = await Rpc.GetBlockAsync(blockIds.First());
+				var blockIds = await Rpc.GenerateToAddressAsync(1, key.GetP2wpkhAddress(Rpc.Network)).ConfigureAwait(false);
+				var block = await Rpc.GetBlockAsync(blockIds.First()).ConfigureAwait(false);
 				var coin = block.Transactions[0].Outputs.GetCoins(key.P2wpkhScript).First();
 				Coins.Add(coin);
 			}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			foreach (var key in keys)
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				var blockIds = await Rpc.GenerateToAddressAsync(1, key.GetP2wpkhAddress(Network.Main));
+				var blockIds = await Rpc.GenerateToAddressAsync(1, key.GetP2wpkhAddress(Rpc.Network));
 				var block = await Rpc.GetBlockAsync(blockIds.First());
 				var coin = block.Transactions[0].Outputs.GetCoins(key.P2wpkhScript).First();
 				Coins.Add(coin);
@@ -42,7 +42,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 		public async Task StartParticipatingAsync(CancellationToken cancellationToken)
 		{
-			using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(1), ApiClient);
+			using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(3), ApiClient);
 			await roundStateUpdater.StartAsync(cancellationToken);
 
 			var kitchen = new Kitchen();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
+{
+	internal class Participant
+	{
+		public Participant(IRPCClient rpc, WabiSabiHttpApiClient apiClient)
+		{
+			Rpc = rpc;
+			ApiClient = apiClient;
+
+			KeyManager = KeyManager.CreateNew(out var _, password: "");
+			KeyManager.AssertCleanKeysIndexed();
+		}
+
+		public KeyManager KeyManager { get; }
+		public List<Coin> Coins { get; } = new ();
+		public IRPCClient Rpc { get; }
+		public WabiSabiHttpApiClient ApiClient { get; }
+
+		public async Task InitializeAsync(int numberOfCoins, CancellationToken cancellationToken)
+		{
+			var keys = KeyManager.GetKeys().Take(numberOfCoins);
+			foreach (var key in keys)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				var blockIds = await Rpc.GenerateToAddressAsync(1, key.GetP2wpkhAddress(Network.Main));
+				var block = await Rpc.GetBlockAsync(blockIds.First());
+				var coin = block.Transactions[0].Outputs.GetCoins(key.P2wpkhScript).First();
+				Coins.Add(coin);
+			}
+		}
+
+		public async Task StartParticipatingAsync(CancellationToken cancellationToken)
+		{
+			using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(1), ApiClient);
+			await roundStateUpdater.StartAsync(cancellationToken);
+
+			var kitchen = new Kitchen();
+			kitchen.Cook("");
+
+			var coinJoinClient = new CoinJoinClient(ApiClient, Coins, kitchen, KeyManager, roundStateUpdater);
+
+			// Run the coinjoin client task.
+			await coinJoinClient.StartCoinJoinAsync(cancellationToken);
+
+			await roundStateUpdater.StopAsync(cancellationToken);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -34,6 +34,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			return host;
 		}
 
+		protected override void ConfigureClient(HttpClient client)
+		{
+			client.Timeout = TimeSpan.FromMinutes(10);
+		}
+
 		protected override IHostBuilder CreateHostBuilder()
 		{
 			var builder = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(x =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -25,6 +25,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 {
 	public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
 	{
+		// There is a deadlock in the current version of the asmp.net testing framework
+		// https://www.strathweb.com/2021/05/the-curious-case-of-asp-net-core-integration-test-deadlock/
+		protected override IHost CreateHost(IHostBuilder builder)
+		{
+			var host = builder.Build();
+			Task.Run(() => host.StartAsync()).GetAwaiter().GetResult();
+			return host;
+		}
+
 		protected override IHostBuilder CreateHostBuilder()
 		{
 			var builder = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(x =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -160,12 +160,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			// Create the API client
 			var apiClient = _apiApplicationFactory.CreateWabiSabiHttpApiClient(httpClient);
 
-			// At the end of the test a coinjoin transaction has to be created and broadcasted.
-			var transactionCompleted = new TaskCompletionSource<Transaction>();
-
 			// Total test timeout.
 			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20 * expectedInputNumber));
-			cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 			var participants = Enumerable
 				.Range(0, NumberOfParticipants)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -131,7 +131,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		[Fact]
 		public async Task MultiClientsCoinJoinTestAsync()
 		{
-			const int NumberOfParticipants = 30;
+			const int NumberOfParticipants = 50;
 			const int NumberOfCoinsPerParticipant = 1;
 			int expectedInputNumber = NumberOfParticipants * NumberOfCoinsPerParticipant;
 
@@ -145,7 +145,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 					// Instruct the coodinator DI container to use these two scoped
 					// services to build everything (wabisabi controller, arena, etc)
 					services.AddScoped<IRPCClient>(s => rpc);
-					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig { MaxInputCountByRound = expectedInputNumber });
+					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig
+					{
+						MaxInputCountByRound = expectedInputNumber,
+						OutputRegistrationTimeout = TimeSpan.FromMinutes(3)
+					});
 				});
 			}).CreateClient();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -132,7 +132,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		public async Task MultiClientsCoinJoinTestAsync()
 		{
 			const int NumberOfParticipants = 50;
-			const int NumberOfCoinsPerParticipant = 1;
+			const int NumberOfCoinsPerParticipant = 2;
 			int expectedInputNumber = NumberOfParticipants * NumberOfCoinsPerParticipant;
 
 			var node = await TestNodeBuilder.CreateAsync();
@@ -147,8 +147,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 					services.AddScoped<IRPCClient>(s => rpc);
 					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig
 					{
+						MaxRegistrableAmount = Money.Coins(500m),
 						MaxInputCountByRound = expectedInputNumber,
-						OutputRegistrationTimeout = TimeSpan.FromMinutes(3)
+						ConnectionConfirmationTimeout = TimeSpan.FromSeconds(10 * expectedInputNumber),
+						OutputRegistrationTimeout = TimeSpan.FromSeconds(15 * expectedInputNumber),
 					});
 				});
 			}).CreateClient();
@@ -160,7 +162,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var transactionCompleted = new TaskCompletionSource<Transaction>();
 
 			// Total test timeout.
-			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30 * expectedInputNumber));
 			cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 			var participants = Enumerable

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -137,7 +137,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			const int NumberOfCoinsPerParticipant = 2;
 			int expectedInputNumber = NumberOfParticipants * NumberOfCoinsPerParticipant;
 
-			var rpc = GetStatefullMockRpc();
+			var node = await TestNodeBuilder.CreateForHeavyConcurrencyAsync();
+			var rpc = node.RpcClient;
 
 			var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -137,7 +137,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var transactionCompleted = new TaskCompletionSource<Transaction>();
 
 			// Total test timeout.
-			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 			cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 			var rpc = GetStatefullMockRpc(transactionCompleted);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -196,6 +196,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 			Assert.True(coinjoin.Outputs.Count >= expectedInputNumber);
 			Assert.True(coinjoin.Inputs.Count == expectedInputNumber);
+			await node.TryStopAsync();
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -21,9 +21,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.5" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-		<PackageReference Include="Moq" Version="4.16.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />		<PackageReference Include="Moq" Version="4.16.1" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<PrivateAssets>all</PrivateAssets>

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -201,6 +201,16 @@ namespace WalletWasabi.BitcoinCore
 					desiredConfigLines.Add($"{configPrefix}.persistmempool = {coreNodeParams.PersistMempool}");
 				}
 
+				if (coreNodeParams.RpcWorkQueue is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.rpcworkqueue = {coreNodeParams.RpcWorkQueue}");
+				}
+
+				if (coreNodeParams.RpcThreads is { })
+				{
+					desiredConfigLines.Add($"{configPrefix}.rpcthreads = {coreNodeParams.RpcThreads}");
+				}
+
 				var sectionComment = $"# The following configuration options were added or modified by Wasabi Wallet.";
 				// If the comment is not already present.
 				// And there would be new config entries added.

--- a/WalletWasabi/BitcoinCore/CoreNodeParams.cs
+++ b/WalletWasabi/BitcoinCore/CoreNodeParams.cs
@@ -57,6 +57,9 @@ namespace WalletWasabi.BitcoinCore
 		public int? Upnp { get; set; }
 		public int? NatPmp { get; set; }
 		public int? PersistMempool { get; set; }
+		public int? RpcWorkQueue { get; set; }
+		public int? RpcThreads { get; set; }
+
 		public EndPointStrategy P2pEndPointStrategy { get; }
 		public EndPointStrategy RpcEndPointStrategy { get; }
 		public IMemoryCache Cache { get; }


### PR DESCRIPTION
This is a first version for a real multi-client test. At this early stage all components (clients and server) use the same single fake rpc interface. Once the concept is validated that instance can be replaced by real regtest nodes.

There is currently a problem in the CJC because it cannot handle very well the errors that it receives from the coordinator. For example, the test creates a round with a maximum of 10 inputs and there are 10 participants with 2 coins each (20 coins in total), when all the participants register their first coin none of them can register the second one and we have a deadlock that is solved by a timeout.

Just as a side note, the test seems to be really slow (i didn't measure it)