### PR TITLE
When To Mix - Do not start while sending

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -208,7 +208,7 @@ public class CoinJoinManager : BackgroundService
 			return false;
 		}
 
-		if (wallet.NonPrivateCoins.TotalAmount() < wallet.KeyManager.PlebStopThreshold)
+		if (wallet.NonPrivateCoins.TotalAmount() <= wallet.KeyManager.PlebStopThreshold)
 		{
 			return false;
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -32,6 +32,7 @@ public class CoinJoinManager : BackgroundService
 	private ImmutableDictionary<string, CoinJoinTracker> TrackedCoinJoins { get; set; } = ImmutableDictionary<string, CoinJoinTracker>.Empty;
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 	private TimeSpan AutoCoinJoinDelayAfterWalletLoaded { get; } = TimeSpan.FromMinutes(Random.Shared.Next(5, 16));
+	public bool IsUserInSendWorkflow { get; set; }
 
 	public CoinJoinClientState HighestCoinJoinClientState
 	{
@@ -153,7 +154,7 @@ public class CoinJoinManager : BackgroundService
 	private ImmutableDictionary<string, Wallet> GetMixableWallets() =>
 		WalletManager.GetWallets()
 			.Where(x => x.State == WalletState.Started) // Only running wallets
-			.Where(x => (x.KeyManager.AutoCoinJoin && x.ElapsedTimeSinceStartup > AutoCoinJoinDelayAfterWalletLoaded && (x.NonPrivateCoins.TotalAmount() >= x.KeyManager.PlebStopThreshold)) || x.AllowManualCoinJoin) // Configured to be mixed automatically or manually.
+			.Where(x => CanStartAutoCoinJoin(x) || x.AllowManualCoinJoin)
 			.Where(x => !x.KeyManager.IsWatchOnly)      // that are not watch-only wallets
 			.Where(x => x.Kitchen.HasIngredients)
 			.ToImmutableDictionary(x => x.WalletName, x => x);
@@ -188,5 +189,30 @@ public class CoinJoinManager : BackgroundService
 
 		var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
 		return pcPrivate;
+	}
+
+	private bool CanStartAutoCoinJoin(Wallet wallet)
+	{
+		if (!wallet.KeyManager.AutoCoinJoin)
+		{
+			return false;
+		}
+
+		if (IsUserInSendWorkflow)
+		{
+			return false;
+		}
+
+		if (wallet.ElapsedTimeSinceStartup < AutoCoinJoinDelayAfterWalletLoaded)
+		{
+			return false;
+		}
+
+		if (wallet.NonPrivateCoins.TotalAmount() < wallet.KeyManager.PlebStopThreshold)
+		{
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -203,7 +203,7 @@ public class CoinJoinManager : BackgroundService
 			return false;
 		}
 
-		if (wallet.ElapsedTimeSinceStartup < AutoCoinJoinDelayAfterWalletLoaded)
+		if (wallet.ElapsedTimeSinceStartup <= AutoCoinJoinDelayAfterWalletLoaded)
 		{
 			return false;
 		}


### PR DESCRIPTION
This PR adds `IsUserInSendWorkflow` and extracts out AutoCJ conditions into a separate function. The UI part is not connected yet but @danwalmsley said adding a boolean is the way to do this - so they will set it externally. 

- `IsUserInSendWorkflow` is not wallet-dependant but a global one. I think it makes sense to save resources on sending and not start CoinJoin in the background even if it is another wallet. 

See https://github.com/zkSNACKs/WalletWasabi/issues/7122 - Do not start while sending