### PR TITLE
Make all RPC calls cancellable

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.CoinJoin.Common.Models;
@@ -248,7 +249,7 @@ namespace WalletWasabi.Backend.Controllers
 					{
 						// Check if mempool would accept a fake transaction created with the registered inputs.
 						// Fake outputs: mixlevels + 1 maximum, +1 because there can be a change.
-						var result = await RpcClient.TestMempoolAcceptAsync(inputs, fakeOutputCount: round.MixingLevels.Count() + 1, round.FeePerInputs, round.FeePerOutputs);
+						var result = await RpcClient.TestMempoolAcceptAsync(inputs, fakeOutputCount: round.MixingLevels.Count() + 1, round.FeePerInputs, round.FeePerOutputs, CancellationToken.None);
 						if (!result.accept)
 						{
 							return BadRequest($"Provided input is from an unconfirmed coinjoin, but a limit is reached: {result.rejectReason}");

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Backend
 			RpcClient = Guard.NotNull(nameof(rpc), rpc);
 
 			// Make sure RPC works.
-			await AssertRpcNodeFullyInitializedAsync();
+			await AssertRpcNodeFullyInitializedAsync(cancel);
 
 			// Make sure P2P works.
 			await InitializeP2pAsync(config.Network, config.GetBitcoinP2pEndPoint(), cancel);
@@ -109,11 +109,11 @@ namespace WalletWasabi.Backend
 			HostedServices.Register<BlockNotifier>(new BlockNotifier(TimeSpan.FromSeconds(7), RpcClient, P2pNode), "Block Notifier");
 		}
 
-		private async Task AssertRpcNodeFullyInitializedAsync()
+		private async Task AssertRpcNodeFullyInitializedAsync(CancellationToken cancellationToken)
 		{
 			try
 			{
-				var blockchainInfo = await RpcClient.GetBlockchainInfoAsync();
+				var blockchainInfo = await RpcClient.GetBlockchainInfoAsync(cancellationToken);
 
 				var blocks = blockchainInfo.Blocks;
 				if (blocks == 0 && Config.Network != Network.RegTest)
@@ -138,13 +138,13 @@ namespace WalletWasabi.Backend
 				{
 					if (blocks < 101)
 					{
-						var generateBlocksResponse = await RpcClient.GenerateAsync(101);
+						var generateBlocksResponse = await RpcClient.GenerateAsync(101, cancellationToken);
 						if (generateBlocksResponse is null)
 						{
 							throw new NotSupportedException($"{Constants.BuiltinBitcoinNodeName} cannot generate blocks on the {Network.RegTest}.");
 						}
 
-						blockchainInfo = await RpcClient.GetBlockchainInfoAsync();
+						blockchainInfo = await RpcClient.GetBlockchainInfoAsync(cancellationToken);
 						blocks = blockchainInfo.Blocks;
 						if (blocks == 0)
 						{

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -54,7 +54,7 @@ namespace WalletWasabi.Tests.Helpers
 		{
 			using Key key = new();
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
 				{
 					IsCoinBase = false,
@@ -64,7 +64,7 @@ namespace WalletWasabi.Tests.Helpers
 				});
 			foreach (var coin in coins)
 			{
-				mockRpc.Setup(rpc => rpc.GetTxOutAsync(coin.Outpoint.Hash, (int)coin.Outpoint.N, true))
+				mockRpc.Setup(rpc => rpc.GetTxOutAsync(coin.Outpoint.Hash, (int)coin.Outpoint.N, true, It.IsAny<CancellationToken>()))
 					.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
 					{
 						IsCoinBase = false,
@@ -73,7 +73,7 @@ namespace WalletWasabi.Tests.Helpers
 						TxOut = coin.TxOut,
 					});
 			}
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse
 				{
 					Blocks = 1000,
@@ -85,7 +85,7 @@ namespace WalletWasabi.Tests.Helpers
 					MinRelayTxFee = 1
 				});
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
-			mockRpc.Setup(rpc => rpc.SendBatchAsync()).Returns(Task.CompletedTask);
+			mockRpc.Setup(rpc => rpc.SendBatchAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 			return mockRpc;
 		}
 

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -156,7 +156,6 @@ namespace WalletWasabi.Tests.UnitTests
 				.ThrowsAsync(new NoEstimationException(1));
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 
-			// here we are testing the mock object WTF!
 			await Assert.ThrowsAsync<NoEstimationException>(async () => await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
 		}
 
@@ -178,7 +177,6 @@ namespace WalletWasabi.Tests.UnitTests
 
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 
-			// WTF!?
 			var ex = await Assert.ThrowsAsync<RPCException>(async () => await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
 			Assert.Equal(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, ex.RPCCode);
 			Assert.Equal("Error-EstimateSmartFee", ex.Message);
@@ -196,7 +194,6 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(8, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(8, 70m));
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
-			// WTF!?
 			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(2, allFee.Estimations.Count);
 			Assert.False(allFee.Estimations.ContainsKey(3));
@@ -221,7 +218,6 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(1008, 31m));
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
-			// WTF!?
 			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.True(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
@@ -258,7 +254,6 @@ namespace WalletWasabi.Tests.UnitTests
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(1008, 1m));
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
-			// WTF!?
 			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(3_500, allFee.Estimations[2]);
 			Assert.True(allFee.Estimations[3] > 500);

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -139,23 +139,24 @@ namespace WalletWasabi.Tests.UnitTests
 		public async Task RpcNotEnoughEstimationsAsync()
 		{
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetBlockchainInfoAsync())
+			mockRpc.Setup(rpc => rpc.GetBlockchainInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new BlockchainInfo
 				{
 					Blocks = 100,
 					Headers = 100
 				});
-			mockRpc.Setup(rpc => rpc.GetPeersInfoAsync())
+			mockRpc.Setup(rpc => rpc.GetPeersInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(Array.Empty<PeerInfo>());
 			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo
 				{
 					MemPoolMinFee = 0.00001000 // 1 s/b (default value)
 				});
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new NoEstimationException(1));
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 
+			// here we are testing the mock object WTF!
 			await Assert.ThrowsAsync<NoEstimationException>(async () => await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
 		}
 
@@ -163,10 +164,10 @@ namespace WalletWasabi.Tests.UnitTests
 		public async Task RpcFailuresAsync()
 		{
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetBlockchainInfoAsync())
+			mockRpc.Setup(rpc => rpc.GetBlockchainInfoAsync(It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error-GetBlockchainInfo", null));
 
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, "Error-EstimateSmartFee", null));
 
 			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
@@ -177,6 +178,7 @@ namespace WalletWasabi.Tests.UnitTests
 
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 
+			// WTF!?
 			var ex = await Assert.ThrowsAsync<RPCException>(async () => await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative));
 			Assert.Equal(RPCErrorCode.RPC_CLIENT_NOT_CONNECTED, ex.RPCCode);
 			Assert.Equal("Error-EstimateSmartFee", ex.Message);
@@ -187,13 +189,14 @@ namespace WalletWasabi.Tests.UnitTests
 		{
 			var mockRpc = CreateAndConfigureRpcClient();
 			var any = EstimateSmartFeeMode.Conservative;
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any)).ReturnsAsync(FeeRateResponse(2, 100m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(3, any)).ThrowsAsync(new RPCException(RPCErrorCode.RPC_INTERNAL_ERROR, "Error", null));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(5, any)).ReturnsAsync(FeeRateResponse(5, 89m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(6, any)).ReturnsAsync(FeeRateResponse(6, 75m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(8, any)).ReturnsAsync(FeeRateResponse(8, 70m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8), any)).ThrowsAsync(new NoEstimationException(0));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 100m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(3, any, It.IsAny<CancellationToken>())).ThrowsAsync(new RPCException(RPCErrorCode.RPC_INTERNAL_ERROR, "Error", null));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(5, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(5, 89m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(6, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(6, 75m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(8, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(8, 70m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
+			// WTF!?
 			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(2, allFee.Estimations.Count);
 			Assert.False(allFee.Estimations.ContainsKey(3));
@@ -207,17 +210,18 @@ namespace WalletWasabi.Tests.UnitTests
 			var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 			var any = EstimateSmartFeeMode.Conservative;
 
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any)).ReturnsAsync(FeeRateResponse(2, 99m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(3, any)).ReturnsAsync(FeeRateResponse(3, 99m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(5, any)).ReturnsAsync(FeeRateResponse(5, 89m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(6, any)).ReturnsAsync(FeeRateResponse(6, 75m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(8, any)).ReturnsAsync(FeeRateResponse(8, 30m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(11, any)).ReturnsAsync(FeeRateResponse(11, 30m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(13, any)).ReturnsAsync(FeeRateResponse(13, 30m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(15, any)).ReturnsAsync(FeeRateResponse(15, 30m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any)).ReturnsAsync(FeeRateResponse(1008, 31m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any)).ThrowsAsync(new NoEstimationException(0));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 99m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(3, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(3, 99m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(5, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(5, 89m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(6, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(6, 75m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(8, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(8, 30m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(11, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(11, 30m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(13, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(13, 30m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(15, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(15, 30m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(1008, 31m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
+			// WTF!?
 			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.True(allFee.IsAccurate);
 			Assert.Equal(3, allFee.Estimations.Count);
@@ -246,14 +250,15 @@ namespace WalletWasabi.Tests.UnitTests
 						Group = x.from
 					}).ToArray()
 				});
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any)).ReturnsAsync(FeeRateResponse(2, 3_500m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(3, any)).ReturnsAsync(FeeRateResponse(3, 500m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(6, any)).ReturnsAsync(FeeRateResponse(6, 10m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(18, any)).ReturnsAsync(FeeRateResponse(18, 5m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(36, any)).ReturnsAsync(FeeRateResponse(36, 5m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any)).ReturnsAsync(FeeRateResponse(1008, 1m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any)).ThrowsAsync(new NoEstimationException(0));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 3_500m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(3, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(3, 500m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(6, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(6, 10m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(18, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(18, 5m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(36, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(36, 5m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(1008, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(1008, 1m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2, 3, 5, 6, 8, 11, 13, 15, 1008), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
+			// WTF!?
 			var allFee = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 			Assert.Equal(3_500, allFee.Estimations[2]);
 			Assert.True(allFee.Estimations[3] > 500);
@@ -266,8 +271,8 @@ namespace WalletWasabi.Tests.UnitTests
 			var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 			var any = EstimateSmartFeeMode.Conservative;
 
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any)).ReturnsAsync(FeeRateResponse(2, 120m));
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2), any)).ThrowsAsync(new NoEstimationException(0));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(2, any, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 120m));
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsNotIn<int>(2), any, It.IsAny<CancellationToken>())).ThrowsAsync(new NoEstimationException(0));
 
 			// Do not throw exception
 			await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
@@ -281,7 +286,7 @@ namespace WalletWasabi.Tests.UnitTests
 				var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
 				var mempoolInfo = MempoolInfoGenerator.GenerateMempoolInfo();
 				mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(mempoolInfo);
-				mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative)).ReturnsAsync(FeeRateResponse(2, 120m));
+				mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 120m));
 				var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
 				var estimations = feeRates.Estimations;
 
@@ -295,13 +300,13 @@ namespace WalletWasabi.Tests.UnitTests
 		private static Mock<IRPCClient> CreateAndConfigureRpcClient(bool isSynchronized = true, bool hasPeersInfo = false, double memPoolMinFee = 0.00001000)
 		{
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetBlockchainInfoAsync()).ReturnsAsync(
+			mockRpc.Setup(rpc => rpc.GetBlockchainInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(
 				new BlockchainInfo
 				{
 					Blocks = isSynchronized ? 100_000UL : 89_765UL,
 					Headers = 100_000L
 				});
-			mockRpc.Setup(rpc => rpc.GetPeersInfoAsync()).ReturnsAsync(
+			mockRpc.Setup(rpc => rpc.GetPeersInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(
 				hasPeersInfo
 					? new[] { new PeerInfo() }
 					: Array.Empty<PeerInfo>());

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -183,7 +183,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			{
 				var rpc = coreNode.RpcClient;
 				using CancellationTokenSource cts = new(TimeSpan.Zero);
-				await Assert.ThrowsAsync<OperationCanceledException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, cts.Token));
+				await Assert.ThrowsAsync<TaskCanceledException>(async () => await rpc.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative, true, cts.Token));
 			}
 			finally
 			{

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -28,88 +28,88 @@ namespace WalletWasabi.Tests.UnitTests
 		public Network Network { get; set; } = Network.RegTest;
 		public RPCCredentialString CredentialString => new();
 
-		public Task<uint256> GetBestBlockHashAsync()
+		public Task<uint256> GetBestBlockHashAsync(CancellationToken cancellationToken = default)
 		{
 			return OnGetBestBlockHashAsync();
 		}
 
-		public Task<Block> GetBlockAsync(uint256 blockId)
+		public Task<Block> GetBlockAsync(uint256 blockId, CancellationToken cancellationToken = default)
 		{
 			return OnGetBlockAsync(blockId);
 		}
 
-		public Task<Block> GetBlockAsync(uint blockHeight)
+		public Task<Block> GetBlockAsync(uint blockHeight, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<BlockchainInfo> GetBlockchainInfoAsync()
+		public Task<BlockchainInfo> GetBlockchainInfoAsync(CancellationToken cancellationToken = default)
 		{
 			return OnGetBlockchainInfoAsync();
 		}
 
-		public Task<int> GetBlockCountAsync()
+		public Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<uint256> GetBlockHashAsync(int height)
+		public Task<uint256> GetBlockHashAsync(int height, CancellationToken cancellationToken = default)
 		{
 			return OnGetBlockHashAsync(height);
 		}
 
-		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		public Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			return OnGetBlockHeaderAsync(blockHash);
 		}
 
-		public Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true)
+		public Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
+		public Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancellationToken = default)
 		{
 			return OnGetMempoolInfoAsync();
 		}
 
-		public Task<BitcoinAddress> GetNewAddressAsync()
+		public Task<BitcoinAddress> GetNewAddressAsync(CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<PeerInfo[]> GetPeersInfoAsync()
+		public Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default)
 		{
 			return OnGetPeersInfoAsync();
 		}
 
-		public Task<uint256[]> GetRawMempoolAsync()
+		public Task<uint256[]> GetRawMempoolAsync(CancellationToken cancellationToken = default)
 		{
 			return OnGetRawMempoolAsync();
 		}
 
-		public Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true)
+		public Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 		{
 			return OnGetRawTransactionAsync(txid, throwIfNotFound);
 		}
 
-		public Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
+		public Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true)
+		public Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true, CancellationToken cancellationToken = default)
 		{
 			var resp = OnGetTxOutAsync(txid, index, includeMempool);
 			return Task.FromResult(resp);
 		}
 
-		public Task InvalidateBlockAsync(uint256 blockHash)
+		public Task InvalidateBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<UnspentCoin[]> ListUnspentAsync()
+		public Task<UnspentCoin[]> ListUnspentAsync(/*CancellationToken cancellationToken = default*/)
 		{
 			throw new NotImplementedException();
 		}
@@ -119,78 +119,78 @@ namespace WalletWasabi.Tests.UnitTests
 			return this;
 		}
 
-		public Task SendBatchAsync()
+		public Task SendBatchAsync(CancellationToken cancellationToken = default)
 		{
 			return Task.CompletedTask;
 		}
 
-		public Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
+		public Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId)
+		public Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId, CancellationToken cancellationToken = default)
 		{
 			return OnGetVerboseBlockAsync(blockId);
 		}
 
-		public Task<uint256> SendRawTransactionAsync(Transaction transaction)
+		public Task<uint256> SendRawTransactionAsync(Transaction transaction, CancellationToken cancellationToken = default)
 		{
 			var resp = OnSendRawTransactionAsync(transaction);
 			return Task.FromResult(resp);
 		}
 
-		public Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, bool replaceable = false)
+		public Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, bool replaceable = false, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request)
+		public Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task StopAsync()
+		public Task StopAsync(CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction)
+		public Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<TimeSpan> UptimeAsync()
+		public Task<TimeSpan> UptimeAsync(CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task AbandonTransactionAsync(uint256 txid)
+		public Task AbandonTransactionAsync(uint256 txid /*, CancellationToken cancellationToken = default*/)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<BumpResponse> BumpFeeAsync(uint256 txid)
+		public Task<BumpResponse> BumpFeeAsync(uint256 txid, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<uint256[]> GenerateAsync(int blockCount)
+		public Task<uint256[]> GenerateAsync(int blockCount, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
+		public Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default)
 		{
 			return OnEstimateSmartFeeAsync(confirmationTarget, estimateMode);
 		}
 
-		public Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address)
+		public Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address, CancellationToken cancellationToken = default)
 		{
 			return OnGenerateToAddressAsync(nBlocks, address);
 		}
 
-		public Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null)
+		public Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null, CancellationToken cancellationToken = default)
 		{
 			throw new NotImplementedException();
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
@@ -130,7 +130,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		{
 			var rpcMock = new Mock<IRPCClient>();
 			rpcMock.SetupGet(rpc => rpc.Network).Returns(Network.Main);
-			rpcMock.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			rpcMock.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { FeeRate = new FeeRate(10m) });
 			rpcMock.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -73,7 +73,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 		{
 			var mockRpcClient = new Mock<IRPCClient>();
 			mockRpcClient.Setup(rpc => rpc.Network).Returns(Network.Main);
-			mockRpcClient.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			mockRpcClient.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse { Blocks = 5, FeeRate = new FeeRate(100m) });
 			mockRpcClient.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var offendingAlice = WabiSabiFactory.CreateAlice(round); // this Alice spent the coin after registration
 
 			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(offendingAlice.Coin.Outpoint.Hash, (int)offendingAlice.Coin.Outpoint.N, true))
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(offendingAlice.Coin.Outpoint.Hash, (int)offendingAlice.Coin.Outpoint.N, true, It.IsAny<CancellationToken>()))
 				.ReturnsAsync((GetTxOutResponse?)null);
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -62,7 +62,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>()))
+			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_TRANSACTION_REJECTED, "", null));
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
@@ -99,7 +99,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>()))
+			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_TRANSACTION_REJECTED, "", null));
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
@@ -140,7 +140,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>()))
+			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_TRANSACTION_REJECTED, "", null));
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
@@ -177,7 +177,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 			var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>()))
+			mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
 				.ThrowsAsync(new RPCException(RPCErrorCode.RPC_TRANSACTION_REJECTED, "", null));
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -197,7 +197,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var round = WabiSabiFactory.CreateRound(cfg);
 
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync((NBitcoin.RPC.GetTxOutResponse?)null);
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
@@ -218,7 +218,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			var round = WabiSabiFactory.CreateRound(cfg);
 
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse { Confirmations = 0 });
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
@@ -238,7 +238,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
 			var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient();
-			var rpcCfg = rpc.SetupSequence(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()));
+			var rpcCfg = rpc.SetupSequence(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
 			foreach (var i in Enumerable.Range(1, 100))
 			{
 				rpcCfg = rpcCfg.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse { Confirmations = i, IsCoinBase = true });
@@ -266,7 +266,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>()))
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
 				{
 					Confirmations = 1,

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -37,14 +37,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			using var key = new Key();
 			var outpoint = BitcoinFactory.CreateOutPoint();
 			var mockRpc = new Mock<IRPCClient>();
-			mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true))
+			mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true, It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
 				{
 					IsCoinBase = false,
 					Confirmations = 200,
 					TxOut = new TxOut(Money.Coins(1m), key.PubKey.WitHash.GetAddress(Network.Main)),
 				});
-			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>()))
+			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(new EstimateSmartFeeResponse
 				{
 					Blocks = 1000,
@@ -56,7 +56,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 					MinRelayTxFee = 1
 				});
 			mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
-			mockRpc.Setup(rpc => rpc.SendBatchAsync()).Returns(Task.CompletedTask);
+			mockRpc.Setup(rpc => rpc.SendBatchAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, mockRpc, round);
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -38,8 +38,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 		public async Task GenerateSourceCoinAsync(CancellationToken cancellationToken)
 		{
 			var minerKey = KeyManager.GetNextReceiveKey("coinbase", out _);
-			var blockIds = await Rpc.GenerateToAddressAsync(1, minerKey.GetP2wpkhAddress(Rpc.Network)).ConfigureAwait(false);
-			var block = await Rpc.GetBlockAsync(blockIds.First()).ConfigureAwait(false);
+			var blockIds = await Rpc.GenerateToAddressAsync(1, minerKey.GetP2wpkhAddress(Rpc.Network), cancellationToken).ConfigureAwait(false);
+			var block = await Rpc.GetBlockAsync(blockIds.First(), cancellationToken).ConfigureAwait(false);
 			SourceCoin = block.Transactions[0].Outputs.GetCoins(minerKey.P2wpkhScript).First();
 			minerKey.SetKeyState(KeyState.Used);
 		}
@@ -78,7 +78,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 			var smartCoins = keys.Select((k, i) => new SmartCoin(stx, (uint)i, k));
 			Coins.AddRange(smartCoins);
-			await Rpc.SendRawTransactionAsync(splitTx).ConfigureAwait(false);
+			await Rpc.SendRawTransactionAsync(splitTx, cancellationToken).ConfigureAwait(false);
 		}
 
 		public async Task StartParticipatingAsync(CancellationToken cancellationToken)

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -231,7 +231,7 @@ namespace WalletWasabi.BitcoinCore
 				cancel.ThrowIfCancellationRequested();
 
 				// If it isn't already running, then we run it.
-				if (await coreNode.RpcClient.TestAsync().ConfigureAwait(false) is null)
+				if (await coreNode.RpcClient.TestAsync(cancel).ConfigureAwait(false) is null)
 				{
 					Logger.LogInfo("A Bitcoin node is already running.");
 				}

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -102,7 +102,7 @@ namespace WalletWasabi.BitcoinCore.Mempool
 
 		private async Task<int> MirrorMempoolAsync(CancellationToken cancel)
 		{
-			var mempoolHashes = await Rpc.GetRawMempoolAsync().ConfigureAwait(false);
+			var mempoolHashes = await Rpc.GetRawMempoolAsync(cancel).ConfigureAwait(false);
 
 			IEnumerable<uint256> missing;
 			lock (MempoolLock)

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.BitcoinCore.Monitoring
 
 				// If Core was running for a day already && it's synchronized, then we can be pretty sure that the estimate is accurate.
 				// It could also be accurate if Core was only shut down for a few minutes, but that's hard to figure out.
-				allFeeEstimate.IsAccurate = RpcMonitor.RpcStatus.Synchronized && await RpcClient.UptimeAsync().ConfigureAwait(false) > TimeSpan.FromDays(1);
+				allFeeEstimate.IsAccurate = RpcMonitor.RpcStatus.Synchronized && await RpcClient.UptimeAsync(cancel).ConfigureAwait(false) > TimeSpan.FromDays(1);
 
 				LastAllFeeEstimate = allFeeEstimate;
 				if (allFeeEstimate?.Estimations?.Any() is true)

--- a/WalletWasabi/BitcoinCore/Processes/BitcoindRpcProcessBridge.cs
+++ b/WalletWasabi/BitcoinCore/Processes/BitcoindRpcProcessBridge.cs
@@ -69,7 +69,7 @@ namespace WalletWasabi.BitcoinCore.Processes
 				{
 					try
 					{
-						TimeSpan timeSpan = await RpcClient.UptimeAsync().ConfigureAwait(false);
+						TimeSpan timeSpan = await RpcClient.UptimeAsync(cancel).ConfigureAwait(false);
 
 						Logger.LogInfo("RPC connection is successfully established.");
 						Logger.LogDebug($"RPC uptime is: {timeSpan}.");

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -37,7 +37,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			}
 		}
 
-		public override async Task<uint256> GetBestBlockHashAsync()
+		public override async Task<uint256> GetBestBlockHashAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetBestBlockHashAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -50,10 +50,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetBestBlockHashAsync()).ConfigureAwait(false);
+				() => base.GetBestBlockHashAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<Block> GetBlockAsync(uint256 blockHash)
+		public override async Task<Block> GetBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetBlockAsync)}:{blockHash}";
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -65,10 +65,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetBlockAsync(blockHash)).ConfigureAwait(false);
+				() => base.GetBlockAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<Block> GetBlockAsync(uint blockHeight)
+		public override async Task<Block> GetBlockAsync(uint blockHeight, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetBlockAsync)}:{blockHeight}";
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -80,10 +80,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetBlockAsync(blockHeight)).ConfigureAwait(false);
+				() => base.GetBlockAsync(blockHeight, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		public override async Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetBlockHeaderAsync)}:{blockHash}";
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -95,10 +95,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetBlockHeaderAsync(blockHash)).ConfigureAwait(false);
+				() => base.GetBlockHeaderAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<int> GetBlockCountAsync()
+		public override async Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetBlockCountAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -111,10 +111,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetBlockCountAsync()).ConfigureAwait(false);
+				() => base.GetBlockCountAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<PeerInfo[]> GetPeersInfoAsync()
+		public override async Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetPeersInfoAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -126,10 +126,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetPeersInfoAsync()).ConfigureAwait(false);
+				() => base.GetPeersInfoAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true)
+		public override async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetMempoolEntryAsync)}:{txid}";
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -142,7 +142,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetMempoolEntryAsync(txid, throwIfNotFound)).ConfigureAwait(false);
+				() => base.GetMempoolEntryAsync(txid, throwIfNotFound, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
@@ -160,7 +160,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				() => base.GetMempoolInfoAsync(cancel)).ConfigureAwait(false);
 		}
 
-		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
+		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(EstimateSmartFeeAsync)}:{confirmationTarget}:{estimateMode}";
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -173,10 +173,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.EstimateSmartFeeAsync(confirmationTarget, estimateMode)).ConfigureAwait(false);
+				() => base.EstimateSmartFeeAsync(confirmationTarget, estimateMode, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<uint256[]> GetRawMempoolAsync()
+		public override async Task<uint256[]> GetRawMempoolAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetRawMempoolAsync);
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -189,10 +189,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetRawMempoolAsync()).ConfigureAwait(false);
+				() => base.GetRawMempoolAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true)
+		public override async Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetTxOutAsync)}:{txid}:{index}:{includeMempool}";
 			var cacheOptions = new MemoryCacheEntryOptions
@@ -204,19 +204,19 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
 				cacheOptions,
-				() => base.GetTxOutAsync(txid, index, includeMempool)).ConfigureAwait(false);
+				() => base.GetTxOutAsync(txid, index, includeMempool, cancellationToken)).ConfigureAwait(false);
 		}
 
-		public override async Task<uint256[]> GenerateAsync(int blockCount)
+		public override async Task<uint256[]> GenerateAsync(int blockCount, CancellationToken cancellationToken = default)
 		{
 			TipChangeCancellationTokenSource.Cancel();
-			return await base.GenerateAsync(blockCount).ConfigureAwait(false);
+			return await base.GenerateAsync(blockCount, cancellationToken).ConfigureAwait(false);
 		}
 
-		public override async Task InvalidateBlockAsync(uint256 blockHash)
+		public override async Task InvalidateBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			TipChangeCancellationTokenSource.Cancel();
-			await base.InvalidateBlockAsync(blockHash).ConfigureAwait(false);
+			await base.InvalidateBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -40,108 +40,70 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		public override async Task<uint256> GetBestBlockHashAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetBestBlockHashAsync);
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 1,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(4) // The best hash doesn't change so often so, keep in cache for 4 seconds.
-			};
-			cacheOptions.AddExpirationToken(new CancellationChangeToken(TipChangeCancellationTokenSource.Token));
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(1, 4, true),
 				() => base.GetBestBlockHashAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<Block> GetBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetBlockAsync)}:{blockHash}";
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 10,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(4) // There is a block every 10 minutes on average so, keep in cache for 4 seconds.
-			};
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(10, 4),
 				() => base.GetBlockAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<Block> GetBlockAsync(uint blockHeight, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetBlockAsync)}:{blockHeight}";
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 10,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(4) // There is a block every 10 minutes on average so, keep in cache for 4 seconds.
-			};
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(10, 4),
 				() => base.GetBlockAsync(blockHeight, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetBlockHeaderAsync)}:{blockHash}";
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 2,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(4) // There is a block every 10 minutes on average so, keep in cache for 4 seconds.
-			};
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(2, 4),
 				() => base.GetBlockHeaderAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetBlockCountAsync);
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 1,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(2) // The blockchain info does not change frequently.
-			};
-			cacheOptions.AddExpirationToken(new CancellationChangeToken(TipChangeCancellationTokenSource.Token));
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(1, 2, true),
 				() => base.GetBlockCountAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetPeersInfoAsync);
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 2,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(0.5)
-			};
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(2, 0.5),
 				() => base.GetPeersInfoAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetMempoolEntryAsync)}:{txid}";
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 20,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(2)
-			};
-			cacheOptions.AddExpirationToken(new CancellationChangeToken(TipChangeCancellationTokenSource.Token));
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(20, 2, true),
 				() => base.GetMempoolEntryAsync(txid, throwIfNotFound, cancellationToken)).ConfigureAwait(false);
 		}
 
@@ -156,54 +118,37 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(1, 10),
 				() => base.GetMempoolInfoAsync(cancel)).ConfigureAwait(false);
 		}
 
 		public override async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(EstimateSmartFeeAsync)}:{confirmationTarget}:{estimateMode}";
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 1,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(4)
-			};
-			cacheOptions.AddExpirationToken(new CancellationChangeToken(TipChangeCancellationTokenSource.Token));
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(1, 4, true),
 				() => base.EstimateSmartFeeAsync(confirmationTarget, estimateMode, cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<uint256[]> GetRawMempoolAsync(CancellationToken cancellationToken = default)
 		{
 			string cacheKey = nameof(GetRawMempoolAsync);
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 20,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(2)
-			};
-			cacheOptions.AddExpirationToken(new CancellationChangeToken(TipChangeCancellationTokenSource.Token));
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(20, 2, true),
 				() => base.GetRawMempoolAsync(cancellationToken)).ConfigureAwait(false);
 		}
 
 		public override async Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true, CancellationToken cancellationToken = default)
 		{
 			string cacheKey = $"{nameof(GetTxOutAsync)}:{txid}:{index}:{includeMempool}";
-			var cacheOptions = new MemoryCacheEntryOptions
-			{
-				Size = 2,
-				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(2)
-			};
 
 			return await Cache.AtomicGetOrCreateAsync(
 				cacheKey,
-				cacheOptions,
+				CacheOptions(2, 2, true),
 				() => base.GetTxOutAsync(txid, index, includeMempool, cancellationToken)).ConfigureAwait(false);
 		}
 
@@ -217,6 +162,20 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		{
 			TipChangeCancellationTokenSource.Cancel();
 			await base.InvalidateBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
+		}
+
+		private MemoryCacheEntryOptions CacheOptions(int size, double expireInSeconds, bool addExpitationToken = false)
+		{
+			var cacheOptions = new MemoryCacheEntryOptions
+			{
+				Size = size,
+				AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(expireInSeconds)
+			};
+			if (addExpitationToken)
+			{
+				cacheOptions.AddExpirationToken(new CancellationChangeToken(TipChangeCancellationTokenSource.Token));
+			}
+			return cacheOptions;
 		}
 	}
 }

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -14,70 +14,70 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		Network Network { get; }
 		RPCCredentialString CredentialString { get; }
 
-		Task<uint256> GetBestBlockHashAsync();
+		Task<uint256> GetBestBlockHashAsync(CancellationToken cancellationToken = default);
 
-		Task<Block> GetBlockAsync(uint256 blockId);
+		Task<Block> GetBlockAsync(uint256 blockId, CancellationToken cancellationToken = default);
 
-		Task<Block> GetBlockAsync(uint blockHeight);
+		Task<Block> GetBlockAsync(uint blockHeight, CancellationToken cancellationToken = default);
 
-		Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash);
+		Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash, CancellationToken cancellationToken = default);
 
-		Task<uint256[]> GenerateAsync(int blockCount);
+		Task<uint256[]> GenerateAsync(int blockCount, CancellationToken cancellationToken = default);
 
-		Task StopAsync();
+		Task StopAsync(CancellationToken cancellationToken = default);
 
-		Task<BlockchainInfo> GetBlockchainInfoAsync();
+		Task<BlockchainInfo> GetBlockchainInfoAsync(CancellationToken cancellationToken = default);
 
-		Task<PeerInfo[]> GetPeersInfoAsync();
+		Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default);
 
-		Task<TimeSpan> UptimeAsync();
+		Task<TimeSpan> UptimeAsync(CancellationToken cancellationToken = default);
 
-		Task<uint256> SendRawTransactionAsync(Transaction transaction);
+		Task<uint256> SendRawTransactionAsync(Transaction transaction, CancellationToken cancellationToken = default);
 
-		Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true);
+		Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default);
 
-		Task<uint256[]> GetRawMempoolAsync();
+		Task<uint256[]> GetRawMempoolAsync(CancellationToken cancellationToken = default);
 
 		Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default);
 
-		Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction);
+		Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, CancellationToken cancellationToken = default);
 
-		Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative);
+		Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default);
 
-		Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true);
+		Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true, CancellationToken cancellationToken = default);
 
 		IRPCClient PrepareBatch();
 
-		Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, bool replaceable = false);
+		Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, bool replaceable = false, CancellationToken cancellationToken = default);
 
-		Task<uint256> GetBlockHashAsync(int height);
+		Task<uint256> GetBlockHashAsync(int height, CancellationToken cancellationToken = default);
 
-		Task InvalidateBlockAsync(uint256 blockHash);
+		Task InvalidateBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default);
 
-		Task AbandonTransactionAsync(uint256 txid);
+		Task AbandonTransactionAsync(uint256 txid /*, CancellationToken cancellationToken*/);
 
-		Task<BumpResponse> BumpFeeAsync(uint256 txid);
+		Task<BumpResponse> BumpFeeAsync(uint256 txid, CancellationToken cancellationToken = default);
 
-		Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true);
+		Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default);
 
 		Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel);
 
-		Task<int> GetBlockCountAsync();
+		Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default);
 
-		Task<BitcoinAddress> GetNewAddressAsync();
+		Task<BitcoinAddress> GetNewAddressAsync(CancellationToken cancellationToken = default);
 
-		Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request);
+		Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request, CancellationToken cancellationToken = default);
 
-		Task<UnspentCoin[]> ListUnspentAsync();
+		Task<UnspentCoin[]> ListUnspentAsync(/*CancellationToken cancellationToken*/);
 
-		Task SendBatchAsync();
+		Task SendBatchAsync(CancellationToken cancellationToken = default);
 
-		Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative);
+		Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default);
 
-		Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId);
+		Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId, CancellationToken cancellationToken = default);
 
-		Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address);
+		Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address, CancellationToken cancellationToken = default);
 
-		Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null);
+		Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null, CancellationToken cancellationToken = default);
 	}
 }

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.BitcoinCore.Rpc
 		{
 			try
 			{
-				var response = await Rpc.SendCommandAsync(RPCOperations.getmempoolinfo, true, cancel).ConfigureAwait(false);
+				var response = await Rpc.SendCommandAsync(RPCOperations.getmempoolinfo, cancel, true).ConfigureAwait(false);
 				static IEnumerable<FeeRateGroup> ExtractFeeRateGroups(JToken jt) =>
 					jt switch
 					{

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -26,46 +26,46 @@ namespace WalletWasabi.BitcoinCore.Rpc
 
 		public RPCCredentialString CredentialString => Rpc.CredentialString;
 
-		public virtual async Task<uint256> GetBestBlockHashAsync()
+		public virtual async Task<uint256> GetBestBlockHashAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBestBlockHashAsync().ConfigureAwait(false);
+			return await Rpc.GetBestBlockHashAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<Block> GetBlockAsync(uint256 blockHash)
+		public virtual async Task<Block> GetBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBlockAsync(blockHash).ConfigureAwait(false);
+			return await Rpc.GetBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<Block> GetBlockAsync(uint blockHeight)
+		public virtual async Task<Block> GetBlockAsync(uint blockHeight, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBlockAsync(blockHeight).ConfigureAwait(false);
+			return await Rpc.GetBlockAsync(blockHeight, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash)
+		public virtual async Task<BlockHeader> GetBlockHeaderAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBlockHeaderAsync(blockHash).ConfigureAwait(false);
+			return await Rpc.GetBlockHeaderAsync(blockHash, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<BlockchainInfo> GetBlockchainInfoAsync()
+		public virtual async Task<BlockchainInfo> GetBlockchainInfoAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBlockchainInfoAsync().ConfigureAwait(false);
+			return await Rpc.GetBlockchainInfoAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<PeerInfo[]> GetPeersInfoAsync()
+		public virtual async Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetPeersInfoAsync().ConfigureAwait(false);
+			return await Rpc.GetPeersInfoAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true)
+		public virtual async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound).ConfigureAwait(false);
+			return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound, cancellationToken).ConfigureAwait(false);
 		}
 
 		public virtual async Task<MemPoolInfo> GetMempoolInfoAsync(CancellationToken cancel = default)
 		{
 			try
 			{
-				var response = await Rpc.SendCommandAsync(RPCOperations.getmempoolinfo, true).ConfigureAwait(false);
+				var response = await Rpc.SendCommandAsync(RPCOperations.getmempoolinfo, true, cancel).ConfigureAwait(false);
 				static IEnumerable<FeeRateGroup> ExtractFeeRateGroups(JToken jt) =>
 					jt switch
 					{
@@ -98,48 +98,48 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			{
 				cancel.ThrowIfCancellationRequested();
 
-				return await Rpc.GetMemPoolAsync().ConfigureAwait(false);
+				return await Rpc.GetMemPoolAsync(cancel).ConfigureAwait(false);
 			}
 		}
 
-		public virtual async Task<uint256[]> GetRawMempoolAsync()
+		public virtual async Task<uint256[]> GetRawMempoolAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetRawMempoolAsync().ConfigureAwait(false);
+			return await Rpc.GetRawMempoolAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true)
+		public virtual async Task<GetTxOutResponse?> GetTxOutAsync(uint256 txid, int index, bool includeMempool = true, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetTxOutAsync(txid, index, includeMempool).ConfigureAwait(false);
+			return await Rpc.GetTxOutAsync(txid, index, includeMempool, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction)
+		public virtual async Task<MempoolAcceptResult> TestMempoolAcceptAsync(Transaction transaction, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.TestMempoolAcceptAsync(transaction).ConfigureAwait(false);
+			return await Rpc.TestMempoolAcceptAsync(transaction, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task StopAsync()
+		public virtual async Task StopAsync(CancellationToken cancellationToken = default)
 		{
-			await Rpc.StopAsync().ConfigureAwait(false);
+			await Rpc.StopAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<uint256[]> GenerateAsync(int blockCount)
+		public virtual async Task<uint256[]> GenerateAsync(int blockCount, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GenerateAsync(blockCount).ConfigureAwait(false);
+			return await Rpc.GenerateAsync(blockCount, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<TimeSpan> UptimeAsync()
+		public virtual async Task<TimeSpan> UptimeAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.UptimeAsync().ConfigureAwait(false);
+			return await Rpc.UptimeAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<uint256> SendRawTransactionAsync(Transaction transaction)
+		public virtual async Task<uint256> SendRawTransactionAsync(Transaction transaction, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.SendRawTransactionAsync(transaction).ConfigureAwait(false);
+			return await Rpc.SendRawTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
+		public virtual async Task<EstimateSmartFeeResponse> EstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode).ConfigureAwait(false);
+			return await Rpc.EstimateSmartFeeAsync(confirmationTarget, estimateMode, cancellationToken).ConfigureAwait(false);
 		}
 
 		public virtual IRPCClient PrepareBatch()
@@ -147,48 +147,48 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return new RpcClientBase(Rpc.PrepareBatch());
 		}
 
-		public async Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId)
+		public async Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId, CancellationToken cancellationToken = default)
 		{
-			var resp = await Rpc.SendCommandAsync(RPCOperations.getblock, blockId, 3).ConfigureAwait(false);
+			var resp = await Rpc.SendCommandAsync(RPCOperations.getblock, cancellationToken, blockId, 3).ConfigureAwait(false);
 			return RpcParser.ParseVerboseBlockResponse(resp.ResultString);
 		}
 
-		public async Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address)
+		public async Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GenerateToAddressAsync(nBlocks, address).ConfigureAwait(false);
+			return await Rpc.GenerateToAddressAsync(nBlocks, address, cancellationToken).ConfigureAwait(false);
 		}
 
 		#region For Testing Only
 
-		public virtual async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, bool replaceable = false)
+		public virtual async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, bool replaceable = false, CancellationToken cancellationToken = default)
 		{
 			var parameters = new SendToAddressParameters{ Replaceable = replaceable };
-			return await Rpc.SendToAddressAsync(address, amount, parameters).ConfigureAwait(false);
+			return await Rpc.SendToAddressAsync(address, amount, parameters, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<uint256> GetBlockHashAsync(int height)
+		public virtual async Task<uint256> GetBlockHashAsync(int height, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBlockHashAsync(height).ConfigureAwait(false);
+			return await Rpc.GetBlockHashAsync(height, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task InvalidateBlockAsync(uint256 blockHash)
+		public virtual async Task InvalidateBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 		{
-			await Rpc.InvalidateBlockAsync(blockHash).ConfigureAwait(false);
+			await Rpc.InvalidateBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task AbandonTransactionAsync(uint256 txid)
+		public virtual async Task AbandonTransactionAsync(uint256 txid /*, CancellationToken cancellationToken = default*/)
 		{
-			await Rpc.AbandonTransactionAsync(txid).ConfigureAwait(false);
+			await Rpc.AbandonTransactionAsync(txid /*, cancellationToken*/).ConfigureAwait(false);
 		}
 
-		public virtual async Task<BumpResponse> BumpFeeAsync(uint256 txid)
+		public virtual async Task<BumpResponse> BumpFeeAsync(uint256 txid, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.BumpFeeAsync(txid).ConfigureAwait(false);
+			return await Rpc.BumpFeeAsync(txid, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true)
+		public virtual async Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetRawTransactionAsync(txid, throwIfNotFound).ConfigureAwait(false);
+			return await Rpc.GetRawTransactionAsync(txid, throwIfNotFound, cancellationToken).ConfigureAwait(false);
 		}
 
 		public virtual async Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
@@ -201,10 +201,10 @@ namespace WalletWasabi.BitcoinCore.Rpc
 				List<Task<Transaction>> tasks = new();
 				foreach (var txid in txidsChunk)
 				{
-					tasks.Add(batchingRpc.GetRawTransactionAsync(txid, throwIfNotFound: false));
+					tasks.Add(batchingRpc.GetRawTransactionAsync(txid, throwIfNotFound: false, cancel));
 				}
 
-				await batchingRpc.SendBatchAsync().ConfigureAwait(false);
+				await batchingRpc.SendBatchAsync(cancel).ConfigureAwait(false);
 
 				foreach (var tx in await Task.WhenAll(tasks).ConfigureAwait(false))
 				{
@@ -219,39 +219,39 @@ namespace WalletWasabi.BitcoinCore.Rpc
 			return acquiredTransactions;
 		}
 
-		public virtual async Task<int> GetBlockCountAsync()
+		public virtual async Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetBlockCountAsync().ConfigureAwait(false);
+			return await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<BitcoinAddress> GetNewAddressAsync()
+		public virtual async Task<BitcoinAddress> GetNewAddressAsync(CancellationToken cancellationToken = default)
 		{
-			return await Rpc.GetNewAddressAsync().ConfigureAwait(false);
+			return await Rpc.GetNewAddressAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request)
+		public virtual async Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request, CancellationToken cancellationToken = default)
 		{
-			return await Rpc.SignRawTransactionWithWalletAsync(request).ConfigureAwait(false);
+			return await Rpc.SignRawTransactionWithWalletAsync(request, cancellationToken).ConfigureAwait(false);
 		}
 
-		public virtual async Task<UnspentCoin[]> ListUnspentAsync()
+		public virtual async Task<UnspentCoin[]> ListUnspentAsync(/*CancellationToken cancellationToken = default*/)
 		{
-			return await Rpc.ListUnspentAsync().ConfigureAwait(false);
+			return await Rpc.ListUnspentAsync(/*cancellationToken*/).ConfigureAwait(false);
 		}
 
-		public virtual async Task SendBatchAsync()
+		public virtual async Task SendBatchAsync(CancellationToken cancellationToken = default)
 		{
-			await Rpc.SendBatchAsync().ConfigureAwait(false);
+			await Rpc.SendBatchAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		public Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative)
+		public Task<EstimateSmartFeeResponse> TryEstimateSmartFeeAsync(int confirmationTarget, EstimateSmartFeeMode estimateMode = EstimateSmartFeeMode.Conservative, CancellationToken cancellationToken = default)
 		{
-			return Rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode: estimateMode);
+			return Rpc.TryEstimateSmartFeeAsync(confirmationTarget, estimateMode: estimateMode, cancellationToken);
 		}
 
-		public Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null)
+		public Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null, CancellationToken cancellationToken = default)
 		{
-			return Rpc.CreateWalletAsync(walletNameOrPath, options);
+			return Rpc.CreateWalletAsync(walletNameOrPath, options, cancellationToken);
 		}
 
 		#endregion For Testing Only

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.Blockchain.Blocks
 			}
 			else
 			{
-				bestBlockHash = await RpcClient.GetBestBlockHashAsync().ConfigureAwait(false);
+				bestBlockHash = await RpcClient.GetBestBlockHashAsync(cancel).ConfigureAwait(false);
 			}
 
 			// If there's no new block.
@@ -74,7 +74,7 @@ namespace WalletWasabi.Blockchain.Blocks
 				return;
 			}
 
-			var arrivedBlock = await RpcClient.GetBlockAsync(bestBlockHash).ConfigureAwait(false);
+			var arrivedBlock = await RpcClient.GetBlockAsync(bestBlockHash, cancel).ConfigureAwait(false);
 			var arrivedHeader = arrivedBlock.Header;
 			arrivedHeader.PrecomputeHash(false, true);
 
@@ -93,7 +93,7 @@ namespace WalletWasabi.Blockchain.Blocks
 				var currentHeader = arrivedHeader;
 				while (reorgProtection7Headers.Count < 7 && currentHeader.GetHash() != Network.GenesisHash)
 				{
-					currentHeader = await RpcClient.GetBlockHeaderAsync(currentHeader.HashPrevBlock).ConfigureAwait(false);
+					currentHeader = await RpcClient.GetBlockHeaderAsync(currentHeader.HashPrevBlock, cancel).ConfigureAwait(false);
 					reorgProtection7Headers.Add(currentHeader);
 				}
 
@@ -135,13 +135,13 @@ namespace WalletWasabi.Blockchain.Blocks
 				return;
 			}
 
-			await HandleMissedBlocksAsync(arrivedBlock).ConfigureAwait(false);
+			await HandleMissedBlocksAsync(arrivedBlock, cancel).ConfigureAwait(false);
 
 			BestBlockHash = bestBlockHash;
 			return;
 		}
 
-		private async Task HandleMissedBlocksAsync(Block arrivedBlock)
+		private async Task HandleMissedBlocksAsync(Block arrivedBlock, CancellationToken cancellationToken)
 		{
 			List<Block> missedBlocks = new()
 			{
@@ -150,7 +150,7 @@ namespace WalletWasabi.Blockchain.Blocks
 			var currentHeader = arrivedBlock.Header;
 			while (true)
 			{
-				Block missedBlock = await RpcClient.GetBlockAsync(currentHeader.HashPrevBlock).ConfigureAwait(false);
+				Block missedBlock = await RpcClient.GetBlockAsync(currentHeader.HashPrevBlock, cancellationToken).ConfigureAwait(false);
 
 				if (missedBlocks.Count > 144)
 				{

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -866,7 +866,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 				var originalConfirmationTarget = AdjustedConfirmationTarget;
 
 				// Note that only dependents matter, spenders do not matter much or at all, they just allow this transaction to be confirmed faster.
-				var dependents = await RpcClient.GetAllDependentsAsync(transactionHashes, includingProvided: true, likelyProvidedManyConfirmedOnes: true).ConfigureAwait(false);
+				var dependents = await RpcClient.GetAllDependentsAsync(transactionHashes, includingProvided: true, likelyProvidedManyConfirmedOnes: true, CancellationToken.None).ConfigureAwait(false);
 				AdjustedConfirmationTarget = AdjustConfirmationTarget(dependents.Count, ConfiguredConfirmationTarget, ConfiguredConfirmationTargetReductionRate);
 
 				if (originalConfirmationTarget != AdjustedConfirmationTarget)
@@ -1350,7 +1350,7 @@ namespace WalletWasabi.CoinJoin.Coordinator.Rounds
 			// Add the change outputs.
 			outputCount += Alices.Count;
 
-			return await RpcClient.TestMempoolAcceptAsync(coinsToTest, fakeOutputCount: outputCount, FeePerInputs, FeePerOutputs).ConfigureAwait(false);
+			return await RpcClient.TestMempoolAcceptAsync(coinsToTest, fakeOutputCount: outputCount, FeePerInputs, FeePerOutputs, CancellationToken.None).ConfigureAwait(false);
 		}
 
 		public int RemoveAlicesBy(params Guid[] ids)

--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -234,7 +234,7 @@ namespace WalletWasabi.Wallets
 			{
 				try
 				{
-					var block = await CoreNode.RpcClient.GetBlockAsync(hash).ConfigureAwait(false);
+					var block = await CoreNode.RpcClient.GetBlockAsync(hash, cancellationToken).ConfigureAwait(false);
 					Logger.LogInfo($"Block acquired from RPC connection: {hash}.");
 					return block;
 				}


### PR DESCRIPTION
NBitcoin 6.0.8 (merged recenty) allows cancellable RPC calls. This PR passes cancellation tokens when possible. The idea is not to pass tokens in every single rpc call but just in those that are more relevant and that don't require to modify all the chain of async methods.