### PR TITLE
Do not let and detect double start of CoinJoinClient

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -141,7 +141,7 @@ public class CoinJoinManager : BackgroundService
 			var walletToStart = startCommand.Wallet;
 			if (trackedCoinJoins.TryGetValue(walletToStart.WalletName, out var tracker))
 			{
-				walletToStart.LogDebug("Cannot start coinjoin, bacause it is already running.");
+				walletToStart.LogDebug("Cannot start coinjoin, because it is already running.");
 				return;
 			}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -139,9 +139,9 @@ public class CoinJoinManager : BackgroundService
 		void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{
 			var walletToStart = startCommand.Wallet;
-			if (trackedCoinJoins.TryGetValue(walletToStart.WalletName, out var tracker) && !tracker.IsCompleted)
+			if (trackedCoinJoins.TryGetValue(walletToStart.WalletName, out var tracker))
 			{
-				walletToStart.LogDebug("Cannot start coinjoin for wallet, bacause it is already running.");
+				walletToStart.LogDebug("Cannot start coinjoin, bacause it is already running.");
 				return;
 			}
 
@@ -180,9 +180,18 @@ public class CoinJoinManager : BackgroundService
 			}
 
 			var coinJoinTracker = coinJoinTrackerFactory.CreateAndStart(walletToStart, coinCandidates, startCommand.RestartAutomatically, startCommand.OverridePlebStop);
+
+			if (!trackedCoinJoins.TryAdd(walletToStart.WalletName, coinJoinTracker))
+			{
+				// This should never happen.
+				walletToStart.LogError($"{nameof(CoinJoinTracker)} was already added.");
+				coinJoinTracker.Stop();
+				coinJoinTracker.Dispose();
+				return;
+			}
+
 			coinJoinTracker.WalletCoinJoinProgressChanged += CoinJoinTracker_WalletCoinJoinProgressChanged;
 
-			trackedCoinJoins.AddOrUpdate(walletToStart.WalletName, _ => coinJoinTracker, (_, cjt) => cjt);
 			var registrationTimeout = TimeSpan.MaxValue;
 			NotifyCoinJoinStarted(walletToStart, registrationTimeout);
 


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/8068

We were running the CoinJoinClient twice! It is started exactly at the same time by the music box. This PR not fixing the music box but the business logic to prevent that kind of situation. 

The real bug here was the: `!tracker.IsCompleted` because at the time of the check it was even not started, so it was indicating false and let go of the code. I am not sure why that condition was added at all. 

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.iscompleted?view=net-6.0

Also, I changed AddOrUpdate to TryAdd to detect any problems. @lontivero was there a reason to specifically use AddOrUpdate? 