### PR TITLE
[Fluent][Trivial] Match text with button

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
@@ -11,7 +11,7 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.AddWallet.RecoverWalletView">
   <c:ContentArea x:Name="RecoveryPageRoot"
-                 Title="{Binding Title}" Caption="Type in your 12 recovery words and click Continue."
+                 Title="{Binding Title}" Caption="Type in your 12 recovery words and click Finish."
                  CancelContent="Cancel"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"

--- a/WalletWasabi.Fluent/Views/Dialogs/AdvancedRecoveryOptionsView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/AdvancedRecoveryOptionsView.axaml
@@ -19,7 +19,7 @@
     </Style>
   </UserControl.Styles>
   <c:ContentArea Title="{Binding Title}"
-                 Caption="Type your wallet-specific recovery options and click Continue."
+                 Caption="Type your wallet-specific recovery options and click OK."
                  CancelContent="Cancel"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"

--- a/WalletWasabi.Fluent/Views/Dialogs/AdvancedRecoveryOptionsView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/AdvancedRecoveryOptionsView.axaml
@@ -26,7 +26,7 @@
                  EnableNext="True" NextContent="OK">
     <StackPanel HorizontalAlignment="Center" Spacing="20" MinWidth="380" Margin="30 0 0 0">
       <StackPanel>
-        <Label Content="Type the Account Key _Derivation Path:" Target="TbKeyPath" />
+        <Label Content="Account Key _Derivation Path:" Target="TbKeyPath" />
         <TextBox Name="TbKeyPath"
                  Watermark="e.g., m/84'/0'/0'"
                  Text="{Binding AccountKeyPath}"
@@ -38,7 +38,7 @@
         </TextBox>
       </StackPanel>
       <StackPanel>
-        <Label Content="Type the Minimum _Gap Limit:" Target="TbGapLimit" />
+        <Label Content="Minimum _Gap Limit:" Target="TbGapLimit" />
         <TextBox Name="TbGapLimit" Watermark="e.g., 63"
                  Text="{Binding MinGapLimit}"
                  DockPanel.Dock="Top"


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/52379387/132026967-22306838-f9ad-4ba6-8bc1-019c72c5b3d6.PNG)

![Enter recovery words](https://user-images.githubusercontent.com/52379387/132026987-1ff441b3-5e82-4265-80e6-34da7a0acbae.PNG)

The text doesn't match the buttons, so this PR fixes that.