### PR TITLE
`TorSettings`: Add `SafeLogging` option.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -28,7 +28,6 @@ namespace WalletWasabi.Tests.UnitTests.Tor
 				$"--DataDirectory \"{Path.Combine("temp", "tempDataDir", "tordata2")}\"",
 				$"--GeoIPFile \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip")}\"",
 				$"--GeoIPv6File \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip6")}\"",
-				$"--SafeLogging 1",
 				$"--Log \"notice file {Path.Combine("temp", "tempDataDir", "TorLogs.txt")}\"",
 				$"__OwningControllerProcess 7");
 

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -73,6 +73,7 @@ namespace WalletWasabi.Tor
 
 		public string GetCmdArguments()
 		{
+			// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.
 			List<string> arguments = new()
 			{
 				$"--SOCKSPort {SocksEndpoint}",
@@ -82,7 +83,6 @@ namespace WalletWasabi.Tor
 				$"--DataDirectory \"{TorDataDir}\"",
 				$"--GeoIPFile \"{GeoIpPath}\"",
 				$"--GeoIPv6File \"{GeoIp6Path}\"",
-				$"--SafeLogging 1",
 				$"--Log \"notice file {LogFilePath}\""
 			};
 


### PR DESCRIPTION
When debugging Tor issues, it is often useful to modify `TorSettings` like this:

```diff
-$"--Log \"notice file {LogFilePath}\""
+$"--SafeLogging 0",
+$"--Log \"debug file {LogFilePath}\""
```

However, I keep forgetting the name of `SafeLogging` parameter so this PR proposes to add it. This also makes people aware that one can have `TorLogs.txt` without those `[scrubbed]` redactions. It is far from being obvious.