### PR TITLE
[VDG] Make Settings child VMs into regular VMs

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -191,26 +191,6 @@ public partial class MainViewModel : ViewModelBase
 		AddWalletPageViewModel.Register(_addWalletPage);
 		SettingsPageViewModel.Register(_settingsPage);
 
-		GeneralSettingsTabViewModel.RegisterLazy(
-			() =>
-			{
-				_settingsPage.SelectedTab = 0;
-				return _settingsPage;
-			});
-
-		TorSettingsTabViewModel.RegisterLazy(
-			() =>
-			{
-				_settingsPage.SelectedTab = 1;
-				return _settingsPage;
-			});
-
-		BitcoinTabSettingsViewModel.RegisterLazy(
-			() =>
-			{
-				_settingsPage.SelectedTab = 2;
-				return _settingsPage;
-			});
 
 		AboutViewModel.RegisterLazy(() => new AboutViewModel());
 

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -10,16 +10,6 @@ using WalletWasabi.Userfacing;
 
 namespace WalletWasabi.Fluent.ViewModels.Settings;
 
-[NavigationMetaData(
-	Title = "Bitcoin",
-	Caption = "Manage Bitcoin settings",
-	Order = 3,
-	Category = "Settings",
-	Keywords = new[]
-	{
-			"Settings", "Bitcoin", "Network", "Main", "TestNet", "RegTest", "Run", "Knots", "Startup", "P2P", "Endpoint"
-	},
-	IconName = "settings_bitcoin_regular")]
 public partial class BitcoinTabSettingsViewModel : SettingsTabViewModelBase
 {
 	[AutoNotify] private Network _network;

--- a/WalletWasabi.Fluent/ViewModels/Settings/SettingsTabViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/SettingsTabViewModelBase.cs
@@ -1,12 +1,11 @@
 using System.Reactive.Concurrency;
 using ReactiveUI;
 using WalletWasabi.Fluent.Models;
-using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Fluent.ViewModels.Settings;
 
-public abstract class SettingsTabViewModelBase : RoutableViewModel
+public abstract class SettingsTabViewModelBase : ViewModelBase
 {
 	protected const int ThrottleTime = 500;
 

--- a/WalletWasabi.Fluent/ViewModels/Settings/ThemeChangeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/ThemeChangeViewModel.cs
@@ -3,12 +3,13 @@ using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using ReactiveUI;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 
 namespace WalletWasabi.Fluent.ViewModels.Settings;
 
 [NavigationMetaData(Title = "")]
-public partial class ThemeChangeViewModel : RoutableViewModel
+public partial class ThemeChangeViewModel : DialogViewModelBase<bool>
 {
 	private readonly Theme _newTheme;
 

--- a/WalletWasabi.Fluent/ViewModels/Settings/TorSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/TorSettingsTabViewModel.cs
@@ -3,16 +3,6 @@ using ReactiveUI;
 
 namespace WalletWasabi.Fluent.ViewModels.Settings;
 
-[NavigationMetaData(
-	Title = "Tor",
-	Caption = "Manage Tor settings",
-	Order = 2,
-	Category = "Settings",
-	Keywords = new[]
-	{
-			"Settings", "Network", "Anonymization", "Tor", "Terminate", "Wasabi", "Shutdown", "SOCKS5", "Endpoint"
-	},
-	IconName = "settings_network_regular")]
 public partial class TorSettingsTabViewModel : SettingsTabViewModelBase
 {
 	[AutoNotify] private bool _useTor;

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -17,7 +17,7 @@
 
     <DockPanel>
       <TextBlock Text="Run Wasabi when computer starts" />
-      <ToggleSwitch IsChecked="{Binding RunOnSystemStartup}" Command="{Binding StartupCommand}" />
+      <ToggleSwitch IsChecked="{Binding RunOnSystemStartup}" Command="{Binding RunOnSystemStartupCommand}" />
     </DockPanel>
 
     <DockPanel>


### PR DESCRIPTION
Converted ViewModels (children of `SettingsTabViewModelBase`) to non-navigatable, since they're not navigated to.

Fixes #6184