### PR TITLE
[Trivial] Remove unnecessary null check

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
@@ -148,9 +148,9 @@ public partial class LabelSelectionViewModel : ViewModelBase
 	{
 		var pocketsToReturn = NonPrivatePockets.Where(x => x.Labels.All(label => LabelsWhiteList.Any(labelViewModel => labelViewModel.Value == label))).ToList();
 
-		if (_includePrivatePocket && _privatePocket is { } privatePocket)
+		if (_includePrivatePocket)
 		{
-			pocketsToReturn.Add(privatePocket);
+			pocketsToReturn.Add(_privatePocket);
 		}
 
 		return pocketsToReturn.ToArray();

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
@@ -361,8 +361,10 @@ public class PocketSelectionTests
 
 		selection.Reset(pockets.ToArray());
 
-		var usedCoins = new List<SmartCoin>();
-		usedCoins.Add(privateCoin);
+		var usedCoins = new List<SmartCoin>
+		{
+			privateCoin
+		};
 		usedCoins.AddRange(pocket2.Coins);
 
 		selection.SetUsedLabel(usedCoins, 10);


### PR DESCRIPTION
`_privatePocket` can't be null, so no need to check for null.
This PR also fixes a warning.