### PR TITLE
[Trivial] Improve confusing log message

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -120,7 +120,7 @@ public class CoinJoinManager : BackgroundService
 					if (success)
 					{
 						CoinRefrigerator.Freeze(finishedCoinJoin.CoinCandidates);
-						Logger.LogInfo($"{logPrefix} finished successfully!");
+						Logger.LogInfo($"{logPrefix} finished!");
 					}
 					else
 					{


### PR DESCRIPTION
This log message was always confusing for me, I thought it indicates that a coinjoin round was successful.

So I propose to change it to:
`Wallet: TestWallet - Coinjoin client finished!` instead of `Wallet: TestWallet - Coinjoin client finished successfully!` to be less confusing.