### PR TITLE
[Fluent] Wallet Balance Chart fixes

### DIFF
--- a/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.Fluent.Helpers
 		public static IEnumerable<(DateTimeOffset timestamp, TResult result)> SelectTimeSampleBackwards<TSource, TResult>(
 			this IEnumerable<TSource> sourceData,
 			Func<TSource, DateTimeOffset> timeSampler, Func<TSource, TResult> sampler,
-			TimeSpan interval, DateTimeOffset endTime, DateTimeOffset? startFrom = default)
+			TimeSpan interval, DateTimeOffset endTime, TResult defaultValue, DateTimeOffset? startFrom = default)
 		{
 			var source = sourceData.ToArray();
 
@@ -44,16 +44,9 @@ namespace WalletWasabi.Fluent.Helpers
 			{
 				var current = source.FirstOrDefault(x => timeSampler(x) <= currentTime);
 
-				if (current is { })
-				{
-					lastFound = (currentTime, sampler(current));
+				lastFound = current is { } ? (currentTime, sampler(current)) : (currentTime, defaultValue);
 
-					yield return lastFound;
-				}
-				else
-				{
-					yield break;
-				}
+				yield return lastFound;
 
 				currentTime -= interval;
 			}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceChartTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceChartTileViewModel.cs
@@ -135,33 +135,23 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles
 				var range = DateTimeOffset.FromUnixTimeMilliseconds((long)maxX) -
 							DateTimeOffset.FromUnixTimeMilliseconds((long)minX);
 
+				var stringFormatOption = "MMM-d";
+
 				if (range <= TimeSpan.FromDays(1))
 				{
-					XLabels = new List<string>
-					{
-						DateTimeOffset.FromUnixTimeMilliseconds((long) minX).DateTime.ToString("t"),
-						DateTimeOffset.FromUnixTimeMilliseconds((long) halfX).DateTime.ToString("t"),
-						DateTimeOffset.FromUnixTimeMilliseconds((long) maxX).DateTime.ToString("t"),
-					};
+					stringFormatOption = "t";
 				}
 				else if (range <= TimeSpan.FromDays(7))
 				{
-					XLabels = new List<string>
-					{
-						DateTimeOffset.FromUnixTimeMilliseconds((long) minX).DateTime.ToString("ddd MMM-d"),
-						DateTimeOffset.FromUnixTimeMilliseconds((long) halfX).DateTime.ToString("ddd MMM-d"),
-						DateTimeOffset.FromUnixTimeMilliseconds((long) maxX).DateTime.ToString("ddd MMM-d"),
-					};
+					stringFormatOption = "ddd MMM-d";
 				}
-				else
+
+				XLabels = new List<string>
 				{
-					XLabels = new List<string>
-					{
-						DateTimeOffset.FromUnixTimeMilliseconds((long) minX).DateTime.ToString("MMM-d"),
-						DateTimeOffset.FromUnixTimeMilliseconds((long) halfX).DateTime.ToString("MMM-d"),
-						DateTimeOffset.FromUnixTimeMilliseconds((long) maxX).DateTime.ToString("MMM-d"),
-					};
-				}
+					DateTimeOffset.FromUnixTimeMilliseconds((long)minX).ToLocalTime().ToString(stringFormatOption),
+					DateTimeOffset.FromUnixTimeMilliseconds((long)halfX).ToLocalTime().ToString(stringFormatOption),
+					DateTimeOffset.FromUnixTimeMilliseconds((long)maxX).ToLocalTime().ToString(stringFormatOption),
+				};
 			}
 			else
 			{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceChartTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceChartTileViewModel.cs
@@ -105,6 +105,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles
 				x => x.Balance,
 				sampleTime,
 				sampleLimit,
+				0,
 				DateTime.Now);
 
 			XValues.Clear();


### PR DESCRIPTION
Fixes #6216.

-  Actually, the graph does update when I click smaller time frames like "1D" but the time is still 3h earlier than in history. https://github.com/zkSNACKs/WalletWasabi/issues/6216#issuecomment-905010370
- Fixes the issue when the chart was not fully built. 

Upcoming PR: 
- Improve the algorithm to not miss the key transactions.