### PR TITLE
Don't use weighted anonscore for change outputs (WW1 anonscore fix)

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -84,6 +84,22 @@ public class CoinJoinAnonScoreTests
 	}
 
 	[Fact]
+	public void ChangeOutputConservativeConsolidation()
+	{
+		var analyser = ServiceFactory.CreateBlockchainAnalyzer();
+		var tx = BitcoinFactory.CreateSmartTransaction(9, Enumerable.Repeat(Money.Coins(1m), 9), new[] { (Money.Coins(3.1m), 1), (Money.Coins(3.1m), 100) }, new[] { (Money.Coins(1m), HdPubKey.DefaultHighAnonymitySet), (Money.Coins(5m), HdPubKey.DefaultHighAnonymitySet) });
+
+		analyser.Analyze(tx);
+
+		var active = tx.WalletOutputs.First(x => x.Amount == Money.Coins(1m));
+		var change = tx.WalletOutputs.First(x => x.Amount == Money.Coins(5m));
+
+		Assert.Equal(1, tx.WalletInputs.First().HdPubKey.AnonymitySet);
+		Assert.Equal(59, active.HdPubKey.AnonymitySet);
+		Assert.Equal(1, change.HdPubKey.AnonymitySet);
+	}
+
+	[Fact]
 	public void ChangeOutputInheritance()
 	{
 		var analyser = ServiceFactory.CreateBlockchainAnalyzer();


### PR DESCRIPTION
As discussed on research meeting with @MaxHillebrand and @BTCparadigm weighted anonscore was implemented with WW2 in mind. I realized it'd ruin WW1 anonscore calculations. This PR fixes it by making sure we only use weighted anonscores for non-unique outputs. For unique outputs I'm basically reintroducing the anonymity punishment. This could also be important for edge cases in WW2. Note that testnet anonscore percentages in the privacy profile are basically halved by this PR, though for my mainnet wallet this did not result in a change.