### PR TITLE
[Fluent] Fix send fee estimations crash

### DIFF
--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -384,7 +384,8 @@ namespace WalletWasabi.Fluent.Controls
 			{
 				if (xAxisValues[i] <= xAxisCurrentValue)
 				{
-					return areaWidth / xAxisValues.Count * i;
+					var cursorPosition = i == 0 ? 0.0 : areaWidth / (xAxisValues.Count - 1) * i;
+					return cursorPosition;
 				}
 			}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -214,11 +214,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 			if (_wallet.Network != Network.TestNet)
 			{
-				var labels = feeEstimates.Select(x => x.Key)
-					.Select(x => FeeTargetTimeConverter.Convert(x, "m", "h", "h", "d", "d"))
-					.Reverse()
-					.ToArray();
-
 				var xs = feeEstimates.Select(x => (double)x.Key).ToArray();
 				var ys = feeEstimates.Select(x => (double)x.Value).ToArray();
 #if true
@@ -229,6 +224,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				confirmationTargetValues = xs.Reverse().ToArray();
 				satoshiPerByteValues = ys.Reverse().ToArray();
 #endif
+				var labels = feeEstimates.Select(x => x.Key)
+					.Select(x => FeeTargetTimeConverter.Convert(x, "m", "h", "h", "d", "d"))
+					.Reverse()
+					.ToArray();
 				confirmationTargetLabels = labels;
 			}
 			else

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -35,13 +35,9 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		[AutoNotify] private double[] _yAxisValues;
 		[AutoNotify] private string[] _xAxisLabels;
 		[AutoNotify] private double _xAxisCurrentValue = 36;
-		[AutoNotify] private int _xAxisCurrentValueIndex;
-
-		[AutoNotify(SetterModifier = AccessModifier.Private)]
-		private int _xAxisMinValue = 0;
-
-		[AutoNotify(SetterModifier = AccessModifier.Private)]
-		private int _xAxisMaxValue = 9;
+		[AutoNotify(SetterModifier = AccessModifier.Private)] private int _sliderMinimum = 0;
+		[AutoNotify(SetterModifier = AccessModifier.Private)] private int _sliderMaximum = 9;
+		[AutoNotify] private int _sliderValue;
 
 		private bool _updatingCurrentValue;
 		private FeeRate _feeRate;
@@ -64,7 +60,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 					}
 				});
 
-			this.WhenAnyValue(x => x.XAxisCurrentValueIndex)
+			this.WhenAnyValue(x => x.SliderValue)
 				.Subscribe(SetXAxisCurrentValue);
 
 			NextCommand = ReactiveCommand.CreateFromTask(async () =>
@@ -187,21 +183,21 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				_updatingCurrentValue = true;
 				if (_xAxisValues is not null)
 				{
-					XAxisCurrentValueIndex = GetCurrentValueIndex(xAxisCurrentValue, _xAxisValues);
+					SliderValue = GetCurrentValueIndex(xAxisCurrentValue, _xAxisValues);
 				}
 
 				_updatingCurrentValue = false;
 			}
 		}
 
-		private void SetXAxisCurrentValue(int xAxisCurrentValueIndex)
+		private void SetXAxisCurrentValue(int sliderValue)
 		{
 			if (_xAxisValues is not null)
 			{
 				if (!_updatingCurrentValue)
 				{
 					_updatingCurrentValue = true;
-					var index = _xAxisValues.Length - xAxisCurrentValueIndex - 1;
+					var index = _xAxisValues.Length - sliderValue - 1;
 					XAxisCurrentValue = _xAxisValues[index];
 					_updatingCurrentValue = false;
 				}
@@ -254,10 +250,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			XAxisLabels = xAxisLabels;
 			XAxisValues = xAxisValues;
 			YAxisValues = yAxisValues;
-			XAxisMinValue = 0;
-			XAxisMaxValue = xAxisValues.Length - 1;
-			XAxisCurrentValue = Math.Clamp(XAxisCurrentValue, XAxisMinValue, XAxisMaxValue);
-			XAxisCurrentValueIndex = GetCurrentValueIndex(XAxisCurrentValue, XAxisValues);
+			SliderMinimum = 0;
+			SliderMaximum = xAxisValues.Length - 1;
+			XAxisCurrentValue = Math.Clamp(XAxisCurrentValue, XAxisValues.Min(), XAxisValues.Max());
+			SliderValue = GetCurrentValueIndex(XAxisCurrentValue, XAxisValues);
 			_updatingCurrentValue = false;
 		}
 
@@ -384,7 +380,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				}
 			}
 
-			return XAxisMaxValue;
+			return SliderMaximum;
 		}
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -352,6 +352,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			xts.Reverse();
 		}
 
+		private static double Interpolate(double from, double to, double t)
+		{
+			return from + (to - from) * t;
+		}
+
 		private decimal GetYAxisValueFromXAxisCurrentValue(double xValue)
 		{
 			if (_xAxisValues is { } && _yAxisValues is { })
@@ -359,9 +364,22 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				var x = _xAxisValues.Reverse().ToArray();
 				var y = _yAxisValues.Reverse().ToArray();
 				double t = xValue;
-				var spline = CubicSpline.InterpolatePchipSorted(x, y);
-				var interpolated = (decimal)spline.Interpolate(t);
-				return Math.Clamp(interpolated, (decimal)y[^1], (decimal)y[0]);
+
+				if (x.Length > 2)
+				{
+					var spline = CubicSpline.InterpolatePchipSorted(x, y);
+					var interpolated = (decimal) spline.Interpolate(t);
+					return Math.Clamp(interpolated, (decimal) y[^1], (decimal) y[0]);
+				}
+				else if (x.Length == 2)
+				{
+					var interpolated = (decimal) Interpolate(y[1], y[0], t);
+					return Math.Clamp(interpolated, (decimal) y[^1], (decimal) y[0]);
+				}
+				else if (x.Length == 1)
+				{
+					return (decimal)y[0];
+				}
 			}
 
 			return XAxisMaxValue;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -178,14 +178,14 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			return time;
 		}
 
-		private void SetSliderValue(double xAxisCurrentValue)
+		private void SetSliderValue(double confirmationTarget)
 		{
 			if (!_updatingCurrentValue)
 			{
 				_updatingCurrentValue = true;
 				if (_confirmationTargetValues is not null)
 				{
-					SliderValue = GetSliderValue(xAxisCurrentValue, _confirmationTargetValues);
+					SliderValue = GetSliderValue(confirmationTarget, _confirmationTargetValues);
 				}
 
 				_updatingCurrentValue = false;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -208,7 +208,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			double[] confirmationTargets;
 			double[] yAxisValues;
 
-			if (_wallet.Network == Network.TestNet)
+			if (_wallet.Network != Network.TestNet)
 			{
 				var labels = feeEstimates.Select(x => x.Key)
 					.Select(x => FeeTargetTimeConverter.Convert(x, "m", "h", "h", "d", "d"))

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -352,11 +352,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			xts.Reverse();
 		}
 
-		private static double Interpolate(double from, double to, double t)
-		{
-			return from + (to - from) * t;
-		}
-
 		private decimal GetYAxisValueFromXAxisCurrentValue(double xValue)
 		{
 			if (_xAxisValues is { } && _yAxisValues is { })
@@ -371,12 +366,19 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 					var interpolated = (decimal) spline.Interpolate(t);
 					return Math.Clamp(interpolated, (decimal) y[^1], (decimal) y[0]);
 				}
-				else if (x.Length == 2)
+
+				if (x.Length == 2)
 				{
-					var interpolated = (decimal) Interpolate(y[1], y[0], t);
+					if (x[1] - x[0] == 0.0)
+					{
+						return (decimal) y[0];
+					}
+					var slope = (y[1] - y[0]) / (x[1] - x[0]);
+					var interpolated = (decimal)(y[0] + (xValue - x[0]) * slope);
 					return Math.Clamp(interpolated, (decimal) y[^1], (decimal) y[0]);
 				}
-				else if (x.Length == 1)
+
+				if (x.Length == 1)
 				{
 					return (decimal)y[0];
 				}

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -136,9 +136,9 @@
               Maximum="{Binding SliderMaximum}"
               Value="{Binding SliderValue}" />
       <c:LineChart Classes="cursor border xAxisLabels yAxis yAxisTitle area"
-                   XAxisLabels="{Binding XAxisLabels}"
-                   XAxisValues="{Binding XAxisValues}"
-                   XAxisCurrentValue="{Binding XAxisCurrentValue, Mode=TwoWay}"
+                   XAxisLabels="{Binding ConfirmationTargetLabels}"
+                   XAxisValues="{Binding ConfirmationTargets}"
+                   XAxisCurrentValue="{Binding CurrentConfirmationTarget, Mode=TwoWay}"
                    YAxisValues="{Binding YAxisValues}">
         <c:LineChart.Styles>
           <Style Selector="c|LineChart">

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -137,9 +137,9 @@
               Value="{Binding SliderValue}" />
       <c:LineChart Classes="cursor border xAxisLabels yAxis yAxisTitle area"
                    XAxisLabels="{Binding ConfirmationTargetLabels}"
-                   XAxisValues="{Binding ConfirmationTargets}"
+                   XAxisValues="{Binding ConfirmationTargetValues}"
                    XAxisCurrentValue="{Binding CurrentConfirmationTarget, Mode=TwoWay}"
-                   YAxisValues="{Binding YAxisValues}">
+                   YAxisValues="{Binding SatoshiPerByteValues}">
         <c:LineChart.Styles>
           <Style Selector="c|LineChart">
             <Setter Property="XAxisPlotMode" Value="EvenlySpaced"/>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -132,6 +132,8 @@
               DockPanel.Dock="Bottom"
               Classes="cursor"
               Focusable="True"
+              IsSnapToTickEnabled="True"
+              TickFrequency="1"
               Minimum="{Binding SliderMinimum}"
               Maximum="{Binding SliderMaximum}"
               Value="{Binding SliderValue}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -132,9 +132,9 @@
               DockPanel.Dock="Bottom"
               Classes="cursor"
               Focusable="True"
-              Minimum="{Binding XAxisMinValue}"
-              Maximum="{Binding XAxisMaxValue}"
-              Value="{Binding XAxisCurrentValueIndex}" />
+              Minimum="{Binding SliderMinimum}"
+              Maximum="{Binding SliderMaximum}"
+              Value="{Binding SliderValue}" />
       <c:LineChart Classes="cursor border xAxisLabels yAxis yAxisTitle area"
                    XAxisLabels="{Binding XAxisLabels}"
                    XAxisValues="{Binding XAxisValues}"


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/6069

The crash occurs when estimates array is less than 3 items long (CubicSpline.InterpolatePchipSorted input array must be at least 3 long).