### PR TITLE
Block sync requests while in critical phase

### DIFF
--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -95,7 +95,7 @@ public class Global
 				HttpClientFactory = new HttpClientFactory(torEndPoint: null, backendUriGetter: () => Config.GetFallbackBackendUri());
 			}
 
-			Synchronizer = new WasabiSynchronizer(BitcoinStore, HttpClientFactory);
+			Synchronizer = new WasabiSynchronizer(BitcoinStore, HttpClientFactory, HostedServices);
 			LegalChecker = new(DataDir);
 			TransactionBroadcaster = new TransactionBroadcaster(Network, BitcoinStore, HttpClientFactory, WalletManager);
 

--- a/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
+++ b/WalletWasabi/CoinJoin/Client/Clients/CoinJoinClient.cs
@@ -207,8 +207,6 @@ public class CoinJoinClient
 
 		try
 		{
-			Synchronizer.BlockRequests();
-
 			Interlocked.Exchange(ref _statusProcessing, 1);
 			using (await MixLock.LockAsync().ConfigureAwait(false))
 			{
@@ -292,7 +290,6 @@ public class CoinJoinClient
 		finally
 		{
 			Interlocked.Exchange(ref _statusProcessing, 0);
-			Synchronizer.EnableRequests();
 		}
 	}
 

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -39,11 +39,10 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	/// </summary>
 	private long _running;
 
-	private long _blockRequests; // There are priority requests in queue.
 	private CoinJoinManager? _coinJoinManager;
 
 	/// <param name="httpClientFactory">The class takes ownership of the instance.</param>
-	public WasabiSynchronizer(BitcoinStore bitcoinStore, HttpClientFactory httpClientFactory, HostedServices hostedServices)
+	public WasabiSynchronizer(BitcoinStore bitcoinStore, HttpClientFactory httpClientFactory, HostedServices? hostedServices = null)
 	{
 		LastResponse = null;
 		_running = StateNotStarted;
@@ -69,7 +68,7 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	/// <summary><see cref="WasabiSynchronizer"/> is responsible for disposing of this object.</summary>
 	public HttpClientFactory HttpClientFactory { get; }
 
-	private HostedServices HostedServices { get; }
+	private HostedServices? HostedServices { get; }
 	public WasabiClient WasabiClient { get; }
 
 	private CoinJoinManager? CoinJoinManager
@@ -78,7 +77,7 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 		{
 			if (_coinJoinManager is null)
 			{
-				var coinJoinManager = HostedServices.GetOrDefault<CoinJoinManager>();
+				var coinJoinManager = HostedServices?.GetOrDefault<CoinJoinManager>();
 				if (coinJoinManager is null)
 				{
 					return null;


### PR DESCRIPTION
Partially addresses: https://github.com/zkSNACKs/WalletWasabi/pull/7647

Implement similar behavior that we had in WW1. While any of the CoinJoinClient is in the critical phase, sync requests are suspended. I consider WasabiSynchronizer as a legacy class, so I did it in a way that caused less change in the code. 

review w/o whitespace changes. 