### PR TITLE
Cancel when not conn conf

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -297,8 +297,7 @@ public class CoinJoinClient
 
 					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 					{
-						var isInConnectionConfirmation = wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation;
-						if (isInConnectionConfirmation)
+						if (wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation)
 						{
 							confirmationsCts.Cancel();
 						}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -290,11 +290,11 @@ public class CoinJoinClient
 			}
 			catch (WabiSabiProtocolException wpe)
 			{
-				// Cancel all remaining pending input registrations because they will arrive late too.
-				registrationsCts.Cancel();
-
 				if (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
 				{
+					// Cancel all remaining pending input registrations because they will arrive late too.
+					registrationsCts.Cancel();
+
 					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 					{
 						if (wrongPhaseExceptionData.CurrentPhase != Phase.InputRegistration

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -292,16 +292,18 @@ public class CoinJoinClient
 			{
 				if (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
 				{
-					// Cancel all remaining pending input registrations because they will arrive late too.
-					registrationsCts.Cancel();
-
 					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 					{
-						if (wrongPhaseExceptionData.CurrentPhase != Phase.InputRegistration
-							&& wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation)
+						if (wrongPhaseExceptionData.CurrentPhase != Phase.InputRegistration)
 						{
-							// Cancel all remaining pending connection confirmations because they will arrive late too.
-							confirmationsCts.Cancel();
+							// Cancel all remaining pending input registrations because they will arrive late too.
+							registrationsCts.Cancel();
+
+							if (wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation)
+							{
+								// Cancel all remaining pending connection confirmations because they will arrive late too.
+								confirmationsCts.Cancel();
+							}
 						}
 					}
 					else

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -297,7 +297,7 @@ public class CoinJoinClient
 
 					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 					{
-						var isInConnectionConfirmation = wrongPhaseExceptionData.CurrentPhase == Phase.ConnectionConfirmation;
+						var isInConnectionConfirmation = wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation;
 						if (isInConnectionConfirmation)
 						{
 							confirmationsCts.Cancel();


### PR DESCRIPTION
1. Step: look at the code
2. Step: read this -->

First note that I am not sure about this change, because the logic here is a bit complex, but here's my take:

For connection confirmation cancellation:

- I believe the original code said: "I want to cancel all ongoing connection confirmation requests, because I am in connection confirmation already."  
- I believe this should say: "I want to cancel all ongoing connection confirmation requests, because I am NOT in input registration, nor in connection confirmation anymore."

`confirmationsCts.Token` is linked up with `connConfTimeoutCancel` and `cancel` tokens, which results in `linkedConfirmationsCts`, which's token flows through all the alices' `RegisterInputAsync`s, `CreateRegisterAndConfirmInputAsync`s to finally cancel `aliceClient.ConfirmConnectionAsync`.