### PR TITLE
[Fluent] Hide block height if the transaction is not confirmed

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -25,7 +25,7 @@
       <c:PreviewItem Icon="{StaticResource transaction_id}"
                      Text="Transaction ID"
                      Content="{Binding TransactionId}"
-                     CopyParameter="{Binding TransactionId}"/>
+                     CopyParameter="{Binding TransactionId}" />
 
       <Separator />
 
@@ -52,8 +52,9 @@
       <c:PreviewItem Icon="{StaticResource block_height}"
                      Text="Block height"
                      Content="{Binding BlockHeight}"
-                     CopyParameter="{Binding BlockHeight}" />
-      <Separator />
+                     CopyParameter="{Binding BlockHeight}"
+                     IsVisible="{Binding IsConfirmed}" />
+      <Separator IsVisible="{Binding IsConfirmed}" />
 
       <!-- Confirmations -->
       <c:PreviewItem Icon="{StaticResource copy_confirmed}"
@@ -69,7 +70,6 @@
                      CopyParameter="{Binding Labels}">
         <c:TagsBox Padding="0" IsReadOnly="True" Items="{Binding Labels}" />
       </c:PreviewItem>
-
     </StackPanel>
   </c:ContentArea>
 </UserControl>


### PR DESCRIPTION
Similar to issue #3878
Currently when a transction is not confirmed/pending we display block height 0 in the transaction details which is wrong.

Master:

![Capture0](https://user-images.githubusercontent.com/52379387/125776807-1316819f-f7fd-4892-a5e1-51e7142576f0.PNG)

This PR:

![Capture1](https://user-images.githubusercontent.com/52379387/125776833-58b20784-c0f5-4fe0-90b9-950143872231.PNG)
