### PR TITLE
[PoC] Use ShutdownMode.OnExplicitShutdown

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Fluent.Desktop
 					// TODO only required due to statusbar vm... to be removed.
 					Locator.CurrentMutable.RegisterConstant(Global);
 
-					Services.Initialize(Global);
+					Services.Initialize(Global, singleInstanceChecker);
 
 					Logger.LogSoftwareStarted("Wasabi GUI");
 					BuildAvaloniaApp()

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -6,12 +6,15 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data;
+using Avalonia.Logging;
 using Avalonia.Markup.Xaml;
 using ReactiveUI;
 using WalletWasabi.Fluent.Behaviors;
 using WalletWasabi.Fluent.Providers;
 using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Fluent.Views;
+using WalletWasabi.Logging;
+using Logger = WalletWasabi.Logging.Logger;
 
 namespace WalletWasabi.Fluent
 {
@@ -81,21 +84,8 @@ namespace WalletWasabi.Fluent
 		{
 			if (CanShutdownProvider is { } provider)
 			{
-				bool hideOnClose = Services.UiConfig.HideOnClose;
-				e.Cancel = !provider.CanShutdown() || hideOnClose;
-
-				if (hideOnClose)
-				{
-					if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-					{
-						// Todo: hide the window and hide taskbar icon as well
-						MainViewModel.Instance!.WindowState = WindowState.Minimized;
-					}
-					else
-					{
-						MainViewModel.Instance!.WindowState = WindowState.Minimized;
-					}
-				}
+				e.Cancel = !provider.CanShutdown();
+				Logger.LogDebug($"Cancellation of the shutdown set to: {e.Cancel}.");
 			}
 		}
 	}

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -84,6 +84,7 @@ namespace WalletWasabi.Fluent
 		{
 			if (CanShutdownProvider is { } provider)
 			{
+				// Shutdown prevention will only work if you directly run the executable.
 				e.Cancel = !provider.CanShutdown();
 				Logger.LogDebug($"Cancellation of the shutdown set to: {e.Cancel}.");
 			}

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -45,6 +45,10 @@ namespace WalletWasabi.Fluent
 		public override void Initialize()
 		{
 			AvaloniaXamlLoader.Load(this);
+			Services.SingleInstanceChecker.OtherInstanceStarted += (sender, args) =>
+			{
+				OnFrameworkInitializationCompleted();
+			};
 		}
 
 		public override void OnFrameworkInitializationCompleted()
@@ -58,6 +62,8 @@ namespace WalletWasabi.Fluent
 				if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
 				{
 					desktop.ShutdownRequested += DesktopOnShutdownRequested;
+
+					desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
 					desktop.MainWindow = new MainWindow
 					{

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Concurrency;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -79,7 +80,21 @@ namespace WalletWasabi.Fluent
 		{
 			if (CanShutdownProvider is { } provider)
 			{
-				e.Cancel = !provider.CanShutdown();
+				bool hideOnClose = Services.UiConfig.HideOnClose;
+				e.Cancel = !provider.CanShutdown() || hideOnClose;
+
+				if (hideOnClose)
+				{
+					if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+					{
+						// Todo: hide the window and hide taskbar icon as well
+						MainViewModel.Instance!.WindowState = WindowState.Minimized;
+					}
+					else
+					{
+						MainViewModel.Instance!.WindowState = WindowState.Minimized;
+					}
+				}
 			}
 		}
 	}

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -74,14 +74,6 @@ namespace WalletWasabi.Fluent
 			}
 
 			base.OnFrameworkInitializationCompleted();
-
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				Services.SingleInstanceChecker.OtherInstanceStarted += (sender, args) =>
-				{
-					MainViewModel.Instance!.WindowState = WindowState.Normal; // Todo: Unhide, Show, BringToFront?
-				};
-			}
 		}
 
 		private void DesktopOnShutdownRequested(object? sender, ShutdownRequestedEventArgs e)

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -74,6 +74,14 @@ namespace WalletWasabi.Fluent
 			}
 
 			base.OnFrameworkInitializationCompleted();
+
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Services.SingleInstanceChecker.OtherInstanceStarted += (sender, args) =>
+				{
+					MainViewModel.Instance!.WindowState = WindowState.Normal; // Todo: Unhide, Show, BringToFront?
+				};
+			}
 		}
 
 		private void DesktopOnShutdownRequested(object? sender, ShutdownRequestedEventArgs e)

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 using ReactiveUI;
 using WalletWasabi.Fluent.Behaviors;
 using WalletWasabi.Fluent.Providers;
@@ -47,7 +48,18 @@ namespace WalletWasabi.Fluent
 			AvaloniaXamlLoader.Load(this);
 			Services.SingleInstanceChecker.OtherInstanceStarted += (sender, args) =>
 			{
-				OnFrameworkInitializationCompleted();
+				Dispatcher.UIThread.Post(() =>
+				{
+					if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+					{
+						desktop.MainWindow = new MainWindow
+						{
+							DataContext = MainViewModel.Instance
+						};
+
+						desktop.MainWindow.Show();
+					}
+				});
 			};
 		}
 

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -1,19 +1,16 @@
 using System;
 using System.Reactive.Concurrency;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data;
-using Avalonia.Logging;
 using Avalonia.Markup.Xaml;
 using ReactiveUI;
 using WalletWasabi.Fluent.Behaviors;
 using WalletWasabi.Fluent.Providers;
 using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Fluent.Views;
-using WalletWasabi.Logging;
 using Logger = WalletWasabi.Logging.Logger;
 
 namespace WalletWasabi.Fluent

--- a/WalletWasabi.Fluent/Behaviors/HideShowBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/HideShowBehavior.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using ReactiveUI;
+using WalletWasabi.Fluent.ViewModels;
+using WalletWasabi.Services;
+
+namespace WalletWasabi.Fluent.Behaviors
+{
+	public class HideShowBehavior : DisposingBehavior<Window>
+	{
+		protected override void OnAttached(CompositeDisposable disposables)
+		{
+			if (AssociatedObject is null)
+			{
+				return;
+			}
+
+			// On macOs the Hide/Show is a natural feature.
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Observable
+					.FromEventPattern(Services.SingleInstanceChecker,
+						nameof(SingleInstanceChecker.OtherInstanceStarted))
+					.ObserveOn(RxApp.MainThreadScheduler)
+					.Subscribe(_ =>
+					{
+						if (AssociatedObject.WindowState == WindowState.Minimized)
+						{
+							AssociatedObject.WindowState = (WindowState)Enum.Parse(typeof(WindowState), Services.UiConfig.WindowState);
+						}
+
+						// Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/6309
+						var temp = AssociatedObject.WindowState;
+						AssociatedObject.Show();
+						AssociatedObject.WindowState = temp;
+
+						AssociatedObject.BringIntoView();
+					})
+					.DisposeWith(disposables);
+			}
+
+			//TODO: we need the close button click only, external close request should not be cancelled.
+			Observable
+				.FromEventPattern<CancelEventArgs>(AssociatedObject, nameof(AssociatedObject.Closing))
+				.ObserveOn(RxApp.MainThreadScheduler)
+				.Subscribe(args =>
+				{
+					if (Services.UiConfig.HideOnClose)
+					{
+						args.EventArgs.Cancel = true;
+						AssociatedObject.Hide();
+					}
+				})
+				.DisposeWith(disposables);
+		}
+	}
+}

--- a/WalletWasabi.Fluent/Behaviors/HideShowBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/HideShowBehavior.cs
@@ -11,6 +11,8 @@ namespace WalletWasabi.Fluent.Behaviors
 {
 	public class HideShowBehavior : DisposingBehavior<Window>
 	{
+		private const string icon_path = "/Assets/WasabiLogo.ico";
+
 		protected override void OnAttached(CompositeDisposable disposables)
 		{
 			if (AssociatedObject is null)
@@ -50,8 +52,8 @@ namespace WalletWasabi.Fluent.Behaviors
 				{
 					if (Services.UiConfig.HideOnClose)
 					{
-						args.EventArgs.Cancel = true;
-						AssociatedObject.Hide();
+						//args.EventArgs.Cancel = true;
+						//AssociatedObject.Hide();
 					}
 				})
 				.DisposeWith(disposables);

--- a/WalletWasabi.Fluent/Behaviors/HideShowBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/HideShowBehavior.cs
@@ -1,16 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using Avalonia;
 using Avalonia.Controls;
 using ReactiveUI;
-using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Services;
 
 namespace WalletWasabi.Fluent.Behaviors

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -33,13 +33,15 @@ namespace WalletWasabi.Fluent
 
 		public static UiConfig UiConfig { get; private set; } = null!;
 
+		public static SingleInstanceChecker SingleInstanceChecker { get; private set; } = null!;
+
 		public static bool IsInitialized { get; private set; }
 
 		/// <summary>
 		/// Initializes global services used by fluent project.
 		/// </summary>
 		/// <param name="global">The global instance.</param>
-		public static void Initialize(Global global)
+		public static void Initialize(Global global, SingleInstanceChecker singleInstanceChecker)
 		{
 			Guard.NotNull(nameof(global.DataDir), global.DataDir);
 			Guard.NotNull(nameof(global.TorSettings), global.TorSettings);
@@ -63,6 +65,7 @@ namespace WalletWasabi.Fluent
 			TransactionBroadcaster = global.TransactionBroadcaster;
 			HostedServices = global.HostedServices;
 			UiConfig = global.UiConfig;
+			SingleInstanceChecker = singleInstanceChecker;
 
 			IsInitialized = true;
 		}

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -73,6 +73,7 @@ namespace WalletWasabi.Fluent.ViewModels
 			_searchPage.Initialise();
 
 			this.WhenAnyValue(x => x.WindowState)
+				.Where(x => x != WindowState.Minimized)
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(windowState => Services.UiConfig.WindowState = windowState.ToString());
 

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -31,6 +31,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 		[AutoNotify] private bool _customChangeAddress;
 		[AutoNotify] private FeeDisplayFormat _selectedFeeDisplayFormat;
 		[AutoNotify] private bool _runOnSystemStartup;
+		[AutoNotify] private bool _hideOnClose;
 
 		public GeneralSettingsTabViewModel()
 		{
@@ -39,6 +40,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 			_customFee = Services.UiConfig.IsCustomFee;
 			_customChangeAddress = Services.UiConfig.IsCustomChangeAddress;
 			_runOnSystemStartup = Services.UiConfig.RunOnSystemStartup;
+			_hideOnClose = Services.UiConfig.HideOnClose;
 			_selectedFeeDisplayFormat = Enum.IsDefined(typeof(FeeDisplayFormat), Services.UiConfig.FeeDisplayFormat)
 				? (FeeDisplayFormat)Services.UiConfig.FeeDisplayFormat
 				: FeeDisplayFormat.SatoshiPerByte;
@@ -86,6 +88,11 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Skip(1)
 				.Subscribe(x => Services.UiConfig.FeeDisplayFormat = (int)x);
+
+			this.WhenAnyValue(x => x.HideOnClose)
+				.ObserveOn(RxApp.TaskpoolScheduler)
+				.Skip(1)
+				.Subscribe(x => Services.UiConfig.HideOnClose = x);
 		}
 
 		public ICommand StartupCommand { get; }

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -18,11 +18,6 @@
       CompactPaneLength="{Binding NavBar.CurrentCompactPaneLength}"
       OpenPaneLength="{Binding NavBar.CurrentOpenPaneLength}"
       IsPaneOpen="{Binding NavBar.IsOpen, Mode=TwoWay}">
-      <i:Interaction.Behaviors>
-        <behaviors:SplitViewAutoBehavior ToggleAction="{Binding NavBar.ToggleAction, Mode=OneWayToSource}"
-                                         CollapseOnClickAction="{Binding NavBar.CollapseOnClickAction, Mode=OneWayToSource}"
-                                         CollapseThreshold="{StaticResource SplitViewCollapseThreshold}" />
-      </i:Interaction.Behaviors>
 
       <SplitView.Pane>
         <Panel>

--- a/WalletWasabi.Fluent/Views/MainWindow.axaml
+++ b/WalletWasabi.Fluent/Views/MainWindow.axaml
@@ -17,7 +17,8 @@
         Title="Wasabi Wallet"
         WindowState="{Binding WindowState, Mode=TwoWay}">
   <i:Interaction.Behaviors>
-    <behaviors:RegisterNotificationHostBehavior/>
+    <behaviors:RegisterNotificationHostBehavior />
+    <behaviors:HideShowBehavior />
   </i:Interaction.Behaviors>
 
   <Panel Margin="{Binding #MainWindow.OffScreenMargin}">

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -21,6 +21,11 @@
     </DockPanel>
 
     <DockPanel>
+      <TextBlock Text="Hide Window on close" />
+      <ToggleSwitch IsChecked="{Binding HideOnClose}" />
+    </DockPanel>
+
+    <DockPanel>
       <TextBlock Text="Auto Copy/Paste Bitcoin addresses" />
       <ToggleSwitch IsChecked="{Binding AutoCopy}" />
     </DockPanel>

--- a/WalletWasabi.Gui/UiConfig.cs
+++ b/WalletWasabi.Gui/UiConfig.cs
@@ -26,6 +26,7 @@ namespace WalletWasabi.Gui
 		private string _windowState = "Normal";
 		private bool _runOnSystemStartup;
 		private bool _oobe;
+		private bool _hideOnClose;
 
 		public UiConfig() : base()
 		{
@@ -45,7 +46,8 @@ namespace WalletWasabi.Gui
 					x => x.Oobe,
 					x => x.RunOnSystemStartup,
 					x => x.PrivacyMode,
-					(_, _, _, _, _, _, _, _, _, _, _) => Unit.Default)
+					x => x.HideOnClose,
+					(_, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default)
 				.Throttle(TimeSpan.FromMilliseconds(500))
 				.Skip(1) // Won't save on UiConfig creation.
 				.ObserveOn(RxApp.TaskpoolScheduler)
@@ -167,5 +169,13 @@ namespace WalletWasabi.Gui
 		[JsonProperty(PropertyName = "HistoryTabViewSortingPreference")]
 		[JsonConverter(typeof(SortingPreferenceJsonConverter))]
 		public SortingPreference HistoryTabViewSortingPreference { get; internal set; } = new SortingPreference(SortOrder.Decreasing, "Date");
+
+		[DefaultValue(false)]
+		[JsonProperty(PropertyName = "HideOnClose", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public bool HideOnClose
+		{
+			get => _hideOnClose;
+			set => RaiseAndSetIfChanged(ref _hideOnClose, value);
+		}
 	}
 }


### PR DESCRIPTION
based on https://github.com/zkSNACKs/WalletWasabi/pull/6297

This is a possible improvement of Hiding the window. With this, the visual objects in the memory would be cleaned as well in case of putting the app in the background. 

### Current blocker

In this PR I set up the property 
`desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;`
Closing of the application is fine, the window is gone and business logic runs. The problem is when I am trying to bring the window back - nothing appears. 

This function is called where I re-instantiate the ViewModel but it seems like it is not enough. 

https://github.com/zkSNACKs/WalletWasabi/pull/6317/files#diff-56c9af58b0cd6b826635e8514e253b82fc8a30c4b30a50c55fbe467cfabd761cR50

>         /// <summary>
>         /// Gets or sets the <see cref="ShutdownMode"/>. This property indicates whether the application is shutdown explicitly or implicitly. 
>         /// If <see cref="ShutdownMode"/> is set to OnExplicitShutdown the application is only closes if Shutdown is called.
>         /// The default is OnLastWindowClose
>         /// </summary>


