### PR TITLE
#7050 Resolved.

### DIFF
--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -252,7 +252,6 @@ public class TagsBox : TemplatedControl
 			.Subscribe(_ =>
 			{
 				InvalidateWatermark();
-				CheckIsCurrentTextValid();
 			})
 			.DisposeWith(_compositeDisposable);
 	}


### PR DESCRIPTION
#7050 Resolved.

The `CheckIsCurrentTextValid `method  is not executed now when the dialog is closing.