### PR TITLE
[Fluent] Dialog to fullwindow on small resolution

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -19,7 +19,7 @@
                     Background="{DynamicResource RegionColor}"
                     MaxWidth="{TemplateBinding MaxContentWidth}" MaxHeight="{TemplateBinding MaxContentHeight}">
               <Panel Name="PART_Dismiss">
-                <ContentPresenter Name="PART_ContentPresenter" Margin="16 28 16 16"
+                <ContentPresenter Name="PART_ContentPresenter"
                                   Background="{TemplateBinding Background}"
                                   BorderBrush="{TemplateBinding BorderBrush}"
                                   BorderThickness="{TemplateBinding BorderThickness}"
@@ -63,6 +63,7 @@
   <Style Selector="c|Dialog /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="MinWidth" Value="382" />
     <Setter Property="MinHeight" Value="284" />
+    <Setter Property="Margin" Value="16 28 16 16"/>
   </Style>
 
   <!-- Dialog Opened State -->
@@ -87,9 +88,16 @@
 
   <!-- Dialog Fullscreen State -->
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Border#PART_Border">
-    <Setter Property="Margin" Value="0" />
+    <Setter Property="Margin" Value="0 30 0 0" />
+    <Setter Property="BoxShadow" Value="0 0 0 0 #000000" />
   </Style>
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Panel#PART_DialogHost">
     <Setter Property="Margin" Value="0" />
+  </Style>
+  <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Panel#PART_Overlay">
+    <Setter Property="Background" Value="{DynamicResource RegionColor}"/>
+  </Style>
+  <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Margin" Value="16 0 16 16" />
   </Style>
 </Styles>

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -84,4 +84,12 @@
   <Style Selector="c|Dialog:not(:open) /template/ Panel#PART_Overlay">
     <Setter Property="Opacity" Value="0"/>
   </Style>
+
+  <!-- Dialog Fullscreen State -->
+  <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Border#PART_Border">
+    <Setter Property="Margin" Value="0" />
+  </Style>
+  <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Panel#PART_DialogHost">
+    <Setter Property="Margin" Value="0" />
+  </Style>
 </Styles>

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -89,7 +89,7 @@
   <!-- Dialog Fullscreen State -->
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Border#PART_Border">
     <Setter Property="Margin" Value="0 30 0 0" />
-    <Setter Property="BoxShadow" Value="0 0 0 0 #000000" />
+    <Setter Property="BoxShadow" Value="{StaticResource EmptyBoxShadow}" />
   </Style>
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Panel#PART_DialogHost">
     <Setter Property="Margin" Value="0" />

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -56,7 +56,7 @@ namespace WalletWasabi.Fluent.Controls
 				{
 					var width = bounds.Width;
 					var height = bounds.Height;
-					FullScreenEnabled = width < 600 && height < 600;
+					FullScreenEnabled = width < 740 && height < 580;
 				});
 		}
 

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
+using ReactiveUI;
 
 namespace WalletWasabi.Fluent.Controls
 {
@@ -43,9 +44,20 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<double> MaxContentWidthProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(MaxContentWidth), double.PositiveInfinity);
 
+		public static readonly StyledProperty<bool> FullScreenEnabledProperty =
+			AvaloniaProperty.Register<Dialog, bool>(nameof(FullScreenEnabled));
+
 		public Dialog()
 		{
 			this.GetObservable(IsDialogOpenProperty).Subscribe(UpdateDelay);
+
+			this.WhenAnyValue(x => x.Bounds)
+				.Subscribe(bounds =>
+				{
+					var width = bounds.Width;
+					var height = bounds.Height;
+					FullScreenEnabled = width < 600 && height < 600;
+				});
 		}
 
 		public bool IsDialogOpen
@@ -94,6 +106,12 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			get => GetValue(MaxContentWidthProperty);
 			set => SetValue(MaxContentWidthProperty, value);
+		}
+
+		public bool FullScreenEnabled
+		{
+			get => GetValue(FullScreenEnabledProperty);
+			set => SetValue(FullScreenEnabledProperty, value);
 		}
 
 		private CancellationTokenSource? CancelPointerPressedDelay { get; set; }

--- a/WalletWasabi.Fluent/Styles/Themes/Base.axaml
+++ b/WalletWasabi.Fluent/Styles/Themes/Base.axaml
@@ -44,6 +44,8 @@
 
     <StaticResource x:Key="NotificationCardInformationBackgroundBrush" ResourceKey="SystemAccentColor" />
 
+    <BoxShadows x:Key="EmptyBoxShadow">0 0 0 0 #000000</BoxShadows>
+
     <LinearGradientBrush x:Key="LogoWashoutOpacityMaskGradient" StartPoint="0%,100%" EndPoint="100%,00%">
       <LinearGradientBrush.GradientStops>
         <GradientStop Color="#4AFFFFFF" Offset="0.1" />


### PR DESCRIPTION
On 600x600 resolution the Dialog will lose its margins and fills the whole window.

![image](https://user-images.githubusercontent.com/16364053/124748643-a7fa9a00-df23-11eb-844a-e0abfa77013d.png)
