### PR TITLE
[VDG] Fix fee slider initial value

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/FeeChartViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/FeeChartViewModel.cs
@@ -187,7 +187,7 @@ public partial class FeeChartViewModel : ViewModelBase
 
 		try
 		{
-			var closestValue = SatoshiPerByteValues.Last(x => (decimal)x <= feeRate.SatoshiPerByte);
+			var closestValue = SatoshiPerByteValues.Last(x => new FeeRate((decimal)x) <= feeRate);
 			var indexOfClosestValue = SatoshiPerByteValues.LastIndexOf(closestValue);
 
 			target = ConfirmationTargetValues[indexOfClosestValue];


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/7642

`FeeRate` class is not as accurate as `decimal` so due to the lost fraction it did not find the exact value.
Comparing `FeeRate` to `FeeRate` solves it.