### PR TITLE
Fix typos in backend files

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -352,7 +352,7 @@ public class BlockchainController : ControllerBase
 			status.FilterCreationActive = true;
 		}
 
-		// Updating the status of CoinJoin
+		// Updating the status of coinjoin
 		var validInterval = TimeSpan.FromSeconds(Global.Coordinator.RoundConfig.InputRegistrationTimeout * 2);
 		if (validInterval < TimeSpan.FromHours(1))
 		{

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -550,7 +550,7 @@ public class ChaumianCoinJoinController : ControllerBase
 	}
 
 	/// <summary>
-	/// Alice asks for the final CoinJoin transaction.
+	/// Alice asks for the final coinjoin transaction.
 	/// </summary>
 	/// <param name="uniqueId">Unique identifier, obtained previously.</param>
 	/// <param name="roundId">Round identifier, obtained previously.</param>
@@ -558,8 +558,8 @@ public class ChaumianCoinJoinController : ControllerBase
 	/// <response code="200">Returns the coinjoin transaction.</response>
 	/// <response code="400">The provided uniqueId or roundId was malformed.</response>
 	/// <response code="404">If Alice or the round is not found.</response>
-	/// <response code="409">CoinJoin can only be requested from Signing phase.</response>
-	/// <response code="410">CoinJoin can only be requested from a Running round.</response>
+	/// <response code="409">Coinjoin can only be requested from Signing phase.</response>
+	/// <response code="410">Coinjoin can only be requested from a Running round.</response>
 	[HttpGet("coinjoin")]
 	[ProducesResponseType(200)]
 	[ProducesResponseType(400)]
@@ -597,7 +597,7 @@ public class ChaumianCoinJoinController : ControllerBase
 			default:
 				{
 					TryLogLateRequest(roundId, RoundPhase.Signing);
-					return Conflict($"CoinJoin can only be requested from Signing phase. Current phase: {phase}.");
+					return Conflict($"Coinjoin can only be requested from Signing phase. Current phase: {phase}.");
 				}
 		}
 	}
@@ -609,7 +609,7 @@ public class ChaumianCoinJoinController : ControllerBase
 	/// <param name="roundId">Round identifier, obtained previously.</param>
 	/// <param name="signatures">Dictionary that has an int index as its key and string witness as its value.</param>
 	/// <returns>Hx of the coinjoin transaction.</returns>
-	/// <response code="204">CoinJoin successfully signed.</response>
+	/// <response code="204">Coinjoin successfully signed.</response>
 	/// <response code="400">The provided uniqueId, roundId or witnesses were malformed.</response>
 	/// <response code="409">Signatures can only be provided from Signing phase.</response>
 	/// <response code="410">Signatures can only be provided from a Running round.</response>
@@ -701,15 +701,15 @@ public class ChaumianCoinJoinController : ControllerBase
 			default:
 				{
 					TryLogLateRequest(roundId, RoundPhase.Signing);
-					return Conflict($"CoinJoin can only be requested from Signing phase. Current phase: {phase}.");
+					return Conflict($"Coinjoin can only be requested from Signing phase. Current phase: {phase}.");
 				}
 		}
 	}
 
 	/// <summary>
-	/// Gets the list of unconfirmed CoinJoin transaction Ids.
+	/// Gets the list of unconfirmed coinjoin transaction Ids.
 	/// </summary>
-	/// <returns>The list of CoinJoin transactions in the mempool.</returns>
+	/// <returns>The list of coinjoin transactions in the mempool.</returns>
 	/// <response code="200">An array of transaction Ids</response>
 	[HttpGet("unconfirmed-coinjoins")]
 	[ProducesResponseType(200)]

--- a/WalletWasabi.Backend/wwwroot/css/style.css
+++ b/WalletWasabi.Backend/wwwroot/css/style.css
@@ -382,7 +382,7 @@ section {
             transform: translateY(0%);
         }
 
-/* CoinJoins Section */
+/* Coinjoins Section */
 .coinjoins .illustration {
     width: 100%;
     height: auto;

--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -3,30 +3,30 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="title" content="Wasabi Wallet - Bitcoin privacy wallet with built-in CoinJoin">
-    <meta name="description" content="Wasabi is an open-source, non-custodial, privacy-focused Bitcoin wallet for Desktop, that implements trustless CoinJoin over the Tor anonymity network.">
+    <meta name="title" content="Wasabi Wallet - Bitcoin privacy wallet with built-in coinjoin">
+    <meta name="description" content="Wasabi is an open-source, non-custodial, privacy-focused Bitcoin wallet for desktop, that implements trustless coinjoin over the Tor anonymity network.">
     <meta http-equiv="onion-location" content="http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://wasabiwallet.io">
-    <meta property="og:title" content="Wasabi Wallet - Bitcoin privacy wallet with built-in CoinJoin">
-    <meta property="og:description" content="Wasabi is an open-source, non-custodial, privacy-focused Bitcoin wallet for Desktop, it implements trustless CoinJoin over the Tor anonymity network.">
+    <meta property="og:title" content="Wasabi Wallet - Bitcoin privacy wallet with built-in coinjoin">
+    <meta property="og:description" content="Wasabi is an open-source, non-custodial, privacy-focused Bitcoin wallet for desktop, it implements trustless coinjoin over the Tor anonymity network.">
     <meta property="og:image" content="https://wasabiwallet.io/images/wasabi-social.jpg">
-    <meta property="og:site_name" content="Wasabi Wallet - Bitcoin privacy wallet with built-in CoinJoin">
+    <meta property="og:site_name" content="Wasabi Wallet - Bitcoin privacy wallet with built-in coinjoin">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://wasabiwallet.io">
-    <meta property="twitter:title" content="Wasabi Wallet - Bitcoin privacy wallet with built-in CoinJoin">
-    <meta property="twitter:description" content="Wasabi is an open-source, non-custodial, privacy-focused Bitcoin wallet for Desktop, it implements trustless CoinJoin over the Tor anonymity network.">
+    <meta property="twitter:title" content="Wasabi Wallet - Bitcoin privacy wallet with built-in coinjoin">
+    <meta property="twitter:description" content="Wasabi is an open-source, non-custodial, privacy-focused Bitcoin wallet for desktop, it implements trustless coinjoin over the Tor anonymity network.">
     <meta property="twitter:image" content="https://wasabiwallet.io/images/wasabi-social.jpg">
 
     <link rel="stylesheet" href="css/bootstrap.css?ver=1.1.0">
     <link rel="stylesheet" href="css/style.css?ver=1.1.0">
     <link rel="shortcut icon" href="images/favicon.ico">
     <link rel="canonical" href="https://wasabiwallet.io">
-    <title>Wasabi Wallet - Bitcoin privacy wallet with built-in CoinJoin</title>
+    <title>Wasabi Wallet - Bitcoin privacy wallet with built-in coinjoin</title>
 </head>
 <body>
     <div itemscope itemtype="https://schema.org/SoftwareApplication">
@@ -83,7 +83,7 @@
                     <div class="col-sm-7 col-xl-4 offset-xl-1 align-self-center">
                         <div class="px-2 py-4 pt-5 mb-2 mb-sm-0">
                             <h1 class="text-lowercase mb-lg-3 d-none d-sm-block mt-3 mt-lg-0">Reclaim your privacy now</h1>
-                            <p class="mb-lg-3"><span itemprop="name">Wasabi</span> is an <strong>open-source, non-custodial, privacy-focused Bitcoin wallet</strong> for <span itemprop="availableOnDevice">Desktop</span>, that implements trustless <strong>CoinJoin</strong>.</p>
+                            <p class="mb-lg-3"><span itemprop="name">Wasabi</span> is an <strong>open-source, non-custodial, privacy-focused Bitcoin wallet</strong> for <span itemprop="availableOnDevice">desktop</span>, that implements trustless <strong>coinjoin</strong>.</p>
 
                             <a href="#download" class="text-uppercase text-dark arrow-right text-center animated-link">
                                 <span data-hover="Download now">Download now</span>
@@ -131,7 +131,7 @@
             <section class="features box-shadow-lg mx-auto mb-5 mb-sm-2">
                 <div class="row row-eq-height">
                     <div class="col-6 col-sm-3 p-0 border-right border-bottom border-bottom-sm-0">
-                        <a href="https://docs.wasabiwallet.io/using-wasabi/CoinJoin.html" title="Read more about CoinJoin" class="feature text-center py-3 px-2 px-md-3 d-block text-dark" target="_blank">
+                        <a href="https://docs.wasabiwallet.io/using-wasabi/CoinJoin.html" title="Read more about coinjoin" class="feature text-center py-3 px-2 px-md-3 d-block text-dark" target="_blank">
                             <svg class="d-block mb-2 m-auto" width="54" height="50" xmlns="http://www.w3.org/2000/svg">
                                 <g fill="#000" fill-rule="nonzero">
                                     <path d="M1.786 0H3.57v1.786H1.786zM1.786 8.929H3.57v1.785H1.786zM1.786 17.857H3.57v1.786H1.786zM36.607 0h15.179v1.786H36.607zM36.607 8.929h15.179v1.785H36.607zM36.607 17.857h15.179v1.786H36.607zM1.786 30.357H3.57v1.786H1.786zM1.786 39.286H3.57v1.785H1.786zM1.786 48.214H3.57V50H1.786zM36.607 30.357h15.179v1.786H36.607zM36.607 39.286h15.179v1.785H36.607zM36.607 48.214h15.179V50H36.607zM53.571 24.107h-2.843a2.679 2.679 0 0 0-2.514-1.786h-3.571a2.679 2.679 0 0 0-2.514 1.786h-1.222a2.679 2.679 0 0 0-2.514-1.786H34.82a2.679 2.679 0 0 0-2.514 1.786h-1.221a2.679 2.679 0 0 0-2.515-1.786H25a2.679 2.679 0 0 0-2.514 1.786h-1.222a2.679 2.679 0 0 0-2.514-1.786h-3.571a2.679 2.679 0 0 0-2.515 1.786h-1.221a2.679 2.679 0 0 0-2.514-1.786H5.357a2.679 2.679 0 0 0-2.514 1.786H0v1.786h2.843a2.679 2.679 0 0 0 2.514 1.786H8.93a2.679 2.679 0 0 0 2.514-1.786h1.221a2.679 2.679 0 0 0 2.515 1.786h3.571a2.679 2.679 0 0 0 2.514-1.786h1.222A2.679 2.679 0 0 0 25 27.679h3.571a2.679 2.679 0 0 0 2.515-1.786h1.221a2.679 2.679 0 0 0 2.514 1.786h3.572a2.679 2.679 0 0 0 2.514-1.786h1.222a2.679 2.679 0 0 0 2.514 1.786h3.571a2.679 2.679 0 0 0 2.514-1.786h2.843v-1.786zM5.357 25.893v-1.786H8.93v1.786H5.357zm9.822 0v-1.786h3.571v1.786h-3.571zm9.821 0v-1.786h3.571v1.786H25zm9.821 0v-1.786h3.572v1.786H34.82zm9.822 0v-1.786h3.571v1.786h-3.571zM34.821 19.643H25a.893.893 0 0 1-.883-.76L21.553 1.785H5.357V0h16.964c.442 0 .818.323.883.76l2.565 17.097h9.052v1.786z" />
@@ -140,7 +140,7 @@
                                 </g>
                             </svg>
                             <br />
-                            <span class="text-uppercase font-weight-bold">Built-In CoinJoins</span>
+                            <span class="text-uppercase font-weight-bold">Built-In coinjoins</span>
                         </a>
                     </div>
                     <div class="col-6 col-sm-3 p-0 border-right border-bottom border-bottom-sm-0">
@@ -180,7 +180,7 @@
                 </div>
             </section>
 
-            <!-- CoinJoins Section -->
+            <!-- Coinjoins Section -->
             <section class="coinjoins mb-4">
                 <div class="container">
                     <div class="row">
@@ -191,10 +191,10 @@
                     <div class="row">
                         <div class="col-sm-6">
                             <p class="mb-2">
-                                Wasabi creates <strong>trustless CoinJoin</strong> transactions over the Tor anonymity network. The <strong>CoinJoin</strong> coordinator cannot steal from, nor breach the <strong>privacy</strong> of the participants.
+                                Wasabi creates <strong>trustless coinjoin</strong> transactions over the Tor anonymity network. The <strong>coinjoin</strong> coordinator cannot steal from, nor breach the <strong>privacy</strong> of the participants.
                             </p>
-                            <a class="mb-3 d-inline-block" href="https://docs.wasabiwallet.io/using-wasabi/CoinJoin.html" title="Read more about CoinJoin" target="_blank">
-                                <small>Learn more about CoinJoins ></small>
+                            <a class="mb-3 d-inline-block" href="https://docs.wasabiwallet.io/using-wasabi/CoinJoin.html" title="Read more about coinjoin" target="_blank">
+                                <small>Learn more about coinjoins ></small>
                             </a>
 
                             <div class="coinjoin-txs box-shadow-lg">
@@ -218,7 +218,7 @@
                                                     </g>
                                                 </g>
                                             </g>
-                                        </svg> Wasabi CoinJoin Examples
+                                        </svg> Wasabi Coinjoin Examples
                                     </span>
                                     <input type="checkbox" id="cjTxs" class="toggle-input toggle-xs" />
                                     <label class="text-light pl-2 mb-2 d-block d-sm-none toggle-label toggle-xs" for="cjTxs">
@@ -227,30 +227,30 @@
                                     <ul class="list-group list-group-flush toggle-content toggle-xs">
                                         <li class="tx list-group-item text-ellipsis">
                                             <img src="images/icon-external.svg?ver=1.1.0" alt="External link icon" loading="lazy">
-                                            <a class="text-light" rel="external nofollow" title="View CoinJoin transaction in a block explorer" href="https://blockstream.info/tx/e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174" target="_blank"> e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174 </a>
+                                            <a class="text-light" rel="external nofollow" title="View coinjoin transaction in a block explorer" href="https://blockstream.info/tx/e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174" target="_blank"> e4a789d16a24a6643dfee06e018ad27648b896daae6a3577ae0f4eddcc4d9174 </a>
                                         </li>
                                         <li class="tx list-group-item text-ellipsis">
                                             <img src="images/icon-external.svg?ver=1.1.0" alt="External link icon" loading="lazy">
-                                            <a class="text-light" rel="external nofollow" title="View CoinJoin transaction in a block explorer" href="https://blockstream.info/tx/c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8" target="_blank"> c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8 </a>
+                                            <a class="text-light" rel="external nofollow" title="View coinjoin transaction in a block explorer" href="https://blockstream.info/tx/c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8" target="_blank"> c69aed505ca50473e2883130221915689c1474be3c66bcf7ac7dc0e26246afc8 </a>
                                         </li>
                                         <li class="tx list-group-item text-ellipsis">
                                             <img src="images/icon-external.svg?ver=1.1.0" alt="External link icon" loading="lazy">
-                                            <a class="text-light" rel="external nofollow" title="View CoinJoin transaction in a block explorer" href="https://blockstream.info/tx/ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce" target="_blank"> ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce </a>
+                                            <a class="text-light" rel="external nofollow" title="View coinjoin transaction in a block explorer" href="https://blockstream.info/tx/ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce" target="_blank"> ef329b3ed8e790f10f0b522346f1b3d9f1c9d45dfa5b918e92d6f0a25d91c7ce </a>
                                         </li>
                                         <li class="tx list-group-item text-ellipsis">
                                             <img src="images/icon-external.svg?ver=1.1.0" alt="External link icon" loading="lazy">
-                                            <a class="text-light" rel="external nofollow" title="View CoinJoin transaction in a block explorer" href="https://blockstream.info/tx/f82206145413db5c1272d5609c88581c414815e36e400aee6410e0de9a2d46b5" target="_blank"> f82206145413db5c1272d5609c88581c414815e36e400aee6410e0de9a2d46b5 </a>
+                                            <a class="text-light" rel="external nofollow" title="View coinjoin transaction in a block explorer" href="https://blockstream.info/tx/f82206145413db5c1272d5609c88581c414815e36e400aee6410e0de9a2d46b5" target="_blank"> f82206145413db5c1272d5609c88581c414815e36e400aee6410e0de9a2d46b5 </a>
                                         </li>
                                         <li class="tx list-group-item text-ellipsis">
                                             <img src="images/icon-external.svg?ver=1.1.0" alt="External link icon" loading="lazy">
-                                            <a class="text-light" rel="external nofollow" title="View CoinJoin transaction in a block explorer" href="https://blockstream.info/tx/a7157780b7c696ab24767113d9d34cdbc0eba5c394c89aec4ed1a9feb326bea5" target="_blank"> a7157780b7c696ab24767113d9d34cdbc0eba5c394c89aec4ed1a9feb326bea5 </a>
+                                            <a class="text-light" rel="external nofollow" title="View coinjoin transaction in a block explorer" href="https://blockstream.info/tx/a7157780b7c696ab24767113d9d34cdbc0eba5c394c89aec4ed1a9feb326bea5" target="_blank"> a7157780b7c696ab24767113d9d34cdbc0eba5c394c89aec4ed1a9feb326bea5 </a>
                                         </li>
                                     </ul>
                                 </div>
                             </div>
                         </div>
                         <div class="col-sm-6">
-                            <img class="illustration" src="images/illustration-coinjoin.svg?ver=1.1.0" alt="CoinJoin illustration" loading="lazy">
+                            <img class="illustration" src="images/illustration-coinjoin.svg?ver=1.1.0" alt="Coinjoin illustration" loading="lazy">
                         </div>
                     </div>
                 </div>
@@ -400,7 +400,7 @@
                     <div class="card bg-white box-shadow border-light mb-2" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
                         <input type="checkbox" id="faq1" class="toggle-input" />
                         <label class="card-header bg-light font-weight-bold text-uppercase border-0 toggle-label pr-3" for="faq1" itemprop="name">
-                            What is a “CoinJoin”?
+                            What is a “coinjoin”?
                         </label>
                         <div class="card-body toggle-content p-0" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
                             <p class="card-text border-top p-2" itemprop="text">
@@ -410,11 +410,11 @@
                                 <br /><br />
                                 It’s possible to do this in a decentralized way so that the service does not rely on external parties or centralized servers. It just needs the participants of the transaction.
                                 <br /><br />
-                                CoinJoin can be applied multiple times, and as many transactions are grouped together, participants may save on transaction fees. CoinJoin is the preferred method of gaining privacy in the Bitcoin network.
+                                Coinjoin can be applied multiple times, and as many transactions are grouped together, participants may save on transaction fees. Coinjoin is the preferred method of gaining privacy in the Bitcoin network.
                                 <br /><br />
-                                CoinJoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.
+                                Coinjoin means: “when you want to make a transaction, find someone else who also wants to make a transaction and make a joint transaction together”.
                                 <br /><br />
-                                <small>Further reading: <a href="https://en.bitcoin.it/wiki/CoinJoin" title="Read Bitcoin Wiki's CoinJoin page" target="_blank" rel="external nofollow">en.bitcoin.it/wiki/CoinJoin</a></small>
+                                <small>Further reading: <a href="https://en.bitcoin.it/wiki/CoinJoin" title="Read Bitcoin Wiki's coinjoin page" target="_blank" rel="external nofollow">en.bitcoin.it/wiki/CoinJoin</a></small>
                             </p>
                         </div>
                     </div>
@@ -428,7 +428,7 @@
                             <p class="card-text border-top p-2" itemprop="text">
                                 No, Wasabi's coinjoin implementation is trustless by design. The participants do not need to trust each other or any third party. Both the sending address (the coinjoin input) and the receiving address (the coinjoin output) are controlled by your own private keys. Wasabi merely coordinates the process of combining the inputs of the participants into one single transaction, but the wallet can neither steal your coins, nor figure out which outputs belong to which inputs.
                                 <br /><br />
-                                <small>Further reading: <a href="https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin" title="Read more about Chaumian CoinJoin" target="_blank" rel="external nofollow">Chaumian Coinjoin</a></small>
+                                <small>Further reading: <a href="https://github.com/nopara73/ZeroLink#ii-chaumian-coinjoin" title="Read more about Chaumian Coinjoin" target="_blank" rel="external nofollow">Chaumian Coinjoin</a></small>
                             </p>
                         </div>
                     </div>
@@ -464,7 +464,7 @@
                     <div class="card bg-white box-shadow border-light mb-2" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
                         <input type="checkbox" id="faq6" class="toggle-input" />
                         <label class="card-header bg-light font-weight-bold text-uppercase border-0 toggle-label pr-3" for="faq6" itemprop="name">
-                            What are the fees for CoinJoins?
+                            What are the fees for coinjoins?
                         </label>
                         <div class="card-body toggle-content p-0" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
                             <p class="card-text border-top p-2" itemprop="text">
@@ -486,7 +486,7 @@
                             <p class="card-text border-top p-2" itemprop="text">
                                 The anonymity set is effectively the size of the group you are hiding in.
                                 <br /><br />
-                                If 3 people take part in a CoinJoin (with equal size inputs) and there are 3 outputs then each of those output coins has an anonymity set of 3.
+                                If 3 people take part in a coinjoin (with equal size inputs) and there are 3 outputs then each of those output coins has an anonymity set of 3.
                                 <br /><br />
                                 <code>
                                     0.1 BTC (Alice)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.1 BTC (Anon set 3)<br>


### PR DESCRIPTION
Write "coinjoin" with small letters unless it starts a sentence or is part of name etc.
Desktop with small "d" unless it starts a sentence.

Breaking down #7047 in to smaller pieces.