### PR TITLE
add nodeCount condition in `LoadWalletAsync`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
@@ -7,6 +7,7 @@ using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Wallets;
+using WalletWasabi.BitcoinP2p;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets
 {
@@ -94,10 +95,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets
 			}
 
 			_isLoading = true;
+			int nodeCount = Services.HostedServices.Get<P2pNetwork>().Nodes.ConnectedNodes.Count;
 
 			await SetInitValuesAsync(isBackendAvailable).ConfigureAwait(false);
 
-			while (isBackendAvailable && RemainingFiltersToDownload > 0)
+			while (isBackendAvailable && RemainingFiltersToDownload > 0 && nodeCount > 0)
 			{
 				await Task.Delay(1000).ConfigureAwait(false);
 			}


### PR DESCRIPTION
I am expecting this PR to fix https://github.com/zkSNACKs/WalletWasabi/issues/6842

Not sure because could not reproduce the issue today. It checks if node count is greater than zero in the `while` loop used in `LoadWalletAsync`