### PR TITLE
[VDG] [Trivial] Set initial value of SearchText to empty string

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
@@ -12,7 +12,7 @@ public partial class SearchBarViewModel : ReactiveObject
 {
 	private readonly ReadOnlyObservableCollection<SearchItemGroup> _groups;
 	[AutoNotify] private bool _isSearchListVisible;
-	[AutoNotify] private string _searchText;
+	[AutoNotify] private string _searchText = "";
 
 	public SearchBarViewModel(IObservable<IChangeSet<ISearchItem, ComposedKey>> itemsObservable)
 	{


### PR DESCRIPTION
Correct reference type. Was mistakenly removed in https://github.com/zkSNACKs/WalletWasabi/pull/7797