### PR TITLE
[WabiSabi] Calculate AliceId without using backend class

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -35,11 +35,13 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 			Deadline = DateTimeOffset.UtcNow + (connectionConfirmationTimeout * 0.9);
 		}
 
-		private uint256 CalculateHash()
+		private uint256 CalculateHash() => CalculateHash(Coin, OwnershipProof);
+
+		public static uint256 CalculateHash(Coin coin, OwnershipProof ownershipProof)
 			=> StrobeHasher.Create(ProtocolConstants.AliceStrobeDomain)
-				.Append(ProtocolConstants.AliceCoinTxOutStrobeLabel, Coin.TxOut)
-				.Append(ProtocolConstants.AliceCoinOutpointStrobeLabel, Coin.Outpoint)
-				.Append(ProtocolConstants.AliceOwnershipProofStrobeLabel, OwnershipProof)
+				.Append(ProtocolConstants.AliceCoinTxOutStrobeLabel, coin.TxOut)
+				.Append(ProtocolConstants.AliceCoinOutpointStrobeLabel, coin.Outpoint)
+				.Append(ProtocolConstants.AliceOwnershipProofStrobeLabel, ownershipProof)
 				.GetHash();
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -1,12 +1,11 @@
 using NBitcoin;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Crypto;
+using WalletWasabi.Crypto.StrobeProtocol;
 using WalletWasabi.Crypto.ZeroKnowledge;
-using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Models;
 
@@ -111,7 +110,8 @@ namespace WalletWasabi.WabiSabi.Client
 			var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
 				bitcoinSecret.PrivateKey,
 				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundId));
-			return new Alice(coin, ownershipProof).Id;
+
+			return Alice.CalculateHash(coin, ownershipProof);
 		}
 	}
 }


### PR DESCRIPTION
Since `Alice` is a part of `Arena`'s internal state, constructing it from `AliceClient` in order to compute the hash means that it can't be modified (the motivating case is to be able to add a non nullable `Round` property as part of #6065).

This results in minor code duplication that can be cleaned up in followup work by moving the calculation into a new shared type under the `Models` namespace, as arguably it is a shared model even though it's computed independently by both client and server and not actually sent on the wire.