### PR TITLE
Update the required macOS version on website

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -295,7 +295,7 @@
                                                     </g>
                                                 </svg>
                                             </span>
-                                            macOS 10.13+
+                                            macOS 10.15+
                                         </a>
                                         <small class="text-muted float-left">.dmg</small>
                                         <small class="float-right">


### PR DESCRIPTION
According to https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1-supported-os.md#macos the Mac OS X supported version for .NET Core 3.1 should be 10.15+