### PR TITLE
`amount` instead of "a total of" at prvw. tx

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -10,7 +10,7 @@
              x:Class="WalletWasabi.Fluent.Views.Wallets.Send.TransactionSummary">
   <StackPanel Spacing="15">
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Text="a total of">
+                     Text="amount">
         <TextBlock Text="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
       </c:PreviewItem>
 


### PR DESCRIPTION
`amount` fits better, because the fee will be added to the amount.
If it is "a total of" it could be confusing, because the fee will be added, i.e. it´s not the end/total amount that will be deducted from the users wallet.
![image](https://user-images.githubusercontent.com/93143998/150784653-1b9f7296-8e9a-4b46-aeb9-2d5a604c045b.png)
