### PR TITLE
Forget clusters when no unique outputs created in coinjoins

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -240,7 +240,10 @@ public class BlockchainAnalyzer
 	{
 		foreach (var newCoin in tx.WalletOutputs)
 		{
-			if (newCoin.HdPubKey.AnonymitySet < PrivacyLevelThreshold)
+			// Forget clusters when no unique outputs created in coinjoins,
+			// otherwise in half mixed wallets all the labels quickly gravitate into a single cluster
+			// making pocket selection unusable.
+			if (newCoin.HdPubKey.AnonymitySet < 2)
 			{
 				// Set clusters.
 				foreach (var spentCoin in tx.WalletInputs)


### PR DESCRIPTION
Forget clusters when no unique outputs created in coinjoins, otherwise in half mixed wallets all the labels quickly gravitate into a single cluster making pocket selection unusable.