### PR TITLE
Fix different warnings in JsonConverters

### DIFF
--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -30,7 +30,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
 		{
 			var endPointString = reader.Value as string;
 			if (EndPointParser.TryParse(endPointString, DefaultPort, out EndPoint? endPoint))
@@ -44,7 +44,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
 		{
 			if (value is EndPoint endPoint)
 			{

--- a/WalletWasabi/JsonConverters/Timing/TimeSpanJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Timing/TimeSpanJsonConverter.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.JsonConverters.Timing
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
 		{
 			var stringValue = reader.Value as string;
 			return Parse(stringValue);
@@ -41,7 +41,7 @@ namespace WalletWasabi.JsonConverters.Timing
 		}
 
 		/// <inheritdoc />
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
 		{
 			var ts = (TimeSpan)value;
 			writer.WriteValue($"{ts.Days}d {ts.Hours}h {ts.Minutes}m {ts.Seconds}s");

--- a/WalletWasabi/JsonConverters/TransactionJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/TransactionJsonConverter.cs
@@ -13,17 +13,17 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
 		{
-			var txHex = reader.Value.ToString();
+			var txHex = reader.Value?.ToString();
 			var tx = Transaction.Parse(txHex, Network.Main);
 			return tx;
 		}
 
 		/// <inheritdoc />
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
 		{
-			writer.WriteValue(((Transaction)value).ToHex());
+			writer.WriteValue(((Transaction?)value)?.ToHex());
 		}
 	}
 }


### PR DESCRIPTION
There are a lot of warnings that can be removed by correctly implementing the abstract members of the `JsonConverter` class.

If this PR makes sense I can do the same for the other JsonConverter classes.