### PR TITLE
TorHttpPool: Split lock to allow concurrent Tor circuits creation

### DIFF
--- a/WalletWasabi/Tor/Socks5/Pool/Circuits/DefaultCircuit.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/Circuits/DefaultCircuit.cs
@@ -13,8 +13,9 @@ public class DefaultCircuit : ICircuit
 
 	private static string RandomName = RandomString.CapitalAlphaNumeric(21);
 
-	private DefaultCircuit()
+	private DefaultCircuit(string? purpose = null)
 	{
+		Purpose = purpose;
 	}
 
 	/// <inheritdoc/>
@@ -24,8 +25,18 @@ public class DefaultCircuit : ICircuit
 	public bool IsActive => true;
 
 	/// <inheritdoc/>
+	public string? Purpose { get; }
+
+	/// <inheritdoc/>
 	public override string ToString()
 	{
-		return $"[{nameof(DefaultCircuit)}:{Name}]";
+		if (Purpose is null)
+		{
+			return $"[{nameof(DefaultCircuit)}:{Name}]";
+		}
+		else
+		{
+			return $"[{nameof(PersonCircuit)}:{Name}|{Purpose}]";
+		}
 	}
 }

--- a/WalletWasabi/Tor/Socks5/Pool/Circuits/ICircuit.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/Circuits/ICircuit.cs
@@ -5,6 +5,10 @@ public interface ICircuit
 	/// <summary>Name of the circuit.</summary>
 	string Name { get; }
 
+	/// <summary>What is the circuit for in human readable form.</summary>
+	/// <remarks>For logging purposes only.</remarks>
+	string? Purpose { get; }
+
 	/// <summary>Denotes whether an HTTP(s) request can be sent using the circuit or not anymore.</summary>
 	/// <remarks>
 	/// Flips only from <c>true</c> to <c>false</c>.

--- a/WalletWasabi/Tor/Socks5/Pool/Circuits/PersonCircuit.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/Circuits/PersonCircuit.cs
@@ -11,19 +11,33 @@ public class PersonCircuit : ICircuit, IDisposable
 {
 	private volatile bool _isActive;
 
-	public PersonCircuit()
+	public PersonCircuit(string? purpose = null)
 	{
 		Name = RandomString.CapitalAlphaNumeric(21);
 		_isActive = true;
+		Purpose = purpose;
 	}
+
+	/// <inheritdoc/>
 	public string Name { get; }
 
+	/// <inheritdoc/>
 	public bool IsActive => _isActive;
+
+	/// <inheritdoc/>
+	public string? Purpose { get; }
 
 	/// <inheritdoc/>
 	public override string ToString()
 	{
-		return $"[{nameof(PersonCircuit)}: {Name}]";
+		if (Purpose is null)
+		{
+			return $"[{nameof(PersonCircuit)}: {Name}]";
+		}
+		else
+		{
+			return $"[{nameof(PersonCircuit)}: {Name}|{Purpose}]";
+		}
 	}
 
 	public void Dispose()

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -216,6 +216,7 @@ public class TorHttpPool : IDisposable
 	{
 		Logger.LogTrace($"> request='{request.RequestUri}', circuit={circuit}");
 
+		DateTime start = DateTime.UtcNow;
 		string host = GetRequestHost(request);
 
 		do
@@ -244,7 +245,8 @@ public class TorHttpPool : IDisposable
 					{
 						ConnectionPerHost[host].Add(connection);
 
-						Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Using new Tor SOCKS5 connection.");
+						DateTime end = DateTime.UtcNow;
+						Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'][{(end - start).TotalSeconds:0.##s}] Using new Tor SOCKS5 connection.");
 						return connection;
 					}
 				}

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -1,4 +1,3 @@
-using Nito.AsyncEx;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -39,7 +38,7 @@ public class TorHttpPool : IDisposable
 {
 	/// <summary>Maximum number of <see cref="TorTcpConnection"/>s per URI host.</summary>
 	/// <remarks>This parameter affects maximum parallelization for given URI host.</remarks>
-	public const int MaxConnectionsPerHost = 100;
+	public const int MaxConnectionsPerHost = 1000;
 
 	private bool _disposedValue;
 
@@ -55,11 +54,11 @@ public class TorHttpPool : IDisposable
 	}
 
 	/// <summary>Key is always a URI host. Value is a list of pool connections that can connect to the URI host.</summary>
-	/// <remarks>All access to this object must be guarded by <see cref="ObtainPoolConnectionLock"/>.</remarks>
+	/// <remarks>All access to this object must be guarded by <see cref="ConnectionsLock"/>.</remarks>
 	private Dictionary<string, List<TorTcpConnection>> ConnectionPerHost { get; } = new();
 
-	/// <remarks>Lock object required for the combination of <see cref="TorTcpConnection"/> selection or creation in <see cref="ObtainFreeConnectionAsync(HttpRequestMessage, ICircuit, CancellationToken)"/>.</remarks>
-	private AsyncLock ObtainPoolConnectionLock { get; } = new();
+	/// <remarks>Lock object to guard <see cref="ConnectionPerHost"/>.</remarks>
+	private object ConnectionsLock { get; } = new();
 
 	private TorTcpConnectionFactory TcpConnectionFactory { get; }
 
@@ -97,7 +96,7 @@ public class TorHttpPool : IDisposable
 	/// <item>Keep waiting 1 second until any of the previous rules cannot be used.</item>
 	/// </list>
 	/// </para>
-	/// <para><see cref="ObtainPoolConnectionLock"/> is acquired only for <see cref="TorTcpConnection"/> selection.</para>
+	/// <para><see cref="ConnectionsLock"/> is acquired only for <see cref="TorTcpConnection"/> selection.</para>
 	/// </summary>
 	/// <exception cref="HttpRequestException">When <paramref name="request"/> fails to be processed.</exception>
 	/// <exception cref="OperationCanceledException">When the operation was canceled.</exception>
@@ -221,34 +220,40 @@ public class TorHttpPool : IDisposable
 
 		do
 		{
-			using (await ObtainPoolConnectionLock.LockAsync(token).ConfigureAwait(false))
+			bool canBeAdded;
+			TorTcpConnection? connection;
+
+			lock (ConnectionsLock)
 			{
-				bool canBeAdded = GetPoolConnectionNoLock(host, circuit, out TorTcpConnection? connection);
+				canBeAdded = GetPoolConnectionNoLock(host, circuit, out connection);
 
 				if (connection is not null)
 				{
 					Logger.LogTrace($"[OLD {connection}]['{request.RequestUri}'] Re-use existing Tor SOCKS5 connection.");
 					return connection;
 				}
+			}
 
-				// The circuit may be disposed almost immediately after this check but we don't mind.
-				if (!circuit.IsActive)
+			// The circuit may be disposed almost immediately after this check but we don't mind.
+			if (!circuit.IsActive)
+			{
+				throw new TorCircuitExpiredException();
+			}
+
+			if (canBeAdded)
+			{
+				connection = await CreateNewConnectionAsync(request, circuit, token).ConfigureAwait(false);
+
+				if (connection is not null)
 				{
-					throw new TorCircuitExpiredException();
-				}
-
-				if (canBeAdded)
-				{
-					connection = await CreateNewConnectionAsync(request, circuit, token).ConfigureAwait(false);
-
-					if (connection is not null)
+					lock (ConnectionsLock)
 					{
 						ConnectionPerHost[host].Add(connection);
-
-						DateTime end = DateTime.UtcNow;
-						Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'][{(end - start).TotalSeconds:0.##s}] Using new Tor SOCKS5 connection.");
-						return connection;
 					}
+
+					DateTime end = DateTime.UtcNow;
+					Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'][{(end - start).TotalSeconds:0.##s}] Using new Tor SOCKS5 connection.");
+					return connection;
 				}
 			}
 
@@ -329,9 +334,9 @@ public class TorHttpPool : IDisposable
 	/// Useful to clean up <see cref="ConnectionPerHost"/> so that we do not exhaust <see cref="MaxConnectionsPerHost"/> limit.
 	/// <para>If client code forgets to dispose <see cref="PersonCircuit"/>, this should help us to recover eventually.</para>
 	/// </remarks>
-	public async Task ReportCircuitClosedAsync(string circuitName, CancellationToken cancellationToken)
+	public void ReportCircuitClosed(string circuitName)
 	{
-		using (await ObtainPoolConnectionLock.LockAsync(cancellationToken).ConfigureAwait(false))
+		lock (ConnectionsLock)
 		{
 			foreach ((string host, List<TorTcpConnection> tcpConnections) in ConnectionPerHost)
 			{
@@ -355,7 +360,7 @@ public class TorHttpPool : IDisposable
 	/// <param name="host">URI's host value.</param>
 	/// <param name="circuit">Tor circuit for which to get a TCP connection.</param>
 	/// <returns>Whether a connection can be added to <see cref="ConnectionPerHost"/> and reserved connection to use, if any.</returns>
-	/// <remarks>Guarded by <see cref="ObtainPoolConnectionLock"/>.</remarks>
+	/// <remarks>Guarded by <see cref="ConnectionsLock"/>.</remarks>
 	private bool GetPoolConnectionNoLock(string host, ICircuit circuit, out TorTcpConnection? connection)
 	{
 		if (!ConnectionPerHost.ContainsKey(host))

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -120,7 +120,7 @@ public class TorMonitor : PeriodicRunner
 						if (info.CircStatus == CircStatus.CLOSED && info.UserName is not null)
 						{
 							Logger.LogTrace($"Tor circuit #{info.CircuitID} ('{info.UserName}') was closed.");
-							await TorHttpPool.ReportCircuitClosedAsync(info.UserName, linkedCts.Token).ConfigureAwait(false);
+							TorHttpPool.ReportCircuitClosed(info.UserName);
 						}
 					}
 				}

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -65,7 +65,7 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 	{
 		var exceptions = new List<Exception>();
 
-		var start = DateTime.Now;
+		var start = DateTime.UtcNow;
 
 		for (var attempt = 0; attempt < MaxRetries; attempt++)
 		{
@@ -74,9 +74,9 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 				using StringContent content = new(jsonString, Encoding.UTF8, "application/json");
 
 				// Any transport layer errors will throw an exception here.
-				var response = await _client.SendAsync(HttpMethod.Post, GetUriEndPoint(action), content, cancellationToken).ConfigureAwait(false);
+				HttpResponseMessage response = await _client.SendAsync(HttpMethod.Post, GetUriEndPoint(action), content, cancellationToken).ConfigureAwait(false);
 
-				var totalTime = DateTime.Now - start;
+				TimeSpan totalTime = DateTime.UtcNow - start;
 
 				if (exceptions.Any())
 				{


### PR DESCRIPTION
Related to #8452

Some measured times:

```log
2022-06-20 10:36:01.304 TorHttpPool.ObtainFreeConnectionAsync [..]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/software/versions'][8.28s] Using new Tor SOCKS5 connection.
2022-06-20 10:48:57.056 TorHttpPool.ObtainFreeConnectionAsync [..]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'][11.02s] Using new Tor SOCKS5 connection.
2022-06-20 10:49:58.738 TorHttpPool.ObtainFreeConnectionAsync [..]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/connection-confirmation'][0.68s] Using new Tor SOCKS5 connection.
2022-06-20 10:55:57.288 TorHttpPool.ObtainFreeConnectionAsync [..]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'][16.41s] Using new Tor SOCKS5 connection.
```