### PR TITLE
Coinjoin Phase event nits

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringInputRegistrationPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringInputRegistrationPhase.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class EnteringInputRegistrationPhase : RoundStateChanged
 {
-	public EnteringInputRegistrationPhase(RoundState roundState, DateTimeOffset timeout) : base(roundState, timeout)
+	public EnteringInputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringOutputRegistrationPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringOutputRegistrationPhase.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class EnteringOutputRegistrationPhase : RoundStateChanged
 {
-	public EnteringOutputRegistrationPhase(RoundState roundState, DateTimeOffset timeout) : base(roundState, timeout)
+	public EnteringOutputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringSigningPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringSigningPhase.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class EnteringSigningPhase : RoundStateChanged
 {
-	public EnteringSigningPhase(RoundState roundState, DateTimeOffset timeout) : base(roundState, timeout)
+	public EnteringSigningPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundStateChanged.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundStateChanged.cs
@@ -4,12 +4,12 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class RoundStateChanged : CoinJoinProgressEventArgs
 {
-	public RoundStateChanged(RoundState roundState, DateTimeOffset timeout)
+	public RoundStateChanged(RoundState roundState, DateTimeOffset timeoutAt)
 	{
 		RoundState = roundState;
-		Timeout = timeout;
+		TimeoutAt = timeoutAt;
 	}
 
 	public RoundState RoundState { get; }
-	public DateTimeOffset Timeout { get; }
+	public DateTimeOffset TimeoutAt { get; }
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/WaitingForBlameRound.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/WaitingForBlameRound.cs
@@ -2,10 +2,10 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class WaitingForBlameRound : CoinJoinProgressEventArgs
 {
-	public WaitingForBlameRound(DateTimeOffset dateTimeOffset)
+	public WaitingForBlameRound(DateTimeOffset timeoutAt)
 	{
-		DateTimeOffset = dateTimeOffset;
+		TimeoutAt = timeoutAt;
 	}
 
-	public DateTimeOffset DateTimeOffset { get; }
+	public DateTimeOffset TimeoutAt { get; }
 }

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CoinJoinStatusEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CoinJoinStatusEventArgs.cs
@@ -3,7 +3,7 @@ using WalletWasabi.Wallets;
 
 namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
-internal class CoinJoinStatusEventArgs : StatusChangedEventArgs
+public class CoinJoinStatusEventArgs : StatusChangedEventArgs
 {
 	public CoinJoinStatusEventArgs(Wallet wallet, CoinJoinProgressEventArgs coinJoinProgressEventArgs) : base(wallet)
 	{


### PR DESCRIPTION
- `CoinJoinStatusEventArgs` to public to be accessible
- `timeout` -> `timeoutAt` for better readability as `timeout` at most places is a timespan.