### PR TITLE
Wire up DesktopOnShutdownRequested event handler

### DIFF
--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -22,7 +22,7 @@ namespace WalletWasabi.Fluent
 		/// Defines the <see cref="CanShutdownProvider"/> property.
 		/// </summary>/
 		public static readonly StyledProperty<ICanShutdownProvider?> CanShutdownProviderProperty =
-			AvaloniaProperty.Register<App, ICanShutdownProvider?>(nameof(CanShutdownProvider), null, defaultBindingMode: BindingMode.TwoWay);
+			AvaloniaProperty.Register<App, ICanShutdownProvider?>(nameof(CanShutdownProvider), new ApplicationViewModel(), defaultBindingMode: BindingMode.TwoWay);
 
 		public App()
 		{

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -22,11 +22,12 @@ namespace WalletWasabi.Fluent
 		/// Defines the <see cref="CanShutdownProvider"/> property.
 		/// </summary>/
 		public static readonly StyledProperty<ICanShutdownProvider?> CanShutdownProviderProperty =
-			AvaloniaProperty.Register<App, ICanShutdownProvider?>(nameof(CanShutdownProvider), new ApplicationViewModel(), defaultBindingMode: BindingMode.TwoWay);
+			AvaloniaProperty.Register<App, ICanShutdownProvider?>(nameof(CanShutdownProvider), null, defaultBindingMode: BindingMode.TwoWay);
 
 		public App()
 		{
 			Name = "Wasabi Wallet";
+			DataContext = new ApplicationViewModel();
 		}
 
 		public App(Func<Task> backendInitialiseAsync) : this()

--- a/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
@@ -1,4 +1,4 @@
-﻿using WalletWasabi.Fluent.Providers;
+using WalletWasabi.Fluent.Providers;
 
 namespace WalletWasabi.Fluent.ViewModels
 {


### PR DESCRIPTION
Closes #6308

With this, the `DesktopOnShutdownRequested` event handler gets called.

How to test:
1. Enable AutoCoinJoin on Testnet/Place a breakpoint to LOC81 https://github.com/zkSNACKs/WalletWasabi/blob/4a3bf2c447c927b3444253951dafea69adaa2f6d/WalletWasabi.Fluent/App.axaml.cs#L81
2. Try to logout of your OS or shut down your PC.

AFAIK Windows and macOS is supported on Avalonia's side. Linux is not yet implemented.
