### PR TITLE
[Fluent] Remove duplicated block targets from FeeChart

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/FeeChartViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/FeeChartViewModel.cs
@@ -192,16 +192,16 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 		public void UpdateFeeEstimates(Dictionary<int, int> feeEstimates)
 		{
-			var correctedFeeEstimations = DistinctByValues(feeEstimates);
+			var correctedFeeEstimates = DistinctByValues(feeEstimates);
 
-			var xs = correctedFeeEstimations.Select(x => (double)x.Key).ToArray();
-			var ys = correctedFeeEstimations.Select(x => (double)x.Value).ToArray();
+			var xs = correctedFeeEstimates.Select(x => (double)x.Key).ToArray();
+			var ys = correctedFeeEstimates.Select(x => (double)x.Value).ToArray();
 
 			GetSmoothValuesSubdivide(xs, ys, out var xts, out var yts);
 			var confirmationTargetValues = xts.ToArray();
 			var satoshiPerByteValues = yts.ToArray();
 
-			var confirmationTargetLabels = correctedFeeEstimations.Select(x => x.Key)
+			var confirmationTargetLabels = correctedFeeEstimates.Select(x => x.Key)
 				.Select(x => FeeTargetTimeConverter.Convert(x, "m", "h", "h", "d", "d"))
 				.Reverse()
 				.ToArray();


### PR DESCRIPTION
In some cases, the estimated fee for some blocks is the same. For instance, for the transaction to be confirmed in 1 week or in 3 days the estimated fee is the same, 5 sat/vbyte. 

In this case, we will show only one time estimation for the 5 sat/vbyte. 
We can be either **pessimists** or **optimists**.

The optimist would say it will be confirmed in 3 days but the pessimist would say 1 week. I went with the optimist way in this PR but perhaps the pessimist would be better because the user should not be disappointed if the transaction gets confirmed way faster.

Before:
![image](https://user-images.githubusercontent.com/16364053/136649234-3f0fb295-1c4f-49d8-b5f4-8d4dee56d6bd.png)

After:
![image](https://user-images.githubusercontent.com/16364053/136649204-787b6ef3-39b8-47af-ab99-fca2c9644d59.png)
