### PR TITLE
[VDG] Make TorIssuesControl have a proper size in StatusIcon

### DIFF
--- a/WalletWasabi.Fluent/Controls/StatusItem.axaml
+++ b/WalletWasabi.Fluent/Controls/StatusItem.axaml
@@ -1,13 +1,24 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:c="using:WalletWasabi.Fluent.Controls">
+        xmlns:c="using:WalletWasabi.Fluent.Controls"
+        xmlns:statusIcon="clr-namespace:WalletWasabi.Fluent.Views.StatusIcon">
+
+  <Design.PreviewWith>
+    <Border Width="200" >
+      <c:StatusItem Title="Title" StatusText="Item text" >
+        <c:StatusItem.Icon>
+          <statusIcon:TorIssuesControl />
+        </c:StatusItem.Icon>
+      </c:StatusItem>
+    </Border>
+  </Design.PreviewWith>
 
   <Style Selector="c|StatusItem">
     <Setter Property="Template">
       <ControlTemplate>
         <Grid ColumnDefinitions="Auto,*"
               RowDefinitions="Auto,Auto">
-          <Viewbox Stretch="UniformToFill" Height="13" Grid.Column="0" Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0 0 5 0" >
+          <Viewbox Stretch="UniformToFill" Height="13" Grid.Column="0" Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0 0 8 0" >
             <ContentPresenter Content="{TemplateBinding Icon}" />
           </Viewbox>
           <TextBlock Grid.Column="1" Grid.Row="0" Text="{TemplateBinding Title}" VerticalAlignment="Center" />

--- a/WalletWasabi.Fluent/Controls/StatusItem.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/StatusItem.axaml.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Media;
 
 namespace WalletWasabi.Fluent.Controls;
 

--- a/WalletWasabi.Fluent/Views/StatusIcon/TorIssuesControl.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/TorIssuesControl.axaml
@@ -13,28 +13,25 @@
     <statusIcon:StatusIconDesignViewModel />
   </Design.DataContext>
 
-  <DockPanel>
+  <Button Classes="activeHyperLink" VerticalAlignment="Center" Foreground="Gold"
+          Command="{Binding OpenTorStatusSiteCommand}">
+    <Button.Content>
+      <PathIcon Foreground="Gold" VerticalAlignment="Center" Data="{StaticResource warning_filled}" />
+    </Button.Content>
+    <ToolTip.Tip>
+      <DockPanel>
+        <TextBlock DockPanel.Dock="Top" Text="Tor network is having issues:" />
+        <TextBlock DockPanel.Dock="Bottom" Text="Click this icon for details" />
+        <ItemsControl Margin="8" Items="{Binding TorIssues}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="tor:Issue">
+              <TextBlock Text="{Binding Title, StringFormat='{}· {0}'}" />
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
 
-    <Button Classes="activeHyperLink" Margin="5" VerticalAlignment="Center" Foreground="Gold"
-            Command="{Binding OpenTorStatusSiteCommand}">
-      <Button.Content>
-        <PathIcon Foreground="Gold" VerticalAlignment="Center" Data="{StaticResource warning_filled}" />
-      </Button.Content>
-      <ToolTip.Tip>
-        <DockPanel>
-          <TextBlock DockPanel.Dock="Top" Text="Tor network is having issues:" />
-          <TextBlock DockPanel.Dock="Bottom" Text="Click this icon for details" />
-          <ItemsControl Margin="8" Items="{Binding TorIssues}">
-            <ItemsControl.ItemTemplate>
-              <DataTemplate x:DataType="tor:Issue">
-                <TextBlock Text="{Binding Title, StringFormat='{}· {0}'}" />
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
-
-        </DockPanel>
-      </ToolTip.Tip>
-    </Button>
-  </DockPanel>
+      </DockPanel>
+    </ToolTip.Tip>
+  </Button>
 
 </UserControl>


### PR DESCRIPTION
As stated by @yahiheb, the Tor network **issues warning symbol** looks smaller than the rest of the items.

This PR makes it have the correct size.

## Current:
![image](https://user-images.githubusercontent.com/3109851/175836629-a8cabc16-8505-41ef-a4a3-4eeef09e15d2.png)


## This PR:
![image](https://user-images.githubusercontent.com/3109851/175836581-d3995a3e-1e99-40dd-aa9f-7e5fbb064ebb.png)

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8527
