### PR TITLE
Fix PrivacyContentControl crash on designer mode.

### DIFF
--- a/WalletWasabi.Fluent/Controls/PrivacyContentControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PrivacyContentControl.axaml.cs
@@ -76,6 +76,11 @@ namespace WalletWasabi.Fluent.Controls
 
 		protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
 		{
+			if (Design.IsDesignMode)
+			{
+				return;
+			}
+
 			base.OnAttachedToVisualTree(e);
 
 			_disposable = new CompositeDisposable();


### PR DESCRIPTION
This is a bug fix for the PCC coz it's  crashing on Rider's Avalonia Preview plugin.

cc @soosr @danwalmsley @wieslawsoltes 