### PR TITLE
Waiting for confirmation, music box

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -72,7 +72,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 	private readonly MusicStatusMessageViewModel _initialisingMessage = new() { Message = "Coinjoin is initialising" };
 
-	private readonly MusicStatusMessageViewModel _finishedMessage = new() { Message = "No balance to coinjoin" };
+	private readonly MusicStatusMessageViewModel _finishedMessage = new() { Message = "Waiting for confirmation" };
 
 	private DateTimeOffset _autoStartTime;
 	private DateTimeOffset _countDownStarted;


### PR DESCRIPTION
When the wallet balance is unconfirmed, `No balance to coinjoin` is in the music box. that's confusing. it should be a separate one with `Waiting for confirmation`.

I'm just naively renaming that one warning, but this is probably the wrong fix, so please someone pick it up and add a seperate catch.