### PR TITLE
Inhibit sleep/shutdown on Linux

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -144,7 +144,16 @@ namespace WalletWasabi.Gui
 				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
 				cancel.ThrowIfCancellationRequested();
 
-				HostedServices.Register<SystemAwakeChecker>(new SystemAwakeChecker(WalletManager), "System Awake Checker");
+				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(WalletManager).ConfigureAwait(false);
+
+				if (systemAwakeChecker is not null)
+				{
+					HostedServices.Register<SystemAwakeChecker>(systemAwakeChecker, "System Awake Checker");
+				}
+				else
+				{
+					Logger.LogInfo("System Awake Checker is not available on this platform.");
+				}
 
 				if (Config.UseTor && Network != Network.RegTest)
 				{

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 		[Fact]
 		public void BasicTests()
 		{
-			// Make sure byte array comparision works within hashset and that the underlying API won't pull the floor out.
+			// Make sure byte array comparison works within hashset and that the underlying API won't pull the floor out.
 			var byteArray = new byte[] { 1, 2, 3 };
 			var sameByteArray = new byte[] { 1, 2, 3 };
 			var differentByteArray = new byte[] { 4, 5, 6 };
@@ -110,10 +110,10 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 		{
 			var mockRandom = new MockRandom();
 
-			// The random should not overfow.
+			// The random should not overflow.
 			mockRandom.GetBytesResults.Add(EC.N.ToBytes());
 
-			// The random should not overfow.
+			// The random should not overflow.
 			mockRandom.GetBytesResults.Add(new Scalar(uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue).ToBytes());
 
 			mockRandom.GetBytesResults.Add(Scalar.Zero.ToBytes());

--- a/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/LinuxInhibitorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/LinuxInhibitorTests.cs
@@ -1,0 +1,57 @@
+using Moq;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Helpers.PowerSaving;
+using WalletWasabi.Microservices;
+using Xunit;
+using static WalletWasabi.Helpers.PowerSaving.LinuxInhibitorTask;
+
+namespace WalletWasabi.Tests.UnitTests.Helpers.PowerSaving
+{
+	/// <summary>
+	/// Tests for <see cref="LinuxInhibitorTask"/> class.
+	/// </summary>
+	public class LinuxInhibitorTests
+	{
+		private const string DefaultReason = "CJ is in progress";
+
+		[Fact]
+		public async Task TestAvailabilityAsync()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				bool isAvailable = await LinuxInhibitorTask.IsSystemdInhibitSupportedAsync();
+				Assert.True(isAvailable);
+			}
+		}
+
+		[Fact]
+		public async Task CancelBehaviorAsync()
+		{
+			Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
+			mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+				.Returns((CancellationToken cancellationToken, bool killOnCancel) => Task.Delay(Timeout.Infinite, cancellationToken));
+			mockProcess.Setup(p => p.HasExited).Returns(false);
+			mockProcess.Setup(p => p.Kill());
+
+			LinuxInhibitorTask psTask = new(InhibitWhat.All, TimeSpan.FromSeconds(10), DefaultReason, mockProcess.Object);
+
+			// Task was started and as such it cannot be done yet.
+			Assert.False(psTask.IsDone);
+
+			// Explicitly ask to stop the task.
+			await psTask.StopAsync();
+
+			// Now the task must be finished.
+			Assert.True(psTask.IsDone);
+
+			// Prolong after exit must fail.
+			Assert.False(psTask.Prolong(TimeSpan.FromSeconds(5)));
+
+			mockProcess.VerifyAll();
+		}
+	}
+}

--- a/WalletWasabi/Helpers/IPowerSavingInhibitorTask.cs
+++ b/WalletWasabi/Helpers/IPowerSavingInhibitorTask.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Helpers
+{
+	/// <summary>Task that makes sure that computer does not go to sleep, switch to idle state, etc.</summary>
+	public interface IPowerSavingInhibitorTask
+	{
+		/// <remarks>Useful to know whether a new task needs to be created.</remarks>
+		bool IsDone { get; }
+
+		/// <summary>Prolongs the interval how long the power saving should be postponed by.</summary>
+		/// <returns><c>true</c> when prolonging of the power saving task succeeded, <c>false</c> when the task is already stopped.</returns>
+		bool Prolong(TimeSpan timeSpan);
+
+		/// <summary>Stop the internal power saving mechanism.</summary>
+		/// <remarks>Once the task is stopped, computer may go idle/reboot, etc. Operating systems' power saving timers may be reseted or not - we provide no guarantees here.</remarks>
+		Task StopAsync();
+	}
+}

--- a/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
@@ -262,6 +262,12 @@ namespace WalletWasabi.Helpers.PowerSaving
 				whatList.Add("suspend");
 			}
 
+			if (what.HasFlag(InhibitWhat.Shutdown))
+			{
+				// The best option available probably.
+				whatList.Add("logout");
+			}
+
 			string whatArgument = string.Join(':', whatList);
 			return whatArgument;
 		}

--- a/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+using WalletWasabi.Microservices;
+
+namespace WalletWasabi.Helpers.PowerSaving
+{
+	/// <summary><c>systemd-inhibitor</c> API wrapper.</summary>
+	/// <remarks>Only works on Linux machines that use systemd.</remarks>
+	/// <seealso href="https://www.freedesktop.org/wiki/Software/systemd/inhibit/"/>
+	public class LinuxInhibitorTask : IPowerSavingInhibitorTask
+	{
+		/// <remarks>Guarded by <see cref="StateLock"/>.</remarks>
+		private bool _isDone;
+
+		/// <remarks>Use the constructor only in tests.</remarks>
+		internal LinuxInhibitorTask(InhibitWhat what, TimeSpan period, string reason, ProcessAsync process)
+		{
+			What = what;
+			BasePeriod = period;
+			Reason = reason;
+			Process = process;
+			Cts = new CancellationTokenSource(period);
+
+			Task = WaitAsync();
+		}
+
+		/// <summary>Linux GUI environments.</summary>
+		public enum GraphicalEnvironment
+		{
+			Gnome,
+			Mate,
+			Other,
+		}
+
+		[Flags]
+		public enum InhibitWhat
+		{
+			/// <summary>
+			/// Inhibits that the system goes into idle mode, possibly resulting in automatic system
+			/// suspend or shutdown depending on configuration.
+			/// </summary>
+			Idle = 1,
+
+			/// <summary>Inhibits system suspend and hibernation requested by (unprivileged) users.</summary>
+			Sleep = 2,
+
+			/// <summary>Inhibits high-level system power-off and reboot requested by (unprivileged) users.</summary>
+			Shutdown = 4,
+
+			All = Idle | Sleep | Shutdown
+		}
+
+		/// <remarks>Guards <see cref="_isDone"/>.</remarks>
+		private object StateLock { get; } = new();
+
+		public InhibitWhat What { get; }
+
+		/// <remarks>It holds: inhibitorEndTime = now + BasePeriod + ProlongInterval.</remarks>
+		public TimeSpan BasePeriod { get; }
+
+		/// <summary>Reason why the power saving is inhibited.</summary>
+		public string Reason { get; }
+		private ProcessAsync Process { get; }
+		private CancellationTokenSource Cts { get; }
+		private TaskCompletionSource StoppedTcs { get; } = new();
+		private Task Task { get; }
+
+		/// <inheritdoc/>
+		public bool IsDone
+		{
+			get
+			{
+				lock (StateLock)
+				{
+					return _isDone;
+				}
+			}
+		}
+
+		private async Task WaitAsync()
+		{
+			try
+			{
+				await Process.WaitForExitAsync(Cts.Token).ConfigureAwait(false);
+
+				// This should be hit only when somebody externally kills the systemd-inhibit process.
+				Logger.LogError("Linux inhibit process ended prematurely.");
+			}
+			catch (OperationCanceledException)
+			{
+				Logger.LogTrace("Elapsed time limit for the inhibitor task to live.");
+			}
+			finally
+			{
+				if (!Process.HasExited)
+				{
+					// Process cannot stop on its own so we know it is actually running.
+					try
+					{
+						Process.Kill();
+						Logger.LogWarning($"XXX: Inhibit task was killed.");
+					}
+					catch (Exception ex)
+					{
+						Logger.LogTrace($"Failed to kill the process. It might have finished already.", ex);
+					}
+				}
+
+				lock (StateLock)
+				{
+					Cts.Cancel();
+					Cts.Dispose();
+					_isDone = true;
+					StoppedTcs.SetResult();
+				}
+
+				Logger.LogTrace("Inhibit task is finished.");
+				Logger.LogWarning($"XXX: Inhibit task is finished.");
+			}
+		}
+
+		/// <inheritdoc/>
+		public bool Prolong(TimeSpan period)
+		{
+			string logMessage = "N/A";
+
+			try
+			{
+				lock (StateLock)
+				{
+					if (!_isDone && !Cts.IsCancellationRequested)
+					{
+						// This does nothing when cancellation of CTS is already requested.
+						Cts.CancelAfter(period);
+						logMessage = $"Power saving task was prolonged to: {DateTime.UtcNow.Add(period)}";
+						return !Cts.IsCancellationRequested;
+					}
+
+					logMessage = "Power saving task is already finished.";
+					return false;
+				}
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError(ex);
+				return false;
+			}
+			finally
+			{
+				Logger.LogWarning($"XXX: {logMessage}");
+				Logger.LogTrace(logMessage);
+			}
+		}
+
+		public Task StopAsync()
+		{
+			lock (StateLock)
+			{
+				if (!_isDone)
+				{
+					Cts.Cancel();
+				}
+			}
+
+			return StoppedTcs.Task;
+		}
+
+		public static Task<bool> IsSystemdInhibitSupportedAsync()
+		{
+			return IsCommandSupportedAsync("systemd-inhibit");
+		}
+
+		public static Task<bool> IsGnomeSessionInhibitSupportedAsync()
+		{
+			return IsCommandSupportedAsync("gnome-session-inhibit");
+		}
+
+		public static Task<bool> IsMateSessionInhibitSupportedAsync()
+		{
+			return IsCommandSupportedAsync("mate-session-inhibit");
+		}
+
+		private static async Task<bool> IsCommandSupportedAsync(string command)
+		{
+			try
+			{
+				using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+				ProcessStartInfo processStartInfo = GetProcessStartInfo(command, "--help");
+				Process process = System.Diagnostics.Process.Start(processStartInfo)!;
+
+				await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+				bool success = process.ExitCode == 0;
+				Logger.LogDebug($"{command} is {(success ? "supported" : "NOT supported")}.");
+
+				return success;
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError($"Failed to find out whether {command} is supported or not.", ex);
+			}
+
+			return false;
+		}
+
+		/// <remarks><paramref name="reason"/> cannot contain apostrophe characters.</remarks>
+		public static LinuxInhibitorTask Create(InhibitWhat what, TimeSpan basePeriod, string reason, GraphicalEnvironment gui = GraphicalEnvironment.Other)
+		{
+			// Make sure that the systemd-inhibit is terminated once the parent process (WW) finishes.
+			string innerCommand = $"tail --pid={Environment.ProcessId} -f /dev/null";
+			string command;
+			string arguments;
+
+			// systemd-inhibit command by default does not seem to inhibit idle behavior on Ubuntu 20.04 (and probably most others).
+			// That's why we use gnome-session-inhibit when we can.
+			if (gui == GraphicalEnvironment.Gnome)
+			{
+				string inhibitArgument = ConstructInhibitArgument(what);
+				command = "gnome-session-inhibit";
+				arguments = $"--reason \"{reason}\" --inhibit {inhibitArgument} {innerCommand}";
+			}
+			else if (gui == GraphicalEnvironment.Mate)
+			{
+				string inhibitArgument = ConstructInhibitArgument(what);
+				command = $"mate-session-inhibit";
+				arguments = $"--reason \"{reason}\" --inhibit {inhibitArgument} {innerCommand}";
+			}
+			else
+			{
+				string whatArgument = ConstructSystemdWhatArgument(what);
+				command = $"systemd-inhibit";
+				arguments = $"--why=\"{reason}\" --what=\"{whatArgument}\" --mode=block {innerCommand}";
+			}
+
+			Logger.LogWarning($"XXX: shell command to invoke: {command}");
+			ProcessStartInfo startInfo = GetProcessStartInfo(command, arguments);
+
+			ProcessAsync process = new(startInfo);
+			process.Start();
+			LinuxInhibitorTask task = new(what, basePeriod, reason, process);
+
+			return task;
+		}
+
+		/// <summary>Constructs argument <c>--inhibit</c> value for <c>gnome-session-inhibit</c> or <c>mate-session-inhibit</c> command.</summary>
+		/// <remarks>The possible values are "logout", "switch-user", "suspend", "idle", "automount".</remarks>
+		private static string ConstructInhibitArgument(InhibitWhat what)
+		{
+			List<string> whatList = new();
+
+			if (what.HasFlag(InhibitWhat.Idle))
+			{
+				whatList.Add("idle");
+			}
+
+			if (what.HasFlag(InhibitWhat.Sleep))
+			{
+				whatList.Add("suspend");
+			}
+
+			string whatArgument = string.Join(':', whatList);
+			return whatArgument;
+		}
+
+		/// <summary>Constructs argument <c>--what</c> value for <c>systemd-inhibit</c> command.</summary>
+		private static string ConstructSystemdWhatArgument(InhibitWhat what)
+		{
+			List<string> whatList = new();
+
+			if (what.HasFlag(InhibitWhat.Idle))
+			{
+				whatList.Add("idle");
+			}
+
+			if (what.HasFlag(InhibitWhat.Sleep))
+			{
+				whatList.Add("sleep");
+			}
+
+			if (what.HasFlag(InhibitWhat.Shutdown))
+			{
+				whatList.Add("shutdown");
+			}
+
+			string whatArgument = string.Join(':', whatList);
+			return whatArgument;
+		}
+
+		private static ProcessStartInfo GetProcessStartInfo(string command, string arguments)
+		{
+			return new()
+			{
+				FileName = command,
+				Arguments = arguments,
+				RedirectStandardOutput = true,
+				UseShellExecute = false,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden
+			};
+		}
+	}
+}

--- a/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
@@ -200,7 +200,8 @@ namespace WalletWasabi.Helpers.PowerSaving
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError($"Failed to find out whether {command} is supported or not.", ex);
+				Logger.LogDebug($"Failed to find out whether {command} is supported or not.");
+				Logger.LogTrace(ex);
 			}
 
 			return false;
@@ -235,7 +236,7 @@ namespace WalletWasabi.Helpers.PowerSaving
 				arguments = $"--why=\"{reason}\" --what=\"{whatArgument}\" --mode=block {innerCommand}";
 			}
 
-			Logger.LogWarning($"XXX: shell command to invoke: {command}");
+			Logger.LogWarning($"XXX: shell command to invoke: {command} {arguments}");
 			ProcessStartInfo startInfo = GetProcessStartInfo(command, arguments);
 
 			ProcessAsync process = new(startInfo);

--- a/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
@@ -25,7 +25,7 @@ namespace WalletWasabi.Helpers.PowerSaving
 			Process = process;
 			Cts = new CancellationTokenSource(period);
 
-			Task = WaitAsync();
+			_ = WaitAsync();
 		}
 
 		/// <summary>Linux GUI environments.</summary>
@@ -67,7 +67,6 @@ namespace WalletWasabi.Helpers.PowerSaving
 		private ProcessAsync Process { get; }
 		private CancellationTokenSource Cts { get; }
 		private TaskCompletionSource StoppedTcs { get; } = new();
-		private Task Task { get; }
 
 		/// <inheritdoc/>
 		public bool IsDone

--- a/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
@@ -102,7 +102,7 @@ namespace WalletWasabi.Helpers.PowerSaving
 					try
 					{
 						Process.Kill();
-						Logger.LogWarning($"XXX: Inhibit task was killed.");
+						Logger.LogTrace("Inhibit task was killed.");
 					}
 					catch (Exception ex)
 					{
@@ -119,7 +119,6 @@ namespace WalletWasabi.Helpers.PowerSaving
 				}
 
 				Logger.LogTrace("Inhibit task is finished.");
-				Logger.LogWarning($"XXX: Inhibit task is finished.");
 			}
 		}
 
@@ -151,7 +150,6 @@ namespace WalletWasabi.Helpers.PowerSaving
 			}
 			finally
 			{
-				Logger.LogWarning($"XXX: {logMessage}");
 				Logger.LogTrace(logMessage);
 			}
 		}
@@ -236,7 +234,7 @@ namespace WalletWasabi.Helpers.PowerSaving
 				arguments = $"--why=\"{reason}\" --what=\"{whatArgument}\" --mode=block {innerCommand}";
 			}
 
-			Logger.LogWarning($"XXX: shell command to invoke: {command} {arguments}");
+			Logger.LogTrace($"Command to invoke: {command} {arguments}");
 			ProcessStartInfo startInfo = GetProcessStartInfo(command, arguments);
 
 			ProcessAsync process = new(startInfo);

--- a/WalletWasabi/Microservices/ProcessAsync.cs
+++ b/WalletWasabi/Microservices/ProcessAsync.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.Microservices
 		public int ExitCode => Process.ExitCode;
 
 		/// <inheritdoc cref="Process.HasExited"/>
-		public bool HasExited => Process.HasExited;
+		public virtual bool HasExited => Process.HasExited;
 
 		/// <inheritdoc cref="Process.Id"/>
 		public int Id => Process.Id;
@@ -69,7 +69,7 @@ namespace WalletWasabi.Microservices
 		}
 
 		/// <inheritdoc cref="Process.Kill()"/>
-		public void Kill()
+		public virtual void Kill()
 		{
 			Process.Kill();
 		}

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -91,6 +91,7 @@ namespace WalletWasabi.Services
 				{
 					Logger.LogWarning($"XXX: Stop task.");
 					await task.StopAsync().ConfigureAwait(false);
+					_powerSavingTask = null;
 				}
 			}
 		}

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Services
 					gui = GraphicalEnvironment.Gnome;
 				}
 
-				taskFactory = () => Task.FromResult<IPowerSavingInhibitorTask>(LinuxInhibitorTask.Create(InhibitWhat.All, Timeout, Reason, gui));
+				taskFactory = () => Task.FromResult<IPowerSavingInhibitorTask>(LinuxInhibitorTask.Create(InhibitWhat.Idle, Timeout, Reason, gui));
 			}
 
 			return new SystemAwakeChecker(walletManager, taskFactory);

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Services
 					if (task is not null)
 					{
 						Logger.LogWarning($"XXX: Prolong power saving prevention task by one minute.");
-						if (!task.Prolong(TimeSpan.FromMinutes(1)))
+						if (!task.Prolong(Timeout.Add(TimeSpan.FromMinutes(1))))
 						{
 							Logger.LogWarning($"XXX: Failed to prolong.");
 							task = null;

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -72,9 +72,14 @@ namespace WalletWasabi.Services
 					if (task is not null)
 					{
 						Logger.LogWarning($"XXX: Prolong power saving prevention task by one minute.");
-						task.Prolong(TimeSpan.FromMinutes(1));
+						if (!task.Prolong(TimeSpan.FromMinutes(1)))
+						{
+							Logger.LogWarning($"XXX: Failed to prolong.");
+							task = null;
+						}
 					}
-					else
+
+					if (task is null)
 					{
 						Logger.LogWarning($"XXX: Create new power saving prevention task.");
 						_powerSavingTask = await TaskFactory!().ConfigureAwait(false);

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -91,7 +91,7 @@ namespace WalletWasabi.Services
 			{
 				if (task is not null)
 				{
-					Logger.LogWarning("Stop the power saving task.");
+					Logger.LogWarning("Computer idle state is allowed again.");
 					await task.StopAsync().ConfigureAwait(false);
 					_powerSavingTask = null;
 				}

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -1,26 +1,97 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
 using WalletWasabi.Helpers;
+using WalletWasabi.Helpers.PowerSaving;
+using WalletWasabi.Logging;
 using WalletWasabi.Wallets;
+using static WalletWasabi.Helpers.PowerSaving.LinuxInhibitorTask;
 
 namespace WalletWasabi.Services
 {
 	public class SystemAwakeChecker : PeriodicRunner
 	{
-		public SystemAwakeChecker(WalletManager walletManager) : base(TimeSpan.FromMinutes(1))
+		private const string Reason = "CoinJoin is in progress.";
+		private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(5);
+
+		private volatile IPowerSavingInhibitorTask? _powerSavingTask;
+
+		private SystemAwakeChecker(WalletManager walletManager, Func<Task<IPowerSavingInhibitorTask>>? taskFactory) : base(TimeSpan.FromMinutes(1))
 		{
 			WalletManager = walletManager;
+			TaskFactory = taskFactory;
 		}
 
 		private WalletManager WalletManager { get; }
+		public Func<Task<IPowerSavingInhibitorTask>>? TaskFactory { get; }
+
+		/// <summary>Checks whether we support awake state prolonging for the current platform.</summary>
+		public static async Task<SystemAwakeChecker?> CreateAsync(WalletManager walletManager)
+		{
+			Func<Task<IPowerSavingInhibitorTask>>? taskFactory = null;
+
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				// Either we have systemd or not.
+				bool isSystemd = await LinuxInhibitorTask.IsSystemdInhibitSupportedAsync().ConfigureAwait(false);
+				if (!isSystemd)
+				{
+					return null;
+				}
+
+				GraphicalEnvironment gui = GraphicalEnvironment.Other;
+
+				// Specialization for GNOME.
+				if (await LinuxInhibitorTask.IsMateSessionInhibitSupportedAsync().ConfigureAwait(false))
+				{
+					gui = GraphicalEnvironment.Mate;
+				}
+				else if (await LinuxInhibitorTask.IsGnomeSessionInhibitSupportedAsync().ConfigureAwait(false))
+				{
+					gui = GraphicalEnvironment.Gnome;
+				}
+
+				taskFactory = () => Task.FromResult<IPowerSavingInhibitorTask>(LinuxInhibitorTask.Create(InhibitWhat.All, Timeout, Reason, gui));
+			}
+
+			return new SystemAwakeChecker(walletManager, taskFactory);
+		}
 
 		protected override async Task ActionAsync(CancellationToken cancel)
 		{
+			IPowerSavingInhibitorTask? task = _powerSavingTask;
+
 			if (WalletManager.AnyCoinJoinInProgress())
 			{
-				await EnvironmentHelpers.ProlongSystemAwakeAsync().ConfigureAwait(false);
+				Logger.LogWarning($"XXX: CJ is in progress, make sure to prolong awake state.");
+
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+				{
+					if (task is not null)
+					{
+						Logger.LogWarning($"XXX: Prolong power saving prevention task by one minute.");
+						task.Prolong(TimeSpan.FromMinutes(1));
+					}
+					else
+					{
+						Logger.LogWarning($"XXX: Create new power saving prevention task.");
+						_powerSavingTask = await TaskFactory!().ConfigureAwait(false);
+					}
+				}
+				else
+				{
+					await EnvironmentHelpers.ProlongSystemAwakeAsync().ConfigureAwait(false);
+				}
+			}
+			else
+			{
+				if (task is not null)
+				{
+					Logger.LogWarning($"XXX: Stop task.");
+					await task.StopAsync().ConfigureAwait(false);
+				}
 			}
 		}
 	}

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -65,23 +65,20 @@ namespace WalletWasabi.Services
 
 			if (WalletManager.AnyCoinJoinInProgress())
 			{
-				Logger.LogWarning($"XXX: CJ is in progress, make sure to prolong awake state.");
-
 				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 				{
 					if (task is not null)
 					{
-						Logger.LogWarning($"XXX: Prolong power saving prevention task by one minute.");
 						if (!task.Prolong(Timeout.Add(TimeSpan.FromMinutes(1))))
 						{
-							Logger.LogWarning($"XXX: Failed to prolong.");
+							Logger.LogTrace("Failed to prolong the power saving task.");
 							task = null;
 						}
 					}
 
 					if (task is null)
 					{
-						Logger.LogWarning($"XXX: Create new power saving prevention task.");
+						Logger.LogTrace("Create new power saving prevention task.");
 						_powerSavingTask = await TaskFactory!().ConfigureAwait(false);
 					}
 				}
@@ -94,7 +91,7 @@ namespace WalletWasabi.Services
 			{
 				if (task is not null)
 				{
-					Logger.LogWarning($"XXX: Stop task.");
+					Logger.LogWarning("Stop the power saving task.");
 					await task.StopAsync().ConfigureAwait(false);
 					_powerSavingTask = null;
 				}

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.Tor
 	/// <seealso href="https://2019.www.torproject.org/docs/tor-manual.html.en"/>
 	public class TorProcessManager : IAsyncDisposable
 	{
-		/// <summary>Task competion source returning a cancellation token which is canceled when Tor process is terminated.</summary>
+		/// <summary>Task completion source returning a cancellation token which is canceled when Tor process is terminated.</summary>
 		private volatile TaskCompletionSource<CancellationToken> _tcs = new();
 
 		public TorProcessManager(TorSettings settings) :
@@ -130,7 +130,7 @@ namespace WalletWasabi.Tor
 
 					await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 				}
-				catch (OperationCanceledException ex)
+				catch (OperationCanceledException)
 				{
 					Logger.LogDebug("User canceled operation.");
 					setNewTcs = false;


### PR DESCRIPTION
Related to #4704

## Testing instructions

* Start old GUI project (not the Fluent one)
* Make sure that you are doing a coinjoin.
* Now you should see a `systemd-inhibit` (or `gnome-session-inhibit` or `mate-session-inhibit`) process in the list of running processes (`ps auxf | grep systemd-inhibit` / `ps auxf | grep gnome-session-inhibit` / `ps auxf | grep mate-session-inhibit`)
* Testing (Edit: fe7e68a5a60650e9918f815bfc837f72e6211233 switched from All to Idle only)
  * **Scenario 1**: In your terminal, run `systemctl reboot` command to attempt to reboot your operating system.
    * If you try to do `sudo shutdown now` (note the `sudo`), your computer will reboot as `systemd-inhibit` process is not run under root user in WW. 
    * <s>You may also try `shutdown now` (that was also correctly inhibited on my Ubuntu 20.04 machine).</s>
  * **Scenario 2**: Set auto suspend for your machine and do not interact with your computer. Your computer should not auto suspend while CJ is running and it should suspend when it is not. This test requires patience ;-). Also make sure that your OS is up to date because unintended upgrades in Debian-like OSs blocks suspending too.
  * **Scenario 3**: Try to restart your computer via the restart button in your graphical environment (i.e. Gnome/xfce/KDE/etc.).
        * Note: I tried to do a restart via Ubuntu GUI and unfortunately it restarted. This would be correctly prevented if `systemd-inhibit` is run under root but we don't do that in this PR.

**Once you are done testing, please attach WW logs from the testing run and send them to me to analyze it.**

## Bit of research

### Documentation

Developer documentation for systemd-inhibit: https://www.freedesktop.org/wiki/Software/systemd/inhibit/

Settings for logind: https://www.freedesktop.org/software/systemd/man/logind.conf.html

### `systemd` support by operating systems

WW officially [supports](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md) Ubuntu 20.10, 20.04 (LTS), 18.04 (LTS), Fedora 32+ and Debian 9+.

* https://en.wikipedia.org/wiki/Fedora_version_history - `systemd` replaced `Init` by default in Fedora 15.
* https://en.wikipedia.org/wiki/Ubuntu_version_history - `systemd` replaced `Init` by default in Ubuntu 15.04
* https://en.wikipedia.org/wiki/Debian_version_history  - `systemd` replaced `Init` by default in Debian 8.

-> So attempting to use `systemd-inhibit` makes sense as it covers all supported Linux distributions.

### Behavior

* https://unix.stackexchange.com/questions/342284/system-shuts-down-even-if-inhibitor-is-present - "The owner of an inhibitor can always ignore his own inhibitor, but not the inhibitors of other users. That is intended behaviour." ([bug](https://bugs.freedesktop.org/show_bug.cgi?id=66321))
    * In our use case, it is: We exectue `systemd-inhibit --why="CJ is in progress" ...` and it is simply ignored by Gnome on my Ubuntu 20.04 because the same users clicks the reboot button and he/she should be aware that there are some inhibitors. 
* man pages
    * https://www.freedesktop.org/software/systemd/man/logind.conf.html
    * http://manpages.ubuntu.com/manpages/bionic/man1/systemd-inhibit.1.html
* Related bug reports explaining `systemd-inhibit` behavior
  * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=961146 - "systemd-logind sometimes ignores a systemd-inhibit lock"
  * https://github.com/systemd/systemd/issues/15887#issuecomment-778319440
  * https://bugs.launchpad.net/ubuntu/+source/xfce4-session/+bug/1615612 - "systemd-inhibit authentication ignored by suspend request" - xfce shows a warning when user clicks the log out button in GUI. (I don't see it in Gnome, missing sudo?)

### Tidbits

> `poweroff` is trying to emulate the pre-systemd interface, while `systemctl poweroff` doesn't have this limitation. There is no expectation that they'll do the same thing. 

\[[source](https://github.com/systemd/systemd/issues/15239#issuecomment-604858790)\]

### `gnome-session-inhibit`

* https://manpages.ubuntu.com/manpages/focal/man1/gnome-session-inhibit.1.html
* https://gitlab.gnome.org/GNOME/gnome-session/-/merge_requests/50
* https://askubuntu.com/questions/502609/what-is-a-simple-command-process-i-can-run-to-prevent-ubuntu-from-sleeping
