### PR TITLE
Only stop restarting if round was intentionally stopped

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -284,7 +284,14 @@ public class CoinJoinManager : BackgroundService
 		}
 		catch (OperationCanceledException)
 		{
-			Logger.LogInfo($"{logPrefix} was cancelled.");
+			if (finishedCoinJoin.IsStopped)
+			{
+				Logger.LogInfo($"{logPrefix} was stopped.");
+			}
+			else
+			{
+				Logger.LogInfo($"{logPrefix} was cancelled.");
+			}
 		}
 		catch (Exception e)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -175,7 +175,7 @@ public class CoinJoinManager : BackgroundService
 			var walletToStop = stopCommand.Wallet;
 			if (trackedCoinJoins.TryGetValue(walletToStop.WalletName, out var coinJoinTrackerToStop))
 			{
-				coinJoinTrackerToStop.Cancel();
+				coinJoinTrackerToStop.Stop();
 			}
 		}
 
@@ -296,7 +296,9 @@ public class CoinJoinManager : BackgroundService
 			coins.CoinJoinInProgress = false;
 		}
 
-		if (finishedCoinJoin.RestartAutomatically && !finishedCoinJoin.CoinJoinTask.IsCanceled)
+		if (finishedCoinJoin.RestartAutomatically &&
+			!finishedCoinJoin.IsStopped &&
+			!cancellationToken.IsCancellationRequested)
 		{
 			Logger.LogInfo($"{logPrefix} restart automatically.");
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -35,9 +35,11 @@ public class CoinJoinTracker : IDisposable
 
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
 	public bool InCriticalCoinJoinState => CoinJoinClient.InCriticalCoinJoinState;
+	public bool IsStopped { get; private set; }
 
-	public void Cancel()
+	public void Stop()
 	{
+		IsStopped = true;
 		CancellationTokenSource.Cancel();
 	}
 


### PR DESCRIPTION
Continuation of https://github.com/zkSNACKs/WalletWasabi/pull/7881

In the case of AutoCoin, it will only stop when:
- Stop command was intentionally called. 
- The whole CoinJoinManager was canceled. 