### PR TITLE
[PoC] Increase MaxRetries and add phase specific timeouts

### DIFF
--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 {
-	private const int MaxRetries = 3;
+	private const int MaxRetries = 20;
 
 	private IHttpClient _client;
 
@@ -108,6 +108,8 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 					throw;
 				}
 			}
+
+			await Task.Delay(100, cancellationToken).ConfigureAwait(false);
 		}
 
 		throw new AggregateException(exceptions);


### PR DESCRIPTION
First to merge is https://github.com/zkSNACKs/WalletWasabi/pull/7521

Why not use the extra time provided by https://github.com/zkSNACKs/WalletWasabi/pull/7501#issuecomment-1063115644?

This PR tries to mitigate the network unreliability problem by trying to succeed until the end of the timeout for that specific phase. For this, I had to create a phase-specific cancellationToken and basically use that.

This is not solving the underlying issue but can be real mitigation of it. 

