### PR TITLE
Remove obsolated hack

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -495,12 +495,6 @@ public class CoinJoinManager : BackgroundService
 			.Where(x => !x.IsBanned)
 			.Where(x => !CoinRefrigerator.IsFrozen(x)));
 
-		// If a small portion of the wallet isn't private, it's better to wait with mixing.
-		if (GetPrivacyPercentage(coins, openedWallet.KeyManager.AnonScoreTarget) > 0.99)
-		{
-			return Enumerable.Empty<SmartCoin>();
-		}
-
 		return coins;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8278#issuecomment-1147188899

In before weighted anonset calculation it was impossible to reach 100% mixability without great cost so we added a safety feature to not eat up the user's balance for little benefit. It's not the case anymore, so this PR removes that hack.