### PR TITLE
[VDG] WalletCoins - Labels column

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -111,7 +111,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 		// Indicators		IndicatorsColumnView	-			Auto		-				-			true
 		// Amount			AmountColumnView		Amount		Auto		-				-			true
 		// AnonymityScore	AnonymityColumnView		<custom>	50			-				-			true
-		// Labels			LabelsColumnView		Labels		*			-				445			true
+		// Labels			LabelsColumnView		Labels		*			-				-			true
 
 		Source = new FlatTreeDataGridSource<WalletCoinViewModel>(_coins)
 		{
@@ -177,7 +177,6 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 						CanUserSortColumn = true,
 						CompareAscending = WalletCoinViewModel.SortAscending(x => x.SmartLabel),
 						CompareDescending = WalletCoinViewModel.SortDescending(x => x.SmartLabel),
-						MaxWidth = new GridLength(445, GridUnitType.Pixel)
 					},
 					width: new GridLength(1, GridUnitType.Star)),
 			}

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/LabelsColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/LabelsColumnView.axaml
@@ -8,5 +8,5 @@
              x:DataType="walletcoins:WalletCoinViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Advanced.WalletCoins.Columns.LabelsColumnView">
-  <c:LabelsListBox VerticalAlignment="Center" Items="{Binding SmartLabel}" />
+  <c:LabelsListBox VerticalAlignment="Center" Items="{Binding SmartLabel}" Margin="0 0 7 0"/>
 </UserControl>


### PR DESCRIPTION
since https://github.com/zkSNACKs/WalletWasabi/pull/8096 `MaxWidth 490` isn't the correct value anymore.
some labels are not visible and scrollbar overlaps labels.
current:
![image](https://user-images.githubusercontent.com/93143998/172236207-700ace69-6805-4b8a-ba3f-53637c2f6410.png)

PR:

https://user-images.githubusercontent.com/93143998/172235910-edf1c245-0576-49d7-913e-205590e8c25f.mp4


