### PR TITLE
WabiSabi: Add tests for `MoneySatoshiJsonConverter`

### DIFF
--- a/WalletWasabi/JsonConverters/Bitcoin/MoneySatoshiJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/MoneySatoshiJsonConverter.cs
@@ -4,16 +4,10 @@ using System;
 
 namespace WalletWasabi.JsonConverters.Bitcoin
 {
-	public class MoneySatoshiJsonConverter : JsonConverter
+	public class MoneySatoshiJsonConverter : JsonConverter<Money>
 	{
 		/// <inheritdoc />
-		public override bool CanConvert(Type objectType)
-		{
-			return objectType == typeof(Money);
-		}
-
-		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override Money ReadJson(JsonReader reader, Type objectType, Money existingValue, bool hasExistingValue, JsonSerializer serializer)
 		{
 			var serialized = (long)reader.Value;
 
@@ -21,11 +15,9 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		}
 
 		/// <inheritdoc />
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		public override void WriteJson(JsonWriter writer, Money value, JsonSerializer serializer)
 		{
-			var money = (Money)value;
-
-			writer.WriteValue(money.Satoshi);
+			writer.WriteValue(value.Satoshi);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.WabiSabi.Models.Serialization
 {
 	public class JsonSerializationOptions
 	{
-		private static readonly JsonSerializerSettings CurrentSettings = new ()
+		private static readonly JsonSerializerSettings CurrentSettings = new()
 		{
 			Converters = new List<JsonConverter>()
 			{


### PR DESCRIPTION
This PR attempts to increase test coverage for `MoneySatoshiJsonConverter`. It seems to be the case that the `MoneySatoshiJsonConverter` class is tested indirectly but I have not found any *direct* tests.

It is certainly interesting to me how many different exceptions can be thrown by the JSON converter. Just for comparison, when you write a custom converter for `System.Text.JSON`, you typically throw only `JsonException`. I guess that `Newtonsoft.Json` differs in this regard.

`Assert.Null(JsonConvert.DeserializeObject<Money>("", converters));` surprised me as well. 

If you spot any weird (de)serialization in the test, please let me know.

Anyway, I hope this is useful.

Edit: I changed `JsonConverter` to `JsonConverter<T>`. I expect that this is preferred way to do this. If you like it, I can do the same modification for other converters.