### PR TITLE
Do not sign Change Avoidence Suggestions when created

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -93,7 +93,9 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 					.SpentCoins
 					.OrderBy(x => x.Amount)
 					.Skip(1)
-					.Select(x => x.OutPoint)));
+					.Select(x => x.OutPoint),
+				payjoinClient: null,
+				tryToSign: false));
 
 			smallerSuggestion = new ChangeAvoidanceSuggestionViewModel(
 				transactionInfo.Amount.ToDecimal(MoneyUnit.BTC), smallerTransaction,
@@ -109,7 +111,9 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 			intent,
 			FeeStrategy.CreateFromFeeRate(transactionInfo.FeeRate),
 			true,
-			requestedTransaction.SpentCoins.Select(x => x.OutPoint)));
+			requestedTransaction.SpentCoins.Select(x => x.OutPoint),
+			payjoinClient: null,
+			tryToSign: false));
 
 		var largerSuggestion = new ChangeAvoidanceSuggestionViewModel(
 			transactionInfo.Amount.ToDecimal(MoneyUnit.BTC), largerTransaction,
@@ -127,7 +131,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 		var results = new List<ChangeAvoidanceSuggestionViewModel>();
 
 		foreach (var suggestion in NormalizeSuggestions(suggestions, defaultSelection)
-			         .Where(x => x != defaultSelection))
+					 .Where(x => x != defaultSelection))
 		{
 			results.Add(suggestion);
 		}

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -215,7 +215,6 @@ public class TransactionFactory
 		}
 
 		// Build the transaction
-		Logger.LogInfo("Signing transaction...");
 
 		// It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
 		psbt.AddKeyPaths(KeyManager);
@@ -228,6 +227,7 @@ public class TransactionFactory
 		}
 		else
 		{
+			Logger.LogInfo("Signing transaction...");
 			IEnumerable<ExtKey> signingKeys = KeyManager.GetSecrets(Password, spentCoins.Select(x => x.ScriptPubKey).ToArray());
 			builder = builder.AddKeys(signingKeys.ToArray());
 			builder.SignPSBT(psbt);


### PR DESCRIPTION
Leftouts from: #7012
Addressing: https://github.com/zkSNACKs/WalletWasabi/pull/7012#issuecomment-1008921089
and https://github.com/zkSNACKs/WalletWasabi/pull/7012#issuecomment-1008923513

The `Change Avoidance Suggestions` were missing the `trySign: false` param, so they got signed right after creation, which is not neccessary.

To make it super clear, we **will** sign the TXs, when the user clicks on the `Confirm` button.