### PR TITLE
[WabiSabi] Unmark coins as unavailable

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -204,9 +204,15 @@ namespace WalletWasabi.WabiSabi.Client
 			}
 		}
 
+		public void Finish()
+		{
+			SmartCoin.CoinJoinInProgress = false;
+		}
+
 		public async Task RemoveInputAsync(CancellationToken cancellationToken)
 		{
 			await ArenaClient.RemoveInputAsync(RoundId, AliceId, cancellationToken).ConfigureAwait(false);
+			SmartCoin.CoinJoinInProgress = false;
 			Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Inputs removed.");
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -149,6 +149,10 @@ namespace WalletWasabi.WabiSabi.Client
 			}
 			finally
 			{
+				foreach (var aliceClient in registeredAliceClients)
+				{
+					aliceClient.Finish();
+				}
 				InCriticalCoinJoinState = false;
 			}
 		}


### PR DESCRIPTION
The `CoinJoinManager` selects the coins based on whether they are available (`CoinjoinInProgress`) or not. This means we have to make sure to unmark the coins once the coinjoin fails (no matter the if successfully or not), otherwise they will not be selected in case they need to participate in a blame round.