### PR TITLE
Start spectrum only when we got into inputregistration phase

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -19,6 +19,7 @@ using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
 using WalletWasabi.Fluent.ViewModels.Wallets.Advanced.WalletCoins;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
+using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
@@ -73,8 +74,8 @@ public partial class WalletViewModel : WalletViewModelBase
 			static bool? MaybeCoinjoining(StatusChangedEventArgs args) =>
 				args switch
 				{
-					WalletStartedCoinJoinEventArgs _ => true,
-					WalletStoppedCoinJoinEventArgs _ => false,
+					CoinJoinStatusEventArgs e when e.CoinJoinProgressEventArgs is EnteringInputRegistrationPhase => true,
+					CompletedEventArgs _ => false,
 					_ => null
 				};
 


### PR DESCRIPTION
Currently Spectrum is visible right after any activation happens in CoinJoin. In auto mode, it is visible always (because the client tries to CoinJoin all the time, even if the conditions are not met). With this PR spectrum will only appear when the client manages to get into the Input registration phase (which is effectively the first step of CoinJoining)

Currently we are indicating the intent to CoinJoin, with this PR we indicate the status. 