### PR TITLE
Typo fix-'To Bitcoin address' instead of 'Via'

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionPreviewView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionPreviewView.axaml
@@ -49,7 +49,7 @@
 
       <Separator />
       <c:PreviewItem Icon="{StaticResource transceive_regular}"
-                     Text="via Bitcoin address">
+                     Text="To Bitcoin address">
         <TextBox Classes="selectableTextBlock" Text="{Binding AddressText, FallbackValue=btc029382398fkj34f98df239823}" />
       </c:PreviewItem>
       <Separator />


### PR DESCRIPTION
Small typo fix at `Send - Preview Transaction` screen: _To Bitcoin address_ instead of current _via Bitcoin address_