### PR TITLE
Move operation critical CoinJoin login into CoinJoinManager

### DIFF
--- a/WalletWasabi.Fluent/State/StateMachine.cs
+++ b/WalletWasabi.Fluent/State/StateMachine.cs
@@ -101,7 +101,10 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 			}
 		}
 
-		current.Enter();
+		if (origin is null || !IsAncestorOfInclusive(origin.Value, current.StateId))
+		{
+			current.Enter();
+		}
 
 		return current;
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -209,13 +209,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 				UpdateAndShowWalletMixedProgress();
 			})
-			.OnExit(() =>
-			{
-				// TODO
-			})
 			.OnTrigger(Trigger.BalanceChanged, UpdateAndShowWalletMixedProgress);
-		//.OnTrigger(Trigger.Play, async () => await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None));
-		//.OnTrigger(Trigger.AutoCoinJoinOn, async () =>);
 
 		_stateMachine.Configure(State.Stopped)
 			.SubstateOf(State.ManualCoinJoin)
@@ -253,10 +247,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 				await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None);
 			})
-			.OnExit(async () =>
-			{
-				await coinJoinManager.StopAsync(_wallet, CancellationToken.None);
-			})
+			.OnExit(async () => await coinJoinManager.StopAsync(_wallet, CancellationToken.None))
 			.Custom(HandleMessages)
 			.OnTrigger(Trigger.Timer, UpdateCountDown)
 			.OnTrigger(Trigger.Stop, () => _overridePlebStop = false);
@@ -264,14 +255,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		_stateMachine.Configure(State.ManualPlayingCritical)
 			.SubstateOf(State.ManualPlaying)
 			.Permit(Trigger.ExitCriticalPhaseMessage, State.ManualPlaying)
-			.OnEntry(() =>
-			{
-				StopVisible = false;
-			})
-			.OnExit(() =>
-			{
-				StopVisible = true;
-			});
+			.OnEntry(() => StopVisible = false)
+			.OnExit(() => StopVisible = true);
 
 		_stateMachine.Configure(State.ManualFinished)
 			.SubstateOf(State.Stopped)
@@ -302,10 +287,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PauseVisible = false;
 				PlayVisible = true;
 			})
-			.OnTrigger(Trigger.Play, () =>
-			{
-				_overridePlebStop = true;
-			});
+			.OnTrigger(Trigger.Play, () => _overridePlebStop = true);
 
 		// AutoCj State
 		_stateMachine.Configure(State.AutoCoinJoin)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -176,7 +176,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		WaitingForRoundMessage,
 		ConnectionConfirmationPhaseMessage,
 		EnterCriticalPhaseMessage,
-		ExitCriticalPhaseMessage
+		ExitCriticalPhaseMessage,
+		AllCoinsPrivate
 	}
 
 	private bool IsCountDownFinished => GetRemainingTime() <= TimeSpan.Zero;
@@ -230,7 +231,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		_stateMachine.Configure(State.ManualPlaying)
 			.SubstateOf(State.ManualCoinJoin)
 			.Permit(Trigger.Stop, State.Stopped)
-			.Permit(Trigger.RoundStartFailed, State.ManualFinished)
+			.Permit(Trigger.AllCoinsPrivate, State.ManualFinished)
 			.Permit(Trigger.PlebStop, State.ManualFinishedPlebStop)
 			.Permit(Trigger.EnterCriticalPhaseMessage, State.ManualPlayingCritical)
 			.OnEntry(async () =>
@@ -500,6 +501,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 			case StartedEventArgs:
 				_stateMachine.Fire(Trigger.RoundStart);
+				break;
+
+			case StartErrorEventArgs start when start.Error is CoinjoinError.AllCoinsPrivate:
+				_stateMachine.Fire(Trigger.AllCoinsPrivate);
 				break;
 
 			case StartErrorEventArgs start when start.Error is CoinjoinError.NotEnoughUnprivateBalance:

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -308,6 +308,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				CurrentStatus = _initialisingMessage;
 			})
 			.OnTrigger(Trigger.Play, async () => await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None))
+			.OnTrigger(Trigger.AutoStartTimeout, async () => await coinJoinManager.StartAutomaticallyAsync(_wallet, _overridePlebStop, CancellationToken.None))
 			.OnTrigger(Trigger.Pause, async () => await coinJoinManager.StopAsync(_wallet, CancellationToken.None))
 			.OnTrigger(Trigger.AutoCoinJoinOff, async () => await coinJoinManager.StopAsync(_wallet, CancellationToken.None));
 

--- a/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
@@ -411,4 +411,33 @@ public class StateMachineTests
 		Assert.Equal(1, pausedEntryCount);
 		Assert.Equal(3, entryCallCount);
 	}
+
+	[Fact]
+	public void Tranistioning_To_State_Exits_All_ChildStates()
+	{
+		StateMachine<JukeBoxState, JukeBoxTrigger> sut =
+			new StateMachine<JukeBoxState, JukeBoxTrigger>(JukeBoxState.PausedChild2);
+
+		int exitCallCount = 0;
+
+		sut.Configure(JukeBoxState.Playing);
+
+		sut.Configure(JukeBoxState.Paused)
+			.OnExit(() => exitCallCount++)
+			.Permit(JukeBoxTrigger.Play, JukeBoxState.Playing);
+
+		sut.Configure(JukeBoxState.PausedChild)
+			.SubstateOf(JukeBoxState.Paused)
+			.OnExit(() => exitCallCount++);
+
+		sut.Configure(JukeBoxState.PausedChild2)
+			.SubstateOf(JukeBoxState.PausedChild)
+			.OnExit(() => exitCallCount++);
+
+		sut.Start();
+
+		sut.Fire(JukeBoxTrigger.Play);
+
+		Assert.Equal(3, exitCallCount);
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
@@ -440,4 +440,33 @@ public class StateMachineTests
 
 		Assert.Equal(3, exitCallCount);
 	}
+
+	[Fact]
+	public void Tranistioning_To_ChildState_Directly_Enters_All_Parent_States()
+	{
+		StateMachine<JukeBoxState, JukeBoxTrigger> sut =
+			new StateMachine<JukeBoxState, JukeBoxTrigger>(JukeBoxState.Playing);
+
+		int enterCallCount = 0;
+
+		sut.Configure(JukeBoxState.Playing)
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.PausedChild2);
+
+		sut.Configure(JukeBoxState.Paused)
+			.OnEntry(() => enterCallCount++);
+
+		sut.Configure(JukeBoxState.PausedChild)
+			.SubstateOf(JukeBoxState.Paused)
+			.OnEntry(() => enterCallCount++);
+
+		sut.Configure(JukeBoxState.PausedChild2)
+			.SubstateOf(JukeBoxState.PausedChild)
+			.OnEntry(() => enterCallCount++);
+
+		sut.Start();
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(3, enterCallCount);
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
@@ -409,7 +409,7 @@ public class StateMachineTests
 		sut.Fire(JukeBoxTrigger.Pause);
 
 		Assert.Equal(1, pausedEntryCount);
-		Assert.Equal(3, entryCallCount);
+		Assert.Equal(2, entryCallCount);
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StateMachineTests.cs
@@ -469,4 +469,26 @@ public class StateMachineTests
 
 		Assert.Equal(3, enterCallCount);
 	}
+
+	[Fact]
+	public void Transitioning_From_Child_To_Parent_Doesnt_Reenter_Parent()
+	{
+		StateMachine<JukeBoxState, JukeBoxTrigger> sut =
+			new StateMachine<JukeBoxState, JukeBoxTrigger>(JukeBoxState.PausedChild);
+
+		int enterCallCount = 0;
+
+		sut.Configure(JukeBoxState.Paused)
+			.OnEntry(() => enterCallCount++);
+
+		sut.Configure(JukeBoxState.PausedChild)
+			.Permit(JukeBoxTrigger.Pause, JukeBoxState.Paused)
+			.SubstateOf(JukeBoxState.Paused);
+
+		sut.Start();
+
+		sut.Fire(JukeBoxTrigger.Pause);
+
+		Assert.Equal(1, enterCallCount);
+	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -246,7 +246,10 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
 			var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
 			var restartTask = Task.Run(async () =>
 			{
 				try
@@ -257,6 +260,11 @@ public class CoinJoinManager : BackgroundService
 				{
 					return;
 				}
+				finally
+				{
+					linkedCts.Dispose();
+				}
+
 				if (trackedAutoStarts.TryRemove(walletToStart, out _))
 				{
 					await StartAutomaticallyAsync(walletToStart, overridePlebStop, stoppingToken).ConfigureAwait(false);
@@ -265,7 +273,6 @@ public class CoinJoinManager : BackgroundService
 				{
 					walletToStart.LogInfo($"AutoStart was already handled.");
 				}
-				linkedCts.Dispose();
 			}, linkedCts.Token);
 
 			if (!trackedAutoStarts.TryAdd(walletToStart, new TrackedAutoStart(restartTask, linkedCts)))

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -154,6 +154,7 @@ public class CoinJoinManager : BackgroundService
 				{
 					ScheduleRestartAutomatically(walletToStart, startCommand.OverridePlebStop);
 				}
+
 				NotifyCoinJoinStartError(walletToStart, CoinjoinError.NotEnoughUnprivateBalance);
 				return;
 			}
@@ -164,6 +165,7 @@ public class CoinJoinManager : BackgroundService
 				{
 					ScheduleRestartAutomatically(walletToStart, startCommand.OverridePlebStop);
 				}
+
 				NotifyCoinJoinStartError(walletToStart, CoinjoinError.BackendNotSynchronized);
 				return;
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -247,8 +247,6 @@ public class CoinJoinManager : BackgroundService
 				await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken).ConfigureAwait(false);
 				if (trackedAutoStarts.TryRemove(walletToStart, out _))
 				{
-
-
 					await StartAutomaticallyAsync(walletToStart, overridePlebStop, stoppingToken).ConfigureAwait(false);
 				}
 				else

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -454,7 +454,7 @@ public class CoinJoinManager : BackgroundService
 	{
 		var coins = new CoinsView(wallet.Coins);
 
-		if (GetPrivacyPercentage(coins, wallet.KeyManager.AnonScoreTarget) >= 1 || IsAllMixed)
+		if (GetPrivacyPercentage(coins, wallet.KeyManager.AnonScoreTarget) >= 1)
 		{
 			return true;
 		}


### PR DESCRIPTION
- Improved the design by removing the control of the CoinJoins. To keep participating in rounds, CoinJoinClient needs to be "restarted" periodically after the previous round finished. In Auto mode this was done by the CoinJoinManager, but in Manual mode this was done by the state machine. This hybrid solution is gone with this PR. 
- Control the CoinJoinManager with Triggers instead of state changes. 
- State machine starts only once at the beginning and then CoinJoinManager runs, emitting events, and if required stops by itself.
- Override plebstop reset logic was duplicated, now it is only in CoinJoinManager. 

