### PR TITLE
Fix macOS CI pipeline

### DIFF
--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
 - job: macOS
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-11'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET'


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml

> In December 2021, we removed the following Azure Pipelines hosted image:
> macOS X Mojave 10.14 (macOS-10.14)