### PR TITLE
Change unobserved task exception logging level

### DIFF
--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -63,7 +63,7 @@ public class InitConfigStartupTask : IStartupTask
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
-		Logger.LogWarning(e.Exception);
+		Logger.LogDebug(e.Exception);
 	}
 
 	private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)


### PR DESCRIPTION
Yesterday while testing the logs were completely flooded with:

```
2022-03-24 14:43:38.756 [2] DEBUG   Program.TaskScheduler_UnobservedTaskException (169) System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing       its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Operation canceled)
  388  ---> System.Net.Sockets.SocketException (125): Operation canceled
  389    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
  390    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
  391    at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
  392    --- End of inner exception stack trace ---
```

This not only looks bad, makes the logs analysis harder by providing useless and redundant info but there is nothing we can do, it is a non-actionable problem. For that reason imo we should write those entries only for non-release versions. 