### PR TITLE
Add new RPC to list pockets or clusters of UTXOs

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -59,7 +59,7 @@ namespace WalletWasabi.Fluent.Rpc
 
 			AssertWalletIsLoaded();
 
-			pocketS.AddRange(activeWallet.Coins.GetPockets(0).Select(x => new PocketViewModel(x)));
+			pocketS.AddRange(activeWallet.Coins.GetPockets(activeWallet.ServiceConfiguration.GetMixUntilAnonymitySetValue()).Select(x => new PocketViewModel(x)));
 
 			return pocketS.Items.ToArray();
 		}

--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using DynamicData;
 using NBitcoin;
 using WalletWasabi.BitcoinP2p;
 using WalletWasabi.Blockchain.Analysis.Clustering;
@@ -8,6 +9,8 @@ using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
+using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.ViewModels.Wallets.Send;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Services.Terminate;
@@ -46,6 +49,19 @@ namespace WalletWasabi.Fluent.Rpc
 				keyPath = x.HdPubKey.FullKeyPath.ToString(),
 				address = x.HdPubKey.GetP2wpkhAddress(Global.Network).ToString()
 			}).ToArray();
+		}
+
+		[JsonRpcMethod("listpockets")]
+		public object[] GetPockets()
+		{
+			var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
+			SourceList<PocketViewModel> pocketS = new();
+
+			AssertWalletIsLoaded();
+
+			pocketS.AddRange(activeWallet.Coins.GetPockets(0).Select(x => new PocketViewModel(x)));
+
+			return pocketS.Items.ToArray();
 		}
 
 		[JsonRpcMethod("createwallet")]


### PR DESCRIPTION
This PR is still in draft mode as the RPC returns nothing when I tried:

![image](https://user-images.githubusercontent.com/13405205/145469369-61b736a9-bc0c-4a4f-91ba-24c777186bff.png)

Expected results:

Get a list of clusters of coins that are used for transactions in WW2. This will be helpful and required for anyone using Wasabi RPC in their project.