### PR TITLE
Proper backend log message when the round is free for everyone

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -387,15 +387,15 @@ public partial class Arena : PeriodicRunner
 		}
 		else
 		{
-			coordinationFee -= round.FeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize());
+			var effectiveCoordinationFee = coordinationFee - round.FeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize());
 
-			if (coordinationFee > coinjoin.Parameters.AllowedOutputAmounts.Min)
+			if (effectiveCoordinationFee > coinjoin.Parameters.AllowedOutputAmounts.Min)
 			{
-				coinjoin = coinjoin.AddOutput(new TxOut(coordinationFee, coordinatorScriptPubKey));
+				coinjoin = coinjoin.AddOutput(new TxOut(effectiveCoordinationFee, coordinatorScriptPubKey));
 			}
 			else
 			{
-				round.LogWarning($"Coordination fee wasn't taken, because it was too small: {nameof(coordinationFee)}: {coordinationFee}.");
+				round.LogWarning($"Effective coordination fee wasn't taken, because it was too small: {effectiveCoordinationFee}.");
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the confusion log message on the backend when nobody is paying fees in the round. 

The current master will display this warning message: 

`2022-01-24 13:34:02.415 [93] WARNING	Arena.Log (392)	Round (): Coordinator fee wasn't taken, because it was too small: coordinationFee: -62.`

However nothing to warn about, so after this PR the message will be:

` Coordination fee wasn't taken, because it was free for everyone. Hurray!`

Better to review without whitespace changes: https://github.com/zkSNACKs/WalletWasabi/pull/7109/files?diff=split&w=1