### PR TITLE
Extend `SmartLabel`'s `Equals` to handle character casing

### DIFF
--- a/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
@@ -110,4 +110,25 @@ public class SmartLabelTests
 		Assert.Equal(4, label.Labels.Count());
 		Assert.Equal("bar, buz, foo, qux", label);
 	}
+
+	[Fact]
+	public void CaseSensitivityTests()
+	{
+		var smartLabel = new SmartLabel("Foo");
+		var smartLabelToCheck = new SmartLabel("fOO");
+		var stringLabelToCheck = "fOO";
+		Assert.True(smartLabel.Equals(smartLabelToCheck, StringComparer.OrdinalIgnoreCase));
+		Assert.False(smartLabel.Equals(smartLabelToCheck, StringComparer.Ordinal));
+		Assert.True(smartLabel.Equals(stringLabelToCheck, StringComparison.OrdinalIgnoreCase));
+		Assert.False(smartLabel.Equals(stringLabelToCheck, StringComparison.Ordinal));
+
+		smartLabel = new SmartLabel("bAr, FOO, Buz");
+		smartLabelToCheck = new SmartLabel("buZ, BaR, fOo");
+		stringLabelToCheck = "buZ, BaR, fOo";
+		Assert.True(smartLabel.Equals(smartLabelToCheck, StringComparer.OrdinalIgnoreCase));
+		Assert.False(smartLabel.Equals(smartLabelToCheck, StringComparer.Ordinal));
+		Assert.False(smartLabel.Equals(stringLabelToCheck, StringComparison.OrdinalIgnoreCase)); // stringLabelToCheck is a string, the order of the element is different, this should be False.
+		Assert.True(smartLabel.Equals(smartLabelToCheck.ToString(), StringComparison.OrdinalIgnoreCase)); // SmartLabel.cs sorts the elements, this should be True.
+		Assert.False(smartLabel.Equals(stringLabelToCheck, StringComparison.Ordinal));
+	}
 }

--- a/WalletWasabi/Blockchain/Analysis/Clustering/SmartLabel.cs
+++ b/WalletWasabi/Blockchain/Analysis/Clustering/SmartLabel.cs
@@ -63,16 +63,20 @@ public class SmartLabel : IEquatable<SmartLabel>, IEquatable<string>, IEnumerabl
 
 		return string.Compare(this, other, StringComparison.OrdinalIgnoreCase);
 	}
-
+	
 	public override bool Equals(object? obj) => Equals(obj as SmartLabel) || Equals(obj as string);
 
-	public bool Equals(SmartLabel? other) => this == other;
+	public bool Equals(SmartLabel? other) => AreEquivalent(this, other);
 
-	public bool Equals(string? other) => this == other;
+	public bool Equals(string? other) => AreEquivalent(other, this);
+
+	public bool Equals(string? other, StringComparison comparison) => AreEquivalent(other, this, comparison);
+
+	public bool Equals(SmartLabel? other, IEqualityComparer<string> comparer) => AreEquivalent(this, other, comparer);
 
 	public override int GetHashCode() => ((IStructuralEquatable)Labels).GetHashCode(EqualityComparer<string>.Default);
 
-	public static bool operator ==(SmartLabel? x, SmartLabel? y)
+	private static bool AreEquivalent(SmartLabel? x, SmartLabel? y, IEqualityComparer<string>? comparer = null)
 	{
 		if (x is null)
 		{
@@ -93,12 +97,12 @@ public class SmartLabel : IEquatable<SmartLabel>, IEquatable<string>, IEnumerabl
 			}
 			else
 			{
-				return x.Labels.SequenceEqual(y.Labels);
+				return x.Labels.SequenceEqual(y.Labels, comparer);
 			}
 		}
 	}
 
-	public static bool operator ==(string? x, SmartLabel? y)
+	private static bool AreEquivalent(string? x, SmartLabel? y, StringComparison? comparison = null)
 	{
 		if (x is null)
 		{
@@ -119,10 +123,19 @@ public class SmartLabel : IEquatable<SmartLabel>, IEquatable<string>, IEnumerabl
 			}
 			else
 			{
+				if (comparison is { })
+				{
+					return string.Equals(x, y.LabelString, comparison.Value);
+				}
+				
 				return x == y.LabelString;
 			}
 		}
 	}
+
+	public static bool operator ==(SmartLabel? x, SmartLabel? y) => AreEquivalent(x, y);
+
+	public static bool operator ==(string? x, SmartLabel? y) => AreEquivalent(x, y);
 
 	public static bool operator ==(SmartLabel? x, string? y) => y == x;
 

--- a/WalletWasabi/Blockchain/Analysis/Clustering/SmartLabel.cs
+++ b/WalletWasabi/Blockchain/Analysis/Clustering/SmartLabel.cs
@@ -18,7 +18,7 @@ public class SmartLabel : IEquatable<SmartLabel>, IEquatable<string>, IEnumerabl
 			   .Select(x => x.Trim())
 			   .Where(x => x.Length != 0)
 			   .Distinct(StringComparer.OrdinalIgnoreCase)
-			   .OrderBy(x => x)
+			   .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
 			   .ToArray();
 
 		IsEmpty = !Labels.Any();


### PR DESCRIPTION
This PR will allow me to simplify in `LabelSelectionViewModel.cs` in several lines.

Example, instead of this:
```c#
knownByRecipientPockets
	.Where(pocket =>
		pocket.Labels.Count() == recipient.Count() &&
		pocket.Labels.All(label => recipient.Contains(label, StringComparer.OrdinalIgnoreCase)))
	.ToArray();
```
I can do this:
```c#
knownByRecipientPockets.Where(pocket => pocket.Labels.Equals(recipient, StringComparer.OrdinalIgnoreCase)).ToArray();
```
