### PR TITLE
[WabiSabi] Stream status 4

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -24,10 +24,10 @@ public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 	private IdempotencyRequestCache IdempotencyRequestCache { get; }
 	private Arena Arena { get; }
 
-	[HttpGet("status")]
-	public Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+	[HttpPost("status")]
+	public Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 	{
-		return Arena.GetStatusAsync(cancellationToken);
+		return Arena.GetStatusAsync(request, cancellationToken);
 	}
 
 	[HttpPost("connection-confirmation")]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using NBitcoin;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
@@ -32,23 +29,23 @@ public class MultipartyTransactionStateTests
 		var state3 = state2.AddInput(coin3 = CreateCoin());
 
 		// Unknown state. Assumes full state is required
-		var diffd30 = state3.GetConstructionStateSince(-1);
+		var diffd30 = state3.GetStateFrom(-1);
 		Assert.Equal(state3.Inputs, diffd30.Inputs);
 		Assert.Equal(state3.Outputs, diffd30.Outputs);
 
 		// Only one event is missing
-		var diffd32 = state3.GetConstructionStateSince(2);
+		var diffd32 = state3.GetStateFrom(2);
 		var input = Assert.Single(diffd32.Inputs);
 		Assert.Equal(coin3.Outpoint, input.Outpoint);
 
-		// two events are missing
-		var diffd31 = state3.GetConstructionStateSince(1);
+		// Two events are missing
+		var diffd31 = state3.GetStateFrom(1);
 		Assert.Collection(diffd31.Inputs,
 			x => Assert.Equal(coin2.Outpoint, x.Outpoint),
 			x => Assert.Equal(coin3.Outpoint, x.Outpoint));
 
 		// No event is missing (already updated)
-		var diffd33 = state3.GetConstructionStateSince(3);
+		var diffd33 = state3.GetStateFrom(3);
 		Assert.Empty(diffd33.Inputs);
 		Assert.Empty(diffd33.Outputs);
 
@@ -59,15 +56,18 @@ public class MultipartyTransactionStateTests
 
 		// Merge state1 with diff between 1 and 3. Expected to get state3
 		var merged13 = state1.Merge(diffd31);
-		Assert.True(merged13.Inputs.SequenceEqual(state3.Inputs));
+		Assert.Equal(state3.Inputs, merged13.Inputs);
+		Assert.Equal(state3.Outputs, merged13.Outputs);
 
-		var diff00 = state0.GetConstructionStateSince(0);
-		var diff10 = state1.GetConstructionStateSince(0);
-		var diff21 = state2.GetConstructionStateSince(1);
-		var diff32 = state3.GetConstructionStateSince(2);
+		var diff00 = state0.GetStateFrom(0);
+		var diff10 = state1.GetStateFrom(0);
+		var diff21 = state2.GetStateFrom(1);
+		var diff32 = state3.GetStateFrom(2);
 		var clientState1 = state1;
-		var clientState3 = state3.GetConstructionStateSince(1).MergeBack(clientState1);
+		var clientState3 = state3.GetStateFrom(1).AddPreviousStates(clientState1);
 		Assert.Equal(state3.Inputs, clientState3.Inputs);
-		Assert.True(clientState3.Inputs.SequenceEqual(state3.Inputs));
+		Assert.Equal(state3.Outputs, clientState3.Outputs);
+		Assert.Equal(clientState3.Inputs, state3.Inputs);
+		Assert.Equal(clientState3.Outputs, state3.Outputs);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.Rounds;
+
+public class MultipartyTransactionStateTests
+{
+	[Fact]
+	public void CanGetDifferentialStateTest()
+	{
+		var cfg = new WabiSabiConfig();
+		var round = WabiSabiFactory.CreateRound(cfg);
+
+		static Coin CreateCoin()
+		{
+			using var key = new Key();
+			return WabiSabiFactory.CreateCoin(key);
+		}
+
+		Coin coin1, coin2, coin3;
+
+		// Three events / three states
+		var state0 = round.Assert<ConstructionState>();
+		var state1 = state0.AddInput(coin1 = CreateCoin());
+		var state2 = state1.AddInput(coin2 = CreateCoin());
+		var state3 = state2.AddInput(coin3 = CreateCoin());
+
+		// Unknown state. Assumes full state is required
+		var diffd30 = state3.GetConstructionStateSince(-1);
+		Assert.Equal(state3.Inputs, diffd30.Inputs);
+		Assert.Equal(state3.Outputs, diffd30.Outputs);
+
+		// Only one event is missing
+		var diffd32 = state3.GetConstructionStateSince(2);
+		var input = Assert.Single(diffd32.Inputs);
+		Assert.Equal(coin3.Outpoint, input.Outpoint);
+
+		// two events are missing
+		var diffd31 = state3.GetConstructionStateSince(1);
+		Assert.Collection(diffd31.Inputs,
+			x => Assert.Equal(coin2.Outpoint, x.Outpoint),
+			x => Assert.Equal(coin3.Outpoint, x.Outpoint));
+
+		// No event is missing (already updated)
+		var diffd33 = state3.GetConstructionStateSince(3);
+		Assert.Empty(diffd33.Inputs);
+		Assert.Empty(diffd33.Outputs);
+
+		// Merge initial state0 with full diff. Expected to get state3
+		var merged03 = state0.Merge(diffd30);
+		Assert.Equal(state3.Inputs, merged03.Inputs);
+		Assert.Equal(state3.Outputs, merged03.Outputs);
+
+		// Merge state1 with diff between 1 and 3. Expected to get state3
+		var merged13 = state1.Merge(diffd31);
+		Assert.True(merged13.Inputs.SequenceEqual(state3.Inputs));
+
+		var diff00 = state0.GetConstructionStateSince(0);
+		var diff10 = state1.GetConstructionStateSince(0);
+		var diff21 = state2.GetConstructionStateSince(1);
+		var diff32 = state3.GetConstructionStateSince(2);
+		var clientState1 = state1;
+		var clientState3 = state3.GetConstructionStateSince(1).MergeBack(clientState1);
+		Assert.Equal(state3.Inputs, clientState3.Inputs);
+		Assert.True(clientState3.Inputs.SequenceEqual(state3.Inputs));
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -233,7 +233,7 @@ public class ArenaClientTests
 		var emptyState = round.Assert<ConstructionState>();
 
 		// We can't use ``emptyState.Finalize()` because this is not a valid transaction so we fake it
-		var finalizedEmptyState = new SigningState(emptyState.Parameters, emptyState.Inputs, emptyState.Outputs);
+		var finalizedEmptyState = new SigningState(emptyState.Parameters, emptyState.Events);
 
 		// No inputs in the coinjoin.
 		await Assert.ThrowsAsync<ArgumentException>(async () =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -18,6 +18,7 @@ using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
@@ -72,7 +73,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 
 	public async Task<ArenaClient> CreateArenaClientAsync(WabiSabiHttpApiClient wabiSabiHttpApiClient)
 	{
-		var rounds = await wabiSabiHttpApiClient.GetStatusAsync(CancellationToken.None);
+		var rounds = await wabiSabiHttpApiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 		var round = rounds.First(x => x.CoinjoinState is ConstructionState);
 		var insecureRandom = new InsecureRandom();
 		var arenaClient = new ArenaClient(

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -41,7 +41,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var httpClient = _apiApplicationFactory.CreateClient();
 
 		var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(httpClient);
-		var rounds = await apiClient.GetStatusAsync(CancellationToken.None);
+		var rounds = await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 		var round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
 		// If an output is not in the utxo dataset then it is not unspent, this
@@ -430,7 +430,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			})).CreateClient();
 
 		ArenaClient apiClient = await _apiApplicationFactory.CreateArenaClientAsync(new StuttererHttpClient(httpClient));
-		RoundState[] rounds = await apiClient.GetStatusAsync(CancellationToken.None);
+		RoundState[] rounds = await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None);
 		RoundState round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -49,14 +49,14 @@ public class MultipartyTransactionTests
 
 		var twoInputs = oneInput.AddInput(alice2Coin);
 
-		Assert.Equal(2, twoInputs.Inputs.Count);
+		Assert.Equal(2, twoInputs.Inputs.Count());
 		Assert.Empty(twoInputs.Outputs);
 
 		// address reuse bad
 		var bob1 = new TxOut(Money.Coins(1), alice1Coin.ScriptPubKey);
 		var withOutput = twoInputs.AddOutput(bob1);
 
-		Assert.Equal(2, withOutput.Inputs.Count);
+		Assert.Equal(2, withOutput.Inputs.Count());
 		Assert.Single(withOutput.Outputs);
 
 		var bob2 = new TxOut(Money.Coins(1), alice2Coin.ScriptPubKey);
@@ -184,7 +184,7 @@ public class MultipartyTransactionTests
 		var bob1 = new TxOut(Money.Coins(1), alice1Coin.ScriptPubKey);
 		var withOutput = state.AddOutput(bob1);
 
-		Assert.Equal(2, withOutput.Inputs.Count);
+		Assert.Equal(2, withOutput.Inputs.Count());
 		Assert.Single(withOutput.Outputs);
 
 		var bob2 = new TxOut(Money.Coins(1), alice2Coin.ScriptPubKey);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -27,7 +27,7 @@ public class RoundStateUpdaterTests
 		// The coordinator creates two rounds.
 		// Each line represents a response for each request.
 		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
-		mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<CancellationToken>()))
+		mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
 			.ReturnsAsync(() => new[] { roundState1 with { Phase = Phase.InputRegistration } })
 			.ReturnsAsync(() => new[] { roundState1 with { Phase = Phase.OutputRegistration } })
 			.ReturnsAsync(() => new[] { roundState1 with { Phase = Phase.OutputRegistration }, roundState2 with { Phase = Phase.InputRegistration } })
@@ -104,7 +104,7 @@ public class RoundStateUpdaterTests
 		// Each line represents a response for each request.
 		// Exceptions, Problems, Errors everywhere!!!
 		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
-		mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<CancellationToken>()))
+		mockApiClient.SetupSequence(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
 			.ReturnsAsync(() => new[] { roundState with { Phase = Phase.InputRegistration } })
 			.ThrowsAsync(new Exception())
 			.ThrowsAsync(new OperationCanceledException())

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -138,7 +138,8 @@ public class SerializationTests
 		AssertSerialization(RoundState.FromRound(round));
 
 		var state = round.Assert<ConstructionState>();
-		round.CoinjoinState = new SigningState(state.Parameters, state.Inputs, state.Outputs);
+		state = state.AddInput(CreateCoin());
+		round.CoinjoinState = new SigningState(state.Parameters, state.Events);
 		AssertSerialization(RoundState.FromRound(round));
 	}
 
@@ -184,4 +185,10 @@ public class SerializationTests
 		new(
 			new[] { MAC.ComputeMAC(IssuerKey, Points.First(), Scalars.First()) },
 			new[] { new Proof(new GroupElementVector(Points.Take(2)), new ScalarVector(Scalars.Take(2))) });
+
+	private static Coin CreateCoin()
+	{
+		using var key = new Key();
+		return WabiSabiFactory.CreateCoin(key);
+	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/IWabiSabiApiRequestHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/IWabiSabiApiRequestHandler.cs
@@ -18,7 +18,7 @@ public interface IWabiSabiApiRequestHandler
 
 	Task<ReissueCredentialResponse> ReissuanceAsync(ReissueCredentialRequest request, CancellationToken cancellationToken);
 
-	Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken);
+	Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken);
 
 	Task ReadyToSignAsync(ReadyToSignRequestRequest request, CancellationToken cancellationToken);
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -1,6 +1,5 @@
 using NBitcoin;
 using Nito.AsyncEx;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -358,11 +357,14 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		return new Coin(input, txOutResponse.TxOut);
 	}
 
-	public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+	public async Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 	{
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
-			return Rounds.Select(x => RoundState.FromRound(x)).ToArray();
+			return Rounds.Select(x => {
+				var checkPoint = request.RoundCheckpoints.FirstOrDefault(y => y.RoundId == x.Id);
+				return RoundState.FromRound(x, checkPoint == default ? 0 : checkPoint.StateId);
+			}).ToArray();
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -176,8 +176,8 @@ public partial class Arena : PeriodicRunner
 				{
 					var coinjoin = round.Assert<ConstructionState>();
 
-					round.LogInfo($"{coinjoin.Inputs.Count} inputs were added.");
-					round.LogInfo($"{coinjoin.Outputs.Count} outputs were added.");
+					round.LogInfo($"{coinjoin.Inputs.Count()} inputs were added.");
+					round.LogInfo($"{coinjoin.Outputs.Count()} outputs were added.");
 
 					coinjoin = AddCoordinationFee(round, coinjoin);
 

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -195,9 +195,9 @@ public class ArenaClient
 		await RequestHandler.SignTransactionAsync(new TransactionSignaturesRequest(roundId, txInput.Index, txInput.WitScript), cancellationToken).ConfigureAwait(false);
 	}
 
-	public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
+	public async Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 	{
-		return await RequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+		return await RequestHandler.GetStatusAsync(request, cancellationToken).ConfigureAwait(false);
 	}
 
 	public async Task ReadyToSignAsync(

--- a/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateUpdater.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,8 +27,20 @@ public class RoundStateUpdater : PeriodicRunner
 
 	protected override async Task ActionAsync(CancellationToken cancellationToken)
 	{
-		var statusResponse = await ArenaRequestHandler.GetStatusAsync(cancellationToken).ConfigureAwait(false);
-		RoundStates = statusResponse.ToDictionary(round => round.Id);
+		var request = new RoundStateRequest(RoundStates.Select(x => (x.Key, x.Value.CoinjoinState.Events.Count)).ToImmutableList());
+		RoundState[] statusResponse = await ArenaRequestHandler.GetStatusAsync(request, cancellationToken).ConfigureAwait(false);
+
+		var updatedRoundStates = statusResponse
+			.Where(rs => RoundStates.ContainsKey(rs.Id))
+			.Select(rs => (Update: rs, CurrentRoundState: RoundStates[rs.Id]))
+			.Select(x => x.Update with {
+				CoinjoinState = x.Update.CoinjoinState.MergeBack(x.CurrentRoundState.CoinjoinState)
+			}).ToList();
+
+		var newRoundStates = statusResponse
+			.Where(rs => !RoundStates.ContainsKey(rs.Id));
+
+		RoundStates = newRoundStates.Concat(updatedRoundStates).ToDictionary(x => x.Id, x => x);
 
 		lock (AwaitersLock)
 		{

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -84,7 +84,10 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 				}
 				else
 				{
-					Logger.LogDebug($"Received a response for {action} in {totalTime.TotalSeconds:0.##s}.");
+					if (action != RemoteAction.GetStatus)
+					{
+						Logger.LogDebug($"Received a response for {action} in {totalTime.TotalSeconds:0.##s}.");
+					}
 				}
 
 				return response;

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -55,17 +55,8 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 	public virtual Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken) =>
 		SendAndReceiveAsync<TransactionSignaturesRequest>(RemoteAction.SignTransaction, request, cancellationToken);
 
-	public async Task<RoundState[]> GetStatusAsync(CancellationToken cancellationToken)
-	{
-		using var response = await _client.SendAsync(HttpMethod.Get, GetUriEndPoint(RemoteAction.GetStatus), cancel: cancellationToken).ConfigureAwait(false);
-
-		if (!response.IsSuccessStatusCode)
-		{
-			await response.ThrowRequestExceptionFromContentAsync(cancellationToken).ConfigureAwait(false);
-		}
-		var jsonString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-		return Deserialize<RoundState[]>(jsonString);
-	}
+	public Task<RoundState[]> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken) =>
+		SendAndReceiveAsync<RoundStateRequest, RoundState[]>(RemoteAction.GetStatus, request, cancellationToken);
 
 	public Task ReadyToSignAsync(ReadyToSignRequestRequest request, CancellationToken cancellationToken) =>
 		SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -60,7 +60,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
 		}
 
-		return this with { Inputs = Inputs.Add(coin) };
+		return this with { Inputs = Inputs.Add(coin), PreviousStates = PreviousStates.Add(this) };
 	}
 
 	public ConstructionState AddOutput(TxOut output)
@@ -93,7 +93,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
 		}
 
-		return this with { Outputs = Outputs.Add(output) };
+		return this with { Outputs = Outputs.Add(output), PreviousStates = PreviousStates.Add(this) };
 	}
 
 	public SigningState Finalize()

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -60,7 +60,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
 		}
 
-		return this with { Inputs = Inputs.Add(coin), PreviousStates = PreviousStates.Add(this) };
+		return this with { Events = Events.Add(new InputAdded(coin)) };
 	}
 
 	public ConstructionState AddOutput(TxOut output)
@@ -93,7 +93,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
 		}
 
-		return this with { Outputs = Outputs.Add(output), PreviousStates = PreviousStates.Add(this) };
+		return this with { Events = Events.Add(new OutputAdded(output)) };
 	}
 
 	public SigningState Finalize()
@@ -108,6 +108,6 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InsufficientFees, $"Effective fee rate {EffectiveFeeRate} is less than required {Parameters.FeeRate}.");
 		}
 
-		return new SigningState(Parameters, Inputs, Outputs);
+		return new SigningState(Parameters, Events);
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -46,9 +46,9 @@ public abstract record MultipartyTransactionState
 
 	public ImmutableList<IEvent> Events { get; init; } = ImmutableList<IEvent>.Empty;
 
-	public MultipartyTransactionState GetConstructionStateSince(int order) =>
+	public MultipartyTransactionState GetStateFrom(int stateId) =>
 		this with {
-			Events = Events.Skip(order).ToImmutableList()
+			Events = Events.Skip(stateId).ToImmutableList()
 		};
 
 	public MultipartyTransactionState Merge(MultipartyTransactionState diff) =>
@@ -56,7 +56,7 @@ public abstract record MultipartyTransactionState
 			Events = Events.AddRange(diff.Events)
 		};
 
-	public MultipartyTransactionState MergeBack(MultipartyTransactionState origin) =>
+	public MultipartyTransactionState AddPreviousStates(MultipartyTransactionState origin) =>
 		this with {
 			Events = origin.Events.AddRange(Events)
 		};

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -25,17 +25,23 @@ public abstract record MultipartyTransactionState
 	[JsonIgnore]
 	public IEnumerable<TxOut> Outputs => Events.OfType<OutputAdded>().Select(x => x.Output);
 
+	[JsonIgnore]
 	public Money Balance => Inputs.Sum(x => x.Amount) - Outputs.Sum(x => x.Value);
+	[JsonIgnore]
 	public int EstimatedInputsVsize => Inputs.Sum(x => x.TxOut.ScriptPubKey.EstimateInputVsize());
+	[JsonIgnore]
 	public int OutputsVsize => Outputs.Sum(x => x.ScriptPubKey.EstimateOutputVsize());
 
+	[JsonIgnore]
 	public int EstimatedVsize => MultipartyTransactionParameters.SharedOverhead + EstimatedInputsVsize + OutputsVsize;
+	[JsonIgnore]
 	public int MaxTransactionSize => Parameters.MaxTransactionSize;
 
 	// With no coordinator fees we can't ensure that the shared overhead
 	// of the transaction also pays at the nominal feerate so this will have
 	// to do for now, but in the future EstimatedVsize should be used
 	// including the shared overhead
+	[JsonIgnore]
 	public FeeRate EffectiveFeeRate => new(Balance, EstimatedInputsVsize + OutputsVsize);
 
 	public ImmutableList<IEvent> Events { get; init; } = ImmutableList<IEvent>.Empty;

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -31,7 +31,7 @@ public record RoundState(
 
 	public DateTimeOffset InputRegistrationEnd => InputRegistrationStart + InputRegistrationTimeout;
 
-	public static RoundState FromRound(Round round, int order = 0) =>
+	public static RoundState FromRound(Round round, int stateId = 0) =>
 		new(
 			round is BlameRound blameRound ? blameRound.BlameOf.Id : uint256.Zero,
 			round.AmountCredentialIssuerParameters,
@@ -48,7 +48,7 @@ public record RoundState(
 			round.MaxAmountCredentialValue,
 			round.MaxVsizeCredentialValue,
 			round.MaxVsizeAllocationPerAlice,
-			round.CoinjoinState.GetConstructionStateSince(order));
+			round.CoinjoinState.GetStateFrom(stateId));
 
 	public TState Assert<TState>() where TState : MultipartyTransactionState =>
 		CoinjoinState switch

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -31,7 +31,7 @@ public record RoundState(
 
 	public DateTimeOffset InputRegistrationEnd => InputRegistrationStart + InputRegistrationTimeout;
 
-	public static RoundState FromRound(Round round, int order = -1) =>
+	public static RoundState FromRound(Round round, int order = 0) =>
 		new(
 			round is BlameRound blameRound ? blameRound.BlameOf.Id : uint256.Zero,
 			round.AmountCredentialIssuerParameters,

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -31,7 +31,7 @@ public record RoundState(
 
 	public DateTimeOffset InputRegistrationEnd => InputRegistrationStart + InputRegistrationTimeout;
 
-	public static RoundState FromRound(Round round) =>
+	public static RoundState FromRound(Round round, int order = -1) =>
 		new(
 			round is BlameRound blameRound ? blameRound.BlameOf.Id : uint256.Zero,
 			round.AmountCredentialIssuerParameters,
@@ -48,7 +48,7 @@ public record RoundState(
 			round.MaxAmountCredentialValue,
 			round.MaxVsizeCredentialValue,
 			round.MaxVsizeAllocationPerAlice,
-			round.CoinjoinState);
+			round.CoinjoinState.GetConstructionStateSince(order));
 
 	public TState Assert<TState>() where TState : MultipartyTransactionState =>
 		CoinjoinState switch

--- a/WalletWasabi/WabiSabi/Models/RoundStateRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundStateRequest.cs
@@ -2,8 +2,9 @@ using System.Collections.Immutable;
 using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Models;
+public record RoundStateCheckpoint(uint256 RoundId, int StateId);
 
-public record RoundStateRequest(ImmutableList<(uint256 RoundId, int StateId)> RoundCheckpoints)
+public record RoundStateRequest(ImmutableList<RoundStateCheckpoint> RoundCheckpoints)
 {
-	public static readonly RoundStateRequest Empty = new (ImmutableList<(uint256 RoundId, int StateId)>.Empty);
+	public static readonly RoundStateRequest Empty = new(ImmutableList<RoundStateCheckpoint>.Empty);
 }

--- a/WalletWasabi/WabiSabi/Models/RoundStateRequest.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundStateRequest.cs
@@ -1,0 +1,9 @@
+using System.Collections.Immutable;
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Models;
+
+public record RoundStateRequest(ImmutableList<(uint256 RoundId, int StateId)> RoundCheckpoints)
+{
+	public static readonly RoundStateRequest Empty = new (ImmutableList<(uint256 RoundId, int StateId)>.Empty);
+}

--- a/WalletWasabi/WabiSabi/Models/Serialization/CoinJoinEventJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/CoinJoinEventJsonConverter.cs
@@ -1,0 +1,10 @@
+using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+
+namespace WalletWasabi.WabiSabi.Models.Serialization;
+
+public class CoinJoinEventJsonConverter : GenericInterfaceJsonConverter<IEvent>
+{
+	public CoinJoinEventJsonConverter() : base(new[] { typeof(InputAdded), typeof(OutputAdded) })
+	{
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/Serialization/GenericInterfaceJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/GenericInterfaceJsonConverter.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace WalletWasabi.WabiSabi.Models.Serialization;
+
+public class GenericInterfaceJsonConverter<T> : JsonConverter<T>
+{
+	// This converter is a bit unusual because we need to add a new property to the
+	// serialized json string but the converter is called recursively and fails with
+	// an "Self referencing loop" exception.
+	// The workaround is detect it and prevent reentering by setting CanRead and
+	// CanWrite to false immediately after entering.
+	// see: https://github.com/JamesNK/Newtonsoft.Json/issues/386
+	[ThreadStatic]
+	private static bool IsReading;
+
+	[ThreadStatic]
+	private static bool IsWriting;
+
+	public GenericInterfaceJsonConverter(IEnumerable<Type> types)
+	{
+		Types = types;
+	}
+
+	public override bool CanWrite => !IsWriting;
+
+	public override bool CanRead => !IsReading;
+
+	public IEnumerable<Type> Types { get; }
+
+	public override void WriteJson(JsonWriter writer, T? value, JsonSerializer serializer)
+	{
+		try
+		{
+			IsWriting = true;
+			if (value is not null)
+			{
+				var stateTypeName = value.GetType().Name;
+				var jObject = (JObject)JToken.FromObject(value, serializer);
+				jObject.AddFirst(new JProperty("Type", stateTypeName));
+				jObject.WriteTo(writer);
+			}
+		}
+		finally
+		{
+			IsWriting = false;
+		}
+	}
+
+	public override T? ReadJson(JsonReader reader, Type objectType, T? existingValue, bool hasExistingValue, JsonSerializer serializer)
+	{
+		try
+		{
+			IsReading = true;
+
+			var jsonObject = JObject.Load(reader);
+			var typeName = jsonObject.Value<string>("Type");
+			var stateType =  Types.Single(t => t.Name == typeName);
+			return (T?)serializer.Deserialize(jsonObject.CreateReader(), stateType);
+		}
+		finally
+		{
+			IsReading = false;
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -26,7 +26,8 @@ public class JsonSerializationOptions
 				new MultipartyTransactionStateJsonConverter(),
 				new ExtPubKeyJsonConverter(),
 				new TimeSpanJsonConverter(),
-				new CoinJsonConverter()
+				new CoinJsonConverter(),
+				new CoinJoinEventJsonConverter(),
 			}
 	};
 	public static readonly JsonSerializationOptions Default = new();

--- a/WalletWasabi/WabiSabi/Models/Serialization/MultipartyTransactionStateJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/MultipartyTransactionStateJsonConverter.cs
@@ -1,72 +1,10 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 namespace WalletWasabi.WabiSabi.Models.Serialization;
 
-public class MultipartyTransactionStateJsonConverter : JsonConverter
+public class MultipartyTransactionStateJsonConverter : GenericInterfaceJsonConverter<MultipartyTransactionState>
 {
-	// This converter is a bit unusual because we need to add a new property to the
-	// serialized json string but the converter is called recursively and fails with
-	// an "Self referencing loop" exception.
-	// The workaround is detect it and prevent reentering by setting CanRead and
-	// CanWrite to false immediately after entering.
-	// see: https://github.com/JamesNK/Newtonsoft.Json/issues/386
-	[ThreadStatic]
-	private static bool IsReading;
-
-	[ThreadStatic]
-	private static bool IsWriting;
-
-	public override bool CanWrite => !IsWriting;
-
-	public override bool CanRead => !IsReading;
-
-	public override bool CanConvert(Type objectType)
+	public MultipartyTransactionStateJsonConverter() : base(new [] { typeof(ConstructionState), typeof(SigningState) })
 	{
-		return typeof(MultipartyTransactionState).IsAssignableFrom(objectType);
-	}
-
-	public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-	{
-		try
-		{
-			IsWriting = true;
-
-			var stateTypeName = value switch
-			{
-				ConstructionState => "Constructing",
-				SigningState => "Signing",
-				_ => throw new InvalidOperationException("")
-			};
-			var jObject = (JObject)JToken.FromObject(value, serializer);
-			jObject.AddFirst(new JProperty("State", stateTypeName));
-			jObject.WriteTo(writer);
-		}
-		finally
-		{
-			IsWriting = false;
-		}
-	}
-
-	public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-	{
-		try
-		{
-			IsReading = true;
-
-			var jsonObject = JObject.Load(reader);
-			var stateType = jsonObject.Value<string>("State") switch
-			{
-				"Constructing" => typeof(ConstructionState),
-				"Signing" => typeof(SigningState),
-				_ => throw new InvalidOperationException("")
-			};
-			return serializer.Deserialize(jsonObject.CreateReader(), stateType);
-		}
-		finally
-		{
-			IsReading = false;
-		}
 	}
 }


### PR DESCRIPTION
### Brief description

This PR allows the clients to fetch updates (news) regarding to new inputs and outputs from the coordinator instead of fetch everything all the time. As a result the bandwidth requirements are much lower.

### Background 

The WabiSabi coinjoin clients need to be updated regularly about the status of the different coordinator's rounds. These updates contains information such as the current phase of the round and the registered inputs and outputs, among other data. The component responsible for keeping the coinjoin clients updated with this information is the `RoundStateUpdater` which hits the coordinator frequently (5 seconds) and fetches the rounds.

### Incremental updates

In a real-world(TM) scenario where the number of inputs and outputs in a coinjoin transaction can be in the order of hundreads, fetching all that data with high frequency over `Tor` is not a good idea and it cannot really work. Instead of doing that this PR fetches the incremental updates to allow the client to add new info to the already known data.

### Design

There are basically two important events that all clients need to be aware of:

    * Input registered event and,
    * Output registered event.

The occurrence of any of these events changes the internal state of the coordinator that is stored in the `CoinJoinState`. In order to be able to calculate the difference between the _user's known state_ and the _latest one_ the coordinator keeps a list of `Events` in the `CoinJoinState`:

```
  COORDINATOR
     STATE
  ┌────────┐                  ─┬─                             ─┬──
  ├────────┤                   │                               │
7 │ OUTPUT │                   │                               │
  ├────────┤                   │ Next update                   │ Next update
6 │ OUTPUT │                   │ will fetch                    │ will fetch
  ├────────┤                   │ missing 5                     │ missing 3
5 │ INPUT  │                   │ events                        │ events
  ├────────┤                   │                   ┌────────┐ ─┼─
4 │ INPUT  │                   │                 4 │ INPUT  │  │
  ├────────┤                   │                   ├────────┤  │
3 │ INPUT  │                   │                 3 │ INPUT  │  │
  ├────────┤                   │                   ├────────┤  │
2 │ INPUT  │                   │                 2 │ INPUT  │  │
  ├────────┤       ┌────────┐ ─┼─                  ├────────┤  │
1 │ INPUT  │     1 │ INPUT  │  │ CLIENT          1 │ INPUT  │  │ CLIENT
  ├────────┤       ├────────┤  │ STATE             ├────────┤  │ STATE
0 │ INPUT  │     0 │ INPUT  │  │ 2 EVENTS        0 │ INPUT  │  │ 4 EVENTS
  └────────┘       └────────┘ ─┴─                  └────────┘ ─┴─
                    CLIENT 0                        CLIENT 1
```
There are two new operations over this state chain:

    * Coordinator: calculate the difference/increment containing the data the client needs to know and,
    * Client: apply the received increment to the old-known state to get the latest snapshot of the state.

This is code implements the idea described in the previous version of this feature: https://github.com/zkSNACKs/WalletWasabi/pull/6515
> The idea is to have an append-only list of events as coinjoin state instead of having an linked-list of coinjoin states. However, doing that requires a bit more time than doing this.



