### PR TITLE
Fix IndexBuilder exception when Reorging

### DIFF
--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -86,9 +86,6 @@ namespace WalletWasabi.Blockchain.BlockFilters
 
 		public void Synchronize()
 		{
-			// Check permissions.
-			using var _ = File.Open(IndexFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
-
 			Task.Run(async () =>
 			{
 				try

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -43,6 +43,12 @@ namespace WalletWasabi.Blockchain.BlockFilters
 			_serviceStatus = NotStarted;
 
 			IoHelpers.EnsureContainingDirectoryExists(IndexFilePath);
+
+			// Testing permissions.
+			using (var _ = File.Open(IndexFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+			{
+			}
+
 			if (File.Exists(IndexFilePath))
 			{
 				if (RpcClient.Network == Network.RegTest)


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/6863

The bug was added by https://github.com/zkSNACKs/WalletWasabi/pull/5875

When reorg happened on the network or block burst the `IndexBuilderService .Synchronize` method got called rapidly and there was a concurrency problem. 

### Why?
Reorging the index files was still running but Synchronize got called by BlockNotifier_OnBlock so the file permission check failed. The check intended to fix the problem when the IndexFile location has a permission problem in general so I moved that to the ctor.

This is a quick fix  - PoC to refactor index builder in the far future https://github.com/zkSNACKs/WalletWasabi/pull/6866