### PR TITLE
Fix Packager if Git is missing

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -627,9 +627,9 @@ public static class Program
 			result = StartProcessAndWaitForExit(command, workingDirectory, writeToStandardInput, arguments, redirectStandardOutput)?.Trim() ?? "";
 			return true;
 		}
-		catch
+		catch (Exception ex)
 		{
-			// Exceptions already displayed in StartProcessAndWaitForExit.
+			Console.WriteLine($"Process failed: '{ex}'.");
 		}
 		return false;
 	}

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -528,9 +529,8 @@ public static class Program
 	/// <remarks>This is important to really release a build that corresponds with a git hash.</remarks>
 	private static void CheckUncommittedGitChanges()
 	{
-		string? gitStatus = StartProcessAndWaitForExit("git", workingDirectory: DesktopProjectDirectory, arguments: "status --porcelain", redirectStandardOutput: true)?.Trim();
+		if (TryStartProcessAndWaitForExit("git", workingDirectory: DesktopProjectDirectory, out var gitStatus, arguments: "status --porcelain", redirectStandardOutput: true) && !string.IsNullOrEmpty(gitStatus))
 
-		if (!string.IsNullOrEmpty(gitStatus))
 		{
 			Console.WriteLine("BEWARE: There are uncommitted changes in the repository. Do you want to continue? (Y/N)");
 			int i = Console.Read();
@@ -554,19 +554,15 @@ public static class Program
 		Version runtimeVersion = Environment.Version;
 
 		// Get .NET SDK version.
-		string? sdkVersion = StartProcessAndWaitForExit("dotnet", workingDirectory: DesktopProjectDirectory, arguments: "--version", redirectStandardOutput: true)?.Trim();
-
-		if (sdkVersion is null)
+		if (!TryStartProcessAndWaitForExit("dotnet", workingDirectory: DesktopProjectDirectory, result: out var sdkVersion, arguments: "--version", redirectStandardOutput: true))
 		{
-			throw new InvalidOperationException($"Failed to get .NET SDK version.");
+			sdkVersion = $"Failed to get .NET SDK version.";
 		}
 
 		// Get git commit ID.
-		string? gitCommitId = StartProcessAndWaitForExit("git", workingDirectory: DesktopProjectDirectory, arguments: "rev-parse HEAD", redirectStandardOutput: true)?.Trim();
-
-		if (gitCommitId is null)
+		if (!TryStartProcessAndWaitForExit("git", workingDirectory: DesktopProjectDirectory, result: out var gitCommitId, arguments: "rev-parse HEAD", redirectStandardOutput: true))
 		{
-			throw new InvalidOperationException($"Failed to get git commit ID.");
+			gitCommitId = $"Failed to get git commit ID.";
 		}
 
 		return JsonSerializer.Serialize(new BuildInfo(runtimeVersion.ToString(), sdkVersion, gitCommitId), new JsonSerializerOptions() { WriteIndented = true });
@@ -621,5 +617,20 @@ public static class Program
 		}
 
 		return output;
+	}
+
+	private static bool TryStartProcessAndWaitForExit(string command, string workingDirectory, [NotNullWhen(true)] out string? result, string? writeToStandardInput = null, string? arguments = null, bool redirectStandardOutput = false)
+	{
+		result = null;
+		try
+		{
+			result = StartProcessAndWaitForExit(command, workingDirectory, writeToStandardInput, arguments, redirectStandardOutput)?.Trim() ?? "";
+			return true;
+		}
+		catch
+		{
+			// Exceptions already displayed in StartProcessAndWaitForExit.
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
Git is not a required component for packager - it is something good to have. CI was failing because of this but in any case, it is better to handle these calls in an error-prone way - this PR does that. 

Fixes: https://github.com/zkSNACKs/WalletWasabi/pull/6810#issuecomment-1023207914