### PR TITLE
Add Wallet Stats

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ReactiveUI;
+using WalletWasabi.Fluent.ViewModels.Navigation;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced;
+
+[NavigationMetaData(Title = "Wallet Stats")]
+public partial class WalletStatsViewModel : RoutableViewModel
+{
+	public WalletStatsViewModel(WalletViewModelBase walletViewModelBase)
+	{
+		var wallet = walletViewModelBase.Wallet;
+
+		// Number of coins in the wallet.
+		// Changes to wallet.WalletRelevantTransactionProcessed
+		var coinCount = wallet.Coins.Unspent().Count();
+
+		// Total amount of money in the wallet.
+		// Changes to wallet.WalletRelevantTransactionProcessed
+		var balance = wallet.Coins.Unspent().TotalAmount();
+
+		// Total amount of confirmed money in the wallet.
+		// Changes to wallet.WalletRelevantTransactionProcessed
+		var confirmedBalance = wallet.Coins.Confirmed().TotalAmount();
+
+		// Total amount of unconfirmed money in the wallet.
+		// Changes to wallet.WalletRelevantTransactionProcessed
+		var unconfirmedBalance = wallet.Coins.Unconfirmed().TotalAmount();
+	}
+}


### PR DESCRIPTION
This PR is to give the UI team the backend logic for a few basic wallet stats. Anyone feel free to take it over and do the view and stuff.

Today we discussed this feature and we decided to have a new page: `Wallet Stats`. Note we also have a `Wallet Info`. The difference is that while the former contains dynamic data, the latter doesn't.

This'd resolve https://github.com/zkSNACKs/WalletWasabi/issues/3046