### PR TITLE
Abort registrations on ended rounds

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -133,6 +133,10 @@ public class AliceClient
                         Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late. Abort the rest of the registrations.");
                         break;
 
+                    case WabiSabiProtocolErrorCode.RoundNotFound:
+	                    Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late because the round doesn't exist anymore. Abort the rest of the registrations.");
+	                    break;
+                    
                     default:
                         Logger.LogInfo($"{coin.Coin.Outpoint} cannot be registered: '{wpe.ErrorCode}'.");
                         break;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -290,7 +290,13 @@ public class CoinJoinClient
 			}
 			catch (WabiSabiProtocolException wpe)
 			{
-				if (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
+				if (wpe.ErrorCode is WabiSabiProtocolErrorCode.RoundNotFound)
+				{
+					// if the round does not exist then it ended/aborted.
+					registrationsCts.Cancel();
+					confirmationsCts.Cancel();
+				}
+				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.WrongPhase)
 				{
 					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 					{


### PR DESCRIPTION
All clients (2.0.x) continue with inputs registration/confirmation even after receiving a `RoundNotFound` error. 