### PR TITLE
[VDG] status icon consistent wording

### DIFF
--- a/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
@@ -71,7 +71,7 @@
                       HorizontalAlignment="Center"
                       Height="30" />
             <TextBlock DockPanel.Dock="Bottom"
-                       Text="Wasabi was unable to connect to the server, some features may be unavailable, the reported balance could also be inaccurate. Retrying to connect."
+                       Text="Wasabi was unable to connect to the backend, some features may be unavailable, the reported balance could also be inaccurate. Retrying to connect."
                        TextWrapping="Wrap"
                        TextAlignment="Center" />
           </DockPanel>


### PR DESCRIPTION
In the status icon it said 'server', when usually it says `backend`.