### PR TITLE
Make NotEnoughAlicesMessage visible and clear

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -34,6 +34,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private readonly MusicStatusMessageViewModel _finishedMessage = new() { Message = "Not enough non-private funds to coinjoin" };
 	private readonly MusicStatusMessageViewModel _roundSucceedMessage = new() { Message = "Successful coinjoin" };
 	private readonly MusicStatusMessageViewModel _roundFailedMessage = new() { Message = "Coinjoin failed, retrying..." };
+	private readonly MusicStatusMessageViewModel _abortedNotEnoughAlicesMessage = new() { Message = "Not enough participants, retrying..." };
 	private readonly MusicStatusMessageViewModel _outputRegistrationMessage = new() { Message = "Constructing coinjoin" };
 	private readonly MusicStatusMessageViewModel _inputRegistrationMessage = new() { Message = "Waiting for others" };
 	private readonly MusicStatusMessageViewModel _transactionSigningMessage = new() { Message = "Finalizing coinjoin" };
@@ -572,9 +573,12 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			{
 				if (_lastStatusMessage is RoundEnded roundEnded)
 				{
-					CurrentStatus = roundEnded.LastRoundState.EndRoundState == EndRoundState.TransactionBroadcasted
-						? _roundSucceedMessage
-						: _roundFailedMessage;
+					CurrentStatus = roundEnded.LastRoundState.EndRoundState switch
+					{
+						EndRoundState.TransactionBroadcasted => _roundSucceedMessage,
+						EndRoundState.AbortedNotEnoughAlices => _abortedNotEnoughAlicesMessage,
+						_ => _roundFailedMessage
+					};
 					StopCountDown();
 				}
 			})

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -186,7 +186,14 @@ public class CoinJoinClient
 			}
 			catch (UnexpectedRoundPhaseException ex)
 			{
-				roundState.LogInfo($"Registration phase ended by the coordinator: '{ex.Message}'.");
+				roundState = ex.RoundState;
+				var message = ex.RoundState.EndRoundState switch
+				{
+					EndRoundState.AbortedNotEnoughAlices => $"Not enough participants in the round to continue. Waiting for a new round.",
+					_ => $"Registration phase ended by the coordinator: '{ex.Message}' code: '{ex.RoundState.EndRoundState}'."
+				};
+
+				roundState.LogInfo(message);
 				return new CoinJoinResult(false);
 			}
 

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs
@@ -63,7 +63,7 @@ public record RoundStateAwaiter
 			{
 				if (roundState.Phase > expectedPhase)
 				{
-					TaskCompletionSource.TrySetException(new UnexpectedRoundPhaseException(RoundId ?? uint256.Zero, expectedPhase, roundState.Phase));
+					TaskCompletionSource.TrySetException(new UnexpectedRoundPhaseException(RoundId ?? uint256.Zero, expectedPhase, roundState));
 					return true;
 				}
 

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/UnexpectedRoundPhaseException.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/UnexpectedRoundPhaseException.cs
@@ -1,20 +1,23 @@
 using NBitcoin;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 
 public class UnexpectedRoundPhaseException : Exception
 {
-	public UnexpectedRoundPhaseException(uint256 roundId, Phase expected, Phase actual)
+	public UnexpectedRoundPhaseException(uint256 roundId, Phase expected, RoundState roundState)
 	{
 		RoundId = roundId;
 		Expected = expected;
-		Actual = actual;
+		Actual = roundState.Phase;
+		RoundState = roundState;
 	}
 
 	public uint256 RoundId { get; }
 	public Phase Expected { get; }
 	public Phase Actual { get; }
+	public RoundState RoundState { get; }
 
-	public override string Message => $"Round {RoundId} unexpected phase change. Waiting for '{Expected}' but the round is in '{Actual}'.";
+	public override string Message => $"Round {RoundId} unexpected phase change. Waiting for '{Expected}' but the round is in '{Actual}' - ErrorCode:'{RoundState.EndRoundState}'.";
 }


### PR DESCRIPTION
This PR clarifies and display a better readable message in Logs and in the Music box for the users. This is one of the most frequent cases (at least in TestNet) and I got many questions with the original error message (unexpected phase change) - if that is a bug or not. 