### PR TITLE
Check if SmartCoin's ban is still valid on client side periodically

### DIFF
--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -175,9 +175,9 @@ public class Global
 					Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
 				}
 
-				SmartCoinBanReleaser smartCoinReleaser = new(TimeSpan.FromSeconds(5), WalletManager);
+				SmartCoinBanReleaser smartCoinBanReleaser = new(TimeSpan.FromSeconds(5), WalletManager);
 
-				HostedServices.Register<SmartCoinBanReleaser>(() => smartCoinReleaser, "SmartCoin Releaser");
+				HostedServices.Register<SmartCoinBanReleaser>(() => smartCoinBanReleaser, "SmartCoin Ban Releaser");
 
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -174,6 +174,11 @@ public class Global
 				{
 					Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
 				}
+
+				SmartCoinReleaser smartCoinReleaser = new(TimeSpan.FromSeconds(5), WalletManager);
+
+				HostedServices.Register<SmartCoinReleaser>(() => smartCoinReleaser, "SmartCoin Releaser");
+
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 
 				var requestInterval = Network == Network.RegTest ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(30);

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -175,9 +175,9 @@ public class Global
 					Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
 				}
 
-				SmartCoinReleaser smartCoinReleaser = new(TimeSpan.FromSeconds(5), WalletManager);
+				SmartCoinBanReleaser smartCoinReleaser = new(TimeSpan.FromSeconds(5), WalletManager);
 
-				HostedServices.Register<SmartCoinReleaser>(() => smartCoinReleaser, "SmartCoin Releaser");
+				HostedServices.Register<SmartCoinBanReleaser>(() => smartCoinReleaser, "SmartCoin Releaser");
 
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -266,4 +266,12 @@ public class CoinsRegistry : ICoinsView
 	public ICoinsView Unspent() => AsCoinsView().Unspent();
 
 	IEnumerator IEnumerable.GetEnumerator() => AsCoinsView().GetEnumerator();
+
+	public void CheckCoinsReleaseTime()
+	{
+		foreach (var coin in Coins.Where(coin => coin.IsBanned))
+		{
+			coin.SetIsBanned();
+		}
+	}
 }

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
@@ -83,6 +83,14 @@ public class CoinsView : ICoinsView
 		}
 	}
 
+	public void CheckCoinsReleaseTime()
+	{
+		foreach(var coin in Coins.Where(coin => coin.IsBanned))
+		{
+			coin.SetIsBanned();
+		}
+	}
+
 	public Money TotalAmount() => Coins.Sum(x => x.Amount);
 
 	public SmartCoin[] ToArray() => Coins.ToArray();

--- a/WalletWasabi/Blockchain/TransactionOutputs/ICoinsView.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/ICoinsView.cs
@@ -37,5 +37,6 @@ public interface ICoinsView : IEnumerable<SmartCoin>
 
 	ICoinsView Unspent();
 
+	void CheckCoinsReleaseTime();
 	bool TryGetByOutPoint(OutPoint outpoint, [NotNullWhen(true)] out SmartCoin? coin);
 }

--- a/WalletWasabi/Services/CoinReleaser.cs
+++ b/WalletWasabi/Services/CoinReleaser.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Bases;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.Services;
+public class SmartCoinReleaser : PeriodicRunner
+{
+	public SmartCoinReleaser(TimeSpan period, WalletManager walletManager) : base(period)
+	{
+		WalletManager = walletManager;
+	}
+
+	public WalletManager WalletManager { get; }
+
+	protected override Task ActionAsync(CancellationToken cancel)
+	{
+		foreach (var coins in WalletManager.GetWallets(refreshWalletList: false).Select(wallet => wallet.Coins).ToList())
+		{
+			coins?.CheckCoinsReleaseTime();
+		}
+
+		return Task.CompletedTask;
+	}
+}

--- a/WalletWasabi/Services/SmartCoinBanReleaser.cs
+++ b/WalletWasabi/Services/SmartCoinBanReleaser.cs
@@ -5,9 +5,9 @@ using WalletWasabi.Bases;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Services;
-public class SmartCoinReleaser : PeriodicRunner
+public class SmartCoinBanReleaser : PeriodicRunner
 {
-	public SmartCoinReleaser(TimeSpan period, WalletManager walletManager) : base(period)
+	public SmartCoinBanReleaser(TimeSpan period, WalletManager walletManager) : base(period)
 	{
 		WalletManager = walletManager;
 	}

--- a/WalletWasabi/Services/SmartCoinBanReleaser.cs
+++ b/WalletWasabi/Services/SmartCoinBanReleaser.cs
@@ -16,7 +16,7 @@ public class SmartCoinBanReleaser : PeriodicRunner
 
 	protected override Task ActionAsync(CancellationToken cancel)
 	{
-		foreach (var coins in WalletManager.GetWallets(refreshWalletList: false).Select(wallet => wallet.Coins).ToList())
+		foreach (var coins in WalletManager.GetWallets(refreshWalletList: false).Select(wallet => wallet.Coins))
 		{
 			coins?.CheckCoinsReleaseTime();
 		}


### PR DESCRIPTION
This PR adds another another service which checks the coins of the wallets `IsBanned` property and sets it to false if the ban is resolved.

On `master`:
On client side we don't check if the ban is resolved or not. So if a coin is banned, only a restart would make it clean.
Why is it bad? 
Well, we won't select banned coins for coinjoins, even if the `BannedUntilUtc` is out-dated.

The service checks the coins "status" every 5 second.

@molnard  @lontivero  WDYT?

How to test:
 - Get RegTest env.
 - Put this line inside this [function](https://github.com/zkSNACKs/WalletWasabi/blob/889ed7f3a60c1f2a91102f14e6fe6128ecbe6f07/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs#L355) 
so your coin will be banned for 1 minute.

 ```
throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(1)));
```

 - Watch your coin list. First your coin will be banned (yellow warning icon), then after a minute the icon will be changed back to the coinjoin icon.



My namings are bad. Feel free to suggest new ones.