### PR TITLE
[VDG] BuildPrivacySuggestionsAsync - Fire and Forget 

### DIFF
--- a/WalletWasabi.Fluent/Extensions/TaskExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/TaskExtension.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Fluent.Extensions;
+
+public static class TaskExtension
+{
+	public static void FireAndForget(this Task task)
+	{
+		_ = RunAsync(task);
+	}
+
+	private static async Task RunAsync(Task task)
+	{
+		try
+		{
+			await task;
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex);
+		}
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -74,7 +74,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			});
 
 		PrivacySuggestions.WhenAnyValue(x => x.SelectedSuggestion)
-			.SubscribeAsync(async x =>
+			.Subscribe(x =>
 			{
 				PrivacySuggestions.IsOpen = false;
 				PrivacySuggestions.SelectedSuggestion = null;
@@ -84,7 +84,9 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 					_info.ChangelessCoins = ca.TransactionResult.SpentCoins;
 					UpdateTransaction(CurrentTransactionSummary, ca.TransactionResult);
 
-					await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, ca.TransactionResult, _isFixedAmount, _cancellationTokenSource.Token);
+					PrivacySuggestions
+						.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, ca.TransactionResult, _isFixedAmount, _cancellationTokenSource.Token)
+						.FireAndForget();
 				}
 			});
 
@@ -129,14 +131,16 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			}
 		});
 
-		UndoCommand = ReactiveCommand.CreateFromTask(async () =>
+		UndoCommand = ReactiveCommand.Create(() =>
 		{
 			if (_undoHistory.TryPop(out var previous))
 			{
 				_info = previous.Item2;
 				UpdateTransaction(CurrentTransactionSummary, previous.Item1, false);
 				CanUndo = _undoHistory.Any();
-				await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, previous.Item1, _isFixedAmount, _cancellationTokenSource.Token);
+				PrivacySuggestions
+					.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, previous.Item1, _isFixedAmount, _cancellationTokenSource.Token)
+					.FireAndForget();
 			}
 		});
 
@@ -222,7 +226,9 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 		{
 			UpdateTransaction(CurrentTransactionSummary, newTransaction);
 
-			await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, newTransaction, _isFixedAmount, _cancellationTokenSource.Token);
+			PrivacySuggestions
+				.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, newTransaction, _isFixedAmount, _cancellationTokenSource.Token)
+				.FireAndForget();
 		}
 	}
 
@@ -414,7 +420,9 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 		{
 			UpdateTransaction(CurrentTransactionSummary, initialTransaction);
 
-			await PrivacySuggestions.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, initialTransaction, _isFixedAmount, _cancellationTokenSource.Token);
+			PrivacySuggestions
+				.BuildPrivacySuggestionsAsync(_wallet, _info, _destination, initialTransaction, _isFixedAmount, _cancellationTokenSource.Token)
+				.FireAndForget();
 		}
 		else
 		{


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8602

This PR adds an extension method `FireAndForget()` which wraps the task in try-catch and logs the exception so at least we are aware if something bad happens.