### PR TITLE
[Fluent] Send - fix tab key navigation

### DIFF
--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -42,7 +42,8 @@
                                 </i:Interaction.Behaviors>
                             </Button>
                             <StackPanel Orientation="Horizontal" Spacing="30" Margin="0 10" HorizontalAlignment="Right">
-                                <Button IsVisible="{TemplateBinding EnableSkip}"
+                                <Button Name="PART_SkipButton"
+                                        IsVisible="{TemplateBinding EnableSkip}"
                                         Content="{TemplateBinding SkipContent}"
                                         Command="{Binding SkipCommand}"
                                         Classes="activeHyperLink skip"
@@ -64,7 +65,8 @@
                             <Panel IsHitTestVisible="False" Background="{TemplateBinding HeaderBackground}" />
                             <StackPanel Name="PART_Header" Spacing="10">
                                 <DockPanel>
-                                    <Button Margin="-31,0,0,0"
+                                    <Button Name="PART_BackButton"
+                                            Margin="-31,0,0,0"
                                             Classes="plain"
                                             Command="{Binding BackCommand}"
                                             IsVisible="{TemplateBinding EnableBack}">

--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -6,7 +6,7 @@
     <Design.PreviewWith>
         <Panel Background="{DynamicResource RegionColor}">
             <c:ContentArea Width="500" Height="300"
-                           IsBusy="True"
+                           IsBusy="False"
                            Title="Add a Wallet"
                            EnableBack="True"
                            EnableCancel="True" CancelContent="Cancel" FocusCancel="False"
@@ -28,23 +28,12 @@
                     <Panel IsHitTestVisible="False" Background="{TemplateBinding Background}" />
                     <c:ProgressRing Name="LoadingRing" IsIndeterminate="True" IsVisible="{TemplateBinding IsBusy}" />
                     <DockPanel Name="MainDockPanel" IsVisible="{Binding !#LoadingRing.IsVisible}">
-                        <Panel DockPanel.Dock="Top">
-                            <Panel IsHitTestVisible="False" Background="{TemplateBinding HeaderBackground}" />
-                            <StackPanel Name="PART_Header" Spacing="10">
-                                <DockPanel>
-                                    <Button Margin="-31,0,0,0" Classes="plain" Command="{Binding BackCommand}"
-                                            IsVisible="{TemplateBinding EnableBack}">
-                                        <PathIcon Data="{StaticResource arrow_left_regular}" Width="16" />
-                                    </Button>
-                                    <ContentPresenter Name="PART_TitlePresenter" Content="{TemplateBinding Title}" />
-                                </DockPanel>
-                                <ContentPresenter Name="PART_CaptionPresenter" Content="{TemplateBinding Caption}" />
-                            </StackPanel>
-                        </Panel>
 
                         <Panel DockPanel.Dock="Bottom" x:Name="PART_ButtonArea">
-                            <Button Name="PART_CancelButton" IsCancel="{TemplateBinding EnableCancel}"
-                                    Classes="invisible" IsVisible="{TemplateBinding EnableCancel}"
+                            <Button Name="PART_CancelButton"
+                                    IsCancel="{TemplateBinding EnableCancel}"
+                                    Classes="invisible"
+                                    IsVisible="{TemplateBinding EnableCancel}"
                                     Content="{TemplateBinding CancelContent}"
                                     HorizontalAlignment="Left" Command="{Binding CancelCommand}">
                                 <i:Interaction.Behaviors>
@@ -54,11 +43,14 @@
                             </Button>
                             <StackPanel Orientation="Horizontal" Spacing="30" Margin="0 10" HorizontalAlignment="Right">
                                 <Button IsVisible="{TemplateBinding EnableSkip}"
-                                        Content="{TemplateBinding SkipContent}" Command="{Binding SkipCommand}"
-                                        Classes="activeHyperLink skip" VerticalAlignment="Center" />
+                                        Content="{TemplateBinding SkipContent}"
+                                        Command="{Binding SkipCommand}"
+                                        Classes="activeHyperLink skip"
+                                        VerticalAlignment="Center" />
                                 <Button Name="PART_NextButton" Classes="action"
                                         IsVisible="{TemplateBinding EnableNext}"
-                                        Content="{TemplateBinding NextContent}" Command="{Binding NextCommand}"
+                                        Content="{TemplateBinding NextContent}"
+                                        Command="{Binding NextCommand}"
                                         IsDefault="True">
                                     <i:Interaction.Behaviors>
                                         <behaviors:FocusOnAttachedBehavior
@@ -67,6 +59,23 @@
                                 </Button>
                             </StackPanel>
                         </Panel>
+
+                        <Panel DockPanel.Dock="Top">
+                            <Panel IsHitTestVisible="False" Background="{TemplateBinding HeaderBackground}" />
+                            <StackPanel Name="PART_Header" Spacing="10">
+                                <DockPanel>
+                                    <Button Margin="-31,0,0,0"
+                                            Classes="plain"
+                                            Command="{Binding BackCommand}"
+                                            IsVisible="{TemplateBinding EnableBack}">
+                                        <PathIcon Data="{StaticResource arrow_left_regular}" Width="16" />
+                                    </Button>
+                                    <ContentPresenter Name="PART_TitlePresenter" Content="{TemplateBinding Title}" />
+                                </DockPanel>
+                                <ContentPresenter Name="PART_CaptionPresenter" Content="{TemplateBinding Caption}" />
+                            </StackPanel>
+                        </Panel>
+
                         <ScrollViewer x:Name="PART_ScrollViewer"
                             HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                             VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -374,7 +374,6 @@ namespace WalletWasabi.Fluent.Controls
 
 			_backspaceEmptyField2 = _backspaceEmptyField1;
 			_backspaceEmptyField1 = currentText.Length == 0;
-			var noTextSelection = Math.Max(0, _internalTextBox!.SelectionEnd - _internalTextBox.SelectionStart) == 0;
 
 			currentText = currentText.Trim();
 

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -272,6 +272,8 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void OnAutoCompleteBoxDropDownClosed(object? sender, EventArgs e)
 		{
+			// TODO: Remove as this is handled now in OnKeyDown
+			/*
 			if (sender is not AutoCompleteBox autoCompleteBox)
 			{
 				return;
@@ -296,6 +298,7 @@ namespace WalletWasabi.Fluent.Controls
 			BackspaceLogicClear();
 			autoCompleteBox.ClearValue(AutoCompleteBox.SelectedItemProperty);
 			Dispatcher.UIThread.Post(() => autoCompleteBox.ClearValue(AutoCompleteBox.TextProperty));
+			*/
 		}
 
 		private void BackspaceLogicClear()
@@ -374,9 +377,16 @@ namespace WalletWasabi.Fluent.Controls
 
 			_backspaceEmptyField2 = _backspaceEmptyField1;
 			_backspaceEmptyField1 = currentText.Length == 0;
-			var selectedTextLength = Math.Max(0, _internalTextBox!.SelectionEnd - _internalTextBox.SelectionStart);
+			var noTextSelection = Math.Max(0, _internalTextBox!.SelectionEnd - _internalTextBox.SelectionStart) == 0;
 
 			currentText = currentText.Trim();
+
+			var canAddTag = _isInputEnabled && !string.IsNullOrEmpty(currentText);
+
+			if (e.Key == Key.Tab && canAddTag)
+			{
+				e.Handled = true;
+			}
 
 			switch (e.Key)
 			{
@@ -384,8 +394,8 @@ namespace WalletWasabi.Fluent.Controls
 					RemoveLastTag();
 					break;
 
-				case Key.Tab when _isInputEnabled && !string.IsNullOrEmpty(currentText) && selectedTextLength == 0:
-				case Key.Enter when _isInputEnabled && !string.IsNullOrEmpty(currentText) && selectedTextLength == 0:
+				case Key.Tab when canAddTag:
+				case Key.Enter when canAddTag && noTextSelection:
 					// Reject entry of the tag when user pressed enter and
 					// the input tag is not on the suggestions list.
 					if (RestrictInputToSuggestions && Suggestions is { } &&
@@ -399,6 +409,7 @@ namespace WalletWasabi.Fluent.Controls
 					AddTag(currentText);
 					ExecuteCompletedCommand();
 
+					autoCompleteBox.ClearValue(AutoCompleteBox.SelectedItemProperty);
 					Dispatcher.UIThread.Post(() => autoCompleteBox.ClearValue(AutoCompleteBox.TextProperty));
 					e.Handled = true;
 

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -383,7 +383,7 @@ namespace WalletWasabi.Fluent.Controls
 
 			var canAddTag = _isInputEnabled && !string.IsNullOrEmpty(currentText);
 
-			if (e.Key == Key.Tab && canAddTag)
+			if ((e.Key == Key.Tab || e.Key == Key.Enter) && canAddTag)
 			{
 				e.Handled = true;
 			}
@@ -395,7 +395,7 @@ namespace WalletWasabi.Fluent.Controls
 					break;
 
 				case Key.Tab when canAddTag:
-				case Key.Enter when canAddTag && noTextSelection:
+				case Key.Enter when canAddTag:
 					// Reject entry of the tag when user pressed enter and
 					// the input tag is not on the suggestions list.
 					if (RestrictInputToSuggestions && Suggestions is { } &&
@@ -408,6 +408,9 @@ namespace WalletWasabi.Fluent.Controls
 					BackspaceLogicClear();
 					AddTag(currentText);
 					ExecuteCompletedCommand();
+
+					_internalTextBox.ClearSelection();
+					_internalTextBox.ClearValue(AutoCompleteBox.TextProperty);
 
 					autoCompleteBox.ClearValue(AutoCompleteBox.SelectedItemProperty);
 					Dispatcher.UIThread.Post(() => autoCompleteBox.ClearValue(AutoCompleteBox.TextProperty));

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -405,8 +405,8 @@ namespace WalletWasabi.Fluent.Controls
 					AddTag(currentText);
 					ExecuteCompletedCommand();
 
-					_internalTextBox.ClearSelection();
-					_internalTextBox.ClearValue(AutoCompleteBox.TextProperty);
+					_internalTextBox?.ClearSelection();
+					_internalTextBox?.ClearValue(AutoCompleteBox.TextProperty);
 
 					autoCompleteBox.ClearValue(AutoCompleteBox.SelectedItemProperty);
 					Dispatcher.UIThread.Post(() => autoCompleteBox.ClearValue(AutoCompleteBox.TextProperty));

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -272,8 +272,6 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void OnAutoCompleteBoxDropDownClosed(object? sender, EventArgs e)
 		{
-			// TODO: Remove as this is handled now in OnKeyDown
-			/*
 			if (sender is not AutoCompleteBox autoCompleteBox)
 			{
 				return;
@@ -298,7 +296,6 @@ namespace WalletWasabi.Fluent.Controls
 			BackspaceLogicClear();
 			autoCompleteBox.ClearValue(AutoCompleteBox.SelectedItemProperty);
 			Dispatcher.UIThread.Post(() => autoCompleteBox.ClearValue(AutoCompleteBox.TextProperty));
-			*/
 		}
 
 		private void BackspaceLogicClear()

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -63,7 +63,6 @@
                    TagSeparator=","
                    SuggestionsAreCaseSensitive="True"
                    RestrictInputToSuggestions="False"
-                   Focusable="True"
                    Items="{Binding Labels}"
                    Suggestions="{Binding PriorLabels}" />
       </DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -63,6 +63,7 @@
                    TagSeparator=","
                    SuggestionsAreCaseSensitive="True"
                    RestrictInputToSuggestions="False"
+                   Focusable="True"
                    Items="{Binding Labels}"
                    Suggestions="{Binding PriorLabels}" />
       </DockPanel>


### PR DESCRIPTION
Part of https://github.com/zkSNACKs/WalletWasabi/issues/6073


[3] Label
Pressing tab key enters the label but the focus jumps to the back button (only if the text that the users enter has highlighted part - The AutoCompleteBox tries to complete it.)

