### PR TITLE
Better logs in AddBlameScript 

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -366,7 +366,15 @@ public partial class Arena : PeriodicRunner
 		if (diffMoney > coinjoin.Parameters.AllowedOutputAmounts.Min)
 		{
 			coinjoin = coinjoin.AddOutput(new TxOut(diffMoney, Config.BlameScript));
-			round.LogInfo($"Filled up the outputs to build a reasonable transaction because some alice failed to provide its output. Added amount: '{diffMoney}'");
+
+			if (allReady)
+			{
+				round.LogInfo($"Filled up the outputs to build a reasonable transaction, all Alices signalled ready. Added amount: '{diffMoney}'.");
+			}
+			else
+			{
+				round.LogWarning($"Filled up the outputs to build a reasonable transaction because some alice failed to provide its output. Added amount: '{diffMoney}'.");
+			}
 		}
 		else if (!allReady)
 		{


### PR DESCRIPTION
The log message was not true. Sometimes it is possible to add blame script output despite that all Alices signaled readiness. For example when those small accepted losses accumulated from clients and reach the `AllowedOutputAmounts.Min`.

However, we can consider letting this amount go to the miners. 