### PR TITLE
Fix warning: Not disposing SingleInstanceChecker in a determinable way

### DIFF
--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -15,6 +15,7 @@
 		<LangVersion>latest</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
 		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<InvariantGlobalization>true</InvariantGlobalization>


### PR DESCRIPTION
We had a warning in Program.cs because SingleInstanceChecker was not being disposed in a determinable way.

Most likely it was not getting disposed because the Task would not be able to run before the program actually exited.

This caused a compiler warning.

This PR makes it dispose synchronously, and keeps the scope to within the `if (runGui)` block, as its not used elsewhere.