### PR TITLE
Txfee slider: Name vertical axis "Fee Rate"

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -180,7 +180,7 @@
             <Setter Property="AreaMinViableWidth" Value="40"/>
             <Setter Property="AreaMinViableHeight" Value="20"/>
             <Setter Property="Focusable" Value="True"/>
-            <Setter Property="YAxisTitle" Value="Fee Amount (sat/vByte)"/>
+            <Setter Property="YAxisTitle" Value="Fee Rate (sat/vByte)"/>
           </Style>
           <Style Selector="c|LineChart.narrow">
             <Setter Property="AreaMargin" Value="30,0,10,45"/>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -180,7 +180,7 @@
             <Setter Property="AreaMinViableWidth" Value="40"/>
             <Setter Property="AreaMinViableHeight" Value="20"/>
             <Setter Property="Focusable" Value="True"/>
-            <Setter Property="YAxisTitle" Value="Increasing Cost (sat/vByte)"/>
+            <Setter Property="YAxisTitle" Value="Fee Amount (sat/vByte)"/>
           </Style>
           <Style Selector="c|LineChart.narrow">
             <Setter Property="AreaMargin" Value="30,0,10,45"/>


### PR DESCRIPTION
At the Transaction fee slider, the vertical axis should be named `Fee Rate` instead of "Increasing Cost".

![image](https://user-images.githubusercontent.com/93143998/150612408-476fc8b7-5b52-49fa-b6dd-f994f01be22f.png)
