### PR TITLE
Bnb: Throw exception at cancellation request

### DIFF
--- a/WalletWasabi/Blockchain/TransactionBuilding/BranchAndBound.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BranchAndBound.cs
@@ -111,7 +111,7 @@ public class BranchAndBound
 			// Micro optimization: Do not check cancellation token every time as it requires accessing volatile memory.
 			if (i % 10_000 == 0 && cancellationToken.IsCancellationRequested)
 			{
-				return false;
+				cancellationToken.ThrowIfCancellationRequested();
 			}
 		}
 		while (depth >= 0);

--- a/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionBuilding.BnB;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Logging;
 
 namespace WalletWasabi.Blockchain.TransactionBuilding;
 
@@ -75,7 +76,17 @@ public static class ChangelessTransactionCoinSelector
 
 		BranchAndBound branchAndBound = new();
 
-		var foundExactMatch = branchAndBound.TryGetMatch(strategy, out List<long>? solution, cancellationToken);
+		bool foundExactMatch = false;
+		List<long>? solution = null;
+
+		try
+		{
+			foundExactMatch = branchAndBound.TryGetMatch(strategy, out solution, cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+			Logger.LogWarning("Computing privacy suggestions was cancelled or timed out.");
+		}
 
 		// If we've not found an optimal solution then we will use the best.
 		if (!foundExactMatch && strategy.GetBestSelectionFound() is long[] bestSolution)

--- a/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
@@ -85,7 +85,7 @@ public static class ChangelessTransactionCoinSelector
 		}
 		catch (OperationCanceledException)
 		{
-			Logger.LogWarning("Computing privacy suggestions was cancelled or timed out.");
+			Logger.LogInfo("Computing privacy suggestions was cancelled or timed out.");
 		}
 
 		// If we've not found an optimal solution then we will use the best.


### PR DESCRIPTION
Same intention as #7328

It felt weird that we use cancellation token, but do not throw `OperationCanceledException`.

With this PR we can throw the exception and still get back the best result the algorithm found so far.