### PR TITLE
Fix Equality Comparision

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -510,7 +510,7 @@ public class CoinJoinClient
 		var constructionState = roundState.Assert<ConstructionState>();
 
 		AmountDecomposer amountDecomposer = new(roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts, Constants.P2wpkhOutputSizeInBytes, (int)availableVsize);
-		var theirCoins = constructionState.Inputs.Except(registeredCoins);
+		var theirCoins = constructionState.Inputs.Where(x => !registeredCoins.Any(y => x.Outpoint == y.Outpoint));
 		var registeredCoinEffectiveValues = registeredAliceClients.Select(x => x.EffectiveValue);
 		var theirCoinEffectiveValues = theirCoins.Select(x => x.EffectiveValue(roundState.FeeRate, roundState.CoordinationFeeRate));
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);


### PR DESCRIPTION
@MaxHillebrand 

The amount organization did not work properly. Accidentally the frequency table was calculated by every client in a way that they double counted users' own coins, because this equality comparison did not work: NBitcoin does not implement equality for `Coin` and the parameters to the amount organizer was relying on that assumption that it does.

Fixing this off by one error is a huge improvement to the amount organization. This will reduce the changes drastically.