### PR TITLE
[VDG] [Trivial] Fix SearchBar caret brush in Light Mode

### DIFF
--- a/WalletWasabi.Fluent/Views/SearchBar/SearchBar.axaml
+++ b/WalletWasabi.Fluent/Views/SearchBar/SearchBar.axaml
@@ -22,6 +22,7 @@
 
     <Style Selector="TextBox#SearchBox">
       <Setter Property="Background" Value="Transparent" />
+      <Setter Property="CaretBrush" Value="{DynamicResource AcrylicTrimForeground}" />
       <Setter Property="BorderThickness" Value="1 1 1 1" />
       <Setter Property="Margin" Value="0" />
       <Setter Property="FontSize" Value="12" />


### PR DESCRIPTION
Previous:
Wrong caret brush in SearchBox (dark caret)
![image](https://user-images.githubusercontent.com/3109851/167592818-68e1e7c3-acaf-43da-8765-1013cfc53a95.png)

This PR:
Correct brush is used (light caret)
![image](https://user-images.githubusercontent.com/3109851/167593721-7b43e838-5e88-48b8-ad6e-d15c60b51de2.png)

