### PR TITLE
Debug-only `<PackageReference>` and packages.lock.json files

### DIFF
--- a/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
+++ b/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
 		<PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="0.10.10" />
 		<PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" Condition="'$(Configuration)' == 'Debug'" />
 		<PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.13.1" />
 		<PackageReference Include="Avalonia.Skia" Version="$(AvaloniaVersion)" />
 		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -168,30 +168,35 @@ public static class Program
 		if (Directory.Exists(BinDistDirectory))
 		{
 			await IoHelpers.TryDeleteDirectoryAsync(BinDistDirectory).ConfigureAwait(false);
-			Console.WriteLine($"Deleted {BinDistDirectory}");
+			Console.WriteLine($"# Deleted {BinDistDirectory}");
 		}
 
+		Console.WriteLine($"# Run dotnet restore");
 		StartProcessAndWaitForExit("dotnet", DesktopProjectDirectory, arguments: "restore --locked-mode");
+
+		Console.WriteLine($"# Run dotnet clean");
 		StartProcessAndWaitForExit("dotnet", DesktopProjectDirectory, arguments: "clean --configuration Release");
 
-		var desktopBinReleaseDirectory = Path.GetFullPath(Path.Combine(DesktopProjectDirectory, "bin", "Release"));
-		var libraryBinReleaseDirectory = Path.GetFullPath(Path.Combine(LibraryProjectDirectory, "bin", "Release"));
+		string desktopBinReleaseDirectory = Path.GetFullPath(Path.Combine(DesktopProjectDirectory, "bin", "Release"));
+		string libraryBinReleaseDirectory = Path.GetFullPath(Path.Combine(LibraryProjectDirectory, "bin", "Release"));
+
 		if (Directory.Exists(desktopBinReleaseDirectory))
 		{
 			await IoHelpers.TryDeleteDirectoryAsync(desktopBinReleaseDirectory).ConfigureAwait(false);
-			Console.WriteLine($"Deleted {desktopBinReleaseDirectory}");
+			Console.WriteLine($"#Deleted {desktopBinReleaseDirectory}");
 		}
+
 		if (Directory.Exists(libraryBinReleaseDirectory))
 		{
 			await IoHelpers.TryDeleteDirectoryAsync(libraryBinReleaseDirectory).ConfigureAwait(false);
-			Console.WriteLine($"Deleted {libraryBinReleaseDirectory}");
+			Console.WriteLine($"# Deleted {libraryBinReleaseDirectory}");
 		}
 
 		var deterministicFileNameTag = IsContinuousDelivery ? $"{DateTimeOffset.UtcNow:ddMMyyyy}{DateTimeOffset.UtcNow.TimeOfDay.TotalSeconds}" : VersionPrefix;
 		var deliveryPath = IsContinuousDelivery ? Path.Combine(BinDistDirectory, "cdelivery") : BinDistDirectory;
 
 		IoHelpers.EnsureDirectoryExists(deliveryPath);
-		Console.WriteLine($"Binaries will be delivered here: {deliveryPath}");
+		Console.WriteLine($"# Binaries will be delivered here: {deliveryPath}");
 
 		string buildInfoJson = GetBuildInfoData();
 
@@ -209,7 +214,7 @@ public static class Program
 			if (!Directory.Exists(currentBinDistDirectory))
 			{
 				Directory.CreateDirectory(currentBinDistDirectory);
-				Console.WriteLine($"Created {currentBinDistDirectory}");
+				Console.WriteLine($"# Created {currentBinDistDirectory}");
 			}
 
 			string buildInfoPath = Path.Combine(currentBinDistDirectory, "BUILDINFO.json");
@@ -333,19 +338,19 @@ public static class Program
 				ZipFile.CreateFromDirectory(currentBinDistDirectory, zipFilePath);
 
 				await IoHelpers.TryDeleteDirectoryAsync(currentBinDistDirectory).ConfigureAwait(false);
-				Console.WriteLine($"Deleted {currentBinDistDirectory}");
+				Console.WriteLine($"# Deleted {currentBinDistDirectory}");
 
 				try
 				{
 					var drive = Tools.GetSingleUsbDrive();
 					var targetFilePath = Path.Combine(drive, zipFileName);
 
-					Console.WriteLine($"Trying to move unsigned zip file to removable ('{targetFilePath}').");
+					Console.WriteLine($"# Trying to move unsigned zip file to removable ('{targetFilePath}').");
 					File.Move(zipFilePath, targetFilePath, overwrite: true);
 				}
 				catch (Exception ex)
 				{
-					Console.WriteLine($"There was an error during copying the file to removable: '{ex.Message}'");
+					Console.WriteLine($"# There was an error during copying the file to removable: '{ex.Message}'");
 				}
 			}
 			else if (target.StartsWith("linux"))
@@ -363,7 +368,7 @@ public static class Program
 					continue;
 				}
 
-				Console.WriteLine("Create Linux .tar.gz");
+				Console.WriteLine("# Create Linux .tar.gz");
 				if (!Directory.Exists(publishedFolder))
 				{
 					throw new Exception($"{publishedFolder} does not exist.");
@@ -395,7 +400,7 @@ public static class Program
 
 				StartProcessAndWaitForExit("wsl", BinDistDirectory, arguments: arguments);
 
-				Console.WriteLine("Create Linux .deb");
+				Console.WriteLine("# Create Linux .deb");
 
 				var debFolderRelativePath = "deb";
 				var debFolderPath = Path.Combine(BinDistDirectory, debFolderRelativePath);
@@ -498,7 +503,7 @@ public static class Program
 				File.Move(oldDeb, newDeb);
 
 				await IoHelpers.TryDeleteDirectoryAsync(publishedFolder).ConfigureAwait(false);
-				Console.WriteLine($"Deleted {publishedFolder}");
+				Console.WriteLine($"# Deleted {publishedFolder}");
 			}
 		}
 	}
@@ -607,7 +612,7 @@ public static class Program
 		}
 		catch (Exception ex)
 		{
-			Console.WriteLine($"Process failed: '{ex}'.");
+			Console.WriteLine($"# Process failed: '{ex}'.");
 		}
 
 		return false;

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -17,7 +17,7 @@ jobs:
     displayName: 'Restore'
     inputs:
       command: 'restore'
-      restoreArguments: '--locked-mode'
+      restoreArguments: '--force --locked-mode'
       feedsToUse: 'config'
       nugetConfigPath: 'NuGet.Config'
   - task: DotNetCoreCLI@2

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -17,7 +17,7 @@ jobs:
     displayName: 'Restore'
     inputs:
       command: 'restore'
-      restoreArguments: '--locked-mode'
+      restoreArguments: '--force --locked-mode'
       feedsToUse: 'config'
       nugetConfigPath: 'NuGet.Config'
   - task: DotNetCoreCLI@2

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -17,7 +17,7 @@ jobs:
     displayName: 'Restore'
     inputs:
       command: 'restore'
-      restoreArguments: '--locked-mode'
+      restoreArguments: '--force --locked-mode'
       feedsToUse: 'config'
       nugetConfigPath: 'NuGet.Config'
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
This PR supersedes #6881 and fixes #6679 properly - i.e. it should be allowed now to define `<PackageReference>` that are "debug only" like:

```xml
<PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" Condition="'$(Configuration)' == 'Debug'" />
```

The PR #6881 was clumsy. The concept there would require to change workflow how people use `dotnet restore` when adding/modifying dependencies[^1].

## Info

There are several pieces of information that are vital to know:

* `dotnet restore` does not support `dotnet restore -c <Configuration>` (notably not `dotnet restore -c Release`). That means that the restore operation is common for all configurations[^2]
* Call `dotnet restore --locked-mode`, modify a `packages.lock.json`, call `dotnet restore --locked-mode` again and it ... succeeds. I don't really know why but `dotnet restore --force --locked-mode` seems to work correctly so I proposed this change in this PR.
* `dotnet build --configuration Release` modifies `packages.lock.json` files and it's pretty unclear to me why. Anyway, one is not supposed to commit these changes to git and even if you make a mistake and do that, then CI should warn you that you committed invalid `packages.lock.json` so no need to keep it in your head.
* I played a lot with an attempt to have `release.packages.lock.json`, so the JSON files would be only for the `Release` configuration but in the end it felt wrong and it did not work as I wanted and people would have to change their worklow so I decided against it.
* Interestingly, we actually partially fixed #6679 by #7827.

## Worklow

This PR does not change typical workflow. So to update `packages.lock.json` files, just use:

```powershell
# Stays the same, no change. After calling this, commit changes to git.
dotnet restore --force-evaluate
```

## Testing

The same as the repro for #6679:

1. Go to `WasabiWallet.Packager` folder
2. Run `dotnet run --onlybinaries`
3. No error should occur.


[^1]: .NET SDK & NuGet features are really not that polished with regard to the locked mode imho. One has to search numerous Github issues to find workarounds to achieve "basic" functionality requirements, some issues are open and no one knows an answer to them. If anything it seems things are under-documented. But it will get better over time.
[^2]: One can actually call: `dotnet restore /property:Configuration=Release`. but then ... all hell breaks loose. So please don't.
