### PR TITLE
[VDG] [Trivial] Action Center - About - Add ToolTip for link

### DIFF
--- a/WalletWasabi.Fluent/Views/HelpAndSupport/LinkView.axaml
+++ b/WalletWasabi.Fluent/Views/HelpAndSupport/LinkView.axaml
@@ -19,6 +19,7 @@
     <Button Classes="plain"
             Command="{Binding OpenBrowserCommand}"
             CommandParameter="{Binding Link}"
+            ToolTip.Tip="{Binding Link}"
             IsVisible="{Binding IsClickable}">
       <TextBlock Text="{Binding Description}" Classes="Hyperlink" />
     </Button>


### PR DESCRIPTION
With this PR  the user can see what link is at the hyperlink when hovering over it with cursor.
![image](https://user-images.githubusercontent.com/93143998/157029216-b484d798-2011-4dc9-abed-bf87722609e2.png)

