### PR TITLE
[VDG] Transaction History - huge cleanup

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using NBitcoin;
 using ReactiveUI;
@@ -40,39 +41,19 @@ public class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 	{
 		IsConfirmed = CoinJoinTransactions.All(x => x.IsConfirmed());
 		Date = CoinJoinTransactions.Select(tx => tx.DateTime).Max().ToLocalTime();
-		UpdateAmount();
+		OutgoingAmount = CoinJoinTransactions.Sum(x => x.Amount) * -1;
 		UpdateDateString();
-	}
-
-	public override void Update(HistoryItemViewModelBase item)
-	{
-		if (item is not CoinJoinsHistoryItemViewModel coinJoinHistoryItemViewModel)
-		{
-			throw new InvalidOperationException("Not the same type!");
-		}
-
-		CoinJoinTransactions = coinJoinHistoryItemViewModel.CoinJoinTransactions;
-		UpdateAmount();
-
-		base.Update(item);
-
-		this.RaisePropertyChanged();
 	}
 
 	protected void UpdateDateString()
 	{
-		var dates = CoinJoinTransactions.Select(tx => tx.DateTime);
+		var dates = CoinJoinTransactions.Select(tx => tx.DateTime).ToImmutableArray();
 		var firstDate = dates.Min().ToLocalTime();
 		var lastDate = dates.Max().ToLocalTime();
 
 		DateString = firstDate.Day == lastDate.Day
 			? $"{firstDate:MM/dd/yy}"
 			: $"{firstDate:MM/dd/yy} - {lastDate:MM/dd/yy}";
-	}
-
-	private void UpdateAmount()
-	{
-		OutgoingAmount = CoinJoinTransactions.Sum(x => x.Amount) * -1;
 	}
 
 	public void SetBalance(Money balance)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
@@ -47,16 +47,6 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 
 	public ICommand? ShowDetailsCommand { get; protected set; }
 
-	public virtual void Update(HistoryItemViewModelBase item)
-	{
-		OrderIndex = item.OrderIndex;
-		Date = item.Date;
-		DateString = item.DateString;
-		IsConfirmed = item.IsConfirmed;
-	}
-
-	public bool IsSimilar(HistoryItemViewModelBase item) => Id == item.Id;
-
 	public static Comparison<HistoryItemViewModelBase?> SortAscending<T>(Func<HistoryItemViewModelBase, T> selector)
 	{
 		return (x, y) =>

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -30,11 +30,14 @@ public partial class HistoryViewModel : ActivatableViewModel
 	private readonly IObservable<Unit> _updateTrigger;
 	private readonly ObservableCollectionExtended<HistoryItemViewModelBase> _transactions;
 	private readonly ObservableCollectionExtended<HistoryItemViewModelBase> _unfilteredTransactions;
-	private readonly object _transactionListLock = new();
 
 	[AutoNotify] private HistoryItemViewModelBase? _selectedItem;
-	[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _isTransactionHistoryEmpty;
-	[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _isInitialized;
+
+	[AutoNotify(SetterModifier = AccessModifier.Private)]
+	private bool _isTransactionHistoryEmpty;
+
+	[AutoNotify(SetterModifier = AccessModifier.Private)]
+	private bool _isInitialized;
 
 	public HistoryViewModel(WalletViewModel walletViewModel, IObservable<Unit> updateTrigger)
 	{
@@ -210,45 +213,15 @@ public partial class HistoryViewModel : ActivatableViewModel
 			var rawHistoryList = await Task.Run(historyBuilder.BuildHistorySummary);
 			var newHistoryList = GenerateHistoryList(rawHistoryList).ToArray();
 
-			lock (_transactionListLock)
+			_transactionSourceList.Edit(x =>
 			{
-				_transactionSourceList.Edit(x =>
-				{
-					var copyList = Transactions.ToList();
+				x.Clear();
+				x.AddRange(newHistoryList);
+			});
 
-					foreach (var oldItem in copyList)
-					{
-						if (newHistoryList.All(x => x.Id != oldItem.Id))
-						{
-							x.Remove(oldItem);
-						}
-					}
-
-					foreach (var newItem in newHistoryList)
-					{
-						if (_transactions.FirstOrDefault(x => x.Id == newItem.Id) is { } item)
-						{
-							if (item.GetType() != newItem.GetType())
-							{
-								x.Remove(item);
-								x.Add(newItem);
-							}
-							else
-							{
-								item.Update(newItem);
-							}
-						}
-						else
-						{
-							x.Add(newItem);
-						}
-					}
-				});
-
-				if (!IsInitialized)
-				{
-					IsInitialized = true;
-				}
+			if (!IsInitialized)
+			{
+				IsInitialized = true;
 			}
 		}
 		catch (Exception ex)
@@ -286,8 +259,8 @@ public partial class HistoryViewModel : ActivatableViewModel
 			}
 
 			if (coinJoinGroup is { } cjg &&
-				(i + 1 < txRecordList.Count && !txRecordList[i + 1].IsOwnCoinjoin || // The next item is not CJ so add the group.
-				 i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
+			    (i + 1 < txRecordList.Count && !txRecordList[i + 1].IsOwnCoinjoin || // The next item is not CJ so add the group.
+			     i == txRecordList.Count - 1)) // There is no following item in the list so add the group.
 			{
 				cjg.SetBalance(balance);
 				yield return cjg;


### PR DESCRIPTION
When we were using `DataGrid` and performance was questionable it made sense to not clear all the items from the `DataGrid` but just update the ones that changed. The downside of it was that sometimes the newly received raw history list was different compared to the previous one (CJ transaction detected as normal or vice versa, outgoing amount detected as incoming, etc), and it caused exceptions and weird information in the list.

With the new `TreeDataGrid` control, all this logic can be removed since the performance is way better and there is no benefit to having them, rather just a complex code and maintenance burden. By this, there won't be exceptions and different information.

Although there is still something to improve somewhere because the cases above should not happen.