### PR TITLE
Optimize mature index appending

### DIFF
--- a/WalletWasabi/Io/DigestableSafeIoManager.cs
+++ b/WalletWasabi/Io/DigestableSafeIoManager.cs
@@ -17,7 +17,6 @@ public class DigestableSafeIoManager : SafeIoManager
 {
 	private const string DigestExtension = ".dig";
 
-	/// <param name="useLastCharacterDigest">Use the random index of the line to create digest faster. -1 is special value, it means the last character. If null then hash whole file.</param>
 	public DigestableSafeIoManager(string filePath, bool useLastCharacterDigest = false) : base(filePath)
 	{
 		UseLastCharacterDigest = useLastCharacterDigest;
@@ -27,9 +26,6 @@ public class DigestableSafeIoManager : SafeIoManager
 
 	public string DigestFilePath { get; }
 
-	/// <summary>
-	/// Gets a random index of the line to create digest faster. -1 is special value, it means the last character. If null then hash whole file.
-	/// </summary>
 	private bool UseLastCharacterDigest { get; }
 
 	#region IoOperations

--- a/WalletWasabi/Io/DigestableSafeIoManager.cs
+++ b/WalletWasabi/Io/DigestableSafeIoManager.cs
@@ -100,7 +100,7 @@ public class DigestableSafeIoManager : SafeIoManager
 			{
 				while (true)
 				{
-					string? line = await sr.ReadLineAsync().ConfigureAwait(false);
+					string? line = sr.ReadLine();
 
 
 					// End of stream.

--- a/WalletWasabi/Io/SafeIoManager.cs
+++ b/WalletWasabi/Io/SafeIoManager.cs
@@ -152,23 +152,24 @@ public class SafeIoManager : IoManager
 
 	public new async Task<string[]> ReadAllLinesAsync(CancellationToken cancellationToken = default)
 	{
-		var filePath = FilePath;
-		if (TryGetSafestFileVersion(out string? safestFilePath))
-		{
-			filePath = safestFilePath;
-		}
-		return await ReadAllLinesAsync(filePath, cancellationToken).ConfigureAwait(false);
+		return await ReadAllLinesAsync(GetSafestFilePath(), cancellationToken).ConfigureAwait(false);
 	}
 
 	public string ReadAllText(Encoding encoding)
 	{
-		var filePath = FilePath;
+		return File.ReadAllText(GetSafestFilePath(), encoding);
+	}
+
+	public string GetSafestFilePath()
+	{
+		string filePath = FilePath;
+
 		if (TryGetSafestFileVersion(out string? safestFilePath))
 		{
 			filePath = safestFilePath;
 		}
 
-		return File.ReadAllText(filePath, encoding);
+		return filePath;
 	}
 
 	/// <summary>
@@ -179,13 +180,7 @@ public class SafeIoManager : IoManager
 	/// <param name="bufferSize">Size of the bytes to handle sync way. The default is 1Mb.</param>
 	public StreamReader OpenText(int bufferSize = Constants.BigFileReadWriteBufferSize)
 	{
-		var filePath = FilePath;
-		if (TryGetSafestFileVersion(out string? safestFilePath))
-		{
-			filePath = safestFilePath;
-		}
-
-		return OpenText(filePath, bufferSize);
+		return OpenText(GetSafestFilePath(), bufferSize);
 	}
 
 	#endregion IoOperations

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -28,9 +28,9 @@ public class IndexStore : IAsyncDisposable
 		WorkFolderPath = Guard.NotNullOrEmptyOrWhitespace(nameof(workFolderPath), workFolderPath, trim: true);
 		IoHelpers.EnsureDirectoryExists(WorkFolderPath);
 		var indexFilePath = Path.Combine(WorkFolderPath, "MatureIndex.dat");
-		MatureIndexFileManager = new DigestableSafeIoManager(indexFilePath, digestRandomIndex: -1);
+		MatureIndexFileManager = new DigestableSafeIoManager(indexFilePath, useLastCharacterDigest: true);
 		var immatureIndexFilePath = Path.Combine(WorkFolderPath, "ImmatureIndex.dat");
-		ImmatureIndexFileManager = new DigestableSafeIoManager(immatureIndexFilePath, digestRandomIndex: -1);
+		ImmatureIndexFileManager = new DigestableSafeIoManager(immatureIndexFilePath, useLastCharacterDigest: true);
 
 		Network = network;
 		StartingFilter = StartingFilters.GetStartingFilter(Network);


### PR DESCRIPTION
The idea of testing this PR is:

1. Open `C:\Users\USER\AppData\Roaming\WalletWasabi\Client\BitcoinStore\TestNet\IndexStore` folder
2. Copy `MatureIndex.dat` somewhere as a backup + delete non-trivial amount of trailing lines (say 10000) so that it needs to be re-downloaded. 
3. `C:\Users\USER\AppData\Roaming\WalletWasabi\Client\BitcoinStore\TestNet\IndexStore` delete all files from this folder and copy your `MatureIndex.dat` file here.
4. Run WW with first, second and third commit respectively and watch for `TODO-DELETE-ME: Total time:` numbers in `Logs.txt`.


Numbers on my machine for testnet mature index:

| git commit | elapsed time (lower is better)| 
|---------|-----------------|
| 1st commit (baseline) |  1.3329037 seconds |
| 2nd commit |  1.0063391 seconds (25% faster) |
| 3rd commit |  0.8996198 seconds (34% faster) |
