### PR TITLE
[WabiSabi] Sort inputs and outputs

### DIFF
--- a/WalletWasabi/Helpers/ByteArrayComparer.cs
+++ b/WalletWasabi/Helpers/ByteArrayComparer.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace WalletWasabi.Helpers
+{
+	public class ByteArrayComparer : IComparer<byte[]>
+	{
+		public static readonly ByteArrayComparer Comparer = new();
+
+		public int Compare(byte[]? x, byte[]? y)
+		{
+			static int InternalCompare(byte[] left, byte[] right)
+			{
+				var min = left.Length < right.Length ? left.Length : right.Length;
+				for (var i = 0; i < min; i++)
+				{
+					if (left[i] < right[i])
+					{
+						return -1;
+					}
+					if (left[i] > right[i])
+					{
+						return 1;
+					}
+				}
+				return left.Length.CompareTo(right.Length);
+			}
+
+			return (x, y) switch
+			{
+				(null, null) => 0,
+				(null,    _) => 1,
+				(_   , null) => -1,
+				({} left, {} right) => InternalCompare(left, right)
+			};
+		}
+	}
+}


### PR DESCRIPTION
This PR sorts the coinjoin transaction's inputs and outpus. Given each client builds the coinjoin transaction independently, it is important to make sure that all of them build exactly the same transaction, for that reason `inputs` are sorted amount in a descending order and then by `prevout` lexicographically (like words in a dictionary) in an ascending order while `outputs` are sorted value in descending order and then  by `scriptPubKey` lexicographically in ascending order.

Tests were aware of the order and assumed the first input added was always in the first position and the same for the outputs, that's why a few test were updated. There was also a redundant test that was removed.

**Note:** the inputs/ouputs sorting cannot be changed easily after deploy without requiring **all** clients to update.  