### PR TITLE
Do not serialize redundant properties in `NBitcoin.Coin`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -142,6 +142,23 @@ public class SerializationTests
 		AssertSerialization(RoundState.FromRound(round));
 	}
 
+	[Fact]
+	public void CoinSerialization()
+	{
+		var coin = new Coin(
+			new OutPoint(
+				uint256.One,
+				1234),
+			new TxOut(
+				Money.Coins(1),
+				new Script("0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210")));
+		AssertSerialization(coin);
+
+		var serializedCoin = JsonConvert.SerializeObject(coin, JsonSerializationOptions.Default.Settings);
+		var expectedJson = "{\"Outpoint\":\"0100000000000000000000000000000000000000000000000000000000000000D2040000\",\"TxOut\":{\"ScriptPubKey\":\"0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210\",\"Value\":100000000}}";
+		Assert.Equal(expectedJson, serializedCoin);
+	}
+
 	private static void AssertSerialization<T>(T message)
 	{
 		var serializedMessage = JsonConvert.SerializeObject(message, JsonSerializationOptions.Default.Settings);

--- a/WalletWasabi/JsonConverters/Bitcoin/CoinJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/CoinJsonConverter.cs
@@ -8,7 +8,8 @@ public class CoinJsonConverter : JsonConverter<Coin>
 	/// <inheritdoc />
 	public override Coin? ReadJson(JsonReader reader, Type objectType, Coin? existingValue, bool hasExistingValue, JsonSerializer serializer)
 	{
-		var coin = serializer.Deserialize<SerializableCoin>(reader);
+		var coin = serializer.Deserialize<SerializableCoin>(reader)
+			?? throw new JsonSerializationException("Coin could not be deserialized.");
 		return new Coin(coin.Outpoint, coin.TxOut);
 	}
 

--- a/WalletWasabi/JsonConverters/Bitcoin/CoinJsonConverter.cs.cs
+++ b/WalletWasabi/JsonConverters/Bitcoin/CoinJsonConverter.cs.cs
@@ -1,0 +1,38 @@
+using NBitcoin;
+using Newtonsoft.Json;
+
+namespace WalletWasabi.JsonConverters.Bitcoin;
+
+public class CoinJsonConverter : JsonConverter<Coin>
+{
+	/// <inheritdoc />
+	public override Coin? ReadJson(JsonReader reader, Type objectType, Coin? existingValue, bool hasExistingValue, JsonSerializer serializer)
+	{
+		var coin = serializer.Deserialize<SerializableCoin>(reader);
+		return new Coin(coin.Outpoint, coin.TxOut);
+	}
+
+	/// <inheritdoc />
+	public override void WriteJson(JsonWriter writer, Coin? coin, JsonSerializer serializer)
+	{
+		if (coin is null)
+		{
+			throw new ArgumentNullException(nameof(coin));
+		}
+
+		var newCoin = new SerializableCoin(coin.Outpoint, coin.TxOut);
+		serializer.Serialize(writer, newCoin);
+	}
+
+	private class SerializableCoin
+	{
+		[JsonConstructor]
+		public SerializableCoin(OutPoint outpoint, TxOut txOut)
+		{
+			Outpoint = outpoint;
+			TxOut = txOut;
+		}
+		public OutPoint Outpoint { get; }
+		public TxOut TxOut { get; }
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -26,6 +26,7 @@ public class JsonSerializationOptions
 				new MultipartyTransactionStateJsonConverter(),
 				new ExtPubKeyJsonConverter(),
 				new TimeSpanJsonConverter(),
+				new CoinJsonConverter()
 			}
 	};
 	public static readonly JsonSerializationOptions Default = new();


### PR DESCRIPTION
Fixes #6856.

The `NBitcoin.Coin` class was serialized with the default serializer and then all the properties were included.

### Before this PR
```json
{
    "isMalleable": false,
    "canGetScriptCode": true,
    "outpoint": "61FEF11BC15B0A9F37C8C72F595BE12D1FFE20CD2B2AE0490D37A9A5028C104E15000000",
    "txOut": {
        "scriptPubKey": "0 fb1667cc73c57c4dbf28f1ef667a1c174d7954fb",
        "value": 177147
    },
    "amount": 177147,
    "scriptPubKey": "0 fb1667cc73c57c4dbf28f1ef667a1c174d7954fb"
}
```

### After this PR
```json
{
     "outpoint": "61FEF11BC15B0A9F37C8C72F595BE12D1FFE20CD2B2AE0490D37A9A5028C104E15000000",
     "txOut": {
       "scriptPubKey": "0 fb1667cc73c57c4dbf28f1ef667a1c174d7954fb",
       "value": 177147
     }
}
```
---------

## Technical considerations

`NBitcoin.Coin` is a thrid-party class and for that reason we cannot decorate its properties with `[JsonIgnore]` and while the popular wisdom in internet says this scenarios have to be address by a custom `IContractResolver` (see: https://stackoverflow.com/questions/25749509/how-can-i-tell-json-net-to-ignore-properties-in-a-3rd-party-object) In my opinion that's introduce a new somehow obscure concept so, i decided to go with an internal type `SerializableCoin` which only existence is be used to serialize/deserialize coins.