### PR TITLE
Make TestWallet behave like a HD wallet

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -14,10 +14,8 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
 
-internal class Participant: IDisposable
+internal class Participant
 {
-	private bool _disposedValue;
-
 	public Participant(string name, IRPCClient rpc, IWasabiHttpClientFactory httpClientFactory)
 	{
 		HttpClientFactory = httpClientFactory;
@@ -31,13 +29,11 @@ internal class Participant: IDisposable
 
 	public async Task GenerateSourceCoinAsync(CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
 		await Wallet.GenerateAsync(1, cancellationToken).ConfigureAwait(false);
 	}
 
 	public async Task GenerateCoinsAsync(int numberOfCoins, int seed, CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
 		var feeRate = new FeeRate(4.0m);
 		var (splitTx, spendingCoin) = Wallet.CreateTemplateTransaction();
 		var availableAmount = spendingCoin.EffectiveValue(feeRate, CoordinationFeeRate.Zero);
@@ -57,20 +53,23 @@ internal class Participant: IDisposable
 			.Select(x => x * availableAmount.Satoshi)
 			.Select(x => Money.Satoshis((long)x));
 
-		var scriptPubKey = Wallet.ScriptPubKey;
 		foreach (var amount in amounts)
 		{
-			var effectiveOutputValue = amount - feeRate.GetFee(scriptPubKey.EstimateOutputVsize());
-			splitTx.Outputs.Add(new TxOut(effectiveOutputValue, scriptPubKey));
+			var outputAddress = Wallet.CreateNewAddress();
+			var effectiveOutputValue = amount - feeRate.GetFee(outputAddress.ScriptPubKey.EstimateOutputVsize());
+			splitTx.Outputs.Add(new TxOut(effectiveOutputValue, Wallet.CreateNewAddress()));
 		}
-
 		await Wallet.SendRawTransactionAsync(Wallet.SignTransaction(splitTx), cancellationToken).ConfigureAwait(false);
 		SplitTransaction = new SmartTransaction(splitTx, new Height(1));
 	}
 
 	public async Task StartParticipatingAsync(CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
+		if (SplitTransaction is null)
+		{
+			throw new InvalidOperationException($"{nameof(GenerateCoinsAsync)} has to be called first.");
+		}
+
 		var apiClient = new WabiSabiHttpApiClient(HttpClientFactory.NewHttpClientWithDefaultCircuit());
 		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(3), apiClient);
 		await roundStateUpdater.StartAsync(cancellationToken).ConfigureAwait(false);
@@ -82,45 +81,21 @@ internal class Participant: IDisposable
 			roundStateUpdater,
 			consolidationMode: true);
 
-		// Run the coinjoin client task.
-		var walletHdPubKey = new HdPubKey(Wallet.PubKey, KeyPath.Parse("m/84'/0/0/0/0"), SmartLabel.Empty, KeyState.Clean);
-		walletHdPubKey.SetAnonymitySet(1); // bug if not settled
-
-		if (SplitTransaction is null)
+		static HdPubKey CreateHdPubKey(ExtPubKey extPubKey)
 		{
-			throw new InvalidOperationException($"{nameof(GenerateCoinsAsync)} has to be called first.");
+			var hdPubKey = new HdPubKey(extPubKey.PubKey, KeyPath.Parse($"m/84'/0/0/0/{extPubKey.Child}"), SmartLabel.Empty, KeyState.Clean);
+			hdPubKey.SetAnonymitySet(1); // bug if not settled
+			return hdPubKey;
 		}
 
 		var smartCoins = SplitTransaction.Transaction.Outputs.AsIndexedOutputs()
-			.Select(x => new SmartCoin(SplitTransaction, x.N, walletHdPubKey))
+		 	.Select(x => (IndexedTxOut: x, HdPubKey: Wallet.GetExtPubKey(x.TxOut.ScriptPubKey)))
+			.Select(x => new SmartCoin(SplitTransaction, x.IndexedTxOut.N, CreateHdPubKey(x.HdPubKey)))
 			.ToList();
 
 		// Run the coinjoin client task.
 		await coinJoinClient.StartCoinJoinAsync(smartCoins, cancellationToken).ConfigureAwait(false);
 
 		await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
-	}
-
-	private void ThrowIfDisposed()
-	{
-		if (_disposedValue)
-		{
-			throw new ObjectDisposedException(nameof(TestWallet));
-		}
-	}
-
-	protected virtual void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			Wallet.Dispose();
-			_disposedValue = true;
-		}
-	}
-
-	public void Dispose()
-	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -316,100 +316,98 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		await roundStateUpdater.StopAsync(CancellationToken.None);
 	}
 
-	// ToDo: Fix this test. It's incorrect, because the TestWallet class doesn't simulate multipe keys, only a single one.
-	//[Theory]
-	//[InlineData(123456)]
-	//public async Task MultiClientsCoinJoinTestAsync(int seed)
-	//{
-	//	const int NumberOfParticipants = 10;
-	//	const int NumberOfCoinsPerParticipant = 2;
-	//	const int ExpectedInputNumber = (NumberOfParticipants * NumberOfCoinsPerParticipant) / 2;
+	[Theory]
+	[InlineData(123456)]
+	public async Task MultiClientsCoinJoinTestAsync(int seed)
+	{
+		const int NumberOfParticipants = 10;
+		const int NumberOfCoinsPerParticipant = 2;
+		const int ExpectedInputNumber = (NumberOfParticipants * NumberOfCoinsPerParticipant) / 2;
 
-	//	var node = await TestNodeBuilder.CreateForHeavyConcurrencyAsync();
-	//	try
-	//	{
-	//		var rpc = node.RpcClient;
+		var node = await TestNodeBuilder.CreateForHeavyConcurrencyAsync();
+		try
+		{
+			var rpc = node.RpcClient;
 
-	//		var app = _apiApplicationFactory.WithWebHostBuilder(builder =>
-	//			builder.ConfigureServices(services =>
-	//			{
-	//				// Instruct the coordinator DI container to use these two scoped
-	//				// services to build everything (WabiSabi controller, arena, etc)
-	//				services.AddScoped<IRPCClient>(s => rpc);
-	//				services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig(Path.GetTempFileName())
-	//				{
-	//					MaxRegistrableAmount = Money.Coins(500m),
-	//					MaxInputCountByRound = ExpectedInputNumber,
-	//					StandardInputRegistrationTimeout = TimeSpan.FromSeconds(10 * ExpectedInputNumber),
-	//					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
-	//					OutputRegistrationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
-	//				});
-	//			}));
+			var app = _apiApplicationFactory.WithWebHostBuilder(builder =>
+				builder.ConfigureServices(services =>
+				{
+					// Instruct the coordinator DI container to use these two scoped
+					// services to build everything (WabiSabi controller, arena, etc)
+					services.AddScoped<IRPCClient>(s => rpc);
+					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig(Path.GetTempFileName())
+					{
+						MaxRegistrableAmount = Money.Coins(500m),
+						MaxInputCountByRound = ExpectedInputNumber,
+						StandardInputRegistrationTimeout = TimeSpan.FromSeconds(10 * ExpectedInputNumber),
+						ConnectionConfirmationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
+						OutputRegistrationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
+					});
+				}));
 
-	//		using PersonCircuit personCircuit = new();
-	//		IHttpClient httpClientWrapper = new HttpClientWrapper(app.CreateClient());
+			using PersonCircuit personCircuit = new();
+			IHttpClient httpClientWrapper = new HttpClientWrapper(app.CreateClient());
 
-	//		var mockHttpClientFactory = new Mock<IWasabiHttpClientFactory>(MockBehavior.Strict);
-	//		mockHttpClientFactory
-	//			.Setup(factory => factory.NewHttpClientWithPersonCircuit(out httpClientWrapper))
-	//			.Returns(personCircuit);
+			var mockHttpClientFactory = new Mock<IWasabiHttpClientFactory>(MockBehavior.Strict);
+			mockHttpClientFactory
+				.Setup(factory => factory.NewHttpClientWithPersonCircuit(out httpClientWrapper))
+				.Returns(personCircuit);
 
-	//		mockHttpClientFactory
-	//			.Setup(factory => factory.NewHttpClientWithCircuitPerRequest())
-	//			.Returns(httpClientWrapper);
+			mockHttpClientFactory
+				.Setup(factory => factory.NewHttpClientWithCircuitPerRequest())
+				.Returns(httpClientWrapper);
 
-	//		mockHttpClientFactory
-	//			.Setup(factory => factory.NewHttpClientWithDefaultCircuit())
-	//			.Returns(httpClientWrapper);
+			mockHttpClientFactory
+				.Setup(factory => factory.NewHttpClientWithDefaultCircuit())
+				.Returns(httpClientWrapper);
 
-	//		// Total test timeout.
-	//		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(40 * ExpectedInputNumber));
+			// Total test timeout.
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(40 * ExpectedInputNumber));
 
-	//		var participants = Enumerable
-	//			.Range(0, NumberOfParticipants)
-	//			.Select(i => new Participant($"participant{i}", rpc, mockHttpClientFactory.Object))
-	//			.ToArray();
+			var participants = Enumerable
+				.Range(0, NumberOfParticipants)
+				.Select(i => new Participant($"participant{i}", rpc, mockHttpClientFactory.Object))
+				.ToArray();
 
-	//		using var disposableParticipants = new CompositeDisposable(participants);
-	//		foreach (var participant in participants)
-	//		{
-	//			await participant.GenerateSourceCoinAsync(cts.Token);
-	//		}
-	//		using var dummyWallet = new TestWallet("dummy", rpc);
-	//		await dummyWallet.GenerateAsync(101, cts.Token);
-	//		foreach (var participant in participants)
-	//		{
-	//			await participant.GenerateCoinsAsync(NumberOfCoinsPerParticipant, seed, cts.Token);
-	//		}
-	//		await dummyWallet.GenerateAsync(101, cts.Token);
+			foreach (var participant in participants)
+			{
+				await participant.GenerateSourceCoinAsync(cts.Token);
+			}
+			var dummyWallet = new TestWallet("dummy", rpc);
+			await dummyWallet.GenerateAsync(101, cts.Token);
+			foreach (var participant in participants)
+			{
+				await participant.GenerateCoinsAsync(NumberOfCoinsPerParticipant, seed, cts.Token);
+			}
+			await dummyWallet.GenerateAsync(101, cts.Token);
 
-	//		var tasks = participants.Select(x => x.StartParticipatingAsync(cts.Token)).ToArray();
+			var tasks = participants.Select(x => x.StartParticipatingAsync(cts.Token)).ToArray();
 
-	//		while ((await rpc.GetRawMempoolAsync()).Length == 0)
-	//		{
-	//			if (cts.IsCancellationRequested)
-	//			{
-	//				throw new TimeoutException("Coinjoin was not propagated.");
-	//			}
+			while ((await rpc.GetRawMempoolAsync()).Length == 0)
+			{
+				if (cts.IsCancellationRequested)
+				{
+					throw new TimeoutException("Coinjoin was not propagated.");
+				}
 
-	//			await Task.Delay(500, cts.Token);
+				await Task.Delay(500, cts.Token);
 
-	//			if (tasks.FirstOrDefault(t => t.IsFaulted)?.Exception is { } exc)
-	//			{
-	//				throw exc;
-	//			}
-	//		}
-	//		var mempool = await rpc.GetRawMempoolAsync();
-	//		var coinjoin = await rpc.GetRawTransactionAsync(mempool.Single());
+				if (tasks.FirstOrDefault(t => t.IsFaulted)?.Exception is { } exc)
+				{
+					throw exc;
+				}
+			}
+			var mempool = await rpc.GetRawMempoolAsync();
+			var coinjoin = await rpc.GetRawTransactionAsync(mempool.Single());
 
-	//		Assert.True(coinjoin.Outputs.Count <= ExpectedInputNumber);
-	//		Assert.Equal(ExpectedInputNumber, coinjoin.Inputs.Count);
-	//	}
-	//	finally
-	//	{
-	//		await node.TryStopAsync();
-	//	}
-	//}
+			Assert.True(coinjoin.Outputs.Count <= ExpectedInputNumber);
+			Assert.Equal(ExpectedInputNumber, coinjoin.Inputs.Count);
+		}
+		finally
+		{
+			await node.TryStopAsync();
+		}
+	}
 
 	[Fact]
 	public async Task RegisterCoinIdempotencyAsync()


### PR DESCRIPTION
Reenable `MultiClientsCoinJoinTestAsync` (The most important test we have). To do that `TestWallet` had been modified to behave as a HD wallet and generate different keys/scripts. 