### PR TITLE
Add FeesDifferentThanExpected test to TransactionFactoryTests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -593,8 +593,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		{
 			// Fee rate: 5.0 sat/vb.
 			{
-				using Key key = new();
-				BuildTransactionResult txResult = ComputeTxResult(key, new FeeRate(5.0m));
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(5.0m));
 				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
 				Assert.Equal(7.2m, txResult.FeePercentOfSent);
 				Assert.Equal(Money.Satoshis(720), txResult.Fee);
@@ -602,8 +601,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// Fee rate: 6.0 sat/vb.
 			{
-				using Key key = new();
-				BuildTransactionResult txResult = ComputeTxResult(key, new FeeRate(6.0m));
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(6.0m));
 				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
 				Assert.Equal(8.64m, txResult.FeePercentOfSent);
 				Assert.Equal(Money.Satoshis(864), txResult.Fee);
@@ -611,8 +609,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// Fee rate: 7.0 sat/vb.
 			{
-				using Key key = new();
-				BuildTransactionResult txResult = ComputeTxResult(key, new FeeRate(7.0m));
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(7.0m));
 				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
 				Assert.Equal(10.08m, txResult.FeePercentOfSent);
 				Assert.Equal(Money.Satoshis(1008), txResult.Fee);
@@ -620,8 +617,7 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// Fee rate: 7.74 sat/vb.
 			{
-				using Key key = new();
-				BuildTransactionResult txResult = ComputeTxResult(key, new FeeRate(7.74m));
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(7.74m));
 				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
 				Assert.Equal(11.14m, txResult.FeePercentOfSent);
 				Assert.Equal(Money.Satoshis(1114), txResult.Fee);
@@ -629,21 +625,20 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 
 			// Fee rate: 7.75 sat/vb.
 			{
-				using Key key = new();
-
-				InvalidTxException ex = Assert.Throws<InvalidTxException>(() => ComputeTxResult(key, new FeeRate(7.75m)));
+				InvalidTxException ex = Assert.Throws<InvalidTxException>(() => ComputeTxResult(new FeeRate(7.75m)));
 				NotEnoughFundsPolicyError expectedPolicyError = new("Fees different than expected");
 				TransactionPolicyError actualTransactionPolicyError = Assert.Single(ex.Errors);
 				Assert.Equal(expectedPolicyError.ToString(), actualTransactionPolicyError.ToString());
 			}
 
-			static BuildTransactionResult ComputeTxResult(Key key, FeeRate feeRate)
+			static BuildTransactionResult ComputeTxResult(FeeRate feeRate)
 			{
 				TransactionFactory transactionFactory = ServiceFactory.CreateTransactionFactory(new[]
 				{
 					(Label: "Pablo", KeyIndex: 0, Amount: 0.00011409m, Confirmed: true, AnonymitySet: 1)
 				});
 
+				using Key key = new();
 				PaymentIntent payment = new(key, MoneyRequest.Create(Money.Coins(0.00010000m)));
 				return transactionFactory.BuildTransaction(payment, feeRate);
 			}

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -591,21 +591,19 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 		[Fact]
 		public void FeesDifferentThanExpected()
 		{
-			var transactionFactory = ServiceFactory.CreateTransactionFactory(new[]
+			TransactionFactory transactionFactory = ServiceFactory.CreateTransactionFactory(new[]
 			{
-				("Pablo", 0, 0.00011409m, confirmed: true, anonymitySet: 1)
+				(Label: "Pablo", KeyIndex: 0, Amount: 0.00011409m, Confirmed: true, AnonymitySet: 1)
 			});
 
 			using Key key = new();
-			var payment = new PaymentIntent(key, MoneyRequest.Create(Money.Coins(0.00010000m)));
+			PaymentIntent payment = new(key, MoneyRequest.Create(Money.Coins(0.00010000m)));
 
-			TransactionPolicyError[] crazyInvalidTxErrors =
-				{
-					new NotEnoughFundsPolicyError("Fees different than expected"),
-				};
+			InvalidTxException ex = Assert.Throws<InvalidTxException>(() => transactionFactory.BuildTransaction(payment, new FeeRate(9.78m)));
 
-			var ex = Assert.Throws<InvalidTxException>(() => transactionFactory.BuildTransaction(payment, new FeeRate(9.78m)));
-			Assert.Contains(crazyInvalidTxErrors[0].ToString(), ex.Message);
+			NotEnoughFundsPolicyError expectedPolicyError = new("Fees different than expected");
+			TransactionPolicyError actualTransactionPolicyError = Assert.Single(ex.Errors);
+			Assert.Equal(expectedPolicyError.ToString(), actualTransactionPolicyError.ToString());
 		}
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionBuilding/PaymentIntent.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/PaymentIntent.cs
@@ -40,7 +40,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 			var subtractFeeCount = requests.Count(x => x.Amount.SubtractFee);
 			if (subtractFeeCount > 1)
 			{
-				// Note: It'd be possible tod implement that the fees to be subtracted equally from more outputs, but I guess nobody would use it.
+				// Note: It'd be possible to implement that the fees to be subtracted equally from more outputs, but I guess nobody would use it.
 				throw new ArgumentException($"Only one request can specify fee subtraction.");
 			}
 
@@ -55,7 +55,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 			{
 				if (subtractFeeCount != 1)
 				{
-					throw new ArgumentException($"You must specifiy fee subtraction strategy if custom change is specified.");
+					throw new ArgumentException("You must specify fee subtraction strategy if custom change is specified.");
 				}
 
 				if (allRemainingCount == 1)
@@ -73,7 +73,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding
 			}
 			else
 			{
-				throw new ArgumentException($"Only one request can contain an all remaining money or change request.");
+				throw new ArgumentException("Only one request can contain an all remaining money or change request.");
 			}
 
 			Requests = requests;

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -254,17 +254,20 @@ namespace WalletWasabi.Blockchain.Transactions
 
 				if (!isPayjoin)
 				{
-					// Manually check the feerate, because some inaccuracy is possible.
+					// Manually check the fee rate, because some inaccuracy is possible.
 					var sb1 = feeRate.SatoshiPerByte;
 					var sb2 = actualFeeRate.SatoshiPerByte;
+
 					if (Math.Abs(sb1 - sb2) > 2) // 2s/b inaccuracy ok.
 					{
-						// So it'll generate a transactionpolicy error thrown below.
+						// So it'll generate a transaction policy error thrown below.
 						checkResults.Add(new NotEnoughFundsPolicyError("Fees different than expected"));
 					}
 				}
+
 				if (checkResults.Count > 0)
 				{
+					Logger.LogDebug($"Found policy error(s)! First error: '{checkResults[0]}'.");
 					throw new InvalidTxException(tx, checkResults);
 				}
 			}
@@ -322,13 +325,13 @@ namespace WalletWasabi.Blockchain.Transactions
 					CancellationToken.None).GetAwaiter().GetResult(); // WTF??!
 				builder.SignPSBT(psbt);
 
-				Logger.LogInfo($"Payjoin payment was negotiated successfully.");
+				Logger.LogInfo("Payjoin payment was negotiated successfully.");
 			}
 			catch (HttpRequestException ex) when (ex.InnerException is TorConnectCommandFailedException innerEx)
 			{
 				if (innerEx.Message.Contains("HostUnreachable"))
 				{
-					Logger.LogWarning($"Payjoin server is not reachable. Ignoring...");
+					Logger.LogWarning("Payjoin server is not reachable. Ignoring...");
 				}
 
 				// Ignore.


### PR DESCRIPTION
This test simulates the `InvalidTxException: Invalid transaction` As suggested here https://github.com/zkSNACKs/WalletWasabi/issues/6750#issuecomment-988917870