### PR TITLE
Add CoinRefrigerator to CoinJoinManager

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public class CoinRefrigerator
+	{
+		private Dictionary<SmartCoin, DateTimeOffset> CoinsInFridge { get; } = new();
+		private TimeSpan FreezeTime { get; } = TimeSpan.FromSeconds(90);
+
+		public void Freeze(IEnumerable<SmartCoin> coins)
+		{
+			foreach (var coin in coins)
+			{
+				if (!CoinsInFridge.ContainsKey(coin))
+				{
+					CoinsInFridge.TryAdd(coin, DateTimeOffset.UtcNow);
+				}
+				else
+				{
+					CoinsInFridge[coin] = DateTimeOffset.UtcNow;
+				}
+			}
+		}
+
+		public bool IsFrozen(SmartCoin coin)
+		{
+			if (!CoinsInFridge.TryGetValue(coin, out var starTime))
+			{
+				return false;
+			}
+
+			// Freeze for one
+			if (starTime.Add(FreezeTime) > DateTimeOffset.UtcNow)
+			{
+				return true;
+			}
+
+			CoinsInFridge.Remove(coin);
+			return false;
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
@@ -26,12 +26,12 @@ namespace WalletWasabi.WabiSabi.Client
 
 		public bool IsFrozen(SmartCoin coin)
 		{
-			if (!FrozenCoins.TryGetValue(coin, out var starTime))
+			if (!FrozenCoins.TryGetValue(coin, out var startTime))
 			{
 				return false;
 			}
 
-			if (starTime.Add(FreezeTime) > DateTimeOffset.UtcNow)
+			if (startTime.Add(FreezeTime) > DateTimeOffset.UtcNow)
 			{
 				return true;
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
@@ -31,7 +31,6 @@ namespace WalletWasabi.WabiSabi.Client
 				return false;
 			}
 
-			// Freeze for one
 			if (starTime.Add(FreezeTime) > DateTimeOffset.UtcNow)
 			{
 				return true;

--- a/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
@@ -13,14 +13,7 @@ namespace WalletWasabi.WabiSabi.Client
 		{
 			foreach (var coin in coins)
 			{
-				if (!FrozenCoins.ContainsKey(coin))
-				{
-					FrozenCoins.TryAdd(coin, DateTimeOffset.UtcNow);
-				}
-				else
-				{
-					FrozenCoins[coin] = DateTimeOffset.UtcNow;
-				}
+				FrozenCoins[coin] = DateTimeOffset.UtcNow;
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinRefrigerator.cs
@@ -6,27 +6,27 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class CoinRefrigerator
 	{
-		private Dictionary<SmartCoin, DateTimeOffset> CoinsInFridge { get; } = new();
+		private Dictionary<SmartCoin, DateTimeOffset> FrozenCoins { get; } = new();
 		private TimeSpan FreezeTime { get; } = TimeSpan.FromSeconds(90);
 
 		public void Freeze(IEnumerable<SmartCoin> coins)
 		{
 			foreach (var coin in coins)
 			{
-				if (!CoinsInFridge.ContainsKey(coin))
+				if (!FrozenCoins.ContainsKey(coin))
 				{
-					CoinsInFridge.TryAdd(coin, DateTimeOffset.UtcNow);
+					FrozenCoins.TryAdd(coin, DateTimeOffset.UtcNow);
 				}
 				else
 				{
-					CoinsInFridge[coin] = DateTimeOffset.UtcNow;
+					FrozenCoins[coin] = DateTimeOffset.UtcNow;
 				}
 			}
 		}
 
 		public bool IsFrozen(SmartCoin coin)
 		{
-			if (!CoinsInFridge.TryGetValue(coin, out var starTime))
+			if (!FrozenCoins.TryGetValue(coin, out var starTime))
 			{
 				return false;
 			}
@@ -36,7 +36,7 @@ namespace WalletWasabi.WabiSabi.Client
 				return true;
 			}
 
-			CoinsInFridge.Remove(coin);
+			FrozenCoins.Remove(coin);
 			return false;
 		}
 	}


### PR DESCRIPTION
Continuation of https://github.com/zkSNACKs/WalletWasabi/pull/6405

Small helper class to detain coins until we are not sure about the CoinJoin they were participating in. Basically we are waiting for the mempool to get the CJ to make sure it was broadcast by the backend. 

It is basically the same but in a different class. I was not able to figure out any breakthrough, so I guess this is it. 