### PR TITLE
[Fluent] fix NRE in transaction history

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -67,7 +67,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 				RxApp.MainThreadScheduler.Schedule(async () =>
 				{
 					await Task.Delay(1260);
-					SelectedItem.IsSelected = false;
+
+					if (SelectedItem is { } item)
+					{
+						item.IsSelected = false;
+					}
 				});
 			}
 		}


### PR DESCRIPTION
When a transaction happens and the row is flashing in the list, at this point if the user navigates away, NRE will occur when we are trying to cancel the flashing animation.
This PR fixes it.