### PR TITLE
Set CoinJoinInProgress false before report RoundEnded

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -403,7 +403,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		switch (coinJoinProgress)
 		{
 			case RoundEnded roundEnded:
-				CurrentStatus = roundEnded.RoundState.WasTransactionBroadcast ? _roundSucceedMessage : _roundFailedMessage;
+				CurrentStatus = roundEnded.LastRoundState.WasTransactionBroadcast ? _roundSucceedMessage : _roundFailedMessage;
 				StopCountDown();
 				break;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -303,11 +303,6 @@ public class CoinJoinManager : BackgroundService
 			Logger.LogError($"{logPrefix} failed with exception:", e);
 		}
 
-		foreach (var coins in finishedCoinJoin.CoinCandidates)
-		{
-			coins.CoinJoinInProgress = false;
-		}
-
 		if (finishedCoinJoin.RestartAutomatically &&
 			!finishedCoinJoin.IsStopped &&
 			!cancellationToken.IsCancellationRequested)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEnded.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEnded.cs
@@ -4,10 +4,10 @@ namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 public class RoundEnded : CoinJoinProgressEventArgs
 {
-	public RoundEnded(RoundState roundState)
+	public RoundEnded(RoundState lastRoundState)
 	{
-		RoundState = roundState;
+		LastRoundState = lastRoundState;
 	}
 
-	public RoundState RoundState { get; }
+	public RoundState LastRoundState { get; }
 }


### PR DESCRIPTION
Solving the issue of getting this message right after the CoinJoin round finished:

`No candidate coins available to mix for wallet`

The problem was that we first reported the round as ended and just later (few secs) set the `SmartCoin.IsCoinJoinInProgress` flag to false. But MusicBox immediately instructed CoinJoinManager to Start mixing and it ended up with the message above and stopped as it was an end condition - thus stopping the CoinJoins permanently in Manual CJ mode.


In CoinJoinManager I did not change anything except the order of some code snippets.