### PR TITLE
Materilize sequences to prevent multiple evaluations

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Wallet/SmartCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/SmartCoinSelectorTests.cs
@@ -29,7 +29,8 @@ public class SmartCoinSelectorTests
 			.Select((key, i) => {
 				var coin =BitcoinFactory.CreateSmartCoin(key, 0.1m * (i+1));
 				coin.HdPubKey.Cluster = cluster;
-				return coin; });
+				return coin; })
+			.ToList();
 
 		var selector = new SmartCoinSelector(smartCoins);
 		var coinsToSpend = selector.Select(Enumerable.Empty<Coin>(), Money.Coins(0.3m));
@@ -117,7 +118,7 @@ public class SmartCoinSelectorTests
 				coin.HdPubKey.Cluster = betoCluster;
 				return coin; });
 
-		var selector = new SmartCoinSelector(coinsKnownByJuan.Concat(coinsKnownByBeto));
+		var selector = new SmartCoinSelector(coinsKnownByJuan.Concat(coinsKnownByBeto).ToList());
 		var coinsToSpend = selector.Select(Enumerable.Empty<Coin>(), Money.Coins(0.3m)).Cast<Coin>().ToList();
 
 		Assert.Equal(2, coinsToSpend.Count);

--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -10,12 +10,12 @@ namespace WalletWasabi.Blockchain.TransactionBuilding;
 
 public class SmartCoinSelector : ICoinSelector
 {
-	public SmartCoinSelector(IEnumerable<SmartCoin> unspentCoins)
+	public SmartCoinSelector(List<SmartCoin> unspentCoins)
 	{
-		UnspentCoins = unspentCoins.Distinct();
+		UnspentCoins = unspentCoins.Distinct().ToList();
 	}
 
-	private IEnumerable<SmartCoin> UnspentCoins { get; }
+	private List<SmartCoin> UnspentCoins { get; }
 
 	public IEnumerable<ICoin> Select(IEnumerable<ICoin> unused, IMoney target)
 	{
@@ -33,12 +33,14 @@ public class SmartCoinSelector : ICoinSelector
 			.Distinct();
 
 		// Build all the possible coin clusters, except when it's computationally too expensive.
-		List<IEnumerable<SmartCoin>> coinClusters = uniqueClusters.Count() < 10
+		List<List<SmartCoin>> coinClusters = uniqueClusters.Count() < 10
 			? uniqueClusters
 				.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
-				.Select(clusterCombination => UnspentCoins.Where(coin => clusterCombination.Contains(coin.HdPubKey.Cluster)))
+				.Select(clusterCombination => UnspentCoins
+					.Where(coin => clusterCombination.Contains(coin.HdPubKey.Cluster))
+					.ToList())
 				.ToList()
-			: new List<IEnumerable<SmartCoin>>();
+			: new List<List<SmartCoin>>();
 
 		coinClusters.Add(UnspentCoins);
 


### PR DESCRIPTION
Related #8103

This PR eliminates the chance of having a problem with sequences being evaluated more than once. However this code does NOT solve the problem described by #8103 because it was impossible to reproduce still. 