### PR TITLE
[Trivial] Use DateTimeOffset.UtcNow instead of DateTimeOffset.Now

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -461,9 +461,9 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		ProgressValue = GetPercentage();
 	}
 
-	private TimeSpan GetElapsedTime() => DateTimeOffset.Now - _countDownStartTime;
+	private TimeSpan GetElapsedTime() => DateTimeOffset.UtcNow - _countDownStartTime;
 
-	private TimeSpan GetRemainingTime() => _countDownEndTime - DateTimeOffset.Now;
+	private TimeSpan GetRemainingTime() => _countDownEndTime - DateTimeOffset.UtcNow;
 
 	private TimeSpan GetTotalTime() => _countDownEndTime - _countDownStartTime;
 


### PR DESCRIPTION
For the sake of consistency, we use `DateTimeOffset.UtcNow` everywhere else.
https://github.com/zkSNACKs/WalletWasabi/pull/8070#issuecomment-1132938211