### PR TITLE
[WabiSab] Long polling for confirmation

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -461,6 +461,13 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				}
 			}
 
+			if (round.Phase == Phase.InputRegistration)
+			{
+				Task.WaitAny(
+					Task.Delay(round.ConnectionConfirmationTimeFrame.Duration / 2),
+					round.InputRegistrationCompletionSource.Task);
+			}
+
 			var amountZeroCredentialTask = round.AmountCredentialIssuer.HandleRequestAsync(request.ZeroAmountCredentialRequests, cancellationToken);
 			var vsizeZeroCredentialTask = round.VsizeCredentialIssuer.HandleRequestAsync(request.ZeroVsizeCredentialRequests, cancellationToken);
 			Task<CredentialsResponse>? amountRealCredentialTask = null;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		public static TimeFrame Create(TimeSpan duration) =>
 			new(DateTimeOffset.MinValue, duration);
 
-		private DateTimeOffset EndTime => StartTime + Duration;
+		public DateTimeOffset EndTime => StartTime + Duration;
 		public DateTimeOffset StartTime { get; init; }
 		public TimeSpan Duration { get; init; }
 		public bool HasStarted => StartTime > DateTimeOffset.MinValue && StartTime < DateTimeOffset.UtcNow;


### PR DESCRIPTION
This change moves the delay to the server, cutting it short it when the input registration phase has ended. The delay is still 1/2 of the timeout. This allows the connection confirmation phase to end more quickly by avoiding unnecessary delays, thereby improving reliability and shortening the critical phase for clients.