### PR TITLE
Remove weight bias, because it ruins the algorithm

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -85,22 +85,14 @@ namespace WalletWasabi.WabiSabi.Client
 			{
 				foreach (var denom in BreakDown(input, demonsForBreakDown))
 				{
-					var weight = Weight(denom.Satoshi);
-
-					if (!denomProbabilities.TryAdd(denom, weight))
+					if (!denomProbabilities.TryAdd(denom, 1))
 					{
-						denomProbabilities[denom] += weight;
+						denomProbabilities[denom] += 1;
 					}
 				}
 			}
 
 			return denomProbabilities;
-		}
-
-		private long Weight(long val)
-		{
-			// Bias denom selection as the square of the value.
-			return val * val;
 		}
 
 		private IEnumerable<Money> BreakDown(Coin coin, IEnumerable<Money> denominations)


### PR DESCRIPTION
The following code expects a frequency table. You wanted to be smart and use some biased weight instead, but you forgot to actually use it. I don't know how to fix it by leaving the weight in the code, but this code expects a frequency table:
```cs
var denoms = histogram
	. OrderByDescending(x => x.Key)
	. Where(x => x.Value > 1)
	. Select(x => x.Key)
	. ToArray();
```