### PR TITLE
Optimize MaxSuggestedAmount variation

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -86,7 +86,7 @@ public class MultipartyTransactionStateTests
 	[InlineData(2 + 32, "1")]
 	[InlineData(1, "0.1")]
 	[InlineData(1 + 32, "0.1")]
-	[InlineData(0, "0.1")]
+	[InlineData(0, "1343.75")]
 	public void GetSuggestedAmountsTest(int roundCounter, string amount)
 	{
 		WabiSabiConfig config = new();

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -62,7 +62,8 @@ public class MaxSuggestedAmountProvider
 			}
 		}
 
-		return RoundCounterDividerAndMaxAmounts.Last().MaxValue;
+		// We always start with the largest whale round.
+		return RoundCounterDividerAndMaxAmounts.First().MaxValue;
 	}
 
 	private record DividerMaxValue(int Divider, Money MaxValue);


### PR DESCRIPTION
- First and most important change, variate the MaxSuggested Amount every time when a round is created. Before we only changed the value when the round successfully got into Conn-confirm. If there were not enough users in the round we never changed the MaxSuggested thus bigger coins never tries to register. 
- Current master generates the round with MaxSuggestedAmount starting with the smallest base value for example 0.1 BTC. This PR let the first round starts with the largest amount which is 1375 BTC. 
- Do not increase the counter in case of Blame round.
