### PR TITLE
Fix LineChart.DrawYAxisLabels after 0.10.12 Avalonia update

### DIFF
--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -710,7 +710,7 @@ public partial class LineChart : Control
 		{
 			formattedTextLabels[i].Constraint = constraintMax;
 
-			var origin = new Point(originLeft - constraintMax.Width,
+			var origin = new Point(originLeft,
 				i * state.YAxisLabelStep - constraintMax.Height / 2 + state.AreaMargin.Top);
 			var offsetCenter = new Point(constraintMax.Width / 2 - constraintMax.Width / 2, 0);
 			offsetCenter = AlignYAxisLabelOffset(offsetCenter, formattedTextLabels[i].Bounds.Height, i, formattedTextLabels.Count, alignment);


### PR DESCRIPTION
Requires https://github.com/zkSNACKs/WalletWasabi/pull/7129

The https://github.com/AvaloniaUI/Avalonia/commit/c04f90685fe0e89c4579d4014cfc9e74b2552369 fixed text alignment issue in avalonia 0.10.12 

This PR remove workaround for above text alignment.