### PR TITLE
Make sure BnB use only private coins

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -50,7 +50,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 		[EnumeratorCancellation] CancellationToken cancellationToken)
 	{
 		var selections = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(
-			transactionInfo.Coins,
+			transactionInfo.Coins.Where(c => c.IsPrivate(wallet.KeyManager.AnonScoreTarget)),
 			transactionInfo.FeeRate,
 			new TxOut(transactionInfo.Amount, destination),
 			maxInputCount,


### PR DESCRIPTION
This makes sure BnB will only use private coins. This is can be improved but what we have right is very dangerous. This is a quick fix. 