### PR TITLE
`RoundStateUpdater`: Simplify

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -108,8 +108,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 						return tx.GetHash();
 					};
 
-					// Instruct the coodinator DI container to use these two scoped
-					// services to build everything (wabisabi controller, arena, etc)
+					// Instruct the coordinator DI container to use these two scoped
+					// services to build everything (WabiSabi controller, arena, etc)
 					services.AddScoped<IRPCClient>(s => rpc);
 					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig { MaxInputCountByRound = inputCount });
 				});

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			Assert.Equal(Phase.InputRegistration, round1.Phase);
 			Assert.All(new[] { round1ORTask, round1TSTask, round1TBTask }, t => Assert.Equal(TaskStatus.WaitingForActivation, t.Status));
 
-			// Force the RoundStatusUpdater to run. After this it will know about the existance of `round2` so,
+			// Force the RoundStatusUpdater to run. After this it will know about the existence of `round2` so,
 			// we can subscribe to events.
 			await roundStatusUpdater.TriggerAndWaitRoundAsync(TestTimeOut);
 			var round2IRTask = roundStatusUpdater.CreateRoundAwaiter(roundState2.Id, rs => rs.Phase == Phase.InputRegistration, cancellationToken);
@@ -78,14 +78,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			round1TSCts.Cancel();
 			Assert.True(round1TSTask.IsCanceled);
 
-			// At this point in time all the rounds have disappeared and then the awaiter that was waiting for round1 to bradcast
+			// At this point in time all the rounds have disappeared and then the awaiter that was waiting for round1 to broadcast
 			// the transaction has to fail to let the sleeping component that the round doesn't exist any more.
 			await roundStatusUpdater.TriggerAndWaitRoundAsync(TestTimeOut);
 			var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await round1TBTask);
 			Assert.Contains(round1.Id.ToString(), ex.Message);
 			Assert.Contains("not running", ex.Message);
 
-			// `Round2 ` awaiter has to be cancelled immediatelly when we stop the updater.
+			// `Round2` awaiter has to be cancelled immediately when we stop the updater.
 			Assert.Equal(TaskStatus.WaitingForActivation, round2TBTask.Status);
 			await roundStatusUpdater.StopAsync(cancellationToken);
 

--- a/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
@@ -25,14 +25,8 @@ namespace WalletWasabi.WabiSabi.Client
 
 		protected override async Task ActionAsync(CancellationToken cancellationToken)
 		{
-			var statusResponse = await ArenaRequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
-			var responseRoundStates = statusResponse.ToDictionary(round => round.Id);
-
-			var updatedRoundStates = responseRoundStates.Where(round => RoundStates.ContainsKey(round.Key));
-			var newRoundStates = responseRoundStates.Where(round => !RoundStates.ContainsKey(round.Key));
-			var removedRoundStates = RoundStates.Where(round => !responseRoundStates.ContainsKey(round.Key));
-
-			RoundStates = updatedRoundStates.Union(newRoundStates).ToDictionary(s => s.Key, s => s.Value);
+			RoundState[] statusResponse = await ArenaRequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+			RoundStates = statusResponse.ToDictionary(round => round.Id);
 
 			lock (AwaitersLock)
 			{


### PR DESCRIPTION
This PR attempts to simplify `RoundStateUpdater` as the operations there seem redundant.