### PR TITLE
Allow override of backend url

### DIFF
--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -23,5 +23,5 @@ public static class Program
 	public static IHostBuilder CreateHostBuilder(string[] args) =>
 		Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => webBuilder
 			.UseStartup<Startup>()
-			.UseUrls(Environment.GetEnvironmentVariable("WASABI_BIND")?? "http://localhost:37127/");
+			.UseUrls(Environment.GetEnvironmentVariable("WASABI_BIND")?? "http://localhost:37127/"));
 }

--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -23,5 +23,5 @@ public static class Program
 	public static IHostBuilder CreateHostBuilder(string[] args) =>
 		Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => webBuilder
 			.UseStartup<Startup>()
-			.UseUrls("http://localhost:37127/"));
+			.UseUrls(Environment.GetEnvironmentVariable("WASABI_BIND")?? "http://localhost:37127/");
 }


### PR DESCRIPTION
This allows an override of the wasabi backend with an env var, to allow binding the backend to ips dynamically (it is currently impossible to run the backend in a docker image as i need to bind to 0.0.0.0)