### PR TITLE
[Fluent[ fix when empty wallet screen shows up for a moment

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive;
-using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -28,6 +27,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 
 		[AutoNotify] private HistoryItemViewModel? _selectedItem;
 		[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _isTransactionHistoryEmpty;
+		[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _isInitialized;
 
 		public HistoryViewModel(WalletViewModel walletViewModel, IObservable<Unit> updateTrigger)
 		{
@@ -113,6 +113,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 						{
 							_transactionSourceList.Add(newItem);
 						}
+					}
+
+					if (!IsInitialized)
+					{
+						IsInitialized = true;
 					}
 				}
 			}

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -14,7 +14,7 @@
              x:CompileBindings="True"
              ClipToBounds="False"
              x:Class="WalletWasabi.Fluent.Views.Wallets.WalletView">
-  <c:ContentArea ScrollViewer.VerticalScrollBarVisibility="Disabled" ClipToBounds="False" HeaderBackground="{DynamicResource HeaderRegionColor}">
+  <c:ContentArea ScrollViewer.VerticalScrollBarVisibility="Disabled" ClipToBounds="False" HeaderBackground="{DynamicResource HeaderRegionColor}" IsBusy="{Binding !History.IsInitialized}">
     <c:ContentArea.Title>
       <StackPanel>
         <DockPanel>


### PR DESCRIPTION
After the loading screen the `Empty wallet screen` was visible just for a moment even if the wallet is not empty. It felt really weird.
This PR fixes it.

Note: A UI freeze is still noticeable, the loading has to be improved.