### PR TITLE
Show unconfirmed CJ in history list

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -33,7 +33,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems
 				throw new InvalidOperationException("Not a coinjoin item!");
 			}
 
-			CoinJoinTransactions.Insert(0,item);
+			CoinJoinTransactions.Insert(0, item);
 			Refresh();
 		}
 
@@ -62,8 +62,9 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems
 
 		protected void UpdateDateString()
 		{
-			var firstDate = CoinJoinTransactions.First().DateTime.ToLocalTime();
-			var lastDate = CoinJoinTransactions.Last().DateTime.ToLocalTime();
+			var dates = CoinJoinTransactions.Select(tx => tx.DateTime);
+			var firstDate = dates.Min().ToLocalTime();
+			var lastDate = dates.Max().ToLocalTime();
 
 			DateString = firstDate.Day == lastDate.Day
 				? $"{firstDate:MM/dd/yy}"

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -33,14 +33,14 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems
 				throw new InvalidOperationException("Not a coinjoin item!");
 			}
 
-			CoinJoinTransactions.Add(item);
+			CoinJoinTransactions.Insert(0,item);
 			Refresh();
 		}
 
 		private void Refresh()
 		{
 			IsConfirmed = CoinJoinTransactions.All(x => x.IsConfirmed());
-			Date = CoinJoinTransactions.Last().DateTime.ToLocalTime();
+			Date = CoinJoinTransactions.First().DateTime.ToLocalTime();
 			UpdateAmount();
 			UpdateDateString();
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems
 		private void Refresh()
 		{
 			IsConfirmed = CoinJoinTransactions.All(x => x.IsConfirmed());
-			Date = CoinJoinTransactions.First().DateTime.ToLocalTime();
+			Date = CoinJoinTransactions.Select(tx => tx.DateTime).Max().ToLocalTime();
 			UpdateAmount();
 			UpdateDateString();
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -141,7 +141,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 					yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 				}
 
-				if (item.IsLikelyCoinJoinOutput && item.IsConfirmed())
+				if (item.IsLikelyCoinJoinOutput)
 				{
 					if (coinJoinGroup is null)
 					{
@@ -154,8 +154,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History
 				}
 
 				if (coinJoinGroup is { } cjg &&
-				    (i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyCoinJoinOutput || // The next item is not CJ so add the group.
-				     i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
+					(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyCoinJoinOutput || // The next item is not CJ so add the group.
+					 i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
 				{
 					cjg.SetBalance(balance);
 					yield return cjg;


### PR DESCRIPTION
The history list in the wallet dashboard is batching CJ transactions. With this PR unconfirmed CJ transactions will be shown as well and flashing the line in the history. Also, I reversed the order at the tx details: the newest on top