### PR TITLE
[VDG] Help&Support - Move Advanded Information to the bottom

### DIFF
--- a/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
+++ b/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
@@ -77,7 +77,15 @@
                 </DataTemplate>
               </ItemsControl.DataTemplates>
             </ItemsControl>
-            <!-- Advanced -->
+          </StackPanel>
+          <!-- License -->
+            <WrapPanel HorizontalAlignment="Center">
+              <TextBlock Margin=" 0 0 0 -0.5"
+                         VerticalAlignment="Center"
+                         Text="This open source software is licensed with " />
+              <ContentControl Content="{Binding License}" />
+            </WrapPanel>
+           <!-- Advanced -->
             <Button HorizontalAlignment="Center" Classes="plain obscured"
                     Command="{Binding AboutAdvancedInfoDialogCommand}">
               <StackPanel Orientation="Horizontal" Spacing="5" Margin="2">
@@ -85,14 +93,6 @@
                 <TextBlock Text="Advanced Information" Classes="Hyperlink" />
               </StackPanel>
             </Button>
-            <!-- License -->
-            <WrapPanel HorizontalAlignment="Center">
-              <TextBlock Margin=" 0 0 0 -0.5"
-                         VerticalAlignment="Center"
-                         Text="This open source software is licensed with " />
-              <ContentControl Content="{Binding License}" />
-            </WrapPanel>
-          </StackPanel>
         </DockPanel>
       </DockPanel>
     </controls:ContentArea>

--- a/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
+++ b/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
@@ -79,15 +79,18 @@
             </ItemsControl>
           </StackPanel>
           <!-- License -->
-            <WrapPanel HorizontalAlignment="Center">
+          <DockPanel HorizontalAlignment="Center" DockPanel.Dock="Top">
               <TextBlock Margin=" 0 0 0 -0.5"
                          VerticalAlignment="Center"
                          Text="This open source software is licensed with " />
               <ContentControl Content="{Binding License}" />
-            </WrapPanel>
-           <!-- Advanced -->
-            <Button HorizontalAlignment="Center" Classes="plain obscured"
-                    Command="{Binding AboutAdvancedInfoDialogCommand}">
+          </DockPanel>
+          <!-- Advanced -->
+          <Button DockPanel.Dock="Bottom"
+                  HorizontalAlignment="Center" 
+                  VerticalAlignment="Bottom"
+                  Classes="plain obscured"
+                  Command="{Binding AboutAdvancedInfoDialogCommand}">
               <StackPanel Orientation="Horizontal" Spacing="5" Margin="2">
                 <PathIcon Data="{StaticResource info_regular}" />
                 <TextBlock Text="Advanced Information" Classes="Hyperlink" />

--- a/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
+++ b/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
@@ -62,7 +62,7 @@
                   <Setter Property="VerticalAlignment" Value="Center" />
                 </Style>
                 <Style Selector="ItemsControl /template/ #PART_ItemsPresenter > WrapPanel">
-                  <Setter Property="HorizontalAlignment" Value="Stretch" />
+                  <Setter Property="HorizontalAlignment" Value="Center" />
                 </Style>
                 <Style Selector="ItemsControl.narrow /template/ #PART_ItemsPresenter > WrapPanel">
                   <Setter Property="HorizontalAlignment" Value="Center" />

--- a/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
+++ b/WalletWasabi.Fluent/Views/HelpAndSupport/AboutView.axaml
@@ -37,7 +37,7 @@
         </Viewbox>
         <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Text="{Binding ClientVersion}" Margin="0,5,0,50" Opacity="0.5" />
         <DockPanel>
-          <StackPanel Spacing="10" DockPanel.Dock="Bottom" HorizontalAlignment="Stretch" Orientation="Vertical">
+          <StackPanel Spacing="10" DockPanel.Dock="Top" HorizontalAlignment="Stretch" Orientation="Vertical">
             <!-- Links -->
             <ItemsControl Items="{Binding Links}"
                           Margin="0 0 0 25"


### PR DESCRIPTION
For consistency, everywhere in the GUI `advanced` is displayed at the bottom

Current
![image](https://user-images.githubusercontent.com/93143998/161152459-31124376-2d88-428a-914d-3c17bfd675fc.png)

This PR
![image](https://user-images.githubusercontent.com/93143998/161152802-1004f3d9-3832-424e-89fe-f659fe8108ed.png)
