### PR TITLE
Remove unnecessary log

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -338,7 +338,7 @@ public partial class Arena : PeriodicRunner
 
 		var cnt = round.Alices.RemoveAll(alice => unsignedOutpoints.Contains(alice.Coin.Outpoint));
 
-		round.LogInfo($"Removed {cnt} alices, because they didn't sign. Remainig: {round.InputCount} alices. Witness count: {state.Witnesses.Count}. Unsigned outpoints: {unsignedOutpoints.Count}. Alices: {round.Alices.Count}");
+		round.LogInfo($"Removed {cnt} alices, because they didn't sign. Remainig: {round.InputCount}");
 
 		if (round.InputCount >= Config.MinInputCountByRound)
 		{


### PR DESCRIPTION
Removing these, because these were consistent with the remaining log entries, so no error was to be found there.