### PR TITLE
[VDG] ContentArea Layout problem fix

### DIFF
--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -41,7 +41,7 @@
                                         IsEnabled="{Binding FocusCancel, RelativeSource={RelativeSource TemplatedParent}}" />
                                 </i:Interaction.Behaviors>
                             </Button>
-                            <StackPanel Orientation="Horizontal" Spacing="30" Margin="0 10" HorizontalAlignment="Right">
+                            <StackPanel Orientation="Horizontal" Spacing="30" HorizontalAlignment="Right">
                                 <Button Name="PART_SkipButton"
                                         IsVisible="{TemplateBinding EnableSkip}"
                                         Content="{TemplateBinding SkipContent}"


### PR DESCRIPTION
The layout problem mentioned [here](https://github.com/zkSNACKs/WalletWasabi/pull/7314#issuecomment-1043174558) was not specific to that particular screen, but rather a general problem found in the `ContentArea` control, as evidenced by the screenshot:

![image](https://user-images.githubusercontent.com/98904713/154872108-3802c082-4464-447d-926a-f3e1197a1919.png)

Where depending on whether the `Continue` button is visible there is an additional margin causing an undesired layout change.

This PR removes the additional margin thus fixing the problem.