### PR TITLE
Adjust wallet header text fade out

### DIFF
--- a/WalletWasabi.Fluent/Controls/FadeOutTextBlock.cs
+++ b/WalletWasabi.Fluent/Controls/FadeOutTextBlock.cs
@@ -23,8 +23,8 @@ public class FadeOutTextBlock : TextBlock, IStyleable
 		GradientStops =
 		{
 			new GradientStop {Color = Colors.White, Offset = 0},
-			new GradientStop {Color = Colors.White, Offset = 0.5},
-			new GradientStop {Color = Colors.Transparent, Offset = 0.77}
+			new GradientStop {Color = Colors.White, Offset = 0.7},
+			new GradientStop {Color = Colors.Transparent, Offset = 0.9}
 		}
 	}.ToImmutable();
 

--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -98,7 +98,7 @@
     <Style Selector="c|NavBarItem :is(Panel).NavBarItemPanel DockPanel LayoutTransformControl">
       <Setter Property="LayoutTransform" Value="scaleY(1)" />
       <Setter Property="Opacity" Value="1" />
-      <Setter Property="Margin" Value="2, 0" />
+      <Setter Property="Margin" Value="1, 0" />
       <Setter Property="Transitions">
         <Transitions>
           <TransformOperationsTransition Property="LayoutTransform" Duration="0:0:0.175" />


### PR DESCRIPTION
Make the header text's fadeout a little less aggressive.

cc @MaxHillebrand @zkSNACKs/visual-design-group 