### PR TITLE
[Trivial] [VDG] Display privacy level in format ##%

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -37,11 +37,11 @@ public partial class PrivacyControlTileViewModel : TileViewModel
 
 		var currentPrivacyScore = _wallet.Coins.Sum(x => x.Amount.Satoshi * Math.Min(x.HdPubKey.AnonymitySet - 1, privateThreshold - 1));
 		var maxPrivacyScore = _wallet.Coins.TotalAmount().Satoshi * (privateThreshold - 1);
-		var pcPrivate = maxPrivacyScore == 0M ? 1d : (double)currentPrivacyScore / maxPrivacyScore;
+		int pcPrivate = maxPrivacyScore == 0M ? 100 : (int)(currentPrivacyScore * 100 / maxPrivacyScore);
 
-		PercentText = $"{pcPrivate:P}";
+		PercentText = $"{pcPrivate} %";
 
-		FullyMixed = pcPrivate >= 1d;
+		FullyMixed = pcPrivate >= 100;
 
 		var privateAmount = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
 		HasPrivateBalance = privateAmount > Money.Zero;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -38,7 +38,8 @@ public partial class PrivacyControlTileViewModel : TileViewModel
 		var currentPrivacyScore = _wallet.Coins.Sum(x => x.Amount.Satoshi * Math.Min(x.HdPubKey.AnonymitySet - 1, privateThreshold - 1));
 		var maxPrivacyScore = _wallet.Coins.TotalAmount().Satoshi * (privateThreshold - 1);
 		var pcPrivate = maxPrivacyScore == 0M ? 1d : (double)currentPrivacyScore / maxPrivacyScore;
-		PercentText = $"\u205F{(int)Math.Floor(pcPrivate * 100)}\u205F/\u205F{100}";
+
+		PercentText = $"{pcPrivate:P}";
 
 		FullyMixed = pcPrivate >= 1d;
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
@@ -26,14 +26,13 @@
       </StackPanel>
 
       <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 3">
-        <Image Height="36" Width="36" VerticalAlignment="Center" HorizontalAlignment="Center"
+        <Image Height="36" Width="36" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 0 10 0"
                Source="{StaticResource privacy_indicator_good}" />
         <TextBlock
           VerticalAlignment="Center" HorizontalAlignment="Center"
           TextAlignment="Center"
           Text="{Binding PercentText}" Classes="h2" />
       </StackPanel>
-
     </DockPanel>
   </controls:TileControl>
 </UserControl>


### PR DESCRIPTION
The current privacy level format is very confusing. It looks like the anonymity score of coins.

Master:

![saasa](https://user-images.githubusercontent.com/52379387/156947199-e1bc20d3-bec6-476a-a499-ebd62afe0531.PNG)

PR:

![asaas](https://user-images.githubusercontent.com/52379387/156947175-8e96c515-842c-47a7-99ab-d16c62f6286d.PNG)