### PR TITLE
`RunningTasks`: Fix the implementation

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Nito/AsyncEx/RunningTasksTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Nito/AsyncEx/RunningTasksTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using WalletWasabi.Nito.AsyncEx;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Nito.AsyncEx
+{
+	/// <summary>
+	/// Tests for <see cref="RunningTasks"/> class.
+	/// </summary>
+	public class RunningTasksTests
+	{
+		[Fact]
+		public async Task RemeberWithTestAsync()
+		{
+			AbandonedTasks processingEvents = new();
+
+			using (RunningTasks.RememberWith(processingEvents))
+			{
+				Assert.Equal(1, processingEvents.Count);
+			}
+
+			Assert.Equal(0, processingEvents.Count);
+
+			using (RunningTasks.RememberWith(processingEvents))
+			{
+				Assert.Equal(1, processingEvents.Count);
+			}
+
+			Assert.Equal(0, processingEvents.Count);
+			await processingEvents.WhenAllAsync();
+		}
+	}
+}

--- a/WalletWasabi/Nito/AsyncEx/AbandonedTasks.cs
+++ b/WalletWasabi/Nito/AsyncEx/AbandonedTasks.cs
@@ -27,6 +27,20 @@ namespace WalletWasabi.Nito.AsyncEx
 			}
 		}
 
+		/// <summary>Gets the number of outstanding tasks.</summary>
+		/// <remarks>As a side-effect completed tasks are removed.</remarks>
+		public int Count
+		{
+			get
+			{
+				lock (Lock)
+				{
+					ClearCompletedNoLock();
+					return Tasks.Count;
+				}
+			}
+		}
+
 		/// <summary>
 		/// Wait for all tasks to complete.
 		/// </summary>

--- a/WalletWasabi/Nito/AsyncEx/RunningTasks.cs
+++ b/WalletWasabi/Nito/AsyncEx/RunningTasks.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace WalletWasabi.Nito.AsyncEx
@@ -14,7 +11,7 @@ namespace WalletWasabi.Nito.AsyncEx
 		}
 
 		private bool DisposedValue { get; set; } = false;
-		public static TaskCompletionSource Completion { get; } = new();
+		private TaskCompletionSource Completion { get; } = new();
 
 		public static IDisposable RememberWith(AbandonedTasks taskCollection) => new RunningTasks(taskCollection);
 


### PR DESCRIPTION
This PR fixes `RunningTasks` class which on the master branch actually does basically nothing as there is only one instance of `TaskCompletionSource` per application in `RunningTasks`.

This PR can be reviewed commit by commit.