### PR TITLE
Suppress warnings about platform incompatibility in ZXing

### DIFF
--- a/WalletWasabi.Fluent/GlobalSuppressions.cs
+++ b/WalletWasabi.Fluent/GlobalSuppressions.cs
@@ -11,3 +11,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0011:Add braces", Justification = "<Pending>", Scope = "namespaceanddescendants", Target = "~N:ZXing")]
 [assembly: SuppressMessage("Style", "IDE0004:Remove Unnecessary Cast", Justification = "<Pending>", Scope = "namespaceanddescendants", Target = "~N:ZXing")]
 [assembly: SuppressMessage("Style", "IDE0003:Remove qualification", Justification = "<Pending>", Scope = "namespaceanddescendants", Target = "~N:ZXing")]
+[assembly: SuppressMessage("Interoperability", "CA1416: Validate platform compatibility", Justification = "<Pending>", Scope = "namespaceanddescendants", Target = "~N:ZXing")]


### PR DESCRIPTION
`System.Drawing.Bitmap` is a windows only type and it is used for the webcamera.
But the compiler doesn't notice that one not on windows can't reach this part of the code as the camera button doesn't even show up for them.