### PR TITLE
[Fluent] Home screen - Tile fixes

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TileHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TileHelper.cs
@@ -107,7 +107,6 @@ namespace WalletWasabi.Fluent.Helpers
 				new("Normal", columnDefinitions:"330,660", rowDefinitions:"150,150"),
 				new("Wide", columnDefinitions: "330,330", rowDefinitions: "150,300")
 			};
-
 		}
 
 		public static IList<TileLayoutViewModel> GetNormalWalletLayout()

--- a/WalletWasabi.Fluent/Helpers/TileHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TileHelper.cs
@@ -18,9 +18,9 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium)
+						new(column: 0, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 0, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 0, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
@@ -29,9 +29,9 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(2, 0, 1, 1, TileSize.Medium),
-						new(0, 1, 1, 1, TileSize.Medium),
-						new(1, 0, 1, 1, TileSize.Medium)
+						new(column: 2, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 0, row: 1, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 1, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
@@ -40,9 +40,9 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(1, 0, 1, 1, TileSize.Medium),
-						new(1, 0, 1, 2, TileSize.Large),
-						new(0, 1, 2, 1, TileSize.Wide)
+						new(column: 1, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 1, row: 0, columnSpan: 1, rowSpan: 2, TileSize.Large),
+						new(column: 0, row: 1, columnSpan: 2, rowSpan: 1, TileSize.Wide)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
@@ -51,9 +51,9 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(3, 0, 1, 1, TileSize.Medium),
-						new(2, 0, 1, 2, TileSize.Wide),
-						new(0, 2, 2, 1, TileSize.Wide)
+						new(column: 3, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 2, row: 0, columnSpan: 1, rowSpan: 2, TileSize.Wide),
+						new(column: 0, row: 2, columnSpan: 2, rowSpan: 1, TileSize.Wide)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
@@ -68,9 +68,9 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium)
+						new(column: 0, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 0, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 0, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
@@ -79,9 +79,9 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(1, 0, 1, 1, TileSize.Medium),
-						new(0, 1, 1, 1, TileSize.Medium),
-						new(1, 0, 1, 1, TileSize.Medium)
+						new(column: 1, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 0, row: 1, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 1, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
@@ -90,12 +90,33 @@ namespace WalletWasabi.Fluent.Helpers
 				{
 					TilePresets = new ObservableCollection<TilePresetViewModel>()
 					{
-						new(2, 0, 1, 1, TileSize.Medium),
-						new(1, 0, 2, 2, TileSize.Wide),
-						new(0, 1, 2, 1, TileSize.Wide)
+						new(column: 2, row: 0, columnSpan: 1, rowSpan: 1, TileSize.Medium),
+						new(column: 1, row: 0, columnSpan: 1, rowSpan: 2, TileSize.Wide),
+						new(column: 0, row: 1, columnSpan: 2, rowSpan: 1, TileSize.Wide)
 					},
 					TilePresetIndex = walletViewModel.LayoutIndex
 				},
+			};
+		}
+
+		public static IList<TileLayoutViewModel> GetWatchOnlyWalletLayout()
+		{
+			return new ObservableCollection<TileLayoutViewModel>()
+			{
+				new("Small", columnDefinitions:"330,330,330", rowDefinitions:"150"),
+				new("Normal", columnDefinitions:"330,660", rowDefinitions:"150,150"),
+				new("Wide", columnDefinitions: "330,330", rowDefinitions: "150,300")
+			};
+
+		}
+
+		public static IList<TileLayoutViewModel> GetNormalWalletLayout()
+		{
+			return new ObservableCollection<TileLayoutViewModel>()
+			{
+				new("Small", columnDefinitions: "330,330,330,330", rowDefinitions: "150"),
+				new("Normal", columnDefinitions: "330,330,330", rowDefinitions: "150,150"),
+				new("Wide", columnDefinitions: "330,330", rowDefinitions: "150,300,300")
 			};
 		}
 	}

--- a/WalletWasabi.Fluent/Helpers/TileHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TileHelper.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reactive;
+using WalletWasabi.Fluent.Models;
+using WalletWasabi.Fluent.ViewModels.Wallets;
+using WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles;
+
+namespace WalletWasabi.Fluent.Helpers
+{
+	public static class TileHelper
+	{
+		public static List<TileViewModel> GetNormalWalletTiles(WalletViewModel walletViewModel, IObservable<Unit> balanceChanged)
+		{
+			return new List<TileViewModel>
+			{
+				new WalletBalanceTileViewModel(walletViewModel.Wallet, balanceChanged, walletViewModel.History.UnfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+
+				new BtcPriceTileViewModel(walletViewModel.Wallet)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(2, 0, 1, 1, TileSize.Medium),
+						new(0, 1, 1, 1, TileSize.Medium),
+						new(1, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+
+				new WalletPieChartTileViewModel(walletViewModel, balanceChanged)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(1, 0, 1, 1, TileSize.Medium),
+						new(1, 0, 1, 2, TileSize.Large),
+						new(0, 1, 2, 1, TileSize.Wide)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+
+				new WalletBalanceChartTileViewModel(walletViewModel.History.UnfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(3, 0, 1, 1, TileSize.Medium),
+						new(2, 0, 1, 2, TileSize.Wide),
+						new(0, 2, 2, 1, TileSize.Wide)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+			};
+		}
+
+		public static List<TileViewModel> GetWatchOnlyWalletTiles(WalletViewModel walletViewModel, IObservable<Unit> balanceChanged)
+		{
+			return new List<TileViewModel>
+			{
+				new WalletBalanceTileViewModel(walletViewModel.Wallet, balanceChanged, walletViewModel.History.UnfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+
+				new BtcPriceTileViewModel(walletViewModel.Wallet)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(1, 0, 1, 1, TileSize.Medium),
+						new(0, 1, 1, 1, TileSize.Medium),
+						new(1, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+
+				new WalletBalanceChartTileViewModel(walletViewModel.History.UnfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(2, 0, 1, 1, TileSize.Medium),
+						new(1, 0, 2, 2, TileSize.Wide),
+						new(0, 1, 2, 1, TileSize.Wide)
+					},
+					TilePresetIndex = walletViewModel.LayoutIndex
+				},
+			};
+		}
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -101,7 +101,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 				{
 					new(2, 0, 1, 1, TileSize.Medium),
 					new(1, 0, 1, 1, TileSize.Medium),
-					new(0, 1, 1, 1, TileSize.Large)
+					new(1, 0, 1, 1, TileSize.Medium)
 				},
 				TilePresetIndex = LayoutIndex
 			};

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -76,12 +76,9 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 			_normalLayoutIndex = 1;
 			_wideLayoutIndex = 2;
 
-			Layouts = new ObservableCollection<TileLayoutViewModel>()
-			{
-				new("Small", "330,330,330,330", "150"),
-				new("Normal", "330,330,330", "150,150"),
-				new("Wide", "330,330", "150,300,300")
-			};
+			Layouts = wallet.KeyManager.IsWatchOnly
+				? TileHelper.GetWatchOnlyWalletLayout()
+				: TileHelper.GetNormalWalletLayout();
 
 			LayoutIndex = _normalLayoutIndex;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using System.Windows.Input;
-using WalletWasabi.Fluent.Models;
+using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Authorization;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Fluent.ViewModels.Wallets.Advanced;
@@ -86,8 +86,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 			LayoutIndex = _normalLayoutIndex;
 
 			_tiles = wallet.KeyManager.IsWatchOnly
-				? GetWatchOnlyWalletTiles(wallet, balanceChanged, History.UnfilteredTransactions)
-				: GetNormalWalletTiles(wallet, balanceChanged, History.UnfilteredTransactions);
+				? TileHelper.GetWatchOnlyWalletTiles(this, balanceChanged)
+				: TileHelper.GetNormalWalletTiles(this, balanceChanged);
 
 			this.WhenAnyValue(x => x.LayoutIndex)
 				.Subscribe(x =>
@@ -156,95 +156,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 		public HistoryViewModel History { get; }
 
 		public TileLayoutViewModel? CurrentLayout => Layouts?[LayoutIndex];
-
-		private List<TileViewModel> GetNormalWalletTiles(Wallet wallet, IObservable<Unit> balanceChanged, ObservableCollection<HistoryItemViewModel> unfilteredTransactions)
-		{
-			return new List<TileViewModel>
-			{
-				new WalletBalanceTileViewModel(wallet, balanceChanged, unfilteredTransactions)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-
-				new BtcPriceTileViewModel(wallet)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(2, 0, 1, 1, TileSize.Medium),
-						new(0, 1, 1, 1, TileSize.Medium),
-						new(1, 0, 1, 1, TileSize.Medium)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-
-				new WalletPieChartTileViewModel(this, balanceChanged)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(1, 0, 1, 1, TileSize.Medium),
-						new(1, 0, 1, 2, TileSize.Large),
-						new(0, 1, 2, 1, TileSize.Wide)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-
-				new WalletBalanceChartTileViewModel(unfilteredTransactions)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(3, 0, 1, 1, TileSize.Medium),
-						new(2, 0, 1, 2, TileSize.Wide),
-						new(0, 2, 2, 1, TileSize.Wide)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-			};
-		}
-
-		private List<TileViewModel> GetWatchOnlyWalletTiles(Wallet wallet, IObservable<Unit> balanceChanged, ObservableCollection<HistoryItemViewModel> unfilteredTransactions)
-		{
-			return new List<TileViewModel>
-			{
-				new WalletBalanceTileViewModel(wallet, balanceChanged, unfilteredTransactions)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium),
-						new(0, 0, 1, 1, TileSize.Medium)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-
-				new BtcPriceTileViewModel(wallet)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(1, 0, 1, 1, TileSize.Medium),
-						new(0, 1, 1, 1, TileSize.Medium),
-						new(1, 0, 1, 1, TileSize.Medium)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-
-				new WalletBalanceChartTileViewModel(unfilteredTransactions)
-				{
-					TilePresets = new ObservableCollection<TilePresetViewModel>()
-					{
-						new(2, 0, 1, 1, TileSize.Medium),
-						new(1, 0, 2, 2, TileSize.Wide),
-						new(0, 1, 2, 1, TileSize.Wide)
-					},
-					TilePresetIndex = LayoutIndex
-				},
-			};
-		}
 
 		private void LayoutSelector(double width, double height)
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -79,60 +79,15 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 			Layouts = new ObservableCollection<TileLayoutViewModel>()
 			{
 				new("Small", "330,330,330,330", "150"),
-				new("Normal", "330,330,330", "150,300"),
+				new("Normal", "330,330,330", "150,150"),
 				new("Wide", "330,330", "150,300,300")
 			};
 
 			LayoutIndex = _normalLayoutIndex;
 
-			BalanceTile = new WalletBalanceTileViewModel(wallet, balanceChanged, History.UnfilteredTransactions)
-			{
-				TilePresets = new ObservableCollection<TilePresetViewModel>()
-				{
-					new(0, 0, 1, 1, TileSize.Medium),
-					new(0, 0, 1, 1, TileSize.Medium),
-					new(0, 0, 1, 1, TileSize.Medium)
-				},
-				TilePresetIndex = LayoutIndex
-			};
-			BtcPriceTile = new BtcPriceTileViewModel(wallet)
-			{
-				TilePresets = new ObservableCollection<TilePresetViewModel>()
-				{
-					new(2, 0, 1, 1, TileSize.Medium),
-					new(1, 0, 1, 1, TileSize.Medium),
-					new(1, 0, 1, 1, TileSize.Medium)
-				},
-				TilePresetIndex = LayoutIndex
-			};
-			WalletPieChart = new WalletPieChartTileViewModel(this, balanceChanged)
-			{
-				TilePresets = new ObservableCollection<TilePresetViewModel>()
-				{
-					new(1, 0, 1, 1, TileSize.Medium),
-					new(0, 1, 1, 1, TileSize.Large),
-					new(0, 1, 2, 1, TileSize.Wide)
-				},
-				TilePresetIndex = LayoutIndex
-			};
-			BalanceChartTile = new WalletBalanceChartTileViewModel(History.UnfilteredTransactions)
-			{
-				TilePresets = new ObservableCollection<TilePresetViewModel>()
-				{
-					new(3, 0, 1, 1, TileSize.Medium),
-					new(1, 1, 2, 1, TileSize.Wide),
-					new(0, 2, 2, 1, TileSize.Wide)
-				},
-				TilePresetIndex = LayoutIndex
-			};
-
-			_tiles = new List<TileViewModel>
-			{
-				BalanceTile,
-				BtcPriceTile,
-				WalletPieChart,
-				BalanceChartTile
-			};
+			_tiles = wallet.KeyManager.IsWatchOnly
+				? GetWatchOnlyWalletTiles(wallet, balanceChanged, History.UnfilteredTransactions)
+				: GetNormalWalletTiles(wallet, balanceChanged, History.UnfilteredTransactions);
 
 			this.WhenAnyValue(x => x.LayoutIndex)
 				.Subscribe(x =>
@@ -200,15 +155,96 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 
 		public HistoryViewModel History { get; }
 
-		public WalletBalanceTileViewModel BalanceTile { get; }
-
-		public BtcPriceTileViewModel BtcPriceTile { get; }
-
-		public WalletPieChartTileViewModel WalletPieChart { get; }
-
-		public WalletBalanceChartTileViewModel BalanceChartTile { get; }
-
 		public TileLayoutViewModel? CurrentLayout => Layouts?[LayoutIndex];
+
+		private List<TileViewModel> GetNormalWalletTiles(Wallet wallet, IObservable<Unit> balanceChanged, ObservableCollection<HistoryItemViewModel> unfilteredTransactions)
+		{
+			return new List<TileViewModel>
+			{
+				new WalletBalanceTileViewModel(wallet, balanceChanged, unfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+
+				new BtcPriceTileViewModel(wallet)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(2, 0, 1, 1, TileSize.Medium),
+						new(0, 1, 1, 1, TileSize.Medium),
+						new(1, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+
+				new WalletPieChartTileViewModel(this, balanceChanged)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(1, 0, 1, 1, TileSize.Medium),
+						new(1, 0, 1, 2, TileSize.Large),
+						new(0, 1, 2, 1, TileSize.Wide)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+
+				new WalletBalanceChartTileViewModel(unfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(3, 0, 1, 1, TileSize.Medium),
+						new(2, 0, 1, 2, TileSize.Wide),
+						new(0, 2, 2, 1, TileSize.Wide)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+			};
+		}
+
+		private List<TileViewModel> GetWatchOnlyWalletTiles(Wallet wallet, IObservable<Unit> balanceChanged, ObservableCollection<HistoryItemViewModel> unfilteredTransactions)
+		{
+			return new List<TileViewModel>
+			{
+				new WalletBalanceTileViewModel(wallet, balanceChanged, unfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium),
+						new(0, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+
+				new BtcPriceTileViewModel(wallet)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(1, 0, 1, 1, TileSize.Medium),
+						new(0, 1, 1, 1, TileSize.Medium),
+						new(1, 0, 1, 1, TileSize.Medium)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+
+				new WalletBalanceChartTileViewModel(unfilteredTransactions)
+				{
+					TilePresets = new ObservableCollection<TilePresetViewModel>()
+					{
+						new(2, 0, 1, 1, TileSize.Medium),
+						new(1, 0, 2, 2, TileSize.Wide),
+						new(0, 1, 2, 1, TileSize.Wide)
+					},
+					TilePresetIndex = LayoutIndex
+				},
+			};
+		}
 
 		private void LayoutSelector(double width, double height)
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -111,7 +111,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 				{
 					new(1, 0, 1, 1, TileSize.Medium),
 					new(0, 1, 1, 1, TileSize.Large),
-					new(1, 1, 1, 1, TileSize.Large)
+					new(0, 1, 2, 1, TileSize.Wide)
 				},
 				TilePresetIndex = LayoutIndex
 			};

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletPieChart/WalletPieChartWideTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletPieChart/WalletPieChartWideTileView.axaml
@@ -7,42 +7,77 @@
              xmlns:wallets="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles"
              xmlns:converters="clr-namespace:WalletWasabi.Fluent.Converters"
              mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="310"
+             ClipToBounds="False"
              x:CompileBindings="True" x:DataType="vm:WalletPieChartTileViewModel"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.WalletPieChart.WalletPieChartWideTileView">
-    <DockPanel LastChildFill="True">
-        <TextBlock Text="Wallet Privacy Status" DockPanel.Dock="Top" />
-        <Grid ColumnDefinitions="*,*">
-          <controls:PrivacyContentControl Grid.ColumnSpan="1" PrivacyReplacementMode="Icon">
-            <controls:RingChartControl Margin="12,28,28,28" VerticalAlignment="Center"
-                                       HorizontalAlignment="Center" DataPoints="{Binding TestDataPoints}" />
-          </controls:PrivacyContentControl>
-
-            <ItemsRepeater Grid.Column="1" VerticalAlignment="Center" Margin="0,0, 0, -16"
-                           Items="{Binding TestDataPointsLegend}">
-                <ItemsRepeater.ItemTemplate>
-                    <DataTemplate x:DataType="wallets:DataLegend">
-                        <Grid ColumnDefinitions="*,*" RowDefinitions="*,*" HorizontalAlignment="Left"
-                              Margin="0,0,0, 16">
-                            <Ellipse Margin="0,0,12,0" Width="10"
-                                     Height="10"
-                                     Fill="{Binding HexColor, Converter={x:Static converters:ColorStringConverters.HexColorToBrush}}" />
-                            <controls:PrivacyContentControl Grid.Column="1" FontSize="19" HorizontalAlignment="Left"
-                                                            NumberOfPrivacyChars="9"
-                                                            Content="{Binding Amount, Converter={x:Static converters:MoneyConverters.ToFormattedString}}" />
-                            <StackPanel Opacity="0.5" Grid.Row="1" Grid.Column="1" TextBlock.FontSize="13"
-                                        Orientation="Horizontal">
-                                <TextBlock Text="{Binding Label}" />
-                                <controls:PrivacyContentControl Margin="8,0,0,0"
-                                                                HorizontalAlignment="Right"
-                                                                Content="{Binding PercentShare, StringFormat=\{0:P1\}}" />
-                            </StackPanel>
-                        </Grid>
-                    </DataTemplate>
-                </ItemsRepeater.ItemTemplate>
-                <ItemsRepeater.Layout>
-                    <StackLayout />
-                </ItemsRepeater.Layout>
-            </ItemsRepeater>
-        </Grid>
+  <Panel>
+    <DockPanel LastChildFill="True" Margin="0 0 0 -16" IsVisible="{Binding !IsAutoCoinJoinEnabled}">
+      <TextBlock Text="Wallet Privacy Status" DockPanel.Dock="Top" />
+      <StackPanel DockPanel.Dock="Bottom">
+        <Separator Margin="-16 0" ClipToBounds="False" />
+        <DockPanel>
+          <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding IsAutoCoinJoinEnabled}" />
+          <TextBlock Text="Wallet Privacy" VerticalAlignment="Center" />
+        </DockPanel>
+      </StackPanel>
+      <Grid Margin="20 10 20 20" RowDefinitions="*,Auto">
+        <Viewbox Grid.RowSpan="1" Height="120" Width="120" VerticalAlignment="Center" HorizontalAlignment="Stretch">
+          <Viewbox.Resources>
+            <LinearGradientBrush x:Key="paint0_linear" StartPoint="0%,1%" EndPoint="100%,100%">
+              <LinearGradientBrush.GradientStops>
+                <GradientStop Color="#EE5C5C" />
+                <GradientStop Color="#C44747" Offset="1" />
+              </LinearGradientBrush.GradientStops>
+            </LinearGradientBrush>
+          </Viewbox.Resources>
+          <Panel>
+            <Path Name="path833" Fill="{StaticResource paint0_linear}"
+                  Data="m 64.9375 11.75 c -9.9878 0 -19.7174 -3.53804 -29.25 -10.6875 -1 -0.75 -2.375 -0.75 -3.375 0 C 22.7799 8.21196 13.0503 11.75 3.0625 11.75 1.5092 11.75 0.25 13.0092 0.25 14.5625 V 34.25 c 0 18.7545 11.0909 32.534 32.7192 41.0543 0.6624 0.2609 1.3992 0.2609 2.0616 0 C 56.6591 66.784 67.75 53.0045 67.75 34.25 V 14.5625 c 0 -1.5533 -1.2592 -2.8125 -2.8125 -2.8125 z" />
+            <Path Name="path835" Fill="White"
+                  Data="M 34.015 34.0437 23.8034 23.8309 c -1.097 -1.0969 -2.8755 -1.0969 -3.9725 0 -1.0969 1.097 -1.0969 2.8755 0 3.9725 L 30.0437 38.015 19.8309 48.2327 19.559 48.5477 c -0.816 1.0997 -0.7253 2.6602 0.2719 3.6575 l 0.3151 0.2719 c 1.0996 0.816 2.6602 0.7253 3.6574 -0.2719 L 34.015 41.99 44.2327 52.2052 c 1.0969 1.0969 2.8755 1.0969 3.9725 0 1.0969 -1.097 1.0969 -2.8756 0 -3.9725 L 37.99 38.015 48.2052 27.8034 l 0.2719 -0.315 c 0.816 -1.0997 0.7253 -2.6602 -0.2719 -3.6575 L 47.8901 23.559 c -1.0997 -0.816 -2.6602 -0.7253 -3.6574 0.2719 z" />
+          </Panel>
+        </Viewbox>
+        <StackPanel Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="5">
+          <TextBlock Classes="h6" FontWeight="Bold" TextAlignment="Center" Text="Warning!" />
+          <TextBlock Classes="h8" Text="Your financial privacy is not currently protected." TextAlignment="Center" TextWrapping="WrapWithOverflow" />
+        </StackPanel>
+      </Grid>
     </DockPanel>
+    <DockPanel LastChildFill="True" IsVisible="{Binding IsAutoCoinJoinEnabled}">
+      <TextBlock Text="Wallet Privacy Status" DockPanel.Dock="Top" />
+      <Grid ColumnDefinitions="*,*">
+        <controls:PrivacyContentControl Grid.ColumnSpan="1" PrivacyReplacementMode="Icon">
+          <controls:RingChartControl Margin="12,28,28,28" VerticalAlignment="Center"
+                                     HorizontalAlignment="Center" DataPoints="{Binding TestDataPoints}" />
+        </controls:PrivacyContentControl>
+
+        <ItemsRepeater Grid.Column="1" VerticalAlignment="Center" Margin="0,0, 0, -16"
+                       Items="{Binding TestDataPointsLegend}">
+          <ItemsRepeater.ItemTemplate>
+            <DataTemplate x:DataType="wallets:DataLegend">
+              <Grid ColumnDefinitions="*,*" RowDefinitions="*,*" HorizontalAlignment="Left"
+                    Margin="0,0,0, 16">
+                <Ellipse Margin="0,0,12,0" Width="10"
+                         Height="10"
+                         Fill="{Binding HexColor, Converter={x:Static converters:ColorStringConverters.HexColorToBrush}}" />
+                <controls:PrivacyContentControl Grid.Column="1" FontSize="19" HorizontalAlignment="Left"
+                                                NumberOfPrivacyChars="9"
+                                                Content="{Binding Amount, Converter={x:Static converters:MoneyConverters.ToFormattedString}}" />
+                <StackPanel Opacity="0.5" Grid.Row="1" Grid.Column="1" TextBlock.FontSize="13"
+                            Orientation="Horizontal">
+                  <TextBlock Text="{Binding Label}" />
+                  <controls:PrivacyContentControl Margin="8,0,0,0"
+                                                  HorizontalAlignment="Right"
+                                                  Content="{Binding PercentShare, StringFormat=\{0:P1\}}" />
+                </StackPanel>
+              </Grid>
+            </DataTemplate>
+          </ItemsRepeater.ItemTemplate>
+          <ItemsRepeater.Layout>
+            <StackLayout />
+          </ItemsRepeater.Layout>
+        </ItemsRepeater>
+      </Grid>
+    </DockPanel>
+  </Panel>
 </UserControl>


### PR DESCRIPTION
- Reorganize the tiles to not have empty gaps
- Make a difference between normal wallet and hardware (watch only) wallet tiles (and their layout)
- Wallet privacy warning was missing on the wide piechart tile, I fixed that.

Once all priority stuff is finished let's do a brainstorming about new tile ideas.

fixes: https://github.com/zkSNACKs/WalletWasabi/issues/6244