### PR TITLE
`WasabiSynchronizer`: Remove request blocking

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
-using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBuilding;
@@ -336,20 +335,18 @@ public class Wallet : BackgroundService
 
 			NewFilterProcessed?.Invoke(this, filterModel);
 
-			do
-			{
-				await Task.Delay(100).ConfigureAwait(false);
-				if (Synchronizer is null || BitcoinStore?.SmartHeaderChain is null)
-				{
-					return;
-				}
+			await Task.Delay(100).ConfigureAwait(false);
 
-				// Make sure fully synced and this filter is the latest filter.
-				if (BitcoinStore.SmartHeaderChain.HashesLeft != 0 || BitcoinStore.SmartHeaderChain.TipHash != filterModel.Header.BlockHash)
-				{
-					return;
-				}
-			} while (Synchronizer.AreRequestsBlocked()); // If requests are blocked, delay mempool cleanup, because coinjoin answers are always priority.
+			if (Synchronizer is null || BitcoinStore?.SmartHeaderChain is null)
+			{
+				return;
+			}
+
+			// Make sure fully synced and this filter is the latest filter.
+			if (BitcoinStore.SmartHeaderChain.HashesLeft != 0 || BitcoinStore.SmartHeaderChain.TipHash != filterModel.Header.BlockHash)
+			{
+				return;
+			}
 
 			var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer.HttpClientFactory);
 


### PR DESCRIPTION
<s>Depends on #8639</s>

Request blocking is no longer used in WW2 code. 

[Review with whitespace off](https://github.com/zkSNACKs/WalletWasabi/pull/8640/files?diff=split&w=1).