### PR TITLE
Fix `CoinJoinManager` stopped

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -77,7 +77,6 @@ namespace WalletWasabi.WabiSabi.Client
 				foreach (var closedWallet in closedWallets.Select(x => x.Value))
 				{
 					closedWallet.CancellationTokenSource.Cancel();
-					closedWallet.CancellationTokenSource.Dispose();
 				}
 
 				var finishedCoinJoins = trackedWallets
@@ -92,7 +91,10 @@ namespace WalletWasabi.WabiSabi.Client
 					{
 						Logger.LogWarning($"Wallet: `{finishedCoinJoin.Wallet.WalletName}` was not removed from tracked wallet list. Will retry in a few seconds.");
 					}
-					finishedCoinJoin.CancellationTokenSource.Dispose();
+					else
+					{
+						finishedCoinJoin.CancellationTokenSource.Dispose();
+					}
 				}
 
 				foreach (var finishedCoinJoin in finishedCoinJoins)


### PR DESCRIPTION
This PR makes sure to dispose the cts only when it gets removed from the tracked list. 
Before it called the `Dispose()` for the second time too because the task was not finished in time, and then an exception happened, thus the CoinJoinManager stopped.

It especially happened when you turn ON then OFF the autoCJ.