### PR TITLE
Send required wabisabi api version for

### DIFF
--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -75,7 +75,8 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 			try
 			{
 				using StringContent content = new(jsonString, Encoding.UTF8, "application/json");
-
+				content.Headers.Add("WabiSabi-Api-Version", "2.0.0");
+					
 				// Any transport layer errors will throw an exception here.
 				HttpResponseMessage response = await _client
 					.SendAsync(HttpMethod.Post, GetUriEndPoint(action), content, combinedToken).ConfigureAwait(false);


### PR DESCRIPTION
After this PR is merged the client will send a new http header (`WabiSabi-Api-Version: 2.0.0') what allow the coordinator to act accordingly. It could be use to keep compatible responses after changes in the api or to deprecate old versions. 

This method is the less intrusive and it compatible with `Microsoft.AspNetCore.Mvc.Versioning` and doesn't require any specific implementation, dependency or anything on the server-side code. This is also specific to the wabisabi api and not to the whole api.

Finally, `2.0.0` is the version of the API and shouldn't be necessarily tight to the client version. 