### PR TITLE
Add `global.json`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.402",
+    "version": "5.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }


### PR DESCRIPTION
[global.json](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json) is a file that is used to make sure that a proper version of .NET is used when `dotnet` command is run from `C:\path\to\WalletWasabi` folder. This is relevant when a user has multiple versions of .NET installed.

The reason why this is a useful thing is because it clearly states what .NET version is expected to be used for the project. This [narrows](https://github.com/zkSNACKs/WalletWasabi/issues/6315#issuecomment-913896164) [down](https://github.com/zkSNACKs/WalletWasabi/issues/6315#issuecomment-916395430) guessing what version of .NET was used to build the official build of WW when attempting to verify the (deterministic) build.

Also I think it is a good practice to have `global.json` as many projects contain `global.json` file:

* https://github.com/dotnet/runtime/blob/main/global.json
* https://github.com/AvaloniaUI/Avalonia/blob/master/global.json
* etc.

I selected .NET version `5.0.402` and `rollForward = latestFeature` and that means that if any .NET of version `5.0.*` is installed, then it is possible to build WW. If, for example, only .NET `3.*.*` is installed, a warning will be shown and the build process will not start when trying `dotnet restore` / `dotnet build` etc. Similarly for any pre-release of .NET 6.

For deterministic builds, it would be great to actually require a specific version of .NET (e.g. `5.0.402` and only that specific version) to be installed so that there is no room for an error. However, given that .NET is installed on linux machines via "apt" (maybe also using a "snap"), this may be problematic because we would force developers to have a specific version of .NET installed and this seems like inconvenient (and probably bad) thing to force upon WW developers. So I didn't do it for this precise reason.

What do you think guys?

PS: I created this PR because I have .NET 6 RC-2 installed and I was building WW by this .NET version unintentionally.