### PR TITLE
Timeout fast when previous phase failed

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -173,14 +173,14 @@ public partial class Arena : PeriodicRunner
 						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
 
 						// Cliens misbehave when they don't confirm everything.
-						if (round is BlameRound)
+						//if (round is BlameRound)
 						{
 							// Unfortunately we would stop the blame round chain completely so we must go to output registration even though we know we'll fail.
 							round.SetPhase(Phase.OutputRegistration);
 						}
-						else
+						//else
 						{
-							round.EndRound(EndRoundState.AbortedNotAllAlicesConfirmed);
+							//	round.EndRound(EndRoundState.AbortedNotAllAlicesConfirmed);
 						}
 					}
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -170,7 +170,6 @@ public partial class Arena : PeriodicRunner
 					else
 					{
 						round.OutputRegistrationTimeFrame = TimeFrame.Create(Config.FailFastOutputRegistrationTimeout);
-						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
 
 						// Cliens misbehave when they don't confirm everything.
 						if (round is BlameRound)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -169,6 +169,9 @@ public partial class Arena : PeriodicRunner
 					}
 					else
 					{
+						round.OutputRegistrationTimeFrame = TimeFrame.Create(Config.FailFastOutputRegistrationTimeout);
+						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
+
 						// Cliens misbehave when they don't confirm everything.
 						if (round is BlameRound)
 						{
@@ -197,8 +200,9 @@ public partial class Arena : PeriodicRunner
 			try
 			{
 				var allReady = round.Alices.All(a => a.ReadyToSign);
+				bool phaseExpired = round.OutputRegistrationTimeFrame.HasExpired(Phase.OutputRegistration);
 
-				if (allReady || round.OutputRegistrationTimeFrame.HasExpired(Phase.OutputRegistration))
+				if (allReady || phaseExpired)
 				{
 					var coinjoin = round.Assert<ConstructionState>();
 
@@ -211,6 +215,11 @@ public partial class Arena : PeriodicRunner
 					coinjoin = await TryAddBlameScriptAsync(round, coinjoin, allReady, round.CoordinatorScript, cancellationToken).ConfigureAwait(false);
 
 					round.CoinjoinState = coinjoin.Finalize();
+
+					if (!allReady && phaseExpired)
+					{
+						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
+					}
 
 					round.SetPhase(Phase.TransactionSigning);
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -173,14 +173,14 @@ public partial class Arena : PeriodicRunner
 						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
 
 						// Cliens misbehave when they don't confirm everything.
-						//if (round is BlameRound)
+						if (round is BlameRound)
 						{
 							// Unfortunately we would stop the blame round chain completely so we must go to output registration even though we know we'll fail.
 							round.SetPhase(Phase.OutputRegistration);
 						}
-						//else
+						else
 						{
-							//	round.EndRound(EndRoundState.AbortedNotAllAlicesConfirmed);
+							round.EndRound(EndRoundState.AbortedNotAllAlicesConfirmed);
 						}
 					}
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -60,8 +60,8 @@ public class Round
 	public Phase Phase { get; private set; } = Phase.InputRegistration;
 	public TimeFrame InputRegistrationTimeFrame { get; internal set; }
 	public TimeFrame ConnectionConfirmationTimeFrame { get; private set; }
-	public TimeFrame OutputRegistrationTimeFrame { get; private set; }
-	public TimeFrame TransactionSigningTimeFrame { get; private set; }
+	public TimeFrame OutputRegistrationTimeFrame { get; set; }
+	public TimeFrame TransactionSigningTimeFrame { get; set; }
 	public DateTimeOffset End { get; private set; }
 	public EndRoundState EndRoundState { get; set; }
 	public int RemainingInputVsizeAllocation => Parameters.InitialInputVsizeAllocation - (InputCount * Parameters.MaxVsizeAllocationPerAlice);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -75,9 +75,9 @@ public record RoundParameters
 	// Anyway, it really doesn't matter for us as it is a reasonable limit so, it doesn't affect us
 	// negatively in any way.
 	public int MaxTransactionSize { get; init; } = StandardTransactionPolicy.MaxTransactionSize ?? 100_000;
-	public FeeRate MinRelayTxFee { get; init; } = StandardTransactionPolicy.MinRelayTxFee 
-	                                              ?? new FeeRate(Money.Satoshis(1000));
-		
+	public FeeRate MinRelayTxFee { get; init; } = StandardTransactionPolicy.MinRelayTxFee
+												  ?? new FeeRate(Money.Satoshis(1000));
+
 	public static RoundParameters Create(
 		WabiSabiConfig wabiSabiConfig,
 		Network network,

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -70,6 +70,14 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "TransactionSigningTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan TransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
+	[DefaultValueTimeSpan("0d 0h 3m 0s")]
+	[JsonProperty(PropertyName = "FailFastOutputRegistrationTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public TimeSpan FailFastOutputRegistrationTimeout { get; set; } = TimeSpan.FromMinutes(3);
+
+	[DefaultValueTimeSpan("0d 0h 1m 0s")]
+	[JsonProperty(PropertyName = "FailFastTransactionSigningTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public TimeSpan FailFastTransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
 	[DefaultValueTimeSpan("0d 0h 5m 0s")]
 	[JsonProperty(PropertyName = "RoundExpiryTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan RoundExpiryTimeout { get; set; } = TimeSpan.FromMinutes(5);


### PR DESCRIPTION
When we already know that the previous phase failed, then we have an opportunity to make the followup phases faster to blame. 

fixes https://github.com/zkSNACKs/WalletWasabi/issues/8447 
fixes https://github.com/zkSNACKs/WalletWasabi/issues/8448 
fixes https://github.com/zkSNACKs/WalletWasabi/issues/8450
fixes https://github.com/zkSNACKs/WalletWasabi/issues/8451