### PR TITLE
Change key combo for Coinlist

### DIFF
--- a/WalletWasabi.Documentation/DeveloperFeatures.md
+++ b/WalletWasabi.Documentation/DeveloperFeatures.md
@@ -1,0 +1,7 @@
+# Developer Features
+
+Super secret key combinations can bring up developer features. These combinations start with `CTRL` + `D`.
+
+## Coinlist
+
+One can list out its wallet coin content by pressing `CTRL` + `D` + `C`.

--- a/WalletWasabi.Fluent/Views/MainWindow.axaml
+++ b/WalletWasabi.Fluent/Views/MainWindow.axaml
@@ -19,7 +19,7 @@
   <i:Interaction.Behaviors>
     <behaviors:RegisterNotificationHostBehavior />
     <behaviors:HideShowBehavior />
-    <behaviors:ShowWalletCoinsOnKeyCombinationBehavior Key1="LeftCtrl" Key2="LeftShift" Key3="C" />
+    <behaviors:ShowWalletCoinsOnKeyCombinationBehavior Key1="LeftCtrl" Key2="D" Key3="C" />
   </i:Interaction.Behaviors>
 
   <Panel Margin="{Binding #MainWindow.OffScreenMargin}">


### PR DESCRIPTION
Pressing (left)CTRL + D + C on the wallet home screen will pop the dialog. The old was conflicting on Qubes. Resolves https://github.com/zkSNACKs/WalletWasabi/pull/7205#pullrequestreview-874436625