### PR TITLE
[Trivial] Correct calculation for cj debug information

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -349,11 +349,11 @@ public class CoinJoinClient
 
 		string[] summary = new string[] {
 		$"Round ({roundState.Id}):",
-		$"\tInput total: {totalInputAmount.ToString(true)} Eff: {totalEffectiveInputAmount.ToString(true)} NetwFee: {inputNetworkFee.ToString(true)} CoordF: {totalCoordinationFee.ToString(true)}",
-		$"\tOutpu total: {totalOutputAmount.ToString(true)} Eff: {totalEffectiveOutputAmount.ToString(true)} NetwFee: {outputNetworkFee.ToString(true)}",
-		$"\tTotal diff : {totalDifference.ToString(true)}",
-		$"\tEffec diff : {effectiveDifference.ToString(true)}",
-		$"\tTotal fee  : {totalNetworkFee.ToString(true)}"
+		$"\tInput total: {totalInputAmount.ToString(true, false)} Eff: {totalEffectiveInputAmount.ToString(true, false)} NetwFee: {inputNetworkFee.ToString(true, false)} CoordF: {totalCoordinationFee.ToString(true)}",
+		$"\tOutpu total: {totalOutputAmount.ToString(true, false)} Eff: {totalEffectiveOutputAmount.ToString(true, false)} NetwFee: {outputNetworkFee.ToString(true, false)}",
+		$"\tTotal diff : {totalDifference.ToString(true, false)}",
+		$"\tEffec diff : {effectiveDifference.ToString(true, false)}",
+		$"\tTotal fee  : {totalNetworkFee.ToString(true, false)}"
 		};
 
 		Logger.LogDebug(string.Join(Environment.NewLine, summary));

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -336,11 +336,11 @@ public class CoinJoinClient
 
 		var totalEffectiveInputAmount = Money.Satoshis(registeredAliceClients.Sum(a => a.EffectiveValue));
 		var totalEffectiveOutputAmount = Money.Satoshis(myOutputs.Sum(a => a.Value - feeRate.GetFee(a.ScriptPubKey.EstimateOutputVsize())));
-		var effectiveDifference = totalEffectiveOutputAmount - totalEffectiveInputAmount;
+		var effectiveDifference = totalEffectiveInputAmount - totalEffectiveOutputAmount;
 
 		var totalInputAmount = Money.Satoshis(registeredAliceClients.Sum(a => a.SmartCoin.Amount));
 		var totalOutputAmount = Money.Satoshis(myOutputs.Sum(a => a.Value));
-		var totalDifference = Money.Satoshis(totalOutputAmount - totalInputAmount);
+		var totalDifference = Money.Satoshis(totalInputAmount - totalOutputAmount);
 
 		var inputNetworkFee = Money.Satoshis(registeredAliceClients.Sum(alice => feeRate.GetFee(alice.SmartCoin.Coin.ScriptPubKey.EstimateInputVsize())));
 		var outputNetworkFee = Money.Satoshis(myOutputs.Sum(output => feeRate.GetFee(output.ScriptPubKey.EstimateOutputVsize())));


### PR DESCRIPTION
This PR corrects the calculation of the total and the effective differences to not get negative values.

With the 2nd commit (amounts displayed with trailing zeros):

```
Input total: +0.00010000 Eff: +0.00009862 NetwFee: +0.00000138 CoordF: 0.00000000
Outpu total: +0.00008192 Eff: +0.00008130 NetwFee: +0.00000062
Total diff : +0.00001808
Effec diff : +0.00001732
Total fee  : +0.00000200
```

Instead of:

```
Input total: +0.0001 Eff: +0.00009862 NetwFee: +0.00000138 CoordF: 0.00
Outpu total: +0.00008192 Eff: +0.0000813 NetwFee: +0.00000062
Total diff : -0.00001808
Effec diff : -0.00001732
Total fee  : +0.000002
```