### PR TITLE
[Fluent] Validation error message fixes

### DIFF
--- a/WalletWasabi.Fluent/Styles/TextBox.axaml
+++ b/WalletWasabi.Fluent/Styles/TextBox.axaml
@@ -104,7 +104,7 @@
 
   <!-- TODO: temporary fix to prevent layout issue when error occurs  -->
   <Style Selector="TextBox /template/ DataValidationErrors">
-    <Setter Property="MinHeight" Value="20" />
+    <Setter Property="MinHeight" Value="21" />
   </Style>
 
   <Style Selector="TextBox:not(.hasCheckMark) /template/ PathIcon.checkMark.checkMarkDataValidation">

--- a/WalletWasabi.Fluent/Styles/TextBox.axaml
+++ b/WalletWasabi.Fluent/Styles/TextBox.axaml
@@ -26,7 +26,7 @@
                             IsVisible="False"
                             Margin="{DynamicResource TextBoxTopHeaderMargin}" />
 
-          <DataValidationErrors DockPanel.Dock="Bottom" Margin="0 10 0 0" />
+          <DataValidationErrors DockPanel.Dock="Bottom" Margin="0 5 0 0" />
 
           <DockPanel>
             <PathIcon Classes="checkMark checkMarkDataValidation" Margin="15  0" VerticalAlignment="Center" DockPanel.Dock="Right">


### PR DESCRIPTION
- When the error message appeared, it pushed the other controls by 1 pixel. I fixed it.
- I decreased the gap between the TextBox and the error message. Usually, the message was closer to another control than to its owner.

Before:
![image](https://user-images.githubusercontent.com/16364053/129615110-e62ab04d-235a-4434-bc3f-1305e5c034be.png)

After:
![image](https://user-images.githubusercontent.com/16364053/129614991-7c2fb793-fc4d-475e-854e-d41bb7178bc0.png)
