### PR TITLE
Exceptions when application is shutting down (2)

### DIFF
--- a/WalletWasabi/Extensions/StreamExtensions.cs
+++ b/WalletWasabi/Extensions/StreamExtensions.cs
@@ -42,12 +42,15 @@ namespace System.IO
 		/// <param name="count">Number of bytes to read.</param>
 		/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
 		/// <returns>Number of read bytes. At most <paramref name="count"/>.</returns>
+		/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
 		public static async Task<int> ReadBlockAsync(this Stream stream, byte[] buffer, int count, CancellationToken cancellationToken = default)
 		{
 			int remaining = count;
 			while (remaining != 0)
 			{
 				int read = await stream.ReadAsync(buffer.AsMemory(count - remaining, remaining), cancellationToken).ConfigureAwait(false);
+
+				cancellationToken.ThrowIfCancellationRequested();
 
 				// End of stream.
 				if (read == 0)

--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -432,7 +432,7 @@ namespace WalletWasabi.Tor.Http.Helpers
 			}
 
 			var allData = new byte[(int)length];
-			var num = await stream.ReadBlockAsync(allData, (int)length, ctsToken).ConfigureAwait(false);
+			int num = await stream.ReadBlockAsync(allData, (int)length, ctsToken).ConfigureAwait(false);
 			if (num < (int)length)
 			{
 				// https://tools.ietf.org/html/rfc7230#section-3.3.3

--- a/WalletWasabi/Tor/Socks5/Exceptions/TorConnectionReadException.cs
+++ b/WalletWasabi/Tor/Socks5/Exceptions/TorConnectionReadException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace WalletWasabi.Tor.Socks5.Exceptions
+{
+	/// <summary>
+	/// For any failures in receiving data from Tor SOCKS5 endpoint.
+	/// </summary>
+	/// <remarks>This covers scenarios like TCP connection dies, HTTP response cannot be parsed, etc.</remarks>
+	public class TorConnectionReadException : TorConnectionException
+	{
+		public TorConnectionReadException(string message) : base(message)
+		{
+		}
+
+		public TorConnectionReadException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
+}

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -133,7 +133,7 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					}
 					catch (TorConnectCommandFailedException e) when (e.RepField == RepField.TtlExpired)
 					{
-						// If we get TTL Expired error then wait and retry again, linux often does this.
+						// If we get TTL Expired error then wait and retry again, Linux often does this.
 						Logger.LogTrace($"['{connection}'] TTL exception occurred.", e);
 
 						await Task.Delay(3000, cancellationToken).ConfigureAwait(false);
@@ -146,19 +146,21 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					}
 					catch (IOException e)
 					{
+						Logger.LogTrace($"['{connection}'] Failed to read/write HTTP(s) request.", e);
+
 						// NetworkStream may throw IOException.
-						TorConnectionException innerException = new($"Failed to read/write HTTP(s) request.", e);
+						TorConnectionException innerException = new("Failed to read/write HTTP(s) request.", e);
 						throw new HttpRequestException("Failed to handle the HTTP request via Tor.", innerException);
 					}
 					catch (SocketException e) when (e.ErrorCode == (int)SocketError.ConnectionRefused)
 					{
-						Logger.LogTrace(e);
+						Logger.LogTrace($"['{connection}'] Connection was refused.", e);
 						TorConnectionException innerException = new("Connection was refused.", e);
 						throw new HttpRequestException("Failed to handle the HTTP request via Tor.", innerException);
 					}
 					catch (Exception e)
 					{
-						Logger.LogTrace(e);
+						Logger.LogTrace($"['{connection}'] Exception occurred.", e);
 						throw;
 					}
 					finally

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -163,7 +163,11 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					}
 					finally
 					{
-						connectionToDispose?.Dispose();
+						if (connectionToDispose is not null)
+						{
+							Logger.LogTrace($"['{connectionToDispose}'] marked as to be disposed.");
+							connectionToDispose.MarkAsToDispose();
+						}
 					}
 				} while (i < attemptsNo);
 			}

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -123,8 +123,7 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					}
 					catch (TorConnectionWriteException e)
 					{
-						Logger.LogDebug($"['{connection}'] TCP connection from the pool is probably dead as we can't write data to the connection.");
-						Logger.LogTrace(e);
+						Logger.LogTrace($"['{connection}'] TCP connection from the pool is probably dead as we can't write data to the connection.", e);
 
 						if (i == attemptsNo)
 						{
@@ -134,8 +133,7 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					}
 					catch (TorConnectionReadException e)
 					{
-						Logger.LogDebug($"['{connection}'] Could not get/read an HTTP response from Tor.");
-						Logger.LogTrace(e);
+						Logger.LogTrace($"['{connection}'] Could not get/read an HTTP response from Tor.", e);
 
 						throw new HttpRequestException("Failed to get/read an HTTP response from Tor.", e);
 					}

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -273,7 +273,7 @@ namespace WalletWasabi.Tor.Socks5.Pool
 				throw new TorConnectionWriteException("Could not use transport stream to write data.", e);
 			}
 
-			return await HttpResponseMessageExtensions.CreateNewAsync(transportStream, request.Method).ConfigureAwait(false);
+			return await HttpResponseMessageExtensions.CreateNewAsync(transportStream, request.Method, token).ConfigureAwait(false);
 		}
 
 		private static string GetRequestHost(HttpRequestMessage request)
@@ -319,6 +319,7 @@ namespace WalletWasabi.Tor.Socks5.Pool
 					{
 						foreach (TorTcpConnection connection in list)
 						{
+							Logger.LogTrace($"Dispose connection: '{connection}'");
 							connection.Dispose();
 						}
 					}

--- a/WalletWasabi/Tor/Socks5/TorTcpConnection.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnection.cs
@@ -91,6 +91,16 @@ namespace WalletWasabi.Tor.Socks5
 			}
 		}
 
+		/// <remarks>Connection transporting an HTTP request that was canceled or otherwise failed must be torn down.</remarks>
+		public void MarkAsToDispose()
+		{
+			lock (StateLock)
+			{
+				Debug.Assert(State == TcpConnectionState.InUse, $"Unexpected state: '{State}'.");
+				State = TcpConnectionState.ToDispose;
+			}
+		}
+
 		/// <inheritdoc/>
 		public override string ToString()
 		{


### PR DESCRIPTION
This is a part of work on #6215. This PR is to be reviewed commit-by-commit. 

The main change is that we want `TorHttpPool.SendAsync` method to throw either `HttpRequestException` or `OperationCanceledException`. On the master branch, this is not true as other exceptions can be thrown - like parsing errors for an HTTP response is being received.

This PR also fixes a bug (8dc8e93089e3883b2005018ac86e51b13b4fb8fa) because the Tor TCP connection dispose operation did not remove that connection from a list of available connections correctly.

This PR also adds missing cancellation token propagation (4df6c245f8701f472b2ab6d67864d8e55200106e) which should help with speed of cancelling and also prevent situation like "WW is shutting down, TorHttpPool ignores cancellation request and reads even when it should not really".