### PR TITLE
Fixes bug that ignored already registered addresses

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -56,11 +56,10 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		using var signingKey = new Key();
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
 
-		var ex = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () =>
 		   await apiClient.RegisterInputAsync(round.Id, nonExistingOutPoint, ownershipProof, CancellationToken.None));
 
-		var wex = Assert.IsType<WabiSabiProtocolException>(ex.InnerException);
-		Assert.Equal(WabiSabiProtocolErrorCode.InputSpent, wex.ErrorCode);
+		Assert.Equal(WabiSabiProtocolErrorCode.InputSpent, ex.ErrorCode);
 	}
 
 	[Fact]
@@ -86,12 +85,11 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		using var signingKey = new Key();
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
 
-		var ex = await Assert.ThrowsAsync<HttpRequestException>(async () =>
+		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () =>
 			await apiClient.RegisterInputAsync(round.Id, bannedOutPoint, ownershipProof, timeoutCts.Token));
 
-		var wex = Assert.IsType<WabiSabiProtocolException>(ex.InnerException);
-		Assert.Equal(WabiSabiProtocolErrorCode.InputLongBanned, wex.ErrorCode);
-		var inputBannedData = Assert.IsType<InputBannedExceptionData>(wex.ExceptionData);
+		Assert.Equal(WabiSabiProtocolErrorCode.InputLongBanned, ex.ErrorCode);
+		var inputBannedData = Assert.IsType<InputBannedExceptionData>(ex.ExceptionData);
 		Assert.True(inputBannedData.BannedUntil > DateTimeOffset.UtcNow);
 	}
 

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -59,6 +59,18 @@ public static class HttpResponseMessageExtensions
 		return response;
 	}
 
+	public static async Task ThrowUnwrapExceptionFromContentAsync(this HttpResponseMessage me, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			await me.ThrowRequestExceptionFromContentAsync(cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception e) when (e.InnerException is {} innerException)
+		{
+			throw innerException;
+		}
+	}
+	
 	public static async Task ThrowRequestExceptionFromContentAsync(this HttpResponseMessage me, CancellationToken cancellationToken = default)
 	{
 		var errorMessage = "";

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -12,6 +12,7 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Socks5.Pool.Circuits;
+using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.CredentialDependencies;
@@ -280,7 +281,7 @@ public class CoinJoinClient
 
 				return (aliceClient, personCircuit);
 			}
-			catch (HttpRequestException)
+			catch (WabiSabiProtocolException)
 			{
 				personCircuit?.Dispose();
 				return (null, null);

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -122,7 +122,7 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 
 		if (!response.IsSuccessStatusCode)
 		{
-			await response.ThrowRequestExceptionFromContentAsync(cancellationToken).ConfigureAwait(false);
+			await response.ThrowUnwrapExceptionFromContentAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
In `DependencyGraphTaskScheduler::StartOutputRegistrationsAsync` The client can handle the `WabiSabiProtocolException` indicating the address is reused; however this was not working because the original exception was wrapped around an HttpRequestException and never caught.

This bug was previously fixed on the reverted PR #8237