### PR TITLE
Add option to search Category in Searchbar

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
@@ -33,7 +33,7 @@ public partial class SearchBarViewModel : ReactiveObject
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe();
 	}
-	
+
 	public ReadOnlyObservableCollection<SearchItemGroup> Groups => _groups;
 
 	private static Func<ISearchItem, bool> SearchItemFilterFunc(string? text)
@@ -46,9 +46,10 @@ public partial class SearchBarViewModel : ReactiveObject
 			}
 
 			var containsName = searchItem.Name.Contains(text, StringComparison.InvariantCultureIgnoreCase);
+			var containsCategory = searchItem.Category.Contains(text, StringComparison.InvariantCultureIgnoreCase);
 			var containsAnyTag =
 				searchItem.Keywords.Any(s => s.Contains(text, StringComparison.InvariantCultureIgnoreCase));
-			return containsName || containsAnyTag;
+			return containsName || containsCategory || containsAnyTag;
 		};
 	}
 }


### PR DESCRIPTION
What I realized and was personaly bothering me, is that if I search "help" in the search bar, nothing came up, altough "Help & Support" is a valid category. If Im not sure how to look for help, well, searching for "help" would be obvious.