### PR TITLE
Improve IsLikelyCoinjoin

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -196,7 +196,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			amount = x.Amount.Satoshi,
 			label = x.Label,
 			tx = x.TransactionId,
-			islikelycoinjoin = x.IsLikelyCoinJoinOutput
+			islikelycoinjoin = x.IsLikelyOwnCoinjoin
 		}).ToArray();
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -27,7 +27,7 @@ public class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 
 	public void Add(TransactionSummary item)
 	{
-		if (!item.IsLikelyCoinJoinOutput)
+		if (!item.IsLikelyOwnCoinjoin)
 		{
 			throw new InvalidOperationException("Not a coinjoin item!");
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -136,12 +136,12 @@ public partial class HistoryViewModel : ActivatableViewModel
 
 			balance += item.Amount;
 
-			if (!item.IsLikelyCoinJoinOutput)
+			if (!item.IsLikelyOwnCoinjoin)
 			{
 				yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 			}
 
-			if (item.IsLikelyCoinJoinOutput)
+			if (item.IsLikelyOwnCoinjoin)
 			{
 				if (coinJoinGroup is null)
 				{
@@ -154,7 +154,7 @@ public partial class HistoryViewModel : ActivatableViewModel
 			}
 
 			if (coinJoinGroup is { } cjg &&
-				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyCoinJoinOutput || // The next item is not CJ so add the group.
+				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyOwnCoinjoin || // The next item is not CJ so add the group.
 				 i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
 			{
 				cjg.SetBalance(balance);

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -14,7 +14,7 @@ public class ProcessedResult
 	public ProcessedResult(SmartTransaction transaction)
 	{
 		Transaction = Guard.NotNull(nameof(transaction), transaction);
-		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.WalletInputs.Any() && Transaction.IsLikelyCoinjoin(), true);
+		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.IsLikelyOwnCoinjoin(), true);
 	}
 
 	public SmartTransaction Transaction { get; }

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -192,6 +192,12 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		BlockIndex = 0;
 	}
 
+	public bool IsLikelyOwnCoinjoin()
+	   => WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
+	   && Transaction.Inputs.Count != WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
+	   && Transaction.Outputs.Count != WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
+	   && Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
+
 	#region LineSerialization
 
 	public string ToLine()

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -49,7 +49,7 @@ public class TransactionHistoryBuilder
 					Label = containingTransaction.Label,
 					TransactionId = coin.TransactionId,
 					BlockIndex = containingTransaction.BlockIndex,
-					IsLikelyCoinJoinOutput = containingTransaction.IsLikelyCoinjoin()
+					IsLikelyOwnCoinjoin = containingTransaction.IsLikelyOwnCoinjoin()
 				});
 			}
 
@@ -74,7 +74,7 @@ public class TransactionHistoryBuilder
 						Label = spenderTransaction.Label,
 						TransactionId = spenderTxId,
 						BlockIndex = spenderTransaction.BlockIndex,
-						IsLikelyCoinJoinOutput = spenderTransaction.IsLikelyCoinjoin()
+						IsLikelyOwnCoinjoin = spenderTransaction.IsLikelyOwnCoinjoin()
 					});
 				}
 			}

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -12,5 +12,5 @@ public class TransactionSummary
 	public SmartLabel Label { get; set; }
 	public uint256 TransactionId { get; set; }
 	public int BlockIndex { get; set; }
-	public bool IsLikelyCoinJoinOutput { get; set; }
+	public bool IsLikelyOwnCoinjoin { get; set; }
 }

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -150,12 +150,6 @@ public static class NBitcoinExtensions
 		return anonsets;
 	}
 
-	public static bool IsLikelyOwnCoinjoin(this SmartTransaction me)
-		=> me.WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
-		&& me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
-		&& me.Transaction.Outputs.Count != me.WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
-		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
-
 	/// <summary>
 	/// Careful, if it's in a legacy block then this won't work.
 	/// </summary>

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -150,8 +150,9 @@ public static class NBitcoinExtensions
 		return anonsets;
 	}
 
-	public static bool IsLikelyCoinjoin(this SmartTransaction me)
-		=> me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
+	public static bool IsLikelyOwnCoinjoin(this SmartTransaction me)
+		=> me.WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
+		&& me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
 		&& me.Transaction.Outputs.Count != me.WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
 		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
 


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/pull/7291

This PR applies @lontivero's suggestion https://github.com/zkSNACKs/WalletWasabi/pull/7291#issuecomment-1039373938 and fixes the bikeshedding by renaming the function. We only care about own coinjoins, don't really mind others'.

I tested it and https://github.com/zkSNACKs/WalletWasabi/issues/7277 is not present anymore with this, however I wouldn't call that fixed, because obviously something wrong with the "islikelyowncoinjoin = true" path.