### PR TITLE
[Arena] Get the status from RoundStates instead of Rounds

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -193,7 +193,7 @@ public class StepOutputRegistrationTests
 		var round = Assert.Single(arena.Rounds);
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;
 
-		// Refresh the Arena States because of vsize manupulation.
+		// Refresh the Arena States because of vsize manipulation.
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -193,6 +193,9 @@ public class StepOutputRegistrationTests
 		var round = Assert.Single(arena.Rounds);
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;
 
+		// Refresh the Arena States because of vsize manupulation.
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -22,13 +22,6 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping;
 
 public class StepTransactionSigningTests
 {
-	private readonly ITestOutputHelper _output;
-
-	public StepTransactionSigningTests(ITestOutputHelper output)
-	{
-		_output = output;
-	}
-
 	[Fact]
 	public async Task EveryoneSignedAsync()
 	{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -16,11 +16,19 @@ using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping;
 
 public class StepTransactionSigningTests
 {
+	private readonly ITestOutputHelper _output;
+
+	public StepTransactionSigningTests(ITestOutputHelper output)
+	{
+		_output = output;
+	}
+
 	[Fact]
 	public async Task EveryoneSignedAsync()
 	{
@@ -235,6 +243,10 @@ public class StepTransactionSigningTests
 
 		var round = Assert.Single(arena.Rounds);
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;
+
+		// Refresh the Arena States because of vsize manupulation.
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		// Register Alices.

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -244,7 +244,7 @@ public class StepTransactionSigningTests
 		var round = Assert.Single(arena.Rounds);
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;
 
-		// Refresh the Arena States because of vsize manupulation.
+		// Refresh the Arena States because of vsize manipulation.
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -143,7 +143,7 @@ public class RegisterOutputTests
 		var round = arena.Rounds.First();
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;
 
-		// Refresh the Arena States because of vsize manupulation.
+		// Refresh the Arena States because of vsize manipulation.
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -143,6 +143,9 @@ public class RegisterOutputTests
 		var round = arena.Rounds.First();
 		round.MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead;
 
+		// Refresh the Arena States because of vsize manupulation.
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 
 		foreach (Phase phase in Enum.GetValues(typeof(Phase)))

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -382,8 +382,12 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		var requestCheckPointDictionary = request.RoundCheckpoints.ToDictionary(r => r.RoundId, r => r);
 		var responseRoundStates = RoundStates.Select(x =>
 		{
-			requestCheckPointDictionary.TryGetValue(x.Id, out RoundStateCheckpoint? checkPoint);
-			return x.GetSubState(checkPoint == default ? 0 : checkPoint.StateId);
+			if (requestCheckPointDictionary.TryGetValue(x.Id, out RoundStateCheckpoint? checkPoint) && checkPoint.StateId != 0)
+			{
+				return x.GetSubState(checkPoint.StateId);
+			}
+
+			return x;
 		}).ToArray();
 
 		return Task.FromResult(new RoundStateResponse(responseRoundStates, Array.Empty<CoinJoinFeeRateMedian>()));

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -382,7 +382,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		var requestCheckPointDictionary = request.RoundCheckpoints.ToDictionary(r => r.RoundId, r => r);
 		var responseRoundStates = RoundStates.Select(x =>
 		{
-			if (requestCheckPointDictionary.TryGetValue(x.Id, out RoundStateCheckpoint? checkPoint) && checkPoint.StateId != 0)
+			if (requestCheckPointDictionary.TryGetValue(x.Id, out RoundStateCheckpoint? checkPoint) && checkPoint.StateId > 0)
 			{
 				return x.GetSubState(checkPoint.StateId);
 			}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -14,6 +14,8 @@ using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using WalletWasabi.WabiSabi.Backend.Statistics;
+using System.Collections.Immutable;
+using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -40,6 +42,7 @@ public partial class Arena : PeriodicRunner
 	}
 
 	public HashSet<Round> Rounds { get; } = new();
+	private ImmutableArray<RoundState> RoundStates { get; set; } = ImmutableArray.Create<RoundState>();
 	private AsyncLock AsyncLock { get; } = new();
 	private Network Network { get; }
 	private WabiSabiConfig Config { get; }
@@ -74,6 +77,8 @@ public partial class Arena : PeriodicRunner
 
 			// Ensure there's at least one non-blame round in input registration.
 			await CreateRoundsAsync(cancel).ConfigureAwait(false);
+
+			RoundStates = Rounds.Select(r => RoundState.FromRound(r, stateId: 0)).ToImmutableArray();
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -78,6 +78,7 @@ public partial class Arena : PeriodicRunner
 			// Ensure there's at least one non-blame round in input registration.
 			await CreateRoundsAsync(cancel).ConfigureAwait(false);
 
+			// RoundStates have to contain all states. Do not change stateId=0.
 			RoundStates = Rounds.Select(r => RoundState.FromRound(r, stateId: 0)).ToImmutableArray();
 		}
 	}

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -26,7 +26,7 @@ public record RoundState(
 	long MaxSuggestedAmount,
 	MultipartyTransactionState CoinjoinState)
 {
-	private uint256 _id;
+	private uint256? _id;
 
 	public uint256 Id => _id ??= CalculateHash();
 
@@ -52,6 +52,27 @@ public record RoundState(
 			round.MaxSuggestedAmount,
 			round.CoinjoinState.GetStateFrom(stateId)
 			);
+
+	public RoundState GetSubState(int skipFromBaseState) =>
+	new(
+		BlameOf,
+		AmountCredentialIssuerParameters,
+		VsizeCredentialIssuerParameters,
+		FeeRate,
+		CoordinationFeeRate,
+		Phase,
+		WasTransactionBroadcast,
+		InputRegistrationStart,
+		InputRegistrationTimeout,
+		ConnectionConfirmationTimeout,
+		OutputRegistrationTimeout,
+		TransactionSigningTimeout,
+		MaxAmountCredentialValue,
+		MaxVsizeCredentialValue,
+		MaxVsizeAllocationPerAlice,
+		MaxSuggestedAmount,
+		CoinjoinState.GetStateFrom(skipFromBaseState)
+		);
 
 	public TState Assert<TState>() where TState : MultipartyTransactionState =>
 		CoinjoinState switch


### PR DESCRIPTION
PoC of this PR with measurements https://github.com/zkSNACKs/WalletWasabi/pull/7852

GetStatus is one of the main blocking requests in Arena. From the tests, it is clear that because of the lock it slows down and prevents the progress of other requests. 

With this PR, not just the lock goes away but generating the state response and updating it became more simple. 

UPDATE

Tests are failing sometimes in CI (I assume it is only a test related issue)- until the fix, take this PR as a concept.