### PR TITLE
[Fluent] Confirm all recovery words instead of 3 random ones.

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -50,15 +50,9 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.Create
 				.Bind(out _confirmationWords)
 				.Subscribe();
 
-#if DEBUG
-			var verificationWordsCount = 3;
-#else
-			var verificationWordsCount = 12;
-#endif
 
 			// Select random words to confirm.
-			confirmationWordsSourceList.AddRange(
-				mnemonicWords.Take(verificationWordsCount));
+			confirmationWordsSourceList.AddRange(mnemonicWords.Take(12));
 		}
 
 		public ReadOnlyObservableCollection<RecoveryWordViewModel> ConfirmationWords => _confirmationWords;

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -50,9 +50,8 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.Create
 				.Bind(out _confirmationWords)
 				.Subscribe();
 
-
-			// Select random words to confirm.
-			confirmationWordsSourceList.AddRange(mnemonicWords.Take(12));
+			// Select all words for confirmation.
+			confirmationWordsSourceList.AddRange(mnemonicWords);
 		}
 
 		public ReadOnlyObservableCollection<RecoveryWordViewModel> ConfirmationWords => _confirmationWords;

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -50,8 +50,17 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.Create
 				.Bind(out _confirmationWords)
 				.Subscribe();
 
+#if DEBUG
+			var verificationWordsCount = 3;
+#else
+			var verificationWordsCount = 12;
+#endif
+
 			// Select random words to confirm.
-			confirmationWordsSourceList.AddRange(mnemonicWords.OrderBy(_ => new Random().NextDouble()).Take(3));
+			confirmationWordsSourceList.AddRange(
+				mnemonicWords
+						.OrderBy(_ => new Random()
+						.NextDouble()).Take(verificationWordsCount));
 		}
 
 		public ReadOnlyObservableCollection<RecoveryWordViewModel> ConfirmationWords => _confirmationWords;

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -58,9 +58,7 @@ namespace WalletWasabi.Fluent.ViewModels.AddWallet.Create
 
 			// Select random words to confirm.
 			confirmationWordsSourceList.AddRange(
-				mnemonicWords
-						.OrderBy(_ => new Random()
-						.NextDouble()).Take(verificationWordsCount));
+				mnemonicWords.Take(verificationWordsCount));
 		}
 
 		public ReadOnlyObservableCollection<RecoveryWordViewModel> ConfirmationWords => _confirmationWords;


### PR DESCRIPTION
Make the user confirm all recovery words on wallet creation to ensure that they dont miss a single word while backing up their recovery phrases.

Basically, we have instances where users think they have a good backup but they figure out that they missed a word or a single character on their backups when they tried to recover it back (testimonials from @danwalmsley and @nothingmuch  and probably other users from 1.0). This PR basically enforces all seeds to verified, at the cost of some inconvenience to the user.

I think that cost is alright given the stakes of losing the recovery phrase.

cc @zkSNACKs/visual-design-group 