### PR TITLE
Slow the growth of client side filters

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -129,27 +129,6 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 			Assert.Equal(9, result.filters.Count());
 		}
 
-		[Fact]
-		public void IncludeTaprootScriptInFilters()
-		{
-			var getBlockRpcRawResponse = File.ReadAllText("./UnitTests/Data/VerboseBlock.json");
-
-			var block = RpcParser.ParseVerboseBlockResponse(getBlockRpcRawResponse);
-			var filter = IndexBuilderService.BuildFilterForBlock(block);
-
-			var txOutputs = block.Transactions.SelectMany(x => x.Outputs);
-			var prevTxOutputs = block.Transactions.SelectMany(x => x.Inputs.Where(y => y.PrevOutput is { }).Select(y => y.PrevOutput));
-			var allOutputs = txOutputs.Concat(prevTxOutputs);
-
-			var indexableOutputs = allOutputs.Where(x => x?.PubkeyType is RpcPubkeyType.TxWitnessV0Keyhash or RpcPubkeyType.TxWitnessV1Taproot);
-			var nonIndexableOutputs = allOutputs.Except(indexableOutputs);
-
-			static byte[] ComputeKey(uint256 blockId) => blockId.ToBytes()[0..16];
-
-			Assert.All(indexableOutputs, x => Assert.True(filter.Match(x?.ScriptPubKey.ToCompressedBytes(), ComputeKey(block.Hash))));
-			Assert.All(nonIndexableOutputs, x => Assert.False(filter.Match(x?.ScriptPubKey.ToCompressedBytes(), ComputeKey(block.Hash))));
-		}
-
 		private IEnumerable<VerboseBlockInfo> GenerateBlockchain() =>
 			from height in Enumerable.Range(0, int.MaxValue).Select(x => (ulong)x)
 			select new VerboseBlockInfo(

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -137,8 +137,7 @@ namespace WalletWasabi.Tests.UnitTests.BitcoinCore
 				BlockHashFromHeight(height + 1),
 				DateTimeOffset.UtcNow.AddMinutes(height * 10),
 				height,
-				Enumerable.Empty<VerboseTransactionInfo>()
-			);
+				Enumerable.Empty<VerboseTransactionInfo>());
 
 		private static uint256 BlockHashFromHeight(ulong height)
 			=> height == 0 ? uint256.Zero : Hashes.DoubleSHA256(BitConverter.GetBytes(height));

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -256,7 +256,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			{
 				foreach (var input in tx.Inputs)
 				{
-					if (input.PrevOutput is { PubkeyType: RpcPubkeyType.TxWitnessV0Keyhash or RpcPubkeyType.TxWitnessV1Taproot })
+					if (input.PrevOutput is { PubkeyType: RpcPubkeyType.TxWitnessV0Keyhash })
 					{
 						scripts.Add(input.PrevOutput.ScriptPubKey);
 					}
@@ -264,7 +264,7 @@ namespace WalletWasabi.Blockchain.BlockFilters
 
 				foreach (var output in tx.Outputs)
 				{
-					if (output is { PubkeyType: RpcPubkeyType.TxWitnessV0Keyhash or RpcPubkeyType.TxWitnessV1Taproot })
+					if (output is { PubkeyType: RpcPubkeyType.TxWitnessV0Keyhash })
 					{
 						scripts.Add(output.ScriptPubKey);
 					}


### PR DESCRIPTION
### Motivation

Our bech32 client side filters are currently 1 GB. This is one of the technological bottlenecks of Wasabi Wallet. A while ago we included taproot outputs in our filters, despite we never used it. Since taproot is a special address type we cannot change to it and it comes with no direct benefits. The size pros are negligible. LN integration is not around the corner and we'll have to change address type again when cross input signature aggregation arrives to Bitcoin.

When LN or similar script heavy stuff is going to be integrated to Wasabi we can always turn these on.


### Summary

#### Taproot Pros for Wasabi

- Takes less blockspace (negligible)
- Inevitable for LN integration (at least half a decade away)

#### Taproot Cons for Wasabi

- Most wallets can't send money to these outputs (expect to be like this for half a decade)
- When cross input signature aggregation comes, we'd have to change it again
- The size of the index is the single largest ever growing bottleneck we have in Wasabi and taproot makes it grow faster