### PR TITLE
[VDG] Fix enter key in password finder

### DIFF
--- a/WalletWasabi.Fluent/Views/Login/PasswordFinder/PasswordFinderIntroduceView.axaml
+++ b/WalletWasabi.Fluent/Views/Login/PasswordFinder/PasswordFinderIntroduceView.axaml
@@ -12,7 +12,8 @@
                  NextContent="Continue"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"
-                 EnableNext="True">
+                 EnableNext="True"
+                 FocusNext="True">
     <DockPanel LastChildFill="True">
       <DockPanel.Styles>
         <Style Selector="TextBlock">


### PR DESCRIPTION
Partially fixes #8274:

> Enter keystroke is not working on the first dialog.