### PR TITLE
`Arena`: Mark properties that are touched in tests as `internal` instea…

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -84,15 +84,10 @@ namespace WalletWasabi.Tests.Helpers
 		}
 
 		public static async Task<Arena> CreateAndStartArenaAsync()
-			=> await CreateAndStartArenaAsync(
-				new WabiSabiConfig(),
-				CreatePreconfiguredRpcClient());
+			=> await CreateAndStartArenaAsync(new WabiSabiConfig(), CreatePreconfiguredRpcClient());
 
 		public static async Task<Arena> CreateAndStartArenaAsync(WabiSabiConfig cfg, params Round[] rounds)
-			=> await CreateAndStartArenaAsync(
-				cfg,
-				CreatePreconfiguredRpcClient(),
-				rounds);
+			=> await CreateAndStartArenaAsync(cfg, CreatePreconfiguredRpcClient(), rounds);
 
 		public static async Task<Arena> CreateAndStartArenaAsync(WabiSabiConfig cfg, IMock<IRPCClient> mockRpc, params Round[] rounds)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -32,13 +32,13 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		public HashSet<Round> Rounds { get; } = new();
 		private AsyncLock AsyncLock { get; } = new();
-		public Network Network { get; }
-		public WabiSabiConfig Config { get; }
-		public IRPCClient Rpc { get; }
-		public Prison Prison { get; }
-		public SecureRandom Random { get; }
+		private Network Network { get; }
+		private WabiSabiConfig Config { get; }
+		internal IRPCClient Rpc { get; }
+		internal Prison Prison { get; }
+		private SecureRandom Random { get; }
 
-		public IEnumerable<Round> ActiveRounds => Rounds.Where(x => x.Phase != Phase.Ended);
+		internal IEnumerable<Round> ActiveRounds => Rounds.Where(x => x.Phase != Phase.Ended);
 
 		protected override async Task ActionAsync(CancellationToken cancel)
 		{


### PR DESCRIPTION
…d of `public`.

This makes it more clear when somebody is accessing the internal state of `Arena`.