### PR TITLE
Keep largest MaxSuggestedAmount until successful input reg

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -59,7 +59,7 @@ public static class WabiSabiFactory
 			Money.Coins(Constants.MaximumNumberOfBitcoins));
 
 	public static Round CreateRound(RoundParameters parameters) =>
-		new(parameters,	new InsecureRandom());
+		new(parameters, new InsecureRandom());
 
 	public static Round CreateRound(WabiSabiConfig cfg) =>
 		CreateRound(CreateRoundParameters(cfg) with
@@ -317,18 +317,18 @@ public static class WabiSabiFactory
 	public static RoundParameterFactory CreateRoundParametersFactory(WabiSabiConfig cfg, Network network, int maxVsizeAllocationPerAlice)
 	{
 		var mockRoundParameterFactory = new Mock<RoundParameterFactory>(cfg, network);
-		mockRoundParameterFactory.Setup(x => x.CreateRoundParameter(It.IsAny<FeeRate>(), It.IsAny<int>()))
+		mockRoundParameterFactory.Setup(x => x.CreateRoundParameter(It.IsAny<FeeRate>()))
 			.Returns(WabiSabiFactory.CreateRoundParameters(cfg)
 				with
-				{
-					MaxVsizeAllocationPerAlice = maxVsizeAllocationPerAlice
-				});
+			{
+				MaxVsizeAllocationPerAlice = maxVsizeAllocationPerAlice
+			});
 		mockRoundParameterFactory.Setup(x => x.CreateBlameRoundParameter(It.IsAny<FeeRate>(), It.IsAny<Round>()))
 			.Returns(WabiSabiFactory.CreateRoundParameters(cfg)
 				with
-				{
-					MaxVsizeAllocationPerAlice = maxVsizeAllocationPerAlice
-				});
+			{
+				MaxVsizeAllocationPerAlice = maxVsizeAllocationPerAlice
+			});
 		return mockRoundParameterFactory.Object;
 	}
 }

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -317,7 +317,7 @@ public static class WabiSabiFactory
 	public static RoundParameterFactory CreateRoundParametersFactory(WabiSabiConfig cfg, Network network, int maxVsizeAllocationPerAlice)
 	{
 		var mockRoundParameterFactory = new Mock<RoundParameterFactory>(cfg, network);
-		mockRoundParameterFactory.Setup(x => x.CreateRoundParameter(It.IsAny<FeeRate>()))
+		mockRoundParameterFactory.Setup(x => x.CreateRoundParameter(It.IsAny<FeeRate>(), It.IsAny<Money>()))
 			.Returns(WabiSabiFactory.CreateRoundParameters(cfg)
 				with
 			{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -383,7 +383,7 @@ public class RegisterInputFailureTests
 
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 		RoundParameterFactory roundParameterFactory = WabiSabiFactory.CreateRoundParametersFactory(cfg, rpc.Object.Network, maxVsizeAllocationPerAlice: 0);
-		Round round = WabiSabiFactory.CreateRound(roundParameterFactory.CreateRoundParameter(new FeeRate(10m)));
+		Round round = WabiSabiFactory.CreateRound(roundParameterFactory.CreateRoundParameter(new FeeRate(10m), Money.Zero));
 		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).With(roundParameterFactory).CreateAndStartAsync(round);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -383,7 +383,7 @@ public class RegisterInputFailureTests
 
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 		RoundParameterFactory roundParameterFactory = WabiSabiFactory.CreateRoundParametersFactory(cfg, rpc.Object.Network, maxVsizeAllocationPerAlice: 0);
-		Round round = WabiSabiFactory.CreateRound(roundParameterFactory.CreateRoundParameter(new FeeRate(10m), 0));
+		Round round = WabiSabiFactory.CreateRound(roundParameterFactory.CreateRoundParameter(new FeeRate(10m)));
 		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).With(roundParameterFactory).CreateAndStartAsync(round);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -76,8 +76,30 @@ public class MultipartyTransactionStateTests
 		Assert.Equal(clientState3.Outputs, state3.Outputs);
 	}
 
+	[Theory]
+	[InlineData(32, "1343.75")]
+	[InlineData(32 + 32, "1343.75")]
+	[InlineData(16, "1000")]
+	[InlineData(16 + 32, "1000")]
+	[InlineData(8, "100")]
+	[InlineData(8 + 32, "100")]
+	[InlineData(4, "10")]
+	[InlineData(4 + 32, "10")]
+	[InlineData(2, "1")]
+	[InlineData(2 + 32, "1")]
+	[InlineData(1, "0.1")]
+	[InlineData(1 + 32, "0.1")]
+	[InlineData(0, "1343.75")]
+	public void GetSuggestedAmountsTest(int roundCounter, string amount)
+	{
+		WabiSabiConfig config = new();
+		MaxSuggestedAmountProvider maxSuggestedAmountProvider = new(config);
+		var expected = Money.Coins(decimal.Parse(amount));
+		Assert.Equal(expected, maxSuggestedAmountProvider.GetMaxSuggestedAmount(roundCounter));
+	}
+
 	[Fact]
-	public void GetSuggestedAmountsTest()
+	public void MaxSuggestedSteppingTest()
 	{
 		WabiSabiConfig config = new();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -118,13 +118,16 @@ public class MultipartyTransactionStateTests
 		Assert.Equal(32, histogram[Money.Coins(0.1m)]);
 
 		// Simulate many unsuccessful input-reg. At the end we should always stick with the largest again.
-		for (int i = 0; i < 40; i++)
+		for (int i = 0; i < 2; i++)
 		{
 			maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, false);
+			Assert.Equal(Money.Coins(1343.75m), maxSuggestedAmountProvider.MaxSuggestedAmount);
 		}
-		Assert.Equal(Money.Coins(1343.75m), maxSuggestedAmountProvider.MaxSuggestedAmount);
 
 		// Finally one successful round.
+		maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
+		Assert.Equal(Money.Coins(1343.75m), maxSuggestedAmountProvider.MaxSuggestedAmount);
+
 		maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
 		Assert.Equal(Money.Coins(0.1m), maxSuggestedAmountProvider.MaxSuggestedAmount);
 
@@ -132,7 +135,7 @@ public class MultipartyTransactionStateTests
 		BlameRound blameRound = new(blameParameters, roundLargest, new HashSet<OutPoint>(), SecureRandom.Instance);
 
 		// Blame rounds never change the MaxSuggestedAmount.
-		for (int i = 0; i < 10; i++)
+		for (int i = 0; i < 2; i++)
 		{
 			maxSuggestedAmountProvider.StepMaxSuggested(blameRound, true);
 			Assert.Equal(Money.Coins(0.1m), maxSuggestedAmountProvider.MaxSuggestedAmount);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -1,7 +1,10 @@
 using NBitcoin;
+using System.Collections.Generic;
+using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using Xunit;
 
@@ -73,25 +76,66 @@ public class MultipartyTransactionStateTests
 		Assert.Equal(clientState3.Outputs, state3.Outputs);
 	}
 
-	[Theory]
-	[InlineData(32, "1343.75")]
-	[InlineData(32 + 32, "1343.75")]
-	[InlineData(16, "1000")]
-	[InlineData(16 + 32, "1000")]
-	[InlineData(8, "100")]
-	[InlineData(8 + 32, "100")]
-	[InlineData(4, "10")]
-	[InlineData(4 + 32, "10")]
-	[InlineData(2, "1")]
-	[InlineData(2 + 32, "1")]
-	[InlineData(1, "0.1")]
-	[InlineData(1 + 32, "0.1")]
-	[InlineData(0, "1343.75")]
-	public void GetSuggestedAmountsTest(int roundCounter, string amount)
+	[Fact]
+	public void GetSuggestedAmountsTest()
 	{
 		WabiSabiConfig config = new();
-		MaxSuggestedAmountProvider maxSuggestedAmountProvider = new(config);
-		var expected = Money.Coins(decimal.Parse(amount));
-		Assert.Equal(expected, maxSuggestedAmountProvider.GetMaxSuggestedAmount(roundCounter));
+
+		RoundParameterFactory roundParameterFactory = new(config, Network.Main);
+		MaxSuggestedAmountProvider maxSuggestedAmountProvider = roundParameterFactory.MaxSuggestedAmountProvider;
+		RoundParameters parameters = roundParameterFactory.CreateRoundParameter(new FeeRate(12m));
+		Round roundLargest = new(parameters, SecureRandom.Instance);
+
+		// First Round is the largest.
+		Assert.Equal(Money.Coins(1343.75m), maxSuggestedAmountProvider.MaxSuggestedAmount);
+
+		// Simulate 63 successful rounds.
+		Dictionary<Money, int> histogram = new();
+		for (int i = 0; i < 63; i++)
+		{
+			maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
+			parameters = roundParameterFactory.CreateRoundParameter(new FeeRate(12m));
+			Round round = new(parameters, SecureRandom.Instance);
+
+			var maxSuggested = round.Parameters.MaxSuggestedAmount;
+
+			if (!histogram.ContainsKey(maxSuggested))
+			{
+				histogram.Add(maxSuggested, 1);
+			}
+			else
+			{
+				histogram[maxSuggested]++;
+			}
+		}
+
+		// Check the distribution of MaxSuggestedAmounts.
+		Assert.Equal(1, histogram[Money.Coins(1343.75m)]);
+		Assert.Equal(2, histogram[Money.Coins(1000)]);
+		Assert.Equal(4, histogram[Money.Coins(100)]);
+		Assert.Equal(8, histogram[Money.Coins(10)]);
+		Assert.Equal(16, histogram[Money.Coins(1)]);
+		Assert.Equal(32, histogram[Money.Coins(0.1m)]);
+
+		// Simulate many unsuccessful input-reg. At the end we should always stick with the largest again.
+		for (int i = 0; i < 40; i++)
+		{
+			maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, false);
+		}
+		Assert.Equal(Money.Coins(1343.75m), maxSuggestedAmountProvider.MaxSuggestedAmount);
+
+		// Finally one successful round.
+		maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
+		Assert.Equal(Money.Coins(0.1m), maxSuggestedAmountProvider.MaxSuggestedAmount);
+
+		RoundParameters blameParameters = roundParameterFactory.CreateBlameRoundParameter(new FeeRate(12m), roundLargest);
+		BlameRound blameRound = new(blameParameters, roundLargest, new HashSet<OutPoint>(), SecureRandom.Instance);
+
+		// Blame rounds never change the MaxSuggestedAmount.
+		for (int i = 0; i < 10; i++)
+		{
+			maxSuggestedAmountProvider.StepMaxSuggested(blameRound, true);
+			Assert.Equal(Money.Coins(0.1m), maxSuggestedAmountProvider.MaxSuggestedAmount);
+		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -57,11 +57,6 @@ public partial class Arena : PeriodicRunner
 	private ICoinJoinIdStore CoinJoinIdStore { get; set; }
 	private RoundParameterFactory RoundParameterFactory { get; }
 
-	/// <summary>
-	/// How many non-blame round get to the end of the Input registration phase.
-	/// </summary>
-	private int InputRegistrationFinishedCounter { get; set; }
-
 	protected override async Task ActionAsync(CancellationToken cancel)
 	{
 		using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
@@ -105,22 +100,20 @@ public partial class Arena : PeriodicRunner
 					}
 				}
 
-				if (round is not BlameRound)
-				{
-					InputRegistrationFinishedCounter++;
-				}
-
 				if (round.InputCount < Config.MinInputCountByRound)
 				{
 					if (!round.InputRegistrationTimeFrame.HasExpired)
 					{
 						continue;
 					}
+
+					RoundParameterFactory.MaxSuggestedAmountProvider.StepMaxSuggested(round, false);
 					round.EndRound(EndRoundState.AbortedNotEnoughAlices);
 					round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.InputRegistration)} phase. The minimum is ({Config.MinInputCountByRound}). {nameof(round.Parameters.MaxSuggestedAmount)} was '{round.Parameters.MaxSuggestedAmount}' BTC.");
 				}
 				else if (round.IsInputRegistrationEnded(Config.MaxInputCountByRound))
 				{
+					RoundParameterFactory.MaxSuggestedAmountProvider.StepMaxSuggested(round, true);
 					round.SetPhase(Phase.ConnectionConfirmation);
 				}
 			}
@@ -376,7 +369,7 @@ public partial class Arena : PeriodicRunner
 			var feeRate = (await Rpc.EstimateSmartFeeAsync((int)Config.ConfirmationTarget, EstimateSmartFeeMode.Conservative, simulateIfRegTest: true, cancellationToken).ConfigureAwait(false)).FeeRate;
 
 			RoundParameters parameters =
-				RoundParameterFactory.CreateRoundParameter(feeRate, InputRegistrationFinishedCounter);
+				RoundParameterFactory.CreateRoundParameter(feeRate);
 			Round r = new(parameters, SecureRandom.Instance);
 			Rounds.Add(r);
 			r.LogInfo($"Created round with params: {nameof(parameters.MaxSuggestedAmount)}:'{parameters.MaxSuggestedAmount}' BTC.");

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -17,6 +17,7 @@ public class MaxSuggestedAmountProvider
 	private WabiSabiConfig Config { get; init; }
 	private int Counter { get; set; }
 	public Money MaxSuggestedAmount { get; private set; }
+	private Money AbsoluteMaximumInput { get; } = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice);
 
 	private void CheckOrGenerateRoundCounterDividerAndMaxAmounts()
 	{
@@ -28,8 +29,6 @@ public class MaxSuggestedAmountProvider
 			return;
 		}
 
-		Money absoluteMaximumInput = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice);
-
 		int level = 0;
 		List<DividerMaxValue> roundCounterDividerAndMaxAmounts = new();
 		bool end = false;
@@ -37,9 +36,9 @@ public class MaxSuggestedAmountProvider
 		{
 			var roundDivider = (int)Math.Pow(2, level);
 			var maxValue = maxSuggestedAmountBase * (long)Math.Pow(10, level);
-			if (maxValue >= absoluteMaximumInput)
+			if (maxValue >= AbsoluteMaximumInput)
 			{
-				maxValue = absoluteMaximumInput;
+				maxValue = AbsoluteMaximumInput;
 				end = true;
 			}
 			roundCounterDividerAndMaxAmounts.Insert(0, new(roundDivider, maxValue));
@@ -82,7 +81,8 @@ public class MaxSuggestedAmountProvider
 		if (!isInputRegistrationSuccessful)
 		{
 			// We will keep this on the maximum - let everyone join.
-			MaxSuggestedAmount = RoundCounterDividerAndMaxAmounts.First().MaxValue;
+			MaxSuggestedAmount = AbsoluteMaximumInput;
+			return;
 		}
 
 		// Alter the value.

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -51,6 +51,9 @@ public class MaxSuggestedAmountProvider
 		LastGeneratedMaxSuggestedAmountBase = maxSuggestedAmountBase;
 	}
 
+	/// <summary>
+	/// Do not use this externally, only for Testing.
+	/// </summary>
 	internal Money GetMaxSuggestedAmount(int roundCounter)
 	{
 		CheckOrGenerateRoundCounterDividerAndMaxAmounts();

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -9,7 +9,7 @@ public class MaxSuggestedAmountProvider
 	public MaxSuggestedAmountProvider(WabiSabiConfig config)
 	{
 		Config = config;
-		MaxSuggestedAmount = GetMaxSuggestedAmount();
+		MaxSuggestedAmount = GetMaxSuggestedAmount(0);
 	}
 
 	private List<DividerMaxValue> RoundCounterDividerAndMaxAmounts { get; set; } = new List<DividerMaxValue>();
@@ -51,14 +51,14 @@ public class MaxSuggestedAmountProvider
 		LastGeneratedMaxSuggestedAmountBase = maxSuggestedAmountBase;
 	}
 
-	private Money GetMaxSuggestedAmount()
+	internal Money GetMaxSuggestedAmount(int roundCounter)
 	{
 		CheckOrGenerateRoundCounterDividerAndMaxAmounts();
-		if (Counter != 0)
+		if (roundCounter != 0)
 		{
 			foreach (var (divider, maxValue) in RoundCounterDividerAndMaxAmounts.Where(v => v.MaxValue <= Config.MaxRegistrableAmount))
 			{
-				if (Counter % divider == 0)
+				if (roundCounter % divider == 0)
 				{
 					return maxValue;
 				}
@@ -91,6 +91,6 @@ public class MaxSuggestedAmountProvider
 		// Alter the value.
 		Counter++;
 
-		MaxSuggestedAmount = GetMaxSuggestedAmount();
+		MaxSuggestedAmount = GetMaxSuggestedAmount(Counter);
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -81,12 +81,8 @@ public class MaxSuggestedAmountProvider
 
 		if (!isInputRegistrationSuccessful)
 		{
-			var largestSuggestedAmount = RoundCounterDividerAndMaxAmounts.First().MaxValue;
-			if (MaxSuggestedAmount == largestSuggestedAmount)
-			{
-				// We will keep this on the maximum - let everyone join.
-				return;
-			}
+			// We will keep this on the maximum - let everyone join.
+			MaxSuggestedAmount = RoundCounterDividerAndMaxAmounts.First().MaxValue;
 		}
 
 		// Alter the value.

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -9,7 +9,7 @@ public class MaxSuggestedAmountProvider
 	public MaxSuggestedAmountProvider(WabiSabiConfig config)
 	{
 		Config = config;
-		MaxSuggestedAmount = GetMaxSuggestedAmount(0);
+		MaxSuggestedAmount = GetMaxSuggestedAmount();
 	}
 
 	private List<DividerMaxValue> RoundCounterDividerAndMaxAmounts { get; set; } = new List<DividerMaxValue>();
@@ -52,17 +52,14 @@ public class MaxSuggestedAmountProvider
 		Counter = 0;
 	}
 
-	/// <summary>
-	/// Do not use this externally, only for Testing.
-	/// </summary>
-	internal Money GetMaxSuggestedAmount(int roundCounter)
+	private Money GetMaxSuggestedAmount()
 	{
 		CheckOrGenerateRoundCounterDividerAndMaxAmounts();
-		if (roundCounter != 0)
+		if (Counter != 0)
 		{
 			foreach (var (divider, maxValue) in RoundCounterDividerAndMaxAmounts.Where(v => v.MaxValue <= Config.MaxRegistrableAmount))
 			{
-				if (roundCounter % divider == 0)
+				if (Counter % divider == 0)
 				{
 					return maxValue;
 				}
@@ -95,6 +92,6 @@ public class MaxSuggestedAmountProvider
 		// Alter the value.
 		Counter++;
 
-		MaxSuggestedAmount = GetMaxSuggestedAmount(Counter);
+		MaxSuggestedAmount = GetMaxSuggestedAmount();
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -49,6 +49,7 @@ public class MaxSuggestedAmountProvider
 
 		RoundCounterDividerAndMaxAmounts = roundCounterDividerAndMaxAmounts;
 		LastGeneratedMaxSuggestedAmountBase = maxSuggestedAmountBase;
+		Counter = 0;
 	}
 
 	/// <summary>

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameterFactory.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameterFactory.cs
@@ -10,20 +10,18 @@ public class RoundParameterFactory
 	{
 		Config = config;
 		Network = network;
-		MaxSuggestedAmountProvider = new(Config);
 	}
 
 	public WabiSabiConfig Config { get; }
 	public Network Network { get; }
-	public MaxSuggestedAmountProvider MaxSuggestedAmountProvider { get; }
 
-	public virtual RoundParameters CreateRoundParameter(FeeRate feeRate) =>
+	public virtual RoundParameters CreateRoundParameter(FeeRate feeRate, Money maxSuggestedAmount) =>
 		RoundParameters.Create(
 			Config,
 			Network,
 			feeRate,
 			Config.CoordinationFeeRate,
-			MaxSuggestedAmountProvider.MaxSuggestedAmount);
+			maxSuggestedAmount);
 
 	public virtual RoundParameters CreateBlameRoundParameter(FeeRate feeRate, Round blameOf) =>
 		RoundParameters.Create(

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameterFactory.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameterFactory.cs
@@ -10,20 +10,20 @@ public class RoundParameterFactory
 	{
 		Config = config;
 		Network = network;
-		MaxSuggestedAmountProvider = new (Config);
+		MaxSuggestedAmountProvider = new(Config);
 	}
 
 	public WabiSabiConfig Config { get; }
 	public Network Network { get; }
 	public MaxSuggestedAmountProvider MaxSuggestedAmountProvider { get; }
-	
-	public virtual RoundParameters CreateRoundParameter(FeeRate feeRate, int connectionConfirmationStartedCounter) =>
+
+	public virtual RoundParameters CreateRoundParameter(FeeRate feeRate) =>
 		RoundParameters.Create(
 			Config,
 			Network,
 			feeRate,
 			Config.CoordinationFeeRate,
-			MaxSuggestedAmountProvider.GetMaxSuggestedAmount(connectionConfirmationStartedCounter));
+			MaxSuggestedAmountProvider.MaxSuggestedAmount);
 
 	public virtual RoundParameters CreateBlameRoundParameter(FeeRate feeRate, Round blameOf) =>
 		RoundParameters.Create(


### PR DESCRIPTION
- After many unsuccessful rounds because of not enough inputs, we should end up with the largest MaxSuggestedAmount  (1375 BTC) to let everyone join the round and keep that value until successful input-reg.
- The logic became more sophisticated so it was moved into MaxSuggestedAmountProvider and slightly refactored the way how it works. 
- MaxSuggestedAmountProvider moved out of CreateRoundParameter

I would begin the review with the Test. 