### PR TITLE
[WabiSabi] Wait for connection confirmation

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -91,6 +91,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 			// Register coins.
 			await RegisterCoinsAsync(aliceClients, cancellationToken).ConfigureAwait(false);
+			roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.Phase == Phase.ConnectionConfirmation, cancellationToken).ConfigureAwait(false);
 
 			// Confirm coins.
 			await scheduler.StartConfirmConnectionsAsync(aliceClients, dependencyGraph, roundState.ConnectionConfirmationTimeout, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
`MultiClientsCoinJoinTestAsync` runtime reduced from 8.4 minutes to 1.8 minutes with this change. Maybe other tests time went down I did not measure those. 

I think the reason is that many of the clients get into [TryConfirmConnectionAsync](https://github.com/molnard/WalletWasabi/blob/1d5eaa20eda260aa18712b87c5935c501b7f2602/WalletWasabi/WabiSabi/Client/AliceClient.cs#L59) and eating up the backend resources, meanwhile clients trying to confirm their inputs are not able to do and just wait. 

For example, when debugging 8 out of 10 Alice ConfirmedConnection were true but 2 was simply not able to confirm for the first time a decent amount of time because the other 8 were keeping the backend busy. 

