### PR TITLE
`IdempotencyRequestCache`: Await task so that it's observed

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabi/IdempotencyRequestCache.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabi/IdempotencyRequestCache.cs
@@ -63,7 +63,9 @@ public class IdempotencyRequestCache
 				catch (Exception e)
 				{
 					responseTcs.SetException(e);
-					throw;
+
+					// To avoid unobserved exception.
+					await responseTcs.Task.ConfigureAwait(false);
 				}
 			}
 			else


### PR DESCRIPTION
Attempts to fix #7113
Alternative to #7569

Test code

This is a simple test case to demonstrate that an unobserved exception happens (should be useful for testing):

```cs
/// <summary>
/// Make sure an unobserved exception is thrown.
/// </summary>
[Fact]
public async Task UnobservedExceptionAsync()
{
	TaskCompletionSource<string> tcs = new();

	TaskScheduler.UnobservedTaskException += (sender, eventArgs) =>
	{
		tcs.TrySetResult($"Unobserved: {eventArgs.Exception.InnerException?.Message}");
	};

	_ = Task.Factory.StartNew(() =>
	{
		TaskCompletionSource experimentTcs = new();
		experimentTcs.SetException(new Exception("Derp."));
                
                // And then uncomment this.
                // try {  await experimentTcs.Task.ConfigureAwait(false); } catch { }
	});

	await Task.Delay(2_000).ConfigureAwait(true);

	GC.Collect();
	GC.WaitForPendingFinalizers();

	await Task.Delay(2_000).ConfigureAwait(true);

	tcs.TrySetResult("Oh no. Didn't happen.");

	string actual = await tcs.Task.ConfigureAwait(true);
	Assert.Equal("Unobserved: Derp.", actual);
}
```
(The test code is not suitatable for CI though so not included in the PR itself.)