### PR TITLE
[VDG] Fast loading for fresh wallets improvement

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -51,23 +51,26 @@ public partial class WalletManagerViewModel : ViewModelBase
 			.AsObservableList();
 
 		Observable
-				.FromEventPattern<WalletState>(Services.WalletManager, nameof(WalletManager.WalletStateChanged))
+			.FromEventPattern<WalletState>(Services.WalletManager, nameof(WalletManager.WalletStateChanged))
 			.ObserveOn(RxApp.MainThreadScheduler)
-			.Subscribe(
-				x =>
+			.Select(x => x.Sender as Wallet)
+			.WhereNotNull()
+			.Subscribe(wallet =>
 			{
-				var wallet = x.Sender as Wallet;
-
-				if (wallet is { } && _walletDictionary.ContainsKey(wallet))
+				if (!_walletDictionary.TryGetValue(wallet, out var walletViewModel))
 				{
-					if (wallet.State == WalletState.Stopping)
-					{
-						RemoveWallet(_walletDictionary[wallet]);
-					}
-					else if (_walletDictionary[wallet] is ClosedWalletViewModel { IsLoggedIn: true } cwvm && wallet.State == WalletState.Started)
-					{
-						OpenClosedWallet(cwvm);
-					}
+					return;
+				}
+
+				if (wallet.State == WalletState.Stopping)
+				{
+					RemoveWallet(walletViewModel);
+				}
+				else if (walletViewModel is ClosedWalletViewModel { IsLoggedIn: true } cwvm &&
+				         ((cwvm.Wallet.KeyManager.SkipSynchronization && cwvm.Wallet.State == WalletState.Starting) ||
+				          cwvm.Wallet.State == WalletState.Started))
+				{
+					OpenClosedWallet(cwvm);
 				}
 
 				AnyWalletStarted = Items.OfType<WalletViewModelBase>().Any(y => y.WalletState == WalletState.Started);
@@ -139,8 +142,6 @@ public partial class WalletManagerViewModel : ViewModelBase
 
 	public async Task LoadWalletAsync(Wallet wallet)
 	{
-		wallet.KeyManager.SetNonNewlyCreated();
-
 		if (wallet.State != WalletState.Uninitialized)
 		{
 			throw new Exception("Wallet is already being logged in.");

--- a/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
@@ -100,7 +100,7 @@ public partial class LoadingViewModel : ActivatableViewModel
 
 		await SetInitValuesAsync(isBackendAvailable).ConfigureAwait(false);
 
-		while (isBackendAvailable && RemainingFiltersToDownload > 0 && !_wallet.KeyManager.IsNewlyCreated)
+		while (isBackendAvailable && RemainingFiltersToDownload > 0 && !_wallet.KeyManager.SkipSynchronization)
 		{
 			await Task.Delay(1000).ConfigureAwait(false);
 		}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -39,7 +39,7 @@ public class KeyManager
 	private static readonly KeyPath TestNetAccountKeyPath = new("m/84h/1h/0h");
 
 	[JsonConstructor]
-	public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, HDFingerprint? masterFingerprint, ExtPubKey extPubKey, bool isNewlyCreated, int? minGapLimit, BlockchainState blockchainState, string? filePath = null, KeyPath? accountKeyPath = null)
+	public KeyManager(BitcoinEncryptedSecretNoEC encryptedSecret, byte[] chainCode, HDFingerprint? masterFingerprint, ExtPubKey extPubKey, bool skipSynchronization, int? minGapLimit, BlockchainState blockchainState, string? filePath = null, KeyPath? accountKeyPath = null)
 	{
 		HdPubKeys = new List<HdPubKey>();
 		HdPubKeyScriptBytes = new List<byte[]>();
@@ -54,7 +54,7 @@ public class KeyManager
 		MasterFingerprint = masterFingerprint;
 		ExtPubKey = Guard.NotNull(nameof(extPubKey), extPubKey);
 
-		IsNewlyCreated = isNewlyCreated;
+		SkipSynchronization = skipSynchronization;
 		SetMinGapLimit(minGapLimit);
 
 		BlockchainState = blockchainState;
@@ -131,8 +131,7 @@ public class KeyManager
 	[JsonConverter(typeof(ExtPubKeyJsonConverter))]
 	public ExtPubKey ExtPubKey { get; }
 
-	[JsonProperty(Order = 5)]
-	public bool IsNewlyCreated { get; private set; } = false;
+	[JsonProperty(Order = 5)] public bool SkipSynchronization { get; private set; } = false;
 
 	[JsonProperty(Order = 6)]
 	public int MinGapLimit { get; private set; }
@@ -206,17 +205,17 @@ public class KeyManager
 		BlockchainState blockchainState = new(network);
 		KeyPath keyPath = GetAccountKeyPath(network);
 		ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
-		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, isNewlyCreated: true, AbsoluteMinGapLimit, blockchainState, filePath, keyPath);
+		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, skipSynchronization: true, AbsoluteMinGapLimit, blockchainState, filePath, keyPath);
 	}
 
 	public static KeyManager CreateNewWatchOnly(ExtPubKey extPubKey, string? filePath = null)
 	{
-		return new KeyManager(null, null, null, extPubKey, isNewlyCreated: false, AbsoluteMinGapLimit, new BlockchainState(), filePath);
+		return new KeyManager(null, null, null, extPubKey, skipSynchronization: false, AbsoluteMinGapLimit, new BlockchainState(), filePath);
 	}
 
 	public static KeyManager CreateNewHardwareWalletWatchOnly(HDFingerprint masterFingerprint, ExtPubKey extPubKey, Network network, string? filePath = null)
 	{
-		return new KeyManager(null, null, masterFingerprint, extPubKey, isNewlyCreated: false, AbsoluteMinGapLimit, new BlockchainState(network), filePath);
+		return new KeyManager(null, null, masterFingerprint, extPubKey, skipSynchronization: false, AbsoluteMinGapLimit, new BlockchainState(network), filePath);
 	}
 
 	public static KeyManager Recover(Mnemonic mnemonic, string password, Network network, KeyPath accountKeyPath, string? filePath = null, int minGapLimit = AbsoluteMinGapLimit)
@@ -231,7 +230,7 @@ public class KeyManager
 
 		KeyPath keyPath = accountKeyPath ?? DefaultAccountKeyPath;
 		ExtPubKey extPubKey = extKey.Derive(keyPath).Neuter();
-		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, isNewlyCreated: false, minGapLimit, new BlockchainState(network), filePath, keyPath);
+		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, extPubKey, skipSynchronization: false, minGapLimit, new BlockchainState(network), filePath, keyPath);
 	}
 
 	public static KeyManager FromFile(string filePath)
@@ -387,6 +386,8 @@ public class KeyManager
 
 		newKey.SetLabel(label, kmToFile: this);
 
+		SetDoNotSkipSynchronization();
+		
 		return newKey;
 	}
 
@@ -407,9 +408,15 @@ public class KeyManager
 		}
 	}
 
-	public void SetNonNewlyCreated()
+	public void SetDoNotSkipSynchronization()
 	{
-		IsNewlyCreated = false;
+		// Don't set it unnecessarily
+		if (SkipSynchronization == false)
+		{
+			return;
+		}
+
+		SkipSynchronization = false;
 		ToFile();
 	}
 


### PR DESCRIPTION
Requested by a user.

Addresses:
```
User prefers no loading screen even for a second on fresh wallet
```

Improvements:
- A new wallet won't be stopped on the loading screen until an address is generated for it.
- In the case of Height < Downloaded filters, it was still stopped on the loading screen, this PR fixes it.