### PR TITLE
`InitConfigStartupTask`: Fix two warnings.

### DIFF
--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -64,7 +64,7 @@ namespace WalletWasabi.Backend
 
 		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
-			if (e?.Exception is Exception ex)
+			if (e.Exception is Exception ex)
 			{
 				Logger.LogWarning(ex);
 			}
@@ -72,7 +72,7 @@ namespace WalletWasabi.Backend
 
 		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 		{
-			if (e?.ExceptionObject is Exception ex)
+			if (e.ExceptionObject is Exception ex)
 			{
 				Logger.LogWarning(ex);
 			}

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -64,12 +64,18 @@ namespace WalletWasabi.Backend
 
 		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
-			Logger.LogWarning(e?.Exception);
+			if (e?.Exception is Exception ex)
+			{
+				Logger.LogWarning(ex);
+			}
 		}
 
 		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 		{
-			Logger.LogWarning(e?.ExceptionObject as Exception);
+			if (e?.ExceptionObject is Exception ex)
+			{
+				Logger.LogWarning(ex);
+			}
 		}
 	}
 }

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -64,10 +64,7 @@ namespace WalletWasabi.Backend
 
 		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
-			if (e.Exception is Exception ex)
-			{
-				Logger.LogWarning(ex);
-			}
+			Logger.LogWarning(e.Exception);
 		}
 
 		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -178,10 +178,7 @@ namespace WalletWasabi.Fluent.Desktop
 
 		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
-			if (e.Exception is Exception ex)
-			{
-				Logger.LogWarning(ex);
-			}
+			Logger.LogWarning(e.Exception);
 		}
 
 		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -176,17 +176,17 @@ namespace WalletWasabi.Fluent.Desktop
 			}
 		}
 
-		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs? e)
+		private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 		{
-			if (e?.Exception is Exception ex)
+			if (e.Exception is Exception ex)
 			{
 				Logger.LogWarning(ex);
 			}
 		}
 
-		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs? e)
+		private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 		{
-			if (e?.ExceptionObject is Exception ex)
+			if (e.ExceptionObject is Exception ex)
 			{
 				Logger.LogWarning(ex);
 			}


### PR DESCRIPTION
Just two warnings fixed in the same way as:

https://github.com/zkSNACKs/WalletWasabi/blob/f9fd1a655d8ce1977f98baac3216c57404e53b94/WalletWasabi.Fluent.Desktop/Program.cs#L179-L193