### PR TITLE
[VDG] Widen up the navbar to accomodate the bottom menu text

### DIFF
--- a/WalletWasabi.Fluent/Controls/NavBarItem.axaml
+++ b/WalletWasabi.Fluent/Controls/NavBarItem.axaml
@@ -51,7 +51,7 @@
                             Padding="{TemplateBinding Padding}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
-          <Border Name="SelectionIndicator" />
+          <Border Name="SelectionIndicator" Margin="1,0,0,0" />
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/WalletWasabi.Fluent/Controls/NavBarItem.axaml
+++ b/WalletWasabi.Fluent/Controls/NavBarItem.axaml
@@ -35,9 +35,14 @@
     <Setter Property="Template">
       <ControlTemplate>
         <!-- The margin here should be compensated with the same amount in the NavBar's topmost content-->
-        <Panel Margin="5" Height="60" Width="60" ClipToBounds="False">
+        <Panel Margin="5"
+               Height="{TemplateBinding Height}"
+               Width="{TemplateBinding Width}"
+               ClipToBounds="False">
           <Border Name="SelectionBackground" />
           <ContentPresenter Name="PART_ContentPresenter"
+                            Height="{TemplateBinding Height}"
+                            Width="{TemplateBinding Width}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"

--- a/WalletWasabi.Fluent/Controls/NavBarItem.axaml
+++ b/WalletWasabi.Fluent/Controls/NavBarItem.axaml
@@ -51,7 +51,9 @@
                             Padding="{TemplateBinding Padding}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
-          <Border Name="SelectionIndicator" Margin="1,0,0,0" />
+          <!-- NOTE: This margin value is to force the dirty rect in Avalonia's Deferred Renderer
+                     to be rounded up so that it doesnt show up the artifacts when animated on high-res displays.  -->
+          <Border Name="SelectionIndicator" Margin="0.5,0,0,0" />
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/WalletWasabi.Fluent/Controls/NavBarItem.axaml
+++ b/WalletWasabi.Fluent/Controls/NavBarItem.axaml
@@ -35,7 +35,7 @@
     <Setter Property="Template">
       <ControlTemplate>
         <!-- The margin here should be compensated with the same amount in the NavBar's topmost content-->
-        <Panel Margin="5"
+        <Panel Margin="5,5,5,0"
                Height="{TemplateBinding Height}"
                Width="{TemplateBinding Width}"
                ClipToBounds="False">

--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -33,7 +33,7 @@
 
     <Style Selector=":is(Panel).NavBarItemPanel" x:DataType="vmw:WalletViewModelBase">
       <Setter Property="Width" Value="52" />
-      <Setter Property="Height" Value="48" />
+      <Setter Property="Height" Value="36" />
       <Setter Property="Background" Value="Transparent" />
     </Style>
 
@@ -114,7 +114,7 @@
     </Style>
 
   </UserControl.Styles>
-  <DockPanel Margin="0 -4 0 4">
+  <DockPanel Margin="0 -5 0 5">
     <DockPanel Background="Transparent" DockPanel.Dock="Bottom">
       <c:NavBarListBox Items="{Binding BottomItems}"
                        SelectedItem="{Binding SelectedItem, Mode=TwoWay}"

--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -32,23 +32,13 @@
     </Style>
 
     <Style Selector=":is(Panel).NavBarItemPanel" x:DataType="vmw:WalletViewModelBase">
-      <Setter Property="Width" Value="64" />
-      <Setter Property="Height" Value="64" />
+      <Setter Property="Width" Value="52" />
+      <Setter Property="Height" Value="48" />
       <Setter Property="Background" Value="Transparent" />
     </Style>
 
     <Style Selector=":is(Panel).NavBarItemPanel DockPanel">
-      <Setter Property="Width" Value="64" />
-      <Setter Property="Margin" Value="4" />
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="HorizontalAlignment" Value="Center" />
-    </Style>
-
-    <Style Selector=":is(Panel).NavBarItemPanel DockPanel TextBlock">
-      <Setter Property="TextAlignment" Value="Center" />
-      <Setter Property="Margin" Value="8,5,8, 0" />
-      <Setter Property="FontSize" Value="{StaticResource FontSizeH9}" />
     </Style>
 
     <Style Selector=":is(Panel).NavBarItemPanel DockPanel > PathIcon">
@@ -95,8 +85,8 @@
 
     <Style Selector="c|NavBarItem :is(Panel).NavBarItemPanel DockPanel LayoutTransformControl">
       <Setter Property="LayoutTransform" Value="scaleY(1)" />
-      <Setter Property="Opacity" Value="1" />
-      <Setter Property="Margin" Value="1, 0" />
+       <Setter Property="Opacity" Value="1" />
+      <Setter Property="Margin" Value="-8, 0" />
       <Setter Property="Transitions">
         <Transitions>
           <TransformOperationsTransition Property="LayoutTransform" Duration="0:0:0.175" />
@@ -107,8 +97,8 @@
 
     <Style Selector=":is(Panel).NavBarItemPanel DockPanel TextBlock">
       <Setter Property="TextAlignment" Value="Center" />
-      <Setter Property="HorizontalAlignment" Value="Stretch" />
-    </Style>
+      <Setter Property="FontSize" Value="{StaticResource FontSizeH9}" />
+     </Style>
 
     <Style Selector="c|NavBarItem:selected :is(Panel).NavBarItemPanel DockPanel LayoutTransformControl">
       <Setter Property="LayoutTransform" Value="scaleY(0)" />
@@ -138,7 +128,8 @@
         </c:NavBarListBox.ItemsPanel>
         <c:NavBarListBox.DataTemplates>
           <DataTemplate DataType="vm:NavBarItemViewModel">
-            <Panel Classes="NavBarItemPanel utilities" ToolTip.Tip="{Binding Title}" ToolTip.Placement="Right" Cursor="Hand">
+            <Panel Classes="NavBarItemPanel utilities" ToolTip.Tip="{Binding Title}" ToolTip.Placement="Right"
+                   Cursor="Hand">
               <DockPanel>
                 <LayoutTransformControl DockPanel.Dock="Bottom">
                   <c:FadeOutTextBlock Text="{Binding Title}" />


### PR DESCRIPTION
<img width="908" alt="Screen Shot 2022-05-17 at 12 02 00 PM" src="https://user-images.githubusercontent.com/16554748/168726174-0a7b8bbe-76b2-4736-a3f9-2a0f88be059b.png">

Fixes #8002

cc @zkSNACKs/visual-design-group @nopara73 