### PR TITLE
Switch HDFingerprintJsonConverter from 'JsonConverter<T>' to 'JsonConverter<T?>'

### DIFF
--- a/WalletWasabi/JsonConverters/HDFingerprintJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/HDFingerprintJsonConverter.cs
@@ -3,23 +3,22 @@ using Newtonsoft.Json;
 
 namespace WalletWasabi.JsonConverters;
 
-public class HDFingerprintJsonConverter : JsonConverter<HDFingerprint>
+public class HDFingerprintJsonConverter : JsonConverter<HDFingerprint?>
 {
 	/// <inheritdoc />
-	public override HDFingerprint ReadJson(JsonReader reader, Type objectType, HDFingerprint existingValue, bool hasExistingValue, JsonSerializer serializer)
+	public override HDFingerprint? ReadJson(JsonReader reader, Type objectType, HDFingerprint? existingValue, bool hasExistingValue, JsonSerializer serializer)
 	{
 		var s = (string?)reader.Value;
 		if (string.IsNullOrWhiteSpace(s))
 		{
-			return default;
+			return null;
 		}
 
-		var fp = new HDFingerprint(ByteHelpers.FromHex(s));
-		return fp;
+		return new HDFingerprint(ByteHelpers.FromHex(s));
 	}
 
 	/// <inheritdoc />
-	public override void WriteJson(JsonWriter writer, HDFingerprint value, JsonSerializer serializer)
+	public override void WriteJson(JsonWriter writer, HDFingerprint? value, JsonSerializer serializer)
 	{
 		writer.WriteValue(value.ToString());
 	}

--- a/WalletWasabi/JsonConverters/HDFingerprintJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/HDFingerprintJsonConverter.cs
@@ -20,6 +20,7 @@ public class HDFingerprintJsonConverter : JsonConverter<HDFingerprint?>
 	/// <inheritdoc />
 	public override void WriteJson(JsonWriter writer, HDFingerprint? value, JsonSerializer serializer)
 	{
-		writer.WriteValue(value.ToString());
+		var stringValue = value?.ToString() ?? throw new ArgumentNullException(nameof(value));
+		writer.WriteValue(stringValue);
 	}
 }


### PR DESCRIPTION
According to @kiminuo in `KeyManager` https://github.com/zkSNACKs/WalletWasabi/blob/eabc03b9c339e2daa8b30f7788c79e1134d15077/WalletWasabi/Blockchain/Keys/KeyManager.cs#L107-L109 we expect to get either `HDFingerprint` or `null`, but in the master branch, we return always `HDFingerprint` and never `null` (which was changed in #7006)

This PR fixes that.