### PR TITLE
Rename taskbar and add ToolTip to TrayIcon

### DIFF
--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -33,7 +33,7 @@
 		</Description>
 		<Copyright>MIT</Copyright>
 		<PackageId>Wasabi Wallet Fluent</PackageId>
-		<AssemblyTitle>Privacy focused Bitcoin wallet.</AssemblyTitle>
+		<AssemblyTitle>Wasabi Wallet</AssemblyTitle>
 		<Company>zkSNACKs</Company>
 		<PackageTags>bitcoin-wallet;privacy;bitcoin;dotnet;nbitcoin;cross-platform;zerolink;wallet;tumbler;coin;tor</PackageTags>
 		<PackageProjectUrl>https://github.com/zkSNACKs/WalletWasabi/</PackageProjectUrl>

--- a/WalletWasabi.Fluent/App.axaml
+++ b/WalletWasabi.Fluent/App.axaml
@@ -49,7 +49,7 @@
   </NativeMenu.Menu>
   <TrayIcon.Icons>
     <TrayIcons>
-      <TrayIcon Icon="{Binding TrayIcon}" Clicked="TrayIcon_OnClicked">
+      <TrayIcon Icon="{Binding TrayIcon}" Clicked="TrayIcon_OnClicked" ToolTipText="Wasabi Wallet">
         <NativeMenu.Menu>
           <NativeMenu>
             <NativeMenuItem Header="Show" Command="{Binding ShowCommand} " />


### PR DESCRIPTION
Fixes #7750 

Now the Task Manager shows _Wasabi Wallet_
& added ToolTip to TrayIcon

![image](https://user-images.githubusercontent.com/93143998/163204885-c1675df1-13b0-42b8-abf5-6c3b17e2999d.png)


![image](https://user-images.githubusercontent.com/93143998/163204956-1343eb89-92bc-45c1-ab6c-9aad06acaf58.png)
