### PR TITLE
[Fluent] Allow enter a recovery word twice

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
@@ -30,7 +30,8 @@
                            RestrictInputToSuggestions="True"
                            Items="{Binding Mnemonics}"
                            Suggestions="{Binding Suggestions}"
-                           CompletedCommand="{Binding NextCommand}">
+                           CompletedCommand="{Binding NextCommand}"
+                           AllowDuplication="True">
                     <i:Interaction.Behaviors>
                         <behaviors:FocusOnAttachedBehavior />
                     </i:Interaction.Behaviors>


### PR DESCRIPTION
We use the `TagsBox` control for entering labels and for entering recovery words, and while I was fixing bugs regarding Labels I forgot to enable `AllowDuplication` at Recover Wallet.
This PR fixes it.