### PR TITLE
Tor: remove digest line for macOS

### DIFF
--- a/WalletWasabi/Microservices/Binaries/osx64/Tor/tor
+++ b/WalletWasabi/Microservices/Binaries/osx64/Tor/tor
@@ -9,4 +9,3 @@ export DYLD_LIBRARY_PATH=.:$DYLD_LIBRARY_PATH
 # https://trac.torproject.org/projects/tor/ticket/10030
 cd "$(dirname "$0")"
 exec ./tor.real "$@"
-# Random Comment Dump to change the digest "je202kjnfoj2iuwkekjjreiejre"


### PR DESCRIPTION
Follow-up to https://github.com/zkSNACKs/WalletWasabi/pull/8613#discussion_r912870252:

> The modification of the digest is not required anymore. Old clients copied Tor executables to that data folder and ran the client from there. Now we are running directly from the binary folder (like program files on windows). The digest was used to compare if an update is required, thus comparing the tor executables in the data folder and in the binary folder.
If this is true we should update the documentation and stop modifying this.

Documentation does not contain this step, so there is nothing to update.

btw: I'm still not sure if we need that file at all. Can anybody clarify?