### PR TITLE
Add Entering and Leaving critical events

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -400,44 +400,56 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 	private void OnCoinJoinPhaseChanged(CoinJoinProgressEventArgs coinJoinProgress)
 	{
-		IsInCriticalPhase = coinJoinProgress.IsInCriticalPhase;
-
 		switch (coinJoinProgress)
 		{
 			case RoundEnded roundEnded:
 				CurrentStatus = roundEnded.RoundState.WasTransactionBroadcast ? _roundSucceedMessage : _roundFailedMessage;
 				StopCountDown();
 				break;
+
 			case EnteringOutputRegistrationPhase enteringOutputRegistrationPhase:
 				StartCountDown(
 					message: _outputRegistrationMessage,
 					start: enteringOutputRegistrationPhase.TimeoutAt - enteringOutputRegistrationPhase.RoundState.CoinjoinState.Parameters.OutputRegistrationTimeout,
 					end: enteringOutputRegistrationPhase.TimeoutAt);
 				break;
+
 			case EnteringSigningPhase enteringSigningPhase:
 				StartCountDown(
 					message: _transactionSigningMessage,
 					start: enteringSigningPhase.TimeoutAt - enteringSigningPhase.RoundState.CoinjoinState.Parameters.TransactionSigningTimeout,
 					end: enteringSigningPhase.TimeoutAt);
 				break;
+
 			case EnteringInputRegistrationPhase enteringInputRegistrationPhase:
 				StartCountDown(
 					message: _inputRegistrationMessage,
 					start: enteringInputRegistrationPhase.TimeoutAt - enteringInputRegistrationPhase.RoundState.CoinjoinState.Parameters.StandardInputRegistrationTimeout,
 					end: enteringInputRegistrationPhase.TimeoutAt);
 				break;
+
 			case WaitingForBlameRound waitingForBlameRound:
 				StartCountDown(message: _waitingForBlameRoundMessage, start: DateTimeOffset.UtcNow, end: waitingForBlameRound.TimeoutAt);
 				break;
+
 			case WaitingForRound:
 				CurrentStatus = _waitingRoundMessage;
 				StopCountDown();
 				break;
+
 			case EnteringConnectionConfirmationPhase enteringConnectionConfirmationPhase:
 				StartCountDown(
 					message: _connectionConfirmationMessage,
 					start: enteringConnectionConfirmationPhase.TimeoutAt - enteringConnectionConfirmationPhase.RoundState.CoinjoinState.Parameters.ConnectionConfirmationTimeout,
 					end: enteringConnectionConfirmationPhase.TimeoutAt);
+				break;
+
+			case EnteringCriticalPhase:
+				IsInCriticalPhase = true;
+				break;
+
+			case LeavingCriticalPhase:
+				IsInCriticalPhase = false;
 				break;
 		}
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -237,16 +237,25 @@ public class CoinJoinClient
 
 		void ReportProgressOnce()
 		{
-			if (!alreadyEnteredToCritical)
+			if (alreadyEnteredToCritical)
 			{
-				lock (alreadyEnteredToCriticalLock)
+				return;
+			}
+
+			// Helper to not invoke event inside the lock.
+			bool reportProgress = false;
+			lock (alreadyEnteredToCriticalLock)
+			{
+				if (alreadyEnteredToCritical)
 				{
-					if (!alreadyEnteredToCritical)
-					{
-						CoinJoinClientProgress.SafeInvoke(this, new EnteringCriticalPhase());
-						alreadyEnteredToCritical = true;
-					}
+					return;
 				}
+				reportProgress = true;
+				alreadyEnteredToCritical = true;
+			}
+			if (reportProgress)
+			{
+				CoinJoinClientProgress.SafeInvoke(this, new EnteringCriticalPhase());
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringConnectionConfirmationPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringConnectionConfirmationPhase.cs
@@ -6,6 +6,5 @@ public class EnteringConnectionConfirmationPhase : RoundStateChanged
 {
 	public EnteringConnectionConfirmationPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
 	{
-		IsInCriticalPhase = true;
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringCriticalPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringCriticalPhase.cs
@@ -1,5 +1,5 @@
 namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
-public class CoinJoinProgressEventArgs : EventArgs
+public class EnteringCriticalPhase : CoinJoinProgressEventArgs
 {
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringOutputRegistrationPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringOutputRegistrationPhase.cs
@@ -6,6 +6,5 @@ public class EnteringOutputRegistrationPhase : RoundStateChanged
 {
 	public EnteringOutputRegistrationPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
 	{
-		IsInCriticalPhase = true;
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringSigningPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/EnteringSigningPhase.cs
@@ -6,6 +6,5 @@ public class EnteringSigningPhase : RoundStateChanged
 {
 	public EnteringSigningPhase(RoundState roundState, DateTimeOffset timeoutAt) : base(roundState, timeoutAt)
 	{
-		IsInCriticalPhase = true;
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/LeavingCriticalPhase.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/LeavingCriticalPhase.cs
@@ -1,5 +1,5 @@
 namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
-public class CoinJoinProgressEventArgs : EventArgs
+public class LeavingCriticalPhase : CoinJoinProgressEventArgs
 {
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -39,7 +39,7 @@ public class CoinJoinTracker : IDisposable
 	public bool RestartAutomatically { get; }
 
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
-	public bool InCriticalCoinJoinState => CoinJoinClient.InCriticalCoinJoinState;
+	public bool InCriticalCoinJoinState { get; private set; }
 	public bool IsStopped { get; private set; }
 
 	public void Stop()
@@ -50,6 +50,17 @@ public class CoinJoinTracker : IDisposable
 
 	private void CoinJoinClient_CoinJoinClientProgress(object? sender, CoinJoinProgressEventArgs coinJoinProgressEventArgs)
 	{
+		switch (coinJoinProgressEventArgs)
+		{
+			case EnteringCriticalPhase:
+				InCriticalCoinJoinState = true;
+				break;
+
+			case LeavingCriticalPhase:
+				InCriticalCoinJoinState = false;
+				break;
+		}
+
 		WalletCoinJoinProgressChanged?.Invoke(Wallet, coinJoinProgressEventArgs);
 	}
 


### PR DESCRIPTION
I know we are moving around this topic a lot, but this is the final concept on this. Entering and leaving the critical should be as close as possible to the actual time and not always related to a phase change. For example it is much safer to report LaevingCritical in the finally clause - it will always happen. 