### PR TITLE
[VDG] Block notification action when dialog is open

### DIFF
--- a/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
@@ -75,7 +75,7 @@ public static class NotificationHelpers
 			bool isReceived = result.NewlyReceivedCoins.Any();
 			bool isConfirmedReceive = result.NewlyConfirmedReceivedCoins.Any();
 			bool isConfirmedSpent = result.NewlyConfirmedReceivedCoins.Any();
-			Money miningFee = result.Transaction.Transaction.GetFee(result.SpentCoins.Select(x => x.Coin).ToArray()) ?? Money.Zero;
+			Money miningFee = result.Transaction.Transaction.GetFee(result.SpentCoins.Select(x => (ICoin)x.Coin).ToArray()) ?? Money.Zero;
 
 			if (isReceived || isSpent)
 			{

--- a/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Notifications;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.TransactionProcessing;
+using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Fluent.Helpers;
@@ -32,8 +33,23 @@ public static class NotificationHelpers
 	{
 		if (NotificationManager is { } nm)
 		{
-			RxApp.MainThreadScheduler.Schedule(() => nm.Show(new Notification(title, message, NotificationType.Information, TimeSpan.FromSeconds(DefaultNotificationTimeout), onClick)));
+			RxApp.MainThreadScheduler.Schedule(() => nm.Show(new Notification(title, message, NotificationType.Information, TimeSpan.FromSeconds(DefaultNotificationTimeout), () => TryExecute(onClick))));
 		}
+	}
+
+	private static void TryExecute(Action? action)
+	{
+		if (action is null)
+		{
+			return;
+		}
+
+		if (!MainViewModel.Instance.IsMainContentEnabled)
+		{
+			return;
+		}
+
+		action();
 	}
 
 	public static void Show(string walletName, ProcessedResult result, Action onClick)


### PR DESCRIPTION
Currently, when a dialog is open and the user click on a notification that navigates elsewhere, the navigation can potentially break. If there's a long running operation, the effect is very confusing as the issue #6977 describes.

This PR introduces a way to overcome this situation by ignoring navigation from notifications when a dialog is active.

Fixes #6977