### PR TITLE
Chaos monkey

### DIFF
--- a/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
+++ b/WalletWasabi.Tests/Helpers/HttpClientWrapper.cs
@@ -24,3 +24,29 @@ public class HttpClientWrapper : IHttpClient
 		return HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
 	}
 }
+
+public class HttpClientWrapperWithMonkeys : IHttpClient
+{
+	public delegate Task Monkey();
+
+	private Monkey[] _monkeys;
+
+	public HttpClientWrapperWithMonkeys(IHttpClient httpClient, params Monkey[] monkeys)
+	{
+		HttpClient = httpClient;
+		_monkeys = monkeys;
+	}
+
+	private IHttpClient HttpClient { get; }
+
+	public Func<Uri>? BaseUriGetter => HttpClient.BaseUriGetter;
+
+	public virtual async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
+	{
+		foreach (var monkey in _monkeys)
+		{
+			await monkey();
+		}
+		return await HttpClient.SendAsync(request, token);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -415,8 +415,16 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 	}
 
 	[Theory]
-	[InlineData(123456)]
-	public async Task MultiClientsCoinJoinTestAsync(int seed)
+	[InlineData(123456, 0.00, 0.00)]
+	//[InlineData(123456, 0.01, 0.01)]
+	//[InlineData(123456, 0.10, 0.00)] // Highly aggressive monkey.
+	//[InlineData(123456, 0.00, 0.10)] // Highly aggressive monkey.
+	//[InlineData(123456, 0.05, 0.05)] // Concurrency of aggressive monkeys
+	//[InlineData(123456, 0.10, 0.10)]
+	public async Task MultiClientsCoinJoinTestAsync(
+		int seed,
+		double faultInjectorMonkeyAggressiveness,
+		double delayInjectorMonkeyAggressiveness)
 	{
 		const int NumberOfParticipants = 10;
 		const int NumberOfCoinsPerParticipant = 2;
@@ -436,17 +444,35 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					services.AddScoped<WabiSabiConfig>(s => new WabiSabiConfig(Path.GetTempFileName())
 					{
 						MaxRegistrableAmount = Money.Coins(500m),
-						MaxInputCountByRound = ExpectedInputNumber,
-						StandardInputRegistrationTimeout = TimeSpan.FromSeconds(10 * ExpectedInputNumber),
-						ConnectionConfirmationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
-						OutputRegistrationTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
-						TransactionSigningTimeout = TimeSpan.FromSeconds(20 * ExpectedInputNumber),
+						MaxInputCountByRound = (int)(ExpectedInputNumber / (1 + 10 * (faultInjectorMonkeyAggressiveness + delayInjectorMonkeyAggressiveness)) ),
+						StandardInputRegistrationTimeout = TimeSpan.FromSeconds(5 * ExpectedInputNumber),
+						BlameInputRegistrationTimeout = TimeSpan.FromSeconds(2 * ExpectedInputNumber),
+						ConnectionConfirmationTimeout = TimeSpan.FromSeconds(2 * ExpectedInputNumber),
+						OutputRegistrationTimeout = TimeSpan.FromSeconds(3 * ExpectedInputNumber),
+						TransactionSigningTimeout = TimeSpan.FromSeconds(2 * ExpectedInputNumber),
 						MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 					});
 				}));
 
 			using PersonCircuit personCircuit = new();
-			IHttpClient httpClientWrapper = new HttpClientWrapper(app.CreateClient());
+			IHttpClient httpClientWrapper = new HttpClientWrapperWithMonkeys(
+				new HttpClientWrapper(app.CreateClient()),
+				// This monkey injects `HttpRequestException` randomly to simulate errors
+				// in the communication.
+				() =>
+				{
+					if (Random.Shared.NextDouble() < faultInjectorMonkeyAggressiveness)
+					{
+						throw new HttpRequestException("Crazy monkey hates you, donkey.");
+					}
+					return Task.CompletedTask;
+				},
+				// This monkey injects `Delays` randomly to simulate slow response times.
+				async () =>
+				{
+					var delay = Random.Shared.NextDouble();
+					await Task.Delay(TimeSpan.FromSeconds(5 * delayInjectorMonkeyAggressiveness));
+				});
 
 			var mockHttpClientFactory = new Mock<IWasabiHttpClientFactory>(MockBehavior.Strict);
 			mockHttpClientFactory
@@ -462,7 +488,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				.Returns(httpClientWrapper);
 
 			// Total test timeout.
-			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(40 * ExpectedInputNumber));
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(70 * ExpectedInputNumber));
 
 			var participants = Enumerable
 				.Range(0, NumberOfParticipants)
@@ -489,19 +515,25 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				{
 					throw new TimeoutException("Coinjoin was not propagated.");
 				}
+				await Task.Delay(1_000, cts.Token);
 
-				await Task.Delay(500, cts.Token);
-
-				if (tasks.FirstOrDefault(t => t.IsFaulted)?.Exception is { } exc)
+				if (tasks.All(t => t.IsCompleted))
 				{
-					throw exc;
+					throw new Exception();
 				}
 			}
 			var mempool = await rpc.GetRawMempoolAsync();
 			var coinjoin = await rpc.GetRawTransactionAsync(mempool.Single());
 
 			Assert.True(coinjoin.Outputs.Count <= ExpectedInputNumber);
-			Assert.Equal(ExpectedInputNumber, coinjoin.Inputs.Count);
+
+			// Only if all things work okay we can expect all the inputs and outputs to
+			// be registered. In those cases where we have monkeys, more aggressive they
+			// are, less inputs and outputs can be registered .
+			if (faultInjectorMonkeyAggressiveness <= 0.00001 && delayInjectorMonkeyAggressiveness <= 0.00001)
+			{
+				Assert.Equal(ExpectedInputNumber, coinjoin.Inputs.Count);
+			}
 		}
 		finally
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -380,7 +380,15 @@ public class CoinJoinClient
 				{
 					await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 				}
-				await aliceClient.ReadyToSignAsync(cancellationToken).ConfigureAwait(false);
+
+				try
+				{
+					await aliceClient.ReadyToSignAsync(cancellationToken).ConfigureAwait(false);
+				}
+				catch (Exception e)
+				{
+					// This cannot fail. Otherwise the whole conjoin process will be halted.
+				}
 			})
 			.ToImmutableArray();
 
@@ -652,18 +660,25 @@ public class CoinJoinClient
 		DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(inputEffectiveValuesAndSizes, outputTxOuts, roundParameters.MiningFeeRate, roundParameters.CoordinationFeeRate, roundParameters.MaxVsizeAllocationPerAlice);
 		DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
 
-		// Re-issuances.
-		var bobClient = CreateBobClient(roundState);
-		roundState.LogInfo("Starting reissuances.");
 		var combinedToken = linkedCts.Token;
-		await scheduler.StartReissuancesAsync(registeredAliceClients, bobClient, combinedToken).ConfigureAwait(false);
+		try
+		{
+			// Re-issuances.
+			var bobClient = CreateBobClient(roundState);
+			roundState.LogInfo("Starting reissuances.");
+			await scheduler.StartReissuancesAsync(registeredAliceClients, bobClient, combinedToken).ConfigureAwait(false);
 
-		// Output registration.
-		roundState.LogDebug($"Output registration started - it will end in: {outputRegistrationEndTime - DateTimeOffset.UtcNow:hh\\:mm\\:ss}.");
+			// Output registration.
+			roundState.LogDebug($"Output registration started - it will end in: {outputRegistrationEndTime - DateTimeOffset.UtcNow:hh\\:mm\\:ss}.");
 
-		var outputRegistrationScheduledDates = GetScheduledDates(outputTxOuts.Count(), outputRegistrationEndTime, MaximumRequestDelay);
-		await scheduler.StartOutputRegistrationsAsync(outputTxOuts, bobClient, KeyChain, outputRegistrationScheduledDates, combinedToken).ConfigureAwait(false);
-		roundState.LogDebug($"Outputs({outputTxOuts.Count()}) were registered.");
+			var outputRegistrationScheduledDates = GetScheduledDates(outputTxOuts.Count(), outputRegistrationEndTime, MaximumRequestDelay);
+			await scheduler.StartOutputRegistrationsAsync(outputTxOuts, bobClient, KeyChain, outputRegistrationScheduledDates, combinedToken).ConfigureAwait(false);
+			roundState.LogDebug($"Outputs({outputTxOuts.Count()}) were registered.");
+		}
+		catch (Exception e)
+		{
+			roundState.LogInfo($"Failed to register outputs. Ignoring...");
+		}
 
 		// ReadyToSign.
 		roundState.LogDebug($"ReadyToSign phase started - it will end in: {readyToSignEndTime - DateTimeOffset.UtcNow:hh\\:mm\\:ss}.");

--- a/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
@@ -182,6 +182,10 @@ public class DependencyGraphTaskScheduler
 						hdPubKey.SetKeyState(KeyState.Used);
 					}
 				}
+				catch (Exception ex)
+				{
+					Logger.LogDebug($"Output registration error message:'{ex.Message}'.");
+				}
 			}
 		).ToImmutableArray();
 


### PR DESCRIPTION
This PR introduces the concept of chaos monkey in the communication channels by adding random exceptions and random delays in the response, what allowed us to discover cases in which the coinjoin process was aborted by exceptions.

After fixing those bugs the tests can finish successfully even with the monkeys creating chaos. 
Closes https://github.com/zkSNACKs/WalletWasabi/issues/8462