### PR TITLE
[Backport] Update the required macOS version for the docs

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -5,7 +5,7 @@ This document lists all the officially supported software and devices by Wasabi 
 # Officially Supported Operating Systems
 
 - Windows 10
-- macOs 10.13+
+- macOs 10.15+
 - Ubuntu 16.04+
 - Fedora 30+
 - Debian 9+


### PR DESCRIPTION
For the released version we are using [.NET Core 3.1](https://github.com/zkSNACKs/WalletWasabi/tree/backport#get-the-requirements), the Mac OS X supported version should be 10.15+ according https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1-supported-os.md#macos.