### PR TITLE
[WabiSabi] Ban alices that are clearly cheating.

### DIFF
--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -14,6 +14,8 @@ namespace WalletWasabi.Tests.Helpers;
 /// </summary>
 public class ArenaBuilder
 {
+	public static readonly ArenaBuilder Default = new();
+
 	public TimeSpan? Period { get; set; }
 	public Network? Network { get; set; }
 	public WabiSabiConfig? Config { get; set; }
@@ -58,6 +60,15 @@ public class ArenaBuilder
 		{
 			toDispose?.Dispose();
 		}
+	}
+
+	public ArenaBuilder With(IMock<IRPCClient> rpc) =>
+		With(rpc.Object);
+
+	public ArenaBuilder With(IRPCClient rpc)
+	{
+		Rpc = rpc;
+		return this;
 	}
 
 	public static ArenaBuilder From(WabiSabiConfig cfg) => new() { Config = cfg };

--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -14,7 +14,7 @@ namespace WalletWasabi.Tests.Helpers;
 /// </summary>
 public class ArenaBuilder
 {
-	public static readonly ArenaBuilder Default = new();
+	public static ArenaBuilder Default => new();
 
 	public TimeSpan? Period { get; set; }
 	public Network? Network { get; set; }

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -95,28 +95,6 @@ public static class WabiSabiFactory
 		return mockRpc;
 	}
 
-	public static async Task<Arena> CreateAndStartArenaAsync()
-		=> await CreateAndStartArenaAsync(
-			new WabiSabiConfig(),
-			CreatePreconfiguredRpcClient());
-
-	public static async Task<Arena> CreateAndStartArenaAsync(WabiSabiConfig cfg, params Round[] rounds)
-		=> await CreateAndStartArenaAsync(
-			cfg,
-			CreatePreconfiguredRpcClient(),
-			rounds);
-
-	public static async Task<Arena> CreateAndStartArenaAsync(WabiSabiConfig cfg, IMock<IRPCClient> mockRpc, params Round[] rounds)
-	{
-		Arena arena = new(TimeSpan.FromHours(1), Network.Main, cfg, mockRpc.Object, new Prison());
-		foreach (var round in rounds)
-		{
-			arena.Rounds.Add(round);
-		}
-		await arena.StartAsync(CancellationToken.None).ConfigureAwait(false);
-		return arena;
-	}
-
 	public static Alice CreateAlice(Coin coin, OwnershipProof ownershipProof, Round round)
 		=> new(coin, ownershipProof, round, Guid.NewGuid()) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -24,7 +24,7 @@ public class AliceTimeoutTests
 		var smartCoin = BitcoinFactory.CreateSmartCoin(key, 10m);
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(smartCoin.Coin);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, rpc, round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
@@ -65,7 +65,7 @@ public class AliceTimeoutTests
 		round.SetPhase(Phase.ConnectionConfirmation);
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 
@@ -88,7 +88,7 @@ public class AliceTimeoutTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 
@@ -113,7 +113,7 @@ public class AliceTimeoutTests
 		round.Alices.Add(alice);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 
@@ -135,7 +135,7 @@ public class AliceTimeoutTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
@@ -28,7 +28,7 @@ public class StepConnectionConfirmationTests
 		round.Alices.Add(a3);
 		round.Alices.Add(a4);
 		round.SetPhase(Phase.ConnectionConfirmation);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.OutputRegistration, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -16,7 +16,7 @@ public class StepInputRegistrationTests
 	{
 		WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
 		var round = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -44,7 +44,7 @@ public class StepInputRegistrationTests
 		mockRpc.Setup(rpc => rpc.GetTxOutAsync(offendingAlice.Coin.Outpoint.Hash, (int)offendingAlice.Coin.Outpoint.N, true, It.IsAny<CancellationToken>()))
 			.ReturnsAsync((GetTxOutResponse?)null);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync(round);
 
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		round.Alices.Add(offendingAlice);
@@ -78,7 +78,7 @@ public class StepInputRegistrationTests
 		round.Alices.Add(alice3);
 		var blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, blameRound);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync( blameRound);
 
 		blameRound.Alices.Add(alice1);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -108,7 +108,7 @@ public class StepInputRegistrationTests
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
@@ -136,7 +136,7 @@ public class StepInputRegistrationTests
 		blameRound.Alices.Add(alice1);
 		blameRound.Alices.Add(alice2);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, blameRound);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync( blameRound);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.ConnectionConfirmation, blameRound.Phase);
 
@@ -153,7 +153,7 @@ public class StepInputRegistrationTests
 			MinInputCountByRoundMultiplier = 0.5
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -184,7 +184,7 @@ public class StepInputRegistrationTests
 		var blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 		blameRound.Alices.Add(alice1);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, blameRound);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync( blameRound);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.Ended, blameRound.Phase);
 		Assert.DoesNotContain(blameRound, arena.GetActiveRounds());
@@ -202,7 +202,7 @@ public class StepInputRegistrationTests
 			MinInputCountByRoundMultiplier = 0.5
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -28,7 +28,7 @@ public class StepOutputRegistrationTests
 		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
@@ -75,7 +75,7 @@ public class StepOutputRegistrationTests
 		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
@@ -111,7 +111,7 @@ public class StepOutputRegistrationTests
 		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);
@@ -161,7 +161,7 @@ public class StepOutputRegistrationTests
 		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, key1, coin1, key2, coin2);
 		var (amountCredentials1, vsizeCredentials1) = (alices[0].IssuedAmountCredentials, alices[0].IssuedVsizeCredentials);
 		var (amountCredentials2, vsizeCredentials2) = (alices[1].IssuedAmountCredentials, alices[1].IssuedVsizeCredentials);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -30,7 +30,7 @@ public class StepTransactionSigningTests
 		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc.Object).CreateAndStartAsync();
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
 
 		await aliceClient1.ReadyToSignAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -30,7 +30,7 @@ public class StepTransactionSigningTests
 		var (key1, coin1, key2, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc.Object).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, key1, coin1, key2, coin2);
 
 		await aliceClient1.ReadyToSignAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
@@ -23,7 +23,7 @@ public class ConfirmConnectionTests
 		var alice = WabiSabiFactory.CreateAlice(round);
 		var preDeadline = alice.Deadline;
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
@@ -51,7 +51,7 @@ public class ConfirmConnectionTests
 		var alice = WabiSabiFactory.CreateAlice(round);
 		var preDeadline = alice.Deadline;
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 
@@ -72,7 +72,7 @@ public class ConfirmConnectionTests
 	{
 		var cfg = new WabiSabiConfig();
 		var nonExistingRound = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
+		using Arena arena = await ArenaBuilder.Default.CreateAndStartAsync();
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(nonExistingRound);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -86,7 +86,7 @@ public class ConfirmConnectionTests
 	public async Task WrongPhaseAsync()
 	{
 		WabiSabiConfig cfg = new();
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync();
 		var round = arena.Rounds.First();
 		var alice = WabiSabiFactory.CreateAlice(round);
 		var preDeadline = alice.Deadline;
@@ -116,7 +116,7 @@ public class ConfirmConnectionTests
 	{
 		WabiSabiConfig cfg = new();
 		var round = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.ConfirmConnectionAsync(req, CancellationToken.None));
@@ -133,7 +133,7 @@ public class ConfirmConnectionTests
 		round.SetPhase(Phase.ConnectionConfirmation);
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 		Assert.Contains(alice, round.Alices);
 
 		var incorrectVsizeCredentials = WabiSabiFactory.CreateRealCredentialRequests(round, null, 234).vsizeRequest;
@@ -154,7 +154,7 @@ public class ConfirmConnectionTests
 		round.SetPhase(Phase.ConnectionConfirmation);
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var incorrectAmountCredentials = WabiSabiFactory.CreateRealCredentialRequests(round, Money.Coins(3), null).amountRequest;
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round) with { RealAmountCredentialRequests = incorrectAmountCredentials };
@@ -191,7 +191,7 @@ public class ConfirmConnectionTests
 		round.SetPhase(Phase.ConnectionConfirmation);
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateConnectionConfirmationRequest(round);
 		var (issuer, issuer2) = credentialIssuerSelector(round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -306,7 +306,7 @@ public class RegisterInputFailureTests
 			async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), ownershipProof, CancellationToken.None));
 
 		Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, ex.ErrorCode);
-
+		Assert.Single(prison.GetInmates());
 		await arena.StopAsync(CancellationToken.None);
 	}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -26,7 +26,7 @@ public class RegisterInputFailureTests
 	public async Task RoundNotFoundAsync()
 	{
 		using Key key = new();
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(new(), WabiSabiFactory.CreatePreconfiguredRpcClient());
+		using Arena arena = await ArenaBuilder.Default.CreateAndStartAsync();
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
@@ -41,7 +41,7 @@ public class RegisterInputFailureTests
 	public async Task WrongPhaseAsync()
 	{
 		WabiSabiConfig cfg = new();
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync();
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		var round = arena.Rounds.First();
 		using Key key = new();
@@ -67,7 +67,7 @@ public class RegisterInputFailureTests
 		using Key key = new();
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(), round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
@@ -92,7 +92,8 @@ public class RegisterInputFailureTests
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 		var coin = WabiSabiFactory.CreateCoin(key);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin));
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync();
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
@@ -113,7 +114,8 @@ public class RegisterInputFailureTests
 		WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.FromHours(1) };
 		using Key key = new();
 		var coin = WabiSabiFactory.CreateCoin(key);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin));
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync();
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
@@ -218,7 +220,7 @@ public class RegisterInputFailureTests
 		mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 			.ReturnsAsync((NBitcoin.RPC.GetTxOutResponse?)null);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync(round);
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -240,7 +242,7 @@ public class RegisterInputFailureTests
 		mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 			.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse { Confirmations = 0 });
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync(round);
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -264,7 +266,7 @@ public class RegisterInputFailureTests
 		{
 			rpcCfg = rpcCfg.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse { Confirmations = i, IsCoinBase = true });
 		}
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, rpc, round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		var req = WabiSabiFactory.CreateInputRegistrationRequest(round: round);
@@ -295,7 +297,8 @@ public class RegisterInputFailureTests
 				TxOut = new(Money.Coins(1), key.PubKey.ScriptPubKey.Hash.GetAddress(Network.Main))
 			});
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, mockRpc, round);
+		var prison = new Prison();
+		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
@@ -314,7 +317,8 @@ public class RegisterInputFailureTests
 		var coin = WabiSabiFactory.CreateCoin(key);
 		WabiSabiConfig cfg = new();
 		var round = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		using Key nonOwnerKey = new();
@@ -335,7 +339,7 @@ public class RegisterInputFailureTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -353,7 +357,7 @@ public class RegisterInputFailureTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(), round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -376,8 +380,8 @@ public class RegisterInputFailureTests
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 		round.MaxVsizeAllocationPerAlice = 0;
-
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -400,8 +404,8 @@ public class RegisterInputFailureTests
 		var anotherAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key), round);
 		round.Alices.Add(anotherAlice);
 		round.SetPhase(Phase.ConnectionConfirmation);
-
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
@@ -426,7 +430,8 @@ public class RegisterInputFailureTests
 		anotherRound.Alices.Add(preAlice);
 		anotherRound.SetPhase(Phase.ConnectionConfirmation);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round, anotherRound);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round, anotherRound);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -29,7 +29,7 @@ public class RegisterInputSuccessTests
 
 		using Key key = new();
 		var coin = WabiSabiFactory.CreateCoin(key);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(WabiSabiFactory.CreatePreconfiguredRpcClient(coin)).CreateAndStartAsync(round);
 
 		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
@@ -55,7 +55,8 @@ public class RegisterInputSuccessTests
 		var preAlice = WabiSabiFactory.CreateAlice(coin, WabiSabiFactory.CreateOwnershipProof(key), round);
 		round.Alices.Add(preAlice);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, WabiSabiFactory.CreatePreconfiguredRpcClient(coin), round);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None).ConfigureAwait(false));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -19,7 +19,7 @@ public class RegisterInputToBlameRoundTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round, blameRound);
 		using Key key = new();
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient();
 
@@ -38,7 +38,7 @@ public class RegisterInputToBlameRoundTests
 		var alice = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice);
 		Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round, blameRound);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round, blameRound);
 
 		var req = WabiSabiFactory.CreateInputRegistrationRequest(prevout: alice.Coin.Outpoint, round: blameRound);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -20,7 +20,7 @@ public class RegisterOutputTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.SetPhase(Phase.OutputRegistration);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round);
 		await arena.RegisterOutputAsync(req, CancellationToken.None);
@@ -34,7 +34,7 @@ public class RegisterOutputTests
 	{
 		var cfg = new WabiSabiConfig();
 		var nonExistingRound = WabiSabiFactory.CreateRound(cfg);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
+		using Arena arena = await ArenaBuilder.Default.CreateAndStartAsync();
 		var req = WabiSabiFactory.CreateOutputRegistrationRequest(nonExistingRound);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.RegisterOutputAsync(req, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
@@ -49,7 +49,7 @@ public class RegisterOutputTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.MaxVsizeAllocationPerAlice = 11 + 34 + MultipartyTransactionParameters.SharedOverhead;
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 		using Key key = new();
 
 		round.SetPhase(Phase.OutputRegistration);
@@ -68,7 +68,7 @@ public class RegisterOutputTests
 		WabiSabiConfig cfg = new();
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.MaxVsizeAllocationPerAlice += 13;
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		round.SetPhase(Phase.OutputRegistration);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1), round));
@@ -90,7 +90,7 @@ public class RegisterOutputTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.SetPhase(Phase.OutputRegistration);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(1), round));
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round);
 
@@ -107,7 +107,7 @@ public class RegisterOutputTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.SetPhase(Phase.OutputRegistration);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(Money.Coins(2), round));
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round);
 
@@ -124,7 +124,7 @@ public class RegisterOutputTests
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.SetPhase(Phase.OutputRegistration);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, vsize: 30);
 
@@ -138,7 +138,7 @@ public class RegisterOutputTests
 	public async Task WrongPhaseAsync()
 	{
 		WabiSabiConfig cfg = new();
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync();
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		var round = arena.Rounds.First();
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -23,7 +23,7 @@ public class RemoveInputTests
 		round.Alices.Add(alice);
 		Assert.True(round.RemainingInputVsizeAllocation < initialRemaining);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		// There's no such alice yet, so success.
 		var req = new InputsRemovalRequest(round.Id, Guid.NewGuid());
@@ -43,7 +43,7 @@ public class RemoveInputTests
 	[Fact]
 	public async Task RoundNotFoundAsync()
 	{
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
+		using Arena arena = await ArenaBuilder.Default.CreateAndStartAsync();
 
 		var req = new InputsRemovalRequest(uint256.Zero, Guid.NewGuid());
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.RemoveInputAsync(req, CancellationToken.None));
@@ -56,7 +56,7 @@ public class RemoveInputTests
 	public async Task WrongPhaseAsync()
 	{
 		WabiSabiConfig cfg = new();
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync();
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		var round = arena.Rounds.First();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -24,7 +24,7 @@ public class SignTransactionTests
 		round.Alices.Add(alice);
 		round.CoinjoinState = round.AddInput(alice.Coin).Finalize();
 		round.SetPhase(Phase.TransactionSigning);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
 		var aliceSignedCoinJoin = round.Assert<SigningState>().CreateUnsignedTransaction();
 		aliceSignedCoinJoin.Sign(key.GetBitcoinSecret(Network.Main), alice.Coin);
@@ -38,7 +38,7 @@ public class SignTransactionTests
 	[Fact]
 	public async Task RoundNotFoundAsync()
 	{
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync();
+		using Arena arena = await ArenaBuilder.Default.CreateAndStartAsync();
 		var req = new TransactionSignaturesRequest(uint256.Zero, 0, WitScript.Empty);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.SignTransactionAsync(req, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.RoundNotFound, ex.ErrorCode);
@@ -49,7 +49,7 @@ public class SignTransactionTests
 	public async Task WrongPhaseAsync()
 	{
 		WabiSabiConfig cfg = new();
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg);
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync();
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		var round = arena.Rounds.First();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -57,7 +57,7 @@ public class ArenaClientTests
 		mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 		mockRpc.Setup(rpc => rpc.SendBatchAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, mockRpc, round);
+		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 
 		using var memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -204,7 +204,7 @@ public class ArenaClientTests
 		Alice alice2 = WabiSabiFactory.CreateAlice(key: key2, round: round);
 		round.Alices.Add(alice2);
 
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, round);
+		using Arena arena = await ArenaBuilder.From(config).CreateAndStartAsync(round);
 
 		var mockRpc = new Mock<IRPCClient>();
 		using var memoryCache = new MemoryCache(new MemoryCacheOptions());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -29,14 +29,14 @@ public class BobClientTests
 		SmartCoin coin1 = BitcoinFactory.CreateSmartCoin(key, Money.Coins(2m));
 
 		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin);
-		using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(config, mockRpc, round);
+		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 
 		using var memoryCache = new MemoryCache(new MemoryCacheOptions());
 		var idempotencyRequestCache = new IdempotencyRequestCache(memoryCache);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena);
 
-		var insecureRandom = new InsecureRandom();
+		using var insecureRandom = new InsecureRandom();
 		var roundState = RoundState.FromRound(round);
 		var aliceArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),

--- a/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
@@ -46,6 +46,11 @@ public class Prison
 		Punish(alice.Coin.Outpoint, Punishment.Banned, lastDisruptedRoundId);
 	}
 
+	public void Ban(OutPoint outpoint, uint256 lastDisruptedRoundId)
+	{
+		Punish(outpoint, Punishment.Banned, lastDisruptedRoundId);
+	}
+
 	public void Punish(OutPoint utxo, Punishment punishment, uint256 lastDisruptedRoundId)
 		=> Punish(new Inmate(utxo, punishment, DateTimeOffset.UtcNow, lastDisruptedRoundId));
 

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -35,3 +35,18 @@ public enum WabiSabiProtocolErrorCode
 	AliceAlreadySignalled,
 	AliceAlreadyConfirmedConnection
 }
+
+public static class WabiSabiProtocolErrorCodeExtension
+{
+	public static bool IsEvidencingClearMisbehavior(this WabiSabiProtocolErrorCode errorCode) =>
+		errorCode
+			is WabiSabiProtocolErrorCode.InputSpent
+			or WabiSabiProtocolErrorCode.WrongOwnershipProof
+			or WabiSabiProtocolErrorCode.ScriptNotAllowed
+			or WabiSabiProtocolErrorCode.NonStandardInput
+			or WabiSabiProtocolErrorCode.NonStandardOutput
+			or WabiSabiProtocolErrorCode.DeltaNotZero
+			or WabiSabiProtocolErrorCode.WrongNumberOfCreds
+			or WabiSabiProtocolErrorCode.NonUniqueInputs
+			or WabiSabiProtocolErrorCode.CryptoException;
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -360,13 +360,5 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceId}) not found.");
 
 	private static bool IsUserCheating(Exception e) =>
-		e is WabiSabiCryptoException || e is WabiSabiProtocolException wpe && wpe.ErrorCode
-			is WabiSabiProtocolErrorCode.InputSpent
-			or WabiSabiProtocolErrorCode.WrongOwnershipProof
-			or WabiSabiProtocolErrorCode.ScriptNotAllowed
-			or WabiSabiProtocolErrorCode.NonStandardInput
-			or WabiSabiProtocolErrorCode.NonStandardOutput
-			or WabiSabiProtocolErrorCode.DeltaNotZero
-			or WabiSabiProtocolErrorCode.WrongNumberOfCreds
-			or WabiSabiProtocolErrorCode.CryptoException;
+		e is WabiSabiCryptoException || (e is WabiSabiProtocolException wpe && wpe.ErrorCode.IsEvidencingClearMisbehavior());
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Crypto;
+using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
@@ -16,6 +17,19 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds;
 public partial class Arena : IWabiSabiApiRequestHandler
 {
 	public async Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request, CancellationToken cancellationToken)
+	{
+		try
+		{
+			return await RegisterInputCoreAsync(request, cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception ex) when (IsUserCheating(ex))
+		{
+			Prison.Ban(request.Input, request.RoundId);
+			throw;
+		}
+	}
+
+	private async Task<InputRegistrationResponse> RegisterInputCoreAsync(InputRegistrationRequest request, CancellationToken cancellationToken)
 	{
 		var coin = await OutpointToCoinAsync(request, cancellationToken).ConfigureAwait(false);
 
@@ -114,6 +128,21 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	}
 
 	public async Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request, CancellationToken cancellationToken)
+	{
+		try
+		{
+			return await ConfirmConnectionCoreAsync(request, cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception ex) when (IsUserCheating(ex))
+		{
+			var round = GetRound(request.RoundId);
+			var alice = GetAlice(request.AliceId, round);
+			Prison.Ban(alice.Coin.Outpoint, round.Id);
+			throw;
+		}
+	}
+
+	private async Task<ConnectionConfirmationResponse> ConfirmConnectionCoreAsync(ConnectionConfirmationRequest request, CancellationToken cancellationToken)
 	{
 		Round round;
 		Alice alice;
@@ -329,4 +358,15 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	private Alice GetAlice(Guid aliceId, Round round) =>
 		round.Alices.Find(x => x.Id == aliceId)
 		?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.AliceNotFound, $"Round ({round.Id}): Alice ({aliceId}) not found.");
+
+	private static bool IsUserCheating(Exception e) =>
+		e is WabiSabiCryptoException || e is WabiSabiProtocolException wpe && wpe.ErrorCode
+			is WabiSabiProtocolErrorCode.InputSpent
+			or WabiSabiProtocolErrorCode.WrongOwnershipProof
+			or WabiSabiProtocolErrorCode.ScriptNotAllowed
+			or WabiSabiProtocolErrorCode.NonStandardInput
+			or WabiSabiProtocolErrorCode.NonStandardOutput
+			or WabiSabiProtocolErrorCode.DeltaNotZero
+			or WabiSabiProtocolErrorCode.WrongNumberOfCreds
+			or WabiSabiProtocolErrorCode.CryptoException;
 }


### PR DESCRIPTION
This PR improves the DoS protection by banning those alices that are clearly trying to fool the coordinator. The cleaner examples are those where the client is sending invalid cryptographic proofs, credentials or serial numbers. In this case it makes no sense to allow those coins to be used again because they are in control of an attacker.

Additionally, this PR removes duplicated code from `WabiSabiFactory` and uses the more convenient `ArenaBuilder`. 