### PR TITLE
[VDG] Make navigation system dispose IDisposable ViewModels when needed

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Navigation/NavigationStack.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/NavigationStack.cs
@@ -6,8 +6,8 @@ namespace WalletWasabi.Fluent.ViewModels.Navigation;
 public partial class NavigationStack<T> : ViewModelBase, INavigationStack<T> where T : class, INavigatable
 {
 	private readonly Stack<T> _backStack;
-	[AutoNotify] private T? _currentPage;
 	[AutoNotify] private bool _canNavigateBack;
+	[AutoNotify] private T? _currentPage;
 	private bool _operationsEnabled = true;
 
 	protected NavigationStack()
@@ -15,90 +15,11 @@ public partial class NavigationStack<T> : ViewModelBase, INavigationStack<T> whe
 		_backStack = new Stack<T>();
 	}
 
-	protected virtual void OnNavigated(T? oldPage, bool oldInStack, T? newPage, bool newInStack)
-	{
-	}
-
-	protected virtual void OnPopped(T page)
-	{
-	}
-
-	private void NavigationOperation(T? oldPage, bool oldInStack, T? newPage, bool newInStack)
-	{
-		if (_operationsEnabled)
-		{
-			oldPage?.OnNavigatedFrom(oldInStack);
-		}
-
-		CurrentPage = newPage;
-
-		if (!oldInStack && oldPage is { })
-		{
-			OnPopped(oldPage);
-		}
-
-		if (_operationsEnabled)
-		{
-			OnNavigated(oldPage, oldInStack, newPage, newInStack);
-		}
-
-		if (_operationsEnabled && newPage is { })
-		{
-			newPage.OnNavigatedTo(newInStack);
-		}
-
-		UpdateCanNavigateBack();
-	}
-
 	protected IEnumerable<T> Stack => _backStack;
 
 	public virtual void Clear()
 	{
 		Clear(false);
-	}
-
-	protected virtual void Clear(bool keepRoot)
-	{
-		var root = _backStack.Count > 0 ? _backStack.Last() : CurrentPage;
-
-		if ((keepRoot && CurrentPage == root) || (!keepRoot && _backStack.Count == 0 && CurrentPage is null))
-		{
-			return;
-		}
-
-		var oldPage = CurrentPage;
-
-		var oldItems = _backStack.ToList();
-
-		_backStack.Clear();
-
-		if (keepRoot)
-		{
-			foreach (var item in oldItems)
-			{
-				if (item != root)
-				{
-					OnPopped(item);
-				}
-			}
-			CurrentPage = root;
-		}
-		else
-		{
-			foreach (var item in oldItems)
-			{
-				if (item is INavigatable navigatable)
-				{
-					navigatable.OnNavigatedFrom(false);
-				}
-
-				OnPopped(item);
-			}
-
-			CurrentPage = null;
-		}
-
-		NavigationOperation(oldPage, false, CurrentPage, CurrentPage is { });
 	}
 
 	public void BackTo(T viewmodel)
@@ -134,8 +55,8 @@ public partial class NavigationStack<T> : ViewModelBase, INavigationStack<T> whe
 	{
 		var oldPage = CurrentPage;
 
-		bool oldInStack = true;
-		bool newInStack = false;
+		var oldInStack = true;
+		var newInStack = false;
 
 		switch (mode)
 		{
@@ -144,6 +65,7 @@ public partial class NavigationStack<T> : ViewModelBase, INavigationStack<T> whe
 				{
 					_backStack.Push(oldPage);
 				}
+
 				break;
 
 			case NavigationMode.Clear:
@@ -175,6 +97,92 @@ public partial class NavigationStack<T> : ViewModelBase, INavigationStack<T> whe
 		{
 			Clear(); // in this case only CurrentPage might be set and Clear will provide correct behavior.
 		}
+	}
+
+	protected virtual void OnNavigated(T? oldPage, bool oldInStack, T? newPage, bool newInStack)
+	{
+	}
+
+	protected virtual void OnPopped(T page)
+	{
+	}
+
+	protected virtual void Clear(bool keepRoot)
+	{
+		var root = _backStack.Count > 0 ? _backStack.Last() : CurrentPage;
+
+		if ((keepRoot && CurrentPage == root) || (!keepRoot && _backStack.Count == 0 && CurrentPage is null))
+		{
+			return;
+		}
+
+		var oldPage = CurrentPage;
+
+		var oldItems = _backStack.ToList();
+
+		_backStack.Clear();
+
+		if (keepRoot)
+		{
+			foreach (var item in oldItems)
+			{
+				if (item != root)
+				{
+					OnPopped(item);
+				}
+			}
+
+			CurrentPage = root;
+		}
+		else
+		{
+			foreach (var item in oldItems)
+			{
+				if (item is INavigatable navigatable)
+				{
+					navigatable.OnNavigatedFrom(false);
+				}
+
+				OnPopped(item);
+			}
+
+			CurrentPage = null;
+		}
+
+		NavigationOperation(oldPage, false, CurrentPage, CurrentPage is { });
+	}
+
+	private static void TryDispose(object? oldPage)
+	{
+		(oldPage as IDisposable)?.Dispose();
+	}
+
+	private void NavigationOperation(T? oldPage, bool oldInStack, T? newPage, bool newInStack)
+	{
+		if (_operationsEnabled)
+		{
+			oldPage?.OnNavigatedFrom(oldInStack);
+		}
+
+		CurrentPage = newPage;
+
+		if (!oldInStack && oldPage is { })
+		{
+			OnPopped(oldPage);
+		}
+
+		if (_operationsEnabled)
+		{
+			OnNavigated(oldPage, oldInStack, newPage, newInStack);
+		}
+
+		if (_operationsEnabled && newPage is { })
+		{
+			newPage.OnNavigatedTo(newInStack);
+		}
+
+		UpdateCanNavigateBack();
+		TryDispose(oldPage);
 	}
 
 	private void UpdateCanNavigateBack()


### PR DESCRIPTION
### Motivation
We **really** need to implement the Disposable pattern in a proper way to avoid memory leaks. This is a starting point to do so.

### Why?

Currently, navigatable ViewModels aren't `IDisposable` themselves, even though they are disposable in nature (most of them them are hosts for disposable instances). 

We currently rely on the `OnNavigatedTo` method to add disposables to the provide `CompositeDisposable`. This moves the responsibility of disposing things out of the owner, that is a mistake. We need to let disposable classes dispose their stuff. Moreover, this is error prone.

### How?

By making proper use of the disposable pattern, that is, making disposable classes implement `IDisposable`.

This PR proposes an mechanism that is more robust:

- Allows ViewModels to use the Disposable Pattern to explicitly release their resources. This way, navigatable ViewModels will be disposed automatically by the navigation system. 
- It doesn't rely on navigation methods (OnNavigationTo). The correct place to create subscriptions is in the constructor, that is where declarative definitions usually reside. 


Potentially fixes https://github.com/zkSNACKs/WalletWasabi/issues/7926