### PR TITLE
Do not save `KeyManager` on Wallet Settings opening

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Linq;
 using ReactiveUI;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 
@@ -20,6 +21,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 			NextCommand = CancelCommand;
 
 			this.WhenAnyValue(x => x.PreferPsbtWorkflow)
+				.Skip(1)
 				.Subscribe(value =>
 				{
 					wallet.KeyManager.PreferPsbtWorkflow = value;


### PR DESCRIPTION
Every time when the Wallet Settings got open, the KeyManager was serialized. This PR fixes it.