### PR TITLE
More correct `.editorconfig` for `WalletWasabi/Nito`

### DIFF
--- a/WalletWasabi/Nito/.editorconfig
+++ b/WalletWasabi/Nito/.editorconfig
@@ -1,5 +1,11 @@
-# For all files.
-[*]
+root = true
 
-# Workaround to suppress all warnings in the Nito folder
-generated_code = true
+[*.cs]
+
+# Disable all .NET analyzers
+dotnet_analyzer_diagnostic.severity = none
+
+# Disable nullable reference type warnings
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8601.severity = none
+dotnet_diagnostic.CS8604.severity = none


### PR DESCRIPTION
Related to #7595

Number of warnings seems to drop by 20 (477 -> 457).

## Resources

* https://til.cazzulino.com/dotnet/disable-diagnostic-analyzers-for-entire-folder-submodules