### PR TITLE
Add WabiSabi CoinJoin monitor to status request API

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -352,7 +352,7 @@ public class BlockchainController : ControllerBase
 			status.FilterCreationActive = true;
 		}
 
-		// Updating the status of coinjoin
+		// Updating the status of coinjoin.
 		var validInterval = TimeSpan.FromSeconds(Global.Coordinator.RoundConfig.InputRegistrationTimeout * 2);
 		if (validInterval < TimeSpan.FromHours(1))
 		{
@@ -361,6 +361,20 @@ public class BlockchainController : ControllerBase
 		if (DateTimeOffset.UtcNow - Global.Coordinator.LastSuccessfulCoinJoinTime < validInterval)
 		{
 			status.CoinJoinCreationActive = true;
+		}
+
+		// Updating the status of WabiSabi coinjoin.
+		if (Global.WabiSabiCoordinator is { } wabiSabiCoordinator)
+		{
+			var wabiSabiValidInterval = wabiSabiCoordinator.Config.StandardInputRegistrationTimeout * 2;
+			if (wabiSabiValidInterval < TimeSpan.FromHours(1))
+			{
+				wabiSabiValidInterval = TimeSpan.FromHours(1);
+			}
+			if (DateTimeOffset.UtcNow - wabiSabiCoordinator.LastSuccessfulCoinJoinTime < wabiSabiValidInterval)
+			{
+				status.WabiSabiCoinJoinCreationActive = true;
+			}
 		}
 
 		return status;

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -44,6 +44,7 @@ public class Global : IDisposable
 
 	public CoordinatorRoundConfig RoundConfig { get; private set; }
 	public CoinJoinIdStore CoinJoinIdStore { get; private set; }
+	public WabiSabiCoordinator? WabiSabiCoordinator { get; private set; }
 
 	public async Task InitializeAsync(Config config, CoordinatorRoundConfig roundConfig, IRPCClient rpc, CancellationToken cancel)
 	{
@@ -92,7 +93,8 @@ public class Global : IDisposable
 
 		CoinJoinIdStore = CoinJoinIdStore.Create(Coordinator.CoinJoinsFilePath, coordinatorParameters.CoinJoinIdStoreFilePath);
 
-		HostedServices.Register<WabiSabiCoordinator>(() => new WabiSabiCoordinator(coordinatorParameters, RpcClient, CoinJoinIdStore), "WabiSabi Coordinator");
+		WabiSabiCoordinator = new WabiSabiCoordinator(coordinatorParameters, RpcClient, CoinJoinIdStore);
+		HostedServices.Register<WabiSabiCoordinator>(() => WabiSabiCoordinator, "WabiSabi Coordinator");
 		HostedServices.Register<RoundBootstrapper>(() => new RoundBootstrapper(TimeSpan.FromMilliseconds(100), Coordinator), "Round Bootstrapper");
 
 		await HostedServices.StartAllAsync(cancel);

--- a/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
@@ -4,4 +4,5 @@ public class StatusResponse
 {
 	public bool FilterCreationActive { get; set; }
 	public bool CoinJoinCreationActive { get; set; }
+	public bool WabiSabiCoinJoinCreationActive { get; set; }
 }

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -57,9 +57,12 @@ public class WabiSabiCoordinator : BackgroundService
 	public CoinJoinFeeRateStatStore CoinJoinFeeRateStatStore { get; }
 
 	public WabiSabiConfig Config => Parameters.RuntimeCoordinatorConfig;
+	public DateTimeOffset LastSuccessfulCoinJoinTime { get; private set; } = DateTimeOffset.UtcNow;
 
 	private void Arena_CoinJoinBroadcast(object? sender, Transaction transaction)
 	{
+		LastSuccessfulCoinJoinTime = DateTimeOffset.UtcNow;
+
 		CoinJoinIdStore.TryAdd(transaction.GetHash());
 
 		var coinJoinScriptStoreFilePath = Parameters.CoinJoinScriptStoreFilePath;


### PR DESCRIPTION
Similar to ZeroLink CoinJoin monitor. If there are no coinjoins for a specific time period the status API request will indicate that. The time period is twice the input reg period but at least 1 hour. 