### PR TITLE
[VDG][Trivial] GitHub writing/typo fix

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/HelpAndSupport/AboutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/HelpAndSupport/AboutViewModel.cs
@@ -40,7 +40,7 @@ public partial class AboutViewModel : RoutableViewModel
 				new LinkViewModel()
 				{
 					Link = SourceCodeLink,
-					Description = "Source Code (Github)",
+					Description = "Source Code (GitHub)",
 					IsClickable = true
 				},
 				new SeparatorViewModel(),


### PR DESCRIPTION
nitpick 
`GitHub` should be with capital `H`
![image](https://user-images.githubusercontent.com/93143998/157033784-4de806a8-c10b-4378-b679-76a9de38b7e2.png)
