### PR TITLE
Increase statista time to 60 minutes

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabi/RequestTimeStatista.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabi/RequestTimeStatista.cs
@@ -12,7 +12,7 @@ public class RequestTimeStatista
 	private Dictionary<string, List<(DateTimeOffset Time, TimeSpan Duration)>> Requests { get; } = new();
 	private object Lock { get; } = new();
 	private DateTimeOffset LastDisplayed { get; set; } = DateTimeOffset.UtcNow;
-	private TimeSpan DisplayFrequency { get; } = TimeSpan.FromMinutes(10);
+	private TimeSpan DisplayFrequency { get; } = TimeSpan.FromMinutes(60);
 
 	public void Add(string request, TimeSpan duration)
 	{


### PR DESCRIPTION
We've seen the initial numbers. Note that normally it should be probably one day.