### PR TITLE
Fix string cipher

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
@@ -8,34 +8,6 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 {
 	public class StringCipherTests
 	{
-
-		[Fact]
-		public void AuthenticateMessageTest()
-		{
-			var count = 0;
-			var errorCount = 0;
-			while (count < 3)
-			{
-				var password = "password";
-				var plainText = "juan carlos";
-				var encypted = StringCipher.Encrypt(plainText, password);
-
-				try
-				{
-					// This must fail because the password is wrong
-					var t = StringCipher.Decrypt(encypted, "WRONG-PASSWORD");
-					errorCount++;
-				}
-				catch (CryptographicException ex)
-				{
-					Assert.StartsWith("Message Authentication failed", ex.Message);
-				}
-				count++;
-			}
-			var rate = errorCount / (double)count;
-			Assert.True(rate is < 0.000001 and > (-0.000001));
-		}
-
 		[Fact]
 		public void CipherTests()
 		{
@@ -62,6 +34,33 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			Logger.TurnOff();
 			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
 			Logger.TurnOn();
+		}
+
+		[Fact]
+		public void AuthenticateMessageTest()
+		{
+			var count = 0;
+			var errorCount = 0;
+			while (count < 3)
+			{
+				var password = "password";
+				var plainText = "juan carlos";
+				var encypted = StringCipher.Encrypt(plainText, password);
+
+				try
+				{
+					// This must fail because the password is wrong
+					var t = StringCipher.Decrypt(encypted, "WRONG-PASSWORD");
+					errorCount++;
+				}
+				catch (CryptographicException ex)
+				{
+					Assert.StartsWith("Message Authentication failed", ex.Message);
+				}
+				count++;
+			}
+			var rate = errorCount / (double)count;
+			Assert.True(rate is < 0.000001 and > (-0.000001));
 		}
 
 		[Fact]

--- a/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
@@ -8,38 +8,6 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 {
 	public class StringCipherTests
 	{
-		[Fact]
-		public void CipherTests()
-		{
-			var toEncrypt = "hello";
-			var password = "password";
-			var encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			var decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
-
-			var builder = new StringBuilder();
-			for (int i = 0; i < 1000000; i++) // check 10MB
-			{
-				builder.Append("0123456789");
-			}
-
-			toEncrypt = builder.ToString();
-			encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
-
-			toEncrypt = "foo@éóüö";
-			password = "";
-			encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
-			Logger.TurnOff();
-			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
-			Logger.TurnOn();
-		}
 
 		[Fact]
 		public void AuthenticateMessageTest()
@@ -66,6 +34,45 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 			}
 			var rate = errorCount / (double)count;
 			Assert.True(rate is < 0.000001 and > (-0.000001));
+		}
+
+		[Fact]
+		public void CipherTests()
+		{
+			var password = "password";
+
+			var builder = new StringBuilder();
+			for (int i = 0; i < 1000000; i++) // check 10MB
+			{
+				builder.Append("0123456789");
+			}
+
+			var toEncrypt = builder.ToString();
+			var encypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encypted);
+			var decrypted = StringCipher.Decrypt(encypted, password);
+			Assert.Equal(toEncrypt, decrypted);
+
+			toEncrypt = "foo@éóüö";
+			password = "";
+			encypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encypted);
+			decrypted = StringCipher.Decrypt(encypted, password);
+			Assert.Equal(toEncrypt, decrypted);
+			Logger.TurnOff();
+			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
+			Logger.TurnOn();
+		}
+
+		[Fact]
+		public void LongTextWithPartialReadTests()
+		{
+			var toEncrypt = "hello world, how are you doing todays?";
+			var password = "password";
+			var encypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encypted);
+			var decrypted = StringCipher.Decrypt(encypted, password);
+			Assert.Equal(toEncrypt, decrypted);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/StringCipherTests.cs
@@ -8,70 +8,78 @@ namespace WalletWasabi.Tests.UnitTests.Crypto
 {
 	public class StringCipherTests
 	{
-		[Fact]
-		public void CipherTests()
+		/// <summary>
+		/// Tests that we can decrypt encrypted text correctly.
+		/// </summary>
+		[Theory]
+		[InlineData("hello", "password")]
+		[InlineData("hello world, how are you doing today?", "password")]
+		[InlineData("01234567890123456789012345678901234567890123456789012345678901234567890123456789", "password")]
+		[InlineData("foo@éóüö", "")]
+		[InlineData("foo@éóüöhellohellohellohellohello", "passwordpassword3232")]
+		public void RoundTripCipherTests(string toEncrypt, string password)
 		{
-			var password = "password";
+			string encrypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encrypted);
 
-			var builder = new StringBuilder();
-			for (int i = 0; i < 1000000; i++) // check 10MB
+			string decrypted = StringCipher.Decrypt(encrypted, password);
+			Assert.Equal(toEncrypt, decrypted);
+		}
+
+		[Fact]
+		public void EncryptLongTextTest()
+		{
+			StringBuilder builder = new();
+
+			for (int i = 0; i < 1000000; i++) // 10MB
 			{
 				builder.Append("0123456789");
 			}
 
-			var toEncrypt = builder.ToString();
-			var encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			var decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
+			string password = "password";
+			string toEncrypt = builder.ToString();
+			string encrypted = StringCipher.Encrypt(toEncrypt, password);
+			Assert.NotEqual(toEncrypt, encrypted);
 
-			toEncrypt = "foo@éóüö";
-			password = "";
-			encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			decrypted = StringCipher.Decrypt(encypted, password);
+			string decrypted = StringCipher.Decrypt(encrypted, password);
 			Assert.Equal(toEncrypt, decrypted);
-			Logger.TurnOff();
-			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
-			Logger.TurnOn();
+		}
+
+		[Fact]
+		public void InvalidDecryptTest()
+		{
+			string encrypted = StringCipher.Encrypt("123456789", "password");
+			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encrypted, "wrong-password"));
 		}
 
 		[Fact]
 		public void AuthenticateMessageTest()
 		{
-			var count = 0;
-			var errorCount = 0;
+			int count = 0;
+			int errorCount = 0;
+
 			while (count < 3)
 			{
-				var password = "password";
-				var plainText = "juan carlos";
-				var encypted = StringCipher.Encrypt(plainText, password);
+				string password = "password";
+				string plainText = "juan carlos";
+				string encrypted = StringCipher.Encrypt(plainText, password);
 
 				try
 				{
 					// This must fail because the password is wrong
-					var t = StringCipher.Decrypt(encypted, "WRONG-PASSWORD");
+					var t = StringCipher.Decrypt(encrypted, "WRONG-PASSWORD");
 					errorCount++;
 				}
 				catch (CryptographicException ex)
 				{
 					Assert.StartsWith("Message Authentication failed", ex.Message);
 				}
+
 				count++;
 			}
-			var rate = errorCount / (double)count;
-			Assert.True(rate is < 0.000001 and > (-0.000001));
-		}
 
-		[Fact]
-		public void LongTextWithPartialReadTests()
-		{
-			var toEncrypt = "hello world, how are you doing todays?";
-			var password = "password";
-			var encypted = StringCipher.Encrypt(toEncrypt, password);
-			Assert.NotEqual(toEncrypt, encypted);
-			var decrypted = StringCipher.Decrypt(encypted, password);
-			Assert.Equal(toEncrypt, decrypted);
+			double rate = errorCount / (double)count;
+			Assert.True(rate is < 0.000001 and > (-0.000001));
 		}
 	}
 }

--- a/WalletWasabi/Crypto/StringCipher.cs
+++ b/WalletWasabi/Crypto/StringCipher.cs
@@ -21,45 +21,34 @@ namespace WalletWasabi.Crypto
 			// Salt is randomly generated each time, but is prepended to encrypted cipher text
 			// so that the same Salt value can be used when decrypting.
 			byte[] salt = Generate128BitsOfRandomEntropy();
-			byte[] iv;
 			byte[] cipherTextBytes;
-			byte[] key;
 			var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
 
-			using (var password = new Rfc2898DeriveBytes(passPhrase, salt, DerivationIterations))
+			byte[] key = DerivateKey(passPhrase, salt);
+			using var aes = CreateAES();
+			aes.GenerateIV();
+			byte[] iv = aes.IV;
+			using var encryptor = aes.CreateEncryptor(key, iv);
+			using var memoryStreamEncryptor = new MemoryStream();
+			using (var cryptoStream = new CryptoStream(memoryStreamEncryptor, encryptor, CryptoStreamMode.Write))
 			{
-				key = password.GetBytes(KeySize / 8);
-				using var aes = CreateAES();
-				aes.GenerateIV();
-				iv = aes.IV;
-				using var encryptor = aes.CreateEncryptor(key, iv);
-				using var memoryStream = new MemoryStream();
-				using (var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write))
-				{
-					cryptoStream.Write(plainTextBytes, 0, plainTextBytes.Length);
-					cryptoStream.FlushFinalBlock();
-				}
-				cipherTextBytes = memoryStream.ToArray();
+				cryptoStream.Write(plainTextBytes, 0, plainTextBytes.Length);
+				cryptoStream.FlushFinalBlock();
 			}
+			cipherTextBytes = memoryStreamEncryptor.ToArray();
 
-			using (var memoryStream = new MemoryStream())
-			{
-				using (var writer = new BinaryWriter(memoryStream))
-				{
-					writer.Write(salt);
-					writer.Write(iv);
-					using (var hmac = new HMACSHA256(key))
-					{
-						var authenticationCode = hmac.ComputeHash(iv.Concat(cipherTextBytes).ToArray());
-						writer.Write(authenticationCode);
-					}
-					writer.Write(cipherTextBytes);
-					writer.Flush();
-				}
+			using var memoryStream = new MemoryStream();
+			using var writer = new BinaryWriter(memoryStream);
+			writer.Write(salt);
+			writer.Write(iv);
+			using var hmac = new HMACSHA256(key);
+			var authenticationCode = hmac.ComputeHash(iv.Concat(cipherTextBytes).ToArray());
+			writer.Write(authenticationCode);
+			writer.Write(cipherTextBytes);
+			writer.Flush();
 
-				var cipherTextWithAuthBytes = memoryStream.ToArray();
-				return Convert.ToBase64String(cipherTextWithAuthBytes);
-			}
+			var cipherTextWithAuthBytes = memoryStream.ToArray();
+			return Convert.ToBase64String(cipherTextWithAuthBytes);
 		}
 
 		public static string Decrypt(string cipherText, string passPhrase)
@@ -79,11 +68,7 @@ namespace WalletWasabi.Crypto
 				cipherStartIndex = (int)memoryStream.Position;
 				cipherLength = (int)(memoryStream.Length - memoryStream.Position);
 				var cipher = reader.ReadBytes(cipherLength);
-
-				using (var password = new Rfc2898DeriveBytes(passPhrase, salt, DerivationIterations))
-				{
-					key = password.GetBytes(KeySize / 8);
-				}
+				key = DerivateKey(passPhrase, salt);
 
 				using var hmac = new HMACSHA256(key);
 				var calculatedAuthenticationCode = hmac.ComputeHash(iv.Concat(cipher).ToArray());
@@ -101,6 +86,12 @@ namespace WalletWasabi.Crypto
 			byte[] plainTextBytes = decryptor.TransformFinalBlock(cipherTextBytesWithSaltAndIv, cipherStartIndex, cipherLength);
 
 			return Encoding.UTF8.GetString(plainTextBytes);
+		}
+
+		private static byte[] DerivateKey(string passPhrase, byte[] salt)
+		{
+			using var password = new Rfc2898DeriveBytes(passPhrase, salt, DerivationIterations);
+			return password.GetBytes(KeySize / 8);
 		}
 
 		private static Aes CreateAES()

--- a/WalletWasabi/Crypto/StringCipher.cs
+++ b/WalletWasabi/Crypto/StringCipher.cs
@@ -101,10 +101,15 @@ namespace WalletWasabi.Crypto
 			memoryStream.Seek(-cipherLength, SeekOrigin.End);
 			using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
 			var plainTextBytes = new byte[cipherLength];
-			var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
+			var read = 0;
+			var totalRead = 0;
+			while ( (read = cryptoStream.Read(plainTextBytes, totalRead, cipherLength - totalRead)) > 0)
+			{
+				totalRead += read;
+			}
 			memoryStream.Close();
 			cryptoStream.Close();
-			return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
+			return Encoding.UTF8.GetString(plainTextBytes, 0, totalRead);
 		}
 
 		private static Aes CreateAES()

--- a/WalletWasabi/Crypto/StringCipher.cs
+++ b/WalletWasabi/Crypto/StringCipher.cs
@@ -38,7 +38,6 @@ namespace WalletWasabi.Crypto
 				{
 					cryptoStream.Write(plainTextBytes, 0, plainTextBytes.Length);
 					cryptoStream.FlushFinalBlock();
-					cryptoStream.Close();
 				}
 				cipherTextBytes = memoryStream.ToArray();
 			}
@@ -59,7 +58,6 @@ namespace WalletWasabi.Crypto
 				}
 
 				var cipherTextWithAuthBytes = memoryStream.ToArray();
-				memoryStream.Close();
 				return Convert.ToBase64String(cipherTextWithAuthBytes);
 			}
 		}
@@ -107,8 +105,6 @@ namespace WalletWasabi.Crypto
 			{
 				totalRead += read;
 			}
-			memoryStream.Close();
-			cryptoStream.Close();
 			return Encoding.UTF8.GetString(plainTextBytes, 0, totalRead);
 		}
 


### PR DESCRIPTION
Fixes: #6732

This PR fixes a bug in the `StringCipher::Decrypt`. Basically the it was not reading all the decrypted stream and ignored the byte's counter returned by the `Stream.Read` method.

This should close #6936 and #6946
