### PR TITLE
Fixing the CI - SelectNonPrivateCoinFromOneNonPrivate

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -464,7 +464,7 @@ public class CoinJoinClient
 			{
 				TryAddGroup(parameters, groups, group);
 
-				if (sw2.Elapsed > TimeSpan.FromSeconds(1))
+				if (sw2.Elapsed > TimeSpan.FromSeconds(1) && groups.Any())
 				{
 					break;
 				}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9844978/169013266-b268807d-cbe1-4746-89ed-ec04659c506d.png)

The PR is based on the assumption that. 

Fixing unreliability of the test `SelectNonPrivateCoinFromOneNonPrivateCoinInBigSetOfCoinsConsolidationMode`