### PR TITLE
Add try/catch to Arena step methods

### DIFF
--- a/WalletWasabi/WabiSabi/LoggerTools.cs
+++ b/WalletWasabi/WabiSabi/LoggerTools.cs
@@ -20,5 +20,10 @@ namespace WalletWasabi.WabiSabi
 		{
 			Log(round, LogLevel.Warning, logMessage, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
 		}
+
+		public static void LogError(this Round round, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+		{
+			Log(round, LogLevel.Error, logMessage, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber);
+		}
 	}
 }


### PR DESCRIPTION
 This PR makes sure that in case of any unexpected error the round will fail and Arena can continue updating other rounds. 

There were 2 pieces of 3 day old Rounds, one was in `InputRegistration`, the other one was in `OutputRegistration`. The rounds stacked without state updates. 

The reason was that an exception happened somewhere between lines:

https://github.com/zkSNACKs/WalletWasabi/blob/954f25302cd7d9b62a94cdd33bcb923b9b0fdd0b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs#L169-L182

In this case, the `Arena.ActionAsync` which is called periodically, fails and stops managing the states of the Rounds.

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/6853