### PR TITLE
Backend: `Startup`: Switch from `IHostApplicationLifetime.ApplicationS…

### DIFF
--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -106,7 +106,7 @@ namespace WalletWasabi.Backend
 			app.UseEndpoints(endpoints => endpoints.MapControllers());
 
 			var applicationLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
-			applicationLifetime.ApplicationStopping.Register(() => OnShutdown(global)); // Don't register async, that won't hold up the shutdown
+			applicationLifetime.ApplicationStopped.Register(() => OnShutdown(global)); // Don't register async, that won't hold up the shutdown
 		}
 
 		private void OnShutdown(Global global)


### PR DESCRIPTION
…topping` to `IHostApplicationLifetime.ApplicationStopped`

This PR is a part of my work on #6257 but I get always side-tracked by things that need to be sorted out first for me to be confident that those idempotent requests are handled correctly.

This PR is *NOT* tested but still the following question stands:

https://github.com/zkSNACKs/WalletWasabi/blob/f9fd1a655d8ce1977f98baac3216c57404e53b94/WalletWasabi.Backend/Startup.cs#L109

**Why do we register `ApplicationStopping` instead of (expected by me) `ApplicationStopped`?**

The difference is explained [here](http://binaryintellect.net/articles/535d4ca7-9726-46cf-bc64-64e94ec55f6e.aspx):

* ApplicationStopping : This property can be used to hook a callback that is executed when an application host is about to stop. Some requests might be pending at this stage.
* ApplicationStopped : This property can be used to hook a callback that is executed when an application has been stopped. All the requests are complete at this stage.

So if I understand correctly, it might happen that: There are `n` HTTP requests that are being handled by asp.net at the moment. We decide to stop Wasabi Backend application. Then `ApplicationStopping` callback is called, we dispose `HostedServices` (and other things) and those `n` requests can continue until a method with proper cancellation token is to be processed. So the HTTP requests are being processed and before they are handled, we dispose stuff.

Is this by design? Or am I missing something?