### PR TITLE
Use variable length integer in CoinJoinInputCommitmentData

### DIFF
--- a/WalletWasabi/Crypto/CoinJoinInputCommitmentData.cs
+++ b/WalletWasabi/Crypto/CoinJoinInputCommitmentData.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text;
 using NBitcoin;
+using NBitcoin.Protocol;
 
 namespace WalletWasabi.Crypto;
 
@@ -21,7 +22,7 @@ public record CoinJoinInputCommitmentData
 	}
 
 	public byte[] ToBytes() =>
-		BitConverter.GetBytes(_coordinatorIdentifier.Length)
+		new VarInt((ulong)_coordinatorIdentifier.Length).ToBytes()
 			.Concat(_coordinatorIdentifier)
 			.Concat(_roundIdentifier)
 			.ToArray();


### PR DESCRIPTION
This PR changes the way `coordinatorIdentifier` is prefixed with its length in `CoinJoinInputCommitmentData`:
* Before this PR, the class used `BitConverter` to convert the length of `coordinatorIdentifier` to bytes. This is not recommended when transmitting the bytes between computers, since the bytes depend on computer architecture. See [this](https://docs.microsoft.com/en-us/dotnet/api/system.bitconverter?view=net-6.0):

> Because the return value of some methods depends on system architecture, be careful when transmitting byte data beyond machine boundaries: [...]


* After this PR, the class uses [variable length integer](https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer) that is platform independent, widely used in Bitcoin protocol and supported probably by every library dealing with Bitcoin.
