### PR TITLE
[VDG] fix hyperlink underline

### DIFF
--- a/WalletWasabi.Fluent/Styles/HyperlinkButton.axaml
+++ b/WalletWasabi.Fluent/Styles/HyperlinkButton.axaml
@@ -7,7 +7,7 @@
     <Setter Property="Background" Value="Transparent" />
   </Style>
 
-  <Style Selector="Button.activeHyperLink TextBlock">
+  <Style Selector="Button.activeHyperLink AccessText">
     <Setter Property="TextDecorations" Value="Underline" />
   </Style>
 


### PR DESCRIPTION
It was lost after an Avalonia update.

Before:
![image](https://user-images.githubusercontent.com/16364053/140324215-d382daec-43a6-4f71-8a51-48e1a2bf37d8.png)

After:
![image](https://user-images.githubusercontent.com/16364053/140324093-2bba2eed-e9ae-4561-b220-d6424499b9f3.png)
