### PR TITLE
`TorMonitor`: Add restarting capability

### DIFF
--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -79,11 +79,18 @@ public class TorMonitor : PeriodicRunner
 
 	private async Task StartBootstrapMonitorAsync(CancellationToken appShutdownToken)
 	{
-		using CancellationTokenSource linkedLoopCts = CancellationTokenSource.CreateLinkedTokenSource(appShutdownToken, LoopCts.Token);
-
-		while (!linkedLoopCts.IsCancellationRequested)
+		try
 		{
-			await MonitorEventsAsync(linkedLoopCts.Token).ConfigureAwait(false);
+			using CancellationTokenSource linkedLoopCts = CancellationTokenSource.CreateLinkedTokenSource(appShutdownToken, LoopCts.Token);
+
+			while (!linkedLoopCts.IsCancellationRequested)
+			{
+				await MonitorEventsAsync(linkedLoopCts.Token).ConfigureAwait(false);
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			Logger.LogDebug("Application is shutting down.");
 		}
 	}
 
@@ -162,7 +169,7 @@ public class TorMonitor : PeriodicRunner
 					if (success)
 					{
 						// Wait a bit so that we don't try to connect to Tor Control until Tor is actually started.
-						await Task.Delay(2_000, CancellationToken.None).ConfigureAwait(false);
+						await Task.Delay(2_000, cancellationToken).ConfigureAwait(false);
 					}
 				}
 				else

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -65,7 +65,7 @@ public class TorMonitor : PeriodicRunner
 	private Task? BootstrapTask { get; set; }
 
 	/// <summary>Whether we should try Tor process restart to fix <see cref="ReplyType.TtlExpired"/> issues.</summary>
-	private bool TryTorRestart { get; set; }
+	private bool TryTorRestart { get; set; } = true;
 
 	/// <remarks>Assignment and cancel operations must be guarded with <see cref="_lock"/>.</remarks>
 	private CancellationTokenSource? ForceTorRestartCts { get; set; }

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -183,6 +183,13 @@ public class TorMonitor : PeriodicRunner
 		{
 			Logger.LogError(ex);
 		}
+		finally
+		{
+			lock (_lock)
+			{
+				ForceTorRestartCts = null;
+			}
+		}
 	}
 
 	private async Task<bool> ShutDownTorAsync(TorControlClient torControlClient)

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -48,7 +48,7 @@ public class TorMonitor : PeriodicRunner
 	private TorHttpPool TorHttpPool { get; }
 
 	private Task? BootstrapTask { get; set; }
-	private bool TriedTorRestart { get; set; } = false;
+	private bool TriedTorRestart { get; set; }
 
 	/// <inheritdoc/>
 	public override Task StartAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
This PR replaces #8655 and adds the missing Tor restarting capability.

[Review with whitespace off.](https://github.com/zkSNACKs/WalletWasabi/pull/8669/files?diff=split&w=1)

To test this PR, one can use this branch https://github.com/kiminuo/WalletWasabi/tree/feature/2022-07-08-TorMonitor-testing-code and most notably the commit https://github.com/kiminuo/WalletWasabi/commit/80adf02670106565e2e5ae446fffd5c68eac0317 so that one:

1. Starts WW and watches running processes
2. After a minute you should see that Tor process disappears and it is started again + the WW logs should describe the same things really.