### PR TITLE
Do not create BUILDINFO.json when in continuous delivery mode.

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -210,7 +210,12 @@ public static class Program
 		IoHelpers.EnsureDirectoryExists(deliveryPath);
 		Console.WriteLine($"Binaries will be delivered here: {deliveryPath}");
 
-		string buildInfoJson = GetBuildInfoData();
+		string? buildInfoJson = null;
+
+		if (!IsContinuousDelivery)
+		{
+			buildInfoJson = GetBuildInfoData();
+		}
 
 		CheckUncommittedGitChanges();
 
@@ -229,8 +234,11 @@ public static class Program
 				Console.WriteLine($"Created {currentBinDistDirectory}");
 			}
 
-			string buildInfoPath = Path.Combine(currentBinDistDirectory, "BUILDINFO.json");
-			File.WriteAllText(buildInfoPath, buildInfoJson);
+			if (buildInfoJson is not null)
+			{
+				string buildInfoPath = Path.Combine(currentBinDistDirectory, "BUILDINFO.json");
+				File.WriteAllText(buildInfoPath, buildInfoJson);
+			}
 
 			StartProcessAndWaitForExit("dotnet", DesktopProjectDirectory, arguments: "clean");
 

--- a/azure-pipelines-detbuild.yml
+++ b/azure-pipelines-detbuild.yml
@@ -1,8 +1,8 @@
 trigger:
   batch: true
-  branches:
-    include:
-      - master
+  # branches:
+  #   include:
+  #     - master
 
 pool:
   vmImage: windows-latest


### PR DESCRIPTION
This PR attempts to fix https://github.com/zkSNACKs/WalletWasabi/pull/6810#issuecomment-1023207914