### PR TITLE
Update `AnonScoreTarget` upon opening Wallet Settings

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -104,6 +104,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
 		PlebStopThreshold = _wallet.KeyManager.PlebStopThreshold.ToString();
+		AnonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
 	}
 
 	private void ValidatePlebStopThreshold(IValidationErrors errors) =>


### PR DESCRIPTION
Fixes #8098

With old wallets, when we choose a CoinJoinProfile, the AnonScoreTarget will be changed in the background, but the `WalletSettingsViewModel` used the default `5` value when created. That should be updated upon navigation.