### PR TITLE
pass `InCriticalCoinJoinState` at the proper places

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinJoinProgressEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinJoinProgressEventArgs.cs
@@ -2,5 +2,10 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class CoinJoinProgressEventArgs : EventArgs
 {
-	public bool IsInCriticalPhase { get; set; }
+	public CoinJoinProgressEventArgs(bool isInCriticalPhase)
+	{
+		IsInCriticalPhase = isInCriticalPhase;
+	}
+	
+	public bool IsInCriticalPhase { get; }
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringInputRegistrationPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringInputRegistrationPhase.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class EnteringInputRegistrationPhase : RoundStateChanged
 {
-	public EnteringInputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
+	public EnteringInputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt, bool isInCriticalPhase) : base(roundState, timeoutAt, isInCriticalPhase)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringOutputRegistrationPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringOutputRegistrationPhase.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class EnteringOutputRegistrationPhase : RoundStateChanged
 {
-	public EnteringOutputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
+	public EnteringOutputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt, bool isInCriticalPhase) : base(roundState, timeoutAt, isInCriticalPhase)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringSigningPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringSigningPhase.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class EnteringSigningPhase : RoundStateChanged
 {
-	public EnteringSigningPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
+	public EnteringSigningPhase(RoundState roundState, DateTimeOffset timeoutAt, bool isInCriticalPhase) : base(roundState, timeoutAt, isInCriticalPhase)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEnded.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEnded.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class RoundEnded : CoinJoinProgressEventArgs
 {
-	public RoundEnded(RoundState roundState)
+	public RoundEnded(RoundState roundState, bool isInCriticalPhase) : base(isInCriticalPhase)
 	{
 		RoundState = roundState;
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundStateChanged.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundStateChanged.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class RoundStateChanged : CoinJoinProgressEventArgs
 {
-	public RoundStateChanged(RoundState roundState, DateTimeOffset timeoutAt)
+	public RoundStateChanged(RoundState roundState, DateTimeOffset timeoutAt, bool isInCriticalPhase) : base(isInCriticalPhase)
 	{
 		RoundState = roundState;
 		TimeoutAt = timeoutAt;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/WaitingForBlameRound.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/WaitingForBlameRound.cs
@@ -2,7 +2,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class WaitingForBlameRound : CoinJoinProgressEventArgs
 {
-	public WaitingForBlameRound(DateTimeOffset timeoutAt)
+	public WaitingForBlameRound(DateTimeOffset timeoutAt, bool isInCriticalPhase) : base(isInCriticalPhase)
 	{
 		TimeoutAt = timeoutAt;
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/WaitingForRound.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/WaitingForRound.cs
@@ -2,4 +2,7 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class WaitingForRound : CoinJoinProgressEventArgs
 {
+	public WaitingForRound(bool isInCriticalPhase) : base(isInCriticalPhase)
+	{
+	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -50,7 +50,6 @@ public class CoinJoinTracker : IDisposable
 
 	private void CoinJoinClient_CoinJoinClientProgress(object? sender, CoinJoinProgressEventArgs coinJoinProgressEventArgs)
 	{
-		coinJoinProgressEventArgs.IsInCriticalPhase = InCriticalCoinJoinState;
 		WalletCoinJoinProgressChanged?.Invoke(Wallet, coinJoinProgressEventArgs);
 	}
 


### PR DESCRIPTION
There are obvious cases when it is sure it is not in a critical phase, so the flag could be hardcoded instead of passing it, but who knows what will change in the future so I rather passed it everywhere.