### PR TITLE
[WabiSabi] Remove redundant tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -56,10 +56,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 	}
 
 	[Theory]
-	[InlineData(new long[] { 20_000_000, 40_000_000, 60_000_000, 80_000_000 })]
 	[InlineData(new long[] { 10_000_000, 20_000_000, 30_000_000, 40_000_000, 100_000_000 })]
-	[InlineData(new long[] { 120_000_000 })]
-	[InlineData(new long[] { 100_000_000, 10_000_000, 10_000 })]
 	public async Task SoloCoinJoinTestAsync(long[] amounts)
 	{
 		int inputCount = amounts.Length;
@@ -165,8 +162,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 	[Theory]
 	[InlineData(new long[] { 20_000_000, 40_000_000, 60_000_000, 80_000_000 })]
-	[InlineData(new long[] { 10_000_000, 20_000_000, 30_000_000, 40_000_000, 100_000_000 })]
-	[InlineData(new long[] { 100_000_000, 10_000_000, 10_000 })]
 	public async Task CoinJoinWithBlameRoundTestAsync(long[] amounts)
 	{
 		int inputCount = amounts.Length;


### PR DESCRIPTION
The integration tests are responsible of most of the time required to run the test but many of them are simply redundant. For example, `SoloCoinJoinTest` runs exactly the same four time and the only thing that changes between runs are the number and amounts. `CoinJoinWithBlameRoundTes` is almost identical to `SoloCoinJoinTest` except that it doesn't sign the transactions and again it runs four times.

`MultiClientCoinJoinTest` is the most complex test that runs with 20 users and 2 coins each so, `SoloCoinJoinTest` is indeed unnecessary but anyway, instead of delete them this PR makes them run only once and with different numbers so, they provide some extra confidence.