### PR TITLE
Balance round compatible with WW2.0.0 clients

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Collections.Generic;
+using System.Diagnostics;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -25,6 +26,7 @@ public enum EndRoundState
 	AbortedNotAllAlicesConfirmed
 }
 
+[DebuggerDisplay("{AsDisplay(),nq}")]
 public class Round
 {
 	public Round(RoundParameters parameters, WasabiRandom random)
@@ -156,4 +158,6 @@ public class Round
 				Parameters.MaxSuggestedAmount,
 				AmountCredentialIssuerParameters,
 				VsizeCredentialIssuerParameters);
+
+	private string AsDisplay() => $"Id: {Id} Hash: {GetHashCode()} Alices: {Alices.Count}";
 }

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -51,10 +51,8 @@ public class RoundStateUpdater : PeriodicRunner
 		var newRoundStates = statusResponse
 			.Where(rs => !RoundStates.ContainsKey(rs.Id));
 
-		// Don't use ToImmutable dictionary, because that ruins the original order and makes the server unable to suggest a round preference.
-		// ToDo: ToDictionary doesn't guarantee the order by design so .NET team might change this out of our feet, so there's room for improvement here.
 		RoundStates = newRoundStates.Concat(updatedRoundStates)
-			.ToDictionary(x => x.Id, x => x);
+			.ToImmutableDictionary(x => x.Id, x => x);
 
 		lock (AwaitersLock)
 		{


### PR DESCRIPTION
This PR contains an implementation that allows the creation of new rounds in a way that wasabi wallet clients 2.0.0 can detect and use.

There is also a new integration test that simulates 40 clients joining to the party one every second. Each participant want to register 2 coins while every round allow maximum 6 inputs. The test takes a lot of time and for that reason it stops once there are at least 5 coinjoins in the mempool.

The code is not cpu intensive at all, in fact rounds are found in less than milliseconds. 

In order to verify clients 2.0.0 can use this code the `ImmutableDictionary` is used (as ww clients 2.0.0 use). Each entry is sorted deterministically by hash so, we only need to find a round with hash(Id) is less than the previous one.

I cannot test it in testnet but it looks promising because at least works in the integration test.