### PR TITLE
[Fluent] Fix navigation issue after `InsufficientBalanceException`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -75,7 +75,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		private async Task OnNextAsync(TransactionInfo transactionInfo,
 			IObservableList<PocketViewModel> selectedList)
 		{
-			_buildingTransaction = true;
 			transactionInfo.Coins = selectedList.Items.SelectMany(x => x.Coins).ToArray();
 
 			if (_privatePocket is not null)
@@ -85,6 +84,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 			try
 			{
+				_buildingTransaction = true;
+
 				if (transactionInfo.PayJoinClient is { })
 				{
 					await BuildTransactionAsPayJoinAsync(transactionInfo);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -28,6 +28,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		[AutoNotify] private decimal _stillNeeded;
 		[AutoNotify] private bool _enoughSelected;
 
+		private bool _buildingTransaction;
+
 		public PrivacyControlViewModel(Wallet wallet, TransactionInfo transactionInfo)
 		{
 			_wallet = wallet;
@@ -73,6 +75,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		private async Task OnNextAsync(TransactionInfo transactionInfo,
 			IObservableList<PocketViewModel> selectedList)
 		{
+			_buildingTransaction = true;
 			transactionInfo.Coins = selectedList.Items.SelectMany(x => x.Coins).ToArray();
 
 			if (_privatePocket is not null)
@@ -96,6 +99,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				Logger.LogError(ex);
 				await ShowErrorAsync("Transaction Building", ex.ToUserFriendlyString(), "Wasabi was unable to create your transaction.");
 				Navigate().BackTo<SendViewModel>();
+			}
+			finally
+			{
+				_buildingTransaction = false;
 			}
 		}
 
@@ -139,6 +146,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 		protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 		{
+			if (_buildingTransaction)
+			{
+				return;
+			}
+
 			base.OnNavigatedTo(isInHistory, disposables);
 
 			if (!isInHistory)


### PR DESCRIPTION
When an `InsufficientBalanceException` happened on the privacy control screen and the user clicked `No`, it navigated to the fee screen instead of the first screen if there was only one pocket.

This PR fixes it.