### PR TITLE
[WabiSabi] Handle Input registration failures 

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -47,7 +47,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var rnd = new Random(seed);
 			double NextNotTooSmall() => 0.00001 + (rnd.NextDouble() * 0.99999);
 			var sampling = Enumerable
-				.Range(0, numberOfCoins-1)
+				.Range(0, numberOfCoins - 1)
 				.Select(_ => NextNotTooSmall())
 				.Prepend(0)
 				.Prepend(1)
@@ -80,10 +80,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var kitchen = new Kitchen();
 			kitchen.Cook("");
 
-			var coinJoinClient = new CoinJoinClient(ApiClient, Coins, kitchen, KeyManager, roundStateUpdater);
+			var coinJoinClient = new CoinJoinClient(ApiClient, kitchen, KeyManager, roundStateUpdater);
 
 			// Run the coinjoin client task.
-			await coinJoinClient.StartCoinJoinAsync(cancellationToken).ConfigureAwait(false);
+			await coinJoinClient.StartCoinJoinAsync(Coins, cancellationToken).ConfigureAwait(false);
 
 			await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -142,7 +142,7 @@ namespace WalletWasabi.WabiSabi.Client
 				var secret = hdKey.PrivateKey.GetBitcoinSecret(Keymanager.GetNetwork());
 				aliceClients.Add(new AliceClient(roundState.Id, aliceArenaClient, coin, roundState.FeeRate, secret));
 			}
-			return aliceClients.MoveToImmutable();
+			return aliceClients.ToImmutable();
 		}
 
 		private async Task<ImmutableArray<AliceClient>> RegisterCoinsAsync(ImmutableArray<AliceClient> aliceClients, CancellationToken cancellationToken)
@@ -162,7 +162,7 @@ namespace WalletWasabi.WabiSabi.Client
 				}
 			}
 
-			return successfulAlices.MoveToImmutable();
+			return successfulAlices.ToImmutable();
 		}
 
 		private static IEnumerable<Money> DecomposeAmounts(IEnumerable<Coin> coins, FeeRate feeRate, Money minimumOutputAmount)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -149,7 +149,10 @@ namespace WalletWasabi.WabiSabi.Client
 		{
 			var successfulAlices = ImmutableArray.CreateBuilder<AliceClient>();
 
-			foreach (var aliceClient in aliceClients.OrderByDescending(x => x.Coin.Amount))
+			List<AliceClient> shuffledAlices = new (aliceClients);
+			shuffledAlices.Shuffle();
+
+			foreach (var aliceClient in shuffledAlices)
 			{
 				try
 				{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -80,7 +80,10 @@ namespace WalletWasabi.WabiSabi.Client
 			// Register coins.
 			aliceClients = await RegisterCoinsAsync(aliceClients, cancellationToken).ConfigureAwait(false);
 
-			//TODO: add sanity check here. What is the feasible limit to proceed forward?
+			if (aliceClients.Length == 0)
+			{
+				throw new InvalidOperationException($"Round ({roundState.Id}): Failed to register any coins.");
+			}
 
 			// Calculate outputs values
 			var outputValues = DecomposeAmounts(aliceClients.Select(a => a.Coin), roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts.Min);


### PR DESCRIPTION
When the round is full then in the Input-Registration phase, it is likely that some clients' Coins will be rejected. The client-side should not fail in that case either and just take the rest of the coins and go forward with the CoinJoin procedure. 

I also made input reg requests in descending order to have the biggest coin first. To be able to ensure this the requests have to be done sequentially. 