### PR TITLE
Restart Tor on long TTLExpired

### DIFF
--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -48,7 +48,7 @@ public class TorMonitor : PeriodicRunner
 	private TorHttpPool TorHttpPool { get; }
 
 	private Task? BootstrapTask { get; set; }
-	private bool TriedTorRestart { get; set; } = false;
+	private bool TriedTorRestart { get; set; }
 
 	/// <inheritdoc/>
 	public override Task StartAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
I caught an error where my Tor was failing for 7.5 hours and only restarting it solved the issue.

@kiminuo can you make a PR on top of this that kills Tor at the place where `// todo: kill Tor` comment is?