### PR TITLE
Safe app init & dispose

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -80,7 +80,6 @@ namespace WalletWasabi.Gui
 		{
 			using (BenchmarkLogger.Measure())
 			{
-				StoppingCts = new CancellationTokenSource();
 				DataDir = dataDir;
 				Config = config;
 				UiConfig = uiConfig;
@@ -121,7 +120,7 @@ namespace WalletWasabi.Gui
 
 		private bool InitializationStarted { get; set; } = false;
 
-		private CancellationTokenSource StoppingCts { get; }
+		private CancellationTokenSource StoppingCts { get; } = new();
 
 		public async Task InitializeNoWalletAsync(TerminateService terminateService)
 		{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -581,7 +581,7 @@ namespace WalletWasabi.Gui
 				finally
 				{
 					StoppingCts.Dispose();
-                    Logger.LogTrace("Dispose finished.");
+					Logger.LogTrace("Dispose finished.");
 				}
 			}
 		}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -117,8 +117,6 @@ namespace WalletWasabi.Gui
 			}
 		}
 
-		private TaskCompletionSource<bool> InitializationCompleted { get; } = new();
-
 		private volatile bool _disposeRequested;
 
 		/// <summary>Lock that makes sure the application initialization and dispose methods do not run concurrently.</summary>
@@ -211,7 +209,6 @@ namespace WalletWasabi.Gui
 				}
 				finally
 				{
-					InitializationCompleted.TrySetResult(true);
 					Logger.LogTrace("Initialization finished.");
 				}
 			}
@@ -469,18 +466,6 @@ namespace WalletWasabi.Gui
 
 				try
 				{
-					Logger.LogDebug("Waiting for initialization to complete.", nameof(Global));
-
-					try
-					{
-						using var initCompletitionWaitCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
-						await InitializationCompleted.Task.WithAwaitCancellationAsync(initCompletitionWaitCts.Token, 100).ConfigureAwait(false);
-					}
-					catch (Exception ex)
-					{
-						Logger.LogError($"Error during wait for initialization to be completed: {ex}");
-					}
-
 					try
 					{
 						using var dequeueCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -117,6 +117,7 @@ namespace WalletWasabi.Gui
 			}
 		}
 
+		/// <remarks>Use this variable as a guard to prevent touching <see cref="StoppingCts"/> that might have already been disposed.</remarks>
 		private volatile bool _disposeRequested;
 
 		/// <summary>Lock that makes sure the application initialization and dispose methods do not run concurrently.</summary>
@@ -127,6 +128,7 @@ namespace WalletWasabi.Gui
 
 		public async Task InitializeNoWalletAsync(TerminateService terminateService)
 		{
+			// StoppingCts may be disposed at this point, so do not forward the cancellation token here.
 			using (await InitializationAsyncLock.LockAsync())
 			{
 				Logger.LogTrace("Initialization started.");

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls.Notifications;
 using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
+using Nito.AsyncEx;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -118,89 +119,101 @@ namespace WalletWasabi.Gui
 
 		private TaskCompletionSource<bool> InitializationCompleted { get; } = new();
 
-		private bool InitializationStarted { get; set; } = false;
+		private volatile bool _disposeRequested;
 
+		/// <summary>Lock that makes sure the application initialization and dispose methods do not run concurrently.</summary>
+		private AsyncLock InitializationAsyncLock { get; } = new();
+
+		/// <summary>Cancellation token to cancel <see cref="InitializeNoWalletAsync(TerminateService)"/> processing.</summary>
 		private CancellationTokenSource StoppingCts { get; } = new();
 
 		public async Task InitializeNoWalletAsync(TerminateService terminateService)
 		{
-			Logger.LogTrace("Initialization started.");
-			InitializationStarted = true;
-			var cancel = StoppingCts.Token;
-
-			try
+			using (await InitializationAsyncLock.LockAsync())
 			{
-				Cache = new MemoryCache(new MemoryCacheOptions
+				Logger.LogTrace("Initialization started.");
+
+				if (_disposeRequested)
 				{
-					SizeLimit = 1_000,
-					ExpirationScanFrequency = TimeSpan.FromSeconds(30)
-				});
-				var bstoreInitTask = BitcoinStore.InitializeAsync(cancel);
-
-				HostedServices.Register<UpdateChecker>(new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer), "Software Update Checker");
-
-				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
-				cancel.ThrowIfCancellationRequested();
-
-				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(WalletManager).ConfigureAwait(false);
-
-				if (systemAwakeChecker is not null)
-				{
-					HostedServices.Register<SystemAwakeChecker>(systemAwakeChecker, "System Awake Checker");
-				}
-				else
-				{
-					Logger.LogInfo("System Awake Checker is not available on this platform.");
+					return;
 				}
 
-				await StartTorProcessManagerAsync(cancel).ConfigureAwait(false);
+				CancellationToken cancel = StoppingCts.Token;
 
 				try
 				{
-					await bstoreInitTask.ConfigureAwait(false);
+					Cache = new MemoryCache(new MemoryCacheOptions
+					{
+						SizeLimit = 1_000,
+						ExpirationScanFrequency = TimeSpan.FromSeconds(30)
+					});
+					var bstoreInitTask = BitcoinStore.InitializeAsync(cancel);
 
-					// Make sure that the height of the wallets will not be better than the current height of the filters.
-					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+					HostedServices.Register<UpdateChecker>(new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer), "Software Update Checker");
+
+					await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
+					cancel.ThrowIfCancellationRequested();
+
+					SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(WalletManager).ConfigureAwait(false);
+
+					if (systemAwakeChecker is not null)
+					{
+						HostedServices.Register<SystemAwakeChecker>(systemAwakeChecker, "System Awake Checker");
+					}
+					else
+					{
+						Logger.LogInfo("System Awake Checker is not available on this platform.");
+					}
+
+					await StartTorProcessManagerAsync(cancel).ConfigureAwait(false);
+
+					try
+					{
+						await bstoreInitTask.ConfigureAwait(false);
+
+						// Make sure that the height of the wallets will not be better than the current height of the filters.
+						WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+					}
+					catch (Exception ex) when (ex is not OperationCanceledException)
+					{
+						// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
+						WalletManager.SetMaxBestHeight(SmartHeader.GetStartingHeader(Network).Height);
+						throw;
+					}
+
+					HostedServices.Register<P2pNetwork>(new P2pNetwork(Network, Config.GetBitcoinP2pEndPoint(), Config.UseTor ? TorSettings.SocksEndpoint : null, Path.Combine(DataDir, "BitcoinP2pNetwork"), BitcoinStore), "Bitcoin P2P Network");
+
+					await StartLocalBitcoinNodeAsync(cancel).ConfigureAwait(false);
+
+					RegisterFeeRateProviders();
+					RegisterCoinJoinComponents();
+
+					await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
+
+					var requestInterval = Network == Network.RegTest ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(30);
+					int maxFiltSyncCount = Network == Network.Main ? 1000 : 10000; // On testnet, filters are empty, so it's faster to query them together
+
+					Synchronizer.Start(requestInterval, maxFiltSyncCount);
+					Logger.LogInfo("Start synchronizing filters...");
+
+					TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);
+					CoinJoinProcessor = new CoinJoinProcessor(Network, Synchronizer, WalletManager, BitcoinCoreNode?.RpcClient);
+
+					await StartRpcServerAsync(terminateService, cancel).ConfigureAwait(false);
+
+					var blockProvider = new CachedBlockProvider(
+						new SmartBlockProvider(
+							new P2pBlockProvider(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode, BackendHttpClientFactory, Config.ServiceConfiguration, Network),
+							Cache),
+						BitcoinStore.BlockRepository);
+
+					WalletManager.RegisterServices(BitcoinStore, Synchronizer, Config.ServiceConfiguration, HostedServices.Get<HybridFeeProvider>(), blockProvider);
 				}
-				catch (Exception ex) when (ex is not OperationCanceledException)
+				finally
 				{
-					// If our internal data structures in the Bitcoin Store gets corrupted, then it's better to rescan all the wallets.
-					WalletManager.SetMaxBestHeight(SmartHeader.GetStartingHeader(Network).Height);
-					throw;
+					InitializationCompleted.TrySetResult(true);
+					Logger.LogTrace("Initialization finished.");
 				}
-
-				HostedServices.Register<P2pNetwork>(new P2pNetwork(Network, Config.GetBitcoinP2pEndPoint(), Config.UseTor ? TorSettings.SocksEndpoint : null, Path.Combine(DataDir, "BitcoinP2pNetwork"), BitcoinStore), "Bitcoin P2P Network");
-
-				await StartLocalBitcoinNodeAsync(cancel).ConfigureAwait(false);
-
-				RegisterFeeRateProviders();
-				RegisterCoinJoinComponents();
-
-				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
-
-				var requestInterval = Network == Network.RegTest ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(30);
-				int maxFiltSyncCount = Network == Network.Main ? 1000 : 10000; // On testnet, filters are empty, so it's faster to query them together
-
-				Synchronizer.Start(requestInterval, maxFiltSyncCount);
-				Logger.LogInfo("Start synchronizing filters...");
-
-				TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);
-				CoinJoinProcessor = new CoinJoinProcessor(Network, Synchronizer, WalletManager, BitcoinCoreNode?.RpcClient);
-
-				await StartRpcServerAsync(terminateService, cancel).ConfigureAwait(false);
-
-				var blockProvider = new CachedBlockProvider(
-					new SmartBlockProvider(
-						new P2pBlockProvider(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode, BackendHttpClientFactory, Config.ServiceConfiguration, Network),
-						Cache),
-					BitcoinStore.BlockRepository);
-
-				WalletManager.RegisterServices(BitcoinStore, Synchronizer, Config.ServiceConfiguration, HostedServices.Get<HybridFeeProvider>(), blockProvider);
-			}
-			finally
-			{
-				InitializationCompleted.TrySetResult(true);
-				Logger.LogTrace("Initialization finished.");
 			}
 		}
 
@@ -439,130 +452,137 @@ namespace WalletWasabi.Gui
 
 		public async Task DisposeAsync()
 		{
-			Logger.LogWarning("Process is exiting.", nameof(Global));
-
-			try
+			// Dispose method may be called just once.
+			if (!_disposeRequested)
 			{
+				_disposeRequested = true;
 				StoppingCts.Cancel();
+			}
+			else
+			{
+				return;
+			}
 
-				if (!InitializationStarted)
-				{
-					return;
-				}
-
-				Logger.LogDebug($"Waiting for initialization to complete.", nameof(Global));
-
-				try
-				{
-					using var initCompletitionWaitCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
-					await InitializationCompleted.Task.WithAwaitCancellationAsync(initCompletitionWaitCts.Token, 100).ConfigureAwait(false);
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError($"Error during wait for initialization to be completed: {ex}");
-				}
+			using (await InitializationAsyncLock.LockAsync())
+			{
+				Logger.LogWarning("Process is exiting.", nameof(Global));
 
 				try
 				{
-					using var dequeueCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
-					await WalletManager.RemoveAndStopAllAsync(dequeueCts.Token).ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(WalletManager)} is stopped.", nameof(Global));
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
-				}
+					Logger.LogDebug("Waiting for initialization to complete.", nameof(Global));
 
-				WalletManager.OnDequeue -= WalletManager_OnDequeue;
-				WalletManager.WalletRelevantTransactionProcessed -= WalletManager_WalletRelevantTransactionProcessed;
-
-				if (RpcServer is { } rpcServer)
-				{
-					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
-					await rpcServer.StopAsync(cts.Token).ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(RpcServer)} is stopped.", nameof(Global));
-				}
-
-				if (CoinJoinProcessor is { } coinJoinProcessor)
-				{
-					coinJoinProcessor.Dispose();
-					Logger.LogInfo($"{nameof(CoinJoinProcessor)} is disposed.");
-				}
-
-				if (LegalChecker is { } legalChecker)
-				{
-					legalChecker.Dispose();
-					Logger.LogInfo($"Disposed {nameof(LegalChecker)}.");
-				}
-
-				if (HostedServices is { } backgroundServices)
-				{
-					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
-					await backgroundServices.StopAllAsync(cts.Token).ConfigureAwait(false);
-					backgroundServices.Dispose();
-					Logger.LogInfo("Stopped background services.");
-				}
-
-				if (Synchronizer is { } synchronizer)
-				{
-					await synchronizer.StopAsync().ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
-				}
-
-				if (ExternalHttpClientFactory is { } externalHttpClientFactory)
-				{
-					externalHttpClientFactory.Dispose();
-					Logger.LogInfo($"{nameof(ExternalHttpClientFactory)} is disposed.");
-				}
-
-				if (BackendHttpClientFactory is { } backendHttpClientFactory)
-				{
-					backendHttpClientFactory.Dispose();
-					Logger.LogInfo($"{nameof(BackendHttpClientFactory)} is disposed.");
-				}
-
-				if (BitcoinCoreNode is { } bitcoinCoreNode)
-				{
-					await bitcoinCoreNode.DisposeAsync().ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(BitcoinCoreNode)} is disposed.");
-
-					if (Config.StopLocalBitcoinCoreOnShutdown)
+					try
 					{
-						await bitcoinCoreNode.TryStopAsync().ConfigureAwait(false);
-						Logger.LogInfo($"{nameof(BitcoinCoreNode)} is stopped.");
+						using var initCompletitionWaitCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
+						await InitializationCompleted.Task.WithAwaitCancellationAsync(initCompletitionWaitCts.Token, 100).ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						Logger.LogError($"Error during wait for initialization to be completed: {ex}");
+					}
+
+					try
+					{
+						using var dequeueCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
+						await WalletManager.RemoveAndStopAllAsync(dequeueCts.Token).ConfigureAwait(false);
+						Logger.LogInfo($"{nameof(WalletManager)} is stopped.", nameof(Global));
+					}
+					catch (Exception ex)
+					{
+						Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
+					}
+
+					WalletManager.OnDequeue -= WalletManager_OnDequeue;
+					WalletManager.WalletRelevantTransactionProcessed -= WalletManager_WalletRelevantTransactionProcessed;
+
+					if (RpcServer is { } rpcServer)
+					{
+						using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
+						await rpcServer.StopAsync(cts.Token).ConfigureAwait(false);
+						Logger.LogInfo($"{nameof(RpcServer)} is stopped.", nameof(Global));
+					}
+
+					if (CoinJoinProcessor is { } coinJoinProcessor)
+					{
+						coinJoinProcessor.Dispose();
+						Logger.LogInfo($"{nameof(CoinJoinProcessor)} is disposed.");
+					}
+
+					if (LegalChecker is { } legalChecker)
+					{
+						legalChecker.Dispose();
+						Logger.LogInfo($"Disposed {nameof(LegalChecker)}.");
+					}
+
+					if (HostedServices is { } backgroundServices)
+					{
+						using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
+						await backgroundServices.StopAllAsync(cts.Token).ConfigureAwait(false);
+						backgroundServices.Dispose();
+						Logger.LogInfo("Stopped background services.");
+					}
+
+					if (Synchronizer is { } synchronizer)
+					{
+						await synchronizer.StopAsync().ConfigureAwait(false);
+						Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
+					}
+
+					if (ExternalHttpClientFactory is { } externalHttpClientFactory)
+					{
+						externalHttpClientFactory.Dispose();
+						Logger.LogInfo($"{nameof(ExternalHttpClientFactory)} is disposed.");
+					}
+
+					if (BackendHttpClientFactory is { } backendHttpClientFactory)
+					{
+						backendHttpClientFactory.Dispose();
+						Logger.LogInfo($"{nameof(BackendHttpClientFactory)} is disposed.");
+					}
+
+					if (BitcoinCoreNode is { } bitcoinCoreNode)
+					{
+						await bitcoinCoreNode.DisposeAsync().ConfigureAwait(false);
+						Logger.LogInfo($"{nameof(BitcoinCoreNode)} is disposed.");
+
+						if (Config.StopLocalBitcoinCoreOnShutdown)
+						{
+							await bitcoinCoreNode.TryStopAsync().ConfigureAwait(false);
+							Logger.LogInfo($"{nameof(BitcoinCoreNode)} is stopped.");
+						}
+					}
+
+					if (TorManager is { } torManager)
+					{
+						await torManager.DisposeAsync().ConfigureAwait(false);
+						Logger.LogInfo($"{nameof(TorManager)} is stopped.");
+					}
+
+					if (Cache is { } cache)
+					{
+						cache.Dispose();
+						Logger.LogInfo($"{nameof(Cache)} is disposed.");
+					}
+
+					try
+					{
+						await BitcoinStore.DisposeAsync().ConfigureAwait(false);
+						Logger.LogInfo($"{nameof(BitcoinStore)} is disposed.");
+					}
+					catch (Exception ex)
+					{
+						Logger.LogError($"Error during the disposal of {nameof(BitcoinStore)}: {ex}");
 					}
 				}
-
-				if (TorManager is { } torManager)
-				{
-					await torManager.DisposeAsync().ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(TorManager)} is stopped.");
-				}
-
-				if (Cache is { } cache)
-				{
-					cache.Dispose();
-					Logger.LogInfo($"{nameof(Cache)} is disposed.");
-				}
-
-				try
-				{
-					await BitcoinStore.DisposeAsync().ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(BitcoinStore)} is disposed.");
-				}
 				catch (Exception ex)
 				{
-					Logger.LogError($"Error during the disposal of {nameof(BitcoinStore)}: {ex}");
+					Logger.LogWarning(ex);
 				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogWarning(ex);
-			}
-			finally
-			{
-				StoppingCts.Dispose();
-				Logger.LogTrace("Dispose finished.");
+				finally
+				{
+					StoppingCts.Dispose();
+                    Logger.LogTrace("Dispose finished.");
+				}
 			}
 		}
 	}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -441,7 +441,7 @@ namespace WalletWasabi.Gui
 
 			try
 			{
-				StoppingCts?.Cancel();
+				StoppingCts.Cancel();
 
 				if (!InitializationStarted)
 				{
@@ -559,7 +559,7 @@ namespace WalletWasabi.Gui
 			}
 			finally
 			{
-				StoppingCts?.Dispose();
+				StoppingCts.Dispose();
 			}
 		}
 	}

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -124,6 +124,7 @@ namespace WalletWasabi.Gui
 
 		public async Task InitializeNoWalletAsync(TerminateService terminateService)
 		{
+			Logger.LogTrace("Initialization started.");
 			InitializationStarted = true;
 			var cancel = StoppingCts.Token;
 
@@ -199,6 +200,7 @@ namespace WalletWasabi.Gui
 			finally
 			{
 				InitializationCompleted.TrySetResult(true);
+				Logger.LogTrace("Initialization finished.");
 			}
 		}
 
@@ -560,6 +562,7 @@ namespace WalletWasabi.Gui
 			finally
 			{
 				StoppingCts.Dispose();
+				Logger.LogTrace("Dispose finished.");
 			}
 		}
 	}

--- a/WalletWasabi/Services/Terminate/TerminateService.cs
+++ b/WalletWasabi/Services/Terminate/TerminateService.cs
@@ -88,7 +88,7 @@ namespace WalletWasabi.Services.Terminate
 		public void Terminate()
 		{
 			var prevValue = Interlocked.CompareExchange(ref _terminateStatus, TerminateStatusInProgress, TerminateStatusNotStarted);
-			Logger.LogTrace($"Terminate was called from ThreadId: {Thread.CurrentThread.ManagedThreadId}");
+			Logger.LogTrace($"Terminate was called from ThreadId: {Environment.CurrentManagedThreadId}");
 			if (prevValue != TerminateStatusNotStarted)
 			{
 				// Secondary callers will be blocked until the end of the termination.


### PR DESCRIPTION
This is a part of work on #6215.

The problem `WalletWasabi.Gui/Global.cs` is that we can actually start initializing and disposing at the same time. I think we should consider putting those two phases under an async lock so that we know that we no longer initializing stuff when disposal is happening.

Review with whitespace turned off: https://github.com/zkSNACKs/WalletWasabi/pull/6310/files?diff=split&w=1

Consequences: I think this PR can help with issues like https://github.com/zkSNACKs/WalletWasabi/issues/3552. I'm not saying it solves the issue but in general, the PR *may* prevent corruptions from happening when user starts WW and stops it immediately which I think is not that rare as one may expect.


## Logs demonstrating the exception

```
2021-09-07 09:37:41.194 [1] INFO	WalletManager:Dispose (28)	.ctor finished in 222 milliseconds.
2021-09-07 09:37:41.208 [1] TRACE	FileSystemBlockRepository:EnsureBackwardsCompatibility (43)	>
2021-09-07 09:37:41.211 [1] TRACE	FileSystemBlockRepository:EnsureBackwardsCompatibility (81)	<
2021-09-07 09:37:41.214 [1] TRACE	FileSystemBlockRepository:Prune (153)	> maxFolderSizeMb=300
2021-09-07 09:37:41.216 [1] TRACE	FileSystemBlockRepository:Prune (200)	<
2021-09-07 09:37:41.219 [1] INFO	FileSystemBlockRepository:Dispose (24)	.ctor finished in 10 milliseconds.
2021-09-07 09:37:41.234 [1] INFO	Global:Dispose (81)	.ctor finished in 33 milliseconds.



2021-09-07 09:37:41.250 [1] INFO	Program:Main (77)	Wasabi GUI started (2b3988f3-b4ee-4052-b59b-fd6135b2184b).
2021-09-07 09:37:41.728 [2] INFO	TerminateService:Default_Unloading (49)	Process context unloading requested by the OS.
2021-09-07 09:37:41.730 [2] TRACE	TerminateService:Terminate (91)	Terminate was called from ThreadId: 2
2021-09-07 09:37:41.732 [2] DEBUG	TerminateService:Terminate (103)	Start shutting down the application.
2021-09-07 09:37:41.749 [4] WARNING	Global:DisposeAsync (442)	Process is exiting.
2021-09-07 09:37:41.751 [4] TRACE	Global:DisposeAsync (565)	Dispose finished.
2021-09-07 09:37:42.907 [1] TRACE	Global:InitializeNoWalletAsync (127)	Initialization started.
2021-09-07 09:37:43.574 [1] CRITICAL	Program:Main (89)	System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.ThrowObjectDisposedException()
   at System.Threading.CancellationTokenSource.get_Token()
   at WalletWasabi.Gui.Global.InitializeNoWalletAsync(TerminateService terminateService) in WalletWasabi.Gui\Global.cs:line 129
   at WalletWasabi.Fluent.Desktop.Program.<>c.<<BuildAvaloniaApp>b__9_1>d.MoveNext() in WalletWasabi.Fluent.Desktop\Program.cs:line 205
--- End of stack trace from previous location ---
   at WalletWasabi.Fluent.App.<OnFrameworkInitializationCompleted>b__8_0() in WalletWasabi.Fluent\App.axaml.cs:line 68
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__140_0(Object state)
   at Avalonia.Threading.AvaloniaSynchronizationContext.<>c__DisplayClass5_0.<Post>b__0() in /_/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs:line 33
   at Avalonia.Threading.JobRunner.Job.Avalonia.Threading.JobRunner.IJob.Run() in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 166
   at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
   at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 247
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32Platform.RunLoop(CancellationToken cancellationToken) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 194
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 61
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 126
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 175
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop\Program.cs:line 78
2021-09-07 09:37:43.576 [1] TRACE	TerminateService:Terminate (91)	Terminate was called from ThreadId: 1
```

The log demonstrates that initialization was started after dispose operation was done.