### PR TITLE
[Fluent] Refactor `TagsBox`

### DIFF
--- a/WalletWasabi.Fluent/Controls/TagControl.axaml
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:c="using:WalletWasabi.Fluent.Controls">
+        xmlns:c="using:WalletWasabi.Fluent.Controls"
+        xmlns:converters="clr-namespace:WalletWasabi.Fluent.Converters">
   <Design.PreviewWith>
     <Border Padding="10">
       <c:TagControl Content="Test" />
@@ -52,7 +53,7 @@
                 </LayoutTransformControl.Transitions>
               </LayoutTransformControl>
               <StackPanel Margin="12,6,12,6" DockPanel.Dock="Left" Spacing="5" Orientation="Horizontal">
-                <TextBlock Name="PART_Index" IsVisible="{TemplateBinding EnableCounter}"/>
+                <TextBlock Text="{TemplateBinding OrdinalIndex, Converter={x:Static converters:IntConverter.ToOrdinalString}}" IsVisible="{TemplateBinding EnableCounter}"/>
                 <ContentPresenter Name="PART_ContentPresenter"
                                   Content="{TemplateBinding Content}"
                                   Padding="{TemplateBinding Padding}"

--- a/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void OnDeleteTagClicked(object? sender, RoutedEventArgs e)
 		{
-			_parentTagBox?.RemoveTargetTag(DataContext);
+			_parentTagBox?.RemoveAt(OrdinalIndex - 1);
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
@@ -59,13 +59,6 @@ namespace WalletWasabi.Fluent.Controls
 			_subscription = Disposable.Create(() => deleteButton.Click -= OnDeleteTagClicked);
 		}
 
-		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-		{
-			base.OnDetachedFromVisualTree(e);
-
-			_subscription?.Dispose();
-		}
-
 		private void OnDeleteTagClicked(object? sender, RoutedEventArgs e)
 		{
 			_parentTagBox?.RemoveAt(OrdinalIndex - 1);

--- a/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
@@ -46,8 +46,6 @@ namespace WalletWasabi.Fluent.Controls
 
 			_parentTagBox = this.FindLogicalAncestorOfType<TagsBox>();
 
-			_subscription?.Dispose();
-
 			var deleteButton = e.NameScope.Find<Button>("PART_DeleteButton");
 
 			if (deleteButton is null)
@@ -58,6 +56,13 @@ namespace WalletWasabi.Fluent.Controls
 			deleteButton.Click += OnDeleteTagClicked;
 
 			_subscription = Disposable.Create(() => deleteButton.Click -= OnDeleteTagClicked);
+		}
+
+		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+		{
+			base.OnDetachedFromVisualTree(e);
+
+			_subscription?.Dispose();
 		}
 
 		private void OnDeleteTagClicked(object? sender, RoutedEventArgs e)

--- a/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
@@ -55,6 +55,7 @@ namespace WalletWasabi.Fluent.Controls
 
 			deleteButton.Click += OnDeleteTagClicked;
 
+			_subscription?.Dispose();
 			_subscription = Disposable.Create(() => deleteButton.Click -= OnDeleteTagClicked);
 		}
 

--- a/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml.cs
@@ -18,7 +18,10 @@ namespace WalletWasabi.Fluent.Controls
 
 		public static readonly StyledProperty<bool> EnableDeleteProperty =
 			AvaloniaProperty.Register<TagControl, bool>(nameof(EnableDelete));
-		
+
+		public static readonly StyledProperty<int> OrdinalIndexProperty =
+			AvaloniaProperty.Register<TagControl, int>(nameof(OrdinalIndex));
+
 		public bool EnableCounter
 		{
 			get => GetValue(EnableCounterProperty);
@@ -29,6 +32,12 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			get => GetValue(EnableDeleteProperty);
 			set => SetValue(EnableDeleteProperty, value);
+		}
+
+		public int OrdinalIndex
+		{
+			get => GetValue(OrdinalIndexProperty);
+			set => SetValue(OrdinalIndexProperty, value);
 		}
 
 		protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml
@@ -75,7 +75,8 @@
                                         <c:ConcatenatingWrapPanel Focusable="False" VerticalAlignment="Center">
                                             <c:ConcatenatingWrapPanel.ConcatenatedChildren>
                                                 <AutoCompleteBox x:Name="PART_AutoCompleteBox"
-                                                                 Items="{Binding #PART_DockPanel.TemplatedParent.Suggestions}" />
+                                                                 Items="{Binding #PART_DockPanel.TemplatedParent.Suggestions}"
+                                                                 FilterMode="StartsWith"/>
                                             </c:ConcatenatingWrapPanel.ConcatenatedChildren>
                                         </c:ConcatenatingWrapPanel>
                                     </ItemsPanelTemplate>

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -258,13 +258,6 @@ namespace WalletWasabi.Fluent.Controls
 			}
 		}
 
-		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-		{
-			base.OnDetachedFromVisualTree(e);
-
-			_compositeDisposable?.Dispose();
-		}
-
 		private void ClearInputField()
 		{
 			_autoCompleteBox?.ClearValue(AutoCompleteBox.SelectedItemProperty);

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -487,57 +487,22 @@ namespace WalletWasabi.Fluent.Controls
 
 		private void OnKeyDown(object? sender, KeyEventArgs e)
 		{
-			if (sender is not AutoCompleteBox autoCompleteBox)
+			if (!_isInputEnabled && e.Key != Key.Back)
 			{
 				return;
 			}
 
-			var currentText = autoCompleteBox.Text ?? "";
-
-			_backspaceEmptyField2 = _backspaceEmptyField1;
-			_backspaceEmptyField1 = currentText.Length == 0;
-
-			currentText = currentText.Trim();
-
-			var canAddTag = _isInputEnabled && !string.IsNullOrEmpty(currentText);
-
-			if ((e.Key == Key.Tab || e.Key == Key.Enter) && canAddTag)
-			{
-				e.Handled = true;
-			}
+			var emptyInputField = string.IsNullOrEmpty(CurrentText);
 
 			switch (e.Key)
 			{
-				case Key.Back when _backspaceEmptyField1 && _backspaceEmptyField2:
+				case Key.Back when emptyInputField:
 					RemoveLastTag();
 					break;
 
-				case Key.Tab when canAddTag:
-				case Key.Enter when canAddTag:
-					// Reject entry of the tag when user pressed enter and
-					// the input tag is not on the suggestions list.
-					if (RestrictInputToSuggestions && Suggestions is { } &&
-						!Suggestions.Cast<string>().Any(
-							x => x.Equals(currentText, _stringComparison)))
-					{
-						break;
-					}
-
-					BackspaceLogicClear();
-					AddTag(currentText);
-					ExecuteCompletedCommand();
-
-					_internalTextBox?.ClearSelection();
-					_internalTextBox?.ClearValue(AutoCompleteBox.TextProperty);
-
-					autoCompleteBox.ClearValue(AutoCompleteBox.SelectedItemProperty);
-					Dispatcher.UIThread.Post(() => autoCompleteBox.ClearValue(AutoCompleteBox.TextProperty), DispatcherPriority.Background);
+				case Key.Enter or Key.Tab when !emptyInputField:
+					RequestAdd = true;
 					e.Handled = true;
-
-					break;
-
-				case Key.Enter:
-					ExecuteCompletedCommand();
 					break;
 			}
 		}

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -490,17 +490,6 @@ namespace WalletWasabi.Fluent.Controls
 			}
 		}
 
-		private void RemoveLastTag()
-		{
-			if (Items is IList { Count: > 0 } list)
-			{
-				list.RemoveAt(list.Count - 1);
-			}
-
-			InvalidateWatermark();
-			CheckIsInputEnabled();
-		}
-
 		protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> e)
 		{
 			base.OnPropertyChanged(e);
@@ -517,38 +506,53 @@ namespace WalletWasabi.Fluent.Controls
 			}
 		}
 
-		internal void RemoveTargetTag(object? tag)
+		private void RemoveLastTag()
 		{
-			if (Items is IList list)
+			if (Items is IList { Count: > 0 } items)
 			{
-				list.Remove(tag);
+				RemoveAt(items.Count - 1);
+			}
+		}
+
+		public void RemoveAt(int index)
+		{
+			if (Items is not IList items)
+			{
+				return;
 			}
 
-			InvalidateWatermark();
+			items.RemoveAt(index);
 			CheckIsInputEnabled();
+			InvalidateWatermark();
 		}
 
 		public void AddTag(string tag)
 		{
-			if (Items is IList x)
+			if (Items is not IList items)
 			{
-				if (ItemCountLimit > 0 && x.Count + 1 > ItemCountLimit)
-				{
-					return;
-				}
-
-				var finalTag = tag.ParseLabel();
-
-				if (!AllowDuplication && x.Contains(finalTag))
-				{
-					return;
-				}
-
-				x.Add(finalTag);
+				return;
 			}
 
-			InvalidateWatermark();
+			if (ItemCountLimit > 0 && items.Count + 1 > ItemCountLimit)
+			{
+				return;
+			}
+
+			if (!AllowDuplication && items.Contains(tag))
+			{
+				return;
+			}
+
+			if (RestrictInputToSuggestions &&
+			    Suggestions is { } suggestions &&
+			    !suggestions.Any(x => x.Equals(tag, _stringComparison)))
+			{
+				return;
+			}
+
+			items.Add(tag);
 			CheckIsInputEnabled();
+			InvalidateWatermark();
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -165,7 +165,9 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			base.OnApplyTemplate(e);
 
+			_compositeDisposable?.Dispose();
 			_compositeDisposable = new CompositeDisposable();
+
 			_watermark = e.NameScope.Find<TextBlock>("PART_Watermark");
 			var presenter = e.NameScope.Find<ItemsPresenter>("PART_ItemsPresenter");
 			presenter.ApplyTemplate();

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -169,8 +169,6 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			base.OnApplyTemplate(e);
 
-			_compositeDisposable?.Dispose();
-
 			_compositeDisposable = new CompositeDisposable();
 
 			var presenter = e.NameScope.Find<ItemsPresenter>("PART_ItemsPresenter");
@@ -211,6 +209,13 @@ namespace WalletWasabi.Fluent.Controls
 				.DisposeWith(_compositeDisposable);
 
 			LayoutUpdated += OnLayoutUpdated;
+		}
+
+		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+		{
+			base.OnDetachedFromVisualTree(e);
+
+			_compositeDisposable?.Dispose();
 		}
 
 		private void OnLayoutUpdated(object? sender, EventArgs e)

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -260,6 +260,27 @@ namespace WalletWasabi.Fluent.Controls
 			_compositeDisposable?.Dispose();
 		}
 
+		private void ClearInputField()
+		{
+			_autoCompleteBox?.ClearValue(AutoCompleteBox.SelectedItemProperty);
+			Dispatcher.UIThread.Post(() => _autoCompleteBox?.ClearValue(AutoCompleteBox.TextProperty));
+		}
+
+		private IEnumerable<string> GetFinalTags(string input, char tagSeparator)
+		{
+			var tags = input.Split(tagSeparator);
+
+			foreach (string tag in tags)
+			{
+				var correctedTag = tag.ParseLabel();
+
+				if (!string.IsNullOrEmpty(correctedTag))
+				{
+					yield return correctedTag;
+				}
+			}
+		}
+
 		private void OnLayoutUpdated(object? sender, EventArgs e)
 		{
 			UpdateCounters();

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -82,7 +82,7 @@ namespace WalletWasabi.Fluent.Controls
 
 		public static readonly StyledProperty<bool> EnableCounterProperty =
 			AvaloniaProperty.Register<TagsBox, bool>(nameof(EnableCounter));
-			
+
 		public static readonly StyledProperty<bool> EnableDeleteProperty =
 			AvaloniaProperty.Register<TagsBox, bool>(nameof(EnableDelete), true);
 
@@ -158,7 +158,7 @@ namespace WalletWasabi.Fluent.Controls
 			get => GetValue(EnableCounterProperty);
 			set => SetValue(EnableCounterProperty, value);
 		}
-		
+
 		public bool EnableDelete
 		{
 			get => GetValue(EnableDeleteProperty);
@@ -228,10 +228,7 @@ namespace WalletWasabi.Fluent.Controls
 
 				for (var i = 0; i < tagItems.Length; i++)
 				{
-					if (tagItems[i].FindDescendantOfType<TextBlock>() is { } textBlock)
-					{
-						textBlock.Text = $"{i + 1}.";
-					}
+					tagItems[i].OrdinalIndex = i + 1;
 				}
 			}
 		}

--- a/WalletWasabi.Fluent/Converters/IntConverter.cs
+++ b/WalletWasabi.Fluent/Converters/IntConverter.cs
@@ -1,0 +1,10 @@
+using Avalonia.Data.Converters;
+
+namespace WalletWasabi.Fluent.Converters
+{
+	public static class IntConverter
+	{
+		public static readonly IValueConverter ToOrdinalString =
+			new FuncValueConverter<int, string>(x => $"{x}.");
+	}
+}

--- a/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
@@ -33,7 +33,6 @@
                    RestrictInputToSuggestions="True"
                    Items="{Binding Mnemonics}"
                    Suggestions="{Binding Suggestions}"
-                   CompletedCommand="{Binding NextCommand}"
                    AllowDuplication="True"
                    EnableCounter="True"
                    EnableDelete="False">


### PR DESCRIPTION
So yeah... TagsBox control is with us from the very beginning of the Fluent project. This control evolved very very much... There were tons of issues with it and it was really hard to touch it without breaking something else. 

Thanks to the refactor some improvements happened:
- The user cannot type whitespace or TagSeparator as the first char.
- In Recover page, if the next typed char would lead to a word that is not possible, then the char won't be typed.
- Fix the issue when there were two same words, and the user wanted to delete the second one, but the first one got deleted.
- Fixes https://github.com/zkSNACKs/WalletWasabi/issues/6353
- Fixes https://github.com/zkSNACKs/WalletWasabi/issues/6351

I remember there were OS specific bugs with this control, I hope I did not break anything with the refactoring. Do not merge until it is not tested everywhere.

- [x] Windows
- [x] OSX
- [x] Linux
