### PR TITLE
Tune down consolidation penalty in coinjoins

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -89,6 +89,12 @@ public class BlockchainAnalyzer
 		// Our smallest anonset is the relevant here, because anonsets cannot grow by intersection punishments.
 		var smallestAnon = anonsets.Min();
 
+		// Consolidation in coinjoins is the only type of consolidation that's acceptable.
+		if (coefficient < 1)
+		{
+			return smallestAnon;
+		}
+
 		// Punish intersection exponentially.
 		// If there is only a single anonset then the exponent should be zero to divide by 1 thus retain the input coin anonset.
 		var intersectPenalty = Math.Pow(2, anonsets.Count() - 1);


### PR DESCRIPTION
This PR turns off the heavy consolidation penalty we incur for input merging when it happens during coinjoins. In this PR we'd only punish anonscores in coinjoins to the smallest inputs' anonscore.

@MaxHillebrand @BTCparadigm @MarnixCroes If you have a wallet in privacy mode with a high anonymity percentage. Can you check if this PR changes the privacy percentage?

@andrewkozlik @onvej-sl