### PR TITLE
[WabiSabi] Round property for Alice

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -103,20 +103,20 @@ namespace WalletWasabi.Tests.Helpers
 			return arena;
 		}
 
-		public static Alice CreateAlice(Coin coin, OwnershipProof ownershipProof)
-			=> new(coin, ownershipProof) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
+		public static Alice CreateAlice(Coin coin, OwnershipProof ownershipProof, Round round)
+			=> new(coin, ownershipProof, round) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
 
-		public static Alice CreateAlice(Key key, Money amount)
-			=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key));
+		public static Alice CreateAlice(Key key, Money amount, Round round)
+			=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key), round);
 
-		public static Alice CreateAlice(Money amount)
-			=> CreateAlice(new Key(), amount);
+		public static Alice CreateAlice(Money amount, Round round)
+			=> CreateAlice(new Key(), amount, round);
 
-		public static Alice CreateAlice(Key key)
-			=> CreateAlice(key, Money.Coins(1));
+		public static Alice CreateAlice(Key key, Round round)
+			=> CreateAlice(key, Money.Coins(1), round);
 
-		public static Alice CreateAlice()
-			=> CreateAlice(new Key(), Money.Coins(1));
+		public static Alice CreateAlice(Round round)
+			=> CreateAlice(new Key(), Money.Coins(1), round);
 
 		public static ArenaClient CreateArenaClient(Arena arena)
 		{
@@ -185,7 +185,7 @@ namespace WalletWasabi.Tests.Helpers
 		{
 			var (amClient, vsClient, _, _, amZeroCredentials, vsZeroCredentials) = CreateWabiSabiClientsAndIssuers(round);
 
-			var alice = round.Alices.FirstOrDefault() ?? CreateAlice();
+			var alice = round.Alices.FirstOrDefault() ?? CreateAlice(round);
 			var (realAmountCredentialRequest, _) = amClient.CreateRequest(
 				new[] { amount?.Satoshi ?? alice.CalculateRemainingAmountCredentials(round.FeeRate).Satoshi },
 				amZeroCredentials,
@@ -219,7 +219,7 @@ namespace WalletWasabi.Tests.Helpers
 		{
 			var (amClient, vsClient, amIssuer, vsIssuer, amZeroCredentials, vsZeroCredentials) = CreateWabiSabiClientsAndIssuers(round);
 
-			var alice = round.Alices.FirstOrDefault() ?? CreateAlice();
+			var alice = round.Alices.FirstOrDefault() ?? CreateAlice(round);
 			var (amCredentialRequest, amValid) = amClient.CreateRequest(
 				new[] { alice.CalculateRemainingAmountCredentials(round.FeeRate).Satoshi },
 				amZeroCredentials, // FIXME doesn't make much sense

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.ConnectionConfirmation);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
@@ -72,7 +72,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			// even though the deadline is reached and still in input reg.
 			WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.Zero };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
@@ -96,10 +96,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			// even though the deadline is reached and still in input reg.
 			WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
@@ -121,7 +121,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			// Alice's deadline is updated by connection confirmation.
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
@@ -15,10 +15,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinInputCountByRoundMultiplier = 0.5 };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var a1 = WabiSabiFactory.CreateAlice();
-			var a2 = WabiSabiFactory.CreateAlice();
-			var a3 = WabiSabiFactory.CreateAlice();
-			var a4 = WabiSabiFactory.CreateAlice();
+			var a1 = WabiSabiFactory.CreateAlice(round);
+			var a2 = WabiSabiFactory.CreateAlice(round);
+			var a3 = WabiSabiFactory.CreateAlice(round);
+			var a4 = WabiSabiFactory.CreateAlice(round);
 			a1.ConfirmedConnection = true;
 			a2.ConfirmedConnection = true;
 			a3.ConfirmedConnection = true;
@@ -41,10 +41,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		{
 			WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinInputCountByRoundMultiplier = 0.5 };
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var a1 = WabiSabiFactory.CreateAlice();
-			var a2 = WabiSabiFactory.CreateAlice();
-			var a3 = WabiSabiFactory.CreateAlice();
-			var a4 = WabiSabiFactory.CreateAlice();
+			var a1 = WabiSabiFactory.CreateAlice(round);
+			var a2 = WabiSabiFactory.CreateAlice(round);
+			var a3 = WabiSabiFactory.CreateAlice(round);
+			var a4 = WabiSabiFactory.CreateAlice(round);
 			a1.ConfirmedConnection = true;
 			a2.ConfirmedConnection = true;
 			a3.ConfirmedConnection = true;
@@ -74,10 +74,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				ConnectionConfirmationTimeout = TimeSpan.Zero
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var a1 = WabiSabiFactory.CreateAlice();
-			var a2 = WabiSabiFactory.CreateAlice();
-			var a3 = WabiSabiFactory.CreateAlice();
-			var a4 = WabiSabiFactory.CreateAlice();
+			var a1 = WabiSabiFactory.CreateAlice(round);
+			var a2 = WabiSabiFactory.CreateAlice(round);
+			var a3 = WabiSabiFactory.CreateAlice(round);
+			var a4 = WabiSabiFactory.CreateAlice(round);
 			a1.ConfirmedConnection = true;
 			a2.ConfirmedConnection = true;
 			a3.ConfirmedConnection = false;
@@ -108,10 +108,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				ConnectionConfirmationTimeout = TimeSpan.Zero
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var a1 = WabiSabiFactory.CreateAlice();
-			var a2 = WabiSabiFactory.CreateAlice();
-			var a3 = WabiSabiFactory.CreateAlice();
-			var a4 = WabiSabiFactory.CreateAlice();
+			var a1 = WabiSabiFactory.CreateAlice(round);
+			var a2 = WabiSabiFactory.CreateAlice(round);
+			var a3 = WabiSabiFactory.CreateAlice(round);
+			var a4 = WabiSabiFactory.CreateAlice(round);
 			a1.ConfirmedConnection = true;
 			a2.ConfirmedConnection = false;
 			a3.ConfirmedConnection = false;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -17,15 +17,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
@@ -41,9 +41,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MinInputCountByRoundMultiplier = 0.5
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice1 = WabiSabiFactory.CreateAlice();
-			var alice2 = WabiSabiFactory.CreateAlice();
-			var alice3 = WabiSabiFactory.CreateAlice();
+			var alice1 = WabiSabiFactory.CreateAlice(round);
+			var alice2 = WabiSabiFactory.CreateAlice(round);
+			var alice3 = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice1);
 			round.Alices.Add(alice2);
 			round.Alices.Add(alice3);
@@ -76,8 +76,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MinInputCountByRoundMultiplier = 0.5
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -97,9 +97,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MinInputCountByRoundMultiplier = 0.5
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice1 = WabiSabiFactory.CreateAlice();
-			var alice2 = WabiSabiFactory.CreateAlice();
-			var alice3 = WabiSabiFactory.CreateAlice();
+			var alice1 = WabiSabiFactory.CreateAlice(round);
+			var alice2 = WabiSabiFactory.CreateAlice(round);
+			var alice3 = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice1);
 			round.Alices.Add(alice2);
 			round.Alices.Add(alice3);
@@ -126,7 +126,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.Ended, round.Phase);
 			Assert.DoesNotContain(round, arena.ActiveRounds);
@@ -148,8 +148,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MinInputCountByRoundMultiplier = 0.5
 			};
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice1 = WabiSabiFactory.CreateAlice();
-			var alice2 = WabiSabiFactory.CreateAlice();
+			var alice1 = WabiSabiFactory.CreateAlice(round);
+			var alice2 = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice1);
 			round.Alices.Add(alice2);
 			var blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
@@ -175,8 +175,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.InputRegistration, round.Phase);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -149,7 +149,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			// the remaining amount after deducting the fees needs to be less
 			// than the minimum.
 			var txParams = round.Assert<ConstructionState>().Parameters;
-			var extraAlice = WabiSabiFactory.CreateAlice(txParams.FeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParams.AllowedOutputAmounts.Min - new Money(1L));
+			var extraAlice = WabiSabiFactory.CreateAlice(txParams.FeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParams.AllowedOutputAmounts.Min - new Money(1L), round);
 			round.Alices.Add(extraAlice);
 			round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -198,7 +198,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
 
 			// Make sure not all alices signed.
-			var alice3 = WabiSabiFactory.CreateAlice();
+			var alice3 = WabiSabiFactory.CreateAlice(round);
 			alice3.ConfirmedConnection = true;
 			round.Alices.Add(alice3);
 			round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			var preDeadline = alice.Deadline;
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
@@ -51,7 +51,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var round = WabiSabiFactory.CreateRound(cfg);
 
 			round.SetPhase(Phase.ConnectionConfirmation);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			var preDeadline = alice.Deadline;
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
@@ -90,12 +90,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		public async Task WrongPhaseAsync()
 		{
 			WabiSabiConfig cfg = new();
-			var alice = WabiSabiFactory.CreateAlice();
-			var preDeadline = alice.Deadline;
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			var round = arena.Rounds.First();
+			var alice = WabiSabiFactory.CreateAlice(round);
+			var preDeadline = alice.Deadline;
 			round.Alices.Add(alice);
+			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21)).ConfigureAwait(false);
 
 			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
@@ -137,9 +137,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.ConnectionConfirmation);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+			Assert.Contains(alice, round.Alices);
 
 			var incorrectVsizeCredentials = WabiSabiFactory.CreateRealCredentialRequests(round, null, 234).vsizeRequest;
 			var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round) with { RealVsizeCredentialRequests = incorrectVsizeCredentials };
@@ -158,7 +159,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.ConnectionConfirmation);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
@@ -196,7 +197,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.ConnectionConfirmation);
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -70,9 +70,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(), round);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 
 			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -364,12 +364,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var coin = WabiSabiFactory.CreateCoin(key);
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var anotherAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
+			var anotherAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key), round);
 			round.Alices.Add(anotherAlice);
 			round.SetPhase(Phase.ConnectionConfirmation);
+
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
 			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -387,12 +388,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var anotherRound = WabiSabiFactory.CreateRound(cfg);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round, anotherRound);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
+			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key), round);
 			anotherRound.Alices.Add(preAlice);
 			anotherRound.SetPhase(Phase.ConnectionConfirmation);
+
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round, anotherRound);
 
 			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -48,11 +48,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 
 			using Key key = new();
 			var coin = WabiSabiFactory.CreateCoin(key);
-			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
 			// Make sure an Alice have already been registered with the same input.
-			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key));
+			var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key), round);
 			round.Alices.Add(preAlice);
+
+			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
 
 			var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, key, CancellationToken.None).ConfigureAwait(false));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
 			using Key key = new();
@@ -36,9 +36,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputWhitelistedAsync()
 		{
-			var alice = WabiSabiFactory.CreateAlice();
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
@@ -58,12 +58,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		[Fact]
 		public async Task InputWhitelistedButBannedAsync()
 		{
-			using Key key = new();
-			var alice = WabiSabiFactory.CreateAlice(key);
-			var bannedCoin = alice.Coin.Outpoint;
-
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
+
+			using Key key = new();
+			var alice = WabiSabiFactory.CreateAlice(key, round);
+			var bannedCoin = alice.Coin.Outpoint;
+
 			round.Alices.Add(alice);
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(alice.Coin);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
@@ -58,7 +58,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1), round));
 
 			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, key.PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.Main).ScriptPubKey);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
@@ -76,7 +76,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1), round));
 
 			var sha256Bounty = Script.FromHex("aa20000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f87");
 			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, sha256Bounty);
@@ -95,7 +95,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new() { MinRegistrableAmount = Money.Coins(2) };
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1), round));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
@@ -113,7 +113,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new() { MaxRegistrableAmount = Money.Coins(1.999m) }; // TODO migrate to MultipartyTransactionParameters
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(2)));
+			round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(2), round));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
@@ -131,7 +131,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			round.SetPhase(Phase.OutputRegistration);
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
@@ -151,7 +151,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			var round = arena.Rounds.First();
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 			{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var initialRemaining = round.RemainingInputVsizeAllocation;
-			var alice = WabiSabiFactory.CreateAlice();
+			var alice = WabiSabiFactory.CreateAlice(round);
 			round.Alices.Add(alice);
 			Assert.True(round.RemainingInputVsizeAllocation < initialRemaining);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Key key = new();
-			Alice alice = WabiSabiFactory.CreateAlice(key: key);
+			Alice alice = WabiSabiFactory.CreateAlice(key: key, round: round);
 			round.Alices.Add(alice);
 			round.CoinjoinState = round.AddInput(alice.Coin).Finalize();
 			round.SetPhase(Phase.TransactionSigning);
@@ -79,9 +79,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			using Key key1 = new();
-			Alice alice1 = WabiSabiFactory.CreateAlice(key: key1);
+			Alice alice1 = WabiSabiFactory.CreateAlice(key: key1, round: round);
 			using Key key2 = new();
-			Alice alice2 = WabiSabiFactory.CreateAlice(key: key2);
+			Alice alice2 = WabiSabiFactory.CreateAlice(key: key2, round: round);
 			round.Alices.Add(alice1);
 			round.Alices.Add(alice2);
 			round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice1.Coin).AddInput(alice2.Coin).Finalize();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RoundCreationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RoundCreationTests.cs
@@ -81,7 +81,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			var round = Assert.Single(arena.Rounds);
 
 			round.SetPhase(Phase.ConnectionConfirmation);
-			round.Alices.Add(WabiSabiFactory.CreateAlice());
+			round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 			Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 			Assert.Equal(Phase.InputRegistration, blameRound.Phase);
 			arena.Rounds.Add(blameRound);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -170,7 +170,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			round.SetPhase(Phase.ConnectionConfirmation);
 			var fundingTx = BitcoinFactory.CreateSmartTransaction(ownOutputCount: 1);
 			var coin = fundingTx.WalletOutputs.First().Coin;
-			var alice = new Alice(coin, new OwnershipProof());
+			var alice = new Alice(coin, new OwnershipProof(), round);
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
 
@@ -191,11 +191,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			Round round = WabiSabiFactory.CreateRound(config);
 
 			using Key key1 = new();
-			Alice alice1 = WabiSabiFactory.CreateAlice(key: key1);
+			Alice alice1 = WabiSabiFactory.CreateAlice(key: key1, round: round);
 			round.Alices.Add(alice1);
 
 			using Key key2 = new();
-			Alice alice2 = WabiSabiFactory.CreateAlice(key: key2);
+			Alice alice2 = WabiSabiFactory.CreateAlice(key: key2, round: round);
 			round.Alices.Add(alice2);
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -2,19 +2,22 @@ using NBitcoin;
 using System;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.StrobeProtocol;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 
 namespace WalletWasabi.WabiSabi.Backend.Models
 {
 	public class Alice
 	{
-		public Alice(Coin coin, OwnershipProof ownershipProof)
+		public Alice(Coin coin, OwnershipProof ownershipProof, Round round)
 		{
 			// TODO init syntax?
+			Round = round;
 			Coin = coin;
 			OwnershipProof = ownershipProof;
 			Id = CalculateHash();
 		}
 
+		public Round Round { get; }
 		public uint256 Id { get; }
 		public DateTimeOffset Deadline { get; set; } = DateTimeOffset.UtcNow;
 		public Coin Coin { get; }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
 			}
 
-			var alice = new Alice(coin, ownershipProof);
+			var alice = new Alice(coin, ownershipProof, round);
 
 			if (alice.TotalInputAmount < round.MinRegistrableAmount)
 			{


### PR DESCRIPTION
This pull request introduces a `Round` property to `Alice`, needed for #6065, where alices are looked up by ID and by outpoint, and this change allows the arena to ensure that it belongs to the right round without requiring a lock on the round itself. Apart from being cleaner and simpler, that also ensuring that invalid requests don't compete over exclusive locks to coordinator state with valid ones.

This does not at all address and slightly exacerbates the problem of white box unit tests modifying `Arena`'s internal state to achieve certain results, the appropriate round parameter was simply added to all of these, but this problem really needs to be addressed independently because `Arena`'s public API is effectively every single implementation detail of `Arena`, `InputRegistrationHandler`, `Round`, `Alice`, and `CredentialIssuer`, including how often the periodic tasks executes and exactly what its effects are, something which came up repeatedly in #6065.

Depends on #6087