### PR TITLE
Differentiate normal and long ban

### DIFF
--- a/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
+++ b/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Newtonsoft.Json;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Crypto;
@@ -19,14 +20,16 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 			WabiSabiProtocolException e => new JsonResult(new Error(
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: e.ErrorCode.ToString(),
-				Description: e.Message))
+				Description: e.Message,
+				Data: JsonConvert.SerializeObject(e.ExceptionData, Formatting.None)))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},
 			WabiSabiCryptoException e => new JsonResult(new Error(
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: WabiSabiProtocolErrorCode.CryptoException.ToString(),
-				Description: e.Message))
+				Description: e.Message,
+				Data: string.Empty))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},

--- a/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
+++ b/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
@@ -21,7 +21,7 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: e.ErrorCode.ToString(),
 				Description: e.Message,
-				Data: JsonConvert.SerializeObject(e.ExceptionData, Formatting.None)))
+				ExceptionData: e.ExceptionData))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},
@@ -29,7 +29,7 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: WabiSabiProtocolErrorCode.CryptoException.ToString(),
 				Description: e.Message,
-				Data: string.Empty))
+				ExceptionData: null))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},

--- a/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
+++ b/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
@@ -21,7 +21,7 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: e.ErrorCode.ToString(),
 				Description: e.Message,
-				ExceptionData: e.ExceptionData ?? new EmptyExceptionData()))
+				ExceptionData: e.ExceptionData ?? EmptyExceptionData.Instance))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},
@@ -29,7 +29,7 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: WabiSabiProtocolErrorCode.CryptoException.ToString(),
 				Description: e.Message,
-				ExceptionData: new EmptyExceptionData()))
+				ExceptionData: EmptyExceptionData.Instance))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},

--- a/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
+++ b/WalletWasabi.Backend/Filters/ExceptionTranslateFilter.cs
@@ -21,7 +21,7 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: e.ErrorCode.ToString(),
 				Description: e.Message,
-				ExceptionData: e.ExceptionData))
+				ExceptionData: e.ExceptionData ?? new EmptyExceptionData()))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},
@@ -29,7 +29,7 @@ public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 				Type: ProtocolConstants.ProtocolViolationType,
 				ErrorCode: WabiSabiProtocolErrorCode.CryptoException.ToString(),
 				Description: e.Message,
-				ExceptionData: null))
+				ExceptionData: new EmptyExceptionData()))
 			{
 				StatusCode = (int)HttpStatusCode.InternalServerError
 			},

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -131,6 +131,34 @@ public class RegisterInputFailureTests
 			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
 
 		Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
+		Assert.IsAssignableFrom<InputBannedExceptionData>(ex.ExceptionData);
+
+		await arena.StopAsync(CancellationToken.None);
+	}
+
+	[Fact]
+	public async Task InputLongBannedAsync()
+	{
+		using Key key = new();
+		var outpoint = BitcoinFactory.CreateOutPoint();
+
+		WabiSabiConfig cfg = new();
+		var round = WabiSabiFactory.CreateRound(cfg);
+
+		Prison prison = new();
+		using Arena arena = await ArenaBuilder.From(cfg, prison).CreateAndStartAsync(round);
+
+		prison.Punish(outpoint, Punishment.LongBanned, uint256.One);
+
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key);
+
+		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+
+		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
+
+		Assert.Equal(WabiSabiProtocolErrorCode.InputLongBanned, ex.ErrorCode);
+		Assert.IsAssignableFrom<InputBannedExceptionData>(ex.ExceptionData);
 
 		await arena.StopAsync(CancellationToken.None);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonTests.cs
@@ -104,7 +104,7 @@ public class UtxoPrisonTests
 		var utxo = BitcoinFactory.CreateOutPoint();
 		var past = DateTimeOffset.UtcNow - TimeSpan.FromDays(40);
 
-		p.Punish(new Inmate(utxo, Punishment.Banned, past, id1, IsLongBan: true));
+		p.Punish(new Inmate(utxo, Punishment.LongBanned, past, id1));
 
 		Assert.Single(p.GetInmates());
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -14,6 +14,7 @@ using WalletWasabi.Tor.Http;
 using WalletWasabi.Tor.Socks5.Pool.Circuits;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
@@ -60,6 +61,36 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		var wex = Assert.IsType<WabiSabiProtocolException>(ex.InnerException);
 		Assert.Equal(WabiSabiProtocolErrorCode.InputSpent, wex.ErrorCode);
+	}
+
+	[Fact]
+	public async Task RegisterBannedCoinAsync()
+	{
+		var bannedOutPoint = BitcoinFactory.CreateOutPoint();
+
+		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
+			builder.ConfigureServices(services =>
+			{
+				var inmate = new Inmate(bannedOutPoint, Punishment.LongBanned, DateTimeOffset.UtcNow, uint256.One);
+				services.AddScoped<Prison>(_ => new Prison(new[] {inmate}));
+			})).CreateClient();
+
+		var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(httpClient);
+		var rounds = (await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None)).RoundStates;
+		var round = rounds.First(x => x.CoinjoinState is ConstructionState);
+
+		// If an output is not in the utxo dataset then it is not unspent, this
+		// means that the output is spent or simply doesn't even exist.
+		using var signingKey = new Key();
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
+
+		var ex = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+			await apiClient.RegisterInputAsync(round.Id, bannedOutPoint, ownershipProof, CancellationToken.None));
+
+		var wex = Assert.IsType<WabiSabiProtocolException>(ex.InnerException);
+		Assert.Equal(WabiSabiProtocolErrorCode.InputLongBanned, wex.ErrorCode);
+		var inputBannedData = Assert.IsType<InputBannedExceptionData>(wex.ExceptionData);
+		Assert.True(inputBannedData.BannedUntil > DateTimeOffset.UtcNow);
 	}
 
 	[Theory]

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -72,7 +72,7 @@ public static class HttpResponseMessageExtensions
 			var innerException = error switch
 			{
 				{ Type: ProtocolConstants.ProtocolViolationType } => Enum.TryParse<WabiSabiProtocolErrorCode>(error.ErrorCode, out var code)
-					? new WabiSabiProtocolException(code, error.Description, exceptionData: GetExceptionData(code, error.Data))
+					? new WabiSabiProtocolException(code, error.Description, exceptionData: error.ExceptionData)
 					: new NotSupportedException($"Received WabiSabi protocol exception with unknown '{error.ErrorCode}' error code.\n\tDescription: '{error.Description}'."),
 				{ Type: "unknown" } => new Exception(error.Description),
 				_ => null
@@ -96,15 +96,5 @@ public static class HttpResponseMessageExtensions
 		}
 
 		throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}");
-	}
-
-	private static ExceptionData? GetExceptionData(WabiSabiProtocolErrorCode errorCode, string data)
-	{
-		return errorCode switch
-		{
-			WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned => JsonConvert.DeserializeObject<InputBannedExceptionData>(data),
-			_ => null
-		};
-
 	}
 }

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -72,7 +72,7 @@ public static class HttpResponseMessageExtensions
 			var innerException = error switch
 			{
 				{ Type: ProtocolConstants.ProtocolViolationType } => Enum.TryParse<WabiSabiProtocolErrorCode>(error.ErrorCode, out var code)
-					? new WabiSabiProtocolException(code, error.Description)
+					? new WabiSabiProtocolException(code, error.Description, exceptionData: JsonConvert.DeserializeObject<InputBannedExceptionData>(error.Data))
 					: new NotSupportedException($"Received WabiSabi protocol exception with unknown '{error.ErrorCode}' error code.\n\tDescription: '{error.Description}'."),
 				{ Type: "unknown" } => new Exception(error.Description),
 				_ => null

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -9,6 +9,7 @@ using WalletWasabi.Tor.Http.Models;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Models;
+using WalletWasabi.WabiSabi.Models.Serialization;
 
 namespace WalletWasabi.Tor.Http.Extensions;
 
@@ -67,6 +68,7 @@ public static class HttpResponseMessageExtensions
 			var contentString = await me.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 			var error = JsonConvert.DeserializeObject<Error>(contentString, new JsonSerializerSettings()
 			{
+				Converters = JsonSerializationOptions.Default.Settings.Converters,
 				Error = (_, e) => e.ErrorContext.Handled = true // Try to deserialize an Error object
 			});
 			var innerException = error switch

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -72,7 +72,7 @@ public static class HttpResponseMessageExtensions
 			var innerException = error switch
 			{
 				{ Type: ProtocolConstants.ProtocolViolationType } => Enum.TryParse<WabiSabiProtocolErrorCode>(error.ErrorCode, out var code)
-					? new WabiSabiProtocolException(code, error.Description, exceptionData: JsonConvert.DeserializeObject<InputBannedExceptionData>(error.Data))
+					? new WabiSabiProtocolException(code, error.Description, exceptionData: GetExceptionData(code, error.Data))
 					: new NotSupportedException($"Received WabiSabi protocol exception with unknown '{error.ErrorCode}' error code.\n\tDescription: '{error.Description}'."),
 				{ Type: "unknown" } => new Exception(error.Description),
 				_ => null
@@ -96,5 +96,15 @@ public static class HttpResponseMessageExtensions
 		}
 
 		throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}");
+	}
+
+	private static ExceptionData? GetExceptionData(WabiSabiProtocolErrorCode errorCode, string data)
+	{
+		return errorCode switch
+		{
+			WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned => JsonConvert.DeserializeObject<InputBannedExceptionData>(data),
+			_ => null
+		};
+
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Inmate.cs
@@ -9,8 +9,7 @@ public record Inmate(
 	OutPoint Utxo,
 	Punishment Punishment,
 	DateTimeOffset Started,
-	uint256 LastDisruptedRoundId,
-	bool IsLongBan = false)
+	uint256 LastDisruptedRoundId)
 {
 	public TimeSpan TimeSpent => DateTimeOffset.UtcNow - Started;
 
@@ -23,20 +22,15 @@ public record Inmate(
 		var utxoHashString = parts[2];
 		var utxoIndexString = parts[3];
 		var disruptedRoundIdString = parts[4];
-		var isLongBan = false;
-		if (parts.Length > 5)
-		{
-			isLongBan = bool.Parse(parts[5]);
-		}
 
 		var started = DateTimeOffset.FromUnixTimeSeconds(long.Parse(startedString));
 		var punishment = Enum.Parse<Punishment>(punishmentString);
 		var utxo = new OutPoint(new uint256(utxoHashString), int.Parse(utxoIndexString));
 		var lastDisruptedRoundId = uint256.Parse(disruptedRoundIdString);
 
-		return new(utxo, punishment, started, lastDisruptedRoundId, isLongBan);
+		return new(utxo, punishment, started, lastDisruptedRoundId);
 	}
 
 	public override string ToString()
-		=> $"{Started.ToUnixTimeSeconds()}:{Punishment}:{Utxo.Hash}:{Utxo.N}:{LastDisruptedRoundId}:{IsLongBan}";
+		=> $"{Started.ToUnixTimeSeconds()}:{Punishment}:{Utxo.Hash}:{Utxo.N}:{LastDisruptedRoundId}";
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
@@ -100,7 +100,7 @@ public class Prison
 
 			foreach (var inmate in Inmates.Values.ToList())
 			{
-				var banPeriod = inmate.IsLongBan ? longBanPeriod : normalBanPeriod;
+				var banPeriod = inmate.Punishment is Punishment.LongBanned ? longBanPeriod : normalBanPeriod;
 				if (inmate.TimeSpent > banPeriod)
 				{
 					Inmates.Remove(inmate.Utxo);

--- a/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
@@ -43,7 +43,7 @@ public class Prison
 
 	public void Ban(Alice alice, uint256 lastDisruptedRoundId, bool isLongBan = false)
 	{
-		Punish(alice.Coin.Outpoint, Punishment.Banned, lastDisruptedRoundId, isLongBan);
+		Punish(alice.Coin.Outpoint, isLongBan ? Punishment.LongBanned : Punishment.Banned, lastDisruptedRoundId);
 	}
 
 	public void Ban(OutPoint outpoint, uint256 lastDisruptedRoundId)
@@ -51,8 +51,8 @@ public class Prison
 		Punish(outpoint, Punishment.Banned, lastDisruptedRoundId);
 	}
 
-	public void Punish(OutPoint utxo, Punishment punishment, uint256 lastDisruptedRoundId, bool isLongBan = false)
-		=> Punish(new Inmate(utxo, punishment, DateTimeOffset.UtcNow, lastDisruptedRoundId, isLongBan));
+	public void Punish(OutPoint utxo, Punishment punishment, uint256 lastDisruptedRoundId)
+		=> Punish(new Inmate(utxo, punishment, DateTimeOffset.UtcNow, lastDisruptedRoundId));
 
 	public void Punish(Inmate inmate)
 	{

--- a/WalletWasabi/WabiSabi/Backend/Banning/Punishment.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/Punishment.cs
@@ -3,5 +3,6 @@ namespace WalletWasabi.WabiSabi.Backend.Banning;
 public enum Punishment
 {
 	Noted,
-	Banned
+	Banned,
+	LongBanned
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/ExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/ExceptionData.cs
@@ -1,0 +1,5 @@
+namespace WalletWasabi.WabiSabi.Backend.Models;
+
+public abstract record ExceptionData
+{
+}

--- a/WalletWasabi/WabiSabi/Backend/Models/ExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/ExceptionData.cs
@@ -4,4 +4,7 @@ public abstract record ExceptionData
 {
 }
 
-public record EmptyExceptionData() : ExceptionData;
+public record EmptyExceptionData() : ExceptionData
+{
+	public static readonly EmptyExceptionData Instance = new();
+}

--- a/WalletWasabi/WabiSabi/Backend/Models/ExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/ExceptionData.cs
@@ -3,3 +3,5 @@ namespace WalletWasabi.WabiSabi.Backend.Models;
 public abstract record ExceptionData
 {
 }
+
+public record EmptyExceptionData() : ExceptionData;

--- a/WalletWasabi/WabiSabi/Backend/Models/InputBannedExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/InputBannedExceptionData.cs
@@ -1,0 +1,5 @@
+using Newtonsoft.Json;
+
+namespace WalletWasabi.WabiSabi.Backend.Models;
+
+public record InputBannedExceptionData([JsonProperty(PropertyName = "BannedUntil")] long BannedUntil) : ExceptionData;

--- a/WalletWasabi/WabiSabi/Backend/Models/InputBannedExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/InputBannedExceptionData.cs
@@ -2,4 +2,4 @@ using Newtonsoft.Json;
 
 namespace WalletWasabi.WabiSabi.Backend.Models;
 
-public record InputBannedExceptionData([JsonProperty(PropertyName = "BannedUntil")] DateTimeOffset BannedUntil) : ExceptionData;
+public record InputBannedExceptionData(DateTimeOffset BannedUntil) : ExceptionData;

--- a/WalletWasabi/WabiSabi/Backend/Models/InputBannedExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/InputBannedExceptionData.cs
@@ -2,4 +2,4 @@ using Newtonsoft.Json;
 
 namespace WalletWasabi.WabiSabi.Backend.Models;
 
-public record InputBannedExceptionData([JsonProperty(PropertyName = "BannedUntil")] long BannedUntil) : ExceptionData;
+public record InputBannedExceptionData([JsonProperty(PropertyName = "BannedUntil")] DateTimeOffset BannedUntil) : ExceptionData;

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -13,6 +13,7 @@ public enum WabiSabiProtocolErrorCode
 	TooMuchFunds,
 	NonUniqueInputs,
 	InputBanned,
+	InputLongBanned,
 	InputNotWhitelisted,
 	AliceNotFound,
 	IncorrectRequestedVsizeCredentials,
@@ -34,8 +35,7 @@ public enum WabiSabiProtocolErrorCode
 	CryptoException,
 	AliceAlreadySignalled,
 	AliceAlreadyConfirmedConnection,
-	AlreadyRegisteredScript,
-	InputLongBanned
+	AlreadyRegisteredScript
 }
 
 public static class WabiSabiProtocolErrorCodeExtension

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -34,7 +34,8 @@ public enum WabiSabiProtocolErrorCode
 	CryptoException,
 	AliceAlreadySignalled,
 	AliceAlreadyConfirmedConnection,
-	AlreadyRegisteredScript
+	AlreadyRegisteredScript,
+	InputLongBanned
 }
 
 public static class WabiSabiProtocolErrorCodeExtension

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolException.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolException.cs
@@ -4,13 +4,15 @@ namespace WalletWasabi.WabiSabi.Backend.Models;
 
 public class WabiSabiProtocolException : Exception
 {
-	public WabiSabiProtocolException(WabiSabiProtocolErrorCode errorCode, string? message = null, Exception? innerException = null)
+	public WabiSabiProtocolException(WabiSabiProtocolErrorCode errorCode, string? message = null, Exception? innerException = null, ExceptionData? exceptionData = null)
 		: base(message ?? ErrorCodeDescription(errorCode), innerException)
 	{
 		ErrorCode = errorCode;
+		ExceptionData = exceptionData;
 	}
 
 	public WabiSabiProtocolErrorCode ErrorCode { get; }
+	public ExceptionData? ExceptionData { get; }
 
 	private static string ErrorCodeDescription(WabiSabiProtocolErrorCode errorCode)
 	{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -358,14 +358,16 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 		if (Prison.TryGet(input, out var inmate))
 		{
+			DateTimeOffset bannedUntil;
 			if (inmate.Punishment == Punishment.LongBanned)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, $"{Config.ReleaseUtxoFromPrisonAfterLongBan - inmate.TimeSpent}");
+				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan;
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(bannedUntil.ToUnixTimeSeconds()));
 			}
-
-			if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
+			else if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, $"{Config.ReleaseUtxoFromPrisonAfter - inmate.TimeSpent}");
+				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, exceptionData: new InputBannedExceptionData(bannedUntil.ToUnixTimeSeconds()));
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -358,18 +358,14 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 		if (Prison.TryGet(input, out var inmate))
 		{
-			var bannedUntil = inmate.Punishment == Punishment.LongBanned ? inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan : inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
-
-			var message = $"Input banned until: {bannedUntil.ToUnixTimeSeconds()}";
-
 			if (inmate.Punishment == Punishment.LongBanned)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, message);
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, $"{Config.ReleaseUtxoFromPrisonAfterLongBan - inmate.TimeSpent}");
 			}
 
 			if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
 			{
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, message);
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, $"{Config.ReleaseUtxoFromPrisonAfter - inmate.TimeSpent}");
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -364,7 +364,8 @@ public partial class Arena : IWabiSabiApiRequestHandler
 				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan;
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
 			}
-			else if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
+
+			if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
 			{
 				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, exceptionData: new InputBannedExceptionData(bannedUntil));

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -360,7 +360,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		{
 			var bannedUntil = inmate.Punishment == Punishment.LongBanned ? inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan : inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
 
-			var message = $"Input banned until: {bannedUntil}";
+			var message = $"Input banned until: {bannedUntil.ToUnixTimeSeconds()}";
 
 			if (inmate.Punishment == Punishment.LongBanned)
 			{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -362,12 +362,12 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			if (inmate.Punishment == Punishment.LongBanned)
 			{
 				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan;
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(bannedUntil.ToUnixTimeSeconds()));
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
 			}
 			else if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
 			{
 				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, exceptionData: new InputBannedExceptionData(bannedUntil.ToUnixTimeSeconds()));
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -114,6 +114,12 @@ public class AliceClient
 						Logger.LogInfo($"{coin.Coin.Outpoint} is banned.");
 						break;
 
+					case WabiSabiProtocolErrorCode.InputLongBanned:
+						coin.BannedUntilUtc = DateTimeOffset.UtcNow.AddDays(31); // TODO: Date should be inside the exc. (backend)
+						coin.SetIsBanned();
+						Logger.LogInfo($"{coin.Coin.Outpoint} is long banned.");
+						break;
+
 					case WabiSabiProtocolErrorCode.InputNotWhitelisted:
 						coin.SpentAccordingToBackend = false;
 						Logger.LogWarning($"{coin.Coin.Outpoint} cannot be registered in the blame round.");

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -108,20 +108,12 @@ public class AliceClient
 						Logger.LogInfo($"{coin.Coin.Outpoint} is spent according to the backend. The wallet is not fully synchronized or corrupted.");
 						break;
 
-					case WabiSabiProtocolErrorCode.InputBanned:
+					case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
 						var remainingTimeAsString = wpe.Message;
 						var remaining = TimeSpan.Parse(remainingTimeAsString);
 						coin.BannedUntilUtc = DateTimeOffset.Now + remaining;
 						coin.SetIsBanned();
 						Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
-						break;
-
-					case WabiSabiProtocolErrorCode.InputLongBanned:
-						remainingTimeAsString = wpe.Message;
-						remaining = TimeSpan.Parse(remainingTimeAsString);
-						coin.BannedUntilUtc = DateTimeOffset.Now + remaining;
-						coin.SetIsBanned();
-						Logger.LogInfo($"{coin.Coin.Outpoint} is long banned until {coin.BannedUntilUtc}.");
 						break;
 
 					case WabiSabiProtocolErrorCode.InputNotWhitelisted:

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -109,15 +109,17 @@ public class AliceClient
 						break;
 
 					case WabiSabiProtocolErrorCode.InputBanned:
-						coin.BannedUntilUtc = DateTimeOffset.UtcNow.AddDays(1);
+						var remainingTimeAsString = wpe.Message;
+						var remaining = TimeSpan.Parse(remainingTimeAsString);
+						coin.BannedUntilUtc = DateTimeOffset.Now + remaining;
 						coin.SetIsBanned();
-						Logger.LogInfo($"{coin.Coin.Outpoint} is banned.");
+						Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
 						break;
 
 					case WabiSabiProtocolErrorCode.InputLongBanned:
-						var split = wpe.Message.Split(" ");
-						var bannedUntilUnixSeconds = long.Parse(split[^1]);
-						coin.BannedUntilUtc = DateTimeOffset.FromUnixTimeSeconds(bannedUntilUnixSeconds);
+						remainingTimeAsString = wpe.Message;
+						remaining = TimeSpan.Parse(remainingTimeAsString);
+						coin.BannedUntilUtc = DateTimeOffset.Now + remaining;
 						coin.SetIsBanned();
 						Logger.LogInfo($"{coin.Coin.Outpoint} is long banned until {coin.BannedUntilUtc}.");
 						break;

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -115,9 +115,11 @@ public class AliceClient
 						break;
 
 					case WabiSabiProtocolErrorCode.InputLongBanned:
-						coin.BannedUntilUtc = DateTimeOffset.UtcNow.AddDays(31); // TODO: Date should be inside the exc. (backend)
+						var split = wpe.Message.Split(" ");
+						var bannedUntilUnixSeconds = long.Parse(split[^1]);
+						coin.BannedUntilUtc = DateTimeOffset.FromUnixTimeSeconds(bannedUntilUnixSeconds);
 						coin.SetIsBanned();
-						Logger.LogInfo($"{coin.Coin.Outpoint} is long banned.");
+						Logger.LogInfo($"{coin.Coin.Outpoint} is long banned until {coin.BannedUntilUtc}.");
 						break;
 
 					case WabiSabiProtocolErrorCode.InputNotWhitelisted:

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -109,10 +109,8 @@ public class AliceClient
 						break;
 
 					case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
-						var remainingTimeAsString = wpe.Message;
-						var remaining = TimeSpan.Parse(remainingTimeAsString);
-						coin.BannedUntilUtc = DateTimeOffset.Now + remaining;
-						coin.SetIsBanned();
+						var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
+						coin.BannedUntilUtc = DateTimeOffset.FromUnixTimeSeconds(inputBannedExData.BannedUntil);
 						Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
 						break;
 

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -110,7 +110,11 @@ public class AliceClient
 
 					case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
 						var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
-						coin.BannedUntilUtc = DateTimeOffset.FromUnixTimeSeconds(inputBannedExData.BannedUntil);
+						if (inputBannedExData is null)
+						{
+							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
+						}
+						coin.BannedUntilUtc =inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
 						Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
 						break;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -403,7 +403,6 @@ public class CoinJoinClient
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputTypes.Any(t => x.ScriptPubKey.IsScriptType(t)))
-			.Where(x => !x.IsBanned)
 			.ToShuffled() // Preshuffle before ordering.
 			.OrderBy(x => x.HdPubKey.AnonymitySet)
 			.ThenByDescending(y => y.Amount)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -403,6 +403,7 @@ public class CoinJoinClient
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputTypes.Any(t => x.ScriptPubKey.IsScriptType(t)))
+			.Where(x => !x.IsBanned)
 			.ToShuffled() // Preshuffle before ordering.
 			.OrderBy(x => x.HdPubKey.AnonymitySet)
 			.ThenByDescending(y => y.Amount)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -376,6 +376,7 @@ public class CoinJoinManager : BackgroundService
 		var coins = new CoinsView(openedWallet.Coins
 			.Available()
 			.Confirmed()
+			.Where(x => !x.IsBanned)
 			.Where(x => x.HdPubKey.AnonymitySet < openedWallet.KeyManager.MaxAnonScoreTarget
 					&& !CoinRefrigerator.IsFrozen(x)));
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -377,6 +377,7 @@ public class CoinJoinManager : BackgroundService
 			.Available()
 			.Confirmed()
 			.Where(x => !x.IsBanned)
+			.Where(x => !x.Transaction.Transaction.IsCoinBase)
 			.Where(x => x.HdPubKey.AnonymitySet < openedWallet.KeyManager.MaxAnonScoreTarget
 					&& !CoinRefrigerator.IsFrozen(x)));
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -377,7 +377,6 @@ public class CoinJoinManager : BackgroundService
 			.Available()
 			.Confirmed()
 			.Where(x => !x.IsBanned)
-			.Where(x => !x.Transaction.Transaction.IsCoinBase)
 			.Where(x => x.HdPubKey.AnonymitySet < openedWallet.KeyManager.MaxAnonScoreTarget
 					&& !CoinRefrigerator.IsFrozen(x)));
 

--- a/WalletWasabi/WabiSabi/Models/Error.cs
+++ b/WalletWasabi/WabiSabi/Models/Error.cs
@@ -1,8 +1,10 @@
+using WalletWasabi.WabiSabi.Backend.Models;
+
 namespace WalletWasabi.WabiSabi.Models;
 
 public record Error(
 	string Type,
 	string ErrorCode,
 	string Description,
-	string Data
+	ExceptionData? ExceptionData
 );

--- a/WalletWasabi/WabiSabi/Models/Error.cs
+++ b/WalletWasabi/WabiSabi/Models/Error.cs
@@ -3,5 +3,6 @@ namespace WalletWasabi.WabiSabi.Models;
 public record Error(
 	string Type,
 	string ErrorCode,
-	string Description
+	string Description,
+	string Data
 );

--- a/WalletWasabi/WabiSabi/Models/Error.cs
+++ b/WalletWasabi/WabiSabi/Models/Error.cs
@@ -6,5 +6,5 @@ public record Error(
 	string Type,
 	string ErrorCode,
 	string Description,
-	ExceptionData? ExceptionData
+	ExceptionData ExceptionData
 );

--- a/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
@@ -1,0 +1,10 @@
+using WalletWasabi.WabiSabi.Backend.Models;
+
+namespace WalletWasabi.WabiSabi.Models.Serialization;
+
+public class ExceptionDataJsonConverter : GenericInterfaceJsonConverter<ExceptionData>
+{
+	public ExceptionDataJsonConverter() : base(new [] { typeof(InputBannedExceptionData) })
+	{
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Models.Serialization;
 
 public class ExceptionDataJsonConverter : GenericInterfaceJsonConverter<ExceptionData>
 {
-	public ExceptionDataJsonConverter() : base(new [] { typeof(InputBannedExceptionData) })
+	public ExceptionDataJsonConverter() : base(new [] { typeof(InputBannedExceptionData), typeof(EmptyExceptionData) })
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Models.Serialization;
 
 public class ExceptionDataJsonConverter : GenericInterfaceJsonConverter<ExceptionData>
 {
-	public ExceptionDataJsonConverter() : base(new [] { typeof(InputBannedExceptionData), typeof(EmptyExceptionData) })
+	public ExceptionDataJsonConverter() : base(new[] { typeof(InputBannedExceptionData), typeof(EmptyExceptionData) })
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -24,6 +24,7 @@ public class JsonSerializationOptions
 				new MoneySatoshiJsonConverter(),
 				new Uint256JsonConverter(),
 				new MultipartyTransactionStateJsonConverter(),
+				new ExceptionDataJsonConverter(),
 				new ExtPubKeyJsonConverter(),
 				new TimeSpanJsonConverter(),
 				new CoinJsonConverter(),


### PR DESCRIPTION
Send `bannedUntil` info to the client.

PR contains: 

- Backend sends the `bannedUntil` property to the client in `DateTimeOffset`
- Adds `ExceptionData` property to the `WabiSabiProtocolException`, so we can send additional data to the client if needed.
- Client marks the coin as banned.
- CjManager won't choose banned coins.
- Clean up in `Prison` and `Inmate` + `Prison Tests`

First part of https://github.com/zkSNACKs/WalletWasabi/pull/7921#issuecomment-1119413770

