### PR TITLE
[Fluent] Dialog size fixes

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -100,4 +100,9 @@
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Margin" Value="16 0 16 16" />
   </Style>
+
+  <!-- Dialog Increased width State -->
+  <Style Selector="c|Dialog[IncreasedWidthEnabled=True] /template/ Border#PART_Border">
+    <Setter Property="Margin" Value="0 40" />
+  </Style>
 </Styles>

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -86,6 +86,11 @@
     <Setter Property="Opacity" Value="0"/>
   </Style>
 
+  <!-- Dialog Increased width State -->
+  <Style Selector="c|Dialog[IncreasedWidthEnabled=True] /template/ Border#PART_Border">
+    <Setter Property="Margin" Value="0 40" />
+  </Style>
+
   <!-- Dialog Fullscreen State -->
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Border#PART_Border">
     <Setter Property="Margin" Value="0 30 0 0" />
@@ -99,10 +104,5 @@
   </Style>
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Margin" Value="16 0 16 16" />
-  </Style>
-
-  <!-- Dialog Increased width State -->
-  <Style Selector="c|Dialog[IncreasedWidthEnabled=True] /template/ Border#PART_Border">
-    <Setter Property="Margin" Value="0 40" />
   </Style>
 </Styles>

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -47,6 +47,9 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<bool> FullScreenEnabledProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(FullScreenEnabled));
 
+		public static readonly StyledProperty<bool> IncreasedWidthEnabledProperty =
+			AvaloniaProperty.Register<Dialog, bool>(nameof(IncreasedWidthEnabled));
+
 		public Dialog()
 		{
 			this.GetObservable(IsDialogOpenProperty).Subscribe(UpdateDelay);
@@ -56,7 +59,8 @@ namespace WalletWasabi.Fluent.Controls
 				{
 					var width = bounds.Width;
 					var height = bounds.Height;
-					FullScreenEnabled = width < 740 && height < 580;
+					IncreasedWidthEnabled = width < 740;
+					FullScreenEnabled = IncreasedWidthEnabled && height < 580;
 				});
 		}
 
@@ -111,7 +115,13 @@ namespace WalletWasabi.Fluent.Controls
 		public bool FullScreenEnabled
 		{
 			get => GetValue(FullScreenEnabledProperty);
-			set => SetValue(FullScreenEnabledProperty, value);
+			private set => SetValue(FullScreenEnabledProperty, value);
+		}
+
+		public bool IncreasedWidthEnabled
+		{
+			get => GetValue(IncreasedWidthEnabledProperty);
+			private set => SetValue(IncreasedWidthEnabledProperty, value);
 		}
 
 		private CancellationTokenSource? CancelPointerPressedDelay { get; set; }

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -112,16 +112,16 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(MaxContentWidthProperty, value);
 		}
 
-		public bool FullScreenEnabled
+		private bool FullScreenEnabled
 		{
 			get => GetValue(FullScreenEnabledProperty);
-			private set => SetValue(FullScreenEnabledProperty, value);
+			set => SetValue(FullScreenEnabledProperty, value);
 		}
 
-		public bool IncreasedWidthEnabled
+		private bool IncreasedWidthEnabled
 		{
 			get => GetValue(IncreasedWidthEnabledProperty);
-			private set => SetValue(IncreasedWidthEnabledProperty, value);
+			set => SetValue(IncreasedWidthEnabledProperty, value);
 		}
 
 		private CancellationTokenSource? CancelPointerPressedDelay { get; set; }

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -106,6 +106,12 @@
               EnableCancelOnEscape="{Binding CurrentPage.EnableCancelOnEscape, FallbackValue=True}"
               IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
               HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+      <c:Dialog.Styles>
+        <Style Selector="c|Dialog[FullScreenEnabled=True]">
+          <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+          <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        </Style>
+      </c:Dialog.Styles>
       <ContentControl Content="{Binding CurrentPage}" />
     </c:Dialog>
   </Panel>


### PR DESCRIPTION
This PR

- adds an increased width state for the dialogs. When the width reaches a specific limit the margins on the sides will be lower. 
Part of https://github.com/zkSNACKs/WalletWasabi/issues/6073 ("99999999.99999999" BTC text crossing the swap button and USD amount not fully visible on the narrowest dialog size (without fullscreen dialog trigger))

- fixes the compact dialogs content alignment when the fullscreen mode is triggered.