### PR TITLE
Re-implement `SecureRandom`

### DIFF
--- a/WalletWasabi/Crypto/Randomness/InsecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/InsecureRandom.cs
@@ -1,5 +1,6 @@
 namespace WalletWasabi.Crypto.Randomness;
 
+/// <seealso href="https://devblogs.microsoft.com/pfxteam/getting-random-numbers-in-a-thread-safe-way/"/>>
 public class InsecureRandom : WasabiRandom
 {
 	public InsecureRandom()

--- a/WalletWasabi/Crypto/Randomness/SecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/SecureRandom.cs
@@ -4,38 +4,22 @@ namespace WalletWasabi.Crypto.Randomness;
 
 public class SecureRandom : WasabiRandom
 {
-	private bool _disposedValue;
-
 	public SecureRandom()
 	{
-		Random = RandomNumberGenerator.Create();
+	}
+	
+	public override void GetBytes(byte[] buffer)
+	{
+		RandomNumberGenerator.Fill(buffer);
 	}
 
-	private RandomNumberGenerator Random { get; }
-
-	public override void GetBytes(byte[] buffer) => Random.GetBytes(buffer);
-
-	public override void GetBytes(Span<byte> buffer) => Random.GetBytes(buffer);
-
-	public override int GetInt(int fromInclusive, int toExclusive) => RandomNumberGenerator.GetInt32(fromInclusive, toExclusive);
-
-	protected virtual void Dispose(bool disposing)
+	public override void GetBytes(Span<byte> buffer)
 	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				Random?.Dispose();
-			}
-
-			_disposedValue = true;
-		}
+		RandomNumberGenerator.Fill(buffer);
 	}
 
-	public override void Dispose()
+	public override int GetInt(int fromInclusive, int toExclusive)
 	{
-		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		return RandomNumberGenerator.GetInt32(fromInclusive, toExclusive);		
 	}
 }


### PR DESCRIPTION
Follow-up to #7654 (and my [comment](https://github.com/zkSNACKs/WalletWasabi/pull/7654#issuecomment-1082333041))

An initial stab to address thread-safety concerns regarding [RandomNumberGenerator](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator?view=net-6.0).

The gist of possible issue is that `RandomNumberGenerator` is not documented to be thread-safe[^1]. To be on a safe side, we should make sure that it really thread-safe is, otherwise we risk #7117 scenario and probably many other bad scenarios.

So there are several ways to make really sure we are safe and that is:

1) Wrap `SecureRandom` internal calls to `RandomNumberGenerator` in `lock` blocks and be done with it.
    * The disadvantage of this approach is that if multiple threads re-use given `SecureRandom` instance then lock contention might be an issue.
    * It seems to me that we instantiate `SecureRandom` in many cases so the scenario of locking contention does not seem to be problematic (currently).
2) https://github.com/dotnet/runtime/blob/041933fd086f69f839cf38733dd56a1ea9f09866/src/libraries/System.Private.CoreLib/src/System/Random.cs#L220-L334 - this is the approach that `Random.Shared` uses which was used in #7654.
    * Not sure if this can modify statistical properties of `RandomNumberGenerator` but I'm not a statistician.
3) **Use [RandomNumberGenerator.Fill(buffer)]() which should be thread-safe based on [this](https://github.com/dotnet/runtime/issues/40169#issuecomment-670174207) and also that API function makes no sense unless it's thread-safe because it's static.**
 
This PR goes with the option 3.

Any review of this PR should be really *serious* in the sense that it's certianly not sufficient to say that "it appears to work".

[^1]: I failed to find any such information. If you know about any such remark, please let me know.

cc @lontivero, @onvej-sl for any opinion on this.

## Resources

Some relevant some not.

* https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator?view=net-6.0
* https://codeblog.jonskeet.uk/2009/11/04/revisiting-randomness/
* https://devblogs.microsoft.com/pfxteam/getting-random-numbers-in-a-thread-safe-way/
* https://github.com/dotnet/dotnet-api-docs/issues/3741 - Document thread safety of RandomNumberGenerator
* https://lowleveldesign.org/2018/08/15/randomness-in-net/ (2018)
* https://stackoverflow.com/questions/38530207/how-to-make-a-c-sharp-thread-safe-random-number-generator?answertab=scoredesc#tab-top
* https://stackoverflow.com/questions/3049467/is-c-sharp-random-number-generator-thread-safe
* https://stackoverflow.com/questions/31908529/randomnumbergenerator-proper-usage
* https://docs.microsoft.com/en-us/dotnet/api/system.random?redirectedfrom=MSDN&view=net-6.0#the-systemrandom-class-and-thread-safety
* https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator.getint32?view=net-6.0
* https://twitter.com/kookiz/status/1281537528357629952
* https://dotnetcoretutorials.com/2021/08/10/generating-random-numbers-in-net/
* https://github.com/dotnet/runtime/issues/42769 - API proposal: RandomNumberGenerator.GetBytes(int) 
  * https://github.com/dotnet/runtime/pull/43221 - Implement RandomNumberGenerator.GetBytes