### PR TITLE
[Fluent] Send - Layout fixes part 1

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/OptimisePrivacyView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/OptimisePrivacyView.axaml
@@ -17,7 +17,7 @@
                    IsBusy="{Binding IsBusy}"
                    ScrollViewer.VerticalScrollBarVisibility="Disabled">
         <DockPanel>
-            <Panel DockPanel.Dock="Bottom" Margin="0 30 0 0" MinHeight="22">
+            <Panel DockPanel.Dock="Bottom" Margin="0 10 0 0">
                 <c:InfoMessage  IsVisible="{Binding ExactAmountWarningVisible}" VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="Some services only accept the exact amount that was requested." Foreground="{DynamicResource PrivacyLevelMediumBrush}" />
             </Panel>
             <ListBox DockPanel.Dock="Top" Background="Transparent" VerticalAlignment="Center" HorizontalAlignment="Center" Items="{Binding PrivacySuggestions}" SelectedItem="{Binding SelectedPrivacySuggestion}">

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyControlView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyControlView.axaml
@@ -15,7 +15,7 @@
                    IsBusy="{Binding IsBusy}"
                    ScrollViewer.VerticalScrollBarVisibility="Disabled">
         <DockPanel>
-            <Panel MinHeight="60" DockPanel.Dock="Bottom">
+            <Panel Margin="0 10 0 0" DockPanel.Dock="Bottom">
                 <c:InfoMessage Foreground="{DynamicResource WarningMessageForeground}"
                                HorizontalAlignment="Center"
                                IsVisible="{Binding !EnoughSelected}">
@@ -30,7 +30,6 @@
                     HorizontalAlignment="Center" />
             </Panel>
             <DataGrid AutoGenerateColumns="False"
-                      Margin="0 20"
                       Items="{Binding Pockets}">
                 <DataGrid.Resources>
                     <SolidColorBrush x:Key="DataGridRowIndicatorBrush" Color="Transparent" />

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendSuccessView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendSuccessView.axaml
@@ -10,7 +10,7 @@
              x:Class="WalletWasabi.Fluent.Views.Wallets.Send.SendSuccessView">
   <c:ContentArea Title="{Binding Title}"
                  EnableNext="True" NextContent="Done"
-                 ScrollViewer.VerticalScrollBarVisibility="Auto">
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
     <DockPanel VerticalAlignment="Center">
       <TextBlock Text="Your transaction has been successfully sent." DockPanel.Dock="Bottom" TextAlignment="Center" TextWrapping="Wrap"/>
 


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/issues/5974

```
- Optimize privacy screen is unusable
- Success page - green thick size should depend on the dialog size
- Privacy control page is unusable
```

Following PR:
The dialog will be shown on fullscreen when it reaches a specific small size. 