### PR TITLE
[VDG] Fix bad flyout behavior after theme switch

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/SearchBarBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/SearchBarBehavior.cs
@@ -93,6 +93,12 @@ public class SearchBarBehavior : AttachedToVisualTreeBehavior<Control>
 		}
 	}
 
+	protected override void OnDetachedFromVisualTree()
+	{
+		HideFlyout();
+		FocusManager.Instance?.Focus(null);
+	}
+
 	private void ToggleFlyoutOpen(bool isOpen)
 	{
 		if (isOpen)


### PR DESCRIPTION
Theme switching from the SearchBar makes the flyout appear in the wrong position.

The problem is that the behavior is detached and reattached. This causes issues with visuals (as popup locating in the wrong place).

This PR is a quick fix for the bad behavior. 
It could have been more elegant (reopen after reattaching of previously detached). Unfortunately, it seems it's more complex than it initially looked. 

Anyways, the behavior after this PR is completely acceptable, in my opinion.

I wouldn't like to spend too much time on this, because I would like to fully rewrite the popup behavior logic.

Fixes #8321