### PR TITLE
[VDG] Fix amount/fee formatting in TxnPreview

### DIFF
--- a/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
@@ -35,7 +35,7 @@ public static class TransactionSummaryExtension
 
 		var feePartText = moneyUnit switch
 		{
-			MoneyUnit.BTC => fee.ToDecimal(moneyUnit).FormattedBtc(),
+			MoneyUnit.BTC => fee.ToFormattedString(),
 			MoneyUnit.Satoshi => fee.Satoshi.ToString(),
 			_ => fee.ToString()
 		};

--- a/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
@@ -40,7 +40,7 @@ public static class TransactionSummaryExtension
 			_ => fee.ToString()
 		};
 
-		var feeText = $"{feePartText} {displayUnit.FriendlyName()} ";
+		var feeText = $"{feePartText} {displayUnit.FriendlyName()}";
 
 		return feeText;
 	}

--- a/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
@@ -33,9 +33,14 @@ public static class TransactionSummaryExtension
 		var displayUnit = Services.UiConfig.FeeDisplayUnit.GetEnumValueOrDefault(FeeDisplayUnit.BTC);
 		var moneyUnit = displayUnit.ToMoneyUnit();
 
-		var feePartText = moneyUnit == MoneyUnit.BTC ? fee.ToDecimal(moneyUnit).FormattedBtc() : fee.ToString();
+		var feePartText = moneyUnit switch
+		{
+			MoneyUnit.BTC => fee.ToDecimal(moneyUnit).FormattedBtc(),
+			MoneyUnit.Satoshi => fee.Satoshi.ToString(),
+			_ => fee.ToString()
+		};
 
-		var feeText = $"{feePartText} {displayUnit.FriendlyName() } ";
+		var feeText = $"{feePartText} {displayUnit.FriendlyName()} ";
 
 		return feeText;
 	}

--- a/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Models;
 
@@ -31,8 +32,10 @@ public static class TransactionSummaryExtension
 
 		var displayUnit = Services.UiConfig.FeeDisplayUnit.GetEnumValueOrDefault(FeeDisplayUnit.BTC);
 		var moneyUnit = displayUnit.ToMoneyUnit();
-		
-		var feeText = $"{fee.ToDecimal(moneyUnit)} {displayUnit.FriendlyName() } ";
+
+		var feePartText = moneyUnit == MoneyUnit.BTC ? fee.ToDecimal(moneyUnit).FormattedBtc() : fee.ToString();
+
+		var feeText = $"{feePartText} {displayUnit.FriendlyName() } ";
 
 		return feeText;
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -25,7 +25,8 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 	{
 		TransactionResult = transactionResult;
 
-		decimal total = transactionResult.CalculateDestinationAmount().ToDecimal(MoneyUnit.BTC);
+		var totalAmount = transactionResult.CalculateDestinationAmount();
+		var total = totalAmount.ToDecimal(MoneyUnit.BTC);
 
 		_amountFiat = total.GenerateFiatText(fiatExchangeRate, "USD");
 
@@ -38,7 +39,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 				: $"{Math.Abs(fiatDifference).GenerateFiatText("USD")} Less")
 			.Replace("(", "").Replace(")", "");
 
-		_amount = $"{total} BTC";
+		_amount = $"{totalAmount.ToFormattedString()} BTC";
 	}
 
 	public BuildTransactionResult TransactionResult { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Wallets;
 
@@ -15,7 +14,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 
 public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 {
-	[AutoNotify] private string? _amount;
+	[AutoNotify] private string _amount;
 	[AutoNotify] private string _amountFiat;
 	[AutoNotify] private string? _differenceFiat;
 
@@ -26,8 +25,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 	{
 		TransactionResult = transactionResult;
 
-		var totalAmount = transactionResult.CalculateDestinationAmount();
-		var total = totalAmount.ToDecimal(MoneyUnit.BTC);
+		decimal total = transactionResult.CalculateDestinationAmount().ToDecimal(MoneyUnit.BTC);
 
 		_amountFiat = total.GenerateFiatText(fiatExchangeRate, "USD");
 
@@ -40,7 +38,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 				: $"{Math.Abs(fiatDifference).GenerateFiatText("USD")} Less")
 			.Replace("(", "").Replace(")", "");
 
-		_amount = totalAmount.ToFeeDisplayUnitString();
+		_amount = $"{total} BTC";
 	}
 
 	public BuildTransactionResult TransactionResult { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Wallets;
 
@@ -14,7 +15,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 
 public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 {
-	[AutoNotify] private string _amount;
+	[AutoNotify] private string? _amount;
 	[AutoNotify] private string _amountFiat;
 	[AutoNotify] private string? _differenceFiat;
 
@@ -25,7 +26,8 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 	{
 		TransactionResult = transactionResult;
 
-		decimal total = transactionResult.CalculateDestinationAmount().ToDecimal(MoneyUnit.BTC);
+		var totalAmount = transactionResult.CalculateDestinationAmount();
+		var total = totalAmount.ToDecimal(MoneyUnit.BTC);
 
 		_amountFiat = total.GenerateFiatText(fiatExchangeRate, "USD");
 
@@ -38,7 +40,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 				: $"{Math.Abs(fiatDifference).GenerateFiatText("USD")} Less")
 			.Replace("(", "").Replace(")", "");
 
-		_amount = $"{total} BTC";
+		_amount = totalAmount.ToFeeDisplayUnitString();
 	}
 
 	public BuildTransactionResult TransactionResult { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -56,13 +56,14 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
 		var destinationAmount = _transaction.CalculateDestinationAmount();
-		var btcAmountText = destinationAmount.ToFeeDisplayUnitString();
+		var btcAmountText = $"{destinationAmount.ToFormattedString()} USD";
 		var fiatAmountText =
 			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = fee.ToFeeDisplayUnitString();
+		var feeText = $"{fee.ToFormattedString()} USD";
+
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -56,18 +56,18 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
 		var destinationAmount = _transaction.CalculateDestinationAmount();
-		var btcAmountText = $"{destinationAmount.ToFormattedString()} USD ";
+		var btcAmountText = $"{destinationAmount.ToFormattedString()} BTC";
 		var fiatAmountText =
 			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
-		AmountText = $"{btcAmountText}{fiatAmountText}";
+		AmountText = $"{btcAmountText} {fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = $"{fee.ToFeeDisplayUnitString()}";
+		var feeText = fee.ToFeeDisplayUnitString();
 
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 
-		FeeText = $"{feeText}{fiatFeeText}";
+		FeeText = $"{feeText} {fiatFeeText}";
 
 		TransactionHasChange =
 			_transaction.InnerWalletOutputs.Any(x => x.ScriptPubKey != _address.ScriptPubKey);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -55,14 +55,14 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
-		var destinationAmount = _transaction.CalculateDestinationAmount().ToDecimal(MoneyUnit.BTC);
-		var btcAmountText = $"{destinationAmount} BTC ";
+		var destinationAmount = _transaction.CalculateDestinationAmount();
+		var btcAmountText = $"{destinationAmount.ToFormattedString()} BTC ";
 		var fiatAmountText =
-			destinationAmount.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
+			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = fee.ToFeeDisplayUnitString();
+		var feeText = $"{fee.ToFormattedString()} BTC ";
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -56,7 +56,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
 		var destinationAmount = _transaction.CalculateDestinationAmount();
-		var btcAmountText = $"{destinationAmount.ToFeeDisplayUnitString()} ";
+		var btcAmountText = destinationAmount.ToFeeDisplayUnitString();
 		var fiatAmountText =
 			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 		AmountText = $"{btcAmountText}{fiatAmountText}";

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -62,7 +62,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = $"{fee.ToFeeDisplayUnitString()} USD ";
+		var feeText = $"{fee.ToFeeDisplayUnitString()}";
 
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -55,14 +55,14 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
-		var destinationAmount = _transaction.CalculateDestinationAmount();
-		var btcAmountText = $"{destinationAmount.ToFormattedString()} BTC ";
+		var destinationAmount = _transaction.CalculateDestinationAmount().ToDecimal(MoneyUnit.BTC);
+		var btcAmountText = $"{destinationAmount} BTC ";
 		var fiatAmountText =
-			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
+			destinationAmount.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = $"{fee.ToFormattedString()} BTC ";
+		var feeText = fee.ToFeeDisplayUnitString();
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -55,10 +55,10 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
-		var destinationAmount = _transaction.CalculateDestinationAmount().ToDecimal(MoneyUnit.BTC);
-		var btcAmountText = $"{destinationAmount} BTC ";
+		var destinationAmount = _transaction.CalculateDestinationAmount();
+		var btcAmountText = $"{destinationAmount.ToFeeDisplayUnitString()} ";
 		var fiatAmountText =
-			destinationAmount.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
+			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -62,7 +62,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = $"{fee.ToFormattedString()} USD";
+		var feeText = $"{fee.ToFeeDisplayUnitString()} USD";
 
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -56,13 +56,13 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		ConfirmationTimeText = $"Approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
 		var destinationAmount = _transaction.CalculateDestinationAmount();
-		var btcAmountText = $"{destinationAmount.ToFormattedString()} USD";
+		var btcAmountText = $"{destinationAmount.ToFormattedString()} USD ";
 		var fiatAmountText =
 			destinationAmount.ToDecimal(MoneyUnit.BTC).GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");
 		AmountText = $"{btcAmountText}{fiatAmountText}";
 
 		var fee = _transaction.Fee;
-		var feeText = $"{fee.ToFeeDisplayUnitString()} USD";
+		var feeText = $"{fee.ToFeeDisplayUnitString()} USD ";
 
 		var fiatFeeText = fee.ToDecimal(MoneyUnit.BTC)
 			.GenerateFiatText(_wallet.Synchronizer.UsdExchangeRate, "USD");

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -11,7 +11,7 @@
   <StackPanel Spacing="15">
     <c:PreviewItem Icon="{StaticResource btc_logo}"
                    Label="a total of">
-      <TextBlock Classes="monoSpaced" Text="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
+      <TextBlock Classes="monoSpaced" Text="{Binding AmountText, FallbackValue=_ BTC (≈_ USD)}" />
     </c:PreviewItem>
 
     <Separator />
@@ -72,7 +72,7 @@
         </c:PreviewItem>
         <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
                        Label="there will be an additional transaction fee of">
-          <TextBlock Classes="monoSpaced" Text="{Binding FeeText, FallbackValue=0.0000 0235 BTC (≈55.34 USD)}" />
+          <TextBlock Classes="monoSpaced" Text="{Binding FeeText, FallbackValue=_ BTC (≈_ USD)}" />
         </c:PreviewItem>
       </StackPanel>
     </DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -11,7 +11,7 @@
   <StackPanel Spacing="15">
     <c:PreviewItem Icon="{StaticResource btc_logo}"
                    Label="a total of">
-      <TextBlock Text="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
+      <TextBlock Classes="monoSpaced" Text="{Binding AmountText, FallbackValue=0.213 BTC (≈55.34 USD)}" />
     </c:PreviewItem>
 
     <Separator />
@@ -72,7 +72,7 @@
         </c:PreviewItem>
         <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
                        Label="there will be an additional transaction fee of">
-          <TextBlock Text="{Binding FeeText, FallbackValue=0.00000235 bitcoin (≈55.34 USD)}" />
+          <TextBlock Classes="monoSpaced" Text="{Binding FeeText, FallbackValue=0.0000 0235 bitcoin (≈55.34 USD)}" />
         </c:PreviewItem>
       </StackPanel>
     </DockPanel>


### PR DESCRIPTION
This PR fixes @BTCparadigm 's report on the meeting regarding inconsistent formatting of all BTC values compared to the ones we have in Tiles. This PR should fix that.

<img width="1009" alt="Screen Shot 2022-06-02 at 5 08 12 PM" src="https://user-images.githubusercontent.com/16554748/171598973-1865ba2f-e6b5-43a9-ae6e-053cf5149f91.png">


cc @BTCparadigm @zkSNACKs/visual-design-group 