### PR TITLE
[test] Replace `foreach` with `Parallel.ForEach` 

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -66,12 +66,12 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 				.Select(x => Money.Satoshis((long)x));
 
 			var keys = Enumerable.Range(0, amounts.Count()).Select(x => KeyManager.GetNextReceiveKey("no-label", out _)).ToImmutableList();
-			foreach (var (amount, key) in amounts.Zip(keys))
+			Parallel.ForEach(amounts.Zip(keys), (amount, key) =>
 			{
 				var scriptPubKey = key.P2wpkhScript;
 				var effectiveOutputValue = amount - feeRate.GetFee(scriptPubKey.EstimateOutputVsize());
 				splitTx.Outputs.Add(new TxOut(effectiveOutputValue, scriptPubKey));
-			}
+			});
 			var minerKey = KeyManager.GetSecrets("", SourceCoin.ScriptPubKey).First();
 			splitTx.Sign(minerKey.PrivateKey.GetBitcoinSecret(Rpc.Network), SourceCoin);
 			var stx = new SmartTransaction(splitTx, new Height(500_000));


### PR DESCRIPTION
This test takes about 4 minutes to run on my machine. Based on my understanding, tests etc. the problem is with the below code:

```C#
	double NextNotTooSmall() => 0.00001 + (rnd.NextDouble() * 0.99999);
	var sampling = Enumerable
		.Range(0, numberOfCoins - 1)
		.Select(_ => NextNotTooSmall())
		.Prepend(0)
		.Prepend(1)
		.OrderBy(x => x)
		.ToArray();
				
	var amounts = sampling
		.Zip(sampling.Skip(1), (x, y) => y - x)
		.Select(x => x * SourceCoin.Amount.Satoshi)
		.Select(x => Money.Satoshis((long)x));

	var keys = Enumerable.Range(0, amounts.Count()).Select(x => KeyManager.GetNextReceiveKey("no-label", out _)).ToImmutableList();
	foreach (var (amount, key) in amounts.Zip(keys))
```
I tried few things from this [article](https://levelup.gitconnected.com/5-ways-to-improve-the-performance-of-c-code-for-free-c89188eba5da) but nothing worked as expected. I think only way to improve performance in this code is to  Replace `foreach` with `Parallel.ForEach`.

I checked if similar approach has been used in any other code in this repository before: https://github.com/zkSNACKs/WalletWasabi/commit/2b80186dabaecb02ea8cf2506ca2027bd368354b

This PR is still in draft mode because code isn't complete and I am looking for suggestions.
