### PR TITLE
Remove OnFeeChanged from TransactionInfo

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
@@ -19,9 +19,6 @@ public partial class TransactionInfo
 	{
 		_privateCoinThreshold = minAnonScoreTarget;
 
-		this.WhenAnyValue(x => x.FeeRate)
-			.Subscribe(_ => OnFeeChanged());
-
 		this.WhenAnyValue(x => x.Coins)
 			.Subscribe(_ => OnCoinsChanged());
 	}
@@ -62,11 +59,6 @@ public partial class TransactionInfo
 		{
 			FeeRate = FeeRate.Zero;
 		}
-	}
-
-	private void OnFeeChanged()
-	{
-		ChangelessCoins = Enumerable.Empty<SmartCoin>();
 	}
 
 	private void OnCoinsChanged()


### PR DESCRIPTION
This way the BnB method won't run twice again, but instead the amount will be changed, while there still be no change.

Related to #7702, only code part