### PR TITLE
Add test to verify round awaiter can be cancelled

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -195,7 +195,8 @@ public class RoundStateUpdaterTests
 		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
 		mockApiClient
 			.Setup(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(() => new RoundStateResponse(new[] { roundState with {Phase = Phase.InputRegistration } },
+			.ReturnsAsync(() =>
+				new RoundStateResponse(new[] { roundState with { Phase = Phase.InputRegistration } },
 				Array.Empty<CoinJoinFeeRateMedian>()));
 
 		using RoundStateUpdater roundStatusUpdater = new(TimeSpan.FromSeconds(100), mockApiClient.Object);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -195,8 +195,8 @@ public class RoundStateUpdaterTests
 		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
 		mockApiClient
 			.Setup(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(() =>
-				new RoundStateResponse(new[] { roundState with { Phase = Phase.InputRegistration } },
+			.ReturnsAsync(
+				() => new RoundStateResponse(new[] { roundState with { Phase = Phase.InputRegistration } },
 				Array.Empty<CoinJoinFeeRateMedian>()));
 
 		using RoundStateUpdater roundStatusUpdater = new(TimeSpan.FromSeconds(100), mockApiClient.Object);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -184,5 +185,31 @@ public class RoundStateUpdaterTests
 
 		// We are expecting output registration phase but the round unexpectedly ends.
 		await Assert.ThrowsAsync<UnexpectedRoundPhaseException>(async () => await roundORTask);
+	}
+
+	[Fact]
+	public async Task CancelAsync()
+	{
+		var roundState = RoundState.FromRound(WabiSabiFactory.CreateRound(new()));
+
+		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
+		mockApiClient
+			.Setup(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(() => new RoundStateResponse(new[] {roundState with {Phase = Phase.InputRegistration}},
+				Array.Empty<CoinJoinFeeRateMedian>()));
+
+		using RoundStateUpdater roundStatusUpdater = new(TimeSpan.FromSeconds(100), mockApiClient.Object);
+		try
+		{
+			await roundStatusUpdater.StartAsync(CancellationToken.None);
+			using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+			await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+				await roundStatusUpdater.CreateRoundAwaiter(uint256.One, Phase.InputRegistration, cancellationTokenSource.Token));
+		}
+		finally
+		{
+			await roundStatusUpdater.StopAsync(CancellationToken.None);
+		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -195,7 +195,7 @@ public class RoundStateUpdaterTests
 		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
 		mockApiClient
 			.Setup(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(() => new RoundStateResponse(new[] {roundState with {Phase = Phase.InputRegistration}},
+			.ReturnsAsync(() => new RoundStateResponse(new[] { roundState with {Phase = Phase.InputRegistration } },
 				Array.Empty<CoinJoinFeeRateMedian>()));
 
 		using RoundStateUpdater roundStatusUpdater = new(TimeSpan.FromSeconds(100), mockApiClient.Object);


### PR DESCRIPTION
Just a test to verify the `RoundStateUpdater` respects the cancellation token.