### PR TITLE
Add possiblity to continue when PlebStop

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -141,8 +141,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			// Only take PlebStop into account when AutoCoinJoin.
-			if (startCommand.RestartAutomatically && walletToStart.NonPrivateCoins.TotalAmount() <= walletToStart.KeyManager.PlebStopThreshold)
+			if (walletToStart.NonPrivateCoins.TotalAmount() < walletToStart.KeyManager.PlebStopThreshold)
 			{
 				Logger.LogDebug($"PlebStop preventing coinjoin for wallet '{walletToStart.WalletName}'.");
 				NotifyCoinJoinStartError(walletToStart, CoinjoinError.NotEnoughUnprivateBalance);


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/7877

Work in progress. 

- In both modes, when the balance fell under Pleb Stop, the wallet stops mixing and provides the Play button to override. 
- The way to override has to be attention-grabbing (for example red play button or dialog).
- Question: if the user has once overridden the pleb stop, shall we even take care later? For example, the user balance is always under the default threshold so when he restarts the wallet, should it be asked again. 

Current solution
- Change pleb stop limit for the wallet to Zero, when overriding the PlebStop. In this way, the setting is permanent and makes sense in general with our current logic. @nopara73 what do you think? 
