### PR TITLE
Revert buffer time

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -104,7 +104,7 @@ public partial class Arena : PeriodicRunner
 
 				if (round.InputCount < Config.MinInputCountByRound)
 				{
-					if (!round.InputRegistrationTimeFrame.HasExpired(Phase.InputRegistration))
+					if (!round.InputRegistrationTimeFrame.HasExpired)
 					{
 						continue;
 					}
@@ -137,7 +137,7 @@ public partial class Arena : PeriodicRunner
 				{
 					round.SetPhase(Phase.OutputRegistration);
 				}
-				else if (round.ConnectionConfirmationTimeFrame.HasExpired(Phase.ConnectionConfirmation))
+				else if (round.ConnectionConfirmationTimeFrame.HasExpired)
 				{
 					var alicesDidntConfirm = round.Alices.Where(x => !x.ConfirmedConnection).ToArray();
 					foreach (var alice in alicesDidntConfirm)
@@ -199,7 +199,7 @@ public partial class Arena : PeriodicRunner
 			try
 			{
 				var allReady = round.Alices.All(a => a.ReadyToSign);
-				bool phaseExpired = round.OutputRegistrationTimeFrame.HasExpired(Phase.OutputRegistration);
+				bool phaseExpired = round.OutputRegistrationTimeFrame.HasExpired;
 
 				if (allReady || phaseExpired)
 				{
@@ -301,7 +301,7 @@ public partial class Arena : PeriodicRunner
 					CoinJoinScriptStore?.AddRange(coinjoin.Outputs.Select(x => x.ScriptPubKey));
 					CoinJoinBroadcast?.Invoke(this, coinjoin);
 				}
-				else if (round.TransactionSigningTimeFrame.HasExpired(Phase.TransactionSigning))
+				else if (round.TransactionSigningTimeFrame.HasExpired)
 				{
 					round.LogWarning($"Signing phase failed with timed out after {round.TransactionSigningTimeFrame.Duration.TotalSeconds} seconds.");
 					await FailTransactionSigningPhaseAsync(round, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -122,7 +122,7 @@ public class Round
 			return true;
 		}
 
-		return InputRegistrationTimeFrame.HasExpired(Phase.InputRegistration);
+		return InputRegistrationTimeFrame.HasExpired;
 	}
 
 	public ConstructionState AddInput(Coin coin)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
@@ -15,28 +15,7 @@ public record TimeFrame
 	public DateTimeOffset StartTime { get; init; }
 	public TimeSpan Duration { get; init; }
 	public bool HasStarted => StartTime > DateTimeOffset.MinValue && StartTime < DateTimeOffset.UtcNow;
-	public bool HasExpired(Phase phase)
-	{
-		TimeSpan bufferTime;
-		if (phase == Phase.InputRegistration)
-		{
-			bufferTime = TimeSpan.Zero;
-		}
-		else if (phase == Phase.ConnectionConfirmation)
-		{
-			bufferTime = TimeSpan.Zero;
-		}
-		else if (phase == Phase.OutputRegistration)
-		{
-			bufferTime = TimeSpan.FromMinutes(1);
-		}
-		else //if (phase == Phase.TransactionSigning)
-		{
-			// Clients those didn't update would miss the blame round completely.
-			bufferTime = TimeSpan.Zero;
-		}
-		return HasStarted && (EndTime + bufferTime) < DateTimeOffset.UtcNow;
-	}
+	public bool HasExpired => HasStarted && EndTime < DateTimeOffset.UtcNow;
 
 	public TimeFrame StartNow() => this with { StartTime = DateTimeOffset.UtcNow };
 }


### PR DESCRIPTION
It turns out buffer time makes no sense at all. For input registration it misbehaves, for conn conf I don't remember, but probably it also misbehaves, one might test this, but for the rest the Poisson does not extend to the full length of the timeouts, so with the buffer time we cannot make the software to hurry.

Resolves https://github.com/zkSNACKs/WalletWasabi/issues/8429
Resolves https://github.com/zkSNACKs/WalletWasabi/issues/8422