### PR TITLE
[BnB] Add Max Input Count check

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -52,6 +52,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 			transactionInfo.Coins,
 			transactionInfo.FeeRate,
 			new TxOut(transactionInfo.Amount, destination),
+			transactionInfo.Coins.Count(),
 			cancellationToken).ConfigureAwait(false);
 
 		await foreach (var selection in selections)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -46,13 +46,14 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 		TransactionInfo transactionInfo,
 		BitcoinAddress destination,
 		Wallet wallet,
+		int originalInputCount,
 		[EnumeratorCancellation] CancellationToken cancellationToken)
 	{
 		var selections = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(
 			transactionInfo.Coins,
 			transactionInfo.FeeRate,
 			new TxOut(transactionInfo.Amount, destination),
-			transactionInfo.Coins.Count(),
+			originalInputCount,
 			cancellationToken).ConfigureAwait(false);
 
 		await foreach (var selection in selections)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -59,7 +59,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 		if (hasChange && !isFixedAmount && !info.IsPayJoin)
 		{
 			var suggestions =
-				ChangeAvoidanceSuggestionViewModel.GenerateSuggestionsAsync(info, destination, wallet, linkedCts.Token);
+				ChangeAvoidanceSuggestionViewModel.GenerateSuggestionsAsync(info, destination, wallet, transaction.SpentCoins.Count(), linkedCts.Token);
 
 			await foreach (var suggestion in suggestions)
 			{

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -207,4 +207,46 @@ public class BranchAndBoundTests
 		// Total costs: (17 + 2) + (10 + 3) + (3 + 1) + (2 + 1) = 39
 		Assert.Equal(new long[] { 17, 10, 3, 2 }, actualSelection);
 	}
+
+	[Fact]
+	public void MaxInputCountTest()
+	{
+		// Less Strategy
+
+		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+
+		long[] inputValues = new long[] { 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+		long[] inputCosts = new long[] { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+		long target = 9;
+
+		BranchAndBound algorithm = new();
+		LessSelectionStrategy lessStrategy = new(target, inputValues, inputCosts);
+		_ = algorithm.TryGetMatch(lessStrategy, out _, cts.Token);
+
+		long[] actualSelection = lessStrategy.GetBestSelectionFound()!;
+
+		Assert.NotNull(actualSelection);
+		Assert.Equal(new long[] { 1, 1, 1, 1, 1, }, actualSelection);
+		Assert.Equal(CoinSelection.MaxCoinCount, actualSelection.Length);
+
+		// More Strategy
+
+		inputValues = new long[] { 20, 10, 10, 10, 5, 5, 5, 1, 1 };
+		inputCosts = new long[] { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+		target = 52;
+
+		algorithm = new();
+		MoreSelectionStrategy moreStrategy = new(target, inputValues, inputCosts);
+		_ = algorithm.TryGetMatch(moreStrategy, out _, cts.Token);
+
+		long[] result = moreStrategy.GetBestSelectionFound()!;
+
+		Assert.NotNull(result);
+
+		// Bnb should have chosen { 20, 10, 10, 10, 1, 1 } but with the MaxInputCount this is the best we can get.
+		Assert.Equal(new long[] { 20, 10, 10, 10, 5 }, result);
+		Assert.Equal(CoinSelection.MaxCoinCount, result.Length);
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -228,7 +228,7 @@ public class BranchAndBoundTests
 
 		Assert.NotNull(actualSelection);
 		Assert.Equal(new long[] { 1, 1, 1, 1, 1, }, actualSelection);
-		Assert.Equal(CoinSelection.MaxCoinCount, actualSelection.Length);
+		Assert.Equal(5, actualSelection.Length);
 
 		// More Strategy
 
@@ -247,6 +247,6 @@ public class BranchAndBoundTests
 
 		// Bnb should have chosen { 20, 10, 10, 10, 1, 1 } but with the MaxInputCount this is the best we can get.
 		Assert.Equal(new long[] { 20, 10, 10, 10, 5 }, result);
-		Assert.Equal(CoinSelection.MaxCoinCount, result.Length);
+		Assert.Equal(5, result.Length);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -23,7 +23,7 @@ public class BranchAndBoundTests
 		long target = 27; // Target that we cannot get as a sum of input values.
 
 		BranchAndBound algorithm = new();
-		MoreSelectionStrategy strategy = new(target, inputValues, inputCosts);
+		MoreSelectionStrategy strategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		Assert.Equal(new long[] { 11, 7, 5, 3, 2 }, strategy.GetBestSelectionFound());
@@ -40,7 +40,7 @@ public class BranchAndBoundTests
 		long target = 27;
 
 		BranchAndBound algorithm = new();
-		MoreSelectionStrategy strategy = new(target, inputValues, inputCosts);
+		MoreSelectionStrategy strategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		long[] actualSelection = strategy.GetBestSelectionFound()!;
@@ -66,7 +66,7 @@ public class BranchAndBoundTests
 		long target = 27; // Target that we cannot get as a sum of input values.
 
 		BranchAndBound algorithm = new();
-		MoreSelectionStrategy strategy = new(target, inputValues, inputCosts);
+		MoreSelectionStrategy strategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		// Selection (35) costs us 35 + 1 = 36.
@@ -105,7 +105,7 @@ public class BranchAndBoundTests
 		long target = 999_999; // Target that we cannot get as a sum of input values.
 
 		BranchAndBound algorithm = new();
-		MoreSelectionStrategy strategy = new(target, inputValues.ToArray(), inputCosts);
+		MoreSelectionStrategy strategy = new(target, inputValues.ToArray(), inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		// Assert that we get expected best solution.
@@ -134,7 +134,7 @@ public class BranchAndBoundTests
 		long target = 1_000_000; // Target that we cannot get as a sum of input values.
 
 		BranchAndBound algorithm = new();
-		LessSelectionStrategy strategy = new(target, inputValues.ToArray(), inputCosts);
+		LessSelectionStrategy strategy = new(target, inputValues.ToArray(), inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		// Assert that we get expected best solution.
@@ -153,7 +153,7 @@ public class BranchAndBoundTests
 		long target = 16;
 
 		BranchAndBound algorithm = new();
-		LessSelectionStrategy strategy = new(target, inputValues, inputCosts);
+		LessSelectionStrategy strategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		long[] actualSelection = strategy.GetBestSelectionFound()!;
@@ -172,7 +172,7 @@ public class BranchAndBoundTests
 		long target = 26;
 
 		BranchAndBound algorithm = new();
-		LessSelectionStrategy strategy = new(target, inputValues, inputCosts);
+		LessSelectionStrategy strategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		long[] actualSelection = strategy.GetBestSelectionFound()!;
@@ -195,7 +195,7 @@ public class BranchAndBoundTests
 		long target = 33;
 
 		BranchAndBound algorithm = new();
-		LessSelectionStrategy strategy = new(target, inputValues, inputCosts);
+		LessSelectionStrategy strategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(strategy, out _, cts.Token);
 
 		long[] actualSelection = strategy.GetBestSelectionFound()!;
@@ -221,10 +221,10 @@ public class BranchAndBoundTests
 		long target = 9;
 
 		BranchAndBound algorithm = new();
-		LessSelectionStrategy lessStrategy = new(target, inputValues, inputCosts);
+		LessSelectionStrategy lessStrategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(lessStrategy, out _, cts.Token);
 
-		long[] actualSelection = lessStrategy.GetBestSelectionFound()!;
+		long[] actualSelection = lessStrategy.GetBestCandidate()!;
 
 		Assert.NotNull(actualSelection);
 		Assert.Equal(new long[] { 1, 1, 1, 1, 1, }, actualSelection);
@@ -238,10 +238,10 @@ public class BranchAndBoundTests
 		target = 52;
 
 		algorithm = new();
-		MoreSelectionStrategy moreStrategy = new(target, inputValues, inputCosts);
+		MoreSelectionStrategy moreStrategy = new(target, inputValues, inputCosts, maxInputCount: 5);
 		_ = algorithm.TryGetMatch(moreStrategy, out _, cts.Token);
 
-		long[] result = moreStrategy.GetBestSelectionFound()!;
+		long[] result = moreStrategy.GetBestCandidate()!;
 
 		Assert.NotNull(result);
 

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -34,7 +34,7 @@ public class ChangelessTransactionCoinSelectorTests
 		long[] inputCosts = coins.Select(x => feeRate.GetFee(x.ScriptPubKey.EstimateInputVsize()).Satoshi).ToArray();
 
 		Dictionary<SmartCoin, long> inputEffectiveValues = new(coins.ToDictionary(x => x, x => x.EffectiveValue(feeRate).Satoshi));
-		var strategy = new MoreSelectionStrategy(target, inputEffectiveValues.Values.ToArray(), inputCosts);
+		var strategy = new MoreSelectionStrategy(target, inputEffectiveValues.Values.ToArray(), inputCosts, maxInputCount: 5);
 
 		bool found = ChangelessTransactionCoinSelector.TryGetCoins(strategy, target, inputEffectiveValues, out var selectedCoins);
 		Assert.True(found);
@@ -59,7 +59,7 @@ public class ChangelessTransactionCoinSelectorTests
 
 		Dictionary<SmartCoin, long> inputEffectiveValues = new(coins.ToDictionary(x => x, x => x.EffectiveValue(feeRate).Satoshi));
 
-		var strategy = new LessSelectionStrategy(target, inputEffectiveValues.Values.ToArray(), inputCosts);
+		var strategy = new LessSelectionStrategy(target, inputEffectiveValues.Values.ToArray(), inputCosts, maxInputCount: 5);
 
 		bool found = ChangelessTransactionCoinSelector.TryGetCoins(strategy, target, inputEffectiveValues, out var selectedCoins);
 		Assert.True(found);
@@ -85,7 +85,7 @@ public class ChangelessTransactionCoinSelectorTests
 
 		Dictionary<SmartCoin, long> inputEffectiveValues = new(coins.ToDictionary(x => x, x => x.EffectiveValue(feeRate).Satoshi));
 
-		var strategy = new LessSelectionStrategy(target, coins.Select(coin => coin.Amount.Satoshi).ToArray(), inputCosts);
+		var strategy = new LessSelectionStrategy(target, coins.Select(coin => coin.Amount.Satoshi).ToArray(), inputCosts, maxInputCount: 5);
 
 		bool found = ChangelessTransactionCoinSelector.TryGetCoins(strategy, target, inputEffectiveValues, out var selectedCoins);
 		Assert.False(found);

--- a/WalletWasabi/Blockchain/TransactionBuilding/BnB/CoinSelection.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BnB/CoinSelection.cs
@@ -28,12 +28,9 @@ public class CoinSelection
 
 	public void Update(long paymentAmount, long totalCosts, long[] selection)
 	{
-		if (selection.Where(x => x > 0).Count() <= MaxCoinCount)
-		{
-			PaymentAmount = paymentAmount;
-			TotalCosts = totalCosts;
-			Selection = selection;
-		}
+		PaymentAmount = paymentAmount;
+		TotalCosts = totalCosts;
+		Selection = selection;
 	}
 
 	public long[]? GetSolutionArray()

--- a/WalletWasabi/Blockchain/TransactionBuilding/BnB/CoinSelection.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BnB/CoinSelection.cs
@@ -8,6 +8,8 @@ namespace WalletWasabi.Blockchain.TransactionBuilding.BnB;
 /// </summary>
 public class CoinSelection
 {
+	internal static readonly int MaxCoinCount = 5;
+
 	public CoinSelection(long sum, long sumWithCosts)
 	{
 		PaymentAmount = sum;
@@ -26,9 +28,12 @@ public class CoinSelection
 
 	public void Update(long paymentAmount, long totalCosts, long[] selection)
 	{
-		PaymentAmount = paymentAmount;
-		TotalCosts = totalCosts;
-		Selection = selection;
+		if (selection.Where(x => x > 0).Count() <= MaxCoinCount)
+		{
+			PaymentAmount = paymentAmount;
+			TotalCosts = totalCosts;
+			Selection = selection;
+		}
 	}
 
 	public long[]? GetSolutionArray()

--- a/WalletWasabi/Blockchain/TransactionBuilding/BnB/CoinSelection.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BnB/CoinSelection.cs
@@ -8,8 +8,6 @@ namespace WalletWasabi.Blockchain.TransactionBuilding.BnB;
 /// </summary>
 public class CoinSelection
 {
-	internal static readonly int MaxCoinCount = 5;
-
 	public CoinSelection(long sum, long sumWithCosts)
 	{
 		PaymentAmount = sum;

--- a/WalletWasabi/Blockchain/TransactionBuilding/BnB/SelectionStrategy.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BnB/SelectionStrategy.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
@@ -8,12 +9,13 @@ public abstract class SelectionStrategy
 	/// <param name="target">Value in satoshis.</param>
 	/// <param name="inputValues">Values in satoshis of the coins the user has (in descending order).</param>
 	/// <param name="inputCosts">Costs of spending coins in satoshis.</param>
-	public SelectionStrategy(long target, long[] inputValues, long[] inputCosts, CoinSelection bestSelection)
+	public SelectionStrategy(long target, long[] inputValues, long[] inputCosts, CoinSelection bestSelection, int maxInputCount)
 	{
 		InputCosts = inputCosts;
 		InputValues = inputValues;
 		Target = target;
 		BestSelection = bestSelection;
+		MaxInputCount = maxInputCount;
 
 		RemainingAmounts = new long[inputValues.Length];
 		long accumulator = InputValues.Sum();
@@ -37,6 +39,8 @@ public abstract class SelectionStrategy
 	/// <summary>Holds best coin selection found so far with some metadata to improve performance.</summary>
 	protected CoinSelection BestSelection { get; }
 
+	public int MaxInputCount { get; }
+
 	/// <summary>Gets best found selection as an array of effective values, or <c>null</c> if none was found.</summary>
 	public long[]? GetBestSelectionFound() => BestSelection.GetSolutionArray();
 
@@ -46,6 +50,8 @@ public abstract class SelectionStrategy
 	/// <summary>Sums of the remaining coins.</summary>
 	/// <remarks>i-th element represents a sum of all <c>i+1, i+2, ..., n</c> input values.</remarks>
 	protected long[] RemainingAmounts { get; set; }
+
+	protected List<long[]> Candidates { get; set; } = new();
 
 	/// <summary>
 	/// Modifies selection sum so that we don't need to recompute it.
@@ -91,4 +97,6 @@ public abstract class SelectionStrategy
 	/// <param name="depth">Number of <paramref name="selection"/> elements that contains the current solution.</param>
 	/// <param name="sum">Sum of first <paramref name="depth"/> elements of <paramref name="selection"/>.</param>
 	public abstract EvaluationResult Evaluate(long[] selection, int depth, long sum);
+
+	public abstract long[] GetBestCandidate();
 }


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/7703

This is a naive solution for the problem. All we do is cap the suggestions not to have more than 5 coins in it.

I choose `MaxInputCount` to be `5` from the top of my head. Fine-tuning this value might be required later on.

Pros of this PR:

-  At maximum we will only use 5 coins in one changeless TX.

Cons:

- We won't show that accurate suggestions.