### PR TITLE
Improve message for entities that know about the tx

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -35,7 +35,7 @@
         </Viewbox>
       </Button>
       <c:PreviewItem Icon="{StaticResource incognito_pathicon}"
-                     Label="some people or companies could know about this">
+                     Label="other people or companies could know about this">
         <c:LabelsListBox Items="{Binding Labels}"
                          HorizontalAlignment="Left"
                          VerticalAlignment="Center" />


### PR DESCRIPTION
I was sending to `Rafe` but I don't see that in the tx preview:

![asasa](https://user-images.githubusercontent.com/52379387/170764041-8b236225-1619-46d8-bcae-a3e7e487754b.PNG)

IMO a better solution would be to display the recipient label also.