### PR TITLE
`IdempotentActionFilterImpl` & concurrency

### DIFF
--- a/WalletWasabi.Backend/Filters/IdempotentActionFilterAttributeImpl.cs
+++ b/WalletWasabi.Backend/Filters/IdempotentActionFilterAttributeImpl.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
 using WalletWasabi.WabiSabi.Models.Serialization;
 
 namespace WalletWasabi.Backend.Filters
@@ -15,13 +15,20 @@ namespace WalletWasabi.Backend.Filters
 	{
 		private static TimeSpan CacheTimeout { get; } = TimeSpan.FromMinutes(5);
 		private const string ContextCacheKey = "cached-key";
-		private readonly IMemoryCache _responseCache;
 
 		public IdempotentActionFilterAttributeImpl(IMemoryCache cache)
 			: base()
 		{
-			_responseCache = cache;
+			ResponseCache = cache;
 		}
+
+		/// <summary>Guards <see cref="ResponseCache"/>.</summary>
+		/// <remarks>Unfortunately, <see cref="CacheExtensions.GetOrCreate{TItem}(IMemoryCache, object, Func{ICacheEntry, TItem})"/> is not atomic.</remarks>
+		/// <seealso href="https://github.com/dotnet/runtime/issues/36499"/>
+		private object ResponseCacheLock { get; } = new();
+
+		/// <remarks>Guarded by <see cref="ResponseCacheLock"/>.</remarks>
+		private IMemoryCache ResponseCache { get; }
 
 		/// <inheritdoc/>
 		public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -34,11 +41,28 @@ namespace WalletWasabi.Backend.Filters
 				{
 					string cacheKey = GetCacheEntryKey(request.Path, model);
 
-					if (_responseCache.TryGetValue(cacheKey, out ObjectResult? cachedResponse))
+					TaskCompletionSource<IActionResult>? cachedResponseTcs = null;
+
+					lock (ResponseCacheLock)
 					{
-						context.Result = cachedResponse;
-						context.HttpContext.Items.Remove(ContextCacheKey);
-						return;
+						if (!ResponseCache.TryGetValue(cacheKey, out cachedResponseTcs))
+						{
+							ResponseCache.Set(cacheKey, new TaskCompletionSource<IActionResult>(), DateTimeOffset.UtcNow.Add(CacheTimeout));
+						}
+					}
+
+					if (cachedResponseTcs is not null)
+					{
+						try
+						{
+							context.Result = await cachedResponseTcs!.Task.WithAwaitCancellationAsync(TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+							context.HttpContext.Items.Remove(ContextCacheKey);
+							return;
+						}
+						catch (OperationCanceledException)
+						{
+							// Failed to get cached response. Continue as if it were a non-cached request.
+						}
 					}
 
 					context.HttpContext.Items[ContextCacheKey] = cacheKey;
@@ -57,7 +81,13 @@ namespace WalletWasabi.Backend.Filters
 		{
 			if (context.HttpContext.Items.TryGetValue(ContextCacheKey, out object? cacheKey) && cacheKey is not null)
 			{
-				_responseCache.Set(cacheKey, context.Result, DateTimeOffset.UtcNow.Add(CacheTimeout));
+				lock (ResponseCacheLock)
+				{
+					if (ResponseCache.TryGetValue(cacheKey, out TaskCompletionSource<IActionResult>? cachedResponseTcs))
+					{
+						cachedResponseTcs!.TrySetResult(context.Result);
+					}
+				}
 			}
 		}
 

--- a/WalletWasabi.Backend/Filters/IdempotentActionFilterAttributeImpl.cs
+++ b/WalletWasabi.Backend/Filters/IdempotentActionFilterAttributeImpl.cs
@@ -14,6 +14,7 @@ namespace WalletWasabi.Backend.Filters
 	public class IdempotentActionFilterAttributeImpl : ActionFilterAttribute
 	{
 		private static TimeSpan CacheTimeout { get; } = TimeSpan.FromMinutes(5);
+		private static TimeSpan RequestTimeout { get; } = TimeSpan.FromMinutes(1);
 		private const string ContextCacheKey = "cached-key";
 
 		public IdempotentActionFilterAttributeImpl(IMemoryCache cache)
@@ -59,7 +60,7 @@ namespace WalletWasabi.Backend.Filters
 				{
 					try
 					{
-						context.Result = await cachedResponseTcs!.Task.WithAwaitCancellationAsync(TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+						context.Result = await cachedResponseTcs!.Task.WithAwaitCancellationAsync(RequestTimeout).ConfigureAwait(false);
 						context.HttpContext.Items.Remove(ContextCacheKey);
 						return;
 					}

--- a/WalletWasabi.Backend/Filters/IdempotentActionFilterAttributeImpl.cs
+++ b/WalletWasabi.Backend/Filters/IdempotentActionFilterAttributeImpl.cs
@@ -76,10 +76,7 @@ namespace WalletWasabi.Backend.Filters
 				// Request failed for some reason, we don't want to hold any other requests that wait for this one request to finish.
 				if (executed.Exception != null && !executed.ExceptionHandled)
 				{
-					if (responseTcs is not null)
-					{
-						responseTcs.TrySetCanceled();
-					}
+					responseTcs?.TrySetCanceled();
 				}
 			}
 			else

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -353,12 +353,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		[Fact]
 		public async Task RegisterCoinIdempotencyAsync()
 		{
-			using var signingKey = new Key();
-			var coinToRegister = new Coin(
-				BitcoinFactory.CreateOutPoint(),
-				new TxOut(Money.Coins(1), signingKey.PubKey.WitHash.ScriptPubKey));
+			using Key signingKey = new();
+			Coin coinToRegister = new(
+				fromOutpoint: BitcoinFactory.CreateOutPoint(),
+				fromTxOut: new TxOut(Money.Coins(1), signingKey.PubKey.WitHash.ScriptPubKey));
 
-			var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
+			HttpClient httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			{
 				builder.ConfigureServices(services =>
 				{
@@ -374,11 +374,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 				});
 			}).CreateClient();
 
-			var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(new StuttererHttpClient(httpClient));
-			var rounds = await apiClient.GetStatusAsync(CancellationToken.None);
-			var round = rounds.First(x => x.CoinjoinState is ConstructionState);
+			ArenaClient apiClient = await _apiApplicationFactory.CreateArenaClientAsync(new StuttererHttpClient(httpClient));
+			RoundState[] rounds = await apiClient.GetStatusAsync(CancellationToken.None);
+			RoundState round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
-			var response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, signingKey, CancellationToken.None);
+			ArenaResponse<uint256> response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, signingKey, CancellationToken.None);
 
 			Assert.NotEqual(uint256.Zero, response.Value);
 		}
@@ -459,10 +459,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 			public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
 			{
-				var result1 = await base.SendAsync(request.Clone(), token);
-				var result2 = await base.SendAsync(request.Clone(), token);
-				var content1 = await result1.Content.ReadAsStringAsync();
-				var content2 = await result2.Content.ReadAsStringAsync();
+				using HttpRequestMessage requestClone1 = request.Clone();
+				using HttpRequestMessage requestClone2 = request.Clone();
+
+				HttpResponseMessage result1 = await base.SendAsync(requestClone1, token).ConfigureAwait(false);
+				HttpResponseMessage result2 = await base.SendAsync(requestClone2, token).ConfigureAwait(false);
+
+				string content1 = await result1.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+				string content2 = await result2.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+
 				Assert.Equal(content1, content2);
 				return result2;
 			}
@@ -474,9 +479,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			{
 			}
 
-			public override async Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken)
+			public override Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken)
 			{
-				return;
+				return Task.CompletedTask;
 			}
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -358,7 +358,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 				fromOutpoint: BitcoinFactory.CreateOutPoint(),
 				fromTxOut: new TxOut(Money.Coins(1), signingKey.PubKey.WitHash.ScriptPubKey));
 
-			HttpClient httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
+			using HttpClient httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			{
 				builder.ConfigureServices(services =>
 				{


### PR DESCRIPTION
## Motivation

`IdempotentActionFilterAttributeImpl` is implemented in a way that if two requests are requested "at the same time", `IdempotentActionFilterAttributeImpl` will not give you the cached version of the "first" request but it lets the second request to be processed again. 

This is the reason why the `RegisterCoinIdempotencyAsync` test is flaky at the moment.

## Solution (?)

I cache `TaskCompletionSource<IActionResult>` before the first request is processed, so that the other request waits until the first one is processed. I'm aware that this is not a foolproof solution, so I would like to get some feedback on what you guys think about it. 

Note: An obvious hard case is when the first request throws an exception or takes very long.

Can be reviewed commit-by-commit.