### PR TITLE
Differentiate between normal and long banning 

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
@@ -23,20 +23,15 @@ public record Inmate(
 		var utxoHashString = parts[2];
 		var utxoIndexString = parts[3];
 		var disruptedRoundIdString = parts[4];
-		var isLongBan = false;
-		if (parts.Length > 5)
-		{
-			isLongBan = bool.Parse(parts[5]);
-		}
 
 		var started = DateTimeOffset.FromUnixTimeSeconds(long.Parse(startedString));
 		var punishment = Enum.Parse<Punishment>(punishmentString);
 		var utxo = new OutPoint(new uint256(utxoHashString), int.Parse(utxoIndexString));
 		var lastDisruptedRoundId = uint256.Parse(disruptedRoundIdString);
 
-		return new(utxo, punishment, started, lastDisruptedRoundId, isLongBan);
+		return new(utxo, punishment, started, lastDisruptedRoundId);
 	}
 
 	public override string ToString()
-		=> $"{Started.ToUnixTimeSeconds()}:{Punishment}:{Utxo.Hash}:{Utxo.N}:{LastDisruptedRoundId}:{IsLongBan}";
+		=> $"{Started.ToUnixTimeSeconds()}:{Punishment}:{Utxo.Hash}:{Utxo.N}:{LastDisruptedRoundId}";
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
@@ -43,7 +43,7 @@ public class Prison
 
 	public void Ban(Alice alice, uint256 lastDisruptedRoundId, bool isLongBan = false)
 	{
-		Punish(alice.Coin.Outpoint, Punishment.Banned, lastDisruptedRoundId, isLongBan);
+		Punish(alice.Coin.Outpoint, isLongBan ? Punishment.LongBanned : Punishment.Banned, lastDisruptedRoundId);
 	}
 
 	public void Ban(OutPoint outpoint, uint256 lastDisruptedRoundId)

--- a/WalletWasabi/WabiSabi/Backend/Banning/Punishment.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Punishment.cs
@@ -3,5 +3,6 @@ namespace WalletWasabi.WabiSabi.Backend.Banning;
 public enum Punishment
 {
 	Noted,
-	Banned
+	Banned,
+	LongBanned
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -34,7 +34,8 @@ public enum WabiSabiProtocolErrorCode
 	CryptoException,
 	AliceAlreadySignalled,
 	AliceAlreadyConfirmedConnection,
-	AlreadyRegisteredScript
+	AlreadyRegisteredScript,
+	InputLongBanned
 }
 
 public static class WabiSabiProtocolErrorCodeExtension

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -355,9 +355,17 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	{
 		OutPoint input = request.Input;
 
-		if (Prison.TryGet(input, out var inmate) && (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted))
+		if (Prison.TryGet(input, out var inmate))
 		{
-			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned);
+			if (inmate.Punishment == Punishment.LongBanned)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned);
+			}
+
+			if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned);
+			}
 		}
 
 		var txOutResponse = await Rpc.GetTxOutAsync(input.Hash, (int)input.N, includeMempool: true, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
![download](https://user-images.githubusercontent.com/9844978/166964709-7cfaae20-90f8-44c4-a7b8-77d41a5a2c5d.png)

With the current code, it is not possible for the user to see and differentiate between different types of bans. Also it is not possible to see when the ban will be resolved (which was available in WW1).

With this PR coins (UTXO) can have two types of ban. Normal and long ban. Prison stores the punishment type in class InMate and WabiSabi config delivers the timeouts for resolving the ban. 

This is a priority because it will slightly change the protocol. 