### PR TITLE
[Fluent] Beautify wallet settings dialog

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -25,6 +25,8 @@
           <ToggleSwitch IsChecked="{Binding AutoCoinJoin}" />
         </DockPanel>
 
+        <Separator />
+
         <StackPanel Spacing="10">
           <TextBlock Text="Minimum Anonymity Score Target" />
           <DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -9,11 +9,10 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.WalletSettingsView">
   <c:ContentArea Title="{Binding Title}"
-                 Caption=""
                  EnableNext="True" NextContent="Done"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}">
-    <StackPanel Spacing="20">
+    <StackPanel Spacing="20" Margin="0 30">
       <StackPanel Classes="settingsLayout">
         <DockPanel IsVisible="{Binding IsHardwareWallet}">
           <TextBlock Text="PSBT workflow" />

--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -9,7 +9,7 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.WalletSettingsView">
   <c:ContentArea Title="{Binding Title}"
-                 Caption="Manage your wallet's settings"
+                 Caption=""
                  EnableNext="True" NextContent="Done"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}">


### PR DESCRIPTION
This PR adds a separator and removes the caption text because IMO it just clutters that dialog.

![0 30](https://user-images.githubusercontent.com/52379387/152655751-58895322-7b1a-4bb4-85cb-10f82f994f48.PNG)
