### PR TITLE
[Fluent] do not allow to click through on the compact dialog's overlay

### DIFF
--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -22,6 +22,7 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="Background" Value="{DynamicResource RegionColor}" />
+        <Setter Property="IsHitTestVisible" Value="{Binding IsActive}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/6120