### PR TITLE
Get rid of most of DirectShow warnings

### DIFF
--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -9,21 +9,21 @@ namespace WalletWasabi.Fluent.Models.Windows;
 
 public static class DirectShow
 {
-	public static object CoCreateInstance(Guid clsid)
+	public static object? CoCreateInstance(Guid clsid)
 	{
-		return Activator.CreateInstance(Type.GetTypeFromCLSID(clsid));
+		return Activator.CreateInstance(type: Type.GetTypeFromCLSID(clsid));
 	}
 
-	public static void ReleaseInstance<T>(ref T com) where T : class
+	public static void ReleaseInstance<T>(ref T? com) where T : class
 	{
 		if (com != null)
 		{
-			Marshal.ReleaseComObject(com);
+			_ = Marshal.ReleaseComObject(com);
 			com = null;
 		}
 	}
 
-	public static IGraphBuilder CreateGraph()
+	public static IGraphBuilder? CreateGraph()
 	{
 		return CoCreateInstance(DsGuid.CLSID_FilterGraph) as IGraphBuilder;
 	}
@@ -69,14 +69,14 @@ public static class DirectShow
 		return result;
 	}
 
-	public static IBaseFilter CreateFilter(Guid clsid)
+	public static IBaseFilter? CreateFilter(Guid clsid)
 	{
 		return CoCreateInstance(clsid) as IBaseFilter;
 	}
 
 	public static IBaseFilter CreateFilter(Guid category, int index)
 	{
-		IBaseFilter result = null;
+		IBaseFilter? result = null;
 
 		int curr_index = 0;
 		EnumMonikers(category, (moniker, prop) =>
@@ -101,15 +101,14 @@ public static class DirectShow
 
 	private static void EnumMonikers(Guid category, Func<IMoniker, IPropertyBag, bool> func)
 	{
-		IEnumMoniker enumerator = null;
-		ICreateDevEnum device = null;
+		IEnumMoniker? enumerator = null;
+		ICreateDevEnum? device = null;
 
 		try
 		{
-			device = (ICreateDevEnum)Activator.CreateInstance(
-				Type.GetTypeFromCLSID(DsGuid.CLSID_SystemDeviceEnum));
+			device = Activator.CreateInstance(Type.GetTypeFromCLSID(DsGuid.CLSID_SystemDeviceEnum)) as ICreateDevEnum;
 
-			device.CreateClassEnumerator(ref category, ref enumerator, 0);
+			device?.CreateClassEnumerator(ref category, ref enumerator, 0);
 
 			if (enumerator == null)
 			{
@@ -188,10 +187,10 @@ public static class DirectShow
 		return result;
 	}
 
-	private static IPin EnumPins(IBaseFilter filter, Func<PIN_INFO, bool> func)
+	private static IPin? EnumPins(IBaseFilter filter, Func<PIN_INFO, bool> func)
 	{
-		IEnumPins pins = null;
-		IPin ipin = null;
+		IEnumPins? pins = null;
+		IPin? ipin = null;
 
 		try
 		{
@@ -251,8 +250,13 @@ public static class DirectShow
 		graph.Connect(out_pin, inp_pin);
 	}
 
-	public static void DeleteMediaType(ref AM_MEDIA_TYPE mt)
+	public static void DeleteMediaType(ref AM_MEDIA_TYPE? mt)
 	{
+		if (mt == null)
+		{
+			return;
+		}
+
 		if (mt.lSampleSize != 0)
 		{
 			Marshal.FreeCoTaskMem(mt.pbFormat);
@@ -682,18 +686,18 @@ public static class DirectShow
 		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
 		public string? achName;
 
-		[MarshalAs(UnmanagedType.IUnknown)] public object pGraph;
+		[MarshalAs(UnmanagedType.IUnknown)] public object? pGraph;
 	}
 
 	[Serializable]
 	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode), ComVisible(false)]
 	public class PIN_INFO
 	{
-		public IBaseFilter pFilter;
+		public IBaseFilter? pFilter;
 		public PIN_DIRECTION dir;
 
 		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
-		public string achName;
+		public string? achName;
 	}
 
 	[Serializable]

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -868,59 +868,55 @@ public static class DirectShow
 
 	public static class DsGuid
 	{
-		public static readonly Guid MEDIATYPE_Video = new Guid("{73646976-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIATYPE_Video = new("{73646976-0000-0010-8000-00AA00389B71}");
 
-		public static readonly Guid MEDIATYPE_Audio = new Guid("{73647561-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIATYPE_Audio = new("{73647561-0000-0010-8000-00AA00389B71}");
 
-		public static readonly Guid MEDIASUBTYPE_None = new Guid("{E436EB8E-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid MEDIASUBTYPE_None = new("{E436EB8E-524F-11CE-9F53-0020AF0BA770}");
 
-		public static readonly Guid MEDIASUBTYPE_YUYV = new Guid("{56595559-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_IYUV = new Guid("{56555949-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_YVU9 = new Guid("{39555659-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_YUY2 = new Guid("{32595559-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_YVYU = new Guid("{55595659-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_UYVY = new Guid("{59565955-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_MJPG = new Guid("{47504A4D-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_RGB565 = new Guid("{E436EB7B-524F-11CE-9F53-0020AF0BA770}");
-		public static readonly Guid MEDIASUBTYPE_RGB555 = new Guid("{E436EB7C-524F-11CE-9F53-0020AF0BA770}");
-		public static readonly Guid MEDIASUBTYPE_RGB24 = new Guid("{E436EB7D-524F-11CE-9F53-0020AF0BA770}");
-		public static readonly Guid MEDIASUBTYPE_RGB32 = new Guid("{E436EB7E-524F-11CE-9F53-0020AF0BA770}");
-		public static readonly Guid MEDIASUBTYPE_ARGB32 = new Guid("{773C9AC0-3274-11D0-B724-00AA006C1A01}");
-		public static readonly Guid MEDIASUBTYPE_PCM = new Guid("{00000001-0000-0010-8000-00AA00389B71}");
-		public static readonly Guid MEDIASUBTYPE_WAVE = new Guid("{E436EB8B-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid MEDIASUBTYPE_YUYV = new("{56595559-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_IYUV = new("{56555949-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_YVU9 = new("{39555659-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_YUY2 = new("{32595559-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_YVYU = new("{55595659-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_UYVY = new("{59565955-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_MJPG = new("{47504A4D-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_RGB565 = new("{E436EB7B-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid MEDIASUBTYPE_RGB555 = new("{E436EB7C-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid MEDIASUBTYPE_RGB24 = new("{E436EB7D-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid MEDIASUBTYPE_RGB32 = new("{E436EB7E-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid MEDIASUBTYPE_ARGB32 = new("{773C9AC0-3274-11D0-B724-00AA006C1A01}");
+		public static readonly Guid MEDIASUBTYPE_PCM = new("{00000001-0000-0010-8000-00AA00389B71}");
+		public static readonly Guid MEDIASUBTYPE_WAVE = new("{E436EB8B-524F-11CE-9F53-0020AF0BA770}");
 
-		public static readonly Guid FORMAT_None = new Guid("{0F6417D6-C318-11D0-A43F-00A0C9223196}");
+		public static readonly Guid FORMAT_None = new("{0F6417D6-C318-11D0-A43F-00A0C9223196}");
 
-		public static readonly Guid FORMAT_VideoInfo = new Guid("{05589F80-C356-11CE-BF01-00AA0055595A}");
-		public static readonly Guid FORMAT_VideoInfo2 = new Guid("{F72A76A0-EB0A-11d0-ACE4-0000C0CC16BA}");
-		public static readonly Guid FORMAT_WaveFormatEx = new Guid("{05589F81-C356-11CE-BF01-00AA0055595A}");
+		public static readonly Guid FORMAT_VideoInfo = new("{05589F80-C356-11CE-BF01-00AA0055595A}");
+		public static readonly Guid FORMAT_VideoInfo2 = new("{F72A76A0-EB0A-11d0-ACE4-0000C0CC16BA}");
+		public static readonly Guid FORMAT_WaveFormatEx = new("{05589F81-C356-11CE-BF01-00AA0055595A}");
 
-		public static readonly Guid CLSID_AudioInputDeviceCategory =
-			new Guid("{33D9A762-90C8-11d0-BD43-00A0C911CE86}");
+		public static readonly Guid CLSID_AudioInputDeviceCategory = new("{33D9A762-90C8-11d0-BD43-00A0C911CE86}");
 
-		public static readonly Guid CLSID_AudioRendererCategory =
-			new Guid("{E0F158E1-CB04-11d0-BD4E-00A0C911CE86}");
+		public static readonly Guid CLSID_AudioRendererCategory = new("{E0F158E1-CB04-11d0-BD4E-00A0C911CE86}");
 
-		public static readonly Guid CLSID_VideoInputDeviceCategory =
-			new Guid("{860BB310-5D01-11d0-BD3B-00A0C911CE86}");
+		public static readonly Guid CLSID_VideoInputDeviceCategory = new("{860BB310-5D01-11d0-BD3B-00A0C911CE86}");
 
-		public static readonly Guid CLSID_VideoCompressorCategory =
-			new Guid("{33D9A760-90C8-11d0-BD43-00A0C911CE86}");
+		public static readonly Guid CLSID_VideoCompressorCategory = new("{33D9A760-90C8-11d0-BD43-00A0C911CE86}");
 
-		public static readonly Guid CLSID_NullRenderer = new Guid("{C1F400A4-3F08-11D3-9F0B-006008039E37}");
-		public static readonly Guid CLSID_SampleGrabber = new Guid("{C1F400A0-3F08-11D3-9F0B-006008039E37}");
+		public static readonly Guid CLSID_NullRenderer = new("{C1F400A4-3F08-11D3-9F0B-006008039E37}");
+		public static readonly Guid CLSID_SampleGrabber = new("{C1F400A0-3F08-11D3-9F0B-006008039E37}");
 
-		public static readonly Guid CLSID_FilterGraph = new Guid("{E436EBB3-524F-11CE-9F53-0020AF0BA770}");
-		public static readonly Guid CLSID_SystemDeviceEnum = new Guid("{62BE5D10-60EB-11d0-BD3B-00A0C911CE86}");
-		public static readonly Guid CLSID_CaptureGraphBuilder2 = new Guid("{BF87B6E1-8C27-11d0-B3F0-00AA003761C5}");
+		public static readonly Guid CLSID_FilterGraph = new("{E436EBB3-524F-11CE-9F53-0020AF0BA770}");
+		public static readonly Guid CLSID_SystemDeviceEnum = new("{62BE5D10-60EB-11d0-BD3B-00A0C911CE86}");
+		public static readonly Guid CLSID_CaptureGraphBuilder2 = new("{BF87B6E1-8C27-11d0-B3F0-00AA003761C5}");
 
-		public static readonly Guid IID_IPropertyBag = new Guid("{55272A00-42CB-11CE-8135-00AA004BB851}");
-		public static readonly Guid IID_IBaseFilter = new Guid("{56a86895-0ad4-11ce-b03a-0020af0ba770}");
-		public static readonly Guid IID_IAMStreamConfig = new Guid("{C6E13340-30AC-11d0-A18C-00A0C9118956}");
+		public static readonly Guid IID_IPropertyBag = new("{55272A00-42CB-11CE-8135-00AA004BB851}");
+		public static readonly Guid IID_IBaseFilter = new("{56a86895-0ad4-11ce-b03a-0020af0ba770}");
+		public static readonly Guid IID_IAMStreamConfig = new("{C6E13340-30AC-11d0-A18C-00A0C9118956}");
 
-		public static readonly Guid PIN_CATEGORY_CAPTURE = new Guid("{fb6c4281-0353-11d1-905f-0000c0cc16ba}");
-		public static readonly Guid PIN_CATEGORY_PREVIEW = new Guid("{fb6c4282-0353-11d1-905f-0000c0cc16ba}");
-		public static readonly Guid PIN_CATEGORY_STILL = new Guid("{fb6c428a-0353-11d1-905f-0000c0cc16ba}");
+		public static readonly Guid PIN_CATEGORY_CAPTURE = new("{fb6c4281-0353-11d1-905f-0000c0cc16ba}");
+		public static readonly Guid PIN_CATEGORY_PREVIEW = new("{fb6c4282-0353-11d1-905f-0000c0cc16ba}");
+		public static readonly Guid PIN_CATEGORY_STILL = new("{fb6c428a-0353-11d1-905f-0000c0cc16ba}");
 
 		private static Dictionary<Guid, string> NicknameCache = null;
 

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -271,7 +271,7 @@ public static class DirectShow
 	 InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 	public interface IFilterGraph
 	{
-		int AddFilter([In] IBaseFilter pFilter, [In, MarshalAs(UnmanagedType.LPWStr)] string pName);
+		int AddFilter([In] IBaseFilter? pFilter, [In, MarshalAs(UnmanagedType.LPWStr)] string pName);
 
 		int RemoveFilter([In] IBaseFilter pFilter);
 

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -59,9 +59,8 @@ public static class DirectShow
 		{
 			object? value = null;
 			_ = prop.Read("FriendlyName", ref value, 0);
-			var name = (string)value;
 
-			result.Add(name);
+			result.Add((string)value);
 
 			return false;
 		});
@@ -619,14 +618,14 @@ public static class DirectShow
 	public interface ICreateDevEnum
 	{
 		int CreateClassEnumerator([In] ref Guid pType,
-			[In, Out] ref IEnumMoniker ppEnumMoniker, [In] int dwFlags);
+			[In, Out] ref IEnumMoniker? ppEnumMoniker, [In] int dwFlags);
 	}
 
 	[ComVisible(true), ComImport(), Guid("55272A00-42CB-11CE-8135-00AA004BB851"),
 	 InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 	public interface IPropertyBag
 	{
-		int Read([MarshalAs(UnmanagedType.LPWStr)] string propName, ref object var, int errorLog);
+		int Read([MarshalAs(UnmanagedType.LPWStr)] string propName, ref object? var, int errorLog);
 
 		int Write(string propName, ref object var);
 	}

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -479,7 +479,7 @@ public static class DirectShow
 	public interface IAMStreamConfig
 	{
 		int SetFormat([In, MarshalAs(UnmanagedType.LPStruct)]
-				AM_MEDIA_TYPE pmt);
+				AM_MEDIA_TYPE? pmt);
 
 		int GetFormat([In, Out, MarshalAs(UnmanagedType.LPStruct)]
 				ref AM_MEDIA_TYPE ppmt);
@@ -487,7 +487,7 @@ public static class DirectShow
 		int GetNumberOfCapabilities(ref int piCount, ref int piSize);
 
 		int GetStreamCaps(int iIndex, [In, Out, MarshalAs(UnmanagedType.LPStruct)]
-				ref AM_MEDIA_TYPE ppmt, IntPtr pSCC);
+				ref AM_MEDIA_TYPE? ppmt, IntPtr pSCC);
 	}
 
 	[ComVisible(true), ComImport(), Guid("56a8689a-0ad4-11ce-b03a-0020af0ba770"),

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -18,7 +18,7 @@ public static class DirectShow
 	{
 		if (com != null)
 		{
-			_ = Marshal.ReleaseComObject(com);
+			Marshal.ReleaseComObject(com);
 			com = null;
 		}
 	}
@@ -197,7 +197,7 @@ public static class DirectShow
 			filter.EnumPins(ref pins);
 
 			int fetched = 0;
-			while (pins.Next(1, ref ipin, ref fetched) == 0)
+			while (pins?.Next(1, ref ipin, ref fetched) == 0)
 			{
 				if (fetched == 0)
 				{
@@ -207,7 +207,7 @@ public static class DirectShow
 				var info = new PIN_INFO();
 				try
 				{
-					ipin.QueryPinInfo(info);
+					ipin?.QueryPinInfo(info);
 					var rc = func(info);
 					if (rc)
 					{
@@ -450,7 +450,7 @@ public static class DirectShow
 
 		int GetSyncSource([In, Out] ref IReferenceClock pClock);
 
-		int EnumPins([In, Out] ref IEnumPins ppEnum);
+		int EnumPins([In, Out] ref IEnumPins? ppEnum);
 
 		int FindPin([In, MarshalAs(UnmanagedType.LPWStr)] string id, [In, Out] ref IPin ppPin);
 
@@ -592,7 +592,7 @@ public static class DirectShow
 	 InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 	public interface IEnumPins
 	{
-		int Next([In] int cPins, [In, Out] ref IPin ppPins, [In, Out] ref int pcFetched);
+		int Next([In] int cPins, [In, Out] ref IPin? ppPins, [In, Out] ref int pcFetched);
 
 		int Skip([In] int cPins);
 
@@ -918,7 +918,7 @@ public static class DirectShow
 		public static readonly Guid PIN_CATEGORY_PREVIEW = new("{fb6c4282-0353-11d1-905f-0000c0cc16ba}");
 		public static readonly Guid PIN_CATEGORY_STILL = new("{fb6c428a-0353-11d1-905f-0000c0cc16ba}");
 
-		private static Dictionary<Guid, string> NicknameCache = null;
+		private static Dictionary<Guid, string>? NicknameCache = null;
 
 		public static string GetNickname(Guid guid)
 		{

--- a/WalletWasabi.Fluent/Models/Windows/WindowsCapture.cs
+++ b/WalletWasabi.Fluent/Models/Windows/WindowsCapture.cs
@@ -110,8 +110,7 @@ public class WindowsCapture
 		return () => sampler.GetBitmap(width, height, stride);
 	}
 
-	private Bitmap
-		GetBitmapFromSampleGrabberBuffer(ISampleGrabber i_grabber, int width, int height, int stride)
+	private Bitmap? GetBitmapFromSampleGrabberBuffer(ISampleGrabber i_grabber, int width, int height, int stride)
 	{
 		try
 		{
@@ -129,8 +128,7 @@ public class WindowsCapture
 		}
 	}
 
-	private Bitmap?
-		GetBitmapFromSampleGrabberBufferMain(ISampleGrabber i_grabber, int width, int height, int stride)
+	private Bitmap? GetBitmapFromSampleGrabberBufferMain(ISampleGrabber i_grabber, int width, int height, int stride)
 	{
 		var sz = 0;
 		i_grabber.GetCurrentBuffer(ref sz, IntPtr.Zero);

--- a/WalletWasabi.Fluent/Models/Windows/WindowsCapture.cs
+++ b/WalletWasabi.Fluent/Models/Windows/WindowsCapture.cs
@@ -68,19 +68,17 @@ public class WindowsCapture
 		var renderer = CoCreateInstance(DsGuid.CLSID_NullRenderer) as IBaseFilter;
 		graph.AddFilter(renderer, "NullRenderer");
 
-		var builder =
+		ICaptureGraphBuilder2? builder =
 			CoCreateInstance(DsGuid.CLSID_CaptureGraphBuilder2) as
 				ICaptureGraphBuilder2;
-		builder.SetFiltergraph(graph);
+		builder?.SetFiltergraph(graph);
 		var pinCategory = DsGuid.PIN_CATEGORY_CAPTURE;
 		var mediaType = DsGuid.MEDIATYPE_Video;
-		builder.RenderStream(ref pinCategory, ref mediaType, vcap_source, grabber, renderer);
+		builder?.RenderStream(ref pinCategory, ref mediaType, vcap_source, grabber, renderer);
 
 		var mt = new AM_MEDIA_TYPE();
 		i_grabber.GetConnectedMediaType(mt);
-		var header =
-			(VIDEOINFOHEADER)Marshal.PtrToStructure(mt.pbFormat,
-				typeof(VIDEOINFOHEADER));
+		VIDEOINFOHEADER header = (VIDEOINFOHEADER)Marshal.PtrToStructure(mt.pbFormat, typeof(VIDEOINFOHEADER));
 		var width = header.bmiHeader.biWidth;
 		var height = header.bmiHeader.biHeight;
 		var stride = width * (header.bmiHeader.biBitCount / 8);

--- a/WalletWasabi.Fluent/Models/Windows/WindowsCapture.cs
+++ b/WalletWasabi.Fluent/Models/Windows/WindowsCapture.cs
@@ -23,7 +23,7 @@ public class WindowsCapture
 		var camera_list = FindDevices();
 		if (cameraIndex >= camera_list.Length)
 		{
-			throw new ArgumentException("USB camera is not available.", "cameraIndex");
+			throw new ArgumentException("USB camera is not available.", nameof(cameraIndex));
 		}
 
 		Init(cameraIndex, format);
@@ -129,7 +129,7 @@ public class WindowsCapture
 		}
 	}
 
-	private Bitmap
+	private Bitmap?
 		GetBitmapFromSampleGrabberBufferMain(ISampleGrabber i_grabber, int width, int height, int stride)
 	{
 		var sz = 0;
@@ -206,15 +206,15 @@ public class WindowsCapture
 			AlphaFormat.Opaque);
 	}
 
-	private IBaseFilter CreateSampleGrabber()
+	private IBaseFilter? CreateSampleGrabber()
 	{
 		var filter = CreateFilter(DsGuid.CLSID_SampleGrabber);
-		var ismp = filter as ISampleGrabber;
+		ISampleGrabber? ismp = filter as ISampleGrabber;
 
 		var mt = new AM_MEDIA_TYPE();
 		mt.MajorType = DsGuid.MEDIATYPE_Video;
 		mt.SubType = DsGuid.MEDIASUBTYPE_RGB24;
-		ismp.SetMediaType(mt);
+		ismp?.SetMediaType(mt);
 		return filter;
 	}
 
@@ -327,7 +327,7 @@ public class WindowsCapture
 		{
 			var entry = new VideoFormat();
 
-			AM_MEDIA_TYPE mt = null;
+			AM_MEDIA_TYPE? mt = null;
 			config.GetStreamCaps(i, ref mt, cap_data);
 			entry.Caps = PtrToStructure<VIDEO_STREAM_CONFIG_CAPS>(cap_data);
 
@@ -373,11 +373,11 @@ public class WindowsCapture
 
 		var cap_data = Marshal.AllocHGlobal(cap_size);
 
-		AM_MEDIA_TYPE mt = null;
+		AM_MEDIA_TYPE? mt = null;
 		config.GetStreamCaps(index, ref mt, cap_data);
-		var cap = PtrToStructure<VIDEO_STREAM_CONFIG_CAPS>(cap_data);
+		_ = PtrToStructure<VIDEO_STREAM_CONFIG_CAPS>(cap_data);
 
-		if (mt.FormatType == DsGuid.FORMAT_VideoInfo)
+		if (mt?.FormatType == DsGuid.FORMAT_VideoInfo)
 		{
 			var vinfo = PtrToStructure<VIDEOINFOHEADER>(mt.pbFormat);
 			if (!size.IsDefault)
@@ -393,7 +393,7 @@ public class WindowsCapture
 
 			Marshal.StructureToPtr(vinfo, mt.pbFormat, true);
 		}
-		else if (mt.FormatType == DsGuid.FORMAT_VideoInfo2)
+		else if (mt?.FormatType == DsGuid.FORMAT_VideoInfo2)
 		{
 			var vinfo = PtrToStructure<VIDEOINFOHEADER2>(mt.pbFormat);
 			if (!size.IsDefault)
@@ -423,10 +423,7 @@ public class WindowsCapture
 		}
 	}
 
-	private static T PtrToStructure<T>(IntPtr ptr)
-	{
-		return (T)Marshal.PtrToStructure(ptr, typeof(T));
-	}
+	private static T? PtrToStructure<T>(IntPtr ptr) => (T)Marshal.PtrToStructure(ptr, typeof(T));
 
 	internal class PropertyItems
 	{
@@ -440,7 +437,7 @@ public class WindowsCapture
 				.Cast<CameraControlProperty>()
 				.Select(item =>
 				{
-					Property prop = null;
+					Property? prop = null;
 					try
 					{
 						if (vcap_source is not IAMCameraControl cam_ctrl)
@@ -474,7 +471,7 @@ public class WindowsCapture
 				.Cast<VideoProcAmpProperty>()
 				.Select(item =>
 				{
-					Property prop = null;
+					Property? prop = null;
 					try
 					{
 						if (vcap_source is not IAMVideoProcAmp vid_ctrl)
@@ -537,7 +534,7 @@ public class WindowsCapture
 			public int Default { get; }
 			public CameraControlFlags Flags { get; }
 			public Action<CameraControlFlags, int> SetValue { get; }
-			public Func<int> GetValue { get; }
+			public Func<int>? GetValue { get; }
 			public bool Available { get; }
 			public bool CanAuto { get; }
 


### PR DESCRIPTION
There were a lot of warnings and errors in files `DirectShow.cs` & `WindowsCapture.cs`. Previusly we disabled the warnings, now I managed to get rid of the most "famous" ones:
 - **IDE0011** : _Add braces_
 - **IDE0019** : _Use pattern matching_
 - **IDE1006** : _Naming Styles_

Most of the warnings got resolved, only some IDE1006 problems stayed that I couldn't manage to get rid of.