### PR TITLE
[Fluent] Try fixing missing privacy percent values in some systems

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -130,7 +130,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles
 			var totalDecimalAmount = privateDecimalAmount + normalDecimalAmount;
 
 			var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
-			var pcNormal = 1 - pcPrivate;
+			var pcNormal = Math.Clamp(1 - pcPrivate, 0d, 1d);
 
 			Percent = pcPrivate * 100;
 


### PR DESCRIPTION
idk if this is gonna work but let's try it anyway

this is a quick fix, but it could be that the problem is on a deeper level than this... 

anyways, this clamps the values to valid range (0d<->1d) that can be displayed and formatted well in string.Format.

cc @MaxHillebrand @yahiheb @zkSNACKs/visual-design-group 