### PR TITLE
Evaluate if CoinJoin is in critical phase 2

### DIFF
--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -142,17 +142,6 @@ namespace WalletWasabi.Gui
 				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
 				cancel.ThrowIfCancellationRequested();
 
-				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
-
-				if (systemAwakeChecker is not null)
-				{
-					HostedServices.Register<SystemAwakeChecker>(systemAwakeChecker, "System Awake Checker");
-				}
-				else
-				{
-					Logger.LogInfo("System Awake Checker is not available on this platform.");
-				}
-
 				await StartTorProcessManagerAsync(cancel).ConfigureAwait(false);
 
 				try
@@ -175,6 +164,17 @@ namespace WalletWasabi.Gui
 
 				RegisterFeeRateProviders();
 				RegisterCoinJoinComponents();
+
+				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
+
+				if (systemAwakeChecker is not null)
+				{
+					HostedServices.Register<SystemAwakeChecker>(systemAwakeChecker, "System Awake Checker");
+				}
+				else
+				{
+					Logger.LogInfo("System Awake Checker is not available on this platform.");
+				}
 
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -41,6 +41,7 @@ namespace WalletWasabi.Gui
 {
 	public class Global
 	{
+		public CoinJoinManager CoinJoinManager { get; private set; }
 		public const string ThemeBackgroundBrushResourceKey = "ThemeBackgroundBrush";
 		public const string ApplicationAccentForegroundBrushResourceKey = "ApplicationAccentForegroundBrush";
 
@@ -76,7 +77,7 @@ namespace WalletWasabi.Gui
 
 		public JsonRpcServer? RpcServer { get; private set; }
 
-		public Global(string dataDir, Config config, UiConfig uiConfig, WalletManager walletManager)
+		public Global(string dataDir, Config config, UiConfig uiConfig, WalletManager walletManager, CoinJoinManager coinJoinManager)
 		{
 			using (BenchmarkLogger.Measure())
 			{
@@ -88,6 +89,7 @@ namespace WalletWasabi.Gui
 
 				HostedServices = new HostedServices();
 				WalletManager = walletManager;
+				CoinJoinManager = coinJoinManager;
 
 				WalletManager.OnDequeue += WalletManager_OnDequeue;
 				WalletManager.WalletRelevantTransactionProcessed += WalletManager_WalletRelevantTransactionProcessed;
@@ -142,7 +144,7 @@ namespace WalletWasabi.Gui
 				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
 				cancel.ThrowIfCancellationRequested();
 
-				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(WalletManager).ConfigureAwait(false);
+				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(CoinJoinManager).ConfigureAwait(false);
 
 				if (systemAwakeChecker is not null)
 				{

--- a/WalletWasabi.Gui/Global.cs
+++ b/WalletWasabi.Gui/Global.cs
@@ -41,7 +41,6 @@ namespace WalletWasabi.Gui
 {
 	public class Global
 	{
-		public CoinJoinManager CoinJoinManager { get; private set; }
 		public const string ThemeBackgroundBrushResourceKey = "ThemeBackgroundBrush";
 		public const string ApplicationAccentForegroundBrushResourceKey = "ApplicationAccentForegroundBrush";
 
@@ -77,7 +76,7 @@ namespace WalletWasabi.Gui
 
 		public JsonRpcServer? RpcServer { get; private set; }
 
-		public Global(string dataDir, Config config, UiConfig uiConfig, WalletManager walletManager, CoinJoinManager coinJoinManager)
+		public Global(string dataDir, Config config, UiConfig uiConfig, WalletManager walletManager)
 		{
 			using (BenchmarkLogger.Measure())
 			{
@@ -89,7 +88,6 @@ namespace WalletWasabi.Gui
 
 				HostedServices = new HostedServices();
 				WalletManager = walletManager;
-				CoinJoinManager = coinJoinManager;
 
 				WalletManager.OnDequeue += WalletManager_OnDequeue;
 				WalletManager.WalletRelevantTransactionProcessed += WalletManager_WalletRelevantTransactionProcessed;
@@ -144,7 +142,7 @@ namespace WalletWasabi.Gui
 				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
 				cancel.ThrowIfCancellationRequested();
 
-				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(CoinJoinManager).ConfigureAwait(false);
+				SystemAwakeChecker? systemAwakeChecker = await SystemAwakeChecker.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
 
 				if (systemAwakeChecker is not null)
 				{

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.Services
 
 		private volatile IPowerSavingInhibitorTask? _powerSavingTask;
 
-		private SystemAwakeChecker(CoinJoinManager coinJoinManager, Func<Task<IPowerSavingInhibitorTask>>? taskFactory) : base(TimeSpan.FromMinutes(1))
+		private SystemAwakeChecker(CoinJoinManager coinJoinManager, Func<Task<IPowerSavingInhibitorTask>>? taskFactory) : base(TimeSpan.FromSeconds(5))
 		{
 			CoinJoinManager = coinJoinManager;
 			TaskFactory = taskFactory;

--- a/WalletWasabi/Services/SystemAwakeChecker.cs
+++ b/WalletWasabi/Services/SystemAwakeChecker.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Bases;
 using WalletWasabi.Helpers;
 using WalletWasabi.Helpers.PowerSaving;
 using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
 using static WalletWasabi.Helpers.PowerSaving.LinuxInhibitorTask;
 
@@ -18,17 +19,17 @@ namespace WalletWasabi.Services
 
 		private volatile IPowerSavingInhibitorTask? _powerSavingTask;
 
-		private SystemAwakeChecker(WalletManager walletManager, Func<Task<IPowerSavingInhibitorTask>>? taskFactory) : base(TimeSpan.FromMinutes(1))
+		private SystemAwakeChecker(CoinJoinManager coinJoinManager, Func<Task<IPowerSavingInhibitorTask>>? taskFactory) : base(TimeSpan.FromMinutes(1))
 		{
-			WalletManager = walletManager;
+			CoinJoinManager = coinJoinManager;
 			TaskFactory = taskFactory;
 		}
 
-		private WalletManager WalletManager { get; }
+		private CoinJoinManager CoinJoinManager { get; }
 		public Func<Task<IPowerSavingInhibitorTask>>? TaskFactory { get; }
 
 		/// <summary>Checks whether we support awake state prolonging for the current platform.</summary>
-		public static async Task<SystemAwakeChecker?> CreateAsync(WalletManager walletManager)
+		public static async Task<SystemAwakeChecker?> CreateAsync(CoinJoinManager coinJoinManager)
 		{
 			Func<Task<IPowerSavingInhibitorTask>>? taskFactory = null;
 
@@ -60,45 +61,56 @@ namespace WalletWasabi.Services
 				taskFactory = () => Task.FromResult<IPowerSavingInhibitorTask>(WindowsPowerAvailabilityTask.Create(Reason));
 			}
 
-			return new SystemAwakeChecker(walletManager, taskFactory);
+			return new SystemAwakeChecker(coinJoinManager, taskFactory);
 		}
 
 		protected override async Task ActionAsync(CancellationToken cancel)
 		{
 			IPowerSavingInhibitorTask? task = _powerSavingTask;
 
-			if (WalletManager.AnyCoinJoinInProgress())
+			switch (CoinJoinManager.HighestCoinJoinClientState)
 			{
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-				{
+				case CoinJoinClientState.Idle:
 					if (task is not null)
 					{
-						if (!task.Prolong(Timeout.Add(TimeSpan.FromMinutes(1))))
-						{
-							Logger.LogTrace("Failed to prolong the power saving task.");
-							task = null;
-						}
+						Logger.LogWarning("Computer idle state is allowed again.");
+						await task.StopAsync().ConfigureAwait(false);
+						_powerSavingTask = null;
 					}
 
-					if (task is null)
+					break;
+
+				case CoinJoinClientState.InProgress:
+					if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					{
-						Logger.LogTrace("Create new power saving prevention task.");
-						_powerSavingTask = await TaskFactory!().ConfigureAwait(false);
+						if (task is not null)
+						{
+							if (!task.Prolong(Timeout.Add(TimeSpan.FromMinutes(1))))
+							{
+								Logger.LogTrace("Failed to prolong the power saving task.");
+								task = null;
+							}
+						}
+
+						if (task is null)
+						{
+							Logger.LogTrace("Create new power saving prevention task.");
+							_powerSavingTask = await TaskFactory!().ConfigureAwait(false);
+						}
 					}
-				}
-				else
-				{
-					await EnvironmentHelpers.ProlongSystemAwakeAsync().ConfigureAwait(false);
-				}
-			}
-			else
-			{
-				if (task is not null)
-				{
-					Logger.LogWarning("Computer idle state is allowed again.");
-					await task.StopAsync().ConfigureAwait(false);
-					_powerSavingTask = null;
-				}
+					else
+					{
+						await EnvironmentHelpers.ProlongSystemAwakeAsync().ConfigureAwait(false);
+					}
+
+					break;
+
+				case CoinJoinClientState.InCriticalPhase:
+
+					break;
+
+				default:
+					throw new ArgumentOutOfRangeException();
 			}
 		}
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -99,7 +99,9 @@ namespace WalletWasabi.WabiSabi.Client
 				{
 					throw new InvalidOperationException($"Round ({roundState.Id}): There is no available alices to participate with.");
 				}
+
 				State = CoinJoinClientState.InCriticalPhase;
+
 				// Calculate outputs values
 				var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
 				var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -24,8 +24,8 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class CoinJoinClient
 	{
-		private volatile bool _inCriticalCoinJoinState;
 		private const int MaxInputsRegistrableByWallet = 7; // how many
+		private volatile bool _inCriticalCoinJoinState;
 
 		public CoinJoinClient(
 			IWabiSabiApiRequestHandler arenaRequestHandler,

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -44,29 +44,38 @@ namespace WalletWasabi.WabiSabi.Client
 		public Kitchen Kitchen { get; }
 		public KeyManager Keymanager { get; }
 		private RoundStateUpdater RoundStatusUpdater { get; }
+		public CoinJoinClientState State { get; private set; }
 
 		public async Task<bool> StartCoinJoinAsync(IEnumerable<SmartCoin> coins, CancellationToken cancellationToken)
 		{
-			var currentRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.Phase == Phase.InputRegistration, cancellationToken).ConfigureAwait(false);
-
-			// This should be roughly log(#inputs), it could be set slightly
-			// higher if more inputs are observed but that involves trusting the
-			// coordinator with those values. Therefore, conservatively set this
-			// so that a maximum of 5 blame rounds are executed.
-			// FIXME should smaller rounds abort earlier?
-			var tryLimit = 6;
-
-			for (var tries = 0; tries < tryLimit; tries++)
+			State = CoinJoinClientState.InProgress;
+			try
 			{
-				if (await StartRoundAsync(coins, currentRoundState, cancellationToken).ConfigureAwait(false))
+				var currentRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.Phase == Phase.InputRegistration, cancellationToken).ConfigureAwait(false);
+
+				// This should be roughly log(#inputs), it could be set slightly
+				// higher if more inputs are observed but that involves trusting the
+				// coordinator with those values. Therefore, conservatively set this
+				// so that a maximum of 5 blame rounds are executed.
+				// FIXME should smaller rounds abort earlier?
+				var tryLimit = 6;
+
+				for (var tries = 0; tries < tryLimit; tries++)
 				{
-					return true;
+					if (await StartRoundAsync(coins, currentRoundState, cancellationToken).ConfigureAwait(false))
+					{
+						return true;
+					}
+					else
+					{
+						var blameRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.BlameOf == currentRoundState.Id, cancellationToken).ConfigureAwait(false);
+						currentRoundState = blameRoundState;
+					}
 				}
-				else
-				{
-					var blameRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.BlameOf == currentRoundState.Id, cancellationToken).ConfigureAwait(false);
-					currentRoundState = blameRoundState;
-				}
+			}
+			finally
+			{
+				State = CoinJoinClientState.Idle;
 			}
 
 			return false;
@@ -77,57 +86,65 @@ namespace WalletWasabi.WabiSabi.Client
 		/// <returns>Whether or not the round resulted in a successful transaction.</returns>
 		public async Task<bool> StartRoundAsync(IEnumerable<SmartCoin> smartCoins, RoundState roundState, CancellationToken cancellationToken)
 		{
-			var constructionState = roundState.Assert<ConstructionState>();
-
-			var coinCandidates = SelectCoinsForRound(smartCoins, constructionState.Parameters);
-
-			// Register coins.
-			var registeredAliceClients = await CreateRegisterAndConfirmCoinsAsync(coinCandidates, roundState, cancellationToken).ConfigureAwait(false);
-			if (!registeredAliceClients.Any())
+			try
 			{
-				throw new InvalidOperationException($"Round ({roundState.Id}): There is no available alices to participate with.");
+				State = CoinJoinClientState.InProgress;
+				var constructionState = roundState.Assert<ConstructionState>();
+
+				var coinCandidates = SelectCoinsForRound(smartCoins, constructionState.Parameters);
+
+				// Register coins.
+				var registeredAliceClients = await CreateRegisterAndConfirmCoinsAsync(coinCandidates, roundState, cancellationToken).ConfigureAwait(false);
+				if (!registeredAliceClients.Any())
+				{
+					throw new InvalidOperationException($"Round ({roundState.Id}): There is no available alices to participate with.");
+				}
+				State = CoinJoinClientState.InCriticalPhase;
+				// Calculate outputs values
+				var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
+				var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);
+				var outputValues = DecomposeAmounts(registeredCoins, roundState.FeeRate, constructionState.Parameters.AllowedOutputAmounts.Min, (int)availableVsize);
+
+				// Get all locked internal keys we have and assert we have enough.
+				Keymanager.AssertLockedInternalKeysIndexed(howMany: outputValues.Count());
+				var allLockedInternalKeys = Keymanager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked);
+				var outputTxOuts = outputValues.Zip(allLockedInternalKeys, (amount, hdPubKey) => new TxOut(amount, hdPubKey.P2wpkhScript));
+
+				DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(registeredCoins, outputTxOuts, roundState.FeeRate, roundState.MaxVsizeAllocationPerAlice);
+				DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
+
+				// Re-issuances.
+				var bobClient = CreateBobClient(roundState);
+				await scheduler.StartReissuancesAsync(registeredAliceClients, bobClient, cancellationToken).ConfigureAwait(false);
+
+				// Output registration.
+				roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.OutputRegistration, cancellationToken).ConfigureAwait(false);
+				await scheduler.StartOutputRegistrationsAsync(outputTxOuts, bobClient, cancellationToken).ConfigureAwait(false);
+
+				// ReadyToSign.
+				await ReadyToSignAsync(registeredAliceClients, cancellationToken).ConfigureAwait(false);
+
+				// Signing.
+				roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.TransactionSigning, cancellationToken).ConfigureAwait(false);
+				var signingState = roundState.Assert<SigningState>();
+				var unsignedCoinJoin = signingState.CreateUnsignedTransaction();
+
+				// Sanity check.
+				if (!SanityCheck(outputTxOuts, unsignedCoinJoin))
+				{
+					throw new InvalidOperationException($"Round ({roundState.Id}): My output is missing.");
+				}
+
+				// Send signature.
+				await SignTransactionAsync(registeredAliceClients, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
+
+				var finalRoundState = await RoundStatusUpdater.CreateRoundAwaiter(s => s.Id == roundState.Id && s.Phase == Phase.Ended, cancellationToken).ConfigureAwait(false);
+				return finalRoundState.WasTransactionBroadcast;
 			}
-
-			// Calculate outputs values
-			var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
-			var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);
-			var outputValues = DecomposeAmounts(registeredCoins, roundState.FeeRate, constructionState.Parameters.AllowedOutputAmounts.Min, (int)availableVsize);
-
-			// Get all locked internal keys we have and assert we have enough.
-			Keymanager.AssertLockedInternalKeysIndexed(howMany: outputValues.Count());
-			var allLockedInternalKeys = Keymanager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked);
-			var outputTxOuts = outputValues.Zip(allLockedInternalKeys, (amount, hdPubKey) => new TxOut(amount, hdPubKey.P2wpkhScript));
-
-			DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(registeredCoins, outputTxOuts, roundState.FeeRate, roundState.MaxVsizeAllocationPerAlice);
-			DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
-
-			// Re-issuances.
-			var bobClient = CreateBobClient(roundState);
-			await scheduler.StartReissuancesAsync(registeredAliceClients, bobClient, cancellationToken).ConfigureAwait(false);
-
-			// Output registration.
-			roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.OutputRegistration, cancellationToken).ConfigureAwait(false);
-			await scheduler.StartOutputRegistrationsAsync(outputTxOuts, bobClient, cancellationToken).ConfigureAwait(false);
-
-			// ReadyToSign.
-			await ReadyToSignAsync(registeredAliceClients, cancellationToken).ConfigureAwait(false);
-
-			// Signing.
-			roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.TransactionSigning, cancellationToken).ConfigureAwait(false);
-			var signingState = roundState.Assert<SigningState>();
-			var unsignedCoinJoin = signingState.CreateUnsignedTransaction();
-
-			// Sanity check.
-			if (!SanityCheck(outputTxOuts, unsignedCoinJoin))
+			finally
 			{
-				throw new InvalidOperationException($"Round ({roundState.Id}): My output is missing.");
+				State = CoinJoinClientState.InProgress;
 			}
-
-			// Send signature.
-			await SignTransactionAsync(registeredAliceClients, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
-
-			var finalRoundState = await RoundStatusUpdater.CreateRoundAwaiter(s => s.Id == roundState.Id && s.Phase == Phase.Ended, cancellationToken).ConfigureAwait(false);
-			return finalRoundState.WasTransactionBroadcast;
 		}
 
 		private async Task<ImmutableArray<AliceClient>> CreateRegisterAndConfirmCoinsAsync(IEnumerable<SmartCoin> smartCoins, RoundState roundState, CancellationToken cancellationToken)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -44,38 +44,30 @@ namespace WalletWasabi.WabiSabi.Client
 		public Kitchen Kitchen { get; }
 		public KeyManager Keymanager { get; }
 		private RoundStateUpdater RoundStatusUpdater { get; }
-		public CoinJoinClientState State { get; private set; }
+		public bool InCriticalCoinJoinState { get; private set; }
 
 		public async Task<bool> StartCoinJoinAsync(IEnumerable<SmartCoin> coins, CancellationToken cancellationToken)
 		{
-			State = CoinJoinClientState.InProgress;
-			try
+			var currentRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.Phase == Phase.InputRegistration, cancellationToken).ConfigureAwait(false);
+
+			// This should be roughly log(#inputs), it could be set slightly
+			// higher if more inputs are observed but that involves trusting the
+			// coordinator with those values. Therefore, conservatively set this
+			// so that a maximum of 5 blame rounds are executed.
+			// FIXME should smaller rounds abort earlier?
+			var tryLimit = 6;
+
+			for (var tries = 0; tries < tryLimit; tries++)
 			{
-				var currentRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.Phase == Phase.InputRegistration, cancellationToken).ConfigureAwait(false);
-
-				// This should be roughly log(#inputs), it could be set slightly
-				// higher if more inputs are observed but that involves trusting the
-				// coordinator with those values. Therefore, conservatively set this
-				// so that a maximum of 5 blame rounds are executed.
-				// FIXME should smaller rounds abort earlier?
-				var tryLimit = 6;
-
-				for (var tries = 0; tries < tryLimit; tries++)
+				if (await StartRoundAsync(coins, currentRoundState, cancellationToken).ConfigureAwait(false))
 				{
-					if (await StartRoundAsync(coins, currentRoundState, cancellationToken).ConfigureAwait(false))
-					{
-						return true;
-					}
-					else
-					{
-						var blameRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.BlameOf == currentRoundState.Id, cancellationToken).ConfigureAwait(false);
-						currentRoundState = blameRoundState;
-					}
+					return true;
 				}
-			}
-			finally
-			{
-				State = CoinJoinClientState.Idle;
+				else
+				{
+					var blameRoundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState => roundState.BlameOf == currentRoundState.Id, cancellationToken).ConfigureAwait(false);
+					currentRoundState = blameRoundState;
+				}
 			}
 
 			return false;
@@ -86,7 +78,6 @@ namespace WalletWasabi.WabiSabi.Client
 		/// <returns>Whether or not the round resulted in a successful transaction.</returns>
 		public async Task<bool> StartRoundAsync(IEnumerable<SmartCoin> smartCoins, RoundState roundState, CancellationToken cancellationToken)
 		{
-			State = CoinJoinClientState.InProgress;
 			var constructionState = roundState.Assert<ConstructionState>();
 
 			var coinCandidates = SelectCoinsForRound(smartCoins, constructionState.Parameters);
@@ -98,50 +89,56 @@ namespace WalletWasabi.WabiSabi.Client
 				throw new InvalidOperationException($"Round ({roundState.Id}): There is no available alices to participate with.");
 			}
 
-			State = CoinJoinClientState.InCriticalPhase;
-
-			// Calculate outputs values
-			var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
-			var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);
-			var outputValues = DecomposeAmounts(registeredCoins, roundState.FeeRate, constructionState.Parameters.AllowedOutputAmounts.Min, (int)availableVsize);
-
-			// Get all locked internal keys we have and assert we have enough.
-			Keymanager.AssertLockedInternalKeysIndexed(howMany: outputValues.Count());
-			var allLockedInternalKeys = Keymanager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked);
-			var outputTxOuts = outputValues.Zip(allLockedInternalKeys, (amount, hdPubKey) => new TxOut(amount, hdPubKey.P2wpkhScript));
-
-			DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(registeredCoins, outputTxOuts, roundState.FeeRate, roundState.MaxVsizeAllocationPerAlice);
-			DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
-
-			// Re-issuances.
-			var bobClient = CreateBobClient(roundState);
-			await scheduler.StartReissuancesAsync(registeredAliceClients, bobClient, cancellationToken).ConfigureAwait(false);
-
-			// Output registration.
-			roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.OutputRegistration, cancellationToken).ConfigureAwait(false);
-			await scheduler.StartOutputRegistrationsAsync(outputTxOuts, bobClient, cancellationToken).ConfigureAwait(false);
-
-			// ReadyToSign.
-			await ReadyToSignAsync(registeredAliceClients, cancellationToken).ConfigureAwait(false);
-
-			// Signing.
-			roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.TransactionSigning, cancellationToken).ConfigureAwait(false);
-			var signingState = roundState.Assert<SigningState>();
-			var unsignedCoinJoin = signingState.CreateUnsignedTransaction();
-
-			// Sanity check.
-			if (!SanityCheck(outputTxOuts, unsignedCoinJoin))
+			try
 			{
-				throw new InvalidOperationException($"Round ({roundState.Id}): My output is missing.");
+				InCriticalCoinJoinState = true;
+
+				// Calculate outputs values
+				var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
+				var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);
+				var outputValues = DecomposeAmounts(registeredCoins, roundState.FeeRate, constructionState.Parameters.AllowedOutputAmounts.Min, (int)availableVsize);
+
+				// Get all locked internal keys we have and assert we have enough.
+				Keymanager.AssertLockedInternalKeysIndexed(howMany: outputValues.Count());
+				var allLockedInternalKeys = Keymanager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked);
+				var outputTxOuts = outputValues.Zip(allLockedInternalKeys, (amount, hdPubKey) => new TxOut(amount, hdPubKey.P2wpkhScript));
+
+				DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(registeredCoins, outputTxOuts, roundState.FeeRate, roundState.MaxVsizeAllocationPerAlice);
+				DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
+
+				// Re-issuances.
+				var bobClient = CreateBobClient(roundState);
+				await scheduler.StartReissuancesAsync(registeredAliceClients, bobClient, cancellationToken).ConfigureAwait(false);
+
+				// Output registration.
+				roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.OutputRegistration, cancellationToken).ConfigureAwait(false);
+				await scheduler.StartOutputRegistrationsAsync(outputTxOuts, bobClient, cancellationToken).ConfigureAwait(false);
+
+				// ReadyToSign.
+				await ReadyToSignAsync(registeredAliceClients, cancellationToken).ConfigureAwait(false);
+
+				// Signing.
+				roundState = await RoundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.TransactionSigning, cancellationToken).ConfigureAwait(false);
+				var signingState = roundState.Assert<SigningState>();
+				var unsignedCoinJoin = signingState.CreateUnsignedTransaction();
+
+				// Sanity check.
+				if (!SanityCheck(outputTxOuts, unsignedCoinJoin))
+				{
+					throw new InvalidOperationException($"Round ({roundState.Id}): My output is missing.");
+				}
+
+				// Send signature.
+				await SignTransactionAsync(registeredAliceClients, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
+
+				var finalRoundState = await RoundStatusUpdater.CreateRoundAwaiter(s => s.Id == roundState.Id && s.Phase == Phase.Ended, cancellationToken).ConfigureAwait(false);
+
+				return finalRoundState.WasTransactionBroadcast;
 			}
-
-			// Send signature.
-			await SignTransactionAsync(registeredAliceClients, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
-
-			var finalRoundState = await RoundStatusUpdater.CreateRoundAwaiter(s => s.Id == roundState.Id && s.Phase == Phase.Ended, cancellationToken).ConfigureAwait(false);
-
-			State = finalRoundState.WasTransactionBroadcast ? CoinJoinClientState.Idle : CoinJoinClientState.InProgress;
-			return finalRoundState.WasTransactionBroadcast;
+			finally
+			{
+				InCriticalCoinJoinState = false;
+			}
 		}
 
 		private async Task<ImmutableArray<AliceClient>> CreateRegisterAndConfirmCoinsAsync(IEnumerable<SmartCoin> smartCoins, RoundState roundState, CancellationToken cancellationToken)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -24,6 +24,7 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class CoinJoinClient
 	{
+		private volatile bool _inCriticalCoinJoinState;
 		private const int MaxInputsRegistrableByWallet = 7; // how many
 
 		public CoinJoinClient(
@@ -44,7 +45,12 @@ namespace WalletWasabi.WabiSabi.Client
 		public Kitchen Kitchen { get; }
 		public KeyManager Keymanager { get; }
 		private RoundStateUpdater RoundStatusUpdater { get; }
-		public bool InCriticalCoinJoinState { get; private set; }
+
+		public bool InCriticalCoinJoinState
+		{
+			get => _inCriticalCoinJoinState;
+			private set => _inCriticalCoinJoinState = value;
+		}
 
 		public async Task<bool> StartCoinJoinAsync(IEnumerable<SmartCoin> coins, CancellationToken cancellationToken)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClientState.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClientState.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace WalletWasabi.WabiSabi.Client
 {
 	public enum CoinJoinClientState

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClientState.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClientState.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public enum CoinJoinClientState
+	{
+		Idle,
+		InProgress,
+		InCriticalPhase
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -39,19 +39,16 @@ namespace WalletWasabi.WabiSabi.Client
 		{
 			get
 			{
-				var coinjoinClients = TrackedWallets.Values
-					.Where(wtd => !wtd.CoinJoinTask.IsCompleted)
-					.GroupBy(wtd => wtd.CoinJoinClient.State)
-					.ToImmutableArray();
+				var inProgress = TrackedWallets.Values.Where(wtd => !wtd.CoinJoinTask.IsCompleted).ToImmutableArray();
 
-				if (coinjoinClients.Any(grp => grp.Key is CoinJoinClientState.InCriticalPhase))
+				if (inProgress.IsEmpty)
 				{
-					return CoinJoinClientState.InCriticalPhase;
+					return CoinJoinClientState.Idle;
 				}
 
-				return coinjoinClients.Any(grp => grp.Key is CoinJoinClientState.InProgress)
-					? CoinJoinClientState.InProgress
-					: CoinJoinClientState.Idle;
+				return inProgress.Any(wtd => wtd.CoinJoinClient.InCriticalCoinJoinState)
+					? CoinJoinClientState.InCriticalPhase
+					: CoinJoinClientState.InProgress;
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -39,13 +39,13 @@ namespace WalletWasabi.WabiSabi.Client
 		{
 			get
 			{
-				var coinjoinClients = TrackedWallets.Values;
-				if (coinjoinClients.Any(wt => wt.CoinJoinClient.State is CoinJoinClientState.InCriticalPhase))
+				var coinjoinClients = TrackedWallets.Values.GroupBy(wtd => wtd.CoinJoinClient.State).ToImmutableArray();
+				if (coinjoinClients.Any(grp => grp.Key is CoinJoinClientState.InCriticalPhase))
 				{
 					return CoinJoinClientState.InCriticalPhase;
 				}
 
-				return coinjoinClients.Any(wt => wt.CoinJoinClient.State is CoinJoinClientState.InProgress)
+				return coinjoinClients.Any(grp => grp.Key is CoinJoinClientState.InProgress)
 					? CoinJoinClientState.InProgress
 					: CoinJoinClientState.Idle;
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -1,19 +1,15 @@
 using Microsoft.Extensions.Hosting;
 using NBitcoin;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Tor.Socks5.Pool.Circuits;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
-using WalletWasabi.WabiSabi.Backend.Rounds;
-using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -39,7 +39,11 @@ namespace WalletWasabi.WabiSabi.Client
 		{
 			get
 			{
-				var coinjoinClients = TrackedWallets.Values.GroupBy(wtd => wtd.CoinJoinClient.State).ToImmutableArray();
+				var coinjoinClients = TrackedWallets.Values
+					.Where(wtd => !wtd.CoinJoinTask.IsCompleted)
+					.GroupBy(wtd => wtd.CoinJoinClient.State)
+					.ToImmutableArray();
+
 				if (coinjoinClients.Any(grp => grp.Key is CoinJoinClientState.InCriticalPhase))
 				{
 					return CoinJoinClientState.InCriticalPhase;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -35,7 +35,7 @@ namespace WalletWasabi.WabiSabi.Client
 		public ServiceConfiguration ServiceConfiguration { get; }
 		private ConcurrentDictionary<string, WalletTrackingData> TrackedWallets { get; } = new();
 
-		public CoinJoinClientState GetMostCoinJoinClientState
+		public CoinJoinClientState HighestCoinJoinClientState
 		{
 			get
 			{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -45,12 +45,9 @@ namespace WalletWasabi.WabiSabi.Client
 					return CoinJoinClientState.InCriticalPhase;
 				}
 
-				if (coinjoinClients.Any(wt => wt.CoinJoinClient.State is CoinJoinClientState.InProgress))
-				{
-					return CoinJoinClientState.InProgress;
-				}
-
-				return CoinJoinClientState.Idle;
+				return coinjoinClients.Any(wt => wt.CoinJoinClient.State is CoinJoinClientState.InProgress)
+					? CoinJoinClientState.InProgress
+					: CoinJoinClientState.Idle;
 			}
 		}
 


### PR DESCRIPTION
Another concept for https://github.com/zkSNACKs/WalletWasabi/pull/6277

Do not review `SystemAwakeChecker` changes. There will be a complete refactor there because the Shutdown prevention was brought by Avalonia, so we need to refactor that with the new possibilities. 

StateChanged event can be added to later if we need faster reaction but this also depends on the "new" SystemAwakeChecker .