### PR TITLE
`TorMonitor`: Verify using software-versions API

### DIFF
--- a/WalletWasabi/Tor/Http/TorHttpClient.cs
+++ b/WalletWasabi/Tor/Http/TorHttpClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,6 +49,7 @@ public class TorHttpClient : IHttpClient
 
 	/// <exception cref="HttpRequestException">When HTTP request fails to be processed. Inner exception may be an instance of <see cref="TorException"/>.</exception>
 	/// <exception cref="OperationCanceledException">When <paramref name="token"/> is canceled by the user.</exception>
+	/// <inheritdoc cref="SendAsync(HttpRequestMessage, CancellationToken)"/>
 	public async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent? content = null, CancellationToken token = default)
 	{
 		if (BaseUriGetter is null)
@@ -68,6 +70,10 @@ public class TorHttpClient : IHttpClient
 
 	/// <exception cref="HttpRequestException">When <paramref name="request"/> fails to be processed.</exception>
 	/// <exception cref="OperationCanceledException">If <paramref name="token"/> is set.</exception>
+	/// <remarks>
+	/// No exception is thrown when the status code of the <see cref="HttpResponseMessage">response</see>
+	/// is, for example, <see cref="HttpStatusCode.NotFound"/>.
+	/// </remarks>
 	public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
 	{
 		if (Mode is Mode.NewCircuitPerRequest)

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -35,7 +35,7 @@ public class TorMonitor : PeriodicRunner
 		GetStatusUri = new Uri(fallbackBackendUri, "/wabisabi/status");
 	}
 
-	public Uri GetStatusUri { get; }
+	private Uri GetStatusUri { get; }
 	private CancellationTokenSource LoopCts { get; } = new();
 
 	public static bool RequestFallbackAddressUsage { get; private set; }

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -172,10 +172,10 @@ public class TorMonitor : PeriodicRunner
 					{
 						Logger.LogInfo("Tor cannot access remote host. Test fallback URI.");
 						using HttpRequestMessage request = new(HttpMethod.Get, TestApiUri);
-						using HttpResponseMessage response = await HttpClient.SendAsync(request, token).ConfigureAwait(false);
 
-						// Throws if the HTTP status code is not in range 200-299.
-						response.EnsureSuccessStatusCode();
+						// Any HTTP response is fine (e.g. the response message might have the status code 403, 404, etc.) as we test only that
+						// the transport layer works.
+						using HttpResponseMessage response = await HttpClient.SendAsync(request, token).ConfigureAwait(false);
 					}
 					catch (Exception ex)
 					{

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -175,7 +175,7 @@ public class TorMonitor : PeriodicRunner
 						using HttpRequestMessage request = new(HttpMethod.Get, TestApiUri);
 						using HttpResponseMessage response = await HttpClient.SendAsync(request, token).ConfigureAwait(false);
 
-						// Throws if the HTTP status code is in range 200-299.
+						// Throws if the HTTP status code is not in range 200-299.
 						response.EnsureSuccessStatusCode();
 					}
 					catch (Exception ex)

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -28,22 +28,21 @@ public class TorMonitor : PeriodicRunner
 
 	public TorMonitor(TimeSpan period, Uri fallbackBackendUri, TorProcessManager torProcessManager, HttpClientFactory httpClientFactory) : base(period)
 	{
-		FallbackBackendUri = fallbackBackendUri;
 		TorProcessManager = torProcessManager;
 		TorHttpPool = httpClientFactory.TorHttpPool!;
 		HttpClient = httpClientFactory.NewTorHttpClient(Mode.DefaultCircuit);
 		TestApiUri = new Uri(fallbackBackendUri, "/api/Software/versions");
 	}
 
-	private Uri TestApiUri { get; }
 	private CancellationTokenSource LoopCts { get; } = new();
-
 	public static bool RequestFallbackAddressUsage { get; private set; }
+
+	/// <summary>Simple Backend API endpoint that allows us to test whether Backend is actually running or not.</summary>
+	private Uri TestApiUri { get; }
 
 	/// <summary>When the fallback address was started to be used, <c>null</c> if fallback address is not in use.</summary>
 	private DateTime? FallbackStarted { get; set; }
 
-	private Uri FallbackBackendUri { get; }
 	private TorHttpClient HttpClient { get; }
 	private TorProcessManager TorProcessManager { get; }
 	private TorHttpPool TorHttpPool { get; }

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -157,7 +157,7 @@ public class TorMonitor : PeriodicRunner
 
 			if (torMisbehavedFor > CheckIfRunningAfterTorMisbehavedFor)
 			{
-				if (TorHttpPool.LatestTorException is TorConnectCommandFailedException torEx)
+				if (TorHttpPool.LatestTorException is TorConnectCommandFailedException)
 				{
 					// Tor must be running for us to consider switching to the fallback address.
 					bool isRunning = await HttpClient.IsTorRunningAsync().ConfigureAwait(false);


### PR DESCRIPTION
Fixes #8413

This PR is an attempt to improve the clearner switching behavior by verifying using <s>`get-status` API</s> `/api/Software/versions` API.


________________
* https://wasabiwallet.io/wabisabi/status
* http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/status