### PR TITLE
`WabiSabiHttpApiIntegrationTests`: Fix NSE in `MultiClientsCoinJoinTestAsync`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
 
 public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
 {
-	// There is a deadlock in the current version of the asmp.net testing framework
+	// There is a deadlock in the current version of the asp.net testing framework
 	// https://www.strathweb.com/2021/05/the-curious-case-of-asp-net-core-integration-test-deadlock/
 	protected override IHost CreateHost(IHostBuilder builder)
 	{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -18,7 +19,6 @@ using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
-using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 
@@ -330,7 +330,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					// Instruct the coordinator DI container to use these two scoped
 					// services to build everything (WabiSabi controller, arena, etc)
 					services.AddScoped<IRPCClient>(s => rpc);
-					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig
+					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig(Path.GetTempFileName())
 					{
 						MaxRegistrableAmount = Money.Coins(500m),
 						MaxInputCountByRound = ExpectedInputNumber,


### PR DESCRIPTION
Fixes:

```
2022-01-24 08:04:52.748 [76] WARNING	Arena.Log (259)	Round (5d58ce5d9322ff70720a58116ac1fca08d40ecbcd1baae05685a9bbb5a1e1c4b): Signing phase failed, reason: 'System.NotSupportedException: FilePath is not set. Use SetFilePath to set it.
   at WalletWasabi.Bases.ConfigBase.AssertFilePathSet() in WalletWasabi\Bases\ConfigBase.cs:line 31
   at WalletWasabi.Bases.ConfigBase.ToFile() in WalletWasabi\Bases\ConfigBase.cs:line 110
   at WalletWasabi.WabiSabi.Backend.WabiSabiConfig.MakeNextCoordinatorScriptDirty() in WalletWasabi\WabiSabi\Backend\WabiSabiConfig.cs:line 107
   at WalletWasabi.WabiSabi.Backend.Rounds.Arena.StepTransactionSigningPhaseAsync(CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Backend\Rounds\Arena.cs:line 243'.
```