### PR TITLE
[Bnb] Use fixed enchange rate

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -80,7 +80,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 					yield return new ChangeAvoidanceSuggestionViewModel(
 						transactionInfo.Amount.ToDecimal(MoneyUnit.BTC),
 						transaction,
-						wallet.Synchronizer.UsdExchangeRate);
+						usdExchangeRate);
 				}
 			}
 		}


### PR DESCRIPTION
We send in the fixed `usd/btc` exchange rate, but don't use it anywhere.

This PR fixes this.