### PR TITLE
add option to hide qr scanner

### DIFF
--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -23,6 +23,7 @@ namespace WalletWasabi.Fluent
 		private bool _runOnSystemStartup;
 		private bool _oobe;
 		private bool _hideOnClose;
+		private bool _hideQRScan;
 
 		public UiConfig() : base()
 		{
@@ -139,6 +140,14 @@ namespace WalletWasabi.Fluent
 		{
 			get => _hideOnClose;
 			set => RaiseAndSetIfChanged(ref _hideOnClose, value);
+		}
+
+		[DefaultValue(true)]
+		[JsonProperty(PropertyName = "HideQRScan", DefaultValueHandling = DefaultValueHandling.Populate)]
+		public bool HideQRScan
+		{
+			get => _hideQRScan;
+			set => RaiseAndSetIfChanged(ref _hideQRScan, value);
 		}
 	}
 }

--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -43,7 +43,8 @@ namespace WalletWasabi.Fluent
 					x => x.RunOnSystemStartup,
 					x => x.PrivacyMode,
 					x => x.HideOnClose,
-					(_, _, _, _, _, _, _, _, _, _, _) => Unit.Default)
+					x => x.HideQRScan,
+					(_, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default)
 				.Throttle(TimeSpan.FromMilliseconds(500))
 				.Skip(1) // Won't save on UiConfig creation.
 				.ObserveOn(RxApp.TaskpoolScheduler)

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -31,6 +31,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 		[AutoNotify] private FeeDisplayFormat _selectedFeeDisplayFormat;
 		[AutoNotify] private bool _runOnSystemStartup;
 		[AutoNotify] private bool _hideOnClose;
+		[AutoNotify] private bool _hideQRScan;
 
 		public GeneralSettingsTabViewModel()
 		{
@@ -92,6 +93,11 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 				.ObserveOn(RxApp.TaskpoolScheduler)
 				.Skip(1)
 				.Subscribe(x => Services.UiConfig.HideOnClose = x);
+
+			this.WhenAnyValue(x => x.HideQRScan)
+				.ObserveOn(RxApp.TaskpoolScheduler)
+				.Skip(1)
+				.Subscribe(x => Services.UiConfig.HideQRScan = x);
 		}
 
 		public ICommand StartupCommand { get; }

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -41,6 +41,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings
 			_customChangeAddress = Services.UiConfig.IsCustomChangeAddress;
 			_runOnSystemStartup = Services.UiConfig.RunOnSystemStartup;
 			_hideOnClose = Services.UiConfig.HideOnClose;
+			_hideQRScan = Services.UiConfig.HideQRScan;
 			_selectedFeeDisplayFormat = Enum.IsDefined(typeof(FeeDisplayFormat), Services.UiConfig.FeeDisplayFormat)
 				? (FeeDisplayFormat)Services.UiConfig.FeeDisplayFormat
 				: FeeDisplayFormat.SatoshiPerByte;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -59,7 +59,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send
 
 			SuggestionLabels = new SuggestionLabelsViewModel(3);
 
-			IsQrButtonVisible = WebcamQrReader.IsOsPlatformSupported;
+			if (Services.UiConfig.HideQRScan is false)
+			{
+				IsQrButtonVisible = WebcamQrReader.IsOsPlatformSupported;
+			}
 
 			ExchangeRate = _wallet.Synchronizer.UsdExchangeRate;
 

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -40,6 +40,11 @@
       <ToggleSwitch IsChecked="{Binding CustomChangeAddress}" />
     </DockPanel>
 
+    <DockPanel>
+      <TextBlock VerticalAlignment="Center" Text="Hide QR scanner" />
+      <ToggleSwitch IsChecked="{Binding HideQRScan}" />
+    </DockPanel>
+
     <StackPanel Spacing="10">
       <TextBlock Text="Fee Display Format" />
       <ComboBox HorizontalAlignment="Stretch" Items="{Binding FeeDisplayFormats}" SelectedItem="{Binding SelectedFeeDisplayFormat}">


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/6713

### What?

Improve privacy in the application by adding an option in general settings to hide QR code scanner

### Why?

https://github.com/zkSNACKs/WalletWasabi/issues/6713#issuecomment-978024807

### How?

Added an `if` statement in `WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs` :

```c#
			if (Services.UiConfig.HideQRScan is false)
			{
				IsQrButtonVisible = WebcamQrReader.IsOsPlatformSupported;
			}
```

and option in general settings which works as expected:

<details>
  <summary>Disabled</summary>
  
  ![image](https://user-images.githubusercontent.com/13405205/143492201-0807f672-6021-4ec4-b031-bfe99624b220.png)

  ![image](https://user-images.githubusercontent.com/13405205/143492235-74c32fca-844a-44a8-bb1c-224cfc124b30.png)
  
</details>


<details>
  <summary>Enabled</summary>
  
![image](https://user-images.githubusercontent.com/13405205/143492257-b7213ddc-fd59-4e94-8f4c-4408603fab11.png)

![image](https://user-images.githubusercontent.com/13405205/143492299-55ba92f9-d606-4756-9406-d69e3ba382ff.png)
  
</details>

---

QR scanner is not hidden by default right now. Can change this behavior based on reviews. Also got some feedback about related things on reddit today: https://www.reddit.com/r/csharp/comments/r1zkk1/disable_webcam_using_c_for_an_application/




