### PR TITLE
[Fluent] [Trivial] Fix SendFeeViewModel

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -113,6 +113,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		{
 			base.OnNavigatedTo(isInHistory, disposables);
 
+			XAxisCurrentValue = _lastXAxisCurrentValue;
+
 			var feeProvider = _wallet.FeeProvider;
 			Observable
 				.FromEventPattern(feeProvider, nameof(feeProvider.AllFeeEstimateChanged))

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -113,7 +113,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		{
 			base.OnNavigatedTo(isInHistory, disposables);
 
-			XAxisCurrentValue = _lastXAxisCurrentValue;
+			CurrentConfirmationTarget = _lastConfirmationTarget;
 
 			var feeProvider = _wallet.FeeProvider;
 			Observable


### PR DESCRIPTION
Reverts https://github.com/zkSNACKs/WalletWasabi/pull/6096
Restores functionality from https://github.com/zkSNACKs/WalletWasabi/pull/6079

The property was renamed from `XAxisCurrentValue` to `CurrentConfirmationTarget` and field from `_lastXAxisCurrentValue` to `_lastConfirmationTarget` in https://github.com/zkSNACKs/WalletWasabi/pull/6071