### PR TITLE
[VDG] Adjust navbar tint colors & Fix icon foreground

### DIFF
--- a/WalletWasabi.Fluent/Styles/Themes/BaseDark.axaml
+++ b/WalletWasabi.Fluent/Styles/Themes/BaseDark.axaml
@@ -4,7 +4,6 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary>
-
           <Color x:Key="SystemAccentColor">#FF5E96ED</Color>
           <Color x:Key="SystemAltHighColor">#FF000000</Color>
           <Color x:Key="SystemAltLowColor">#FF000000</Color>
@@ -73,8 +72,7 @@
     <Color x:Key="TileRegionColor">#21252D</Color>
     <Color x:Key="TileBorderColor">#66757575</Color>
     <Color x:Key="AcrylicTrimForeground">White</Color>
-    <Color x:Key="AcrylicTrimBackground">#232A33</Color>
-    <Color x:Key="AcrylicTrimOverlayBackground">Transparent</Color>
+    <Color x:Key="AcrylicTrimBackground">#A0202020</Color>
 
     <Color x:Key="WelcomeScreenButtonBackground">#1D273E</Color>
     <Color x:Key="WelcomeScreenButtonBackgroundPressed">#141B2A</Color>

--- a/WalletWasabi.Fluent/Styles/Themes/BaseLight.axaml
+++ b/WalletWasabi.Fluent/Styles/Themes/BaseLight.axaml
@@ -73,8 +73,7 @@
     <Color x:Key="TileRegionColor">White</Color>
     <Color x:Key="TileBorderColor">#14000000</Color>
     <Color x:Key="AcrylicTrimForeground">#FCFCFC</Color>
-    <Color x:Key="AcrylicTrimBackground">#285687</Color>
-    <Color x:Key="AcrylicTrimOverlayBackground">#AE134074</Color>
+    <Color x:Key="AcrylicTrimBackground">#90134074</Color>
 
     <Color x:Key="WelcomeScreenButtonBackground">#DADFE7</Color>
     <Color x:Key="WelcomeScreenButtonBackgroundPressed">#C1CBD7</Color>

--- a/WalletWasabi.Fluent/Views/MainView.axaml
+++ b/WalletWasabi.Fluent/Views/MainView.axaml
@@ -21,13 +21,13 @@
         <ExperimentalAcrylicBorder IsHitTestVisible="False">
           <ExperimentalAcrylicBorder.Material>
             <ExperimentalAcrylicMaterial BackgroundSource="Digger"
-                                         TintColor="{DynamicResource AcrylicTrimBackground}"
-                                         TintOpacity="1"
+                                         TintColor="Transparent"
+                                         TintOpacity="0"
                                          FallbackColor="{DynamicResource AcrylicTrimBackground}"
-                                         MaterialOpacity="0.9" />
+                                         MaterialOpacity="0" />
           </ExperimentalAcrylicBorder.Material>
         </ExperimentalAcrylicBorder>
-        <Panel IsHitTestVisible="False" Background="{DynamicResource AcrylicTrimOverlayBackground}"/>
+        <Panel IsHitTestVisible="False" Background="{DynamicResource AcrylicTrimBackground}"/>
 
         <Grid ColumnDefinitions="68, *, 150" RowDefinitions="48, *">
 

--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -143,7 +143,7 @@
                 <LayoutTransformControl DockPanel.Dock="Bottom">
                   <c:FadeOutTextBlock Text="{Binding Title}" />
                 </LayoutTransformControl>
-                <PathIcon Classes="new size24" />
+                <PathIcon Foreground="{DynamicResource AcrylicTrimForeground}" Classes="new size24" />
               </DockPanel>
             </Panel>
           </DataTemplate>
@@ -168,7 +168,7 @@
                 <LayoutTransformControl DockPanel.Dock="Bottom">
                   <c:FadeOutTextBlock Text="{Binding Title}" />
                 </LayoutTransformControl>
-                <PathIcon Classes="new size24" />
+                <PathIcon Foreground="{DynamicResource AcrylicTrimForeground}" Classes="new size24" />
               </DockPanel>
             </Panel>
           </DataTemplate>


### PR DESCRIPTION
- Fixes the icon's foreground on Light mode.
- Adjust the tint colors on Dark mode so that it shows the blur behind it a bit better.

Windows

<img width="1095" alt="Screen Shot 2022-05-07 at 6 20 53 PM" src="https://user-images.githubusercontent.com/16554748/167250171-69af5cd7-ebd6-4cba-89d0-e76f23e7e252.png">

<img width="1135" alt="Screen Shot 2022-05-07 at 6 21 36 PM" src="https://user-images.githubusercontent.com/16554748/167250208-c813e237-6ba9-4699-872f-e54aee093486.png">

Mac
 
<img width="1222" alt="Screen Shot 2022-05-07 at 6 07 47 PM" src="https://user-images.githubusercontent.com/16554748/167249708-997b1103-47d2-4878-af03-cc37f90e906a.png">

<img width="1207" alt="Screen Shot 2022-05-07 at 6 07 57 PM" src="https://user-images.githubusercontent.com/16554748/167249712-90ed23f7-ae22-4405-a03f-e4cd9b86e43c.png">


cc @zkSNACKs/visual-design-group