### PR TITLE
Upgrade xUnit to get NRT support

### DIFF
--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -27,7 +27,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="Moq" Version="4.16.1" />
-		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2-pre.12" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
The latest available version has [NRT](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references) support which is nice because `Assert.NotNull(variable)` makes analyzers aware of the fact that `variable` is later certainly not `null`.

The version is called `pre` but it works as good as the current version. By the way, dotnet/runtime is on a pre version too https://github.com/dotnet/runtime/pull/63948.

# Resources

* https://github.com/xunit/xunit/discussions/2414