### PR TITLE
[VDG] [Fluent] Dialog screen size optimization - width and height thresholds

### DIFF
--- a/WalletWasabi.Fluent/Controls/Dialog.axaml
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml
@@ -91,6 +91,16 @@
     <Setter Property="Margin" Value="0 40" />
   </Style>
 
+  <!-- Dialog Increased height State -->
+  <Style Selector="c|Dialog[IncreasedHeightEnabled=True] /template/ Border#PART_Border">
+    <Setter Property="Margin" Value="40 0" />
+  </Style>
+
+  <!-- Dialog Increased size State -->
+  <Style Selector="c|Dialog[IncreasedSizeEnabled=True] /template/ Border#PART_Border">
+    <Setter Property="Margin" Value="0 0" />
+  </Style>
+
   <!-- Dialog Fullscreen State -->
   <Style Selector="c|Dialog[FullScreenEnabled=True] /template/ Border#PART_Border">
     <Setter Property="Margin" Value="0 30 0 0" />

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -50,6 +50,9 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<double> IncreasedWidthThresholdProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(IncreasedWidthThreshold), double.NaN);
 
+		public static readonly StyledProperty<double> IncreasedHeightThresholdProperty =
+			AvaloniaProperty.Register<Dialog, double>(nameof(IncreasedHeightThreshold), double.NaN);
+
 		public static readonly StyledProperty<double> FullScreenHeightThresholdProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(FullScreenHeightThreshold), double.NaN);
 
@@ -58,6 +61,12 @@ namespace WalletWasabi.Fluent.Controls
 
 		public static readonly StyledProperty<bool> IncreasedWidthEnabledProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(IncreasedWidthEnabled));
+
+		public static readonly StyledProperty<bool> IncreasedHeightEnabledProperty =
+			AvaloniaProperty.Register<Dialog, bool>(nameof(IncreasedHeightEnabled));
+
+		public static readonly StyledProperty<bool> IncreasedSizeEnabledProperty =
+			AvaloniaProperty.Register<Dialog, bool>(nameof(IncreasedSizeEnabled));
 
 		public Dialog()
 		{
@@ -69,10 +78,22 @@ namespace WalletWasabi.Fluent.Controls
 					var width = bounds.Width;
 					var height = bounds.Height;
 					var increasedWidthThreshold = IncreasedWidthThreshold;
+					var increasedHeightThreshold = IncreasedHeightThreshold;
 					var fullScreenHeightThreshold = FullScreenHeightThreshold;
-					IncreasedWidthEnabled = !double.IsNaN(increasedWidthThreshold)
+
+					var increasedWidthEnabled = !double.IsNaN(increasedWidthThreshold)
 					                        && width < increasedWidthThreshold;
-					FullScreenEnabled = IncreasedWidthEnabled
+
+					var increasedHeightEnabled = !double.IsNaN(increasedHeightThreshold)
+					                            && height < increasedHeightThreshold;
+
+					IncreasedWidthEnabled = increasedWidthEnabled && !increasedHeightEnabled;
+
+					IncreasedHeightEnabled = !increasedWidthEnabled && increasedHeightEnabled;
+
+					IncreasedSizeEnabled = increasedWidthEnabled && increasedHeightEnabled;
+
+					FullScreenEnabled = increasedWidthEnabled
 					                    && !double.IsNaN(fullScreenHeightThreshold)
 					                    && height < fullScreenHeightThreshold;
 				});
@@ -138,6 +159,12 @@ namespace WalletWasabi.Fluent.Controls
 			set => SetValue(IncreasedWidthThresholdProperty, value);
 		}
 
+		public double IncreasedHeightThreshold
+		{
+			get => GetValue(IncreasedHeightThresholdProperty);
+			set => SetValue(IncreasedHeightThresholdProperty, value);
+		}
+
 		public double FullScreenHeightThreshold
 		{
 			get => GetValue(FullScreenHeightThresholdProperty);
@@ -154,6 +181,18 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			get => GetValue(IncreasedWidthEnabledProperty);
 			set => SetValue(IncreasedWidthEnabledProperty, value);
+		}
+
+		private bool IncreasedHeightEnabled
+		{
+			get => GetValue(IncreasedHeightEnabledProperty);
+			set => SetValue(IncreasedHeightEnabledProperty, value);
+		}
+
+		private bool IncreasedSizeEnabled
+		{
+			get => GetValue(IncreasedSizeEnabledProperty);
+			set => SetValue(IncreasedSizeEnabledProperty, value);
 		}
 
 		private CancellationTokenSource? CancelPointerPressedDelay { get; set; }

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -47,6 +47,12 @@ namespace WalletWasabi.Fluent.Controls
 		public static readonly StyledProperty<double> MaxContentWidthProperty =
 			AvaloniaProperty.Register<Dialog, double>(nameof(MaxContentWidth), double.PositiveInfinity);
 
+		public static readonly StyledProperty<double> IncreasedWidthThresholdProperty =
+			AvaloniaProperty.Register<Dialog, double>(nameof(IncreasedWidthThreshold), double.NaN);
+
+		public static readonly StyledProperty<double> FullScreenHeightThresholdProperty =
+			AvaloniaProperty.Register<Dialog, double>(nameof(FullScreenHeightThreshold), double.NaN);
+
 		public static readonly StyledProperty<bool> FullScreenEnabledProperty =
 			AvaloniaProperty.Register<Dialog, bool>(nameof(FullScreenEnabled));
 
@@ -62,8 +68,13 @@ namespace WalletWasabi.Fluent.Controls
 				{
 					var width = bounds.Width;
 					var height = bounds.Height;
-					IncreasedWidthEnabled = width < 740;
-					FullScreenEnabled = IncreasedWidthEnabled && height < 580;
+					var increasedWidthThreshold = IncreasedWidthThreshold;
+					var fullScreenHeightThreshold = FullScreenHeightThreshold;
+					IncreasedWidthEnabled = !double.IsNaN(increasedWidthThreshold)
+					                        && width < increasedWidthThreshold;
+					FullScreenEnabled = IncreasedWidthEnabled
+					                    && !double.IsNaN(fullScreenHeightThreshold)
+					                    && height < fullScreenHeightThreshold;
 				});
 		}
 
@@ -119,6 +130,18 @@ namespace WalletWasabi.Fluent.Controls
 		{
 			get => GetValue(MaxContentWidthProperty);
 			set => SetValue(MaxContentWidthProperty, value);
+		}
+
+		public double IncreasedWidthThreshold
+		{
+			get => GetValue(IncreasedWidthThresholdProperty);
+			set => SetValue(IncreasedWidthThresholdProperty, value);
+		}
+
+		public double FullScreenHeightThreshold
+		{
+			get => GetValue(FullScreenHeightThresholdProperty);
+			set => SetValue(FullScreenHeightThresholdProperty, value);
 		}
 
 		private bool FullScreenEnabled

--- a/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/Dialog.axaml.cs
@@ -80,22 +80,16 @@ namespace WalletWasabi.Fluent.Controls
 					var increasedWidthThreshold = IncreasedWidthThreshold;
 					var increasedHeightThreshold = IncreasedHeightThreshold;
 					var fullScreenHeightThreshold = FullScreenHeightThreshold;
-
-					var increasedWidthEnabled = !double.IsNaN(increasedWidthThreshold)
+					var canIncreasedWidth = !double.IsNaN(increasedWidthThreshold)
 					                        && width < increasedWidthThreshold;
-
-					var increasedHeightEnabled = !double.IsNaN(increasedHeightThreshold)
-					                            && height < increasedHeightThreshold;
-
-					IncreasedWidthEnabled = increasedWidthEnabled && !increasedHeightEnabled;
-
-					IncreasedHeightEnabled = !increasedWidthEnabled && increasedHeightEnabled;
-
-					IncreasedSizeEnabled = increasedWidthEnabled && increasedHeightEnabled;
-
-					FullScreenEnabled = increasedWidthEnabled
-					                    && !double.IsNaN(fullScreenHeightThreshold)
-					                    && height < fullScreenHeightThreshold;
+					var canIncreasedHeight = !double.IsNaN(increasedHeightThreshold)
+					                         && height < increasedHeightThreshold;
+					var canGoToFullScreen = !double.IsNaN(fullScreenHeightThreshold)
+					                        && height < fullScreenHeightThreshold;
+					IncreasedWidthEnabled = canIncreasedWidth && !canIncreasedHeight;
+					IncreasedHeightEnabled = !canIncreasedWidth && canIncreasedHeight;
+					IncreasedSizeEnabled = canIncreasedWidth && canIncreasedHeight;
+					FullScreenEnabled = canIncreasedWidth && canGoToFullScreen;
 				});
 		}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems
 			}
 
 			ShowDetailsCommand = ReactiveCommand.Create(() =>
-				RoutableViewModel.Navigate(NavigationTarget.DialogScreen).To(
+				RoutableViewModel.Navigate(NavigationTarget.CompactDialogScreen).To(
 					new TransactionDetailsViewModel(transactionSummary, walletViewModel.Wallet, updateTrigger)));
 
 			DateString = $"{Date.ToLocalTime():MM/dd/yyyy HH:mm}";

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
@@ -36,7 +36,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems
 			}
 
 			ShowDetailsCommand = ReactiveCommand.Create(() =>
-				RoutableViewModel.Navigate(NavigationTarget.CompactDialogScreen).To(
+				RoutableViewModel.Navigate(NavigationTarget.DialogScreen).To(
 					new TransactionDetailsViewModel(transactionSummary, walletViewModel.Wallet, updateTrigger)));
 
 			DateString = $"{Date.ToLocalTime():MM/dd/yyyy HH:mm}";

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -112,6 +112,12 @@
               HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
               MaxContentWidth="800" MaxContentHeight="700"
               IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
+      <c:Dialog.Styles>
+        <Style Selector="c|Dialog[FullScreenEnabled=True]">
+          <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+          <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        </Style>
+      </c:Dialog.Styles>
       <ContentControl Content="{Binding CurrentPage}" />
     </c:Dialog>
     <c:Dialog x:CompileBindings="False"

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -84,7 +84,8 @@
               EnableCancelOnEscape="{Binding CurrentPage.EnableCancelOnEscape, FallbackValue=True}"
               IsEnabled="{Binding $parent.DataContext.IsFullScreenEnabled}"
               HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
-              HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+              IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
       <c:Dialog.Styles>
         <Style Selector="c|Dialog /template/ Panel#PART_Overlay">
           <Setter Property="Background" Value="{DynamicResource RegionColor}" />
@@ -109,7 +110,8 @@
               IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
               HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
-              MaxContentWidth="800" MaxContentHeight="700">
+              MaxContentWidth="800" MaxContentHeight="700"
+              IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
       <ContentControl Content="{Binding CurrentPage}" />
     </c:Dialog>
     <c:Dialog x:CompileBindings="False"
@@ -122,7 +124,8 @@
               EnableCancelOnPressed="{Binding CurrentPage.EnableCancelOnPressed, FallbackValue=True}"
               EnableCancelOnEscape="{Binding CurrentPage.EnableCancelOnEscape, FallbackValue=True}"
               IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
-              HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+              IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
       <c:Dialog.Styles>
         <Style Selector="c|Dialog[FullScreenEnabled=True]">
           <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -113,12 +113,6 @@
               HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
               MaxContentWidth="800" MaxContentHeight="700"
               IncreasedWidthThreshold="740" IncreasedHeightThreshold="580" FullScreenHeightThreshold="580">
-      <c:Dialog.Styles>
-        <Style Selector="c|Dialog[FullScreenEnabled=True]">
-          <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-          <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        </Style>
-      </c:Dialog.Styles>
       <ContentControl Content="{Binding CurrentPage}" />
     </c:Dialog>
     <c:Dialog x:CompileBindings="False"

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -85,7 +85,7 @@
               IsEnabled="{Binding $parent.DataContext.IsFullScreenEnabled}"
               HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-              IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
+              IncreasedWidthThreshold="740" IncreasedHeightThreshold="580" FullScreenHeightThreshold="580">
       <c:Dialog.Styles>
         <Style Selector="c|Dialog /template/ Panel#PART_Overlay">
           <Setter Property="Background" Value="{DynamicResource RegionColor}" />
@@ -111,7 +111,7 @@
               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
               HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
               MaxContentWidth="800" MaxContentHeight="700"
-              IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
+              IncreasedWidthThreshold="740" IncreasedHeightThreshold="580" FullScreenHeightThreshold="580">
       <c:Dialog.Styles>
         <Style Selector="c|Dialog[FullScreenEnabled=True]">
           <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -131,7 +131,7 @@
               EnableCancelOnEscape="{Binding CurrentPage.EnableCancelOnEscape, FallbackValue=True}"
               IsEnabled="{Binding $parent.DataContext.IsDialogScreenEnabled}"
               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-              IncreasedWidthThreshold="740" FullScreenHeightThreshold="580">
+              IncreasedWidthThreshold="740" IncreasedHeightThreshold="580" FullScreenHeightThreshold="580">
       <c:Dialog.Styles>
         <Style Selector="c|Dialog[FullScreenEnabled=True]">
           <Setter Property="HorizontalContentAlignment" Value="Stretch" />


### PR DESCRIPTION
Partial fix for #6690

This is split from work done in https://github.com/zkSNACKs/WalletWasabi/pull/6730

This PR enables controlling dialog sizing depending on bounds width and height.

- [x] Add IncreasedWidthThreshold property to control separately when dialog width is increased
- [x] Add IncreasedHeightThreshold property to control separately when dialog height is increased
- [x] Add FullScreenHeightThreshold property to control when dialog is in full screen mode (IncreasedWidthThreshold must also be reached)

Using CompactDialogScreen didn't really help as it sizes dialog content to minimal width and height. Additional dialog size saving can be achieved if necessary by bottom button repositioning, that work will continue in https://github.com/zkSNACKs/WalletWasabi/pull/6730


https://user-images.githubusercontent.com/2297442/144048312-367d90c8-c7cb-4271-a916-dd4f8bbd0a84.mp4

