### PR TITLE
Logger: Change format from `class:method` to `class.method` so that one can f…

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -137,10 +137,10 @@ namespace WalletWasabi.Logging
 				}
 
 				message = Guard.Correct(message);
-				var category = string.IsNullOrWhiteSpace(callerFilePath) ? "" : $"{EnvironmentHelpers.ExtractFileName(callerFilePath)}:{callerMemberName} ({callerLineNumber})";
+				var category = string.IsNullOrWhiteSpace(callerFilePath) ? "" : $"{EnvironmentHelpers.ExtractFileName(callerFilePath)}.{callerMemberName} ({callerLineNumber})";
 
 				var messageBuilder = new StringBuilder();
-				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Thread.CurrentThread.ManagedThreadId}] {level.ToString().ToUpperInvariant()}\t");
+				messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId}] {level.ToString().ToUpperInvariant()}\t");
 
 				if (message.Length == 0)
 				{


### PR DESCRIPTION
…ind the method in an IDE faster.

This is a very minor change but in VS2022 (and probably other IDEs), you can simply copy (e.g.) `TorControlClient.SendCommandNoLockAsync` from your log file, press CTRL+. and paste the string and it will find the `SendCommandNoLockAsync` method. That's the motivation for this PR.