### PR TITLE
Fixing CheckIsCurrentTextValid execution when the dialog is closing (Results in crash)

### DIFF
--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -273,7 +273,7 @@ public class TagsBox : TemplatedControl
 			return;
 		}
 
-		throw new InvalidOperationException($"Invalid configuration! {nameof(Suggestions)} are not set!");
+		IsCurrentTextValid = false;
 	}
 
 	private void OnKeyDown(object? sender, KeyEventArgs e)


### PR DESCRIPTION
Fixes : #7050 
Mention : #7169 