### PR TITLE
[WabiSabi] Retry requests that fail due to transport errors

### DIFF
--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -17,6 +17,8 @@ namespace WalletWasabi.WabiSabi.Client
 {
 	public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 	{
+		private const int MaxRetries = 3;
+
 		private IHttpClient _client;
 
 		public WabiSabiHttpApiClient(IHttpClient client)
@@ -69,17 +71,17 @@ namespace WalletWasabi.WabiSabi.Client
 		public Task ReadyToSignAsync(ReadyToSignRequestRequest request, CancellationToken cancellationToken) =>
 			SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken);
 
-		private async Task<HttpResponseMessage> SendWithRetriesAsync(RemoteAction action, string jsonString, CancellationToken cancellationToken, int maxAttempts = 3)
+		private async Task<HttpResponseMessage> SendWithRetriesAsync(RemoteAction action, string jsonString, CancellationToken cancellationToken)
 		{
 			var errors = new List<Exception>();
 
 			var start = DateTime.Now;
 
-			for (var attempt = 0; attempt < maxAttempts; attempt++)
+			for (var attempt = 0; attempt < MaxRetries; attempt++)
 			{
 				try
 				{
-					using StringContent content = new (jsonString, Encoding.UTF8, "application/json");
+					using StringContent content = new(jsonString, Encoding.UTF8, "application/json");
 
 					// Any transport layer errors will throw an exception here.
 					var response = await _client.SendAsync(HttpMethod.Post, GetUriEndPoint(action), content, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This helps rounds succeed when there are tor related errors, which for me are quite frequent (unstable internet connection).

A more complete approach would be to only retry in some circumstances. For standard HTTP things, the behavior described in [this blog post](https://sergeyakopov.com/transient-http-error-retry/) for instance seems like a good policy. In addition to that we will also want to catch `TorException`, and perhaps others, and only treat those exceptions as transient (e.g. if sending a request generates `InvalidOperationException`, it makes no sense to retry).

Note that there are no unit tests, but in manual testing this has made it possible for me to reliably complete testnet coinjoins.