### PR TITLE
`TorTcpConnectionFactory`: Log only on trace level

### DIFF
--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -285,7 +285,7 @@ public class TorTcpConnectionFactory
 		}
 		catch (TorException e)
 		{
-			Logger.LogError($"Exception occurred when connecting to '{host}:{port}'.", e);
+			Logger.LogTrace($"Exception occurred when connecting to '{host}:{port}'.", e);
 			throw;
 		}
 		finally


### PR DESCRIPTION
Related to #8617

This PR should reduce repeated exception logs. We log an exception in `TorTcpConnectionFactory` to log it again in `TorHttpPool` basically.

