### PR TITLE
[WabiSabi] Stream status

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -21,10 +21,10 @@ namespace WalletWasabi.Backend.Controllers
 
 		private ArenaRequestHandler RequestHandler { get; }
 
-		[HttpGet("status")]
-		public Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		[HttpPost("status")]
+		public Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 		{
-			return RequestHandler.GetStatusAsync(cancellationToken);
+			return RequestHandler.GetStatusAsync(request, cancellationToken);
 		}
 
 		[HttpPost("connection-confirmation")]

--- a/WalletWasabi.Tests/Helpers/ArenaRequestHandlerAdapter.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaRequestHandlerAdapter.cs
@@ -19,8 +19,8 @@ namespace WalletWasabi.Tests.Helpers
 		public Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request, CancellationToken cancellationToken)
 			=> arena.ConfirmConnectionAsync(request, cancellationToken);
 
-		public Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
-			=> arena.GetStatusAsync(cancellationToken);
+		public Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
+			=> arena.GetStatusAsync(request, cancellationToken);
 
 		public Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request, CancellationToken cancellationToken)
 			=> arena.RegisterInputAsync(request, cancellationToken);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
+{
+	public class MultipartyTransactionStateTests
+	{
+		[Fact]
+		public void CanGetDifferentialStateTest()
+		{
+			var cfg = new WabiSabiConfig();
+			var round = WabiSabiFactory.CreateRound(cfg);
+
+			static Coin CreateCoin()
+			{
+				using var key = new Key();
+				return WabiSabiFactory.CreateCoin(key);
+			}
+
+			Coin coin1, coin2, coin3;
+
+			// Three events / three states
+			var state0 = round.Assert<ConstructionState>();
+			var state1 = state0.AddInput(coin1 = CreateCoin());
+			var state2 = state1.AddInput(coin2 = CreateCoin());
+			var state3 = state2.AddInput(coin3 = CreateCoin());
+
+			// Unknown state. Assumes full state is required
+			var diffd30 = state3.GetConstructionStateSince(-1);
+			Assert.Equal(state3, diffd30);
+
+			// Only one event is missing
+			var diffd32 = state3.GetConstructionStateSince(state2.Order);
+			var input = Assert.Single(diffd32.Inputs);
+			Assert.Equal(coin3.Outpoint, input.Outpoint);
+
+			// two events are missing
+			var diffd31 = state3.GetConstructionStateSince(state1.Order);
+			Assert.Collection(diffd31.Inputs,
+				x => Assert.Equal(coin2.Outpoint, x.Outpoint),
+				x => Assert.Equal(coin3.Outpoint, x.Outpoint));
+
+			// No event is missing (already updated)
+			var diffd33 = state3.GetConstructionStateSince(state3.Order);
+			Assert.Empty(diffd33.Inputs);
+
+			// Merge initial state0 with full diff. Expected to get state3
+			var merged03 = state0.Merge(diffd30);
+			Assert.Equal(state3, merged03);
+
+			// Merge state1 with diff between 1 and 3. Expected to get state3
+			var merged13 = state1.Merge(diffd31);
+			Assert.Equal(state3.Order, merged13.Order);
+			Assert.True(merged13.Inputs.SequenceEqual(state3.Inputs));
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -58,6 +58,18 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 			var merged13 = state1.Merge(diffd31);
 			Assert.Equal(state3.Order, merged13.Order);
 			Assert.True(merged13.Inputs.SequenceEqual(state3.Inputs));
+
+			//---------------------
+			var diff00 = state0.GetConstructionStateSince(0);
+			var diff10 = state1.GetConstructionStateSince(0);
+			var diff21 = state2.GetConstructionStateSince(1);
+			var diff32 = state3.GetConstructionStateSince(2);
+
+			var clientState1 = state1;
+			var clientState3 = state3.GetConstructionStateSince(clientState1.Order).MergeBack(clientState1);
+
+			Assert.Equal(state3.Order, clientState3.Order);
+			Assert.True(clientState3.Inputs.SequenceEqual(state3.Inputs));
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -42,7 +42,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend
 
 			// two events are missing
 			var diffd31 = state3.GetConstructionStateSince(state1.Order);
-			Assert.Collection(diffd31.Inputs,
+			Assert.Collection(
+				diffd31.Inputs,
 				x => Assert.Equal(coin2.Outpoint, x.Outpoint),
 				x => Assert.Equal(coin3.Outpoint, x.Outpoint));
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -217,7 +217,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			var emptyState = round.Assert<ConstructionState>();
 
 			// We can't use ``emptyState.Finalize()` because this is not a valid transaction so we fake it
-			var finalizedEmptyState = new SigningState(emptyState.Parameters, emptyState.Inputs, emptyState.Outputs);
+			var finalizedEmptyState = new SigningState(emptyState.Parameters, emptyState.Inputs, emptyState.Outputs, 0);
 
 			// No inputs in the CoinJoin.
 			await Assert.ThrowsAsync<ArgumentException>(async () =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -20,6 +20,7 @@ using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Crypto;
+using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
@@ -77,7 +78,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 
 		public async Task<ArenaClient> CreateArenaClientAsync(WabiSabiHttpApiClient wabiSabiHttpApiClient)
 		{
-			var rounds = await wabiSabiHttpApiClient.GetStatusAsync(CancellationToken.None);
+			var rounds = await wabiSabiHttpApiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 			var round = rounds.First(x => x.CoinjoinState is ConstructionState);
 			var insecureRandom = new InsecureRandom();
 			var arenaClient = new ArenaClient(

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -39,7 +40,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var httpClient = _apiApplicationFactory.CreateClient();
 
 			var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(httpClient);
-			var rounds = await apiClient.GetStatusAsync(CancellationToken.None);
+			var rounds = await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 			var round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
 			// If an output is not in the utxo dataset then it is not unspent, this
@@ -375,7 +376,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			}).CreateClient();
 
 			var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(httpClient);
-			var rounds = await apiClient.GetStatusAsync(CancellationToken.None);
+			var rounds = await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 			var round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
 			var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
@@ -409,7 +410,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			}).CreateClient();
 
 			ArenaClient apiClient = await _apiApplicationFactory.CreateArenaClientAsync(new StuttererHttpClient(httpClient));
-			RoundState[] rounds = await apiClient.GetStatusAsync(CancellationToken.None);
+			RoundState[] rounds = await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 			RoundState round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
 			var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -27,7 +27,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// The coordinator creates two rounds.
 			// Each line represents a response for each request.
 			var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
-			mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<CancellationToken>()))
+			mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(() => new[] { roundState1 with { Phase = Phase.InputRegistration } })
 				.ReturnsAsync(() => new[] { roundState1 with { Phase = Phase.OutputRegistration } })
 				.ReturnsAsync(() => new[] { roundState1 with { Phase = Phase.OutputRegistration }, roundState2 with { Phase = Phase.InputRegistration } })

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -144,7 +144,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			AssertSerialization(RoundState.FromRound(round));
 
 			var state = round.Assert<ConstructionState>();
-			round.CoinjoinState = new SigningState(state.Parameters, state.Inputs, state.Outputs);
+			round.CoinjoinState = new SigningState(state.Parameters, state.Inputs, state.Outputs, 0);
 			AssertSerialization(RoundState.FromRound(round));
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/ArenaRequestHandler.cs
@@ -87,12 +87,12 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 			}
 		}
 
-		public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		public async Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 		{
 			DisposeGuard();
 			using (RunningTasks.RememberWith(RunningRequests))
 			{
-				return await Arena.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+				return await Arena.GetStatusAsync(request, cancellationToken).ConfigureAwait(false);
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/IWabiSabiApiRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/IWabiSabiApiRequestHandler.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 
 		Task<ReissueCredentialResponse> ReissueCredentialAsync(ReissueCredentialRequest request, CancellationToken cancellationToken);
 
-		Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken);
+		Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken);
 
 		Task ReadyToSign(ReadyToSignRequestRequest request, CancellationToken cancellationToken);
 	}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -330,7 +330,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
-				return Rounds.Select(x => {
+				return Rounds.Select(x =>
+				{
 					var checkPoint = request.RoundCheckpoints.FirstOrDefault(y => y.RoundId == x.Id);
 					return RoundState.FromRound(x, checkPoint == default ? -1 : checkPoint.EventId);
 				}).ToArray();

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -326,11 +326,14 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			}
 		}
 
-		public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		public async Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 		{
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
-				return Rounds.Select(x => RoundState.FromRound(x)).ToArray();
+				return Rounds.Select(x => {
+					var checkPoint = request.RoundCheckpoints.FirstOrDefault(y => y.RoundId == x.Id);
+					return RoundState.FromRound(x, checkPoint == default ? -1 : checkPoint.EventId);
+				}).ToArray();
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -214,9 +214,9 @@ namespace WalletWasabi.WabiSabi.Client
 			await RequestHandler.SignTransactionAsync(new TransactionSignaturesRequest(roundId, signatures), cancellationToken).ConfigureAwait(false);
 		}
 
-		public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+		public async Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 		{
-			return await RequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+			return await RequestHandler.GetStatusAsync(request, cancellationToken).ConfigureAwait(false);
 		}
 
 		public async Task ReadyToSignAsync(

--- a/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
@@ -32,9 +32,8 @@ namespace WalletWasabi.WabiSabi.Client
 			var updatedRoundStates = statusResponse
 				.Where(rs => RoundStates.ContainsKey(rs.Id))
 				.Select(rs => (Update: rs, CurrentRoundState: RoundStates[rs.Id]))
-				.Select(x => x.Update with {
-					CoinjoinState = x.Update.CoinjoinState.MergeBack(x.CurrentRoundState.CoinjoinState)
-					}).ToList();
+				.Select(x => x.Update with { CoinjoinState = x.Update.CoinjoinState.MergeBack(x.CurrentRoundState.CoinjoinState) })
+				.ToList();
 
 			var newRoundStates = statusResponse
 				.Where(rs => !RoundStates.ContainsKey(rs.Id));

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -52,17 +53,8 @@ namespace WalletWasabi.WabiSabi.Client
 		public virtual Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken) =>
 			SendAndReceiveAsync<TransactionSignaturesRequest>(RemoteAction.SignTransaction, request, cancellationToken);
 
-		public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
-		{
-			using var response = await _client.SendAsync(HttpMethod.Get, GetUriEndPoint(RemoteAction.GetStatus), cancel: cancellationToken).ConfigureAwait(false);
-
-			if (!response.IsSuccessStatusCode)
-			{
-				await response.ThrowRequestExceptionFromContentAsync(cancellationToken).ConfigureAwait(false);
-			}
-			var jsonString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-			return Deserialize<RoundState[]>(jsonString);
-		}
+		public Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken) =>
+			SendAndReceiveAsync<RoundStateRequest, RoundState[]>(RemoteAction.GetStatus, request, cancellationToken);
 
 		public Task ReadyToSign(ReadyToSignRequestRequest request, CancellationToken cancellationToken) =>
 			SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -109,7 +109,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InsufficientFees);
 			}
 
-			return new SigningState(Parameters, Inputs, Outputs);
+			return new SigningState(Parameters, Inputs, Outputs, Order);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -61,7 +61,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
 			}
 
-			return this with { Inputs = Inputs.Add(coin) };
+			return this with { Inputs = Inputs.Add(coin), PreviousState = this, Order = Order + 1 };
 		}
 
 		public ConstructionState AddOutput(TxOut output)
@@ -94,7 +94,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
 			}
 
-			return this with { Outputs = Outputs.Add(output) };
+			return this with { Outputs = Outputs.Add(output), PreviousState = this, Order = Order + 1 };
 		}
 
 		public SigningState Finalize()

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -34,6 +34,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 		// of the transaction also pays at the nominal feerate so this will have
 		// to do for now, but in the future EstimatedVsize should be used
 		// including the shared overhead
+		[JsonIgnore]
 		public FeeRate EffectiveFeeRate => new(Balance, EstimatedInputsVsize + OutputsVsize);
 
 		public MultipartyTransactionState GetConstructionStateSince(long order)
@@ -63,6 +64,14 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 				Outputs = Outputs.AddRange(diff.Outputs),
 				PreviousState = diff.PreviousState,
 				Order = diff.Order
+			};
+		}
+
+		public MultipartyTransactionState MergeBack(MultipartyTransactionState origin)
+		{
+			return this with {
+				Inputs = origin.Inputs.AddRange(Inputs),
+				Outputs = origin.Outputs.AddRange(Outputs),
 			};
 		}
 	}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -39,6 +39,10 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 
 		public MultipartyTransactionState GetConstructionStateSince(long order)
 		{
+			if (this.Order < order)
+			{
+				return null;
+			}
 			var visitedState = this;
 			while (visitedState is not null && visitedState.Order != order)
 			{

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
@@ -12,34 +12,43 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 {
 	public record SigningState : MultipartyTransactionState
 	{
-		public SigningState(MultipartyTransactionParameters parameters, IEnumerable<Coin> inputs, IEnumerable<TxOut> outputs)
+		public SigningState(MultipartyTransactionParameters parameters, IEnumerable<Coin> inputs, IEnumerable<TxOut> outputs, long order)
 			: base(parameters)
 		{
+			Order = order;
 			Inputs = inputs
+				.ToImmutableList();
+
+			Outputs = outputs
+				.ToImmutableList();
+		}
+
+		public ImmutableList<Coin> GetInputs() =>
+			Inputs
 				.OrderByDescending(x => x.Amount)
 				.ThenBy(x => x.Outpoint.ToBytes(), ByteArrayComparer.Comparer)
 				.ToImmutableList();
 
-			Outputs = outputs
+		public ImmutableList<TxOut>	 GetOutputs() =>
+			Outputs
 				.GroupBy(x => x.ScriptPubKey)
 				.Select(x => new TxOut(x.Sum(y => y.Value), x.Key))
 				.OrderByDescending(x => x.Value)
 				.ThenBy(x => x.ScriptPubKey.ToBytes(true), ByteArrayComparer.Comparer)
 				.ToImmutableList();
-		}
 
 		public ImmutableDictionary<int, WitScript> Witnesses { get; init; } = ImmutableDictionary<int, WitScript>.Empty;
 
 		public bool IsFullySigned => Witnesses.Count == Inputs.Count;
 
 		[JsonIgnore]
-		public IEnumerable<Coin> UnsignedInputs => Inputs.Where((_, i) => !IsInputSigned(i));
+		public IEnumerable<Coin> UnsignedInputs => GetInputs().Where((_, i) => !IsInputSigned(i));
 
 		public bool IsInputSigned(int index) => Witnesses.ContainsKey(index);
 
 		public bool IsInputSigned(OutPoint prevout) => IsInputSigned(GetInputIndex(prevout));
 
-		public int GetInputIndex(OutPoint prevout) => Inputs.ToList().FindIndex(coin => coin.Outpoint == prevout); // this is inefficient but is only used in tests, see also dotnet/runtime#45366
+		public int GetInputIndex(OutPoint prevout) => GetInputs().FindIndex(coin => coin.Outpoint == prevout); // this is inefficient but is only used in tests, see also dotnet/runtime#45366
 
 		public SigningState AddWitness(int index, WitScript witness)
 		{
@@ -59,7 +68,8 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 			IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
 
 			// 4. Find the corresponding registered input.
-			Coin registeredCoin = Inputs[index];
+			var sortedInputs = GetInputs();
+			Coin registeredCoin = sortedInputs[index];
 
 			// 5. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
 			if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
@@ -74,14 +84,14 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
 		{
 			var tx = Parameters.CreateTransaction();
 
-			foreach (var coin in Inputs)
+			foreach (var coin in GetInputs())
 			{
 				// implied:
 				// nSequence = FINAL
 				tx.Inputs.Add(coin.Outpoint);
 			}
 
-			foreach (var txout in Outputs)
+			foreach (var txout in GetOutputs())
 			{
 				tx.Outputs.Add(txout);
 			}

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -31,7 +31,7 @@ namespace WalletWasabi.WabiSabi.Models
 
 		public DateTimeOffset InputRegistrationEnd => InputRegistrationStart + InputRegistrationTimeout;
 
-		public static RoundState FromRound(Round round) =>
+		public static RoundState FromRound(Round round, long order = -1) =>
 			new(
 				round is BlameRound blameRound ? blameRound.BlameOf.Id : uint256.Zero,
 				round.AmountCredentialIssuerParameters,
@@ -47,7 +47,7 @@ namespace WalletWasabi.WabiSabi.Models
 				round.MaxAmountCredentialValue,
 				round.MaxVsizeCredentialValue,
 				round.MaxVsizeAllocationPerAlice,
-				round.CoinjoinState);
+				round.CoinjoinState.GetConstructionStateSince(order));
 
 		public TState Assert<TState>() where TState : MultipartyTransactionState =>
 			CoinjoinState switch

--- a/WalletWasabi/WabiSabi/Models/RoundStateRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundStateRequest.cs
@@ -1,0 +1,10 @@
+using System.Collections.Immutable;
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Models
+{
+	public record RoundStateRequest(ImmutableList<(uint256 RoundId, long EventId)> RoundCheckpoints)
+	{
+		public static readonly RoundStateRequest Empty = new (ImmutableList<(uint256 RoundId, long EventId)>.Empty);
+	}
+}


### PR DESCRIPTION
The WabiSabi coinjoin clients need to be updated regularly about the status of the different coordinator's rounds. These updates contains information such as the current phase of the round and the registered inputs and outputs, among other data. The component responsible for keeping the coinjoin clients updated with this information is the `RoundStateUpdater` which hits the coordinator frequently (5 seconds) and fetches the rounds.

## Incremental updates

In a real-world scenario where the number of inputs and outputs in a coinjoin transaction can be big, fetching all that data with high frequency over Tor is not a good idea and it cannot really work. Instead of doing that this PR fetches the incremental updates to allow the client to add new info to the already known data.

## Design

There are basically two important events that all clients need to be aware of: 
* Input registered event and,
* Output registered event.

The occurrence of any of these events changes the internal state of the coordinator that is stored in the `CoinJoinState`. In order to be able to calculate the difference between the user's known state and the latest one the coordinator links the `CoinJoinState` with a reference to the previous state, creating a linked list of states (one for each event): 

```
         ─┬──
          │        ┌──────────┐
          │        │          │
Client    │        │   0      │
 knows    │        │          │
 one      │        └──────────┘
event     │              ▲
          │              │         Input registration Event
          │              │      ┌──────────┐
          │      prev    │      │          │
          │              └──────┤    1     │
          │                     │          │
          │                     └──────────┘
         ─┴──                         ▲
                                      │          Input registration Event
         ─┬──                         │      ┌──────────┐
          │                   prev    │      │          │
Server    │                           └──────┤    2     │
responses │                                  │          │
with      │                                  └──────────┘
the       │                                        ▲
two       │                                        │           Output registration Event
new       │                                        │      ┌──────────┐
events    │                                prev    │      │          │
          │                                        └──────┤ current 3│
          │                                               │          │
          │                                               └──────────┘
        ──┴─
```

There are two new operations over this state chain:
* **Coordinator:** calculate the difference/increment containing the data the client needs to know and,
* **Client:** apply the received increment to the old-known state to get the latest snapshot of the state.

----------------------------

 **Disclaimer:** this is not the final version but just an step in the right direction. 

The final design is conceptually similar to this one but simpler. The idea is to have an append-only list of events as coinjoin state instead of having an linked-list of coinjoin states. However, doing that requires a bit more time than doing this.