### PR TITLE
Keep retrying for any transport exception

### DIFF
--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -100,14 +100,17 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 			}
 			catch (HttpRequestException e)
 			{
+				Logger.LogTrace($"Attempt {attempt} failed with {nameof(HttpRequestException)}: {e.Message}.");
 				exceptions.Add(e);
 			}
 			catch (TorException e)
 			{
+				Logger.LogTrace($"Attempt {attempt} failed with {nameof(TorException)}: {e.Message}.");
 				exceptions.Add(e);
 			}
 			catch (Exception e)
 			{
+				Logger.LogDebug($"Attempt {attempt} failed with exception {e}.");
 				if (exceptions.Any())
 				{
 					exceptions.Add(e);

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -102,8 +102,15 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 				exceptions.Add(e);
 			}
 
-			// Wait before the next try.
-			await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+			try
+			{
+				// Wait before the next try.
+				await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+			}
+			catch (Exception e)
+			{
+				exceptions.Add(e);
+			}
 			attempt++;
 		} while (!combinedToken.IsCancellationRequested);
 

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -97,21 +97,9 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 
 				return response;
 			}
-			catch (HttpRequestException e)
-			{
-				exceptions.Add(e);
-			}
 			catch (Exception e)
 			{
-				if (exceptions.Any())
-				{
-					exceptions.Add(e);
-					throw new AggregateException(exceptions);
-				}
-				else
-				{
-					throw;
-				}
+				exceptions.Add(e);
 			}
 
 			// Wait before the next try.


### PR DESCRIPTION
During yesterday's testnet testing session I noticed I DoS attacked the round in signing phase: I got an exception and instead of keep retrying to signing I did not even though I still had a lot of time to do that.

```
2022-06-26 19:04:51.955 [384] DEBUG     CoinJoinClient.ProceedWithSigningStateAsync (760)       Round (5a624f4b4d7fce071218570b0cc836575e015f8bb8cd078d47afa273135b2dd9): 7 out of 7 Alices have signed the coinjoin tx.
2022-06-26 19:06:32.960 [312] WARNING   TorTcpConnectionFactory.ConnectToDestinationAsync (265) Connection response indicates a failure. Actual response is: 'TtlExpired'. Request: 'testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion:80'.
2022-06-26 19:06:32.964 [312] ERROR     TorTcpConnectionFactory.ConnectToDestinationAsync (288) Exception occurred when connecting to 'testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion:80'. Exception: WalletWasabi.Tor.Socks5.Exceptions.TorConnectCommandFailedException: Tor SOCKS5 proxy responded with TtlExpired.
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectToDestinationAsync(TcpClient tcpClient, String host, Int32 port, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 266
2022-06-26 19:06:32.967 [312] DEBUG     TorHttpPool.CreateNewConnectionAsync (277)      ['http://testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion/wabisabi/transaction-signature'][ERROR] Failed to create a new pool connection. Exception: WalletWasabi.Tor.Socks5.Exceptions.TorConnectCommandFailedException: Tor SOCKS5 proxy responded with TtlExpired.
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectToDestinationAsync(TcpClient tcpClient, String host, Int32 port, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 266
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectAsync(String host, Int32 port, Boolean useSsl, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 94
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectAsync(Uri requestUri, ICircuit circuit, CancellationToken token) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 54
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.CreateNewConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 272
2022-06-26 19:06:33.156 [315] ERROR     CoinJoinManager.HandleCoinJoinFinalizationAsync (414)   Wallet (T4): CoinJoinClient failed with exception: 'System.AggregateException: One or more errors occurred. (Failed to get/read an HTTP response from Tor.) (Tor SOCKS5 proxy responded with TtlExpired.)
 ---> System.Net.Http.HttpRequestException: Failed to get/read an HTTP response from Tor.
 ---> WalletWasabi.Tor.Socks5.Exceptions.TorConnectionReadException: Could not read HTTP response.
 ---> System.IO.IOException: Unable to read data from the transport connection: An established connection was aborted by the software in your host machine..
 ---> System.Net.Sockets.SocketException (10053): An established connection was aborted by the software in your host machine.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ReceiveAsync(Socket socket, CancellationToken cancellationToken)
   at System.Net.Sockets.NetworkStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
   at WalletWasabi.Extensions.StreamExtensions.ReadByteAsync(Stream stream, CancellationToken cancellationToken) in WalletWasabi\Extensions\StreamExtensions.cs:line 23
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Extensions.StreamExtensions.ReadByteAsync(Stream stream, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.ReadStartLineAsync(Stream stream, CancellationToken ctsToken) in WalletWasabi\Tor\Http\Helpers\HttpMessageHelper.cs:line 37
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.ReadStartLineAsync(Stream stream, CancellationToken ctsToken)
   at WalletWasabi.Tor.Http.Extensions.HttpResponseMessageExtensions.CreateNewAsync(Stream responseStream, HttpMethod requestMethod, CancellationToken cancellationToken) in WalletWasabi\Tor\Http\Extensions\HttpResponseMessageExtensions.cs:line 39
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Tor.Http.Extensions.HttpResponseMessageExtensions.CreateNewAsync(Stream responseStream, HttpMethod requestMethod, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 323
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 120
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 86
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpRequestMessage request, CancellationToken token)
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpMethod method, String relativeUri, HttpContent content, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 68
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpMethod method, String relativeUri, HttpContent content, CancellationToken token)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 80
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 127
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendAndReceiveAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 139
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendAndReceiveAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 55
   at WalletWasabi.WabiSabi.Client.ArenaClient.SignTransactionAsync(uint256 roundId, Coin coin, OwnershipProof ownershipProof, IKeyChain keyChain, Transaction unsignedCoinJoin, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\ArenaClient.cs:line 200
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.WabiSabi.Client.ArenaClient.SignTransactionAsync(uint256 roundId, Coin coin, OwnershipProof ownershipProof, IKeyChain keyChain, Transaction unsignedCoinJoin, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.SignTransactionAsync(Transaction unsignedCoinJoin, IKeyChain keyChain, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 238
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at WalletWasabi.WabiSabi.Client.AliceClient.SignTransactionAsync(Transaction unsignedCoinJoin, IKeyChain keyChain, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass43_0.<<SignTransactionAsync>b__0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 393
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task.TrySetResult()
   at System.Threading.Tasks.Task.DelayPromise.CompleteTimedOut()
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
--- End of stack trace from previous location ---

   --- End of inner exception stack trace ---
   at WalletWasabi.Extensions.StreamExtensions.ReadByteAsync(Stream stream, CancellationToken cancellationToken) in WalletWasabi\Extensions\StreamExtensions.cs:line 23
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.ReadStartLineAsync(Stream stream, CancellationToken ctsToken) in WalletWasabi\Tor\Http\Helpers\HttpMessageHelper.cs:line 37
   at WalletWasabi.Tor.Http.Extensions.HttpResponseMessageExtensions.CreateNewAsync(Stream responseStream, HttpMethod requestMethod, CancellationToken cancellationToken) in WalletWasabi\Tor\Http\Extensions\HttpResponseMessageExtensions.cs:line 39
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 323
   --- End of inner exception stack trace ---
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 327
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 120
   --- End of inner exception stack trace ---
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 148
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 86
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpMethod method, String relativeUri, HttpContent content, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 68
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 80
   --- End of inner exception stack trace ---
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 109
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 127
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendAndReceiveAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 139
   at WalletWasabi.WabiSabi.Client.ArenaClient.SignTransactionAsync(uint256 roundId, Coin coin, OwnershipProof ownershipProof, IKeyChain keyChain, Transaction unsignedCoinJoin, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\ArenaClient.cs:line 200
   at WalletWasabi.WabiSabi.Client.AliceClient.SignTransactionAsync(Transaction unsignedCoinJoin, IKeyChain keyChain, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 238
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass43_0.<<SignTransactionAsync>b__0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 393
--- End of stack trace from previous location ---
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.SignTransactionAsync(IEnumerable`1 aliceClients, Transaction unsignedCoinJoinTransaction, DateTimeOffset signingEndTime, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 397
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.ProceedWithSigningStateAsync(uint256 roundId, ImmutableArray`1 registeredAliceClients, IEnumerable`1 outputTxOuts, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 759
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartRoundAsync(IEnumerable`1 smartCoins, RoundState roundState, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 212
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartCoinJoinAsync(IEnumerable`1 coinCandidates, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 153
   at WalletWasabi.WabiSabi.Client.CoinJoinManager.HandleCoinJoinFinalizationAsync(CoinJoinTracker finishedCoinJoin, ConcurrentDictionary`2 trackedCoinJoins, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\CoinJoinManager.cs:line 372
 ---> (Inner Exception #1) WalletWasabi.Tor.Socks5.Exceptions.TorConnectCommandFailedException: Tor SOCKS5 proxy responded with TtlExpired.
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectToDestinationAsync(TcpClient tcpClient, String host, Int32 port, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 266
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectAsync(String host, Int32 port, Boolean useSsl, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 94
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectAsync(Uri requestUri, ICircuit circuit, CancellationToken token) in WalletWasabi\Tor\Socks5\TorTcpConnectionFactory.cs:line 54
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.CreateNewConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 272
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.ObtainFreeConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 245
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 114
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 86
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpMethod method, String relativeUri, HttpContent content, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 68
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 80<---
'
2022-06-26 19:06:33.206 [315] INFO      CoinJoinManager.MonitorAndHandlingCoinJoinFinallizationAsync (337)      Wallet (T4): CoinJoinClient restart automatically.
```

Upon investigation of these logs I found that we're only retrying if we got a http request exception, not for any kinds of exceptions. I think we should keep retrying for any exceptions happening here until the cancellation token is called (user or phase timeout)

Truly fixes https://github.com/zkSNACKs/WalletWasabi/issues/8424