### PR TITLE
[Fluent] Don't throw exceptions when CheckIsCurrentTextValid is called.

### DIFF
--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -273,7 +273,7 @@ public class TagsBox : TemplatedControl
 			return;
 		}
 
-		throw new InvalidOperationException($"Invalid configuration! {nameof(Suggestions)} are not set!");
+		IsCurrentTextValid = false;
 	}
 
 	private void OnKeyDown(object? sender, KeyEventArgs e)


### PR DESCRIPTION
I can't see any reason why we should throw here since it wont invalidate the TagsBox state anyway.

cc @soosr 

Fixes #7050  