### PR TITLE
Remove Wasabi Inc label suggestion

### DIFF
--- a/WalletWasabi.Fluent/Styles/Themes/Base.axaml
+++ b/WalletWasabi.Fluent/Styles/Themes/Base.axaml
@@ -79,7 +79,7 @@
     <x:Double x:Key="DataGridRowSelectedBackgroundOpacity">1.0</x:Double>
     <x:Double x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity">1.0</x:Double>
 
-    <x:String x:Key="LabelsWatermarkText">i.e. Alice, Bob, Wasabi Inc, Exchange</x:String>
+    <x:String x:Key="LabelsWatermarkText">i.e. Alice, Bob, Pizza Inc, Exchange</x:String>
 
     <StaticResource x:Key="NotificationCardInformationBackgroundBrush" ResourceKey="SystemAccentColor" />
     <StaticResource x:Key="TextControlForeground" ResourceKey="SystemBaseHighColor" />


### PR DESCRIPTION
There is no `Wasabi Inc`.

Not sure if `Pizza Inc` is understandable either - I think the goal is to show the user that this can be a company too?