### PR TITLE
[Fluent] macOS/KDE-Linux default AppMenu items replacement 

### DIFF
--- a/WalletWasabi.Fluent/App.axaml
+++ b/WalletWasabi.Fluent/App.axaml
@@ -38,7 +38,11 @@
     <StyleInclude Source="avares://WalletWasabi.Fluent/Controls/StatusItem.axaml" />
     <StyleInclude Source="avares://WalletWasabi.Fluent/Controls/PrivacyContentControl.axaml" />
   </Application.Styles>
-
+  <NativeMenu.Menu>
+    <NativeMenu>
+      <NativeMenuItem Header="About Wasabi Wallet" Command="{Binding AboutCommand}" />
+    </NativeMenu>
+  </NativeMenu.Menu>
   <TrayIcon.Icons>
     <TrayIcons>
       <TrayIcon Icon="{Binding TrayIcon}" Clicked="TrayIcon_OnClicked">

--- a/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Input;
 using Avalonia;
@@ -6,6 +7,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using ReactiveUI;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Providers;
+using WalletWasabi.Fluent.ViewModels.HelpAndSupport;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.WabiSabi.Client;
 
@@ -38,6 +40,21 @@ public class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 
 		ShowCommand = ReactiveCommand.Create(() => ShowRequested?.Invoke(this, EventArgs.Empty));
 
+		var dialogScreen = MainViewModel.Instance.DialogScreen;
+
+		AboutCommand = ReactiveCommand.Create(
+			() => dialogScreen.To(new AboutViewModel(navigateBack: dialogScreen.CurrentPage is not null)),
+			canExecute: dialogScreen.WhenAnyValue(x => x.CurrentPage)
+				.SelectMany(x =>
+				{
+					return x switch
+					{
+						null => Observable.Return(true),
+						AboutViewModel => Observable.Return(false),
+						_ => x.WhenAnyValue(page => page.IsBusy).Select(isBusy => !isBusy)
+					};
+				}));
+
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
 		{
 			using var bitmap = AssetHelpers.GetBitmapAsset("avares://WalletWasabi.Fluent/Assets/WasabiLogo_white.ico");
@@ -56,8 +73,9 @@ public class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 
 	public event EventHandler? ShowRequested;
 
-	public ICommand QuitCommand { get; }
+	public ICommand AboutCommand { get; }
 	public ICommand ShowCommand { get; }
+	public ICommand QuitCommand { get; }
 
 	public bool CanShutdown()
 	{

--- a/WalletWasabi.Fluent/ViewModels/HelpAndSupport/AboutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/HelpAndSupport/AboutViewModel.cs
@@ -24,8 +24,10 @@ namespace WalletWasabi.Fluent.ViewModels.HelpAndSupport;
 	NavigationTarget = NavigationTarget.DialogScreen)]
 public partial class AboutViewModel : RoutableViewModel
 {
-	public AboutViewModel()
+	public AboutViewModel(bool navigateBack = false)
 	{
+		EnableBack = navigateBack;
+
 		Links = new List<ViewModelBase>()
 			{
 				new LinkViewModel()

--- a/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
+++ b/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
@@ -22,7 +22,9 @@
     </Style>
   </UserControl.Styles>
   <Panel>
-    <controls:ContentArea EnableNext="True" NextContent="Close">
+    <controls:ContentArea EnableNext="{Binding !EnableBack}"
+                          NextContent="Close"
+                          EnableBack="{Binding EnableBack}">
       <DockPanel LastChildFill="True">
         <Viewbox DockPanel.Dock="Top" Margin="25,25,25,50" Width="112" VerticalAlignment="Center"
                  HorizontalAlignment="Center">


### PR DESCRIPTION
Replaces the "About Avalonia" entry in global app menu in macOS and KDE based Linux distros with our own that triggers the About page dialog.