### PR TITLE
Only logtrace OperationCanceledException

### DIFF
--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -110,7 +110,15 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 			}
 			catch (Exception e)
 			{
-				Logger.LogDebug($"Attempt {attempt} failed with exception {e}.");
+				if (e is OperationCanceledException)
+				{
+					Logger.LogTrace($"Attempt {attempt} failed with {nameof(OperationCanceledException)}: {e.Message}.");
+				}
+				else
+				{
+					Logger.LogDebug($"Attempt {attempt} failed with exception {e}.");
+				}
+
 				if (exceptions.Any())
 				{
 					exceptions.Add(e);


### PR DESCRIPTION
So we don't get this noise in the debug logs:

```
2022-07-02 22:02:24.043 [74] DEBUG	WabiSabiHttpApiClient.SendWithRetriesAsync (113)	Attempt 1 failed with exception System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Net.Http.HttpContent.LoadIntoBufferAsyncCore(Task serializeToStreamTask, MemoryStream tempBuffer)
   at System.Net.Http.HttpContent.WaitAndReturnAsync[TState,TResult](Task waitTask, TState state, Func`2 returnFunc)
   at WalletWasabi.Tor.Http.Extensions.HttpRequestMessageExtensions.ToHttpStringAsync(HttpRequestMessage request, CancellationToken cancellationToken) in WalletWasabi\Tor\Http\Extensions\HttpRequestMessageExtensions.cs:line 80
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 306
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 120
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 86
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpMethod method, String relativeUri, HttpContent content, CancellationToken token) in WalletWasabi\Tor\Http\TorHttpClient.cs:line 68
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\WabiSabiHttpApiClient.cs:line 81.
```