### PR TITLE
`WasabiRandom` is no longer `IDisposable`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -16,7 +16,6 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	private static int GetRandom(int minInclusive, int maxExclusive)
 	{
-		using SecureRandom rand = new();
-		return rand.GetInt(minInclusive, maxExclusive);
+		return SecureRandom.Instance.GetInt(minInclusive, maxExclusive);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Crypto/MacTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/MacTests.cs
@@ -8,12 +8,13 @@ namespace WalletWasabi.Tests.UnitTests.Crypto;
 
 public class MacTests
 {
+	public static readonly SecureRandom Rnd = SecureRandom.Instance;
+
 	[Fact]
 	[Trait("UnitTest", "UnitTest")]
 	public void CannotBuildWrongMac()
 	{
-		using var rnd = new SecureRandom();
-		var sk = new CredentialIssuerSecretKey(rnd);
+		var sk = new CredentialIssuerSecretKey(Rnd);
 
 		Assert.Throws<ArgumentNullException>(() => MAC.ComputeMAC(null!, Generators.G, Scalar.One));
 		Assert.Throws<ArgumentNullException>(() => MAC.ComputeMAC(sk, null!, Scalar.One));
@@ -25,11 +26,10 @@ public class MacTests
 	[Trait("UnitTest", "UnitTest")]
 	public void CanProduceAndVerifyMAC()
 	{
-		using var rnd = new SecureRandom();
-		var sk = new CredentialIssuerSecretKey(rnd);
+		var sk = new CredentialIssuerSecretKey(Rnd);
 
-		var attribute = rnd.GetScalar() * Generators.G;  // any random point
-		var t = rnd.GetScalar();
+		var attribute = Rnd.GetScalar() * Generators.G;  // any random point
+		var t = Rnd.GetScalar();
 
 		var mac = MAC.ComputeMAC(sk, attribute, t);
 
@@ -40,23 +40,22 @@ public class MacTests
 	[Trait("UnitTest", "UnitTest")]
 	public void CanDetectInvalidMAC()
 	{
-		using var rnd = new SecureRandom();
-		var sk = new CredentialIssuerSecretKey(rnd);
+		var sk = new CredentialIssuerSecretKey(Rnd);
 
-		var attribute = rnd.GetScalar() * Generators.G;  // any random point
-		var differentAttribute = rnd.GetScalar() * Generators.G;  // any other random point
-		var t = rnd.GetScalar();
+		var attribute = Rnd.GetScalar() * Generators.G;  // any random point
+		var differentAttribute = Rnd.GetScalar() * Generators.G;  // any other random point
+		var t = Rnd.GetScalar();
 
 		// Create MAC for realAttribute and verify with fake/wrong attribute
 		var mac = MAC.ComputeMAC(sk, attribute, t);
 		Assert.False(mac.VerifyMAC(sk, differentAttribute));
 
-		var differentT = rnd.GetScalar();
+		var differentT = Rnd.GetScalar();
 		var differentMac = MAC.ComputeMAC(sk, attribute, differentT);
 		Assert.NotEqual(mac, differentMac);
 
 		mac = MAC.ComputeMAC(sk, attribute, differentT);
-		var differentSk = new CredentialIssuerSecretKey(rnd);
+		var differentSk = new CredentialIssuerSecretKey(Rnd);
 		Assert.False(mac.VerifyMAC(differentSk, attribute));
 	}
 
@@ -64,10 +63,9 @@ public class MacTests
 	[Trait("UnitTest", "UnitTest")]
 	public void EqualityTests()
 	{
-		using var rnd = new SecureRandom();
 
-		var right = (attribute: rnd.GetScalar() * Generators.G, sk: new CredentialIssuerSecretKey(rnd), t: rnd.GetScalar());
-		var wrong = (attribute: rnd.GetScalar() * Generators.G, sk: new CredentialIssuerSecretKey(rnd), t: rnd.GetScalar());
+		var right = (attribute: Rnd.GetScalar() * Generators.G, sk: new CredentialIssuerSecretKey(Rnd), t: Rnd.GetScalar());
+		var wrong = (attribute: Rnd.GetScalar() * Generators.G, sk: new CredentialIssuerSecretKey(Rnd), t: Rnd.GetScalar());
 
 		var cases = new[]
 		{

--- a/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/RandomTests.cs
@@ -11,7 +11,7 @@ public class RandomTests
 	[Fact]
 	public void BasicTests()
 	{
-		// Make sure byte array comparison works within hashset and that the underlying API won't pull the floor out.
+		// Make sure byte array comparison works within hash set and that the underlying API won't pull the floor out.
 		var byteArray = new byte[] { 1, 2, 3 };
 		var sameByteArray = new byte[] { 1, 2, 3 };
 		var differentByteArray = new byte[] { 4, 5, 6 };
@@ -30,8 +30,8 @@ public class RandomTests
 		var pseudoSet = new HashSet<byte[]>();
 		var secureSet = new HashSet<byte[]>();
 		var count = 100;
-		using var insecureRandom = new InsecureRandom();
-		using var secureRandom = new SecureRandom();
+		InsecureRandom insecureRandom = InsecureRandom.Instance;
+		SecureRandom secureRandom = SecureRandom.Instance;
 		for (int i = 0; i < count; i++)
 		{
 			pseudoSet.Add(insecureRandom.GetBytes(10));
@@ -46,8 +46,8 @@ public class RandomTests
 	{
 		var randoms = new List<WasabiRandom>
 			{
-				new SecureRandom(),
-				new InsecureRandom(),
+				SecureRandom.Instance,
+				InsecureRandom.Instance,
 			};
 
 		foreach (var random in randoms)
@@ -71,7 +71,7 @@ public class RandomTests
 	[Fact]
 	public void ScalarTests()
 	{
-		// Make sure first that scalar equality works within hashset and that the underlying API won't pull the floor out.
+		// Make sure first that scalar equality works within hash set and that the underlying API won't pull the floor out.
 		var singleSet = new HashSet<Scalar>
 			{
 				new Scalar(5),
@@ -107,7 +107,7 @@ public class RandomTests
 	[Fact]
 	public void ScalarInternalTests()
 	{
-		using var mockRandom = new MockRandom();
+		MockRandom mockRandom = new();
 
 		// The random should not overflow.
 		mockRandom.GetBytesResults.Add(EC.N.ToBytes());

--- a/WalletWasabi.Tests/UnitTests/Crypto/TranscriptTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/TranscriptTests.cs
@@ -52,7 +52,7 @@ public class TranscriptTests
 	public void SyntheticNoncesTest()
 	{
 		var protocol = Encoding.UTF8.GetBytes("test TranscriptRng collisions");
-		using var rnd = new SecureRandom();
+		SecureRandom rnd = SecureRandom.Instance;
 
 		var commitment1 = new[] { Generators.Gx0 };
 		var commitment2 = new[] { Generators.Gx1 };
@@ -146,7 +146,7 @@ public class TranscriptTests
 	{
 		var protocol = Encoding.UTF8.GetBytes("witness size");
 
-		using var rnd = new SecureRandom();
+		SecureRandom rnd = SecureRandom.Instance;
 
 		var witness = new Scalar[size];
 
@@ -163,7 +163,7 @@ public class TranscriptTests
 	{
 		var protocol = Encoding.UTF8.GetBytes("empty witness not allowed");
 
-		using var rnd = new SecureRandom();
+		SecureRandom rnd = SecureRandom.Instance;
 
 		var transcript = new Transcript(protocol);
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfDlogTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfDlogTests.cs
@@ -38,8 +38,7 @@ public class KnowledgeOfDLogTests
 			var generator = Generators.G;
 			var publicPoint = secret * generator;
 			var statement = new Statement(publicPoint, Generators.G);
-			using var rand = new SecureRandom();
-			var proof = ProofSystemHelpers.Prove(statement, secret, rand);
+			var proof = ProofSystemHelpers.Prove(statement, secret, SecureRandom.Instance);
 			Assert.True(ProofSystemHelpers.Verify(statement, proof));
 		}
 	}
@@ -47,7 +46,7 @@ public class KnowledgeOfDLogTests
 	[Fact]
 	public void End2EndVerificationLargeScalar()
 	{
-		using var random = new SecureRandom();
+		var random = SecureRandom.Instance;
 		uint val = int.MaxValue;
 		var gen = new Scalar(4) * Generators.G;
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfRepTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/ZeroKnowledge/KnowledgeOfRepTests.cs
@@ -46,7 +46,7 @@ public class KnowledgeOfRepTests
 				var generators = new GroupElementVector(Generators.G, Generators.Ga);
 				var publicPoint = secrets * generators;
 				var statement = new Statement(publicPoint, generators);
-				using var rand = new SecureRandom();
+				SecureRandom rand = SecureRandom.Instance;
 				var proof = ProofSystemHelpers.Prove(statement, secrets, rand);
 				Assert.True(ProofSystemHelpers.Verify(statement, proof));
 			}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -229,7 +229,7 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore);
 
-		using var rnd = new InsecureRandom();
+		InsecureRandom rnd = InsecureRandom.Instance;
 		var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, rnd, 4300000000000L);
 		var vsizeClient = new WabiSabiClient(round.VsizeCredentialIssuerParameters, rnd, 2000L);
 		var apiClient = new ArenaClient(amountClient, vsizeClient, wabiSabiApi);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -41,7 +41,7 @@ public class BobClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore);
 
-		using var insecureRandom = new InsecureRandom();
+		InsecureRandom insecureRandom = InsecureRandom.Instance;
 		var roundState = RoundState.FromRound(round);
 		var aliceArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/CredentialTests.cs
@@ -11,7 +11,7 @@ public class CredentialTests
 	[Trait("UnitTest", "UnitTest")]
 	public void CorrectRangeProof()
 	{
-		using var rnd = new SecureRandom();
+		SecureRandom rnd = SecureRandom.Instance;
 		var sk = new CredentialIssuerSecretKey(rnd);
 
 		var client = new WabiSabiClient(sk.ComputeCredentialIssuerParameters(), rnd, 4300000000000);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/SerializationTests.cs
@@ -183,7 +183,7 @@ public class SerializationTests
 				new MoneySatoshiJsonConverter()
 		};
 
-		using var rnd = new SecureRandom();
+		SecureRandom rnd = SecureRandom.Instance;
 		var sk = new CredentialIssuerSecretKey(rnd);
 
 		var issuer = new CredentialIssuer(sk, rnd, 4300000000000);

--- a/WalletWasabi/Crypto/Randomness/InsecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/InsecureRandom.cs
@@ -3,6 +3,8 @@ namespace WalletWasabi.Crypto.Randomness;
 /// <seealso href="https://devblogs.microsoft.com/pfxteam/getting-random-numbers-in-a-thread-safe-way/"/>>
 public class InsecureRandom : WasabiRandom
 {
+	public static readonly InsecureRandom Instance = new();
+
 	public InsecureRandom()
 	{
 		Random = Random.Shared;

--- a/WalletWasabi/Crypto/Randomness/RandomString.cs
+++ b/WalletWasabi/Crypto/Randomness/RandomString.cs
@@ -6,7 +6,7 @@ public static class RandomString
 {
 	public static string FromCharacters(int length, string characters, bool secureRandom = false)
 	{
-		using WasabiRandom random = secureRandom ? new SecureRandom() : new InsecureRandom();
+		WasabiRandom random = secureRandom ? SecureRandom.Instance : InsecureRandom.Instance;
 
 		var res = random.GetString(length, characters);
 		return res;

--- a/WalletWasabi/Crypto/Randomness/SecureRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/SecureRandom.cs
@@ -4,6 +4,8 @@ namespace WalletWasabi.Crypto.Randomness;
 
 public class SecureRandom : WasabiRandom
 {
+	public static readonly SecureRandom Instance = new();
+
 	public SecureRandom()
 	{
 	}

--- a/WalletWasabi/Crypto/Randomness/WasabiRandom.cs
+++ b/WalletWasabi/Crypto/Randomness/WasabiRandom.cs
@@ -5,7 +5,7 @@ using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Crypto.Randomness;
 
-public abstract class WasabiRandom : IRandom, IDisposable
+public abstract class WasabiRandom : IRandom
 {
 	public abstract void GetBytes(byte[] output);
 
@@ -45,9 +45,5 @@ public abstract class WasabiRandom : IRandom, IDisposable
 		}
 		while (overflow != 0 || randomScalar.IsZero);
 		return randomScalar;
-	}
-
-	public virtual void Dispose()
-	{
 	}
 }

--- a/WalletWasabi/Crypto/StringCipher.cs
+++ b/WalletWasabi/Crypto/StringCipher.cs
@@ -26,12 +26,10 @@ public static class StringCipher
 
 	public static string Encrypt(string plainText, string passPhrase)
 	{
-		using SecureRandom secureRandom = new();
-
 		// Salt is randomly generated each time, but is prepended to encrypted cipher text
 		// so that the same Salt value can be used when decrypting.
-		byte[] iv = secureRandom.GetBytes(AesBlockByteSize);
-		byte[] encryptionKeySalt = secureRandom.GetBytes(PasswordSaltByteSize);
+		byte[] iv = SecureRandom.Instance.GetBytes(AesBlockByteSize);
+		byte[] encryptionKeySalt = SecureRandom.Instance.GetBytes(PasswordSaltByteSize);
 		byte[] encryptionKey = DerivateKey(passPhrase, encryptionKeySalt);
 
 		// Encrypt the plain text.
@@ -40,7 +38,7 @@ public static class StringCipher
 		byte[] cipherTextBytes = aes.EncryptCbc(plainTextBytes, iv);
 
 		// Authenticate.
-		byte[] authKeySalt = secureRandom.GetBytes(PasswordSaltByteSize);
+		byte[] authKeySalt = SecureRandom.Instance.GetBytes(PasswordSaltByteSize);
 		byte[] authKey = DerivateKey(passPhrase, authKeySalt);
 		byte[] result = MergeArrays(additionalCapacity: SignatureByteSize, encryptionKeySalt, iv, authKeySalt, cipherTextBytes);
 

--- a/WalletWasabi/Extensions/TimeSpanExtensions.cs
+++ b/WalletWasabi/Extensions/TimeSpanExtensions.cs
@@ -14,9 +14,8 @@ public static class TimeSpanExtensions
 
 	public static ImmutableList<TimeSpan> SamplePoissonDelays(this TimeSpan timeFrame, int numberOfEvents)
 	{
-		using var random = new SecureRandom();
-		TimeSpan Sample(int milliseconds) =>
-			milliseconds <= 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(random.GetInt(0, milliseconds));
+		static TimeSpan Sample(int milliseconds) =>
+			milliseconds <= 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(SecureRandom.Instance.GetInt(0, milliseconds));
 
 		return Enumerable
 			.Range(0, numberOfEvents)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -12,6 +12,7 @@ using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.Logging;
+using WalletWasabi.Crypto.Randomness;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -71,7 +72,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			// that it is not guessable (Guid.NewGuid() documentation does
 			// not say anything about GUID version or randomness source,
 			// only that the probability of duplicates is very low).
-			var id = new Guid(Random.GetBytes(16));
+			var id = new Guid(SecureRandom.Instance.GetBytes(16));
 
 			var isPayingZeroCoordinationFee = CoinJoinIdStore.Contains(coin.Outpoint.Hash);
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -34,7 +34,6 @@ public partial class Arena : PeriodicRunner
 		Rpc = rpc;
 		Prison = prison;
 		TransactionArchiver = archiver;
-		Random = new SecureRandom();
 		CoinJoinIdStore = coinJoinIdStore;
 		CoinJoinScriptStore = coinJoinScriptStore;
 		MaxSuggestedAmountProvider = new(Config);
@@ -46,7 +45,6 @@ public partial class Arena : PeriodicRunner
 	private WabiSabiConfig Config { get; }
 	internal IRPCClient Rpc { get; }
 	private Prison Prison { get; }
-	private SecureRandom Random { get; }
 	private CoinJoinTransactionArchiver? TransactionArchiver { get; }
 	public CoinJoinScriptStore? CoinJoinScriptStore { get; }
 	private ICoinJoinIdStore CoinJoinIdStore { get; set; }
@@ -333,7 +331,7 @@ public partial class Arena : PeriodicRunner
 	private async Task CreateBlameRoundAsync(Round round, CancellationToken cancellationToken)
 	{
 		var feeRate = (await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, cancellationToken).ConfigureAwait(false)).FeeRate;
-		RoundParameters parameters = new(Config, Network, Random, feeRate, round.CoordinationFeeRate, round.MaxSuggestedAmount);
+		RoundParameters parameters = new(Config, Network, SecureRandom.Instance, feeRate, round.CoordinationFeeRate, round.MaxSuggestedAmount);
 		var blameWhitelist = round.Alices
 			.Select(x => x.Coin.Outpoint)
 			.Where(x => !Prison.IsBanned(x))
@@ -352,7 +350,7 @@ public partial class Arena : PeriodicRunner
 			RoundParameters roundParams = new(
 				Config,
 				Network,
-				Random,
+				SecureRandom.Instance,
 				feeRate,
 				Config.CoordinationFeeRate,
 				MaxSuggestedAmountProvider.GetMaxSuggestedAmount(ConnectionConfirmationStartedCounter));
@@ -396,7 +394,7 @@ public partial class Arena : PeriodicRunner
 		var diffMoney = Money.Satoshis(diff) - coinjoin.Parameters.FeeRate.GetFee(blameScript.EstimateOutputVsize());
 		if (diffMoney > coinjoin.Parameters.AllowedOutputAmounts.Min)
 		{
-			// If diff is smaller than max feerate of a tx, then add it as fee.
+			// If diff is smaller than max fee rate of a tx, then add it as fee.
 			var highestFeeRate = (await Rpc.EstimateSmartFeeAsync(2, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, cancellationToken).ConfigureAwait(false)).FeeRate;
 			// ToDo: This condition could be more sophisticated by always trying to max out the miner fees to target 2 and only deal with the remaining diffMoney.
 			if (coinjoin.EffectiveFeeRate > highestFeeRate)
@@ -453,7 +451,7 @@ public partial class Arena : PeriodicRunner
 	{
 		var coordinatorScriptPubKey = Config.GetNextCleanCoordinatorScript();
 
-		// Prevent coord script reuse.
+		// Prevent coordinator script reuse.
 		if (Rounds.Any(r => r.CoordinatorScript == coordinatorScriptPubKey))
 		{
 			Config.MakeNextCoordinatorScriptDirty();
@@ -462,11 +460,5 @@ public partial class Arena : PeriodicRunner
 		}
 
 		return coordinatorScriptPubKey;
-	}
-
-	public override void Dispose()
-	{
-		Random.Dispose();
-		base.Dispose();
 	}
 }


### PR DESCRIPTION
After #7688, it is no longer necessary to have `WasabiRandom` as `IDisposable` which in turn should fix a few warnings where we do not dispose properly.

Removes 12 warnings (355 remains)