### PR TITLE
`WasabiSynchronizer`: Remove `WithAwaitCancellationAsync`

### DIFF
--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -168,7 +168,6 @@ namespace WalletWasabi.Services
 
 								response = await WasabiClient
 									.GetSynchronizeAsync(BitcoinStore.SmartHeaderChain.TipHash, maxFiltersToSyncAtInitialization, EstimateSmartFeeMode.Conservative, StopCts.Token)
-									.WithAwaitCancellationAsync(StopCts.Token, 300)
 									.ConfigureAwait(false);
 
 								// NOT GenSocksServErr

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
@@ -44,7 +44,7 @@ namespace WalletWasabi.WebClients.BlockstreamInfo
 
 			if (!response.IsSuccessStatusCode)
 			{
-				await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+				await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
 			}
 
 			var responseString = await response.Content.ReadAsStringAsync(cancel).ConfigureAwait(false);


### PR DESCRIPTION
This is a part of work on #6215.

This PR proposes not to use `WithAwaitCancellationAsync` in WasabiSynchronizer as we now have cancellation tokens propagated very well down to TorHttpClient and in many other places. 

The advantage of `.WithAwaitCancellationAsync(StopCts.Token, 300)` is that we may stop sooner when WW terminates but then `TorHttpPool` may be fast enough to dispose the actual TCP connection and an exception may be reported in console to the user. 

As `GetSynchronizeAsync` varies a lot in how long it takes, I'm not exactly sure but it *looks* like the proposed code behaves essentially the same. Also, we don't really use `WithAwaitCancellationAsync` everywhere when we send HTTP requests so even in this regard, it seems reasonable to change this (or propose a different solution). 

I don't see any significant slowdown using the "naive perf code" below:

<details>
  <summary>Naive perf checking code</summary>

```C#
string exceptionMessage = "N/A";
Stopwatch sw = Stopwatch.StartNew();
try
{

	response = await WasabiClient
		.GetSynchronizeAsync(BitcoinStore.SmartHeaderChain.TipHash, maxFiltersToSyncAtInitialization, EstimateSmartFeeMode.Conservative, StopCts.Token)
		.ConfigureAwait(false);

}
catch (Exception exxxx)
{
	exceptionMessage = exxxx.Message;
	throw;
}
finally
{
	Logger.LogTrace($"XXX: Done in {sw.ElapsedMilliseconds}ms; exception message: '{exceptionMessage}'");
}
```
</details>

It would be great if anyone could try to measure the change too.
