### PR TITLE
[WabiSabi] Do not throw exceptions when no Alice is available

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -95,7 +95,8 @@ namespace WalletWasabi.WabiSabi.Client
 			var registeredAliceClients = await CreateRegisterAndConfirmCoinsAsync(coinCandidates, roundState, cancellationToken).ConfigureAwait(false);
 			if (!registeredAliceClients.Any())
 			{
-				throw new InvalidOperationException($"Round ({roundState.Id}): There is no available alices to participate with.");
+				Logger.LogInfo($"Round ({roundState.Id}): There is no available alices to participate with.");
+				return true;
 			}
 
 			try


### PR DESCRIPTION
Some times no inputs are registered and in that case the CJC throws an `InvalidOperationException` when in fact it is not necessarily an exceptional condition or error. 