### PR TITLE
Remove EffectiveValue calculation form AmoutDecomposer

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
@@ -31,13 +31,13 @@ public class AmountDecomposerTests
 		var availableVsize = maxAvailableOutputs * Constants.P2wpkhOutputSizeInBytes;
 		var feeRate = new FeeRate(feeRateDecimal);
 		var feePerOutput = feeRate.GetFee(Constants.P2wpkhOutputSizeInBytes);
-		var registeredCoins = GenerateRandomCoins().Take(3).ToList();
-		var theirCoins = GenerateRandomCoins().Take(30).ToList();
+		var registeredCoinEffectiveValues = GenerateRandomCoins().Take(3).Select(c => c.EffectiveValue(feeRate)).ToList();
+		var theirCoinEffectiveValues = GenerateRandomCoins().Take(30).Select(c => c.EffectiveValue(feeRate)).ToList();
 
 		var amountDecomposer = new AmountDecomposer(feeRate, minOutputAmount, Constants.P2wpkhOutputSizeInBytes, availableVsize);
-		var outputValues = amountDecomposer.Decompose(registeredCoins, theirCoins);
+		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
 
-		var totalEffectiveValue = registeredCoins.Sum(x => x.EffectiveValue(feeRate));
+		var totalEffectiveValue = registeredCoinEffectiveValues.Sum(x => x);
 		var totalEffectiveCost = outputValues.Count() * feePerOutput;
 
 		Assert.InRange(outputValues.Count(), 1, maxAvailableOutputs);

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -238,4 +238,12 @@ public class AliceClient
 		await ArenaClient.ReadyToSignAsync(RoundId, AliceId, cancellationToken).ConfigureAwait(false);
 		Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Ready to sign.");
 	}
+
+	public Money EffectiveValue
+	{
+		get
+		{
+			return SmartCoin.EffectiveValue(FeeRate);
+		}
+	}
 }

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -239,11 +239,5 @@ public class AliceClient
 		Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Ready to sign.");
 	}
 
-	public Money EffectiveValue
-	{
-		get
-		{
-			return SmartCoin.EffectiveValue(FeeRate);
-		}
-	}
+	public Money EffectiveValue => SmartCoin.EffectiveValue(FeeRate);
 }

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -161,7 +161,7 @@ public class AmountDecomposer
 			.Select(x => x.Key)
 			.ToArray();
 
-		var myInputs = myInputCoinEffectiveValues.ToArray(); ;
+		var myInputs = myInputCoinEffectiveValues.ToArray();
 		var myInputSum = myInputs.Sum();
 		var remaining = myInputSum;
 		var remainingVsize = AvailableVsize;

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -150,9 +150,9 @@ public class AmountDecomposer
 		return denominations.OrderByDescending(x => x);
 	}
 
-	public IEnumerable<Money> Decompose(IEnumerable<Money> myInputCoinEffectiveValues, IEnumerable<Money> othersInputCoins)
+	public IEnumerable<Money> Decompose(IEnumerable<Money> myInputCoinEffectiveValues, IEnumerable<Money> othersInputCoinEffectiveValues)
 	{
-		var histogram = GetDenominationFrequencies(othersInputCoins.Concat(myInputCoinEffectiveValues));
+		var histogram = GetDenominationFrequencies(othersInputCoinEffectiveValues.Concat(myInputCoinEffectiveValues));
 
 		// Filter out and order denominations those have occurred in the frequency table at least twice.
 		var denoms = histogram

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -150,9 +150,9 @@ public class AmountDecomposer
 		return denominations.OrderByDescending(x => x);
 	}
 
-	public IEnumerable<Money> Decompose(IEnumerable<Coin> myInputCoins, IEnumerable<Coin> othersInputCoins)
+	public IEnumerable<Money> Decompose(IEnumerable<Money> myInputCoinEffectiveValues, IEnumerable<Money> othersInputCoins)
 	{
-		var histogram = GetDenominationFrequencies(othersInputCoins.Concat(myInputCoins));
+		var histogram = GetDenominationFrequencies(othersInputCoins.Concat(myInputCoinEffectiveValues));
 
 		// Filter out and order denominations those have occurred in the frequency table at least twice.
 		var denoms = histogram
@@ -161,7 +161,7 @@ public class AmountDecomposer
 			.Select(x => x.Key)
 			.ToArray();
 
-		var myInputs = myInputCoins.Select(x => x.EffectiveValue(FeeRate)).ToArray();
+		var myInputs = myInputCoinEffectiveValues.ToArray(); ;
 		var myInputSum = myInputs.Sum();
 		var remaining = myInputSum;
 		var remainingVsize = AvailableVsize;
@@ -336,13 +336,13 @@ public class AmountDecomposer
 	}
 
 	/// <returns>Pair of denomination and the number of times we found it in a breakdown.</returns>
-	private Dictionary<ulong, long> GetDenominationFrequencies(IEnumerable<Coin> inputs)
+	private Dictionary<ulong, long> GetDenominationFrequencies(IEnumerable<Money> inputEffectiveValues)
 	{
-		var secondLargestInput = inputs.OrderByDescending(x => x.Amount).Skip(1).First();
-		IEnumerable<ulong> demonsForBreakDown = DenominationsPlusFees.Where(x => x <= (ulong)secondLargestInput.EffectiveValue(FeeRate).Satoshi);
+		var secondLargestInput = inputEffectiveValues.OrderByDescending(x => x).Skip(1).First();
+		IEnumerable<ulong> demonsForBreakDown = DenominationsPlusFees.Where(x => x <= (ulong)secondLargestInput.Satoshi);
 
 		Dictionary<ulong, long> denomFrequencies = new();
-		foreach (var input in inputs)
+		foreach (var input in inputEffectiveValues)
 		{
 			foreach (var denom in BreakDown(input, demonsForBreakDown))
 			{
@@ -359,9 +359,9 @@ public class AmountDecomposer
 	/// <summary>
 	/// Greedily decomposes an amount to the given denominations.
 	/// </summary>
-	private IEnumerable<ulong> BreakDown(Coin coin, IEnumerable<ulong> denominations)
+	private IEnumerable<ulong> BreakDown(Money coininputEffectiveValue, IEnumerable<ulong> denominations)
 	{
-		var remaining = coin.EffectiveValue(FeeRate);
+		var remaining = coininputEffectiveValue;
 
 		foreach (var denomPlusFee in denominations)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -123,7 +123,10 @@ public class CoinJoinClient
 			constructionState = roundState.Assert<ConstructionState>();
 			AmountDecomposer amountDecomposer = new(roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts.Min, Constants.P2wpkhOutputSizeInBytes, (int)availableVsize);
 			var theirCoins = constructionState.Inputs.Except(registeredCoins);
-			var outputValues = amountDecomposer.Decompose(registeredCoins, theirCoins);
+
+			var registeredCoinEffectiveValues = registeredAliceClients.Select(x => x.EffectiveValue);
+			var theirCoinEffectiveValues = theirCoins.Select(x => x.EffectiveValue(roundState.FeeRate));
+			var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
 
 			// Get all locked internal keys we have and assert we have enough.
 			Keymanager.AssertLockedInternalKeysIndexed(howMany: outputValues.Count());


### PR DESCRIPTION
In harmony with our plans regarding coordination fees - the input fee calculation will require more parameters that won't be available inside the amount decomposer nor belong to there - thus this PR born. 

Part of https://github.com/zkSNACKs/WalletWasabi/pull/6953