### PR TITLE
Improve reliability for alices

### DIFF
--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -72,6 +72,9 @@ namespace WalletWasabi.Tor.Socks5
 			{
 				tcpClient = new(TorSocks5EndPoint.AddressFamily);
 				tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true );
+				tcpClient.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 30);
+				tcpClient.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 5);
+				tcpClient.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 5);
 
 				transportStream = await ConnectAsync(tcpClient, cancellationToken).ConfigureAwait(false);
 				await HandshakeAsync(tcpClient, circuit, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -71,6 +71,7 @@ namespace WalletWasabi.Tor.Socks5
 			try
 			{
 				tcpClient = new(TorSocks5EndPoint.AddressFamily);
+				tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true );
 
 				transportStream = await ConnectAsync(tcpClient, cancellationToken).ConfigureAwait(false);
 				await HandshakeAsync(tcpClient, circuit, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This PR is for making sure the Wasabi Client's connection to the Tor socks proxy remain alive, what reduces the number reseted connections when signaling ready to sign.

The problem is still there, not sure why, but the frequency of the occurrences does down by a significant number.