### PR TITLE
[WabiSabi] Unregister Alice

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Crypto.ZeroKnowledge;
@@ -260,5 +261,15 @@ namespace WalletWasabi.Tests.Helpers
 
 		public static Round CreateBlameRound(Round round, WabiSabiConfig cfg)
 			=> new(new(cfg, round.Network, new InsecureRandom(), round.FeeRate, blameOf: round));
+
+		public static (Key, SmartCoin, Key, SmartCoin) CreateCoinKeyPairs()
+		{
+			var km = ServiceFactory.CreateKeyManager("");
+			var smartCoin1 = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m));
+			var smartCoin2 = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(2m));
+			var sk1 = km.GetSecrets("", smartCoin1.ScriptPubKey).Single();
+			var sk2 = km.GetSecrets("", smartCoin2.ScriptPubKey).Single();
+			return (sk1.PrivateKey, smartCoin1, sk2.PrivateKey, smartCoin2);
+		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
@@ -25,12 +26,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MaxInputCountByRound = 2,
 				MinInputCountByRoundMultiplier = 0.5
 			};
-			using Key key1 = new();
-			using Key key2 = new();
-			var coin1 = WabiSabiFactory.CreateCoin(key1);
-			var coin2 = WabiSabiFactory.CreateCoin(key2);
+			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
-			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1, coin2);
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
 			var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 			var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
@@ -75,12 +73,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MinInputCountByRoundMultiplier = 0.5,
 				OutputRegistrationTimeout = TimeSpan.Zero
 			};
-			using Key key1 = new();
-			using Key key2 = new();
-			var coin1 = WabiSabiFactory.CreateCoin(key1);
-			var coin2 = WabiSabiFactory.CreateCoin(key2);
+			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
-			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1, coin2);
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
 			var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 			var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
@@ -114,12 +109,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MinInputCountByRoundMultiplier = 0.5,
 				OutputRegistrationTimeout = TimeSpan.Zero
 			};
-			using Key key1 = new();
-			using Key key2 = new();
-			var coin1 = WabiSabiFactory.CreateCoin(key1);
-			var coin2 = WabiSabiFactory.CreateCoin(key2);
+			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
-			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1, coin2);
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
 			var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 			var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
@@ -167,12 +159,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				MaxInputCountByRound = 2,
 				MinInputCountByRoundMultiplier = 0.5
 			};
-			using Key key1 = new();
-			using Key key2 = new();
-			var coin1 = WabiSabiFactory.CreateCoin(key1);
-			var coin2 = WabiSabiFactory.CreateCoin(key2);
+			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
-			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1, coin2);
+			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
 			var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 			var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
@@ -194,7 +183,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 		}
 
 		private async Task<(Round Round, ArenaClient ArenaClient, AliceClient[] alices)>
-			CreateRoundWithTwoConfirmedConnectionsAsync(Arena arena, Key key1, Coin coin1, Key key2, Coin coin2)
+			CreateRoundWithTwoConfirmedConnectionsAsync(Arena arena, Key key1, SmartCoin coin1, Key key2, SmartCoin coin2)
 		{
 			// Create the round.
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
 
-			var aliceClient = new AliceClient(RoundState.FromRound(round), aliceArenaClient, coin1.Coin, bitcoinSecret);
+			var aliceClient = new AliceClient(RoundState.FromRound(round), aliceArenaClient, coin1, bitcoinSecret);
 
 			using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), wabiSabiApi);
 			await roundStateUpdater.StartAsync(CancellationToken.None);

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Crypto;
-using WalletWasabi.Crypto.StrobeProtocol;
 using WalletWasabi.Crypto.ZeroKnowledge;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -79,10 +78,8 @@ namespace WalletWasabi.WabiSabi.Client
 
 		private async Task<bool> TryConfirmConnectionAsync(IEnumerable<long> amountsToRequest, IEnumerable<long> vsizesToRequest, CancellationToken cancellationToken)
 		{
-			var inputVsize = Coin.ScriptPubKey.EstimateInputVsize();
-
-			var totalFeeToPay = FeeRate.GetFee(Coin.ScriptPubKey.EstimateInputVsize());
-			var totalAmount = Coin.Amount;
+			var totalFeeToPay = FeeRate.GetFee(SmartCoin.ScriptPubKey.EstimateInputVsize());
+			var totalAmount = SmartCoin.Amount;
 			var effectiveAmount = totalAmount - totalFeeToPay;
 
 			if (effectiveAmount <= Money.Zero)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -40,7 +39,6 @@ namespace WalletWasabi.WabiSabi.Client
 		}
 
 		private SecureRandom SecureRandom { get; }
-		private Random Random { get; } = new();
 		public IWabiSabiApiRequestHandler ArenaRequestHandler { get; }
 		public Kitchen Kitchen { get; }
 		public KeyManager Keymanager { get; }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -79,7 +79,7 @@ namespace WalletWasabi.WabiSabi.Client
 			var constructionState = roundState.Assert<ConstructionState>();
 
 			var coinCandidates = SelectCoinsForRound(smartCoins, constructionState.Parameters);
-			var aliceClientsToRegister = coinCandidates.Select(x => (SmartCoin: x, AliceClient: CreateAliceClient(x.Coin, roundState))).ToImmutableArray();
+			var aliceClientsToRegister = coinCandidates.Select(x => CreateAliceClient(x, roundState)).ToImmutableArray();
 
 			// Register coins.
 			var registeredAliceClients = await RegisterAndConfirmCoinsAsync(aliceClientsToRegister, cancellationToken).ConfigureAwait(false);
@@ -89,8 +89,7 @@ namespace WalletWasabi.WabiSabi.Client
 			}
 
 			// Calculate outputs values
-			var registeredCoins = registeredAliceClients.Select(x => x.Coin);
-
+			var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
 			var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);
 			var outputValues = DecomposeAmounts(registeredCoins, roundState.FeeRate, constructionState.Parameters.AllowedOutputAmounts.Min, (int)availableVsize);
 
@@ -131,7 +130,7 @@ namespace WalletWasabi.WabiSabi.Client
 			return finalRoundState.WasTransactionBroadcast;
 		}
 
-		private AliceClient CreateAliceClient(Coin coin, RoundState roundState)
+		private AliceClient CreateAliceClient(SmartCoin coin, RoundState roundState)
 		{
 			var aliceArenaClient = new ArenaClient(
 				roundState.CreateAmountCredentialClient(SecureRandom),
@@ -148,52 +147,22 @@ namespace WalletWasabi.WabiSabi.Client
 		}
 
 		private async Task<ImmutableArray<AliceClient>> RegisterAndConfirmCoinsAsync(
-			IEnumerable<(SmartCoin SmartCoin, AliceClient AliceClient)> aliceClients, CancellationToken cancellationToken)
+			IEnumerable<AliceClient> aliceClients, CancellationToken cancellationToken)
 		{
-			async Task<AliceClient?> RegisterInputTask(SmartCoin smartCoin, AliceClient aliceClient)
+			async Task<AliceClient?> RegisterInputTask(AliceClient aliceClient)
 			{
 				try
 				{
 					await aliceClient.RegisterAndConfirmInputAsync(RoundStatusUpdater, cancellationToken).ConfigureAwait(false);
-					smartCoin.CoinJoinInProgress = true;
 					return aliceClient;
 				}
 				catch (System.Net.Http.HttpRequestException ex)
 				{
-					if (ex.InnerException is WabiSabiProtocolException wpe)
-					{
-						switch (wpe.ErrorCode)
-						{
-							case WabiSabiProtocolErrorCode.InputSpent:
-								smartCoin.SpentAccordingToBackend = true;
-								Logger.LogInfo($"{smartCoin.Coin.Outpoint} is spent according to the backend. The wallet is not fully synchronized or corrupted.");
-								break;
-
-							case WabiSabiProtocolErrorCode.InputBanned:
-								smartCoin.BannedUntilUtc = DateTimeOffset.UtcNow.AddDays(1);
-								smartCoin.SetIsBanned();
-								Logger.LogInfo($"{smartCoin.Coin.Outpoint} is banned.");
-								break;
-
-							case WabiSabiProtocolErrorCode.InputNotWhitelisted:
-								smartCoin.SpentAccordingToBackend = false;
-								Logger.LogInfo($"{smartCoin.Coin.Outpoint} cannot be registered in the blame round.");
-								break;
-
-							case WabiSabiProtocolErrorCode.AliceAlreadyRegistered:
-								Logger.LogInfo($"{smartCoin.Coin.Outpoint} was already registered.");
-								return aliceClient;
-
-							case WabiSabiProtocolErrorCode.WrongPhase:
-								return null; // The coin didn't get it and arrived too late to the party.
-						}
-					}
-					Logger.LogInfo($"{smartCoin.Coin.Outpoint} registration failed with {ex}.");
 					return null;
 				}
 			}
 
-			var registerRequests = aliceClients.Select(x => RegisterInputTask(x.SmartCoin, x.AliceClient)).ToImmutableArray();
+			var registerRequests = aliceClients.Select(RegisterInputTask).ToImmutableArray();
 			await Task.WhenAll(registerRequests).ConfigureAwait(false);
 
 			return registerRequests


### PR DESCRIPTION
This PR makes `AliceClient` aware of `SmartCoin` in order to update the coin state depending on the coordinator responses during a coinjoin session interaction.

Additionally is tries to unregister Alice in case a cancellarion request is received during InputRegistration or ConnectionConfirmation phases.

Finally it moved some relevant error handling from `CoinJoinClient` to `AliceClient`.