### PR TITLE
Add simple lock to ConfigBase

### DIFF
--- a/WalletWasabi/Bases/ConfigBase.cs
+++ b/WalletWasabi/Bases/ConfigBase.cs
@@ -44,7 +44,7 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 			throw new FileNotFoundException($"{GetType().Name} file did not exist at path: `{FilePath}`.");
 		}
 
-		string? jsonString = null;
+		string jsonString;
 		lock (FileLocker)
 		{
 			jsonString = File.ReadAllText(FilePath, Encoding.UTF8);

--- a/WalletWasabi/Bases/ConfigBase.cs
+++ b/WalletWasabi/Bases/ConfigBase.cs
@@ -23,7 +23,7 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 	/// <inheritdoc />
 	public string FilePath { get; private set; } = "";
 
-	private object FileLocker { get; } = new object();
+	private object FileLocker { get; } = new();
 
 	/// <inheritdoc />
 	public void AssertFilePathSet()

--- a/WalletWasabi/Bases/ConfigBase.cs
+++ b/WalletWasabi/Bases/ConfigBase.cs
@@ -85,7 +85,7 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 	/// <inheritdoc />
 	public virtual void LoadFile()
 	{
-		string? jsonString = null;
+		string jsonString;
 		lock (FileLocker)
 		{
 			jsonString = File.ReadAllText(FilePath, Encoding.UTF8);

--- a/WalletWasabi/Bases/ConfigBase.cs
+++ b/WalletWasabi/Bases/ConfigBase.cs
@@ -23,6 +23,8 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 	/// <inheritdoc />
 	public string FilePath { get; private set; } = "";
 
+	private object FileLocker { get; } = new object();
+
 	/// <inheritdoc />
 	public void AssertFilePathSet()
 	{
@@ -42,7 +44,11 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 			throw new FileNotFoundException($"{GetType().Name} file did not exist at path: `{FilePath}`.");
 		}
 
-		string jsonString = File.ReadAllText(FilePath, Encoding.UTF8);
+		string? jsonString = null;
+		lock (FileLocker)
+		{
+			jsonString = File.ReadAllText(FilePath, Encoding.UTF8);
+		}
 
 		var newConfigObject = Activator.CreateInstance(GetType())!;
 		JsonConvert.PopulateObject(jsonString, newConfigObject, JsonSerializationOptions.Default.Settings);
@@ -79,7 +85,11 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 	/// <inheritdoc />
 	public virtual void LoadFile()
 	{
-		var jsonString = File.ReadAllText(FilePath, Encoding.UTF8);
+		string? jsonString = null;
+		lock (FileLocker)
+		{
+			jsonString = File.ReadAllText(FilePath, Encoding.UTF8);
+		}
 
 		JsonConvert.PopulateObject(jsonString, this, JsonSerializationOptions.Default.Settings);
 
@@ -110,7 +120,10 @@ public abstract class ConfigBase : NotifyPropertyChangedBase, IConfig
 		AssertFilePathSet();
 
 		string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented, JsonSerializationOptions.Default.Settings);
-		File.WriteAllText(FilePath, jsonString, Encoding.UTF8);
+		lock (FileLocker)
+		{
+			File.WriteAllText(FilePath, jsonString, Encoding.UTF8);
+		}
 	}
 
 	protected virtual bool TryEnsureBackwardsCompatibility(string jsonString) => true;


### PR DESCRIPTION
The following issue caused a crash after starting Wasabi

```
2022-06-13 13:15:53.335 [1] DEBUG	Program.Main (41)	Wasabi was started with these argument(s): none.
2022-06-13 13:15:55.848 [14] WARNING	Program.CurrentDomain_UnhandledException (209)	System.IO.IOException: The process cannot access the file 'C:\Users\user\AppData\Roaming\WalletWasabi\Client\UiConfig.json' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.StreamWriter.ValidateArgsAndOpenPath(String path, Boolean append, Encoding encoding, Int32 bufferSize)
   at System.IO.File.WriteAllText(String path, String contents, Encoding encoding)
   at WalletWasabi.Bases.ConfigBase.ToFile() in WalletWasabi\Bases\ConfigBase.cs:line 113
   at WalletWasabi.Fluent.UiConfig.<.ctor>b__14_13(Unit _) in WalletWasabi.Fluent\UiConfig.cs:line 51
   at System.Reactive.AnonymousSafeObserver`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousSafeObserver.cs:line 43
   at System.Reactive.ObserveOnObserverLongRunning`1.Drain() in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 732
   at System.Reactive.ObserveOnObserverLongRunning`1.<>c.<.cctor>b__17_0(ObserveOnObserverLongRunning`1 self, ICancelable cancelable) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 680
   at System.Reactive.Concurrency.DefaultScheduler.LongRunning.LongScheduledWorkItem`1.<>c.<.ctor>b__3_0(Object thisObject) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/DefaultScheduler.cs:line 181
   at System.Reactive.Concurrency.ConcurrencyAbstractionLayerImpl.<>c.<StartThread>b__8_0(Object itemObject) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs:line 75
   at System.Threading.Thread.StartCallback()
```