### PR TITLE
Lower DefaultPlebStopThreshold to 0.005 BTC

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -28,7 +28,7 @@ public class KeyManager
 
 	public const int AbsoluteMinGapLimit = 21;
 	public const int MaxGapLimit = 10_000;
-	public static Money DefaultPlebStopThreshold = Money.Coins(0.005m);
+	private static Money DefaultPlebStopThreshold = Money.Coins(0.005m);
 
 	// BIP84-ish derivation scheme
 	// m / purpose' / coin_type' / account' / change / address_index

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -28,7 +28,7 @@ public class KeyManager
 
 	public const int AbsoluteMinGapLimit = 21;
 	public const int MaxGapLimit = 10_000;
-	public static Money DefaultPlebStopThreshold = Money.Coins(0.01m);
+	public static Money DefaultPlebStopThreshold = Money.Coins(0.005m);
 
 	// BIP84-ish derivation scheme
 	// m / purpose' / coin_type' / account' / change / address_index


### PR DESCRIPTION
This lowers the `DefaultPlebStopThreshold` to 0.005 BTC, by default it is lower than `PlebsDontPayThreshold` of 0.01 BTC so plebs can enjoy both the ease of use of WW2 (auto coinjoin) and the free coinjoin.

https://github.com/zkSNACKs/WalletWasabi/issues/7122#issuecomment-1028967606