### PR TITLE
[VDG] [Trivial] Enable Avalonia Previewer

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -192,7 +192,13 @@ public class Program
 		}
 	}
 
-	// Avalonia configuration, don't remove; also used by visual designer.
+	// This is required to bootstrap Avalonia's Visual Previewer
+	private static AppBuilder BuildAvaloniaApp()
+	{
+		return BuildAvaloniaApp(false);
+	}
+
+	// Avalonia configuration, don't remove
 	private static AppBuilder BuildAvaloniaApp(bool startInBg)
 	{
 		bool useGpuLinux = true;


### PR DESCRIPTION
Currently, the Avalonia Previewer is broken:

> 16:45:52.366 [Information] 0 Starting previewer process for '"E:\Repos\SuperJMN\WalletWasabi\WalletWasabi.Fluent.Desktop\bin\Debug\net6.0\WalletWasabi.Fluent.Desktop.dll"'
16:45:52.368 [Information] 5152 Started previewer process for '"E:\Repos\SuperJMN\WalletWasabi\WalletWasabi.Fluent.Desktop\bin\Debug\net6.0\WalletWasabi.Fluent.Desktop.dll"'. Waiting for connection to be initialized.
16:45:52.466 [Information] 5152 Connection initialized
16:45:52.482 [Error] 5152 <= "WalletWasabi.Fluent.Desktop.Program doesn't have a method named BuildAvaloniaApp"
16:45:52.485 [Information]  Process exited
16:45:52.487 [Information]  Stopping previewer process

This adds a simple bootstrap code to enable the Avalonia Previewer.