### PR TITLE
Fix rare null exception when broadcasting transaction to the backend

### DIFF
--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -106,7 +106,10 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 					OutPoint input = transaction.Transaction.Inputs.First().PrevOut;
 					foreach (var coin in WalletManager.CoinsByOutPoint(input))
 					{
-						coin.SpentAccordingToBackend = true;
+						if (coin is { })
+						{
+							coin.SpentAccordingToBackend = true;
+						}
 					}
 				}
 

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -106,10 +106,7 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting
 					OutPoint input = transaction.Transaction.Inputs.First().PrevOut;
 					foreach (var coin in WalletManager.CoinsByOutPoint(input))
 					{
-						if (coin is { })
-						{
-							coin.SpentAccordingToBackend = true;
-						}
+						coin.SpentAccordingToBackend = true;
 					}
 				}
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
@@ -70,7 +70,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs
 			return new CoinsView(smartCoins);
 		}
 
-		public SmartCoin GetByOutPoint(OutPoint outpoint) => Coins.FirstOrDefault(x => x.OutPoint == outpoint);
+		public SmartCoin GetByOutPoint(OutPoint outpoint) => Coins.First(x => x.OutPoint == outpoint);
 
 		public Money TotalAmount() => Coins.Sum(x => x.Amount);
 


### PR DESCRIPTION
This should be the fix for #4766 & #4955, and the logs added in PR #4965 helped catching this.

In the logs of https://github.com/zkSNACKs/WalletWasabi/discussions/6653#discussioncomment-1614436 we see:

```
2021-11-06 23:16:59 INFO	TransactionBroadcaster (93)	Broadcasting with backend...
2021-11-06 23:17:03 INFO	TransactionBroadcaster (153)	coin is null, suspect found.
2021-11-06 23:17:03 ERROR	SendControlViewModel (361)	System.NullReferenceException: Object reference not set to an instance of an object.
```

Note that #6653 is a discussion about another exception (No space left on device).

fixes https://github.com/zkSNACKs/WalletWasabi/issues/4955
fixes https://github.com/zkSNACKs/WalletWasabi/issues/4955