### PR TITLE
Change the default fallback address

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -76,7 +76,7 @@ public static class Constants
 		MinProtocolCapabilities = new ProtocolCapabilities { SupportGetBlock = true, SupportWitness = true }
 	};
 
-	public static readonly ExtPubKey FallBackCoordinatorExtPubKey = NBitcoinHelpers.BetterParseExtPubKey("xpub6D2PqhWBAbF3xgfaAUW73KnaCXUroArcgMTzNkNzfVX7ykkSzQGbqaXZeaNyxKbZojAAqDwsne6B7NcVhiTrXbGYrQNq1yF76NkgdonGrEa");
+	public static readonly ExtPubKey FallBackCoordinatorExtPubKey = NBitcoinHelpers.BetterParseExtPubKey("xpub6BgAZqHhxw6pgEi2F38w5RBqctqCEoVWqcMdrn1epQZceKHtn8f8zHBduM3fwYQEKEGUf4efD6qRPc9wvDF4neoc6JjDbHNiaHbs3we5qL3");
 
 	public static readonly string[] UserAgents = new[]
 	{


### PR DESCRIPTION
I could not find the recovery words for the TestNet fallback wallet. Created a new wallet that I am aware of the recovery words. 

Keep in mind that this xpub will be only used if someone forgets to change the coordinator fee xpub before going into production - which is not likely.