### PR TITLE
[VDG] Fix splash animation triggered by the SearchBar

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/SearchBar/Sources/ActionsSource.cs
+++ b/WalletWasabi.Fluent/ViewModels/SearchBar/Sources/ActionsSource.cs
@@ -46,6 +46,10 @@ public class ActionsSource : ISearchItemSource
 			{
 				item.OpenCommand.Execute(default);
 			}
+			else if (vm is TriggerCommandViewModel triggerCommandViewModel && triggerCommandViewModel.TargetCommand.CanExecute(default))
+			{
+				triggerCommandViewModel.TargetCommand.Execute(default);
+			}
 			else
 			{
 				RoutableViewModel.Navigate(vm.DefaultTarget).To(vm);

--- a/WalletWasabi.Fluent/ViewModels/TriggerCommandViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/TriggerCommandViewModel.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Disposables;
 using System.Windows.Input;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 
@@ -7,14 +6,4 @@ namespace WalletWasabi.Fluent.ViewModels;
 public abstract class TriggerCommandViewModel : RoutableViewModel
 {
 	public abstract ICommand TargetCommand { get; }
-
-	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
-	{
-		if (TargetCommand.CanExecute(null))
-		{
-			TargetCommand.Execute(null);
-		}
-		Navigate().Back();
-		base.OnNavigatedTo(isInHistory, disposables);
-	}
 }


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/7983

I still disagree with the fact that `TriggerCommandViewModel` is a `RoutableViewModel` but it seems it has to be that because of the NavigationMetaData. Removing the navigation hack and calling its command properly fixes the issue.