### PR TITLE
Remove dead code

### DIFF
--- a/WalletWasabi/Services/Terminate/TerminateService.cs
+++ b/WalletWasabi/Services/Terminate/TerminateService.cs
@@ -37,8 +37,6 @@ public class TerminateService
 
 	private bool IsSystemEventsSubscribed { get; }
 
-	public bool IsTerminateRequested => Interlocked.Read(ref _terminateStatus) > TerminateStatusNotStarted;
-
 	private void CurrentDomain_DomainUnload(object? sender, EventArgs e)
 	{
 		Logger.LogInfo($"Process domain unloading requested by the OS.");


### PR DESCRIPTION
Second attempt after #5253

`IsTerminateRequested` was used in the `Daemon` class which was removed.