### PR TITLE
Distinguish two TorHttpPools.

### DIFF
--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -92,13 +92,13 @@ namespace WalletWasabi.Fluent
 
 				if (Config.UseTor)
 				{
-					BackendHttpClientFactory = new HttpClientFactory(TorSettings.SocksEndpoint, backendUriGetter: () => Config.GetCurrentBackendUri());
-					ExternalHttpClientFactory = new HttpClientFactory(TorSettings.SocksEndpoint, backendUriGetter: null);
+					BackendHttpClientFactory = new HttpClientFactory(TorSettings.SocksEndpoint, backendUriGetter: () => Config.GetCurrentBackendUri(), instanceName: "TorBackend");
+					ExternalHttpClientFactory = new HttpClientFactory(TorSettings.SocksEndpoint, backendUriGetter: null, instanceName: "TorExternal");
 				}
 				else
 				{
-					BackendHttpClientFactory = new HttpClientFactory(torEndPoint: null, backendUriGetter: () => Config.GetFallbackBackendUri());
-					ExternalHttpClientFactory = new HttpClientFactory(torEndPoint: null, backendUriGetter: null);
+					BackendHttpClientFactory = new HttpClientFactory(torEndPoint: null, backendUriGetter: () => Config.GetFallbackBackendUri(), instanceName: "ClearnetBackend");
+					ExternalHttpClientFactory = new HttpClientFactory(torEndPoint: null, backendUriGetter: null, instanceName: "ClearnetExternal");
 				}
 
 				Synchronizer = new WasabiSynchronizer(BitcoinStore, BackendHttpClientFactory);

--- a/WalletWasabi.Tests/UnitTests/Tor/Socks5/TorHttpPoolTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Socks5/TorHttpPoolTests.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.Tests.UnitTests.Tor.Socks5
 			TorTcpConnectionFactory tcpConnectionFactory = mockTcpConnectionFactory.Object;
 
 			// Use implementation of TorHttpPool and only replace SendCoreAsync behavior.
-			Mock<TorHttpPool> mockTorHttpPool = new(MockBehavior.Loose, tcpConnectionFactory) { CallBase = true };
+			Mock<TorHttpPool> mockTorHttpPool = new(MockBehavior.Loose, tcpConnectionFactory, null!) { CallBase = true };
 			mockTorHttpPool.Setup(x => x.SendCoreAsync(It.IsAny<TorTcpConnection>(), It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
 				.Returns((TorTcpConnection tcpConnection, HttpRequestMessage request, CancellationToken cancellationToken) =>
 				{

--- a/WalletWasabi/WebClients/Wasabi/HttpClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/HttpClientFactory.cs
@@ -21,7 +21,8 @@ namespace WalletWasabi.WebClients.Wasabi
 		/// Creates a new instance of the object.
 		/// </summary>
 		/// <param name="torEndPoint">If <c>null</c> then clearnet (not over Tor) is used, otherwise HTTP requests are routed through provided Tor endpoint.</param>
-		public HttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter)
+		/// <param name="instanceName">Name of the factory for logging purposes.</param>
+		public HttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter, string instanceName = "Pool")
 		{
 			SocketHandler = new()
 			{
@@ -38,7 +39,7 @@ namespace WalletWasabi.WebClients.Wasabi
 			// Connecting to loopback's URIs cannot be done via Tor.
 			if (TorEndpoint is { } && (BackendUriGetter is null || !BackendUriGetter().IsLoopback))
 			{
-				TorHttpPool = new(TorEndpoint);
+				TorHttpPool = new(TorEndpoint, instanceName);
 				BackendHttpClient = new TorHttpClient(BackendUriGetter, TorHttpPool, Mode.DefaultCircuit);
 			}
 			else


### PR DESCRIPTION
Related to #6874

This is an idea how to distinguish the two `TorHttpPool`s we have in code. I'm not sure if it is a good idea to have it there permanently but it seems useful to know if we are having issues with Backend HTTP requests or with those external HTTP requests. My guess is that we have problem with both based on #6874 but I'm not sure at the moment.