### PR TITLE
Set Width and Height for PasswordAuthDialog

### DIFF
--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -13,7 +13,8 @@
   <UserControl.KeyBindings>
     <KeyBinding Gesture="Enter" Command="{Binding NextCommand}" />
   </UserControl.KeyBindings>
-  <c:ContentArea Title="{Binding Title}"
+  <c:ContentArea Width="500" Height="300"
+                 Title="{Binding Title}"
                  CancelContent="Cancel"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"


### PR DESCRIPTION
If you type a long password this is how the password dialog looks on Master:

![psss](https://user-images.githubusercontent.com/52379387/144712323-137c8044-740f-435b-b21c-851946dde927.PNG)

This PR fixes that.