### PR TITLE
Make autoCJ default sophisticated

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
@@ -79,6 +79,7 @@ public partial class RecoverWalletViewModel : RoutableViewModel
 							walletFilePath,
 							MinGapLimit);
 
+						result.AutoCoinJoin = true;
 						result.SetNetwork(Services.WalletManager.Network);
 
 						return result;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -25,7 +25,7 @@ public class KeyManager
 {
 	public const int DefaultMinAnonScoreTarget = 5;
 	public const int DefaultMaxAnonScoreTarget = 10;
-	public const bool DefaultAutoCoinjoin = true;
+	public const bool DefaultAutoCoinjoin = false;
 
 	public const int AbsoluteMinGapLimit = 21;
 	public const int MaxGapLimit = 10_000;

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -42,6 +42,7 @@ public class WalletGenerator
 		PasswordHelper.Guard(password);
 
 		var km = KeyManager.CreateNew(out Mnemonic mnemonic, password, Network);
+		km.AutoCoinJoin = true;
 		km.SetNetwork(Network);
 		km.SetBestHeight(new Height(TipHeight));
 		km.SetFilePath(walletFilePath);


### PR DESCRIPTION
The correct behavior of autocoinjoin is for new and recovered wallets it should default to true, but for existing wallets it should default to false to keep the behavior of the old wasabi wallets unchanged and not cause surprises for old users.