### PR TITLE
Rename Fee display unit to Transaction Fee display units

### DIFF
--- a/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/TransactionSummaryExtension.cs
@@ -15,12 +15,12 @@ public static class TransactionSummaryExtension
 		return confirmations > 0;
 	}
 
-	public static MoneyUnit ToMoneyUnit(this FeeDisplayUnit feeDisplayUnit) =>
-		feeDisplayUnit switch
+	public static MoneyUnit ToMoneyUnit(this TxnFeeDisplayUnit txnFeeDisplayUnit) =>
+		txnFeeDisplayUnit switch
 		{
-			FeeDisplayUnit.BTC => MoneyUnit.BTC,
-			FeeDisplayUnit.Satoshis => MoneyUnit.Satoshi,
-			_ => throw new InvalidOperationException($"Invalid Fee Display Unit value: {feeDisplayUnit}")
+			TxnFeeDisplayUnit.BTC => MoneyUnit.BTC,
+			TxnFeeDisplayUnit.Satoshis => MoneyUnit.Satoshi,
+			_ => throw new InvalidOperationException($"Invalid Fee Display Unit value: {txnFeeDisplayUnit}")
 		};
 
 	public static string? ToFeeDisplayUnitString(this Money? fee)
@@ -30,7 +30,7 @@ public static class TransactionSummaryExtension
 			return null;
 		}
 
-		var displayUnit = Services.UiConfig.FeeDisplayUnit.GetEnumValueOrDefault(FeeDisplayUnit.BTC);
+		var displayUnit = Services.UiConfig.FeeDisplayUnit.GetEnumValueOrDefault(TxnFeeDisplayUnit.BTC);
 		var moneyUnit = displayUnit.ToMoneyUnit();
 
 		var feePartText = moneyUnit switch

--- a/WalletWasabi.Fluent/Models/TxnFeeDisplayUnit.cs
+++ b/WalletWasabi.Fluent/Models/TxnFeeDisplayUnit.cs
@@ -3,7 +3,7 @@ using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.Models;
 
-public enum FeeDisplayUnit
+public enum TxnFeeDisplayUnit
 {
 	BTC,
 

--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -82,7 +82,7 @@ public class UiConfig : ConfigBase
 	}
 
 	[DefaultValue(0)]
-	[JsonProperty(PropertyName = "FeeDisplayUnit", DefaultValueHandling = DefaultValueHandling.Populate)]
+	[JsonProperty(PropertyName = "TxnFeeDisplayUnit", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public int FeeDisplayUnit
 	{
 		get => _feeDisplayUnit;

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -26,7 +26,7 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 	[AutoNotify] private bool _autoCopy;
 	[AutoNotify] private bool _autoPaste;
 	[AutoNotify] private bool _customChangeAddress;
-	[AutoNotify] private FeeDisplayUnit _selectedFeeDisplayUnit;
+	[AutoNotify] private TxnFeeDisplayUnit _selectedTxnFeeDisplayUnit;
 	[AutoNotify] private bool _runOnSystemStartup;
 	[AutoNotify] private bool _hideOnClose;
 	[AutoNotify] private bool _useTor;
@@ -40,9 +40,9 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 		_customChangeAddress = Services.UiConfig.IsCustomChangeAddress;
 		_runOnSystemStartup = Services.UiConfig.RunOnSystemStartup;
 		_hideOnClose = Services.UiConfig.HideOnClose;
-		_selectedFeeDisplayUnit = Enum.IsDefined(typeof(FeeDisplayUnit), Services.UiConfig.FeeDisplayUnit)
-			? (FeeDisplayUnit)Services.UiConfig.FeeDisplayUnit
-			: FeeDisplayUnit.Satoshis;
+		_selectedTxnFeeDisplayUnit = Enum.IsDefined(typeof(TxnFeeDisplayUnit), Services.UiConfig.FeeDisplayUnit)
+			? (TxnFeeDisplayUnit)Services.UiConfig.FeeDisplayUnit
+			: TxnFeeDisplayUnit.Satoshis;
 		_useTor = Services.Config.UseTor;
 		_terminateTorOnExit = Services.Config.TerminateTorOnExit;
 
@@ -85,7 +85,7 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 			.Skip(1)
 			.Subscribe(x => Services.UiConfig.IsCustomChangeAddress = x);
 
-		this.WhenAnyValue(x => x.SelectedFeeDisplayUnit)
+		this.WhenAnyValue(x => x.SelectedTxnFeeDisplayUnit)
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Skip(1)
 			.Subscribe(x => Services.UiConfig.FeeDisplayUnit = (int)x);
@@ -106,8 +106,8 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 
 	public ICommand StartupCommand { get; }
 
-	public IEnumerable<FeeDisplayUnit> FeeDisplayUnits =>
-		Enum.GetValues(typeof(FeeDisplayUnit)).Cast<FeeDisplayUnit>();
+	public IEnumerable<TxnFeeDisplayUnit> TxnFeeDisplayUnits =>
+		Enum.GetValues(typeof(TxnFeeDisplayUnit)).Cast<TxnFeeDisplayUnit>();
 
 	protected override void EditConfigOnSave(Config config)
 	{

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -53,8 +53,8 @@
     </DockPanel>
 
     <StackPanel Spacing="10">
-      <TextBlock Text="Fee display unit" />
-      <ComboBox HorizontalAlignment="Stretch" Items="{Binding FeeDisplayUnits}" SelectedItem="{Binding SelectedFeeDisplayUnit}">
+      <TextBlock Text="Transaction Fee display unit" />
+      <ComboBox HorizontalAlignment="Stretch" Items="{Binding TxnFeeDisplayUnits}" SelectedItem="{Binding SelectedTxnFeeDisplayUnit}">
         <ComboBox.ItemTemplate>
           <DataTemplate>
             <TextBlock Text="{Binding Converter={x:Static conv:EnumConverters.ToFriendlyName}}" />


### PR DESCRIPTION
When i was implementing https://github.com/zkSNACKs/WalletWasabi/pull/8227 I got confused with the terms "amount" and "fee". Making "fee" into "Transaction Fee" should help alleviate that confusion. at least for me :) 
Also rename the class name to reflect the change in the settings as well
cc @soosr @zkSNACKs/visual-design-group 