### PR TITLE
[Bnb] Use only private coins & add fallback suggestions

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -112,7 +112,8 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 					tryToSign: false);
 
 				smallerSuggestion = new ChangeAvoidanceSuggestionViewModel(
-					info.Amount.ToDecimal(MoneyUnit.BTC), smallerTransaction,
+					info.Amount.ToDecimal(MoneyUnit.BTC),
+					smallerTransaction,
 					usdExchangeRate);
 
 				// Sanity check not to show crazy suggestions

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -52,14 +52,16 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 
 		var hasChange = transaction.InnerWalletOutputs.Any(x => x.ScriptPubKey != destination.ScriptPubKey);
 
-		if (hasChange && !isFixedAmount && !info.IsPayJoin)
+		var onlyPrivateCoinsUsed = transaction.SpentCoins.All(x => x.HdPubKey.AnonymitySet > wallet.KeyManager.AnonScoreTarget);
+
+		if (hasChange && onlyPrivateCoinsUsed && !isFixedAmount && !info.IsPayJoin)
 		{
 			// Exchange rate can change substantially during computation itself.
 			// Reporting up-to-date exchange rates would just confuse users.
 			decimal usdExchangeRate = wallet.Synchronizer.UsdExchangeRate;
 
 			int originalInputCount = transaction.SpentCoins.Count();
-			int maxInputCount = (int)(Math.Max(3, originalInputCount * 1.3));
+			int maxInputCount = (int)Math.Max(3, originalInputCount * 1.3);
 
 			var pockets = wallet.GetPockets();
 			var spentCoins = transaction.SpentCoins;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -91,7 +91,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 
 			var largerSuggestion = new ChangeAvoidanceSuggestionViewModel(info.Amount.ToDecimal(MoneyUnit.BTC), largerTransaction, usdExchangeRate);
 
-			// Sanity check not to show crazy suggestions
+			// Sanity check
 			if (largerTransaction.CalculateDestinationAmount().Satoshi < MoreSelectionStrategy.MaxExtraPayment * transaction.CalculateDestinationAmount().Satoshi)
 			{
 				Suggestions.Insert(Suggestions.Count - 1, largerSuggestion);
@@ -107,7 +107,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 					info.FeeRate,
 					transaction
 						.SpentCoins
-						.OrderByDescending(x => x.Amount)
+						.OrderBy(x => x.Amount)
 						.Skip(1),
 					tryToSign: false);
 
@@ -116,7 +116,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 					smallerTransaction,
 					usdExchangeRate);
 
-				// Sanity check not to show crazy suggestions
+				// Sanity check
 				if (smallerTransaction.CalculateDestinationAmount().Satoshi > LessSelectionStrategy.MinPaymentThreshold * transaction.CalculateDestinationAmount().Satoshi)
 				{
 					Suggestions.Insert(Suggestions.Count - 1, smallerSuggestion);


### PR DESCRIPTION
Tries to address https://github.com/zkSNACKs/WalletWasabi/pull/8147#issuecomment-1144652683 (1. part)

So, what this PR does:

It tries to minimize the privacy damage `Bnb` can do.

1. Bnb will only run if the original tx used only private coins.
2. If non-private coins were used for the OG tx, we fallback to the basic suggestions.

Basic suggestions:

1. Smaller suggestion takes out the smallest UTXO and builds a changeless tx with the remaining ones.
2. Larger suggestion tries to build a changeless tx with the original transaction's `SpentCoins`.

