### PR TITLE
Use weighted average for consolidation in coinjoin

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModelBase.cs
@@ -8,9 +8,7 @@ public abstract class CoinJoinProfileViewModelBase : ViewModelBase
 
 	public virtual bool AutoCoinjoin { get; } = true;
 
-	public virtual int MinAnonScoreTarget { get; } = 5;
-
-	public virtual int MaxAnonScoreTarget { get; } = 10;
+	public virtual int AnonScoreTarget { get; } = 5;
 
 	public abstract int FeeRateMedianTimeFrameHours { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -60,7 +60,7 @@ public partial class CoinJoinProfilesViewModel : DialogViewModelBase<bool>
 		var selected = SelectedProfile ?? SelectedManualProfile ?? Profiles.First();
 
 		keyManager.AutoCoinJoin = selected.AutoCoinjoin;
-		keyManager.SetAnonScoreTargets(selected.MinAnonScoreTarget, selected.MaxAnonScoreTarget, toFile: false);
+		keyManager.SetAnonScoreTarget(selected.AnonScoreTarget, toFile: false);
 		keyManager.SetFeeRateMedianTimeFrame(selected.FeeRateMedianTimeFrameHours, toFile: false);
 		keyManager.IsCoinjoinProfileSelected = true;
 

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/ManualCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/ManualCoinJoinProfileViewModel.cs
@@ -2,11 +2,10 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 public class ManualCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
-	public ManualCoinJoinProfileViewModel(bool autoCoinjoin, int minAnonScoreTarget, int maxAnonScoreTarget, int feeRateMedianTimeFrameHours)
+	public ManualCoinJoinProfileViewModel(bool autoCoinjoin, int anonScoreTarget, int feeRateMedianTimeFrameHours)
 	{
 		AutoCoinjoin = autoCoinjoin;
-		MinAnonScoreTarget = minAnonScoreTarget;
-		MaxAnonScoreTarget = maxAnonScoreTarget;
+		AnonScoreTarget = anonScoreTarget;
 		FeeRateMedianTimeFrameHours = feeRateMedianTimeFrameHours;
 	}
 
@@ -16,9 +15,7 @@ public class ManualCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public override bool AutoCoinjoin { get; }
 
-	public override int MinAnonScoreTarget { get; }
-
-	public override int MaxAnonScoreTarget { get; }
+	public override int AnonScoreTarget { get; }
 
 	public override int FeeRateMedianTimeFrameHours { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -8,9 +8,7 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public override string Description => "Choice of the paranoid. Optimizes for privacy at all costs.";
 
-	public override int MinAnonScoreTarget { get; } = GetRandom(40, 61);
-
-	public override int MaxAnonScoreTarget { get; } = GetRandom(90, 111);
+	public override int AnonScoreTarget { get; } = GetRandom(50, 101);
 
 	public override int FeeRateMedianTimeFrameHours => 0;
 

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/ManualCoinJoinProfileDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/ManualCoinJoinProfileDialogViewModel.cs
@@ -12,8 +12,7 @@ namespace WalletWasabi.Fluent.ViewModels.Dialogs;
 public partial class ManualCoinJoinProfileDialogViewModel : DialogViewModelBase<ManualCoinJoinProfileViewModel?>
 {
 	[AutoNotify] private bool _autoCoinjoin;
-	[AutoNotify] private int _minAnonScoreTarget;
-	[AutoNotify] private int _maxAnonScoreTarget;
+	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private TimeFrameItem[] _timeFrames;
 	[AutoNotify] private TimeFrameItem _selectedTimeFrame;
 
@@ -21,8 +20,7 @@ public partial class ManualCoinJoinProfileDialogViewModel : DialogViewModelBase<
 	{
 		_autoCoinjoin = true;
 
-		_minAnonScoreTarget = current.MinAnonScoreTarget;
-		_maxAnonScoreTarget = current.MaxAnonScoreTarget;
+		_anonScoreTarget = current.AnonScoreTarget;
 
 		_timeFrames = new[]
 		{
@@ -38,35 +36,13 @@ public partial class ManualCoinJoinProfileDialogViewModel : DialogViewModelBase<
 
 		EnableBack = false;
 
-		this.WhenAnyValue(x => x.MinAnonScoreTarget)
-			.Subscribe(
-				x =>
-				{
-					if (x >= MaxAnonScoreTarget)
-					{
-						MaxAnonScoreTarget = x + 1;
-					}
-				});
-
-		this.WhenAnyValue(x => x.MaxAnonScoreTarget)
-			.Subscribe(
-				x =>
-				{
-					if (x <= MinAnonScoreTarget)
-					{
-						MinAnonScoreTarget = x - 1;
-					}
-				});
-
-
 		NextCommand = ReactiveCommand.Create(() =>
 		{
 			var auto = AutoCoinjoin;
-			var min = MinAnonScoreTarget;
-			var max = MaxAnonScoreTarget;
+			var target = AnonScoreTarget;
 			var hours = (int)Math.Floor(SelectedTimeFrame.TimeFrame.TotalHours);
 
-			Close(DialogResultKind.Normal, new ManualCoinJoinProfileViewModel(auto, min, max, hours));
+			Close(DialogResultKind.Normal, new ManualCoinJoinProfileViewModel(auto, target, hours));
 		});
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -362,7 +362,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			return;
 		}
 
-		var privateThreshold = _wallet.KeyManager.MinAnonScoreTarget;
+		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
 
 		var privateAmount = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
 		var normalAmount = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -33,7 +33,7 @@ public partial class PrivacyControlTileViewModel : TileViewModel
 
 	private void Update()
 	{
-		var privateThreshold = _wallet.KeyManager.MinAnonScoreTarget;
+		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
 
 		var currentPrivacyScore = _wallet.Coins.Sum(x => x.Amount.Satoshi * Math.Min(x.HdPubKey.AnonymitySet - 1, privateThreshold - 1));
 		var maxPrivacyScore = _wallet.Coins.TotalAmount().Satoshi * (privateThreshold - 1);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -64,7 +64,7 @@ public partial class WalletBalanceTileViewModel : TileViewModel
 
 		BalanceFiat = fiatAmount.GenerateFiatText("USD", fiatFormat);
 
-		var privateThreshold = _wallet.KeyManager.MinAnonScoreTarget;
+		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
 		var privateCoins = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold);
 		var normalCoins = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -46,7 +46,7 @@ public partial class PrivacyControlViewModel : DialogViewModelBase<IEnumerable<S
 
 	private void InitializeLabels()
 	{
-		var privateThreshold = _wallet.KeyManager.MinAnonScoreTarget;
+		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
 
 		LabelSelection.Reset(_wallet.Coins.GetPockets(privateThreshold).Select(x => new Pocket(x)).ToArray());
 		LabelSelection.SetUsedLabel(_usedCoins, privateThreshold);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -48,7 +48,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 
 		if (!info.IsPrivate)
 		{
-			Suggestions.Add(new PocketSuggestionViewModel(SmartLabel.Merge(transaction.SpentCoins.Select(x => x.GetLabels(wallet.KeyManager.MinAnonScoreTarget)))));
+			Suggestions.Add(new PocketSuggestionViewModel(SmartLabel.Merge(transaction.SpentCoins.Select(x => x.GetLabels(wallet.KeyManager.AnonScoreTarget)))));
 		}
 
 		var loadingRing = new LoadingSuggestionViewModel();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -56,7 +56,7 @@ public partial class SendViewModel : RoutableViewModel
 	{
 		_to = "";
 		_wallet = wallet;
-		_transactionInfo = new TransactionInfo(wallet.KeyManager.MinAnonScoreTarget);
+		_transactionInfo = new TransactionInfo(wallet.KeyManager.AnonScoreTarget);
 		_coinJoinManager = Services.HostedServices.GetOrDefault<CoinJoinManager>();
 
 		_conversionReversed = Services.UiConfig.SendAmountConversionReversed;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
@@ -15,9 +15,9 @@ public partial class TransactionInfo
 	[AutoNotify] private FeeRate _feeRate = FeeRate.Zero;
 	[AutoNotify] private IEnumerable<SmartCoin> _coins = Enumerable.Empty<SmartCoin>();
 
-	public TransactionInfo(int minAnonScoreTarget)
+	public TransactionInfo(int anonScoreTarget)
 	{
-		_privateCoinThreshold = minAnonScoreTarget;
+		_privateCoinThreshold = anonScoreTarget;
 
 		this.WhenAnyValue(x => x.FeeRate)
 			.Subscribe(_ => OnFeeChanged());

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -393,7 +393,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 
 	private async Task<bool> NavigateConfirmLabelsDialogAsync(BuildTransactionResult transaction)
 	{
-		var labels = SmartLabel.Merge(transaction.SpentCoins.Select(x => x.GetLabels(_wallet.KeyManager.MinAnonScoreTarget)));
+		var labels = SmartLabel.Merge(transaction.SpentCoins.Select(x => x.GetLabels(_wallet.KeyManager.AnonScoreTarget)));
 		var suggestionViewModel = new PocketSuggestionViewModel(labels);
 		var dialog = new ConfirmLabelsDialogViewModel(suggestionViewModel);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -17,8 +17,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 {
 	[AutoNotify] private bool _preferPsbtWorkflow;
 	[AutoNotify] private bool _autoCoinJoin;
-	[AutoNotify] private int _minAnonScoreTarget;
-	[AutoNotify] private int _maxAnonScoreTarget;
+	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private string _plebStopThreshold;
 
 	private Wallet _wallet;
@@ -67,36 +66,13 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 			}
 		});
 
-		_minAnonScoreTarget = _wallet.KeyManager.MinAnonScoreTarget;
-		_maxAnonScoreTarget = _wallet.KeyManager.MaxAnonScoreTarget;
+		_anonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
 
-		this.WhenAnyValue(
-				x => x.MinAnonScoreTarget,
-				x => x.MaxAnonScoreTarget)
+		this.WhenAnyValue(x => x.AnonScoreTarget)
 			.ObserveOn(RxApp.TaskpoolScheduler)
 			.Throttle(TimeSpan.FromMilliseconds(1000))
 			.Skip(1)
-			.Subscribe(_ => _wallet.KeyManager.SetAnonScoreTargets(MinAnonScoreTarget, MaxAnonScoreTarget));
-
-		this.WhenAnyValue(x => x.MinAnonScoreTarget)
-			.Subscribe(
-				x =>
-				{
-					if (x >= MaxAnonScoreTarget)
-					{
-						MaxAnonScoreTarget = x + 1;
-					}
-				});
-
-		this.WhenAnyValue(x => x.MaxAnonScoreTarget)
-			.Subscribe(
-				x =>
-				{
-					if (x <= MinAnonScoreTarget)
-					{
-						MinAnonScoreTarget = x - 1;
-					}
-				});
+			.Subscribe(_ => _wallet.KeyManager.SetAnonScoreTarget(AnonScoreTarget));
 
 		this.ValidateProperty(x => x.PlebStopThreshold, ValidatePlebStopThreshold);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -58,7 +58,7 @@ public partial class WalletViewModel : WalletViewModelBase
 					.Select(_ => Unit.Default))
 				.Merge(Services.UiConfig.WhenAnyValue(x => x.PrivacyMode).Select(_ => Unit.Default))
 				.Merge(Wallet.Synchronizer.WhenAnyValue(x => x.UsdExchangeRate).Select(_ => Unit.Default))
-				.Merge(Settings.WhenAnyValue(x => x.MinAnonScoreTarget, x => x.MaxAnonScoreTarget).Select(_ => Unit.Default).Skip(1).Throttle(TimeSpan.FromMilliseconds(3000))
+				.Merge(Settings.WhenAnyValue(x => x.AnonScoreTarget).Select(_ => Unit.Default).Skip(1).Throttle(TimeSpan.FromMilliseconds(3000))
 				.Throttle(TimeSpan.FromSeconds(0.1))
 				.ObserveOn(RxApp.MainThreadScheduler));
 

--- a/WalletWasabi.Fluent/Views/Dialogs/ManualCoinJoinProfileDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/ManualCoinJoinProfileDialogView.axaml
@@ -21,18 +21,10 @@
       </DockPanel>
 
       <StackPanel Spacing="10">
-        <TextBlock Text="Privacy Threshold" />
+        <TextBlock Text="Anonymity Score Target" />
         <DockPanel>
-          <TextBlock MinWidth="24" DockPanel.Dock="Right" Text="{Binding MinAnonScoreTarget}" VerticalAlignment="Center" />
-          <Slider Minimum="2" Maximum="98" Value="{Binding MinAnonScoreTarget}" />
-        </DockPanel>
-      </StackPanel>
-
-      <StackPanel Spacing="10">
-        <TextBlock Text="Privacy Sanity Check" />
-        <DockPanel>
-          <TextBlock MinWidth="24" DockPanel.Dock="Right" Text="{Binding MaxAnonScoreTarget}" VerticalAlignment="Center" />
-          <Slider Minimum="3" Maximum="99" Value="{Binding MaxAnonScoreTarget}" />
+          <TextBlock MinWidth="24" DockPanel.Dock="Right" Text="{Binding AnonScoreTarget}" VerticalAlignment="Center" />
+          <Slider Minimum="2" Maximum="150" Value="{Binding AnonScoreTarget}" />
         </DockPanel>
       </StackPanel>
 

--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -33,21 +33,12 @@
         <Separator />
 
         <StackPanel Spacing="10" ToolTip.Tip="Minimum anonymity score for a coin to be considered private.">
-          <TextBlock Text="Privacy threshold" />
+          <TextBlock Text="Anonymity score target" />
           <DockPanel>
             <PathIcon DockPanel.Dock="Left" Foreground="{StaticResource PrivacyLevelMinimalBrush}"
                       Data="{StaticResource privacy_minimal}" />
-            <TextBlock MinWidth="24" DockPanel.Dock="Right" Text="{Binding MinAnonScoreTarget}" VerticalAlignment="Center" />
-            <Slider Minimum="2" Maximum="98" Value="{Binding MinAnonScoreTarget}" Margin="10 0" />
-          </DockPanel>
-        </StackPanel>
-        <StackPanel Spacing="10" ToolTip.Tip="A coin will not be automatically registered for coinjoin after this anonymity score is reached.">
-          <TextBlock Text="Privacy sanity check" />
-          <DockPanel>
-            <PathIcon DockPanel.Dock="Left" Foreground="{StaticResource PrivacyLevelMediumBrush}"
-                      Data="{StaticResource privacy_medium}" />
-            <TextBlock MinWidth="24" DockPanel.Dock="Right" Text="{Binding MaxAnonScoreTarget}" VerticalAlignment="Center" />
-            <Slider Minimum="3" Maximum="99" Value="{Binding MaxAnonScoreTarget}" Margin="10 0" />
+            <TextBlock MinWidth="24" DockPanel.Dock="Right" Text="{Binding AnonScoreTarget}" VerticalAlignment="Center" />
+            <Slider Minimum="2" Maximum="150" Value="{Binding AnonScoreTarget}" Margin="10 0" />
           </DockPanel>
         </StackPanel>
       </StackPanel>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -31,18 +31,18 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNothingFromFullyPrivateSetOfCoins()
 	{
 		// This test is to make sure no coins are selected when all coins are private.
-		const int AnonimitySet = 10;
+		const int AnonymitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Range(0, 10)
-			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet + 1))
+			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet + 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			anonScoreTarget: AnonimitySet,
+			anonScoreTarget: AnonymitySet,
 			ConfigureRng(5));
 
 		Assert.Empty(coins);
@@ -52,12 +52,12 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNonPrivateCoinFromOneNonPrivateCoinInBigSetOfCoinsConsolidationMode()
 	{
 		// This test is to make sure that we select the non-private coin in the set.
-		const int AnonimitySet = 10;
+		const int AnonymitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
-		SmartCoin smallerAnonCoin = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1);
+		SmartCoin smallerAnonCoin = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet - 1);
 		var coinsToSelectFrom = Enumerable
 			.Range(0, 10)
-			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet + 1))
+			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet + 1))
 			.Prepend(smallerAnonCoin)
 			.ToList();
 
@@ -65,7 +65,7 @@ public class CoinJoinCoinSelectionTests
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: true,
-			anonScoreTarget: AnonimitySet,
+			anonScoreTarget: AnonymitySet,
 			ConfigureRng(5));
 
 		Assert.Contains(smallerAnonCoin, coins);
@@ -76,18 +76,18 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNonPrivateCoinFromOneCoinSetOfCoins()
 	{
 		// This test is to make sure that we select the only non-private coin when it is the only coin in the wallet.
-		const int AnonimitySet = 10;
+		const int AnonymitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Empty<SmartCoin>()
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet - 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			anonScoreTarget: AnonimitySet,
+			anonScoreTarget: AnonymitySet,
 			ConfigureRng(1));
 
 		Assert.Single(coins);
@@ -97,19 +97,19 @@ public class CoinJoinCoinSelectionTests
 	public void SelectOneNonPrivateCoinFromTwoCoinsSetOfCoins()
 	{
 		// This test is to make sure that we select only one non-private coin.
-		const int AnonimitySet = 10;
+		const int AnonymitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Empty<SmartCoin>()
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet - 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			anonScoreTarget: AnonimitySet,
+			anonScoreTarget: AnonymitySet,
 			ConfigureRng(1));
 
 		Assert.Single(coins);
@@ -119,19 +119,19 @@ public class CoinJoinCoinSelectionTests
 	public void SelectTwoNonPrivateCoinsFromTwoCoinsSetOfCoinsConsolidationMode()
 	{
 		// This test is to make sure that we select more than one non-private coin.
-		const int AnonimitySet = 10;
+		const int AnonymitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Empty<SmartCoin>()
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonymitySet - 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: true,
-			anonScoreTarget: AnonimitySet,
+			anonScoreTarget: AnonymitySet,
 			ConfigureRng(1));
 
 		Assert.Equal(2, coins.Count);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -21,7 +21,7 @@ public class CoinJoinCoinSelectionTests
 			coins: Enumerable.Empty<SmartCoin>(),
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			minAnonScoreTarget: 10,
+			anonScoreTarget: 10,
 			ConfigureRng(5));
 
 		Assert.Empty(coins);
@@ -31,18 +31,18 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNothingFromFullyPrivateSetOfCoins()
 	{
 		// This test is to make sure no coins are selected when all coins are private.
-		const int MinAnonimitySet = 10;
+		const int AnonimitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Range(0, 10)
-			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet + 1))
+			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet + 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			minAnonScoreTarget: MinAnonimitySet,
+			anonScoreTarget: AnonimitySet,
 			ConfigureRng(5));
 
 		Assert.Empty(coins);
@@ -52,12 +52,12 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNonPrivateCoinFromOneNonPrivateCoinInBigSetOfCoinsConsolidationMode()
 	{
 		// This test is to make sure that we select the non-private coin in the set.
-		const int MinAnonimitySet = 10;
+		const int AnonimitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
-		SmartCoin smallerAnonCoin = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet - 1);
+		SmartCoin smallerAnonCoin = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1);
 		var coinsToSelectFrom = Enumerable
 			.Range(0, 10)
-			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet + 1))
+			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet + 1))
 			.Prepend(smallerAnonCoin)
 			.ToList();
 
@@ -65,7 +65,7 @@ public class CoinJoinCoinSelectionTests
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: true,
-			minAnonScoreTarget: MinAnonimitySet,
+			anonScoreTarget: AnonimitySet,
 			ConfigureRng(5));
 
 		Assert.Contains(smallerAnonCoin, coins);
@@ -76,18 +76,18 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNonPrivateCoinFromOneCoinSetOfCoins()
 	{
 		// This test is to make sure that we select the only non-private coin when it is the only coin in the wallet.
-		const int MinAnonimitySet = 10;
+		const int AnonimitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Empty<SmartCoin>()
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			minAnonScoreTarget: MinAnonimitySet,
+			anonScoreTarget: AnonimitySet,
 			ConfigureRng(1));
 
 		Assert.Single(coins);
@@ -97,19 +97,19 @@ public class CoinJoinCoinSelectionTests
 	public void SelectOneNonPrivateCoinFromTwoCoinsSetOfCoins()
 	{
 		// This test is to make sure that we select only one non-private coin.
-		const int MinAnonimitySet = 10;
+		const int AnonimitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Empty<SmartCoin>()
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet - 1))
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: false,
-			minAnonScoreTarget: MinAnonimitySet,
+			anonScoreTarget: AnonimitySet,
 			ConfigureRng(1));
 
 		Assert.Single(coins);
@@ -119,19 +119,19 @@ public class CoinJoinCoinSelectionTests
 	public void SelectTwoNonPrivateCoinsFromTwoCoinsSetOfCoinsConsolidationMode()
 	{
 		// This test is to make sure that we select more than one non-private coin.
-		const int MinAnonimitySet = 10;
+		const int AnonimitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		var coinsToSelectFrom = Enumerable
 			.Empty<SmartCoin>()
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet - 1))
-			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: MinAnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
+			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), 0, anonymitySet: AnonimitySet - 1))
 			.ToList();
 
 		var coins = CoinJoinClient.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			CreateMultipartyTransactionParameters(),
 			consolidationMode: true,
-			minAnonScoreTarget: MinAnonimitySet,
+			anonScoreTarget: AnonimitySet,
 			ConfigureRng(1));
 
 		Assert.Equal(2, coins.Count);

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -36,25 +36,25 @@ public class BlockchainAnalyzer
 		}
 		else
 		{
-			AnalyzeWalletInputs(tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int newInputAnonset);
+			AnalyzeWalletInputs(tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int startingOutputAnonset);
 
 			if (inputCount == ownInputCount)
 			{
-				AnalyzeSelfSpend(tx, newInputAnonset);
+				AnalyzeSelfSpend(tx, startingOutputAnonset);
 			}
 			else
 			{
-				AnalyzeCoinjoin(tx, newInputAnonset, distinctWalletInputPubKeys);
+				AnalyzeCoinjoin(tx, startingOutputAnonset, distinctWalletInputPubKeys);
 			}
 
-			AdjustWalletInputs(tx, distinctWalletInputPubKeys, newInputAnonset);
+			AdjustWalletInputs(tx, distinctWalletInputPubKeys, startingOutputAnonset);
 		}
 
 		AnalyzeClusters(tx);
 	}
 
-	/// <param name="newInputAnonset">The new anonymity set of the inputs.</param>
-	private void AnalyzeWalletInputs(SmartTransaction tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int newInputAnonset)
+	/// <param name="startingOutputAnonset">The new anonymity set of the inputs.</param>
+	private void AnalyzeWalletInputs(SmartTransaction tx, out HashSet<HdPubKey> distinctWalletInputPubKeys, out int startingOutputAnonset)
 	{
 		// We want to weaken the punishment if the input merge happens in coinjoins.
 		// Our strategy would be is to set the coefficient in proportion to our own inputs compared to the total inputs of the transaction.
@@ -66,19 +66,27 @@ public class BlockchainAnalyzer
 		var pubKeyReuseCount = tx.WalletInputs.Count - distinctWalletInputPubKeyCount;
 		double coefficient = (double)distinctWalletInputPubKeyCount / (tx.Transaction.Inputs.Count - pubKeyReuseCount);
 
-		newInputAnonset = Intersect(distinctWalletInputPubKeys.Select(x => x.AnonymitySet), coefficient);
-
-		foreach (var key in distinctWalletInputPubKeys)
+		// Consolidation in coinjoins is the only type of consolidation that's acceptable,
+		// because coinjoins are an exception from common input ownership heuristic.
+		if (coefficient < 1)
 		{
-			key.SetAnonymitySet(newInputAnonset);
+			// Calculate weighted average.
+			startingOutputAnonset = (int)(tx.WalletInputs.Sum(x => x.HdPubKey.AnonymitySet * x.Amount) / tx.WalletInputs.Sum(x => x.Amount));
+		}
+		else
+		{
+			startingOutputAnonset = Intersect(distinctWalletInputPubKeys.Select(x => x.AnonymitySet));
+			foreach (var key in distinctWalletInputPubKeys)
+			{
+				key.SetAnonymitySet(startingOutputAnonset);
+			}
 		}
 	}
 
 	/// <summary>
 	/// Estimate input cluster anonymity set size, penalizing input consolidations to accounting for intersection attacks.
 	/// </summary>
-	/// <param name="coefficient">If larger than 1, then penalty is larger, if smaller than 1 then penalty is smaller.</param>
-	private int Intersect(IEnumerable<int> anonsets, double coefficient)
+	private int Intersect(IEnumerable<int> anonsets)
 	{
 		// Sanity check.
 		if (!anonsets.Any())
@@ -89,23 +97,17 @@ public class BlockchainAnalyzer
 		// Our smallest anonset is the relevant here, because anonsets cannot grow by intersection punishments.
 		var smallestAnon = anonsets.Min();
 
-		// Consolidation in coinjoins is the only type of consolidation that's acceptable.
-		if (coefficient < 1)
-		{
-			return smallestAnon;
-		}
-
 		// Punish intersection exponentially.
 		// If there is only a single anonset then the exponent should be zero to divide by 1 thus retain the input coin anonset.
 		var intersectPenalty = Math.Pow(2, anonsets.Count() - 1);
-		var intersectionAnonset = smallestAnon / Math.Max(1, intersectPenalty * coefficient);
+		var intersectionAnonset = smallestAnon / Math.Max(1, intersectPenalty);
 
 		// The minimum anonymity set size is 1, enforce it when the punishment is very large.
 		var normalizedIntersectionAnonset = Math.Max(1, (int)intersectionAnonset);
 		return normalizedIntersectionAnonset;
 	}
 
-	private void AnalyzeCoinjoin(SmartTransaction tx, int newInputAnonset, ISet<HdPubKey> distinctWalletInputPubKeys)
+	private void AnalyzeCoinjoin(SmartTransaction tx, int startingOutputAnonset, ISet<HdPubKey> distinctWalletInputPubKeys)
 	{
 		var indistinguishableWalletOutputs = tx
 			.WalletOutputs.GroupBy(x => x.Amount)
@@ -134,7 +136,7 @@ public class BlockchainAnalyzer
 
 			// Account for the inherited anonymity set size from the inputs in the
 			// anonymity set size estimate.
-			anonset += newInputAnonset;
+			anonset += startingOutputAnonset;
 
 			HdPubKey hdPubKey = newCoin.HdPubKey;
 			uint256 txid = tx.GetHash();
@@ -149,12 +151,12 @@ public class BlockchainAnalyzer
 			else if (distinctWalletInputPubKeys.Contains(hdPubKey))
 			{
 				// If it's a reuse of an input's pubkey, then intersection punishment is senseless.
-				hdPubKey.SetAnonymitySet(newInputAnonset, txid);
+				hdPubKey.SetAnonymitySet(startingOutputAnonset, txid);
 			}
 			else if (tx.WalletOutputs.Where(x => x != newCoin).Select(x => x.HdPubKey).Contains(hdPubKey))
 			{
 				// If it's a reuse of another output's pubkey, then intersection punishment can only go as low as the inherited anonset.
-				hdPubKey.SetAnonymitySet(Math.Max(newInputAnonset, Intersect(new[] { anonset, hdPubKey.AnonymitySet }, 1)), txid);
+				hdPubKey.SetAnonymitySet(Math.Max(startingOutputAnonset, Intersect(new[] { anonset, hdPubKey.AnonymitySet })), txid);
 			}
 			else if (hdPubKey.OutputAnonSetReasons.Contains(txid))
 			{
@@ -171,7 +173,7 @@ public class BlockchainAnalyzer
 			else
 			{
 				// It's address reuse.
-				hdPubKey.SetAnonymitySet(Intersect(new[] { anonset, hdPubKey.AnonymitySet }, 1), txid);
+				hdPubKey.SetAnonymitySet(Intersect(new[] { anonset, hdPubKey.AnonymitySet }), txid);
 			}
 		}
 	}
@@ -179,7 +181,7 @@ public class BlockchainAnalyzer
 	/// <summary>
 	/// Adjusts the anonset of the inputs to the newly calculated output anonsets.
 	/// </summary>
-	private static void AdjustWalletInputs(SmartTransaction tx, HashSet<HdPubKey> distinctWalletInputPubKeys, int newInputAnonset)
+	private static void AdjustWalletInputs(SmartTransaction tx, HashSet<HdPubKey> distinctWalletInputPubKeys, int startingOutputAnonset)
 	{
 		// Sanity check.
 		if (!tx.WalletOutputs.Any())
@@ -188,7 +190,7 @@ public class BlockchainAnalyzer
 		}
 
 		var smallestOutputAnonset = tx.WalletOutputs.Min(x => x.HdPubKey.AnonymitySet);
-		if (smallestOutputAnonset < newInputAnonset)
+		if (smallestOutputAnonset < startingOutputAnonset)
 		{
 			foreach (var key in distinctWalletInputPubKeys)
 			{
@@ -197,17 +199,17 @@ public class BlockchainAnalyzer
 		}
 	}
 
-	private void AnalyzeSelfSpend(SmartTransaction tx, int newInputAnonset)
+	private void AnalyzeSelfSpend(SmartTransaction tx, int startingOutputAnonset)
 	{
 		foreach (var key in tx.WalletOutputs.Select(x => x.HdPubKey))
 		{
 			if (key.AnonymitySet == HdPubKey.DefaultHighAnonymitySet)
 			{
-				key.SetAnonymitySet(newInputAnonset, tx.GetHash());
+				key.SetAnonymitySet(startingOutputAnonset, tx.GetHash());
 			}
 			else
 			{
-				key.SetAnonymitySet(Intersect(new[] { newInputAnonset, key.AnonymitySet }, 1), tx.GetHash());
+				key.SetAnonymitySet(Intersect(new[] { startingOutputAnonset, key.AnonymitySet }), tx.GetHash());
 			}
 		}
 	}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -22,8 +22,7 @@ namespace WalletWasabi.Blockchain.Keys;
 [JsonObject(MemberSerialization.OptIn)]
 public class KeyManager
 {
-	public const int DefaultMinAnonScoreTarget = 5;
-	public const int DefaultMaxAnonScoreTarget = 10;
+	public const int DefaultAnonScoreTarget = 5;
 	public const bool DefaultAutoCoinjoin = false;
 	public const int DefaultFeeRateMedianTimeFrameHours = 0;
 
@@ -157,16 +156,13 @@ public class KeyManager
 	[JsonProperty(Order = 12, PropertyName = "Icon")]
 	public string? Icon { get; private set; }
 
-	[JsonProperty(Order = 13, PropertyName = "MinAnonScoreTarget")]
-	public int MinAnonScoreTarget { get; private set; } = DefaultMinAnonScoreTarget;
+	[JsonProperty(Order = 13, PropertyName = "AnonScoreTarget")]
+	public int AnonScoreTarget { get; private set; } = DefaultAnonScoreTarget;
 
-	[JsonProperty(Order = 14, PropertyName = "MaxAnonScoreTarget")]
-	public int MaxAnonScoreTarget { get; private set; } = DefaultMaxAnonScoreTarget;
-
-	[JsonProperty(Order = 15, PropertyName = "FeeRateMedianTimeFrameHours")]
+	[JsonProperty(Order = 14, PropertyName = "FeeRateMedianTimeFrameHours")]
 	public int FeeRateMedianTimeFrameHours { get; private set; } = DefaultFeeRateMedianTimeFrameHours;
 
-	[JsonProperty(Order = 16, PropertyName = "IsCoinjoinProfileSelected")]
+	[JsonProperty(Order = 15, PropertyName = "IsCoinjoinProfileSelected")]
 	public bool IsCoinjoinProfileSelected { get; set; } = false;
 
 	[JsonProperty(Order = 999)]
@@ -703,15 +699,9 @@ public class KeyManager
 		SetIcon(type.ToString());
 	}
 
-	public void SetAnonScoreTargets(int minAnonScoreTarget, int maxAnonScoreTarget, bool toFile = true)
+	public void SetAnonScoreTarget(int anonScoreTarget, bool toFile = true)
 	{
-		if (maxAnonScoreTarget <= minAnonScoreTarget)
-		{
-			throw new ArgumentException($"{nameof(maxAnonScoreTarget)} should be greater than {nameof(minAnonScoreTarget)}.", nameof(maxAnonScoreTarget));
-		}
-
-		MinAnonScoreTarget = minAnonScoreTarget;
-		MaxAnonScoreTarget = maxAnonScoreTarget;
+		AnonScoreTarget = anonScoreTarget;
 		if (toFile)
 		{
 			ToFile();

--- a/WalletWasabi/CoinJoin/Client/Rounds/ClientState.cs
+++ b/WalletWasabi/CoinJoin/Client/Rounds/ClientState.cs
@@ -241,16 +241,16 @@ public class ClientState
 					{
 						// Generating toxic change leads to mass merging so it's better to merge sooner in coinjoin than the user do it himself in a non-CJ.
 						// The best selection's anonset should not be lowered by this merge.
-						int bestMinAnonset = bestSet.Min(x => x.HdPubKey.AnonymitySet);
+						int bestAnonset = bestSet.Min(x => x.HdPubKey.AnonymitySet);
 						var bestSum = Money.Satoshis(bestSet.Sum(x => x.Amount));
 
 						if (!bestSum.Almost(amountNeeded, Money.Coins(0.0001m)) // Otherwise it wouldn't generate change so consolidation would make no sense.
-							&& bestMinAnonset > 1) // Red coins should never be merged.
+							&& bestAnonset > 1) // Red coins should never be merged.
 						{
 							IEnumerable<SmartCoin> coinsThatCanBeConsolidated = coins
 								.Except(bestSet) // Get all the registrable coins, except the already chosen ones.
 								.Where(x =>
-									x.HdPubKey.AnonymitySet >= bestMinAnonset // The anonset must be at least equal to the bestSet's anonset so we do not ruin the change's after mix anonset.
+									x.HdPubKey.AnonymitySet >= bestAnonset // The anonset must be at least equal to the bestSet's anonset so we do not ruin the change's after mix anonset.
 									&& x.HdPubKey.AnonymitySet > 1 // Red coins should never be merged.
 									&& x.Amount < amountNeeded // The amount needs to be smaller than the amountNeeded (so to make sure this is toxic change.)
 									&& bestSum + x.Amount > amountNeeded) // Sanity check that the amount added do not ruin the registration.

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -449,7 +449,9 @@ public class CoinJoinClient
 			.ToArray();
 
 		// How many inputs do we want to provide to the mix?
-		int inputCount = consolidationMode ? MaxInputsRegistrableByWallet : GetInputTarget(filteredCoins.Length, rnd);
+		int inputCount = Math.Min(
+			filteredCoins.Length,
+			consolidationMode ? MaxInputsRegistrableByWallet : GetInputTarget(filteredCoins.Length, rnd));
 
 		var nonPrivateFilteredCoins = filteredCoins
 			.Where(x => x.HdPubKey.AnonymitySet < anonScoreTarget)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -490,11 +490,6 @@ public class CoinJoinClient
 			}
 		}
 
-		if (groups.Count == 0)
-		{
-			return ImmutableList<SmartCoin>.Empty;
-		}
-
 		// Select the group where the less coins coming from the same tx.
 		var bestRep = groups.Values.Select(x => GetReps(x)).Min(x => x);
 		var bestRepGroups = groups.Values.Where(x => GetReps(x) == bestRep);
@@ -503,7 +498,7 @@ public class CoinJoinClient
 			.ToShuffled()
 			.MaxBy(x => x.Sum(y => y.Amount))!;
 
-		return bestgroup.ToShuffled().ToImmutableList();
+		return bestgroup?.ToShuffled()?.ToImmutableList() ?? ImmutableList<SmartCoin>.Empty;
 	}
 
 	private static int GetReps(IEnumerable<SmartCoin> group)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -496,6 +496,11 @@ public class CoinJoinClient
 			}
 		}
 
+		if (!groups.Any())
+		{
+			return ImmutableList<SmartCoin>.Empty;
+		}
+
 		// Select the group where the less coins coming from the same tx.
 		var bestRep = groups.Values.Select(x => GetReps(x)).Min(x => x);
 		var bestRepGroups = groups.Values.Where(x => GetReps(x) == bestRep);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -457,7 +457,7 @@ public class CoinJoinClient
 			.Where(x => x.HdPubKey.AnonymitySet < anonScoreTarget)
 			.ToArray();
 
-		// Always have the top largest amounts playing to not participate with insignificant amounts and fragment needlessly.
+		// Always use the largest amounts, so we do not participate with insignificant amounts and fragment wallet needlessly.
 		var largestAmounts = nonPrivateFilteredCoins
 			.OrderByDescending(x => x.Amount)
 			.Take(3)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -496,7 +496,7 @@ public class CoinJoinClient
 
 		var bestgroup = bestRepGroups
 			.ToShuffled()
-			.MaxBy(x => x.Sum(y => y.Amount))!;
+			.MaxBy(x => x.Sum(y => y.Amount));
 
 		return bestgroup?.ToShuffled()?.ToImmutableList() ?? ImmutableList<SmartCoin>.Empty;
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -371,11 +371,10 @@ public class CoinJoinManager : BackgroundService
 			.Available()
 			.Confirmed()
 			.Where(x => !x.IsBanned)
-			.Where(x => x.HdPubKey.AnonymitySet < openedWallet.KeyManager.MaxAnonScoreTarget
-					&& !CoinRefrigerator.IsFrozen(x)));
+			.Where(x => !CoinRefrigerator.IsFrozen(x)));
 
 		// If a small portion of the wallet isn't private, it's better to wait with mixing.
-		if (GetPrivacyPercentage(coins, openedWallet.KeyManager.MinAnonScoreTarget) > 0.99)
+		if (GetPrivacyPercentage(coins, openedWallet.KeyManager.AnonScoreTarget) > 0.99)
 		{
 			return Enumerable.Empty<SmartCoin>();
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -30,7 +30,7 @@ public class CoinJoinTrackerFactory
 			new KeyChain(wallet.KeyManager, wallet.Kitchen),
 			new InternalDestinationProvider(wallet.KeyManager),
 			RoundStatusUpdater,
-			wallet.KeyManager.MinAnonScoreTarget,
+			wallet.KeyManager.AnonScoreTarget,
 			feeRateMedianTimeFrame: TimeSpan.FromHours(wallet.KeyManager.FeeRateMedianTimeFrameHours),
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -94,7 +94,7 @@ public class Wallet : BackgroundService
 	public bool AllowManualCoinJoin { get; set; }
 
 	public Kitchen Kitchen { get; } = new();
-	public ICoinsView NonPrivateCoins => new CoinsView(Coins.Where(c => c.HdPubKey.AnonymitySet < KeyManager.MinAnonScoreTarget));
+	public ICoinsView NonPrivateCoins => new CoinsView(Coins.Where(c => c.HdPubKey.AnonymitySet < KeyManager.AnonScoreTarget));
 
 	public bool TryLogin(string password, out string? compatibilityPasswordUsed)
 	{
@@ -139,7 +139,7 @@ public class Wallet : BackgroundService
 			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
 			FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
 
-			TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold, KeyManager.MinAnonScoreTarget);
+			TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold, KeyManager.AnonScoreTarget);
 			Coins = TransactionProcessor.Coins;
 
 			TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;


### PR DESCRIPTION
## Summary

This PR at its core changes the anonymity calculation in case of coinjoins during registration of multiple inputs. Previously the anonymity scores of outputs started from the lowest input's anonscore. In this PR, it uses amount weighted averages of the input anonscores. While it may seem like a trivial change, it does come with a plethora of implications.

An alternative way to think about this PR is that it drops the conservative assumption of common input ownership heuristics in coinjoins.

## Implications

- From this PR on the privacy progress percentage is never going to go down after a coinjoin. This enables us to have a wallet 100% coinjoined out, which previously it was often not possible, except at a great cost of coinjoining insignificant amounts, effectively spamming the blockchain.
- From this PR we need not to concern ourselves anymore with anonymity scores in coin selection for coinjoins. The direct importance of this is its privacy benefits: Previously, we had to always select coins close to each other with anonymity scores, which resulted in [sub-optimal privacy](https://github.com/zkSNACKs/WalletWasabi/issues/7938#issuecomment-1123665487) for coin selection. This was the classic case of our measurement technique ruining our results.
- Since anonymity score was dominating our CJ coin selection, dropping it also results in other factors to be more significant. For example we're trying to not select coins from the same transaction, which results in greater interconnectedness of coinjoins.
- Another smaller benefit would be that our coin selection algorithm can now be less non-deterministic.
- Another greater benefit would be that we're now able to coinjoin larger amounts. Previously, we kept mixing insignificant amounts, spamming the blockchain and having a very bad user experience for coinjoins. This also comes with the benefit that overall coinjoin volumes will be much larger, providing much more privacy for our users.
- Then there are the anonymity score targets. Previously, we had two of them: a min and a max. This was a terrible UX issue and resulted in some friction with not being able to fully set the number of coins in the wallet. With this PR we don't need the "max anonscore target" anymore. 
- Finally the plebstop. Previously we had to apply the plebstop even for wallets those had large amounts of money. This was because we couldn't fully coinjoin out wallets. This was as well a terrible UX friction. We don't need it anymore.

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/7903
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/7938
Replaces https://github.com/zkSNACKs/WalletWasabi/pull/7940