### PR TITLE
[VDG] Make styles of NavBar's ScrollBar more restrictive

### DIFF
--- a/WalletWasabi.Fluent/Styles/CuedScrollViewer.axaml
+++ b/WalletWasabi.Fluent/Styles/CuedScrollViewer.axaml
@@ -124,6 +124,7 @@
           </ScrollContentPresenter>
 
           <ScrollBar Name="PART_HorizontalScrollBar"
+                     Classes="cued"
                      MaxHeight="10"
                      MinHeight="2"
                      AllowAutoHide="{TemplateBinding AllowAutoHide}"
@@ -138,6 +139,7 @@
                      Focusable="False" />
 
           <ScrollBar Name="PART_VerticalScrollBar"
+                     Classes="cued"
                      MaxWidth="10"
                      MinWidth="2"
                      AllowAutoHide="{TemplateBinding AllowAutoHide}"
@@ -209,14 +211,11 @@
     <Setter Property="Stretch" Value="Fill" />
   </Style>
 
-  <Style Selector="RepeatButton">
+  <Style Selector="navBar|NavBar RepeatButton">
+    <Setter Property="IsVisible" Value="False" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="Grid.ColumnSpan" Value="2"/>
     <Setter Property="Background" Value="Transparent" />
-  </Style>
-
-  <Style Selector="ScrollBar RepeatButton">
-    <Setter Property="IsVisible" Value="False" />
   </Style>
 
 </Styles>


### PR DESCRIPTION
*(this is a fix for a regression introduced by https://github.com/zkSNACKs/WalletWasabi/pull/7326)*

The Styles in CuedScrollViewer.xaml are supposed to be applied only to the NavBar, but some of them are applied to controls outside it.

Current: 
![image](https://user-images.githubusercontent.com/3109851/173316520-7ca3ee1d-dc23-4b7e-8c08-4c3fa7e76aa5.png)

This PR:
![image](https://user-images.githubusercontent.com/3109851/173316662-32f357f8-a5e8-49f5-9ba8-55f2e6f921ae.png)

Please, notice how the arrow buttons (Repeaters) 