### PR TITLE
Add MaxLength to Searchbar

### DIFF
--- a/WalletWasabi.Fluent/Views/SearchBar/SearchBar.axaml
+++ b/WalletWasabi.Fluent/Views/SearchBar/SearchBar.axaml
@@ -131,7 +131,7 @@
 
   </UserControl.Styles>
 
-  <TextBox x:Name="SearchBox" Watermark="Search settings / advanced features" HorizontalAlignment="Left"
+  <TextBox x:Name="SearchBox" Watermark="Search settings / advanced features" MaxLength="50" HorizontalAlignment="Left"
            Text="{Binding SearchText, Mode=TwoWay}" Width="400" VerticalAlignment="Center">
     <TextBox.InnerLeftContent>
       <PathIcon Name="LeftIcon" Data="{DynamicResource action_center_regular}" />


### PR DESCRIPTION
Currently it is possible to enter an indefinite amount of characters to the searchar:
![image](https://user-images.githubusercontent.com/93143998/162272748-2b18972b-0875-453e-813f-6a8092ca83d9.png)


This PR adds a MaxLength