### PR TITLE
Implement parallel rounds

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -81,7 +81,7 @@ public partial class Arena : PeriodicRunner
 			await CreateRoundsAsync(cancel).ConfigureAwait(false);
 
 			// RoundStates have to contain all states. Do not change stateId=0.
-			RoundStates = Rounds.ToShuffled().Select(r => RoundState.FromRound(r, stateId: 0)).ToImmutableArray();
+			RoundStates = Rounds.OrderBy(x => x.InputCount).Select(r => RoundState.FromRound(r, stateId: 0)).ToImmutableArray();
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -384,7 +384,7 @@ public partial class Arena : PeriodicRunner
 
 	private async Task CreateRoundsAsync(CancellationToken cancellationToken)
 	{
-		var registrableRoundCount = Rounds.Count(x => x is not BlameRound && x.Phase == Phase.InputRegistration);
+		var registrableRoundCount = Rounds.Count(x => x is not BlameRound && x.Phase == Phase.InputRegistration && x.InputRegistrationTimeFrame.Remaining > TimeSpan.FromMinutes(1));
 		int roundsToCreate = Config.ParallelRounds - registrableRoundCount;
 		for (int i = 0; i < roundsToCreate; i++)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -81,7 +81,7 @@ public partial class Arena : PeriodicRunner
 			await CreateRoundsAsync(cancel).ConfigureAwait(false);
 
 			// RoundStates have to contain all states. Do not change stateId=0.
-			RoundStates = Rounds.OrderBy(x => x.InputCount).Select(r => RoundState.FromRound(r, stateId: 0)).ToImmutableArray();
+			RoundStates = Rounds.ToShuffled().Select(r => RoundState.FromRound(r, stateId: 0)).ToImmutableArray();
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/TimeFrame.cs
@@ -14,6 +14,7 @@ public record TimeFrame
 	public DateTimeOffset EndTime => StartTime + Duration;
 	public DateTimeOffset StartTime { get; init; }
 	public TimeSpan Duration { get; init; }
+	public TimeSpan Remaining => EndTime - DateTimeOffset.UtcNow;
 	public bool HasStarted => StartTime > DateTimeOffset.MinValue && StartTime < DateTimeOffset.UtcNow;
 	public bool HasExpired => HasStarted && EndTime < DateTimeOffset.UtcNow;
 

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -108,6 +108,10 @@ public class WabiSabiConfig : ConfigBase
 	[JsonConverter(typeof(MoneyBtcJsonConverter))]
 	public Money MaxSuggestedAmountBase { get; set; } = Money.Coins(0.1m);
 
+	[DefaultValue(1)]
+	[JsonProperty(PropertyName = "ParallelRounds", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public int ParallelRounds { get; set; } = 1;
+
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs
@@ -36,7 +36,7 @@ public record RoundStateAwaiter
 
 	public Task<RoundState> Task => TaskCompletionSource.Task;
 
-	public bool IsCompleted(ImmutableDictionary<uint256, RoundState> allRoundStates)
+	public bool IsCompleted(IDictionary<uint256, RoundState> allRoundStates)
 	{
 		if (Task.IsCompleted)
 		{

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -52,6 +52,7 @@ public class RoundStateUpdater : PeriodicRunner
 			.Where(rs => !RoundStates.ContainsKey(rs.Id));
 
 		// Don't use ToImmutable dictionary, because that ruins the original order and makes the server unable to suggest a round preference.
+		// ToDo: ToDictionary doesn't guarantee the order by design so .NET team might change this out of our feet, so there's room for improvement here.
 		RoundStates = newRoundStates.Concat(updatedRoundStates)
 			.ToDictionary(x => x.Id, x => x);
 

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -20,7 +20,7 @@ public class RoundStateUpdater : PeriodicRunner
 	}
 
 	private IWabiSabiApiRequestHandler ArenaRequestHandler { get; }
-	private ImmutableDictionary<uint256, RoundState> RoundStates { get; set; } = ImmutableDictionary.Create<uint256, RoundState>();
+	private IDictionary<uint256, RoundState> RoundStates { get; set; } = new Dictionary<uint256, RoundState>();
 	public Dictionary<TimeSpan, FeeRate> CoinJoinFeeRateMedians { get; private set; } = new();
 
 	private List<RoundStateAwaiter> Awaiters { get; } = new();
@@ -51,7 +51,9 @@ public class RoundStateUpdater : PeriodicRunner
 		var newRoundStates = statusResponse
 			.Where(rs => !RoundStates.ContainsKey(rs.Id));
 
-		RoundStates = newRoundStates.Concat(updatedRoundStates).ToImmutableDictionary(x => x.Id, x => x);
+		// Don't use ToImmutable dictionary, because that ruins the original order and makes the server unable to suggest a round preference.
+		RoundStates = newRoundStates.Concat(updatedRoundStates)
+			.ToDictionary(x => x.Id, x => x);
 
 		lock (AwaitersLock)
 		{


### PR DESCRIPTION
Now coinjoins are failing because we have too many users. This PR introduces the concept of running multiple rounds in parallel depending on the configuration.

This also orders the round state response based on input count so the first state will be returned has the least amount of inputs so we can balance the load.  

This does not work on regtest in the sense that my clients still keep registering to the exact same round and I am not sure why that's happening as when I reviewed the client code it seemed to be keeping the order it got from the server. I have a theory though: maybe that it's because the regtest wallets share the same status response and that's somehow ensures old order. We'll have to test this on testnet.

Edit: it won't work. It'll help a bit though. The good news is that I made the client side work here and incidentally this solves the migration to WW2.0.1 @lontivero