### PR TITLE
Increase number of generated decompositions

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -261,7 +261,7 @@ public class AmountDecomposer
 			foreach (var (sum, count, decomp) in Decomposer.Decompose(
 				target: (long)myInputSum,
 				tolerance: (long)Math.Max(loss, 0.5 * (ulong)MinAllowedOutputAmountPlusFee),
-				maxCount: Math.Min(maxNumberOfOutputsAllowed, Math.Max(5, naiveSet.Count)),
+				maxCount: 8,
 				stdDenoms: stdDenoms))
 			{
 				var currentSet = Decomposer.ToRealValuesArray(


### PR DESCRIPTION
As we discussed in a pair-programming session with @nopara73, the amount of generated decompositions is low. 
In rare cases there is only one.

This PR maxes out the decompositions AFAIK.