### PR TITLE
[WabiSabi] Let CoinJoinClient communicate using events

### DIFF
--- a/WalletWasabi/Extensions/EventHandlerExtensions.cs
+++ b/WalletWasabi/Extensions/EventHandlerExtensions.cs
@@ -1,0 +1,18 @@
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Extensions;
+
+public static class EventHandlerExtensions
+{
+	public static void SafeInvoke<T>(this EventHandler<T>? handler, object sender, T args) where T : EventArgs
+	{
+		try
+		{
+			handler?.Invoke(sender, args);
+		}
+		catch (Exception e)
+		{
+			Logger.LogError(e);
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -54,6 +54,7 @@ public class CoinJoinClient
 		DoNotRegisterInLastMinuteTimeLimit = doNotRegisterInLastMinuteTimeLimit;
 	}
 
+	public EventHandler<CoinJoinProgressEventArgs>? CoinJoinClientProgress;
 	private SecureRandom SecureRandom { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	private IKeyChain KeyChain { get; }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEventArgs.cs
@@ -3,3 +3,10 @@ namespace WalletWasabi.WabiSabi.Client;
 public class CoinJoinProgressEventArgs : EventArgs
 {
 }
+
+public class CoinJoinEnteringInCriticalPhaseEventArgs : CoinJoinProgressEventArgs
+{
+}
+public class CoinJoinLeavingCriticalPhaseEventArgs : CoinJoinProgressEventArgs
+{
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEventArgs.cs
@@ -1,0 +1,5 @@
+namespace WalletWasabi.WabiSabi.Client;
+
+public class CoinJoinProgressEventArgs : EventArgs
+{
+}


### PR DESCRIPTION
Currently the CJCs have no mechanism for communicating with the outside world what is going on internally, for example: are we starting a blame round? what number of attempt? are we in critical phase? etc.

To solve this limitation we introduced properties and update its value to allow other components to check and decide what to do accordingly, problems are notified  by exceptions, other by returned value others by updating the smartCoins and so on. 

This PR is the beginning of a more general mechanism for doing communicating with events.

It is not done. It will we on draft until no more higher priority task in the todo list.