### PR TITLE
Rename P2wpkhOutputSizeInBytes to P2wpkhOutputVirtualSize

### DIFF
--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -64,7 +64,7 @@ public class TestWallet : IKeyChain, IDestinationProvider
 	public Transaction CreateSelfTransfer(FeeRate feeRate)
 	{
 		var (tx, spendingCoin) = CreateTemplateTransaction();
-		tx.Outputs.Add(spendingCoin.Amount - feeRate.GetFee(Constants.P2wpkhOutputSizeInBytes), CreateNewAddress());
+		tx.Outputs.Add(spendingCoin.Amount - feeRate.GetFee(Constants.P2wpkhOutputVirtualSize), CreateNewAddress());
 		return tx;
 	}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
@@ -29,14 +29,14 @@ public class AmountDecomposerTests
 	[InlineData(5000, 0, 8)]
 	public void DecompositionsInvariantTest(decimal feeRateDecimal, long minOutputAmount, int maxAvailableOutputs)
 	{
-		var availableVsize = maxAvailableOutputs * Constants.P2wpkhOutputSizeInBytes;
+		var availableVsize = maxAvailableOutputs * Constants.P2wpkhOutputVirtualSize;
 		var feeRate = new FeeRate(feeRateDecimal);
-		var feePerOutput = feeRate.GetFee(Constants.P2wpkhOutputSizeInBytes);
+		var feePerOutput = feeRate.GetFee(Constants.P2wpkhOutputVirtualSize);
 		var registeredCoinEffectiveValues = GenerateRandomCoins().Take(3).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
 		var theirCoinEffectiveValues = GenerateRandomCoins().Take(30).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
 		var allowedOutputAmountRange = new MoneyRange(Money.Satoshis(minOutputAmount), Money.Satoshis(ProtocolConstants.MaxAmountPerAlice));
 
-		var amountDecomposer = new AmountDecomposer(feeRate, allowedOutputAmountRange, Constants.P2wpkhOutputSizeInBytes, Constants.P2wpkhInputVirtualSize, availableVsize);
+		var amountDecomposer = new AmountDecomposer(feeRate, allowedOutputAmountRange, Constants.P2wpkhOutputVirtualSize, Constants.P2wpkhInputVirtualSize, availableVsize);
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
 
 		var totalEffectiveValue = registeredCoinEffectiveValues.Sum(x => x);

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -20,7 +20,7 @@ public static class Constants
 	public const int P2wpkhInputSizeInBytes = 41;
 	public const int P2wpkhInputVirtualSize = 69;
 	public const int P2pkhInputSizeInBytes = 145;
-	public const int P2wpkhOutputSizeInBytes = 31;
+	public const int P2wpkhOutputVirtualSize = 31;
 
 	/// <summary>
 	/// OBSOLATED, USE SPECIFIC TYPE

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -392,7 +392,7 @@ public class CoinJoinClient
 			}
 
 			var inSum = group.Sum(x => x.EffectiveValue(parameters.FeeRate, parameters.CoordinationFeeRate));
-			var outFee = parameters.FeeRate.GetFee(Constants.P2wpkhOutputSizeInBytes);
+			var outFee = parameters.FeeRate.GetFee(Constants.P2wpkhOutputVirtualSize);
 			if (inSum >= outFee + parameters.AllowedOutputAmounts.Min)
 			{
 				groups.Add(group);
@@ -509,7 +509,7 @@ public class CoinJoinClient
 		// Calculate outputs values
 		var constructionState = roundState.Assert<ConstructionState>();
 
-		AmountDecomposer amountDecomposer = new(roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts, Constants.P2wpkhOutputSizeInBytes, Constants.P2wpkhInputVirtualSize, (int)availableVsize);
+		AmountDecomposer amountDecomposer = new(roundState.FeeRate, roundState.CoinjoinState.Parameters.AllowedOutputAmounts, Constants.P2wpkhOutputVirtualSize, Constants.P2wpkhInputVirtualSize, (int)availableVsize);
 		var theirCoins = constructionState.Inputs.Where(x => !registeredCoins.Any(y => x.Outpoint == y.Outpoint));
 		var registeredCoinEffectiveValues = registeredAliceClients.Select(x => x.EffectiveValue);
 		var theirCoinEffectiveValues = theirCoins.Select(x => x.EffectiveValue(roundState.FeeRate, roundState.CoordinationFeeRate));


### PR DESCRIPTION
This PR is a part of a larger changes that I'm going to do in a near future (see https://github.com/trezor/WalletWasabi/commit/eea7ae9d092895c057c635d6b919d75982360aa5). Until that it would helps us if would merge this PR so we can avoid complicated rebase.