### PR TITLE
Fix ReadJson method in HDFingerprintJsonConverter

### DIFF
--- a/WalletWasabi/JsonConverters/HDFingerprintJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/HDFingerprintJsonConverter.cs
@@ -11,7 +11,7 @@ public class HDFingerprintJsonConverter : JsonConverter<HDFingerprint>
 		var s = (string?)reader.Value;
 		if (string.IsNullOrWhiteSpace(s))
 		{
-			throw new ArgumentNullException(nameof(reader.Value));
+			return default;
 		}
 
 		var fp = new HDFingerprint(ByteHelpers.FromHex(s));


### PR DESCRIPTION
This PR tries to fix and issue introduced after #7006 was merged.
Now you get the following in the logs file if you have a watch-only wallet:

```
2022-01-10 01:24:54.680 [1] WARNING	WalletManager.AddWallet (207)	Wallet got corrupted.
Wallet Filepath: C:\Users\chihe\AppData\Roaming\WalletWasabi\Client\Wallets\TestNet\WatchOnly - Ashes.json
Trying to recover it from backup.
Backup path: C:\Users\chihe\AppData\Roaming\WalletWasabi\Client\WalletBackups\TestNet\WatchOnly - Ashes.json
Exception: System.ArgumentNullException: Value cannot be null. (Parameter 'Value')
   at WalletWasabi.JsonConverters.HDFingerprintJsonConverter.ReadJson(JsonReader reader, Type objectType, HDFingerprint existingValue, Boolean hasExistingValue, JsonSerializer serializer) in WalletWasabi\JsonConverters\HDFingerprintJsonConverter.cs:line 14
   at Newtonsoft.Json.JsonConverter`1.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolvePropertyAndCreatorValues(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, Type objectType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObjectUsingCreatorWithParameters(JsonReader reader, JsonObjectContract contract, JsonProperty containerProperty, ObjectConstructor`1 creator, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateNewObject(JsonReader reader, JsonObjectContract objectContract, JsonProperty containerMember, JsonProperty containerProperty, String id, Boolean& createdFromNonDefaultCreator)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value)
   at WalletWasabi.Blockchain.Keys.KeyManager.FromFile(String filePath) in WalletWasabi\Blockchain\Keys\KeyManager.cs:line 214
   at WalletWasabi.Wallets.Wallet..ctor(String dataDir, Network network, String filePath) in WalletWasabi\Wallets\Wallet.cs:line 30
   at WalletWasabi.Wallets.WalletManager.AddWallet(String walletName) in WalletWasabi\Wallets\WalletManager.cs:line 198
2022-01-10 01:24:54.683 [1] INFO	WalletManager.AddWallet (218)	Deleted previous corrupted wallet file backup from `C:\Users\chihe\AppData\Roaming\WalletWasabi\Client\WalletBackups\TestNet\WatchOnly - Ashes.json_CorruptedBackup`.
2022-01-10 01:24:54.684 [1] INFO	WalletManager.AddWallet (221)	Backed up corrupted wallet file to `C:\Users\chihe\AppData\Roaming\WalletWasabi\Client\WalletBackups\TestNet\WatchOnly - Ashes.json_CorruptedBackup`.
2022-01-10 01:24:54.686 [1] WARNING	WalletManager.RefreshWalletList (97)	System.ArgumentNullException: Value cannot be null. (Parameter 'Value')
   at WalletWasabi.JsonConverters.HDFingerprintJsonConverter.ReadJson(JsonReader reader, Type objectType, HDFingerprint existingValue, Boolean hasExistingValue, JsonSerializer serializer) in WalletWasabi\JsonConverters\HDFingerprintJsonConverter.cs:line 14
   at Newtonsoft.Json.JsonConverter`1.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolvePropertyAndCreatorValues(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, Type objectType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObjectUsingCreatorWithParameters(JsonReader reader, JsonObjectContract contract, JsonProperty containerProperty, ObjectConstructor`1 creator, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateNewObject(JsonReader reader, JsonObjectContract objectContract, JsonProperty containerMember, JsonProperty containerProperty, String id, Boolean& createdFromNonDefaultCreator)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value)
   at WalletWasabi.Blockchain.Keys.KeyManager.FromFile(String filePath) in WalletWasabi\Blockchain\Keys\KeyManager.cs:line 214
   at WalletWasabi.Wallets.Wallet..ctor(String dataDir, Network network, String filePath) in WalletWasabi\Wallets\Wallet.cs:line 30
   at WalletWasabi.Wallets.WalletManager.AddWallet(String walletName) in WalletWasabi\Wallets\WalletManager.cs:line 225
   at WalletWasabi.Wallets.WalletManager.RefreshWalletList() in WalletWasabi\Wallets\WalletManager.cs:line 93
```