### PR TITLE
[VDG] Simplify transaction details view

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -40,7 +40,7 @@
             <TextBlock Text="Confirmed" IsVisible="{Binding IsConfirmed}" />
             <TextBlock Text="Pending" IsVisible="{Binding !IsConfirmed}" />
           </Panel>
-          <TextBlock Margin="4 0 0 0 " Text="{Binding Confirmations, StringFormat='({0} confirmations)'}" />
+          <TextBlock IsVisible="{Binding IsConfirmed}" Margin="4 0 0 0 " Text="{Binding Confirmations, StringFormat='({0} confirmations)'}" />
         </StackPanel>
       </c:PreviewItem>
 


### PR DESCRIPTION
Joins **Status** and **Confirmations** into a single item:

![image](https://user-images.githubusercontent.com/3109851/171499903-a011a0f6-41dd-44b1-a82d-b1cfbc86e6a5.png)

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8182