### PR TITLE
[VDG] Loading wallet - no seconds displayed when more than 1 hr 

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
@@ -147,7 +147,14 @@ public partial class LoadingViewModel : ActivatableViewModel
 		var percentText = $"{Percent}% completed";
 
 		var remainingMilliseconds = (double)_stopwatch.ElapsedMilliseconds / processedCount * remainingCount;
-		var userFriendlyTime = TextHelpers.TimeSpanToFriendlyString(TimeSpan.FromMilliseconds(remainingMilliseconds));
+		var remainingTimeSpan = TimeSpan.FromMilliseconds(remainingMilliseconds);
+
+		if (remainingTimeSpan > TimeSpan.FromHours(1))
+		{
+ 		  remainingTimeSpan = new TimeSpan(remainingTimeSpan.Days, remainingTimeSpan.Hours, remainingTimeSpan.Minutes, seconds: 0);
+		}
+
+		var userFriendlyTime = TextHelpers.TimeSpanToFriendlyString(remainingTimeSpan);
 		var remainingTimeText = string.IsNullOrEmpty(userFriendlyTime) ? "" : $"- {userFriendlyTime} remaining";
 
 		StatusText = $"{percentText} {remainingTimeText}";


### PR DESCRIPTION
When a wallet is loading,
with this PR it will not display the seconds when the estimated loading time is more than 1hr.
![image](https://user-images.githubusercontent.com/93143998/165104979-59909afb-e253-4e9a-bd03-f7b2f36f37cd.png)

fixed together with @soosr 