### PR TITLE
Reduce buffer of signing to zero

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
@@ -32,7 +32,8 @@ public record TimeFrame
 		}
 		else //if (phase == Phase.TransactionSigning)
 		{
-			bufferTime = TimeSpan.FromMinutes(2);
+			// Clients those didn't update would miss the blame round completely.
+			bufferTime = TimeSpan.Zero;
 		}
 		return HasStarted && (EndTime + bufferTime) < DateTimeOffset.UtcNow;
 	}


### PR DESCRIPTION
I noticed only me getting into the blame rounds, because others are thinking the signing ends and I am using the master. Since testnet mixes were also with the master, it didn't come out at testnet deployment.