### PR TITLE
[Fluent] Fix closing when multiple dialog is opened

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -182,13 +182,14 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void CancelPointerPressed(object? sender, PointerPressedEventArgs e)
 		{
-			if (IsDialogOpen && EnableCancelOnPressed && !IsBusy && _dismissPanel is { } && _overlayPanel is { } && _canCancelOnPointerPressed)
+			if (IsDialogOpen && IsKeyboardFocusWithin && EnableCancelOnPressed && !IsBusy && _dismissPanel is { } && _overlayPanel is { } && _canCancelOnPointerPressed)
 			{
 				var point = e.GetPosition(_dismissPanel);
 				var isPressedOnTitleBar = e.GetPosition(_overlayPanel).Y < 30;
 
 				if (!_dismissPanel.Bounds.Contains(point) && !isPressedOnTitleBar)
 				{
+					e.Handled = true;
 					Close();
 				}
 			}
@@ -196,8 +197,9 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void CancelKeyDown(object? sender, KeyEventArgs e)
 		{
-			if (e.Key == Key.Escape && EnableCancelOnEscape && !IsBusy)
+			if (e.Key == Key.Escape && EnableCancelOnEscape && !IsBusy && IsKeyboardFocusWithin)
 			{
+				e.Handled = true;
 				Close();
 			}
 		}


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/6107.

Now, only the topmost dialog will close if the user presses ESC or clicking outside of the dialog.

