### PR TITLE
[VDG] fix missing last CJ item in transaction history

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -137,13 +137,13 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 
 				balance += item.Amount;
 
-				if (item.IsLikelyCoinJoinOutput)
+				if (!item.IsLikelyCoinJoinOutput)
 				{
-					if (!item.IsConfirmed())
-					{
-						continue;
-					}
+					yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
+				}
 
+				if (item.IsLikelyCoinJoinOutput && item.IsConfirmed())
+				{
 					if (coinJoinGroup is null)
 					{
 						coinJoinGroup = new CoinJoinsHistoryItemViewModel(i, item);
@@ -152,10 +152,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 					{
 						coinJoinGroup.Add(item);
 					}
-				}
-				else
-				{
-					yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 				}
 
 				if (coinJoinGroup is { } cjg &&

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -155,21 +155,17 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 				}
 				else
 				{
-					if (coinJoinGroup is { } cjg)
-					{
-						cjg.SetBalance(balance);
-						yield return cjg;
-						coinJoinGroup = null;
-					}
-
 					yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 				}
-			}
 
-			if (coinJoinGroup is { })
-			{
-				coinJoinGroup.SetBalance(balance);
-				yield return coinJoinGroup;
+				if (coinJoinGroup is { } cjg &&
+				    (i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyCoinJoinOutput || // The next item is not CJ so add the group.
+				     i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
+				{
+					cjg.SetBalance(balance);
+					yield return cjg;
+					coinJoinGroup = null;
+				}
 			}
 		}
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -165,6 +165,12 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 					yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 				}
 			}
+
+			if (coinJoinGroup is { })
+			{
+				coinJoinGroup.SetBalance(balance);
+				yield return coinJoinGroup;
+			}
 		}
 	}
 }


### PR DESCRIPTION
During the history building, we group the consecutive CJs into a group and add that group to the history list once a non CJ txn is the next. If all the last txn was CJ, the group adding never happened.
This PR fixes it.