### PR TITLE
[VDG] Settings dialog

### DIFF
--- a/WalletWasabi.Fluent/Styles/SettingsLayout.axaml
+++ b/WalletWasabi.Fluent/Styles/SettingsLayout.axaml
@@ -1,11 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Style Selector="StackPanel.settingsLayout">
-    <Setter Property="Spacing" Value="20"/>
-    <Setter Property="MinWidth" Value="360"/>
-    <Setter Property="MaxWidth" Value="650"/>
-    <Setter Property="HorizontalAlignment" Value="Left"/>
-    <Setter Property="Orientation" Value="Vertical"/>
+    <Setter Property="Spacing" Value="15" />
+    <Setter Property="MinWidth" Value="360" />
+    <Setter Property="MaxWidth" Value="650" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="Orientation" Value="Vertical" />
   </Style>
 
   <Style Selector="StackPanel.settingsLayout > DockPanel > ToggleSwitch">

--- a/WalletWasabi.Fluent/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/SettingsPageViewModel.cs
@@ -1,8 +1,10 @@
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Windows.Input;
 using ReactiveUI;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
+using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Fluent.ViewModels.NavBar;
 
 namespace WalletWasabi.Fluent.ViewModels.Settings;
@@ -16,8 +18,9 @@ namespace WalletWasabi.Fluent.ViewModels.Settings;
 	IconName = "nav_settings_24_regular",
 	IconNameFocused = "nav_settings_24_filled",
 	Searchable = false,
-	NavBarPosition = NavBarPosition.Bottom)]
-public partial class SettingsPageViewModel : NavBarItemViewModel
+	NavBarPosition = NavBarPosition.Bottom,
+	NavigationTarget = NavigationTarget.DialogScreen)]
+public partial class SettingsPageViewModel : DialogViewModelBase<Unit>
 {
 	[AutoNotify] private bool _isModified;
 	[AutoNotify] private int _selectedTab;
@@ -26,10 +29,14 @@ public partial class SettingsPageViewModel : NavBarItemViewModel
 	{
 		_selectedTab = 0;
 
+		SelectionMode = NavBarItemSelectionMode.Button;
+
 		GeneralSettingsTab = new GeneralSettingsTabViewModel();
 		BitcoinTabSettings = new BitcoinTabSettingsViewModel();
 
 		RestartCommand = ReactiveCommand.Create(AppLifetimeHelper.Restart);
+
+		NextCommand = CancelCommand;
 	}
 
 	public ICommand RestartCommand { get; }
@@ -45,6 +52,8 @@ public partial class SettingsPageViewModel : NavBarItemViewModel
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
+
+		IsModified = SettingsTabViewModelBase.CheckIfRestartIsNeeded();
 
 		SettingsTabViewModelBase.RestartNeeded += OnRestartNeeded;
 

--- a/WalletWasabi.Fluent/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/SettingsPageViewModel.cs
@@ -28,14 +28,14 @@ public partial class SettingsPageViewModel : DialogViewModelBase<Unit>
 	public SettingsPageViewModel()
 	{
 		_selectedTab = 0;
-
 		SelectionMode = NavBarItemSelectionMode.Button;
+
+		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		GeneralSettingsTab = new GeneralSettingsTabViewModel();
 		BitcoinTabSettings = new BitcoinTabSettingsViewModel();
 
 		RestartCommand = ReactiveCommand.Create(AppLifetimeHelper.Restart);
-
 		NextCommand = CancelCommand;
 	}
 

--- a/WalletWasabi.Fluent/Views/Settings/SettingsPageView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/SettingsPageView.axaml
@@ -23,32 +23,38 @@
       <Setter Property="Padding" Value="0" />
     </Style>
   </UserControl.Styles>
-  <DockPanel LastChildFill="True">
-    <c:InfoMessage Foreground="{StaticResource WarningMessageForeground}"
-                   Margin="0,16"
-                   HorizontalAlignment="Center"
-                   Opacity="{Binding IsModified, Converter={x:Static conv:BoolOpacityConverters.BoolToOpacity}}"
-                   DockPanel.Dock="Bottom">
-      <StackPanel Orientation="Horizontal">
-        <TextBlock Text="Changes will be applied after restarting the application." />
-        <Button Content="Restart Wasabi" Classes="activeHyperLink plain" Margin="5 0 0 0" Command="{Binding RestartCommand}" />
-      </StackPanel>
-    </c:InfoMessage>
 
-    <c:ContentArea Title="{Binding Title}"
-                   Caption="Manage appearance, privacy and other settings">
-      <DockPanel LastChildFill="True">
+  <c:ContentArea Title="{Binding Title}"
+                 Caption="Manage appearance, privacy and other settings"
+                 EnableNext="True"
+                 NextContent="Close"
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
+    <DockPanel LastChildFill="True">
 
-        <TabControl SelectedIndex="{Binding SelectedTab, Mode=TwoWay}">
-          <TabItem Header="General">
+      <c:InfoMessage Foreground="{StaticResource WarningMessageForeground}"
+                     Margin="0,16,0,0"
+                     HorizontalAlignment="Center"
+                     Opacity="{Binding IsModified, Converter={x:Static conv:BoolOpacityConverters.BoolToOpacity}}"
+                     DockPanel.Dock="Bottom">
+        <StackPanel Orientation="Horizontal">
+          <TextBlock Text="Changes will be applied after restarting the application." />
+          <Button Content="Restart Wasabi" Classes="activeHyperLink plain" Margin="5 0 0 0" Command="{Binding RestartCommand}" />
+        </StackPanel>
+      </c:InfoMessage>
+
+      <TabControl SelectedIndex="{Binding SelectedTab, Mode=TwoWay}">
+        <TabItem Header="General">
+          <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
             <v:GeneralSettingsTabView DataContext="{Binding GeneralSettingsTab}" />
-          </TabItem>
+          </ScrollViewer>
+        </TabItem>
 
-          <TabItem Header="Bitcoin">
+        <TabItem Header="Bitcoin">
+          <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
             <v:BitcoinTabSettingsView DataContext="{Binding BitcoinTabSettings}" />
-          </TabItem>
-        </TabControl>
-      </DockPanel>
-    </c:ContentArea>
-  </DockPanel>
+          </ScrollViewer>
+        </TabItem>
+      </TabControl>
+    </DockPanel>
+  </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Settings/SettingsPageView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/SettingsPageView.axaml
@@ -27,7 +27,7 @@
   <c:ContentArea Title="{Binding Title}"
                  Caption="Manage appearance, privacy and other settings"
                  EnableNext="True"
-                 NextContent="Close"
+                 NextContent="Done"
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
     <DockPanel LastChildFill="True">
 


### PR DESCRIPTION
Fixes #8573 

- Settings UI is now a dialog:

![image](https://user-images.githubusercontent.com/98904713/176988041-0f443930-09f1-4562-a548-595192de7c84.png)

As per [this comment](https://github.com/zkSNACKs/WalletWasabi/issues/8573#issue-1288609034) this could have caused a problem where settings would have required a "live refresh" behavior if they were used in possible active screens throughout the software, which would remain active since there is no longer a navigation occurring when you open the settings UI.

- All settings currently available in the UI have been tracked, and fall into one of these categories:
  - The setting is used in the UI, but inside a dialog (such as send or receive dialog), and therefore does not need "live refresh"
  - The setting requires a restart, therefore it does not need "live refresh"

Therefore no further action is required.