### PR TITLE
Add `CoinJoinIdStore` to store old and new coinjoins at one place

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -90,8 +90,9 @@ public class Global : IDisposable
 		Coordinator = new(RpcClient.Network, blockNotifier, Path.Combine(DataDir, "CcjCoordinator"), RpcClient, roundConfig);
 		Coordinator.CoinJoinBroadcasted += Coordinator_CoinJoinBroadcasted;
 
+		// First, import all coinjoins to one place, so CoinJoinIdStore can load all into memory during creation
+		CoinJoinIdStore.ImportWW1CoinJoinsToWW2(Coordinator.CoinJoinsFilePath, coordinatorParameters.CoinJoinIdStoreFilePath);
 		CoinJoinIdStore = new(coordinatorParameters.CoinJoinIdStoreFilePath);
-		CoinJoinIdStore.InMemoryCoinJoinIdStore.ImportWW1CoinJoinsToWW2(Coordinator.CoinJoinsFilePath, coordinatorParameters.CoinJoinIdStoreFilePath);
 
 		HostedServices.Register<WabiSabiCoordinator>(() => new WabiSabiCoordinator(coordinatorParameters, RpcClient, CoinJoinIdStore), "WabiSabi Coordinator");
 		HostedServices.Register<RoundBootstrapper>(() => new RoundBootstrapper(TimeSpan.FromMilliseconds(100), Coordinator), "Round Bootstrapper");

--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -22,7 +22,7 @@ public class ArenaBuilder
 	public WabiSabiConfig? Config { get; set; }
 	public IRPCClient? Rpc { get; set; }
 	public Prison? Prison { get; set; }
-	public CoinJoinIdStore? CoinJoinIdStore { get; set; }
+	public ICoinJoinIdStore? CoinJoinIdStore { get; set; }
 
 	/// <param name="rounds">Rounds to initialize <see cref="Arena"/> with.</param>
 	public Arena Create(params Round[] rounds)
@@ -32,7 +32,7 @@ public class ArenaBuilder
 		WabiSabiConfig config = Config ?? new();
 		IRPCClient rpc = Rpc ?? WabiSabiFactory.CreatePreconfiguredRpcClient().Object;
 		Network network = Network ?? Network.Main;
-		CoinJoinIdStore coinJoinIdStore = CoinJoinIdStore ?? new();
+		ICoinJoinIdStore coinJoinIdStore = CoinJoinIdStore ?? new CoinJoinIdStore();
 
 		Arena arena = new(period, network, config, rpc, prison, coinJoinIdStore);
 
@@ -65,7 +65,7 @@ public class ArenaBuilder
 		}
 	}
 
-	public ArenaBuilder With(CoinJoinIdStore store)
+	public ArenaBuilder With(ICoinJoinIdStore store)
 	{
 		CoinJoinIdStore = store;
 		return this;

--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -22,7 +22,7 @@ public class ArenaBuilder
 	public WabiSabiConfig? Config { get; set; }
 	public IRPCClient? Rpc { get; set; }
 	public Prison? Prison { get; set; }
-	public InMemoryCoinJoinIdStore? CoinJoinIdStore { get; set; }
+	public CoinJoinIdStore? CoinJoinIdStore { get; set; }
 
 	/// <param name="rounds">Rounds to initialize <see cref="Arena"/> with.</param>
 	public Arena Create(params Round[] rounds)
@@ -32,7 +32,7 @@ public class ArenaBuilder
 		WabiSabiConfig config = Config ?? new();
 		IRPCClient rpc = Rpc ?? WabiSabiFactory.CreatePreconfiguredRpcClient().Object;
 		Network network = Network ?? Network.Main;
-		InMemoryCoinJoinIdStore coinJoinIdStore = CoinJoinIdStore ?? new();
+		CoinJoinIdStore coinJoinIdStore = CoinJoinIdStore ?? new();
 
 		Arena arena = new(period, network, config, rpc, prison, coinJoinIdStore);
 
@@ -65,7 +65,7 @@ public class ArenaBuilder
 		}
 	}
 
-	public ArenaBuilder With(InMemoryCoinJoinIdStore store)
+	public ArenaBuilder With(CoinJoinIdStore store)
 	{
 		CoinJoinIdStore = store;
 		return this;

--- a/WalletWasabi.Tests/UnitTests/CoinjoinIdStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/CoinjoinIdStoreTests.cs
@@ -1,0 +1,64 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests;
+
+public class CoinjoinIdStoreTests
+{
+	[Fact]
+	public void CanAdd()
+	{
+		var cjIdStore = new CoinJoinIdStore();
+
+		cjIdStore.TryAdd(uint256.One);
+
+		Assert.True(cjIdStore.Contains(uint256.One));
+
+		cjIdStore.TryAdd(uint256.One);
+		cjIdStore.TryAdd(uint256.One);
+
+		Assert.Single(cjIdStore.GetCoinJoinIds);
+	}
+
+	[Fact]
+	public void CanValidate()
+	{
+		var listOfCoinjoinHashes = new List<string>
+		{
+			"9690826aab03c7b9ca15af2d79083445df1ac94e79858acc146efa9a52c73b5b",
+			"a79e7544d32f9c5e0c3a6ed9bcbb29723125f38461bb7a735823eddc7dac7ad2",
+			"90f1e3893a890ae314fba50c3dc870b0b5e5aab6e14f9e0fe9e56c95f20a2b36",
+			"1fa685dbf8273369762a4f88ad1ce7f3fd14907130b878fbbb96e4140bf2bc96"
+		};
+
+		IEnumerable<uint256> ids = CoinJoinIdStore.GetValidCoinjoinIds(listOfCoinjoinHashes, out var validCoinjoinIds, out bool wasError);
+
+		Assert.Equal(listOfCoinjoinHashes.Count, ids.Count());
+		Assert.Equal(listOfCoinjoinHashes, validCoinjoinIds);
+		Assert.False(wasError);
+	}
+
+	[Fact]
+	public void CanTolerateError()
+	{
+		var listOfCoinjoinHashes = new List<string>
+		{
+			"9690826aab03c7b9ca15af2d79083445df1ac94e79858acc146efa9a52c73b5b",
+			"dummy",
+			"90f1e3893a890ae314fba50c3dc870b0b5e5aab6e14f9e0fe9e56c95f20a2b36",
+			"1fa685dbf8273369762a4f88ad1ce7f3fd14907130b878fbbb96e4140bf2bc96"
+		};
+
+		IEnumerable<uint256> ids = CoinJoinIdStore.GetValidCoinjoinIds(listOfCoinjoinHashes, out var validCoinjoinIds, out bool wasError);
+
+		Assert.Equal(ids.Count(), validCoinjoinIds.Count);
+		Assert.Equal(ids.Count(), listOfCoinjoinHashes.Count - 1);
+		Assert.True(wasError);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
@@ -10,6 +10,7 @@ using WalletWasabi.JsonConverters.Timing;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
@@ -22,7 +23,7 @@ public class ConfigTests
 		var workDir = Common.GetWorkDir();
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 		CoordinatorParameters coordinatorParameters = new(workDir);
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator.StartAsync(CancellationToken.None);
 
 		Assert.True(File.Exists(Path.Combine(workDir, "WabiSabiConfig.json")));
@@ -38,7 +39,7 @@ public class ConfigTests
 		CoordinatorParameters coordinatorParameters = new(workDir);
 
 		// Create the config first with default value.
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator.StartAsync(CancellationToken.None);
 		await coordinator.StopAsync(CancellationToken.None);
 
@@ -52,7 +53,7 @@ public class ConfigTests
 		configChanger.ToFile();
 
 		// Assert the new value is loaded and not the default one.
-		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator2.StartAsync(CancellationToken.None);
 		Assert.Equal(newTarget, coordinator2.Config.ConfirmationTarget);
 		await coordinator2.StopAsync(CancellationToken.None);
@@ -66,7 +67,7 @@ public class ConfigTests
 		CoordinatorParameters coordinatorParameters = new(workDir);
 
 		// Create the config first with default value.
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator.StartAsync(CancellationToken.None);
 		await coordinator.StopAsync(CancellationToken.None);
 
@@ -79,7 +80,7 @@ public class ConfigTests
 
 		// Assert the new default value is loaded.
 		CoordinatorParameters coordinatorParameters2 = new(workDir);
-		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters2, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters2, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator2.StartAsync(CancellationToken.None);
 		var defaultValue = TimeSpanJsonConverter.Parse("0d 3h 0m 0s");
 		Assert.Equal(TimeSpan.FromHours(3), defaultValue);
@@ -106,7 +107,7 @@ public class ConfigTests
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 
 		CoordinatorParameters coordinatorParameters = new(workDir);
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator.StartAsync(CancellationToken.None);
 
 		var configPath = Path.Combine(workDir, "WabiSabiConfig.json");

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -7,6 +7,7 @@ using NBitcoin.RPC;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
@@ -19,7 +20,7 @@ public class CoordinatorTests
 		var workDir = Common.GetWorkDir();
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 		CoordinatorParameters coordinatorParameters = new(workDir);
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator.StartAsync(CancellationToken.None);
 		await coordinator.StopAsync(CancellationToken.None);
 	}
@@ -31,32 +32,32 @@ public class CoordinatorTests
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 		CoordinatorParameters coordinatorParameters = new(workDir);
 
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		using CancellationTokenSource cts = new();
 		cts.Cancel();
 		await coordinator.StartAsync(cts.Token);
 		await coordinator.StopAsync(CancellationToken.None);
 
-		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		using CancellationTokenSource cts2 = new();
 		await coordinator2.StartAsync(cts2.Token);
 		cts2.Cancel();
 		await coordinator2.StopAsync(CancellationToken.None);
 
-		using WabiSabiCoordinator coordinator3 = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator3 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		using CancellationTokenSource cts3 = new();
 		var t = coordinator3.StartAsync(cts3.Token);
 		cts3.Cancel();
 		await t;
 		await coordinator3.StopAsync(CancellationToken.None);
 
-		using WabiSabiCoordinator coordinator4 = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator4 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator4.StartAsync(CancellationToken.None);
 		using CancellationTokenSource cts4 = new();
 		cts4.Cancel();
 		await coordinator4.StopAsync(cts4.Token);
 
-		using WabiSabiCoordinator coordinator5 = new(coordinatorParameters, NewMockRpcClient());
+		using WabiSabiCoordinator coordinator5 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
 		await coordinator5.StartAsync(CancellationToken.None);
 		using CancellationTokenSource cts5 = new();
 		t = coordinator5.StopAsync(cts5.Token);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -53,7 +53,7 @@ public class RegisterInputSuccessTests
 		var coin = WabiSabiFactory.CreateCoin(key);
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 		var coinJoinIdsStore = new CoinJoinIdStore();
-		coinJoinIdsStore.Append(coin.Outpoint.Hash);
+		coinJoinIdsStore.TryAdd(coin.Outpoint.Hash);
 		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).With(coinJoinIdsStore).CreateAndStartAsync(round);
 
 		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -52,8 +52,8 @@ public class RegisterInputSuccessTests
 		using Key key = new();
 		var coin = WabiSabiFactory.CreateCoin(key);
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
-		var coinJoinIdsStore = new InMemoryCoinJoinIdStore();
-		coinJoinIdsStore.Add(coin.Outpoint.Hash);
+		var coinJoinIdsStore = new CoinJoinIdStore();
+		coinJoinIdsStore.Append(coin.Outpoint.Hash);
 		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).With(coinJoinIdsStore).CreateAndStartAsync(round);
 
 		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -52,9 +52,9 @@ public class RegisterInputSuccessTests
 		using Key key = new();
 		var coin = WabiSabiFactory.CreateCoin(key);
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
-		var coinJoinIdsStore = new CoinJoinIdStore();
-		coinJoinIdsStore.TryAdd(coin.Outpoint.Hash);
-		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).With(coinJoinIdsStore).CreateAndStartAsync(round);
+		var coinJoinIdStore = new CoinJoinIdStore();
+		coinJoinIdStore.TryAdd(coin.Outpoint.Hash);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).With(coinJoinIdStore).CreateAndStartAsync(round);
 
 		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RoundCreationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/RoundCreationTests.cs
@@ -26,7 +26,7 @@ public class RoundCreationTests
 				FeeRate = new FeeRate(10m)
 			});
 
-		using Arena arena = new(TimeSpan.FromSeconds(1), Network.Main, cfg, mockRpc, new Prison(), new InMemoryCoinJoinIdStore());
+		using Arena arena = new(TimeSpan.FromSeconds(1), Network.Main, cfg, mockRpc, new Prison(), new CoinJoinIdStore());
 		Assert.Empty(arena.Rounds);
 		await arena.StartAsync(CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -47,7 +47,7 @@ public class RoundCreationTests
 				FeeRate = new FeeRate(10m)
 			});
 
-		using Arena arena = new(TimeSpan.FromSeconds(1), Network.Main, cfg, mockRpc, new Prison(), new InMemoryCoinJoinIdStore());
+		using Arena arena = new(TimeSpan.FromSeconds(1), Network.Main, cfg, mockRpc, new Prison(), new CoinJoinIdStore());
 		Assert.Empty(arena.Rounds);
 		await arena.StartAsync(CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -72,7 +72,7 @@ public class RoundCreationTests
 				FeeRate = new FeeRate(10m)
 			});
 
-		using Arena arena = new(TimeSpan.FromSeconds(1), Network.Main, cfg, mockRpc, new Prison(), new InMemoryCoinJoinIdStore());
+		using Arena arena = new(TimeSpan.FromSeconds(1), Network.Main, cfg, mockRpc, new Prison(), new CoinJoinIdStore());
 		Assert.Empty(arena.Rounds);
 		await arena.StartAsync(CancellationToken.None);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -58,7 +58,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddScoped<Prison>();
 			services.AddScoped<WabiSabiConfig>();
 			services.AddScoped(typeof(TimeSpan), _ => TimeSpan.FromSeconds(2));
-			services.AddScoped(s => new CoinJoinIdStore());
+			services.AddScoped<ICoinJoinIdStore>(s => new CoinJoinIdStore());
 			services.AddSingleton<CoinJoinFeeRateStatStore>();
 		});
 		builder.ConfigureLogging(o =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -58,7 +58,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddScoped<Prison>();
 			services.AddScoped<WabiSabiConfig>();
 			services.AddScoped(typeof(TimeSpan), _ => TimeSpan.FromSeconds(2));
-			services.AddScoped(s => new InMemoryCoinJoinIdStore());
+			services.AddScoped(s => new CoinJoinIdStore());
 			services.AddSingleton<CoinJoinFeeRateStatStore>();
 		});
 		builder.ConfigureLogging(o =>

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -73,14 +73,14 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			// only that the probability of duplicates is very low).
 			var id = new Guid(Random.GetBytes(16));
 
-			var isPayingZeroCoordinationFee = InMemoryCoinJoinIdStore.Contains(coin.Outpoint.Hash);
+			var isPayingZeroCoordinationFee = CoinJoinIdStore.Contains(coin.Outpoint.Hash);
 
 			if (!isPayingZeroCoordinationFee)
 			{
 				// If the coin comes from a tx that all of the tx inputs are coming from a CJ (1 hop - no pay).
 				Transaction tx = await Rpc.GetRawTransactionAsync(coin.Outpoint.Hash, true, cancellationToken).ConfigureAwait(false);
 
-				if (tx.Inputs.All(input => InMemoryCoinJoinIdStore.Contains(input.PrevOut.Hash)))
+				if (tx.Inputs.All(input => CoinJoinIdStore.Contains(input.PrevOut.Hash)))
 				{
 					isPayingZeroCoordinationFee = true;
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -25,7 +25,7 @@ public partial class Arena : PeriodicRunner
 		WabiSabiConfig config,
 		IRPCClient rpc,
 		Prison prison,
-		CoinJoinIdStore coinJoinIdStore,
+		ICoinJoinIdStore coinJoinIdStore,
 		CoinJoinTransactionArchiver? archiver = null,
 		CoinJoinScriptStore? coinJoinScriptStore = null) : base(period)
 	{
@@ -48,7 +48,7 @@ public partial class Arena : PeriodicRunner
 	private SecureRandom Random { get; }
 	private CoinJoinTransactionArchiver? TransactionArchiver { get; }
 	public CoinJoinScriptStore? CoinJoinScriptStore { get; }
-	public CoinJoinIdStore CoinJoinIdStore { get; private set; }
+	public ICoinJoinIdStore CoinJoinIdStore { get; private set; }
 
 	public event EventHandler<Transaction>? CoinJoinBroadcast;
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -48,7 +48,7 @@ public partial class Arena : PeriodicRunner
 	private SecureRandom Random { get; }
 	private CoinJoinTransactionArchiver? TransactionArchiver { get; }
 	public CoinJoinScriptStore? CoinJoinScriptStore { get; }
-	public ICoinJoinIdStore CoinJoinIdStore { get; private set; }
+	private ICoinJoinIdStore CoinJoinIdStore { get; set; }
 
 	public event EventHandler<Transaction>? CoinJoinBroadcast;
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -25,7 +25,7 @@ public partial class Arena : PeriodicRunner
 		WabiSabiConfig config,
 		IRPCClient rpc,
 		Prison prison,
-		InMemoryCoinJoinIdStore inMemoryCoinJoinIdStore,
+		ICoinJoinIdStore coinJoinIdStore,
 		CoinJoinTransactionArchiver? archiver = null,
 		CoinJoinScriptStore? coinJoinScriptStore = null) : base(period)
 	{
@@ -35,7 +35,7 @@ public partial class Arena : PeriodicRunner
 		Prison = prison;
 		TransactionArchiver = archiver;
 		Random = new SecureRandom();
-		InMemoryCoinJoinIdStore = inMemoryCoinJoinIdStore;
+		CoinJoinIdStore = coinJoinIdStore;
 		CoinJoinScriptStore = coinJoinScriptStore;
 	}
 
@@ -48,7 +48,7 @@ public partial class Arena : PeriodicRunner
 	private SecureRandom Random { get; }
 	private CoinJoinTransactionArchiver? TransactionArchiver { get; }
 	public CoinJoinScriptStore? CoinJoinScriptStore { get; }
-	private InMemoryCoinJoinIdStore InMemoryCoinJoinIdStore { get; }
+	public ICoinJoinIdStore CoinJoinIdStore { get; private set; }
 
 	public event EventHandler<Transaction>? CoinJoinBroadcast;
 
@@ -265,7 +265,6 @@ public partial class Arena : PeriodicRunner
 					round.SetPhase(Phase.Ended);
 					round.LogInfo($"Successfully broadcast the CoinJoin: {coinjoin.GetHash()}.");
 
-					InMemoryCoinJoinIdStore.Add(coinjoin.GetHash());
 					CoinJoinScriptStore?.AddRange(coinjoin.Outputs.Select(x => x.ScriptPubKey));
 					CoinJoinBroadcast?.Invoke(this, coinjoin);
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -25,7 +25,7 @@ public partial class Arena : PeriodicRunner
 		WabiSabiConfig config,
 		IRPCClient rpc,
 		Prison prison,
-		ICoinJoinIdStore coinJoinIdStore,
+		CoinJoinIdStore coinJoinIdStore,
 		CoinJoinTransactionArchiver? archiver = null,
 		CoinJoinScriptStore? coinJoinScriptStore = null) : base(period)
 	{
@@ -48,7 +48,7 @@ public partial class Arena : PeriodicRunner
 	private SecureRandom Random { get; }
 	private CoinJoinTransactionArchiver? TransactionArchiver { get; }
 	public CoinJoinScriptStore? CoinJoinScriptStore { get; }
-	public ICoinJoinIdStore CoinJoinIdStore { get; private set; }
+	public CoinJoinIdStore CoinJoinIdStore { get; private set; }
 
 	public event EventHandler<Transaction>? CoinJoinBroadcast;
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using System.IO;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+
+public class CoinJoinIdStore : ICoinJoinIdStore
+{
+	public InMemoryCoinJoinIdStore InMemoryCoinJoinIdStore { get; set; }
+	public string CoinJoinsFilePath { get; set; }
+	private object FileWriteLock { get; set; } = new();
+
+	public CoinJoinIdStore(string ww2CoinjoinsFilePath)
+	{
+		CoinJoinsFilePath = ww2CoinjoinsFilePath;
+		InMemoryCoinJoinIdStore = InMemoryCoinJoinIdStore.LoadFromFile(ww2CoinjoinsFilePath);
+	}
+
+	public void Append(uint256 id)
+	{
+		InMemoryCoinJoinIdStore.Add(id);
+		try
+		{
+			lock (FileWriteLock)
+			{
+				File.AppendAllLines(CoinJoinsFilePath, new[] { id.ToString() });
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError($"Could not write file {CoinJoinsFilePath}.", ex);
+		}
+	}
+
+	public bool Contains(uint256 id)
+	{
+		return InMemoryCoinJoinIdStore.Contains(id);
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -86,7 +86,7 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 		}
 
 		var parsedIds = ParseIds(coinjoins, out var stringIds);
-		if (stringIds.Count() != coinjoins.Count())
+		if (stringIds.Count != coinjoins.Count())
 		{
 			updateFile = true;
 		}
@@ -99,16 +99,16 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 		return new CoinJoinIdStore(parsedIds, coinJoinIdStoreFilePath);
 	}
 
-	private static IEnumerable<uint256> ParseIds(IEnumerable<string> coinjoins, out IEnumerable<string> stringIds)
+	private static IEnumerable<uint256> ParseIds(IEnumerable<string> coinjoins, out List<string> stringIds)
 	{
-		stringIds = Enumerable.Empty<string>();
-		var ids = Enumerable.Empty<uint256>();
+		stringIds = new();
+		List<uint256> ids = new();
 		foreach (var line in coinjoins)
 		{
 			if (uint256.TryParse(line, out uint256 id))
 			{
-				ids = ids.Append(id);
-				stringIds = stringIds.Append(line);
+				ids.Add(id);
+				stringIds.Add(line);
 			}
 			else
 			{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -12,7 +12,8 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 	private string CoinJoinIdStoreFilePath { get; set; }
 	private object FileWriteLock { get; set; } = new();
 
-	public CoinJoinIdStore() : this(Enumerable.Empty<uint256>(), string.Empty)
+	// Only for testing purposes.
+	internal CoinJoinIdStore() : this(Enumerable.Empty<uint256>(), string.Empty)
 	{
 	}
 
@@ -70,6 +71,7 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 			{
 				coinjoins = missingWw1Coinjoins.Concat(coinjoins);
 				updateFile = true;
+				Logger.LogWarning($"Imported {missingWw1Coinjoins.Count()} WW1 coinjoins.");
 			}
 		}
 		catch (Exception ex)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -57,7 +57,7 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 		}
 		else
 		{
-			coinjoins = File.ReadAllLines(coinJoinIdStoreFilePath);
+			coinjoins = File.ReadAllLines(coinJoinIdStoreFilePath).Where(line => !string.IsNullOrEmpty(line));
 		}
 
 		// Try to import ww1 coinjoins.
@@ -65,7 +65,7 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 		{
 			var ww1Coinjoins = File.ReadAllLines(ww1CoinJoinsFilePath);
 
-			var missingWw1Coinjoins = ww1Coinjoins.Except(coinjoins);
+			var missingWw1Coinjoins = ww1Coinjoins.Except(coinjoins).Where(line => !string.IsNullOrEmpty(line));
 
 			if (missingWw1Coinjoins.Any())
 			{
@@ -94,6 +94,8 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 		{
 			File.WriteAllLines(coinJoinIdStoreFilePath, validCoinjoinIds);
 		}
+
+		Logger.LogInfo($"{parsedCoinjoinIds.Count()} coinjoins were imported from files.");
 
 		return new CoinJoinIdStore(parsedCoinjoinIds, coinJoinIdStoreFilePath);
 	}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 public class CoinJoinIdStore : ICoinJoinIdStore
 {
 	private InMemoryCoinJoinIdStore InMemoryCoinJoinIdStore { get; set; }
-	public string CoinJoinsFilePath { get; set; }
+	public string CoinJoinIdStoreFilePath { get; set; }
 	private object FileWriteLock { get; set; } = new();
 
 	public CoinJoinIdStore() : this(string.Empty)
@@ -17,7 +17,7 @@ public class CoinJoinIdStore : ICoinJoinIdStore
 
 	public CoinJoinIdStore(string coinJoinIdStoreFilePath)
 	{
-		CoinJoinsFilePath = coinJoinIdStoreFilePath;
+		CoinJoinIdStoreFilePath = coinJoinIdStoreFilePath;
 		InMemoryCoinJoinIdStore = InMemoryCoinJoinIdStore.LoadFromFile(coinJoinIdStoreFilePath);
 	}
 
@@ -28,12 +28,12 @@ public class CoinJoinIdStore : ICoinJoinIdStore
 		{
 			lock (FileWriteLock)
 			{
-				File.AppendAllLines(CoinJoinsFilePath, new[] { id.ToString() });
+				File.AppendAllLines(CoinJoinIdStoreFilePath, new[] { id.ToString() });
 			}
 		}
 		catch (Exception ex)
 		{
-			Logger.LogError($"Could not write file {CoinJoinsFilePath}.", ex);
+			Logger.LogError($"Could not write to file {CoinJoinIdStoreFilePath}.", ex);
 		}
 	}
 
@@ -55,9 +55,9 @@ public class CoinJoinIdStore : ICoinJoinIdStore
 				File.AppendAllLines(coinJoinIdStoreFilePath, missingOldCoinjoins);
 			}
 		}
-		catch (Exception exc)
+		catch (Exception ex)
 		{
-			Logger.LogError("Failed to import old coinjoins. Reason:", exc);
+			Logger.LogError("Failed to import old coinjoins. Reason:", ex);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -98,7 +98,7 @@ public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 		return new CoinJoinIdStore(parsedCoinjoinIds, coinJoinIdStoreFilePath);
 	}
 
-	private static IEnumerable<uint256> GetValidCoinjoinIds(IEnumerable<string> coinjoins, out List<string> validCoinJoins, out bool wasError)
+	internal static IEnumerable<uint256> GetValidCoinjoinIds(IEnumerable<string> coinjoins, out List<string> validCoinJoins, out bool wasError)
 	{
 		wasError = false;
 		validCoinJoins = new List<string>();

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -1,35 +1,36 @@
 using NBitcoin;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 
-public class CoinJoinIdStore : ICoinJoinIdStore
+public class CoinJoinIdStore : InMemoryCoinJoinIdStore
 {
-	private InMemoryCoinJoinIdStore InMemoryCoinJoinIdStore { get; set; }
 	private string CoinJoinIdStoreFilePath { get; set; }
 	private object FileWriteLock { get; set; } = new();
 
-	public CoinJoinIdStore() : this(string.Empty)
+	public CoinJoinIdStore() : this(Enumerable.Empty<uint256>(), string.Empty)
 	{
 	}
 
-	public CoinJoinIdStore(string coinJoinIdStoreFilePath)
+	public CoinJoinIdStore(IEnumerable<uint256> coinjoinIds, string coinJoinIdStoreFilePath) : base(coinjoinIds)
 	{
 		CoinJoinIdStoreFilePath = coinJoinIdStoreFilePath;
-		InMemoryCoinJoinIdStore = InMemoryCoinJoinIdStore.LoadFromFile(coinJoinIdStoreFilePath);
 	}
 
-	public void Append(uint256 id)
+	public override bool TryAdd(uint256 id)
 	{
-		if (InMemoryCoinJoinIdStore.TryAdd(id))
+		if (base.TryAdd(id))
 		{
 			try
 			{
 				lock (FileWriteLock)
 				{
 					File.AppendAllLines(CoinJoinIdStoreFilePath, new[] { id.ToString() });
+					return true;
 				}
 			}
 			catch (Exception ex)
@@ -37,29 +38,58 @@ public class CoinJoinIdStore : ICoinJoinIdStore
 				Logger.LogError($"Could not write to file {CoinJoinIdStoreFilePath}.", ex);
 			}
 		}
+		return false;
 	}
 
-	public bool Contains(uint256 id)
+	public override bool Contains(uint256 id)
 	{
-		return InMemoryCoinJoinIdStore.Contains(id);
+		return base.Contains(id);
 	}
 
-	public static void ImportWW1CoinJoinsToWW2(string ww1CoinJoinsFilePath, string coinJoinIdStoreFilePath)
+	public static CoinJoinIdStore Create(string ww1CoinJoinsFilePath, string coinJoinIdStoreFilePath)
 	{
+		bool updateFile = false;
+		var coinjoins = Enumerable.Empty<string>();
+		if (!File.Exists(coinJoinIdStoreFilePath))
+		{
+			IoHelpers.EnsureContainingDirectoryExists(coinJoinIdStoreFilePath);
+		}
+		else
+		{
+			coinjoins = File.ReadAllLines(coinJoinIdStoreFilePath);
+		}
+
+		// Try to import ww1 coinjoins.
 		try
 		{
-			var oldCoinjoins = File.ReadAllLines(ww1CoinJoinsFilePath);
+			var ww1Coinjoins = File.ReadAllLines(ww1CoinJoinsFilePath);
 
-			var newCoinjoins = File.ReadAllLines(coinJoinIdStoreFilePath);
-			var missingOldCoinjoins = oldCoinjoins.Except(newCoinjoins);
-			if (missingOldCoinjoins.Any())
+			var missingWw1Coinjoins = ww1Coinjoins.Except(coinjoins);
+
+			if (missingWw1Coinjoins.Any())
 			{
-				File.AppendAllLines(coinJoinIdStoreFilePath, missingOldCoinjoins);
+				coinjoins = missingWw1Coinjoins.Concat(coinjoins);
+				updateFile = true;
 			}
 		}
 		catch (Exception ex)
 		{
 			Logger.LogError("Failed to import WW1 coinjoins. Reason:", ex);
 		}
+
+		// Checking duplicates.
+		var distinctCoinJoins = coinjoins.Distinct();
+		if (distinctCoinJoins.Count() != coinjoins.Count())
+		{
+			coinjoins = distinctCoinJoins;
+			updateFile = true;
+		}
+
+		if (updateFile)
+		{
+			File.WriteAllLines(coinJoinIdStoreFilePath, coinjoins);
+		}
+
+		return new CoinJoinIdStore(coinjoins.Select(id => uint256.Parse(id)), coinJoinIdStoreFilePath);
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/CoinJoinIdStore.cs
@@ -10,6 +10,10 @@ public class CoinJoinIdStore : ICoinJoinIdStore
 	public string CoinJoinsFilePath { get; set; }
 	private object FileWriteLock { get; set; } = new();
 
+	public CoinJoinIdStore() : this(string.Empty)
+	{
+	}
+
 	public CoinJoinIdStore(string ww2CoinjoinsFilePath)
 	{
 		CoinJoinsFilePath = ww2CoinjoinsFilePath;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/ICoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/ICoinJoinIdStore.cs
@@ -1,0 +1,10 @@
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+
+public interface ICoinJoinIdStore
+{
+	public void Append(uint256 id);
+
+	public bool Contains(uint256 id);
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/ICoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/ICoinJoinIdStore.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 
 public interface ICoinJoinIdStore
 {
-	public void Append(uint256 id);
+	public bool TryAdd(uint256 id);
 
 	public bool Contains(uint256 id);
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
@@ -18,6 +18,9 @@ public class InMemoryCoinJoinIdStore : ICoinJoinIdStore
 	{
 	}
 
+	// For testing only.
+	internal IEnumerable<uint256> GetCoinJoinIds => CoinJoinIds.Keys;
+
 	// We would use a HashSet here but ConcurrentHashSet not exists.
 	private ConcurrentDictionary<uint256, byte> CoinJoinIds { get; }
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using WalletWasabi.Logging;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 
@@ -39,5 +40,28 @@ public class InMemoryCoinJoinIdStore
 
 		var store = new InMemoryCoinJoinIdStore(lines);
 		return store;
+	}
+
+	public void ImportWW1CoinJoinsToWW2(string ww1CoinJoinsFilePath, string coinJoinIdStoreFilePath)
+	{
+		try
+		{
+			var oldCoinjoins = File.ReadAllLines(ww1CoinJoinsFilePath);
+
+			var newCoinjoins = File.ReadAllLines(coinJoinIdStoreFilePath);
+			var missingOldCoinjoins = oldCoinjoins.Except(newCoinjoins);
+			if (missingOldCoinjoins.Any())
+			{
+				foreach (var coinjoinId in missingOldCoinjoins)
+				{
+					Add(uint256.Parse(coinjoinId));
+				}
+				File.AppendAllLines(coinJoinIdStoreFilePath, missingOldCoinjoins);
+			}
+		}
+		catch (Exception exc)
+		{
+			Logger.LogError("Failed to import old coinjoins. Reason:", exc);
+		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
@@ -7,11 +7,11 @@ using WalletWasabi.Logging;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 
-public class InMemoryCoinJoinIdStore
+public class InMemoryCoinJoinIdStore : ICoinJoinIdStore
 {
 	public InMemoryCoinJoinIdStore(IEnumerable<uint256> coinJoinHashes)
 	{
-		CoinJoinIds = new ConcurrentDictionary<uint256, byte>(coinJoinHashes.ToDictionary(x => x, x => byte.MinValue));
+		CoinJoinIds = new ConcurrentDictionary<uint256, byte>(coinJoinHashes.Distinct().ToDictionary(x => x, x => byte.MinValue));
 	}
 
 	public InMemoryCoinJoinIdStore() : this(Enumerable.Empty<uint256>())
@@ -21,24 +21,14 @@ public class InMemoryCoinJoinIdStore
 	// We would use a HashSet here but ConcurrentHashSet not exists.
 	private ConcurrentDictionary<uint256, byte> CoinJoinIds { get; }
 
-	public bool Contains(uint256 hash)
+	public virtual bool Contains(uint256 hash)
 	{
 		return CoinJoinIds.ContainsKey(hash);
 	}
 
-	public bool TryAdd(uint256 hash)
+	public virtual bool TryAdd(uint256 hash)
 	{
 		// The byte is just a dummy value, we are not using it.
 		return CoinJoinIds.TryAdd(hash, byte.MinValue);
-	}
-
-	public static InMemoryCoinJoinIdStore LoadFromFile(string filePath)
-	{
-		var lines = File.Exists(filePath)
-			? File.ReadAllLines(filePath).Select(x => uint256.Parse(x))
-			: Enumerable.Empty<uint256>();
-
-		var store = new InMemoryCoinJoinIdStore(lines);
-		return store;
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
@@ -41,27 +41,4 @@ public class InMemoryCoinJoinIdStore
 		var store = new InMemoryCoinJoinIdStore(lines);
 		return store;
 	}
-
-	public void ImportWW1CoinJoinsToWW2(string ww1CoinJoinsFilePath, string coinJoinIdStoreFilePath)
-	{
-		try
-		{
-			var oldCoinjoins = File.ReadAllLines(ww1CoinJoinsFilePath);
-
-			var newCoinjoins = File.ReadAllLines(coinJoinIdStoreFilePath);
-			var missingOldCoinjoins = oldCoinjoins.Except(newCoinjoins);
-			if (missingOldCoinjoins.Any())
-			{
-				foreach (var coinjoinId in missingOldCoinjoins)
-				{
-					Add(uint256.Parse(coinjoinId));
-				}
-				File.AppendAllLines(coinJoinIdStoreFilePath, missingOldCoinjoins);
-			}
-		}
-		catch (Exception exc)
-		{
-			Logger.LogError("Failed to import old coinjoins. Reason:", exc);
-		}
-	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/CoinJoinStorage/InMemoryCoinJoinIdStore.cs
@@ -26,10 +26,10 @@ public class InMemoryCoinJoinIdStore
 		return CoinJoinIds.ContainsKey(hash);
 	}
 
-	public void Add(uint256 hash)
+	public bool TryAdd(uint256 hash)
 	{
 		// The byte is just a dummy value, we are not using it.
-		CoinJoinIds.TryAdd(hash, byte.MinValue);
+		return CoinJoinIds.TryAdd(hash, byte.MinValue);
 	}
 
 	public static InMemoryCoinJoinIdStore LoadFromFile(string filePath)

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.WabiSabi;
 
 public class WabiSabiCoordinator : BackgroundService
 {
-	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, CoinJoinIdStore coinJoinIdStore)
+	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, ICoinJoinIdStore coinJoinIdStore)
 	{
 		Parameters = parameters;
 

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -60,7 +60,7 @@ public class WabiSabiCoordinator : BackgroundService
 
 	private void Arena_CoinJoinBroadcast(object? sender, Transaction transaction)
 	{
-		CoinJoinIdStore.Append(transaction.GetHash());
+		CoinJoinIdStore.TryAdd(transaction.GetHash());
 
 		var coinJoinScriptStoreFilePath = Parameters.CoinJoinScriptStoreFilePath;
 		try

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.WabiSabi;
 
 public class WabiSabiCoordinator : BackgroundService
 {
-	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, ICoinJoinIdStore coinJoinIdStore)
+	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, CoinJoinIdStore coinJoinIdStore)
 	{
 		Parameters = parameters;
 

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -17,20 +17,18 @@ namespace WalletWasabi.WabiSabi;
 
 public class WabiSabiCoordinator : BackgroundService
 {
-	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc)
+	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, ICoinJoinIdStore coinJoinIdStore)
 	{
 		Parameters = parameters;
 
 		Warden = new(parameters.UtxoWardenPeriod, parameters.PrisonFilePath, Config);
 		ConfigWatcher = new(parameters.ConfigChangeMonitoringPeriod, Config, () => Logger.LogInfo("WabiSabi configuration has changed."));
-
+		CoinJoinIdStore = coinJoinIdStore;
 		CoinJoinTransactionArchiver transactionArchiver = new(Path.Combine(parameters.CoordinatorDataDir, "CoinJoinTransactions"));
 
 		CoinJoinFeeRateStatStore = CoinJoinFeeRateStatStore.LoadFromFile(parameters.CoinJoinFeeRateStatStoreFilePath, Config, rpc);
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinFeeRateStatStoreFilePath);
 		CoinJoinFeeRateStatStore.NewStat += FeeRateStatStore_NewStat;
-
-		var inMemoryCoinJoinIdStore = InMemoryCoinJoinIdStore.LoadFromFile(parameters.CoinJoinIdStoreFilePath);
 
 		var coinJoinScriptStore = CoinJoinScriptStore.LoadFromFile(parameters.CoinJoinScriptStoreFilePath);
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinScriptStoreFilePath);
@@ -41,7 +39,7 @@ public class WabiSabiCoordinator : BackgroundService
 			Config,
 			rpc,
 			Warden.Prison,
-			inMemoryCoinJoinIdStore,
+			coinJoinIdStore,
 			transactionArchiver,
 			coinJoinScriptStore);
 
@@ -50,6 +48,7 @@ public class WabiSabiCoordinator : BackgroundService
 	}
 
 	public ConfigWatcher ConfigWatcher { get; }
+	public ICoinJoinIdStore CoinJoinIdStore { get; private set; }
 	public Warden Warden { get; }
 
 	public CoordinatorParameters Parameters { get; }
@@ -59,22 +58,14 @@ public class WabiSabiCoordinator : BackgroundService
 
 	public WabiSabiConfig Config => Parameters.RuntimeCoordinatorConfig;
 
-	private void Arena_CoinJoinBroadcast(object? sender, Transaction e)
+	private void Arena_CoinJoinBroadcast(object? sender, Transaction transaction)
 	{
-		var coinJoinIdStoreFilePath = Parameters.CoinJoinIdStoreFilePath;
-		try
-		{
-			File.AppendAllLines(coinJoinIdStoreFilePath, new[] { e.GetHash().ToString() });
-		}
-		catch (Exception ex)
-		{
-			Logger.LogError($"Could not write file {coinJoinIdStoreFilePath}.", ex);
-		}
+		CoinJoinIdStore.Append(transaction.GetHash());
 
 		var coinJoinScriptStoreFilePath = Parameters.CoinJoinScriptStoreFilePath;
 		try
 		{
-			File.AppendAllLines(coinJoinScriptStoreFilePath, e.Outputs.Select(x => x.ScriptPubKey.ToHex()));
+			File.AppendAllLines(coinJoinScriptStoreFilePath, transaction.Outputs.Select(x => x.ScriptPubKey.ToHex()));
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Prerequisite for future works.
Also it makes it easier to implement the _Pay-no-fee_ and _Friends-dont-pay_ for coinjoins.

This class wires up both old- and new coinjoins to store all of them, in file & memory.
Had to tinker and add `CoinJoinIdStore` at some places in the tests to make them pass.