### PR TITLE
[Fluent] Use monospaced font for legal text.

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/LegalDocumentsView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/LegalDocumentsView.axaml
@@ -14,7 +14,7 @@
                  EnableBack="{Binding EnableBack}"
                  FocusCancel="True">
     <Panel>
-      <TextBlock TextWrapping="Wrap" Text="{Binding Content}" IsVisible="{Binding !IsBusy}" />
+      <TextBlock TextWrapping="Wrap" Classes="monoSpaced" Text="{Binding Content}" IsVisible="{Binding !IsBusy}" />
       <c:ProgressRing IsVisible="{Binding IsBusy}" Margin="15" IsIndeterminate="True" Height="100" Width="100" VerticalAlignment="Center" HorizontalAlignment="Center" />
     </Panel>
   </c:ContentArea>


### PR DESCRIPTION
cc @zkSNACKs/visual-design-group 

before:
<img width="1090" alt="Screen Shot 2022-02-21 at 2 17 54 PM" src="https://user-images.githubusercontent.com/16554748/154899692-5878c0af-d059-4154-9459-ab93f0f90072.png">


after:
<img width="1097" alt="Screen Shot 2022-02-21 at 2 08 01 PM" src="https://user-images.githubusercontent.com/16554748/154898670-1aceaa99-dc09-4fbd-bd00-571c55a415be.png">

