### PR TITLE
Remove PlatformTarget from Backend, Packager, Tests

### DIFF
--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<PlatformTarget>x64</PlatformTarget>
 		<TargetFramework>net6.0</TargetFramework>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>

--- a/WalletWasabi.Packager/WalletWasabi.Packager.csproj
+++ b/WalletWasabi.Packager/WalletWasabi.Packager.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<PlatformTarget>x64</PlatformTarget>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<PlatformTarget>x64</PlatformTarget>
 		<TargetFramework>net6.0</TargetFramework>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>


### PR DESCRIPTION
Without the proposed change one cannot run Backend or Tests on arm64 platforms. Dropping the setting allows this.

Before the change:

```
$ dotnet run --project WalletWasabi.Backend
Unhandled exception. System.BadImageFormatException: Could not load file or assembly '/Users/stick/work/zksnacks/WalletWasabi/WalletWasabi.Backend/bin/Debug/net6.0/WalletWasabi.Backend.dll'. An attempt was made to load a program with an incorrect format.

File name: '/.../WalletWasabi/WalletWasabi.Backend/bin/Debug/net6.0/WalletWasabi.Backend.dll'
```

After the change:

```
$ dotnet run --project WalletWasabi.Backend
2021-12-18 18:55:39.984 [1] INFO	InitConfigStartupTask.ExecuteAsync (31)	Wasabi Backend started ...
...
```