### PR TITLE
Change client version back to 1.1.13.1

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -57,7 +57,7 @@ public static class Constants
 	public const string AppName = "Wasabi Wallet";
 	public const string BuiltinBitcoinNodeName = "Bitcoin Knots";
 
-	public static readonly Version ClientVersion = new(1, 99, 1, 0);
+	public static readonly Version ClientVersion = new(1, 1, 13, 1);
 
 	public static readonly Version HwiVersion = new("2.0.2");
 	public static readonly Version BitcoinCoreVersion = new("21.2");


### PR DESCRIPTION
Some users are confused about the message on the status bar that there is a new version to download.

Similar to https://github.com/zkSNACKs/WalletWasabi/pull/8109 this PR changes back the client version to not disturb existing ww1 users.