### PR TITLE
[WabiSabi] Disable ASP.NET logs in tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Crypto.Randomness;
@@ -61,6 +62,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 				services.AddScoped<Prison>();
 				services.AddScoped<WabiSabiConfig>();
 				services.AddScoped(typeof(TimeSpan), _ => TimeSpan.FromSeconds(2));
+			});
+			builder.ConfigureLogging(o =>
+			{
+				o.SetMinimumLevel(LogLevel.Warning);
 			});
 		}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -267,9 +267,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 							OutputRegistrationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
 						});
 					});
-					builder.ConfigureLogging(o=> {
-						o.SetMinimumLevel(LogLevel.Warning);
-					});
 				});
 
 				// Total test timeout.


### PR DESCRIPTION
This PR disables the logs for all the WabiSabi integration tests and not only for the Multiclients one.