### PR TITLE
Make ToolTip work at textbox

### DIFF
--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -42,8 +42,9 @@
       <TextBox Text="{Binding BitcoinP2PEndPoint}" />
     </DockPanel>
 
-    <StackPanel Spacing="10">
-      <TextBlock ToolTip.Tip="Coins under the dust threshold won't appear in the coin lists." Text= "Dust Threshold (BTC)" />
+    <StackPanel Spacing="10"
+                ToolTip.Tip="Coins under the dust threshold won't appear in the coin lists.">
+      <TextBlock Text= "Dust Threshold (BTC)" />
       <TextBox Text="{Binding DustThreshold}" />
     </StackPanel>
 


### PR DESCRIPTION
Fixes #7232 

ToolTip now also works when cursor is on TextBox