### PR TITLE
Optimize startup time a bit more

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Filters/IndexStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Filters/IndexStoreTests.cs
@@ -40,7 +40,6 @@ public class IndexStoreTests
 		await using var indexStore = new IndexStore(dir, network, headersChain);
 		var dummyFilter = GolombRiceFilter.Parse("00");
 
-		static DateTimeOffset MinutesAgo(int mins) => DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(mins));
 		var matureIndexStoreContent = new[]
 		{
 				new FilterModel(new SmartHeader(new uint256(2), new uint256(1), 1, MinutesAgo(30)), dummyFilter),
@@ -67,8 +66,6 @@ public class IndexStoreTests
 		await using var indexStore = new IndexStore(dir, network, headersChain);
 
 		var dummyFilter = GolombRiceFilter.Parse("00");
-
-		static DateTimeOffset MinutesAgo(int mins) => DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(mins));
 		var startingFilter = StartingFilters.GetStartingFilter(network);
 
 		var immatureIndexStoreContent = new[]
@@ -98,7 +95,6 @@ public class IndexStoreTests
 
 		var dummyFilter = GolombRiceFilter.Parse("00");
 
-		static DateTimeOffset MinutesAgo(int mins) => DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(mins));
 		var matureIndexStoreContent = new[]
 		{
 				new FilterModel(new SmartHeader(new uint256(2), new uint256(1), 1, MinutesAgo(30)), dummyFilter),
@@ -131,7 +127,6 @@ public class IndexStoreTests
 
 		var dummyFilter = GolombRiceFilter.Parse("00");
 
-		static DateTimeOffset MinutesAgo(int mins) => DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(mins));
 		var matureIndexStoreContent = new[]
 		{
 				new FilterModel(new SmartHeader(new uint256(2), new uint256(1), 1, MinutesAgo(30)), dummyFilter),
@@ -171,4 +166,6 @@ public class IndexStoreTests
 		IoHelpers.EnsureContainingDirectoryExists(immatureFilters);
 		return (dir, matureFilters, immatureFilters);
 	}
+
+	private static DateTimeOffset MinutesAgo(int mins) => DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(mins));
 }

--- a/WalletWasabi/Backend/Models/FilterModel.cs
+++ b/WalletWasabi/Backend/Models/FilterModel.cs
@@ -1,11 +1,8 @@
 using NBitcoin;
 using NBitcoin.DataEncoders;
-using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using WalletWasabi.Blockchain.Blocks;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Backend.Models;
 
@@ -47,7 +44,7 @@ public class FilterModel
 		byte[] filterData = Encoders.Hex.DecodeData(parts[2]);
 		Lazy<GolombRiceFilter> filter = new(() => new GolombRiceFilter(filterData, 20, 1 << 20), LazyThreadSafetyMode.ExecutionAndPublication);
 		uint256 prevBlockHash = uint256.Parse(parts[3]);
-		DateTimeOffset blockTime = DateTimeOffset.FromUnixTimeSeconds(long.Parse(parts[4]));
+		long blockTime = long.Parse(parts[4]);
 
 		return new FilterModel(new SmartHeader(blockHash, prevBlockHash, blockHeight, blockTime), filter);
 	}
@@ -63,7 +60,7 @@ public class FilterModel
 		builder.Append(':');
 		builder.Append(Header.PrevHash);
 		builder.Append(':');
-		builder.Append(Header.BlockTime.ToUnixTimeSeconds());
+		builder.Append(Header.BlockTimeSeconds);
 
 		return builder.ToString();
 	}

--- a/WalletWasabi/Backend/Models/FilterModel.cs
+++ b/WalletWasabi/Backend/Models/FilterModel.cs
@@ -60,7 +60,7 @@ public class FilterModel
 		builder.Append(':');
 		builder.Append(Header.PrevHash);
 		builder.Append(':');
-		builder.Append(Header.BlockTimeSeconds);
+		builder.Append(Header.EpochBlockTime);
 
 		return builder.ToString();
 	}

--- a/WalletWasabi/Blockchain/BlockFilters/StartingFilters.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/StartingFilters.cs
@@ -12,16 +12,16 @@ public static class StartingFilters
 		var startingHeader = SmartHeader.GetStartingHeader(network);
 		if (network == Network.Main)
 		{
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:02832810ec08a0:{startingHeader.PrevHash}:{startingHeader.BlockTime.ToUnixTimeSeconds()}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:02832810ec08a0:{startingHeader.PrevHash}:{startingHeader.BlockTimeSeconds}");
 		}
 		else if (network == Network.TestNet)
 		{
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:{startingHeader.PrevHash}:{startingHeader.BlockTime.ToUnixTimeSeconds()}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:{startingHeader.PrevHash}:{startingHeader.BlockTimeSeconds}");
 		}
 		else if (network == Network.RegTest)
 		{
 			GolombRiceFilter filter = IndexBuilderService.CreateDummyEmptyFilter(startingHeader.BlockHash);
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.PrevHash}:{startingHeader.BlockTime.ToUnixTimeSeconds()}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.PrevHash}:{startingHeader.BlockTimeSeconds}");
 		}
 		else
 		{

--- a/WalletWasabi/Blockchain/BlockFilters/StartingFilters.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/StartingFilters.cs
@@ -12,16 +12,16 @@ public static class StartingFilters
 		var startingHeader = SmartHeader.GetStartingHeader(network);
 		if (network == Network.Main)
 		{
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:02832810ec08a0:{startingHeader.PrevHash}:{startingHeader.BlockTimeSeconds}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:02832810ec08a0:{startingHeader.PrevHash}:{startingHeader.EpochBlockTime}");
 		}
 		else if (network == Network.TestNet)
 		{
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:{startingHeader.PrevHash}:{startingHeader.BlockTimeSeconds}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:{startingHeader.PrevHash}:{startingHeader.EpochBlockTime}");
 		}
 		else if (network == Network.RegTest)
 		{
 			GolombRiceFilter filter = IndexBuilderService.CreateDummyEmptyFilter(startingHeader.BlockHash);
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.PrevHash}:{startingHeader.BlockTimeSeconds}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.PrevHash}:{startingHeader.EpochBlockTime}");
 		}
 		else
 		{

--- a/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
+++ b/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
@@ -7,6 +7,11 @@ namespace WalletWasabi.Blockchain.Blocks;
 public class SmartHeader
 {
 	public SmartHeader(uint256 blockHash, uint256 prevHash, uint height, DateTimeOffset blockTime)
+		: this(blockHash, prevHash, height, blockTime.ToUnixTimeSeconds())
+	{
+	}
+
+	public SmartHeader(uint256 blockHash, uint256 prevHash, uint height, long blockTimeSeconds)
 	{
 		BlockHash = Guard.NotNull(nameof(blockHash), blockHash);
 		PrevHash = Guard.NotNull(nameof(prevHash), prevHash);
@@ -16,13 +21,17 @@ public class SmartHeader
 		}
 
 		Height = height;
-		BlockTime = blockTime;
+		BlockTimeSeconds = blockTimeSeconds;
 	}
 
 	public uint256 BlockHash { get; }
 	public uint256 PrevHash { get; }
 	public uint Height { get; }
-	public DateTimeOffset BlockTime { get; }
+
+	/// <summary>Timestamp in seconds.</summary>
+	public long BlockTimeSeconds { get; }
+
+	public DateTimeOffset BlockTime => DateTimeOffset.FromUnixTimeSeconds(BlockTimeSeconds);
 
 	#region SpecialHeaders
 
@@ -30,13 +39,13 @@ public class SmartHeader
 		new uint256("0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893"),
 		new uint256("000000000000000000cbeff0b533f8e1189cf09dfbebf57a8ebe349362811b80"),
 		481824,
-		DateTimeOffset.FromUnixTimeSeconds(1503539857));
+		1503539857);
 
 	private static SmartHeader StartingHeaderTestNet { get; } = new SmartHeader(
 		new uint256("00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a"),
 		new uint256("0000000000211a4d54bceb763ea690a4171a734c48d36f7d8e30b51d6df6ea85"),
 		828575,
-		DateTimeOffset.FromUnixTimeSeconds(1463079943));
+		1463079943);
 
 	private static SmartHeader StartingHeaderRegTest { get; } = new SmartHeader(
 		Network.RegTest.GenesisHash,

--- a/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
+++ b/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
@@ -11,7 +11,7 @@ public class SmartHeader
 	{
 	}
 
-	public SmartHeader(uint256 blockHash, uint256 prevHash, uint height, long blockTimeSeconds)
+	public SmartHeader(uint256 blockHash, uint256 prevHash, uint height, long epochBlockTime)
 	{
 		BlockHash = Guard.NotNull(nameof(blockHash), blockHash);
 		PrevHash = Guard.NotNull(nameof(prevHash), prevHash);
@@ -21,7 +21,7 @@ public class SmartHeader
 		}
 
 		Height = height;
-		BlockTimeSeconds = blockTimeSeconds;
+		EpochBlockTime = epochBlockTime;
 	}
 
 	public uint256 BlockHash { get; }
@@ -29,9 +29,9 @@ public class SmartHeader
 	public uint Height { get; }
 
 	/// <summary>Timestamp in seconds.</summary>
-	public long BlockTimeSeconds { get; }
+	public long EpochBlockTime { get; }
 
-	public DateTimeOffset BlockTime => DateTimeOffset.FromUnixTimeSeconds(BlockTimeSeconds);
+	public DateTimeOffset BlockTime => DateTimeOffset.FromUnixTimeSeconds(EpochBlockTime);
 
 	#region SpecialHeaders
 


### PR DESCRIPTION
This PR improves startup time by shaving off a bit of work when loading mature index. The PR builds on knowledge that I got when working on #7136.

## Numbers

| git commit | elapsed time (lower is better)| 
|---------|-----------------|
| master |  5.22 seconds |
| with 1st commit |  4.42 seconds |
| with 2nd commit |  4 seconds |

note: Measured in `Debug` configuration (not `Release` configuration). The time it tooks in `Release` configuration with the 2nd commit is `3.71` seconds.

I know, we have new priorities now, but I did not want to lose this changes as they seem useful.