### PR TITLE
Weakly consider AS for coin selection

### DIFF
--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -55,6 +55,24 @@ public static class LinqExtensions
 		return current;
 	}
 
+	/// <summary>
+	/// Selects a random element based on order bias.
+	/// </summary>
+	/// <param name="biasPercent">1-100, eg. if 80, then 80% probability for the first element.</param>
+	/// <returns></returns>
+	public static T? BiasedRandomElement<T>(this IOrderedEnumerable<T> source, int biasPercent)
+	{
+		foreach (T element in source)
+		{
+			if (Random.Shared.Next(1, 101) <= biasPercent)
+			{
+				return element;
+			}
+		}
+
+		return default;
+	}
+
 	public static IList<T> Shuffle<T>(this IList<T> list)
 	{
 		int n = list.Count;

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Extensions;
 
 namespace WalletWasabi.Extensions;
@@ -63,7 +64,7 @@ public static class LinqExtensions
 	{
 		foreach (T element in source)
 		{
-			if (Random.Shared.Next(1, 101) <= biasPercent)
+			if (SecureRandom.Instance.GetInt(1, 101) <= biasPercent)
 			{
 				return element;
 			}

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -70,7 +70,7 @@ public static class LinqExtensions
 			}
 		}
 
-		return default;
+		return source.Any() ? source.First() : default;
 	}
 
 	public static IList<T> Shuffle<T>(this IList<T> list)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -537,6 +537,11 @@ public class CoinJoinClient
 		}
 		nonPrivateCoins.Shuffle();
 
+		// How many inputs do we want to provide to the mix?
+		int inputCount = Math.Min(
+			privateCoins.Length + nonPrivateCoins.Count,
+			consolidationMode ? MaxInputsRegistrableByWallet : GetInputTarget(nonPrivateCoins.Count, privateCoins.Length, rnd));
+
 		// Make sure it's ordered by 1 private and 1 non-private coins.
 		// Otherwise we'd keep mixing private coins too much during the end of our mixing sessions.
 		var organizedCoins = new List<SmartCoin>();
@@ -553,11 +558,6 @@ public class CoinJoinClient
 				organizedCoins.Add(pc);
 			}
 		}
-
-		// How many inputs do we want to provide to the mix?
-		int inputCount = Math.Min(
-			organizedCoins.Count,
-			consolidationMode ? MaxInputsRegistrableByWallet : GetInputTarget(nonPrivateCoins.Count, privateCoins.Length, rnd));
 
 		// Always use the largest amounts, so we do not participate with insignificant amounts and fragment wallet needlessly.
 		var largestAmounts = nonPrivateCoins


### PR DESCRIPTION
Best to review commit by commit.

In order to mix AS of selected coins, previously a quick solution was used for coin selection that was altering high and low AS coins. This PR changes the alternation pattern to shuffling while biasing towards lower AS.

In this PR I also limit the number of private coins those might participate to `desired input count - 1`. `-1` because a non-private coins' place must be always ensured.