### PR TITLE
Add space in coinjoin tx status

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/CoinJoinDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/CoinJoinDetailsViewModel.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 		private void Update()
 		{
 			Date = _coinJoinGroup.DateString;
-			Status = _coinJoinGroup.IsConfirmed ? "Confirmed" : "Pending";
+			Status = _coinJoinGroup.IsConfirmed ? "Confirmed\u0020" : "Pending\u0020";
 			CoinJoinFee = _coinJoinGroup.OutgoingAmount;
 			TransactionIds = new ObservableCollection<uint256>(_coinJoinGroup.CoinJoinTransactions.Select(x => x.TransactionId));
 		}


### PR DESCRIPTION
Not sure why last character is not printed for Coinjoin Details -> Status. I found this issue got resolved by adding a space after string used for status. Let me know if this works fine on Linux and Mac or there is a better solution to fix this. I have tried this on Win 10.

Master Branch: 

![image](https://user-images.githubusercontent.com/13405205/143914558-ed1188dc-5432-4e91-bf64-c704ff28a973.png)


PR Branch: 

![image](https://user-images.githubusercontent.com/13405205/143914201-3ed47bb9-089f-45d8-b543-0d34b290d18e.png)
