### PR TITLE
When To Mix - CoinJoin FeeRate statistical data

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -8,6 +8,7 @@ using DynamicData.Binding;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 
 namespace WalletWasabi.Fluent.ViewModels.AddWallet.Create;
@@ -57,7 +58,7 @@ public partial class ConfirmRecoveryWordsViewModel : RoutableViewModel
 
 	private void OnNext(KeyManager keyManager)
 	{
-		Navigate().To(new AddedWalletPageViewModel(keyManager));
+		Navigate().To(new CoinJoinProfilesViewModel(keyManager));
 	}
 
 	private void OnCancel()

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModel.cs
@@ -1,18 +1,16 @@
 using Avalonia.Media;
-using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Blockchain.Keys;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
-public class CoinJoinProfileViewModel : ViewModelBase
+public abstract class CoinJoinProfileViewModel : ViewModelBase
 {
-	public string Title { get; }
-	public string Description { get; }
-	public IImage Icon { get; }
+	public abstract string Title { get; }
+	public abstract string Description { get; }
+	public abstract IImage Icon { get; }
 
-	public CoinJoinProfileViewModel(string title, string description)
-	{
-		Title = title;
-		Description = description;
-		Icon = AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
-	}
+	public virtual int MinAnonScoreTarget { get; } = 5;
+
+	public virtual int MaxAnonScoreTarget { get; } = 10;
+	public abstract int FeeTargetAvarageTimeFrameHours { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModel.cs
@@ -1,0 +1,18 @@
+using Avalonia.Media;
+using WalletWasabi.Fluent.Helpers;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+
+public class CoinJoinProfileViewModel : ViewModelBase
+{
+	public string Title { get; }
+	public string Description { get; }
+	public IImage Icon { get; }
+
+	public CoinJoinProfileViewModel(string title, string description)
+	{
+		Title = title;
+		Description = description;
+		Icon = AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModelBase.cs
@@ -1,16 +1,18 @@
 using Avalonia.Media;
-using WalletWasabi.Blockchain.Keys;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
-public abstract class CoinJoinProfileViewModel : ViewModelBase
+public abstract class CoinJoinProfileViewModelBase : ViewModelBase
 {
 	public abstract string Title { get; }
+
 	public abstract string Description { get; }
+
 	public abstract IImage Icon { get; }
 
 	public virtual int MinAnonScoreTarget { get; } = 5;
 
 	public virtual int MaxAnonScoreTarget { get; } = 10;
-	public abstract int FeeTargetAvarageTimeFrameHours { get; }
+
+	public abstract int FeeTargetAverageTimeFrameHours { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -1,6 +1,7 @@
 using ReactiveUI;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
+using System.Windows.Input;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.ViewModels.AddWallet;
 using WalletWasabi.Fluent.ViewModels.Navigation;
@@ -27,9 +28,18 @@ public partial class CoinJoinProfilesViewModel : RoutableViewModel
 		};
 
 		_selectedProfile = privateProfile;
+
+		ManualSetupCommand = ReactiveCommand.Create(OnManualSetup);
 	}
 
+	public ICommand ManualSetupCommand { get; }
+
 	public List<CoinJoinProfileViewModel> Profiles { get; }
+
+	private void OnManualSetup()
+	{
+
+	}
 
 	private void OnNext(KeyManager keyManager)
 	{

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -1,9 +1,11 @@
 using ReactiveUI;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.ViewModels.AddWallet;
+using WalletWasabi.Fluent.ViewModels.Dialogs;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
@@ -11,7 +13,7 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 [NavigationMetaData(Title = "CoinJoin Profiles")]
 public partial class CoinJoinProfilesViewModel : RoutableViewModel
 {
-	[AutoNotify] private CoinJoinProfileViewModel _selectedProfile;
+	[AutoNotify] private CoinJoinProfileViewModelBase _selectedProfile;
 
 	public CoinJoinProfilesViewModel(KeyManager keyManager)
 	{
@@ -29,16 +31,22 @@ public partial class CoinJoinProfilesViewModel : RoutableViewModel
 
 		_selectedProfile = privateProfile;
 
-		ManualSetupCommand = ReactiveCommand.Create(OnManualSetup);
+		ManualSetupCommand = ReactiveCommand.CreateFromTask(async () => await OnManualSetupAsync());
 	}
 
 	public ICommand ManualSetupCommand { get; }
 
-	public List<CoinJoinProfileViewModel> Profiles { get; }
+	public List<CoinJoinProfileViewModelBase> Profiles { get; }
 
-	private void OnManualSetup()
+	private async Task OnManualSetupAsync()
 	{
+		var dialog = new ManualCoinJoinProfileDialogViewModel();
 
+		var dialogResult = await NavigateDialogAsync(dialog, NavigationTarget.CompactDialogScreen);
+
+		if (dialogResult.Result is { })
+		{
+		}
 	}
 
 	private void OnNext(KeyManager keyManager)
@@ -46,7 +54,7 @@ public partial class CoinJoinProfilesViewModel : RoutableViewModel
 		var selected = SelectedProfile;
 
 		keyManager.SetAnonScoreTargets(selected.MinAnonScoreTarget, selected.MaxAnonScoreTarget, toFile: false);
-		keyManager.SetFeeTargetAvarageTimeFrame(selected.FeeTargetAvarageTimeFrameHours, toFile: false);
+		keyManager.SetFeeTargetAvarageTimeFrame(selected.FeeTargetAverageTimeFrameHours, toFile: false);
 
 		Navigate().To(new AddedWalletPageViewModel(keyManager));
 	}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -1,4 +1,5 @@
 using ReactiveUI;
+using System.Collections.Generic;
 using System.Reactive.Disposables;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.ViewModels.AddWallet;
@@ -9,14 +10,34 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 [NavigationMetaData(Title = "CoinJoin Profiles")]
 public partial class CoinJoinProfilesViewModel : RoutableViewModel
 {
+	[AutoNotify] private CoinJoinProfileViewModel _selectedProfile;
+
 	public CoinJoinProfilesViewModel(KeyManager keyManager)
 	{
 		NextCommand = ReactiveCommand.Create(() => OnNext(keyManager));
 		EnableBack = true;
+
+		var privateProfile = new PrivateCoinJoinProfile();
+
+		Profiles = new()
+		{
+			new SpeedyCoinJoinProfile(),
+			new EconomyCoinJoinProfile(),
+			privateProfile
+		};
+
+		_selectedProfile = privateProfile;
 	}
+
+	public List<CoinJoinProfileViewModel> Profiles { get; }
 
 	private void OnNext(KeyManager keyManager)
 	{
+		var selected = SelectedProfile;
+
+		keyManager.SetAnonScoreTargets(selected.MinAnonScoreTarget, selected.MaxAnonScoreTarget, toFile: false);
+		keyManager.SetFeeTargetAvarageTimeFrame(selected.FeeTargetAvarageTimeFrameHours, toFile: false);
+
 		Navigate().To(new AddedWalletPageViewModel(keyManager));
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -1,0 +1,30 @@
+using ReactiveUI;
+using System.Reactive.Disposables;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Fluent.ViewModels.AddWallet;
+using WalletWasabi.Fluent.ViewModels.Navigation;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+
+[NavigationMetaData(Title = "CoinJoin Profiles")]
+public partial class CoinJoinProfilesViewModel : RoutableViewModel
+{
+	public CoinJoinProfilesViewModel(KeyManager keyManager)
+	{
+		NextCommand = ReactiveCommand.Create(() => OnNext(keyManager));
+		EnableBack = true;
+	}
+
+	private void OnNext(KeyManager keyManager)
+	{
+		Navigate().To(new AddedWalletPageViewModel(keyManager));
+	}
+
+	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
+	{
+		base.OnNavigatedTo(isInHistory, disposables);
+
+		var enableCancel = Services.WalletManager.HasWallet();
+		SetupCancel(enableCancel: false, enableCancelOnEscape: enableCancel, enableCancelOnPressed: false);
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -21,9 +21,9 @@ public partial class CoinJoinProfilesViewModel : RoutableViewModel
 
 		Profiles = new()
 		{
+			privateProfile,
 			new SpeedyCoinJoinProfile(),
-			new EconomyCoinJoinProfile(),
-			privateProfile
+			new EconomyCoinJoinProfile()
 		};
 
 		_selectedProfile = privateProfile;

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomyCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomyCoinJoinProfile.cs
@@ -1,0 +1,20 @@
+using Avalonia.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Fluent.Helpers;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+
+internal class EconomyCoinJoinProfile : CoinJoinProfileViewModel
+{
+	public override string Title => "Speedy";
+
+	public override string Description => "very speedy";
+
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+
+	public override int FeeTargetAvarageTimeFrameHours => 168; // One week avarage.
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomyCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomyCoinJoinProfile.cs
@@ -8,7 +8,7 @@ using WalletWasabi.Fluent.Helpers;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
-internal class EconomyCoinJoinProfile : CoinJoinProfileViewModel
+internal class EconomyCoinJoinProfile : CoinJoinProfileViewModelBase
 {
 	public override string Title => "Economy";
 
@@ -16,5 +16,5 @@ internal class EconomyCoinJoinProfile : CoinJoinProfileViewModel
 
 	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/WalletIcons/{ThemeHelper.CurrentTheme}/ledger.png");
 
-	public override int FeeTargetAvarageTimeFrameHours => 168; // One week avarage.
+	public override int FeeTargetAverageTimeFrameHours => 168; // One week avarage.
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomyCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomyCoinJoinProfile.cs
@@ -10,11 +10,11 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 internal class EconomyCoinJoinProfile : CoinJoinProfileViewModel
 {
-	public override string Title => "Speedy";
+	public override string Title => "Economy";
 
-	public override string Description => "very speedy";
+	public override string Description => "very Economy";
 
-	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/WalletIcons/{ThemeHelper.CurrentTheme}/ledger.png");
 
 	public override int FeeTargetAvarageTimeFrameHours => 168; // One week avarage.
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/ManualCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/ManualCoinJoinProfile.cs
@@ -1,0 +1,31 @@
+using Avalonia.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Fluent.Helpers;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+
+public class ManualCoinJoinProfile : CoinJoinProfileViewModelBase
+{
+	public ManualCoinJoinProfile(int minAnonScoreTarget, int maxAnonScoreTarget, int feeTargetAverageTimeFrameHours)
+	{
+		MinAnonScoreTarget = minAnonScoreTarget;
+		MaxAnonScoreTarget = maxAnonScoreTarget;
+		FeeTargetAverageTimeFrameHours = feeTargetAverageTimeFrameHours;
+	}
+
+	public override string Title => "Economy";
+
+	public override string Description => "very Economy";
+
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/WalletIcons/{ThemeHelper.CurrentTheme}/ledger.png");
+
+	public override int MinAnonScoreTarget { get; }
+
+	public override int MaxAnonScoreTarget { get; }
+
+	public override int FeeTargetAverageTimeFrameHours { get; }
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfile.cs
@@ -1,0 +1,22 @@
+using Avalonia.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Fluent.Helpers;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+
+internal class PrivateCoinJoinProfile : CoinJoinProfileViewModel
+{
+	public override string Title => "Speedy";
+
+	public override string Description => "very speedy";
+
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+	public override int MinAnonScoreTarget => 50;
+	public override int MaxAnonScoreTarget => 100;
+
+	public override int FeeTargetAvarageTimeFrameHours => 0;
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfile.cs
@@ -10,11 +10,11 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 internal class PrivateCoinJoinProfile : CoinJoinProfileViewModel
 {
-	public override string Title => "Speedy";
+	public override string Title => "Private";
 
-	public override string Description => "very speedy";
+	public override string Description => "very Private";
 
-	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/WalletIcons/{ThemeHelper.CurrentTheme}/coldcard.png");
 	public override int MinAnonScoreTarget => 50;
 	public override int MaxAnonScoreTarget => 100;
 

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfile.cs
@@ -8,7 +8,7 @@ using WalletWasabi.Fluent.Helpers;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
-internal class PrivateCoinJoinProfile : CoinJoinProfileViewModel
+internal class PrivateCoinJoinProfile : CoinJoinProfileViewModelBase
 {
 	public override string Title => "Private";
 
@@ -18,5 +18,5 @@ internal class PrivateCoinJoinProfile : CoinJoinProfileViewModel
 	public override int MinAnonScoreTarget => 50;
 	public override int MaxAnonScoreTarget => 100;
 
-	public override int FeeTargetAvarageTimeFrameHours => 0;
+	public override int FeeTargetAverageTimeFrameHours => 0;
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfile.cs
@@ -1,0 +1,20 @@
+using Avalonia.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Fluent.Helpers;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+
+internal class SpeedyCoinJoinProfile : CoinJoinProfileViewModel
+{
+	public override string Title => "Speedy";
+
+	public override string Description => "very speedy";
+
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+
+	public override int FeeTargetAvarageTimeFrameHours => 0;
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfile.cs
@@ -8,7 +8,7 @@ using WalletWasabi.Fluent.Helpers;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
-internal class SpeedyCoinJoinProfile : CoinJoinProfileViewModel
+internal class SpeedyCoinJoinProfile : CoinJoinProfileViewModelBase
 {
 	public override string Title => "Speedy";
 
@@ -16,5 +16,5 @@ internal class SpeedyCoinJoinProfile : CoinJoinProfileViewModel
 
 	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/WalletIcons/{ThemeHelper.CurrentTheme}/trezor.png");
 
-	public override int FeeTargetAvarageTimeFrameHours => 0;
+	public override int FeeTargetAverageTimeFrameHours => 0;
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfile.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfile.cs
@@ -14,7 +14,7 @@ internal class SpeedyCoinJoinProfile : CoinJoinProfileViewModel
 
 	public override string Description => "very speedy";
 
-	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/PasswordFinder/{ThemeHelper.CurrentTheme}/numbers.png");
+	public override IImage Icon => AssetHelpers.GetBitmapAsset($"avares://WalletWasabi.Fluent/Assets/WalletIcons/{ThemeHelper.CurrentTheme}/trezor.png");
 
 	public override int FeeTargetAvarageTimeFrameHours => 0;
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/ManualCoinJoinProfileDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/ManualCoinJoinProfileDialogViewModel.cs
@@ -1,0 +1,14 @@
+using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
+
+namespace WalletWasabi.Fluent.ViewModels.Dialogs;
+
+[NavigationMetaData(Title = "Manual CoinJoin Profile")]
+public partial class ManualCoinJoinProfileDialogViewModel : DialogViewModelBase<ManualCoinJoinProfile?>
+{
+	public ManualCoinJoinProfileDialogViewModel()
+	{
+		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
+		EnableBack = false;
+	}
+}

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:WalletWasabi.Fluent.ViewModels.CoinJoinProfiles"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="450"
-             x:DataType="vm:CoinJoinProfileViewModel"
+             x:DataType="vm:CoinJoinProfileViewModelBase"
              ClipToBounds="False"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.CoinJoinProfiles.CoinJoinProfileControl">

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:WalletWasabi.Fluent.ViewModels.CoinJoinProfiles"
+             mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="450"
+             x:DataType="vm:CoinJoinProfileViewModel"
+             ClipToBounds="False"
+             x:CompileBindings="True"
+             x:Class="WalletWasabi.Fluent.Views.CoinJoinProfiles.CoinJoinProfileControl">
+  <StackPanel Spacing="20">
+    <TextBlock Text="{Binding Title}" HorizontalAlignment="Center" />
+    <Viewbox HorizontalAlignment="Center" Height="70">
+      <Image Source="{Binding Icon}" />
+    </Viewbox>
+    <TextBlock Text="{Binding Description}" HorizontalAlignment="Center" />
+  </StackPanel>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml
@@ -8,7 +8,7 @@
              ClipToBounds="False"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.CoinJoinProfiles.CoinJoinProfileControl">
-  <StackPanel Spacing="20">
+  <StackPanel Spacing="20" Width="110" Height="180">
     <TextBlock Text="{Binding Title}" HorizontalAlignment="Center" />
     <Viewbox HorizontalAlignment="Center" Height="70">
       <Image Source="{Binding Icon}" />

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml.cs
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfileControl.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.CoinJoinProfiles;
+
+public class CoinJoinProfileControl : UserControl
+{
+	public CoinJoinProfileControl()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -76,7 +76,7 @@
           </ItemsPanelTemplate>
         </ListBox.ItemsPanel>
         <ListBox.DataTemplates>
-          <DataTemplate DataType="vm:CoinJoinProfileViewModel">
+          <DataTemplate DataType="vm:CoinJoinProfileViewModelBase">
             <c:SuggestionItem>
               <prof:CoinJoinProfileControl />
             </c:SuggestionItem>

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -24,10 +24,10 @@
           <Setter Property="Background" Value="Transparent" />
         </Style>
 
-        <Style
+        <!--<Style
           Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter, ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
           <Setter Property="Background" Value="Transparent" />
-        </Style>
+        </Style>-->
 
         <Style Selector="ListBoxItem Border#PART_MainContentBorder">
           <Setter Property="Padding" Value="30,25,30,25" />

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -15,10 +15,58 @@
                  EnableBack="{Binding EnableBack}"
                  NextContent="Continue" EnableNext="True"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
-    <ListBox Items="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}">
+    <ListBox Items="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}" Background="Transparent">
+      <ListBox.Styles>
+        <Style Selector="ListBoxItem">
+          <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="ListBoxItem /template/ ContentPresenter#PART_ContentPresenter">
+          <Setter Property="Background" Value="Transparent" />
+        </Style>
+
+        <Style
+          Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter, ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+          <Setter Property="Background" Value="Transparent" />
+        </Style>
+
+        <Style Selector="ListBoxItem Border#PART_MainContentBorder">
+          <Setter Property="Padding" Value="30,25,30,25" />
+          <Setter Property="CornerRadius" Value="4" />
+          <Setter Property="MaxWidth" Value="250" />
+          <Setter Property="MaxHeight" Value="300" />
+        </Style>
+
+        <Style Selector="ListBoxItem Border#PART_DecorationBorderUnselected">
+          <Setter Property="Padding" Value="15 25 15 25" />
+          <Setter Property="CornerRadius" Value="4" />
+          <Setter Property="Margin" Value="5" />
+
+          <Setter Property="BorderBrush" Value="#14FFFFFF" />
+          <Setter Property="BorderThickness" Value="1" />
+          <Setter Property="Background" Value="{StaticResource OptimizePrivacyOptionSelectedColor}" />
+          <Setter Property="BoxShadow" Value="{StaticResource OptimizePrivacyOptionBoxShadow1}" />
+        </Style>
+
+        <Style Selector="ListBoxItem Border#PART_DecorationBorderHover">
+          <Setter Property="Padding" Value="15 25 15 25" />
+          <Setter Property="CornerRadius" Value="4" />
+          <Setter Property="Margin" Value="5" />
+
+          <Setter Property="BorderBrush" Value="#2AFFFFFF" />
+          <Setter Property="BorderThickness" Value="1" />
+          <Setter Property="Background" Value="{StaticResource OptimizePrivacyOptionSelectedColor}" />
+          <Setter Property="BoxShadow" Value="{StaticResource OptimizePrivacyOptionBoxShadow2}" />
+
+          <Setter Property="Opacity" Value="0" />
+        </Style>
+
+        <Style Selector="ListBoxItem:pointerover Border#PART_DecorationBorderHover">
+          <Setter Property="Opacity" Value="1" />
+        </Style>
+      </ListBox.Styles>
       <ListBox.ItemsPanel>
         <ItemsPanelTemplate>
-          <WrapPanel Orientation="Horizontal" />
+          <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" />
         </ItemsPanelTemplate>
       </ListBox.ItemsPanel>
       <ListBox.DataTemplates>

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:WalletWasabi.Fluent.ViewModels.CoinJoinProfiles"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:conv="using:WalletWasabi.Fluent.Converters"
+             xmlns:prof="clr-namespace:WalletWasabi.Fluent.Views.CoinJoinProfiles"
              mc:Ignorable="d" d:DesignWidth="428" d:DesignHeight="371"
              x:DataType="vm:CoinJoinProfilesViewModel"
              x:CompileBindings="True"
@@ -14,5 +15,19 @@
                  EnableBack="{Binding EnableBack}"
                  NextContent="Continue" EnableNext="True"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
+    <ListBox Items="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}">
+      <ListBox.ItemsPanel>
+        <ItemsPanelTemplate>
+          <WrapPanel Orientation="Horizontal" />
+        </ItemsPanelTemplate>
+      </ListBox.ItemsPanel>
+      <ListBox.DataTemplates>
+        <DataTemplate DataType="vm:CoinJoinProfileViewModel">
+          <c:SuggestionItem>
+            <prof:CoinJoinProfileControl />
+          </c:SuggestionItem>
+        </DataTemplate>
+      </ListBox.DataTemplates>
+    </ListBox>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -15,67 +15,75 @@
                  EnableBack="{Binding EnableBack}"
                  NextContent="Continue" EnableNext="True"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
-    <ListBox Items="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}" Background="Transparent">
-      <ListBox.Styles>
-        <Style Selector="ListBoxItem">
-          <Setter Property="Cursor" Value="Hand" />
-        </Style>
-        <Style Selector="ListBoxItem /template/ ContentPresenter#PART_ContentPresenter">
-          <Setter Property="Background" Value="Transparent" />
-        </Style>
+    <DockPanel>
+      <Button Classes="h8 plain activeHyperLink" Margin="0 10 0 0"
+              DockPanel.Dock="Bottom"
+              Command="{Binding ManualSetupCommand}"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Bottom"
+              Content="Manual setup" />
 
-        <!--<Style
-          Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter, ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-          <Setter Property="Background" Value="Transparent" />
-        </Style>-->
+      <ListBox Items="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}" Background="Transparent">
+        <ListBox.Styles>
+          <Style Selector="ListBoxItem">
+            <Setter Property="Cursor" Value="Hand" />
+          </Style>
+          <Style Selector="ListBoxItem /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+          </Style>
 
-        <Style Selector="ListBoxItem Border#PART_MainContentBorder">
-          <Setter Property="Padding" Value="30,25,30,25" />
-          <Setter Property="CornerRadius" Value="4" />
-          <Setter Property="MaxWidth" Value="250" />
-          <Setter Property="MaxHeight" Value="300" />
-        </Style>
+          <Style Selector="ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter, ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+          </Style>
+          <Style Selector="ListBoxItem:selected Border#PART_DecorationBorderHover, ListBoxItem:selected Border#PART_DecorationBorderUnselected">
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
+          </Style>
 
-        <Style Selector="ListBoxItem Border#PART_DecorationBorderUnselected">
-          <Setter Property="Padding" Value="15 25 15 25" />
-          <Setter Property="CornerRadius" Value="4" />
-          <Setter Property="Margin" Value="5" />
+          <Style Selector="ListBoxItem Border#PART_MainContentBorder">
+            <Setter Property="Padding" Value="20,25,20,25" />
+            <Setter Property="CornerRadius" Value="4" />
+          </Style>
 
-          <Setter Property="BorderBrush" Value="#14FFFFFF" />
-          <Setter Property="BorderThickness" Value="1" />
-          <Setter Property="Background" Value="{StaticResource OptimizePrivacyOptionSelectedColor}" />
-          <Setter Property="BoxShadow" Value="{StaticResource OptimizePrivacyOptionBoxShadow1}" />
-        </Style>
+          <Style Selector="ListBoxItem Border#PART_DecorationBorderUnselected">
+            <Setter Property="Padding" Value="15 25 15 25" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Margin" Value="5" />
+            <Setter Property="BorderBrush" Value="#14FFFFFF" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Background" Value="{StaticResource OptimizePrivacyOptionSelectedColor}" />
+            <Setter Property="BoxShadow" Value="{StaticResource OptimizePrivacyOptionBoxShadow1}" />
+          </Style>
 
-        <Style Selector="ListBoxItem Border#PART_DecorationBorderHover">
-          <Setter Property="Padding" Value="15 25 15 25" />
-          <Setter Property="CornerRadius" Value="4" />
-          <Setter Property="Margin" Value="5" />
+          <Style Selector="ListBoxItem Border#PART_DecorationBorderHover">
+            <Setter Property="Padding" Value="15 25 15 25" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Margin" Value="5" />
+            <Setter Property="BorderBrush" Value="#2AFFFFFF" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Background" Value="{StaticResource OptimizePrivacyOptionSelectedColor}" />
+            <Setter Property="BoxShadow" Value="{StaticResource OptimizePrivacyOptionBoxShadow2}" />
 
-          <Setter Property="BorderBrush" Value="#2AFFFFFF" />
-          <Setter Property="BorderThickness" Value="1" />
-          <Setter Property="Background" Value="{StaticResource OptimizePrivacyOptionSelectedColor}" />
-          <Setter Property="BoxShadow" Value="{StaticResource OptimizePrivacyOptionBoxShadow2}" />
+            <Setter Property="Opacity" Value="0" />
+          </Style>
 
-          <Setter Property="Opacity" Value="0" />
-        </Style>
+          <Style Selector="ListBoxItem:pointerover Border#PART_DecorationBorderHover">
+            <Setter Property="Opacity" Value="1" />
+          </Style>
+        </ListBox.Styles>
+        <ListBox.ItemsPanel>
+          <ItemsPanelTemplate>
+            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" />
+          </ItemsPanelTemplate>
+        </ListBox.ItemsPanel>
+        <ListBox.DataTemplates>
+          <DataTemplate DataType="vm:CoinJoinProfileViewModel">
+            <c:SuggestionItem>
+              <prof:CoinJoinProfileControl />
+            </c:SuggestionItem>
+          </DataTemplate>
+        </ListBox.DataTemplates>
+      </ListBox>
+    </DockPanel>
 
-        <Style Selector="ListBoxItem:pointerover Border#PART_DecorationBorderHover">
-          <Setter Property="Opacity" Value="1" />
-        </Style>
-      </ListBox.Styles>
-      <ListBox.ItemsPanel>
-        <ItemsPanelTemplate>
-          <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" />
-        </ItemsPanelTemplate>
-      </ListBox.ItemsPanel>
-      <ListBox.DataTemplates>
-        <DataTemplate DataType="vm:CoinJoinProfileViewModel">
-          <c:SuggestionItem>
-            <prof:CoinJoinProfileControl />
-          </c:SuggestionItem>
-        </DataTemplate>
-      </ListBox.DataTemplates>
-    </ListBox>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:WalletWasabi.Fluent.ViewModels.CoinJoinProfiles"
+             xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:conv="using:WalletWasabi.Fluent.Converters"
+             mc:Ignorable="d" d:DesignWidth="428" d:DesignHeight="371"
+             x:DataType="vm:CoinJoinProfilesViewModel"
+             x:CompileBindings="True"
+             x:Class="WalletWasabi.Fluent.Views.CoinJoinProfiles.CoinJoinProfilesView">
+  <c:ContentArea Title="{Binding Title}"
+                 EnableCancel="{Binding EnableCancel}"
+                 EnableBack="{Binding EnableBack}"
+                 NextContent="Continue" EnableNext="True"
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
+  </c:ContentArea>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.CoinJoinProfiles;
+
+public class CoinJoinProfilesView : UserControl
+{
+	public CoinJoinProfilesView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Dialogs/ManualCoinJoinProfileDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ManualCoinJoinProfileDialogView.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:dialogs="clr-namespace:WalletWasabi.Fluent.ViewModels.Dialogs"
+             mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="270"
+             x:DataType="dialogs:ManualCoinJoinProfileDialogViewModel"
+             x:CompileBindings="True"
+             x:Class="WalletWasabi.Fluent.Views.Dialogs.ManualCoinJoinProfileDialogView">
+  <c:ContentArea Width="500" Height="300"
+                 Title="{Binding Title}"
+                 CancelContent="Cancel"
+                 EnableCancel="{Binding EnableCancel}"
+                 EnableBack="{Binding EnableBack}"
+                 EnableNext="True" NextContent="Done">
+
+  </c:ContentArea>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/ManualCoinJoinProfileDialogView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Dialogs/ManualCoinJoinProfileDialogView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Dialogs;
+
+public class ManualCoinJoinProfileDialogView : UserControl
+{
+	public ManualCoinJoinProfileDialogView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -26,6 +26,7 @@ public class KeyManager
 	public const int DefaultMinAnonScoreTarget = 5;
 	public const int DefaultMaxAnonScoreTarget = 10;
 	public const bool DefaultAutoCoinjoin = false;
+	public const int DefaultFeeTargetAvarageTimeFrameHours = 24;
 
 	public const int AbsoluteMinGapLimit = 21;
 	public const int MaxGapLimit = 10_000;
@@ -161,6 +162,9 @@ public class KeyManager
 
 	[JsonProperty(Order = 14, PropertyName = "MaxAnonScoreTarget")]
 	public int MaxAnonScoreTarget { get; private set; } = DefaultMaxAnonScoreTarget;
+
+	[JsonProperty(Order = 15, PropertyName = "FeeTargetAvarageTimeFrameHours")]
+	public int FeeTargetAvarageTimeFrameHours { get; private set; } = DefaultFeeTargetAvarageTimeFrameHours;
 
 	[JsonProperty(Order = 999)]
 	private List<HdPubKey> HdPubKeys { get; }
@@ -695,7 +699,7 @@ public class KeyManager
 		SetIcon(type.ToString());
 	}
 
-	public void SetAnonScoreTargets(int minAnonScoreTarget, int maxAnonScoreTarget)
+	public void SetAnonScoreTargets(int minAnonScoreTarget, int maxAnonScoreTarget, bool toFile = true)
 	{
 		if (maxAnonScoreTarget <= minAnonScoreTarget)
 		{
@@ -704,7 +708,19 @@ public class KeyManager
 
 		MinAnonScoreTarget = minAnonScoreTarget;
 		MaxAnonScoreTarget = maxAnonScoreTarget;
-		ToFile();
+		if (toFile)
+		{
+			ToFile();
+		}
+	}
+
+	public void SetFeeTargetAvarageTimeFrame(int hours, bool toFile = true)
+	{
+		FeeTargetAvarageTimeFrameHours = hours;
+		if (toFile)
+		{
+			ToFile();
+		}
 	}
 
 	public void AssertNetworkOrClearBlockState(Network expectedNetwork)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -230,7 +230,7 @@ public partial class Arena : PeriodicRunner
 					// Store transaction.
 					if (TransactionArchiver is not null)
 					{
-						await TransactionArchiver.StoreJsonAsync(coinjoin).ConfigureAwait(false);
+						await TransactionArchiver.StoreJsonAsync(coinjoin, feeRate).ConfigureAwait(false);
 					}
 
 					// Broadcasting.

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -46,7 +46,7 @@ public partial class Arena : PeriodicRunner
 	private CoinJoinTransactionArchiver? TransactionArchiver { get; }
 	private InMemoryCoinJoinIdStore InMemoryCoinJoinIdStore { get; }
 
-	public event EventHandler<Transaction>? CoinJoinBroadcast;
+	public event EventHandler<(Transaction Transaction, FeeRate FeeRate)>? CoinJoinBroadcast;
 
 	protected override async Task ActionAsync(CancellationToken cancel)
 	{
@@ -247,7 +247,7 @@ public partial class Arena : PeriodicRunner
 					round.LogInfo($"Successfully broadcast the CoinJoin: {coinjoin.GetHash()}.");
 
 					InMemoryCoinJoinIdStore.Add(coinjoin.GetHash());
-					CoinJoinBroadcast?.Invoke(this, coinjoin);
+					CoinJoinBroadcast?.Invoke(this, (coinjoin, feeRate));
 				}
 				else if (round.TransactionSigningTimeFrame.HasExpired)
 				{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinFeeRateStatistics.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinFeeRateStatistics.cs
@@ -1,0 +1,52 @@
+using NBitcoin;
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+
+namespace WalletWasabi.WabiSabi.Backend.Rounds;
+
+public class CoinJoinFeeRateStatistics
+{
+	private const int MaximumDaysToStore = 30;
+	private List<DateTimeAndFeeRate> FeeRates { get; }
+
+	private CoinJoinFeeRateStatistics(IEnumerable<DateTimeAndFeeRate> dateAndfeeRates)
+	{
+		FeeRates = new(dateAndfeeRates.OrderBy(x => x.DateTimeOffset));
+	}
+
+	public static CoinJoinFeeRateStatistics LoadFromCoinJoinTransactionArchiver(CoinJoinTransactionArchiver coinJoinTransactionArchiver)
+	{
+		DateTimeOffset now = DateTimeOffset.UtcNow;
+		var from = now - TimeSpan.FromDays(MaximumDaysToStore);
+		var dateAndFeeRates = coinJoinTransactionArchiver.ReadJson(from, now)
+			.Select(txinfo => new DateTimeAndFeeRate(
+				DateTimeOffset.FromUnixTimeMilliseconds(txinfo.Created),
+				new FeeRate(txinfo.FeeRate)));
+
+		return new(dateAndFeeRates);
+	}
+
+	public void Add(FeeRate feeRate)
+	{
+		DateTimeOffset now = DateTimeOffset.UtcNow;
+
+		FeeRates.Add(new(now, feeRate));
+
+		// Prune old items.
+		DateTimeOffset removeBefore = now - TimeSpan.FromDays(MaximumDaysToStore);
+		while (FeeRates.Any() && (FeeRates[0].DateTimeOffset < removeBefore))
+		{
+			FeeRates.RemoveAt(0);
+		}
+	}
+
+	public FeeRate GetAvarage(DateTimeOffset from)
+	{
+		return new FeeRate(FeeRates.Where(x => x.DateTimeOffset >= from).Average(x => x.FeeRate.SatoshiPerByte));
+	}
+
+	private record DateTimeAndFeeRate(
+		DateTimeOffset DateTimeOffset,
+		FeeRate FeeRate);
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinTransactionArchiver.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinTransactionArchiver.cs
@@ -65,7 +65,7 @@ public class CoinJoinTransactionArchiver
 
 		do
 		{
-			DateTimeOffset date = new(from.Year, from.Month + monthOffset, from.Day, 0, 0, 0, from.Offset);
+			DateTimeOffset date = new(from.Year, from.Month + monthOffset, 1, 0, 0, 0, from.Offset);
 			if (date > to)
 			{
 				break;


### PR DESCRIPTION
Related feature: the client should only start auto coin joining if the fees are low (economy mode). What does it mean "low"? The idea is to calculate the average of CoinJoin fee rates in the past and if the round's fee rate is below the average then the client can mix. 

This PR adds the functionality to store the fee rate of past CoinJoins by using the `CoinJoinTransactionArchiver` and loading it after starting the backend, then manages the values in memory with the `CoinJoinFeeRateStatistics` class. 

Next steps:

- Add API request where this information is delivered to the client. 
- Add CoinJoinClient the functionality to wait until the CoinJoin is economical. 