### PR TITLE
[WIP] Make CJM testeable and write first test.

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -240,7 +240,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				StopVisible = true;
 				CurrentStatus = _waitingMessage;
 
-				if (_overridePlebStop && !_wallet.IsUnderPlebStop)
+				if (_overridePlebStop && !_wallet.IsUnderPlebStop())
 				{
 					// If we are not below the threshold anymore, we turn off the override.
 					_overridePlebStop = false;
@@ -370,7 +370,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PauseVisible = true;
 				PlayVisible = false;
 
-				if (_overridePlebStop && !_wallet.IsUnderPlebStop)
+				if (_overridePlebStop && !_wallet.IsUnderPlebStop())
 				{
 					// If we are not below the threshold anymore, we turn off the override.
 					_overridePlebStop = false;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinManagerTests.cs
@@ -1,0 +1,154 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Moq;
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Fluent.Models.Windows;
+using WalletWasabi.Models;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.Tor.Http;
+using WalletWasabi.Tor.Socks5.Pool.Circuits;
+using WalletWasabi.WabiSabi.Backend.PostRequests;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
+using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
+using WalletWasabi.WabiSabi.Models;
+using WalletWasabi.Wallets;
+using WalletWasabi.WebClients.Wasabi;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
+
+public class CoinJoinManagerTests
+{
+	[Fact]
+	public async Task XTestAsync()
+	{
+		// Creates the dependencies: Wallets, RoundStateUpdater, HttpClientFactory and Best Height provider
+
+		// List of wallets (typically owned by the wallet manager)
+		var wallets = new List<IWallet>();
+
+		// RoundStatusUpdater that returns a RoundState in InputRegistration phase
+		var roundState = RoundState.FromRound(WabiSabiFactory.CreateRound(cfg: new()));
+		using var roundStatusUpdater = BuildRoundStatusUpdater(roundState);
+		await roundStatusUpdater.StartAsync(CancellationToken.None);
+
+		// HttpClientFactory
+		using PersonCircuit personCircuit = new();
+		var httpClientFactory = BuildHttpClientFactory(personCircuit);
+
+		// Best height provider (very-poor man implementation)
+		int? bestHeight = null;
+		void SetBestHeight(int? height) => bestHeight = height;
+		int? GetBestHeight() => bestHeight;
+
+		var serviceConfiguration = new ServiceConfiguration(new IPEndPoint(IPAddress.Loopback, 8080), Money.Zero);
+
+		// Creates the CoinJoinManager instances and start it. (note that at this moment the wallet is not synchronized yet)
+		using var cjm = new CoinJoinManager(wallets, roundStatusUpdater, httpClientFactory, serviceConfiguration, GetBestHeight);
+		await cjm.StartAsync(CancellationToken.None);
+
+		// creates a wallet with one coin and add it to the wallet list (this is exactly what happens when we open a new wallet)
+		var keyManager = KeyManager.Recover(new Mnemonic("all all all all all all all all all all all all"), "", Network.Main, KeyManager.GetAccountKeyPath(Network.Main));
+		var coin = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(keyManager), Money.Coins(0.1m));
+		var wallet = new TesteableWallet("My little wallet", keyManager, new []{ coin });
+		wallets.Add(wallet);
+
+		// The CoinJoinManager detects there is a new available wallet and raise the `LoadedEventArgs` event.
+		var evnt = await cjm.WaitForEvent(TimeSpan.FromSeconds(1));
+		Assert.True(evnt is LoadedEventArgs loaded && loaded.Wallet == wallet);
+
+		// We instruct the CJM to start mixing the wallet.
+		await cjm.StartAsync(wallet, stopWhenAllMixed: true, overridePlebStop: true, CancellationToken.None);
+
+		// The wallet is not synchronized and that's why it communicates that with a `BackendNotSynchronized` error.
+		// The CJM will wait for 30 seconds before trying again.
+		evnt = await cjm.WaitForEvent(TimeSpan.FromSeconds(1));
+		Assert.True(evnt is StartErrorEventArgs {Error: CoinjoinError.BackendNotSynchronized});
+
+		// We simulate the wallet is finally synchronized (latest wasabiSynchronizer response has arrived)
+		SetBestHeight(700_000);
+
+		// After aprox 30 seconds the wallet will start coinjoining.
+		evnt = await cjm.WaitForEvent(TimeSpan.FromSeconds(40));
+		Assert.True(evnt is StartedEventArgs started /*&& started.RegistrationTimeout == roundState.InputRegistrationTimeout*/);
+
+		await cjm.StopAsync(CancellationToken.None);
+		await roundStatusUpdater.StopAsync(CancellationToken.None);
+	}
+
+	private static IWasabiHttpClientFactory BuildHttpClientFactory(PersonCircuit personCircuit)
+	{
+		IHttpClient httpClientWrapper = new HttpClientWrapper(new HttpClient());
+		var mockHttpClientFactory = new Mock<IWasabiHttpClientFactory>(MockBehavior.Strict);
+
+		mockHttpClientFactory
+			.Setup(factory => factory.NewHttpClientWithPersonCircuit(out httpClientWrapper))
+			.Returns(personCircuit);
+		return mockHttpClientFactory.Object;
+	}
+
+	private static RoundStateUpdater BuildRoundStatusUpdater(RoundState roundState)
+	{
+		var mockApiClient = new Mock<IWabiSabiApiRequestHandler>();
+		mockApiClient
+			.Setup(apiClient => apiClient.GetStatusAsync(It.IsAny<RoundStateRequest>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(
+				() => new RoundStateResponse(
+					new[] { roundState with {Phase = Phase.InputRegistration}},
+					Array.Empty<CoinJoinFeeRateMedian>()));
+
+		using RoundStateUpdater roundStatusUpdater = new(TimeSpan.FromSeconds(100), mockApiClient.Object);
+		return roundStatusUpdater;
+	}
+}
+
+public class TesteableWallet : IWallet
+{
+	private readonly IEnumerable<SmartCoin> _coins;
+	public string WalletName { get; }
+	public bool CanSpend { get; } = true;
+	public KeyManager KeyManager { get; }
+	public Kitchen Kitchen { get; }
+
+	public TesteableWallet(string name, KeyManager keyManager, IEnumerable<SmartCoin> coins)
+	{
+		WalletName = name;
+		KeyManager = keyManager;
+		Kitchen = new Kitchen();
+		_coins = coins;
+	}
+
+	public IEnumerator<SmartCoin> GetEnumerator()
+	{
+		return _coins.GetEnumerator();
+	}
+
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return GetEnumerator();
+	}
+}
+
+public static class CoinJoinManagerExtensions
+{
+	public static async Task<StatusChangedEventArgs> WaitForEvent(this CoinJoinManager cjm, TimeSpan waitTime)
+	{
+		EventsAwaiter<StatusChangedEventArgs> statusChanged = new(
+			h => cjm.StatusChanged += h,
+			h => cjm.StatusChanged -= h, 1);
+
+		var events = await statusChanged.WaitAsync(waitTime);
+		return events.Single();
+	}
+
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -12,7 +12,7 @@ public class CoinJoinTracker : IDisposable
 	private bool _disposedValue;
 
 	public CoinJoinTracker(
-		Wallet wallet,
+		IWallet wallet,
 		CoinJoinClient coinJoinClient,
 		IEnumerable<SmartCoin> coinCandidates,
 		bool stopWhenAllMixed,
@@ -35,7 +35,7 @@ public class CoinJoinTracker : IDisposable
 	private CoinJoinClient CoinJoinClient { get; }
 	private CancellationTokenSource CancellationTokenSource { get; }
 
-	public Wallet Wallet { get; }
+	public IWallet Wallet { get; }
 	public Task<CoinJoinResult> CoinJoinTask { get; }
 	public IEnumerable<SmartCoin> CoinCandidates { get; }
 	public bool StopWhenAllMixed { get; }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -23,7 +23,7 @@ public class CoinJoinTrackerFactory
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private CancellationToken CancellationToken { get; }
 
-	public CoinJoinTracker CreateAndStart(Wallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
+	public CoinJoinTracker CreateAndStart(IWallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
 	{
 		var coinJoinClient = new CoinJoinClient(
 			HttpClientFactory,

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CompletedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CompletedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class CompletedEventArgs : StatusChangedEventArgs
 {
-	public CompletedEventArgs(Wallet wallet, CompletionStatus completionStatus)
+	public CompletedEventArgs(IWallet wallet, CompletionStatus completionStatus)
 		: base(wallet)
 	{
 		CompletionStatus = completionStatus;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/LoadedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/LoadedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class LoadedEventArgs : StatusChangedEventArgs
 {
-	public LoadedEventArgs(Wallet wallet)
+	public LoadedEventArgs(IWallet wallet)
 		: base(wallet)
 	{
 	}

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartErrorEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartErrorEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class StartErrorEventArgs : StatusChangedEventArgs
 {
-	public StartErrorEventArgs(Wallet wallet, CoinjoinError error)
+	public StartErrorEventArgs(IWallet wallet, CoinjoinError error)
 		: base(wallet)
 	{
 		Error = error;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class StartedEventArgs : StatusChangedEventArgs
 {
-	public StartedEventArgs(Wallet wallet, TimeSpan registrationTimeout)
+	public StartedEventArgs(IWallet wallet, TimeSpan registrationTimeout)
 		: base(wallet)
 	{
 		RegistrationTimeout = registrationTimeout;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StatusChangedEventArgs.cs
@@ -27,10 +27,10 @@ public enum CoinjoinError
 
 public class StatusChangedEventArgs : EventArgs
 {
-	public StatusChangedEventArgs(Wallet wallet)
+	public StatusChangedEventArgs(IWallet wallet)
 	{
 		Wallet = wallet;
 	}
 
-	public Wallet Wallet { get; }
+	public IWallet Wallet { get; }
 }

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StoppedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StoppedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class StoppedEventArgs : StatusChangedEventArgs
 {
-	public StoppedEventArgs(Wallet wallet, StopReason reason)
+	public StoppedEventArgs(IWallet wallet, StopReason reason)
 		: base(wallet)
 	{
 		Reason = reason;

--- a/WalletWasabi/WabiSabi/LoggerTools.cs
+++ b/WalletWasabi/WabiSabi/LoggerTools.cs
@@ -47,27 +47,27 @@ public static class LoggerTools
 		Log(roundState, LogLevel.Debug, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void Log(this Wallet wallet, LogLevel logLevel, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void Log(this IWallet wallet, LogLevel logLevel, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Logger.Log(logLevel, $"Wallet ({wallet.WalletName}): {logMessage}", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogInfo(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogInfo(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Info, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogDebug(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogDebug(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Debug, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogWarning(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogWarning(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Warning, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogError(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogError(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Error, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using NBitcoin;
 using Nito.AsyncEx;
 using System.Collections.Generic;
@@ -19,7 +20,7 @@ using WalletWasabi.Stores;
 
 namespace WalletWasabi.Wallets;
 
-public class WalletManager
+public class WalletManager : IEnumerable<Wallet>
 {
 	/// <remarks>All access must be guarded by <see cref="Lock"/> object.</remarks>
 	private volatile bool _disposedValue = false;
@@ -409,5 +410,15 @@ public class WalletManager
 		{
 			return Wallets.Single(x => x.KeyManager.WalletName == walletName);
 		}
+	}
+
+	public IEnumerator<Wallet> GetEnumerator()
+	{
+		return GetWallets().GetEnumerator();
+	}
+
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return GetEnumerator();
 	}
 }


### PR DESCRIPTION
`CoinJoinManager` is perhaps the most complex machine in Wasabi 2.0 what means it's risky to modify and the knowledge in concentrated in a very very few people. 

The harder obstacle for making the CJM testeable is the `Wallet` class (a background service) and at some extend the `CoinJoinClient` class. This PR abstracts away the `Wallet` in a simple way that could be improved/simplified/replaces/removed in the future and uses the CJM events to verify the expected  behavior.

This is not ready and was inspired by the nature and scope of the changes in #8140 so, this should be finished and merged after #8140.