### PR TITLE
[VDG] Dont use monospace on all text in TileControl

### DIFF
--- a/WalletWasabi.Fluent/Controls/TileControl.axaml
+++ b/WalletWasabi.Fluent/Controls/TileControl.axaml
@@ -18,7 +18,6 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="PART_MainBorder"
-                TextBlock.FontFamily="{StaticResource MonospacedFont}"
                 CornerRadius="2" BorderThickness="1"
                 Margin="6"
                 Background="{DynamicResource TileRegionColor}"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/BtcPriceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/BtcPriceTileView.axaml
@@ -12,9 +12,10 @@
     <DockPanel>
       <TextBlock Text="EXCHANGE RATE" DockPanel.Dock="Top" Classes="h8 bold" />
       <TextBlock Margin="0 3"
+                 Classes="h2 monoSpaced"
                  VerticalAlignment="Center" HorizontalAlignment="Center"
                  TextAlignment="Center"
-                 Text="{Binding BtcPrice, FallbackValue='53 540.00'}" Classes="h2" />
+                 Text="{Binding BtcPrice, FallbackValue='53 540.00'}" />
     </DockPanel>
   </controls:TileControl>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
@@ -14,7 +14,7 @@
       <StackPanel DockPanel.Dock="Bottom" Height="25" Spacing="8" IsVisible="{Binding HasBalance}">
         <Separator />
         <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-          <controls:PrivacyContentControl Classes="bold" NumberOfPrivacyChars="9" Margin="4"
+          <controls:PrivacyContentControl Classes="bold monoSpaced" NumberOfPrivacyChars="9" Margin="4"
                                           VerticalAlignment="Center"
                                           Opacity="0.8"
                                           Content="{Binding BalanceFiat}" />
@@ -22,8 +22,9 @@
       </StackPanel>
 
       <controls:PrivacyContentControl Margin="0 3" NumberOfPrivacyChars="9"
+                                      Classes="h2 monoSpaced"
                                       VerticalAlignment="Center" HorizontalAlignment="Center"
-                                      Content="{Binding BalanceBtc}" Classes="h2" />
+                                      Content="{Binding BalanceBtc}" />
     </DockPanel>
   </controls:TileControl>
 </UserControl>


### PR DESCRIPTION
It doesnt fit the aesthetic there honestly. 

cc @zkSNACKs/visual-design-group 