### PR TITLE
[Fluent] Hide coinjoins in UI

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -94,7 +94,10 @@ namespace WalletWasabi.Fluent.ViewModels
 				{
 					var (sender, e) = arg;
 
-					if (Services.UiConfig.PrivacyMode || !e.IsNews || sender is not Wallet { IsLoggedIn: true, State: WalletState.Started } wallet)
+					if (Services.UiConfig.PrivacyMode ||
+					    !e.IsNews ||
+					    sender is not Wallet { IsLoggedIn: true, State: WalletState.Started } wallet ||
+					    e.IsLikelyOwnCoinJoin)
 					{
 						return;
 					}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -49,6 +49,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 				.ObserveOn(RxApp.MainThreadScheduler)
 				.Sort(SortExpressionComparer<HistoryItemViewModel>.Descending(x => x.OrderIndex))
 				.Bind(_unfilteredTransactions)
+				.Filter(model => !model.IsCoinJoin)
 				.Bind(_transactions)
 				.Subscribe();
 		}


### PR DESCRIPTION
part of https://github.com/zkSNACKs/WalletWasabi/issues/6422

This PR hides the CJs in the history table and prevents CJ notifications. 

Note that the CJ transaction detection is not working correctly at the moment. https://github.com/zkSNACKs/WalletWasabi/issues/6205