### PR TITLE
Fix typos in test files

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CoinJoinTests.cs
@@ -1161,7 +1161,7 @@ public class CoinJoinTests
 			{
 				if (timeout.IsCompletedSuccessfully)
 				{
-					throw new TimeoutException("CoinJoin was not propagated.");
+					throw new TimeoutException("Coinjoin was not propagated.");
 				}
 
 				await Task.Delay(1000);
@@ -1179,7 +1179,7 @@ public class CoinJoinTests
 				{
 					if (timeout.IsCompletedSuccessfully)
 					{
-						throw new TimeoutException("CoinJoin was not noticed.");
+						throw new TimeoutException("Coinjoin was not noticed.");
 					}
 					await Task.Delay(1000);
 				}
@@ -1309,7 +1309,7 @@ public class CoinJoinTests
 			{
 				if (timeout.IsCompletedSuccessfully)
 				{
-					throw new TimeoutException("CoinJoin was not propagated.");
+					throw new TimeoutException("Coinjoin was not propagated.");
 				}
 				await Task.Delay(1000);
 			}

--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -146,7 +146,7 @@ public class CoinJoinAnonScoreTests
 	[Fact]
 	public void SelfAnonsetSanityCheck()
 	{
-		// If we have multiple same denomination in the same CoinJoin, then our anonset would be total coins/our coins.
+		// If we have multiple same denomination in the same coinjoin, then our anonset would be total coins/our coins.
 		var analyser = ServiceFactory.CreateBlockchainAnalyzer();
 		var othersOutputs = new[] { 1, 1, 1 };
 		var ownOutputs = new[] { 1, 1 };

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -234,14 +234,14 @@ public class ArenaClientTests
 		// We can't use ``emptyState.Finalize()` because this is not a valid transaction so we fake it
 		var finalizedEmptyState = new SigningState(emptyState.Parameters, emptyState.Inputs, emptyState.Outputs);
 
-		// No inputs in the CoinJoin.
+		// No inputs in the coinjoin.
 		await Assert.ThrowsAsync<ArgumentException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice1.Coin, coins[0].OwnershipProof, keyChain, finalizedEmptyState.CreateUnsignedTransaction(), CancellationToken.None));
 
 		var oneInput = emptyState.AddInput(alice1.Coin).Finalize();
 		round.CoinjoinState = oneInput;
 
-		// Trying to sign coins those are not in the CoinJoin.
+		// Trying to sign coins those are not in the coinjoin.
 		await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice2.Coin, coins[1].OwnershipProof, keyChain, oneInput.CreateUnsignedTransaction(), CancellationToken.None));
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -126,7 +126,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				}
 
 				);
-				// Emulate that the first coin is coming from a CoinJoin.
+				// Emulate that the first coin is coming from a coinjoin.
 				services.AddScoped(s => new InMemoryCoinJoinIdStore(new[] { coins.First().Coin.Outpoint.Hash }));
 			})).CreateClient();
 
@@ -382,7 +382,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			{
 				if (cts.IsCancellationRequested)
 				{
-					throw new TimeoutException("CoinJoin was not propagated.");
+					throw new TimeoutException("Coinjoin was not propagated.");
 				}
 
 				await Task.Delay(500, cts.Token);


### PR DESCRIPTION
Write "coinjoin" with small letters unless it starts a sentence or is part of name etc.

Breaking down #7047 in to smaller pieces. 