### PR TITLE
Abort pending requests when we are late

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -37,7 +37,7 @@ public class AliceTimeoutTests
 		var keyChain = new KeyChain(km, new Kitchen(""));
 
 		using CancellationTokenSource cancellationTokenSource = new();
-		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, cancellationTokenSource.Token);
+		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, cancellationTokenSource.Token, CancellationToken.None);
 
 		while (round.Alices.Count == 0)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -197,8 +197,8 @@ public class StepOutputRegistrationTests
 
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None);
 
 		while (Phase.ConnectionConfirmation != round.Phase)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -240,8 +240,8 @@ public class StepTransactionSigningTests
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None);
 
 		while (Phase.OutputRegistration != round.Phase)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -57,7 +57,7 @@ public class BobClientTests
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
 		var keyChain = new KeyChain(km, new Kitchen(""));
-		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), aliceArenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None);
+		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), aliceArenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None);
 
 		do
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -172,7 +172,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(mockHttpClientFactory.Object, keyManager, roundStateUpdater);
 
 		// Run the coinjoin client task.
-		var coinjoinResult = (await coinJoinClient.StartCoinJoinAsync(coins, cts.Token));
+		var coinjoinResult = await coinJoinClient.StartCoinJoinAsync(coins, cts.Token);
 		Assert.True(coinjoinResult.SuccessfulBroadcast);
 
 		var broadcastedTx = await transactionCompleted.Task; // wait for the transaction to be broadcasted.

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -134,7 +134,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				// services to build everything (WabiSabi controller, arena, etc)
 				services.AddScoped(s => new WabiSabiConfig
 				{
-					MaxInputCountByRound = inputCount,
+					MaxInputCountByRound = inputCount - 1,  // Make sure that at least one IR fails for WrongPhase
 					StandardInputRegistrationTimeout = TimeSpan.FromSeconds(60),
 					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(60),
 					OutputRegistrationTimeout = TimeSpan.FromSeconds(60),
@@ -172,7 +172,8 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(mockHttpClientFactory.Object, keyManager, roundStateUpdater);
 
 		// Run the coinjoin client task.
-		Assert.True((await coinJoinClient.StartCoinJoinAsync(coins, cts.Token)).SuccessfulBroadcast);
+		var coinjoinResult = (await coinJoinClient.StartCoinJoinAsync(coins, cts.Token));
+		Assert.True(coinjoinResult.SuccessfulBroadcast);
 
 		var broadcastedTx = await transactionCompleted.Task; // wait for the transaction to be broadcasted.
 		Assert.NotNull(broadcastedTx);

--- a/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
@@ -17,7 +17,7 @@ public class WrongPhaseException : WabiSabiProtocolException
 	public uint256 RoundId { get; }
 
 	public WrongPhaseException(Round round, params Phase[] expectedPhases)
-		: base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).")
+		: base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).", exceptionData: new WrongPhaseExceptionData(round.Phase))
 	{
 		var latestExpectedPhase = expectedPhases.MaxBy(p => (int)p);
 		var now = DateTimeOffset.UtcNow;

--- a/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseExceptionData.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseExceptionData.cs
@@ -1,0 +1,6 @@
+using Newtonsoft.Json;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+
+namespace WalletWasabi.WabiSabi.Backend.Models;
+
+public record WrongPhaseExceptionData(Phase CurrentPhase) : ExceptionData;

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -84,7 +84,7 @@ public class AliceClient
 		return aliceClient;
 	}
 
-	public static async Task<AliceClient> RegisterInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, CancellationToken cancellationToken)
+	private static async Task<AliceClient> RegisterInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, CancellationToken cancellationToken)
 	{
 		AliceClient? aliceClient;
 		try
@@ -145,7 +145,7 @@ public class AliceClient
 		return aliceClient;
 	}
 
-	public async Task ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken)
+	private async Task ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken)
 	{
 		long[] amountsToRequest = { EffectiveValue.Satoshi };
 		long[] vsizesToRequest = { MaxVsizeAllocationPerAlice - SmartCoin.ScriptPubKey.EstimateInputVsize() };

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -293,10 +293,18 @@ public class CoinJoinClient
 					// Cancel all remaining pending input registrations because they will arrive late too.
 					registrationsCts.Cancel();
 
-					var isInConnectionConfirmation = wpe.Message.Contains(nameof(Phase.ConnectionConfirmation));
-					if (isInConnectionConfirmation)
+					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 					{
-						confirmationsCts.Cancel();
+						var isInConnectionConfirmation = wrongPhaseExceptionData.CurrentPhase == Phase.ConnectionConfirmation;
+						if (isInConnectionConfirmation)
+						{
+							confirmationsCts.Cancel();
+						}
+					}
+					else
+					{
+						throw new InvalidOperationException(
+							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
 					}
 				}
 				personCircuit?.Dispose();

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -290,7 +290,7 @@ public class CoinJoinClient
 			{
 				if (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
 				{
-					// After receiving a WrongPhase, cancel all the pending registrations because they will arrive late too.
+					// Cancel all remaining pending input registrations because they will arrive late too.
 					registrationsCts.Cancel();
 
 					var isInConnectionConfirmation = wpe.Message.Contains(nameof(Phase.ConnectionConfirmation));

--- a/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/ExceptionDataJsonConverter.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Models.Serialization;
 
 public class ExceptionDataJsonConverter : GenericInterfaceJsonConverter<ExceptionData>
 {
-	public ExceptionDataJsonConverter() : base(new[] { typeof(InputBannedExceptionData), typeof(EmptyExceptionData) })
+	public ExceptionDataJsonConverter() : base(new[] { typeof(InputBannedExceptionData), typeof(EmptyExceptionData), typeof(WrongPhaseExceptionData) })
 	{
 	}
 }


### PR DESCRIPTION
Closes #8487

When received a WrongPhase error from the coordinator the client now cancels all pending input registration requests and connection confirmation requests depending on the current phase. 
