### PR TITLE
Tor: Add `ExtendedErrors`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -21,7 +21,8 @@ public class TorSettingsTests
 
 		string expected = string.Join(
 			" ",
-			$"--SOCKSPort 127.0.0.1:37150",
+			$"--LogTimeGranularity 1",
+			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors\"",
 			$"--CookieAuthentication 1",
 			$"--ControlPort 37151",
 			$"--CookieAuthFile \"{Path.Combine("temp", "tempDataDir", "control_auth_cookie")}\"",

--- a/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RepField.cs
+++ b/WalletWasabi/Tor/Socks5/Models/Fields/OctetFields/RepField.cs
@@ -24,7 +24,7 @@ public class RepField : OctetSerializableBase
 
 	public static readonly RepField GeneralSocksServerFailure = new((byte)ReplyType.GeneralSocksServerFailure);
 
-	public static readonly RepField CconnectionNotAllowedByRuleset = new((byte)ReplyType.ConnectionNotAllowedByRuleset);
+	public static readonly RepField ConnectionNotAllowedByRuleset = new((byte)ReplyType.ConnectionNotAllowedByRuleset);
 
 	public static readonly RepField NetworkUnreachable = new((byte)ReplyType.NetworkUnreachable);
 

--- a/WalletWasabi/Tor/Socks5/Models/ReplyType.cs
+++ b/WalletWasabi/Tor/Socks5/Models/ReplyType.cs
@@ -1,5 +1,9 @@
+using Microsoft.VisualBasic;
+
 namespace WalletWasabi.Tor.Socks5.Models;
 
+/// <seealso href="https://github.com/torproject/torspec/blob/main/proposals/304-socks5-extending-hs-error-codes.txt"/>
+/// <seealso href="https://github.com/torproject/tor/blob/ea2ada6d1459f829446b6b1e66c557d1b084e78b/src/lib/net/socks5_status.h"/>
 public enum ReplyType : byte
 {
 	Succeeded = 0x00,
@@ -10,5 +14,66 @@ public enum ReplyType : byte
 	ConnectionRefused = 0x05,
 	TtlExpired = 0x06,
 	CommandNotSupported = 0x07,
-	AddressTypeNotSupported = 0x08
+	AddressTypeNotSupported = 0x08,
+
+	// Extended errors follow. "ExtendedErrors" must be provided in "SocksPort"  for the
+	// error codes to be returned.
+
+	/// <summary>Onion service descriptor can not be found</summary>
+	/// <remarks>
+	/// The requested onion service descriptor can't be found on the hashring
+	/// and thus not reachable by the client.
+	/// </remarks>
+	OnionServiceNotFound = 0xF0,
+
+	/// <summary>Onion service descriptor is invalid</summary>
+	/// <remarks>
+	/// The requested onion service descriptor can't be parsed or signature validation failed.
+	/// </remarks>
+	OnionServiceIsInvalid = 0xF1,
+
+	/// <summary>Onion service introduction failed</summary>
+	/// <remarks>
+	/// Client failed to introduce to the service meaning the descriptor was
+	/// found but the service is not anymore at the introduction points. The
+	/// service has likely changed its descriptor or is not running.
+	/// </remarks>
+	OnionServiceIntroFailed = 0xF2,
+
+	/// <summary>Onion service rendezvous failed</summary>
+	/// <remarks>
+	/// Client failed to rendezvous with the service which means that the client is
+	/// unable to finalize the connection.
+	/// </remarks>
+	OnionServiceRendFailed = 0xF3,
+
+	/// <summary>Onion service missing client authorization</summary>
+	/// <remarks>
+	/// Tor was able to download the requested onion service descriptor but is unable
+	/// to decrypt its content because it is missing client authorization information for it.
+	/// </remarks>
+	OnionServiceMissingClient_Auth = 0xF4,
+
+	/// <summary>Onion service wrong client authorization</summary>
+	/// <remarks>
+	/// Tor was able to download the requested onion service descriptor but is
+	/// unable to decrypt its content using the client authorization information
+	/// it has.This means the client access were revoked.
+    /// </remarks>
+	OnionServiceBadClientAuth = 0xF5,
+
+	/// <summary>Onion service invalid address</summary>
+	/// <remarks>
+	/// The given .onion address is invalid. In one of these cases this
+	/// error is returned: address checksum doesn't match, ed25519 public
+	/// key is invalid or the encoding is invalid. (v3 only)
+	/// </remarks>
+	OnionServiceBadAddress = 0xF6,
+
+	/// <summary> Onion service introduction timed out</summary>
+	/// <remarks>
+	/// Similar to X'F2' code but in this case, all introduction attempts
+	/// have failed due to a time out. (v3 only)
+	/// </remarks>
+	OnionServiceIntroTimedOut = 0xF7,
 }

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -77,7 +77,7 @@ public class TorSettings
 		List<string> arguments = new()
 		{
 			$"--LogTimeGranularity 1",
-			$"--SOCKSPort {SocksEndpoint}",
+			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors\"",
 			$"--CookieAuthentication 1",
 			$"--ControlPort {ControlEndpoint.Port}",
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -76,6 +76,7 @@ public class TorSettings
 		// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.
 		List<string> arguments = new()
 		{
+			$"--LogTimeGranularity 1",
 			$"--SOCKSPort {SocksEndpoint}",
 			$"--CookieAuthentication 1",
 			$"--ControlPort {ControlEndpoint.Port}",


### PR DESCRIPTION
Contributes to #7434

The idea of this PR is to get more useful error codes. David's log provided in #7434 contains:

```log
2022-03-01 16:48:05.173 [39] WARNING	TorTcpConnectionFactory.ConnectToDestinationAsync (258)	Connection response indicates a failure. Actual response is: 'GeneralSocksServerFailure'. Request: 'testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion:80'.
```

with this PR, it should report a more precise error code I believe. Thus we might be able to dig deeper into the issue.


## Resources

* https://github.com/torproject/tor/blob/331b2aa34874d5ef57b45ff591e1f64b695ff06c/doc/man/tor.1.txt#L1581-L1627