### PR TITLE
Firefox blur effect fixes

### DIFF
--- a/WalletWasabi.Backend/wwwroot/css/style.css
+++ b/WalletWasabi.Backend/wwwroot/css/style.css
@@ -1144,3 +1144,13 @@ hr {
         transform: translateY(-50%);
     }
 }
+/* Firefox fixes */
+@supports (-moz-appearance:none) {
+    .navbar {
+        background: rgba(0, 16, 31, 0.8);
+    }
+    .blured-section {
+        background: rgba(0, 0, 0, 0.9);
+        background: linear-gradient(180deg, rgba(0, 16, 31, 0.8) 0%, rgba(0, 16, 31, 1) 80%);
+    }
+}


### PR DESCRIPTION
We recognized a bug on the Firefox browser that can't handle the backdrop-filter CSS attribute, so on Firefox, there is a bit different effect.