### PR TITLE
Fix shutdown prevention logic for Preview

### DIFF
--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Fluent
 			if (CanShutdownProvider is { } provider)
 			{
 				// Shutdown prevention will only work if you directly run the executable.
-				e.Cancel = !provider.CanShutdown();
+				e.Cancel = provider.CanShutdown();
 				Logger.LogDebug($"Cancellation of the shutdown set to: {e.Cancel}.");
 			}
 		}

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Fluent
 			if (CanShutdownProvider is { } provider)
 			{
 				// Shutdown prevention will only work if you directly run the executable.
-				e.Cancel = provider.CanShutdown();
+				e.Cancel = !provider.CanShutdown();
 				Logger.LogDebug($"Cancellation of the shutdown set to: {e.Cancel}.");
 			}
 		}

--- a/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
@@ -1,9 +1,19 @@
+using System;
 using WalletWasabi.Fluent.Providers;
+using WalletWasabi.WabiSabi.Client;
 
 namespace WalletWasabi.Fluent.ViewModels
 {
 	public partial class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 	{
-		bool ICanShutdownProvider.CanShutdown() => Services.WalletManager.AnyCoinJoinInProgress();
+		bool ICanShutdownProvider.CanShutdown()
+		{
+			return Services.HostedServices.Get<CoinJoinManager>().HighestCoinJoinClientState switch
+			{
+				CoinJoinClientState.InCriticalPhase => false,
+				CoinJoinClientState.Idle or CoinJoinClientState.InProgress => true,
+				_ => throw new ArgumentOutOfRangeException(),
+			};
+		}
 	}
 }


### PR DESCRIPTION
**This PR is important only IF the different CJ Phases and the new** `SystemAwakeChecker` **don't get merged before the PREVIEW release.**

The shutdown prevention logic on master right now is the opposite of what we want.

If https://github.com/zkSNACKs/WalletWasabi/blob/08fa77093c94ec56e1f94a66a24c0d122742c484/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs#L7

returns `false`, then
https://github.com/zkSNACKs/WalletWasabi/blob/08fa77093c94ec56e1f94a66a24c0d122742c484/WalletWasabi.Fluent/App.axaml.cs#L85
will change it to `true` and try to cancel the shutdown/logout.
But we don't want to do that.

