### PR TITLE
Ignore rounds w/ too high min allowed output

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -68,6 +68,7 @@ public class CoinJoinClient
 			.CreateRoundAwaiter(
 				roundState =>
 					roundState.InputRegistrationEnd - DateTimeOffset.UtcNow > DoNotRegisterInLastMinuteTimeLimit &&
+					roundState.CoinjoinState.Parameters.AllowedOutputAmounts.Min < Money.Coins(0.0001m) && // ignore rounds with too big minimum denominations
 					roundState.Phase == Phase.InputRegistration,
 				cancellationToken)
 			.ConfigureAwait(false);


### PR DESCRIPTION
This PR makes the Wasabi client to do not trust on the min allowed output value provided by the coordinator and only consider rounds with min allowed output below a threshold.