### PR TITLE
Dispose CTS before creating a new instance

### DIFF
--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -27,8 +27,9 @@ public class CachedRpcClient : RpcClientBase
 		{
 			lock (CancellationTokenSourceLock)
 			{
-				if (_tipChangeCancellationTokenSource is null || _tipChangeCancellationTokenSource.IsCancellationRequested)
+				if (_tipChangeCancellationTokenSource.IsCancellationRequested)
 				{
+					_tipChangeCancellationTokenSource.Dispose();
 					_tipChangeCancellationTokenSource = new CancellationTokenSource();
 				}
 			}


### PR DESCRIPTION
Fixes #7530

Dispose CTS in `CachedRpcClient` before creating new instance of it. 
Just to be super sure.

Credit goes to https://github.com/zkSNACKs/WalletWasabi/issues/7530#issuecomment-1065599035