### PR TITLE
Lower DefaultPlebStopThreshold on Client side

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -29,7 +29,7 @@ public class KeyManager
 
 	public const int AbsoluteMinGapLimit = 21;
 	public const int MaxGapLimit = 10_000;
-	public static Money DefaultPlebStopThreshold = Money.Coins(0.01m);
+	public static Money DefaultPlebStopThreshold = Money.Coins(0.0001m);
 
 	// BIP84-ish derivation scheme
 	// m / purpose' / coin_type' / account' / change / address_index


### PR DESCRIPTION
Lower `DefaultPlebStopThreshold` on `Client` side, so the Testnet Release users can enjoy auto CJ, even if their Faucet gave them low amount of `tBTC`.

Idea came from @MaxHillebrand 