### PR TITLE
Increase the log size in case of TraceLevel

### DIFF
--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -45,8 +45,8 @@ namespace WalletWasabi.Logging
 		/// <summary>
 		/// Gets or sets the maximum log file size in KB.
 		/// </summary>
-		/// <remarks>Default value is approximately 10 MB.</remarks>
-		private static long MaximumLogFileSize { get; set; } = MinimumLevel == LogLevel.Trace ? 50_000 : 10_000;
+		/// <remarks>Default value is approximately 10 MB. But it also depends on <see cref="LogLevel"/>.</remarks>
+		private static long MaximumLogFileSize { get; set; } = 10_000;
 
 		#endregion PropertiesAndMembers
 
@@ -75,6 +75,7 @@ namespace WalletWasabi.Logging
 			SetMinimumLevel(logLevel ??= LogLevel.Debug);
 			SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
 #endif
+			MaximumLogFileSize = MinimumLevel == LogLevel.Trace ? 50_000 : 10_000;
 		}
 
 		public static void SetMinimumLevel(LogLevel level) => MinimumLevel = level;

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -46,7 +46,7 @@ namespace WalletWasabi.Logging
 		/// Gets or sets the maximum log file size in KB.
 		/// </summary>
 		/// <remarks>Default value is approximately 10 MB.</remarks>
-		private static long MaximumLogFileSize { get; set; } = 10_000;
+		private static long MaximumLogFileSize { get; set; } = MinimumLevel == LogLevel.Trace ? 50_000 : 10_000;
 
 		#endregion PropertiesAndMembers
 


### PR DESCRIPTION
Running the software with LogLevel Trace increments the log size at a pace that hits the limit in a few hours (~10). Unfortunately, if the limit is reached the whole file is deleted and started over. 

This is a temporary solution as this does not scale. 