### PR TITLE
Fix ArgumentNullException when cancelling a tx import

### DIFF
--- a/WalletWasabi.Fluent/Helpers/FileDialogHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/FileDialogHelper.cs
@@ -48,7 +48,7 @@ namespace WalletWasabi.Fluent.Helpers
 			var window = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).MainWindow;
 			var selected = await ofd.ShowAsync(window);
 
-			return selected.FirstOrDefault();
+			return selected?.FirstOrDefault();
 		}
 
 		private static async Task<string?> GetDialogResultAsync(SaveFileDialog sfd)


### PR DESCRIPTION
Steps to reproduce for reviewers:

1. Open 'Transaction Broadcaster'
2. Click on 'Import Transaction'
3. Cancel OpenFileDialog

Error on master branch: `ArgumentNullException: Value cannot be null. (Parameter 'source')`

<details>
  <summary>Screenshot</summary>
  
![image](https://user-images.githubusercontent.com/13405205/143017006-9fa0ea06-92ef-4c46-a104-37c629a588c2.png)

</details>

No error on PR branch