### PR TITLE
`WasabiSynchronizer`: Improve exception handling

### DIFF
--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Stores;
 using WalletWasabi.Tor.Socks5.Exceptions;
+using WalletWasabi.Tor.Socks5.Models.Fields.OctetFields;
 using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services;
@@ -178,7 +179,6 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 						{
 							TorStatus = innerEx is TorConnectionException ? TorStatus.NotRunning : TorStatus.Running;
 							BackendStatus = BackendStatus.NotConnected;
-							HandleIfGenSocksServFail(ex);
 							HandleIfGenSocksServFail(innerEx);
 							throw;
 						}
@@ -292,7 +292,7 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 			finally
 			{
 				Interlocked.CompareExchange(ref _running, StateStopped, StateStopping); // If IsStopping, make it stopped.
-				Logger.LogTrace("< Wasabi synchronizer thread ends.");
+				Logger.LogDebug("Synchronizer is fully stopped now.");
 			}
 		});
 
@@ -305,15 +305,19 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 
 	private void HandleIfGenSocksServFail(Exception ex)
 	{
-		// IS GenSocksServFail?
-		if (ex.ToString().Contains("GeneralSocksServerFailure", StringComparison.OrdinalIgnoreCase))
+		bool isFail = false;
+
+		if (ex is TorConnectCommandFailedException torEx)
 		{
-			// IS GenSocksServFail
+			isFail = torEx.RepField == RepField.GeneralSocksServerFailure || torEx.RepField == RepField.OnionServiceIntroFailed;
+		}
+
+		if (isFail)
+		{
 			DoGenSocksServFail();
 		}
 		else
 		{
-			// NOT GenSocksServFail
 			DoNotGenSocksServFail();
 		}
 	}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -307,6 +307,11 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	{
 		bool isFail = false;
 
+		if (ex is HttpRequestException httpRequestException && httpRequestException.InnerException is not null)
+		{
+			ex = httpRequestException.InnerException;
+		}
+
 		if (ex is TorConnectCommandFailedException torEx)
 		{
 			isFail = torEx.RepField == RepField.GeneralSocksServerFailure || torEx.RepField == RepField.OnionServiceIntroFailed;

--- a/WalletWasabi/Tor/Socks5/Exceptions/TorConnectCommandFailedException.cs
+++ b/WalletWasabi/Tor/Socks5/Exceptions/TorConnectCommandFailedException.cs
@@ -6,7 +6,7 @@ namespace WalletWasabi.Tor.Socks5.Exceptions;
 /// <summary>
 /// Thrown when Tor SOCKS5 responds with an error code to previously sent <see cref="CmdField.Connect"/> command.
 /// </summary>
-public class TorConnectCommandFailedException : TorException
+public class TorConnectCommandFailedException : TorConnectionException
 {
 	public TorConnectCommandFailedException(RepField rep) : base($"Tor SOCKS5 proxy responded with {rep}.")
 	{

--- a/WalletWasabi/Tor/Socks5/Models/ReplyType.cs
+++ b/WalletWasabi/Tor/Socks5/Models/ReplyType.cs
@@ -1,5 +1,3 @@
-using Microsoft.VisualBasic;
-
 namespace WalletWasabi.Tor.Socks5.Models;
 
 /// <seealso href="https://github.com/torproject/torspec/blob/main/proposals/304-socks5-extending-hs-error-codes.txt"/>
@@ -12,7 +10,16 @@ public enum ReplyType : byte
 	NetworkUnreachable = 0x03,
 	HostUnreachable = 0x04,
 	ConnectionRefused = 0x05,
+
+	/// <summary>An operation failed because we waited too long for an [Tor] exit to do something.</summary>
+	/// <remarks>
+	/// This error can happen if the host you're trying to connect to isn't
+	/// responding to traffic. It can also happen if an exit is overloaded, and
+	/// unable to answer your replies in a timely manner.
+	/// <para>In either case, trying later, or on a different circuit, might help.</para>
+	/// </remarks>
 	TtlExpired = 0x06,
+
 	CommandNotSupported = 0x07,
 	AddressTypeNotSupported = 0x08,
 
@@ -59,7 +66,7 @@ public enum ReplyType : byte
 	/// Tor was able to download the requested onion service descriptor but is
 	/// unable to decrypt its content using the client authorization information
 	/// it has.This means the client access were revoked.
-    /// </remarks>
+	/// </remarks>
 	OnionServiceBadClientAuth = 0xF5,
 
 	/// <summary>Onion service invalid address</summary>


### PR DESCRIPTION
Hopefully improves #8618

I believe that what can happen is simply:

1. https://github.com/zkSNACKs/WalletWasabi/blob/b72765fe834e068fa6d8feae83473bc0ef05ccbb/WalletWasabi/Services/WasabiSynchronizer.cs#L168-L170 throws because Tor circuit dies (TTL expiration) or fails in any way.
2. We get here https://github.com/zkSNACKs/WalletWasabi/blob/b72765fe834e068fa6d8feae83473bc0ef05ccbb/WalletWasabi/Services/WasabiSynchronizer.cs#L177-L184
3. We throw https://github.com/zkSNACKs/WalletWasabi/blob/b72765fe834e068fa6d8feae83473bc0ef05ccbb/WalletWasabi/Services/WasabiSynchronizer.cs#L183
4. https://github.com/zkSNACKs/WalletWasabi/blob/b72765fe834e068fa6d8feae83473bc0ef05ccbb/WalletWasabi/Services/WasabiSynchronizer.cs#L273 is executed and an exception is logged.

However, #8553 should make it less likely that a `TorConnectCommandFailedException` is thrown in the first place.