### PR TITLE
[VDG] Fix SubscribeAsync workaround in PreviewItem

### DIFF
--- a/WalletWasabi.Fluent/App.axaml
+++ b/WalletWasabi.Fluent/App.axaml
@@ -38,6 +38,7 @@
     <StyleInclude Source="avares://WalletWasabi.Fluent/Controls/StatusItem.axaml" />
     <StyleInclude Source="avares://WalletWasabi.Fluent/Controls/PrivacyContentControl.axaml" />
     <StyleInclude Source="avares://WalletWasabi.Fluent/Controls/SuggestionItem.axaml" />
+    <StyleInclude Source="avares://WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml" />
   </Application.Styles>
   <NativeMenu.Menu>
     <NativeMenu>

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
@@ -1,0 +1,26 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:c="using:WalletWasabi.Fluent.Controls">
+  <Design.PreviewWith>
+    <c:ClipboardCopyButton Height="100" Width="200" />
+  </Design.PreviewWith>
+
+  <Style Selector="c|ClipboardCopyButton">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <c:AnimatedButton x:Name="CopyButton" Command="{TemplateBinding CopyCommand}"
+                            ToolTip.Tip="{Binding ToolTipText}"
+                            NormalIcon="{StaticResource copy_regular}"
+                            ClickIcon="{StaticResource copy_confirmed}"
+                            InitialOpacity="0.6"/>
+          <Popup IsOpen="{TemplateBinding IsPopupOpen}" PlacementTarget="CopyButton" PlacementMode="AnchorAndGravity" PlacementGravity="Top" PlacementAnchor="Top">
+            <Border Margin="6" Padding="10" Background="{StaticResource SystemBaseLowColor}" BorderBrush="{StaticResource TextForegroundColor}" CornerRadius="10" BorderThickness="1">
+              <TextBlock Text="{TemplateBinding CopiedMessage}" />
+            </Border>
+          </Popup>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+</Styles>

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
@@ -8,12 +8,10 @@
   <Style Selector="c|ClipboardCopyButton">
     <Setter Property="Template">
       <ControlTemplate>
-        <Panel>
-          <c:AnimatedButton x:Name="CopyButton" Command="{TemplateBinding CopyCommand}"
-                            NormalIcon="{StaticResource copy_regular}"
-                            ClickIcon="{StaticResource copy_confirmed}"
-                            InitialOpacity="0.6" />
-        </Panel>
+        <c:AnimatedButton x:Name="CopyButton" Command="{TemplateBinding CopyCommand}"
+                          NormalIcon="{StaticResource copy_regular}"
+                          ClickIcon="{StaticResource copy_confirmed}"
+                          InitialOpacity="0.6" />
       </ControlTemplate>
     </Setter>
   </Style>

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
@@ -10,18 +10,9 @@
       <ControlTemplate>
         <Panel>
           <c:AnimatedButton x:Name="CopyButton" Command="{TemplateBinding CopyCommand}"
-                            ToolTip.Tip="{Binding ToolTipText}"
                             NormalIcon="{StaticResource copy_regular}"
                             ClickIcon="{StaticResource copy_confirmed}"
                             InitialOpacity="0.6" />
-          <Popup IsOpen="{TemplateBinding IsPopupOpen}" PlacementTarget="CopyButton" PlacementMode="AnchorAndGravity"
-                 PlacementGravity="Top" PlacementAnchor="Top">
-            <Border IsVisible="{TemplateBinding IsPopupVisible}" Margin="6" Padding="10"
-                    Background="{StaticResource SystemBaseLowColor}" BorderBrush="{StaticResource TextForegroundColor}"
-                    CornerRadius="10" BorderThickness="1">
-              <TextBlock Text="{TemplateBinding CopiedMessage}" />
-            </Border>
-          </Popup>
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml
@@ -13,9 +13,12 @@
                             ToolTip.Tip="{Binding ToolTipText}"
                             NormalIcon="{StaticResource copy_regular}"
                             ClickIcon="{StaticResource copy_confirmed}"
-                            InitialOpacity="0.6"/>
-          <Popup IsOpen="{TemplateBinding IsPopupOpen}" PlacementTarget="CopyButton" PlacementMode="AnchorAndGravity" PlacementGravity="Top" PlacementAnchor="Top">
-            <Border Margin="6" Padding="10" Background="{StaticResource SystemBaseLowColor}" BorderBrush="{StaticResource TextForegroundColor}" CornerRadius="10" BorderThickness="1">
+                            InitialOpacity="0.6" />
+          <Popup IsOpen="{TemplateBinding IsPopupOpen}" PlacementTarget="CopyButton" PlacementMode="AnchorAndGravity"
+                 PlacementGravity="Top" PlacementAnchor="Top">
+            <Border IsVisible="{TemplateBinding IsPopupVisible}" Margin="6" Padding="10"
+                    Background="{StaticResource SystemBaseLowColor}" BorderBrush="{StaticResource TextForegroundColor}"
+                    CornerRadius="10" BorderThickness="1">
               <TextBlock Text="{TemplateBinding CopiedMessage}" />
             </Border>
           </Popup>

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
@@ -1,0 +1,71 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls.Primitives;
+using ReactiveUI;
+
+namespace WalletWasabi.Fluent.Controls;
+
+public class ClipboardCopyButton : TemplatedControl
+{
+	public static readonly StyledProperty<ReactiveCommand<Unit, Unit>> CopyCommandProperty =
+		AvaloniaProperty.Register<ClipboardCopyButton, ReactiveCommand<Unit, Unit>>(nameof(CopyCommand));
+
+	public static readonly StyledProperty<bool> IsPopupOpenProperty =
+		AvaloniaProperty.Register<ClipboardCopyButton, bool>(nameof(IsPopupOpen));
+
+	public static readonly StyledProperty<string> TextProperty =
+		AvaloniaProperty.Register<ClipboardCopyButton, string>(nameof(Text));
+
+	public static readonly StyledProperty<string> CopiedMessageProperty =
+		AvaloniaProperty.Register<ClipboardCopyButton, string>(nameof(Text), "Copied");
+
+	public ReactiveCommand<Unit, Unit> CopyCommand
+	{
+		get => GetValue(CopyCommandProperty);
+		set => SetValue(CopyCommandProperty, value);
+	}
+
+	public bool IsPopupOpen
+	{
+		get => GetValue(IsPopupOpenProperty);
+		set => SetValue(IsPopupOpenProperty, value);
+	}
+
+	public string Text
+	{
+		get => GetValue(TextProperty);
+		set => SetValue(TextProperty, value);
+	}
+
+	public string CopiedMessage
+	{
+		get => GetValue(CopiedMessageProperty);
+		set => SetValue(CopiedMessageProperty, value);
+	}
+
+	public ClipboardCopyButton()
+	{
+		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboard);
+		var obs = CopyCommand.Select(unit => true)
+			.Merge(CopyCommand.Delay(TimeSpan.FromSeconds(2)).Select(_ => false));
+
+		var o = CopyCommand
+			.Select(unit =>
+				Observable.Return(true).Concat(Observable.Timer(HidePopupTime).Select(l => false)))
+			.Switch();
+
+		this.Bind(IsPopupOpenProperty, o);
+	}
+
+	public TimeSpan HidePopupTime { get; set; } = TimeSpan.FromSeconds(2);
+
+	private async Task CopyToClipboard()
+	{
+		if (Application.Current is {Clipboard: { } clipboard})
+		{
+			await clipboard.SetTextAsync(Text);
+		}
+	}
+}

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
@@ -1,5 +1,4 @@
 using System.Reactive;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.Primitives;
@@ -12,34 +11,13 @@ public class ClipboardCopyButton : TemplatedControl
 	public static readonly StyledProperty<ReactiveCommand<Unit, Unit>> CopyCommandProperty =
 		AvaloniaProperty.Register<ClipboardCopyButton, ReactiveCommand<Unit, Unit>>(nameof(CopyCommand));
 
-	public static readonly StyledProperty<bool> IsPopupOpenProperty =
-		AvaloniaProperty.Register<ClipboardCopyButton, bool>(nameof(IsPopupOpen));
-
-	public static readonly StyledProperty<bool> IsPopupVisibleProperty =
-		AvaloniaProperty.Register<ClipboardCopyButton, bool>(nameof(IsPopupVisible), true);
-
 	public static readonly StyledProperty<string> TextProperty =
 		AvaloniaProperty.Register<ClipboardCopyButton, string>(nameof(Text));
-
-	public static readonly StyledProperty<string> CopiedMessageProperty =
-		AvaloniaProperty.Register<ClipboardCopyButton, string>(nameof(Text), "Copied");
 
 	public ReactiveCommand<Unit, Unit> CopyCommand
 	{
 		get => GetValue(CopyCommandProperty);
 		set => SetValue(CopyCommandProperty, value);
-	}
-
-	public bool IsPopupOpen
-	{
-		get => GetValue(IsPopupOpenProperty);
-		set => SetValue(IsPopupOpenProperty, value);
-	}
-
-	public bool IsPopupVisible
-	{
-		get => GetValue(IsPopupVisibleProperty);
-		set => SetValue(IsPopupVisibleProperty, value);
 	}
 
 	public string Text
@@ -48,26 +26,11 @@ public class ClipboardCopyButton : TemplatedControl
 		set => SetValue(TextProperty, value);
 	}
 
-	public string CopiedMessage
-	{
-		get => GetValue(CopiedMessageProperty);
-		set => SetValue(CopiedMessageProperty, value);
-	}
-
 	public ClipboardCopyButton()
 	{
-		var canCopy = this.WhenAnyValue(c => c.Text, selector: s => s is not null);
+		var canCopy = this.WhenAnyValue(x => x.Text, selector: text => text is not null);
 		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboardAsync, canCopy);
-
-		var isPopupOpen = CopyCommand
-			.Select(_ =>
-				Observable.Return(true).Concat(Observable.Timer(HidePopupTime).Select(l => false)))
-			.Switch();
-
-		this.Bind(IsPopupOpenProperty, isPopupOpen);
 	}
-
-	public TimeSpan HidePopupTime { get; set; } = TimeSpan.FromSeconds(1);
 
 	private async Task CopyToClipboardAsync()
 	{

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
@@ -15,6 +15,9 @@ public class ClipboardCopyButton : TemplatedControl
 	public static readonly StyledProperty<bool> IsPopupOpenProperty =
 		AvaloniaProperty.Register<ClipboardCopyButton, bool>(nameof(IsPopupOpen));
 
+	public static readonly StyledProperty<bool> IsPopupVisibleProperty =
+		AvaloniaProperty.Register<ClipboardCopyButton, bool>(nameof(IsPopupVisible), true);
+
 	public static readonly StyledProperty<string> TextProperty =
 		AvaloniaProperty.Register<ClipboardCopyButton, string>(nameof(Text));
 
@@ -33,6 +36,12 @@ public class ClipboardCopyButton : TemplatedControl
 		set => SetValue(IsPopupOpenProperty, value);
 	}
 
+	public bool IsPopupVisible
+	{
+		get => GetValue(IsPopupVisibleProperty);
+		set => SetValue(IsPopupVisibleProperty, value);
+	}
+
 	public string Text
 	{
 		get => GetValue(TextProperty);
@@ -48,19 +57,19 @@ public class ClipboardCopyButton : TemplatedControl
 	public ClipboardCopyButton()
 	{
 		var canCopy = this.WhenAnyValue(c => c.Text, selector: s => s is not null);
-		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboard, canCopy);
+		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboardAsync, canCopy);
 
 		var isPopupOpen = CopyCommand
-			.Select(unit =>
+			.Select(_ =>
 				Observable.Return(true).Concat(Observable.Timer(HidePopupTime).Select(l => false)))
 			.Switch();
 
 		this.Bind(IsPopupOpenProperty, isPopupOpen);
 	}
 
-	public TimeSpan HidePopupTime { get; set; } = TimeSpan.FromSeconds(2);
+	public TimeSpan HidePopupTime { get; set; } = TimeSpan.FromSeconds(1);
 
-	private async Task CopyToClipboard()
+	private async Task CopyToClipboardAsync()
 	{
 		if (Application.Current is {Clipboard: { } clipboard})
 		{

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
@@ -47,17 +47,15 @@ public class ClipboardCopyButton : TemplatedControl
 
 	public ClipboardCopyButton()
 	{
-		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboard,
-			this.WhenAnyValue(c => c.Text, selector: s => s is not null));
-		var obs = CopyCommand.Select(unit => true)
-			.Merge(CopyCommand.Delay(TimeSpan.FromSeconds(2)).Select(_ => false));
+		var canCopy = this.WhenAnyValue(c => c.Text, selector: s => s is not null);
+		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboard, canCopy);
 
-		var o = CopyCommand
+		var isPopupOpen = CopyCommand
 			.Select(unit =>
 				Observable.Return(true).Concat(Observable.Timer(HidePopupTime).Select(l => false)))
 			.Switch();
 
-		this.Bind(IsPopupOpenProperty, o);
+		this.Bind(IsPopupOpenProperty, isPopupOpen);
 	}
 
 	public TimeSpan HidePopupTime { get; set; } = TimeSpan.FromSeconds(2);

--- a/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/ClipboardCopyButton.axaml.cs
@@ -47,7 +47,8 @@ public class ClipboardCopyButton : TemplatedControl
 
 	public ClipboardCopyButton()
 	{
-		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboard);
+		CopyCommand = ReactiveCommand.CreateFromTask(CopyToClipboard,
+			this.WhenAnyValue(c => c.Text, selector: s => s is not null));
 		var obs = CopyCommand.Select(unit => true)
 			.Merge(CopyCommand.Delay(TimeSpan.FromSeconds(2)).Select(_ => false));
 

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -5,73 +5,78 @@
   <Design.PreviewWith>
     <Border Height="100" Width="400">
       <c:PreviewItem Label="Transaction ID"
-                     TextValue="Text to copy">
-      </c:PreviewItem>
+                     TextValue="Text to copy" />
     </Border>
   </Design.PreviewWith>
 
-    <Style Selector="c|PreviewItem">
-        <Setter Property="Template">
-            <ControlTemplate>
-                <DockPanel Background="Transparent">
-                    <PathIcon Width="{TemplateBinding IconSize}" Height="{TemplateBinding IconSize}"
-                              Data="{TemplateBinding Icon}"
-                              Opacity="0.5"
-                              Foreground="{StaticResource SystemAccentNeutralColor}"
-                              IsVisible="{TemplateBinding IsIconVisible}" DockPanel.Dock="Left" />
-                    <DockPanel DockPanel.Dock="Right" Margin="30 0 0 0">
-                        <TextBlock Name="PART_Text" Text="{TemplateBinding Label}" DockPanel.Dock="Top" Margin="0 0 0 5" Opacity="0.6" />
-                        <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
-                          <c:ClipboardCopyButton ToolTip.Tip="Copy" ToolTip.Placement="Bottom" DockPanel.Dock="Right" Width="30" Text="{TemplateBinding TextValue}" IsVisible="{TemplateBinding IsCopyButtonVisible}" />
-                          <Panel>
-                              <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
-                                                ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                IsVisible="{Binding !#PART_ContentReplacementTextBlock.IsVisible}" />
-                              <TextBlock Name="PART_ContentReplacementTextBlock" IsVisible="{TemplateBinding PrivacyModeEnabled}"/>
-                            </Panel>
-                        </DockPanel>
-                    </DockPanel>
-                </DockPanel>
-            </ControlTemplate>
-        </Setter>
-    </Style>
+  <Style Selector="c|PreviewItem">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockPanel Background="Transparent">
+          <PathIcon Width="{TemplateBinding IconSize}" Height="{TemplateBinding IconSize}"
+                    Data="{TemplateBinding Icon}"
+                    Opacity="0.5"
+                    Foreground="{StaticResource SystemAccentNeutralColor}"
+                    DockPanel.Dock="Left" IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}" />
+          <DockPanel DockPanel.Dock="Right" Margin="20 0 0 0">
+            <TextBlock Name="PART_Text" Text="{TemplateBinding Label}" DockPanel.Dock="Top" Margin="0 0 0 5"
+                       Opacity="0.6" />
+            <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
+              <c:ClipboardCopyButton ToolTip.Tip="Copy" ToolTip.Placement="Bottom" DockPanel.Dock="Right" Width="30"
+                                     Text="{TemplateBinding TextValue}"
+                                     IsVisible="{TemplateBinding IsCopyButtonVisible}" />
+              <Panel>
+                <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
+                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  IsVisible="{Binding !#PART_ContentReplacementTextBlock.IsVisible}" />
+                <TextBlock Name="PART_ContentReplacementTextBlock" IsVisible="{TemplateBinding PrivacyModeEnabled}" />
+              </Panel>
+            </DockPanel>
+          </DockPanel>
+        </DockPanel>
+      </ControlTemplate>
+    </Setter>
+  </Style>
 
-    <Style Selector="c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="TextBlock.FontSize" Value="14" />
-    </Style>
+  <Style Selector="c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="TextBlock.FontSize" Value="14" />
+  </Style>
 
-    <Style Selector="c|PreviewItem /template/ TextBlock#PART_Text">
-        <Setter Property="FontSize" Value="14" />
-        <Setter Property="TextWrapping" Value="Wrap" />
-    </Style>
+  <Style Selector="c|PreviewItem /template/ TextBlock#PART_Text">
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+  </Style>
 
-    <Style Selector="c|PreviewItem :is(Control) TextBlock, c|PreviewItem :is(TextBlock)">
-        <Setter Property="TextWrapping" Value="Wrap" />
-    </Style>
+  <Style Selector="c|PreviewItem :is(Control) TextBlock, c|PreviewItem :is(TextBlock)">
+    <Setter Property="TextWrapping" Value="Wrap" />
+  </Style>
 
-    <Style Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock">
-        <Setter Property="Text" Value="Sensitive Data" />
-        <Setter Property="Foreground" Value="IndianRed" />
-    </Style>
+  <Style Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock">
+    <Setter Property="Text" Value="Sensitive Data" />
+    <Setter Property="Foreground" Value="IndianRed" />
+  </Style>
 
-    <!-- Transitions -->
-    <Style Selector="c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter,
+  <!-- Transitions -->
+  <Style
+    Selector="c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter,
                      c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock">
-        <Setter Property="Transitions">
-            <Transitions>
-                <DoubleTransition Property="Opacity" Duration="0:0:0.3" />
-            </Transitions>
-        </Setter>
-    </Style>
-    <Style Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=True],
+    <Setter Property="Transitions">
+      <Transitions>
+        <DoubleTransition Property="Opacity" Duration="0:0:0.3" />
+      </Transitions>
+    </Setter>
+  </Style>
+  <Style
+    Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=True],
                      c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter[IsVisible=True]">
-        <Setter Property="Opacity" Value="1" />
-    </Style>
-    <Style Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=False],
+    <Setter Property="Opacity" Value="1" />
+  </Style>
+  <Style
+    Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=False],
                      c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter[IsVisible=False]">
-        <Setter Property="Opacity" Value="0" />
-    </Style>
+    <Setter Property="Opacity" Value="0" />
+  </Style>
 
 </Styles>

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -3,7 +3,7 @@
         xmlns:c="using:WalletWasabi.Fluent.Controls">
 
   <Design.PreviewWith>
-    <c:PreviewItem Text="Text to preview"></c:PreviewItem>
+    <c:PreviewItem Label="Text to preview"></c:PreviewItem>
   </Design.PreviewWith>
 
     <Style Selector="c|PreviewItem">
@@ -16,9 +16,9 @@
                               Foreground="{StaticResource SystemAccentNeutralColor}"
                               IsVisible="{TemplateBinding IsIconVisible}" DockPanel.Dock="Left" />
                     <DockPanel DockPanel.Dock="Right" Margin="30 0 0 0">
-                        <TextBlock Name="PART_Text" Text="{TemplateBinding Text}" DockPanel.Dock="Top" Margin="0 0 0 5" Opacity="0.6" />
+                        <TextBlock Name="PART_Text" Text="{TemplateBinding Label}" DockPanel.Dock="Top" Margin="0 0 0 5" Opacity="0.6" />
                         <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
-                          <c:ClipboardCopyButton DockPanel.Dock="Right"  Width="30" Text="{TemplateBinding Text}" IsVisible="{TemplateBinding CopyButtonVisibility}" />
+                          <c:ClipboardCopyButton ToolTip.Tip="Copy" ToolTip.Placement="Bottom" DockPanel.Dock="Right" Width="30" Text="{TemplateBinding Value}" IsVisible="{TemplateBinding CopyButtonVisibility}" />
                           <Panel>
                               <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -23,7 +23,6 @@
                        Opacity="0.6" />
             <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
               <c:ClipboardCopyButton x:Name="PART_ClipboardCopyButton"
-                                     IsPopupVisible="False"
                                      ToolTip.Tip="Copy"
                                      DockPanel.Dock="Right" Width="30"
                                      Text="{TemplateBinding TextValue}"

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -3,7 +3,11 @@
         xmlns:c="using:WalletWasabi.Fluent.Controls">
 
   <Design.PreviewWith>
-    <c:PreviewItem Label="Text to preview"></c:PreviewItem>
+    <Border Height="100" Width="400">
+      <c:PreviewItem Label="Transaction ID"
+                     TextValue="Text to copy">
+      </c:PreviewItem>
+    </Border>
   </Design.PreviewWith>
 
     <Style Selector="c|PreviewItem">
@@ -18,7 +22,7 @@
                     <DockPanel DockPanel.Dock="Right" Margin="30 0 0 0">
                         <TextBlock Name="PART_Text" Text="{TemplateBinding Label}" DockPanel.Dock="Top" Margin="0 0 0 5" Opacity="0.6" />
                         <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
-                          <c:ClipboardCopyButton ToolTip.Tip="Copy" ToolTip.Placement="Bottom" DockPanel.Dock="Right" Width="30" Text="{TemplateBinding Value}" IsVisible="{TemplateBinding CopyButtonVisibility}" />
+                          <c:ClipboardCopyButton ToolTip.Tip="Copy" ToolTip.Placement="Bottom" DockPanel.Dock="Right" Width="30" Text="{TemplateBinding TextValue}" IsVisible="{TemplateBinding IsCopyButtonVisible}" />
                           <Panel>
                               <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -22,7 +22,10 @@
             <TextBlock Name="PART_Text" Text="{TemplateBinding Label}" DockPanel.Dock="Top" Margin="0 0 0 5"
                        Opacity="0.6" />
             <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
-              <c:ClipboardCopyButton ToolTip.Tip="Copy" ToolTip.Placement="Bottom" DockPanel.Dock="Right" Width="30"
+              <c:ClipboardCopyButton x:Name="PART_ClipboardCopyButton"
+                                     IsPopupVisible="False"
+                                     ToolTip.Tip="Copy"
+                                     DockPanel.Dock="Right" Width="30"
                                      Text="{TemplateBinding TextValue}"
                                      IsVisible="{TemplateBinding IsCopyButtonVisible}" />
               <Panel>

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -61,23 +61,20 @@
   </Style>
 
   <!-- Transitions -->
-  <Style
-    Selector="c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter,
-                     c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock">
+  <Style Selector="c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter,
+                   c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock">
     <Setter Property="Transitions">
       <Transitions>
         <DoubleTransition Property="Opacity" Duration="0:0:0.3" />
       </Transitions>
     </Setter>
   </Style>
-  <Style
-    Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=True],
-                     c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter[IsVisible=True]">
+  <Style Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=True],
+                   c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter[IsVisible=True]">
     <Setter Property="Opacity" Value="1" />
   </Style>
-  <Style
-    Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=False],
-                     c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter[IsVisible=False]">
+  <Style Selector="c|PreviewItem /template/ TextBlock#PART_ContentReplacementTextBlock[IsVisible=False],
+                   c|PreviewItem /template/ ContentPresenter#PART_ContentPresenter[IsVisible=False]">
     <Setter Property="Opacity" Value="0" />
   </Style>
 

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml
@@ -2,6 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:c="using:WalletWasabi.Fluent.Controls">
 
+  <Design.PreviewWith>
+    <c:PreviewItem Text="Text to preview"></c:PreviewItem>
+  </Design.PreviewWith>
+
     <Style Selector="c|PreviewItem">
         <Setter Property="Template">
             <ControlTemplate>
@@ -14,17 +18,8 @@
                     <DockPanel DockPanel.Dock="Right" Margin="30 0 0 0">
                         <TextBlock Name="PART_Text" Text="{TemplateBinding Text}" DockPanel.Dock="Top" Margin="0 0 0 5" Opacity="0.6" />
                         <DockPanel HorizontalAlignment="Left" DockPanel.Dock="Bottom">
-                            <Panel DockPanel.Dock="Right"
-                                   Width="30">
-                                <c:AnimatedButton Command="{TemplateBinding CopyCommand}"
-                                                  CommandParameter="{TemplateBinding CopyParameter}"
-                                                  ToolTip.Tip="Copy"
-                                                  NormalIcon="{StaticResource copy_regular}"
-                                                  ClickIcon="{StaticResource copy_confirmed}"
-                                                  InitialOpacity="0.6"
-                                                  IsVisible="{TemplateBinding CopyButtonVisibility}" />
-                            </Panel>
-                            <Panel>
+                          <c:ClipboardCopyButton DockPanel.Dock="Right"  Width="30" Text="{TemplateBinding Text}" IsVisible="{TemplateBinding CopyButtonVisibility}" />
+                          <Panel>
                               <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -88,14 +88,13 @@ public class PreviewItem : ContentControl
 
 		var hasBeenJustCopied = Observable.Return(false)
 			.Concat(button.CopyCommand
-			.Select(_ =>
-				Observable.Return(true).Concat(Observable.Timer(TimeSpan.FromSeconds(1)).Select(l => false)))
-			.Switch());
+				.Select(_ => Observable.Return(true).Concat(Observable.Timer(TimeSpan.FromSeconds(1)).Select(_ => false)))
+				.Switch());
 
 		var isCopyButtonVisible = this
 			.WhenAnyValue(item => item.IsPointerOver, item => item.TextValue, (a, b) => a && !string.IsNullOrWhiteSpace(b))
 			.CombineLatest(hasBeenJustCopied, (over, justCopied) => over || justCopied);
-		
+
 		this.Bind(IsCopyButtonVisibleProperty, isCopyButtonVisible);
 
 		base.OnApplyTemplate(e);

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using ReactiveUI;
-using WalletWasabi.Fluent.Extensions;
 
 namespace WalletWasabi.Fluent.Controls;
 
@@ -35,49 +32,9 @@ public class PreviewItem : ContentControl
 	public static readonly StyledProperty<bool> PrivacyModeEnabledProperty =
 		AvaloniaProperty.Register<PreviewItem, bool>(nameof(PrivacyModeEnabled));
 
-	private Stopwatch? _copyButtonPressedStopwatch;
-
 	public PreviewItem()
 	{
-		CopyCommand = ReactiveCommand.CreateFromTask<object>(async obj =>
-		{
-			if (obj.ToString() is { } text)
-			{
-				_copyButtonPressedStopwatch = Stopwatch.StartNew();
-
-				if (Application.Current is { Clipboard: { } clipboard })
-				{
-					await clipboard.SetTextAsync(text);
-				}
-			}
-		});
-
-		this.WhenAnyValue(x => x.Icon)
-			.Subscribe(x => IsIconVisible = x is not null);
-
-		this.WhenAnyValue(
-				x => x.CopyParameter,
-				x => x.IsPointerOver,
-				x => x.PrivacyModeEnabled,
-				(copyParameter, isPointerOver, privacyModeEnabled) => !string.IsNullOrEmpty(copyParameter?.ToString()) && isPointerOver && !privacyModeEnabled)
-			.SubscribeAsync(async value =>
-			{
-				if (_copyButtonPressedStopwatch is { } sw)
-				{
-					var elapsedMilliseconds = sw.ElapsedMilliseconds;
-
-					var millisecondsToWait = 1050 - (int)elapsedMilliseconds;
-
-					if (millisecondsToWait > 0)
-					{
-						await Task.Delay(millisecondsToWait);
-					}
-
-					_copyButtonPressedStopwatch = null;
-				}
-
-				CopyButtonVisibility = value;
-			});
+		this.Bind(CopyButtonVisibilityProperty, this.WhenAnyValue(item => item.IsPointerOver));
 	}
 
 	public string Text

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -85,11 +85,16 @@ public class PreviewItem : ContentControl
 	protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
 	{
 		var button = e.NameScope.Find<ClipboardCopyButton>("PART_ClipboardCopyButton");
-		var isPopupOpen = button.WhenAnyValue(b => b.IsPopupOpen);
 
-		var isCopyButtonVisible = this.WhenAnyValue(item => item.IsPointerOver, item => item.TextValue,
-			(a, b) => a && !string.IsNullOrWhiteSpace(b))
-			.CombineLatest(isPopupOpen, (over, isPopupVisible) => over || isPopupVisible);
+		var hasBeenJustCopied = Observable.Return(false)
+			.Concat(button.CopyCommand
+			.Select(_ =>
+				Observable.Return(true).Concat(Observable.Timer(TimeSpan.FromSeconds(1)).Select(l => false)))
+			.Switch());
+
+		var isCopyButtonVisible = this
+			.WhenAnyValue(item => item.IsPointerOver, item => item.TextValue, (a, b) => a && !string.IsNullOrWhiteSpace(b))
+			.CombineLatest(hasBeenJustCopied, (over, justCopied) => over || justCopied);
 		
 		this.Bind(IsCopyButtonVisibleProperty, isCopyButtonVisible);
 

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -1,6 +1,8 @@
+using System.Reactive.Linq;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using ReactiveUI;
 
@@ -31,13 +33,6 @@ public class PreviewItem : ContentControl
 
 	public static readonly StyledProperty<bool> PrivacyModeEnabledProperty =
 		AvaloniaProperty.Register<PreviewItem, bool>(nameof(PrivacyModeEnabled));
-
-	public PreviewItem()
-	{
-		var isCopyButtonVisible = this.WhenAnyValue(item => item.IsPointerOver, item => item.TextValue,
-			(a, b) => a && !string.IsNullOrWhiteSpace(b));
-		this.Bind(IsCopyButtonVisibleProperty, isCopyButtonVisible);
-	}
 
 	public string Label
 	{
@@ -85,5 +80,19 @@ public class PreviewItem : ContentControl
 	{
 		get => GetValue(PrivacyModeEnabledProperty);
 		set => SetValue(PrivacyModeEnabledProperty, value);
+	}
+
+	protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+	{
+		var button = e.NameScope.Find<ClipboardCopyButton>("PART_ClipboardCopyButton");
+		var isPopupOpen = button.WhenAnyValue(b => b.IsPopupOpen);
+
+		var isCopyButtonVisible = this.WhenAnyValue(item => item.IsPointerOver, item => item.TextValue,
+			(a, b) => a && !string.IsNullOrWhiteSpace(b))
+			.CombineLatest(isPopupOpen, (over, isPopupVisible) => over || isPopupVisible);
+		
+		this.Bind(IsCopyButtonVisibleProperty, isCopyButtonVisible);
+
+		base.OnApplyTemplate(e);
 	}
 }

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -20,21 +20,23 @@ public class PreviewItem : ContentControl
 	public static readonly StyledProperty<bool> IsIconVisibleProperty =
 		AvaloniaProperty.Register<PreviewItem, bool>(nameof(IsIconVisible));
 
-	public static readonly StyledProperty<string> ValueProperty =
-		AvaloniaProperty.Register<PreviewItem, string>(nameof(Value));
+	public static readonly StyledProperty<string> TextValueProperty =
+		AvaloniaProperty.Register<PreviewItem, string>(nameof(TextValue));
 
 	public static readonly StyledProperty<ICommand> CopyCommandProperty =
 		AvaloniaProperty.Register<PreviewItem, ICommand>(nameof(CopyCommand));
 
-	public static readonly StyledProperty<bool> CopyButtonVisibilityProperty =
-		AvaloniaProperty.Register<PreviewItem, bool>(nameof(CopyButtonVisibility));
+	public static readonly StyledProperty<bool> IsCopyButtonVisibleProperty =
+		AvaloniaProperty.Register<PreviewItem, bool>(nameof(IsCopyButtonVisible));
 
 	public static readonly StyledProperty<bool> PrivacyModeEnabledProperty =
 		AvaloniaProperty.Register<PreviewItem, bool>(nameof(PrivacyModeEnabled));
 
 	public PreviewItem()
 	{
-		this.Bind(CopyButtonVisibilityProperty, this.WhenAnyValue(item => item.IsPointerOver));
+		var isCopyButtonVisible = this.WhenAnyValue(item => item.IsPointerOver, item => item.TextValue,
+			(a, b) => a && !string.IsNullOrWhiteSpace(b));
+		this.Bind(IsCopyButtonVisibleProperty, isCopyButtonVisible);
 	}
 
 	public string Label
@@ -61,10 +63,10 @@ public class PreviewItem : ContentControl
 		set => SetValue(IsIconVisibleProperty, value);
 	}
 
-	public string Value
+	public string TextValue
 	{
-		get => GetValue(ValueProperty);
-		set => SetValue(ValueProperty, value);
+		get => GetValue(TextValueProperty);
+		set => SetValue(TextValueProperty, value);
 	}
 
 	public ICommand CopyCommand
@@ -73,10 +75,10 @@ public class PreviewItem : ContentControl
 		set => SetValue(CopyCommandProperty, value);
 	}
 
-	public bool CopyButtonVisibility
+	public bool IsCopyButtonVisible
 	{
-		get => GetValue(CopyButtonVisibilityProperty);
-		set => SetValue(CopyButtonVisibilityProperty, value);
+		get => GetValue(IsCopyButtonVisibleProperty);
+		set => SetValue(IsCopyButtonVisibleProperty, value);
 	}
 
 	public bool PrivacyModeEnabled

--- a/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PreviewItem.axaml.cs
@@ -8,8 +8,8 @@ namespace WalletWasabi.Fluent.Controls;
 
 public class PreviewItem : ContentControl
 {
-	public static readonly StyledProperty<string> TextProperty =
-		AvaloniaProperty.Register<PreviewItem, string>(nameof(Text));
+	public static readonly StyledProperty<string> LabelProperty =
+		AvaloniaProperty.Register<PreviewItem, string>(nameof(Label));
 
 	public static readonly StyledProperty<Geometry> IconProperty =
 		AvaloniaProperty.Register<PreviewItem, Geometry>(nameof(Icon));
@@ -20,8 +20,8 @@ public class PreviewItem : ContentControl
 	public static readonly StyledProperty<bool> IsIconVisibleProperty =
 		AvaloniaProperty.Register<PreviewItem, bool>(nameof(IsIconVisible));
 
-	public static readonly StyledProperty<object?> CopyParameterProperty =
-		AvaloniaProperty.Register<PreviewItem, object?>(nameof(CopyParameter));
+	public static readonly StyledProperty<string> ValueProperty =
+		AvaloniaProperty.Register<PreviewItem, string>(nameof(Value));
 
 	public static readonly StyledProperty<ICommand> CopyCommandProperty =
 		AvaloniaProperty.Register<PreviewItem, ICommand>(nameof(CopyCommand));
@@ -37,10 +37,10 @@ public class PreviewItem : ContentControl
 		this.Bind(CopyButtonVisibilityProperty, this.WhenAnyValue(item => item.IsPointerOver));
 	}
 
-	public string Text
+	public string Label
 	{
-		get => GetValue(TextProperty);
-		set => SetValue(TextProperty, value);
+		get => GetValue(LabelProperty);
+		set => SetValue(LabelProperty, value);
 	}
 
 	public Geometry Icon
@@ -61,10 +61,10 @@ public class PreviewItem : ContentControl
 		set => SetValue(IsIconVisibleProperty, value);
 	}
 
-	public object? CopyParameter
+	public string Value
 	{
-		get => GetValue(CopyParameterProperty);
-		set => SetValue(CopyParameterProperty, value);
+		get => GetValue(ValueProperty);
+		set => SetValue(ValueProperty, value);
 	}
 
 	public ICommand CopyCommand

--- a/WalletWasabi.Fluent/Views/TransactionBroadcasting/BroadcastTransactionView.axaml
+++ b/WalletWasabi.Fluent/Views/TransactionBroadcasting/BroadcastTransactionView.axaml
@@ -12,27 +12,27 @@
                  IsBusy="{Binding IsBusy}">
     <StackPanel Spacing="20">
       <c:PreviewItem Icon="{StaticResource transaction_id}"
-                     Text="Transaction ID"
+                     Label="Transaction ID"
                      Content="{Binding TransactionId, FallbackValue=ab550cbedcacc9e4d1d6d37b1dc54eee0cax7b70c4e0beeac2d0915353b70ae0}" />
       <Separator />
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Text="Input amount"
+                     Label="Input amount"
                      Content="{Binding InputAmountString, FallbackValue=0.0001 1234 BTC}" />
       <Separator />
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Text="Output amount"
+                     Label="Output amount"
                      Content="{Binding OutputAmountString, FallbackValue=0.0001 1234 BTC}" />
       <Separator />
       <c:PreviewItem Icon="{StaticResource arrow_down_right_circle_regular}"
-                     Text="Input count"
+                     Label="Input count"
                      Content="{Binding InputCount, FallbackValue=1}" />
       <Separator />
       <c:PreviewItem Icon="{StaticResource arrow_up_right_circle_regular}"
-                     Text="Output count"
+                     Label="Output count"
                      Content="{Binding OutputCount, FallbackValue=1}" />
       <Separator />
       <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
-                     Text="Fee"
+                     Label="Fee"
                      Content="{Binding FeeString, FallbackValue=0.0001 1234 BTC}" />
     </StackPanel>
   </c:ContentArea>

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -22,8 +22,8 @@
     <StackPanel Spacing="10" Margin="0 0 20 0">
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
-                     Text="Extended Master Private Key"
-                     CopyParameter="{Binding ExtendedMasterPrivateKey}"
+                     Label="Extended Master Private Key"
+                     Value="{Binding ExtendedMasterPrivateKey}"
                      IsVisible="{Binding !!ExtendedMasterPrivateKey}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedMasterPrivateKey}" />
@@ -31,8 +31,8 @@
       <Separator IsVisible="{Binding !!ExtendedMasterPrivateKey}" />
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
-                     Text="Extended Master zprv"
-                     CopyParameter="{Binding ExtendedMasterZprv}"
+                     Label="Extended Master zprv"
+                     Value="{Binding ExtendedMasterZprv}"
                      IsVisible="{Binding !!ExtendedMasterZprv}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedMasterZprv}" />
@@ -40,22 +40,22 @@
       <Separator IsVisible="{Binding !!ExtendedMasterZprv}" />
 
       <c:PreviewItem Icon="{StaticResource fingerprint_regular}"
-                     Text="Extended Master Fingerprint"
-                     CopyParameter="{Binding MasterKeyFingerprint}" >
+                     Label="Extended Master Fingerprint"
+                     Value="{Binding MasterKeyFingerprint}" >
         <TextBlock Classes="monoSpaced" Text="{Binding MasterKeyFingerprint}" />
       </c:PreviewItem>
       <Separator />
 
       <c:PreviewItem Icon="{StaticResource organization_regular}"
-                     Text="Account Key Path"
-                     CopyParameter="{Binding AccountKeyPath}" >
+                     Label="Account Key Path"
+                     Value="{Binding AccountKeyPath}" >
         <TextBlock Classes="monoSpaced" Text="{Binding AccountKeyPath}" />
       </c:PreviewItem>
       <Separator />
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
-                     Text="Extended Account Private Key xpriv"
-                     CopyParameter="{Binding ExtendedAccountPrivateKey}"
+                     Label="Extended Account Private Key xpriv"
+                     Value="{Binding ExtendedAccountPrivateKey}"
                      IsVisible="{Binding !!ExtendedAccountPrivateKey}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedAccountPrivateKey}" />
@@ -63,8 +63,8 @@
       <Separator IsVisible="{Binding !!ExtendedAccountPrivateKey}" />
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
-                     Text="Extended Account Private Key zprv"
-                     CopyParameter="{Binding ExtendedAccountZprv}"
+                     Label="Extended Account Private Key zprv"
+                     Value="{Binding ExtendedAccountZprv}"
                      IsVisible="{Binding !!ExtendedAccountZprv}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedAccountZprv}" />
@@ -72,42 +72,42 @@
       <Separator IsVisible="{Binding !!ExtendedAccountZprv}" />
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
-                     Text="Public External Output descriptor"
-                     CopyParameter="{Binding WpkhOutputDescriptors.PublicExternal}">
+                     Label="Public External Output descriptor"
+                     Value="{Binding WpkhOutputDescriptors.PublicExternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PublicExternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
       <c:PreviewItem Icon="{StaticResource key_regular}"
-                     Text="Public Internal Output descriptor"
-                     CopyParameter="{Binding WpkhOutputDescriptors.PublicInternal}">
+                     Label="Public Internal Output descriptor"
+                     Value="{Binding WpkhOutputDescriptors.PublicInternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PublicInternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
-                     Text="Private External Output descriptor"
+                     Label="Private External Output descriptor"
                      IsVisible="{Binding !!WpkhOutputDescriptors.PrivateExternal}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}"
-                     CopyParameter="{Binding WpkhOutputDescriptors.PrivateExternal}">
+                     Value="{Binding WpkhOutputDescriptors.PrivateExternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PrivateExternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
       <c:PreviewItem Icon="{StaticResource key_regular}"
-                     Text="Private Internal Output descriptor"
+                     Label="Private Internal Output descriptor"
                      IsVisible="{Binding !!WpkhOutputDescriptors.PrivateInternal}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}"
-                     CopyParameter="{Binding WpkhOutputDescriptors.PrivateInternal}">
+                     Value="{Binding WpkhOutputDescriptors.PrivateInternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PrivateInternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
-                     Text="Extended Account Public Key"
-                     CopyParameter="{Binding ExtendedAccountPublicKey}">
+                     Label="Extended Account Public Key"
+                     Value="{Binding ExtendedAccountPublicKey}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding ExtendedAccountPublicKey}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
       <Separator />
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
-                     Text="Extended Account zpub"
-                     CopyParameter="{Binding ExtendedAccountZpub}">
+                     Label="Extended Account zpub"
+                     Value="{Binding ExtendedAccountZpub}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding ExtendedAccountZpub}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
     </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -23,7 +23,7 @@
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
                      Label="Extended Master Private Key"
-                     Value="{Binding ExtendedMasterPrivateKey}"
+                     TextValue="{Binding ExtendedMasterPrivateKey}"
                      IsVisible="{Binding !!ExtendedMasterPrivateKey}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedMasterPrivateKey}" />
@@ -32,7 +32,7 @@
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
                      Label="Extended Master zprv"
-                     Value="{Binding ExtendedMasterZprv}"
+                     TextValue="{Binding ExtendedMasterZprv}"
                      IsVisible="{Binding !!ExtendedMasterZprv}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedMasterZprv}" />
@@ -41,21 +41,21 @@
 
       <c:PreviewItem Icon="{StaticResource fingerprint_regular}"
                      Label="Extended Master Fingerprint"
-                     Value="{Binding MasterKeyFingerprint}" >
+                     TextValue="{Binding MasterKeyFingerprint}" >
         <TextBlock Classes="monoSpaced" Text="{Binding MasterKeyFingerprint}" />
       </c:PreviewItem>
       <Separator />
 
       <c:PreviewItem Icon="{StaticResource organization_regular}"
                      Label="Account Key Path"
-                     Value="{Binding AccountKeyPath}" >
+                     TextValue="{Binding AccountKeyPath}" >
         <TextBlock Classes="monoSpaced" Text="{Binding AccountKeyPath}" />
       </c:PreviewItem>
       <Separator />
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
                      Label="Extended Account Private Key xpriv"
-                     Value="{Binding ExtendedAccountPrivateKey}"
+                     TextValue="{Binding ExtendedAccountPrivateKey}"
                      IsVisible="{Binding !!ExtendedAccountPrivateKey}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedAccountPrivateKey}" />
@@ -64,7 +64,7 @@
 
       <c:PreviewItem Icon="{StaticResource private_key_regular}"
                      Label="Extended Account Private Key zprv"
-                     Value="{Binding ExtendedAccountZprv}"
+                     TextValue="{Binding ExtendedAccountZprv}"
                      IsVisible="{Binding !!ExtendedAccountZprv}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}" >
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedAccountZprv}" />
@@ -73,12 +73,12 @@
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Label="Public External Output descriptor"
-                     Value="{Binding WpkhOutputDescriptors.PublicExternal}">
+                     TextValue="{Binding WpkhOutputDescriptors.PublicExternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PublicExternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Label="Public Internal Output descriptor"
-                     Value="{Binding WpkhOutputDescriptors.PublicInternal}">
+                     TextValue="{Binding WpkhOutputDescriptors.PublicInternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PublicInternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
@@ -86,20 +86,20 @@
                      Label="Private External Output descriptor"
                      IsVisible="{Binding !!WpkhOutputDescriptors.PrivateExternal}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}"
-                     Value="{Binding WpkhOutputDescriptors.PrivateExternal}">
+                     TextValue="{Binding WpkhOutputDescriptors.PrivateExternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PrivateExternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Label="Private Internal Output descriptor"
                      IsVisible="{Binding !!WpkhOutputDescriptors.PrivateInternal}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}"
-                     Value="{Binding WpkhOutputDescriptors.PrivateInternal}">
+                     TextValue="{Binding WpkhOutputDescriptors.PrivateInternal}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhOutputDescriptors.PrivateInternal}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Label="Extended Account Public Key"
-                     Value="{Binding ExtendedAccountPublicKey}">
+                     TextValue="{Binding ExtendedAccountPublicKey}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding ExtendedAccountPublicKey}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
 
@@ -107,7 +107,7 @@
 
       <c:PreviewItem Icon="{StaticResource key_regular}"
                      Label="Extended Account zpub"
-                     Value="{Binding ExtendedAccountZpub}">
+                     TextValue="{Binding ExtendedAccountZpub}">
         <c:PrivacyContentControl Classes="monoSpaced" Content="{Binding ExtendedAccountZpub}" ForceShow="{Binding ShowSensitiveData}" NumberOfPrivacyChars="38" />
       </c:PreviewItem>
     </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
@@ -12,25 +12,25 @@
   <c:ContentArea Title="{Binding Title}"
                  EnableNext="True" NextContent="Done">
     <StackPanel Spacing="10" Margin="0 20 20 0">
-      <c:PreviewItem Text="Number of coins (UTXOs)"
-                     CopyParameter="{Binding CoinCount}">
+      <c:PreviewItem Label="Number of coins (UTXOs)"
+                     Value="{Binding CoinCount}">
         <c:PrivacyContentControl Classes="monoSpaced"
                                  NumberOfPrivacyChars="8"
                                  Content="{Binding CoinCount}" />
       </c:PreviewItem>
       <Separator />
-      <c:PreviewItem Text="Unconfirmed balance"
-                     CopyParameter="{Binding UnconfirmedBalance}">
+      <c:PreviewItem Label="Unconfirmed balance"
+                     Value="{Binding UnconfirmedBalance}">
         <c:PrivacyContentControl NumberOfPrivacyChars="11" Content="{Binding UnconfirmedBalance, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
       <Separator />
-      <c:PreviewItem Text="Confirmed balance"
-                     CopyParameter="{Binding ConfirmedBalance}">
+      <c:PreviewItem Label="Confirmed balance"
+                     Value="{Binding ConfirmedBalance}">
         <c:PrivacyContentControl NumberOfPrivacyChars="11" Content="{Binding ConfirmedBalance, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
       <Separator />
-      <c:PreviewItem Text="Total balance"
-                     CopyParameter="{Binding Balance}">
+      <c:PreviewItem Label="Total balance"
+                     Value="{Binding Balance}">
         <c:PrivacyContentControl NumberOfPrivacyChars="11" Content="{Binding Balance, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
     </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
@@ -13,24 +13,24 @@
                  EnableNext="True" NextContent="Done">
     <StackPanel Spacing="10" Margin="0 20 20 0">
       <c:PreviewItem Label="Number of coins (UTXOs)"
-                     Value="{Binding CoinCount}">
+                     TextValue="{Binding CoinCount}">
         <c:PrivacyContentControl Classes="monoSpaced"
                                  NumberOfPrivacyChars="8"
                                  Content="{Binding CoinCount}" />
       </c:PreviewItem>
       <Separator />
       <c:PreviewItem Label="Unconfirmed balance"
-                     Value="{Binding UnconfirmedBalance}">
+                     TextValue="{Binding UnconfirmedBalance}">
         <c:PrivacyContentControl NumberOfPrivacyChars="11" Content="{Binding UnconfirmedBalance, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
       <Separator />
       <c:PreviewItem Label="Confirmed balance"
-                     Value="{Binding ConfirmedBalance}">
+                     TextValue="{Binding ConfirmedBalance}">
         <c:PrivacyContentControl NumberOfPrivacyChars="11" Content="{Binding ConfirmedBalance, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
       <Separator />
       <c:PreviewItem Label="Total balance"
-                     Value="{Binding Balance}">
+                     TextValue="{Binding Balance}">
         <c:PrivacyContentControl NumberOfPrivacyChars="11" Content="{Binding Balance, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
     </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
@@ -17,7 +17,7 @@
       <!-- Date -->
       <c:PreviewItem Icon="{StaticResource timer_regular}"
                      Label="Date"
-                     Value="{Binding Date}">
+                     TextValue="{Binding Date}">
         <TextBlock Text="{Binding Date}" />
       </c:PreviewItem>
 
@@ -29,24 +29,11 @@
           <ItemsRepeater Items="{Binding TransactionIds}">
             <ItemsRepeater.ItemTemplate>
               <DataTemplate>
-                <c:AdorningContentControl ClipToBounds="False" HorizontalAlignment="Left">
-                  <c:AdorningContentControl.Adornment>
-                    <c:AnimatedButton ToolTip.Tip="Copy"
-                                      x:CompileBindings="False"
-                                      Command="{Binding #CoinJoinDetails.DataContext.CopyCommand}"
-                                      CommandParameter="{Binding .}"
-                                      NormalIcon="{StaticResource copy_regular}"
-                                      ClickIcon="{StaticResource copy_confirmed}"
-                                      InitialOpacity="0.6"
-                                      HorizontalAlignment="Right"
-                                      Margin="0 0 -30 0" />
-                  </c:AdorningContentControl.Adornment>
-
+                <c:PreviewItem Icon="{StaticResource transaction_id}" TextValue="{Binding }">
                   <c:PrivacyContentControl NumberOfPrivacyChars="48">
-                    <TextBlock Classes="monoSpaced" Text="{Binding .}" />
+                    <TextBlock Text="{Binding }" Classes="monoSpaced"/>
                   </c:PrivacyContentControl>
-
-                </c:AdorningContentControl>
+                </c:PreviewItem>
               </DataTemplate>
             </ItemsRepeater.ItemTemplate>
             <ItemsRepeater.Layout>
@@ -68,7 +55,7 @@
       <!-- CJ fee  -->
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Label="Coinjoin fee:"
-                     Value="{Binding CoinJoinFee}">
+                     TextValue="{Binding CoinJoinFee}">
         <TextBlock Text="{Binding CoinJoinFeeString, Mode=OneWay}" />
       </c:PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
@@ -29,7 +29,7 @@
           <ItemsRepeater Items="{Binding TransactionIds}">
             <ItemsRepeater.ItemTemplate>
               <DataTemplate>
-                <c:PreviewItem Icon="{StaticResource transaction_id}" TextValue="{Binding }">
+                <c:PreviewItem TextValue="{Binding }">
                   <c:PrivacyContentControl NumberOfPrivacyChars="48">
                     <TextBlock Text="{Binding }" Classes="monoSpaced"/>
                   </c:PrivacyContentControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/CoinJoinDetailsView.axaml
@@ -16,8 +16,8 @@
 
       <!-- Date -->
       <c:PreviewItem Icon="{StaticResource timer_regular}"
-                     Text="Date"
-                     CopyParameter="{Binding Date}">
+                     Label="Date"
+                     Value="{Binding Date}">
         <TextBlock Text="{Binding Date}" />
       </c:PreviewItem>
 
@@ -25,7 +25,7 @@
 
       <!-- Transaction IDs -->
       <c:PreviewItem Icon="{StaticResource transaction_id}"
-                     Text="Transaction ID">
+                     Label="Transaction ID">
           <ItemsRepeater Items="{Binding TransactionIds}">
             <ItemsRepeater.ItemTemplate>
               <DataTemplate>
@@ -59,7 +59,7 @@
 
       <!-- Status -->
       <c:PreviewItem Icon="{StaticResource status_regular}"
-                     Text="Status">
+                     Label="Status">
         <TextBlock Text="{Binding Status}" />
       </c:PreviewItem>
 
@@ -67,8 +67,8 @@
 
       <!-- CJ fee  -->
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Text="Coinjoin fee:"
-                     CopyParameter="{Binding CoinJoinFee}">
+                     Label="Coinjoin fee:"
+                     Value="{Binding CoinJoinFee}">
         <TextBlock Text="{Binding CoinJoinFeeString, Mode=OneWay}" />
       </c:PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -16,7 +16,7 @@
       <!-- Date -->
       <c:PreviewItem Icon="{StaticResource timer_regular}"
                      Label="Date / Time"
-                     Value="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}">
+                     TextValue="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}">
         <TextBlock Text="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}"  Classes="monoSpaced"/>
       </c:PreviewItem>
       <Separator />
@@ -24,7 +24,7 @@
       <!-- Transaction ID -->
       <c:PreviewItem Icon="{StaticResource transaction_id}"
                      Label="Transaction ID"
-                     Value="{Binding TransactionId}">
+                     TextValue="{Binding TransactionId}">
         <c:PrivacyContentControl NumberOfPrivacyChars="48">
           <TextBlock Text="{Binding TransactionId}" Classes="monoSpaced"/>
         </c:PrivacyContentControl>
@@ -46,7 +46,7 @@
       <!-- Incoming amount  -->
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Label="Amount"
-                     Value="{Binding Amount}">
+                     TextValue="{Binding Amount}">
         <TextBlock Text="{Binding Amount, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
 
@@ -55,7 +55,7 @@
       <!-- Block height -->
       <c:PreviewItem Icon="{StaticResource block_height}"
                      Label="Block height"
-                     Value="{Binding BlockHeight}"
+                     TextValue="{Binding BlockHeight}"
                      IsVisible="{Binding IsConfirmed}">
         <TextBlock Text="{Binding BlockHeight}" />
       </c:PreviewItem>
@@ -64,7 +64,7 @@
       <!-- Confirmations -->
       <c:PreviewItem Icon="{StaticResource copy_confirmed}"
                      Label="Confirmations"
-                     Value="{Binding Confirmations}">
+                     TextValue="{Binding Confirmations}">
         <TextBlock Text="{Binding Confirmations}" />
       </c:PreviewItem>
 
@@ -73,7 +73,7 @@
       <!-- Labels -->
       <c:PreviewItem Icon="{StaticResource entities_regular}"
                      Label="Labels"
-                     Value="{Binding Labels}">
+                     TextValue="{Binding Labels}">
         <c:PrivacyContentControl NumberOfPrivacyChars="20">
           <c:TagsBox Padding="0" IsReadOnly="True" Items="{Binding Labels}" />
         </c:PrivacyContentControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/TransactionDetailsView.axaml
@@ -15,16 +15,16 @@
 
       <!-- Date -->
       <c:PreviewItem Icon="{StaticResource timer_regular}"
-                     Text="Date / Time"
-                     CopyParameter="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}">
+                     Label="Date / Time"
+                     Value="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}">
         <TextBlock Text="{Binding Date, StringFormat='{}{0:MM/dd/yyyy HH:mm}', Mode=OneWay}"  Classes="monoSpaced"/>
       </c:PreviewItem>
       <Separator />
 
       <!-- Transaction ID -->
       <c:PreviewItem Icon="{StaticResource transaction_id}"
-                     Text="Transaction ID"
-                     CopyParameter="{Binding TransactionId}">
+                     Label="Transaction ID"
+                     Value="{Binding TransactionId}">
         <c:PrivacyContentControl NumberOfPrivacyChars="48">
           <TextBlock Text="{Binding TransactionId}" Classes="monoSpaced"/>
         </c:PrivacyContentControl>
@@ -34,7 +34,7 @@
 
       <!-- Status -->
       <c:PreviewItem Icon="{StaticResource status_regular}"
-                     Text="Status">
+                     Label="Status">
         <Panel>
           <TextBlock Text="Confirmed" IsVisible="{Binding IsConfirmed}" />
           <TextBlock Text="Pending" IsVisible="{Binding !IsConfirmed}" />
@@ -45,8 +45,8 @@
 
       <!-- Incoming amount  -->
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Text="Amount"
-                     CopyParameter="{Binding Amount}">
+                     Label="Amount"
+                     Value="{Binding Amount}">
         <TextBlock Text="{Binding Amount, StringFormat={}{0} BTC, Mode=OneWay}" Classes="monoSpaced" />
       </c:PreviewItem>
 
@@ -54,8 +54,8 @@
 
       <!-- Block height -->
       <c:PreviewItem Icon="{StaticResource block_height}"
-                     Text="Block height"
-                     CopyParameter="{Binding BlockHeight}"
+                     Label="Block height"
+                     Value="{Binding BlockHeight}"
                      IsVisible="{Binding IsConfirmed}">
         <TextBlock Text="{Binding BlockHeight}" />
       </c:PreviewItem>
@@ -63,8 +63,8 @@
 
       <!-- Confirmations -->
       <c:PreviewItem Icon="{StaticResource copy_confirmed}"
-                     Text="Confirmations"
-                     CopyParameter="{Binding Confirmations}">
+                     Label="Confirmations"
+                     Value="{Binding Confirmations}">
         <TextBlock Text="{Binding Confirmations}" />
       </c:PreviewItem>
 
@@ -72,8 +72,8 @@
 
       <!-- Labels -->
       <c:PreviewItem Icon="{StaticResource entities_regular}"
-                     Text="Labels"
-                     CopyParameter="{Binding Labels}">
+                     Label="Labels"
+                     Value="{Binding Labels}">
         <c:PrivacyContentControl NumberOfPrivacyChars="20">
           <c:TagsBox Padding="0" IsReadOnly="True" Items="{Binding Labels}" />
         </c:PrivacyContentControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -10,14 +10,14 @@
              x:Class="WalletWasabi.Fluent.Views.Wallets.Send.TransactionSummary">
   <StackPanel Spacing="15">
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Text="a total of">
+                     Label="a total of">
         <TextBlock Text="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
       </c:PreviewItem>
 
       <Separator />
 
       <c:PreviewItem Icon="{StaticResource transceive_regular}"
-                     Text="will be sent to the Bitcoin address">
+                     Label="will be sent to the Bitcoin address">
         <TextBlock Classes="monoSpaced" Text="{Binding AddressText, FallbackValue=btc029382398fkj34f98df239823}" />
       </c:PreviewItem>
 
@@ -45,12 +45,12 @@
 
         <StackPanel Spacing="10">
           <c:PreviewItem Icon="{StaticResource timer_regular}"
-                         Text="your transaction should be confirmed within"
+                         Label="your transaction should be confirmed within"
                          IsVisible="{Binding !IsCustomFeeUsed}">
             <TextBlock Text="{Binding ConfirmationTimeText, FallbackValue=~20 minutes }" />
           </c:PreviewItem>
           <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
-                         Text="there will be an additional transaction fee of">
+                         Label="there will be an additional transaction fee of">
             <TextBlock Text="{Binding FeeText, FallbackValue=0.00000235 bitcoin (≈55.34 USD)}" />
           </c:PreviewItem>
         </StackPanel>


### PR DESCRIPTION
This replaces the workaround introduced in https://github.com/zkSNACKs/WalletWasabi/pull/7578 with a proper solution.

- The logic has been reviewed to improve the design and simplify it.
- The clipboard copy logic has been segregated into a different specialized control `ClipboardCopyButton` that will enable us to better adhere to the SRP.
~~- Improved UX: when the user copies the text to the clipboard, a small feedback popup appears showing "Copied" for 2 seconds and disappears. This behavior is similar a many applications/websites like GitHub's copy repo URL button.~~
- Usage of `PrewiewItem` is now consistent in transaction detail views.
- Eliminated the need to pass `CommandParameter`'s, that makes code less obvious.
https://user-images.githubusercontent.com/3109851/160582342-2bcef3e1-504b-4bdd-be06-0f23af65a8c9.mp4


https://user-images.githubusercontent.com/3109851/160589576-8e638b28-1e1e-410c-8c9f-347930e6f4cc.mp4


