### PR TITLE
Filter out WW2.0.0 Clients in the First Round

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
@@ -95,8 +95,8 @@ public class StepConnectionConfirmationTests
 		using Arena arena = await ArenaBuilder.From(cfg, prison).CreateAndStartAsync(round);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
-		Assert.Equal(Phase.Ended, round.Phase);
-		//Assert.Equal(Phase.OutputRegistration, round.Phase);
+
+		Assert.Equal(Phase.OutputRegistration, round.Phase);
 		Assert.Equal(2, round.Alices.Count);
 		Assert.Equal(2, prison.CountInmates().noted);
 		Assert.Equal(0, prison.CountInmates().banned);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -206,17 +206,7 @@ public partial class Arena : PeriodicRunner
 					else
 					{
 						round.OutputRegistrationTimeFrame = TimeFrame.Create(Config.FailFastOutputRegistrationTimeout);
-
-						// Clients misbehave when they don't confirm everything.
-						if (round is BlameRound)
-						{
-							// Unfortunately we would stop the blame round chain completely so we must go to output registration even though we know we'll fail.
-							round.SetPhase(Phase.OutputRegistration);
-						}
-						else
-						{
-							round.EndRound(EndRoundState.AbortedNotAllAlicesConfirmed);
-						}
+						round.SetPhase(Phase.OutputRegistration);
 					}
 				}
 			}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -12,6 +12,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds;
 /// <summary>
 /// DO ONLY APPEND TO THE END
 /// Otherwise serialization ruins compatibility with clients.
+/// Do not insert, do not delete, do not reorder, only append!
 /// </summary>
 public enum EndRoundState
 {


### PR DESCRIPTION
This removes the temporary fix of ending the round we introduced recently due to a bug in 2.0.0 clients. I believe now we have enough 2.0.1 clients so that going into the blame chain is more preferable than bailing out early on. This is also the blocker of bringing back the max suggested input count concept.