### PR TITLE
[WabiSabi] Fix edge case when there is not remaining time

### DIFF
--- a/WalletWasabi/Extensions/TimeSpanExtensions.cs
+++ b/WalletWasabi/Extensions/TimeSpanExtensions.cs
@@ -6,13 +6,16 @@ namespace System
 {
 	public static class TimeSpanExtensions
 	{
-		public static ImmutableList<DateTimeOffset> Sample(this TimeSpan timeFrame, int numberOfEvents)
+		public static ImmutableList<DateTimeOffset> SamplePoisson(this TimeSpan timeFrame, int numberOfEvents)
 		{
 			var startTime = DateTimeOffset.UtcNow;
 			using var random = new SecureRandom();
+			TimeSpan Sample(int milliseconds) =>
+				milliseconds <= 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(random.GetInt(0, milliseconds));
+
 			return Enumerable
 				.Range(0, numberOfEvents)
-				.Select(_ => startTime + (0.8 * TimeSpan.FromMilliseconds(random.GetInt(0, (int)timeFrame.TotalMilliseconds))))
+				.Select(_ => startTime + (0.8 * Sample((int)timeFrame.TotalMilliseconds)))
 				.OrderBy(t => t)
 				.ToImmutableList();
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -192,7 +192,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 			// Gets the list of scheduled dates/time in the remaining available time frame when each alice has to be registered.
 			var remainingTimeForRegistration = roundState.InputRegistrationEnd - DateTimeOffset.UtcNow;
-			var scheduledDates = remainingTimeForRegistration.Sample(smartCoins.Count());
+			var scheduledDates = remainingTimeForRegistration.SamplePoisson(smartCoins.Count());
 
 			// Creates scheduled tasks (tasks that wait until the specified date/time and then perform the real registration)
 			var aliceClients = smartCoins.Zip(scheduledDates, (coin, date) => RegisterInputAsync(coin, cancellationToken).RunAsScheduledAsync(date, cancellationToken)).ToImmutableArray();
@@ -242,7 +242,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 			// Gets the list of scheduled dates/time in the remaining available time frame when each alice has to sign.
 			var transactionSigningTimeFrame = roundState.TransactionSigningTimeout - RoundStatusUpdater.Period;
-			var scheduledDates = transactionSigningTimeFrame.Sample(aliceClients.Count());
+			var scheduledDates = transactionSigningTimeFrame.SamplePoisson(aliceClients.Count());
 
 			// Creates scheduled tasks (tasks that wait until the specified date/time and then perform the real registration)
 			var signingRequests = aliceClients.Zip(scheduledDates, (alice, date) => SignTransactionAsync(alice, cancellationToken).RunAsScheduledAsync(date, cancellationToken)).ToImmutableArray();


### PR DESCRIPTION
This bug found by @MaxHillebrand 

```
2021-10-04 16:39:53.311 [17] ERROR	CoinJoinManager:ExecuteAsync (134)	Wallet: `Business` - Coinjoin client failed with exception: Exception: System.ArgumentException: Range of random number does not contain at least one possibility.
   at System.Security.Cryptography.RandomNumberGenerator.GetInt32(Int32 fromInclusive, Int32 toExclusive)
   at WalletWasabi.Crypto.Randomness.SecureRandom.GetInt(Int32 fromInclusive, Int32 toExclusive) in WalletWasabi/Crypto/Randomness/SecureRandom.cs:line 21
   at System.TimeSpanExtensions.<>c__DisplayClass0_0.<Sample>b__0(Int32 _) in WalletWasabi/Extensions/TimeSpanExtensions.cs:line 15
   at System.Linq.Enumerable.SelectRangeIterator`1.ToArray()
   at System.Linq.OrderedEnumerable`1.ToArray()
   at System.Collections.Immutable.ImmutableExtensions.FallbackWrapper`1.get_Count()
   at System.Collections.Immutable.ImmutableList`1.CreateRange(IEnumerable`1 items)
   at System.TimeSpanExtensions.Sample(TimeSpan timeFrame, Int32 numberOfEvents) in WalletWasabi/Extensions/TimeSpanExtensions.cs:line 13
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.CreateRegisterAndConfirmCoinsAsync(IEnumerable`1 smartCoins, RoundState roundState, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 195
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartRoundAsync(IEnumerable`1 smartCoins, RoundState roundState, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 92
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartCoinJoinAsync(IEnumerable`1 coins, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 68
   at WalletWasabi.WabiSabi.Client.CoinJoinManager.ExecuteAsync(CancellationToken stoppingToken) in WalletWasabi/WabiSabi/Client/CoinJoinManager.cs:line 112
   ```