### PR TITLE
Unify source of coinjoin related events

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -70,12 +70,19 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		if (Services.HostedServices.GetOrDefault<CoinJoinManager>() is { } coinJoinManager)
 		{
+			static bool? MaybeCoinjoining(StatusChangedEventArgs args) =>
+				args switch {
+					StartedEventArgs _ => true,
+					StoppedEventArgs _ => false,
+					_ => null
+				};
+
 			Observable
-				.FromEventPattern<WalletStatusChangedEventArgs>(coinJoinManager, nameof(CoinJoinManager.WalletStatusChanged))
+				.FromEventPattern<StatusChangedEventArgs>(coinJoinManager, nameof(CoinJoinManager.StatusChanged))
 				.Select(args => args.EventArgs)
 				.Where(e => e.Wallet == Wallet)
 				.ObserveOn(RxApp.MainThreadScheduler)
-				.Subscribe(e => IsCoinJoining = e.IsCoinJoining)
+				.Subscribe(e => IsCoinJoining = MaybeCoinjoining(e) ?? IsCoinJoining)
 				.DisposeWith(Disposables);
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -32,8 +32,6 @@ public class CoinJoinManager : BackgroundService
 		ServiceConfiguration = serviceConfiguration;
 	}
 
-	public event EventHandler<WalletStatusChangedEventArgs>? WalletStatusChanged;
-
 	public WalletManager WalletManager { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
@@ -125,7 +123,6 @@ public class CoinJoinManager : BackgroundService
 				trackedCoinJoins.Add(openedWallet.WalletName, coinJoinTracker);
 				var registrationTimeout = TimeSpan.MaxValue;
 				NotifyCoinJoinStarted(openedWallet, registrationTimeout);
-				WalletStatusChanged?.Invoke(this, new WalletStatusChangedEventArgs(openedWallet, IsCoinJoining: true));
 			}
 
 			foreach (var closedWallet in closedWallets.Select(x => x.Value))
@@ -150,7 +147,6 @@ public class CoinJoinManager : BackgroundService
 				}
 				else
 				{
-					WalletStatusChanged?.Invoke(this, new WalletStatusChangedEventArgs(walletToRemove, IsCoinJoining: false));
 					finishedCoinJoin.Dispose();
 				}
 			}

--- a/WalletWasabi/WabiSabi/Client/WalletStatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/WalletStatusChangedEventArgs.cs
@@ -1,5 +1,0 @@
-using WalletWasabi.Wallets;
-
-namespace WalletWasabi.WabiSabi.Client;
-
-public record WalletStatusChangedEventArgs(Wallet Wallet, bool IsCoinJoining);


### PR DESCRIPTION
This PR unifies the status event and event args used by the coinjoin manager. Basically removes one of the events.

@danwalmsley could you please take a look? How can I test it. 

Btw, I need to clean the code a bit before starting the redesign for Start[Manual|Auto], Stop and that's why I am doing this.