### PR TITLE
[VDG] Retry after wrong password entry for wallet authorization

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
@@ -11,7 +11,10 @@ public abstract class AuthorizationDialogBase : DialogViewModelBase<bool>
 		NextCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
 			var result = await Authorize();
-			Close(DialogResultKind.Normal, result);
+			if (result)
+			{
+				Close(DialogResultKind.Normal, result);
+			}
 		});
 
 		EnableAutoBusyOn(NextCommand);

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
@@ -12,7 +12,7 @@ public abstract partial class AuthorizationDialogBase : DialogViewModelBase<bool
 	{
 		NextCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
-			var result = await AuthorizeCore();
+			var result = await AuthorizeCoreAsync();
 			if (result)
 			{
 				Close(DialogResultKind.Normal, result);
@@ -24,11 +24,11 @@ public abstract partial class AuthorizationDialogBase : DialogViewModelBase<bool
 
 	protected abstract string AuthorizationFailedMessage { get; }
 
-	protected abstract Task<bool> Authorize();
+	protected abstract Task<bool> AuthorizeAsync();
 
-	private async Task<bool> AuthorizeCore()
+	private async Task<bool> AuthorizeCoreAsync()
 	{
-		var success = await Authorize();
+		var success = await AuthorizeAsync();
 
 		if (!success)
 		{

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
@@ -6,35 +6,27 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs.Authorization;
 
 public abstract partial class AuthorizationDialogBase : DialogViewModelBase<bool>
 {
-	[AutoNotify] private string _errorMessage = "";
+	[AutoNotify] private bool _hasAuthorizationFailed;
+
+	[AutoNotify(SetterModifier = AccessModifier.Protected)]
+	private string _authorizationFailedMessage = "The Authorization has failed, please try again.";
 
 	protected AuthorizationDialogBase()
 	{
-		NextCommand = ReactiveCommand.CreateFromTask(async () =>
-		{
-			var result = await AuthorizeCoreAsync();
-			if (result)
-			{
-				Close(DialogResultKind.Normal, result);
-			}
-		});
+		NextCommand = ReactiveCommand.CreateFromTask(AuthorizeCoreAsync);
 
 		EnableAutoBusyOn(NextCommand);
 	}
 
-	protected abstract string AuthorizationFailedMessage { get; }
-
 	protected abstract Task<bool> AuthorizeAsync();
 
-	private async Task<bool> AuthorizeCoreAsync()
+	private async Task AuthorizeCoreAsync()
 	{
-		var success = await AuthorizeAsync();
+		HasAuthorizationFailed = !await AuthorizeAsync();
 
-		if (!success)
+		if (!HasAuthorizationFailed)
 		{
-			ErrorMessage = AuthorizationFailedMessage;
+			Close(DialogResultKind.Normal, true);
 		}
-
-		return success;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/AuthorizationDialogBase.cs
@@ -4,13 +4,15 @@ using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 
 namespace WalletWasabi.Fluent.ViewModels.Dialogs.Authorization;
 
-public abstract class AuthorizationDialogBase : DialogViewModelBase<bool>
+public abstract partial class AuthorizationDialogBase : DialogViewModelBase<bool>
 {
+	[AutoNotify] private string _errorMessage = "";
+
 	protected AuthorizationDialogBase()
 	{
 		NextCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
-			var result = await Authorize();
+			var result = await AuthorizeCore();
 			if (result)
 			{
 				Close(DialogResultKind.Normal, result);
@@ -20,5 +22,19 @@ public abstract class AuthorizationDialogBase : DialogViewModelBase<bool>
 		EnableAutoBusyOn(NextCommand);
 	}
 
+	protected abstract string AuthorizationFailedMessage { get; }
+
 	protected abstract Task<bool> Authorize();
+
+	private async Task<bool> AuthorizeCore()
+	{
+		var success = await Authorize();
+
+		if (!success)
+		{
+			ErrorMessage = AuthorizationFailedMessage;
+		}
+
+		return success;
+	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
@@ -55,4 +55,6 @@ public partial class HardwareWalletAuthDialogViewModel : AuthorizationDialogBase
 			return false;
 		}
 	}
+
+	protected override string AuthorizationFailedMessage => $"Authorization failed.{Environment.NewLine}Please, check that your device is connected and try again.";
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
@@ -56,5 +56,5 @@ public partial class HardwareWalletAuthDialogViewModel : AuthorizationDialogBase
 		}
 	}
 
-	protected override string AuthorizationFailedMessage => $"Authorization failed.{Environment.NewLine}Please, check that your device is connected and try again.";
+	protected override string AuthorizationFailedMessage => $"Authorization failed.{Environment.NewLine}Please, check your device and try again.";
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
@@ -29,6 +29,8 @@ public partial class HardwareWalletAuthDialogViewModel : AuthorizationDialogBase
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		EnableBack = false;
+
+		AuthorizationFailedMessage = $"Authorization failed.{Environment.NewLine}Please, check your device and try again.";
 	}
 
 	public WalletType WalletType { get; }
@@ -55,6 +57,4 @@ public partial class HardwareWalletAuthDialogViewModel : AuthorizationDialogBase
 			return false;
 		}
 	}
-
-	protected override string AuthorizationFailedMessage => $"Authorization failed.{Environment.NewLine}Please, check your device and try again.";
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/HardwareWalletAuthDialogViewModel.cs
@@ -33,7 +33,7 @@ public partial class HardwareWalletAuthDialogViewModel : AuthorizationDialogBase
 
 	public WalletType WalletType { get; }
 
-	protected override async Task<bool> Authorize()
+	protected override async Task<bool> AuthorizeAsync()
 	{
 		try
 		{

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
@@ -1,4 +1,7 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
+using WalletWasabi.Fluent.Validation;
 using WalletWasabi.Userfacing;
 using WalletWasabi.Wallets;
 
@@ -9,6 +12,7 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 {
 	private readonly Wallet _wallet;
 	[AutoNotify] private string _password;
+	[AutoNotify] private string _errorMessage;
 
 	public PasswordAuthDialogViewModel(Wallet wallet)
 	{
@@ -32,6 +36,13 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 
 	protected override async Task<bool> Authorize()
 	{
-		return await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
+		var result = await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
+
+		if (!result)
+		{
+			ErrorMessage = "The password is incorrect! Try Again.";
+		}
+
+		return result;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
@@ -23,22 +23,14 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		EnableBack = false;
-	}
 
-	protected override void OnDialogClosed()
-	{
-		Password = "";
+		AuthorizationFailedMessage = $"The password is incorrect.{Environment.NewLine}Please, try Again.";
 	}
-
-	protected override string AuthorizationFailedMessage => $"The password is incorrect.{Environment.NewLine}Please, try Again.";
 
 	protected override async Task<bool> AuthorizeAsync()
 	{
 		var success = await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
-		if (!success)
-		{
-			Password = "";
-		}
+		Password = "";
 		return success;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
@@ -1,7 +1,4 @@
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
-using WalletWasabi.Fluent.Validation;
 using WalletWasabi.Userfacing;
 using WalletWasabi.Wallets;
 
@@ -12,7 +9,6 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 {
 	private readonly Wallet _wallet;
 	[AutoNotify] private string _password;
-	[AutoNotify] private string _errorMessage;
 
 	public PasswordAuthDialogViewModel(Wallet wallet)
 	{
@@ -34,15 +30,10 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 		Password = "";
 	}
 
+	protected override string AuthorizationFailedMessage => $"The password is incorrect.{Environment.NewLine}Please, Try Again.";
+
 	protected override async Task<bool> Authorize()
 	{
-		var result = await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
-
-		if (!result)
-		{
-			ErrorMessage = "The password is incorrect! Try Again.";
-		}
-
-		return result;
+		return await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
@@ -30,10 +30,15 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 		Password = "";
 	}
 
-	protected override string AuthorizationFailedMessage => $"The password is incorrect.{Environment.NewLine}Please, Try Again.";
+	protected override string AuthorizationFailedMessage => $"The password is incorrect.{Environment.NewLine}Please, try Again.";
 
 	protected override async Task<bool> Authorize()
 	{
-		return await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
+		var success = await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
+		if (!success)
+		{
+			Password = "";
+		}
+		return success;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/Authorization/PasswordAuthDialogViewModel.cs
@@ -32,7 +32,7 @@ public partial class PasswordAuthDialogViewModel : AuthorizationDialogBase
 
 	protected override string AuthorizationFailedMessage => $"The password is incorrect.{Environment.NewLine}Please, try Again.";
 
-	protected override async Task<bool> Authorize()
+	protected override async Task<bool> AuthorizeAsync()
 	{
 		var success = await Task.Run(() => PasswordHelper.TryPassword(_wallet.KeyManager, Password, out _));
 		if (!success)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -485,11 +485,6 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 		var authDialog = AuthorizationHelpers.GetAuthorizationDialog(_wallet, transactionAuthorizationInfo);
 		var authDialogResult = await NavigateDialogAsync(authDialog, authDialog.DefaultTarget, NavigationMode.Clear);
 
-		if (!authDialogResult.Result && authDialogResult.Kind == DialogResultKind.Normal)
-		{
-			await ShowErrorAsync("Authorization", "The Authorization has failed, please try again.", "");
-		}
-
 		return authDialogResult.Result;
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -133,14 +133,9 @@ public partial class WalletViewModel : WalletViewModelBase
 			if (!string.IsNullOrEmpty(wallet.Kitchen.SaltSoup()))
 			{
 				var pwAuthDialog = new PasswordAuthDialogViewModel(wallet);
-				var res = await NavigateDialogAsync(pwAuthDialog, NavigationTarget.CompactDialogScreen);
+				var dialogResult = await NavigateDialogAsync(pwAuthDialog, NavigationTarget.CompactDialogScreen);
 
-				if (!res.Result && res.Kind == DialogResultKind.Normal)
-				{
-					await ShowErrorAsync("Wallet Info", "The password is incorrect! Try Again.", "");
-					return;
-				}
-				else if (res.Kind is DialogResultKind.Back or DialogResultKind.Cancel)
+				if (!dialogResult.Result)
 				{
 					return;
 				}

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
@@ -22,9 +22,9 @@
         <Image Source="{Binding WalletType, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
       </Viewbox>
       <TextBlock TextAlignment="Center" Foreground="{StaticResource SystemErrorTextColor}"
-                 Text="{Binding ErrorMessage}"
+                 Text="{Binding AuthorizationFailedMessage}"
                  TextWrapping="Wrap"
-                 IsVisible="{Binding ErrorMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                 IsVisible="{Binding HasAuthorizationFailed}" />
     </StackPanel>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
@@ -18,7 +18,7 @@
                  IsBusy="{Binding IsBusy}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
     <StackPanel>
-      <Viewbox MaxHeight="150">
+      <Viewbox MaxHeight="120">
         <Image Source="{Binding WalletType, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
       </Viewbox>
       <TextBlock TextAlignment="Center" Foreground="{StaticResource SystemErrorTextColor}"

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/HardwareWalletAuthDialogView.axaml
@@ -17,8 +17,14 @@
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
-    <Viewbox MaxHeight="150">
-      <Image Source="{Binding WalletType, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}"/>
-    </Viewbox>
+    <StackPanel>
+      <Viewbox MaxHeight="150">
+        <Image Source="{Binding WalletType, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
+      </Viewbox>
+      <TextBlock TextAlignment="Center" Foreground="{StaticResource SystemErrorTextColor}"
+                 Text="{Binding ErrorMessage}"
+                 TextWrapping="Wrap"
+                 IsVisible="{Binding ErrorMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
+    </StackPanel>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -18,10 +18,17 @@
                  EnableNext="True" NextContent="Continue"
                  IsBusy="{Binding IsBusy}">
 
-    <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton" VerticalAlignment="Top" HorizontalAlignment="Stretch">
-      <i:Interaction.Behaviors>
-        <behaviors:FocusOnAttachedBehavior />
-      </i:Interaction.Behaviors>
-    </TextBox>
+    <StackPanel>
+      <TextBox Name="TbPassword" Watermark="Password" Text="{Binding Password}" PasswordChar="•"
+               Classes="revealPasswordButton" VerticalAlignment="Top" HorizontalAlignment="Stretch">
+        <i:Interaction.Behaviors>
+          <behaviors:FocusOnAttachedBehavior />
+        </i:Interaction.Behaviors>
+      </TextBox>
+      <TextBlock TextAlignment="Center" Foreground="{StaticResource SystemErrorTextColor}"
+                 Text="{Binding ErrorMessage}"
+                 IsVisible="{Binding ErrorMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
+    </StackPanel>
+
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -27,8 +27,8 @@
       </TextBox>
       <TextBlock TextAlignment="Center" Foreground="{StaticResource SystemErrorTextColor}"
                  TextWrapping="Wrap"
-                 Text="{Binding ErrorMessage}"
-                 IsVisible="{Binding ErrorMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                 Text="{Binding AuthorizationFailedMessage}"
+                 IsVisible="{Binding HasAuthorizationFailed}" />
     </StackPanel>
 
   </c:ContentArea>

--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -26,6 +26,7 @@
         </i:Interaction.Behaviors>
       </TextBox>
       <TextBlock TextAlignment="Center" Foreground="{StaticResource SystemErrorTextColor}"
+                 TextWrapping="Wrap"
                  Text="{Binding ErrorMessage}"
                  IsVisible="{Binding ErrorMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
     </StackPanel>


### PR DESCRIPTION
This is similar as https://github.com/zkSNACKs/WalletWasabi/pull/7679, but with "in-place" wrong password message, as requested by @soosr and @MaxHillebrand.
This means that there is no navigation at all when the user enters a wrong password.

![image](https://user-images.githubusercontent.com/3109851/162409023-f9973282-6893-4651-b848-b8481668cdc9.png)

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/7507