### PR TITLE
generate suggestions even if user doesn't change the pockets

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -416,10 +416,8 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			{
 				await OnChangePocketsAsync();
 			}
-			else
-			{
-				await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, initialTransaction, _isFixedAmount, _cancellationTokenSource.Token);
-			}
+
+			await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, initialTransaction, _isFixedAmount, _cancellationTokenSource.Token);
 		}
 		else
 		{


### PR DESCRIPTION
We broke it here https://github.com/zkSNACKs/WalletWasabi/pull/7070.

If the user wants to change their pockets when first got to the preview screen, and then they change their mind by pressing back button. The `BuildPrivacySuggestionsAsync` didn't get called.