### PR TITLE
Fix of CombinationsWithoutRepetition()

### DIFF
--- a/WalletWasabi.Tests/AssertAsync.cs
+++ b/WalletWasabi.Tests/AssertAsync.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Tests;
+
+// Taken from https://stackoverflow.com/a/44718318
+public static class AssertAsync
+{
+	public static void CompletesIn(int timeout, Action action)
+	{
+		var task = Task.Run(action);
+		var completedInTime = Task.WaitAll(new[] { task }, TimeSpan.FromSeconds(timeout));
+
+		if (task.Exception != null)
+		{
+			if (task.Exception.InnerExceptions.Count == 1)
+			{
+				throw task.Exception.InnerExceptions[0];
+			}
+
+			throw task.Exception;
+		}
+
+		if (!completedInTime)
+		{
+			throw new TimeoutException($"Task did not complete in {timeout} seconds.");
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -70,6 +70,12 @@ public class LinqExtensionsTests
 	}
 
 	[Fact]
+	public void CombinationsWithoutRepetitionZeroLength()
+	{
+		AssertAsync.CompletesIn(1, () => Enumerable.Range(0, 32).CombinationsWithoutRepetition(ofLength: 0).ToArray());
+	}
+
+	[Fact]
 	public void ZippingTests()
 	{
 		var collection1 = new int[] { 1, 3, 5, 14 };

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -96,14 +96,14 @@ public static class LinqExtensions
 	public static IEnumerable<IEnumerable<T>> CombinationsWithoutRepetition<T>(
 		this IEnumerable<T> items,
 		int ofLength)
+	=> ofLength switch
 	{
-		return (ofLength == 1)
-			? items.Select(item => new[] { item })
-			: items.SelectMany((item, i) => items
+		1 => items.Select(item => new[] { item }),
+		_ => items.SelectMany((item, i) => items
 				.Skip(i + 1)
 				.CombinationsWithoutRepetition(ofLength - 1)
-				.Select(result => new T[] { item }.Concat(result)));
-	}
+				.Select(result => new T[] { item }.Concat(result)))
+	};
 
 	public static IEnumerable<IEnumerable<T>> CombinationsWithoutRepetition<T>(
 		this IEnumerable<T> items,

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -98,6 +98,7 @@ public static class LinqExtensions
 		int ofLength)
 	=> ofLength switch
 	{
+		<= 0 => Enumerable.Empty<IEnumerable<T>>(),
 		1 => items.Select(item => new[] { item }),
 		_ => items.SelectMany((item, i) => items
 				.Skip(i + 1)


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8619.

https://github.com/zkSNACKs/WalletWasabi/commit/4d05490b85ce7d8feb12d3f6e629bca80f9dc5bf and https://github.com/zkSNACKs/WalletWasabi/commit/76a58f9aef77aa80879df3c9d55fca205e31c685 test the desired behaviour. Feel free to remove them if you think they are not needed.

https://github.com/zkSNACKs/WalletWasabi/commit/b8ca7461658d61025ee69be6ba0d73c051e95f09 is mere refactoring commit.

https://github.com/zkSNACKs/WalletWasabi/commit/141d5cc45bcecfea263dcfc6b0b3f374ab5e586b actually fixes the bug.