### PR TITLE
Fix coinjoin tracking

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -89,8 +89,8 @@ public class CoinJoinManager : BackgroundService
 			var mixableWallets = RoundStatusUpdater.AnyRound
 				? GetMixableWallets()
 				: ImmutableDictionary<string, Wallet>.Empty;
-			var openedWallets = mixableWallets.Where(x => !trackedCoinJoins.ContainsKey(x.Key));
-			var closedWallets = trackedCoinJoins.Where(x => !mixableWallets.ContainsKey(x.Key));
+			var openedWallets = mixableWallets.Where(x => !trackedCoinJoins.ContainsKey(x.Key)).ToImmutableList();
+			var closedWallets = trackedCoinJoins.Where(x => !mixableWallets.ContainsKey(x.Key)).ToImmutableList();
 
 			foreach (var openedWallet in openedWallets.Select(x => x.Value))
 			{


### PR DESCRIPTION
Before this PR the filter to determine which wallet isn't tracked was done based on  the `trackedCoinJoins` which was modify in a `foreach` loop causing coinjoins to be cancelled.
 