### PR TITLE
Fix StateMachine IsInState logic

### DIFF
--- a/WalletWasabi.Fluent/State/StateMachine.cs
+++ b/WalletWasabi.Fluent/State/StateMachine.cs
@@ -17,7 +17,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 	public bool IsInState(TState state)
 	{
-		return _currentState.StateId.Equals(state) || (_currentState.Parent?.StateId.Equals(state) ?? false);
+		return IsAncestorOf(_currentState.StateId, state);
 	}
 
 	public StateMachine(TState initialState)
@@ -44,7 +44,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 		return this;
 	}
 
-	public bool IsAncestorOf(TState state, TState parent)
+	private bool IsAncestorOf(TState state, TState parent)
 	{
 		if (_states.ContainsKey(state))
 		{

--- a/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
@@ -30,7 +30,8 @@ public class StateMachineTests
 	{
 		Playing,
 		Paused,
-		PausedChild
+		PausedChild,
+		PausedChild2
 	}
 
 	[Fact]
@@ -332,5 +333,38 @@ public class StateMachineTests
 		sut.Fire(JukeBoxTrigger.Pause);
 
 		Assert.Equal(1, entryCallCount);
+	}
+
+	[Fact]
+	public void Is_In_State_Works_With_Child_Child_States()
+	{
+		StateMachine<JukeBoxState, JukeBoxTrigger> sut =
+			new StateMachine<JukeBoxState, JukeBoxTrigger>(JukeBoxState.Paused);
+
+		int entryCallCount = 0;
+
+		sut.Configure(JukeBoxState.Paused)
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.PausedChild);
+
+		sut.Configure(JukeBoxState.PausedChild)
+			.SubstateOf(JukeBoxState.Paused)
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.PausedChild2)
+			.OnEntry(() => entryCallCount++);
+
+		sut.Configure(JukeBoxState.PausedChild2)
+			.SubstateOf(JukeBoxState.PausedChild)
+			.OnEntry(() => entryCallCount++);
+
+		sut.Start();
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(1, entryCallCount);
+		Assert.True(sut.IsInState(JukeBoxState.Paused));
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(2, entryCallCount);
+		Assert.True(sut.IsInState(JukeBoxState.Paused));
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
@@ -367,4 +367,48 @@ public class StateMachineTests
 		Assert.Equal(2, entryCallCount);
 		Assert.True(sut.IsInState(JukeBoxState.Paused));
 	}
+
+	[Fact]
+	public void Parent_Entry_Isnt_Called_Entering_Child_Child_States()
+	{
+		StateMachine<JukeBoxState, JukeBoxTrigger> sut =
+			new StateMachine<JukeBoxState, JukeBoxTrigger>(JukeBoxState.Paused);
+
+		int entryCallCount = 0;
+		int pausedEntryCount = 0;
+
+		sut.Configure(JukeBoxState.Paused)
+			.OnEntry(() =>
+			{
+				pausedEntryCount++;
+			})
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.PausedChild);
+
+		sut.Configure(JukeBoxState.PausedChild)
+			.SubstateOf(JukeBoxState.Paused)
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.PausedChild2)
+			.OnEntry(() => entryCallCount++);
+
+		sut.Configure(JukeBoxState.PausedChild2)
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.PausedChild)
+			.SubstateOf(JukeBoxState.PausedChild)
+			.OnEntry(() => entryCallCount++);
+
+		sut.Start();
+
+		Assert.Equal(1, pausedEntryCount);
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(1, entryCallCount);
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(2, entryCallCount);
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(1, pausedEntryCount);
+		Assert.Equal(3, entryCallCount);
+	}
 }


### PR DESCRIPTION
@molnard reported that AutoCoinJoinState.OnEntry was getting called after each round, this caused auto cj to stop incorrectly.

I confirmed this was the case, this is incorrect behavior.

It turns out that I had forgotten to update a method to be compatible with child states.. so it was unable to detect we are in a parent state from a child state correctly.

This meant that the Parent states OnEntry could be called... despite already being in that state.

AutoCoinJoin now works continuously. StateMachine now behaves as per spec... (https://github.com/dotnet-state-machine/stateless)