### PR TITLE
Remove feerate different sanity check

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -586,5 +586,82 @@ namespace WalletWasabi.Tests.UnitTests.Transactions
 			var rest = dict.Where(x => x.Key < 0).Select(x => x.Value);
 			Assert.DoesNotContain(rest, x => x > samplingSize * 0.001);
 		}
+
+		[Fact]
+		public void HowFeeRateAffectsFeeAndNumberOfOutputs()
+		{
+			// Fee rate: 5.0 sat/vb.
+			{
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(5.0m));
+				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
+				AssertOutputValues(mainValue: Money.Satoshis(10000m), changeValue: Money.Satoshis(689m), txResult.Transaction.Transaction.Outputs);
+				Assert.Equal(7.2m, txResult.FeePercentOfSent);
+				Assert.Equal(Money.Satoshis(720), txResult.Fee);
+			}
+
+			// Fee rate: 6.0 sat/vb.
+			{
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(6.0m));
+				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
+				AssertOutputValues(mainValue: Money.Satoshis(10000m), changeValue: Money.Satoshis(545m), txResult.Transaction.Transaction.Outputs);
+				Assert.Equal(8.64m, txResult.FeePercentOfSent);
+				Assert.Equal(Money.Satoshis(864), txResult.Fee);
+			}
+
+			// Fee rate: 7.0 sat/vb.
+			{
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(7.0m));
+				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
+				AssertOutputValues(mainValue: Money.Satoshis(10000m), changeValue: Money.Satoshis(401m), txResult.Transaction.Transaction.Outputs);
+				Assert.Equal(10.08m, txResult.FeePercentOfSent);
+				Assert.Equal(Money.Satoshis(1008), txResult.Fee);
+			}
+
+			// Fee rate: 7.74 sat/vb.
+			{
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(7.74m));
+				Assert.Equal(2, txResult.Transaction.Transaction.Outputs.Count);
+				AssertOutputValues(mainValue: Money.Satoshis(10000m), changeValue: Money.Satoshis(295m), txResult.Transaction.Transaction.Outputs);
+				Assert.Equal(11.14m, txResult.FeePercentOfSent);
+				Assert.Equal(Money.Satoshis(1114), txResult.Fee);
+			}
+
+			// Fee rate: 7.75 sat/vb. There is only ONE output now!
+			{
+				BuildTransactionResult txResult = ComputeTxResult(new FeeRate(7.75m));
+				Assert.Single(txResult.Transaction.Transaction.Outputs);
+				Assert.Equal(Money.Satoshis(10000m), txResult.Transaction.Transaction.Outputs[0].Value);
+				Assert.Equal(14.09m, txResult.FeePercentOfSent);
+				Assert.Equal(Money.Satoshis(1409), txResult.Fee);
+			}
+
+			static BuildTransactionResult ComputeTxResult(FeeRate feeRate)
+			{
+				TransactionFactory transactionFactory = ServiceFactory.CreateTransactionFactory(new[]
+				{
+					(Label: "Pablo", KeyIndex: 0, Amount: 0.00011409m, Confirmed: true, AnonymitySet: 1)
+				});
+
+				using Key key = new();
+				PaymentIntent payment = new(key, MoneyRequest.Create(Money.Coins(0.00010000m)));
+				return transactionFactory.BuildTransaction(payment, feeRate);
+			}
+
+			static void AssertOutputValues(Money mainValue, Money changeValue, TxOutList txOuts)
+			{
+				if (mainValue == txOuts[0].Value)
+				{
+					Assert.Equal(changeValue, txOuts[1].Value);
+				}
+				else if (mainValue == txOuts[1].Value)
+				{
+					Assert.Equal(changeValue, txOuts[0].Value);
+				}
+				else
+				{
+					Assert.True(false, "Main value is not correct.");
+				}
+			}
+		}
 	}
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -153,8 +153,7 @@ namespace WalletWasabi.Blockchain.Transactions
 
 			builder.OptInRBF = true;
 
-			FeeRate feeRate = feeRateFetcher();
-			builder.SendEstimatedFees(feeRate);
+			builder.SendEstimatedFees(feeRateFetcher());
 
 			var psbt = builder.BuildPSBT(false);
 
@@ -232,13 +231,10 @@ namespace WalletWasabi.Blockchain.Transactions
 				builder = builder.AddKeys(signingKeys.ToArray());
 				builder.SignPSBT(psbt);
 
-				var isPayjoin = false;
-
 				// Try to pay using payjoin
 				if (payjoinClient is not null)
 				{
 					psbt = TryNegotiatePayjoin(payjoinClient, builder, psbt, changeHdPubKey);
-					isPayjoin = true;
 					psbt.AddKeyPaths(KeyManager);
 					psbt.AddPrevTxs(TransactionStore);
 				}
@@ -246,26 +242,9 @@ namespace WalletWasabi.Blockchain.Transactions
 				psbt.Finalize();
 				tx = psbt.ExtractTransaction();
 
-				var checkResults = builder.Check(tx).ToList();
-				if (!psbt.TryGetEstimatedFeeRate(out var actualFeeRate))
+				if (!psbt.TryGetEstimatedFeeRate(out _))
 				{
 					throw new InvalidOperationException("Impossible to get the fee rate of the PSBT, this should never happen.");
-				}
-
-				if (!isPayjoin)
-				{
-					// Manually check the feerate, because some inaccuracy is possible.
-					var sb1 = feeRate.SatoshiPerByte;
-					var sb2 = actualFeeRate.SatoshiPerByte;
-					if (Math.Abs(sb1 - sb2) > 2) // 2s/b inaccuracy ok.
-					{
-						// So it'll generate a transactionpolicy error thrown below.
-						checkResults.Add(new NotEnoughFundsPolicyError("Fees different than expected"));
-					}
-				}
-				if (checkResults.Count > 0)
-				{
-					throw new InvalidTxException(tx, checkResults);
 				}
 			}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -241,6 +241,12 @@ namespace WalletWasabi.Blockchain.Transactions
 
 				psbt.Finalize();
 				tx = psbt.ExtractTransaction();
+
+				var checkResults = builder.Check(tx).ToList();
+				if (checkResults.Count > 0)
+				{
+					throw new InvalidTxException(tx, checkResults);
+				}
 			}
 
 			var smartTransaction = new SmartTransaction(tx, Height.Unknown, label: SmartLabel.Merge(payments.Requests.Select(x => x.Label)));

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -241,11 +241,6 @@ namespace WalletWasabi.Blockchain.Transactions
 
 				psbt.Finalize();
 				tx = psbt.ExtractTransaction();
-
-				if (!psbt.TryGetEstimatedFeeRate(out _))
-				{
-					throw new InvalidOperationException("Impossible to get the fee rate of the PSBT, this should never happen.");
-				}
 			}
 
 			var smartTransaction = new SmartTransaction(tx, Height.Unknown, label: SmartLabel.Merge(payments.Requests.Select(x => x.Label)));


### PR DESCRIPTION
#6871 should be merged first.

Fixes #6750

When we try to make a transaction we first assume that it creates 2 outputs, 1 as a payment and 1 as a change, thus it has an estimated size and estimated fee.

In an edge case and with certain selected fee rate the built transaction creates only 1 output because the one that is supposed to be a change is uneconomical (less than dust 294 sat), so the transaction builder adds that change to the fee which results in a difference of fees between the expected fee and the actual one.

More context about this in #2116 where this part of the code was added.