### PR TITLE
Do not freeze all the coins after CoinJoin only the registered ones

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -164,7 +164,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			consolidationMode: true);
 
 		// Run the coinjoin client task.
-		Assert.True(await coinJoinClient.StartCoinJoinAsync(coins, cts.Token));
+		Assert.True((await coinJoinClient.StartCoinJoinAsync(coins, cts.Token)).SuccessfulBroadcast);
 
 		var broadcastedTx = await transactionCompleted.Task; // wait for the transaction to be broadcasted.
 		Assert.NotNull(broadcastedTx);
@@ -309,7 +309,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		await Assert.ThrowsAsync<AggregateException>(async () => await Task.WhenAll(new Task[] { badCoinsTask, coinJoinTask }));
 
 		Assert.True(badCoinsTask.IsFaulted);
-		Assert.True(coinJoinTask.Result);
+		Assert.True(coinJoinTask.Result.SuccessfulBroadcast);
 
 		var broadcastedTx = await transactionCompleted.Task; // wait for the transaction to be broadcasted.
 		Assert.NotNull(broadcastedTx);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -152,7 +152,8 @@ public class CoinJoinClient
 			return new CoinJoinResult(
 				GoForBlameRound: false,
 				SuccessfulBroadcast: false,
-				RegisteredCoins: Enumerable.Empty<SmartCoin>());
+				RegisteredCoins: ImmutableList<SmartCoin>.Empty,
+				RegisteredOutputs: ImmutableList<Script>.Empty);
 		}
 
 		if (!registeredAliceClients.Any())
@@ -162,7 +163,8 @@ public class CoinJoinClient
 			return new CoinJoinResult(
 				GoForBlameRound: false,
 				SuccessfulBroadcast: false,
-				RegisteredCoins: Enumerable.Empty<SmartCoin>());
+				RegisteredCoins: ImmutableList<SmartCoin>.Empty,
+				RegisteredOutputs: ImmutableList<Script>.Empty);
 		}
 
 		try
@@ -242,7 +244,8 @@ public class CoinJoinClient
 			return new CoinJoinResult(
 				GoForBlameRound: !finalRoundState.WasTransactionBroadcast,
 				SuccessfulBroadcast: finalRoundState.WasTransactionBroadcast,
-				RegisteredCoins: registeredAliceClients.Select(a => a.SmartCoin));
+				RegisteredCoins: registeredAliceClients.Select(a => a.SmartCoin).ToImmutableList(),
+				RegisteredOutputs: outputTxOuts.Select(o => o.ScriptPubKey).ToImmutableList());
 		}
 		finally
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -160,10 +160,10 @@ public class CoinJoinManager : BackgroundService
 
 				try
 				{
-					var success = await finishedCoinJoin.CoinJoinTask.ConfigureAwait(false);
-					if (success)
+					var result = await finishedCoinJoin.CoinJoinTask.ConfigureAwait(false);
+					if (result.SuccessfulBroadcast)
 					{
-						CoinRefrigerator.Freeze(finishedCoinJoin.CoinCandidates);
+						CoinRefrigerator.Freeze(result.RegisteredCoins);
 						MarkDestinationsUsed(finishedCoinJoin);
 						Logger.LogInfo($"{logPrefix} finished!");
 					}
@@ -231,7 +231,7 @@ public class CoinJoinManager : BackgroundService
 			finishedCoinJoin.Wallet,
 			finishedCoinJoin.CoinJoinTask.Status switch
 			{
-				TaskStatus.RanToCompletion when finishedCoinJoin.CoinJoinTask.Result => CompletionStatus.Success,
+				TaskStatus.RanToCompletion when finishedCoinJoin.CoinJoinTask.Result.SuccessfulBroadcast => CompletionStatus.Success,
 				TaskStatus.Canceled => CompletionStatus.Canceled,
 				TaskStatus.Faulted => CompletionStatus.Failed,
 				_ => CompletionStatus.Unknown,

--- a/WalletWasabi/WabiSabi/Client/CoinJoinResult.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinResult.cs
@@ -1,4 +1,6 @@
+using NBitcoin;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using WalletWasabi.Blockchain.TransactionOutputs;
 
 namespace WalletWasabi.WabiSabi.Client;
@@ -6,6 +8,7 @@ namespace WalletWasabi.WabiSabi.Client;
 public record CoinJoinResult(
 	bool GoForBlameRound,
 	bool SuccessfulBroadcast,
-	IEnumerable<SmartCoin> RegisteredCoins)
+	ImmutableList<SmartCoin> RegisteredCoins,
+	ImmutableList<Script> RegisteredOutputs)
 {
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinResult.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinResult.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public record CoinJoinResult(
+	bool GoForBlameRound,
+	bool SuccessfulBroadcast,
+	IEnumerable<SmartCoin> RegisteredCoins)
+{
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -29,7 +29,7 @@ public class CoinJoinTracker : IDisposable
 	private CancellationTokenSource CancellationTokenSource { get; }
 
 	public Wallet Wallet { get; }
-	public Task<bool> CoinJoinTask { get; }
+	public Task<CoinJoinResult> CoinJoinTask { get; }
 	public IEnumerable<SmartCoin> CoinCandidates { get; }
 	public IEnumerable<IDestination> Destinations => CoinJoinClient.Destinations;
 	public bool IsCompleted => CoinJoinTask.IsCompleted;


### PR DESCRIPTION
My wallet had 56 coins that were candidates for coinjoin. After successful CJ all those coins were frozen but only 5 were actually used in the CoinJoin. This PR fixes this and also simplifies the code by adding a CoinJoinResult class. 