### PR TITLE
Logging late requests

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
@@ -11,7 +11,7 @@ public record TimeFrame
 	public static TimeFrame Create(TimeSpan duration) =>
 		new(DateTimeOffset.MinValue, duration);
 
-	private DateTimeOffset EndTime => StartTime + Duration;
+	public DateTimeOffset EndTime => StartTime + Duration;
 	public DateTimeOffset StartTime { get; init; }
 	public TimeSpan Duration { get; init; }
 	public bool HasStarted => StartTime > DateTimeOffset.MinValue && StartTime < DateTimeOffset.UtcNow;


### PR DESCRIPTION
This was a very useful tool in WW1 to diagnose network issues. 

Logging requests are coming too late. 

Solving one task on this list https://github.com/zkSNACKs/WalletWasabi/issues/5288

TODO: 

- [ ] Increase time "RoundExpiryTimeout": "0d 10h 0m 0s",