### PR TITLE
explicitly specify one way bindings where string format is used.

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/Create/ConfirmRecoveryWordsView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/Create/ConfirmRecoveryWordsView.axaml
@@ -28,7 +28,7 @@
         <ItemsControl.ItemTemplate>
           <DataTemplate>
             <DockPanel>
-              <Label Content="{Binding Index, StringFormat=Recovery word {0}}" DockPanel.Dock="Top" />
+              <Label Content="{Binding Index, StringFormat=Recovery word {0}, Mode=OneWay}" DockPanel.Dock="Top" />
               <TextBox Watermark="Type the word here..." Classes="hasCheckMarkBoolean" validation:CheckMarkStatus.IsEnabled="{Binding IsConfirmed}" Text="{Binding Input}" IsEnabled="{Binding !IsConfirmed}" DockPanel.Dock="Top">
                 <i:Interaction.Behaviors>
                   <behaviors:FocusNextItemBehavior IsFocused="{Binding !IsConfirmed}" />

--- a/WalletWasabi.Fluent/Views/AddWallet/Create/RecoveryWordsView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/Create/RecoveryWordsView.axaml
@@ -30,7 +30,7 @@
       <ItemsControl.ItemTemplate>
         <DataTemplate>
           <StackPanel Orientation="Horizontal" Margin="20 0">
-            <TextBlock Text="{Binding Index, StringFormat={}{0}.}" />
+            <TextBlock Text="{Binding Index, Mode=OneWay, StringFormat={}{0}.}" />
             <TextBlock Text="{Binding Word}" FontWeight="SemiBold" Margin="5 0 0 0" />
           </StackPanel>
         </DataTemplate>

--- a/WalletWasabi.Fluent/Views/Login/PasswordFinder/SearchPasswordView.axaml
+++ b/WalletWasabi.Fluent/Views/Login/PasswordFinder/SearchPasswordView.axaml
@@ -42,7 +42,7 @@
       <Viewbox MaxHeight="200" DockPanel.Dock="Top" Margin="0 0 0 10">
         <Panel HorizontalAlignment="Center">
           <c:ProgressRing Height="150" Width="150" IsIndeterminate="True"/>
-          <TextBlock Text="{Binding Percentage, StringFormat={}{0}%}" FontSize="20" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+          <TextBlock Text="{Binding Percentage, Mode=OneWay, StringFormat={}{0}%}" FontSize="20" VerticalAlignment="Center" HorizontalAlignment="Center"/>
         </Panel>
       </Viewbox>
 

--- a/WalletWasabi.Fluent/Views/StatusBar/StatusBar.axaml
+++ b/WalletWasabi.Fluent/Views/StatusBar/StatusBar.axaml
@@ -63,7 +63,7 @@
                           StatusText="{Binding BackendStatus, Converter={x:Static converters:StatusConverters.BackendStatusToString}}" />
             <c:StatusItem Icon="{StaticResource entities_regular}"
                           Title="Peers"
-                          StatusText="{Binding Peers, StringFormat={}{0} connected}" />
+                          StatusText="{Binding Peers Mode=OneWay, StringFormat={}{0} connected}" />
             <c:StatusItem Icon="{StaticResource btc_logo}"
                           Title="{Binding BitcoinCoreName}"
                           StatusText="{Binding BitcoinCoreStatus, Converter={x:Static converters:StatusConverters.RpcStatusStringConverter}}"

--- a/WalletWasabi.Fluent/Views/StatusBar/StatusBar.axaml
+++ b/WalletWasabi.Fluent/Views/StatusBar/StatusBar.axaml
@@ -63,7 +63,7 @@
                           StatusText="{Binding BackendStatus, Converter={x:Static converters:StatusConverters.BackendStatusToString}}" />
             <c:StatusItem Icon="{StaticResource entities_regular}"
                           Title="Peers"
-                          StatusText="{Binding Peers Mode=OneWay, StringFormat={}{0} connected}" />
+                          StatusText="{Binding Peers, Mode=OneWay, StringFormat={}{0} connected}" />
             <c:StatusItem Icon="{StaticResource btc_logo}"
                           Title="{Binding BitcoinCoreName}"
                           StatusText="{Binding BitcoinCoreStatus, Converter={x:Static converters:StatusConverters.RpcStatusStringConverter}}"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
@@ -69,7 +69,7 @@
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Text="Mining fee paid"
                      CopyParameter="{Binding CoinJoinFee}">
-        <TextBox Classes="selectableTextBlock" Text="{Binding CoinJoinFee, StringFormat={}{0} BTC}" />
+        <TextBox Classes="selectableTextBlock" Text="{Binding CoinJoinFee, StringFormat={}{0} BTC, Mode=OneWay}" />
       </c:PreviewItem>
 
     </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -16,8 +16,8 @@
       <!-- Date -->
       <c:PreviewItem Icon="{StaticResource timer_regular}"
                      Text="Date / Time"
-                     CopyParameter="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}'}">
-        <TextBox Classes="selectableTextBlock" Text="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}'}" />
+                     CopyParameter="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}' Mode=OneWay}">
+        <TextBox Classes="selectableTextBlock" Text="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}" />
       </c:PreviewItem>
       <Separator />
 
@@ -47,7 +47,7 @@
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Text="Amount"
                      CopyParameter="{Binding Amount}">
-        <TextBox Classes="selectableTextBlock" Text="{Binding Amount, StringFormat={}{0} BTC}" />
+        <TextBox Classes="selectableTextBlock" Text="{Binding Amount, StringFormat={}{0} BTC, Mode=OneWay}" />
       </c:PreviewItem>
 
       <Separator />


### PR DESCRIPTION
Fix crash that Marnix found!

Exception: TwoWay Bindings do not support string format.