### PR TITLE
Fix "Not the same type!" issue

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -106,14 +106,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 					{
 						if (_transactions.FirstOrDefault(x => x.Id == newItem.Id) is { } item)
 						{
-							if (newItem is CoinJoinsHistoryItemViewModel model)
-							{
-								item.Update(model);
-							}
-							else
-							{
-								item.Update(newItem);
-							}
+							item.Update(newItem);
 						}
 						else
 						{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -106,7 +106,14 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 					{
 						if (_transactions.FirstOrDefault(x => x.Id == newItem.Id) is { } item)
 						{
-							item.Update(newItem);
+							if (newItem is CoinJoinsHistoryItemViewModel model)
+							{
+								item.Update(model);
+							}
+							else
+							{
+								item.Update(newItem);
+							}
 						}
 						else
 						{

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -75,7 +75,7 @@ namespace WalletWasabi.Blockchain.Transactions
 							Label = spenderTransaction.Label,
 							TransactionId = spenderTxId,
 							BlockIndex = spenderTransaction.BlockIndex,
-							IsLikelyCoinJoinOutput = containingTransaction.Transaction.IsLikelyCoinjoin()
+							IsLikelyCoinJoinOutput = spenderTransaction.Transaction.IsLikelyCoinjoin()
 						});
 					}
 				}


### PR DESCRIPTION
Fixes #6661

Before:  

https://github.com/zkSNACKs/WalletWasabi/blob/10fa57e360d99c99356d8e7cfb6b6934044f6cf8/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs#L109

After a successful CJ, this line was called with wrong object type. We assigned wrong type, because its `TransactionSummary` was falsely built.

Because of the wrong type, this sanity check threw the exc.
https://github.com/zkSNACKs/WalletWasabi/blob/10fa57e360d99c99356d8e7cfb6b6934044f6cf8/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs#L53


