### PR TITLE
[WabiSabi] Verify ownership proofs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/OwnershipProofValidatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/OwnershipProofValidatorTests.cs
@@ -27,7 +27,7 @@ public class OwnershipProofValidatorTests
 	{
 		// We need the `TransactionStore` instance to verify coins created in transactions (coinjoins by sure)
 		// that are saved in our disk (because they are relevant for us). The `BlockProvider` and the `IndexStore`
-		// are used to find and get the blocks containing the transactions that creates the coins that we have
+		// are used to find and get the blocks containing the transactions that create the coins that we have
 		// to verify.
 		await using var indexStore = await CreateIndexStoreAsync().ConfigureAwait(false);
 		await using var transactionStore = await CreateTransactionStoreAsync().ConfigureAwait(false);
@@ -100,7 +100,7 @@ public class OwnershipProofValidatorTests
 		using var identificationKey = Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main);
 		var stx = CreateCreditingTransaction(scriptPubKey, Money.Coins(0.1234m));
 
-		// put the transaction is a block.
+		// put the transaction in a block.
 		var block = Consensus.Main.ConsensusFactory.CreateBlock();
 		block.AddTransaction(stx.Transaction);
 		var blockHash = block.GetHash();
@@ -125,7 +125,7 @@ public class OwnershipProofValidatorTests
 			new OwnershipIdentifier(identificationKey, otherAliceKey.PubKey.WitHash.ScriptPubKey),
 			coinJoinInputCommitmentData);
 
-		// verify the proof is valied.
+		// verify the proof is valid.
 		var validator = new OwnershipProofValidator(indexStore, transactionStore, blockProvider.Object);
 		var validProofs = await validator.VerifyOtherAlicesOwnershipProofsAsync(
 			coinJoinInputCommitmentData,
@@ -134,7 +134,7 @@ public class OwnershipProofValidatorTests
 			CancellationToken.None);
 		Assert.Equal(1, validProofs);
 
-		// validate a coin comming from an non-existing transaction.
+		// validate a coin coming from a non-existing transaction.
 		var fakeCoin = new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(8.118736401m), BitcoinFactory.CreateScript()));
 		validProofs = await validator.VerifyOtherAlicesOwnershipProofsAsync(
 			coinJoinInputCommitmentData,

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/OwnershipProofValidatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/OwnershipProofValidatorTests.cs
@@ -1,0 +1,175 @@
+using Moq;
+using NBitcoin;
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Backend.Models;
+using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.Crypto;
+using WalletWasabi.Models;
+using WalletWasabi.Stores;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.Wallets;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
+
+public class OwnershipProofValidatorTests
+{
+	[Fact]
+	public async Task CoinsAlreadySeenTestAsync()
+	{
+		// We need the `TransactionStore` instance to verify coins created in transactions (coinjoins by sure)
+		// that are saved in our disk (because they are relevant for us). The `BlockProvider` and the `IndexStore`
+		// are used to find and get the blocks containing the transactions that creates the coins that we have
+		// to verify.
+		await using var indexStore = await CreateIndexStoreAsync().ConfigureAwait(false);
+		await using var transactionStore = await CreateTransactionStoreAsync().ConfigureAwait(false);
+		var blockProvider = new Mock<IBlockProvider>();
+
+		using var otherAliceKey = new Key();
+		var scriptPubKey = BitcoinFactory.CreateScript(otherAliceKey);
+		using var identificationKey = Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main);
+		var tx = CreateCreditingTransaction(scriptPubKey, Money.Coins(0.1234m));
+
+		// Store the transaction in the store.
+		transactionStore.TryAddOrUpdate(tx);
+
+		var roundId = uint256.Zero;
+		var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData ("wasabiwallet.io", roundId);
+
+		var proof = OwnershipProof.GenerateCoinJoinInputProof(
+			otherAliceKey,
+			new OwnershipIdentifier(identificationKey, otherAliceKey.PubKey.WitHash.ScriptPubKey),
+			coinJoinInputCommitmentData);
+
+		var validator = new OwnershipProofValidator(indexStore, transactionStore, blockProvider.Object);
+
+		// Verify the ownership proof is valid.
+		var coin = tx.Transaction.Outputs.AsCoins().First();
+		var validProofs = await validator.VerifyOtherAlicesOwnershipProofsAsync(
+			coinJoinInputCommitmentData,
+			new[] { (coin, proof) }.ToImmutableList(),
+			10,
+			CancellationToken.None);
+		Assert.Equal(1, validProofs);
+
+		// Verify the ownership proof is valid (different script).
+		coin.ScriptPubKey = BitcoinFactory.CreateScript();
+		var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await validator.VerifyOtherAlicesOwnershipProofsAsync(
+			coinJoinInputCommitmentData,
+			new[] { (coin, proof) }.ToImmutableList(),
+			10,
+			CancellationToken.None));
+		Assert.Equal(1, validProofs);
+
+		// Verify the ownership proof is valid (non-existing one).
+		coin.Outpoint.N = 10; // non-existing coin
+		ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await validator.VerifyOtherAlicesOwnershipProofsAsync(
+			coinJoinInputCommitmentData,
+			new[] { (coin, proof) }.ToImmutableList(),
+			10,
+			CancellationToken.None));
+
+		// Verify the ownership proof is valid (non-existing one).
+		coin.Outpoint = BitcoinFactory.CreateOutPoint(); // non-existing transaction
+		validProofs = await validator.VerifyOtherAlicesOwnershipProofsAsync(
+			coinJoinInputCommitmentData,
+			new[] { (coin, proof) }.ToImmutableList(),
+			10,
+			CancellationToken.None);
+
+		Assert.Equal(0, validProofs);
+	}
+
+	[Fact]
+	public async Task CoinsNeverSeenBeforeTestAsync()
+	{
+		await using var indexStore = await CreateIndexStoreAsync().ConfigureAwait(false);
+		await using var transactionStore = await CreateTransactionStoreAsync().ConfigureAwait(false);
+		var blockProvider = new Mock<IBlockProvider>();
+
+		using var otherAliceKey = new Key();
+		var scriptPubKey = BitcoinFactory.CreateScript(otherAliceKey);
+		using var identificationKey = Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main);
+		var stx = CreateCreditingTransaction(scriptPubKey, Money.Coins(0.1234m));
+
+		// put the transaction is a block.
+		var block = Consensus.Main.ConsensusFactory.CreateBlock();
+		block.AddTransaction(stx.Transaction);
+		var blockHash = block.GetHash();
+		blockProvider.Setup(x => x.GetBlockAsync(blockHash, It.IsAny<CancellationToken>())).ReturnsAsync(block);
+
+		// index the block
+		var filter = new GolombRiceFilterBuilder()
+			.SetKey(block.GetHash())
+			.SetP(20)
+			.SetM(1 << 20)
+			.AddEntries(block.Transactions.SelectMany(tx => tx.Outputs.Select(o => o.ScriptPubKey.ToCompressedBytes())))
+			.Build();
+
+		var filterModel = new FilterModel(new SmartHeader(blockHash, uint256.Zero, 1, DateTimeOffset.Now), filter);
+		await indexStore.AddNewFiltersAsync(new[] { filterModel }, CancellationToken.None).ConfigureAwait(false);
+
+		var roundId = uint256.Zero;
+		var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData ("wasabiwallet.io", roundId);
+
+		var proof = OwnershipProof.GenerateCoinJoinInputProof(
+			otherAliceKey,
+			new OwnershipIdentifier(identificationKey, otherAliceKey.PubKey.WitHash.ScriptPubKey),
+			coinJoinInputCommitmentData);
+
+		// verify the proof is valied.
+		var validator = new OwnershipProofValidator(indexStore, transactionStore, blockProvider.Object);
+		var validProofs = await validator.VerifyOtherAlicesOwnershipProofsAsync(
+			coinJoinInputCommitmentData,
+			new[] { (stx.Transaction.Outputs.AsCoins().First(), proof) }.ToImmutableList(),
+			10,
+			CancellationToken.None);
+		Assert.Equal(1, validProofs);
+
+		// validate a coin comming from an non-existing transaction.
+		var fakeCoin = new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(8.118736401m), BitcoinFactory.CreateScript()));
+		validProofs = await validator.VerifyOtherAlicesOwnershipProofsAsync(
+			coinJoinInputCommitmentData,
+			new[] { (fakeCoin, proof) }.ToImmutableList(),
+			10,
+			CancellationToken.None);
+
+		Assert.Equal(0, validProofs);
+	}
+
+	private async Task<TransactionStore> CreateTransactionStoreAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "")
+	{
+		string dir = Path.Combine(Common.GetWorkDir(callerFilePath, callerMemberName), "TransactionStore");
+		await IoHelpers.TryDeleteDirectoryAsync(dir);
+		var txStore = new TransactionStore();
+		await txStore.InitializeAsync(dir, Network.Main, "", CancellationToken.None);
+		return txStore;
+	}
+
+	private async Task<IndexStore> CreateIndexStoreAsync([CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "")
+	{
+		string dir = Path.Combine(Common.GetWorkDir(callerFilePath, callerMemberName), "IndexStore");
+		await IoHelpers.TryDeleteDirectoryAsync(dir);
+		var indexStore = new IndexStore(dir, Network.Main, new SmartHeaderChain());
+		return indexStore;
+	}
+
+	private static SmartTransaction CreateCreditingTransaction(Script scriptPubKey, Money amount, int height = 0)
+	{
+		var tx = Network.RegTest.CreateTransaction();
+		tx.Version = 1;
+		tx.LockTime = LockTime.Zero;
+		tx.Inputs.Add(BitcoinFactory.CreateOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
+		tx.Inputs.Add(BitcoinFactory.CreateOutPoint(), new Script(OpcodeType.OP_0, OpcodeType.OP_0), sequence: Sequence.Final);
+		tx.Outputs.Add(amount, scriptPubKey);
+		return new SmartTransaction(tx, height == 0 ? Height.Mempool : new Height(height));
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/MaliciousCoordinatorException.cs
+++ b/WalletWasabi/WabiSabi/Client/MaliciousCoordinatorException.cs
@@ -1,0 +1,9 @@
+namespace WalletWasabi.WabiSabi.Client;
+
+public class MaliciousCoordinatorException : Exception
+{
+	public MaliciousCoordinatorException(string message)
+		: base(message)
+	{
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/OwnershipProofValidator.cs
+++ b/WalletWasabi/WabiSabi/Client/OwnershipProofValidator.cs
@@ -1,0 +1,150 @@
+using NBitcoin;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.Crypto;
+using WalletWasabi.Models;
+using WalletWasabi.Stores;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+// OwnershipProofValidator validates the ownership proofs provided by the coordinator.
+public class OwnershipProofValidator
+{
+	public OwnershipProofValidator(IndexStore indexStore, TransactionStore transactionStore, IBlockProvider blockProvider)
+	{
+		IndexStore = indexStore;
+		TransactionStore = transactionStore;
+		BlockProvider = blockProvider;
+	}
+
+	private IndexStore IndexStore { get; }
+	private TransactionStore TransactionStore { get; }
+	private IBlockProvider BlockProvider { get; }
+
+	// Verifies the coins and ownership proofs. These proofs are provided by the coordinator who should
+	// have validate them before which means that when dealing with a honest coordinator all these proof
+	// are valid.
+	//
+	// In case one proof is invalid we have evidence enough to know the coordinator is malicious and we
+	// have to abort the process, notify the user and ban the coordinator.
+	public async ValueTask<int> VerifyOtherAlicesOwnershipProofsAsync(
+		CoinJoinInputCommitmentData coinJoinInputCommitmentData,
+		ImmutableList<(Coin Coin, OwnershipProof OwnershipProof)> othersCoins,
+		int stopAfter,
+		CancellationToken cancellationToken)
+	{
+		var proofChannel = Channel.CreateBounded<(Coin, Coin, OwnershipProof)>(10);
+			
+		var coinsSearchingTask = Task.Run(() => FindCoinsToVerifyAsync(proofChannel.Writer, othersCoins, cancellationToken), cancellationToken);
+		var coinsValidationTask = Task.Run(() => ValidateCoinsAsync(proofChannel.Reader, coinJoinInputCommitmentData, stopAfter, cancellationToken));
+
+		await Task.WhenAll(coinsSearchingTask, coinsValidationTask).ConfigureAwait(false);
+		return await coinsValidationTask.ConfigureAwait(false);
+	}
+
+	private async Task FindCoinsToVerifyAsync(
+		ChannelWriter<(Coin, Coin, OwnershipProof)> proofChannelWriter,
+		ImmutableList<(Coin Coin, OwnershipProof OwnershipProof)> othersCoins,
+		CancellationToken cancellationToken)
+	{
+			
+		// What follows is an optimization where we try to verify coins that are already known by us.
+		var mineTxIds = TransactionStore.GetTransactionHashes();
+		var alreadySeenCoins = othersCoins.Where(x => mineTxIds.Contains(x.Coin.Outpoint.Hash));
+
+		// In case one Alice is trying to spend a output from a transaction that we already have
+		// seen before then we can verify its script without downloading anything from the network.
+		// However it is impossible for us to know it the coins is unspent!.
+		foreach (var (coin, ownershipProof) in alreadySeenCoins)
+		{
+			if (TransactionStore.TryGetTransaction(coin.Outpoint.Hash, out var stx))
+			{
+				var coinIndex = (int) coin.Outpoint.N; 
+				if (coinIndex >= stx.Transaction.Outputs.Count)
+				{
+					throw new MaliciousCoordinatorException("Fake coin with impossible index.");
+				}
+				var foundCoin = new Coin(stx.Transaction, stx.Transaction.Outputs[coinIndex]);
+				await proofChannelWriter.WriteAsync((coin, foundCoin, ownershipProof), cancellationToken).ConfigureAwait(false);
+			}
+		}
+
+		// In case there are no filters.
+		if (IndexStore.SmartHeaderChain.HashCount == 0)
+		{
+			proofChannelWriter.Complete();
+			return;
+		}
+
+		// In case we cannot validate enough proofs using only our already seen transactions, we
+		// would need to start downloading the blocks containing the coins that need to be
+		// validated. We use our block filters for that.
+		var scripts = othersCoins.Select(x => x.Coin.ScriptPubKey.ToCompressedBytes()).ToArray();
+			
+		// Do not query more than 10% of the blocks
+		var maxFiltersToQueryCount = (uint)(IndexStore.SmartHeaderChain.HashCount / 10.0);
+		var filters = IndexStore.GetFiltersFromHeightAsync(
+			fromHeight: new Height(IndexStore.SmartHeaderChain.TipHeight - maxFiltersToQueryCount),
+			cancellationToken).ConfigureAwait(false);
+
+		await foreach (var filterModel in filters)
+		{
+			var matchFound = filterModel.Filter.MatchAny(scripts, filterModel.FilterKey);
+			if (matchFound)
+			{
+				var blockId = filterModel.Header.BlockHash;
+				var block = await BlockProvider.GetBlockAsync(blockId, cancellationToken).ConfigureAwait(false);
+
+				foreach (var (coin, ownershipProof) in othersCoins)
+				{
+					if (block.Transactions.FirstOrDefault(x => x.GetHash() == coin.Outpoint.Hash) is { } tx)
+					{
+						var coinIndex = (int) coin.Outpoint.N; 
+						if (coinIndex >= tx.Outputs.Count)
+						{
+							throw new MaliciousCoordinatorException("Fake coin with impossible index.");
+						}
+						var foundCoin = new Coin(tx, tx.Outputs[coinIndex]);
+						await proofChannelWriter.WriteAsync((coin, foundCoin, ownershipProof), cancellationToken).ConfigureAwait(false);
+					}
+				}
+			}
+		}
+			
+		// there are no more filters
+		//if (filterModel.Header.BlockHash == IndexStore.SmartHeaderChain.TipHash)
+		//{
+		proofChannelWriter.Complete();
+		//}
+	}
+
+	private async Task<int> ValidateCoinsAsync(
+		ChannelReader<(Coin, Coin, OwnershipProof)> proofChannelReader,
+		CoinJoinInputCommitmentData coinJoinInputCommitmentData,
+		int stopAfter,
+		CancellationToken cancellationToken)
+	{
+		// Consumes and validates the coins and their proofs.
+		var validProofs = 0;
+		while (validProofs < stopAfter && await proofChannelReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+		{
+			var (aliceCoin, realCoin, ownershipProof) = await proofChannelReader.ReadAsync(cancellationToken).ConfigureAwait(false);
+			if (realCoin is not { } coin || (aliceCoin.TxOut, aliceCoin.Outpoint) != (coin.TxOut, coin.Outpoint))
+			{
+				throw new MaliciousCoordinatorException("Coin doesn't exists or is different than the provided by the coordinator.");
+			}
+			if (!OwnershipProof.VerifyCoinJoinInputProof(ownershipProof, aliceCoin.ScriptPubKey, coinJoinInputCommitmentData))
+			{
+				throw new MaliciousCoordinatorException("The ownership proof is not valid what means Alice cannot really spend it.");
+			}
+			validProofs++;
+		}
+
+		return validProofs;
+	}
+}


### PR DESCRIPTION
Thrid attempt to implement client-side coins ownership verification. Comes from: https://github.com/zkSNACKs/WalletWasabi/pull/5994. We are now closer to implement this after https://github.com/zkSNACKs/WalletWasabi/pull/8635 was merged. (there are still many things to consider and think about but we should try to have this feature running, at least for users with a full node)
 
This PR verifies the other participants coins ownership proofs to make sure the coordinator is not cheating. This is done by a new component `OwnershipProofValidator` which given a given a list of (coin, ownership proof) tuples can verify those proofs or at least to do its best effort.

`OwnershipProofValidator` component tries first to verify others' coins that come from transactions already known by the wallet, this is because if our wallet has been mixing for a while, there are high chances that we are remixing with others that have also participated in the same previous coinjoins that we had.

After that it uses the latest 10% of the compact filters to see if the any coin matches and downloads the block (or take it from disk in case it already is there) to verify the script matches and that the coin can be spent by one Alice.

Note: without a full node it is impossible to really verify the existence and spendability condition of a coin. That means that the coordinator can cheat to those that doesn't have access to a node (the majority). For this reason this feature should be enabled only for those with a node.

Next thing to do: https://github.com/zkSNACKs/WalletWasabi/pull/5994/commits/a48aafff6b73e7f8859fc416c1c489df86eb053e
This means to do not use the filters but the block hash to search for the blocks.