### PR TITLE
[Fluent] Simplify transaction confirmation text

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionPreviewView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionPreviewView.axaml
@@ -98,7 +98,7 @@
 
         <StackPanel Spacing="10">
           <c:PreviewItem Icon="{StaticResource timer_regular}"
-                         Text="miners will work hard to confirm your transaction within">
+                         Text="your transaction should be confirmed within">
             <TextBox Classes="selectableTextBlock" Text="{Binding ConfirmationTimeText, FallbackValue=~20 minutes }" />
           </c:PreviewItem>
           <c:PreviewItem Icon="{StaticResource paper_cash_regular}"


### PR DESCRIPTION
Users don't need to know that miners confirm transactions.

[follow-up to #6755]