### PR TITLE
[VDG] Improved rounding

### DIFF
--- a/WalletWasabi.Fluent/Extensions/TimeSpanMixin.cs
+++ b/WalletWasabi.Fluent/Extensions/TimeSpanMixin.cs
@@ -38,6 +38,4 @@ public static class TimeSpanMixin
 	{
 		return TimeSpan.FromMinutes(input.Minutes);
 	}
-
-	
 }

--- a/WalletWasabi.Fluent/Extensions/TimeSpanMixin.cs
+++ b/WalletWasabi.Fluent/Extensions/TimeSpanMixin.cs
@@ -1,3 +1,5 @@
+using WalletWasabi.Fluent.Helpers;
+
 namespace WalletWasabi.Fluent.Extensions;
 
 public static class TimeSpanMixin
@@ -11,7 +13,7 @@ public static class TimeSpanMixin
 
 		if (input.Hours > 0)
 		{
-			return ReduceToHours(input);
+			return ReduceToHoursAndMinutes(input);
 		}
 
 		return ReduceToMinutes(input);
@@ -27,23 +29,15 @@ public static class TimeSpanMixin
 		return TimeSpan.FromDays(input.Days);
 	}
 
-	private static TimeSpan ReduceToHours(TimeSpan input)
+	private static TimeSpan ReduceToHoursAndMinutes(TimeSpan input)
 	{
-		if (input.Hours >= 12)
-		{
-			return TimeSpan.FromDays(input.Days + 1);
-		}
-
-		if (input.Minutes >= 30)
-		{
-			return TimeSpan.FromHours(input.Hours + 1);
-		}
-
-		return TimeSpan.FromHours(input.Hours);
+		return TimeSpan.FromHours(input.Hours).Add(TimeSpan.FromMinutes(MathUtils.Round(input.Minutes, 30)));
 	}
 
 	private static TimeSpan ReduceToMinutes(TimeSpan input)
 	{
 		return TimeSpan.FromMinutes(input.Minutes);
 	}
+
+	
 }

--- a/WalletWasabi.Fluent/Helpers/MathUtils.cs
+++ b/WalletWasabi.Fluent/Helpers/MathUtils.cs
@@ -1,0 +1,12 @@
+namespace WalletWasabi.Fluent.Helpers;
+
+public class MathUtils
+{
+	public static int Round(int n, int precision)
+	{
+		var fraction = n / (double)precision;
+		var roundedFraction = Math.Round(fraction);
+		var rounded = roundedFraction * precision;
+		return (int)rounded;
+	}
+}

--- a/WalletWasabi.Fluent/ZXing/MathUtils.cs
+++ b/WalletWasabi.Fluent/ZXing/MathUtils.cs
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2012 ZXing authors
  *

--- a/WalletWasabi.Fluent/ZXing/MathUtils.cs
+++ b/WalletWasabi.Fluent/ZXing/MathUtils.cs
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2012 ZXing authors
  *

--- a/WalletWasabi.Tests/UnitTests/Extensions/TimeSpanMixinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Extensions/TimeSpanMixinTests.cs
@@ -10,18 +10,20 @@ public class TimeSpanMixinTests
 	[InlineData("1:0:0", "1:0:0")]  // input and expected are formatted as {days}:{hours}:{minutes}
 	[InlineData("1:0:33", "1:0:0")]
 	[InlineData("1:1:0", "1:0:0")]
-	[InlineData("0:12:0", "1:0:0")]
+	[InlineData("0:12:0", "0:12:0")]
 	[InlineData("1:12:0", "2:0:0")]
 	[InlineData("1:13:0", "2:0:0")]
-	[InlineData("0:15:59", "1:0:0")]
+	[InlineData("0:15:59", "0:16:0")]
 	[InlineData("0:9:59", "0:10:0")]
 	[InlineData("0:0:35", "0:0:35")]
 	[InlineData("0:0:20", "0:0:20")]
 	[InlineData("0:0:50", "0:0:50")]
-	[InlineData("0:1:30", "0:2:0")]
+	[InlineData("0:1:30", "0:1:30")]
 	[InlineData("0:1:1", "0:1:0")]
 	[InlineData("0:0:1", "0:0:1")]
 	[InlineData("0:0:0", "0:0:0")]
+	[InlineData("0:8:40", "0:8:30")]
+	[InlineData("0:2:16", "0:2:30")]
 	public void Reduce(string inputStr, string expectedStr)
 	{
 		var input = ParseExact(inputStr);

--- a/WalletWasabi.Tests/UnitTests/Helpers/MathUtilsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/MathUtilsTests.cs
@@ -15,5 +15,4 @@ public class MathUtilsTests
 	{
 		Assert.Equal(expected, MathUtils.Round(actual, precision));
 	}
-
 }

--- a/WalletWasabi.Tests/UnitTests/Helpers/MathUtilsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/MathUtilsTests.cs
@@ -1,0 +1,19 @@
+using WalletWasabi.Fluent.Helpers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Helpers;
+
+public class MathUtilsTests
+{
+	[Theory]
+	[InlineData(45, 15, 45)]
+	[InlineData(30, 15, 30)]
+	[InlineData(31, 15, 30)]
+	[InlineData(40, 15, 45)]
+	[InlineData(55, 20, 60)]
+	public void Round(int actual, int precision, int expected)
+	{
+		Assert.Equal(expected, MathUtils.Round(actual, precision));
+	}
+
+}


### PR DESCRIPTION
Improves the time estimation rounding in labels.

This is an improvement over
https://github.com/zkSNACKs/WalletWasabi/pull/7570#issuecomment-1076299249

The following rounding is made for time spans:

- When it contains a number of days, it will round to full days
- Else if it contains hours, it will take full hours and round minutes in 30 time intervals: 
Eg. 
   8:10h => 8:00h
   8:35h => 8:30h
   8:50h => 9:00h 
- Else, it will take full minutes