### PR TITLE
[WabiSabi] CoinJoinClient interface simplification

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -21,6 +21,7 @@ using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Tests.Helpers;
 
@@ -258,13 +259,13 @@ public static class WabiSabiFactory
 	public static BlameRound CreateBlameRound(Round round, WabiSabiConfig cfg)
 		=> new(new(cfg, round.Network, new InsecureRandom(), round.FeeRate, round.CoordinationFeeRate), round, round.Alices.Select(x => x.Coin.Outpoint).ToHashSet());
 
-	public static (Key, SmartCoin, Key, SmartCoin) CreateCoinKeyPairs()
+	public static (IKeyChain, SmartCoin, SmartCoin) CreateCoinKeyPairs()
 	{
 		var km = ServiceFactory.CreateKeyManager("");
+		var keyChain = new KeyChain(km);
+
 		var smartCoin1 = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m));
 		var smartCoin2 = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(2m));
-		var sk1 = km.GetSecrets("", smartCoin1.ScriptPubKey).Single();
-		var sk2 = km.GetSecrets("", smartCoin2.ScriptPubKey).Single();
-		return (sk1.PrivateKey, smartCoin1, sk2.PrivateKey, smartCoin2);
+		return (keyChain, smartCoin1, smartCoin2);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -7,6 +7,7 @@ using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Models;
+using WalletWasabi.Wallets;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
@@ -31,11 +32,10 @@ public class AliceTimeoutTests
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
 		// Register Alices.
-		using var identificationKey = new Key();
-		var esk = km.GetSecrets("", smartCoin.ScriptPubKey).Single();
+		var keyChain = new KeyChain(km);
 
 		using CancellationTokenSource cancellationTokenSource = new();
-		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, esk.PrivateKey.GetBitcoinSecret(round.Network), identificationKey, roundStateUpdater, cancellationTokenSource.Token);
+		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, cancellationTokenSource.Token);
 
 		while (round.Alices.Count == 0)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -25,11 +25,11 @@ public class StepOutputRegistrationTests
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 0.5,
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
-		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
+		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, keyChain, coin1, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
 
@@ -72,11 +72,11 @@ public class StepOutputRegistrationTests
 			MinInputCountByRoundMultiplier = 0.5,
 			OutputRegistrationTimeout = TimeSpan.Zero
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
-		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
+		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, keyChain, coin1, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
 
@@ -108,11 +108,11 @@ public class StepOutputRegistrationTests
 			MinInputCountByRoundMultiplier = 0.5,
 			OutputRegistrationTimeout = TimeSpan.Zero,
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
-		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
+		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, keyChain, coin1, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
 
@@ -158,11 +158,11 @@ public class StepOutputRegistrationTests
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 0.5
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
-		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
+		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, keyChain, coin1, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
 
@@ -182,7 +182,7 @@ public class StepOutputRegistrationTests
 	}
 
 	private async Task<(Round Round, ArenaClient ArenaClient, AliceClient[] alices)>
-		CreateRoundWithTwoConfirmedConnectionsAsync(Arena arena, Key key1, SmartCoin coin1, Key key2, SmartCoin coin2)
+			CreateRoundWithTwoConfirmedConnectionsAsync(Arena arena, IKeyChain keyChain, SmartCoin coin1, SmartCoin coin2)
 	{
 		// Create the round.
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -192,9 +192,8 @@ public class StepOutputRegistrationTests
 
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
-		var identificationKey = new Key();
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, key1.GetBitcoinSecret(round.Network), identificationKey, roundStateUpdater, CancellationToken.None);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, key2.GetBitcoinSecret(round.Network), identificationKey, roundStateUpdater, CancellationToken.None);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None);
 
 		while (Phase.ConnectionConfirmation != round.Phase)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -27,11 +27,11 @@ public class StepTransactionSigningTests
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 0.5
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
-		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
+		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
 		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
 		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
@@ -41,8 +41,8 @@ public class StepTransactionSigningTests
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
 
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.DoesNotContain(round, arena.GetActiveRounds());
 		Assert.Equal(Phase.Ended, round.Phase);
@@ -58,7 +58,7 @@ public class StepTransactionSigningTests
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 0.5
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
@@ -67,7 +67,7 @@ public class StepTransactionSigningTests
 		Prison prison = new();
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 
-		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
+		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
 		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
 		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
@@ -77,8 +77,8 @@ public class StepTransactionSigningTests
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
 
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Equal(Phase.Ended, round.Phase);
@@ -97,7 +97,7 @@ public class StepTransactionSigningTests
 			MinInputCountByRoundMultiplier = 0.5
 		};
 
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
@@ -106,7 +106,7 @@ public class StepTransactionSigningTests
 		Prison prison = new();
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 
-		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
+		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
 		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
 		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
@@ -116,8 +116,8 @@ public class StepTransactionSigningTests
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
 
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Equal(Phase.Ended, round.Phase);
@@ -140,7 +140,7 @@ public class StepTransactionSigningTests
 			MinInputCountByRoundMultiplier = 1,
 			TransactionSigningTimeout = TimeSpan.Zero
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
@@ -149,7 +149,7 @@ public class StepTransactionSigningTests
 		Prison prison = new();
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 
-		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
+		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
 		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
 		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
@@ -158,7 +158,7 @@ public class StepTransactionSigningTests
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Equal(Phase.Ended, round.Phase);
@@ -179,7 +179,7 @@ public class StepTransactionSigningTests
 			TransactionSigningTimeout = TimeSpan.Zero,
 			OutputRegistrationTimeout = TimeSpan.Zero
 		};
-		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
 		mockRpc.Setup(rpc => rpc.SendRawTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
@@ -188,7 +188,7 @@ public class StepTransactionSigningTests
 		Prison prison = new();
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 
-		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
+		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
 		// Make sure not all alices signed.
 		var alice3 = WabiSabiFactory.CreateAlice(round);
@@ -199,8 +199,8 @@ public class StepTransactionSigningTests
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, CancellationToken.None);
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Single(arena.Rounds.Where(x => x is BlameRound));
@@ -221,7 +221,7 @@ public class StepTransactionSigningTests
 	}
 
 	private async Task<(Round Round, AliceClient AliceClient1, AliceClient AliceClient2)>
-		CreateRoundWithOutputsReadyToSignAsync(Arena arena, Key key1, SmartCoin coin1, Key key2, SmartCoin coin2)
+			CreateRoundWithOutputsReadyToSignAsync(Arena arena, IKeyChain keyChain, SmartCoin coin1, SmartCoin coin2)
 	{
 		// Create the round.
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -234,9 +234,8 @@ public class StepTransactionSigningTests
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
-		using var identificationKey = new Key();
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, key1.GetBitcoinSecret(round.Network), identificationKey, roundStateUpdater, CancellationToken.None);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, key2.GetBitcoinSecret(round.Network), identificationKey, roundStateUpdater, CancellationToken.None);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None);
 
 		while (Phase.OutputRegistration != round.Phase)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -13,6 +13,7 @@ using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Models;
+using WalletWasabi.Wallets;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
@@ -48,13 +49,11 @@ public class BobClientTests
 			wabiSabiApi);
 		Assert.Equal(Phase.InputRegistration, round.Phase);
 
-		var bitcoinSecret = km.GetSecrets("", coin1.ScriptPubKey).Single().PrivateKey.GetBitcoinSecret(Network.Main);
-
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), wabiSabiApi);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
-		using var identificationKey = new Key();
-		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), aliceArenaClient, coin1, bitcoinSecret, identificationKey, roundStateUpdater, CancellationToken.None);
+			var keyChain = new KeyChain(km);
+			var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), aliceArenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);
 
 		do
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
@@ -1,0 +1,35 @@
+using NBitcoin;
+using System.Linq;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Crypto;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.Wallets;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client
+{
+	public class KeyChainTests
+	{
+		[Fact]
+		public void SignTransactionTest()
+		{
+			var keyManager = KeyManager.CreateNew(out _, "", Network.Main);
+			var destinationProvider = new InternalDestinationProvider(keyManager);
+			var keyChain = new KeyChain(keyManager);
+
+			var coinDestination = destinationProvider.GetNextDestinations(1).First();
+			var coin = new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(1.0m), coinDestination));
+			var ownershipProof = keyChain.GetOwnershipProof(coinDestination, new CoinJoinInputCommitmentData("test", uint256.One));
+
+			var transaction = Transaction.Create(Network.Main); // the transaction doesn't contain the input that we request to be signed.
+
+			Assert.Throws<ArgumentException>( () => keyChain.Sign(transaction, coin, ownershipProof));
+
+			transaction.Inputs.Add(coin.Outpoint);
+			var signedTx = keyChain.Sign(transaction, coin, ownershipProof);
+			Assert.True(signedTx.HasWitness);
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -92,10 +92,12 @@ internal class Participant
 		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(3), apiClient);
 		await roundStateUpdater.StartAsync(cancellationToken).ConfigureAwait(false);
 
-		var kitchen = new Kitchen();
-		kitchen.Cook("");
-
-		var coinJoinClient = new CoinJoinClient(HttpClientFactory, kitchen, KeyManager, roundStateUpdater, consolidationMode: true);
+		var coinJoinClient = new CoinJoinClient(
+			HttpClientFactory,
+			new KeyChain(KeyManager),
+			new InternalDestinationProvider(KeyManager),
+			roundStateUpdater,
+			consolidationMode: true);
 
 		// Run the coinjoin client task.
 		await coinJoinClient.StartCoinJoinAsync(Coins, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -148,10 +148,11 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
-		var kitchen = new Kitchen();
-		kitchen.Cook("");
-
-		var coinJoinClient = new CoinJoinClient(mockHttpClientFactory.Object, kitchen, keyManager, roundStateUpdater, consolidationMode: true);
+		var coinJoinClient = new CoinJoinClient(mockHttpClientFactory.Object,
+			new KeyChain(keyManager),
+			new InternalDestinationProvider(keyManager),
+			roundStateUpdater,
+			consolidationMode: true);
 
 		// Run the coinjoin client task.
 		Assert.True(await coinJoinClient.StartCoinJoinAsync(coins, cts.Token));
@@ -255,10 +256,11 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		var roundState = await roundStateUpdater.CreateRoundAwaiter(roundState => roundState.Phase == Phase.InputRegistration, cts.Token);
 
-		var kitchen = new Kitchen();
-		kitchen.Cook("");
-
-		var coinJoinClient = new CoinJoinClient(mockHttpClientFactory.Object, kitchen, keyManager1, roundStateUpdater, consolidationMode: true);
+		var coinJoinClient = new CoinJoinClient(mockHttpClientFactory.Object,
+			new KeyChain(keyManager1),
+			new InternalDestinationProvider(keyManager1),
+			roundStateUpdater,
+			consolidationMode: true);
 
 		// Run the coinjoin client task.
 		var coinJoinTask = Task.Run(async () => await coinJoinClient.StartCoinJoinAsync(coins, cts.Token).ConfigureAwait(false), cts.Token);
@@ -286,7 +288,12 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			.Setup(factory => factory.NewHttpClientWithCircuitPerRequest())
 			.Returns(nonSigningHttpClient);
 
-		var badCoinJoinClient = new CoinJoinClient(mockNonSigningHttpClientFactory.Object, kitchen, keyManager2, roundStateUpdater, consolidationMode: true);
+		var badCoinJoinClient = new CoinJoinClient(mockNonSigningHttpClientFactory.Object,
+			new KeyChain(keyManager2),
+			new InternalDestinationProvider(keyManager2),
+			roundStateUpdater,
+			consolidationMode: true);
+
 		var badCoinsTask = Task.Run(async () => await badCoinJoinClient.StartRoundAsync(badCoins, roundState, cts.Token).ConfigureAwait(false), cts.Token);
 
 		await Task.WhenAll(new Task[] { badCoinsTask, coinJoinTask });

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs;
 /// An UTXO that knows more.
 /// </summary>
 [DebuggerDisplay("{Amount}BTC {Confirmed} {HdPubKey.Label} OutPoint={Coin.Outpoint}")]
-public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>
+public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDestination
 {
 	private Height _height;
 	private SmartTransaction? _spenderTransaction;

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -19,7 +19,7 @@ public class AliceClient
 		RoundState roundState,
 		ArenaClient arenaClient,
 		SmartCoin coin,
-		BitcoinSecret bitcoinSecret,
+		OwnershipProof ownershipProof,
 		IEnumerable<Credential> issuedAmountCredentials,
 		IEnumerable<Credential> issuedVsizeCredentials,
 		bool isPayingZeroCoordinationFee)
@@ -28,9 +28,9 @@ public class AliceClient
 		RoundId = roundState.Id;
 		ArenaClient = arenaClient;
 		SmartCoin = coin;
+		OwnershipProof = ownershipProof;
 		FeeRate = roundState.FeeRate;
 		CoordinationFeeRate = roundState.CoordinationFeeRate;
-		BitcoinSecret = bitcoinSecret;
 		IssuedAmountCredentials = issuedAmountCredentials;
 		IssuedVsizeCredentials = issuedVsizeCredentials;
 		MaxVsizeAllocationPerAlice = roundState.MaxVsizeAllocationPerAlice;
@@ -42,9 +42,9 @@ public class AliceClient
 	public uint256 RoundId { get; }
 	private ArenaClient ArenaClient { get; }
 	public SmartCoin SmartCoin { get; }
+	private OwnershipProof OwnershipProof { get; }
 	private FeeRate FeeRate { get; }
 	private CoordinationFeeRate CoordinationFeeRate { get; }
-	private BitcoinSecret BitcoinSecret { get; }
 	public IEnumerable<Credential> IssuedAmountCredentials { get; private set; }
 	public IEnumerable<Credential> IssuedVsizeCredentials { get; private set; }
 	private long MaxVsizeAllocationPerAlice { get; }
@@ -55,15 +55,14 @@ public class AliceClient
 		RoundState roundState,
 		ArenaClient arenaClient,
 		SmartCoin coin,
-		BitcoinSecret bitcoinSecret,
-		Key identificationKey,
+		IKeyChain keyChain,
 		RoundStateUpdater roundStatusUpdater,
 		CancellationToken cancellationToken)
 	{
 		AliceClient? aliceClient = null;
 		try
 		{
-			aliceClient = await RegisterInputAsync(roundState, arenaClient, coin, bitcoinSecret, identificationKey, cancellationToken).ConfigureAwait(false);
+			aliceClient = await RegisterInputAsync(roundState, arenaClient, coin, keyChain, cancellationToken).ConfigureAwait(false);
 			await aliceClient.ConfirmConnectionAsync(roundStatusUpdater, cancellationToken).ConfigureAwait(false);
 
 			Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({aliceClient.AliceId}): Connection successfully confirmed.");
@@ -81,19 +80,17 @@ public class AliceClient
 		return aliceClient;
 	}
 
-	private static async Task<AliceClient> RegisterInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, BitcoinSecret bitcoinSecret, Key identificationKey, CancellationToken cancellationToken)
+		private static async Task<AliceClient> RegisterInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, CancellationToken cancellationToken)
 	{
 		AliceClient? aliceClient;
 		try
 		{
-			var signingKey = bitcoinSecret.PrivateKey;
-			var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
-				signingKey,
-				new OwnershipIdentifier(identificationKey, signingKey.PubKey.WitHash.ScriptPubKey),
+			var ownershipProof = keyChain.GetOwnershipProof(
+				coin,
 				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundState.Id));
 
 			var (response, isPayingZeroCoordinationFee) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
-			aliceClient = new(response.Value, roundState, arenaClient, coin, bitcoinSecret, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isPayingZeroCoordinationFee);
+			aliceClient = new(response.Value, roundState, arenaClient, coin, ownershipProof, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isPayingZeroCoordinationFee);
 			coin.CoinJoinInProgress = true;
 
 			Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.OutPoint}.");
@@ -229,9 +226,9 @@ public class AliceClient
 		Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Inputs removed.");
 	}
 
-	public async Task SignTransactionAsync(Transaction unsignedCoinJoin, CancellationToken cancellationToken)
+	public async Task SignTransactionAsync(Transaction unsignedCoinJoin, IKeyChain keyChain, CancellationToken cancellationToken)
 	{
-		await ArenaClient.SignTransactionAsync(RoundId, SmartCoin.Coin, BitcoinSecret, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
+			await ArenaClient.SignTransactionAsync(RoundId, SmartCoin.Coin, OwnershipProof, keyChain, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
 
 		Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Posted a signature.");
 	}

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -183,23 +183,10 @@ public class ArenaClient
 		return new(false, zeroAmountCredentials, zeroVsizeCredentials);
 	}
 
-	public async Task SignTransactionAsync(uint256 roundId, Coin coin, BitcoinSecret bitcoinSecret, Transaction unsignedCoinJoin, CancellationToken cancellationToken)
+	public async Task SignTransactionAsync(uint256 roundId, Coin coin, OwnershipProof ownershipProof, IKeyChain keyChain, Transaction unsignedCoinJoin, CancellationToken cancellationToken)
 	{
-		if (unsignedCoinJoin.Inputs.Count == 0)
-		{
-			throw new ArgumentException("No inputs to sign.", nameof(unsignedCoinJoin));
-		}
-
-		var signedCoinJoin = unsignedCoinJoin.Clone();
-		var txInput = signedCoinJoin.Inputs.AsIndexedInputs().FirstOrDefault(input => input.PrevOut == coin.Outpoint);
-
-		if (txInput is null)
-		{
-			throw new InvalidOperationException($"Missing input.");
-		}
-
-		signedCoinJoin.Sign(bitcoinSecret, coin);
-
+		var signedCoinJoin = keyChain.Sign(unsignedCoinJoin, coin, ownershipProof);
+		var txInput = signedCoinJoin.Inputs.AsIndexedInputs().First(input => input.PrevOut == coin.Outpoint);
 		if (!txInput.VerifyScript(coin, out var error))
 		{
 			throw new InvalidOperationException($"Witness is missing. Reason {nameof(ScriptError)} code: {error}.");

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -16,7 +15,6 @@ using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client.CredentialDependencies;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
-using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.WabiSabi.Client;
@@ -30,15 +28,15 @@ public class CoinJoinClient
 	/// <param name="consolidationMode">If true, then aggressively try to consolidate as many coins as it can.</param>
 	public CoinJoinClient(
 		IWasabiHttpClientFactory httpClientFactory,
-		Kitchen kitchen,
-		KeyManager keymanager,
+		IKeyChain keyChain,
+		IDestinationProvider destinationProvider,
 		RoundStateUpdater roundStatusUpdater,
 		int minAnonScoreTarget = int.MaxValue,
 		bool consolidationMode = false)
 	{
 		HttpClientFactory = httpClientFactory;
-		Kitchen = kitchen;
-		Keymanager = keymanager;
+		KeyChain = keyChain;
+		DestinationProvider = destinationProvider;
 		RoundStatusUpdater = roundStatusUpdater;
 		MinAnonScoreTarget = minAnonScoreTarget;
 		ConsolidationMode = consolidationMode;
@@ -47,8 +45,8 @@ public class CoinJoinClient
 
 	private SecureRandom SecureRandom { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
-	public Kitchen Kitchen { get; }
-	public KeyManager Keymanager { get; }
+	private IKeyChain KeyChain { get; }
+	private IDestinationProvider DestinationProvider { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	public int MinAnonScoreTarget { get; }
 
@@ -130,10 +128,9 @@ public class CoinJoinClient
 			var theirCoinEffectiveValues = theirCoins.Select(x => x.EffectiveValue(roundState.FeeRate, roundState.CoordinationFeeRate));
 			var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
 
-			// Get all locked internal keys we have and assert we have enough.
-			Keymanager.AssertLockedInternalKeysIndexed(howMany: outputValues.Count());
-			var allLockedInternalKeys = Keymanager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked);
-			var outputTxOuts = outputValues.Zip(allLockedInternalKeys, (amount, hdPubKey) => new TxOut(amount, hdPubKey.P2wpkhScript));
+			// Get as many destinations as outputs we need.
+			var destinations = DestinationProvider.GetNextDestinations(outputValues.Count()).ToArray();
+			var outputTxOuts = outputValues.Zip(destinations, (amount, destination) => new TxOut(amount, destination.ScriptPubKey));
 
 			DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(inputEffectiveValuesAndSizes, outputTxOuts, roundState.FeeRate, roundState.CoordinationFeeRate, roundState.MaxVsizeAllocationPerAlice);
 			DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
@@ -200,18 +197,7 @@ public class CoinJoinClient
 					roundState.CreateVsizeCredentialClient(SecureRandom),
 					arenaRequestHandler);
 
-				var hdKey = Keymanager.GetSecrets(Kitchen.SaltSoup(), coin.ScriptPubKey).Single();
-				var secret = hdKey.PrivateKey.GetBitcoinSecret(Keymanager.GetNetwork());
-				if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != coin.ScriptPubKey)
-				{
-					throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
-				}
-
-				var masterKey = Keymanager.GetMasterExtKey(Kitchen.SaltSoup()).PrivateKey;
-				var identificationMasterKey = Slip21Node.FromSeed(masterKey.ToBytes());
-				var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019").DeriveChild("Ownership identification key").Key;
-
-				return await AliceClient.CreateRegisterAndConfirmInputAsync(roundState, aliceArenaClient, coin, secret, identificationKey, RoundStatusUpdater, cancellationToken).ConfigureAwait(false);
+				return await AliceClient.CreateRegisterAndConfirmInputAsync(roundState, aliceArenaClient, coin, KeyChain, RoundStatusUpdater, cancellationToken).ConfigureAwait(false);
 			}
 			catch (HttpRequestException)
 			{
@@ -272,7 +258,7 @@ public class CoinJoinClient
 		{
 			try
 			{
-				await aliceClient.SignTransactionAsync(unsignedCoinJoinTransaction, cancellationToken).ConfigureAwait(false);
+				await aliceClient.SignTransactionAsync(unsignedCoinJoinTransaction, KeyChain, cancellationToken).ConfigureAwait(false);
 				return aliceClient;
 			}
 			catch (Exception e)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -76,7 +76,13 @@ public class CoinJoinManager : BackgroundService
 					continue;
 				}
 
-				var coinjoinClient = new CoinJoinClient(HttpClientFactory, openedWallet.Kitchen, openedWallet.KeyManager, RoundStatusUpdater, openedWallet.ServiceConfiguration.MinAnonScoreTarget);
+				var coinjoinClient = new CoinJoinClient(
+					HttpClientFactory,
+					new KeyChain(openedWallet.KeyManager),
+					new InternalDestinationProvider(openedWallet.KeyManager),
+					RoundStatusUpdater,
+					openedWallet.ServiceConfiguration.MinAnonScoreTarget);
+
 				var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
 				var coinjoinTask = coinjoinClient.StartCoinJoinAsync(coinCandidates, cts.Token);
 

--- a/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
@@ -1,0 +1,10 @@
+using NBitcoin;
+using System.Collections.Generic;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public interface IDestinationProvider
+	{
+		IEnumerable<IDestination> GetNextDestinations(int count);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/IKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/IKeyChain.cs
@@ -1,0 +1,11 @@
+using NBitcoin;
+using WalletWasabi.Crypto;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public interface IKeyChain
+	{
+		OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData commitedData);
+		Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
@@ -1,0 +1,24 @@
+using NBitcoin;
+using System.Linq;
+using System.Collections.Generic;
+using WalletWasabi.Blockchain.Keys;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public class InternalDestinationProvider : IDestinationProvider
+	{
+		public InternalDestinationProvider(KeyManager keyManager)
+		{
+			KeyManager = keyManager;
+		}
+
+		private KeyManager KeyManager { get; }
+
+		public IEnumerable<IDestination> GetNextDestinations(int count)
+		{
+			// Get all locked internal keys we have and assert we have enough.
+			KeyManager.AssertLockedInternalKeysIndexed(count);
+			return KeyManager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked).Select(x => x.PubKey.WitHash);
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -1,0 +1,75 @@
+using NBitcoin;
+using System.Linq;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Crypto;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public class KeyChain : IKeyChain
+	{
+		public KeyChain(KeyManager keyManager, string passPhrase = "")
+		{
+			if (keyManager.IsWatchOnly)
+			{
+				throw new ArgumentException("A watch-only keymanager cannot be used to initialize a keychain.");
+			}
+			KeyManager = keyManager;
+			PassPhrase = passPhrase;
+		}
+
+		private KeyManager KeyManager { get; }
+		public string PassPhrase { get; }
+
+		public OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData commitmentData)
+		{
+			var secret = GetBitcoinSecret(destination.ScriptPubKey);
+
+			var masterKey = KeyManager.GetMasterExtKey(PassPhrase).PrivateKey;
+			var identificationMasterKey = Slip21Node.FromSeed(masterKey.ToBytes());
+			var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019").DeriveChild("Ownership identification key").Key;
+
+			var signingKey = secret.PrivateKey;
+			var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
+					signingKey,
+					new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
+					commitmentData);
+			return ownershipProof;
+		}
+
+		public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof)
+		{
+			transaction = transaction.Clone();
+			if (transaction.Inputs.Count == 0)
+			{
+				throw new ArgumentException("No inputs to sign.", nameof(transaction));
+			}
+
+			var txInput = transaction.Inputs.AsIndexedInputs().FirstOrDefault(input => input.PrevOut == coin.Outpoint);
+
+			if (txInput is null)
+			{
+				throw new InvalidOperationException("Missing input.");
+			}
+
+			var secret = GetBitcoinSecret(coin.ScriptPubKey);
+
+			transaction.Sign(secret, coin);
+			return transaction;
+		}
+
+		private BitcoinSecret GetBitcoinSecret(Script scriptPubKey)
+		{
+			var hdKey = KeyManager.GetSecrets(PassPhrase, scriptPubKey).Single();
+			if (hdKey is null)
+			{
+				throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
+			}
+			if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != scriptPubKey)
+			{
+				throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
+			}
+			var secret = hdKey.PrivateKey.GetBitcoinSecret(KeyManager.GetNetwork());
+			return secret;
+		}
+	}
+}


### PR DESCRIPTION
Right now the `CoinJoinClient` creates the ownership proofs, handles private keys, uses those private keys to sign inputs among other things that are out of its responsibilities. This is a well-known design problem[¹]  that has gone under radar simply because prioritization but it is important to improve code by moving those parts to where they suite better.

As another side note, this work is compatible with the vision regarding interfacing with other hardware/software as described here: https://github.com/zkSNACKs/WalletWasabi/discussions/6467

## KeyChain

Things like providing the `ownership proof` for  a given `scriptPubKey` is something that has to be done by the device (physical or logical, it doesn't really matter) that knows the corresponding private keys. The same is true for signing the transactions, that's something that can only be done by the device that knows the private keys. Those devices could be called `signers` (it can be a Hardware wallet, for example). For that reason the `CoinJoinClient` shouldn't handle private keys at all because it could have no access to them. Instead, it should simply keep a reference to the device that can generate the `ownership proofs` and `sign` transactions.

In this PR the device that knows the private keys to prove ownership of the utxos and  sign transactions is called `KeyChain` and the `CoinJoinClient` just uses it, in this way the CJC doesn't know anything about private keys anymore. 

## DestinationProvider

*Note:* a better name has to exist.

It is not so uncommon that the provision the addresses and the signing of the transactions are done for two different devices, this is the case in `watch-only` wallets in conjunction with hardware wallets. The device that generates addresses (scripts) in this PR is called `DestinationProvider` and it is able to provide destinations (in NBitcoin jardon this is whatever has `scriptPubKey`)

The `CoinJoinClient` doesn't need to interact with the `KeyManager` directly anymore, instead it uses the `DestinationProvider` to get the number of `scriptPubKey` its need.

## Next

This is the first step in the process to simplify the `CoinJoinClient` interface (there should be on more small PR) and allow other godnesses and cross-wallets coinjoins. 
[^1] See: https://github.com/zkSNACKs/WalletWasabi/pull/6147#discussion_r687032217