### PR TITLE
Unit test to verify we don't reveal common ownership of inputs

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -15,6 +15,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using WalletWasabi.WabiSabi.Backend.Statistics;
 
 namespace WalletWasabi.Backend;
 
@@ -94,8 +95,9 @@ public class Global : IDisposable
 		}
 
 		CoinJoinIdStore = CoinJoinIdStore.Create(Coordinator.CoinJoinsFilePath, coordinatorParameters.CoinJoinIdStoreFilePath);
+		var coinJoinScriptStore = CoinJoinScriptStore.LoadFromFile(coordinatorParameters.CoinJoinScriptStoreFilePath);
 
-		WabiSabiCoordinator = new WabiSabiCoordinator(coordinatorParameters, RpcClient, CoinJoinIdStore);
+		WabiSabiCoordinator = new WabiSabiCoordinator(coordinatorParameters, RpcClient, CoinJoinIdStore, coinJoinScriptStore);
 		HostedServices.Register<WabiSabiCoordinator>(() => WabiSabiCoordinator, "WabiSabi Coordinator");
 		HostedServices.Register<RoundBootstrapper>(() => new RoundBootstrapper(TimeSpan.FromMilliseconds(100), Coordinator), "Round Bootstrapper");
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/ConfigTests.cs
@@ -11,6 +11,7 @@ using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using WalletWasabi.WabiSabi.Backend.Statistics;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
@@ -23,7 +24,7 @@ public class ConfigTests
 		var workDir = Common.GetWorkDir();
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 		CoordinatorParameters coordinatorParameters = new(workDir);
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator = CreateWabiSabiCoordinator(coordinatorParameters);
 		await coordinator.StartAsync(CancellationToken.None);
 
 		Assert.True(File.Exists(Path.Combine(workDir, "WabiSabiConfig.json")));
@@ -39,7 +40,7 @@ public class ConfigTests
 		CoordinatorParameters coordinatorParameters = new(workDir);
 
 		// Create the config first with default value.
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator = CreateWabiSabiCoordinator(coordinatorParameters);
 		await coordinator.StartAsync(CancellationToken.None);
 		await coordinator.StopAsync(CancellationToken.None);
 
@@ -53,7 +54,7 @@ public class ConfigTests
 		configChanger.ToFile();
 
 		// Assert the new value is loaded and not the default one.
-		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator2 = CreateWabiSabiCoordinator(coordinatorParameters);
 		await coordinator2.StartAsync(CancellationToken.None);
 		Assert.Equal(newTarget, coordinator2.Config.ConfirmationTarget);
 		await coordinator2.StopAsync(CancellationToken.None);
@@ -67,7 +68,7 @@ public class ConfigTests
 		CoordinatorParameters coordinatorParameters = new(workDir);
 
 		// Create the config first with default value.
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator = CreateWabiSabiCoordinator(coordinatorParameters);
 		await coordinator.StartAsync(CancellationToken.None);
 		await coordinator.StopAsync(CancellationToken.None);
 
@@ -80,7 +81,7 @@ public class ConfigTests
 
 		// Assert the new default value is loaded.
 		CoordinatorParameters coordinatorParameters2 = new(workDir);
-		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters2, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator2 = CreateWabiSabiCoordinator(coordinatorParameters2);
 		await coordinator2.StartAsync(CancellationToken.None);
 		var defaultValue = TimeSpanJsonConverter.Parse("0d 3h 0m 0s");
 		Assert.Equal(TimeSpan.FromHours(3), defaultValue);
@@ -107,7 +108,7 @@ public class ConfigTests
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 
 		CoordinatorParameters coordinatorParameters = new(workDir);
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator = CreateWabiSabiCoordinator(coordinatorParameters);
 		await coordinator.StartAsync(CancellationToken.None);
 
 		var configPath = Path.Combine(workDir, "WabiSabiConfig.json");
@@ -142,4 +143,7 @@ public class ConfigTests
 			.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 		return rpcMock.Object;
 	}
+
+	private static WabiSabiCoordinator CreateWabiSabiCoordinator(CoordinatorParameters coordinatorParameters)
+		=> new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore(), new CoinJoinScriptStore());
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -8,6 +8,7 @@ using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using WalletWasabi.WabiSabi.Backend.Statistics;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
@@ -20,7 +21,7 @@ public class CoordinatorTests
 		var workDir = Common.GetWorkDir();
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 		CoordinatorParameters coordinatorParameters = new(workDir);
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator = CreateWabiSabiCoordinator(coordinatorParameters);
 		await coordinator.StartAsync(CancellationToken.None);
 		await coordinator.StopAsync(CancellationToken.None);
 	}
@@ -32,32 +33,32 @@ public class CoordinatorTests
 		await IoHelpers.TryDeleteDirectoryAsync(workDir);
 		CoordinatorParameters coordinatorParameters = new(workDir);
 
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator = CreateWabiSabiCoordinator(coordinatorParameters);
 		using CancellationTokenSource cts = new();
 		cts.Cancel();
 		await coordinator.StartAsync(cts.Token);
 		await coordinator.StopAsync(CancellationToken.None);
 
-		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator2 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore(), new CoinJoinScriptStore());
 		using CancellationTokenSource cts2 = new();
 		await coordinator2.StartAsync(cts2.Token);
 		cts2.Cancel();
 		await coordinator2.StopAsync(CancellationToken.None);
 
-		using WabiSabiCoordinator coordinator3 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator3 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore(), new CoinJoinScriptStore());
 		using CancellationTokenSource cts3 = new();
 		var t = coordinator3.StartAsync(cts3.Token);
 		cts3.Cancel();
 		await t;
 		await coordinator3.StopAsync(CancellationToken.None);
 
-		using WabiSabiCoordinator coordinator4 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator4 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore(), new CoinJoinScriptStore());
 		await coordinator4.StartAsync(CancellationToken.None);
 		using CancellationTokenSource cts4 = new();
 		cts4.Cancel();
 		await coordinator4.StopAsync(cts4.Token);
 
-		using WabiSabiCoordinator coordinator5 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore());
+		using WabiSabiCoordinator coordinator5 = new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore(), new CoinJoinScriptStore());
 		await coordinator5.StartAsync(CancellationToken.None);
 		using CancellationTokenSource cts5 = new();
 		t = coordinator5.StopAsync(cts5.Token);
@@ -75,4 +76,7 @@ public class CoordinatorTests
 			.ReturnsAsync(new MemPoolInfo { MemPoolMinFee = 0.00001000 });
 		return mockRpcClient.Object;
 	}
+
+	private static WabiSabiCoordinator CreateWabiSabiCoordinator(CoordinatorParameters coordinatorParameters)
+		=> new(coordinatorParameters, NewMockRpcClient(), new CoinJoinIdStore(), new CoinJoinScriptStore());
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/IWebHostBuilderExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/IWebHostBuilderExtensions.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using NBitcoin;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Tests.Helpers;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
+
+public static class IWebHostBuilderExtensions
+{
+	public static IWebHostBuilder AddMockRpcClient(this IWebHostBuilder builder, SmartCoin[] coins, Action<MockRpcClient> options)
+	{
+		var rpc = BitcoinFactory.GetMockMinimalRpc();
+
+		// Make the coordinator to believe that the coins are real and
+		// that they exist in the blockchain with many confirmations.
+		rpc.OnGetTxOutAsync = (txId, idx, _) => new()
+		{
+			Confirmations = 101,
+			IsCoinBase = false,
+			ScriptPubKeyType = "witness_v0_keyhash",
+			TxOut = coins.Single(x => x.TransactionId == txId && x.Index == idx).TxOut
+		};
+
+		rpc.OnGetRawTransactionAsync = (txid, throwIfNotFound) =>
+		{
+			var tx = coins.First(coin => coin.TransactionId == txid)?.Transaction?.Transaction;
+
+			if (tx is null)
+			{
+				return Task.FromException<Transaction>(new InvalidOperationException("tx not found"));
+			}
+
+			return Task.FromResult(tx);
+		};
+
+		options(rpc);
+
+		builder.ConfigureServices(services =>
+		{
+			// Instruct the coordinator DI container to use these two scoped
+			// services to build everything (WabiSabi controller, arena, etc)
+			services.AddScoped<IRPCClient>(s => rpc);
+		});
+		return builder;
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -60,6 +60,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddScoped<RoundParameterFactory>();
 			services.AddScoped(typeof(TimeSpan), _ => TimeSpan.FromSeconds(2));
 			services.AddScoped<ICoinJoinIdStore>(s => new CoinJoinIdStore());
+			services.AddScoped(s => new CoinJoinScriptStore());
 			services.AddSingleton<CoinJoinFeeRateStatStore>();
 		});
 		builder.ConfigureLogging(o =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -18,7 +19,9 @@ using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using WalletWasabi.WabiSabi.Backend.Statistics;
 using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
@@ -198,6 +201,144 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		Assert.NotNull(broadcastedTx);
 
 		await roundStateUpdater.StopAsync(CancellationToken.None);
+	}
+
+	[Fact]
+	public async Task FailToRegisterOutputsCoinJoinTestAsync()
+	{
+		var amounts = new long[] {10_000_000, 20_000_000, 30_000_000};
+		int inputCount = amounts.Length;
+
+		// At the end of the test a coinjoin transaction has to be created and broadcasted.
+		var transactionCompleted = new TaskCompletionSource<Transaction>();
+
+		// Create a key manager and use it to create fake coins.
+		_output.WriteLine("Creating key manager...");
+		var keyManager = KeyManager.CreateNew(out var _, password: "", Network.Main);
+		keyManager.AssertCleanKeysIndexed();
+		var coins = keyManager.GetKeys()
+			.Take(inputCount)
+			.Select((x, i) => BitcoinFactory.CreateSmartCoin(x, amounts[i]))
+			.ToArray();
+		_output.WriteLine("Coins were created successfully");
+
+		keyManager.AssertLockedInternalKeysIndexed();
+		var outputScriptCandidates = keyManager
+			.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked)
+			.Select(x => x.PubKey.WitHash.ScriptPubKey)
+			.ToImmutableArray();
+
+		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
+			builder.ConfigureServices(services =>
+			{
+				var rpc = BitcoinFactory.GetMockMinimalRpc();
+
+				// Make the coordinator to believe that the coins are real and
+				// that they exist in the blockchain with many confirmations.
+				rpc.OnGetTxOutAsync = (txId, idx, _) => new()
+				{
+					Confirmations = 101,
+					IsCoinBase = false,
+					ScriptPubKeyType = "witness_v0_keyhash",
+					TxOut = coins.Single(x => x.TransactionId == txId && x.Index == idx).TxOut
+				};
+
+				// Make the coordinator believe that the transaction is being
+				// broadcasted using the RPC interface. Once we receive this tx
+				// (the `SendRawTransationAsync` was invoked) we stop waiting
+				// and finish the waiting tasks to finish the test successfully.
+				rpc.OnSendRawTransactionAsync = (tx) =>
+				{
+					transactionCompleted.SetResult(tx);
+					return tx.GetHash();
+				};
+
+				// Simulates that all the transactions that created our coins
+				// really exists in the blockchain.
+				rpc.OnGetRawTransactionAsync = (txid, throwIfNotFound) =>
+				{
+					var tx = coins.First(coin => coin.TransactionId == txid)?.Transaction?.Transaction;
+
+					if (tx is null)
+					{
+						return Task.FromException<Transaction>(new InvalidOperationException("tx not found"));
+					}
+
+					return Task.FromResult(tx);
+				};
+
+				// Instruct the coordinator DI container to use these two scoped
+				// services to build everything (WabiSabi controller, arena, etc)
+				services.AddScoped<IRPCClient>(s => rpc);
+				services.AddScoped(s => new WabiSabiConfig
+				{
+					MaxInputCountByRound = inputCount,
+					StandardInputRegistrationTimeout = TimeSpan.FromSeconds(60),
+					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(60),
+					OutputRegistrationTimeout = TimeSpan.FromSeconds(60),
+					TransactionSigningTimeout = TimeSpan.FromSeconds(60),
+					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
+				});
+
+				// Emulate that the all our outputs had been already used in the past.
+				// the server will prevent the registration and fail with an WabiSabiProtocolError.
+				services.AddScoped(s => new CoinJoinScriptStore(outputScriptCandidates));
+			})).CreateClient();
+
+		// Create the coinjoin client
+		using PersonCircuit personCircuit = new();
+		IHttpClient httpClientWrapper = new HttpClientWrapper(httpClient);
+		var apiClient = _apiApplicationFactory.CreateWabiSabiHttpApiClient(httpClient);
+		var mockHttpClientFactory = new Mock<IWasabiHttpClientFactory>(MockBehavior.Strict);
+
+		mockHttpClientFactory
+			.Setup(factory => factory.NewHttpClientWithPersonCircuit(out httpClientWrapper))
+			.Returns(personCircuit);
+
+		mockHttpClientFactory
+			.Setup(factory => factory.NewHttpClientWithCircuitPerRequest())
+			.Returns(httpClientWrapper);
+
+		// Total test timeout.
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(200));
+		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
+
+		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(1), apiClient);
+
+		await roundStateUpdater.StartAsync(CancellationToken.None);
+
+		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(mockHttpClientFactory.Object, keyManager, roundStateUpdater);
+
+		bool failedBecauseNotAllAlicesSigned = false;
+		void HandleCoinJoinProgress(object? sender, CoinJoinProgressEventArgs coinJoinProgress)
+		{
+			if (coinJoinProgress is RoundEnded roundEnded)
+			{
+				if (roundEnded.LastRoundState.EndRoundState is EndRoundState.NotAllAlicesSign)
+				{
+					failedBecauseNotAllAlicesSigned = true;
+				}
+				cts.Cancel(); // this is what we were waiting for so, end the test.
+			}
+		}
+
+		try
+		{
+			coinJoinClient.CoinJoinClientProgress += HandleCoinJoinProgress;
+
+			// Run the coinjoin client task.
+			await coinJoinClient.StartCoinJoinAsync(coins, cts.Token);
+			throw new Exception("Coinjoin should have never finished successfully.");
+		}
+		catch (OperationCanceledException)
+		{
+			Assert.True(failedBecauseNotAllAlicesSigned);
+		}
+		finally
+		{
+			coinJoinClient.CoinJoinClientProgress -= HandleCoinJoinProgress;
+			await roundStateUpdater.StopAsync(CancellationToken.None);
+		}
 	}
 
 	[Theory]

--- a/WalletWasabi/WabiSabi/Backend/Statistics/CoinJoinScriptStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Statistics/CoinJoinScriptStore.cs
@@ -10,6 +10,11 @@ namespace WalletWasabi.WabiSabi.Backend.Statistics;
 
 public class CoinJoinScriptStore
 {
+	public CoinJoinScriptStore()
+		: this(Enumerable.Empty<Script>())
+	{
+	}
+	
 	public CoinJoinScriptStore(IEnumerable<Script> scripts)
 	{
 		Scripts = new HashSet<Script>(scripts);

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -17,7 +17,7 @@ namespace WalletWasabi.WabiSabi;
 
 public class WabiSabiCoordinator : BackgroundService
 {
-	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, ICoinJoinIdStore coinJoinIdStore)
+	public WabiSabiCoordinator(CoordinatorParameters parameters, IRPCClient rpc, ICoinJoinIdStore coinJoinIdStore, CoinJoinScriptStore coinJoinScriptStore)
 	{
 		Parameters = parameters;
 
@@ -30,7 +30,6 @@ public class WabiSabiCoordinator : BackgroundService
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinFeeRateStatStoreFilePath);
 		CoinJoinFeeRateStatStore.NewStat += FeeRateStatStore_NewStat;
 
-		var coinJoinScriptStore = CoinJoinScriptStore.LoadFromFile(parameters.CoinJoinScriptStoreFilePath);
 		IoHelpers.EnsureContainingDirectoryExists(Parameters.CoinJoinScriptStoreFilePath);
 
 		RoundParameterFactory roundParameterFactory = new RoundParameterFactory(Config, rpc.Network);


### PR DESCRIPTION
Adds a unit test that verifies the client is not revealing common ownership of inputs in case of errors.

Note: it is important to notice that in this specific case, in the test, the client ignores the fact that the coordinator has already seen the output and then, in the end of the process, it doesn't know what was wrong and only see there are missing outputs. 

IMO it is important to know that it is the client the one that is misbehaving and not the coordinator because in case we implement the banning of misbehaving coordinators (i think we should) then the client would ban it.
