### PR TITLE
[VDG] Fix threading issue related to Theme switch

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/SearchBar/SearchItemGroup.cs
+++ b/WalletWasabi.Fluent/ViewModels/SearchBar/SearchItemGroup.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData;
 using ReactiveUI;
@@ -7,8 +8,9 @@ using WalletWasabi.Fluent.ViewModels.SearchBar.SearchItems;
 
 namespace WalletWasabi.Fluent.ViewModels.SearchBar;
 
-public class SearchItemGroup
+public class SearchItemGroup : IDisposable
 {
+	private readonly CompositeDisposable _disposables = new();
 	private readonly ReadOnlyObservableCollection<ISearchItem> _items;
 
 	public SearchItemGroup(string title, IObservableCache<ISearchItem, ComposedKey> groupCache)
@@ -18,10 +20,16 @@ public class SearchItemGroup
 			.Bind(out _items)
 			.DisposeMany()
 			.ObserveOn(RxApp.MainThreadScheduler)
-			.Subscribe();
+			.Subscribe()
+			.DisposeWith(_disposables);
 	}
 
 	public string Title { get; }
 
 	public ReadOnlyObservableCollection<ISearchItem> Items => _items;
+
+	public void Dispose()
+	{
+		_disposables.Dispose();
+	}
 }

--- a/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
+++ b/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
@@ -24,16 +24,6 @@
       <Setter Property="Background" Value="Transparent" />
     </Style>
 
-    <Style Selector="ItemsControl:empty">
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <TextBlock Margin="10">No results</TextBlock>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
-    </Style>
-
     <Style Selector="Button.searchItem /template/ ContentPresenter">
       <Setter Property="Background" Value="Transparent" />
     </Style>
@@ -114,15 +104,18 @@
 
   </UserControl.DataTemplates>
 
-  <ItemsControl Items="{Binding Groups}">
-    <ItemsControl.ItemTemplate>
-      <DataTemplate DataType="{x:Type sb:SearchItemGroup}">
-        <DockPanel Margin="0 0 0 10">
-          <TextBlock Text="{Binding Title}" DockPanel.Dock="Top" />
-          <ItemsControl x:Name="ListBox" Items="{Binding Items}" />
-        </DockPanel>
-      </DataTemplate>
-    </ItemsControl.ItemTemplate>
-  </ItemsControl>
+  <Panel VerticalAlignment="Center">
+    <TextBlock IsVisible="{Binding !Any^}" Margin="10">No results</TextBlock>
+    <ItemsControl IsVisible="{Binding Any^}" Items="{Binding Groups}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="{x:Type sb:SearchItemGroup}">
+          <DockPanel Margin="0 0 0 10">
+            <TextBlock Text="{Binding Title}" DockPanel.Dock="Top" />
+            <ItemsControl x:Name="ListBox" Items="{Binding Items}" />
+          </DockPanel>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </Panel>
 
 </UserControl>


### PR DESCRIPTION
Fixes #7956

### Important

The observed behavior was **very** strange. I had to implement a "clever" workaround to avoid the problem.

Apparently, the problem is related with this Style setter:

```xml
    <Style Selector="ItemsControl:empty">
      <Setter Property="Template">
        <Setter.Value>
          <ControlTemplate>
            <TextBlock Margin="10">No results</TextBlock>
          </ControlTemplate>
        </Setter.Value>
      </Setter>
    </Style>
```

#### What I've observed

*According to the repro steps detailed here https://github.com/zkSNACKs/WalletWasabi/issues/7956*

First, you type a search text in the `SearchBar` that has no results ("ff" for instance). In such case, this setter will be applied. Then, you toggle the Theme via **Settings**. Nothing bad happens yet. The problem comes when this style setter no longer applies and the default `Template` needs to be set back. This is when everything goes wild.

My guess is that **Theme switching breaks something in the Styling system**, so when it tries to go back to the default Template, it uses a non-UI thread for some reason. I completely ignore why this is happening but it might potentially be related to Avalonia itself.

Why? It's very unlikely that I could overcome the issue like I did 😁 

Please, have this into account in the future. This kind of issue is REALLY hard to test and tricky to fix. This time, we were lucky!