### PR TITLE
[VDG] AutoPaste - fix NRE when trimming

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/PasteButtonFlashBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/PasteButtonFlashBehavior.cs
@@ -76,7 +76,6 @@ public class PasteButtonFlashBehavior : AttachedToVisualTreeBehavior<AnimatedBut
 	{
 		if (Application.Current is { Clipboard: { } clipboard })
 		{
-			await clipboard.ClearAsync();
 			var clipboardValue = (await clipboard.GetTextAsync()) ?? "";
 
 			if (AssociatedObject is null)

--- a/WalletWasabi.Fluent/Behaviors/PasteButtonFlashBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/PasteButtonFlashBehavior.cs
@@ -76,7 +76,8 @@ public class PasteButtonFlashBehavior : AttachedToVisualTreeBehavior<AnimatedBut
 	{
 		if (Application.Current is { Clipboard: { } clipboard })
 		{
-			var clipboardValue = await clipboard.GetTextAsync();
+			await clipboard.ClearAsync();
+			var clipboardValue = (await clipboard.GetTextAsync()) ?? "";
 
 			if (AssociatedObject is null)
 			{
@@ -90,10 +91,7 @@ public class PasteButtonFlashBehavior : AttachedToVisualTreeBehavior<AnimatedBut
 
 			AssociatedObject.Classes.Remove(FlashAnimation);
 
-			if (!string.IsNullOrEmpty(clipboardValue))
-			{
-				clipboardValue = clipboardValue.Trim();
-			}
+			clipboardValue = clipboardValue.Trim();
 
 			if (clipboardValue != CurrentAddress &&
 			    AddressStringParser.TryParse(clipboardValue, Services.WalletManager.Network, out _))

--- a/WalletWasabi.Fluent/Behaviors/PasteButtonFlashBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/PasteButtonFlashBehavior.cs
@@ -90,7 +90,10 @@ public class PasteButtonFlashBehavior : AttachedToVisualTreeBehavior<AnimatedBut
 
 			AssociatedObject.Classes.Remove(FlashAnimation);
 
-			clipboardValue = clipboardValue.Trim();
+			if (!string.IsNullOrEmpty(clipboardValue))
+			{
+				clipboardValue = clipboardValue.Trim();
+			}
 
 			if (clipboardValue != CurrentAddress &&
 			    AddressStringParser.TryParse(clipboardValue, Services.WalletManager.Network, out _))


### PR DESCRIPTION
Fixes
```
Object reference not set to an instance of an object.

   at WalletWasabi.Fluent.Behaviors.PasteButtonFlashBehavior.CheckClipboardForValidAddressAsync(Boolean forceCheck)
   at WalletWasabi.Fluent.Behaviors.PasteButtonFlashBehavior.<OnAttachedToVisualTree>b__9_7(Unit _)
   at System.Reactive.PlatformServices.ExceptionServicesImpl.Rethrow(Exception exception) in /_/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServicesImpl.cs:line 19
   at System.Reactive.ExceptionHelpers.Throw(Exception exception) in /_/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs:line 16
   at System.Reactive.Stubs.<>c.<.cctor>b__2_1(Exception ex) in /_/Rx.NET/Source/src/System.Reactive/Internal/Stubs.cs:line 16
   at System.Reactive.AnonymousObserver`1.OnErrorCore(Exception error) in /_/Rx.NET/Source/src/System.Reactive/AnonymousObserver.cs:line 73
   at System.Reactive.ObserverBase`1.OnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/ObserverBase.cs:line 59
   at System.Reactive.Linq.ObservableImpl.ConcatMany`1.ConcatManyOuterObserver.Drain() in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/ConcatMany.cs:line 149
   at System.Reactive.ObserveOnObserverNew`1.DrainStep(ConcurrentQueue`1 q) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 573
   at System.Reactive.ObserveOnObserverNew`1.DrainShortRunning(IScheduler recursiveScheduler) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 513
   at Avalonia.Threading.AvaloniaScheduler.<>c__DisplayClass4_1`1.<Schedule>b__1() in /_/src/Avalonia.Base/Threading/AvaloniaScheduler.cs:line 45
   at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
   at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 283
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32Platform.RunLoop(CancellationToken cancellationToken) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 210
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 65
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 120
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args)
```

Also fixes #8314