### PR TITLE
[Fluent] call 'OpenCommand' if 'NavBarItem' instead of simple navigation

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Search/SearchItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Search/SearchItemViewModel.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using System.Windows.Input;
 using ReactiveUI;
+using WalletWasabi.Fluent.ViewModels.NavBar;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 
 namespace WalletWasabi.Fluent.ViewModels.Search
@@ -24,7 +25,12 @@ namespace WalletWasabi.Fluent.ViewModels.Search
 			owner.IsBusy = true;
 			var view = await NavigationManager.MaterialiseViewModelAsync(metaData);
 
-			if (view is { })
+
+			if (view is NavBarItemViewModel navBarItem && navBarItem.OpenCommand.CanExecute(default))
+			{
+				navBarItem.OpenCommand.Execute(default);
+			}
+			else if (view is { })
 			{
 				Navigate(view.DefaultTarget).To(view);
 			}


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/6471

I am not sure about the solution. I think the problem was that if we usually want to open a `NavBarItemViewModel` then we call its `OpenCommand`. But the Action Center didn't do this, it just simply navigated to the viewmodel.

This PR fixes it, although would be nice if somebody who is more familiar with that code could review this.