### PR TITLE
Fix wassabee permission on Linux distros

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -402,7 +402,7 @@ public static class Program
 
 				var linuxPath = $"/mnt/{driveLetterLower}/{Tools.LinuxPath(BinDistDirectory[3..])}";
 
-				var chmodExecutablesArgs = "-type f \\( -name 'wassabee' -o -name 'hwi' -o -name 'bitcoind' -o -name 'tor' \\) -exec chmod u+x {} \\;";
+				var chmodExecutablesArgs = "-type f \\( -name 'wassabee' -o -name 'hwi' -o -name 'bitcoind' -o -name 'tor' \\) -exec chmod +x {} \\;";
 
 				var commands = new[]
 				{


### PR DESCRIPTION
Fixes #7427

Previously:
After installing the `Testnet Release` on a Linux distro, somehow you didn't have permission to run `wassabee`.

This PR makes sure that the executables are executable for everyone.

`chmod u+x some_file` will grant only the owner of that file execution permissions,
whereas `chmod +x some_file` will grant everyone execution permission.

How to test:

- Grab this PR and run the `Packager` project in a computer.
- Move the `.deb` file to another PC and install it.
- See that there is no permission errors and wassabee is runnable by default.