### PR TITLE
Execute 'builder.CoinFinder' when payjoin tx only

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -229,13 +229,10 @@ public class TransactionFactory
 			builder = builder.AddKeys(signingKeys.ToArray());
 			builder.SignPSBT(psbt);
 
-			var isPayjoin = false;
-
 			// Try to pay using payjoin
 			if (payjoinClient is not null)
 			{
 				psbt = TryNegotiatePayjoin(payjoinClient, builder, psbt, changeHdPubKey);
-				isPayjoin = true;
 				psbt.AddKeyPaths(KeyManager);
 				psbt.AddPrevTxs(TransactionStore);
 			}
@@ -243,7 +240,7 @@ public class TransactionFactory
 			psbt.Finalize();
 			tx = psbt.ExtractTransaction();
 
-			if (isPayjoin)
+			if (payjoinClient is not null)
 			{
 				builder.CoinFinder = (outpoint) => psbt.Inputs.Select(x => x.GetCoin()).Single(x => x?.Outpoint == outpoint)!;
 			}

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -229,10 +229,13 @@ public class TransactionFactory
 			builder = builder.AddKeys(signingKeys.ToArray());
 			builder.SignPSBT(psbt);
 
+			var isPayjoin = false;
+
 			// Try to pay using payjoin
 			if (payjoinClient is not null)
 			{
 				psbt = TryNegotiatePayjoin(payjoinClient, builder, psbt, changeHdPubKey);
+				isPayjoin = true;
 				psbt.AddKeyPaths(KeyManager);
 				psbt.AddPrevTxs(TransactionStore);
 			}
@@ -240,7 +243,10 @@ public class TransactionFactory
 			psbt.Finalize();
 			tx = psbt.ExtractTransaction();
 
-			builder.CoinFinder = (outpoint) => psbt.Inputs.Select(x => x.GetCoin()).Single(x => x?.Outpoint == outpoint)!;
+			if (isPayjoin)
+			{
+				builder.CoinFinder = (outpoint) => psbt.Inputs.Select(x => x.GetCoin()).Single(x => x?.Outpoint == outpoint)!;
+			}
 
 			var checkResults = builder.Check(tx).ToList();
 			if (checkResults.Count > 0)


### PR DESCRIPTION
@nopara73 mentioned that this should be executed only for payjoin tx.

> > I wonder whether builder.CoinFinder = (outpoint) => psbt.Inputs.Select(x => x.GetCoin()).Single(x => x?.Outpoint == outpoint)!; should be executed only when there is actually a payjoin involved. But I don't know an answer for that.
> 
> It is. The "fix" happened in the `TransactionFactory`.

https://github.com/zkSNACKs/WalletWasabi/pull/7136#issuecomment-1030771671

The `HonestPayjoinServerTest` does pass.