### PR TITLE
[VDG] decrease CPU & GPU usage

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -39,7 +39,6 @@
             BorderBrush="{DynamicResource GlassEdgeColor}"
             BorderThickness="1,1,1,0">
       <Panel DataContext="{Binding CurrentWallet.CoinJoinStateViewModel}">
-        <controls:BlurBehind BlurRadius="10,10" />
         <Panel Background="{DynamicResource TileRegionColor}" Opacity="0.35" />
         <StackPanel Margin="10 5" Orientation="Horizontal" Spacing="20">
           <Image Height="35" Width="35" VerticalAlignment="Center" HorizontalAlignment="Center" Source="{DynamicResource wasabi_logo_dynamic}" />


### PR DESCRIPTION
With the help of @jmacato, we debugged what is responsible for the high CPU and GPU usage. And it seems the MusicBox control contained a redundant blur effect. 

I removed it and waited until 12 peers connected.
My test results are the following:

This PR:
```
	CPU	GPU
no CJ:	2-4.5%	3.7%
   CJ:	3-6%	3.7%
```
Master:
```
	CPU	GPU
no CJ:	10-12%	9.6%
   CJ:	9-14%	9.8%
```