### PR TITLE
[WabiSabi] Alices are identified by a secret cookie, not a public ID

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -223,7 +223,7 @@ namespace WalletWasabi.Tests.Helpers
 
 			return new ConnectionConfirmationRequest(
 				round.Id,
-				alice.Id,
+				alice.Secret,
 				zeroAmountCredentialRequest,
 				realAmountCredentialRequest,
 				zeroVsizeCredentialRequest,

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ReadyToSignRequestRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ReadyToSignRequestRequestTests.cs
@@ -18,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Guid guid = Guid.NewGuid();
 
 			// Request #1.
-			ReadyToSignRequestRequest request1 = new(RoundId: roundId, AliceId: guid);
+			ReadyToSignRequestRequest request1 = new(RoundId: roundId, AliceSecret: guid);
 
 			// Request #2.
-			ReadyToSignRequestRequest request2 = new(RoundId: roundId, AliceId: guid);
+			ReadyToSignRequestRequest request2 = new(RoundId: roundId, AliceSecret: guid);
 
 			Assert.Equal(request1, request2);
 
 			// Request #3.
-			ReadyToSignRequestRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceId: guid);
+			ReadyToSignRequestRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecret: guid);
 
 			Assert.NotEqual(request1, request3);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ReadyToSignRequestRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ReadyToSignRequestRequestTests.cs
@@ -18,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Guid guid = Guid.NewGuid();
 
 			// Request #1.
-			ReadyToSignRequestRequest request1 = new(RoundId: roundId, AliceSecret: guid);
+			ReadyToSignRequestRequest request1 = new(RoundId: roundId, AliceSecretId: guid);
 
 			// Request #2.
-			ReadyToSignRequestRequest request2 = new(RoundId: roundId, AliceSecret: guid);
+			ReadyToSignRequestRequest request2 = new(RoundId: roundId, AliceSecretId: guid);
 
 			Assert.Equal(request1, request2);
 
 			// Request #3.
-			ReadyToSignRequestRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecret: guid);
+			ReadyToSignRequestRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecretId: guid);
 
 			Assert.NotEqual(request1, request3);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -32,7 +32,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			await arena.RemoveInputAsync(req, CancellationToken.None);
 
 			// There was the alice we want to remove so success.
-			req = new InputsRemovalRequest(round.Id, alice.Id);
+			req = new InputsRemovalRequest(round.Id, alice.Secret);
 			await arena.RemoveInputAsync(req, CancellationToken.None);
 
 			// Ensure that removing an alice freed up the input vsize

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 			var inputRegistrationResponse = await aliceArenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None);
-			var aliceSecret = inputRegistrationResponse.Value;
+			var aliceSecretId = inputRegistrationResponse.Value;
 
 			var inputVsize = Constants.P2wpkhInputVirtualSize;
 			var amountsToRequest = new[]
@@ -94,7 +94,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			var connectionConfirmationResponse1 = await aliceArenaClient.ConfirmConnectionAsync(
 				round.Id,
-				aliceSecret,
+				aliceSecretId,
 				amountsToRequest,
 				vsizesToRequest,
 				inputRegistrationResponse.IssuedAmountCredentials,
@@ -107,7 +107,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			// Phase: Connection Confirmation
 			var connectionConfirmationResponse2 = await aliceArenaClient.ConfirmConnectionAsync(
 				round.Id,
-				aliceSecret,
+				aliceSecretId,
 				amountsToRequest,
 				vsizesToRequest,
 				connectionConfirmationResponse1.IssuedAmountCredentials,
@@ -156,7 +156,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				new[] { vsizeCred2, zeroVsizeCred2 },
 				CancellationToken.None);
 
-			await aliceArenaClient.ReadyToSignAsync(round.Id, aliceSecret, CancellationToken.None);
+			await aliceArenaClient.ReadyToSignAsync(round.Id, aliceSecretId, CancellationToken.None);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 			var inputRegistrationResponse = await aliceArenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None);
-			var aliceId = inputRegistrationResponse.Value;
+			var aliceSecret = inputRegistrationResponse.Value;
 
 			var inputVsize = Constants.P2wpkhInputVirtualSize;
 			var amountsToRequest = new[]
@@ -94,7 +94,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			var connectionConfirmationResponse1 = await aliceArenaClient.ConfirmConnectionAsync(
 				round.Id,
-				aliceId,
+				aliceSecret,
 				amountsToRequest,
 				vsizesToRequest,
 				inputRegistrationResponse.IssuedAmountCredentials,
@@ -107,7 +107,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 			// Phase: Connection Confirmation
 			var connectionConfirmationResponse2 = await aliceArenaClient.ConfirmConnectionAsync(
 				round.Id,
-				aliceId,
+				aliceSecret,
 				amountsToRequest,
 				vsizesToRequest,
 				connectionConfirmationResponse1.IssuedAmountCredentials,
@@ -156,7 +156,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 				new[] { vsizeCred2, zeroVsizeCred2 },
 				CancellationToken.None);
 
-			await aliceArenaClient.ReadyToSignAsync(round.Id, aliceId, CancellationToken.None);
+			await aliceArenaClient.ReadyToSignAsync(round.Id, aliceSecret, CancellationToken.None);
 
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -187,7 +187,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
 
 			round.SetPhase(Phase.InputRegistration);
 
-			await apiClient.RemoveInputAsync(round.Id, alice.Id, CancellationToken.None);
+			await apiClient.RemoveInputAsync(round.Id, alice.Secret, CancellationToken.None);
 			Assert.Empty(round.Alices);
 		}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConnectionConfirmationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConnectionConfirmationRequestTests.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// Request #1.
 			ConnectionConfirmationRequest request1 = new(
 				RoundId: roundId,
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -38,7 +38,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #2.
 			ConnectionConfirmationRequest request2 = new(
 				RoundId: roundId,
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -50,7 +50,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #3.
 			ConnectionConfirmationRequest request3 = new(
 				RoundId: BitcoinFactory.CreateUint256(), // Intentionally changed.
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -62,7 +62,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #4.
 			ConnectionConfirmationRequest request4 = new(
 				RoundId: roundId,
-				AliceSecret: Guid.NewGuid(), // Intentionally changed.
+				AliceSecretId: Guid.NewGuid(), // Intentionally changed.
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #5.
 			ConnectionConfirmationRequest request5 = new(
 				RoundId: roundId,
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1337), // Intentionally changed.
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -86,7 +86,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #6.
 			ConnectionConfirmationRequest request6 = new(
 				RoundId: roundId,
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1337), // Intentionally changed.
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -98,7 +98,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #7.
 			ConnectionConfirmationRequest request7 = new(
 				RoundId: roundId,
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 1337), // Intentionally changed.
@@ -110,7 +110,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// Request #8.
 			ConnectionConfirmationRequest request8 = new(
 				RoundId: roundId,
-				AliceSecret: guid,
+				AliceSecretId: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConnectionConfirmationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConnectionConfirmationRequestTests.cs
@@ -28,7 +28,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// Request #1.
 			ConnectionConfirmationRequest request1 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -38,7 +38,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #2.
 			ConnectionConfirmationRequest request2 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -50,7 +50,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #3.
 			ConnectionConfirmationRequest request3 = new(
 				RoundId: BitcoinFactory.CreateUint256(), // Intentionally changed.
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -62,7 +62,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #4.
 			ConnectionConfirmationRequest request4 = new(
 				RoundId: roundId,
-				AliceId: Guid.NewGuid(), // Intentionally changed.
+				AliceSecret: Guid.NewGuid(), // Intentionally changed.
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -74,7 +74,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #5.
 			ConnectionConfirmationRequest request5 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1337), // Intentionally changed.
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -86,7 +86,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #6.
 			ConnectionConfirmationRequest request6 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1337), // Intentionally changed.
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -98,7 +98,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			//// Request #7.
 			ConnectionConfirmationRequest request7 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 1337), // Intentionally changed.
@@ -110,7 +110,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			// Request #8.
 			ConnectionConfirmationRequest request8 = new(
 				RoundId: roundId,
-				AliceId: guid,
+				AliceSecret: guid,
 				ZeroAmountCredentialRequests: NewZeroCredentialsRequest(modifier: 1),
 				RealAmountCredentialRequests: NewRealCredentialsRequest(modifier: 1),
 				ZeroVsizeCredentialRequests: NewZeroCredentialsRequest(modifier: 2),
@@ -121,7 +121,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 		}
 
 		private static GroupElement NewGroupElement(int i) => Generators.FromText($"T{i}");
+
 		private static GroupElementVector NewGroupElementVector(params int[] arr) => new(arr.Select(i => NewGroupElement(i)));
+
 		private static ScalarVector NewScalarVector(params uint[] arr) => new(arr.Select(i => new Scalar(i)));
 
 		/// <remarks>Each instance represents the same request but a new object instance.</remarks>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputsRemovalRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputsRemovalRequestTests.cs
@@ -18,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			Guid guid = Guid.NewGuid();
 
 			// Request #1.
-			InputsRemovalRequest request1 = new(RoundId: roundId, AliceId: guid);
+			InputsRemovalRequest request1 = new(RoundId: roundId, AliceSecret: guid);
 
 			// Request #2.
-			InputsRemovalRequest request2 = new(RoundId: roundId, AliceId: guid);
+			InputsRemovalRequest request2 = new(RoundId: roundId, AliceSecret: guid);
 
 			Assert.Equal(request1, request2);
 
 			// Request #3.
-			InputsRemovalRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceId: guid);
+			InputsRemovalRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecret: guid);
 
 			Assert.NotEqual(request1, request3);
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputsRemovalRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputsRemovalRequestTests.cs
@@ -18,15 +18,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			Guid guid = Guid.NewGuid();
 
 			// Request #1.
-			InputsRemovalRequest request1 = new(RoundId: roundId, AliceSecret: guid);
+			InputsRemovalRequest request1 = new(RoundId: roundId, AliceSecretId: guid);
 
 			// Request #2.
-			InputsRemovalRequest request2 = new(RoundId: roundId, AliceSecret: guid);
+			InputsRemovalRequest request2 = new(RoundId: roundId, AliceSecretId: guid);
 
 			Assert.Equal(request1, request2);
 
 			// Request #3.
-			InputsRemovalRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecret: guid);
+			InputsRemovalRequest request3 = new(RoundId: BitcoinFactory.CreateUint256(), AliceSecretId: guid);
 
 			Assert.NotEqual(request1, request3);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -8,17 +8,17 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 {
 	public class Alice
 	{
-		public Alice(Coin coin, OwnershipProof ownershipProof, Round round, Guid id)
+		public Alice(Coin coin, OwnershipProof ownershipProof, Round round, Guid secret)
 		{
 			// TODO init syntax?
 			Round = round;
 			Coin = coin;
 			OwnershipProof = ownershipProof;
-			Id = id;
+			Secret = secret;
 		}
 
 		public Round Round { get; }
-		public Guid Id { get; }
+		public Guid Secret { get; }
 		public DateTimeOffset Deadline { get; set; } = DateTimeOffset.UtcNow;
 		public Coin Coin { get; }
 		public OwnershipProof OwnershipProof { get; }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -99,7 +99,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
 				var round = GetRound(request.RoundId);
-				var alice = GetAlice(request.AliceSecret, round);
+				var alice = GetAlice(request.AliceSecretId, round);
 				alice.ReadyToSign = true;
 			}
 		}
@@ -110,7 +110,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				var round = GetRound(request.RoundId, Phase.InputRegistration);
 
-				round.Alices.RemoveAll(x => x.Secret == request.AliceSecret);
+				round.Alices.RemoveAll(x => x.Secret == request.AliceSecretId);
 			}
 		}
 
@@ -125,12 +125,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				round = GetRound(request.RoundId, Phase.InputRegistration, Phase.ConnectionConfirmation);
 
-				alice = GetAlice(request.AliceSecret, round);
+				alice = GetAlice(request.AliceSecretId, round);
 
 				if (alice.ConfirmedConnection)
 				{
 					Prison.Ban(alice, round.Id);
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection, $"Round ({request.RoundId}): Alice ({request.AliceSecret}) already confirmed connection.");
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection, $"Round ({request.RoundId}): Alice ({request.AliceSecretId}) already confirmed connection.");
 				}
 
 				if (realVsizeCredentialRequests.Delta != alice.CalculateRemainingVsizeCredentials(round.MaxVsizeAllocationPerAlice))
@@ -156,7 +156,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
-				alice = GetAlice(request.AliceSecret, round);
+				alice = GetAlice(request.AliceSecretId, round);
 
 				switch (round.Phase)
 				{
@@ -326,8 +326,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		private Round GetRound(uint256 roundId, params Phase[] phases) =>
 			InPhase(GetRound(roundId), phases);
 
-		private Alice GetAlice(Guid aliceSecret, Round round) =>
-			round.Alices.Find(x => x.Secret == aliceSecret)
-			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceSecret}) not found.");
+		private Alice GetAlice(Guid aliceSecretId, Round round) =>
+			round.Alices.Find(x => x.Secret == aliceSecretId)
+			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceSecretId}) not found.");
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -88,7 +88,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 				round.Alices.Add(alice);
 
-				return new(alice.Id,
+				return new(alice.Secret,
 					commitAmountCredentialResponse,
 					commitVsizeCredentialResponse);
 			}
@@ -99,7 +99,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
 				var round = GetRound(request.RoundId);
-				var alice = GetAlice(request.AliceId, round);
+				var alice = GetAlice(request.AliceSecret, round);
 				alice.ReadyToSign = true;
 			}
 		}
@@ -110,7 +110,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				var round = GetRound(request.RoundId, Phase.InputRegistration);
 
-				round.Alices.RemoveAll(x => x.Id == request.AliceId);
+				round.Alices.RemoveAll(x => x.Secret == request.AliceSecret);
 			}
 		}
 
@@ -125,12 +125,12 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			{
 				round = GetRound(request.RoundId, Phase.InputRegistration, Phase.ConnectionConfirmation);
 
-				alice = GetAlice(request.AliceId, round);
+				alice = GetAlice(request.AliceSecret, round);
 
 				if (alice.ConfirmedConnection)
 				{
 					Prison.Ban(alice, round.Id);
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection, $"Round ({request.RoundId}): Alice ({request.AliceId}) already confirmed connection.");
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection, $"Round ({request.RoundId}): Alice ({request.AliceSecret}) already confirmed connection.");
 				}
 
 				if (realVsizeCredentialRequests.Delta != alice.CalculateRemainingVsizeCredentials(round.MaxVsizeAllocationPerAlice))
@@ -156,7 +156,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 			using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
-				alice = GetAlice(request.AliceId, round);
+				alice = GetAlice(request.AliceSecret, round);
 
 				switch (round.Phase)
 				{
@@ -326,8 +326,8 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		private Round GetRound(uint256 roundId, params Phase[] phases) =>
 			InPhase(GetRound(roundId), phases);
 
-		private Alice GetAlice(Guid aliceId, Round round) =>
-			round.Alices.Find(x => x.Id == aliceId)
-			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceId}) not found.");
+		private Alice GetAlice(Guid aliceSecret, Round round) =>
+			round.Alices.Find(x => x.Secret == aliceSecret)
+			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceSecret}) not found.");
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.WabiSabi.Client
 	public class AliceClient
 	{
 		private AliceClient(
-			Guid aliceId,
+			Guid secret,
 			RoundState roundState,
 			ArenaClient arenaClient,
 			SmartCoin coin,
@@ -24,7 +24,7 @@ namespace WalletWasabi.WabiSabi.Client
 			IEnumerable<Credential> issuedAmountCredentials,
 			IEnumerable<Credential> issuedVsizeCredentials)
 		{
-			AliceId = aliceId;
+			Secret = secret;
 			RoundId = roundState.Id;
 			ArenaClient = arenaClient;
 			SmartCoin = coin;
@@ -36,7 +36,7 @@ namespace WalletWasabi.WabiSabi.Client
 			ConfirmationTimeout = roundState.ConnectionConfirmationTimeout / 2;
 		}
 
-		public Guid AliceId { get; }
+		public Guid Secret { get; }
 		public uint256 RoundId { get; }
 		private ArenaClient ArenaClient { get; }
 		public SmartCoin SmartCoin { get; }
@@ -62,7 +62,7 @@ namespace WalletWasabi.WabiSabi.Client
 				aliceClient = await RegisterInputAsync(roundState, arenaClient, coin, bitcoinSecret, identificationKey, cancellationToken).ConfigureAwait(false);
 				await aliceClient.ConfirmConnectionAsync(roundStatusUpdater, cancellationToken).ConfigureAwait(false);
 
-				Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({aliceClient.AliceId}): Connection successfully confirmed.");
+				Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({aliceClient.Secret}): Connection successfully confirmed.");
 			}
 			catch (OperationCanceledException)
 			{
@@ -92,7 +92,7 @@ namespace WalletWasabi.WabiSabi.Client
 				aliceClient = new(response.Value, roundState, arenaClient, coin, bitcoinSecret, response.IssuedAmountCredentials, response.IssuedVsizeCredentials);
 				coin.CoinJoinInProgress = true;
 
-				Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.OutPoint}.");
+				Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.Secret}): Registered {coin.OutPoint}.");
 			}
 			catch (System.Net.Http.HttpRequestException ex)
 			{
@@ -162,13 +162,13 @@ namespace WalletWasabi.WabiSabi.Client
 
 			if (effectiveAmount <= Money.Zero)
 			{
-				throw new InvalidOperationException($"Round({ RoundId }), Alice({ AliceId}): Adding this input is uneconomical.");
+				throw new InvalidOperationException($"Round({ RoundId }), Alice({ Secret}): Adding this input is uneconomical.");
 			}
 
 			var response = await ArenaClient
 				.ConfirmConnectionAsync(
 					RoundId,
-					AliceId,
+					Secret,
 					amountsToRequest,
 					vsizesToRequest,
 					IssuedAmountCredentials,
@@ -181,7 +181,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 			var isConfirmed = response.Value;
 
-			Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Connection confirmed.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Connection confirmed.");
 			return isConfirmed;
 		}
 
@@ -191,7 +191,7 @@ namespace WalletWasabi.WabiSabi.Client
 			{
 				await RemoveInputAsync(cancellationToken).ConfigureAwait(false);
 				SmartCoin.CoinJoinInProgress = false;
-				Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Unregistered {SmartCoin.OutPoint}.");
+				Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Unregistered {SmartCoin.OutPoint}.");
 			}
 			catch (System.Net.Http.HttpRequestException ex)
 			{
@@ -222,22 +222,22 @@ namespace WalletWasabi.WabiSabi.Client
 
 		public async Task RemoveInputAsync(CancellationToken cancellationToken)
 		{
-			await ArenaClient.RemoveInputAsync(RoundId, AliceId, cancellationToken).ConfigureAwait(false);
+			await ArenaClient.RemoveInputAsync(RoundId, Secret, cancellationToken).ConfigureAwait(false);
 			SmartCoin.CoinJoinInProgress = false;
-			Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Inputs removed.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Inputs removed.");
 		}
 
 		public async Task SignTransactionAsync(Transaction unsignedCoinJoin, CancellationToken cancellationToken)
 		{
 			await ArenaClient.SignTransactionAsync(RoundId, SmartCoin.Coin, BitcoinSecret, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
 
-			Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Posted a signature.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Posted a signature.");
 		}
 
 		public async Task ReadyToSignAsync(CancellationToken cancellationToken)
 		{
-			await ArenaClient.ReadyToSignAsync(RoundId, AliceId, cancellationToken).ConfigureAwait(false);
-			Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Ready to sign.");
+			await ArenaClient.ReadyToSignAsync(RoundId, Secret, cancellationToken).ConfigureAwait(false);
+			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Ready to sign.");
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -62,7 +62,7 @@ namespace WalletWasabi.WabiSabi.Client
 				aliceClient = await RegisterInputAsync(roundState, arenaClient, coin, bitcoinSecret, identificationKey, cancellationToken).ConfigureAwait(false);
 				await aliceClient.ConfirmConnectionAsync(roundStatusUpdater, cancellationToken).ConfigureAwait(false);
 
-				Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({aliceClient.Secret}): Connection successfully confirmed.");
+				Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({coin.OutPoint}): Connection successfully confirmed.");
 			}
 			catch (OperationCanceledException)
 			{
@@ -92,7 +92,7 @@ namespace WalletWasabi.WabiSabi.Client
 				aliceClient = new(response.Value, roundState, arenaClient, coin, bitcoinSecret, response.IssuedAmountCredentials, response.IssuedVsizeCredentials);
 				coin.CoinJoinInProgress = true;
 
-				Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.Secret}): Registered {coin.OutPoint}.");
+				Logger.LogInfo($"Round ({roundState.Id}), Alice ({coin.OutPoint}): Registered {coin.OutPoint}.");
 			}
 			catch (System.Net.Http.HttpRequestException ex)
 			{
@@ -181,7 +181,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 			var isConfirmed = response.Value;
 
-			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Connection confirmed.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({SmartCoin.OutPoint}): Connection confirmed.");
 			return isConfirmed;
 		}
 
@@ -191,7 +191,7 @@ namespace WalletWasabi.WabiSabi.Client
 			{
 				await RemoveInputAsync(cancellationToken).ConfigureAwait(false);
 				SmartCoin.CoinJoinInProgress = false;
-				Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Unregistered {SmartCoin.OutPoint}.");
+				Logger.LogInfo($"Round ({RoundId}), Alice ({SmartCoin.OutPoint}): Unregistered.");
 			}
 			catch (System.Net.Http.HttpRequestException ex)
 			{
@@ -224,20 +224,20 @@ namespace WalletWasabi.WabiSabi.Client
 		{
 			await ArenaClient.RemoveInputAsync(RoundId, Secret, cancellationToken).ConfigureAwait(false);
 			SmartCoin.CoinJoinInProgress = false;
-			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Inputs removed.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({SmartCoin.OutPoint}): Inputs removed.");
 		}
 
 		public async Task SignTransactionAsync(Transaction unsignedCoinJoin, CancellationToken cancellationToken)
 		{
 			await ArenaClient.SignTransactionAsync(RoundId, SmartCoin.Coin, BitcoinSecret, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
 
-			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Posted a signature.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({SmartCoin.OutPoint}): Posted a signature.");
 		}
 
 		public async Task ReadyToSignAsync(CancellationToken cancellationToken)
 		{
 			await ArenaClient.ReadyToSignAsync(RoundId, Secret, cancellationToken).ConfigureAwait(false);
-			Logger.LogInfo($"Round ({RoundId}), Alice ({Secret}): Ready to sign.");
+			Logger.LogInfo($"Round ({RoundId}), Alice ({SmartCoin.OutPoint}): Ready to sign.");
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -51,12 +51,12 @@ namespace WalletWasabi.WabiSabi.Client
 			var realAmountCredentials = AmountCredentialClient.HandleResponse(inputRegistrationResponse.AmountCredentials, zeroAmountCredentialRequestData.CredentialsResponseValidation);
 			var realVsizeCredentials = VsizeCredentialClient.HandleResponse(inputRegistrationResponse.VsizeCredentials, zeroVsizeCredentialRequestData.CredentialsResponseValidation);
 
-			return new(inputRegistrationResponse.AliceSecret, realAmountCredentials, realVsizeCredentials);
+			return new(inputRegistrationResponse.AliceSecretId, realAmountCredentials, realVsizeCredentials);
 		}
 
-		public async Task RemoveInputAsync(uint256 roundId, Guid aliceSecret, CancellationToken cancellationToken)
+		public async Task RemoveInputAsync(uint256 roundId, Guid aliceSecretId, CancellationToken cancellationToken)
 		{
-			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceSecret), cancellationToken).ConfigureAwait(false);
+			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceSecretId), cancellationToken).ConfigureAwait(false);
 		}
 
 		public async Task RegisterOutputAsync(

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -51,12 +51,12 @@ namespace WalletWasabi.WabiSabi.Client
 			var realAmountCredentials = AmountCredentialClient.HandleResponse(inputRegistrationResponse.AmountCredentials, zeroAmountCredentialRequestData.CredentialsResponseValidation);
 			var realVsizeCredentials = VsizeCredentialClient.HandleResponse(inputRegistrationResponse.VsizeCredentials, zeroVsizeCredentialRequestData.CredentialsResponseValidation);
 
-			return new(inputRegistrationResponse.AliceId, realAmountCredentials, realVsizeCredentials);
+			return new(inputRegistrationResponse.AliceSecret, realAmountCredentials, realVsizeCredentials);
 		}
 
-		public async Task RemoveInputAsync(uint256 roundId, Guid aliceId, CancellationToken cancellationToken)
+		public async Task RemoveInputAsync(uint256 roundId, Guid aliceSecret, CancellationToken cancellationToken)
 		{
-			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceId), cancellationToken).ConfigureAwait(false);
+			await RequestHandler.RemoveInputAsync(new InputsRemovalRequest(roundId, aliceSecret), cancellationToken).ConfigureAwait(false);
 		}
 
 		public async Task RegisterOutputAsync(

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -203,7 +203,7 @@ namespace WalletWasabi.WabiSabi.Client
 			}
 
 			// Gets the list of scheduled dates/time in the remaining available time frame when each alice has to be registered.
-			var remainingTimeForRegistration = ( roundState.InputRegistrationEnd - DateTimeOffset.UtcNow ) - TimeSpan.FromSeconds(15);
+			var remainingTimeForRegistration = (roundState.InputRegistrationEnd - DateTimeOffset.UtcNow) - TimeSpan.FromSeconds(15);
 
 			Logger.LogDebug($"Round ({roundState.Id}): Input registration started, it will end in {remainingTimeForRegistration.TotalMinutes} minutes.");
 
@@ -260,7 +260,7 @@ namespace WalletWasabi.WabiSabi.Client
 				}
 				catch (Exception e)
 				{
-					Logger.LogWarning($"Round ({aliceClient.RoundId}), Alice ({aliceClient.AliceId}): Could not sign, reason:'{e}'.");
+					Logger.LogWarning($"Round ({aliceClient.RoundId}), Alice ({aliceClient.Secret}): Could not sign, reason:'{e}'.");
 					return default;
 				}
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -260,7 +260,7 @@ namespace WalletWasabi.WabiSabi.Client
 				}
 				catch (Exception e)
 				{
-					Logger.LogWarning($"Round ({aliceClient.RoundId}), Alice ({aliceClient.Secret}): Could not sign, reason:'{e}'.");
+					Logger.LogWarning($"Round ({aliceClient.RoundId}), Alice ({aliceClient.SmartCoin.OutPoint}): Could not sign, reason:'{e}'.");
 					return default;
 				}
 			}

--- a/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
@@ -4,12 +4,12 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-	public record ConnectionConfirmationRequest(
-		uint256 RoundId,
-		Guid AliceId,
-		ZeroCredentialsRequest ZeroAmountCredentialRequests,
-		RealCredentialsRequest RealAmountCredentialRequests,
-		ZeroCredentialsRequest ZeroVsizeCredentialRequests,
-		RealCredentialsRequest RealVsizeCredentialRequests
-	);
+    public record ConnectionConfirmationRequest(
+        uint256 RoundId,
+        Guid AliceSecret,
+        ZeroCredentialsRequest ZeroAmountCredentialRequests,
+        RealCredentialsRequest RealAmountCredentialRequests,
+        ZeroCredentialsRequest ZeroVsizeCredentialRequests,
+        RealCredentialsRequest RealVsizeCredentialRequests
+    );
 }

--- a/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ConnectionConfirmationRequest.cs
@@ -4,12 +4,12 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-    public record ConnectionConfirmationRequest(
-        uint256 RoundId,
-        Guid AliceSecret,
-        ZeroCredentialsRequest ZeroAmountCredentialRequests,
-        RealCredentialsRequest RealAmountCredentialRequests,
-        ZeroCredentialsRequest ZeroVsizeCredentialRequests,
-        RealCredentialsRequest RealVsizeCredentialRequests
-    );
+	public record ConnectionConfirmationRequest(
+		uint256 RoundId,
+		Guid AliceSecretId,
+		ZeroCredentialsRequest ZeroAmountCredentialRequests,
+		RealCredentialsRequest RealAmountCredentialRequests,
+		ZeroCredentialsRequest ZeroVsizeCredentialRequests,
+		RealCredentialsRequest RealVsizeCredentialRequests
+	);
 }

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -5,7 +5,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputRegistrationResponse(
-		Guid AliceSecret,
+		Guid AliceSecretId,
 		CredentialsResponse AmountCredentials,
 		CredentialsResponse VsizeCredentials
 	);

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -5,7 +5,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 namespace WalletWasabi.WabiSabi.Models
 {
 	public record InputRegistrationResponse(
-		Guid AliceId,
+		Guid AliceSecret,
 		CredentialsResponse AmountCredentials,
 		CredentialsResponse VsizeCredentials
 	);

--- a/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
@@ -3,8 +3,8 @@ using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-    public record InputsRemovalRequest(
-        uint256 RoundId,
-        Guid AliceSecret
-    );
+	public record InputsRemovalRequest(
+		uint256 RoundId,
+		Guid AliceSecretId
+	);
 }

--- a/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/InputsRemovalRequest.cs
@@ -3,8 +3,8 @@ using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Models
 {
-	public record InputsRemovalRequest(
-		uint256 RoundId,
-		Guid AliceId
-	);
+    public record InputsRemovalRequest(
+        uint256 RoundId,
+        Guid AliceSecret
+    );
 }

--- a/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
@@ -3,5 +3,5 @@ using System;
 
 namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
-    public record ReadyToSignRequestRequest(uint256 RoundId, Guid AliceSecret);
+	public record ReadyToSignRequestRequest(uint256 RoundId, Guid AliceSecretId);
 }

--- a/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/ReadyToSignRequestRequest.cs
@@ -3,5 +3,5 @@ using System;
 
 namespace WalletWasabi.WabiSabi.Backend.PostRequests
 {
-	public record ReadyToSignRequestRequest(uint256 RoundId, Guid AliceId);
+    public record ReadyToSignRequestRequest(uint256 RoundId, Guid AliceSecret);
 }


### PR DESCRIPTION
Rename the `Guid Id` property to `Secret`, and treat it as such. References to alices in the logs just use the outpoint, since that's a unique identifier even in failed rounds, since an input can't be added to two rounds at a time.

This is based on @molnard's master, but master has seen no changes relating to this. Basing it off of an older head is to make merging with #6734 easier. Continued in molnard#38