### PR TITLE
Thread safe random number generator

### DIFF
--- a/WalletWasabi/Crypto/Randomness/InsecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/InsecureRandom.cs
@@ -4,7 +4,7 @@ public class InsecureRandom : WasabiRandom
 {
 	public InsecureRandom()
 	{
-		Random = new Random();
+		Random = Random.Shared;
 	}
 
 	private Random Random { get; }


### PR DESCRIPTION
### Issue
I was looking for the reason why the tests `TimeoutSufficientPeersAsync` and `TimeoutInsufficientPeersAsync` nondeterministically fails with:

```
[xUnit.net 00:00:04.75]     TimeoutInsufficientPeersAsync [FAIL]
  Failed TimeoutInsufficientPeersAsync [3 s]
  Error Message:
   WalletWasabi.WabiSabi.Crypto.WabiSabiCryptoException : Serial number reused
  Stack Trace:
     at WalletWasabi.WabiSabi.Crypto.CredentialIssuer.HandleRequest(ICredentialsRequest registrationRequest) in WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs:line 170
   at WalletWasabi.WabiSabi.Crypto.CredentialIssuer.<>c__DisplayClass27_0.<HandleRequestAsync>b__0() in WalletWasabi/WabiSabi/Crypto/CredentialIssuer.cs:line 102
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__271_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at WalletWasabi.WabiSabi.Backend.Rounds.Arena.RegisterOutputCoreAsync(OutputRegistrationRequest request, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs:line 289
   at WalletWasabi.WabiSabi.Client.ArenaClient.RegisterOutputAsync(uint256 roundId, Script scriptPubKey, IEnumerable`1 amountCredentialsToPresent, IEnumerable`1 vsizeCredentialsToPresent, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/ArenaClient.cs:line 80
   at WalletWasabi.WabiSabi.Client.BobClient.RegisterOutputAsync(Script scriptPubKey, IEnumerable`1 amountCredentials, IEnumerable`1 vsizeCredentials, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/BobClient.cs:line 22
   at WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping.StepTransactionSigningTests.CreateRoundWithOutputsReadyToSignAsync(Arena arena, IKeyChain keyChain, SmartCoin coin1, SmartCoin coin2) in WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs:line 261
   at WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping.StepTransactionSigningTests.TimeoutInsufficientPeersAsync() in WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs:line 153
--- End of stack trace from previous location ---

Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1, Duration: < 1 ms
```

I turned out that the random number generator that is used in tests is not thread-safe while it is used by multiple threads concurrently. As consequence, it sometimes generate two identical sequences of bytes in a row.

### PR
This tiny PR should fix it, see the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.random?view=net-6.0).

### Related problems
The random number generator that is used in production seems to be thread-safe. Although I couldn't find it in the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator?view=net-6.0), [this post](https://github.com/dotnet/dotnet-api-docs/issues/3741#issuecomment-718989978) claims it and my quick tests confirm it.

Anyway, the behaviour may vary from platform to platform, so I would strongly recommend you to make the class `SecureRandom` explicitly thread-safe with the lock statement. A bad random number generator can have disastrous consequences.