### PR TITLE
Improve `isLikelyCoinjoin`

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -38,7 +38,7 @@ public class BlockchainAnalyzer
 		{
 			AnalyzeWalletInputs(tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int newInputAnonset);
 
-			if (!tx.IsLikelyCoinjoin())
+			if (inputCount == ownInputCount)
 			{
 				AnalyzeSelfSpend(tx, newInputAnonset);
 			}

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -52,10 +52,7 @@ public class BlockchainAnalyzer
 			AdjustWalletInputs(tx, distinctWalletInputPubKeys, newInputAnonset);
 		}
 
-		if (!isLikelyCoinjoin)
-		{
-			AnalyzeClusters(tx);
-		}
+		AnalyzeClusters(tx);
 	}
 
 	/// <param name="newInputAnonset">The new anonymity set of the inputs.</param>

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -20,6 +20,8 @@ public class BlockchainAnalyzer
 	/// </summary>
 	public void Analyze(SmartTransaction tx)
 	{
+		bool isLikelyCoinjoin = tx.IsLikelyCoinjoin();
+
 		var inputCount = tx.Transaction.Inputs.Count;
 		var outputCount = tx.Transaction.Outputs.Count;
 
@@ -38,7 +40,7 @@ public class BlockchainAnalyzer
 		{
 			AnalyzeWalletInputs(tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int newInputAnonset);
 
-			if (!tx.IsLikelyCoinjoin())
+			if (!isLikelyCoinjoin)
 			{
 				AnalyzeSelfSpend(tx, newInputAnonset);
 			}
@@ -50,7 +52,10 @@ public class BlockchainAnalyzer
 			AdjustWalletInputs(tx, distinctWalletInputPubKeys, newInputAnonset);
 		}
 
-		AnalyzeClusters(tx);
+		if (isLikelyCoinjoin)
+		{
+			AnalyzeClusters(tx);
+		}
 	}
 
 	/// <param name="newInputAnonset">The new anonymity set of the inputs.</param>
@@ -231,6 +236,10 @@ public class BlockchainAnalyzer
 
 	private void AnalyzeClusters(SmartTransaction tx)
 	{
+		if (tx.IsLikelyCoinjoin())
+		{
+			return;
+		}
 		foreach (var newCoin in tx.WalletOutputs)
 		{
 			if (newCoin.HdPubKey.AnonymitySet < PrivacyLevelThreshold)

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -20,8 +20,6 @@ public class BlockchainAnalyzer
 	/// </summary>
 	public void Analyze(SmartTransaction tx)
 	{
-		bool isLikelyCoinjoin = tx.IsLikelyCoinjoin();
-
 		var inputCount = tx.Transaction.Inputs.Count;
 		var outputCount = tx.Transaction.Outputs.Count;
 
@@ -40,7 +38,7 @@ public class BlockchainAnalyzer
 		{
 			AnalyzeWalletInputs(tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int newInputAnonset);
 
-			if (!isLikelyCoinjoin)
+			if (!tx.IsLikelyCoinjoin())
 			{
 				AnalyzeSelfSpend(tx, newInputAnonset);
 			}

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -52,7 +52,7 @@ public class BlockchainAnalyzer
 			AdjustWalletInputs(tx, distinctWalletInputPubKeys, newInputAnonset);
 		}
 
-		if (isLikelyCoinjoin)
+		if (!isLikelyCoinjoin)
 		{
 			AnalyzeClusters(tx);
 		}
@@ -236,10 +236,6 @@ public class BlockchainAnalyzer
 
 	private void AnalyzeClusters(SmartTransaction tx)
 	{
-		if (tx.IsLikelyCoinjoin())
-		{
-			return;
-		}
 		foreach (var newCoin in tx.WalletOutputs)
 		{
 			if (newCoin.HdPubKey.AnonymitySet < PrivacyLevelThreshold)

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -38,7 +38,7 @@ public class BlockchainAnalyzer
 		{
 			AnalyzeWalletInputs(tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int newInputAnonset);
 
-			if (inputCount == ownInputCount)
+			if (!tx.IsLikelyCoinjoin())
 			{
 				AnalyzeSelfSpend(tx, newInputAnonset);
 			}

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -14,7 +14,7 @@ public class ProcessedResult
 	public ProcessedResult(SmartTransaction transaction)
 	{
 		Transaction = Guard.NotNull(nameof(transaction), transaction);
-		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.WalletInputs.Any() && Transaction.Transaction.IsLikelyCoinjoin(), true);
+		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.WalletInputs.Any() && Transaction.IsLikelyCoinjoin(), true);
 	}
 
 	public SmartTransaction Transaction { get; }

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -49,7 +49,7 @@ public class TransactionHistoryBuilder
 					Label = containingTransaction.Label,
 					TransactionId = coin.TransactionId,
 					BlockIndex = containingTransaction.BlockIndex,
-					IsLikelyCoinJoinOutput = containingTransaction.Transaction.IsLikelyCoinjoin()
+					IsLikelyCoinJoinOutput = containingTransaction.IsLikelyCoinjoin()
 				});
 			}
 
@@ -74,7 +74,7 @@ public class TransactionHistoryBuilder
 						Label = spenderTransaction.Label,
 						TransactionId = spenderTxId,
 						BlockIndex = spenderTransaction.BlockIndex,
-						IsLikelyCoinJoinOutput = spenderTransaction.Transaction.IsLikelyCoinjoin()
+						IsLikelyCoinJoinOutput = spenderTransaction.IsLikelyCoinjoin()
 					});
 				}
 			}

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -152,6 +152,7 @@ public static class NBitcoinExtensions
 
 	public static bool IsLikelyCoinjoin(this SmartTransaction me)
 		=> me.Transaction.Inputs.Count > 1 // The tx must have more than one input in order to be a coinjoin.
+		&& me.Transaction.Inputs.Count != me.WalletInputs.Count
 		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
 
 	/// <summary>

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -151,8 +151,7 @@ public static class NBitcoinExtensions
 	}
 
 	public static bool IsLikelyCoinjoin(this SmartTransaction me)
-		=> me.Transaction.Inputs.Count > 1 // The tx must have more than one input in order to be a coinjoin.
-		&& me.Transaction.Inputs.Count != me.WalletInputs.Count
+		=> me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
 		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
 
 	/// <summary>

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -150,9 +150,9 @@ public static class NBitcoinExtensions
 		return anonsets;
 	}
 
-	public static bool IsLikelyCoinjoin(this Transaction me)
-		=> me.Inputs.Count > 1 // The tx must have more than one input in order to be a coinjoin.
-		&& me.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
+	public static bool IsLikelyCoinjoin(this SmartTransaction me)
+		=> me.Transaction.Inputs.Count > 1 // The tx must have more than one input in order to be a coinjoin.
+		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
 
 	/// <summary>
 	/// Careful, if it's in a legacy block then this won't work.


### PR DESCRIPTION
Fixes #7167
_This PR slightly improves the functionality of the `isLikelyCoinjoin()` function._
**Related to label problems.**
Here we prevent merging labels in case of a CoinJoin transaction.
We don't want to merge them, as in theory, the exact opposite happens, as a coin will be less known by the people after CJ.