### PR TITLE
Remove unnecessary stop command in autoCJ mode

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -311,7 +311,9 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PlayVisible = false;
 
 				CurrentStatus = _initialisingMessage;
-			});
+			})
+			.OnTrigger(Trigger.Play, async () => await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None).ConfigureAwait(false))
+			.OnTrigger(Trigger.AutoStartTimeout, async () => await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None).ConfigureAwait(false));
 
 		_stateMachine.Configure(State.AutoStarting)
 			.SubstateOf(State.AutoCoinJoin)
@@ -371,9 +373,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				{
 					// If we are not below the threshold anymore, we turn off the override.
 					_overridePlebStop = false;
+					await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None);
 				}
-
-				await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None);
 			})
 			.Custom(HandleMessages)
 			.OnEntry(UpdateAndShowWalletMixedProgress)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -311,8 +311,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PlayVisible = false;
 
 				CurrentStatus = _initialisingMessage;
-
-				await coinJoinManager.StopAsync(_wallet, CancellationToken.None);
 			});
 
 		_stateMachine.Configure(State.AutoStarting)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -303,7 +303,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		_stateMachine.Configure(State.AutoCoinJoin)
 			.InitialTransition(State.AutoStarting)
 			.Permit(Trigger.AutoCoinJoinOff, State.ManualCoinJoin)
-			.OnEntry(async () =>
+			.OnEntry(() =>
 			{
 				IsAuto = true;
 				StopVisible = false;


### PR DESCRIPTION


`_stateMachine.Configure(State.AutoCoinJoin).OnEntry` was hit after every round stopping the AutoCoinJoin every time. 
The problem was hidden because right after that the state machine proceeded into 

`_stateMachine.Configure(State.AutoPlaying).OnEntry` where it was started again - in most of the cases. 

The correct behavior would be:
- in auto coinjoin mode the state machine should not touch CoinJoin manager at all, only at the beginning - to start it and only in pause mode. 