### PR TITLE
Add `HasChange` to `BuildTransactionResult`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -293,7 +293,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 			FeeText = $"{btcFeeText}{fiatFeeText}";
 
-			TransactionHasChange = _transaction.OuterWalletOutputs.Sum(x => x.Amount) > fee && _transaction.InnerWalletOutputs.Sum(x => x.Amount) > 0;
+			TransactionHasChange = transactionResult.HasChange;
 
 			TransactionHasPockets = !_info.IsPrivatePocketUsed;
 		}

--- a/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
@@ -10,13 +10,14 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 {
 	public class BuildTransactionResult
 	{
-		public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent)
+		public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent, bool hasChange)
 		{
 			Transaction = transaction;
 			Psbt = psbt;
 			Signed = signed;
 			Fee = fee;
 			FeePercentOfSent = feePercentOfSent;
+			HasChange = hasChange;
 		}
 
 		public SmartTransaction Transaction { get; }
@@ -24,6 +25,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 		public bool Signed { get; }
 		public Money Fee { get; }
 		public decimal FeePercentOfSent { get; }
+		public bool HasChange { get; }
 		public bool SpendsUnconfirmed => Transaction.WalletInputs.Any(c => !c.Confirmed);
 
 		public IEnumerable<SmartCoin> InnerWalletOutputs => Transaction.WalletOutputs;

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -306,7 +306,8 @@ namespace WalletWasabi.Blockchain.Transactions
 
 			Logger.LogInfo($"Transaction is successfully built: {tx.GetHash()}.");
 			var sign = !KeyManager.IsWatchOnly;
-			return new BuildTransactionResult(smartTransaction, psbt, sign, fee, feePc);
+			var hasChange = changeHdPubKey is { } && tx.Outputs.Count > 1 && tx.Outputs.Any(x => x.ScriptPubKey == changeHdPubKey.P2wpkhScript);
+			return new BuildTransactionResult(smartTransaction, psbt, sign, fee, feePc, hasChange);
 		}
 
 		private PSBT TryNegotiatePayjoin(IPayjoinClient payjoinClient, TransactionBuilder builder, PSBT psbt, HdPubKey changeHdPubKey)


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/pull/6551#issuecomment-953639672

Refactor the way how we detect if a transaction has change or not. This solution works in self-spend case as well.