### PR TITLE
Only ignore coins BELOW the dust threshold

### DIFF
--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -218,7 +218,7 @@ public class TransactionProcessor
 				}
 
 				foundKey.SetKeyState(KeyState.Used, KeyManager);
-				if (output.Value <= DustThreshold)
+				if (output.Value < DustThreshold)
 				{
 					result.ReceivedDusts.Add(output);
 					continue;


### PR DESCRIPTION
Closes #8216. This is the smallest possible change that fixes _the problem_ caused by the default dust threshold being the same as the smallest, and highly frequent, standard denomination `5000`.

There are other alternatives like ignoring the dust threshold for coinjoin outputs. 