### PR TITLE
[WabiSabi] Disable WabiSabi coinjoin manager on mainet

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -35,6 +35,11 @@ namespace WalletWasabi.WabiSabi.Client
 
 		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 		{
+			if (WalletManager.Network == Network.Main)
+			{
+				Logger.LogInfo("WabiSabi coinjoin client-side functionality is disabled temporarily on mainnet.");
+				return;
+			}
 			var trackedWallets = new Dictionary<string, WalletTrackingData>();
 
 			while (!stoppingToken.IsCancellationRequested)


### PR DESCRIPTION
Disable it to prevent accidents once the new coordinator version is deployed.