### PR TITLE
Wasabi.Packager: Report error more clearly

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -551,7 +551,18 @@ namespace WalletWasabi.Packager
 
 			if (process.ExitCode is not 0)
 			{
-				throw new InvalidOperationException($"Process exited with code '{process.ExitCode}'.{ (redirectStandardOutput ? output : "") }");
+				Console.WriteLine($"Process failed:");
+				Console.WriteLine($"* Command: '{command} {arguments}'");
+				Console.WriteLine($"* Working directory: '{workingDirectory}'");
+				Console.WriteLine($"* Exit code: '{process.ExitCode}'");
+
+				if (redirectStandardOutput)
+				{
+					string prettyPrint = string.Join(Environment.NewLine, (output ?? "").Split(Environment.NewLine).Select(line => $"  > {line}"));
+					Console.WriteLine($"* Output:\n{prettyPrint}");
+				}
+
+				throw new InvalidOperationException("Process exited with unexpected exit code");
 			}
 
 			return output;


### PR DESCRIPTION
This is a part of the output we get with this PR:

```
Process failed:
* Command: 'dotnet publish --configuration Release --force --output "C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent.Desktop\bin\dist\win7-x64" --self-contained true --runtime "win7-x64" --disable-parallel --no-cache /p:VersionPrefix=1.1.12.9 /p:DebugType=none /p:DebugSymbols=false /p:ErrorReport=none /p:DocumentationFile="" /p:Deterministic=true /p:RestoreLockedMode=true'
* Working directory: 'C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent.Desktop'
* Exit code: '1'
* Output:
  > Microsoft (R) Build Engine version 17.0.0-preview-21501-01+bbcce1dff for .NET
  > Copyright (C) Microsoft Corporation. All rights reserved.
  >
  >   Determining projects to restore...
  > C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent\WalletWasabi.Fluent.csproj : error NU1004: The package references have changed for net5.0. Lock file's package references: Avalonia:[0.10.8, ), Avalonia.Controls.DataGrid:[0.10.8, ), Avalonia.Diagnostics:[0.10.8, ), Avalonia.ReactiveUI:[0.10.8, ), Avalonia.Xaml.Behaviors:[0.10.8, ), OpenCvSharp4:[4.5.2.20210404, ), OpenCvSharp4.runtime.win:[4.5.2.20210404, ), System.Reactive:[5.0.0, ), System.Runtime:[4.3.1, ), project's package references: Avalonia:[0.10.8, ), Avalonia.Controls.DataGrid:[0.10.8, ), Avalonia.ReactiveUI:[0.10.8, ), Avalonia.Xaml.Behaviors:[0.10.8, ), OpenCvSharp4:[4.5.2.20210404, ), OpenCvSharp4.runtime.win:[4.5.2.20210404, ), System.Reactive:[5.0.0, ), System.Runtime:[4.3.1, ).The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file. [C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj]
  >   Failed to restore C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent\WalletWasabi.Fluent.csproj (in 103 ms).
  >   Restored C:\WasabiWallet\WalletWasabi\WalletWasabi\WalletWasabi.csproj (in 262 ms).
  >   Restored C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent.Generators\WalletWasabi.Fluent.Generators.csproj (in 36 ms).
  > C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj : error NU1004: The project reference walletwasabi.fluent has changed. Current dependencies: Avalonia,Avalonia.Controls.DataGrid,Avalonia.ReactiveUI,Avalonia.Xaml.Behaviors,C:\WasabiWallet\WalletWasabi\WalletWasabi\WalletWasabi.csproj,OpenCvSharp4,OpenCvSharp4.runtime.win,System.Reactive,System.Runtime lock file's dependencies: Avalonia,Avalonia.Controls.DataGrid,Avalonia.Diagnostics,Avalonia.ReactiveUI,Avalonia.Xaml.Behaviors,OpenCvSharp4,OpenCvSharp4.runtime.win,System.Reactive,System.Runtime,WalletWasabi.The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file.
  >   Failed to restore C:\WasabiWallet\WalletWasabi\WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj (in 15 ms).
  >
```

I got here when testing https://github.com/zkSNACKs/WalletWasabi/pull/6526. I followed https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md#2-reproduce-builds and I got the following error:

<details>
  <summary>Packager error</summary>

```
C:\WalletWasabi\WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj : error NU1004: The project reference walletwasabi.fluent has changed. 
Current dependencies:     Avalonia,Avalonia.Controls.DataGrid,Avalonia.ReactiveUI,Avalonia.Xaml.Behaviors,C:\WalletWasabi\WalletWasabi\WalletWasabi.csproj,OpenCvSharp4,OpenCvSharp4.runtime.win,System.Reactive,System.Runtime 
lock file's dependencies: Avalonia,Avalonia.Controls.DataGrid,Avalonia.Diagnostics,Avalonia.ReactiveUI,Avalonia.Xaml.Behaviors,OpenCvSharp4,OpenCvSharp4.runtime.win,System.Reactive,System.Runtime,WalletWasabi.

The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file.

The package references have changed for net5.0. Lock file's package references: 

Avalonia:[0.10.8, ),
Avalonia.Controls.DataGrid:[0.10.8, ),
Avalonia.Diagnostics:[0.10.8, ),
Avalonia.ReactiveUI:[0.10.8, ),
Avalonia.Xaml.Behaviors:[0.10.8, ),
OpenCvSharp4:[4.5.2.20210404, ),
OpenCvSharp4.runtime.win:[4.5.2.20210404, ),
System.Reactive:[5.0.0, ), System.Runtime:[4.3.1, ), 

project's package references: 
Avalonia:[0.10.8, )
Avalonia.Controls.DataGrid:[0.10.8, )
Avalonia.ReactiveUI:[0.10.8, )
Avalonia.Xaml.Behaviors:[0.10.8, )
OpenCvSharp4:[4.5.2.20210404, )
OpenCvSharp4.runtime.win:[4.5.2.20210404, )
System.Reactive:[5.0.0, )
System.Runtime:[4.3.1, ).

The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file. [C:\WalletWasabi\WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj]
  Failed to restore C:\WalletWasabi\WalletWasabi.Fluent\WalletWasabi.Fluent.csproj (in 3 ms).
  Restored C:\WalletWasabi\WalletWasabi\WalletWasabi.csproj (in 125 ms).
```
</details>

No matter what I did I could not get rid of the error. In the end I believe I fixed it by calling `dotnet build --configuration Release` by hand - I think we should call `dotnet build --configuration Release` in `WalletWasabi.Packager.Program`. We call `dotnet clean` and `dotnet publish` which should be sufficient but it seems like ... not always. But that's another issue.