### PR TITLE
Fix Backend Global

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -61,6 +61,15 @@ public class Global : IDisposable
 		var p2pNode = Guard.NotNull(nameof(P2pNode), P2pNode);
 		HostedServices.Register<MempoolMirror>(() => new MempoolMirror(TimeSpan.FromSeconds(21), RpcClient, p2pNode), "Full Node Mempool Mirror");
 
+		// Initialize index building
+		var indexBuilderServiceDir = Path.Combine(DataDir, "IndexBuilderService");
+		var indexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{RpcClient.Network}.dat");
+		var blockNotifier = HostedServices.Get<BlockNotifier>();
+
+		CoordinatorParameters coordinatorParameters = new(DataDir);
+		Coordinator = new(RpcClient.Network, blockNotifier, Path.Combine(DataDir, "CcjCoordinator"), RpcClient, roundConfig);
+		Coordinator.CoinJoinBroadcasted += Coordinator_CoinJoinBroadcasted;
+
 		var coordinator = Guard.NotNull(nameof(Coordinator), Coordinator);
 		if (roundConfig.FilePath is { })
 		{
@@ -83,15 +92,6 @@ public class Global : IDisposable
 				   }),
 				"Config Watcher");
 		}
-
-		// Initialize index building
-		var indexBuilderServiceDir = Path.Combine(DataDir, "IndexBuilderService");
-		var indexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{RpcClient.Network}.dat");
-		var blockNotifier = HostedServices.Get<BlockNotifier>();
-
-		CoordinatorParameters coordinatorParameters = new(DataDir);
-		Coordinator = new(RpcClient.Network, blockNotifier, Path.Combine(DataDir, "CcjCoordinator"), RpcClient, roundConfig);
-		Coordinator.CoinJoinBroadcasted += Coordinator_CoinJoinBroadcasted;
 
 		CoinJoinIdStore = CoinJoinIdStore.Create(Coordinator.CoinJoinsFilePath, coordinatorParameters.CoinJoinIdStoreFilePath);
 


### PR DESCRIPTION
I tried to test something in RegTest, but couldn't start the backend locally.
The error was `Backend/Global.cs: ArgumentNullException: Parameter is null. (Parameter: Coordinator)` so the `Guard.NotNull` throw the exception as it's expected.
 
PR fixes this by moving the `Guard` and the `ConfigWatcher` init further down.

Git shows the diff quiet stupidly, all I did was cut the `Guard` and the `ConfigWatcher` stuff and pasted it under the Coordinator initialization.