### PR TITLE
`StringCipher` and Tom Rucki's implementation.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
@@ -1,70 +1,82 @@
 using System.Security.Cryptography;
 using System.Text;
 using WalletWasabi.Crypto;
-using WalletWasabi.Logging;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Crypto
 {
 	public class StringCipherTests
 	{
-		[Fact]
-		public void CipherTests()
+		/// <summary>
+		/// Tests that we can decrypt encrypted text correctly.
+		/// </summary>
+		[Theory]
+		[InlineData("hello", "password")]
+		[InlineData("hellohellohellohellohello", "password")]
+		[InlineData("01234567890123456789012345678901234567890123456789012345678901234567890123456789", "password")]
+		[InlineData("foo@éóüö", "")]
+		[InlineData("foo@éóüöhellohellohellohellohello", "passwordpassword3232")]
+		public void RoundTripCipherTests(string toEncrypt, string password)
 		{
-			var toEncrypt = "hello";
-			var password = "password";
-			var encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			var decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
+			string encrypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encrypted);
 
+			string decrypted = StringCipher.Decrypt(encrypted, password);
+			Assert.Equal(toEncrypt, decrypted);			
+		}
+
+		[Fact]
+		public void EncryptLongTextTest()
+		{
 			var builder = new StringBuilder();
 			for (int i = 0; i < 1000000; i++) // check 10MB
 			{
 				builder.Append("0123456789");
 			}
 
-			toEncrypt = builder.ToString();
-			encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
+			string password = "password";
+			string toEncrypt = builder.ToString();
+			string encrypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encrypted);
 
-			toEncrypt = "foo@éóüö";
-			password = "";
-			encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			decrypted = StringCipher.Decrypt(encypted, password);
+			string decrypted = StringCipher.Decrypt(encrypted, password);
 			Assert.Equal(toEncrypt, decrypted);
-			Logger.TurnOff();
-			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
-			Logger.TurnOn();
+		}
+
+		[Fact]
+		public void InvalidDecryptTest()
+		{
+			string encrypted = StringCipher.Encrypt("123456789", password: "password");
+			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encrypted, "wrong-password"));
 		}
 
 		[Fact]
 		public void AuthenticateMessageTest()
 		{
-			var count = 0;
-			var errorCount = 0;
+			int count = 0;
+			int errorCount = 0;
+
 			while (count < 3)
 			{
-				var password = "password";
-				var plainText = "juan carlos";
-				var encypted = StringCipher.Encrypt(plainText, password);
+				string password = "password";
+				string plainText = "juan carlos";
+				string encypted = StringCipher.Encrypt(plainText, password);
 
 				try
 				{
 					// This must fail because the password is wrong
-					var t = StringCipher.Decrypt(encypted, "WRONG-PASSWORD");
+					_ = StringCipher.Decrypt(encypted, "WRONG-PASSWORD");
 					errorCount++;
 				}
 				catch (CryptographicException ex)
 				{
-					Assert.StartsWith("Message Authentication failed", ex.Message);
+					Assert.StartsWith("Invalid signature", ex.Message, StringComparison.Ordinal);
 				}
+
 				count++;
 			}
-			var rate = errorCount / (double)count;
+
+			double rate = errorCount / (double)count;
 			Assert.True(rate is < 0.000001 and > (-0.000001));
 		}
 	}


### PR DESCRIPTION
An alternative to #6936. The PR is (basically) copy-paste of https://tomrucki.com/posts/aes-encryption-in-csharp/ (good read) but beware that:

> Complete code
>
> As promised at the start of the post here is the final version of the code. To make it easier to see the changes, in other words make shorter, I have intentionally omitted error handling and argument verification and kept only the most important checks. To make it more robust and production ready, some additional validations will have to be added.

This PR's goal is more to fix a #6732 than to change the encryption algorithm. 

* I have added tests from David's #6936, so that we know whether this implementation fixes the issue or not.
* The article above is from 2019 and as such `PasswordIterationCount` may need adjustments.
* I don't know why the original implementation of `StringCipher` fails why this one doesn't (yet?)

Anyway, I thought I would put it here just to maybe show a (viable?) alternative or maybe it can be used to compare the original implementation with this one to spot the bug.

cc @molnard
