### PR TITLE
[Fluent] Transaction history performance improvement

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -90,14 +90,31 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 
 				lock (_transactionListLock)
 				{
-					_transactionSourceList.Clear();
+					var copyList = Transactions.ToList();
+
+					foreach (HistoryItemViewModel historyItemViewModel in copyList)
+					{
+						if (txRecordList.All(x => x.TransactionId != historyItemViewModel.TransactionSummary.TransactionId))
+						{
+							_transactionSourceList.Remove(historyItemViewModel);
+						}
+					}
 
 					Money balance = Money.Zero;
 					for (var i = 0; i < txRecordList.Count; i++)
 					{
 						var transactionSummary = txRecordList[i];
 						balance += transactionSummary.Amount;
-						_transactionSourceList.Add(new HistoryItemViewModel(i, transactionSummary, _walletViewModel, balance, _updateTrigger));
+						var newItem = new HistoryItemViewModel(i, transactionSummary, _walletViewModel, balance, _updateTrigger);
+
+						if (_transactions.FirstOrDefault(x => x.TransactionSummary.TransactionId == newItem.TransactionSummary.TransactionId) is { } item)
+						{
+							item.Update(newItem);
+						}
+						else
+						{
+							_transactionSourceList.Add(newItem);
+						}
 					}
 				}
 			}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -79,8 +79,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 			_updateTrigger
 				.Subscribe(async _ => await UpdateAsync())
 				.DisposeWith(disposables);
-
-			disposables.Add(Disposable.Create(() => _transactionSourceList.Clear()));
 		}
 
 		private async Task UpdateAsync()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -76,8 +76,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 		{
 			base.OnActivated(disposables);
 
-			RxApp.MainThreadScheduler.Schedule(async () => await UpdateAsync());
-
 			_updateTrigger
 				.Subscribe(async _ => await UpdateAsync())
 				.DisposeWith(disposables);


### PR DESCRIPTION
Home screen loading caused UI freeze which mostly was because of the transaction history DataGrid.

I made a few changes which made the loading twice faster.
- Fixed the issue where the History was updated twice.
- Instead of clearing and building up the list every time, build up once then update the items that changed.

![image](https://user-images.githubusercontent.com/16364053/125790160-07a5f71d-b41d-4814-a906-3327620f1ff1.png)
![image](https://user-images.githubusercontent.com/16364053/125790228-9fff613a-90ae-4004-9ec0-c14d9b7b4ceb.png)

