### PR TITLE
[trivial] Fix analyzer error.

### DIFF
--- a/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
@@ -88,14 +88,15 @@ public class DependencyGraphTaskScheduler
 
 		// Build tasks and link them together.
 		List<SmartRequestNode> smartRequestNodes = new();
-		List<Task> allTasks = new();
-
-		// Temporary workaround because we don't yet have a mechanism to
-		// propagate the final amounts to request amounts to AliceClient's
-		// connection confirmation loop even though they are already known
-		// after the final successful input registration, which may be well
-		// before the connection confirmation phase actually starts.
-		allTasks.Add(CompleteConnectionConfirmationAsync(aliceClients, bobClient, cancellationToken));
+		List<Task> allTasks = new()
+		{
+			// Temporary workaround because we don't yet have a mechanism to
+			// propagate the final amounts to request amounts to AliceClient's
+			// connection confirmation loop even though they are already known
+			// after the final successful input registration, which may be well
+			// before the connection confirmation phase actually starts.
+			CompleteConnectionConfirmationAsync(aliceClients, bobClient, cancellationToken)
+		};
 
 		using CancellationTokenSource ctsOnError = new();
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ctsOnError.Token);


### PR DESCRIPTION
Visual Studio shows an analyzer error without this patch. It's distracting. No need to merge any time soon.