### PR TITLE
Add walletname in `createwallet` RPC response

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -55,7 +55,11 @@ namespace WalletWasabi.Fluent.Rpc
 			walletGenerator.TipHeight = Global.BitcoinStore.SmartHeaderChain.TipHeight;
 			var (keyManager, mnemonic) = walletGenerator.GenerateWallet(walletName, password);
 			Global.WalletManager.AddWallet(keyManager);
-			return mnemonic.ToString();
+			return new
+			{
+				mnemonic = mnemonic.ToString(),
+				walletname = walletName
+			};
 		}
 
 		[JsonRpcMethod("getwalletinfo")]


### PR DESCRIPTION
Master Branch:

```
{
    "jsonrpc": "2.0",
    "result": "bubble pride once ghost occur citizen knife memory inhale alpha warfare arch",
    "id": "1"
}
```



PR Branch: 

```
{
    "jsonrpc": "2.0",
    "result": {        
        "mnemonic": "ladder stone such segment flush then entry funny depart online under comfort",
        "walletname": "W20"
    },
    "id": "1"
}
```

This PR adds wallet name in the response for `createwallet` RPC. A simple change to add relevant information and make things consistent with Bitcoin Core JSON-RPC which is used by lot of projects.

Bitcoin Core/Knots:

```
bitcoin-cli createwallet "testwallet"

{
  "name": "testwallet",
  "warning": ""
}
```