### PR TITLE
Mark coin as `InCoinJoin` only after registered

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -79,15 +79,14 @@ namespace WalletWasabi.WabiSabi.Client
 			AliceClient? aliceClient;
 			try
 			{
-				coin.CoinJoinInProgress = true;
 				var response = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, bitcoinSecret.PrivateKey, cancellationToken).ConfigureAwait(false);
 				aliceClient = new(response.Value, roundState, arenaClient, coin, bitcoinSecret, response.IssuedAmountCredentials, response.IssuedVsizeCredentials);
+				coin.CoinJoinInProgress = true;
 
 				Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.OutPoint}.");
 			}
 			catch (System.Net.Http.HttpRequestException ex)
 			{
-				coin.CoinJoinInProgress = false;
 				if (ex.InnerException is WabiSabiProtocolException wpe)
 				{
 					switch (wpe.ErrorCode)


### PR DESCRIPTION
Mark a coin as `CoinjoinInProgress` only if it was successfully registered.

Related https://github.com/zkSNACKs/WalletWasabi/issues/6329