### PR TITLE
IsLikelyCoinjoin -> IsOwnCoinjoin 

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -196,7 +196,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			amount = x.Amount.Satoshi,
 			label = x.Label,
 			tx = x.TransactionId,
-			islikelycoinjoin = x.IsLikelyCoinJoinOutput
+			islikelycoinjoin = x.IsLikelyOwnCoinjoin
 		}).ToArray();
 	}
 

--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -196,7 +196,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			amount = x.Amount.Satoshi,
 			label = x.Label,
 			tx = x.TransactionId,
-			islikelycoinjoin = x.IsLikelyOwnCoinjoin
+			islikelycoinjoin = x.IsOwnCoinjoin
 		}).ToArray();
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -101,7 +101,7 @@ public partial class WalletManagerViewModel : ViewModelBase
 
 				if (_walletDictionary.TryGetValue(wallet, out var walletViewModel) && walletViewModel is WalletViewModel wvm)
 				{
-					if (!e.IsLikelyOwnCoinJoin)
+					if (!e.IsOwnCoinJoin)
 					{
 						NotificationHelpers.Show(wallet.WalletName, e, onClick: () => wvm.NavigateAndHighlight(e.Transaction.GetHash()));
 					}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -27,7 +27,7 @@ public class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 
 	public void Add(TransactionSummary item)
 	{
-		if (!item.IsLikelyCoinJoinOutput)
+		if (!item.IsLikelyOwnCoinjoin)
 		{
 			throw new InvalidOperationException("Not a coinjoin item!");
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -27,7 +27,7 @@ public class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 
 	public void Add(TransactionSummary item)
 	{
-		if (!item.IsLikelyOwnCoinjoin)
+		if (!item.IsOwnCoinjoin)
 		{
 			throw new InvalidOperationException("Not a coinjoin item!");
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -136,12 +136,12 @@ public partial class HistoryViewModel : ActivatableViewModel
 
 			balance += item.Amount;
 
-			if (!item.IsLikelyOwnCoinjoin)
+			if (!item.IsOwnCoinjoin)
 			{
 				yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 			}
 
-			if (item.IsLikelyOwnCoinjoin)
+			if (item.IsOwnCoinjoin)
 			{
 				if (coinJoinGroup is null)
 				{
@@ -154,7 +154,7 @@ public partial class HistoryViewModel : ActivatableViewModel
 			}
 
 			if (coinJoinGroup is { } cjg &&
-				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyOwnCoinjoin || // The next item is not CJ so add the group.
+				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsOwnCoinjoin || // The next item is not CJ so add the group.
 				 i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
 			{
 				cjg.SetBalance(balance);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -136,12 +136,12 @@ public partial class HistoryViewModel : ActivatableViewModel
 
 			balance += item.Amount;
 
-			if (!item.IsLikelyCoinJoinOutput)
+			if (!item.IsLikelyOwnCoinjoin)
 			{
 				yield return new TransactionHistoryItemViewModel(i, item, _walletViewModel, balance, _updateTrigger);
 			}
 
-			if (item.IsLikelyCoinJoinOutput)
+			if (item.IsLikelyOwnCoinjoin)
 			{
 				if (coinJoinGroup is null)
 				{
@@ -154,7 +154,7 @@ public partial class HistoryViewModel : ActivatableViewModel
 			}
 
 			if (coinJoinGroup is { } cjg &&
-				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyCoinJoinOutput || // The next item is not CJ so add the group.
+				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsLikelyOwnCoinjoin || // The next item is not CJ so add the group.
 				 i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
 			{
 				cjg.SetBalance(balance);

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -108,7 +108,7 @@ public class TransactionProcessorTests
 		var res3 = results[2];
 		var res4 = results[3];
 
-		Assert.False(res1.IsLikelyOwnCoinJoin);
+		Assert.False(res1.IsOwnCoinJoin);
 		Assert.Empty(res1.NewlyConfirmedReceivedCoins);
 		Assert.Empty(res1.NewlyConfirmedSpentCoins);
 		Assert.Single(res1.NewlyReceivedCoins);
@@ -122,7 +122,7 @@ public class TransactionProcessorTests
 		Assert.True(res1.IsNews);
 		Assert.NotNull(res1.Transaction);
 
-		Assert.False(res2.IsLikelyOwnCoinJoin);
+		Assert.False(res2.IsOwnCoinJoin);
 		Assert.Single(res2.NewlyConfirmedReceivedCoins);
 		Assert.Empty(res2.NewlyConfirmedSpentCoins);
 		Assert.Empty(res2.NewlyReceivedCoins);
@@ -136,7 +136,7 @@ public class TransactionProcessorTests
 		Assert.True(res2.IsNews);
 		Assert.NotNull(res2.Transaction);
 
-		Assert.False(res3.IsLikelyOwnCoinJoin);
+		Assert.False(res3.IsOwnCoinJoin);
 		Assert.Empty(res3.NewlyConfirmedReceivedCoins);
 		Assert.Empty(res3.NewlyConfirmedSpentCoins);
 		Assert.Empty(res3.NewlyReceivedCoins);
@@ -150,7 +150,7 @@ public class TransactionProcessorTests
 		Assert.True(res3.IsNews);
 		Assert.NotNull(res3.Transaction);
 
-		Assert.False(res4.IsLikelyOwnCoinJoin);
+		Assert.False(res4.IsOwnCoinJoin);
 		Assert.Empty(res4.NewlyConfirmedReceivedCoins);
 		Assert.Single(res4.NewlyConfirmedSpentCoins);
 		Assert.Empty(res4.NewlyReceivedCoins);

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -14,7 +14,7 @@ public class ProcessedResult
 	public ProcessedResult(SmartTransaction transaction)
 	{
 		Transaction = Guard.NotNull(nameof(transaction), transaction);
-		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.WalletInputs.Any() && Transaction.IsLikelyCoinjoin(), true);
+		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.IsLikelyOwnCoinjoin(), true);
 	}
 
 	public SmartTransaction Transaction { get; }

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -9,12 +9,12 @@ namespace WalletWasabi.Blockchain.TransactionProcessing;
 
 public class ProcessedResult
 {
-	private Lazy<bool> _isLikelyOwnCoinJoin;
+	private Lazy<bool> _isOwnCoinJoin;
 
 	public ProcessedResult(SmartTransaction transaction)
 	{
 		Transaction = Guard.NotNull(nameof(transaction), transaction);
-		_isLikelyOwnCoinJoin = new Lazy<bool>(() => Transaction.IsLikelyOwnCoinjoin(), true);
+		_isOwnCoinJoin = new Lazy<bool>(() => Transaction.IsOwnCoinjoin(), true);
 	}
 
 	public SmartTransaction Transaction { get; }
@@ -29,7 +29,7 @@ public class ProcessedResult
 		|| NewlyConfirmedSpentCoins.Any()
 		|| ReceivedDusts.Any(); // To be fair it isn't necessarily news, the algorithm of the processor can be improved for that. Not sure it is worth it though.
 
-	public bool IsLikelyOwnCoinJoin => _isLikelyOwnCoinJoin.Value;
+	public bool IsOwnCoinJoin => _isOwnCoinJoin.Value;
 
 	/// <summary>
 	/// Gets the dust outputs we received in this transaction. We may or may not have known about

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -192,6 +192,12 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		BlockIndex = 0;
 	}
 
+	public bool IsLikelyOwnCoinjoin()
+	   => WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
+	   && Transaction.Inputs.Count != WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
+	   && Transaction.Outputs.Count != WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
+	   && Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
+
 	#region LineSerialization
 
 	public string ToLine()

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -192,11 +192,9 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		BlockIndex = 0;
 	}
 
-	public bool IsLikelyOwnCoinjoin()
+	public bool IsOwnCoinjoin()
 	   => WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
-	   && Transaction.Inputs.Count != WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
-	   && Transaction.Outputs.Count != WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
-	   && Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
+	   && Transaction.Inputs.Count != WalletInputs.Count; // Some inputs must not be ours for it to be a coinjoin.
 
 	#region LineSerialization
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -49,7 +49,7 @@ public class TransactionHistoryBuilder
 					Label = containingTransaction.Label,
 					TransactionId = coin.TransactionId,
 					BlockIndex = containingTransaction.BlockIndex,
-					IsLikelyOwnCoinjoin = containingTransaction.IsLikelyOwnCoinjoin()
+					IsOwnCoinjoin = containingTransaction.IsOwnCoinjoin()
 				});
 			}
 
@@ -74,7 +74,7 @@ public class TransactionHistoryBuilder
 						Label = spenderTransaction.Label,
 						TransactionId = spenderTxId,
 						BlockIndex = spenderTransaction.BlockIndex,
-						IsLikelyOwnCoinjoin = spenderTransaction.IsLikelyOwnCoinjoin()
+						IsOwnCoinjoin = spenderTransaction.IsOwnCoinjoin()
 					});
 				}
 			}

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -49,7 +49,7 @@ public class TransactionHistoryBuilder
 					Label = containingTransaction.Label,
 					TransactionId = coin.TransactionId,
 					BlockIndex = containingTransaction.BlockIndex,
-					IsLikelyCoinJoinOutput = containingTransaction.IsLikelyCoinjoin()
+					IsLikelyOwnCoinjoin = containingTransaction.IsLikelyOwnCoinjoin()
 				});
 			}
 
@@ -74,7 +74,7 @@ public class TransactionHistoryBuilder
 						Label = spenderTransaction.Label,
 						TransactionId = spenderTxId,
 						BlockIndex = spenderTransaction.BlockIndex,
-						IsLikelyCoinJoinOutput = spenderTransaction.IsLikelyCoinjoin()
+						IsLikelyOwnCoinjoin = spenderTransaction.IsLikelyOwnCoinjoin()
 					});
 				}
 			}

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -12,5 +12,5 @@ public class TransactionSummary
 	public SmartLabel Label { get; set; }
 	public uint256 TransactionId { get; set; }
 	public int BlockIndex { get; set; }
-	public bool IsLikelyOwnCoinjoin { get; set; }
+	public bool IsOwnCoinjoin { get; set; }
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -12,5 +12,5 @@ public class TransactionSummary
 	public SmartLabel Label { get; set; }
 	public uint256 TransactionId { get; set; }
 	public int BlockIndex { get; set; }
-	public bool IsLikelyCoinJoinOutput { get; set; }
+	public bool IsLikelyOwnCoinjoin { get; set; }
 }

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -150,12 +150,6 @@ public static class NBitcoinExtensions
 		return anonsets;
 	}
 
-	public static bool IsLikelyOwnCoinjoin(this SmartTransaction me)
-		=> me.WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
-		&& me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
-		&& me.Transaction.Outputs.Count != me.WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
-		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
-
 	/// <summary>
 	/// Careful, if it's in a legacy block then this won't work.
 	/// </summary>

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -150,8 +150,9 @@ public static class NBitcoinExtensions
 		return anonsets;
 	}
 
-	public static bool IsLikelyCoinjoin(this SmartTransaction me)
-		=> me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
+	public static bool IsLikelyOwnCoinjoin(this SmartTransaction me)
+		=> me.WalletInputs.Any() // We must be a participant in order to be this transaction our coinjoin.
+		&& me.Transaction.Inputs.Count != me.WalletInputs.Count // Some inputs must not be ours for it to be a coinjoin.
 		&& me.Transaction.Outputs.Count != me.WalletOutputs.Count // Some outputs must not be ours for it to be a coinjoin.
 		&& me.Transaction.HasIndistinguishableOutputs(); // The tx must have more than one equal output in order to be a coinjoin.
 


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/pull/7302
Closes https://github.com/zkSNACKs/WalletWasabi/pull/7291
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/7277 (but not satisfactorily, explained here: https://github.com/zkSNACKs/WalletWasabi/pull/7302#issue-1139694405)

This PR perfects the `IsLikelyCoinjoin` method. It is now `IsOwnCoinjoin`. No "likely" there and no general coinjoin, but own coinjoin there.

This is more dangerous, but it fixes more display issues. The only one left that may bother people on testnet is that self spend coinjoins aren't coinjoins, but that's not a bug, it's a feature. If someone does a self coinjoin, then that's not really a coinjoin.