### PR TITLE
Update tail command in BackendDeployment.md

### DIFF
--- a/WalletWasabi.Documentation/BackendDeployment.md
+++ b/WalletWasabi.Documentation/BackendDeployment.md
@@ -33,7 +33,7 @@ sudo service nginx start
 rm -rf WalletWasabi/WalletWasabi.Backend/bin && dotnet publish ~/WalletWasabi/WalletWasabi.Backend --configuration Release --self-contained false
 sudo systemctl start walletwasabi.service
 echo -n 'Tor: '; systemctl is-active tor; echo -n 'Wasabi: '; systemctl is-active walletwasabi; echo -n 'Bitcoind: '; ps -C bitcoind >/dev/null && echo "active" || echo "incative";
-tail -200 ~/.walletwasabi/backend/Logs.txt
+tail -200 /home/user/.walletwasabi/backend/Logs.txt
 
 # Advanced status checks
 systemctl status nginx


### PR DESCRIPTION
Now that we have different profiles on the server, this cmd `tail -200 ~/.walletwasabi/backend/Logs.txt` tries to query this `/home/<my_user>/.walletwasabi/Logs.txt` and  doesn't find it, because the `.walletwasabi` folder is under the `user` profile.

This might only affect new maintainers and i can speak only for the TestNet server, i'm not aware of the different profiles in the MainNet server.

If this change does more harm than good, then please close this.