### PR TITLE
[Fleunt] ContentArea - Remove `IsCancel` from cancel button

### DIFF
--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -32,7 +32,6 @@
 
                         <Panel DockPanel.Dock="Bottom" x:Name="PART_ButtonArea">
                             <Button Name="PART_CancelButton"
-                                    IsCancel="{TemplateBinding EnableCancel}"
                                     Classes="invisible"
                                     IsVisible="{TemplateBinding EnableCancel}"
                                     Content="{TemplateBinding CancelContent}"


### PR DESCRIPTION
Since we are handling the cancelation in `Dialog.axaml.cs`, no need to `IsCancel` be set, thus some issue gets fixed:

- It was possible to close the dialog while `IsBusy` was true on TransactionPreview screen. (while the progress ring is visible after the confirmation)
- Pressing ESC triggers the Restart Wasabi button. https://github.com/zkSNACKs/WalletWasabi/pull/4842#pullrequestreview-729383303
- And probably at other places.