### PR TITLE
[WabiSabi] Fix blocked round updater

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -103,6 +103,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 
 			// The coordinator creates two rounds.
 			// Each line represents a response for each request.
+			// Exceptions, Problems, Errors everywhere!!!
 			var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
 			mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<CancellationToken>()))
 				.ReturnsAsync(() => new[] { roundState with { Phase = Phase.InputRegistration } })
@@ -130,6 +131,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			Assert.Equal(TaskStatus.WaitingForActivation, roundORTask.Status);
 
 			// Force the RoundStatusUpdater to run again just to make it trigger the events.
+			// Lots of exceptions in the meanwhile
 			roundStatusUpdater.TriggerRound();
 			roundStatusUpdater.TriggerRound();
 			roundStatusUpdater.TriggerRound();
@@ -137,7 +139,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			roundStatusUpdater.TriggerRound();
 			await Task.Delay(TimeSpan.FromSeconds(1));
 
-			// Wait for round1 in input registration.
+			// But in the end everything is alright.
 			round = await roundORTask;
 			Assert.Equal(Phase.OutputRegistration, round.Phase);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
@@ -90,6 +91,55 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			await roundStatusUpdater.StopAsync(cancellationToken);
 
 			Assert.Equal(TaskStatus.Canceled, round2TBTask.Status);
+		}
+
+		[Fact]
+		public async Task RoundStateUpdaterFailureRecoveryTestsAsync()
+		{
+			var roundState = RoundState.FromRound(WabiSabiFactory.CreateRound(new()));
+
+			using var cancellationTokenSource = new CancellationTokenSource();
+			var cancellationToken = cancellationTokenSource.Token;
+
+			// The coordinator creates two rounds.
+			// Each line represents a response for each request.
+			var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
+			mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<CancellationToken>()))
+				.ReturnsAsync(() => new[] { roundState with { Phase = Phase.InputRegistration } })
+				.ThrowsAsync(new Exception())
+				.ThrowsAsync(new OperationCanceledException())
+				.ThrowsAsync(new InvalidOperationException())
+				.ThrowsAsync(new HttpRequestException())
+				.ReturnsAsync(() => new[] { roundState with { Phase = Phase.OutputRegistration } })
+				.ReturnsAsync(() => Array.Empty<RoundState>());
+
+			using RoundStateUpdater roundStatusUpdater = new(TimeSpan.FromMilliseconds(100), mockApiClient.Object);
+
+			// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
+			// events for that round.
+			using var roundTSCts = new CancellationTokenSource();
+			var roundIRTask = roundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.InputRegistration, cancellationToken);
+			var roundORTask = roundStatusUpdater.CreateRoundAwaiter(roundState.Id, rs => rs.Phase == Phase.OutputRegistration, cancellationToken);
+
+			// Start
+			await roundStatusUpdater.StartAsync(cancellationTokenSource.Token);
+
+			// Wait for round1 in input registration.
+			var round = await roundIRTask;
+			Assert.Equal(Phase.InputRegistration, round.Phase);
+			Assert.Equal(TaskStatus.WaitingForActivation, roundORTask.Status);
+
+			// Force the RoundStatusUpdater to run again just to make it trigger the events.
+			roundStatusUpdater.TriggerRound();
+			roundStatusUpdater.TriggerRound();
+			roundStatusUpdater.TriggerRound();
+			roundStatusUpdater.TriggerRound();
+			roundStatusUpdater.TriggerRound();
+			await Task.Delay(TimeSpan.FromSeconds(1));
+
+			// Wait for round1 in input registration.
+			round = await roundORTask;
+			Assert.Equal(Phase.OutputRegistration, round.Phase);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
@@ -27,28 +27,16 @@ namespace WalletWasabi.WabiSabi.Client
 
 		protected override async Task ActionAsync(CancellationToken cancellationToken)
 		{
-			var success = false;
-			RoundState[] statusResponse = Array.Empty<RoundState>();
-			try
-			{
-				statusResponse = await ArenaRequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
-				success = true;
-			}
-			finally
-			{
-				if (success)
-				{
-					RoundStates = statusResponse.ToDictionary(round => round.Id);
+			var statusResponse = await ArenaRequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+			RoundStates = statusResponse.ToDictionary(round => round.Id);
 
-					lock (AwaitersLock)
-					{
-						foreach (var awaiter in Awaiters.Where(awaiter => awaiter.IsCompleted(RoundStates)).ToArray())
-						{
-							// The predicate was fulfilled.
-							Awaiters.Remove(awaiter);
-							break;
-						}
-					}
+			lock (AwaitersLock)
+			{
+				foreach (var awaiter in Awaiters.Where(awaiter => awaiter.IsCompleted(RoundStates)).ToArray())
+				{
+					// The predicate was fulfilled.
+					Awaiters.Remove(awaiter);
+					break;
 				}
 			}
 		}

--- a/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
@@ -27,22 +27,27 @@ namespace WalletWasabi.WabiSabi.Client
 
 		protected override async Task ActionAsync(CancellationToken cancellationToken)
 		{
+			var success = false;
 			RoundState[] statusResponse = Array.Empty<RoundState>();
 			try
 			{
 				statusResponse = await ArenaRequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+				success = true;
 			}
 			finally
 			{
-				RoundStates = statusResponse.ToDictionary(round => round.Id);
-
-				lock (AwaitersLock)
+				if (success)
 				{
-					foreach (var awaiter in Awaiters.Where(awaiter => awaiter.IsCompleted(RoundStates)).ToArray())
+					RoundStates = statusResponse.ToDictionary(round => round.Id);
+
+					lock (AwaitersLock)
 					{
-						// The predicate was fulfilled.
-						Awaiters.Remove(awaiter);
-						break;
+						foreach (var awaiter in Awaiters.Where(awaiter => awaiter.IsCompleted(RoundStates)).ToArray())
+						{
+							// The predicate was fulfilled.
+							Awaiters.Remove(awaiter);
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Before this PR the `RoundStateUpdater` reported that the round was not running anymore when it received an exception.