### PR TITLE
Throw exception if value is null (JsonConverters)

### DIFF
--- a/WalletWasabi/JsonConverters/Bitcoin/FeeRateJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/FeeRateJsonConverter.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NullReferenceException();
 			}
 			else
 			{

--- a/WalletWasabi/JsonConverters/Bitcoin/FeeRateJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/FeeRateJsonConverter.cs
@@ -15,14 +15,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, FeeRate? value, JsonSerializer serializer)
 		{
-			if (value is null)
-			{
-				throw new NullReferenceException();
-			}
-			else
-			{
-				writer.WriteValue(value.FeePerK.Satoshi);
-			}
+			writer.WriteValue(value.FeePerK.Satoshi);
 		}
 	}
 }

--- a/WalletWasabi/JsonConverters/Bitcoin/MoneyBtcJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/MoneyBtcJsonConverter.cs
@@ -27,14 +27,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, Money? value, JsonSerializer serializer)
 		{
-			if (value is null)
-			{
-				throw new NullReferenceException();
-			}
-			else
-			{
-				writer.WriteValue(value.ToString(fplus: false, trimExcessZero: true));
-			}
+			writer.WriteValue(value.ToString(fplus: false, trimExcessZero: true));
 		}
 	}
 }

--- a/WalletWasabi/JsonConverters/Bitcoin/MoneyBtcJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/MoneyBtcJsonConverter.cs
@@ -29,7 +29,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NullReferenceException();
 			}
 			else
 			{

--- a/WalletWasabi/JsonConverters/Bitcoin/MoneySatoshiJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/MoneySatoshiJsonConverter.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NullReferenceException();
 			}
 			else
 			{

--- a/WalletWasabi/JsonConverters/Bitcoin/MoneySatoshiJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/MoneySatoshiJsonConverter.cs
@@ -16,14 +16,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, Money? value, JsonSerializer serializer)
 		{
-			if (value is null)
-			{
-				throw new NullReferenceException();
-			}
-			else
-			{
-				writer.WriteValue(value.Satoshi);
-			}
+			writer.WriteValue(value.Satoshi);
 		}
 	}
 }

--- a/WalletWasabi/JsonConverters/Bitcoin/ScriptJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/ScriptJsonConverter.cs
@@ -22,7 +22,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NullReferenceException();
 			}
 			else
 			{

--- a/WalletWasabi/JsonConverters/Bitcoin/ScriptJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/ScriptJsonConverter.cs
@@ -20,14 +20,7 @@ namespace WalletWasabi.JsonConverters.Bitcoin
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, Script? value, JsonSerializer serializer)
 		{
-			if (value is null)
-			{
-				throw new NullReferenceException();
-			}
-			else
-			{
-				writer.WriteValue(value.ToString());
-			}
+			writer.WriteValue(value.ToString());
 		}
 	}
 }

--- a/WalletWasabi/JsonConverters/BitcoinAddressJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/BitcoinAddressJsonConverter.cs
@@ -23,14 +23,7 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, BitcoinAddress? value, JsonSerializer serializer)
 		{
-			if (value is null)
-			{
-				throw new NullReferenceException();
-			}
-			else
-			{
-				writer.WriteValue(value.ToString());
-			}
+			writer.WriteValue(value.ToString());
 		}
 	}
 }

--- a/WalletWasabi/JsonConverters/BitcoinAddressJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/BitcoinAddressJsonConverter.cs
@@ -25,7 +25,7 @@ namespace WalletWasabi.JsonConverters
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NullReferenceException();
 			}
 			else
 			{

--- a/WalletWasabi/JsonConverters/BitcoinEncryptedSecretNoECJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/BitcoinEncryptedSecretNoECJsonConverter.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.JsonConverters
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NullReferenceException();
 			}
 			else
 			{

--- a/WalletWasabi/JsonConverters/BitcoinEncryptedSecretNoECJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/BitcoinEncryptedSecretNoECJsonConverter.cs
@@ -21,14 +21,7 @@ namespace WalletWasabi.JsonConverters
 		/// <inheritdoc />
 		public override void WriteJson(JsonWriter writer, BitcoinEncryptedSecretNoEC? value, JsonSerializer serializer)
 		{
-			if (value is null)
-			{
-				throw new NullReferenceException();
-			}
-			else
-			{
-				writer.WriteValue(value.ToWif());
-			}
+			writer.WriteValue(value.ToWif());
 		}
 	}
 }

--- a/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/EndPointJsonConverter.cs
@@ -41,7 +41,7 @@ namespace WalletWasabi.JsonConverters
 		{
 			if (value is null)
 			{
-				writer.WriteNull();
+				throw new NotSupportedException($"{nameof(EndPointJsonConverter)} can only convert {nameof(EndPoint)}.");
 			}
 			else
 			{


### PR DESCRIPTION
According to https://github.com/zkSNACKs/WalletWasabi/pull/6806#discussion_r767552159 and https://github.com/zkSNACKs/WalletWasabi/pull/6806#discussion_r770871670 we should:

> keep the original behavior: throw an exception in case of null

> I think we shouldn't change the existing behavior if we are not sure that that is correct. I assumed (wrongly?) that it was writing null before but if that's not the case and as @molnard says it was throwing an exception before then it has to throw an exception now too (and the same exception, btw)

We changed the behavior in [previous PRs](https://github.com/zkSNACKs/WalletWasabi/pulls?q=is%3Apr+author%3Ayahiheb+is%3Aclosed+from+%27JsonConverter%27+to+%27JsonConverter%3CT%3E%27+) and PR fixes that.
