### PR TITLE
[VDG] [Trivial] Fix incorrect tab index

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -203,7 +203,7 @@ public partial class MainViewModel : ViewModelBase
 		BitcoinTabSettingsViewModel.RegisterLazy(
 			() =>
 			{
-				_settingsPage.SelectedTab = 2;
+				_settingsPage.SelectedTab = 1;
 				return _settingsPage;
 			});
 


### PR DESCRIPTION
The tab index was set incorrectly to 2, but it should be 1.

Fixes regression caused by https://github.com/zkSNACKs/WalletWasabi/pull/8139