### PR TITLE
[VDG] Fix wrong dialog behavior

### DIFF
--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -70,8 +70,8 @@
             </Panel>
           </Border>
 
-          <searchBar:SearchBar DataContext="{Binding SearchBar}" Width="400" VerticalAlignment="Stretch"
-                               Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" />
+          <searchBar:SearchBar DataContext="{Binding SearchBar}" Width="400" VerticalAlignment="Stretch" x:CompileBindings="False"
+                               Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" IsHitTestVisible="{Binding $parent.DataContext.IsMainContentEnabled}" />
 
         </Grid>
       </Panel>

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -16,7 +16,7 @@
              x:Class="WalletWasabi.Fluent.Views.MainView">
   <Panel>
     <Panel>
-      <Panel>
+      <Panel IsEnabled="{Binding IsMainContentEnabled}">
         <ExperimentalAcrylicBorder IsHitTestVisible="False">
           <ExperimentalAcrylicBorder.Material>
             <ExperimentalAcrylicMaterial BackgroundSource="Digger"

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -71,7 +71,7 @@
           </Border>
 
           <searchBar:SearchBar DataContext="{Binding SearchBar}" Width="400" VerticalAlignment="Stretch" x:CompileBindings="False"
-                               Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" IsHitTestVisible="{Binding $parent.DataContext.IsMainContentEnabled}" />
+                               Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" IsHitTestVisible="{Binding $parent.DataContext.IsMainContentEnabled, FallbackValue=True}" />
 
         </Grid>
       </Panel>


### PR DESCRIPTION
*This is a regression introduced with the new "Store" style.*

When a dialog is visible, the user can still interact with the items behind. This **fixes that** by disabling the behind content when a dialog is shown.

This fixes https://github.com/zkSNACKs/WalletWasabi/issues/7763