### PR TITLE
Log phase duration in case of late requests, so we can analyze it

### DIFF
--- a/WalletWasabi.Backend/Filters/LateResponseLoggerFilter.cs
+++ b/WalletWasabi.Backend/Filters/LateResponseLoggerFilter.cs
@@ -15,6 +15,6 @@ public class LateResponseLoggerFilter : ExceptionFilterAttribute
 
 		var actionName = ((Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor)context.ActionDescriptor).ActionName;
 
-		Logger.LogInfo($"Request '{actionName}' missing the phase '{string.Join(",", ex.ExpectedPhases)}' by '{ex.Late}'. Round id '{ex.RoundId}' is in phase '{ex.CurrentPhase}'.");
+		Logger.LogInfo($"Request '{actionName}' missing the phase '{string.Join(",", ex.ExpectedPhases)}' ('{ex.PhaseTimeout}' timeout) by '{ex.Late}'. Round id '{ex.RoundId}'.");
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
@@ -11,11 +11,12 @@ namespace WalletWasabi.WabiSabi.Backend.Models;
 public class WrongPhaseException : WabiSabiProtocolException
 {
 	public TimeSpan Late { get; }
+	public TimeSpan PhaseTimeout { get; }
 	public Phase CurrentPhase { get; }
 	public Phase[] ExpectedPhases { get; }
 	public uint256 RoundId { get; }
 
-	public WrongPhaseException(Round round, params Phase[] expectedPhases) 
+	public WrongPhaseException(Round round, params Phase[] expectedPhases)
 		: base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).")
 	{
 		var latestExpectedPhase = expectedPhases.MaxBy(p => (int)p);
@@ -32,6 +33,17 @@ public class WrongPhaseException : WabiSabiProtocolException
 		};
 
 		Late = now - endTime;
+
+		PhaseTimeout = round.Phase switch
+		{
+			Phase.InputRegistration => round.InputRegistrationTimeFrame.Duration,
+			Phase.ConnectionConfirmation => round.ConnectionConfirmationTimeFrame.Duration,
+			Phase.OutputRegistration => round.OutputRegistrationTimeFrame.Duration,
+			Phase.TransactionSigning => round.TransactionSigningTimeFrame.Duration,
+			Phase.Ended => TimeSpan.Zero,
+			_ => throw new ArgumentException($"Unknown phase {latestExpectedPhase}.")
+		};
+
 		CurrentPhase = round.Phase;
 		RoundId = round.Id;
 		ExpectedPhases = expectedPhases;


### PR DESCRIPTION
Fixes: #8449

So we can analyze it and fine-tune the config if it's needed.