### PR TITLE
[VDG] [Trivial] Unset default monospaced font for Flyouts

### DIFF
--- a/WalletWasabi.Fluent/Styles/FlyoutPresenter.axaml
+++ b/WalletWasabi.Fluent/Styles/FlyoutPresenter.axaml
@@ -33,7 +33,6 @@
         <Panel MaxHeight="500">
           <Border Name="LayoutRoot" Margin="3 20 3 0"
                   Classes.IsActive="{Binding IsActive, FallbackValue=false}"
-                  TextBlock.FontFamily="{StaticResource MonospacedFont}"
                   BoxShadow="0 0 5 0 #7F000000"
                   Background="Transparent"
                   BorderBrush="{TemplateBinding BorderBrush}"

--- a/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
+++ b/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
@@ -32,11 +32,6 @@
       </Setter>
     </Style>
 
-    <!-- TODO: Investigate why this is needed. Removing it will render monospaced font in Flyout -->
-    <Style Selector="TextBlock">
-      <Setter Property="FontFamily" Value="Arial" />
-    </Style>
-
     <Style Selector="Button.searchItem /template/ ContentPresenter">
       <Setter Property="Background" Value="Transparent" />
     </Style>


### PR DESCRIPTION
Monospaced font was set explicitly as the font for Flyouts. This fixes it as requested in https://github.com/zkSNACKs/WalletWasabi/pull/7797#pullrequestreview-951591041