### PR TITLE
Remove MinGapLimit from Wallet Stats

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
@@ -23,7 +23,6 @@ public partial class WalletStatsViewModel : RoutableViewModel
 	[AutoNotify] private int _generatedCleanKeyCount;
 	[AutoNotify] private int _generatedLockedKeyCount;
 	[AutoNotify] private int _generatedUsedKeyCount;
-	[AutoNotify] private int _minGapLimit;
 	[AutoNotify] private int _largestExternalKeyGap;
 	[AutoNotify] private int _largestInternalKeyGap;
 
@@ -65,7 +64,6 @@ public partial class WalletStatsViewModel : RoutableViewModel
 		GeneratedLockedKeyCount = _wallet.KeyManager.GetKeys(KeyState.Locked).Count();
 		GeneratedUsedKeyCount = _wallet.KeyManager.GetKeys(KeyState.Used).Count();
 
-		MinGapLimit = _wallet.KeyManager.MinGapLimit;
 		LargestExternalKeyGap = _wallet.KeyManager.CountConsecutiveUnusedKeys(isInternal: false, ignoreTail: true);
 		LargestInternalKeyGap = _wallet.KeyManager.CountConsecutiveUnusedKeys(isInternal: true, ignoreTail: true);
 	}

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
@@ -63,13 +63,6 @@
       </c:PreviewItem>
 
       <Separator />
-      <c:PreviewItem Label="MinGapLimit"
-                     TextValue="{Binding MinGapLimit}">
-        <c:PrivacyContentControl Classes="monoSpaced"
-                                 NumberOfPrivacyChars="8"
-                                 Content="{Binding MinGapLimit}" />
-      </c:PreviewItem>
-      <Separator />
       <c:PreviewItem Label="Largest receive key gap"
                      TextValue="{Binding LargestExternalKeyGap}">
         <c:PrivacyContentControl Classes="monoSpaced"


### PR DESCRIPTION
There's no good name for it, because it's quite a special thing. Also maybe it's redundant assuming the code is correct and the gaps are increased accordingly.