### PR TITLE
[PoC] Use SafeIoManager when save/load wallet files

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -10,6 +10,7 @@ using System.Security;
 using System.Text;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Helpers;
+using WalletWasabi.Io;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
@@ -194,7 +195,9 @@ namespace WalletWasabi.Blockchain.Keys
 				throw new FileNotFoundException($"Wallet file not found at: `{filePath}`.");
 			}
 
-			string jsonString = File.ReadAllText(filePath, Encoding.UTF8);
+			SafeIoManager safeIoManager = new(filePath);
+			string jsonString = safeIoManager.ReadAllText(Encoding.UTF8);
+
 			var km = JsonConvert.DeserializeObject<KeyManager>(jsonString);
 
 			km.SetFilePath(filePath);
@@ -587,7 +590,9 @@ namespace WalletWasabi.Blockchain.Keys
 			BlockchainState.Height = new Height(matureHeight);
 
 			string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented);
-			File.WriteAllText(filePath, jsonString, Encoding.UTF8);
+
+			SafeIoManager safeIoManager = new(filePath);
+			safeIoManager.WriteAllText(jsonString, Encoding.UTF8);
 
 			// Re-add removed items for further operations.
 			BlockchainState.Height = prevHeight;

--- a/WalletWasabi/Io/SafeIoManager.cs
+++ b/WalletWasabi/Io/SafeIoManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
@@ -136,6 +137,19 @@ namespace WalletWasabi.Io
 			SafeMoveNewToOriginal();
 		}
 
+		public void WriteAllText(string text, Encoding encoding)
+		{
+			if (string.IsNullOrEmpty(text))
+			{
+				return;
+			}
+
+			IoHelpers.EnsureContainingDirectoryExists(NewFilePath);
+
+			File.WriteAllText(NewFilePath, text, encoding);
+			SafeMoveNewToOriginal();
+		}
+
 		public new async Task<string[]> ReadAllLinesAsync(CancellationToken cancellationToken = default)
 		{
 			var filePath = FilePath;
@@ -144,6 +158,17 @@ namespace WalletWasabi.Io
 				filePath = safestFilePath;
 			}
 			return await ReadAllLinesAsync(filePath, cancellationToken).ConfigureAwait(false);
+		}
+
+		public string ReadAllText(Encoding encoding)
+		{
+			var filePath = FilePath;
+			if (TryGetSafestFileVersion(out string? safestFilePath))
+			{
+				filePath = safestFilePath;
+			}
+
+			return File.ReadAllText(filePath, encoding);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR is about saving the wallet file by using SafeIoManager. It makes file writes more error-prone in case of a crash (can be a shutdown) and is able to recover from the last correct state. This is a quick and cheap fix and still not address when the wallet file changed externally. 