### PR TITLE
Fix bad StateMachine configuration

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -251,7 +251,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.Permit(Trigger.Pause, State.Paused)
 			.Permit(Trigger.PlebStop, State.Paused)
 			.Permit(Trigger.RoundStartFailed, State.AutoFinished)
-			.Permit(Trigger.RoundStart, State.AutoPlaying)
 			.OnEntry(() =>
 			{
 				IsAutoWaiting = false;


### PR DESCRIPTION
Fixes crash when opening a wallet.

The old configuration adds state re-entrancy, that isn't allowed.