### PR TITLE
Improve DDoS Protection

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -120,9 +120,6 @@ public class CoinJoinClient
 
 	public async Task<CoinJoinResult> StartCoinJoinAsync(IEnumerable<SmartCoin> coinCandidates, CancellationToken cancellationToken)
 	{
-		// 1000 input rounds are unlikely, but may be possible in the future.
-		var tryLimit = 1000;
-
 		RoundState? currentRoundState;
 		uint256 excludeRound = uint256.Zero;
 		ImmutableList<SmartCoin> coins;
@@ -150,7 +147,9 @@ public class CoinJoinClient
 			throw new NoCoinsToMixException($"No coin was selected from '{coinCandidates.Count()}' number of coins. Probably it was not economical, total amount of coins were: {Money.Satoshis(coinCandidates.Sum(c => c.Amount))} BTC.");
 		}
 
-		for (var tries = 0; tries < tryLimit; tries++)
+		// Keep going to blame round until there's none, so CJs won't be DDoS-ed.
+		// ToDo research: Do we do client side verification that blame rounds only contain the blame of round's inputs?
+		while (true)
 		{
 			CoinJoinResult result = await StartRoundAsync(coins, currentRoundState, cancellationToken).ConfigureAwait(false);
 			if (!result.GoForBlameRound)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -120,7 +120,7 @@ public class CoinJoinClient
 
 	public async Task<CoinJoinResult> StartCoinJoinAsync(IEnumerable<SmartCoin> coinCandidates, CancellationToken cancellationToken)
 	{
-		var tryLimit = 6;
+		var tryLimit = 21;
 
 		RoundState? currentRoundState;
 		uint256 excludeRound = uint256.Zero;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -148,7 +148,6 @@ public class CoinJoinClient
 		}
 
 		// Keep going to blame round until there's none, so CJs won't be DDoS-ed.
-		// ToDo research: Do we do client side verification that blame rounds only contain the blame of round's inputs?
 		while (true)
 		{
 			CoinJoinResult result = await StartRoundAsync(coins, currentRoundState, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -120,7 +120,8 @@ public class CoinJoinClient
 
 	public async Task<CoinJoinResult> StartCoinJoinAsync(IEnumerable<SmartCoin> coinCandidates, CancellationToken cancellationToken)
 	{
-		var tryLimit = 21;
+		// 1000 input rounds are unlikely, but may be possible in the future.
+		var tryLimit = 1000;
 
 		RoundState? currentRoundState;
 		uint256 excludeRound = uint256.Zero;


### PR DESCRIPTION
There's an ongoing DDoS attack on the Tor network. This effectively simulates a DDoS attack on the protocol. We observe that blame rounds not concluding to `minInputCount`, but stop execution after 6 times often prevents coinjoins from happening at all. This PR fixes this DDoS (as well as centralized DoS) attack vector.

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8498