### PR TITLE
Implement code review suggestions

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -118,6 +118,7 @@ public class RandomTests
 		mockRandom.GetBytesResults.Add(Scalar.Zero.ToBytes());
 		var one = new Scalar(1);
 		mockRandom.GetBytesResults.Add(one.ToBytes());
+		mockRandom.GetBytesResults.Add(one.ToBytes());
 		var two = new Scalar(2);
 		mockRandom.GetBytesResults.Add(two.ToBytes());
 		var big = new Scalar(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
@@ -126,7 +127,7 @@ public class RandomTests
 		mockRandom.GetBytesResults.Add(biggest.ToBytes());
 
 		var randomScalar = mockRandom.GetScalar();
-		Assert.Equal(Scalar.Zero, randomScalar);
+		Assert.Equal(one, randomScalar);
 		randomScalar = mockRandom.GetScalar();
 		Assert.Equal(one, randomScalar);
 		randomScalar = mockRandom.GetScalar();

--- a/WalletWasabi/Crypto/CredentialIssuerSecretKey.cs
+++ b/WalletWasabi/Crypto/CredentialIssuerSecretKey.cs
@@ -1,6 +1,7 @@
 using NBitcoin.Secp256k1;
 using WalletWasabi.Crypto.Groups;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Crypto;
 
@@ -13,11 +14,11 @@ public record CredentialIssuerSecretKey
 
 	private CredentialIssuerSecretKey(Scalar w, Scalar wp, Scalar x0, Scalar x1, Scalar ya)
 	{
-		W = w;
-		Wp = wp;
-		X0 = x0;
-		X1 = x1;
-		Ya = ya;
+		W = Guard.NotZero(nameof(w), w);
+		Wp = Guard.NotZero(nameof(wp), wp);
+		X0 = Guard.NotZero(nameof(x0), x0);
+		X1 = Guard.NotZero(nameof(x1), x1);
+		Ya = Guard.NotZero(nameof(ya), ya);
 	}
 
 	public Scalar W { get; }

--- a/WalletWasabi/Crypto/Randomness/WasabiRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/WasabiRandom.cs
@@ -33,24 +33,17 @@ public abstract class WasabiRandom : IRandom, IDisposable
 		return random;
 	}
 
-	public virtual Scalar GetScalar(bool allowZero = true)
+	public virtual Scalar GetScalar()
 	{
 		Scalar randomScalar;
 		int overflow;
 		Span<byte> buffer = stackalloc byte[32];
-		var randomWasZero = false;
 		do
 		{
 			GetBytes(buffer);
 			randomScalar = new Scalar(buffer, out overflow);
-
-			if (randomScalar.IsZero && randomWasZero)
-			{
-				throw new InvalidOperationException("Random generator generated zero scalar twice in a row. Stop using this computer now!");
-			}
-			randomWasZero = randomScalar.IsZero;
 		}
-		while (overflow != 0 || (!allowZero && randomScalar.IsZero));
+		while (overflow != 0 || randomScalar.IsZero);
 		return randomScalar;
 	}
 

--- a/WalletWasabi/Crypto/ZeroKnowledge/SyntheticSecretNonceProvider.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/SyntheticSecretNonceProvider.cs
@@ -31,7 +31,14 @@ public class SyntheticSecretNonceProvider
 	{
 		while (true)
 		{
-			yield return new Scalar(_strobe.Prf(32, false));
+			Scalar scalar;
+			int overflow;
+			do
+			{
+				scalar = new Scalar(_strobe.Prf(32, false), out overflow);
+			}
+			while (overflow != 0);
+			yield return scalar;
 		}
 	}
 

--- a/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
+++ b/WalletWasabi/Crypto/ZeroKnowledge/Transcript.cs
@@ -65,8 +65,15 @@ public sealed class Transcript
 	// Generate Fiat Shamir challenges
 	public Scalar GenerateChallenge()
 	{
-		_strobe.AddAssociatedMetaData(ChallengeTag, false);
-		return new Scalar(_strobe.Prf(KeySizeInBytes, false));
+		Scalar scalar;
+		int overflow;
+		do
+		{
+			_strobe.AddAssociatedMetaData(ChallengeTag, false);
+			scalar = new Scalar(_strobe.Prf(KeySizeInBytes, false), out overflow);
+		}
+		while(overflow != 0);
+		return scalar;
 	}
 
 	private void AddMessage(byte[] label, byte[] message)

--- a/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
+++ b/WalletWasabi/WabiSabi/Crypto/WabiSabiClient.cs
@@ -55,7 +55,7 @@ public class WabiSabiClient
 
 		for (var i = 0; i < NumberOfCredentials; i++)
 		{
-			var randomness = RandomNumberGenerator.GetScalar(allowZero: false);
+			var randomness = RandomNumberGenerator.GetScalar();
 			var ma = randomness * Generators.Gh;
 
 			knowledge[i] = ProofSystem.ZeroProofKnowledge(ma, randomness);
@@ -144,7 +144,7 @@ public class WabiSabiClient
 			var value = credentialAmountsToRequest[i];
 			var scalar = new Scalar((ulong)value);
 
-			var randomness = RandomNumberGenerator.GetScalar(allowZero: false);
+			var randomness = RandomNumberGenerator.GetScalar();
 			var ma = ProofSystem.PedersenCommitment(scalar, randomness);
 
 			var (rangeKnowledge, bitCommitments) = ProofSystem.RangeProofKnowledge(scalar, randomness, RangeProofWidth, RandomNumberGenerator);


### PR DESCRIPTION
In this PR we introduce the audit recommendations

* In ProofSystem.cs, typo line 169: it should be rb_i -> r_i * b_i

   This is incorrect because the 3rd terms are called `rb` (`r` times `b`) everywhere and its `i`th component is also called `rb_i`.

* In `CredentialIssuerSecretKey()`, we recommend to check that scalars are non-zero, as it would be an insecure key and would reveal other problems (with the PRNG). 

   We have already discussed this thing a million times and we know zero is a valid number and that the chances of getting a zero are much much lower than winning the national lottery a million times in a row.   

   Anyway, I checked for zero in the constructor, write the UTs that verify it and made sure the `GetScalar` never returns zero.

* The `GetInt()` implementation used in https://github.com/zkSNACKs/WalletWasabi/blob/58dbe7572df8386560b224906eec2bf009d1ca8f/WalletWasabi/Crypto/Randomness/WasabiRandom.cs#L31 must return uniformly distributed values (the actual implementation was unclear to us).  

   We assume it does because it uses a CSPRNG provided by the OS.

* In the algebraic MAC in `Mac.cs`, a given t must not be repeated with the same key `sk`, otherwise part of the key leaks. The application seems to only call it with random values.

   We must assume the probability of generating duplicated `t` is negligible.

* In `NBitcoin`, Scalar elements constructed from a byte array can in certain cases overflow the modulus p of the scalar field of the curve. For this reason, the constructor can additionally return a flag which indicated whether a reduction modulo p occurs. This flag is not checked in `SyntheticSecretNonceProvider.Sequence()` or `Transcript.GenerateChallenge()` and therefore may cause the comparisons against 0 to fail in `Equation.Verify()` and Equation.Respond(). While these events only happen with negligible probability, we recommend that the functions responsible for generating random scalars generate retry if the modulus is overflowed.

   I have introduced the recommendation.

* We also noticed a typo in `SchnorrBlindingSignature.cs#L80` where the wrong variable was being checked against zero. Instead of `_v.IsZero` it should be `_w.IsZero`.

   Fixed