### PR TITLE
[VDG] Call BnB cancellation when it is safe

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -425,8 +425,6 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 
 	private async Task OnConfirmAsync()
 	{
-		_cancellationTokenSource.Cancel();
-
 		var transaction = await Task.Run(() => TransactionHelpers.BuildTransaction(_wallet, _info, _destination));
 		var transactionAuthorizationInfo = new TransactionAuthorizationInfo(transaction);
 		var authResult = await AuthorizeAsync(transactionAuthorizationInfo);
@@ -439,6 +437,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				var finalTransaction =
 					await GetFinalTransactionAsync(transactionAuthorizationInfo.Transaction, _info);
 				await SendTransactionAsync(finalTransaction);
+				_cancellationTokenSource.Cancel();
 				Navigate().To(new SendSuccessViewModel(_wallet, finalTransaction));
 			}
 			catch (Exception ex)


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/7648

BnB cancellation was called immediately when the user pressed the `Confirm` button, which caused a crash in the case when the user canceled the confirmation dialog and tried to modify something (something that cause a rebuild).

I moved the cancellation call after the broadcasting because if that finishes successfully we can make sure there is no need anymore for the BnB.