### PR TITLE
[Fluent] Improve homescreen loading time

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceChartTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceChartTileViewModel.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using DynamicData.Binding;
 using NBitcoin;
+using ReactiveUI;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.Morph;
@@ -42,6 +44,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles
 			base.OnActivated(disposables);
 
 			_history.ToObservableChangeSet()
+				.Throttle(TimeSpan.FromMilliseconds(50))
+				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => UpdateSample(TimePeriodOptions.First(x => x.IsSelected)))
 				.DisposeWith(disposables);
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -3,8 +3,10 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using DynamicData.Binding;
 using NBitcoin;
+using ReactiveUI;
 using WalletWasabi.Wallets;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.History;
@@ -42,10 +44,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles
 				.DisposeWith(disposables);
 
 			_history.ToObservableChangeSet()
+				.Throttle(TimeSpan.FromMilliseconds(50))
+				.ObserveOn(RxApp.MainThreadScheduler)
 				.Subscribe(_ => UpdateRecentTransaction())
 				.DisposeWith(disposables);
-
-			UpdateBalance();
 		}
 
 		private void UpdateBalance()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletPieChartTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletPieChartTileViewModel.cs
@@ -54,8 +54,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles
 			_balanceChanged
 				.Subscribe(_ => Update())
 				.DisposeWith(disposables);
-
-			Update();
 		}
 
 		private void Update()


### PR DESCRIPTION
I noticed some tiles update function is executed several times... for example the balance chart as many as transaction I have (334).

On login:
```
Tile		times
--------------------------
Balance		2	
BTC rate	1	
PieChart	2	
Recent tx	334 (Is this working btw?)	
Update Chart	334	
```
Re open the wallet:
```
Tile		times
--------------------------
Balance		2	
BTC rate	1	
PieChart	2	
Recent tx	1
Update Chart	1
```

This PR fixes it so all tiles get updated only once a time.