### PR TITLE
BnB: Add optimization that takes into account remaining values to prune search space

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -75,4 +75,42 @@ public class BranchAndBoundTests
 
 		Assert.Equal(new long[] { 35 }, actualSelection);
 	}
+
+	/// <summary>
+	/// The goal of the test is to verify that we prune branches at points when it is clear that
+	/// the sum of remaining coins is less than what we need to hit our target.
+	/// </summary>
+	/// <remarks>
+	/// This is especially important for cases where user has many coins.
+	/// <para>If the optimization is not in place, you should observe that this test does not really finish fast.</para>
+	/// </remarks>
+	[Fact]
+	public void CheapestSelection_RemainingAmountOptimization()
+	{
+		List<long> inputValues = new();
+		inputValues.Add(1_000_000);
+
+		for (int i = 0; i < 1000; i++)
+		{
+			inputValues.Add(1);
+		}
+
+		// All inputs cost the same.
+		long[] inputCosts = inputValues.Select(x => 1L).ToArray();
+		
+		long target = 999_999; // Target that we cannot get as a sum of input values.
+
+		BranchAndBound algorithm = new();
+		CheapestSelectionStrategy strategy = new(target, inputValues.ToArray(), inputCosts);
+		bool wasSuccessful = algorithm.TryGetMatch(strategy, out List<long>? selectedCoins);
+
+		Assert.False(wasSuccessful);
+		Assert.Null(selectedCoins);
+
+		// Assert that we get expected best solution.
+		long[] actualSelection = strategy.GetBestSelectionFound()!;
+		Assert.NotNull(actualSelection);
+
+		Assert.Equal(new long[] { 1_000_000 }, actualSelection);
+	}
 }


### PR DESCRIPTION
This PR is an attempt to make #7220 smaller by extracting independent features that are done. This is a feature suggested by Lucas that Adam added to #7220. Unfortunately, it looks to me that the implementation there is not correct so I attempted to fix it here and the structure of the PR is:

* First commit adds a test. You should observe that the test does not finish really (the search space is big and the algorithm is blind to the remaining values).
* Second commit adds the optimization. You should observe that the test finishes in a few milliseconds.
* Overall, I attempt to get closer to #7220 so fields are changed to properties.