### PR TITLE
`TorHttpPool`: Reserve connections upfront

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/Socks5/TorHttpPoolTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Socks5/TorHttpPoolTests.cs
@@ -35,9 +35,9 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Socks5
 			using TorTcpConnection defaultConnection = new(null!, new MemoryStream(), defaultIdentity, true);
 
 			Mock<TorTcpConnectionFactory> mockTcpConnectionFactory = new(MockBehavior.Strict, new IPEndPoint(IPAddress.Loopback, 7777));
-			_ = mockTcpConnectionFactory.Setup(c => c.ConnectAsync(It.IsAny<Uri>(), aliceIdentity, It.IsAny<CancellationToken>())).ReturnsAsync(aliceConnection);
-			_ = mockTcpConnectionFactory.Setup(c => c.ConnectAsync(It.IsAny<Uri>(), bobIdentity, It.IsAny<CancellationToken>())).ReturnsAsync(bobConnection);
-			_ = mockTcpConnectionFactory.Setup(c => c.ConnectAsync(It.IsAny<Uri>(), defaultIdentity, It.IsAny<CancellationToken>())).ReturnsAsync(defaultConnection);
+			_ = mockTcpConnectionFactory.Setup(c => c.EstablishConnectionAsync(It.IsAny<Uri>(), aliceIdentity, It.IsAny<CancellationToken>())).ReturnsAsync(aliceConnection);
+			_ = mockTcpConnectionFactory.Setup(c => c.EstablishConnectionAsync(It.IsAny<Uri>(), bobIdentity, It.IsAny<CancellationToken>())).ReturnsAsync(bobConnection);
+			_ = mockTcpConnectionFactory.Setup(c => c.EstablishConnectionAsync(It.IsAny<Uri>(), defaultIdentity, It.IsAny<CancellationToken>())).ReturnsAsync(defaultConnection);
 
 			TorTcpConnectionFactory tcpConnectionFactory = mockTcpConnectionFactory.Object;
 
@@ -102,7 +102,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Socks5
 			using TorTcpConnection connection = new(tcpClient: null!, transportStream.Client, circuit, allowRecycling: true);
 
 			Mock<TorTcpConnectionFactory> mockFactory = new(MockBehavior.Strict, new IPEndPoint(IPAddress.Loopback, 7777));
-			mockFactory.Setup(c => c.ConnectAsync(It.IsAny<Uri>(), It.IsAny<ICircuit>(), It.IsAny<CancellationToken>())).ReturnsAsync(connection);
+			mockFactory.Setup(c => c.EstablishConnectionAsync(It.IsAny<Uri>(), It.IsAny<ICircuit>(), It.IsAny<CancellationToken>())).ReturnsAsync(connection);
 
 			using StreamReader serverReader = new(transportStream.Server);
 			using StreamWriter serverWriter = new(transportStream.Server);

--- a/WalletWasabi.Tests/UnitTests/Tor/Socks5/TorTcpConnectionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Socks5/TorTcpConnectionFactoryTests.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Socks5
 						TorTcpConnectionFactory factory = new(new IPEndPoint(IPAddress.Loopback, serverPort));
 
 						Logger.LogTrace($"[{nameof(AuthenticationErrorScenarioAsync)}][client] About to make connection.");
-						using TorTcpConnection torConnection = await factory.ConnectAsync(httpRequestHost, httpRequestPort, useSsl: false, DefaultCircuit.Instance, timeoutToken).ConfigureAwait(false);
+						using TorTcpConnection torConnection = await factory.EstablishConnectionAsync(httpRequestHost, httpRequestPort, useSsl: false, DefaultCircuit.Instance, timeoutToken).ConfigureAwait(false);
 						Logger.LogTrace($"[{nameof(AuthenticationErrorScenarioAsync)}][client] Connection established.");
 					},
 					timeoutToken);
@@ -132,7 +132,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Socks5
 						TorTcpConnectionFactory factory = new(new IPEndPoint(IPAddress.Loopback, serverPort));
 
 						Logger.LogTrace($"[{nameof(TtlExpiredScenarioAsync)}][client] About to make connection.");
-						using TorTcpConnection torConnection = await factory.ConnectAsync(httpRequestHost, httpRequestPort, useSsl: false, DefaultCircuit.Instance, timeoutToken);
+						using TorTcpConnection torConnection = await factory.EstablishConnectionAsync(httpRequestHost, httpRequestPort, useSsl: false, DefaultCircuit.Instance, timeoutToken);
 						Logger.LogTrace($"[{nameof(TtlExpiredScenarioAsync)}][client] Connection established.");
 					},
 					timeoutToken);

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -65,7 +65,7 @@ namespace WalletWasabi.Tor.Http
 		/// <exception cref="OperationCanceledException">If <paramref name="token"/> is set.</exception>
 		public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
 		{
-			ICircuit circuit = Mode is Mode.NewCircuitPerRequest ? new OneOffCircuit() : PredefinedCircuit!;
+			ICircuit circuit = Mode is Mode.NewCircuitPerRequest ? new OneOffCircuit(isPreEstablished: false) : PredefinedCircuit!;
 			return TorHttpPool.SendAsync(request, circuit, token);
 		}
 
@@ -76,7 +76,7 @@ namespace WalletWasabi.Tor.Http
 				throw new InvalidOperationException($"{nameof(BaseUriGetter)} is not set.");
 			}
 
-			return TorHttpPool.EstablishConnectionsForFutureUseAsync(BaseUriGetter().DnsSafeHost, count, byWhen);
+			return TorHttpPool.EstablishConnectionsForFutureUseAsync(BaseUriGetter(), count, byWhen);
 		}
 
 		public Task<bool> IsTorRunningAsync()

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -69,6 +69,16 @@ namespace WalletWasabi.Tor.Http
 			return TorHttpPool.SendAsync(request, circuit, token);
 		}
 
+		public Task EstablishConnectionsForFutureUseAsync(int count, DateTimeOffset byWhen)
+		{
+			if (BaseUriGetter is null)
+			{
+				throw new InvalidOperationException($"{nameof(BaseUriGetter)} is not set.");
+			}
+
+			return TorHttpPool.EstablishConnectionsForFutureUseAsync(BaseUriGetter().DnsSafeHost, count, byWhen);
+		}
+
 		public Task<bool> IsTorRunningAsync()
 		{
 			return TorHttpPool.IsTorRunningAsync();

--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Tor.Socks5;
 using WalletWasabi.Tor.Socks5.Exceptions;
 using WalletWasabi.Tor.Socks5.Pool;
 using WalletWasabi.Tor.Socks5.Pool.Circuits;
@@ -69,7 +70,7 @@ namespace WalletWasabi.Tor.Http
 			return TorHttpPool.SendAsync(request, circuit, token);
 		}
 
-		public Task EstablishConnectionsForFutureUseAsync(int count, DateTimeOffset byWhen)
+		public Task<TorTcpConnection[]> EstablishConnectionsForFutureUseAsync(int count, DateTimeOffset byWhen)
 		{
 			if (BaseUriGetter is null)
 			{

--- a/WalletWasabi/Tor/Socks5/Pool/Circuits/OneOffCircuit.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/Circuits/OneOffCircuit.cs
@@ -7,17 +7,25 @@ namespace WalletWasabi.Tor.Socks5.Pool.Circuits
 	/// </summary>
 	public class OneOffCircuit : ICircuit
 	{
-		public OneOffCircuit()
+		public OneOffCircuit(bool isPreEstablished)
 		{
 			Name = RandomString.CapitalAlphaNumeric(21);
+			IsPreEstablished = isPreEstablished;
 		}
 
 		public string Name { get; }
 
+		/// <summary>Specifies whether the circuit was pre-established to be used later or not.</summary>
+		/// <remarks>
+		/// Pre-established connections are useful to avoid latency when we know we will
+		/// need a set of connections later.
+		/// </remarks>
+		public bool IsPreEstablished { get; }
+
 		/// <inheritdoc/>
 		public override string ToString()
 		{
-			return $"[{nameof(OneOffCircuit)}: {Name}]";
+			return $"[{nameof(OneOffCircuit)}: {Name}|{IsPreEstablished}]";
 		}
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -384,10 +384,19 @@ namespace WalletWasabi.Tor.Socks5.Pool
 				return canUse && connection.IsFreeToUse();
 			}).ToArray();
 
-			// Get random TCP connection from the candidates.
-			connection = (candidates.Count > 0)
-				? candidates[Random.GetInt(0, candidates.Count - 1)]
-				: null;
+			connection = null;
+
+			// Get random TCP connection from the candidates, if we have more than one.
+			if (candidates.Count == 1)
+			{
+				connection = candidates[0];
+			}
+			else if (candidates.Count > 1)
+			{
+				connection = (candidates.Count > 0)
+					? candidates[Random.GetInt(fromInclusive: 0, toExclusive: candidates.Count)]
+					: null;
+			}
 
 			if (connection is not null)
 			{

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -214,10 +214,12 @@ namespace WalletWasabi.Tor.Socks5.Pool
 
 					if (canBeAdded)
 					{
-						connection = await CreateNewConnectionNoLockAsync(request, circuit, token).ConfigureAwait(false);
+						connection = await CreateNewConnectionAsync(request, circuit, token).ConfigureAwait(false);
 
 						if (connection is { })
 						{
+							ConnectionPerHost[host].Add(connection);
+
 							Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Using new Tor SOCKS5 connection.");
 							return connection;
 						}
@@ -229,17 +231,15 @@ namespace WalletWasabi.Tor.Socks5.Pool
 			} while (true);
 		}
 
-		/// <remarks>Caller is responsible for acquiring <see cref="ObtainPoolConnectionLock"/>.</remarks>
-		private async Task<TorTcpConnection?> CreateNewConnectionNoLockAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken token)
+		private async Task<TorTcpConnection?> CreateNewConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
 		{
 			TorTcpConnection? connection;
 			string host = GetRequestHost(request);
 
 			try
 			{
-				connection = await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, token).ConfigureAwait(false);
+				connection = await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
 				Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Created new Tor SOCKS5 connection.");
-				ConnectionPerHost[host].Add(connection);
 			}
 			catch (TorException e)
 			{

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -238,7 +238,7 @@ namespace WalletWasabi.Tor.Socks5.Pool
 
 			try
 			{
-				connection = await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
+				connection = await TcpConnectionFactory.EstablishConnectionAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
 				Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Created new Tor SOCKS5 connection.");
 			}
 			catch (TorException e)

--- a/WalletWasabi/Tor/Socks5/TorTcpConnection.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnection.cs
@@ -36,14 +36,23 @@ namespace WalletWasabi.Tor.Socks5
 		private object StateLock { get; } = new();
 
 		/// <remarks>All access to this property must be guarded by <see cref="StateLock"/>.</remarks>
-		public TcpConnectionState State { get; private set; }
+		private TcpConnectionState State { get; set; }
 
 		/// <summary>Gets whether this pool item can be potentially re-used.</summary>
 		private bool AllowRecycling { get; }
 
 		/// <summary>Gets whether internal <see cref="TcpClient"/> can be re-used for a new HTTP(s) request.</summary>
 		/// <returns><c>true</c> when <see cref="TorTcpConnection"/> must be disposed, <c>false</c> otherwise.</returns>
-		public bool NeedDisposal => State == TcpConnectionState.ToDispose;
+		public bool NeedDisposal
+		{
+			get
+			{
+				lock (StateLock)
+				{
+					return State == TcpConnectionState.ToDispose;
+				}
+			}
+		}
 
 		/// <summary>Unique identifier of the pool item for logging purposes.</summary>
 		private long Id { get; }
@@ -65,15 +74,27 @@ namespace WalletWasabi.Tor.Socks5
 		public Stream GetTransportStream() => TransportStream;
 
 		/// <summary>Reserve the pool item for an HTTP(s) request so no other consumer can use this pool item.</summary>
+		public bool IsFreeToUse()
+		{
+			lock (StateLock)
+			{
+				return State == TcpConnectionState.FreeToUse;
+			}
+		}
+
+		/// <summary>Reserve the pool item for an HTTP(s) request so no other consumer can use this pool item.</summary>
 		public bool TryReserve()
 		{
-			if (State == TcpConnectionState.FreeToUse)
+			lock (StateLock)
 			{
-				State = TcpConnectionState.InUse;
-				return true;
-			}
+				if (State == TcpConnectionState.FreeToUse)
+				{
+					State = TcpConnectionState.InUse;
+					return true;
+				}
 
-			return false;
+				return false;
+			}
 		}
 
 		/// <summary>

--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -209,7 +209,7 @@ namespace WalletWasabi.Tor.Socks5
 		private static async Task<SslStream> UpgradeToSslAsync(TcpClient tcpClient, string host)
 		{
 			SslStream sslStream = new(tcpClient.GetStream(), leaveInnerStreamOpen: true);
-			await sslStream.AuthenticateAsClientAsync(host, new(), true).ConfigureAwait(false);
+			await sslStream.AuthenticateAsClientAsync(host, clientCertificates: new(), checkCertificateRevocation: true).ConfigureAwait(false);
 			return sslStream;
 		}
 

--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -41,16 +41,16 @@ namespace WalletWasabi.Tor.Socks5
 		private int TorPort { get; }
 
 		/// <summary>
-		/// Creates a new connected TCP client connected to Tor SOCKS5 endpoint.
+		/// Creates a new connected TCP client connected to Tor SOCKS5 endpoint with <paramref name="requestUri"/> host in mind.
 		/// </summary>
-		/// <inheritdoc cref="ConnectAsync(string, int, bool, ICircuit, CancellationToken)"/>
-		public virtual async Task<TorTcpConnection> ConnectAsync(Uri requestUri, ICircuit circuit, CancellationToken token = default)
+		/// <inheritdoc cref="EstablishConnectionAsync(string, int, bool, ICircuit, CancellationToken)"/>
+		public virtual async Task<TorTcpConnection> EstablishConnectionAsync(Uri requestUri, ICircuit circuit, CancellationToken token = default)
 		{
 			bool useSsl = requestUri.Scheme == Uri.UriSchemeHttps;
 			string host = requestUri.DnsSafeHost;
 			int port = requestUri.Port;
 
-			return await ConnectAsync(host, port, useSsl, circuit, token).ConfigureAwait(false);
+			return await EstablishConnectionAsync(host, port, useSsl, circuit, token).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -61,9 +61,9 @@ namespace WalletWasabi.Tor.Socks5
 		/// <param name="useSsl">Whether to use SSL to send the HTTP request over Tor.</param>
 		/// <param name="circuit">Tor circuit we want to use in authentication.</param>
 		/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
-		/// <returns>New <see cref="TorTcpConnection"/> instance.</returns>
+		/// <returns>New <see cref="TorTcpConnection"/> instance ready to accept HTTP(s) requests with given <paramref name="host"/>.</returns>
 		/// <exception cref="TorConnectionException">When <see cref="ConnectAsync(TcpClient, CancellationToken)"/> fails.</exception>
-		public async Task<TorTcpConnection> ConnectAsync(string host, int port, bool useSsl, ICircuit circuit, CancellationToken cancellationToken = default)
+		public async Task<TorTcpConnection> EstablishConnectionAsync(string host, int port, bool useSsl, ICircuit circuit, CancellationToken cancellationToken = default)
 		{
 			TcpClient? tcpClient = null;
 			Stream? transportStream = null;


### PR DESCRIPTION
This PR adds:

`public async Task<TorTcpConnection[]> EstablishConnectionsForFutureUseAsync(Uri baseUri, int count, DateTimeOffset deadline, CancellationToken cancellationToken = default)`

which allows the caller to create Tor circuits/connections upfront and use them later (without the latency cost).

There are also various small improvements. I plan to split the PR into a few small ones to make the review easier.