### PR TITLE
Add state to CoinJoinClient

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClientState.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClientState.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public enum CoinJoinClientState
+	{
+		Idle,
+		WaitingForInputRegistration,
+		ConnectionConfirmed
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClientStateExtensions.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClientStateExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public static class CoinJoinClientStateExtensions
+	{
+		public static bool IsInCriticalSection(this CoinJoinClientState state)
+		{
+			return state >= CoinJoinClientState.ConnectionConfirmed;
+		}
+
+		public static bool IsCoinJoinInProgress(this CoinJoinClientState state)
+		{
+			return state > CoinJoinClientState.Idle;
+		}
+	}
+}


### PR DESCRIPTION
In order to be able to determine if we need to prevent the sleep/shutdown we need to know the state of the coinjoin client. This is the first step. 