### PR TITLE
[Fluent][Trivial] Fix recovery words message

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/RecoverWalletView.axaml
@@ -11,7 +11,7 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.AddWallet.RecoverWalletView">
   <c:ContentArea x:Name="RecoveryPageRoot"
-                 Title="{Binding Title}" Caption="Type in your 12 recovery words and click Finish."
+                 Title="{Binding Title}" Caption="Type in your recovery words and click Finish."
                  CancelContent="Cancel"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"


### PR DESCRIPTION
Wasabi generates 12 word recovery words, but can recover 12 or 15 or 18 or 21 or 24 words according to BIP39.

This was pointed out by Lucas on slack.