### PR TITLE
Fix TagControl's text wrapping

### DIFF
--- a/WalletWasabi.Fluent/Controls/TagControl.axaml
+++ b/WalletWasabi.Fluent/Controls/TagControl.axaml
@@ -71,6 +71,7 @@
     <Setter Property="ContentTemplate">
       <DataTemplate DataType="x:String">
         <TextBlock Text="{Binding .}"
+                   MaxWidth="120"
                    TextTrimming="CharacterEllipsis" />
       </DataTemplate>
     </Setter>

--- a/WalletWasabi.Fluent/Views/Wallets/Receive/ReceiveAddressesView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Receive/ReceiveAddressesView.axaml
@@ -79,7 +79,7 @@
         </DataBoxTemplateColumn>
 
         <DataBoxTemplateColumn Header="Labels"
-                               Width="Auto"
+                               Width="240"
                                CanUserSort="True">
           <DataBoxTemplateColumn.CellTemplate>
             <DataTemplate>


### PR DESCRIPTION
Fixes the tagsbox not cutting its text off when it's too long. 120px is a good enough MaxWidth i suppose.

![IMAGE 2021-12-13 21:42:06](https://user-images.githubusercontent.com/16554748/145823037-b2909af6-83e2-4768-a7e1-a90f22bbff15.jpg)

cc @zkSNACKs/visual-design-group 