### PR TITLE
[Fluent] [LineChart] Auto label alignment

### DIFF
--- a/WalletWasabi.Fluent/Controls/LineChart.Properties.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.Properties.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Media;

--- a/WalletWasabi.Fluent/Controls/LineChart.Properties.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.Properties.cs
@@ -12,6 +12,32 @@ namespace WalletWasabi.Fluent.Controls
 		Logarithmic
 	}
 
+	/// <summary>
+	/// Defines how a label aligns itself along axis.
+	/// </summary>
+	public enum LabelAlignment
+	{
+		/// <summary>
+		/// The label is auto-aligned.
+		/// </summary>
+		Auto,
+
+		/// <summary>
+		/// The label is left-aligned.
+		/// </summary>
+		Left,
+
+		/// <summary>
+		/// The label is centered.
+		/// </summary>
+		Center,
+
+		/// <summary>
+		/// The label is right-aligned.
+		/// </summary>
+		Right,
+	}
+
 	public partial class LineChart
 	{
 		// Area

--- a/WalletWasabi.Fluent/Controls/LineChart.Properties.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.Properties.cs
@@ -126,8 +126,8 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<Point> XAxisLabelOffsetProperty =
 			AvaloniaProperty.Register<LineChart, Point>(nameof(XAxisLabelOffset), new Point(0, 5));
 
-		public static readonly StyledProperty<TextAlignment> XAxisLabelAlignmentProperty =
-			AvaloniaProperty.Register<LineChart, TextAlignment>(nameof(XAxisLabelAlignment), TextAlignment.Center);
+		public static readonly StyledProperty<LabelAlignment> XAxisLabelAlignmentProperty =
+			AvaloniaProperty.Register<LineChart, LabelAlignment>(nameof(XAxisLabelAlignment), LabelAlignment.Center);
 
 		public static readonly StyledProperty<double> XAxisLabelAngleProperty =
 			AvaloniaProperty.Register<LineChart, double>(nameof(XAxisLabelAngle));
@@ -231,8 +231,8 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<Point> YAxisLabelOffsetProperty =
 			AvaloniaProperty.Register<LineChart, Point>(nameof(YAxisLabelOffset), new Point(-5, 0));
 
-		public static readonly StyledProperty<TextAlignment> YAxisLabelAlignmentProperty =
-			AvaloniaProperty.Register<LineChart, TextAlignment>(nameof(YAxisLabelAlignment), TextAlignment.Right);
+		public static readonly StyledProperty<LabelAlignment> YAxisLabelAlignmentProperty =
+			AvaloniaProperty.Register<LineChart, LabelAlignment>(nameof(YAxisLabelAlignment), LabelAlignment.Right);
 
 		public static readonly StyledProperty<double> YAxisLabelAngleProperty =
 			AvaloniaProperty.Register<LineChart, double>(nameof(YAxisLabelAngle));
@@ -591,7 +591,7 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(XAxisLabelOffsetProperty, value);
 		}
 
-		public TextAlignment XAxisLabelAlignment
+		public LabelAlignment XAxisLabelAlignment
 		{
 			get => GetValue(XAxisLabelAlignmentProperty);
 			set => SetValue(XAxisLabelAlignmentProperty, value);
@@ -795,7 +795,7 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(YAxisLabelOffsetProperty, value);
 		}
 
-		public TextAlignment YAxisLabelAlignment
+		public LabelAlignment YAxisLabelAlignment
 		{
 			get => GetValue(YAxisLabelAlignmentProperty);
 			set => SetValue(YAxisLabelAlignmentProperty, value);

--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -657,8 +657,8 @@ namespace WalletWasabi.Fluent.Controls
 				LabelAlignment.Auto => isFirst
 					? offsetCenter.WithY(offsetCenter.Y + height / 2)
 					: isLast
-						? offsetCenter.WithY(offsetCenter.Y - height / 2)
-						: offsetCenter.WithY(offsetCenter.Y + height - height / 2),
+						? offsetCenter.WithY(offsetCenter.Y - height + height / 2)
+						: offsetCenter.WithY(offsetCenter.Y),
 				LabelAlignment.Left => offsetCenter,
 				LabelAlignment.Center => offsetCenter,
 				LabelAlignment.Right => offsetCenter,

--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -540,10 +540,20 @@ namespace WalletWasabi.Fluent.Controls
 			var formattedTextLabels = new List<FormattedText>();
 			var constrainWidthMax = 0.0;
 			var constrainHeightMax = 0.0;
+			var labels = state.XAxisLabels;
 
-			foreach (var label in state.XAxisLabels)
+			for (var i = 0; i < labels.Count; i++)
 			{
-				var formattedText = CreateFormattedText(label, typeface, alignment, fontSize, Size.Empty);
+				var label = labels[i];
+				var textAlignment = alignment switch
+				{
+					LabelAlignment.Auto => i == 0 ? TextAlignment.Left : i == labels.Count - 1 ? TextAlignment.Right : TextAlignment.Center,
+					LabelAlignment.Left => TextAlignment.Left,
+					LabelAlignment.Center => TextAlignment.Center,
+					LabelAlignment.Right => TextAlignment.Right,
+					_ => TextAlignment.Center
+				};
+				var formattedText = CreateFormattedText(label, typeface, textAlignment, fontSize, Size.Empty);
 				formattedTextLabels.Add(formattedText);
 				constrainWidthMax = Math.Max(constrainWidthMax, formattedText.Bounds.Width);
 				constrainHeightMax = Math.Max(constrainHeightMax, formattedText.Bounds.Height);
@@ -640,11 +650,20 @@ namespace WalletWasabi.Fluent.Controls
 			var formattedTextLabels = new List<FormattedText>();
 			var constrainWidthMax = 0.0;
 			var constrainHeightMax = 0.0;
+			var labels = state.YAxisLabels;
 
-			for (var index = state.YAxisLabels.Count - 1; index >= 0; index--)
+			for (var i = labels.Count - 1; i >= 0; i--)
 			{
-				var label = state.YAxisLabels[index];
-				var formattedText = CreateFormattedText(label, typeface, alignment, fontSize, Size.Empty);
+				var label = labels[i];
+				var textAlignment = alignment switch
+				{
+					LabelAlignment.Auto => i == 0 ? TextAlignment.Left : i == labels.Count - 1 ? TextAlignment.Right : TextAlignment.Center,
+					LabelAlignment.Left => TextAlignment.Left,
+					LabelAlignment.Center => TextAlignment.Center,
+					LabelAlignment.Right => TextAlignment.Right,
+					_ => TextAlignment.Center
+				};
+				var formattedText = CreateFormattedText(label, typeface, textAlignment, fontSize, Size.Empty);
 				formattedTextLabels.Add(formattedText);
 				constrainWidthMax = Math.Max(constrainWidthMax, formattedText.Bounds.Width);
 				constrainHeightMax = Math.Max(constrainHeightMax, formattedText.Bounds.Height);

--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -624,6 +624,22 @@ namespace WalletWasabi.Fluent.Controls
 			opacityState.Dispose();
 		}
 
+		private static TextAlignment GetLabelTextAlignment(LabelAlignment alignment, int index, int count)
+		{
+			var isFirst = index == 0;
+			var isLast = index == count - 1;
+
+			return alignment switch
+			{
+				LabelAlignment.Auto => isFirst ? TextAlignment.Left :
+					isLast ? TextAlignment.Right : TextAlignment.Center,
+				LabelAlignment.Left => TextAlignment.Left,
+				LabelAlignment.Center => TextAlignment.Center,
+				LabelAlignment.Right => TextAlignment.Right,
+				_ => TextAlignment.Center
+			};
+		}
+
 		private void DrawYAxisLabels(DrawingContext context, LineChartState state)
 		{
 			var foreground = YAxisLabelForeground;
@@ -655,14 +671,7 @@ namespace WalletWasabi.Fluent.Controls
 			for (var i = labels.Count - 1; i >= 0; i--)
 			{
 				var label = labels[i];
-				var textAlignment = alignment switch
-				{
-					LabelAlignment.Auto => i == 0 ? TextAlignment.Left : i == labels.Count - 1 ? TextAlignment.Right : TextAlignment.Center,
-					LabelAlignment.Left => TextAlignment.Left,
-					LabelAlignment.Center => TextAlignment.Center,
-					LabelAlignment.Right => TextAlignment.Right,
-					_ => TextAlignment.Center
-				};
+				var textAlignment = GetLabelTextAlignment(alignment, i, labels.Count);
 				var formattedText = CreateFormattedText(label, typeface, textAlignment, fontSize, Size.Empty);
 				formattedTextLabels.Add(formattedText);
 				constrainWidthMax = Math.Max(constrainWidthMax, formattedText.Bounds.Width);

--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -579,6 +579,7 @@ namespace WalletWasabi.Fluent.Controls
 				var origin = new Point(i * state.XAxisLabelStep + constraintMax.Width / 2 + state.AreaMargin.Left,
 					originTop);
 				var offsetCenter = new Point(constraintMax.Width / 2 - constraintMax.Width / 2, 0);
+				offsetCenter = AlignXAxisLabelOffset(offsetCenter, formattedTextLabels[i].Bounds.Width, i, formattedTextLabels.Count, alignment);
 				var xPosition = origin.X + constraintMax.Width / 2;
 				var yPosition = origin.Y + constraintMax.Height / 2;
 				var matrix = Matrix.CreateTranslation(-xPosition, -yPosition)
@@ -586,7 +587,6 @@ namespace WalletWasabi.Fluent.Controls
 							 * Matrix.CreateTranslation(xPosition, yPosition);
 				var labelTransform = context.PushPreTransform(matrix);
 				var opacityState = context.PushOpacity(opacity);
-				offsetCenter = AlignXAxisLabelOffset(offsetCenter, formattedTextLabels[i].Bounds.Width, i, formattedTextLabels.Count, alignment);
 				context.DrawText(foreground, origin + offsetCenter, formattedTextLabels[i]);
 				opacityState.Dispose();
 				labelTransform.Dispose();
@@ -635,19 +635,34 @@ namespace WalletWasabi.Fluent.Controls
 			opacityState.Dispose();
 		}
 
-		private static TextAlignment GetLabelTextAlignment(LabelAlignment alignment, int index, int count)
+		private static TextAlignment GetYAxisLabelTextAlignment(LabelAlignment alignment)
+		{
+			return alignment switch
+			{
+				LabelAlignment.Auto => TextAlignment.Right,
+				LabelAlignment.Left => TextAlignment.Left,
+				LabelAlignment.Center => TextAlignment.Center,
+				LabelAlignment.Right => TextAlignment.Right,
+				_ => TextAlignment.Center
+			};
+		}
+
+		private static Point AlignYAxisLabelOffset(Point offsetCenter, double height, int index, int count, LabelAlignment alignment)
 		{
 			var isFirst = index == 0;
 			var isLast = index == count - 1;
 
 			return alignment switch
 			{
-				LabelAlignment.Auto => isFirst ? TextAlignment.Left :
-					isLast ? TextAlignment.Right : TextAlignment.Center,
-				LabelAlignment.Left => TextAlignment.Left,
-				LabelAlignment.Center => TextAlignment.Center,
-				LabelAlignment.Right => TextAlignment.Right,
-				_ => TextAlignment.Center
+				LabelAlignment.Auto => isFirst
+					? offsetCenter.WithY(offsetCenter.Y + height / 2)
+					: isLast
+						? offsetCenter.WithY(offsetCenter.Y - height / 2)
+						: offsetCenter.WithY(offsetCenter.Y + height - height / 2),
+				LabelAlignment.Left => offsetCenter,
+				LabelAlignment.Center => offsetCenter,
+				LabelAlignment.Right => offsetCenter,
+				_ => offsetCenter
 			};
 		}
 
@@ -682,7 +697,7 @@ namespace WalletWasabi.Fluent.Controls
 			for (var i = labels.Count - 1; i >= 0; i--)
 			{
 				var label = labels[i];
-				var textAlignment = GetLabelTextAlignment(alignment, i, labels.Count);
+				var textAlignment = GetYAxisLabelTextAlignment(alignment);
 				var formattedText = CreateFormattedText(label, typeface, textAlignment, fontSize, Size.Empty);
 				formattedTextLabels.Add(formattedText);
 				constrainWidthMax = Math.Max(constrainWidthMax, formattedText.Bounds.Width);
@@ -699,6 +714,7 @@ namespace WalletWasabi.Fluent.Controls
 				var origin = new Point(originLeft - constraintMax.Width,
 					i * state.YAxisLabelStep - constraintMax.Height / 2 + state.AreaMargin.Top);
 				var offsetCenter = new Point(constraintMax.Width / 2 - constraintMax.Width / 2, 0);
+				offsetCenter = AlignYAxisLabelOffset(offsetCenter, formattedTextLabels[i].Bounds.Height, i, formattedTextLabels.Count, alignment);
 				var xPosition = origin.X + constraintMax.Width / 2;
 				var yPosition = origin.Y + constraintMax.Height / 2;
 				var matrix = Matrix.CreateTranslation(-xPosition, -yPosition)

--- a/WalletWasabi.Fluent/Styles/BalanceLineChart.axaml
+++ b/WalletWasabi.Fluent/Styles/BalanceLineChart.axaml
@@ -37,7 +37,7 @@
     <Setter Property="XAxisLabelForeground" Value="{DynamicResource TextForegroundColor}" />
     <Setter Property="XAxisLabelAngle" Value="0" />
     <Setter Property="XAxisLabelOffset" Value="0,10" />
-    <Setter Property="XAxisLabelAlignment" Value="Center" />
+    <Setter Property="XAxisLabelAlignment" Value="Auto" />
     <Setter Property="XAxisLabelFontSize" Value="10" />
     <Setter Property="XAxisLabelOpacity" Value="0.8" />
   </Style>

--- a/WalletWasabi.Fluent/Styles/BalanceLineChart.axaml
+++ b/WalletWasabi.Fluent/Styles/BalanceLineChart.axaml
@@ -56,7 +56,7 @@
     <Setter Property="YAxisLabelForeground" Value="{DynamicResource TextForegroundColor}" />
     <Setter Property="YAxisLabelAngle" Value="0" />
     <Setter Property="YAxisLabelOffset" Value="-10,0" />
-    <Setter Property="YAxisLabelAlignment" Value="Right" />
+    <Setter Property="YAxisLabelAlignment" Value="Auto" />
     <Setter Property="YAxisLabelFontSize" Value="10" />
     <Setter Property="YAxisLabelOpacity" Value="0.8" />
   </Style>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -160,6 +160,7 @@
             <Setter Property="AreaMargin" Value="10,0,10,45"/>
             <Setter Property="MinHeight" Value="170"/>
             <Setter Property="XAxisLabelAngle" Value="45" />
+            <Setter Property="XAxisLabelOffset" Value="-18,54" />
           </Style>
         </c:LineChart.Styles>
         <i:Interaction.Behaviors>


### PR DESCRIPTION
This adds LabelAlignment enum for LineChart labels alignment, currently the alignment was using TextAlignment enum but we could not customize the alignments for better looking chart so I have added new option `LabelAlignment.Auto` that aligns labels in custom way (first label start from XAxis 0 point , last label ends at XAxis end, the rest of labels are center aligned, similar for Y axis).

![image](https://user-images.githubusercontent.com/2297442/130945754-e6f888b9-25d8-480e-ae17-f4a0a1de2f7e.png)
