### PR TITLE
do not block dialog while BnB is running

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -412,12 +412,14 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 		{
 			UpdateTransaction(CurrentTransactionSummary, initialTransaction);
 
-			await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, initialTransaction, _isFixedAmount, _cancellationTokenSource.Token);
+			var suggestionTask = PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, initialTransaction, _isFixedAmount, _cancellationTokenSource.Token);
 
 			if (CurrentTransactionSummary.TransactionHasPockets && !await NavigateConfirmLabelsDialog(initialTransaction))
 			{
 				await OnChangePocketsAsync();
 			}
+
+			await suggestionTask;
 		}
 		else
 		{


### PR DESCRIPTION
I made a mistake here https://github.com/zkSNACKs/WalletWasabi/pull/7304/. If the BnB algorithm is running for seconds, the dialog is blocked until then.

This PR fixes it.