### PR TITLE
[Fluent] Send - Remember fee slider value

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -115,6 +115,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		{
 			base.OnNavigatedTo(isInHistory, disposables);
 
+			XAxisCurrentValue = _lastXAxisCurrentValue;
+
 			var feeProvider = _wallet.FeeProvider;
 			Observable
 				.FromEventPattern(feeProvider, nameof(feeProvider.AllFeeEstimateChanged))


### PR DESCRIPTION
part of https://github.com/zkSNACKs/WalletWasabi/issues/6073.

The selected value is now remembered when the user navigates away and back to the slider page.