### PR TITLE
Allow only single run of `PrivacySuggestionsFlyoutViewModel.BuildPrivacySuggestionsAsync`

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -200,14 +200,14 @@ public class Program
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
-		// Logger.LogDebug(e.Exception);
+		Logger.LogDebug(e.Exception);
 	}
 
 	private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 	{
 		if (e.ExceptionObject is Exception ex)
 		{
-			//Logger.LogWarning(ex);
+			Logger.LogWarning(ex);
 		}
 	}
 

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -93,7 +93,8 @@ public class Program
 
 			Logger.LogSoftwareStarted("Wasabi GUI");
 			AppBuilder
-				.Configure(() => new App(async () => await Global.InitializeNoWalletAsync(terminateService), runGuiInBackground)).UseReactiveUI()
+				.Configure(() => new App(async () => await Global.InitializeNoWalletAsync(terminateService), runGuiInBackground))
+				.UseReactiveUI()
 				.SetupAppBuilder()
 				.AfterSetup(_ =>
 					{
@@ -199,14 +200,14 @@ public class Program
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
-		Logger.LogDebug(e.Exception);
+		// Logger.LogDebug(e.Exception);
 	}
 
 	private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
 	{
 		if (e.ExceptionObject is Exception ex)
 		{
-			Logger.LogWarning(ex);
+			//Logger.LogWarning(ex);
 		}
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/ChangeAvoidanceSuggestionViewModel.cs
@@ -54,16 +54,16 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 		decimal usdExchangeRate,
 		[EnumeratorCancellation] CancellationToken cancellationToken)
 	{
-		var selections = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(
+		IAsyncEnumerable<IEnumerable<SmartCoin>> selectionsTask = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(
 			coinsToUse,
 			transactionInfo.FeeRate,
 			new TxOut(transactionInfo.Amount, destination),
 			maxInputCount,
-			cancellationToken).ConfigureAwait(false);
+			cancellationToken);
 
 		HashSet<Money> foundSolutionsByAmount = new();
 
-		await foreach (var selection in selections)
+		await foreach (IEnumerable<SmartCoin> selection in selectionsTask.ConfigureAwait(false))
 		{
 			if (selection.Any())
 			{
@@ -86,7 +86,7 @@ public partial class ChangeAvoidanceSuggestionViewModel : SuggestionViewModel
 
 				if (transaction is not null)
 				{
-					var destinationAmount = transaction.CalculateDestinationAmount();
+					Money destinationAmount = transaction.CalculateDestinationAmount();
 
 					// If BnB solutions become the same transaction somehow, do not show the same suggestion twice.
 					if (!foundSolutionsByAmount.Contains(destinationAmount))

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -16,15 +16,15 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 
 public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 {
-	[AutoNotify] private SuggestionViewModel? _previewSuggestion;
-	[AutoNotify] private SuggestionViewModel? _selectedSuggestion;
-	[AutoNotify] private bool _isOpen;
-
 	/// <remarks>Guards use of <see cref="_suggestionCancellationTokenSource"/>.</remarks>
 	private readonly object _lock = new();
 
 	/// <summary>Allow at most one suggestion generation run.</summary>
 	private readonly AsyncLock _asyncLock = new();
+
+	[AutoNotify] private SuggestionViewModel? _previewSuggestion;
+	[AutoNotify] private SuggestionViewModel? _selectedSuggestion;
+	[AutoNotify] private bool _isOpen;
 
 	private CancellationTokenSource? _suggestionCancellationTokenSource;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -19,13 +19,14 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 	[AutoNotify] private SuggestionViewModel? _previewSuggestion;
 	[AutoNotify] private SuggestionViewModel? _selectedSuggestion;
 	[AutoNotify] private bool _isOpen;
-	private CancellationTokenSource? _suggestionCancellationTokenSource;
 
 	/// <remarks>Guards use of <see cref="_suggestionCancellationTokenSource"/>.</remarks>
 	private readonly object _lock = new();
 
 	/// <summary>Allow at most one suggestion generation run.</summary>
 	private readonly AsyncLock _asyncLock = new();
+
+	private CancellationTokenSource? _suggestionCancellationTokenSource;
 
 	public PrivacySuggestionsFlyoutViewModel()
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using Nito.AsyncEx;
 using ReactiveUI;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -6,9 +7,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Logging;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
@@ -19,6 +20,12 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 	[AutoNotify] private SuggestionViewModel? _selectedSuggestion;
 	[AutoNotify] private bool _isOpen;
 	private CancellationTokenSource? _suggestionCancellationTokenSource;
+
+	/// <remarks>Guards use of <see cref="_suggestionCancellationTokenSource"/>.</remarks>
+	private readonly object _lock = new();
+
+	/// <summary>Allow at most one suggestion generation run.</summary>
+	private readonly AsyncLock _asyncLock = new();
 
 	public PrivacySuggestionsFlyoutViewModel()
 	{
@@ -36,45 +43,68 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 
 	public ObservableCollection<SuggestionViewModel> Suggestions { get; }
 
+	/// <remarks>Method supports being called multiple times. In that case the last call cancels the previous one.</remarks>
 	public async Task BuildPrivacySuggestionsAsync(Wallet wallet, TransactionInfo info, BitcoinAddress destination, BuildTransactionResult transaction, bool isFixedAmount, CancellationToken cancellationToken)
 	{
-		_suggestionCancellationTokenSource?.Cancel();
-		_suggestionCancellationTokenSource?.Dispose();
+		using CancellationTokenSource singleRunCts = new();
 
-		_suggestionCancellationTokenSource = new(TimeSpan.FromSeconds(15));
-		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_suggestionCancellationTokenSource.Token, cancellationToken);
-
-		Suggestions.Clear();
-		SelectedSuggestion = null;
-
-		var loadingRing = new LoadingSuggestionViewModel();
-		Suggestions.Add(loadingRing);
-
-		var hasChange = transaction.InnerWalletOutputs.Any(x => x.ScriptPubKey != destination.ScriptPubKey);
-
-		if (hasChange && !isFixedAmount && !info.IsPayJoin)
+		lock (_lock)
 		{
-			// Exchange rate can change substantially during computation itself.
-			// Reporting up-to-date exchange rates would just confuse users.
-			decimal usdExchangeRate = wallet.Synchronizer.UsdExchangeRate;
-
-			// Only allow to create 1 more input with BnB. This accounts for the change created.
-			int maxInputCount = transaction.SpentCoins.Count() + 1;
-
-			var pockets = wallet.GetPockets();
-			var spentCoins = transaction.SpentCoins;
-			var usedPockets = pockets.Where(x => x.Coins.Any(coin => spentCoins.Contains(coin)));
-			var coinsToUse = usedPockets.SelectMany(x => x.Coins).ToImmutableArray();
-
-			IAsyncEnumerable<ChangeAvoidanceSuggestionViewModel> suggestions =
-				ChangeAvoidanceSuggestionViewModel.GenerateSuggestionsAsync(info, destination, wallet, coinsToUse, maxInputCount, usdExchangeRate, linkedCts.Token);
-
-			await foreach (var suggestion in suggestions)
-			{
-				Suggestions.Insert(Suggestions.Count - 1, suggestion);
-			}
+			_suggestionCancellationTokenSource?.Cancel();
+			_suggestionCancellationTokenSource = singleRunCts;
 		}
 
-		Suggestions.Remove(loadingRing);
+		using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(15));
+		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, singleRunCts.Token, cancellationToken);
+
+		using (await _asyncLock.LockAsync(CancellationToken.None))
+		{
+			try
+			{
+				Suggestions.Clear();
+				SelectedSuggestion = null;
+
+				var loadingRing = new LoadingSuggestionViewModel();
+				Suggestions.Add(loadingRing);
+
+				var hasChange = transaction.InnerWalletOutputs.Any(x => x.ScriptPubKey != destination.ScriptPubKey);
+
+				if (hasChange && !isFixedAmount && !info.IsPayJoin)
+				{
+					// Exchange rate can change substantially during computation itself.
+					// Reporting up-to-date exchange rates would just confuse users.
+					decimal usdExchangeRate = wallet.Synchronizer.UsdExchangeRate;
+
+					// Only allow to create 1 more input with BnB. This accounts for the change created.
+					int maxInputCount = transaction.SpentCoins.Count() + 1;
+
+					var pockets = wallet.GetPockets();
+					var spentCoins = transaction.SpentCoins;
+					var usedPockets = pockets.Where(x => x.Coins.Any(coin => spentCoins.Contains(coin)));
+					var coinsToUse = usedPockets.SelectMany(x => x.Coins).ToImmutableArray();
+
+					IAsyncEnumerable<ChangeAvoidanceSuggestionViewModel> suggestions =
+						ChangeAvoidanceSuggestionViewModel.GenerateSuggestionsAsync(info, destination, wallet, coinsToUse, maxInputCount, usdExchangeRate, linkedCts.Token);
+
+					await foreach (var suggestion in suggestions)
+					{
+						Suggestions.Insert(Suggestions.Count - 1, suggestion);
+					}
+				}
+
+				Suggestions.Remove(loadingRing);
+			}
+			catch (OperationCanceledException)
+			{
+				Logger.LogTrace("Operation was cancelled.");
+			}
+			finally
+			{
+				lock (_lock)
+				{
+					_suggestionCancellationTokenSource = null;
+				}
+			}
+		}
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -482,7 +482,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 	private async Task<bool> AuthorizeAsync(TransactionAuthorizationInfo transactionAuthorizationInfo)
 	{
 		if (!_wallet.KeyManager.IsHardwareWallet &&
-		    string.IsNullOrEmpty(_wallet.Kitchen.SaltSoup())) // Do not show auth dialog when password is empty
+		    string.IsNullOrEmpty(_wallet.Kitchen.SaltSoup())) // Do not show authentication dialog when password is empty
 		{
 			return true;
 		}


### PR DESCRIPTION
Fixes: #8565
Alternative to: #8567
Review with [whitespace changes off](https://github.com/zkSNACKs/WalletWasabi/pull/8594/files?diff=split&w=1)

Current master allows to call `PrivacySuggestionsFlyoutViewModel.BuildPrivacySuggestionsAsync` method multiple times because `BuildPrivacySuggestionsAsync` contains method calls with `ConfigureAwait(false)`. It is not optimal because it seems it leads to exceptions like the one mentioned in #8565 but also it leads to higher use of CPU than necessary (only for limited amount of time though).

