### PR TITLE
Loglatefancy

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -12,6 +12,7 @@ namespace WalletWasabi.Backend.Controllers;
 
 [ApiController]
 [ExceptionTranslate]
+[LateResponseLoggerFilter]
 [Route("[controller]")]
 [Produces("application/json")]
 public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler

--- a/WalletWasabi.Backend/Filters/LateResponseLoggerFilter.cs
+++ b/WalletWasabi.Backend/Filters/LateResponseLoggerFilter.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Backend.Models;
+
+namespace WalletWasabi.Backend.Filters;
+
+public class LateResponseLoggerFilter : ExceptionFilterAttribute
+{
+	public override void OnException(ExceptionContext context)
+	{
+		if (context.Exception is not WrongPhaseException ex)
+		{
+			return;
+		}
+
+		var actionName = ((Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor)context.ActionDescriptor).ActionName;
+
+		Logger.LogInfo($"Request '{actionName}' missing the phase '{string.Join(",", ex.ExpectedPhases)}' by '{ex.Late}'. Round id '{ex.RoundId}' is in phase '{ex.CurrentPhase}'.");
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
@@ -99,7 +99,7 @@ public class ConfirmConnectionTests
 			if (phase != Phase.InputRegistration && phase != Phase.ConnectionConfirmation)
 			{
 				round.SetPhase(phase);
-				var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+				var ex = await Assert.ThrowsAsync<WrongPhaseException>(
 					async () => await arena.ConfirmConnectionAsync(req, CancellationToken.None));
 
 				Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -18,7 +18,7 @@ public class RegisterInputFailureTests
 {
 	private static async Task RegisterAndAssertWrongPhaseAsync(InputRegistrationRequest req, Arena handler)
 	{
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
+		var ex = await Assert.ThrowsAsync<WrongPhaseException>(async () => await handler.RegisterInputAsync(req, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 	}
 
@@ -75,7 +75,7 @@ public class RegisterInputFailureTests
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+		var ex = await Assert.ThrowsAsync<WrongPhaseException>(
 			async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 		Assert.Equal(Phase.InputRegistration, round.Phase);
@@ -100,7 +100,7 @@ public class RegisterInputFailureTests
 		arena.Rounds.Add(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+		var ex = await Assert.ThrowsAsync<WrongPhaseException>(
 			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 		Assert.Equal(Phase.InputRegistration, round.Phase);
@@ -125,7 +125,7 @@ public class RegisterInputFailureTests
 		round.InputRegistrationTimeFrame = round.InputRegistrationTimeFrame with { Duration = TimeSpan.Zero };
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+		var ex = await Assert.ThrowsAsync<WrongPhaseException>(
 			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 		Assert.Equal(Phase.InputRegistration, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -151,7 +151,7 @@ public class RegisterOutputTests
 			{
 				var req = WabiSabiFactory.CreateOutputRegistrationRequest(round);
 				round.SetPhase(phase);
-				var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.RegisterOutputAsync(req, CancellationToken.None));
+				var ex = await Assert.ThrowsAsync<WrongPhaseException>(async () => await arena.RegisterOutputAsync(req, CancellationToken.None));
 				Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 			}
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RemoveInputTests.cs
@@ -66,7 +66,7 @@ public class RemoveInputTests
 			if (phase != Phase.InputRegistration)
 			{
 				round.SetPhase(phase);
-				var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.RemoveInputAsync(req, CancellationToken.None));
+				var ex = await Assert.ThrowsAsync<WrongPhaseException>(async () => await arena.RemoveInputAsync(req, CancellationToken.None));
 				Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 			}
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -60,7 +60,7 @@ public class SignTransactionTests
 			{
 				round.SetPhase(phase);
 
-				var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () =>
+				var ex = await Assert.ThrowsAsync<WrongPhaseException>(async () =>
 					await arena.SignTransactionAsync(req, CancellationToken.None));
 				Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 			}

--- a/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
@@ -1,0 +1,36 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+
+namespace WalletWasabi.WabiSabi.Backend.Models;
+
+public class WrongPhaseException : WabiSabiProtocolException
+{
+	public TimeSpan Late { get; }
+	public Phase CurrentPhase { get; }
+	public Phase[] ExpectedPhases { get; }
+	public uint256 RoundId { get; }
+
+	public WrongPhaseException(Round round, Phase[] expectedPhases) : base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).")
+	{
+		var latestExpectedPhase = expectedPhases.OrderBy(p => (int)p).Last();
+		var now = DateTimeOffset.UtcNow;
+
+		Late = latestExpectedPhase switch
+		{
+			Phase.InputRegistration => now - round.InputRegistrationTimeFrame.EndTime,
+			Phase.ConnectionConfirmation => now - round.ConnectionConfirmationTimeFrame.EndTime,
+			Phase.OutputRegistration => now - round.OutputRegistrationTimeFrame.EndTime,
+			Phase.TransactionSigning => now - round.TransactionSigningTimeFrame.EndTime,
+			_ => TimeSpan.MaxValue
+		};
+
+		CurrentPhase = round.Phase;
+		RoundId = round.Id;
+		ExpectedPhases = expectedPhases;
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
@@ -15,7 +15,7 @@ public class WrongPhaseException : WabiSabiProtocolException
 	public Phase[] ExpectedPhases { get; }
 	public uint256 RoundId { get; }
 
-	public WrongPhaseException(Round round, Phase[] expectedPhases) : base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).")
+	public WrongPhaseException(Round round, params Phase[] expectedPhases) : base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).")
 	{
 		var latestExpectedPhase = expectedPhases.OrderBy(p => (int)p).Last();
 		var now = DateTimeOffset.UtcNow;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -132,7 +132,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	{
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
-			var round = GetRound(request.RoundId);
+			var round = GetRound(request.RoundId, Phase.OutputRegistration);
 			var alice = GetAlice(request.AliceId, round);
 			alice.ReadyToSign = true;
 		}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -392,7 +392,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	private Round InPhase(Round round, Phase[] phases) =>
 		phases.Contains(round.Phase)
 		? round
-		: throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).");
+		: throw new WrongPhaseException(round, phases);
 
 	private Round GetRound(uint256 roundId, params Phase[] phases) =>
 		InPhase(GetRound(roundId), phases);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -241,7 +241,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 					}
 
 				default:
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({request.RoundId}): Wrong phase ({round.Phase}).");
+					throw new WrongPhaseException(round, Phase.InputRegistration, Phase.ConnectionConfirmation);
 			}
 		}
 	}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -48,7 +48,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 			if (round.IsInputRegistrationEnded(Config.MaxInputCountByRound))
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase);
+				throw new WrongPhaseException(round, Phase.InputRegistration);
 			}
 
 			if (round is BlameRound blameRound && !blameRound.BlameWhitelist.Contains(coin.Outpoint))

--- a/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
@@ -11,7 +11,7 @@ public record TimeFrame
 	public static TimeFrame Create(TimeSpan duration) =>
 		new(DateTimeOffset.MinValue, duration);
 
-	private DateTimeOffset EndTime => StartTime + Duration;
+	public DateTimeOffset EndTime => StartTime + Duration;
 	public DateTimeOffset StartTime { get; init; }
 	public TimeSpan Duration { get; init; }
 	public bool HasStarted => StartTime > DateTimeOffset.MinValue && StartTime < DateTimeOffset.UtcNow;


### PR DESCRIPTION
Another implementation of https://github.com/zkSNACKs/WalletWasabi/pull/7561

Example:

`2022-03-17 15:26:22.052 [57] INFO       LateResponseLoggerFilter.OnException (18)       Request 'ReadyToSign' missing the phase 'OutputRegistration' by '00:00:08.4190598'. Round id '250505a8fc3b7633e3f6687042de6ee17e56e17f11d6db881a330d4ff7225cc5' is in phase 'TransactionSigning'.`
