### PR TITLE
[Fluent] Privacy Control - skip screen if there is only one cluster

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -172,6 +172,19 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			if (_pocketSource.Count == 1)
 			{
 				_pocketSource.Items.First().IsSelected = true;
+
+				if (isInHistory)
+				{
+					Navigate().Back();
+				}
+				else
+				{
+					if (NextCommand is {} cmd && cmd.CanExecute(default))
+					{
+						cmd.Execute(default);
+					}
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
If there is only one cluster the user has nothing to do on that screen. It will automatically jump to the next page and will automatically jump to the previous page (when back navigation happens).

Just like if it would be sent from private funds.

https://user-images.githubusercontent.com/16364053/129679333-5bb7a956-1739-4e98-bc90-77204b847047.mp4

