### PR TITLE
Remove static from decomposer

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -251,19 +251,27 @@ public class AmountDecomposer
 
 		// Create many decompositions for optimization.
 		var stdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-		foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)Math.Max(loss, 0.5 * (ulong)MinAllowedOutputAmountPlusFee), Math.Min(8, Math.Max(5, naiveSet.Count)), stdDenoms))
+		var maxNumberOfOutputsAllowed = Math.Min(AvailableVsize / OutputSize, 8);
+		if (maxNumberOfOutputsAllowed > 1)
 		{
-			var currentSet = Decomposer.ToRealValuesArray(
-				decomp,
-				count,
-				stdDenoms).Select(Money.Satoshis).ToList();
-
-			hash = new();
-			foreach (var item in currentSet.OrderBy(x => x))
+			foreach (var (sum, count, decomp) in Decomposer.Decompose(
+				target: (long)myInputSum,
+				tolerance: (long)Math.Max(loss, 0.5 * (ulong)MinAllowedOutputAmountPlusFee),
+				maxCount: Math.Min(maxNumberOfOutputsAllowed, Math.Max(5, naiveSet.Count)),
+				stdDenoms: stdDenoms))
 			{
-				hash.Add(item);
+				var currentSet = Decomposer.ToRealValuesArray(
+					decomp,
+					count,
+					stdDenoms).Select(Money.Satoshis).ToList();
+
+				hash = new();
+				foreach (var item in currentSet.OrderBy(x => x))
+				{
+					hash.Add(item);
+				}
+				setCandidates.TryAdd(hash.ToHashCode(), (currentSet, myInputSum - (ulong)currentSet.Sum() + (ulong)count * OutputFee)); // The cost is the remaining + output cost.
 			}
-			setCandidates.TryAdd(hash.ToHashCode(), (currentSet, myInputSum - (ulong)currentSet.Sum() + (ulong)count * OutputFee)); // The cost is the remaining + output cost.
 		}
 
 		var denomHashSet = preFilteredDenoms.ToHashSet();

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -250,13 +250,13 @@ public class AmountDecomposer
 			(naiveSet, loss + (ulong)naiveSet.Count * OutputFee)); // The cost is the remaining + output cost.
 
 		// Create many decompositions for optimization.
-		Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-		foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)Math.Max(loss, 0.5 * (ulong)MinAllowedOutputAmountPlusFee), Math.Min(8, Math.Max(5, naiveSet.Count))))
+		var stdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
+		foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)Math.Max(loss, 0.5 * (ulong)MinAllowedOutputAmountPlusFee), Math.Min(8, Math.Max(5, naiveSet.Count)), stdDenoms))
 		{
 			var currentSet = Decomposer.ToRealValuesArray(
 				decomp,
 				count,
-				Decomposer.StdDenoms).Select(Money.Satoshis).ToList();
+				stdDenoms).Select(Money.Satoshis).ToList();
 
 			hash = new();
 			foreach (var item in currentSet.OrderBy(x => x))

--- a/WalletWasabi/WabiSabi/Client/Decomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/Decomposer.cs
@@ -8,9 +8,7 @@ namespace WalletWasabi.WabiSabi.Client;
 /// </summary>
 public static class Decomposer
 {
-	public static long[] StdDenoms;
-
-	public static IEnumerable<(long Sum, int Count, ulong Decomposition)> Decompose(long target, long tolerance, int maxCount)
+	public static IEnumerable<(long Sum, int Count, ulong Decomposition)> Decompose(long target, long tolerance, int maxCount, long[] stdDenoms)
 	{
 		if (maxCount is <= 1 or > 8)
 		{
@@ -21,7 +19,7 @@ public static class Decomposer
 			throw new ArgumentException("Only positive numbers can be decomposed.", nameof(target));
 		}
 
-		var denoms = StdDenoms.SkipWhile(x => x > target).ToArray();
+		var denoms = stdDenoms.SkipWhile(x => x > target).ToArray();
 
 		if (denoms.Length > 255)
 		{
@@ -95,6 +93,7 @@ public static class LinqEx
 public class ReverseComparer : IComparer<long>
 {
 	public static readonly ReverseComparer Default = new();
+
 	public int Compare(long x, long y)
 	{
 		// Compare y and x in reverse order.


### PR DESCRIPTION
- Removed static from decomposer, it was modified by multiple clients at the same time. 
- Add check to not try to decompose in case of maxNumberOfOutputsAllowed is less than 2. 