### PR TITLE
Disable `AutoCoinJoin` when coinjoin profile is not selected

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Login/LoginViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Login/LoginViewModel.cs
@@ -3,8 +3,6 @@ using System.Windows.Input;
 using ReactiveUI;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.ViewModels.AddWallet;
-using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
-using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Fluent.ViewModels.Login.PasswordFinder;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Fluent.ViewModels.Wallets;
@@ -69,25 +67,7 @@ public partial class LoginViewModel : RoutableViewModel
 
 		if (legalResult)
 		{
-			var km = closedWalletViewModel.Wallet.KeyManager;
-			bool shouldSelectProfile = !km.IsCoinjoinProfileSelected && km.AutoCoinJoin;
-			bool isProfileSelected = false;
-
-			// This should be impossible, this is just a sanity check
-			if (shouldSelectProfile)
-			{
-				DialogResult<bool> profileDialogResult = await NavigateDialogAsync(new CoinJoinProfilesViewModel(closedWalletViewModel.Wallet.KeyManager, false), NavigationTarget.DialogScreen);
-				isProfileSelected = profileDialogResult.Result;
-			}
-
-			if (isProfileSelected || !shouldSelectProfile)
-			{
-				LoginWallet(closedWalletViewModel);
-			}
-			else
-			{
-				wallet.Logout();
-			}
+			LoginWallet(closedWalletViewModel);
 		}
 		else
 		{

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -92,7 +92,7 @@ public class KeyManager
 	}
 
 	[OnDeserialized]
-	internal void OnDeserializedMethod(StreamingContext context)
+	private void OnDeserializedMethod(StreamingContext context)
 	{
 		// This should be impossible but in any case, coinjoin can only happen,
 		// if a profile is selected. Otherwise, the user's money can be drained.

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Security;
 using System.Text;
 using WalletWasabi.Blockchain.Analysis.Clustering;
@@ -88,6 +89,17 @@ public class KeyManager
 		MasterFingerprint = extKey.Neuter().PubKey.GetHDFingerPrint();
 		AccountKeyPath = GetAccountKeyPath(BlockchainState.Network);
 		ExtPubKey = extKey.Derive(AccountKeyPath).Neuter();
+	}
+
+	[OnDeserialized]
+	internal void OnDeserializedMethod(StreamingContext context)
+	{
+		// This should be impossible but in any case, coinjoin can only happen,
+		// if a profile is selected. Otherwise, the user's money can be drained.
+		if (AutoCoinJoin && !IsCoinjoinProfileSelected)
+		{
+			AutoCoinJoin = false;
+		}
 	}
 
 	public static KeyPath GetAccountKeyPath(Network network) =>


### PR DESCRIPTION
Even if it shouldn't be possible my wallet was created before the coinjoin profiles and the autocoinjoin was enabled so it happened the profile selection popped on login (in real life, it won't) and it didn't feel good. 

It didn't feel good because I didn't want to coinjoin at all. So instead of not allowing the user to log in until they select a profile, just let them in and disable the autocoinjoin. After all, this is the question, how the autocoinjoin can be enabled without a profile.

This PR disables the autocoinjoin and lets the user in and relays the other safety checks, when they want to do coinjoin (or enable it) the dialog will pop and they must select one before conjoining.