### PR TITLE
[VDG] [Trivial] Fix flicking "No results" title in SearchBar

### DIFF
--- a/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
+++ b/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
@@ -105,7 +105,7 @@
   </UserControl.DataTemplates>
 
   <Panel VerticalAlignment="Center">
-    <TextBlock IsVisible="{Binding !Any^}" Margin="10">No results</TextBlock>
+    <TextBlock IsVisible="{Binding !Any^, FallbackValue=False}" Margin="10">No results</TextBlock>
     <ItemsControl IsVisible="{Binding Any^}" Items="{Binding Groups}">
       <ItemsControl.ItemTemplate>
         <DataTemplate DataType="{x:Type sb:SearchItemGroup}">


### PR DESCRIPTION
When SearchBar is open, the text "No results" flicks for a very short time, that gives a wrong feeling to the UX.

*Fixes a regression caused by this: https://github.com/zkSNACKs/WalletWasabi/pull/8155*

