### PR TITLE
[WabiSabi] One http client per participant

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -249,7 +249,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			{
 				var rpc = node.RpcClient;
 
-				var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
+				var app = _apiApplicationFactory.WithWebHostBuilder(builder =>
 				{
 					builder.ConfigureServices(services =>
 					{
@@ -264,17 +264,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 							OutputRegistrationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
 						});
 					});
-				}).CreateClient();
-
-				// Create the API client
-				var apiClient = _apiApplicationFactory.CreateWabiSabiHttpApiClient(httpClient);
+				});
 
 				// Total test timeout.
 				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20 * ExpectedInputNumber));
 
 				var participants = Enumerable
 					.Range(0, NumberOfParticipants)
-					.Select(_ => new Participant(rpc, apiClient))
+					.Select(_ => new Participant(rpc, _apiApplicationFactory.CreateWabiSabiHttpApiClient(app.CreateClient())))
 					.ToArray();
 
 				foreach (var participant in participants)


### PR DESCRIPTION
This PR makes sure each simulated participant use a new  `HttpClient` instance. In other words, participants don't share the same http client instance as before, what makes the test more real and increase concurrency. 