### PR TITLE
Fix `isLongBan` missing after restart

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
@@ -38,5 +38,5 @@ public record Inmate(
 	}
 
 	public override string ToString()
-		=> $"{Started.ToUnixTimeSeconds()}:{Punishment}:{Utxo.Hash}:{Utxo.N}:{LastDisruptedRoundId}";
+		=> $"{Started.ToUnixTimeSeconds()}:{Punishment}:{Utxo.Hash}:{Utxo.N}:{LastDisruptedRoundId}:{IsLongBan}";
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
@@ -23,13 +23,18 @@ public record Inmate(
 		var utxoHashString = parts[2];
 		var utxoIndexString = parts[3];
 		var disruptedRoundIdString = parts[4];
+		var isLongBan = false;
+		if (parts.Length > 5)
+		{
+			isLongBan = bool.Parse(parts[5]);
+		}
 
 		var started = DateTimeOffset.FromUnixTimeSeconds(long.Parse(startedString));
 		var punishment = Enum.Parse<Punishment>(punishmentString);
 		var utxo = new OutPoint(new uint256(utxoHashString), int.Parse(utxoIndexString));
 		var lastDisruptedRoundId = uint256.Parse(disruptedRoundIdString);
 
-		return new(utxo, punishment, started, lastDisruptedRoundId);
+		return new(utxo, punishment, started, lastDisruptedRoundId, isLongBan);
 	}
 
 	public override string ToString()


### PR DESCRIPTION
While testing the software I realized that `Inmate.isLongBan` has a bug.
As long as the backend is not restarted, the cached `Inmate`s will have the assigned value, so the release logic is correct.
But the `isLongBan` value is not saved, so after restart, all `Inmate`s will have `false` for `isLongBan`, as it is the default, so people would be freed much faster.