### PR TITLE
[VDG] Toggle switch in Settings to enable/disable display of decimal numbers in balance tile for fiat amount

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TextHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TextHelpers.cs
@@ -49,14 +49,14 @@ public static class TextHelpers
 		return result;
 	}
 
-	public static string GenerateFiatText(this decimal amountBtc, decimal exchangeRate, string fiatCode)
+	public static string GenerateFiatText(this decimal amountBtc, decimal exchangeRate, string fiatCode, string format = "N2")
 	{
-		return GenerateFiatText(amountBtc * exchangeRate, fiatCode);
+		return GenerateFiatText(amountBtc * exchangeRate, fiatCode, format);
 	}
 
-	public static string GenerateFiatText(this decimal amountFiat, string fiatCode)
+	public static string GenerateFiatText(this decimal amountFiat, string fiatCode, string format = "N2")
 	{
-		return $"(≈{(amountFiat).FormattedFiat()} {fiatCode}) ";
+		return $"(≈{(amountFiat).FormattedFiat(format)} {fiatCode}) ";
 	}
 
 	public static string ToFormattedString(this Money money)

--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -55,9 +55,9 @@ public class UiConfig : ConfigBase
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(_ => ToFile());
 
-		this.WhenAnyValue(x =>
-			x.SendAmountConversionReversed,
-			x => x.ShowDecimalsInFiatBalance)
+		this.WhenAnyValue(
+				x => x.SendAmountConversionReversed,
+				x => x.ShowDecimalsInFiatBalance)
 			.Throttle(TimeSpan.FromMilliseconds(500))
 			.Skip(1) // Won't save on UiConfig creation.
 			.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -28,6 +28,7 @@ public class UiConfig : ConfigBase
 	private bool _autoPaste;
 	private int _feeTarget;
 	private bool _sendAmountConversionReversed;
+	private bool _showDecimalsInFiatBalance;
 
 	public UiConfig() : base()
 	{
@@ -54,7 +55,9 @@ public class UiConfig : ConfigBase
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(_ => ToFile());
 
-		this.WhenAnyValue(x => x.SendAmountConversionReversed)
+		this.WhenAnyValue(x =>
+			x.SendAmountConversionReversed,
+			x => x.ShowDecimalsInFiatBalance)
 			.Throttle(TimeSpan.FromMilliseconds(500))
 			.Skip(1) // Won't save on UiConfig creation.
 			.ObserveOn(RxApp.MainThreadScheduler)
@@ -131,6 +134,14 @@ public class UiConfig : ConfigBase
 	{
 		get => _feeDisplayUnit;
 		set => RaiseAndSetIfChanged(ref _feeDisplayUnit, value);
+	}
+
+	[DefaultValue(true)]
+	[JsonProperty(PropertyName = "ShowDecimalsInFiatBalance", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool ShowDecimalsInFiatBalance
+	{
+		get => _showDecimalsInFiatBalance;
+		set => RaiseAndSetIfChanged(ref _showDecimalsInFiatBalance, value);
 	}
 
 	[DefaultValue(true)]

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -30,6 +30,7 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 	[AutoNotify] private FeeDisplayUnit _selectedFeeDisplayUnit;
 	[AutoNotify] private bool _runOnSystemStartup;
 	[AutoNotify] private bool _hideOnClose;
+	[AutoNotify] private bool _showDecimalsInFiatBalance;
 
 	public GeneralSettingsTabViewModel()
 	{
@@ -39,6 +40,7 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 		_customChangeAddress = Services.UiConfig.IsCustomChangeAddress;
 		_runOnSystemStartup = Services.UiConfig.RunOnSystemStartup;
 		_hideOnClose = Services.UiConfig.HideOnClose;
+		_showDecimalsInFiatBalance = Services.UiConfig.ShowDecimalsInFiatBalance;
 		_selectedFeeDisplayUnit = Enum.IsDefined(typeof(FeeDisplayUnit), Services.UiConfig.FeeDisplayUnit)
 			? (FeeDisplayUnit)Services.UiConfig.FeeDisplayUnit
 			: FeeDisplayUnit.Satoshis;
@@ -91,6 +93,11 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 			.ObserveOn(RxApp.TaskpoolScheduler)
 			.Skip(1)
 			.Subscribe(x => Services.UiConfig.HideOnClose = x);
+
+		this.WhenAnyValue(x => x.ShowDecimalsInFiatBalance)
+			.ObserveOn(RxApp.TaskpoolScheduler)
+			.Skip(1)
+			.Subscribe(x => Services.UiConfig.ShowDecimalsInFiatBalance = x);
 	}
 
 	public ICommand StartupCommand { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -56,8 +56,14 @@ public partial class WalletBalanceTileViewModel : TileViewModel
 
 		BalanceBtc = $"{totalAmount.ToFormattedString()} BTC";
 
-		BalanceFiat = _wallet.Coins.TotalAmount().ToDecimal(MoneyUnit.BTC)
-			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
+		var fiatAmount = _wallet.Coins.TotalAmount().ToDecimal(MoneyUnit.BTC) * _wallet.Synchronizer.UsdExchangeRate;
+		var format =
+			fiatAmount > 1
+			? "N0"
+			: "N2";
+
+		BalanceFiat =
+			fiatAmount.GenerateFiatText("USD", format);
 
 		var privateThreshold = _wallet.KeyManager.MinAnonScoreTarget;
 		var privateCoins = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -48,6 +48,10 @@ public partial class WalletBalanceTileViewModel : TileViewModel
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(_ => UpdateRecentTransaction())
 			.DisposeWith(disposables);
+
+		Services.UiConfig.WhenAnyValue(x => x.ShowDecimalsInFiatBalance)
+						 .Subscribe(x => UpdateBalance())
+						 .DisposeWith(disposables);
 	}
 
 	private void UpdateBalance()
@@ -58,9 +62,9 @@ public partial class WalletBalanceTileViewModel : TileViewModel
 
 		var fiatAmount = _wallet.Coins.TotalAmount().ToDecimal(MoneyUnit.BTC) * _wallet.Synchronizer.UsdExchangeRate;
 		var format =
-			fiatAmount > 1
-			? "N0"
-			: "N2";
+			Services.UiConfig.ShowDecimalsInFiatBalance
+			? "N2"
+			: "N0";
 
 		BalanceFiat =
 			fiatAmount.GenerateFiatText("USD", format);

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -36,7 +36,7 @@
     </DockPanel>
 
     <DockPanel>
-      <TextBlock VerticalAlignment="Center" Text="Custom change address" />
+      <TextBlock Text="Custom change address" />
       <ToggleSwitch IsChecked="{Binding CustomChangeAddress}" />
     </DockPanel>
 
@@ -52,7 +52,7 @@
     </StackPanel>
 
     <DockPanel>
-      <TextBlock VerticalAlignment="Top" Text="Show decimals for fiat amount in balance" />
+      <TextBlock Text="Show decimals for fiat amount in balance" />
       <ToggleSwitch IsChecked="{Binding ShowDecimalsInFiatBalance}" />
     </DockPanel>
   </StackPanel>

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -50,5 +50,10 @@
         </ComboBox.ItemTemplate>
       </ComboBox>
     </StackPanel>
+
+    <DockPanel>
+      <TextBlock VerticalAlignment="Top" Text="Show decimals for fiat amount in balance" />
+      <ToggleSwitch IsChecked="{Binding ShowDecimalsInFiatBalance}" />
+    </DockPanel>
   </StackPanel>
 </UserControl>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/98904713/166093338-0c4636a0-a5ba-4744-9f56-51ac1ea1c602.png)

 - Removes decimals from fiat amount display in balance tile, ONLY when balance is above 1 USD
 - Does NOT remove decimals for fiat amounts in other places, such as privacy suggestions, because many times these are less than 1 USD and it would not make sense not to show the cents
 - I was thinking of adding a `show decimal amounts for fiat currency` toggle in `Settings` for this, but it seemed way too overkill, to add such complexity to the application, so I went for a sane default.

