### PR TITLE
Exceptions when application is shutting down (1)

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls.Notifications;
 using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -270,6 +271,7 @@ namespace WalletWasabi.Gui
 			}
 		}
 
+		[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Services are disposed by HostedServices class.")]
 		private void RegisterLocalNodeDependantComponents()
 		{
 			HostedServices.Register<BlockNotifier>(new BlockNotifier(TimeSpan.FromSeconds(7), BitcoinCoreNode.RpcClient, BitcoinCoreNode.P2pNode), "Block Notifier");
@@ -278,6 +280,7 @@ namespace WalletWasabi.Gui
 			HostedServices.Register<MempoolMirror>(new MempoolMirror(TimeSpan.FromSeconds(21), BitcoinCoreNode.RpcClient, BitcoinCoreNode.P2pNode), "Full Node Mempool Mirror");
 		}
 
+		[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Services are disposed by HostedServices class.")]
 		private void RegisterFeeRateProviders()
 		{
 			HostedServices.Register<BlockstreamInfoFeeProvider>(new BlockstreamInfoFeeProvider(TimeSpan.FromMinutes(3), new(Network, ExternalHttpClientFactory)) { IsPaused = true }, "Blockstream.info Fee Provider");
@@ -285,6 +288,7 @@ namespace WalletWasabi.Gui
 			HostedServices.Register<HybridFeeProvider>(new HybridFeeProvider(HostedServices.Get<ThirdPartyFeeProvider>(), HostedServices.GetOrDefault<RpcFeeProvider>()), "Hybrid Fee Provider");
 		}
 
+		[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Services are disposed by HostedServices class.")]
 		private void RegisterCoinJoinComponents()
 		{
 			HostedServices.Register<RoundStateUpdater>(new RoundStateUpdater(TimeSpan.FromSeconds(5), new WabiSabiHttpApiClient(BackendHttpClientFactory.NewBackendHttpClient(Mode.SingleCircuitPerLifetime))), "Round info updater");

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -504,9 +504,15 @@ namespace WalletWasabi.Gui
 					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
 				}
 
-				if (BackendHttpClientFactory is { } httpClientFactory)
+				if (ExternalHttpClientFactory is { } externalHttpClientFactory)
 				{
-					httpClientFactory.Dispose();
+					externalHttpClientFactory.Dispose();
+					Logger.LogInfo($"{nameof(ExternalHttpClientFactory)} is disposed.");
+				}
+
+				if (BackendHttpClientFactory is { } backendHttpClientFactory)
+				{
+					backendHttpClientFactory.Dispose();
 					Logger.LogInfo($"{nameof(BackendHttpClientFactory)} is disposed.");
 				}
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -287,7 +287,7 @@ namespace WalletWasabi.Gui
 
 		private void RegisterCoinJoinComponents()
 		{
-			HostedServices.Register<RoundStateUpdater>(new RoundStateUpdater(TimeSpan.FromSeconds(5), new WabiSabiHttpApiClient(BackendHttpClientFactory.NewBackendHttpClient(Mode.SingleCircuitPerLifetime))), "Round infor updater");
+			HostedServices.Register<RoundStateUpdater>(new RoundStateUpdater(TimeSpan.FromSeconds(5), new WabiSabiHttpApiClient(BackendHttpClientFactory.NewBackendHttpClient(Mode.SingleCircuitPerLifetime))), "Round info updater");
 			HostedServices.Register<CoinJoinManager>(new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), BackendHttpClientFactory, Config.ServiceConfiguration), "CoinJoin Manager");
 		}
 

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -1,4 +1,3 @@
-using NBitcoin;
 using NBitcoin.RPC;
 using System;
 using System.Linq;
@@ -250,6 +249,13 @@ namespace WalletWasabi.Services
 						}
 						catch (TorConnectionException ex)
 						{
+							// When stopping, we do not want to wait.
+							if (!IsRunning)
+							{
+								Logger.LogTrace(ex);
+								return;
+							}
+
 							Logger.LogError(ex);
 							try
 							{
@@ -288,9 +294,8 @@ namespace WalletWasabi.Services
 				finally
 				{
 					Interlocked.CompareExchange(ref _running, StateStopped, StateStopping); // If IsStopping, make it stopped.
+					Logger.LogTrace("< Wasabi synchronizer thread ends.");
 				}
-
-				Logger.LogTrace("< Wasabi synchronizer thread ends.");
 			});
 
 			Logger.LogTrace("<");

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -84,7 +84,7 @@ namespace WalletWasabi.Tor.Http.Extensions
 					throw new HttpRequestException("Remote coordinator responded with an error.", innerException, me.StatusCode);
 				}
 
-				// Remove " from beginning and end to ensure backwards compatibility and it's kindof trash, too.
+				// Remove " from beginning and end to ensure backwards compatibility and it's kind of trash, too.
 				if (contentString.Count(f => f == '"') <= 2)
 				{
 					contentString = contentString.Trim('"');

--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -81,7 +81,7 @@ namespace WalletWasabi.Tor.Http.Helpers
 					firstRead = false;
 				}
 
-				builder.Append(header + CRLF); // CRLF is part of the headerstring
+				builder.Append(header + CRLF); // CRLF is part of the header string
 			}
 
 			headers = builder.ToString();
@@ -281,7 +281,7 @@ namespace WalletWasabi.Tor.Http.Helpers
 				var chunkData = await ReadBytesTillLengthAsync(stream, chunkSize, ctsToken).ConfigureAwait(false);
 				string crlfLine = await ReadCRLFLineAsync(stream, Encoding.ASCII, ctsToken).ConfigureAwait(false);
 
-				// If more than a CRLF was read, then it's not an empty estring.
+				// If more than a CRLF was read, then it's not an empty string.
 				if (crlfLine.Length != 0)
 				{
 					throw new FormatException("Chunk does not end with CRLF.");


### PR DESCRIPTION
This is a part of work on https://github.com/zkSNACKs/WalletWasabi/issues/6215.

This PR fixes three things

* `ExternalHttpClientFactory` in Global.cs is supposed to be disposed.
* When WasabiSynchronizer is stopping, it can throw `TorConnectionException` but that may just scare user for nothing. This is not certainly elegant but I don't know about a better solution at the moment.
* A few CA2000 warning suppressions were added as IMHO it distracts from other warnings in `Global.cs` which may be actually valid issues. Anyway, if you don't like this commit, I'll revert it.