### PR TITLE
[PoC] Spend coins participating in a CoinJoin - Pull Out

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Dialogs;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
@@ -72,7 +73,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 		private async Task OnNextAsync(TransactionInfo transactionInfo,
 			IObservableList<PocketViewModel> selectedList)
 		{
-			transactionInfo.Coins = selectedList.Items.SelectMany(x => x.Coins).ToArray();
+			var coinJoinManager = Services.HostedServices.GetOrDefault<CoinJoinManager>()!;
+			var coins = selectedList.Items.SelectMany(x => x.Coins).ToArray();
+
+			coinJoinManager.PullOutCoinsFromCoinJoin(coins);
+			transactionInfo.Coins = coins;
 
 			try
 			{
@@ -168,7 +173,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				}
 				else
 				{
-					if (NextCommand is {} cmd && cmd.CanExecute(default))
+					if (NextCommand is { } cmd && cmd.CanExecute(default))
 					{
 						cmd.Execute(default);
 					}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -157,5 +157,19 @@ namespace WalletWasabi.WabiSabi.Client
 		}
 
 		private record WalletTrackingData(Wallet Wallet, CoinJoinClient CoinJoinClient, Task<bool> CoinJoinTask, IEnumerable<SmartCoin> CoinCandidates, CancellationTokenSource CancellationTokenSource);
+
+		public void PullOutCoinsFromCoinJoin(IEnumerable<SmartCoin> coinsToPullOutCoins)
+		{
+			var coins = coinsToPullOutCoins.ToHashSet();
+
+			// Freeze the coins.
+			CoinRefrigerator.Freeze(coins);
+
+			var walletsToAbort = TrackedWallets.Values.Where(wtd => wtd.CoinCandidates.Any(coins.Contains));
+			foreach (var wallet in walletsToAbort)
+			{
+				wallet.CancellationTokenSource.Cancel();
+			}
+		}
 	}
 }


### PR DESCRIPTION
Another concept for https://github.com/zkSNACKs/WalletWasabi/pull/6446

- Priority is the UX => if the user wants to send, make it possible whatever it takes. 

In descending order of probability, the situation occurs (top => most probable)

- If there are enough private coins, we don't need to care, the coins are not under mixing - we can send.
- There are not enough private coins, so the Coin Pockets screen appears. The user has to select one or more of the pockets.
- All the coins selected were immediately pulled out of any CoinJoin and got Frozen. 
- CoinJoinClients that contain at least one of the coins got canceled
- Most cases it will unregister the coin [here]( https://github.com/molnard/WalletWasabi/blob/d698d61b988df88f347807f131f609821ba95149/WalletWasabi/WabiSabi/Client/AliceClient.cs#L69).
- If the CoinJoinClient was in a critical phase all of the coins got banned. (Can throw another dialog to warn the user, but IMO this is edge case)
- In the next update the CoinJoinManager can still mix with the wallet but the Frozen coins will not be used.

Next steps:
- When to UnFreeze the coins, what happens if the user changed his mind and cancels the send? 
- How to modify the freezer to be able to handle send-related freeze? 90 sec makes no sense here. 



