### PR TITLE
Improve locked key usage

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
@@ -123,7 +123,7 @@ public partial class RecoverWalletViewModel : RoutableViewModel
 
 	private KeyPath AccountKeyPath { get; set; } = KeyManager.GetAccountKeyPath(Services.WalletManager.Network);
 
-	private int MinGapLimit { get; set; } = 100;
+	private int MinGapLimit { get; set; } = 114;
 
 	public ObservableCollection<string> Mnemonics { get; } = new();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -199,7 +199,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			.ToArray();
 		_output.WriteLine("Coins were created successfully");
 
-		keyManager.AssertLockedInternalKeysIndexed();
+		keyManager.AssertLockedInternalKeysIndexed(14);
 		var outputScriptCandidates = keyManager
 			.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked)
 			.Select(x => x.PubKey.WitHash.ScriptPubKey)

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -238,12 +238,6 @@ public class TransactionProcessor
 
 					// Make sure there's always 21 clean keys generated and indexed.
 					KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
-
-					if (foundKey.IsInternal)
-					{
-						// Make sure there's always 14 internal locked keys generated and indexed.
-						KeyManager.AssertLockedInternalKeysIndexed(14);
-					}
 				}
 				else // If we had this coin already.
 				{

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -143,7 +143,6 @@ public class TransactionFactory
 		else
 		{
 			KeyManager.AssertCleanKeysIndexed(isInternal: true);
-			KeyManager.AssertLockedInternalKeysIndexed(14);
 			changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).First();
 
 			builder.SetChange(changeHdPubKey.P2wpkhScript);

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -42,7 +42,6 @@ public class Wallet : BackgroundService
 		HandleFiltersLock = new AsyncLock();
 
 		KeyManager.AssertCleanKeysIndexed();
-		KeyManager.AssertLockedInternalKeysIndexed(14);
 	}
 
 	public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;


### PR DESCRIPTION
WW1 and WW2's locked key usage differs. This addresses https://github.com/zkSNACKs/WalletWasabi/pull/8348#issuecomment-1153115851.

One of the major changes is that we won't assure to have locked keys available at all times anymore, rather WW2 coinjoins are going to ask for them on-demand. WW1 coinjoins were expecting them to be available. As a consequence I had to increase the recovery `MinGapLimit` by 14 as 14 locked internal keys were generated previously (thus also indexed.) Which resolves https://github.com/zkSNACKs/WalletWasabi/issues/7550