### PR TITLE
[Fluent] Add OSX support for QR scanning

### DIFF
--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -426,6 +426,11 @@
           "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Transitive",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
+      },
       "OpenCvSharp4.runtime.win": {
         "type": "Transitive",
         "resolved": "4.5.2.20210404",
@@ -1015,6 +1020,7 @@
           "Avalonia.ReactiveUI": "0.10.999-cibuild0014678-beta",
           "Avalonia.Xaml.Behaviors": "0.10.6.10",
           "OpenCvSharp4": "4.5.2.20210404",
+          "OpenCvSharp4.runtime.osx.10.15-x64": "4.5.3.20210725",
           "OpenCvSharp4.runtime.win": "4.5.2.20210404",
           "WalletWasabi": "1.0.0",
           "Wasabi Wallet": "1.0.0"
@@ -1070,6 +1076,11 @@
         "dependencies": {
           "Microsoft.NETCore.Platforms": "5.0.0"
         }
+      },
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Transitive",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
       },
       "OpenCvSharp4.runtime.win": {
         "type": "Transitive",
@@ -1607,6 +1618,11 @@
           "Microsoft.NETCore.Platforms": "5.0.0"
         }
       },
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Transitive",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
+      },
       "OpenCvSharp4.runtime.win": {
         "type": "Transitive",
         "resolved": "4.5.2.20210404",
@@ -2142,6 +2158,11 @@
         "dependencies": {
           "Microsoft.NETCore.Platforms": "5.0.0"
         }
+      },
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Transitive",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
       },
       "OpenCvSharp4.runtime.win": {
         "type": "Transitive",

--- a/WalletWasabi.Fluent/Models/WebcamQrReader.cs
+++ b/WalletWasabi.Fluent/Models/WebcamQrReader.cs
@@ -34,7 +34,15 @@ namespace WalletWasabi.Fluent.Models
 		private bool RequestEnd { get; set; }
 		private Network Network { get; }
 		private Task? ScanningTask { get; set; }
-		public static bool IsOsPlatformSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+		public static bool IsOsPlatformSupported()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				return true;
+			}
+			return false;
+		}
 
 		public async Task StartScanningAsync()
 		{
@@ -50,7 +58,7 @@ namespace WalletWasabi.Fluent.Models
 					VideoCapture? camera = null;
 					try
 					{
-						if (!IsOsPlatformSupported)
+						if (!IsOsPlatformSupported())
 						{
 							throw new NotImplementedException("This operating system is not supported.");
 						}

--- a/WalletWasabi.Fluent/Models/WebcamQrReader.cs
+++ b/WalletWasabi.Fluent/Models/WebcamQrReader.cs
@@ -10,6 +10,7 @@ using WalletWasabi.Userfacing;
 using NBitcoin;
 using Nito.AsyncEx;
 using Avalonia.Platform;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Fluent.Models
 {
@@ -53,7 +54,7 @@ namespace WalletWasabi.Fluent.Models
 					return;
 				}
 				RequestEnd = false;
-				ScanningTask = Task.Run(() =>
+				ScanningTask = Task.Run(async () =>
 				{
 					VideoCapture? camera = null;
 					try
@@ -66,7 +67,7 @@ namespace WalletWasabi.Fluent.Models
 						camera.SetExceptionMode(true);
 						// Setting VideoCaptureAPI to DirectShow, to remove warning logs,
 						// might need to be changed in the future for other operating systems
-						if (!camera.Open(DefaultCameraId, VideoCaptureAPIs.DSHOW))
+						if (!camera.Open(DefaultCameraId, VideoCaptureAPIs.ANY))
 						{
 							throw new InvalidOperationException("Could not open webcamera.");
 						}
@@ -75,6 +76,11 @@ namespace WalletWasabi.Fluent.Models
 					catch (Exception ex)
 					{
 						Logger.LogError("QR scanning stopped. Reason:", ex);
+						if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+						{
+							var command = "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh) \"";
+							await EnvironmentHelpers.ShellExecAsync(command).ConfigureAwait(false);
+						}
 						ErrorOccured?.Invoke(this, ex);
 					}
 					finally

--- a/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
+++ b/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net5.0</TargetFramework>
 		<AnalysisLevel>latest</AnalysisLevel>
@@ -20,6 +20,7 @@
 		<PackageReference Include="Avalonia.ReactiveUI" Version="0.10.999-cibuild0014678-beta" />
 		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.999-cibuild0014678-beta" />
 		<PackageReference Include="OpenCvSharp4" Version="4.5.2.20210404" />
+		<PackageReference Include="OpenCvSharp4.runtime.osx.10.15-x64" Version="4.5.3.20210725" />
 		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.5.2.20210404" />
 		<PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.6.10" />
 	</ItemGroup>

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -62,6 +62,12 @@
           "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Direct",
+        "requested": "[4.5.3.20210725, )",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
+      },
       "OpenCvSharp4.runtime.win": {
         "type": "Direct",
         "requested": "[4.5.2.20210404, )",
@@ -2127,6 +2133,12 @@
       }
     },
     ".NETCoreApp,Version=v5.0/linux-x64": {
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Direct",
+        "requested": "[4.5.3.20210725, )",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
+      },
       "OpenCvSharp4.runtime.win": {
         "type": "Direct",
         "requested": "[4.5.2.20210404, )",
@@ -3161,6 +3173,12 @@
       }
     },
     ".NETCoreApp,Version=v5.0/osx-x64": {
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Direct",
+        "requested": "[4.5.3.20210725, )",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
+      },
       "OpenCvSharp4.runtime.win": {
         "type": "Direct",
         "requested": "[4.5.2.20210404, )",
@@ -4195,6 +4213,12 @@
       }
     },
     ".NETCoreApp,Version=v5.0/win7-x64": {
+      "OpenCvSharp4.runtime.osx.10.15-x64": {
+        "type": "Direct",
+        "requested": "[4.5.3.20210725, )",
+        "resolved": "4.5.3.20210725",
+        "contentHash": "tGTgCfN37gpPb2o+zquKqW0armxoLMoA6HQ2zjy4Ly9D92sriOlBSizGZCz5unGk6Z+7oxiz5rIR2ZmVrVQjrQ=="
+      },
       "OpenCvSharp4.runtime.win": {
         "type": "Direct",
         "requested": "[4.5.2.20210404, )",


### PR DESCRIPTION
##### Expands #6002 

## Description

As already mentioned and discussed, to use the camera for QR code scanning and reading on **MacOS**, we need certain [dependencies](https://github.com/shimat/opencvsharp/blob/master/.github/workflows/macos10.yml#L26).
This PR has
#### 4 main task:
- [x] Add MacOS runtime package
- [ ] Install [Brew](https://brew.sh) without user interactions
- [ ] Install dependencies via Brew (without user interactions)
- [ ] Check if Brew is already installed

#### Side task
- [ ] Display progress of installation

## Breakdown

**1. Add MacOS runtime package:** Straightforward, we need **OpenCvSharp MacOS runtime package** to use this on OSX.

**2. Install Brew without user interactions:** Brew is a usefull tool to install the missing dependencies, fast(relative) & easy. The second part is more important. Installing Brew the usual way requires user input via the terminal, the user's password. This can be avoided by getting the source code and run brew from there.

**3. Install dependencies via Brew:** With Brew and a few line, we can install all the dependencies we need. This takes time, but is necessary for this code to run. We might be able to do this without further user input if Brew is called from a cloned repository.

**4. Check if Brew is already installed:** Checking for an already installed/copied Brew is a **must do** to avoid installing/cloning it over and over again.

**5. Display progress of installation:** To improve UX. If we install the dependencies one by one, instead of installing it all in one line, we can easily display the progress bar for the user, which is great to follow.