### PR TITLE
[Fluent] QR camera stays visible if content is not correct

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
@@ -15,6 +15,7 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 	public partial class ShowQrCameraDialogViewModel : DialogViewModelBase<string?>
 	{
 		[AutoNotify] private WriteableBitmap? _qrImage;
+		[AutoNotify] private string _message = "";
 
 		private WebcamQrReader _qrReader;
 
@@ -44,7 +45,13 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 
 			Observable.FromEventPattern<string>(_qrReader, nameof(_qrReader.InvalidAddressFound))
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(args => Close(DialogResultKind.Normal, args.EventArgs));
+				.Subscribe(args =>
+				{
+					if (string.IsNullOrWhiteSpace(Message))
+					{
+						Message = $"Invalid content. Please make sure the QR code contains a correct {network.Name} address.";
+					}
+				});
 
 			Observable.FromEventPattern<Exception>(_qrReader, nameof(_qrReader.ErrorOccured))
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
@@ -45,13 +45,7 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 
 			Observable.FromEventPattern<string>(_qrReader, nameof(_qrReader.InvalidAddressFound))
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(args =>
-				{
-					if (string.IsNullOrWhiteSpace(Message))
-					{
-						Message = $"Invalid QR code.";
-					}
-				});
+				.Subscribe(args => Message = $"Invalid QR code.");
 
 			Observable.FromEventPattern<Exception>(_qrReader, nameof(_qrReader.ErrorOccured))
 				.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 				{
 					if (string.IsNullOrWhiteSpace(Message))
 					{
-						Message = $"Invalid content. Please make sure the QR code contains a correct {network.Name} address.";
+						Message = $"Invalid QR code.";
 					}
 				});
 

--- a/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
@@ -11,11 +11,14 @@
   <c:ContentArea EnableNext="False"
                  EnableCancel="{Binding EnableCancel}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
-    <!-- QR Camera -->
-    <Panel Width="400" Height="300">
-      <c:ProgressRing IsIndeterminate="True" Height="100" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNull}}" />
-      <Image Name="qrImage" Source="{Binding QrImage}" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNotNull}}" />
-    </Panel>
+    <DockPanel>
+      <TextBlock DockPanel.Dock="Bottom" Text="{Binding Message}" Margin="10,10,10,10"></TextBlock>
+      <!-- QR Camera -->
+      <Panel Width="400" Height="300">
+        <c:ProgressRing IsIndeterminate="True" Height="100" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNull}}" />
+        <Image Name="qrImage" Source="{Binding QrImage}" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNotNull}}" />
+      </Panel>
+    </DockPanel>
     <!-- Insert message binding & display here -->
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
@@ -16,5 +16,6 @@
       <c:ProgressRing IsIndeterminate="True" Height="100" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNull}}" />
       <Image Name="qrImage" Source="{Binding QrImage}" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNotNull}}" />
     </Panel>
+    <!-- Insert message binding & display here -->
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
@@ -12,7 +12,7 @@
                  EnableCancel="{Binding EnableCancel}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
     <DockPanel>
-      <TextBlock DockPanel.Dock="Bottom" Text="{Binding Message}" Height="30"></TextBlock>
+      <TextBlock DockPanel.Dock="Bottom" Text="{Binding Message}"></TextBlock>
       <!-- QR Camera -->
       <Panel Width="400" Height="300">
         <c:ProgressRing IsIndeterminate="True" Height="100" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNull}}" />

--- a/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ShowQrCameraDialogView.axaml
@@ -12,7 +12,7 @@
                  EnableCancel="{Binding EnableCancel}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
     <DockPanel>
-      <TextBlock DockPanel.Dock="Bottom" Text="{Binding Message}" Margin="10,10,10,10"></TextBlock>
+      <TextBlock DockPanel.Dock="Bottom" Text="{Binding Message}" Height="30"></TextBlock>
       <!-- QR Camera -->
       <Panel Width="400" Height="300">
         <c:ProgressRing IsIndeterminate="True" Height="100" IsVisible="{Binding QrImage,Converter={x:Static ObjectConverters.IsNull}}" />


### PR DESCRIPTION
This PR fixes an "issue", when an incorrect QR image is read (TestNet address on MainNet, URL, random text etc.), the camera closes and automatically inserts the content.

This PR leaves the camera open and should display an error message, indicating that the QR code's content is invalid for a transaction.