### PR TITLE
`KeyManager`: Remove `SetLastAccessTimeForNow` and the corresponding …

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -609,31 +609,6 @@ namespace WalletWasabi.Blockchain.Keys
 			BlockchainState.Height = prevHeight;
 		}
 
-		public void SetLastAccessTimeForNow()
-		{
-			if (FilePath is { })
-			{
-				// Set the LastAccessTime.
-				new FileInfo(FilePath)
-				{
-					LastAccessTimeUtc = DateTime.UtcNow
-				};
-			}
-		}
-
-		public DateTime GetLastAccessTime()
-		{
-			if (FilePath is { })
-			{
-				// Set the LastAccessTime.
-				return new FileInfo(FilePath).LastAccessTimeUtc;
-			}
-			else
-			{
-				return DateTime.UtcNow;
-			}
-		}
-
 		#region BlockchainState
 
 		public Height GetBestHeight()

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -13,7 +13,6 @@ using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.Blockchain.Transactions;
-using WalletWasabi.CoinJoin.Client.Clients;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -171,8 +170,6 @@ namespace WalletWasabi.Wallets
 			{
 				State = WalletState.Starting;
 				InitializingChanged?.Invoke(this, true);
-
-				KeyManager.SetLastAccessTimeForNow();
 
 				if (!Synchronizer.IsRunning)
 				{


### PR DESCRIPTION
…getter as they are unused in the Fluent project

Discussion on [Slack](https://app.slack.com/client/T34SFJ13J/CFBJX6MN0/thread/CFBJX6MN0-1634822937.001500):

> I have noticed that [KeyManager.GetLastAccessTime](https://github.com/zkSNACKs/WalletWasabi/blob/97adc4f3937949f6ebe704d8edf747ae867f8a7e/WalletWasabi/Blockchain/Keys/KeyManager.cs#L624) is unused. KeyManager.SetLastAccessTimeForNow is still in use at least theoretically. Does anyone know why these methods were added and what is their purpose?

@danwalmsley mentioned:

> we use [this property](https://github.com/zkSNACKs/WalletWasabi/blob/9bfad0b71f537025655dfde55a65ba14e87beec7/WalletWasabi.Fluent/UiConfig.cs#L146) to save which wallet will be selected in the navbar next time the ui opens