### PR TITLE
Fix typos in WabiSabi and CoinJoin folders

### DIFF
--- a/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/AliceClientBase.cs
@@ -183,7 +183,7 @@ public abstract class AliceClientBase
 		var coinjoinHex = await response.Content.ReadAsJsonAsync<string>().ConfigureAwait(false);
 
 		Transaction coinJoin = Transaction.Parse(coinjoinHex, Network.Main);
-		Logger.LogInfo($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned CoinJoin: {coinJoin.GetHash()}.");
+		Logger.LogInfo($"Round ({RoundId}), Alice ({UniqueId}): Acquired unsigned coinjoin: {coinJoin.GetHash()}.");
 		return coinJoin;
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -56,7 +56,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputNotWhitelisted);
 			}
 
-			// Compute but don't commit updated CoinJoin to round state, it will
+			// Compute but don't commit updated coinjoin to round state, it will
 			// be re-calculated on input confirmation. This is computed it here
 			// for validation purposes.
 			_ = round.Assert<ConstructionState>().AddInput(coin);
@@ -233,7 +233,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 							await amountRealCredentialTask.ConfigureAwait(false),
 							await vsizeRealCredentialTask.ConfigureAwait(false));
 
-						// Update the CoinJoin state, adding the confirmed input.
+						// Update the coinjoin state, adding the confirmed input.
 						round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice.Coin);
 						alice.ConfirmedConnection = true;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -166,7 +166,7 @@ public class CoinJoinClient
 
 			// Send signature.
 			await SignTransactionAsync(registeredAliceClients, unsignedCoinJoin, roundState, cancellationToken).ConfigureAwait(false);
-			Logger.LogDebug($"Round ({roundState.Id}): Alices({registeredAliceClients.Length}) successfully signed the CoinJoin tx.");
+			Logger.LogDebug($"Round ({roundState.Id}): Alices({registeredAliceClients.Length}) successfully signed the coinjoin tx.");
 
 			var finalRoundState = await RoundStatusUpdater.CreateRoundAwaiter(s => s.Id == roundState.Id && s.Phase == Phase.Ended, cancellationToken).ConfigureAwait(false);
 			Logger.LogDebug($"Round ({roundState.Id}): Round Ended - WasTransactionBroadcast: '{finalRoundState.WasTransactionBroadcast}'.");


### PR DESCRIPTION
Write "coinjoin" with small letters unless it starts a sentence or is part of name etc.
Includes spacing changes in WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs by my Visual Studio.

Breaking down #7047 in to smaller pieces.

