### PR TITLE
[Fluent] Fix blinking hamburger icon

### DIFF
--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -185,7 +185,7 @@
         </c:NavBarListBox.Styles>
         <c:NavBarListBox.ItemTemplate>
           <DataTemplate x:DataType="vm:NavBarItemViewModel">
-            <Panel Width="45" Background="Transparent" HorizontalAlignment="Center" ToolTip.Tip="{Binding Title}" ToolTip.Placement="Right">
+            <Panel Width="45" Background="Transparent" HorizontalAlignment="Center" ToolTip.Tip="{Binding Title}" ToolTip.VerticalOffset="-17" ToolTip.Placement="Top">
               <PathIcon HorizontalAlignment="Left">
                 <PathIcon.Data>
                   <Binding Path="IconName" Converter="{x:Static conv:NavBarIconConverter.Instance}" />


### PR DESCRIPTION
Partially fixes https://github.com/zkSNACKs/WalletWasabi/issues/6510

When the cursor enters into the NavBar area, the Wasabi logo is changing to a hamburger icon, thus gives an opportunity to close/open the NavBar manually.

When Wasabi is on fullscreen and the cursor point to a bottom left NavBarItem, then its tooltip shows up.
The issue was... Since the Window is in fullscreen the only place where the tooltip could show up is exactly where the cursor was.
So that caused the blinking effect because the cursor continuously entered/left the NavBar area.

This PR fixes it by showing the tooltip on right instead of on the cursor's position.