### PR TITLE
[VDG] Fix Downloading map resize issue

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/LoadingControl.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/LoadingControl.axaml
@@ -23,7 +23,7 @@
         TextAlignment="Center" TextWrapping="Wrap" Opacity="0.6" />
 
       <ProgressBar Value="{Binding Percent}" IsIndeterminate="{Binding !Percent}" Margin="0 20 0 0" />
-      <TextBlock Text="{Binding StatusText, StringFormat={}{0}⠀}" TextAlignment="Center" Opacity="0.6"  />
+      <TextBlock Text="{Binding StatusText, StringFormat={}{0}⠀}" TextAlignment="Center" Opacity="0.6" />
     </StackPanel>
 
     <Panel Margin="80 40">

--- a/WalletWasabi.Fluent/Views/Wallets/LoadingControl.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/LoadingControl.axaml
@@ -23,7 +23,7 @@
         TextAlignment="Center" TextWrapping="Wrap" Opacity="0.6" />
 
       <ProgressBar Value="{Binding Percent}" IsIndeterminate="{Binding !Percent}" Margin="0 20 0 0" />
-      <TextBlock Text="{Binding StatusText}" TextAlignment="Center" Opacity="0.6" />
+      <TextBlock Text="{Binding StatusText, StringFormat={}{0}⠀}" TextAlignment="Center" Opacity="0.6"  />
     </StackPanel>
 
     <Panel Margin="80 40">


### PR DESCRIPTION
Fixes a layout glitch that occurs when "downloading blockchain data" screen displays "% complete" text