### PR TITLE
Upgrade NBitcoin to `6.0.19` from `6.0.8`

### DIFF
--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -311,8 +311,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "6.0.8",
-        "contentHash": "s9NPG+BWuylHXi6AkQILTPYP9613PoHWTZzBxfBrhnooJuUt9hT+bAs8EPNyzZAZ33SjW80nQgNtBM8gxLxVoQ==",
+        "resolved": "6.0.19",
+        "contentHash": "l/iN8TX/rNwzJvYLVM0Zspd0NzfGZ77HZXJ0upFS8Oyrd3NaKaW3Tj9sDIX2aYijpIeGUVOUPRXM/MhID5u4ng==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"
@@ -681,7 +681,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "6.0.0",
           "Microsoft.Win32.SystemEvents": "6.0.0",
-          "NBitcoin": "6.0.8",
+          "NBitcoin": "6.0.19",
           "NBitcoin.Secp256k1": "1.0.10"
         }
       },

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -241,7 +241,7 @@ public partial class SendViewModel : RoutableViewModel
 				_transactionInfo.UserLabels = new SmartLabel(label.Labels);
 			}
 
-			if (url.UnknowParameters.TryGetValue("pj", out var endPoint))
+			if (url.UnknownParameters.TryGetValue("pj", out var endPoint))
 			{
 				PayJoinEndPoint = endPoint;
 			}

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -246,8 +246,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "6.0.8",
-        "contentHash": "s9NPG+BWuylHXi6AkQILTPYP9613PoHWTZzBxfBrhnooJuUt9hT+bAs8EPNyzZAZ33SjW80nQgNtBM8gxLxVoQ==",
+        "resolved": "6.0.19",
+        "contentHash": "l/iN8TX/rNwzJvYLVM0Zspd0NzfGZ77HZXJ0upFS8Oyrd3NaKaW3Tj9sDIX2aYijpIeGUVOUPRXM/MhID5u4ng==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"
@@ -530,7 +530,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "6.0.0",
           "Microsoft.Win32.SystemEvents": "6.0.0",
-          "NBitcoin": "6.0.8",
+          "NBitcoin": "6.0.19",
           "NBitcoin.Secp256k1": "1.0.10"
         }
       }

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -59,8 +59,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "6.0.8",
-        "contentHash": "s9NPG+BWuylHXi6AkQILTPYP9613PoHWTZzBxfBrhnooJuUt9hT+bAs8EPNyzZAZ33SjW80nQgNtBM8gxLxVoQ==",
+        "resolved": "6.0.19",
+        "contentHash": "l/iN8TX/rNwzJvYLVM0Zspd0NzfGZ77HZXJ0upFS8Oyrd3NaKaW3Tj9sDIX2aYijpIeGUVOUPRXM/MhID5u4ng==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"
@@ -275,7 +275,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "6.0.0",
           "Microsoft.Win32.SystemEvents": "6.0.0",
-          "NBitcoin": "6.0.8",
+          "NBitcoin": "6.0.19",
           "NBitcoin.Secp256k1": "1.0.10"
         }
       }

--- a/WalletWasabi/BestEffortEndpointConnector.cs
+++ b/WalletWasabi/BestEffortEndpointConnector.cs
@@ -57,9 +57,9 @@ public class BestEffortEndpointConnector : IEnpointConnector
 			socketEndpoint = socksSettings.SocksEndpoint;
 		}
 
-		if (socketEndpoint is IPEndPoint mappedv4 && mappedv4.Address.IsIPv4MappedToIPv6Ex())
+		if (socketEndpoint is IPEndPoint mappedv4 && mappedv4.Address.IsIPv4MappedToIPv6)
 		{
-			socketEndpoint = new IPEndPoint(mappedv4.Address.MapToIPv4Ex(), mappedv4.Port);
+			socketEndpoint = new IPEndPoint(mappedv4.Address.MapToIPv4(), mappedv4.Port);
 		}
 		await socket.ConnectAsync(socketEndpoint, cancellationToken).ConfigureAwait(false);
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -240,6 +240,8 @@ public class TransactionFactory
 			psbt.Finalize();
 			tx = psbt.ExtractTransaction();
 
+			builder.CoinFinder = (outpoint) => psbt.Inputs.Select(x => x.GetCoin()).Single(x => x?.Outpoint == outpoint)!;
+
 			var checkResults = builder.Check(tx).ToList();
 			if (checkResults.Count > 0)
 			{

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using NBitcoin.Policy;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -37,9 +36,7 @@ public class TransactionFactory
 	public bool AllowUnconfirmed { get; }
 	private AllTransactionStore TransactionStore { get; }
 
-	/// <exception cref="ArgumentException"></exception>
-	/// <exception cref="ArgumentNullException"></exception>
-	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	/// <inheritdoc cref="BuildTransaction(PaymentIntent, Func{FeeRate}, IEnumerable{OutPoint}?, Func{LockTime}?, IPayjoinClient?, bool)"/>
 	public BuildTransactionResult BuildTransaction(
 		PaymentIntent payments,
 		FeeRate feeRate,
@@ -47,9 +44,9 @@ public class TransactionFactory
 		IPayjoinClient? payjoinClient = null)
 		=> BuildTransaction(payments, () => feeRate, allowedInputs, () => LockTime.Zero, payjoinClient);
 
-	/// <exception cref="ArgumentException"></exception>
-	/// <exception cref="ArgumentNullException"></exception>
-	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	/// <exception cref="ArgumentException"/>
+	/// <exception cref="ArgumentNullException"/>
+	/// <exception cref="ArgumentOutOfRangeException"/>
 	public BuildTransactionResult BuildTransaction(
 		PaymentIntent payments,
 		Func<FeeRate> feeRateFetcher,

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -75,7 +75,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
 		}
 
-		if (output.IsDust(Parameters.MinRelayTxFee))
+		if (output.IsDust())
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.DustOutput);
 		}

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -30,7 +30,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.0" />
-		<PackageReference Include="NBitcoin" Version="6.0.8" />
+		<PackageReference Include="NBitcoin" Version="6.0.19" />
 		<PackageReference Include="NBitcoin.Secp256k1" Version="1.0.10" />
 	</ItemGroup>
 

--- a/WalletWasabi/Wallets/PasswordFinder/PasswordFinderHelper.cs
+++ b/WalletWasabi/Wallets/PasswordFinder/PasswordFinderHelper.cs
@@ -36,16 +36,12 @@ public static class PasswordFinderHelper
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 
-			try
+			if (encryptedSecret.TryGetKey(pwd, out _))
 			{
-				encryptedSecret.GetKey(pwd);
 				foundPassword = pwd;
 				return true;
 			}
-			catch (SecurityException)
-			{
-			}
-
+			
 			attempts++;
 			var percentage = (double)attempts / maxNumberAttempts * 100;
 			var remainingMilliseconds = sw.Elapsed.TotalMilliseconds / percentage * (100 - percentage);

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -21,9 +21,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[6.0.8, )",
-        "resolved": "6.0.8",
-        "contentHash": "s9NPG+BWuylHXi6AkQILTPYP9613PoHWTZzBxfBrhnooJuUt9hT+bAs8EPNyzZAZ33SjW80nQgNtBM8gxLxVoQ==",
+        "requested": "[6.0.19, )",
+        "resolved": "6.0.19",
+        "contentHash": "l/iN8TX/rNwzJvYLVM0Zspd0NzfGZ77HZXJ0upFS8Oyrd3NaKaW3Tj9sDIX2aYijpIeGUVOUPRXM/MhID5u4ng==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "11.0.2"


### PR DESCRIPTION
## Intro

#7058 recently [touched](https://github.com/zkSNACKs/WalletWasabi/pull/7058/files#diff-23f66197c41b2d2d7b25e00ac706928acd1eebc3b580f3692973acf810133e9eR143) `IndexStore`. I have found no significant impact of that change. However, it lead me to thinking how to speed up index loading a bit because [it takes 4 seconds on my machine to load the mature index](https://github.com/zkSNACKs/WalletWasabi/blob/756f6e930ae5ea317552b91501aa9e9c14c456d1/WalletWasabi/Stores/IndexStore.cs#L143). The startup of the wallet is impacted by that so it might be useful to invest a bit time to shave some overhead off.

## How?

One quite easy way to make it faster is to switch to the newer NBitcoin version because it contains the following commit:

https://github.com/MetacoSA/NBitcoin/commit/1a3f5c63ec7a596f2e8af3b702c4d273b7fb7e87 -  "Improve perf of hex encoder/decoder by 30%"

## Numbers

| git commit | elapsed time (lower is better)|
|---------|-----------------|
| master |  4.11 seconds. |
| this PR |  3.45 seconds. |

## Broken tests

* `HonestPayjoinServerTest` seems to be broken because of this commit https://github.com/MetacoSA/NBitcoin/commit/f1de6d1e616c909280d2183e2d3383657048176b

cc @nopara73 
