### PR TITLE
Switch 'EndPointJsonConverter' from 'JsonConverter' to 'JsonConverter<T>'

### DIFF
--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -40,9 +40,9 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, EndPoint? value, JsonSerializer serializer)
 		{
-			if (value is EndPoint endPoint)
+			if (value is { })
 			{
-				var endPointString = endPoint.ToString(DefaultPort);
+				var endPointString = value.ToString(DefaultPort);
 				writer.WriteValue(endPointString);
 			}
 			else

--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -40,14 +40,14 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, EndPoint? value, JsonSerializer serializer)
 		{
-			if (value is { })
+			if (value is null)
 			{
-				var endPointString = value.ToString(DefaultPort);
-				writer.WriteValue(endPointString);
+				writer.WriteNull();
 			}
 			else
 			{
-				throw new NotSupportedException($"{nameof(EndPointJsonConverter)} can only convert {nameof(EndPoint)}.");
+				var endPointString = value.ToString(DefaultPort);
+				writer.WriteValue(endPointString);
 			}
 		}
 	}

--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -5,7 +5,7 @@ using WalletWasabi.Userfacing;
 
 namespace WalletWasabi.JsonConverters
 {
-	public class EndPointJsonConverter : JsonConverter
+	public class EndPointJsonConverter : JsonConverter<EndPoint>
 	{
 		private EndPointJsonConverter()
 		{
@@ -24,13 +24,7 @@ namespace WalletWasabi.JsonConverters
 		public int DefaultPort { get; }
 
 		/// <inheritdoc />
-		public override bool CanConvert(Type objectType)
-		{
-			return objectType == typeof(EndPoint);
-		}
-
-		/// <inheritdoc />
-		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		public override EndPoint? ReadJson(JsonReader reader, Type objectType, EndPoint? existingValue, bool hasExistingValue, JsonSerializer serializer)
 		{
 			var endPointString = reader.Value as string;
 			if (EndPointParser.TryParse(endPointString, DefaultPort, out EndPoint? endPoint))
@@ -44,7 +38,7 @@ namespace WalletWasabi.JsonConverters
 		}
 
 		/// <inheritdoc />
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		public override void WriteJson(JsonWriter writer, EndPoint? value, JsonSerializer serializer)
 		{
 			if (value is EndPoint endPoint)
 			{


### PR DESCRIPTION
This is similar to what @kiminuo did in https://github.com/zkSNACKs/WalletWasabi/pull/6158 and a better way to fix warning than #6728