### PR TITLE
Add `.editorconfig` for the external `Gma` library

### DIFF
--- a/WalletWasabi/Gma/.editorconfig
+++ b/WalletWasabi/Gma/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*.cs]
+
+# Disable all .NET analyzers
+dotnet_analyzer_diagnostic.severity = none
+
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8601.severity = none
+dotnet_diagnostic.CS8603.severity = none
+dotnet_diagnostic.CS8604.severity = none
+dotnet_diagnostic.CS8618.severity = none
+dotnet_diagnostic.CS8619.severity = none
+dotnet_diagnostic.CS8625.severity = none
+dotnet_diagnostic.CS8765.severity = none
+dotnet_diagnostic.CS8767.severity = none


### PR DESCRIPTION
Similar to #7664 and #7677.

End result[^1]: 457 warnings -> 449 warnings

[^1]: I don't vouch for the `.editorconfig` being "minimal". Some lines might be extra but I don't think we should spend more time on this. In this case I think we just want to get the job done.