### PR TITLE
Clarify wording + Increase Time

### DIFF
--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Tor;
 /// <summary>Monitors Tor process bootstrap and reachability of Wasabi Backend.</summary>
 public class TorMonitor : PeriodicRunner
 {
-	public static readonly TimeSpan CheckIfRunningAfterTorMisbehavedFor = TimeSpan.FromSeconds(7);
+	public static readonly TimeSpan CheckIfRunningAfterTorMisbehavedFor = TimeSpan.FromSeconds(21);
 
 	public TorMonitor(TimeSpan period, Uri fallbackBackendUri, TorProcessManager torProcessManager, HttpClientFactory httpClientFactory) : base(period)
 	{
@@ -165,7 +165,7 @@ public class TorMonitor : PeriodicRunner
 						return;
 					}
 
-					// Check if the fallback address (clearnet) works. It must work.
+					// Check if the fallback address (clearnet through exit nodes) works. It must work.
 					try
 					{
 						Logger.LogInfo("Tor cannot access remote host. Test fallback URI.");
@@ -175,11 +175,11 @@ public class TorMonitor : PeriodicRunner
 					catch (Exception ex)
 					{
 						// The fallback address does not work too. We do not want to switch.
-						Logger.LogInfo($"Clearnet communication with the backend does not work either. Probably it is down, keep trying... Exception: '{ex}'");
+						Logger.LogInfo($"Communication through the fallback URL with the backend does not work either. Probably it is down, keep trying... Exception: '{ex}'");
 						return;
 					}
 
-					Logger.LogInfo("Switching to the clearnet mode.");
+					Logger.LogInfo("Switching to the fallback URL.");
 					RequestFallbackAddressUsage = true;
 					FallbackStarted = DateTime.UtcNow;
 				}


### PR DESCRIPTION
We say in our logs that we're switching to clearnet, which is not true. We're still over Tor, it's just we utilize an exit node, that's all. This PR clarifies wording, as well it increases the time from 7 to 21 sec before we do this.