### PR TITLE
[Fluent] Add output descriptors

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
@@ -47,6 +47,12 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced
 			ExtendedAccountZpub = wallet.KeyManager.ExtPubKey.ToZpub(network);
 			AccountKeyPath = $"m/{wallet.KeyManager.AccountKeyPath}";
 			MasterKeyFingerprint = wallet.KeyManager.MasterFingerprint.ToString();
+
+			var descriptors = wallet.KeyManager.GetOutputDescriptors(wallet.Kitchen.SaltSoup(), network);
+			PublicExternalOutputDescriptor  = descriptors[0].ToString();
+			PublicInternalOutputDescriptor  = descriptors[1].ToString();
+			PrivateExternalOutputDescriptor = descriptors[2].ToString();
+			PrivateInternalOutputDescriptor = descriptors[3].ToString();
 		}
 
 		public string ExtendedAccountPublicKey { get; }
@@ -64,6 +70,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced
 		public string? ExtendedMasterZprv { get; }
 
 		public string? ExtendedAccountZprv { get; }
+
+		public string PublicInternalOutputDescriptor  { get; }
+		public string PublicExternalOutputDescriptor  { get; }
+		public string PrivateInternalOutputDescriptor  { get; }
+		public string PrivateExternalOutputDescriptor  { get; }
 
 		public bool IsHardwareWallet { get; }
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
@@ -49,10 +49,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced
 			MasterKeyFingerprint = wallet.KeyManager.MasterFingerprint.ToString();
 
 			var descriptors = wallet.KeyManager.GetOutputDescriptors(wallet.Kitchen.SaltSoup(), network);
-			PublicExternalOutputDescriptor  = descriptors[0].ToString();
-			PublicInternalOutputDescriptor  = descriptors[1].ToString();
-			PrivateExternalOutputDescriptor = descriptors[2].ToString();
-			PrivateInternalOutputDescriptor = descriptors[3].ToString();
+			PublicExternalOutputDescriptor  = descriptors[0];
+			PublicInternalOutputDescriptor  = descriptors[1];
+			PrivateExternalOutputDescriptor = descriptors[2];
+			PrivateInternalOutputDescriptor = descriptors[3];
 		}
 
 		public string ExtendedAccountPublicKey { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
@@ -1,9 +1,8 @@
-using System;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Userfacing;
-using WalletWasabi.Wallets;
+using static WalletWasabi.Blockchain.Keys.WpkhOutputDescriptorHelper;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced
 {
@@ -48,11 +47,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced
 			AccountKeyPath = $"m/{wallet.KeyManager.AccountKeyPath}";
 			MasterKeyFingerprint = wallet.KeyManager.MasterFingerprint.ToString();
 
-			var descriptors = wallet.KeyManager.GetOutputDescriptors(wallet.Kitchen.SaltSoup(), network);
-			PublicExternalOutputDescriptor  = descriptors[0];
-			PublicInternalOutputDescriptor  = descriptors[1];
-			PrivateExternalOutputDescriptor = descriptors[2];
-			PrivateInternalOutputDescriptor = descriptors[3];
+			WpkhOutputDescriptors = wallet.KeyManager.GetOutputDescriptors(wallet.Kitchen.SaltSoup(), network);
 		}
 
 		public string ExtendedAccountPublicKey { get; }
@@ -71,10 +66,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced
 
 		public string? ExtendedAccountZprv { get; }
 
-		public string PublicInternalOutputDescriptor  { get; }
-		public string PublicExternalOutputDescriptor  { get; }
-		public string PrivateInternalOutputDescriptor  { get; }
-		public string PrivateExternalOutputDescriptor  { get; }
+		public WpkhDescriptors WpkhOutputDescriptors { get; }
 
 		public bool IsHardwareWallet { get; }
 	}

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -66,10 +66,33 @@
       <Separator IsVisible="{Binding !!ExtendedAccountZprv}" />
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
+                     Text="Public External Output descriptor"
+                     CopyParameter="{Binding PublicExternalOutputDescriptor}">
+        <c:PrivacyContentControl Content="{Binding PublicExternalOutputDescriptor}" NumberOfPrivacyChars="38" />
+      </c:PreviewItem>
+      <c:PreviewItem Icon="{StaticResource key_regular}"
+                     Text="Public Internal Output descriptor"
+                     CopyParameter="{Binding PublicInternalOutputDescriptor}">
+        <c:PrivacyContentControl Content="{Binding PublicInternalOutputDescriptor}" NumberOfPrivacyChars="38" />
+      </c:PreviewItem>
+
+      <c:PreviewItem Icon="{StaticResource key_regular}"
+                     Text="Private External Output descriptor"
+                     CopyParameter="{Binding PrivateExternalOutputDescriptor}">
+        <c:PrivacyContentControl Content="{Binding PrivateExternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
+      </c:PreviewItem>
+      <c:PreviewItem Icon="{StaticResource key_regular}"
+                     Text="Private Internal Output descriptor"
+                     CopyParameter="{Binding PrivateInternalOutputDescriptor}">
+        <c:PrivacyContentControl Content="{Binding PrivateInternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
+      </c:PreviewItem>
+
+      <c:PreviewItem Icon="{StaticResource key_regular}"
                      Text="Extended Account Public Key"
                      CopyParameter="{Binding ExtendedAccountPublicKey}">
         <c:PrivacyContentControl Content="{Binding ExtendedAccountPublicKey}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
+
         <Separator />
 
       <c:PreviewItem Icon="{StaticResource key_regular}"

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -67,24 +67,24 @@
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Text="Public External Output descriptor"
-                     CopyParameter="{Binding PublicExternalOutputDescriptor}">
-        <c:PrivacyContentControl Content="{Binding PublicExternalOutputDescriptor}" NumberOfPrivacyChars="38" />
+                     CopyParameter="{Binding WpkhOutputDescriptors.PublicExternal}">
+        <c:PrivacyContentControl Content="{Binding WpkhOutputDescriptors.PublicExternal}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Text="Public Internal Output descriptor"
-                     CopyParameter="{Binding PublicInternalOutputDescriptor}">
-        <c:PrivacyContentControl Content="{Binding PublicInternalOutputDescriptor}" NumberOfPrivacyChars="38" />
+                     CopyParameter="{Binding WpkhOutputDescriptors.PublicInternal}">
+        <c:PrivacyContentControl Content="{Binding WpkhOutputDescriptors.PublicInternal}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Text="Private External Output descriptor"
-                     CopyParameter="{Binding PrivateExternalOutputDescriptor}">
-        <c:PrivacyContentControl Content="{Binding PrivateExternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
+                     CopyParameter="{Binding WpkhOutputDescriptors.PrivateExternal}">
+        <c:PrivacyContentControl Content="{Binding WpkhOutputDescriptors.PrivateExternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Text="Private Internal Output descriptor"
-                     CopyParameter="{Binding PrivateInternalOutputDescriptor}">
-        <c:PrivacyContentControl Content="{Binding PrivateInternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
+                     CopyParameter="{Binding WpkhOutputDescriptors.PrivateInternal}">
+        <c:PrivacyContentControl Content="{Binding WpkhOutputDescriptors.PrivateInternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
       <c:PreviewItem Icon="{StaticResource key_regular}"

--- a/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
@@ -1,0 +1,28 @@
+using NBitcoin;
+using System;
+using WalletWasabi.Blockchain.Keys;
+using Xunit;
+using static WalletWasabi.Blockchain.Keys.WpkhOutputDescriptorHelper;
+
+namespace WalletWasabi.Tests.UnitTests.Blockchain.Keys
+{
+	public class WpkhOutputDescriptorHelperTests
+	{
+		[Fact]
+		public void BasicTest()
+		{
+			Network testNet = Network.TestNet;
+			BitcoinEncryptedSecretNoEC encryptedSecret = new(wif: "6PYJxoa2SLZdYADFyMp3wo41RKaKGNedC3vviix4VdjFfrt1LkKDmXmYTM", Network.Main);
+			byte[]? chainCode = ByteHelpers.FromHex("D9DAD5377AB84A44815403FF57B0ABC6825701560DAA0F0FCDDB5A52EBE12A6E");
+			ExtKey accountPrivateKey = new(encryptedSecret.GetKey(password: "123456"), chainCode);
+			KeyPath keyPath = new("84'/0'/0'");
+			HDFingerprint masterFingerprint = new(0x2fc4a4f3);
+
+			WpkhDescriptors descriptors = WpkhOutputDescriptorHelper.GetOutputDescriptors(testNet, masterFingerprint, accountPrivateKey, keyPath);
+			Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/1/*)#z2666dqc", descriptors.PublicInternal.ToString());
+			Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/0/*)#n7lm8csq", descriptors.PublicExternal.ToString());
+			Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/1/*)#ktc4yfd7", descriptors.PrivateInternal);
+			Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/0/*)#8la5euax", descriptors.PrivateExternal);
+		}
+	}
+}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using NBitcoin.Scripting;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -81,6 +82,20 @@ namespace WalletWasabi.Blockchain.Keys
 			SetFilePath(filePath);
 			ToFileLock = new object();
 			ToFile();
+		}
+
+		public OutputDescriptor[] GetOutputDescriptors(string password, Network network)
+		{
+			var commonPart = $"[{MasterFingerprint}/{AccountKeyPath}]";
+			var publicDescriptor = $"{commonPart}{ExtPubKey.ToString(network)}";
+			var privateDescriptor = $"{commonPart}{GetMasterExtKey(password).ToString(network)}";
+			return new[]
+			{
+				OutputDescriptor.Parse($"wpkh({publicDescriptor}/0/*)", network),
+				OutputDescriptor.Parse($"wpkh({publicDescriptor}/1/*)", network),
+				OutputDescriptor.Parse($"wpkh({privateDescriptor}/0/*)", network),
+				OutputDescriptor.Parse($"wpkh({privateDescriptor}/1/*)", network),
+			};
 		}
 
 		[JsonProperty(Order = 1)]

--- a/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
+++ b/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
@@ -1,0 +1,41 @@
+using NBitcoin.Scripting;
+using NBitcoin;
+
+namespace WalletWasabi.Blockchain.Keys
+{
+	public class WpkhOutputDescriptorHelper
+	{
+		/// <seealso href="https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#reference"/>
+		public static WpkhDescriptors GetOutputDescriptors(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
+		{
+			ExtKey accountKey = notDerivedAccountKey.Derive(accountKeyPath);
+
+			// Optional part looks like this, for example: [2fc4a4f3/84'/0'/0']
+			string optionalPart = $"[{masterFingerprint}/{accountKeyPath}]";
+
+			// Optional part is followed by the actual private key: "tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk"
+			string privateDescriptor = $"{optionalPart}{accountKey.ToString(network)}";
+
+			FlatSigningRepository internalRepo = new();
+			FlatSigningRepository externalRepo = new();
+
+			// Descriptor for all unhardened children (`/*`)
+			OutputDescriptor internalPublicDescriptor = OutputDescriptor.Parse($"wpkh({privateDescriptor}/1/*)", network, requireCheckSum: false, internalRepo);
+			OutputDescriptor externalPublicDescriptor = OutputDescriptor.Parse($"wpkh({privateDescriptor}/0/*)", network, requireCheckSum: false, externalRepo);
+
+			externalPublicDescriptor.TryGetPrivateString(externalRepo, out string? privateExternalDescriptor);
+			internalPublicDescriptor.TryGetPrivateString(internalRepo, out string? privateInternalDescriptor);
+
+			return new(internalPublicDescriptor, externalPublicDescriptor, privateInternalDescriptor, privateExternalDescriptor);
+		}
+
+		/// <summary>
+		/// Set of public and private + internal and external descriptors.
+		/// </summary>
+		/// <param name="PublicInternal">Descriptor describing something like:   <c>wpkh([2fc4a4f3/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/1/*)#wjx95ths</c>.</param>
+		/// <param name="PublicExternal">Descriptor describing something like:   <c>wpkh([2fc4a4f3/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/0/*)#lxryf78g</c>.</param>
+		/// <param name="PrivateInternal">A string similar to the following one: <c>wpkh([2fc4a4f3/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/1/*)#6ny2206k</c>.</param>
+		/// <param name="PrivateExternal">A string similar to the following one: <c>wpkh([2fc4a4f3/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/0/*)#t8pth62w</c>.</param>
+		public record WpkhDescriptors(OutputDescriptor PublicInternal, OutputDescriptor PublicExternal, string? PrivateInternal, string? PrivateExternal);
+	}
+}


### PR DESCRIPTION
This PR is for displaying the wallet descriptors. Currently all the descriptors are shown but only the public ones should be visible while the private ones should be displayed only is the user wants to see the sensitive information because with the private wallet descriptor you can recover your wallet.

I think we need different icons for these pieces of info and also remove redundancy basically because the wallet descriptors contain everything so, all the rest is redundant. We could keep it just for convenience.

@danwalmsley could someone from the UI team help to finish this in a decent way?