### PR TITLE
`StreamExtensions`: Improve cancellation.

### DIFF
--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Socks5.Exceptions;


### PR DESCRIPTION
Related to #8354 (improves the log part, not the "Object was already disposed" part)

This PR attempts to improve the cancelling behavior of `StreamExtensions.ReadByteAsync(..)` in the way that `OperationCancelledException` is thrown (as it should be) rather than returning `-1` (denoting that no data are available for reading).

The effect of this PR should be that `OperationCancelledException` is logged on trace level and normally it should not be seen in logs. So we should have cleaner logs when the app is shutting down. 

The PR should not affect anything else than logs really.