### PR TITLE
Preparation for anonymity calculation improvement

### DIFF
--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -60,11 +60,11 @@ public static class BitcoinFactory
 
 		foreach (var sc in walletInputs)
 		{
-			stx.AddWalletInput(sc);
+			stx.TryAddWalletInput(sc);
 		}
 		foreach (var sc in walletOutputs)
 		{
-			stx.AddWalletOutput(sc);
+			stx.TryAddWalletOutput(sc);
 		}
 		return stx;
 	}

--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -60,11 +60,11 @@ public static class BitcoinFactory
 
 		foreach (var sc in walletInputs)
 		{
-			stx.WalletInputs.Add(sc);
+			stx.AddWalletInput(sc);
 		}
 		foreach (var sc in walletOutputs)
 		{
-			stx.WalletOutputs.Add(sc);
+			stx.AddWalletOutput(sc);
 		}
 		return stx;
 	}

--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -47,16 +47,17 @@ public static class BitcoinFactory
 			tx.Outputs.Add(output);
 		}
 
+		var stx = new SmartTransaction(tx, Height.Mempool);
 		var idx = (uint)othersOutputs.Count() - 1;
 		foreach (var txo in ownOutputs)
 		{
 			idx++;
 			var hdpk = txo.hdpk;
 			tx.Outputs.Add(new TxOut(txo.value, hdpk.P2wpkhScript));
-			var sc = new SmartCoin(new SmartTransaction(tx, Height.Mempool), idx, hdpk);
+			var sc = new SmartCoin(stx, idx, hdpk);
 			walletOutputs.Add(sc);
 		}
-		var stx = new SmartTransaction(tx, Height.Mempool);
+
 		foreach (var sc in walletInputs)
 		{
 			stx.WalletInputs.Add(sc);

--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -41,9 +41,9 @@ public class CoinJoinAnonScoreTests
 		var analyser = ServiceFactory.CreateBlockchainAnalyzer();
 		var tx = BitcoinFactory.CreateSmartTransaction(9, Enumerable.Repeat(Money.Coins(1m), 8), new[] { (Money.Coins(1.1m), 1) }, new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet), (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) });
 		var sc = tx.WalletOutputs.First();
-		tx.RemoveWalletOutput(sc);
+		tx.TryRemoveWalletOutput(sc);
 		analyser.Analyze(tx);
-		tx.AddWalletOutput(sc);
+		tx.TryAddWalletOutput(sc);
 		analyser.Analyze(tx);
 		Assert.Equal(1, tx.WalletInputs.First().HdPubKey.AnonymitySet);
 

--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -43,7 +43,7 @@ public class CoinJoinAnonScoreTests
 		var sc = tx.WalletOutputs.First();
 		Assert.True(tx.TryRemoveWalletOutput(sc));
 		analyser.Analyze(tx);
-		tx.TryAddWalletOutput(sc);
+		Assert.True(tx.TryAddWalletOutput(sc));
 		analyser.Analyze(tx);
 		Assert.Equal(1, tx.WalletInputs.First().HdPubKey.AnonymitySet);
 

--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -41,9 +41,9 @@ public class CoinJoinAnonScoreTests
 		var analyser = ServiceFactory.CreateBlockchainAnalyzer();
 		var tx = BitcoinFactory.CreateSmartTransaction(9, Enumerable.Repeat(Money.Coins(1m), 8), new[] { (Money.Coins(1.1m), 1) }, new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet), (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) });
 		var sc = tx.WalletOutputs.First();
-		tx.WalletOutputs.Remove(sc);
+		tx.RemoveWalletOutput(sc);
 		analyser.Analyze(tx);
-		tx.WalletOutputs.Add(sc);
+		tx.AddWalletOutput(sc);
 		analyser.Analyze(tx);
 		Assert.Equal(1, tx.WalletInputs.First().HdPubKey.AnonymitySet);
 

--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -41,7 +41,7 @@ public class CoinJoinAnonScoreTests
 		var analyser = ServiceFactory.CreateBlockchainAnalyzer();
 		var tx = BitcoinFactory.CreateSmartTransaction(9, Enumerable.Repeat(Money.Coins(1m), 8), new[] { (Money.Coins(1.1m), 1) }, new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet), (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet) });
 		var sc = tx.WalletOutputs.First();
-		tx.TryRemoveWalletOutput(sc);
+		Assert.True(tx.TryRemoveWalletOutput(sc));
 		analyser.Analyze(tx);
 		tx.TryAddWalletOutput(sc);
 		analyser.Analyze(tx);

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -20,17 +20,16 @@ public class BlockchainAnalyzer
 	/// </summary>
 	public void Analyze(SmartTransaction tx)
 	{
-		var inputCount = tx.Transaction.Inputs.Count;
-		var outputCount = tx.Transaction.Outputs.Count;
-
 		var ownInputCount = tx.WalletInputs.Count;
-		var ownOutputCount = tx.WalletOutputs.Count;
+
+		var foreignInputCount = tx.ForeignInputs.Count;
+		var foreignOutputCount = tx.ForeignOutputs.Count;
 
 		if (ownInputCount == 0)
 		{
 			AnalyzeReceive(tx);
 		}
-		else if (inputCount == ownInputCount && outputCount != ownOutputCount)
+		else if (foreignInputCount == 0 && foreignOutputCount > 0)
 		{
 			AnalyzeNormalSpend(tx);
 		}
@@ -39,7 +38,7 @@ public class BlockchainAnalyzer
 			int startingOutputAnonset;
 			var distinctWalletInputPubKeys = tx.WalletInputs.Select(x => x.HdPubKey).ToHashSet();
 
-			if (inputCount == ownInputCount)
+			if (foreignInputCount == 0)
 			{
 				startingOutputAnonset = AnalyzeSelfSpendWalletInputs(distinctWalletInputPubKeys);
 
@@ -113,8 +112,7 @@ public class BlockchainAnalyzer
 			.GroupBy(x => x.Value)
 			.ToDictionary(x => x.Key, y => y.Count());
 
-		var inputCount = tx.Transaction.Inputs.Count;
-		var ownInputCount = tx.WalletInputs.Count;
+		var foreignInputCount = tx.ForeignInputs.Count;
 
 		foreach (var newCoin in tx.WalletOutputs)
 		{
@@ -123,7 +121,7 @@ public class BlockchainAnalyzer
 			var ownEqualOutputCount = indistinguishableWalletOutputs[output.Value];
 
 			// Anonset gain cannot be larger than others' input count.
-			var anonset = Math.Min(equalOutputCount - ownEqualOutputCount, inputCount - ownInputCount);
+			var anonset = Math.Min(equalOutputCount - ownEqualOutputCount, foreignInputCount);
 
 			// Picking randomly an output would make our anonset: total/ours.
 			anonset /= ownEqualOutputCount;

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -48,7 +48,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 
 		HdPubKey = pubKey;
 
-		Transaction.WalletOutputs.Add(this);
+		Transaction.AddWalletOutput(this);
 	}
 
 	public SmartTransaction Transaction { get; }
@@ -79,7 +79,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 		get => _spenderTransaction;
 		set
 		{
-			value?.WalletInputs.Add(this);
+			value?.AddWalletInput(this);
 			RaiseAndSetIfChanged(ref _spenderTransaction, value);
 		}
 	}

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -48,7 +48,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 
 		HdPubKey = pubKey;
 
-		Transaction.AddWalletOutput(this);
+		Transaction.TryAddWalletOutput(this);
 	}
 
 	public SmartTransaction Transaction { get; }
@@ -79,8 +79,10 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 		get => _spenderTransaction;
 		set
 		{
-			value?.AddWalletInput(this);
-			RaiseAndSetIfChanged(ref _spenderTransaction, value);
+			if (value?.TryAddWalletInput(this) is true)
+			{
+				RaiseAndSetIfChanged(ref _spenderTransaction, value);
+			}
 		}
 	}
 
@@ -151,17 +153,16 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 
 	public bool RefreshAndGetIsBanned()
 	{
-		if(BannedUntilUtc is { } && BannedUntilUtc > DateTimeOffset.UtcNow)
+		if (BannedUntilUtc is { } && BannedUntilUtc > DateTimeOffset.UtcNow)
 		{
 			IsBanned = true;
 			return true;
 		}
-		
+
 		IsBanned = false;
 		BannedUntilUtc = null;
 
 		return false;
-		
 	}
 
 	[MemberNotNullWhen(returnValue: true, nameof(SpenderTransaction))]

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -32,23 +32,44 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		FirstSeen = firstSeen == default ? DateTimeOffset.UtcNow : firstSeen;
 
 		IsReplacement = isReplacement;
-		WalletInputs = new HashSet<SmartCoin>(Transaction.Inputs.Count);
-		WalletOutputs = new HashSet<SmartCoin>(Transaction.Outputs.Count);
+		_walletInputs = new HashSet<SmartCoin>(Transaction.Inputs.Count);
+		_walletOutputs = new HashSet<SmartCoin>(Transaction.Outputs.Count);
 	}
 
 	#endregion Constructors
 
 	#region Members
 
-	/// <summary>
-	/// Coins those are on the input side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.
-	/// </summary>
-	public HashSet<SmartCoin> WalletInputs { get; }
+	public IReadOnlyCollection<SmartCoin> WalletInputs
+	{
+		get
+		{
+			return _walletInputs;
+		}
+	}
 
-	/// <summary>
-	/// Coins those are on the output side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.
-	/// </summary>
-	public HashSet<SmartCoin> WalletOutputs { get; }
+	public void AddWalletInput(SmartCoin input)
+	{
+		_walletInputs.Add(input);
+	}
+
+	public IReadOnlyCollection<SmartCoin> WalletOutputs
+	{
+		get
+		{
+			return _walletOutputs;
+		}
+	}
+
+	public void AddWalletOutput(SmartCoin output)
+	{
+		_walletOutputs.Add(output);
+	}
+
+	public void RemoveWalletOutput(SmartCoin output)
+	{
+		_walletOutputs.Remove(output);
+	}
 
 	[JsonProperty]
 	[JsonConverter(typeof(TransactionJsonConverter))]
@@ -105,6 +126,16 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	/// * Implicitly in case one of its unconfirmed ancestors are replaceable
 	/// </summary>
 	public bool IsRBF => !Confirmed && (Transaction.RBF || IsReplacement || WalletInputs.Any(x => x.IsReplaceable()));
+
+	/// <summary>
+	/// Coins those are on the input side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.
+	/// </summary>
+	private HashSet<SmartCoin> _walletInputs;
+
+	/// <summary>
+	/// Coins those are on the output side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.
+	/// </summary>
+	private HashSet<SmartCoin> _walletOutputs;
 
 	#endregion Members
 

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -51,6 +51,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	/// </summary>
 	private HashSet<SmartCoin> WalletOutputsInternal { get; }
 
+	/// <summary>Cached computation of <see cref="ForeignInputs"/> or <c>null</c> when re-computation is needed.</summary>
 	private HashSet<IndexedTxIn>? ForeignInputsInternal { get; set; }
 	private HashSet<IndexedTxOut>? ForeignOutputsInternal { get; set; }
 

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -53,6 +53,8 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 
 	/// <summary>Cached computation of <see cref="ForeignInputs"/> or <c>null</c> when re-computation is needed.</summary>
 	private HashSet<IndexedTxIn>? ForeignInputsInternal { get; set; }
+
+	/// <summary>Cached computation of <see cref="ForeignOutputs"/> or <c>null</c> when re-computation is needed.</summary>
 	private HashSet<IndexedTxOut>? ForeignOutputsInternal { get; set; }
 
 	public IReadOnlyCollection<SmartCoin> WalletInputs => WalletInputsInternal;

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -146,6 +146,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletInputsInternal.Add(input))
 		{
+			// Null it out so we recalculate on demand.
 			ForeignInputsInternal = null;
 			return true;
 		}
@@ -156,6 +157,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletOutputsInternal.Add(output))
 		{
+			// Null it out so we recalculate on demand.
 			ForeignOutputsInternal = null;
 			return true;
 		}
@@ -166,6 +168,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletInputsInternal.Remove(input))
 		{
+			// Null it out so we recalculate on demand.
 			ForeignInputsInternal = null;
 			return true;
 		}
@@ -176,6 +179,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletOutputsInternal.Remove(output))
 		{
+			// Null it out so we recalculate on demand.
 			ForeignOutputsInternal = null;
 			return true;
 		}

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -48,10 +48,10 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	private HashSet<SmartCoin> WalletOutputsInternal { get; }
 
 	/// <summary>Cached computation of <see cref="ForeignInputs"/> or <c>null</c> when re-computation is needed.</summary>
-	private HashSet<IndexedTxIn>? ForeignInputsInternal { get; set; }
+	private HashSet<IndexedTxIn>? ForeignInputsCache { get; set; }
 
 	/// <summary>Cached computation of <see cref="ForeignOutputs"/> or <c>null</c> when re-computation is needed.</summary>
-	private HashSet<IndexedTxOut>? ForeignOutputsInternal { get; set; }
+	private HashSet<IndexedTxOut>? ForeignOutputsCache { get; set; }
 
 	public IReadOnlyCollection<SmartCoin> WalletInputs => WalletInputsInternal;
 
@@ -61,12 +61,12 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		get
 		{
-			if (ForeignInputsInternal is null)
+			if (ForeignInputsCache is null)
 			{
 				var walletInputOutpoints = WalletInputs.Select(smartCoin => smartCoin.OutPoint).ToHashSet();
-				ForeignInputsInternal = Transaction.Inputs.AsIndexedInputs().Where(i => !walletInputOutpoints.Contains(i.PrevOut)).ToHashSet();
+				ForeignInputsCache = Transaction.Inputs.AsIndexedInputs().Where(i => !walletInputOutpoints.Contains(i.PrevOut)).ToHashSet();
 			}
-			return ForeignInputsInternal;
+			return ForeignInputsCache;
 		}
 	}
 
@@ -74,12 +74,12 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		get
 		{
-			if (ForeignOutputsInternal is null)
+			if (ForeignOutputsCache is null)
 			{
 				var walletOutputIndices = WalletOutputs.Select(smartCoin => smartCoin.OutPoint.N).ToHashSet();
-				ForeignOutputsInternal = Transaction.Outputs.AsIndexedOutputs().Where(o => !walletOutputIndices.Contains(o.N)).ToHashSet();
+				ForeignOutputsCache = Transaction.Outputs.AsIndexedOutputs().Where(o => !walletOutputIndices.Contains(o.N)).ToHashSet();
 			}
-			return ForeignOutputsInternal;
+			return ForeignOutputsCache;
 		}
 	}
 
@@ -145,8 +145,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletInputsInternal.Add(input))
 		{
-			// Null it out so we recalculate on demand.
-			ForeignInputsInternal = null;
+			ForeignInputsCache = null;
 			return true;
 		}
 		return false;
@@ -157,7 +156,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		if (WalletOutputsInternal.Add(output))
 		{
 			// Null it out so we recalculate on demand.
-			ForeignOutputsInternal = null;
+			ForeignOutputsCache = null;
 			return true;
 		}
 		return false;
@@ -167,8 +166,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletInputsInternal.Remove(input))
 		{
-			// Null it out so we recalculate on demand.
-			ForeignInputsInternal = null;
+			ForeignInputsCache = null;
 			return true;
 		}
 		return false;
@@ -179,7 +177,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		if (WalletOutputsInternal.Remove(output))
 		{
 			// Null it out so we recalculate on demand.
-			ForeignOutputsInternal = null;
+			ForeignOutputsCache = null;
 			return true;
 		}
 		return false;

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -41,14 +41,10 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 
 	#region Members
 
-	/// <summary>
-	/// Coins those are on the input side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.
-	/// </summary>
+	/// <summary>Coins those are on the input side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.</summary>
 	private HashSet<SmartCoin> WalletInputsInternal { get; }
 
-	/// <summary>
-	/// Coins those are on the output side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.
-	/// </summary>
+	/// <summary>Coins those are on the output side of the tx and belong to ANY loaded wallet. Later if more wallets are loaded this list can increase.</summary>
 	private HashSet<SmartCoin> WalletOutputsInternal { get; }
 
 	/// <summary>Cached computation of <see cref="ForeignInputs"/> or <c>null</c> when re-computation is needed.</summary>
@@ -189,9 +185,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		return false;
 	}
 
-	/// <summary>
-	/// Update the transaction with the data acquired from another transaction. (For example merge their labels.)
-	/// </summary>
+	/// <summary>Update the transaction with the data acquired from another transaction. (For example merge their labels.)</summary>
 	public bool TryUpdate(SmartTransaction tx)
 	{
 		var updated = false;
@@ -241,9 +235,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		IsReplacement = true;
 	}
 
-	/// <summary>
-	/// First looks at height, then block index, then mempool firstseen.
-	/// </summary>
+	/// <summary>First looks at height, then block index, then mempool firstseen.</summary>
 	public static IComparer<SmartTransaction> GetBlockchainComparer()
 	{
 		return Comparer<SmartTransaction>.Create((a, b) =>

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -155,7 +155,6 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletOutputsInternal.Add(output))
 		{
-			// Null it out so we recalculate on demand.
 			ForeignOutputsCache = null;
 			return true;
 		}
@@ -176,7 +175,6 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	{
 		if (WalletOutputsInternal.Remove(output))
 		{
-			// Null it out so we recalculate on demand.
 			ForeignOutputsCache = null;
 			return true;
 		}

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -256,7 +256,7 @@ public class TransactionFactory
 		var smartTransaction = new SmartTransaction(tx, Height.Unknown, label: SmartLabel.Merge(payments.Requests.Select(x => x.Label)));
 		foreach (var coin in spentCoins)
 		{
-			smartTransaction.WalletInputs.Add(coin);
+			smartTransaction.AddWalletInput(coin);
 		}
 		var label = SmartLabel.Merge(payments.Requests.Select(x => x.Label).Concat(smartTransaction.WalletInputs.Select(x => x.HdPubKey.Label)));
 
@@ -267,7 +267,7 @@ public class TransactionFactory
 			{
 				var smartCoin = new SmartCoin(smartTransaction, i, foundKey);
 				label = SmartLabel.Merge(label, smartCoin.HdPubKey.Label); // foundKey's label is already added to the coinlabel.
-				smartTransaction.WalletOutputs.Add(smartCoin);
+				smartTransaction.AddWalletOutput(smartCoin);
 			}
 		}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -256,7 +256,7 @@ public class TransactionFactory
 		var smartTransaction = new SmartTransaction(tx, Height.Unknown, label: SmartLabel.Merge(payments.Requests.Select(x => x.Label)));
 		foreach (var coin in spentCoins)
 		{
-			smartTransaction.AddWalletInput(coin);
+			smartTransaction.TryAddWalletInput(coin);
 		}
 		var label = SmartLabel.Merge(payments.Requests.Select(x => x.Label).Concat(smartTransaction.WalletInputs.Select(x => x.HdPubKey.Label)));
 
@@ -267,7 +267,7 @@ public class TransactionFactory
 			{
 				var smartCoin = new SmartCoin(smartTransaction, i, foundKey);
 				label = SmartLabel.Merge(label, smartCoin.HdPubKey.Label); // foundKey's label is already added to the coinlabel.
-				smartTransaction.AddWalletOutput(smartCoin);
+				smartTransaction.TryAddWalletOutput(smartCoin);
 			}
 		}
 


### PR DESCRIPTION
Following the suggestion (https://github.com/zkSNACKs/WalletWasabi/pull/7932#issuecomment-1139666528) of @onvej-sl this PR brings in the first bunch of commits to the Wasabi repository. My modifications do not touch the logic, the goals were to keep things consistent and to avoid directly accessing private members.

Skipped https://github.com/zkSNACKs/WalletWasabi/commit/d24c7d264fe8c9489d3558ac8569c77eb57d029a as it was reverted later.  

Skipped https://github.com/zkSNACKs/WalletWasabi/commit/f7fc29423ab95670a7f30258b1135c6f239a7dac as this code isn't in the master anymore and https://github.com/zkSNACKs/WalletWasabi/commit/c46ee54a1e8c895bd60504ec56f563130361ae37 as it makes no sense without the previous code.