### PR TITLE
[WabiSabi] Make status requests concurrency safe

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -21,6 +21,12 @@ namespace WalletWasabi.Backend.Controllers
 
 		private ArenaRequestHandler RequestHandler { get; }
 
+		[HttpGet("status")]
+		public Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		{
+			return RequestHandler.GetStatusAsync(cancellationToken);
+		}
+
 		[HttpPost("connection-confirmation")]
 		[Idempotent]
 		public Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request, CancellationToken cancellableToken)
@@ -59,12 +65,6 @@ namespace WalletWasabi.Backend.Controllers
 		public Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellableToken)
 		{
 			return RequestHandler.SignTransactionAsync(request, cancellableToken);
-		}
-
-		[HttpGet("status")]
-		public Task<RoundState[]> GetStatusAsync(CancellationToken cancellableToken)
-		{
-			return Task.FromResult(RequestHandler.Arena.Rounds.Select(x => RoundState.FromRound(x)).ToArray());
 		}
 
 		[HttpPost("ready-to-sign")]

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
@@ -93,6 +93,15 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			}
 		}
 
+		public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		{
+			DisposeGuard();
+			using (RunningTasks.RememberWith(RunningRequests))
+			{
+				return await Arena.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+			}
+		}
+
 		public async ValueTask DisposeAsync()
 		{
 			lock (DisposeStartedLock)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -247,6 +247,14 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			}
 		}
 
+		public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		{
+			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
+			{
+				return Rounds.Select(x => RoundState.FromRound(x)).ToArray();
+			}
+		}
+
 		public async Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request)
 		{
 			var coin = await InputRegistrationHandler.OutpointToCoinAsync(request, Prison, Rpc, Config).ConfigureAwait(false);


### PR DESCRIPTION
Since status requests access internal mutable structures of `Arena` they
need to be protected by the async lock to avoid reading inconsistent
states.