### PR TITLE
[VDG] Remember MainWindow Position

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -46,8 +46,8 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 			return;
 		}
 
-		var centerX = (int)((AssociatedObject!.Screens.Primary.Bounds.Width - vm.WindowWidth) / 2);
-		var centerY = (int)((AssociatedObject!.Screens.Primary.Bounds.Height - vm.WindowHeight) / 2);
+		var centerX = (int)((AssociatedObject!.Screens.Primary.WorkingArea.Width - vm.WindowWidth) / 2);
+		var centerY = (int)((AssociatedObject!.Screens.Primary.WorkingArea.Height - vm.WindowHeight) / 2);
 
 		var position =
 			vm.WindowPosition

--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -80,14 +80,18 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 		var currentScreen = AssociatedObject.Screens.ScreenFromPoint(AssociatedObject.Position);
 
 		var isValidWidth =
-			vm.WindowWidth * currentScreen.PixelDensity <= currentScreen.WorkingArea.Width * currentScreen.PixelDensity;
+			currentScreen is { } && vm.WindowWidth * currentScreen.PixelDensity <= currentScreen.WorkingArea.Width * currentScreen.PixelDensity;
 
 		var isValidHeight =
-			vm.WindowHeight * currentScreen.PixelDensity <= currentScreen.WorkingArea.Height;
+			currentScreen is { } && vm.WindowHeight * currentScreen.PixelDensity <= currentScreen.WorkingArea.Height;
 
 		if (!isValidWidth || !isValidHeight)
 		{
 			vm.WindowState = WindowState.Maximized;
+			AssociatedObject.Position = PixelPoint.Origin;
+			currentScreen = AssociatedObject.Screens.ScreenFromPoint(AssociatedObject.Position);
+			vm.WindowHeight = currentScreen.WorkingArea.Height;
+			vm.WindowWidth = currentScreen.WorkingArea.Width;
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -31,8 +31,8 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 				  .DisposeWith(disposables);
 
 			vm.WhenAnyValue(x => x.WindowPosition)
-			  .Where(x => x is { })
-			  .Subscribe(x => AssociatedObject.Position = x.Value)
+			  .WhereNotNull()
+			  .Subscribe(x => AssociatedObject.Position = x!.Value)
 			  .DisposeWith(disposables);
 
 			SetInitialPosition(vm);

--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -1,0 +1,87 @@
+using Avalonia;
+using Avalonia.Controls;
+using ReactiveUI;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using WalletWasabi.Fluent.ViewModels;
+using System.Linq;
+
+namespace WalletWasabi.Fluent.Behaviors;
+
+public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
+{
+	protected override void OnAttached(CompositeDisposable disposables)
+	{
+		if (AssociatedObject is null)
+		{
+			return;
+		}
+
+		Observable.FromEventPattern(AssociatedObject, nameof(Window.DataContextChanged))
+				  .Subscribe(_ => BindPosition(disposables))
+				  .DisposeWith(disposables);
+	}
+
+	private void BindPosition(CompositeDisposable disposables)
+	{
+		if (AssociatedObject!.DataContext is MainViewModel vm)
+		{
+			Observable.FromEventPattern(AssociatedObject, nameof(Window.PositionChanged))
+				  .Subscribe(_ => vm.WindowPosition = AssociatedObject.Position)
+				  .DisposeWith(disposables);
+
+			vm.WhenAnyValue(x => x.WindowPosition)
+			  .Subscribe(x => AssociatedObject.Position = x)
+			  .DisposeWith(disposables);
+
+			SetInitialPosition(vm);
+		}
+	}
+
+	private void SetInitialPosition(MainViewModel vm)
+	{
+		if (vm.WindowState != WindowState.Normal)
+		{
+			return;
+		}	
+
+		var position = vm.WindowPosition;
+
+		var isValidLeft =
+			AssociatedObject!.Screens.All.Any(s => s.Bounds.X <= position.X);
+
+		var isValidRight =
+			AssociatedObject.Screens.All.Any(s => s.Bounds.Right >= position.X);
+
+		var isValidTop =
+			AssociatedObject!.Screens.All.Any(s => s.Bounds.TopLeft.Y <= position.Y);
+
+		var isValidBottom =
+			AssociatedObject.Screens.All.Any(s => s.Bounds.BottomRight.Y >= position.Y);
+
+		var x =
+			isValidLeft && isValidRight
+			? position.X
+			: (int)((AssociatedObject.Screens.Primary.Bounds.Width - vm.WindowWidth) / 2);
+
+		var y =
+			isValidTop && isValidBottom
+			? position.Y
+			: (int)((AssociatedObject.Screens.Primary.Bounds.Height - vm.WindowHeight) / 2);
+
+		AssociatedObject.Position = new PixelPoint(x, y);
+
+		var currentScreen = AssociatedObject.Screens.ScreenFromPoint(AssociatedObject.Position);
+
+		var isValidWidth =
+			vm.WindowWidth * currentScreen.PixelDensity <= currentScreen.WorkingArea.Width * currentScreen.PixelDensity;
+
+		var isValidHeight =
+			vm.WindowHeight * currentScreen.PixelDensity <= currentScreen.WorkingArea.Height;
+
+		if (!isValidWidth || !isValidHeight)
+		{
+			vm.WindowState = WindowState.Maximized;
+		}
+	}
+}

--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -31,7 +31,8 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 				  .DisposeWith(disposables);
 
 			vm.WhenAnyValue(x => x.WindowPosition)
-			  .Subscribe(x => AssociatedObject.Position = x)
+			  .Where(x => x is { })
+			  .Subscribe(x => AssociatedObject.Position = x.Value)
 			  .DisposeWith(disposables);
 
 			SetInitialPosition(vm);
@@ -43,9 +44,14 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 		if (vm.WindowState != WindowState.Normal)
 		{
 			return;
-		}	
+		}
 
-		var position = vm.WindowPosition;
+		var centerX = (int)((AssociatedObject!.Screens.Primary.Bounds.Width - vm.WindowWidth) / 2);
+		var centerY = (int)((AssociatedObject!.Screens.Primary.Bounds.Height - vm.WindowHeight) / 2);
+
+		var position =
+			vm.WindowPosition
+			??= new PixelPoint(centerX, centerY);
 
 		var isValidLeft =
 			AssociatedObject!.Screens.All.Any(s => s.Bounds.X <= position.X);
@@ -62,12 +68,12 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 		var x =
 			isValidLeft && isValidRight
 			? position.X
-			: (int)((AssociatedObject.Screens.Primary.Bounds.Width - vm.WindowWidth) / 2);
+			: centerX;
 
 		var y =
 			isValidTop && isValidBottom
 			? position.Y
-			: (int)((AssociatedObject.Screens.Primary.Bounds.Height - vm.WindowHeight) / 2);
+			: centerY;
 
 		AssociatedObject.Position = new PixelPoint(x, y);
 

--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -47,20 +47,20 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 		}
 
 		var centerX = (int)((AssociatedObject!.Screens.Primary.WorkingArea.Width - vm.WindowWidth) / 2);
-		var centerY = (int)((AssociatedObject!.Screens.Primary.WorkingArea.Height - vm.WindowHeight) / 2);
+		var centerY = (int)((AssociatedObject.Screens.Primary.WorkingArea.Height - vm.WindowHeight) / 2);
 
 		var position =
 			vm.WindowPosition
 			??= new PixelPoint(centerX, centerY);
 
 		var isValidLeft =
-			AssociatedObject!.Screens.All.Any(s => s.Bounds.X <= position.X);
+			AssociatedObject.Screens.All.Any(s => s.Bounds.X <= position.X);
 
 		var isValidRight =
 			AssociatedObject.Screens.All.Any(s => s.Bounds.Right >= position.X);
 
 		var isValidTop =
-			AssociatedObject!.Screens.All.Any(s => s.Bounds.TopLeft.Y <= position.Y);
+			AssociatedObject.Screens.All.Any(s => s.Bounds.TopLeft.Y <= position.Y);
 
 		var isValidBottom =
 			AssociatedObject.Screens.All.Any(s => s.Bounds.BottomRight.Y >= position.Y);

--- a/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/MainWindowPersistPositionBehavior.cs
@@ -24,7 +24,7 @@ public class MainWindowBindPositionBehavior : DisposingBehavior<Window>
 
 	private void BindPosition(CompositeDisposable disposables)
 	{
-		if (AssociatedObject!.DataContext is MainViewModel vm)
+		if (AssociatedObject?.DataContext is MainViewModel vm)
 		{
 			Observable.FromEventPattern(AssociatedObject, nameof(Window.PositionChanged))
 				  .Subscribe(_ => vm.WindowPosition = AssociatedObject.Position)

--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -18,6 +18,10 @@ public class UiConfig : ConfigBase
 	private bool _darkModeEnabled;
 	private string? _lastSelectedWallet;
 	private string _windowState = "Normal";
+	private int? _windowX;
+	private int? _windowY;
+	private double? _windowWidth;
+	private double? _windowHeight;
 	private bool _runOnSystemStartup;
 	private bool _oobe;
 	private bool _hideOnClose;
@@ -48,6 +52,18 @@ public class UiConfig : ConfigBase
 			.Skip(1) // Won't save on UiConfig creation.
 			.ObserveOn(RxApp.TaskpoolScheduler)
 			.Subscribe(_ => ToFile());
+
+		this.WhenAnyValue(
+				x => x.WindowState,
+				x => x.WindowX,
+				x => x.WindowY,
+				x => x.WindowWidth,
+				x => x.WindowHeight,
+				(_, _, _, _, _) => Unit.Default)
+			.Throttle(TimeSpan.FromMilliseconds(500))
+			.Skip(1) // Won't save on UiConfig creation.
+			.ObserveOn(RxApp.TaskpoolScheduler)
+			.Subscribe(_ => ToFile());
 	}
 
 	[JsonProperty(PropertyName = "Oobe", DefaultValueHandling = DefaultValueHandling.Populate)]
@@ -64,6 +80,34 @@ public class UiConfig : ConfigBase
 	{
 		get => _windowState;
 		internal set => RaiseAndSetIfChanged(ref _windowState, value);
+	}
+
+	[JsonProperty(PropertyName = "WindowX")]
+	public int? WindowX
+	{
+		get => _windowX;
+		internal set => RaiseAndSetIfChanged(ref _windowX, value);
+	}
+
+	[JsonProperty(PropertyName = "WindowY")]
+	public int? WindowY
+	{
+		get => _windowY;
+		internal set => RaiseAndSetIfChanged(ref _windowY, value);
+	}
+
+	[JsonProperty(PropertyName = "WindowWidth")]
+	public double? WindowWidth
+	{
+		get => _windowWidth;
+		internal set => RaiseAndSetIfChanged(ref _windowWidth, value);
+	}
+
+	[JsonProperty(PropertyName = "WindowHeight")]
+	public double? WindowHeight
+	{
+		get => _windowHeight;
+		internal set => RaiseAndSetIfChanged(ref _windowHeight, value);
 	}
 
 	[DefaultValue(2)]

--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -60,7 +60,7 @@ public class UiConfig : ConfigBase
 				x => x.WindowWidth,
 				x => x.WindowHeight,
 				(_, _, _, _, _) => Unit.Default)
-			.Throttle(TimeSpan.FromMilliseconds(500))
+			.Throttle(TimeSpan.FromMilliseconds(750))
 			.Skip(1) // Won't save on UiConfig creation.
 			.ObserveOn(RxApp.TaskpoolScheduler)
 			.Subscribe(_ => ToFile());

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -97,15 +97,17 @@ public partial class MainViewModel : ViewModelBase
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(t =>
 			{
-				Services.UiConfig.WindowState = t.Item1.ToString();
-				if (t.Item2 is { })
+				var (state, position, width, height) = t;
+				
+				Services.UiConfig.WindowState = state.ToString();
+				if (position is { })
 				{
-					Services.UiConfig.WindowX = t.Item2.Value.X;
-					Services.UiConfig.WindowY = t.Item2.Value.Y;
+					Services.UiConfig.WindowX = position.Value.X;
+					Services.UiConfig.WindowY = position.Value.Y;
 				}
 				
-				Services.UiConfig.WindowWidth = t.Item3;
-				Services.UiConfig.WindowHeight = t.Item4;
+				Services.UiConfig.WindowWidth = width;
+				Services.UiConfig.WindowHeight = height;
 			});
 
 		this.WhenAnyValue(

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -93,6 +93,7 @@ public partial class MainViewModel : ViewModelBase
 
 		this.WhenAnyValue(x => x.WindowState, x => x.WindowPosition, x => x.WindowWidth, x => x.WindowHeight)
 			.Where(x => x.Item1 != WindowState.Minimized)
+			.Where(x => x.Item2 != new PixelPoint(-32000,-32000)) // value when minimized
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(t =>
 			{

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -88,24 +88,24 @@ public partial class MainViewModel : ViewModelBase
 		RegisterViewModels();
 
 		RxApp.MainThreadScheduler.Schedule(async () => await _navBar.InitialiseAsync());
-		
+
 		_searchPage.Initialise();
 
 		this.WhenAnyValue(x => x.WindowState, x => x.WindowPosition, x => x.WindowWidth, x => x.WindowHeight)
 			.Where(x => x.Item1 != WindowState.Minimized)
-			.Where(x => x.Item2 != new PixelPoint(-32000,-32000)) // value when minimized
+			.Where(x => x.Item2 != new PixelPoint(-32000, -32000)) // value when minimized
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(t =>
 			{
 				var (state, position, width, height) = t;
-				
+
 				Services.UiConfig.WindowState = state.ToString();
 				if (position is { })
 				{
 					Services.UiConfig.WindowX = position.Value.X;
 					Services.UiConfig.WindowY = position.Value.Y;
 				}
-				
+
 				Services.UiConfig.WindowWidth = width;
 				Services.UiConfig.WindowHeight = height;
 			});

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -18,6 +18,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.Fluent.ViewModels.StatusBar;
 using WalletWasabi.Fluent.ViewModels.Wallets;
 using WalletWasabi.WabiSabi.Client;
+using Avalonia;
 
 namespace WalletWasabi.Fluent.ViewModels;
 
@@ -39,10 +40,22 @@ public partial class MainViewModel : ViewModelBase
 	[AutoNotify] private WindowState _windowState;
 	[AutoNotify] private bool _isOobeBackgroundVisible;
 	[AutoNotify] private bool _isCoinJoinActive;
+	[AutoNotify] private double _windowWidth;
+	[AutoNotify] private double _windowHeight;
+	[AutoNotify] private PixelPoint _windowPosition;
 
 	public MainViewModel()
 	{
 		_windowState = (WindowState)Enum.Parse(typeof(WindowState), Services.UiConfig.WindowState);
+		_windowWidth = Services.UiConfig.WindowWidth ?? 1280;
+		_windowHeight = Services.UiConfig.WindowHeight ?? 960;
+
+		var (x, y) = (Services.UiConfig.WindowX, Services.UiConfig.WindowY);
+		if (x != null && y != null)
+		{
+			_windowPosition = new PixelPoint(x.Value, y.Value);
+		}
+
 		_dialogScreen = new DialogScreenViewModel();
 
 		_fullScreen = new DialogScreenViewModel(NavigationTarget.FullScreen);
@@ -75,13 +88,20 @@ public partial class MainViewModel : ViewModelBase
 		RegisterViewModels();
 
 		RxApp.MainThreadScheduler.Schedule(async () => await _navBar.InitialiseAsync());
-
+		
 		_searchPage.Initialise();
 
-		this.WhenAnyValue(x => x.WindowState)
-			.Where(x => x != WindowState.Minimized)
+		this.WhenAnyValue(x => x.WindowState, x => x.WindowPosition, x => x.WindowWidth, x => x.WindowHeight)
+			.Where(x => x.Item1 != WindowState.Minimized)
 			.ObserveOn(RxApp.MainThreadScheduler)
-			.Subscribe(windowState => Services.UiConfig.WindowState = windowState.ToString());
+			.Subscribe(t =>
+			{
+				Services.UiConfig.WindowState = t.Item1.ToString();
+				Services.UiConfig.WindowX = t.Item2.X;
+				Services.UiConfig.WindowY = t.Item2.Y;
+				Services.UiConfig.WindowWidth = t.Item3;
+				Services.UiConfig.WindowHeight = t.Item4;
+			});
 
 		this.WhenAnyValue(
 				x => x.DialogScreen!.IsDialogOpen,

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -42,7 +42,7 @@ public partial class MainViewModel : ViewModelBase
 	[AutoNotify] private bool _isCoinJoinActive;
 	[AutoNotify] private double _windowWidth;
 	[AutoNotify] private double _windowHeight;
-	[AutoNotify] private PixelPoint _windowPosition;
+	[AutoNotify] private PixelPoint? _windowPosition;
 
 	public MainViewModel()
 	{
@@ -97,8 +97,12 @@ public partial class MainViewModel : ViewModelBase
 			.Subscribe(t =>
 			{
 				Services.UiConfig.WindowState = t.Item1.ToString();
-				Services.UiConfig.WindowX = t.Item2.X;
-				Services.UiConfig.WindowY = t.Item2.Y;
+				if (t.Item2 is { })
+				{
+					Services.UiConfig.WindowX = t.Item2.Value.X;
+					Services.UiConfig.WindowY = t.Item2.Value.Y;
+				}
+				
 				Services.UiConfig.WindowWidth = t.Item3;
 				Services.UiConfig.WindowHeight = t.Item4;
 			});

--- a/WalletWasabi.Fluent/Views/MainWindow.axaml
+++ b/WalletWasabi.Fluent/Views/MainWindow.axaml
@@ -9,7 +9,9 @@
         x:Class="WalletWasabi.Fluent.Views.MainWindow"
         x:Name="MainWindow"
         MinWidth="640" MinHeight="480"
-        WindowStartupLocation="CenterScreen"
+        Width="{Binding WindowWidth, Mode=TwoWay}"
+        Height="{Binding WindowHeight, Mode=TwoWay}"
+        WindowStartupLocation="Manual"
         Background="{x:Null}"
         TransparencyLevelHint="Mica"
         ExtendClientAreaToDecorationsHint="True"
@@ -20,6 +22,7 @@
     <behaviors:RegisterNotificationHostBehavior />
     <behaviors:HideShowBehavior />
     <behaviors:ShowWalletCoinsOnKeyCombinationBehavior Key1="LeftCtrl" Key2="D" Key3="C" />
+    <behaviors:MainWindowBindPositionBehavior/>
   </i:Interaction.Behaviors>
 
   <Panel Margin="{Binding #MainWindow.OffScreenMargin}">


### PR DESCRIPTION
Fixes #6923 

Initial implementation. 
Stores MainWindow X, Y, Left and Width in UIConfig.json

Covers:

 - Multi monitor scenarios
   - if the secondary Monitor has been disabled between restarts and previous window location is no longer visible, main window will be centered on primary screen.
 
 - DPI or screen resolution changes:
   - if the window size exceeds screen size due to DPI or screen resolution changes between restarts, it will be maximized. The user can then choose another size and position