### PR TITLE
[WabiSabi] Reduce the `RangeProof` by 5 bits

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
@@ -34,8 +34,9 @@ public class AmountDecomposerTests
 		var feePerOutput = feeRate.GetFee(Constants.P2wpkhOutputSizeInBytes);
 		var registeredCoinEffectiveValues = GenerateRandomCoins().Take(3).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
 		var theirCoinEffectiveValues = GenerateRandomCoins().Take(30).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
+		var allowedOutputAmountRange = new MoneyRange(Money.Satoshis(minOutputAmount), Money.Satoshis(ProtocolConstants.MaxAmountPerAlice));
 
-		var amountDecomposer = new AmountDecomposer(feeRate, minOutputAmount, Constants.P2wpkhOutputSizeInBytes, availableVsize);
+		var amountDecomposer = new AmountDecomposer(feeRate, allowedOutputAmountRange, Constants.P2wpkhOutputSizeInBytes, availableVsize);
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
 
 		var totalEffectiveValue = registeredCoinEffectiveValues.Sum(x => x);

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -37,10 +37,10 @@ public class WabiSabiConfig : ConfigBase
 	/// <summary>
 	/// The width of the rangeproofs are calculated from this, so don't choose stupid numbers.
 	/// </summary>
-	[DefaultValueMoneyBtc("43000")]
+	[DefaultValueMoneyBtc("1343.75")]
 	[JsonProperty(PropertyName = "MaxRegistrableAmount", DefaultValueHandling = DefaultValueHandling.Populate)]
 	[JsonConverter(typeof(MoneyBtcJsonConverter))]
-	public Money MaxRegistrableAmount { get; set; } = Money.Coins(43_000m);
+	public Money MaxRegistrableAmount { get; set; } = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice);
 
 	[DefaultValue(true)]
 	[JsonProperty(PropertyName = "AllowNotedInputRegistration", DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -505,7 +505,7 @@ public class CoinJoinClient
 		// Calculate outputs values
 		var constructionState = roundState.Assert<ConstructionState>();
 
-		AmountDecomposer amountDecomposer = new(roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts.Min, Constants.P2wpkhOutputSizeInBytes, (int)availableVsize);
+		AmountDecomposer amountDecomposer = new(roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts, Constants.P2wpkhOutputSizeInBytes, (int)availableVsize);
 		var theirCoins = constructionState.Inputs.Except(registeredCoins);
 		var registeredCoinEffectiveValues = registeredAliceClients.Select(x => x.EffectiveValue);
 		var theirCoinEffectiveValues = theirCoins.Select(x => x.EffectiveValue(roundState.FeeRate, roundState.CoordinationFeeRate));

--- a/WalletWasabi/WabiSabi/ProtocolContants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolContants.cs
@@ -3,7 +3,7 @@ namespace WalletWasabi.WabiSabi;
 public static class ProtocolConstants
 {
 	public const int CredentialNumber = 2;
-	public const long MaxAmountPerAlice = 4_300_000_000_000L;
+	public const long MaxAmountPerAlice = 4_300_000_000_000L >> 5; // Use 5 bits less than initially
 	public const long MaxVsizeCredentialValue = 255;
 
 	public const string WabiSabiProtocolIdentifier = "WabiSabi_v1.0";


### PR DESCRIPTION
While coinjoining we can see that every new credential reissuance request takes more time than the previous one.

It seems the coordinator cannot keep up with the amount of work required to reissue the credentials and that makes the reissuance requests to take more and more time to complete. 

The new max amount per Alice is 1,343.75 BTCs.

## Why 5bits? 

There is not good reason for any specific number and requires to be tested and validated in real world. Take into account that while it is possible to reduce it even further, at the extreme it become really inexpensive in CPU terms, this is not THE solution because the real problem is the coordinator is single threaded at this point.
  