### PR TITLE
`Logger`: Do not write to `Console.Write*` when testing

### DIFF
--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -14,7 +14,7 @@ public static class Common
 	{
 		Logger.SetFilePath(Path.Combine(DataDir, "Logs.txt"));
 		Logger.SetMinimumLevel(LogLevel.Info);
-		Logger.SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
+		Logger.SetModes(LogMode.Debug, LogMode.File);
 	}
 
 	public static EndPoint TorSocks5Endpoint => new IPEndPoint(IPAddress.Loopback, 37150);


### PR DESCRIPTION
Fixes #7609

This PR makes it so that `dotnet test` does not print log messages and output is thus clean. The change should be visible only on linux & macOs as on Windows it is not printed anyway (it seems that's the correct behavior).

WDYT?