### PR TITLE
`WasabiClient`: Add missing cancellation tokens.

### DIFF
--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -63,7 +63,7 @@ namespace WalletWasabi.Tor.Http.Extensions
 		{
 			var errorMessage = "";
 
-			if (me.Content is { })
+			if (me.Content is not null)
 			{
 				var contentString = await me.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 				var error = JsonConvert.DeserializeObject<Error>(contentString, new JsonSerializerSettings()
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tor.Http.Extensions
 				{
 					{ Type: ProtocolConstants.ProtocolViolationType } => Enum.TryParse<WabiSabiProtocolErrorCode>(error.ErrorCode, out var code)
 						? new WabiSabiProtocolException(code, error.Description)
-						: new NotSupportedException($"Received wabisabi protocol exception with unknown '{error.ErrorCode}' error code.\n\tDescription: '{error.Description}'."),
+						: new NotSupportedException($"Received WabiSabi protocol exception with unknown '{error.ErrorCode}' error code.\n\tDescription: '{error.Description}'."),
 					{ Type: "unknown"} => new Exception(error.Description),
 					_ => null
 				};

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			using HttpContent content = response.Content;
@@ -78,7 +78,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			using HttpContent content = response.Content;
@@ -109,7 +109,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
-					await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+					await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 				}
 
 				using HttpContent content = response.Content;
@@ -168,7 +168,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			using HttpContent content = response.Content;
@@ -191,7 +191,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			using HttpContent content = response.Content;
@@ -229,7 +229,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			using HttpContent content = response.Content;
@@ -267,7 +267,7 @@ namespace WalletWasabi.WebClients.Wasabi
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			using HttpContent content = response.Content;


### PR DESCRIPTION
This is a part of work on #6215.

This fixes several warnings that we do not forward cancellation tokens. 