### PR TITLE
Change KeyPath for TestNet

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
@@ -124,7 +124,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 
 		public ICommand AdvancedRecoveryOptionsDialogCommand { get; }
 
-		private KeyPath AccountKeyPath { get; set; } = KeyPath.Parse("m/84'/0'/0'");
+		private KeyPath AccountKeyPath { get; set; } = KeyManager.GetAccountKeyPath(Services.WalletManager.Network);
 
 		private int MinGapLimit { get; set; } = 63;
 

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
@@ -75,8 +75,9 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet
 							var result = KeyManager.Recover(
 								CurrentMnemonics!,
 								password!,
-								walletFilePath,
+								Services.WalletManager.Network,
 								AccountKeyPath,
+								walletFilePath,
 								MinGapLimit);
 
 							result.SetNetwork(Services.WalletManager.Network);

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/AdvancedRecoveryOptionsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/AdvancedRecoveryOptionsViewModel.cs
@@ -70,7 +70,7 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs
 			{
 				var accountKeyPath = keyPath.GetAccountKeyPath();
 				if (keyPath.Length != accountKeyPath.Length ||
-					accountKeyPath.Length != KeyManager.DefaultAccountKeyPath.Length)
+					accountKeyPath.Length != KeyManager.GetAccountKeyPath(Network.Main).Length)
 				{
 					errors.Add(ErrorSeverity.Error, "Path is not a compatible account derivation path.");
 				}

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -174,8 +174,8 @@ namespace WalletWasabi.Tests.AcceptanceTests
 			// ColdCard doesn't support it.
 			await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			Assert.NotNull(xpub1);
@@ -254,8 +254,8 @@ namespace WalletWasabi.Tests.AcceptanceTests
 
 			await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			Assert.NotNull(xpub1);
@@ -337,8 +337,8 @@ namespace WalletWasabi.Tests.AcceptanceTests
 
 			await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			Assert.NotNull(xpub1);

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.Tests.Helpers
 		}
 
 		public static KeyManager CreateKeyManager(string password = "blahblahblah")
-			=> KeyManager.CreateNew(out var _, password);
+			=> KeyManager.CreateNew(out var _, password, null, Network.Main);
 
 		public static KeyManager CreateWatchOnlyKeyManager()
 			=> KeyManager.CreateNewWatchOnly(new Mnemonic(Wordlist.English, WordCount.Twelve).DeriveExtKey().Neuter());

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.Tests.Helpers
 		}
 
 		public static KeyManager CreateKeyManager(string password = "blahblahblah")
-			=> KeyManager.CreateNew(out var _, password, null, Network.Main);
+			=> KeyManager.CreateNew(out var _, password, Network.Main);
 
 		public static KeyManager CreateWatchOnlyKeyManager()
 			=> KeyManager.CreateNewWatchOnly(new Mnemonic(Wordlist.English, WordCount.Twelve).DeriveExtKey().Neuter());

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -94,7 +94,7 @@ namespace WalletWasabi.Tests.IntegrationTests
 
 			using var nodes = new NodesGroup(network, connectionParameters, requirements: Constants.NodeRequirements);
 
-			KeyManager keyManager = KeyManager.CreateNew(out _, "password");
+			KeyManager keyManager = KeyManager.CreateNew(out _, "password", network);
 			using HttpClientFactory httpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: () => new Uri("http://localhost:12345"));
 			WasabiSynchronizer synchronizer = new(bitcoinStore, httpClientFactory);
 			var feeProvider = new HybridFeeProvider(synchronizer, null);

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();
@@ -212,7 +212,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -56,7 +56,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();
@@ -534,7 +534,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();
@@ -708,7 +708,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 4. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 5. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -120,7 +120,7 @@ namespace WalletWasabi.Tests.RegressionTests
 		{
 			(string password, IRPCClient rpc, Network network, _, _, BitcoinStore bitcoinStore, Backend.Global global) = await Common.InitializeTestEnvironmentAsync(RegTestFixture, 1);
 
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// Mine some coins, make a few bech32 transactions then make it confirm.
 			await rpc.GenerateAsync(1);
@@ -243,7 +243,7 @@ namespace WalletWasabi.Tests.RegressionTests
 			HybridFeeProvider feeProvider = new(synchronizer, null);
 
 			// 3. Create key manager service.
-			var keyManager = KeyManager.CreateNew(out _, password);
+			var keyManager = KeyManager.CreateNew(out _, password, network);
 
 			// 4. Create wallet service.
 			var workDir = Helpers.Common.GetWorkDir();

--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -159,6 +159,20 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 						: "{\"address\": \"bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf\"}\r\n";
 				}
 			}
+			else if (CompareArguments(out bool _, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/1h/0h --addr-type wit", false))
+			{
+				if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+				{
+					response = "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n";
+				}
+			}
+			else if (CompareArguments(out bool _, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/1h/0h/1 --addr-type wit", false))
+			{
+				if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+				{
+					response = "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n";
+				}
+			}
 
 			return response is null
 				? throw new NotImplementedException($"Mocking is not implemented for '{arguments}'.")
@@ -220,6 +234,14 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 				else if (keyPath == "m/84h/0h/0h/1")
 				{
 					extPubKey = "xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu";
+				}
+				else if (keyPath == "m/84h/1h/0h")
+				{
+					extPubKey = "xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c";
+				}
+				else if (keyPath == "m/84h/1h/0h/1")
+				{
+					extPubKey = "xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA";
 				}
 			}
 

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -65,10 +65,20 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
-			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
-			var expecteXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
-			Assert.Equal(expecteXpub1, xpub1);
-			Assert.Equal(expecteXpub2, xpub2);
+			ExtPubKey expectedXpub1;
+			ExtPubKey expectedXpub2;
+			if (network == Network.TestNet)
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+			}
+			else
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+			}
+			Assert.Equal(expectedXpub1, xpub1);
+			Assert.Equal(expectedXpub2, xpub2);
 
 			BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
 			BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
@@ -139,10 +149,20 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
-			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
-			var expecteXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
-			Assert.Equal(expecteXpub1, xpub1);
-			Assert.Equal(expecteXpub2, xpub2);
+			ExtPubKey expectedXpub1;
+			ExtPubKey expectedXpub2;
+			if (network == Network.TestNet)
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+			}
+			else
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+			}
+			Assert.Equal(expectedXpub1, xpub1);
+			Assert.Equal(expectedXpub2, xpub2);
 
 			BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
 			BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
@@ -225,10 +245,20 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
-			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
-			var expecteXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
-			Assert.Equal(expecteXpub1, xpub1);
-			Assert.Equal(expecteXpub2, xpub2);
+			ExtPubKey expectedXpub1;
+			ExtPubKey expectedXpub2;
+			if (network == Network.TestNet)
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+			}
+			else
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+			}
+			Assert.Equal(expectedXpub1, xpub1);
+			Assert.Equal(expectedXpub2, xpub2);
 
 			BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
 			BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
@@ -305,10 +335,20 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
-			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
-			var expecteXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
-			Assert.Equal(expecteXpub1, xpub1);
-			Assert.Equal(expecteXpub2, xpub2);
+			ExtPubKey expectedXpub1;
+			ExtPubKey expectedXpub2;
+			if (network == Network.TestNet)
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+			}
+			else
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+			}
+			Assert.Equal(expectedXpub1, xpub1);
+			Assert.Equal(expectedXpub2, xpub2);
 
 			BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
 			BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
@@ -385,10 +425,20 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
-			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
-			var expecteXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
-			Assert.Equal(expecteXpub1, xpub1);
-			Assert.Equal(expecteXpub2, xpub2);
+			ExtPubKey expectedXpub1;
+			ExtPubKey expectedXpub2;
+			if (network == Network.TestNet)
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+			}
+			else
+			{
+				expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+				expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+			}
+			Assert.Equal(expectedXpub1, xpub1);
+			Assert.Equal(expectedXpub2, xpub2);
 
 			BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
 			BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -61,8 +61,8 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			Assert.Equal("The PIN has already been sent to this device", sendpin.Message);
 			Assert.Equal(HwiErrorCode.DeviceAlreadyUnlocked, sendpin.ErrorCode);
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
@@ -135,8 +135,8 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			Assert.Equal("The PIN has already been sent to this device", sendpin.Message);
 			Assert.Equal(HwiErrorCode.DeviceAlreadyUnlocked, sendpin.ErrorCode);
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
@@ -221,8 +221,8 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			Assert.Equal("The Coldcard does not need a PIN sent from the host", sendpin.Message);
 			Assert.Equal(HwiErrorCode.UnavailableAction, sendpin.ErrorCode);
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
@@ -301,8 +301,8 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			Assert.Equal("The Ledger Nano S does not need a PIN sent from the host", sendpin.Message);
 			Assert.Equal(HwiErrorCode.UnavailableAction, sendpin.ErrorCode);
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
@@ -381,8 +381,8 @@ namespace WalletWasabi.Tests.UnitTests.Hwi
 			Assert.Equal("The Ledger Nano X does not need a PIN sent from the host", sendpin.Message);
 			Assert.Equal(HwiErrorCode.UnavailableAction, sendpin.ErrorCode);
 
-			KeyPath keyPath1 = KeyManager.DefaultAccountKeyPath;
-			KeyPath keyPath2 = KeyManager.DefaultAccountKeyPath.Derive(1);
+			KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network);
+			KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive(1);
 			ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
 			ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 			var expecteXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -144,7 +144,8 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanGenerateKeys()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out _, password, Network.Main);
+			var network = Network.Main;
+			var manager = KeyManager.CreateNew(out _, password, network);
 
 			var random = new Random();
 
@@ -163,7 +164,7 @@ namespace WalletWasabi.Tests.UnitTests
 				Assert.Equal(isInternal, generatedKey.IsInternal);
 				Assert.Equal(label, generatedKey.Label);
 				Assert.Equal(keyState, generatedKey.KeyState);
-				Assert.StartsWith(KeyManager.DefaultAccountKeyPath.ToString(), generatedKey.FullKeyPath.ToString());
+				Assert.StartsWith(KeyManager.GetAccountKeyPath(network).ToString(), generatedKey.FullKeyPath.ToString());
 			}
 		}
 

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -38,10 +38,10 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.NotNull(manager3.EncryptedSecret);
 			Assert.NotNull(manager3.ExtPubKey);
 
-			var sameManager = new KeyManager(manager.EncryptedSecret, manager.ChainCode, manager.MasterFingerprint, manager.ExtPubKey, true, null, new BlockchainState());
-			var sameManager2 = new KeyManager(manager.EncryptedSecret, manager.ChainCode, password);
+			var sameManager = new KeyManager(manager.EncryptedSecret, manager.ChainCode, manager.MasterFingerprint, manager.ExtPubKey, true, null, new BlockchainState(Network.Main));
+			var sameManager2 = new KeyManager(manager.EncryptedSecret, manager.ChainCode, password, Network.Main);
 			Logger.TurnOff();
-			Assert.Throws<SecurityException>(() => new KeyManager(manager.EncryptedSecret, manager.ChainCode, "differentPassword"));
+			Assert.Throws<SecurityException>(() => new KeyManager(manager.EncryptedSecret, manager.ChainCode, "differentPassword", Network.Main));
 			Logger.TurnOn();
 
 			Assert.Equal(manager.ChainCode, sameManager.ChainCode);
@@ -58,7 +58,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.NotEqual(manager.EncryptedSecret, differentManager.EncryptedSecret);
 			Assert.NotEqual(manager.ExtPubKey, differentManager.ExtPubKey);
 
-			var manager5 = new KeyManager(manager2.EncryptedSecret, manager2.ChainCode, password: null!);
+			var manager5 = new KeyManager(manager2.EncryptedSecret, manager2.ChainCode, password: null!, Network.Main);
 			Assert.Equal(manager2.ChainCode, manager5.ChainCode);
 			Assert.Equal(manager2.EncryptedSecret, manager5.EncryptedSecret);
 			Assert.Equal(manager2.ExtPubKey, manager5.ExtPubKey);

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -18,9 +18,9 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanCreateNew()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password);
-			var manager2 = KeyManager.CreateNew(out Mnemonic mnemonic2, "");
-			var manager3 = KeyManager.CreateNew(out _, "P@ssw0rdé");
+			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network.Main);
+			var manager2 = KeyManager.CreateNew(out Mnemonic mnemonic2, "", Network.Main);
+			var manager3 = KeyManager.CreateNew(out _, "P@ssw0rdé", Network.Main);
 
 			Assert.Equal(12, mnemonic.ToString().Split(' ').Length);
 			Assert.Equal(12, mnemonic2.ToString().Split(' ').Length);
@@ -52,7 +52,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.Equal(manager.EncryptedSecret, sameManager2.EncryptedSecret);
 			Assert.Equal(manager.ExtPubKey, sameManager2.ExtPubKey);
 
-			var differentManager = KeyManager.CreateNew(out Mnemonic mnemonic4, password);
+			var differentManager = KeyManager.CreateNew(out Mnemonic mnemonic4, password, Network.Main);
 			Assert.NotEqual(mnemonic, mnemonic4);
 			Assert.NotEqual(manager.ChainCode, differentManager.ChainCode);
 			Assert.NotEqual(manager.EncryptedSecret, differentManager.EncryptedSecret);
@@ -68,7 +68,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanRecover()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password, null, Network.Main);
+			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network.Main, null);
 			var sameManager = KeyManager.Recover(mnemonic, password, Network.Main, KeyManager.GetAccountKeyPath(Network.Main), null);
 
 			Assert.Equal(manager.ChainCode, sameManager.ChainCode);
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanHandleGap()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out _, password);
+			var manager = KeyManager.CreateNew(out _, password, Network.Main);
 
 			manager.AssertCleanKeysIndexed();
 			var lastKey = manager.GetKeys(KeyState.Clean, isInternal: false).Last();
@@ -111,7 +111,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.Throws<FileNotFoundException>(() => KeyManager.FromFile(filePath));
 			Logger.TurnOn();
 
-			var manager = KeyManager.CreateNew(out _, password, filePath);
+			var manager = KeyManager.CreateNew(out _, password, Network.Main, filePath);
 			KeyManager.FromFile(filePath);
 
 			manager.ToFile();
@@ -144,7 +144,7 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanGenerateKeys()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out _, password);
+			var manager = KeyManager.CreateNew(out _, password, Network.Main);
 
 			var random = new Random();
 
@@ -170,7 +170,7 @@ namespace WalletWasabi.Tests.UnitTests
 		[Fact]
 		public void GapCountingTests()
 		{
-			var km = KeyManager.CreateNew(out _, "");
+			var km = KeyManager.CreateNew(out _, "", Network.Main);
 			Assert.Equal(0, km.CountConsecutiveUnusedKeys(true));
 			Assert.Equal(0, km.CountConsecutiveUnusedKeys(false));
 

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -68,8 +68,8 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanRecover()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network.Main, null);
-			var sameManager = KeyManager.Recover(mnemonic, password, Network.Main, KeyManager.GetAccountKeyPath(Network.Main), null);
+			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network.Main);
+			var sameManager = KeyManager.Recover(mnemonic, password, Network.Main, KeyManager.GetAccountKeyPath(Network.Main));
 
 			Assert.Equal(manager.ChainCode, sameManager.ChainCode);
 			Assert.Equal(manager.EncryptedSecret, sameManager.EncryptedSecret);

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -68,14 +68,14 @@ namespace WalletWasabi.Tests.UnitTests
 		public void CanRecover()
 		{
 			string password = "password";
-			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password);
-			var sameManager = KeyManager.Recover(mnemonic, password);
+			var manager = KeyManager.CreateNew(out Mnemonic mnemonic, password, null, Network.Main);
+			var sameManager = KeyManager.Recover(mnemonic, password, Network.Main, KeyManager.GetAccountKeyPath(Network.Main), null);
 
 			Assert.Equal(manager.ChainCode, sameManager.ChainCode);
 			Assert.Equal(manager.EncryptedSecret, sameManager.EncryptedSecret);
 			Assert.Equal(manager.ExtPubKey, sameManager.ExtPubKey);
 
-			var differentManager = KeyManager.Recover(mnemonic, "differentPassword", null, KeyPath.Parse("m/999'/999'/999'"), 55);
+			var differentManager = KeyManager.Recover(mnemonic, "differentPassword", Network.Main, KeyPath.Parse("m/999'/999'/999'"), null, 55);
 			Assert.NotEqual(manager.ChainCode, differentManager.ChainCode);
 			Assert.NotEqual(manager.EncryptedSecret, differentManager.EncryptedSecret);
 			Assert.NotEqual(manager.ExtPubKey, differentManager.ExtPubKey);

--- a/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartCoinTests.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.Tests.UnitTests
 		{
 			var tx = Transaction.Parse("0100000000010176f521a178a4b394b647169a89b29bb0d95b6bce192fd686d533eb4ea98464a20000000000ffffffff02ed212d020000000016001442da650f25abde0fef57badd745df7346e3e7d46fbda6400000000001976a914bd2e4029ce7d6eca7d2c3779e8eac36c952afee488ac02483045022100ea43ccf95e1ac4e8b305c53761da7139dbf6ff164e137a6ce9c09e15f316c22902203957818bc505bbafc181052943d7ab1f3ae82c094bf749813e8f59108c6c268a012102e59e61f20c7789aa73faf5a92dc8c0424e538c635c55d64326d95059f0f8284200000000", Network.TestNet);
 			var index = 0U;
-			var km = KeyManager.CreateNew(out _, "");
+			var km = KeyManager.CreateNew(out _, "", Network.Main);
 			var hdpk1 = km.GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false);
 			var hdpk2 = km.GenerateNewKey(SmartLabel.Empty, KeyState.Clean, false);
 			tx.Outputs[0].ScriptPubKey = hdpk1.P2wpkhScript;

--- a/WalletWasabi.Tests/UnitTests/Transactions/PayjoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/PayjoinTests.cs
@@ -227,6 +227,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var walletCoins = new[] { ("Pablo", 0, 0.1m, confirmed: true, anonymitySet: 1) };
 			var amountToPay = Money.Coins(0.001m);
 			var payment = new PaymentIntent(BitcoinFactory.CreateScript(), amountToPay);
+			var network = Network.Main;
 
 			// This tests the scenario where the payjoin server does not clean GloablXPubs.
 			var mockHttpClient = new Mock<IHttpClient>();
@@ -234,7 +235,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				.Returns((HttpRequestMessage req, CancellationToken _) => PayjoinServerOkAsync(req, psbt =>
 				{
 					var extPubkey = new ExtKey().Neuter().GetWif(Network.Main);
-					psbt.GlobalXPubs.Add(extPubkey, new RootedKeyPath(extPubkey.GetPublicKey().GetHDFingerPrint(), KeyManager.DefaultAccountKeyPath));
+					psbt.GlobalXPubs.Add(extPubkey, new RootedKeyPath(extPubkey.GetPublicKey().GetHDFingerPrint(), KeyManager.GetAccountKeyPath(network)));
 					return psbt;
 				}));
 
@@ -248,7 +249,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				.Returns((HttpRequestMessage req, CancellationToken _) => PayjoinServerOkAsync(req, psbt =>
 				{
 					var extPubkey = new ExtKey().Neuter().GetWif(Network.Main);
-					psbt.Inputs[0].AddKeyPath(new Key().PubKey, new RootedKeyPath(extPubkey.GetPublicKey().GetHDFingerPrint(), KeyManager.DefaultAccountKeyPath));
+					psbt.Inputs[0].AddKeyPath(new Key().PubKey, new RootedKeyPath(extPubkey.GetPublicKey().GetHDFingerPrint(), KeyManager.GetAccountKeyPath(network)));
 					return psbt;
 				}));
 
@@ -301,7 +302,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 				.Returns((HttpRequestMessage req, CancellationToken _) => PayjoinServerOkAsync(req, psbt =>
 				{
 					var extPubkey = new ExtKey().Neuter().GetWif(Network.Main);
-					psbt.Outputs[0].AddKeyPath(new Key().PubKey, new RootedKeyPath(extPubkey.GetPublicKey().GetHDFingerPrint(), KeyManager.DefaultAccountKeyPath));
+					psbt.Outputs[0].AddKeyPath(new Key().PubKey, new RootedKeyPath(extPubkey.GetPublicKey().GetHDFingerPrint(), KeyManager.GetAccountKeyPath(network)));
 					return psbt;
 				}));
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -1373,7 +1373,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 		private TransactionProcessor CreateTransactionProcessor(AllTransactionStore transactionStore, int privacyLevelThreshold = 100)
 		{
-			var keyManager = KeyManager.CreateNew(out _, "password");
+			var keyManager = KeyManager.CreateNew(out _, "password", Network.Main);
 			keyManager.AssertCleanKeysIndexed();
 
 			return new TransactionProcessor(

--- a/WalletWasabi.Tests/UnitTests/Userfacing/PasswordTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/PasswordTests.cs
@@ -7,6 +7,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Userfacing;
+using NBitcoin;
 
 namespace WalletWasabi.Tests.UnitTests
 {
@@ -50,7 +51,7 @@ namespace WalletWasabi.Tests.UnitTests
 			string original = "    w¾3AÍ-dCdï×¾M\\Øò¹ãÔÕýÈÝÁÐ9oEp¨}r:SR¦·ßNó±¥*W!¢ê#ikÇå<ðtÇf·a\\]§,à±H7«®È4nèNmæo4.qØ-¾ûda¯ºíö¾,¥¢½\\¹õèKeÁìÍSÈ@r±ØÙ2[r©UQÞ¶xN\"?:Ö@°&\n";
 
 			// Creating a wallet with buggy password.
-			var keyManager = KeyManager.CreateNew(out _, Guard.Correct(buggy)); // Every wallet was created with Guard.Correct before.
+			var keyManager = KeyManager.CreateNew(out _, Guard.Correct(buggy), Network.Main); // Every wallet was created with Guard.Correct before.
 
 			Logger.TurnOff();
 
@@ -93,7 +94,7 @@ namespace WalletWasabi.Tests.UnitTests
 			Assert.True(PasswordHelper.IsTrimmable(buggy, out buggy));
 
 			// Creating a wallet with buggy password.
-			var keyManager = KeyManager.CreateNew(out _, buggy!);
+			var keyManager = KeyManager.CreateNew(out _, buggy!, Network.Main);
 
 			Assert.True(PasswordHelper.IsTrimmable(original, out original));
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			Rpc = rpc;
 			HttpClientFactory = httpClientFactory;
 
-			KeyManager = KeyManager.CreateNew(out var _, password: "");
+			KeyManager = KeyManager.CreateNew(out var _, password: "", Network.Main);
 			KeyManager.AssertCleanKeysIndexed();
 		}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -72,7 +72,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 			// Create a key manager and use it to create fake coins.
-			var keyManager = KeyManager.CreateNew(out var _, password: "");
+			var keyManager = KeyManager.CreateNew(out var _, password: "", Network.Main);
 			keyManager.AssertCleanKeysIndexed();
 			var coins = keyManager.GetKeys()
 				.Take(inputCount)
@@ -116,7 +116,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 				});
 			}).CreateClient();
 
-
 			// Create the coinjoin client
 			var apiClient = _apiApplicationFactory.CreateWabiSabiHttpApiClient(httpClient);
 			var mockHttpClientFactory = new Mock<IBackendHttpClientFactory>();
@@ -156,10 +155,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 			cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
-			var keyManager1 = KeyManager.CreateNew(out var _, password: "");
+			var keyManager1 = KeyManager.CreateNew(out var _, password: "", Network.Main);
 			keyManager1.AssertCleanKeysIndexed();
 
-			var keyManager2 = KeyManager.CreateNew(out var _, password: "");
+			var keyManager2 = KeyManager.CreateNew(out var _, password: "", Network.Main);
 			keyManager2.AssertCleanKeysIndexed();
 
 			var coins = keyManager1.GetKeys()

--- a/WalletWasabi/Blockchain/Keys/BlockchainState.cs
+++ b/WalletWasabi/Blockchain/Keys/BlockchainState.cs
@@ -15,16 +15,14 @@ namespace WalletWasabi.Blockchain.Keys
 			Height = height;
 		}
 
-		public BlockchainState(Network network)
-		{
-			Network = network;
-			Height = 0;
-		}
-
 		public BlockchainState()
 		{
 			Network = Network.Main;
 			Height = 0;
+		}
+
+		public BlockchainState(Network network) : this(network, 0)
+		{
 		}
 
 		[JsonProperty]

--- a/WalletWasabi/Blockchain/Keys/BlockchainState.cs
+++ b/WalletWasabi/Blockchain/Keys/BlockchainState.cs
@@ -15,6 +15,12 @@ namespace WalletWasabi.Blockchain.Keys
 			Height = height;
 		}
 
+		public BlockchainState(Network network)
+		{
+			Network = network;
+			Height = 0;
+		}
+
 		public BlockchainState()
 		{
 			Network = Network.Main;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
-		public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, string password, int minGapLimit = AbsoluteMinGapLimit, string? filePath = null, KeyPath? accountKeyPath = null)
+		public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, string password, Network network, int minGapLimit = AbsoluteMinGapLimit, string? filePath = null, KeyPath? accountKeyPath = null)
 		{
 			HdPubKeys = new List<HdPubKey>();
 			HdPubKeyScriptBytes = new List<byte[]>();
@@ -68,7 +68,7 @@ namespace WalletWasabi.Blockchain.Keys
 			HdPubKeysLock = new object();
 			HdPubKeyScriptBytesLock = new object();
 			ScriptHdPubKeyMapLock = new object();
-			BlockchainState = new BlockchainState();
+			BlockchainState = new BlockchainState(network);
 			BlockchainStateLock = new object();
 
 			password ??= "";

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -28,9 +28,9 @@ namespace WalletWasabi.Blockchain.Keys
 		// BIP84-ish derivation scheme
 		// m / purpose' / coin_type' / account' / change / address_index
 		// https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
-		public static readonly KeyPath DefaultAccountKeyPath = new("m/84h/0h/0h");
+		private static readonly KeyPath DefaultAccountKeyPath = new("m/84h/0h/0h");
 
-		public static readonly KeyPath TestNetAccountKeyPath = new("m/84h/1h/0h");
+		private static readonly KeyPath TestNetAccountKeyPath = new("m/84h/1h/0h");
 
 		[JsonConstructor]
 		public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, HDFingerprint? masterFingerprint, ExtPubKey extPubKey, bool? passwordVerified, int? minGapLimit, BlockchainState blockchainState, string? filePath = null, KeyPath? accountKeyPath = null)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -164,7 +164,7 @@ namespace WalletWasabi.Blockchain.Keys
 		private object ToFileLock { get; }
 		public string WalletName => string.IsNullOrWhiteSpace(FilePath) ? "" : Path.GetFileNameWithoutExtension(FilePath);
 
-		public static KeyManager CreateNew(out Mnemonic mnemonic, string password, string? filePath = null, Network? network = null)
+		public static KeyManager CreateNew(out Mnemonic mnemonic, string password, Network? network = null, string? filePath = null)
 		{
 			password ??= "";
 

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 			BlockchainState = blockchainState ?? new BlockchainState();
 
-			AccountKeyPath = accountKeyPath ?? GetKeyPathByNetwork();
+			AccountKeyPath = accountKeyPath ?? GetAccountKeyPath(BlockchainState.Network);
 
 			SetFilePath(filePath);
 			ToFileLock = new object();
@@ -80,7 +80,7 @@ namespace WalletWasabi.Blockchain.Keys
 			var extKey = new ExtKey(encryptedSecret.GetKey(password), chainCode);
 
 			MasterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			AccountKeyPath = accountKeyPath ?? GetKeyPathByNetwork();
+			AccountKeyPath = accountKeyPath ?? GetAccountKeyPath(BlockchainState.Network);
 			ExtPubKey = extKey.Derive(AccountKeyPath).Neuter();
 
 			SetFilePath(filePath);
@@ -88,15 +88,8 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
-		public static KeyPath GetCorrectAccountKeyPath(Network? network)
-		{
-			if (network == Network.TestNet)
-			{
-				return TestNetAccountKeyPath;
-			}
-
-			return DefaultAccountKeyPath;
-		}
+		public static KeyPath GetAccountKeyPath(Network network) =>
+			network == Network.TestNet ? TestNetAccountKeyPath : DefaultAccountKeyPath;
 
 		public WpkhDescriptors GetOutputDescriptors(string password, Network network)
 		{
@@ -106,16 +99,6 @@ namespace WalletWasabi.Blockchain.Keys
 			}
 
 			return WpkhOutputDescriptorHelper.GetOutputDescriptors(network, MasterFingerprint.Value, GetMasterExtKey(password), AccountKeyPath);
-		}
-
-		private KeyPath? GetKeyPathByNetwork()
-		{
-			if (GetNetwork() == Network.TestNet)
-			{
-				return TestNetAccountKeyPath;
-			}
-
-			return DefaultAccountKeyPath;
 		}
 
 		[JsonProperty(Order = 1)]
@@ -191,7 +174,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 			HDFingerprint masterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
 			BlockchainState blockchainState = network is null ? new BlockchainState() : new BlockchainState(network);
-			KeyPath keyPath = GetCorrectAccountKeyPath(network);
+			KeyPath keyPath = GetAccountKeyPath(network);
 			ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
 			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, false, AbsoluteMinGapLimit, blockchainState, filePath, keyPath);
 		}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -60,7 +60,7 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
-		public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, string password, Network network, int minGapLimit = AbsoluteMinGapLimit, string? filePath = null, KeyPath? accountKeyPath = null)
+		public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, string password, Network network)
 		{
 			HdPubKeys = new List<HdPubKey>();
 			HdPubKeyScriptBytes = new List<byte[]>();
@@ -73,17 +73,17 @@ namespace WalletWasabi.Blockchain.Keys
 
 			password ??= "";
 
-			SetMinGapLimit(minGapLimit);
+			SetMinGapLimit(AbsoluteMinGapLimit);
 
 			EncryptedSecret = Guard.NotNull(nameof(encryptedSecret), encryptedSecret);
 			ChainCode = Guard.NotNull(nameof(chainCode), chainCode);
 			var extKey = new ExtKey(encryptedSecret.GetKey(password), chainCode);
 
 			MasterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			AccountKeyPath = accountKeyPath ?? GetAccountKeyPath(BlockchainState.Network);
+			AccountKeyPath = GetAccountKeyPath(BlockchainState.Network);
 			ExtPubKey = extKey.Derive(AccountKeyPath).Neuter();
 
-			SetFilePath(filePath);
+			SetFilePath(null);
 			ToFileLock = new object();
 			ToFile();
 		}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -53,7 +53,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 			BlockchainState = blockchainState ?? new BlockchainState();
 
-			AccountKeyPath = SetAccountKeyPath(accountKeyPath);
+			AccountKeyPath = accountKeyPath ?? GetKeyPathByNetwork();
 
 			SetFilePath(filePath);
 			ToFileLock = new object();
@@ -80,7 +80,7 @@ namespace WalletWasabi.Blockchain.Keys
 			var extKey = new ExtKey(encryptedSecret.GetKey(password), chainCode);
 
 			MasterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			AccountKeyPath = SetAccountKeyPath(accountKeyPath);
+			AccountKeyPath = accountKeyPath ?? GetKeyPathByNetwork();
 			ExtPubKey = extKey.Derive(AccountKeyPath).Neuter();
 
 			SetFilePath(filePath);
@@ -110,13 +110,9 @@ namespace WalletWasabi.Blockchain.Keys
 			return WpkhOutputDescriptorHelper.GetOutputDescriptors(network, MasterFingerprint.Value, GetMasterExtKey(password), AccountKeyPath);
 		}
 
-		private KeyPath? SetAccountKeyPath(KeyPath? keyPath)
+		private KeyPath? GetKeyPathByNetwork()
 		{
-			if (keyPath is not null)
-			{
-				return keyPath;
-			}
-			else if (GetNetwork() == Network.TestNet)
+			if (GetNetwork() == Network.TestNet)
 			{
 				return TestNetAccountKeyPath;
 			}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -88,7 +88,7 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
-		public static KeyPath GetCorrectAccountKeyPath(Network network)
+		public static KeyPath GetCorrectAccountKeyPath(Network? network)
 		{
 			if (network == Network.TestNet)
 			{
@@ -187,7 +187,7 @@ namespace WalletWasabi.Blockchain.Keys
 		private object ToFileLock { get; }
 		public string WalletName => string.IsNullOrWhiteSpace(FilePath) ? "" : Path.GetFileNameWithoutExtension(FilePath);
 
-		public static KeyManager CreateNew(out Mnemonic mnemonic, string password, string? filePath = null)
+		public static KeyManager CreateNew(out Mnemonic mnemonic, string password, string? filePath = null, Network? network = null)
 		{
 			password ??= "";
 
@@ -196,9 +196,10 @@ namespace WalletWasabi.Blockchain.Keys
 			var encryptedSecret = extKey.PrivateKey.GetEncryptedBitcoinSecret(password, Network.Main);
 
 			HDFingerprint masterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			KeyPath keyPath = DefaultAccountKeyPath;
+			BlockchainState blockchainState = network is null ? new BlockchainState() : new BlockchainState(network);
+			KeyPath keyPath = GetCorrectAccountKeyPath(network);
 			ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
-			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, false, AbsoluteMinGapLimit, new BlockchainState(), filePath, keyPath);
+			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, false, AbsoluteMinGapLimit, blockchainState, filePath, keyPath);
 		}
 
 		public static KeyManager CreateNewWatchOnly(ExtPubKey extPubKey, string? filePath = null)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Blockchain.Keys
 			PasswordVerified = passwordVerified;
 			SetMinGapLimit(minGapLimit);
 
-			BlockchainState = blockchainState ?? new BlockchainState();
+			BlockchainState = blockchainState;
 
 			AccountKeyPath = accountKeyPath ?? GetAccountKeyPath(BlockchainState.Network);
 
@@ -164,7 +164,7 @@ namespace WalletWasabi.Blockchain.Keys
 		private object ToFileLock { get; }
 		public string WalletName => string.IsNullOrWhiteSpace(FilePath) ? "" : Path.GetFileNameWithoutExtension(FilePath);
 
-		public static KeyManager CreateNew(out Mnemonic mnemonic, string password, Network? network = null, string? filePath = null)
+		public static KeyManager CreateNew(out Mnemonic mnemonic, string password, Network network, string? filePath = null)
 		{
 			password ??= "";
 
@@ -173,7 +173,7 @@ namespace WalletWasabi.Blockchain.Keys
 			var encryptedSecret = extKey.PrivateKey.GetEncryptedBitcoinSecret(password, Network.Main);
 
 			HDFingerprint masterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			BlockchainState blockchainState = network is null ? new BlockchainState() : new BlockchainState(network);
+			BlockchainState blockchainState = new BlockchainState(network);
 			KeyPath keyPath = GetAccountKeyPath(network);
 			ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
 			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, false, AbsoluteMinGapLimit, blockchainState, filePath, keyPath);

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -173,7 +173,7 @@ namespace WalletWasabi.Blockchain.Keys
 			var encryptedSecret = extKey.PrivateKey.GetEncryptedBitcoinSecret(password, Network.Main);
 
 			HDFingerprint masterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
-			BlockchainState blockchainState = new BlockchainState(network);
+			BlockchainState blockchainState = new(network);
 			KeyPath keyPath = GetAccountKeyPath(network);
 			ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
 			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, false, AbsoluteMinGapLimit, blockchainState, filePath, keyPath);

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -94,10 +94,8 @@ namespace WalletWasabi.Blockchain.Keys
 			{
 				return TestNetAccountKeyPath;
 			}
-			else
-			{
-				return DefaultAccountKeyPath;
-			}
+
+			return DefaultAccountKeyPath;
 		}
 
 		public WpkhDescriptors GetOutputDescriptors(string password, Network network)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -88,6 +88,18 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
+		public static KeyPath GetCorrectAccountKeyPath(Network network)
+		{
+			if (network == Network.TestNet)
+			{
+				return TestNetAccountKeyPath;
+			}
+			else
+			{
+				return DefaultAccountKeyPath;
+			}
+		}
+
 		public WpkhDescriptors GetOutputDescriptors(string password, Network network)
 		{
 			if (!MasterFingerprint.HasValue)
@@ -194,9 +206,9 @@ namespace WalletWasabi.Blockchain.Keys
 			return new KeyManager(null, null, null, extPubKey, null, AbsoluteMinGapLimit, new BlockchainState(), filePath);
 		}
 
-		public static KeyManager CreateNewHardwareWalletWatchOnly(HDFingerprint masterFingerprint, ExtPubKey extPubKey, string? filePath = null)
+		public static KeyManager CreateNewHardwareWalletWatchOnly(HDFingerprint masterFingerprint, ExtPubKey extPubKey, Network network, string? filePath = null)
 		{
-			return new KeyManager(null, null, masterFingerprint, extPubKey, null, AbsoluteMinGapLimit, new BlockchainState(), filePath);
+			return new KeyManager(null, null, masterFingerprint, extPubKey, null, AbsoluteMinGapLimit, new BlockchainState(network), filePath);
 		}
 
 		public static KeyManager Recover(Mnemonic mnemonic, string password, string? filePath = null, KeyPath? accountKeyPath = null, int minGapLimit = AbsoluteMinGapLimit)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -82,10 +82,6 @@ namespace WalletWasabi.Blockchain.Keys
 			MasterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
 			AccountKeyPath = GetAccountKeyPath(BlockchainState.Network);
 			ExtPubKey = extKey.Derive(AccountKeyPath).Neuter();
-
-			SetFilePath(null);
-			ToFileLock = new object();
-			ToFile();
 		}
 
 		public static KeyPath GetAccountKeyPath(Network network) =>

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -189,7 +189,7 @@ namespace WalletWasabi.Blockchain.Keys
 			return new KeyManager(null, null, masterFingerprint, extPubKey, null, AbsoluteMinGapLimit, new BlockchainState(network), filePath);
 		}
 
-		public static KeyManager Recover(Mnemonic mnemonic, string password, string? filePath = null, KeyPath? accountKeyPath = null, int minGapLimit = AbsoluteMinGapLimit)
+		public static KeyManager Recover(Mnemonic mnemonic, string password, Network network, KeyPath accountKeyPath, string? filePath = null, int minGapLimit = AbsoluteMinGapLimit)
 		{
 			Guard.NotNull(nameof(mnemonic), mnemonic);
 			password ??= "";
@@ -201,7 +201,7 @@ namespace WalletWasabi.Blockchain.Keys
 
 			KeyPath keyPath = accountKeyPath ?? DefaultAccountKeyPath;
 			ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
-			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, true, minGapLimit, new BlockchainState(), filePath, keyPath);
+			return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, true, minGapLimit, new BlockchainState(network), filePath, keyPath);
 		}
 
 		public static KeyManager FromFile(string filePath)

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Blockchain.Keys
 			// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password because of compatibility.
 			PasswordHelper.Guard(password);
 
-			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, null, Network);
+			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network, null);
 			km.SetNetwork(Network);
 			km.SetBestHeight(new Height(TipHeight));
 			km.SetFilePath(walletFilePath);

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Blockchain.Keys
 			// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password because of compatibility.
 			PasswordHelper.Guard(password);
 
-			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network, null);
+			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network);
 			km.SetNetwork(Network);
 			km.SetBestHeight(new Height(TipHeight));
 			km.SetFilePath(walletFilePath);

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -42,7 +42,7 @@ namespace WalletWasabi.Blockchain.Keys
 			// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password because of compatibility.
 			PasswordHelper.Guard(password);
 
-			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password);
+			var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, null, Network);
 			km.SetNetwork(Network);
 			km.SetBestHeight(new Height(TipHeight));
 			km.SetFilePath(walletFilePath);

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -318,7 +318,7 @@ namespace WalletWasabi.Blockchain.Transactions
 				psbt = payjoinClient.RequestPayjoin(
 					psbt,
 					KeyManager.ExtPubKey,
-					new RootedKeyPath(KeyManager.MasterFingerprint.Value, KeyManager.DefaultAccountKeyPath),
+					new RootedKeyPath(KeyManager.MasterFingerprint.Value, KeyManager.GetAccountKeyPath(Network)),
 					changeHdPubKey,
 					CancellationToken.None).GetAwaiter().GetResult(); // WTF??!
 				builder.SignPSBT(psbt);

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -318,7 +318,7 @@ namespace WalletWasabi.Blockchain.Transactions
 				psbt = payjoinClient.RequestPayjoin(
 					psbt,
 					KeyManager.ExtPubKey,
-					new RootedKeyPath(KeyManager.MasterFingerprint.Value, KeyManager.GetAccountKeyPath(Network)),
+					new RootedKeyPath(KeyManager.MasterFingerprint.Value, KeyManager.AccountKeyPath),
 					changeHdPubKey,
 					CancellationToken.None).GetAwaiter().GetResult(); // WTF??!
 				builder.SignPSBT(psbt);

--- a/WalletWasabi/Helpers/HardwareWalletOperationHelpers.cs
+++ b/WalletWasabi/Helpers/HardwareWalletOperationHelpers.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Helpers
 			var extPubKey = await client.GetXpubAsync(
 				device.Model,
 				device.Path,
-				KeyManager.GetCorrectAccountKeyPath(network),
+				KeyManager.GetAccountKeyPath(network),
 				genCts.Token).ConfigureAwait(false);
 
 			return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, extPubKey, network, walletFilePath);

--- a/WalletWasabi/Helpers/HardwareWalletOperationHelpers.cs
+++ b/WalletWasabi/Helpers/HardwareWalletOperationHelpers.cs
@@ -28,10 +28,10 @@ namespace WalletWasabi.Helpers
 			var extPubKey = await client.GetXpubAsync(
 				device.Model,
 				device.Path,
-				KeyManager.DefaultAccountKeyPath,
+				KeyManager.GetCorrectAccountKeyPath(network),
 				genCts.Token).ConfigureAwait(false);
 
-			return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, extPubKey, walletFilePath);
+			return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, extPubKey, network, walletFilePath);
 		}
 
 		public static async Task InitHardwareWalletAsync(HwiEnumerateEntry device, Network network, CancellationToken cancelToken)

--- a/WalletWasabi/Helpers/ImportWalletHelper.cs
+++ b/WalletWasabi/Helpers/ImportWalletHelper.cs
@@ -85,7 +85,7 @@ namespace WalletWasabi.Helpers
 
 			ExtPubKey extPubKey = NBitcoinHelpers.BetterParseExtPubKey(xpubString);
 
-			return KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, walletFullPath);
+			return KeyManager.CreateNewHardwareWalletWatchOnly(mfp, extPubKey, manager.Network, walletFullPath);
 		}
 	}
 }


### PR DESCRIPTION
#### This PR is still in progress, but testing is always appreciated.
Related to issue #6218 

## Description
When creating a _Wallet_, regardless of having a property that indicates if the wallet is used on **Main**- or **TestNet**, the `AccountKeyPath` for all wallets are set to be the same. `"84'/0'/0'"`, which is the default **KeyPath** for **MainNet**.
But as discussed in the issue above, this keeps the users from using _Trezor One_ on **TestNet**, because the Trezor rules are strict for BIP44, and will deny transactions and cause exception that has wrong **KeyPath**.

This PR should solve this issue. Altough **it won't touch older wallets** for the purpose of not risking to mess up files and the user's money, all wallets - including **hot** and _cold_ - that's generated afterwards on **TestNet** will have KeyPath set to `"84'/1'/0'"`, thus fixing the Trezor One issue on **TestNet**. 

## Tests

For the purpose of passing tests, I had to add a few things to the mocked hardware wallet tests, including:

- New ExtPubKeys for TestNet
- New argument checks for TestNet keypaths

## How to test

0. Remove `[yourHardwareWalletsName].json` file from the TestNet's Wallets folder if you have one.
1. Pull this issue
2. Run Wasabi
3. Load your Hardware Wallet and log in
4. Try to send some satoshis to a TestNet address
5. Confirm on hardware wallet

### +1 Internal test: 
Check your newly created wallet.json file to see if `"Network": "TestNet",` and `"AccountKeyPath":  "84'/1'/0'",`.
You can also create a new MainNet wallet and check if its the opposite. `"Network": "Main",` and `"AccountKeyPath":  "84'/0'/0'",`.