### PR TITLE
Replace `IsNullOrEmpty()` with `IsNullOrWhiteSpace()`

### DIFF
--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -161,7 +161,7 @@ namespace WalletWasabi.Hwi.Parsers
 			if (JsonHelpers.TryParseJToken(json, out JToken? token))
 			{
 				var extPubKeyString = token["xpub"]?.ToString().Trim();
-				var extPubKey = string.IsNullOrEmpty(extPubKeyString) ? null : NBitcoinHelpers.BetterParseExtPubKey(extPubKeyString);
+				var extPubKey = string.IsNullOrWhiteSpace(extPubKeyString) ? null : NBitcoinHelpers.BetterParseExtPubKey(extPubKeyString);
 				return extPubKey;
 			}
 			else
@@ -241,13 +241,13 @@ namespace WalletWasabi.Hwi.Parsers
 			}
 
 			bool? needsPinSent = null;
-			if (!string.IsNullOrEmpty(needsPinSentString))
+			if (!string.IsNullOrWhiteSpace(needsPinSentString))
 			{
 				needsPinSent = bool.Parse(needsPinSentString);
 			}
 
 			bool? needsPassphraseSent = null;
-			if (!string.IsNullOrEmpty(needsPassphraseSentString))
+			if (!string.IsNullOrWhiteSpace(needsPassphraseSentString))
 			{
 				needsPassphraseSent = bool.Parse(needsPassphraseSentString);
 			}


### PR DESCRIPTION
Reason: 

`string.IsNullOrEmpty(string)` is called on the result of `string.Trim()`.

Example: 

https://github.com/zkSNACKs/WalletWasabi/blob/99bb5d5ac0ed7e1cea4423fbdd6974896ef9c926/WalletWasabi/Hwi/Parsers/HwiParser.cs#L228

https://github.com/zkSNACKs/WalletWasabi/blob/99bb5d5ac0ed7e1cea4423fbdd6974896ef9c926/WalletWasabi/Hwi/Parsers/HwiParser.cs#L250

 The call to `string.Trim()` may allocate a new string. This allocation can be avoided by calling `string.IsNullOrWhiteSpace(string)`. Not only does that avoid the **memory allocation**, it is also **faster** in most cases and never slower.

https://github.com/u2uconsult/codeanalyzers/blob/master/docs/U2U1113.md

