### PR TITLE
Implement WW2.0.0 Compatible CJ Load Balancer

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -109,12 +109,15 @@ public class WabiSabiConfig : ConfigBase
 	public Money MaxSuggestedAmountBase { get; set; } = Money.Coins(0.1m);
 
 	[DefaultValue(1)]
-	[JsonProperty(PropertyName = "ParallelRounds", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public int ParallelRounds { get; set; } = 1;
+	[JsonProperty(PropertyName = "RoundParallelization", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public int RoundParallelization { get; set; } = 1;
 
-	[DefaultValue(false)]
-	[JsonProperty(PropertyName = "RegistrationLoadBalancer", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public bool RegistrationLoadBalancer { get; set; } = false;
+	/// <summary>
+	/// Try to keep this below 6. The compatibility hack is computationally expensive.
+	/// </summary>
+	[DefaultValue(1)]
+	[JsonProperty(PropertyName = "WW200CompatibleRoundParallelization", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public int WW200CompatibleRoundParallelization { get; set; } = 1;
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -112,6 +112,10 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "ParallelRounds", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public int ParallelRounds { get; set; } = 1;
 
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "RegistrationLoadBalancer", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool RegistrationLoadBalancer { get; set; } = false;
+
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;


### PR DESCRIPTION
Our latest issue is having too many inputs registered to coinjoins. So many that we rounds are almost failing for sure.

This PR implements a load balancer that is compatible with WW2.0.0 coinjoin clients. The tricky thing there is that they accidentally enforce ordering with `ToImmutableDictionary` and so when we want them to prefer a smaller input count round we must create a round that is ordered to the beginning by `ToImmutableDictionary`.