### PR TITLE
Spend coins participating in a CoinJoin - Just do it

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -67,7 +67,7 @@ namespace WalletWasabi.Blockchain.Transactions
 			}
 
 			// Get allowed coins to spend.
-			var availableCoinsView = Coins.Available();
+			var availableCoinsView = Coins.Unspent();
 			List<SmartCoin> allowedSmartCoinInputs = AllowUnconfirmed // Inputs that can be used to build the transaction.
 					? availableCoinsView.ToList()
 					: availableCoinsView.Confirmed().ToList();


### PR DESCRIPTION
According to reasons enumerated here: https://github.com/zkSNACKs/WalletWasabi/pull/6448#issuecomment-932269789 the solution is to let the user send, no matter what is the status of the coin regarding CoinJoin progress. 

Consequences only coming when sending a CoinJoin critical phase happens just in the same time: 

- Edge case: selected coin CoinJoined during Send wizard. The user will get an error message and has to redo the wizard. 
- Edge case: If the user spends during the critical section of CJ, all the coins registered from that wallet will be Noted .
