### PR TITLE
[WabiSabi] Compute round hash

### DIFF
--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
@@ -23,6 +23,9 @@ namespace WalletWasabi.Crypto.StrobeProtocol
 		public StrobeHasher Append(string fieldName, IBitcoinSerializable serializable)
 			=> Append(fieldName, serializable.ToBytes());
 
+		public StrobeHasher Append(string fieldName, TimeSpan time)
+			=> Append(fieldName, time.Ticks);
+
 		public StrobeHasher Append(string fieldName, Money money)
 			=> Append(fieldName, money.Satoshi);
 

--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -34,10 +35,12 @@ namespace WalletWasabi.Crypto.StrobeProtocol
 		public StrobeHasher Append(string fieldName, MoneyRange range)
 			=> Append(fieldName + "-min", range.Min).Append(fieldName + "-max", range.Max);
 
-		public StrobeHasher Append(string fieldName, IEnumerable<ScriptType> scriptTypes)
-			=> scriptTypes
-				.Select((scriptType, idx) => (scriptType, idx))
-				.Aggregate(this, (hasher, scriptTypeIdxPair) => hasher.Append(fieldName + "-" + scriptTypeIdxPair.idx, Enum.GetName(scriptTypeIdxPair.scriptType)));
+		public StrobeHasher Append(string fieldName, ImmutableSortedSet<ScriptType> scriptTypes)
+		{
+			return scriptTypes
+						   .Select((scriptType, idx) => (scriptType, idx))
+						   .Aggregate(this, (hasher, scriptTypeIdxPair) => hasher.Append(fieldName + "-" + scriptTypeIdxPair.idx, Enum.GetName(scriptTypeIdxPair.scriptType)));
+		}
 
 		public StrobeHasher Append(string fieldName, int num)
 			=> Append(fieldName, BitConverter.GetBytes(num));

--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasher.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using NBitcoin;
 using WalletWasabi.WabiSabi;
+using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.Crypto.StrobeProtocol
 {
@@ -28,6 +30,14 @@ namespace WalletWasabi.Crypto.StrobeProtocol
 
 		public StrobeHasher Append(string fieldName, Money money)
 			=> Append(fieldName, money.Satoshi);
+
+		public StrobeHasher Append(string fieldName, MoneyRange range)
+			=> Append(fieldName + "-min", range.Min).Append(fieldName + "-max", range.Max);
+
+		public StrobeHasher Append(string fieldName, IEnumerable<ScriptType> scriptTypes)
+			=> scriptTypes
+				.Select((scriptType, idx) => (scriptType, idx))
+				.Aggregate(this, (hasher, scriptTypeIdxPair) => hasher.Append(fieldName + "-" + scriptTypeIdxPair.idx, Enum.GetName(scriptTypeIdxPair.scriptType)));
 
 		public StrobeHasher Append(string fieldName, int num)
 			=> Append(fieldName, BitConverter.GetBytes(num));

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -355,11 +355,11 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				var id = new Guid(Random.GetBytes(16));
 				var alice = new Alice(coin, request.OwnershipProof, round, id);
 
-				if (alice.TotalInputAmount < round.MinRegistrableAmount)
+				if (alice.TotalInputAmount < round.MinAmountCredentialValue)
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
 				}
-				if (alice.TotalInputAmount > round.MaxRegistrableAmount)
+				if (alice.TotalInputAmount > round.MaxAmountCredentialValue)
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -145,12 +145,17 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					ConnectionConfirmationTimeout,
 					OutputRegistrationTimeout,
 					TransactionSigningTimeout,
-					MinRegistrableAmount,
-					MaxRegistrableAmount,
+					CoinjoinState.Parameters.AllowedInputAmounts,
+					CoinjoinState.Parameters.AllowedInputTypes,
+					CoinjoinState.Parameters.AllowedOutputAmounts,
+					CoinjoinState.Parameters.AllowedOutputTypes,
+					CoinjoinState.Parameters.Network,
+					CoinjoinState.Parameters.FeeRate.FeePerK,
+					CoinjoinState.Parameters.MaxTransactionSize,
+					CoinjoinState.Parameters.MinRelayTxFee.FeePerK,
 					MaxRegistrableVsize,
 					MaxVsizeAllocationPerAlice,
 					AmountCredentialIssuerParameters,
-					VsizeCredentialIssuerParameters,
-					FeeRate.FeePerK);
+					VsizeCredentialIssuerParameters);
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -12,6 +12,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 {
 	public class Round
 	{
+		private uint256 _id;
 		public Round(RoundParameters roundParameters)
 		{
 			RoundParameters = roundParameters;
@@ -28,12 +29,10 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			VsizeCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, MaxRegistrableVsize);
 			AmountCredentialIssuerParameters = AmountCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 			VsizeCredentialIssuerParameters = VsizeCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
-
-			Id = CalculateHash();
 		}
 
+		public uint256 Id => _id ??= CalculateHash();
 		public MultipartyTransactionState CoinjoinState { get; set; }
-		public uint256 Id { get; }
 		public Network Network => RoundParameters.Network;
 		public Money MinRegistrableAmount => RoundParameters.MinRegistrableAmount;
 		public Money MaxRegistrableAmount => RoundParameters.MaxRegistrableAmount;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -22,11 +22,11 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			CoinjoinState = new ConstructionState(txParams);
 
 			InitialInputVsizeAllocation = CoinjoinState.Parameters.MaxTransactionSize - MultipartyTransactionParameters.SharedOverhead;
-			MaxRegistrableVsize = Math.Min(InitialInputVsizeAllocation / RoundParameters.MaxInputCountByRound, (int)ProtocolConstants.MaxVsizeCredentialValue);
-			MaxVsizeAllocationPerAlice = MaxRegistrableVsize;
+			MaxVsizeCredentialValue = Math.Min(InitialInputVsizeAllocation / RoundParameters.MaxInputCountByRound, (int)ProtocolConstants.MaxVsizeCredentialValue);
+			MaxVsizeAllocationPerAlice = MaxVsizeCredentialValue;
 
-			AmountCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, MaxRegistrableAmount);
-			VsizeCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, MaxRegistrableVsize);
+			AmountCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, MaxAmountCredentialValue);
+			VsizeCredentialIssuer = new(new(RoundParameters.Random), RoundParameters.Random, MaxVsizeCredentialValue);
 			AmountCredentialIssuerParameters = AmountCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 			VsizeCredentialIssuerParameters = VsizeCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 		}
@@ -34,9 +34,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public uint256 Id => _id ??= CalculateHash();
 		public MultipartyTransactionState CoinjoinState { get; set; }
 		public Network Network => RoundParameters.Network;
-		public Money MinRegistrableAmount => RoundParameters.MinRegistrableAmount;
-		public Money MaxRegistrableAmount => RoundParameters.MaxRegistrableAmount;
-		public int MaxRegistrableVsize { get; }
+		public Money MinAmountCredentialValue => RoundParameters.MinRegistrableAmount;
+		public Money MaxAmountCredentialValue => RoundParameters.MaxRegistrableAmount;
+		public int MaxVsizeCredentialValue { get; }
 		public int MaxVsizeAllocationPerAlice { get; internal set; }
 		public FeeRate FeeRate => RoundParameters.FeeRate;
 		public CredentialIssuer AmountCredentialIssuer { get; }
@@ -153,7 +153,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					CoinjoinState.Parameters.FeeRate.FeePerK,
 					CoinjoinState.Parameters.MaxTransactionSize,
 					CoinjoinState.Parameters.MinRelayTxFee.FeePerK,
-					MaxRegistrableVsize,
+					MaxAmountCredentialValue,
+					MaxVsizeCredentialValue,
 					MaxVsizeAllocationPerAlice,
 					AmountCredentialIssuerParameters,
 					VsizeCredentialIssuerParameters);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -141,18 +141,17 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			=> Assert<SigningState>().AddWitness(index, witness);
 
 		private uint256 CalculateHash()
-			=> StrobeHasher.Create(ProtocolConstants.RoundStrobeDomain)
-				.Append(ProtocolConstants.RoundInputRegistrationTimeoutStrobeLabel, InputRegistrationTimeout)
-				.Append(ProtocolConstants.RoundConnectionConfirmationTimeoutStrobeLabel, ConnectionConfirmationTimeout)
-				.Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, OutputRegistrationTimeout)
-				.Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, TransactionSigningTimeout)
-				.Append(ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, MinRegistrableAmount)
-				.Append(ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, MaxRegistrableAmount)
-				.Append(ProtocolConstants.RoundMaxRegistrableVsizeStrobeLabel, MaxRegistrableVsize)
-				.Append(ProtocolConstants.RoundMaxVsizePerAliceStrobeLabel, MaxVsizeAllocationPerAlice)
-				.Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, AmountCredentialIssuerParameters)
-				.Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, VsizeCredentialIssuerParameters)
-				.Append(ProtocolConstants.RoundFeeRateStrobeLabel, FeeRate.FeePerK)
-				.GetHash();
+			=> RoundHasher.CalculateHash(
+					InputRegistrationTimeout,
+					ConnectionConfirmationTimeout,
+					OutputRegistrationTimeout,
+					TransactionSigningTimeout,
+					MinRegistrableAmount,
+					MaxRegistrableAmount,
+					MaxRegistrableVsize,
+					MaxVsizeAllocationPerAlice,
+					AmountCredentialIssuerParameters,
+					VsizeCredentialIssuerParameters,
+					FeeRate.FeePerK);
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -52,6 +52,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public bool IsBlameRound => RoundParameters.IsBlameRound;
 		public ISet<OutPoint> BlameWhitelist => RoundParameters.BlameWhitelist;
 
+		public TimeSpan InputRegistrationTimeout => IsBlameRound ? RoundParameters.BlameInputRegistrationTimeout : RoundParameters.StandardInputRegistrationTimeout;
 		public TimeSpan ConnectionConfirmationTimeout => RoundParameters.ConnectionConfirmationTimeout;
 		public TimeSpan OutputRegistrationTimeout => RoundParameters.OutputRegistrationTimeout;
 		public TimeSpan TransactionSigningTimeout => RoundParameters.TransactionSigningTimeout;
@@ -141,6 +142,10 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		private uint256 CalculateHash()
 			=> StrobeHasher.Create(ProtocolConstants.RoundStrobeDomain)
+				.Append(ProtocolConstants.RoundInputRegistrationTimeoutStrobeLabel, InputRegistrationTimeout)
+				.Append(ProtocolConstants.RoundConnectionConfirmationTimeoutStrobeLabel, ConnectionConfirmationTimeout)
+				.Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, OutputRegistrationTimeout)
+				.Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, TransactionSigningTimeout)
 				.Append(ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, MinRegistrableAmount)
 				.Append(ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, MaxRegistrableAmount)
 				.Append(ProtocolConstants.RoundMaxRegistrableVsizeStrobeLabel, MaxRegistrableVsize)

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -1,0 +1,36 @@
+using System;
+using NBitcoin;
+using WalletWasabi.Crypto;
+using WalletWasabi.Crypto.StrobeProtocol;
+
+namespace WalletWasabi.WabiSabi.Crypto
+{
+	public static class RoundHasher
+	{
+		public static uint256 CalculateHash(
+				TimeSpan inputRegistrationTimeout,
+				TimeSpan connectionConfirmationTimeout,
+				TimeSpan outputRegistrationTimeout,
+				TimeSpan transactionSigningTimeout,
+				long minRegistrableAmount,
+				long maxRegistrableAmount,
+				long maxRegistrableVsize,
+				long maxVsizeAllocationPerAlice,
+				CredentialIssuerParameters amountCredentialIssuerParameters,
+				CredentialIssuerParameters vsizeCredentialIssuerParameters,
+				long feePerK)
+				=> StrobeHasher.Create(ProtocolConstants.RoundStrobeDomain)
+					.Append(ProtocolConstants.RoundInputRegistrationTimeoutStrobeLabel, inputRegistrationTimeout)
+					.Append(ProtocolConstants.RoundConnectionConfirmationTimeoutStrobeLabel, connectionConfirmationTimeout)
+					.Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, outputRegistrationTimeout)
+					.Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, transactionSigningTimeout)
+					.Append(ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, minRegistrableAmount)
+					.Append(ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, maxRegistrableAmount)
+					.Append(ProtocolConstants.RoundMaxRegistrableVsizeStrobeLabel, maxRegistrableVsize)
+					.Append(ProtocolConstants.RoundMaxVsizePerAliceStrobeLabel, maxVsizeAllocationPerAlice)
+					.Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, amountCredentialIssuerParameters)
+					.Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, vsizeCredentialIssuerParameters)
+					.Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
+					.GetHash();
+	}
+}

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using NBitcoin;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.StrobeProtocol;
@@ -15,14 +16,15 @@ namespace WalletWasabi.WabiSabi.Crypto
 				TimeSpan outputRegistrationTimeout,
 				TimeSpan transactionSigningTimeout,
 				MoneyRange allowedInputAmounts,
-				IEnumerable<ScriptType> allowedInputTypes,
+				ImmutableSortedSet<ScriptType> allowedInputTypes,
 				MoneyRange allowedOutputAmounts,
-				IEnumerable<ScriptType> allowedOutputTypes,
+				ImmutableSortedSet<ScriptType> allowedOutputTypes,
 				Network network,
 				long feePerK,
 				int maxTransactionSize,
 				long minRelayTxFeePerK,
-				long maxRegistrableVsize,
+				long maxAmountCredentialValue,
+				long maxVsizeCredentialValue,
 				long maxVsizeAllocationPerAlice,
 				CredentialIssuerParameters amountCredentialIssuerParameters,
 				CredentialIssuerParameters vsizeCredentialIssuerParameters)
@@ -39,7 +41,8 @@ namespace WalletWasabi.WabiSabi.Crypto
 					.Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
 					.Append(ProtocolConstants.RoundMaxTransactionSizeStrobeLabel, maxTransactionSize)
 					.Append(ProtocolConstants.RoundMinRelayTxFeeStrobeLabel, minRelayTxFeePerK)
-					.Append(ProtocolConstants.RoundMaxRegistrableVsizeStrobeLabel, maxRegistrableVsize)
+					.Append(ProtocolConstants.RoundMaxAmountCredentialValueStrobeLabel, maxAmountCredentialValue)
+					.Append(ProtocolConstants.RoundMaxVsizeCredentialValueStrobeLabel, maxVsizeCredentialValue)
 					.Append(ProtocolConstants.RoundMaxVsizePerAliceStrobeLabel, maxVsizeAllocationPerAlice)
 					.Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, amountCredentialIssuerParameters)
 					.Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, vsizeCredentialIssuerParameters)

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using NBitcoin;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.StrobeProtocol;
+using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.WabiSabi.Crypto
 {
@@ -12,25 +14,35 @@ namespace WalletWasabi.WabiSabi.Crypto
 				TimeSpan connectionConfirmationTimeout,
 				TimeSpan outputRegistrationTimeout,
 				TimeSpan transactionSigningTimeout,
-				long minRegistrableAmount,
-				long maxRegistrableAmount,
+				MoneyRange allowedInputAmounts,
+				IEnumerable<ScriptType> allowedInputTypes,
+				MoneyRange allowedOutputAmounts,
+				IEnumerable<ScriptType> allowedOutputTypes,
+				Network network,
+				long feePerK,
+				int maxTransactionSize,
+				long minRelayTxFeePerK,
 				long maxRegistrableVsize,
 				long maxVsizeAllocationPerAlice,
 				CredentialIssuerParameters amountCredentialIssuerParameters,
-				CredentialIssuerParameters vsizeCredentialIssuerParameters,
-				long feePerK)
+				CredentialIssuerParameters vsizeCredentialIssuerParameters)
 				=> StrobeHasher.Create(ProtocolConstants.RoundStrobeDomain)
 					.Append(ProtocolConstants.RoundInputRegistrationTimeoutStrobeLabel, inputRegistrationTimeout)
 					.Append(ProtocolConstants.RoundConnectionConfirmationTimeoutStrobeLabel, connectionConfirmationTimeout)
 					.Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, outputRegistrationTimeout)
 					.Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, transactionSigningTimeout)
-					.Append(ProtocolConstants.RoundMinRegistrableAmountStrobeLabel, minRegistrableAmount)
-					.Append(ProtocolConstants.RoundMaxRegistrableAmountStrobeLabel, maxRegistrableAmount)
+					.Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
+					.Append(ProtocolConstants.RoundAllowedInputTypesStrobeLabel, allowedInputTypes)
+					.Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)
+					.Append(ProtocolConstants.RoundAllowedOutputTypesStrobeLabel, allowedOutputTypes)
+					.Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())
+					.Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
+					.Append(ProtocolConstants.RoundMaxTransactionSizeStrobeLabel, maxTransactionSize)
+					.Append(ProtocolConstants.RoundMinRelayTxFeeStrobeLabel, minRelayTxFeePerK)
 					.Append(ProtocolConstants.RoundMaxRegistrableVsizeStrobeLabel, maxRegistrableVsize)
 					.Append(ProtocolConstants.RoundMaxVsizePerAliceStrobeLabel, maxVsizeAllocationPerAlice)
 					.Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, amountCredentialIssuerParameters)
 					.Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, vsizeCredentialIssuerParameters)
-					.Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
 					.GetHash();
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -19,9 +19,8 @@ namespace WalletWasabi.WabiSabi.Models
 		TimeSpan ConnectionConfirmationTimeout,
 		TimeSpan OutputRegistrationTimeout,
 		TimeSpan TransactionSigningTimeout,
-		long MinRegistrableAmount,
-		long MaxRegistrableAmount,
-		long MaxRegistrableVsize,
+		long MaxAmountCredentialValue,
+		long MaxVsizeCredentialValue,
 		long MaxVsizeAllocationPerAlice,
 		MultipartyTransactionState CoinjoinState)
 	{
@@ -41,9 +40,8 @@ namespace WalletWasabi.WabiSabi.Models
 				round.ConnectionConfirmationTimeout,
 				round.OutputRegistrationTimeout,
 				round.TransactionSigningTimeout,
-				round.MinRegistrableAmount,
-				round.MaxRegistrableAmount,
-				round.MaxRegistrableVsize,
+				round.MaxAmountCredentialValue,
+				round.MaxVsizeCredentialValue,
 				round.MaxVsizeAllocationPerAlice,
 				round.CoinjoinState);
 
@@ -55,10 +53,10 @@ namespace WalletWasabi.WabiSabi.Models
 			};
 
 		public WabiSabiClient CreateAmountCredentialClient(WasabiRandom random) =>
-			new(AmountCredentialIssuerParameters, random, MaxRegistrableAmount);
+			new(AmountCredentialIssuerParameters, random, MaxAmountCredentialValue);
 
 		public WabiSabiClient CreateVsizeCredentialClient(WasabiRandom random) =>
-			new(VsizeCredentialIssuerParameters, random, MaxRegistrableVsize);
+			new(VsizeCredentialIssuerParameters, random, MaxVsizeCredentialValue);
 
 		private uint256 CalculateHash() =>
 			RoundHasher.CalculateHash(
@@ -74,7 +72,8 @@ namespace WalletWasabi.WabiSabi.Models
 				CoinjoinState.Parameters.FeeRate.FeePerK,
 				CoinjoinState.Parameters.MaxTransactionSize,
 				CoinjoinState.Parameters.MinRelayTxFee.FeePerK,
-				MaxRegistrableVsize,
+				MaxAmountCredentialValue,
+				MaxVsizeCredentialValue,
 				MaxVsizeAllocationPerAlice,
 				AmountCredentialIssuerParameters,
 				VsizeCredentialIssuerParameters);

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -66,12 +66,17 @@ namespace WalletWasabi.WabiSabi.Models
 				ConnectionConfirmationTimeout,
 				OutputRegistrationTimeout,
 				TransactionSigningTimeout,
-				MinRegistrableAmount,
-				MaxRegistrableAmount,
+				CoinjoinState.Parameters.AllowedInputAmounts,
+				CoinjoinState.Parameters.AllowedInputTypes,
+				CoinjoinState.Parameters.AllowedOutputAmounts,
+				CoinjoinState.Parameters.AllowedOutputTypes,
+				CoinjoinState.Parameters.Network,
+				CoinjoinState.Parameters.FeeRate.FeePerK,
+				CoinjoinState.Parameters.MaxTransactionSize,
+				CoinjoinState.Parameters.MinRelayTxFee.FeePerK,
 				MaxRegistrableVsize,
 				MaxVsizeAllocationPerAlice,
 				AmountCredentialIssuerParameters,
-				VsizeCredentialIssuerParameters,
-				FeeRate.FeePerK);
+				VsizeCredentialIssuerParameters);
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -9,29 +9,39 @@ using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record RoundState(
-		uint256 Id,
 		uint256? BlameOf,
 		CredentialIssuerParameters AmountCredentialIssuerParameters,
 		CredentialIssuerParameters VsizeCredentialIssuerParameters,
 		FeeRate FeeRate,
 		Phase Phase,
 		bool WasTransactionBroadcast,
+		TimeSpan InputRegistrationTimeout,
 		TimeSpan ConnectionConfirmationTimeout,
+		TimeSpan OutputRegistrationTimeout,
+		TimeSpan TransactionSigningTimeout,
+		long MinRegistrableAmount,
 		long MaxRegistrableAmount,
 		long MaxRegistrableVsize,
 		long MaxVsizeAllocationPerAlice,
 		MultipartyTransactionState CoinjoinState)
 	{
+		private uint256 _id;
+
+		public uint256 Id => _id ??= CalculateHash();
+
 		public static RoundState FromRound(Round round) =>
 			new(
-				round.Id,
 				round.BlameOf?.Id,
 				round.AmountCredentialIssuerParameters,
 				round.VsizeCredentialIssuerParameters,
 				round.FeeRate,
 				round.Phase,
 				round.WasTransactionBroadcast,
+				round.InputRegistrationTimeout,
 				round.ConnectionConfirmationTimeout,
+				round.OutputRegistrationTimeout,
+				round.TransactionSigningTimeout,
+				round.MinRegistrableAmount,
 				round.MaxRegistrableAmount,
 				round.MaxRegistrableVsize,
 				round.MaxVsizeAllocationPerAlice,
@@ -49,5 +59,19 @@ namespace WalletWasabi.WabiSabi.Models
 
 		public WabiSabiClient CreateVsizeCredentialClient(WasabiRandom random) =>
 			new(VsizeCredentialIssuerParameters, random, MaxRegistrableVsize);
+
+		private uint256 CalculateHash() =>
+			RoundHasher.CalculateHash(
+				InputRegistrationTimeout,
+				ConnectionConfirmationTimeout,
+				OutputRegistrationTimeout,
+				TransactionSigningTimeout,
+				MinRegistrableAmount,
+				MaxRegistrableAmount,
+				MaxRegistrableVsize,
+				MaxVsizeAllocationPerAlice,
+				AmountCredentialIssuerParameters,
+				VsizeCredentialIssuerParameters,
+				FeeRate.FeePerK);
 	}
 }

--- a/WalletWasabi/WabiSabi/ProtocolContants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolContants.cs
@@ -11,8 +11,14 @@ namespace WalletWasabi.WabiSabi
 
 		// Round hashing labels
 		public const string RoundStrobeDomain = "round-parameters";
-		public const string RoundMinRegistrableAmountStrobeLabel = "minimum-registrable-amount";
-		public const string RoundMaxRegistrableAmountStrobeLabel = "maximum-registrable-amount";
+		public const string RoundAllowedInputAmountsStrobeLabel = "allowed-input-amounts";
+		public const string RoundAllowedOutputAmountsStrobeLabel = "allowed-output-amounts";
+		public const string RoundAllowedInputTypesStrobeLabel = "allowed-input-types";
+		public const string RoundAllowedOutputTypesStrobeLabel = "allowed-output-types";
+		public const string RoundNetworkStrobeLabel = "network";
+		public const string RoundMaxTransactionSizeStrobeLabel = "max-transaction-size";
+		public const string RoundMinRelayTxFeeStrobeLabel = "min-relay-tx-fee";
+
 		public const string RoundMaxRegistrableVsizeStrobeLabel = "maximum-registrable-vsize";
 		public const string RoundMaxVsizePerAliceStrobeLabel = "per-alice-vsize-allocation";
 		public const string RoundAmountCredentialIssuerParametersStrobeLabel = "amount-credential-issuer-parameters";

--- a/WalletWasabi/WabiSabi/ProtocolContants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolContants.cs
@@ -19,7 +19,8 @@ namespace WalletWasabi.WabiSabi
 		public const string RoundMaxTransactionSizeStrobeLabel = "max-transaction-size";
 		public const string RoundMinRelayTxFeeStrobeLabel = "min-relay-tx-fee";
 
-		public const string RoundMaxRegistrableVsizeStrobeLabel = "maximum-registrable-vsize";
+		public const string RoundMaxAmountCredentialValueStrobeLabel = "maximum-amount-credential-value";
+		public const string RoundMaxVsizeCredentialValueStrobeLabel = "maximum-vsize-credential-value";
 		public const string RoundMaxVsizePerAliceStrobeLabel = "per-alice-vsize-allocation";
 		public const string RoundAmountCredentialIssuerParametersStrobeLabel = "amount-credential-issuer-parameters";
 		public const string RoundVsizeCredentialIssuerParametersStrobeLabel = "vsize-credential-issuer-parameters";

--- a/WalletWasabi/WabiSabi/ProtocolContants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolContants.cs
@@ -18,6 +18,10 @@ namespace WalletWasabi.WabiSabi
 		public const string RoundAmountCredentialIssuerParametersStrobeLabel = "amount-credential-issuer-parameters";
 		public const string RoundVsizeCredentialIssuerParametersStrobeLabel = "vsize-credential-issuer-parameters";
 		public const string RoundFeeRateStrobeLabel = "fee-rate";
+		public const string RoundInputRegistrationTimeoutStrobeLabel= "input-registration-timeout";
+		public const string RoundConnectionConfirmationTimeoutStrobeLabel= "connection-confirmation-timeout";
+		public const string RoundOutputRegistrationTimeoutStrobeLabel= "output-registration-timeout";
+		public const string RoundTransactionSigningTimeoutStrobeLabel= "transaction-signing-timeout";
 
 		// Alice hashing labels
 		public const string AliceStrobeDomain = "alice-parameters";


### PR DESCRIPTION
This PR computes the round hash on the client side too, it was missing and that's an important mistake. Additionally round hash commits to missing parameters and to timeouts that are required to calculate and to schedule the communication delays. 