### PR TITLE
[WabiSabi] Properly authenticate ReadyToSign requests by making AliceId secret again

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -111,7 +111,7 @@ namespace WalletWasabi.Tests.Helpers
 		}
 
 		public static Alice CreateAlice(Coin coin, OwnershipProof ownershipProof, Round round)
-			=> new(coin, ownershipProof, round) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
+			=> new(coin, ownershipProof, round, Guid.NewGuid()) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
 
 		public static Alice CreateAlice(Key key, Money amount, Round round)
 			=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key), round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 {
 	public class RegisterInputSuccessTests
 	{
-		private static void AssertSingleAliceSuccessfullyRegistered(Round round, DateTimeOffset minAliceDeadline, ArenaResponse<uint256> resp)
+		private static void AssertSingleAliceSuccessfullyRegistered(Round round, DateTimeOffset minAliceDeadline, ArenaResponse<Guid> resp)
 		{
 			var alice = Assert.Single(round.Alices);
 			Assert.NotNull(resp);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 
 			// There's no such alice yet, so success.
-			var req = new InputsRemovalRequest(round.Id, BitcoinFactory.CreateUint256());
+			var req = new InputsRemovalRequest(round.Id, Guid.NewGuid());
 			await handler.RemoveInputAsync(req, CancellationToken.None);
 
 			// There was the alice we want to remove so success.
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
 
 			await using ArenaRequestHandler handler = new(new WabiSabiConfig(), new Prison(), arena, new MockRpcClient());
-			var req = new InputsRemovalRequest(uint256.Zero, BitcoinFactory.CreateUint256());
+			var req = new InputsRemovalRequest(uint256.Zero, Guid.NewGuid());
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RemoveInputAsync(req, CancellationToken.None));
 			Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
 
@@ -68,7 +68,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			var round = arena.Rounds.First();
 
-			var req = new InputsRemovalRequest(round.Id, BitcoinFactory.CreateUint256());
+			var req = new InputsRemovalRequest(round.Id, Guid.NewGuid());
 			foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 			{
 				if (phase != Phase.InputRegistration)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -171,7 +171,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			round.SetPhase(Phase.ConnectionConfirmation);
 			var fundingTx = BitcoinFactory.CreateSmartTransaction(ownOutputCount: 1);
 			var coin = fundingTx.WalletOutputs.First().Coin;
-			var alice = new Alice(coin, new OwnershipProof(), round);
+			var alice = new Alice(coin, new OwnershipProof(), round, Guid.NewGuid());
 			round.Alices.Add(alice);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -153,7 +153,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				new[] { vsizeCred2, zeroVsizeCred2 },
 				CancellationToken.None);
 
-			await aliceArenaClient.ReadyToSignAsync(round.Id, aliceId, key, CancellationToken.None);
+			await aliceArenaClient.ReadyToSignAsync(round.Id, aliceId, CancellationToken.None);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -343,7 +343,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 			var response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, signingKey, CancellationToken.None);
 
-			Assert.NotEqual(uint256.Zero, response.Value);
+			Assert.NotEqual(Guid.Empty, response.Value);
 		}
 
 		[Fact]
@@ -374,9 +374,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			RoundState[] rounds = await apiClient.GetStatusAsync(CancellationToken.None);
 			RoundState round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
-			ArenaResponse<uint256> response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, signingKey, CancellationToken.None);
+			ArenaResponse<Guid> response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, signingKey, CancellationToken.None);
 
-			Assert.NotEqual(uint256.Zero, response.Value);
+			Assert.NotEqual(Guid.Empty, response.Value);
 		}
 
 		private class StuttererHttpClient : HttpClientWrapper

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		public void InputRegistrationResponseMessageSerialization()
 		{
 			var message = new InputRegistrationResponse(
-				BitcoinFactory.CreateUint256(),
+				Guid.NewGuid(),
 				CreateCredentialsResponse(),
 				CreateCredentialsResponse());
 
@@ -53,7 +53,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		{
 			var message = new ConnectionConfirmationRequest(
 				BitcoinFactory.CreateUint256(),
-				BitcoinFactory.CreateUint256(),
+				Guid.NewGuid(),
 				CreateZeroCredentialsRequest(),
 				CreateRealCredentialsRequest(),
 				CreateZeroCredentialsRequest(),
@@ -116,7 +116,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		{
 			var message = new InputsRemovalRequest(
 				BitcoinFactory.CreateUint256(),
-				BitcoinFactory.CreateUint256());
+				Guid.NewGuid());
 
 			AssertSerialization(message);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -8,17 +8,17 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 {
 	public class Alice
 	{
-		public Alice(Coin coin, OwnershipProof ownershipProof, Round round)
+		public Alice(Coin coin, OwnershipProof ownershipProof, Round round, Guid id)
 		{
 			// TODO init syntax?
 			Round = round;
 			Coin = coin;
 			OwnershipProof = ownershipProof;
-			Id = CalculateHash();
+			Id = id;
 		}
 
 		public Round Round { get; }
-		public uint256 Id { get; }
+		public Guid Id { get; }
 		public DateTimeOffset Deadline { get; set; } = DateTimeOffset.UtcNow;
 		public Coin Coin { get; }
 		public OwnershipProof OwnershipProof { get; }
@@ -37,14 +37,5 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 			// Have alice timeouts a bit sooner than the timeout of connection confirmation phase.
 			Deadline = DateTimeOffset.UtcNow + (connectionConfirmationTimeout * 0.9);
 		}
-
-		private uint256 CalculateHash() => CalculateHash(Coin, OwnershipProof);
-
-		public static uint256 CalculateHash(Coin coin, OwnershipProof ownershipProof)
-			=> StrobeHasher.Create(ProtocolConstants.AliceStrobeDomain)
-				.Append(ProtocolConstants.AliceCoinTxOutStrobeLabel, coin.TxOut)
-				.Append(ProtocolConstants.AliceCoinOutpointStrobeLabel, coin.Outpoint)
-				.Append(ProtocolConstants.AliceOwnershipProofStrobeLabel, ownershipProof)
-				.GetHash();
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -391,13 +391,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
-				if (Rounds.FirstOrDefault(r => r.Id == request.RoundId) is not { } round)
+				if (Rounds.FirstOrDefault(r => r.Id == request.RoundId) is not Round round)
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound, $"Round ({request.RoundId}) not found.");
 				}
 
-				var alice = round.Alices.FirstOrDefault(a => a.Id == request.AliceId);
-				if (alice is null)
+				if (round.Alices.FirstOrDefault(a => a.Id == request.AliceId) is not Alice alice)
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({request.RoundId}): Alice id ({request.AliceId}).");
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -402,12 +402,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({request.RoundId}): Alice id ({request.AliceId}).");
 				}
 
-				if (alice.ReadyToSign)
-				{
-					Prison.Ban(alice, round.Id);
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadySignalled, $"Round ({request.RoundId}): Alice id ({request.AliceId}) already signaled readiness.");
-				}
-
 				alice.ReadyToSign = true;
 			}
 		}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -346,7 +346,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
 				}
 
-				var alice = new Alice(coin, request.OwnershipProof, round);
+				// Generate a new Guid with the secure random source, to be sure
+				// that it is not guessable (Guid.NewGuid() documentation does
+				// not say anything about GUID version or randomness source,
+				// only that the probability of duplicates is very low).
+				var id = new Guid(Random.GetBytes(16));
+				var alice = new Alice(coin, request.OwnershipProof, round, id);
 
 				if (alice.TotalInputAmount < round.MinRegistrableAmount)
 				{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -402,12 +402,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({request.RoundId}): Alice id ({request.AliceId}).");
 				}
 
-				var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", request.RoundId);
-				if (!OwnershipProof.VerifyCoinJoinInputProof(request.OwnershipProof, alice.Coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
-				}
-
 				if (alice.ReadyToSign)
 				{
 					Prison.Ban(alice, round.Id);

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -119,7 +119,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 		public async Task ReadyToSignAsync(CancellationToken cancellationToken)
 		{
-			await ArenaClient.ReadyToSignAsync(RoundId, (Guid)AliceId, BitcoinSecret.PrivateKey, cancellationToken).ConfigureAwait(false);
+			await ArenaClient.ReadyToSignAsync(RoundId, (Guid)AliceId, cancellationToken).ConfigureAwait(false);
 			Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Ready to sign.");
 		}
 	}

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.WabiSabi.Client
 		public WabiSabiClient VsizeCredentialClient { get; }
 		public IWabiSabiApiRequestHandler RequestHandler { get; }
 
-		public async Task<ArenaResponse<uint256>> RegisterInputAsync(
+		public async Task<ArenaResponse<Guid>> RegisterInputAsync(
 			uint256 roundId,
 			OutPoint outPoint,
 			Key key,
@@ -58,7 +58,7 @@ namespace WalletWasabi.WabiSabi.Client
 			return new(inputRegistrationResponse.AliceId, realAmountCredentials, realVsizeCredentials);
 		}
 
-		public async Task RemoveInputAsync(uint256 roundId, uint256 aliceId, CancellationToken cancellationToken)
+		public async Task RemoveInputAsync(uint256 roundId, Guid aliceId, CancellationToken cancellationToken)
 		{
 			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceId), cancellationToken).ConfigureAwait(false);
 		}
@@ -141,7 +141,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 		public async Task<ArenaResponse<bool>> ConfirmConnectionAsync(
 			uint256 roundId,
-			uint256 aliceId,
+			Guid aliceId,
 			IEnumerable<long> amountsToRequest,
 			IEnumerable<long> vsizesToRequest,
 			IEnumerable<Credential> amountCredentialsToPresent,
@@ -225,7 +225,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 		public async Task ReadyToSignAsync(
 			uint256 roundId,
-			uint256 aliceId,
+			Guid aliceId,
 			Key key,
 			CancellationToken cancellationToken)
 		{

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -226,18 +226,12 @@ namespace WalletWasabi.WabiSabi.Client
 		public async Task ReadyToSignAsync(
 			uint256 roundId,
 			Guid aliceId,
-			Key key,
 			CancellationToken cancellationToken)
 		{
-			var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
-				key,
-				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundId));
-
 			await RequestHandler.ReadyToSign(
 				new ReadyToSignRequestRequest(
 					roundId,
-					aliceId,
-					ownershipProof),
+					aliceId),
 				cancellationToken).ConfigureAwait(false);
 		}
 	}

--- a/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
@@ -6,10 +6,10 @@ namespace WalletWasabi.WabiSabi.Models
 {
 	public record ConnectionConfirmationRequest(
 		uint256 RoundId,
-		uint256 AliceId, 
-		ZeroCredentialsRequest ZeroAmountCredentialRequests, 
-		RealCredentialsRequest RealAmountCredentialRequests, 
-		ZeroCredentialsRequest ZeroVsizeCredentialRequests, 
+		Guid AliceId,
+		ZeroCredentialsRequest ZeroAmountCredentialRequests,
+		RealCredentialsRequest RealAmountCredentialRequests,
+		ZeroCredentialsRequest ZeroVsizeCredentialRequests,
 		RealCredentialsRequest RealVsizeCredentialRequests
 	);
 }

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -5,7 +5,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputRegistrationResponse(
-		uint256 AliceId,
+		Guid AliceId,
 		CredentialsResponse AmountCredentials,
 		CredentialsResponse VsizeCredentials
 	);

--- a/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
@@ -5,6 +5,6 @@ namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputsRemovalRequest(
 		uint256 RoundId,
-		uint256 AliceId
+		Guid AliceId
 	);
 }

--- a/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
@@ -10,6 +10,5 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
 	public record ReadyToSignRequestRequest(
 		uint256 RoundId,
-		Guid AliceId,
-		OwnershipProof OwnershipProof);
+		Guid AliceId);
 }

--- a/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
@@ -10,6 +10,6 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
 	public record ReadyToSignRequestRequest(
 		uint256 RoundId,
-		uint256 AliceId,
+		Guid AliceId,
 		OwnershipProof OwnershipProof);
 }


### PR DESCRIPTION
TODO:

- [x] ~regression test~ no need since ownership proofs are just removed
- [x] make AliceId secret or introduce secret field to avoid 2nd ownership proof

Related #6252