### PR TITLE
[Trivial] Fix AreTransactionFeesEqual() logic

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Fluent.Helpers
 			return wallet.Network == Network.TestNet ? TestNetFeeEstimates : wallet.FeeProvider.AllFeeEstimate.Estimations;
 		}
 
-		public static bool AreTransactionFeesLow(Wallet wallet)
+		public static bool AreTransactionFeesEqual(Wallet wallet)
 		{
 			var feeEstimates = GetFeeEstimates(wallet);
 

--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -39,7 +39,7 @@ namespace WalletWasabi.Fluent.Helpers
 			var first = feeEstimates.First();
 			var last = feeEstimates.Last();
 
-			return first.Value != last.Value;
+			return first.Value == last.Value;
 		}
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			AddressText = info.Address.ToString();
 			PayJoinUrl = info.PayJoinClient?.PaymentUrl.AbsoluteUri;
 			IsPayJoin = PayJoinUrl is not null;
-			AdjustFeeAvailable = !TransactionFeeHelper.AreTransactionFeesLow(_wallet);
+			AdjustFeeAvailable = !TransactionFeeHelper.AreTransactionFeesEqual(_wallet);
 
 			if (PreferPsbtWorkflow)
 			{
@@ -305,7 +305,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 			Observable
 				.FromEventPattern(_wallet.FeeProvider, nameof(_wallet.FeeProvider.AllFeeEstimateChanged))
-				.Subscribe(_ => AdjustFeeAvailable = !TransactionFeeHelper.AreTransactionFeesLow(_wallet))
+				.Subscribe(_ => AdjustFeeAvailable = !TransactionFeeHelper.AreTransactionFeesEqual(_wallet))
 				.DisposeWith(disposables);
 
 			if (!isInHistory)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -50,7 +50,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 			AddressText = info.Address.ToString();
 			PayJoinUrl = info.PayJoinClient?.PaymentUrl.AbsoluteUri;
 			IsPayJoin = PayJoinUrl is not null;
-			AdjustFeeAvailable = TransactionFeeHelper.AreTransactionFeesLow(_wallet);
+			AdjustFeeAvailable = !TransactionFeeHelper.AreTransactionFeesLow(_wallet);
 
 			if (PreferPsbtWorkflow)
 			{
@@ -173,7 +173,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 				{
 					return false;
 				}
-
 			}
 
 			return true;
@@ -306,7 +305,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 			Observable
 				.FromEventPattern(_wallet.FeeProvider, nameof(_wallet.FeeProvider.AllFeeEstimateChanged))
-				.Subscribe(_ => AdjustFeeAvailable = TransactionFeeHelper.AreTransactionFeesLow(_wallet))
+				.Subscribe(_ => AdjustFeeAvailable = !TransactionFeeHelper.AreTransactionFeesLow(_wallet))
 				.DisposeWith(disposables);
 
 			if (!isInHistory)


### PR DESCRIPTION
Transaction fees are considered to be equal if the first and last estimations are equal.