### PR TITLE
Fix NRE in UT

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -134,8 +134,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			roundStatusUpdater.TriggerRound();
 			roundStatusUpdater.TriggerRound();
 			roundStatusUpdater.TriggerRound();
-			roundStatusUpdater.TriggerRound();
-			roundStatusUpdater.TriggerRound();
 			await Task.Delay(TimeSpan.FromSeconds(1));
 
 			// But in the end everything is alright.


### PR DESCRIPTION
When Moq is not well configured it returns `null` after the sequence of configured returns reaches its limit,
 
```
2021-12-30 16:05:22.669 [19] ERROR	RoundStateUpdater.ActionAsync (47)	System.NullReferenceException: Object reference not set to an instance of an object.
   at WalletWasabi.WabiSabi.Client.RoundStateUpdater.ActionAsync(CancellationToken cancellationToken) in /mnt/data/GitHub/WalletWasabi/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs:line 34
```