### PR TITLE
[WabiSabi] Refactor MultiClient test and fix bug

### DIFF
--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -1,0 +1,108 @@
+using NBitcoin;
+using NBitcoin.Crypto;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Crypto;
+using WalletWasabi.WabiSabi.Client;
+
+namespace WalletWasabi.Tests.UnitTests;
+
+public class TestWallet : IKeyChain, IDestinationProvider
+{
+	public TestWallet(string name, IRPCClient rpc)
+	{
+		Rpc = rpc;
+		Key = new Key(Hashes.SHA256(Encoding.ASCII.GetBytes(name)));
+	}
+
+	private IRPCClient Rpc { get; }
+	private List<Coin> Utxos { get; } = new ();
+	private Key Key { get; }
+	public PubKey PubKey => Key.PubKey;
+	public Script ScriptPubKey => Key.GetScriptPubKey(ScriptPubKeyType.Segwit);
+	public BitcoinAddress Address => Key.PubKey.GetAddress(ScriptPubKeyType.Segwit, Rpc.Network);
+
+	public async Task GenerateAsync(int blocks, CancellationToken cancellationToken)
+	{
+		var blockIds = await Rpc.GenerateToAddressAsync(blocks, Address, cancellationToken).ConfigureAwait(false);
+		foreach(var blockId in blockIds)
+		{
+			var block = await Rpc.GetBlockAsync(blockId, cancellationToken).ConfigureAwait(false);
+			var coinbaseTx = block.Transactions[0];
+			ScanTransaction(coinbaseTx);
+		}
+	}
+
+	public Transaction CreateSelfTransfer(FeeRate feeRate)
+	{
+		var biggestUtxo = Utxos.MaxBy(x => x.Amount);
+		var tx = Rpc.Network.CreateTransaction();
+		tx.Inputs.Add(biggestUtxo.Outpoint);
+		tx.Outputs.Add(biggestUtxo.Amount - feeRate.GetFee(82), Address);
+		return tx;
+	}
+
+	public async Task<uint256> SendToAsync(Money amount, Script scriptPubKey, FeeRate feeRate, CancellationToken cancellationToken)
+	{
+		var cost = feeRate.GetFee(113);
+		var tx = CreateSelfTransfer(FeeRate.Zero);
+		if (tx.Outputs[0].Value < amount + cost)
+		{
+			throw new ArgumentException("Not enought satoshis in input.");
+		}
+		tx.Outputs[0].Value -= (amount + cost);
+		tx.Outputs.Add(amount, scriptPubKey);
+		return await SendRawTransactionAsync(tx, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<uint256> SendRawTransactionAsync(Transaction tx, CancellationToken cancellationToken)
+	{
+		var txid = await Rpc.SendRawTransactionAsync(tx, cancellationToken).ConfigureAwait(false);
+		ScanTransaction(tx);
+		return txid;
+	}
+
+	public Transaction SignTransaction(Transaction tx)
+	{
+		var signedTx = tx.Clone();
+		var inputTable = signedTx.Inputs.Select(x => x.PrevOut).ToHashSet();
+		var inputsToSign = Utxos.Where(x => inputTable.Contains(x.Outpoint));
+		signedTx.Sign(Key.GetBitcoinSecret(Rpc.Network), inputsToSign);
+		return signedTx;
+	}
+	private void ScanTransaction(Transaction tx)
+	{
+		foreach(var indexedOutput in tx.Outputs.AsIndexedOutputs())
+		{
+			if(indexedOutput.TxOut.ScriptPubKey == ScriptPubKey)
+			{
+				Utxos.Add(indexedOutput.ToCoin());
+			}
+		}
+	}
+
+	public OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData commitedData)
+	{
+		using var identificationKey = new Key();
+		return OwnershipProof.GenerateCoinJoinInputProof(
+				Key,
+				new OwnershipIdentifier(identificationKey, ScriptPubKey),
+				commitedData);
+	}
+
+	public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof)
+	{
+		transaction.Sign(Key.GetBitcoinSecret(Rpc.Network), coin);
+		return transaction;
+	}
+
+	public IEnumerable<IDestination> GetNextDestinations(int count)
+	{
+		return Enumerable.Repeat(Address, count);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -105,6 +105,7 @@ public class TestWallet : IKeyChain, IDestinationProvider, IDisposable
 				commitedData);
 	}
 
+    /// <remarks>Test wallet assumes that the ownership proof is always correct.</remarks>
 	public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof)
 	{
 		ThrowIfDisposed();

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -17,7 +17,7 @@ public class TestWallet : IKeyChain, IDestinationProvider
 	public TestWallet(string name, IRPCClient rpc)
 	{
 		Rpc = rpc;
-		Key = new Key(Hashes.SHA256(Encoding.ASCII.GetBytes(name)));
+		Key = new Key(Hashes.SHA256(Encoding.UTF8.GetBytes(name)));
 	}
 
 	private IRPCClient Rpc { get; }

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -41,7 +41,7 @@ public class TestWallet : IKeyChain, IDestinationProvider, IDisposable
 		}
 	}
 
-	public Transaction CreateSelfTransfer(FeeRate feeRate)
+	public (Transaction, Coin) CreateTemplateTransaction()
 	{
 		ThrowIfDisposed();
 		var biggestUtxo = Utxos.MaxBy(x => x.Amount);
@@ -53,7 +53,14 @@ public class TestWallet : IKeyChain, IDestinationProvider, IDisposable
 
 		var tx = Rpc.Network.CreateTransaction();
 		tx.Inputs.Add(biggestUtxo.Outpoint);
-		tx.Outputs.Add(biggestUtxo.Amount - feeRate.GetFee(Constants.P2wpkhOutputSizeInBytes), Address);
+		return (tx, biggestUtxo);
+	}
+
+	public Transaction CreateSelfTransfer(FeeRate feeRate)
+	{
+		ThrowIfDisposed();
+		var (tx, spendingCoin) = CreateTemplateTransaction();
+		tx.Outputs.Add(spendingCoin.Amount - feeRate.GetFee(Constants.P2wpkhOutputSizeInBytes), Address);
 		return tx;
 	}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -86,7 +86,7 @@ internal class Participant: IDisposable
 		var walletHdPubKey = new HdPubKey(Wallet.PubKey, KeyPath.Parse("m/84'/0/0/0/0"), SmartLabel.Empty, KeyState.Clean);
 		walletHdPubKey.SetAnonymitySet(1); // bug if not settled
 
-		if (SplitTransaction != null)
+		if (SplitTransaction is null)
 		{
 			throw new InvalidOperationException($"{nameof(GenerateCoinsAsync)} has to be called first.");
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -392,7 +392,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			var mempool = await rpc.GetRawMempoolAsync();
 			var coinjoin = await rpc.GetRawTransactionAsync(mempool.Single());
 
-			Assert.True(coinjoin.Outputs.Count >= ExpectedInputNumber);
+			Assert.True(coinjoin.Outputs.Count <= ExpectedInputNumber);
 			Assert.True(coinjoin.Inputs.Count == ExpectedInputNumber);
 		}
 		finally

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -356,20 +356,20 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 			var participants = Enumerable
 				.Range(0, NumberOfParticipants)
-				.Select(_ => new Participant(rpc, mockHttpClientFactory.Object))
+				.Select(i => new Participant($"participant{i}", rpc, mockHttpClientFactory.Object))
 				.ToArray();
 
 			foreach (var participant in participants)
 			{
 				await participant.GenerateSourceCoinAsync(cts.Token);
 			}
-			using var dummyKey = new Key();
-			await rpc.GenerateToAddressAsync(101, dummyKey.PubKey.GetAddress(ScriptPubKeyType.Segwit, rpc.Network));
+			var dummyWallet = new TestWallet("dummy", rpc);
+			await dummyWallet.GenerateAsync(101, cts.Token);
 			foreach (var participant in participants)
 			{
 				await participant.GenerateCoinsAsync(NumberOfCoinsPerParticipant, seed, cts.Token);
 			}
-			await rpc.GenerateToAddressAsync(101, dummyKey.PubKey.GetAddress(ScriptPubKeyType.Segwit, rpc.Network));
+			await dummyWallet.GenerateAsync(101, cts.Token);
 
 			var tasks = participants.Select(x => x.StartParticipatingAsync(cts.Token)).ToArray();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Reactive.Disposables;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -359,11 +360,12 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				.Select(i => new Participant($"participant{i}", rpc, mockHttpClientFactory.Object))
 				.ToArray();
 
+			using var disposableParticipants = new CompositeDisposable(participants);
 			foreach (var participant in participants)
 			{
 				await participant.GenerateSourceCoinAsync(cts.Token);
 			}
-			var dummyWallet = new TestWallet("dummy", rpc);
+			using var dummyWallet = new TestWallet("dummy", rpc);
 			await dummyWallet.GenerateAsync(101, cts.Token);
 			foreach (var participant in participants)
 			{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -21,7 +21,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinClient
 {
-	private const int MaxInputsRegistrableByWallet = 10; // how many
+	const int MaxInputsRegistrableByWallet = 10; // how many
 	private volatile bool _inCriticalCoinJoinState;
 
 	/// <param name="minAnonScoreTarget">Coins those have reached anonymity target, but still can be mixed if desired.</param>
@@ -319,7 +319,7 @@ public class CoinJoinClient
 		List<IEnumerable<SmartCoin>> groups = new();
 
 		// I can take more coins those are already reached the minimum privacy threshold.
-		int nonPrivateCoinCount = filteredCoins.Where(x => x.HdPubKey.AnonymitySet < MinAnonScoreTarget).Count();
+		int nonPrivateCoinCount = filteredCoins.Count(x => x.HdPubKey.AnonymitySet < MinAnonScoreTarget);
 		for (int i = 0; i < nonPrivateCoinCount; i++)
 		{
 			// Make sure the group can at least register an output even after paying fees.
@@ -352,7 +352,7 @@ public class CoinJoinClient
 			anonScoreCosts.Add((cost, group));
 		}
 
-		var bestCost = anonScoreCosts.Select(g => g.Cost).Min();
+		var bestCost = anonScoreCosts.Min(g => g.Cost);
 		var bestgroups = anonScoreCosts.Where(x => x.Cost == bestCost).Select(x => x.Group);
 
 		// Select the group where the less coins coming from the same tx.
@@ -374,6 +374,7 @@ public class CoinJoinClient
 	/// <returns>Desired input count.</returns>
 	private int GetInputTarget(int utxoCount)
 	{
+		const int MaxInputsRegistrableByWallet = 10; // how many
 		int targetInputCount;
 		if (utxoCount < 35)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -248,7 +248,9 @@ public class CoinJoinClient
 	private bool SanityCheck(IEnumerable<TxOut> expectedOutputs, Transaction unsignedCoinJoinTransaction)
 	{
 		var coinJoinOutputs = unsignedCoinJoinTransaction.Outputs.Select(o => (o.Value, o.ScriptPubKey));
-		var expectedOutputTuples = expectedOutputs.Select(o => (o.Value, o.ScriptPubKey));
+		var expectedOutputTuples = expectedOutputs
+			.GroupBy(x => x.ScriptPubKey)
+			.Select(o => (o.Select(x => x.Value).Sum(), o.Key));
 		return coinJoinOutputs.IsSuperSetOf(expectedOutputTuples);
 	}
 


### PR DESCRIPTION
This PR simplifies the `MultiClientsCoinJoinTest` test by moving reusable logic from `Participant` class  to `TestWallet` class. `TestWallet` is a tiny wallet similar to the Bitcoin Core `MiniWallet` that is used for testing.

By playing with this I found a few bugs that worth to mention:

* [BUG] When clients register more than one output using the same scriptPubKey the coordinator consolidates them in a single output but the client's sanity check was not aware of that behavior and detected there were missing outputs and for that reason it aborted and didn't sign the coinjoin transaction. **FIXED**
* [BUG] in `CoinJoinClient::SelectCoinsForRound` there are many ways end up with a `Sequence contains no elements` exceptions. The one that repeated more happens when `groups` is empty. I didn't fix it because I don't fully understand the logic and there are no unit test. I will address this in next PRs.

