### PR TITLE
Return ownership proofs

### DIFF
--- a/WalletWasabi.Fluent/Config.cs
+++ b/WalletWasabi.Fluent/Config.cs
@@ -115,6 +115,10 @@ public class Config : ConfigBase
 	[JsonConverter(typeof(MoneyBtcJsonConverter))]
 	public Money DustThreshold { get; internal set; } = DefaultDustThreshold;
 
+	[DefaultValue("wasabiwallet.io")]
+	[JsonProperty(PropertyName = "CoordinatorIdentifier", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public string CoordinatorIdentifier { get; set; } = "wasabiwallet.io";
+
 	public ServiceConfiguration ServiceConfiguration { get; private set; }
 
 	public Uri GetCurrentBackendUri()

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -297,7 +297,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = HttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(5), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Config.ServiceConfiguration), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Config.ServiceConfiguration, Config.CoordinatorIdentifier), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -41,7 +41,7 @@ public static class WabiSabiFactory
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			GetOwnershipIdentifier(key.PubKey.WitHash.ScriptPubKey),
-			new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash ?? BitcoinFactory.CreateUint256()));
+			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash ?? BitcoinFactory.CreateUint256()));
 
 	public static OwnershipIdentifier GetOwnershipIdentifier(Script scriptPubKey)
 	{

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -30,13 +30,12 @@ namespace WalletWasabi.Tests.Helpers;
 
 public static class WabiSabiFactory
 {
-	public static Coin CreateCoin(Key key)
-		=> CreateCoin(key, Money.Coins(1));
-
-	public static Coin CreateCoin(Key key, Money amount)
-		=> new(
-			new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0),
-			new TxOut(amount, key.PubKey.WitHash.ScriptPubKey));
+	public static Coin CreateCoin(Key? key = null, Money? amount = null)
+	{
+		key ??= new();
+		amount ??= Money.Coins(1);
+		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.WitHash.ScriptPubKey));
+	}
 
 	public static OwnershipProof CreateOwnershipProof(Key key, uint256? roundHash = null)
 		=> OwnershipProof.GenerateCoinJoinInputProof(

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -136,6 +136,7 @@ public static class WabiSabiFactory
 		return new ArenaClient(
 			roundState.CreateAmountCredentialClient(random),
 			roundState.CreateVsizeCredentialClient(random),
+			"wasabiwallet.io",
 			arena);
 	}
 
@@ -299,6 +300,7 @@ public static class WabiSabiFactory
 			keyChain,
 			destinationProvider,
 			roundStateUpdater,
+			"wasabiwallet.io",
 			int.MaxValue,
 			true,
 			TimeSpan.Zero,

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -37,6 +37,18 @@ public static class WabiSabiFactory
 		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.WitHash.ScriptPubKey));
 	}
 
+	public static Tuple<Coin, OwnershipProof> CreateCoinWithOwnershipProof(Key? key = null, Money? amount = null, uint256? roundId = null)
+	{
+		key = key ?? new();
+		var coin = WabiSabiFactory.CreateCoin(key, amount);
+		roundId ??= uint256.One;
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, roundId);
+		return new Tuple<Coin, OwnershipProof>(coin, ownershipProof);
+	}
+
+	public static CoinJoinInputCommitmentData CreateCommitmentData(uint256? RoundId = null)
+		=> new CoinJoinInputCommitmentData("wasabiwallet.io", RoundId ?? uint256.One);
+
 	public static OwnershipProof CreateOwnershipProof(Key key, uint256? roundHash = null)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
@@ -112,7 +124,7 @@ public static class WabiSabiFactory
 		=> new(coin, ownershipProof, round, Guid.NewGuid(), false) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
 
 	public static Alice CreateAlice(Key key, Money amount, Round round)
-		=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key), round);
+		=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key, round.Id), round);
 
 	public static Alice CreateAlice(Money amount, Round round)
 	{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -141,7 +141,7 @@ public class StepOutputRegistrationTests
 		var txParams = round.Parameters;
 		var extraAlice = WabiSabiFactory.CreateAlice(round.Parameters.MiningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParams.AllowedOutputAmounts.Min - new Money(1L), round);
 		round.Alices.Add(extraAlice);
-		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin);
+		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin, extraAlice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.TransactionSigning, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -264,7 +264,7 @@ public class StepTransactionSigningTests
 			CancellationToken.None).ConfigureAwait(false);
 
 		await bobClient.RegisterOutputAsync(
-			destKey1.PubKey.WitHash.ScriptPubKey,
+			destKey2.PubKey.WitHash.ScriptPubKey,
 			aliceClient2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient2.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None).ConfigureAwait(false);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -201,7 +201,7 @@ public class StepTransactionSigningTests
 		var alice3 = WabiSabiFactory.CreateAlice(round);
 		alice3.ConfirmedConnection = true;
 		round.Alices.Add(alice3);
-		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin);
+		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin, alice3.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -22,7 +22,7 @@ public class SignTransactionTests
 		using Key key = new();
 		Alice alice = WabiSabiFactory.CreateAlice(key: key, round: round);
 		round.Alices.Add(alice);
-		round.CoinjoinState = round.AddInput(alice.Coin).Finalize();
+		round.CoinjoinState = round.AddInput(alice.Coin, alice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id)).Finalize();
 		round.SetPhase(Phase.TransactionSigning);
 		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -4,7 +4,6 @@ using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
-using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using Xunit;
 
@@ -18,19 +17,13 @@ public class MultipartyTransactionStateTests
 		var cfg = new WabiSabiConfig();
 		var round = WabiSabiFactory.CreateRound(cfg);
 
-		static Coin CreateCoin()
-		{
-			using var key = new Key();
-			return WabiSabiFactory.CreateCoin(key);
-		}
-
 		Coin coin1, coin2, coin3;
 
 		// Three events / three states
 		var state0 = round.Assert<ConstructionState>();
-		var state1 = state0.AddInput(coin1 = CreateCoin());
-		var state2 = state1.AddInput(coin2 = CreateCoin());
-		var state3 = state2.AddInput(coin3 = CreateCoin());
+		var state1 = state0.AddInput(coin1 = WabiSabiFactory.CreateCoin());
+		var state2 = state1.AddInput(coin2 = WabiSabiFactory.CreateCoin());
+		var state3 = state2.AddInput(coin3 = WabiSabiFactory.CreateCoin());
 
 		// Unknown state. Assumes full state is required
 		var diffd30 = state3.GetStateFrom(-1);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -17,13 +17,17 @@ public class MultipartyTransactionStateTests
 		var cfg = new WabiSabiConfig();
 		var round = WabiSabiFactory.CreateRound(cfg);
 
-		Coin coin1, coin2, coin3;
+		var commitmentData = WabiSabiFactory.CreateCommitmentData(round.Id);
+
+		(var coin1, var ownershipProof1) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
+		(var coin2, var ownershipProof2) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
+		(var coin3, var ownershipProof3) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
 
 		// Three events / three states
 		var state0 = round.Assert<ConstructionState>();
-		var state1 = state0.AddInput(coin1 = WabiSabiFactory.CreateCoin());
-		var state2 = state1.AddInput(coin2 = WabiSabiFactory.CreateCoin());
-		var state3 = state2.AddInput(coin3 = WabiSabiFactory.CreateCoin());
+		var state1 = state0.AddInput(coin1, ownershipProof1, commitmentData);
+		var state2 = state1.AddInput(coin2, ownershipProof2, commitmentData);
+		var state3 = state2.AddInput(coin3, ownershipProof3, commitmentData);
 
 		// Unknown state. Assumes full state is required
 		var diffd30 = state3.GetStateFrom(-1);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -74,6 +74,7 @@ public class ArenaClientTests
 		var aliceArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
+			"wasabiwallet.io",
 			wabiSabiApi);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
@@ -126,6 +127,7 @@ public class ArenaClientTests
 		var bobArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
+			"wasabiwallet.io",
 			wabiSabiApi);
 
 		var reissuanceResponse = await bobArenaClient.ReissueCredentialAsync(
@@ -188,7 +190,7 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore);
 
-		var apiClient = new ArenaClient(null!, null!, wabiSabiApi);
+		var apiClient = new ArenaClient(null!, null!, "wasabiwallet.io", wabiSabiApi);
 
 		round.SetPhase(Phase.InputRegistration);
 
@@ -231,7 +233,7 @@ public class ArenaClientTests
 		InsecureRandom rnd = InsecureRandom.Instance;
 		var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, rnd, 4300000000000L);
 		var vsizeClient = new WabiSabiClient(round.VsizeCredentialIssuerParameters, rnd, 2000L);
-		var apiClient = new ArenaClient(amountClient, vsizeClient, wabiSabiApi);
+		var apiClient = new ArenaClient(amountClient, vsizeClient, "wasabiwallet.io", wabiSabiApi);
 
 		round.SetPhase(Phase.TransactionSigning);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -212,7 +212,7 @@ public class ArenaClientTests
 		var coins = destinationProvider.GetNextDestinations(2)
 			.Select(dest => (
 				Coin: new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(1.0m), dest)),
-				OwnershipProof: keyChain.GetOwnershipProof(dest, new CoinJoinInputCommitmentData("test", uint256.One))))
+				OwnershipProof: keyChain.GetOwnershipProof(dest, WabiSabiFactory.CreateCommitmentData(round.Id))))
 			.ToArray();
 
 		Alice alice1 = WabiSabiFactory.CreateAlice(coins[0].Coin, coins[0].OwnershipProof, round: round);
@@ -238,6 +238,7 @@ public class ArenaClientTests
 		round.SetPhase(Phase.TransactionSigning);
 
 		var emptyState = round.Assert<ConstructionState>();
+		var commitmentData = WabiSabiFactory.CreateCommitmentData(round.Id);
 
 		// We can't use ``emptyState.Finalize()` because this is not a valid transaction so we fake it
 		var finalizedEmptyState = new SigningState(round.Parameters, emptyState.Events);
@@ -246,14 +247,14 @@ public class ArenaClientTests
 		await Assert.ThrowsAsync<ArgumentException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice1.Coin, coins[0].OwnershipProof, keyChain, finalizedEmptyState.CreateUnsignedTransaction(), CancellationToken.None));
 
-		var oneInput = emptyState.AddInput(alice1.Coin).Finalize();
+		var oneInput = emptyState.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData).Finalize();
 		round.CoinjoinState = oneInput;
 
 		// Trying to sign coins those are not in the coinjoin.
 		await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice2.Coin, coins[1].OwnershipProof, keyChain, oneInput.CreateUnsignedTransaction(), CancellationToken.None));
 
-		var twoInputs = emptyState.AddInput(alice1.Coin).AddInput(alice2.Coin).Finalize();
+		var twoInputs = emptyState.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData).AddInput(alice2.Coin, alice2.OwnershipProof, commitmentData).Finalize();
 		round.CoinjoinState = twoInputs;
 
 		Assert.False(round.Assert<SigningState>().IsFullySigned);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -46,10 +46,12 @@ public class BobClientTests
 		var aliceArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
+			"wasabiwallet.io",
 			wabiSabiApi);
 		var bobArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
+			"wasabiwallet.io",
 			wabiSabiApi);
 		Assert.Equal(Phase.InputRegistration, round.Phase);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
@@ -39,5 +39,5 @@ public class OwnershipProofTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey),
-			new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash));
+			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -83,6 +83,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 		var arenaClient = new ArenaClient(
 			round.CreateAmountCredentialClient(insecureRandom),
 			round.CreateVsizeCredentialClient(insecureRandom),
+			"wasabiwallet.io",
 			wabiSabiHttpApiClient);
 		return arenaClient;
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
@@ -123,5 +123,5 @@ public class InputRegistrationRequestTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main), key.PubKey.WitHash.ScriptPubKey),
-			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash));
+			WabiSabiFactory.CreateCommitmentData(roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
@@ -123,5 +123,5 @@ public class InputRegistrationRequestTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main), key.PubKey.WitHash.ScriptPubKey),
-			new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash));
+			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Collections.Immutable;
+using WalletWasabi.Crypto;
 using System.Linq;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Models;
@@ -22,6 +23,8 @@ public class MultipartyTransactionTests
 		MaxSuggestedAmountBase = Money.Coins(Constants.MaximumNumberOfBitcoins)
 	}) with { MiningFeeRate = new FeeRate(0m)};
 
+	private static CoinJoinInputCommitmentData commitmentData = WabiSabiFactory.CreateCommitmentData();
+
 	private static void ThrowsProtocolException(WabiSabiProtocolErrorCode expectedError, Action action) =>
 		Assert.Equal(expectedError, Assert.Throws<WabiSabiProtocolException>(action).ErrorCode);
 
@@ -31,15 +34,15 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		var alice1Coin = WabiSabiFactory.CreateCoin(key1);
-		var alice2Coin = WabiSabiFactory.CreateCoin(key2);
+		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key1);
+		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key2);
 
 		var state = new ConstructionState(DefaultParameters);
 
 		Assert.Empty(state.Inputs);
 		Assert.Empty(state.Outputs);
 
-		var oneInput = state.AddInput(alice1Coin);
+		var oneInput = state.AddInput(alice1Coin, alice1OwnershipProof, commitmentData);
 
 		Assert.Single(oneInput.Inputs);
 		Assert.Empty(oneInput.Outputs);
@@ -48,14 +51,14 @@ public class MultipartyTransactionTests
 		Assert.Empty(state.Inputs);
 		Assert.Empty(state.Outputs);
 
-		var differentInput = state.AddInput(alice2Coin);
+		var differentInput = state.AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
 
 		Assert.Single(differentInput.Inputs);
 		Assert.Empty(differentInput.Outputs);
 		Assert.NotEqual(oneInput.Inputs, differentInput.Inputs);
 		Assert.Equal(oneInput.Outputs, differentInput.Outputs);
 
-		var twoInputs = oneInput.AddInput(alice2Coin);
+		var twoInputs = oneInput.AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
 
 		Assert.Equal(2, twoInputs.Inputs.Count());
 		Assert.Empty(twoInputs.Outputs);
@@ -107,9 +110,9 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void AddWithOptimize()
 	{
-		var coin = WabiSabiFactory.CreateCoin();
+		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
 
-		var state = new ConstructionState(DefaultParameters).AddInput(coin);
+		var state = new ConstructionState(DefaultParameters).AddInput(coin, ownershipProof, commitmentData);
 
 		var script = BitcoinFactory.CreateScript();
 		var bob = new TxOut(coin.Amount / 2, script);
@@ -125,13 +128,14 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void WitnessValidation()
 	{
+
 		using Key key1 = new();
 		using Key key2 = new();
 
-		var alice1Coin = WabiSabiFactory.CreateCoin(key1);
-		var alice2Coin = WabiSabiFactory.CreateCoin(key2);
+		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key1);
+		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key2);
 
-		var state = new ConstructionState(DefaultParameters).AddInput(alice1Coin).AddInput(alice2Coin);
+		var state = new ConstructionState(DefaultParameters).AddInput(alice1Coin, alice1OwnershipProof, commitmentData).AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
 
 		// address reuse bad
 		var bob1 = new TxOut(Money.Coins(1), alice1Coin.ScriptPubKey);
@@ -182,12 +186,12 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		var alice1Coin = WabiSabiFactory.CreateCoin(key1);
-		var alice2Coin = WabiSabiFactory.CreateCoin(key2);
+		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key1);
+		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key2);
 
 		var state = new ConstructionState(DefaultParameters with { MiningFeeRate = feeRate })
-			.AddInput(alice1Coin)
-			.AddInput(alice2Coin);
+			.AddInput(alice1Coin, alice1OwnershipProof, commitmentData)
+			.AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
 
 		var bob1 = new TxOut(Money.Coins(1), alice1Coin.ScriptPubKey);
 		var withOutput = state.AddOutput(bob1);
@@ -238,9 +242,9 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void NoDuplicateInputs()
 	{
-		var coin = WabiSabiFactory.CreateCoin();
-		var state = new ConstructionState(DefaultParameters).AddInput(coin);
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(coin));
+		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
+		var state = new ConstructionState(DefaultParameters).AddInput(coin, ownershipProof, commitmentData);
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(coin, ownershipProof, commitmentData));
 		Assert.Single(state.Inputs);
 	}
 
@@ -250,31 +254,31 @@ public class MultipartyTransactionTests
 	public void OnlyAllowedInputTypes()
 	{
 		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
-		var coin = WabiSabiFactory.CreateCoin();
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(coin));
+		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(coin, ownershipProof, commitmentData));
 	}
 
 	[Fact]
 	public void InputAmountRanges()
 	{
-		var coin = WabiSabiFactory.CreateCoin();
+		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
 
 		var exact = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(coin.Amount, coin.Amount) });
 		var above = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(2 * coin.Amount, 3 * coin.Amount) });
 		var below = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(coin.Amount - Money.Coins(0.001m), coin.Amount - Money.Coins(0.0001m)) });
 
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds, () => above.AddInput(coin));
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds, () => below.AddInput(coin));
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds, () => above.AddInput(coin, ownershipProof, commitmentData));
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds, () => below.AddInput(coin, ownershipProof, commitmentData));
 
 		// Allowed range is inclusive:
-		Assert.Equal(coin.Amount, Assert.Single(exact.AddInput(coin).Inputs).Amount);
+		Assert.Equal(coin.Amount, Assert.Single(exact.AddInput(coin, ownershipProof, commitmentData).Inputs).Amount);
 	}
 
 	[Fact]
 	public void UneconomicalInputs()
 	{
-		var alice1Coin = WabiSabiFactory.CreateCoin(amount: new Money(1000L));
-		var alice2Coin = WabiSabiFactory.CreateCoin(amount: new Money(1001L));
+		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(amount: new Money(1000L));
+		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(amount: new Money(2000L));
 
 		// requires 1k sats per input in sat/vKB
 		var inputVsize = alice1Coin.ScriptPubKey.EstimateInputVsize();
@@ -283,9 +287,9 @@ public class MultipartyTransactionTests
 
 		var state = new ConstructionState(DefaultParameters with { MiningFeeRate = feeRate });
 
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.UneconomicalInput, () => state.AddInput(alice1Coin));
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.UneconomicalInput, () => state.AddInput(alice1Coin, alice1OwnershipProof, commitmentData));
 
-		Assert.Equal(alice2Coin.Amount, Assert.Single(state.AddInput(alice2Coin).Inputs).Amount);
+		Assert.Equal(alice2Coin.Amount, Assert.Single(state.AddInput(alice2Coin, alice2OwnershipProof, commitmentData).Inputs).Amount);
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -31,8 +31,8 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		var alice1Coin = CreateCoin(script: key1.PubKey.WitHash.ScriptPubKey);
-		var alice2Coin = CreateCoin(script: key2.PubKey.WitHash.ScriptPubKey);
+		var alice1Coin = WabiSabiFactory.CreateCoin(key1);
+		var alice2Coin = WabiSabiFactory.CreateCoin(key2);
 
 		var state = new ConstructionState(DefaultParameters);
 
@@ -107,7 +107,7 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void AddWithOptimize()
 	{
-		var coin = CreateCoin();
+		var coin = WabiSabiFactory.CreateCoin();
 
 		var state = new ConstructionState(DefaultParameters).AddInput(coin);
 
@@ -128,8 +128,8 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		var alice1Coin = CreateCoin(script: key1.PubKey.WitHash.ScriptPubKey);
-		var alice2Coin = CreateCoin(script: key2.PubKey.WitHash.ScriptPubKey);
+		var alice1Coin = WabiSabiFactory.CreateCoin(key1);
+		var alice2Coin = WabiSabiFactory.CreateCoin(key2);
 
 		var state = new ConstructionState(DefaultParameters).AddInput(alice1Coin).AddInput(alice2Coin);
 
@@ -182,8 +182,8 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		var alice1Coin = CreateCoin(script: key1.PubKey.WitHash.ScriptPubKey);
-		var alice2Coin = CreateCoin(script: key2.PubKey.WitHash.ScriptPubKey);
+		var alice1Coin = WabiSabiFactory.CreateCoin(key1);
+		var alice2Coin = WabiSabiFactory.CreateCoin(key2);
 
 		var state = new ConstructionState(DefaultParameters with { MiningFeeRate = feeRate })
 			.AddInput(alice1Coin)
@@ -238,7 +238,7 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void NoDuplicateInputs()
 	{
-		var coin = CreateCoin();
+		var coin = WabiSabiFactory.CreateCoin();
 		var state = new ConstructionState(DefaultParameters).AddInput(coin);
 		ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(coin));
 		Assert.Single(state.Inputs);
@@ -250,14 +250,14 @@ public class MultipartyTransactionTests
 	public void OnlyAllowedInputTypes()
 	{
 		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
-		var coin = CreateCoin();
+		var coin = WabiSabiFactory.CreateCoin();
 		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(coin));
 	}
 
 	[Fact]
 	public void InputAmountRanges()
 	{
-		var coin = CreateCoin();
+		var coin = WabiSabiFactory.CreateCoin();
 
 		var exact = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(coin.Amount, coin.Amount) });
 		var above = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(2 * coin.Amount, 3 * coin.Amount) });
@@ -273,8 +273,8 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void UneconomicalInputs()
 	{
-		var alice1Coin = CreateCoin(new Money(1000L));
-		var alice2Coin = CreateCoin(new Money(1001L));
+		var alice1Coin = WabiSabiFactory.CreateCoin(amount: new Money(1000L));
+		var alice2Coin = WabiSabiFactory.CreateCoin(amount: new Money(1001L));
 
 		// requires 1k sats per input in sat/vKB
 		var inputVsize = alice1Coin.ScriptPubKey.EstimateInputVsize();
@@ -331,9 +331,4 @@ public class MultipartyTransactionTests
 		var updated = state.AddOutput(output);
 		Assert.Equal(output, Assert.Single(updated.Outputs));
 	}
-
-	private Coin CreateCoin(Money? amount = null, Script? script = null)
-		=> new Coin(
-			BitcoinFactory.CreateOutPoint(),
-			new TxOut(amount ?? Money.Coins(1), script ?? BitcoinFactory.CreateScript()));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -139,7 +139,7 @@ public class SerializationTests
 		AssertSerialization(RoundState.FromRound(round));
 
 		var state = round.Assert<ConstructionState>();
-		state = state.AddInput(CreateCoin());
+		state = state.AddInput(WabiSabiFactory.CreateCoin());
 		round.CoinjoinState = new SigningState(round.Parameters, state.Events);
 		AssertSerialization(RoundState.FromRound(round));
 	}
@@ -206,10 +206,4 @@ public class SerializationTests
 		new(
 			new[] { MAC.ComputeMAC(IssuerKey, Points.First(), Scalars.First()) },
 			new[] { new Proof(new GroupElementVector(Points.Take(2)), new ScalarVector(Scalars.Take(2))) });
-
-	private static Coin CreateCoin()
-	{
-		using var key = new Key();
-		return WabiSabiFactory.CreateCoin(key);
-	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -139,8 +139,9 @@ public class SerializationTests
 		AssertSerialization(RoundState.FromRound(round));
 
 		var state = round.Assert<ConstructionState>();
-		state = state.AddInput(WabiSabiFactory.CreateCoin());
-		round.CoinjoinState = new SigningState(round.Parameters, state.Events);
+		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
+		state = state.AddInput(coin, ownershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
+		round.CoinjoinState = new SigningState(state.Parameters, state.Events);
 		AssertSerialization(RoundState.FromRound(round));
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -63,7 +63,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			// for validation purposes.
 			_ = round.Assert<ConstructionState>().AddInput(coin);
 
-			var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", round.Id);
+			var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData(Config.CoordinatorIdentifier, round.Id);
 			if (!OwnershipProof.VerifyCoinJoinInputProof(request.OwnershipProof, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -127,8 +127,8 @@ public class Round
 		return InputRegistrationTimeFrame.HasExpired;
 	}
 
-	public ConstructionState AddInput(Coin coin)
-		=> Assert<ConstructionState>().AddInput(coin);
+	public ConstructionState AddInput(Coin coin, OwnershipProof ownershipProof, CoinJoinInputCommitmentData coinJoinInputCommitmentData)
+		=> Assert<ConstructionState>().AddInput(coin, ownershipProof, coinJoinInputCommitmentData);
 
 	public ConstructionState AddOutput(TxOut output)
 		=> Assert<ConstructionState>().AddOutput(output);

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -120,6 +120,10 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "WW200CompatibleLoadBalancingInputSplit", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public double WW200CompatibleLoadBalancingInputSplit { get; set; } = 0.75;
 
+	[DefaultValue("wasabiwallet.io")]
+	[JsonProperty(PropertyName = "CoordinatorIdentifier", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public string CoordinatorIdentifier { get; set; } = "wasabiwallet.io";
+
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -94,7 +94,7 @@ public class AliceClient
 		{
 			var ownershipProof = keyChain.GetOwnershipProof(
 				coin,
-				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundState.Id));
+				new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Id));
 
 			var (response, isPayingZeroCoordinationFee) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
 			aliceClient = new(response.Value, roundState, arenaClient, coin, ownershipProof, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isPayingZeroCoordinationFee);

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -17,15 +17,18 @@ public class ArenaClient
 	public ArenaClient(
 		WabiSabiClient amountCredentialClient,
 		WabiSabiClient vsizeCredentialClient,
+		string coordinatorIdentifier,
 		IWabiSabiApiRequestHandler requestHandler)
 	{
 		AmountCredentialClient = amountCredentialClient;
 		VsizeCredentialClient = vsizeCredentialClient;
+		CoordinatorIdentifier = coordinatorIdentifier;
 		RequestHandler = requestHandler;
 	}
 
 	public WabiSabiClient AmountCredentialClient { get; }
 	public WabiSabiClient VsizeCredentialClient { get; }
+	public string CoordinatorIdentifier { get; }
 	public IWabiSabiApiRequestHandler RequestHandler { get; }
 
 	public async Task<(ArenaResponse<Guid> ArenaResponse, bool IsPayingZeroCoordinationFee)> RegisterInputAsync(

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -41,6 +41,7 @@ public class CoinJoinClient
 		IKeyChain keyChain,
 		IDestinationProvider destinationProvider,
 		RoundStateUpdater roundStatusUpdater,
+		string coordinatorIdentifier,
 		int anonScoreTarget = int.MaxValue,
 		bool consolidationMode = false,
 		TimeSpan feeRateMedianTimeFrame = default,
@@ -51,6 +52,7 @@ public class CoinJoinClient
 		DestinationProvider = destinationProvider;
 		RoundStatusUpdater = roundStatusUpdater;
 		AnonScoreTarget = anonScoreTarget;
+		CoordinatorIdentifier = coordinatorIdentifier;
 		ConsolidationMode = consolidationMode;
 		FeeRateMedianTimeFrame = feeRateMedianTimeFrame;
 		SecureRandom = new SecureRandom();
@@ -64,6 +66,7 @@ public class CoinJoinClient
 	private IKeyChain KeyChain { get; }
 	private IDestinationProvider DestinationProvider { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
+	public string CoordinatorIdentifier { get; }
 	public int AnonScoreTarget { get; }
 	private TimeSpan DoNotRegisterInLastMinuteTimeLimit { get; }
 
@@ -282,6 +285,7 @@ public class CoinJoinClient
 				var aliceArenaClient = new ArenaClient(
 					roundState.CreateAmountCredentialClient(SecureRandom),
 					roundState.CreateVsizeCredentialClient(SecureRandom),
+					CoordinatorIdentifier,
 					arenaRequestHandler);
 
 				var aliceClient = await AliceClient.CreateRegisterAndConfirmInputAsync(roundState, aliceArenaClient, coin, KeyChain, RoundStatusUpdater, linkedUnregisterCts.Token, linkedRegistrationsCts.Token, linkedConfirmationsCts.Token).ConfigureAwait(false);
@@ -375,6 +379,7 @@ public class CoinJoinClient
 			new(
 				roundState.CreateAmountCredentialClient(SecureRandom),
 				roundState.CreateVsizeCredentialClient(SecureRandom),
+				CoordinatorIdentifier,
 				arenaRequestHandler));
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -26,18 +26,20 @@ public class CoinJoinManager : BackgroundService
 	private record StartCoinJoinCommand(Wallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
 	private record StopCoinJoinCommand(Wallet Wallet) : CoinJoinCommand(Wallet);
 
-	public CoinJoinManager(WalletManager walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, ServiceConfiguration serviceConfiguration)
+	public CoinJoinManager(WalletManager walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, ServiceConfiguration serviceConfiguration, string coordinatorIdentifier)
 	{
 		WalletManager = walletManager;
 		HttpClientFactory = backendHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		ServiceConfiguration = serviceConfiguration;
+		CoordinatorIdentifier = coordinatorIdentifier;
 	}
 
 	public WalletManager WalletManager { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
 	public ServiceConfiguration ServiceConfiguration { get; }
+	public string CoordinatorIdentifier { get; }
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 	public bool IsUserInSendWorkflow { get; set; }
 
@@ -129,7 +131,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<Wallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
 	{
-		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, stoppingToken);
+		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, stoppingToken);
 
 		void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -12,16 +12,19 @@ public class CoinJoinTrackerFactory
 	public CoinJoinTrackerFactory(
 		IWasabiHttpClientFactory httpClientFactory,
 		RoundStateUpdater roundStatusUpdater,
+		string coordinatorIdentifier,
 		CancellationToken cancellationToken)
 	{
 		HttpClientFactory = httpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
+		CoordinatorIdentifier = coordinatorIdentifier;
 		CancellationToken = cancellationToken;
 	}
 
 	private IWasabiHttpClientFactory HttpClientFactory { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private CancellationToken CancellationToken { get; }
+	private string CoordinatorIdentifier { get; }
 
 	public CoinJoinTracker CreateAndStart(Wallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
 	{
@@ -30,6 +33,7 @@ public class CoinJoinTrackerFactory
 			new KeyChain(wallet.KeyManager, wallet.Kitchen),
 			new InternalDestinationProvider(wallet.KeyManager),
 			RoundStatusUpdater,
+			CoordinatorIdentifier,
 			wallet.KeyManager.AnonScoreTarget,
 			feeRateMedianTimeFrame: TimeSpan.FromHours(wallet.KeyManager.FeeRateMedianTimeFrameHours),
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -66,7 +66,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
 		}
 
-		return this with { Events = Events.Add(new InputAdded(coin)) };
+		return this with { Events = Events.Add(new InputAdded(coin, ownershipProof)) };
 	}
 
 	public ConstructionState AddOutput(TxOut output)

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using WalletWasabi.Crypto;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 
 namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
@@ -11,7 +12,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 public interface IEvent{};
 
 public record RoundCreated(RoundParameters RoundParameters) : IEvent;
-public record InputAdded (Coin Coin) : IEvent;
+public record InputAdded (Coin Coin, OwnershipProof ownershipProof) : IEvent;
 public record OutputAdded (TxOut Output) : IEvent;
 
 public abstract record MultipartyTransactionState


### PR DESCRIPTION
This PR makes wabisabi coordinator return [ownership proofs](https://github.com/satoshilabs/slips/blob/master/slip-0019.md) for all coinjoin inputs. This is needed by hardware wallets to support coinjoin, see [this](https://github.com/satoshilabs/slips/blob/master/slip-0019.md#motivation):
> In certain applications like CoinJoin or opening a dual-funded channel in the Lightning Network, a wallet has to sign transactions containing external inputs. To calculate the actual amount the user is spending, the wallet needs to reliably determine for each input whether it belongs to the wallet or not. Without such a mechanism an attacker can deceive the wallet into displaying incorrect information about the amount being spent, which can result in theft of user funds. This was first recognized in a bitcoin-dev [mailing list discussion](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-August/014843.html).

1362bac27b4f3cee10443fdb5f26dd8b5be99e49 fixes a typo in a test.

68dc069653d96554f838bed65d62962ccc5c32c7 is a mere refactoring commit, it should not change the bahaviour of the code.

61f8bfe80d87fbd3f8bb7425f2ee24e0cfb65a52, df63bda321dcc800dacf7d65dedf021f318ca249, e27bf08b425690a084ae883e9a01394697f5c297, 1e505d0fc0b994afb1d81a9cbffe15316204ee77 introduce a configuration option for the coordinator identifier (that is used together with a round identifier as [additional commitment data](https://github.com/satoshilabs/slips/blob/master/slip-0019.md#additional-commitment-data) in ownership proofs) in both the server and the coordinator. Note that I changed the coordinator identifier from "CoinJoinCoordinatorIdentifier" to ""wasabiwallet.io". Since both the coordinator and all participants must use the same coordinator, this requires synchronized update of the server and all the clients. If you don't want to do it now, you can simply set the value of the identifier back to "CoinJoinCoordinatorIdentifier".

28519d684294a35054f0419fb9abece1467d2d33 is a refactoring commit suggested [here](https://github.com/zkSNACKs/WalletWasabi/blob/c3d2b4d3153cbc16706660ae45487be73d22f2f4/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs#L16).  b30e05db5715671c0238c902e193f19db7068205 tests the preceding commit.
b30e05db5715671c0238c902e193f19db7068205 is the most important commit. This commit makes coordinator return ownership proofs in the input events.