### PR TITLE
[Fluent] Persist Fiat to BTC setting on CurrencyEntryBox

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -372,8 +372,6 @@ public class CurrencyEntryBox : TextBox
 	private void SwapButtonOnClick(object? sender, RoutedEventArgs e)
 	{
 		IsConversionReversed = !IsConversionReversed;
-		UpdateDisplay(true);
-		CaretIndex = SelectionStart = SelectionEnd = Text.Length;
 	}
 
 	private void InputText(string text)
@@ -487,6 +485,10 @@ public class CurrencyEntryBox : TextBox
 		else if (change.Property == ConversionRateProperty)
 		{
 			PseudoClasses.Set(":noexchangerate", change.NewValue.GetValueOrDefault<decimal>() == 0m);
+		} else if (change.Property == IsConversionReversedProperty)
+		{
+			UpdateDisplay(true);
+			CaretIndex = SelectionStart = SelectionEnd = Text.Length;
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -485,7 +485,8 @@ public class CurrencyEntryBox : TextBox
 		else if (change.Property == ConversionRateProperty)
 		{
 			PseudoClasses.Set(":noexchangerate", change.NewValue.GetValueOrDefault<decimal>() == 0m);
-		} else if (change.Property == IsConversionReversedProperty)
+		}
+		else if (change.Property == IsConversionReversedProperty)
 		{
 			UpdateDisplay(true);
 			CaretIndex = SelectionStart = SelectionEnd = Text.Length;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -41,6 +41,8 @@ public partial class SendViewModel : RoutableViewModel
 	[AutoNotify] private bool _isFixedAmount;
 	[AutoNotify] private bool _isPayJoin;
 	[AutoNotify] private string? _payJoinEndPoint;
+	[AutoNotify] private bool _conversionReversed;
+
 	private bool _parsingUrl;
 	private BitcoinAddress? _currentAddress;
 

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -60,7 +60,7 @@
                                 NormalIcon="{StaticResource paste_regular}"
                                 ClickIcon="{StaticResource copy_confirmed}">
                 <i:Interaction.Behaviors>
-                  <behaviors:PasteButtonFlashBehavior FlashAnimation="flash" CurrentAddress="{Binding To}"/>
+                  <behaviors:PasteButtonFlashBehavior FlashAnimation="flash" CurrentAddress="{Binding To}" />
                 </i:Interaction.Behaviors>
               </c:AnimatedButton>
               <c:AnimatedButton IsVisible="{Binding IsQrButtonVisible}"
@@ -79,12 +79,16 @@
         <DockPanel>
           <Image Width="120" Source="avares://WalletWasabi.Fluent/Assets/TechnologyLogos/payjoin.png"
                  DockPanel.Dock="Right" IsVisible="{Binding IsPayJoin}" Margin="0 8 8 0" VerticalAlignment="Top" />
-          <c:CurrencyEntryBox KeyboardNavigation.IsTabStop="{Binding !IsFixedAmount}" x:Name="amountTb"
-                              IsReadOnly="{Binding IsFixedAmount}" AmountBtc="{Binding AmountBtc}"
-                              ConversionRate="{Binding ExchangeRate}" ConversionCurrencyCode="USD" />
+          <c:CurrencyEntryBox x:Name="amountTb"
+                              KeyboardNavigation.IsTabStop="{Binding !IsFixedAmount}"
+                              IsReadOnly="{Binding IsFixedAmount}"
+                              AmountBtc="{Binding AmountBtc}"
+                              ConversionRate="{Binding ExchangeRate}"
+                              ConversionCurrencyCode="USD"
+                              IsConversionReversed="{Binding ConversionReversed, Mode=TwoWay}" />
         </DockPanel>
       </DockPanel>
-     
+
       <!-- Advanced -->
       <Button Classes="h8 plain activeHyperLink" Margin="0 10 0 0"
               Command="{Binding AdvancedOptionsCommand}"


### PR DESCRIPTION
Fixes #6982 by keeping track of CurrencyEntryBox's state in the SendViewModel object.

cc @MarnixCroes @zkSNACKs/visual-design-group 