### PR TITLE
Fix server-side exception

### DIFF
--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -102,9 +103,10 @@ public class MempoolMirror : PeriodicRunner
 		IEnumerable<uint256> missing;
 		lock (MempoolLock)
 		{
-			missing = mempoolHashes.Except(Mempool.Keys);
+			var mempoolKeys = Mempool.Keys.ToImmutableArray();
+			missing = mempoolHashes.Except(mempoolKeys);
 
-			foreach (var txid in Mempool.Keys.Except(mempoolHashes).ToHashSet())
+			foreach (var txid in mempoolKeys.Except(mempoolHashes).ToHashSet())
 			{
 				Mempool.Remove(txid);
 			}


### PR DESCRIPTION
Previous to this PR the `GetRawTransactionsAsync` is called with an enumerable that is modified by the caller.

```
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]: 2022-02-22 14:29:24.700 [80] ERROR#011PeriodicRunner:ExecuteAsync (100)#011System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.MoveNext()
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Collections.Generic.HashSet`1.UnionWith(IEnumerable`1 other)
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Collections.Generic.HashSet`1..ctor(IEnumerable`1 collection, IEqualityComparer`1 comparer)
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Linq.Enumerable.ExceptIterator[TSource](IEnumerable`1 first, IEnumerable`1 second, IEqualityComparer`1 comparer)+MoveNext()
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Linq.Enumerable.SelectIterator[TSource,TResult](IEnumerable`1 source, Func`3 selector)+MoveNext()
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Linq.Lookup`2.Create(IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Linq.GroupedEnumerable`2.GetEnumerator()
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at WalletWasabi.BitcoinCore.Rpc.RpcClientBase.GetRawTransactionsAsync(IEnumerable`1 txids, CancellationToken cancel)
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at WalletWasabi.BitcoinCore.Mempool.MempoolMirror.MirrorMempoolAsync(CancellationToken cancel)
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at WalletWasabi.BitcoinCore.Mempool.MempoolMirror.ActionAsync(CancellationToken cancel)
Feb 22 14:29:24 WalletWasabi walletwasabi-backend[21295]:    at WalletWasabi.Bases.PeriodicRunner.ExecuteAsync(CancellationToken stoppingToken)

```