### PR TITLE
Revert "Return ownership proofs"

### DIFF
--- a/WalletWasabi.Fluent/Config.cs
+++ b/WalletWasabi.Fluent/Config.cs
@@ -115,10 +115,6 @@ public class Config : ConfigBase
 	[JsonConverter(typeof(MoneyBtcJsonConverter))]
 	public Money DustThreshold { get; internal set; } = DefaultDustThreshold;
 
-	[DefaultValue("wasabiwallet.io")]
-	[JsonProperty(PropertyName = "CoordinatorIdentifier", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public string CoordinatorIdentifier { get; set; } = "wasabiwallet.io";
-
 	public ServiceConfiguration ServiceConfiguration { get; private set; }
 
 	public Uri GetCurrentBackendUri()

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -297,7 +297,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = HttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(5), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Config.ServiceConfiguration, Config.CoordinatorIdentifier), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Config.ServiceConfiguration), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -30,30 +30,19 @@ namespace WalletWasabi.Tests.Helpers;
 
 public static class WabiSabiFactory
 {
-	public static Coin CreateCoin(Key? key = null, Money? amount = null)
-	{
-		key ??= new();
-		amount ??= Money.Coins(1);
-		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.WitHash.ScriptPubKey));
-	}
+	public static Coin CreateCoin(Key key)
+		=> CreateCoin(key, Money.Coins(1));
 
-	public static Tuple<Coin, OwnershipProof> CreateCoinWithOwnershipProof(Key? key = null, Money? amount = null, uint256? roundId = null)
-	{
-		key = key ?? new();
-		var coin = WabiSabiFactory.CreateCoin(key, amount);
-		roundId ??= uint256.One;
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, roundId);
-		return new Tuple<Coin, OwnershipProof>(coin, ownershipProof);
-	}
-
-	public static CoinJoinInputCommitmentData CreateCommitmentData(uint256? RoundId = null)
-		=> new CoinJoinInputCommitmentData("wasabiwallet.io", RoundId ?? uint256.One);
+	public static Coin CreateCoin(Key key, Money amount)
+		=> new(
+			new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0),
+			new TxOut(amount, key.PubKey.WitHash.ScriptPubKey));
 
 	public static OwnershipProof CreateOwnershipProof(Key key, uint256? roundHash = null)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			GetOwnershipIdentifier(key.PubKey.WitHash.ScriptPubKey),
-			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash ?? BitcoinFactory.CreateUint256()));
+			new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash ?? BitcoinFactory.CreateUint256()));
 
 	public static OwnershipIdentifier GetOwnershipIdentifier(Script scriptPubKey)
 	{
@@ -124,7 +113,7 @@ public static class WabiSabiFactory
 		=> new(coin, ownershipProof, round, Guid.NewGuid(), false) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
 
 	public static Alice CreateAlice(Key key, Money amount, Round round)
-		=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key, round.Id), round);
+		=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key), round);
 
 	public static Alice CreateAlice(Money amount, Round round)
 	{
@@ -148,7 +137,6 @@ public static class WabiSabiFactory
 		return new ArenaClient(
 			roundState.CreateAmountCredentialClient(random),
 			roundState.CreateVsizeCredentialClient(random),
-			"wasabiwallet.io",
 			arena);
 	}
 
@@ -314,7 +302,6 @@ public static class WabiSabiFactory
 			keyChain,
 			destinationProvider,
 			roundStateUpdater,
-			"wasabiwallet.io",
 			int.MaxValue,
 			true,
 			redCoinIsolation,

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -141,7 +141,7 @@ public class StepOutputRegistrationTests
 		var txParams = round.Parameters;
 		var extraAlice = WabiSabiFactory.CreateAlice(round.Parameters.MiningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParams.AllowedOutputAmounts.Min - new Money(1L), round);
 		round.Alices.Add(extraAlice);
-		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin, extraAlice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
+		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.TransactionSigning, round.Phase);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -201,7 +201,7 @@ public class StepTransactionSigningTests
 		var alice3 = WabiSabiFactory.CreateAlice(round);
 		alice3.ConfirmedConnection = true;
 		round.Alices.Add(alice3);
-		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin, alice3.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
+		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
@@ -264,7 +264,7 @@ public class StepTransactionSigningTests
 			CancellationToken.None).ConfigureAwait(false);
 
 		await bobClient.RegisterOutputAsync(
-			destKey2.PubKey.WitHash.ScriptPubKey,
+			destKey1.PubKey.WitHash.ScriptPubKey,
 			aliceClient2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient2.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None).ConfigureAwait(false);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
-using WalletWasabi.Crypto;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -316,21 +315,24 @@ public class RegisterInputFailureTests
 	}
 
 	[Fact]
-	public async Task WrongScriptPubKeyInOwnershipProofAsync()
+	public async Task WrongOwnershipProofAsync()
 	{
-		await TestOwnershipProof((key, roundId) => WabiSabiFactory.CreateOwnershipProof(new Key(), roundId));
-	}
+		using Key key = new();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		WabiSabiConfig cfg = new();
+		var round = WabiSabiFactory.CreateRound(cfg);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
-	[Fact]
-	public async Task WrongRoundIdInOwnershipProofAsync()
-	{
-		await TestOwnershipProof((key, roundId) => WabiSabiFactory.CreateOwnershipProof(key, uint256.One));
-	}
+		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
+		using Key nonOwnerKey = new();
+		var wrongOwnershipProof = WabiSabiFactory.CreateOwnershipProof(nonOwnerKey, round.Id);
 
-	[Fact]
-	public async Task WrongCoordinatorIdentifierInOwnershipProofAsync()
-	{
-		await TestOwnershipProof((key, roundId) => OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey), new CoinJoinInputCommitmentData("test", roundId)));
+		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
+			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, wrongOwnershipProof, CancellationToken.None));
+		Assert.Equal(WabiSabiProtocolErrorCode.WrongOwnershipProof, ex.ErrorCode);
+
+		await arena.StopAsync(CancellationToken.None);
 	}
 
 	[Fact]
@@ -439,25 +441,6 @@ public class RegisterInputFailureTests
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
 			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.AliceAlreadyRegistered, ex.ErrorCode);
-
-		await arena.StopAsync(CancellationToken.None);
-	}
-
-	private async Task TestOwnershipProof(Func<Key, uint256, OwnershipProof> ownershipProofFunc)
-	{
-		using Key key = new();
-		var coin = WabiSabiFactory.CreateCoin(key);
-		WabiSabiConfig cfg = new();
-		var round = WabiSabiFactory.CreateRound(cfg);
-		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
-		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
-
-		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-		OwnershipProof ownershipProof = ownershipProofFunc(key, round.Id);
-
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
-		Assert.Equal(WabiSabiProtocolErrorCode.WrongOwnershipProof, ex.ErrorCode);
 
 		await arena.StopAsync(CancellationToken.None);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -1,16 +1,12 @@
 using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Linq;
-using WalletWasabi.Crypto;
-using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using WalletWasabi.WabiSabi.Client;
-using WalletWasabi.WabiSabi.Models;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests;
@@ -40,35 +36,6 @@ public class RegisterInputSuccessTests
 		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
-
-		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
-		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
-
-		await arena.StopAsync(CancellationToken.None);
-	}
-
-	[Fact]
-	public async Task SuccessCustomCoordinatorIdentifierAsync()
-	{
-		WabiSabiConfig cfg = new();
-		cfg.CoordinatorIdentifier = "test";
-		var round = WabiSabiFactory.CreateRound(cfg);
-
-		using Key key = new();
-		var coin = WabiSabiFactory.CreateCoin(key);
-		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
-		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
-
-		var minAliceDeadline = DateTimeOffset.UtcNow + cfg.ConnectionConfirmationTimeout * 0.9;
-
-		var roundState = RoundState.FromRound(arena.Rounds.First());
-		var random = new InsecureRandom();
-		var arenaClient = new ArenaClient(
-			roundState.CreateAmountCredentialClient(random),
-			roundState.CreateVsizeCredentialClient(random),
-			"test",
-			arena);
-		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey), new CoinJoinInputCommitmentData("test", round.Id));
 
 		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -22,7 +22,7 @@ public class SignTransactionTests
 		using Key key = new();
 		Alice alice = WabiSabiFactory.CreateAlice(key: key, round: round);
 		round.Alices.Add(alice);
-		round.CoinjoinState = round.AddInput(alice.Coin, alice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id)).Finalize();
+		round.CoinjoinState = round.AddInput(alice.Coin).Finalize();
 		round.SetPhase(Phase.TransactionSigning);
 		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -4,6 +4,7 @@ using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using Xunit;
 
@@ -17,17 +18,19 @@ public class MultipartyTransactionStateTests
 		var cfg = new WabiSabiConfig();
 		var round = WabiSabiFactory.CreateRound(cfg);
 
-		var commitmentData = WabiSabiFactory.CreateCommitmentData(round.Id);
+		static Coin CreateCoin()
+		{
+			using var key = new Key();
+			return WabiSabiFactory.CreateCoin(key);
+		}
 
-		(var coin1, var ownershipProof1) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
-		(var coin2, var ownershipProof2) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
-		(var coin3, var ownershipProof3) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
+		Coin coin1, coin2, coin3;
 
 		// Three events / three states
 		var state0 = round.Assert<ConstructionState>();
-		var state1 = state0.AddInput(coin1, ownershipProof1, commitmentData);
-		var state2 = state1.AddInput(coin2, ownershipProof2, commitmentData);
-		var state3 = state2.AddInput(coin3, ownershipProof3, commitmentData);
+		var state1 = state0.AddInput(coin1 = CreateCoin());
+		var state2 = state1.AddInput(coin2 = CreateCoin());
+		var state3 = state2.AddInput(coin3 = CreateCoin());
 
 		// Unknown state. Assumes full state is required
 		var diffd30 = state3.GetStateFrom(-1);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -74,7 +74,6 @@ public class ArenaClientTests
 		var aliceArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
-			"wasabiwallet.io",
 			wabiSabiApi);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
@@ -127,7 +126,6 @@ public class ArenaClientTests
 		var bobArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
-			"wasabiwallet.io",
 			wabiSabiApi);
 
 		var reissuanceResponse = await bobArenaClient.ReissueCredentialAsync(
@@ -190,7 +188,7 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore);
 
-		var apiClient = new ArenaClient(null!, null!, "wasabiwallet.io", wabiSabiApi);
+		var apiClient = new ArenaClient(null!, null!, wabiSabiApi);
 
 		round.SetPhase(Phase.InputRegistration);
 
@@ -212,7 +210,7 @@ public class ArenaClientTests
 		var coins = destinationProvider.GetNextDestinations(2)
 			.Select(dest => (
 				Coin: new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(1.0m), dest)),
-				OwnershipProof: keyChain.GetOwnershipProof(dest, WabiSabiFactory.CreateCommitmentData(round.Id))))
+				OwnershipProof: keyChain.GetOwnershipProof(dest, new CoinJoinInputCommitmentData("test", uint256.One))))
 			.ToArray();
 
 		Alice alice1 = WabiSabiFactory.CreateAlice(coins[0].Coin, coins[0].OwnershipProof, round: round);
@@ -233,12 +231,11 @@ public class ArenaClientTests
 		InsecureRandom rnd = InsecureRandom.Instance;
 		var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, rnd, 4300000000000L);
 		var vsizeClient = new WabiSabiClient(round.VsizeCredentialIssuerParameters, rnd, 2000L);
-		var apiClient = new ArenaClient(amountClient, vsizeClient, "wasabiwallet.io", wabiSabiApi);
+		var apiClient = new ArenaClient(amountClient, vsizeClient, wabiSabiApi);
 
 		round.SetPhase(Phase.TransactionSigning);
 
 		var emptyState = round.Assert<ConstructionState>();
-		var commitmentData = WabiSabiFactory.CreateCommitmentData(round.Id);
 
 		// We can't use ``emptyState.Finalize()` because this is not a valid transaction so we fake it
 		var finalizedEmptyState = new SigningState(round.Parameters, emptyState.Events);
@@ -247,14 +244,14 @@ public class ArenaClientTests
 		await Assert.ThrowsAsync<ArgumentException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice1.Coin, coins[0].OwnershipProof, keyChain, finalizedEmptyState.CreateUnsignedTransaction(), CancellationToken.None));
 
-		var oneInput = emptyState.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData).Finalize();
+		var oneInput = emptyState.AddInput(alice1.Coin).Finalize();
 		round.CoinjoinState = oneInput;
 
 		// Trying to sign coins those are not in the coinjoin.
 		await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice2.Coin, coins[1].OwnershipProof, keyChain, oneInput.CreateUnsignedTransaction(), CancellationToken.None));
 
-		var twoInputs = emptyState.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData).AddInput(alice2.Coin, alice2.OwnershipProof, commitmentData).Finalize();
+		var twoInputs = emptyState.AddInput(alice1.Coin).AddInput(alice2.Coin).Finalize();
 		round.CoinjoinState = twoInputs;
 
 		Assert.False(round.Assert<SigningState>().IsFullySigned);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -46,12 +46,10 @@ public class BobClientTests
 		var aliceArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
-			"wasabiwallet.io",
 			wabiSabiApi);
 		var bobArenaClient = new ArenaClient(
 			roundState.CreateAmountCredentialClient(insecureRandom),
 			roundState.CreateVsizeCredentialClient(insecureRandom),
-			"wasabiwallet.io",
 			wabiSabiApi);
 		Assert.Equal(Phase.InputRegistration, round.Phase);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
@@ -39,5 +39,5 @@ public class OwnershipProofTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey),
-			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash));
+			new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -83,7 +83,6 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 		var arenaClient = new ArenaClient(
 			round.CreateAmountCredentialClient(insecureRandom),
 			round.CreateVsizeCredentialClient(insecureRandom),
-			"wasabiwallet.io",
 			wabiSabiHttpApiClient);
 		return arenaClient;
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
@@ -123,5 +123,5 @@ public class InputRegistrationRequestTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main), key.PubKey.WitHash.ScriptPubKey),
-			WabiSabiFactory.CreateCommitmentData(roundHash));
+			new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -1,6 +1,5 @@
 using NBitcoin;
 using System.Collections.Immutable;
-using WalletWasabi.Crypto;
 using System.Linq;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Models;
@@ -23,8 +22,6 @@ public class MultipartyTransactionTests
 		MaxSuggestedAmountBase = Money.Coins(Constants.MaximumNumberOfBitcoins)
 	}) with { MiningFeeRate = new FeeRate(0m)};
 
-	private static CoinJoinInputCommitmentData commitmentData = WabiSabiFactory.CreateCommitmentData();
-
 	private static void ThrowsProtocolException(WabiSabiProtocolErrorCode expectedError, Action action) =>
 		Assert.Equal(expectedError, Assert.Throws<WabiSabiProtocolException>(action).ErrorCode);
 
@@ -34,15 +31,15 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key1);
-		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key2);
+		var alice1Coin = CreateCoin(script: key1.PubKey.WitHash.ScriptPubKey);
+		var alice2Coin = CreateCoin(script: key2.PubKey.WitHash.ScriptPubKey);
 
 		var state = new ConstructionState(DefaultParameters);
 
 		Assert.Empty(state.Inputs);
 		Assert.Empty(state.Outputs);
 
-		var oneInput = state.AddInput(alice1Coin, alice1OwnershipProof, commitmentData);
+		var oneInput = state.AddInput(alice1Coin);
 
 		Assert.Single(oneInput.Inputs);
 		Assert.Empty(oneInput.Outputs);
@@ -51,14 +48,14 @@ public class MultipartyTransactionTests
 		Assert.Empty(state.Inputs);
 		Assert.Empty(state.Outputs);
 
-		var differentInput = state.AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
+		var differentInput = state.AddInput(alice2Coin);
 
 		Assert.Single(differentInput.Inputs);
 		Assert.Empty(differentInput.Outputs);
 		Assert.NotEqual(oneInput.Inputs, differentInput.Inputs);
 		Assert.Equal(oneInput.Outputs, differentInput.Outputs);
 
-		var twoInputs = oneInput.AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
+		var twoInputs = oneInput.AddInput(alice2Coin);
 
 		Assert.Equal(2, twoInputs.Inputs.Count());
 		Assert.Empty(twoInputs.Outputs);
@@ -110,9 +107,9 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void AddWithOptimize()
 	{
-		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
+		var coin = CreateCoin();
 
-		var state = new ConstructionState(DefaultParameters).AddInput(coin, ownershipProof, commitmentData);
+		var state = new ConstructionState(DefaultParameters).AddInput(coin);
 
 		var script = BitcoinFactory.CreateScript();
 		var bob = new TxOut(coin.Amount / 2, script);
@@ -128,14 +125,13 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void WitnessValidation()
 	{
-
 		using Key key1 = new();
 		using Key key2 = new();
 
-		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key1);
-		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key2);
+		var alice1Coin = CreateCoin(script: key1.PubKey.WitHash.ScriptPubKey);
+		var alice2Coin = CreateCoin(script: key2.PubKey.WitHash.ScriptPubKey);
 
-		var state = new ConstructionState(DefaultParameters).AddInput(alice1Coin, alice1OwnershipProof, commitmentData).AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
+		var state = new ConstructionState(DefaultParameters).AddInput(alice1Coin).AddInput(alice2Coin);
 
 		// address reuse bad
 		var bob1 = new TxOut(Money.Coins(1), alice1Coin.ScriptPubKey);
@@ -186,12 +182,12 @@ public class MultipartyTransactionTests
 		using Key key1 = new();
 		using Key key2 = new();
 
-		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key1);
-		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(key2);
+		var alice1Coin = CreateCoin(script: key1.PubKey.WitHash.ScriptPubKey);
+		var alice2Coin = CreateCoin(script: key2.PubKey.WitHash.ScriptPubKey);
 
 		var state = new ConstructionState(DefaultParameters with { MiningFeeRate = feeRate })
-			.AddInput(alice1Coin, alice1OwnershipProof, commitmentData)
-			.AddInput(alice2Coin, alice2OwnershipProof, commitmentData);
+			.AddInput(alice1Coin)
+			.AddInput(alice2Coin);
 
 		var bob1 = new TxOut(Money.Coins(1), alice1Coin.ScriptPubKey);
 		var withOutput = state.AddOutput(bob1);
@@ -242,9 +238,9 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void NoDuplicateInputs()
 	{
-		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
-		var state = new ConstructionState(DefaultParameters).AddInput(coin, ownershipProof, commitmentData);
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(coin, ownershipProof, commitmentData));
+		var coin = CreateCoin();
+		var state = new ConstructionState(DefaultParameters).AddInput(coin);
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs, () => state.AddInput(coin));
 		Assert.Single(state.Inputs);
 	}
 
@@ -254,31 +250,31 @@ public class MultipartyTransactionTests
 	public void OnlyAllowedInputTypes()
 	{
 		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
-		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(coin, ownershipProof, commitmentData));
+		var coin = CreateCoin();
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(coin));
 	}
 
 	[Fact]
 	public void InputAmountRanges()
 	{
-		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
+		var coin = CreateCoin();
 
 		var exact = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(coin.Amount, coin.Amount) });
 		var above = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(2 * coin.Amount, 3 * coin.Amount) });
 		var below = new ConstructionState(DefaultParameters with { AllowedInputAmounts = new MoneyRange(coin.Amount - Money.Coins(0.001m), coin.Amount - Money.Coins(0.0001m)) });
 
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds, () => above.AddInput(coin, ownershipProof, commitmentData));
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds, () => below.AddInput(coin, ownershipProof, commitmentData));
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds, () => above.AddInput(coin));
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds, () => below.AddInput(coin));
 
 		// Allowed range is inclusive:
-		Assert.Equal(coin.Amount, Assert.Single(exact.AddInput(coin, ownershipProof, commitmentData).Inputs).Amount);
+		Assert.Equal(coin.Amount, Assert.Single(exact.AddInput(coin).Inputs).Amount);
 	}
 
 	[Fact]
 	public void UneconomicalInputs()
 	{
-		(var alice1Coin, var alice1OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(amount: new Money(1000L));
-		(var alice2Coin, var alice2OwnershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(amount: new Money(2000L));
+		var alice1Coin = CreateCoin(new Money(1000L));
+		var alice2Coin = CreateCoin(new Money(1001L));
 
 		// requires 1k sats per input in sat/vKB
 		var inputVsize = alice1Coin.ScriptPubKey.EstimateInputVsize();
@@ -287,9 +283,9 @@ public class MultipartyTransactionTests
 
 		var state = new ConstructionState(DefaultParameters with { MiningFeeRate = feeRate });
 
-		ThrowsProtocolException(WabiSabiProtocolErrorCode.UneconomicalInput, () => state.AddInput(alice1Coin, alice1OwnershipProof, commitmentData));
+		ThrowsProtocolException(WabiSabiProtocolErrorCode.UneconomicalInput, () => state.AddInput(alice1Coin));
 
-		Assert.Equal(alice2Coin.Amount, Assert.Single(state.AddInput(alice2Coin, alice2OwnershipProof, commitmentData).Inputs).Amount);
+		Assert.Equal(alice2Coin.Amount, Assert.Single(state.AddInput(alice2Coin).Inputs).Amount);
 	}
 
 	[Fact]
@@ -335,4 +331,9 @@ public class MultipartyTransactionTests
 		var updated = state.AddOutput(output);
 		Assert.Equal(output, Assert.Single(updated.Outputs));
 	}
+
+	private Coin CreateCoin(Money? amount = null, Script? script = null)
+		=> new Coin(
+			BitcoinFactory.CreateOutPoint(),
+			new TxOut(amount ?? Money.Coins(1), script ?? BitcoinFactory.CreateScript()));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -139,9 +139,8 @@ public class SerializationTests
 		AssertSerialization(RoundState.FromRound(round));
 
 		var state = round.Assert<ConstructionState>();
-		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(roundId: round.Id);
-		state = state.AddInput(coin, ownershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
-		round.CoinjoinState = new SigningState(state.Parameters, state.Events);
+		state = state.AddInput(CreateCoin());
+		round.CoinjoinState = new SigningState(round.Parameters, state.Events);
 		AssertSerialization(RoundState.FromRound(round));
 	}
 
@@ -207,4 +206,10 @@ public class SerializationTests
 		new(
 			new[] { MAC.ComputeMAC(IssuerKey, Points.First(), Scalars.First()) },
 			new[] { new Proof(new GroupElementVector(Points.Take(2)), new ScalarVector(Scalars.Take(2))) });
+
+	private static Coin CreateCoin()
+	{
+		using var key = new Key();
+		return WabiSabiFactory.CreateCoin(key);
+	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -46,7 +46,6 @@ public class Round
 		TransactionSigningTimeFrame = TimeFrame.Create(Parameters.TransactionSigningTimeout);
 
 		Id = CalculateHash();
-		CoinJoinInputCommitmentData = new CoinJoinInputCommitmentData(Parameters.CoordinationIdentifier, Id);
 	}
 
 	public uint256 Id { get; }
@@ -71,8 +70,6 @@ public class Round
 
 	public RoundParameters Parameters { get; }
 	public Script CoordinatorScript { get; set; }
-
-	public CoinJoinInputCommitmentData CoinJoinInputCommitmentData { get; init; }
 
 	public TState Assert<TState>() where TState : MultipartyTransactionState =>
 		CoinjoinState switch
@@ -130,8 +127,8 @@ public class Round
 		return InputRegistrationTimeFrame.HasExpired;
 	}
 
-	public ConstructionState AddInput(Coin coin, OwnershipProof ownershipProof, CoinJoinInputCommitmentData coinJoinInputCommitmentData)
-		=> Assert<ConstructionState>().AddInput(coin, ownershipProof, coinJoinInputCommitmentData);
+	public ConstructionState AddInput(Coin coin)
+		=> Assert<ConstructionState>().AddInput(coin);
 
 	public ConstructionState AddOutput(TxOut output)
 		=> Assert<ConstructionState>().AddOutput(output);
@@ -159,7 +156,6 @@ public class Round
 				Parameters.MaxVsizeCredentialValue,
 				Parameters.MaxVsizeAllocationPerAlice,
 				Parameters.MaxSuggestedAmount,
-				Parameters.CoordinationIdentifier,
 				AmountCredentialIssuerParameters,
 				VsizeCredentialIssuerParameters);
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -23,8 +23,7 @@ public record RoundParameters
 		TimeSpan connectionConfirmationTimeout,
 		TimeSpan outputRegistrationTimeout,
 		TimeSpan transactionSigningTimeout,
-		TimeSpan blameInputRegistrationTimeout,
-		string coordinationIdentifier)
+		TimeSpan blameInputRegistrationTimeout)
 	{
 		Network = network;
 		MiningFeeRate = miningFeeRate;
@@ -43,7 +42,6 @@ public record RoundParameters
 		InitialInputVsizeAllocation = MaxTransactionSize - MultipartyTransactionParameters.SharedOverhead;
 		MaxVsizeCredentialValue = Math.Min(InitialInputVsizeAllocation / MaxInputCountByRound, (int)ProtocolConstants.MaxVsizeCredentialValue);
 		MaxVsizeAllocationPerAlice = MaxVsizeCredentialValue;
-		CoordinationIdentifier = coordinationIdentifier;
 	}
 
 	public Network Network { get; init; }
@@ -69,8 +67,6 @@ public record RoundParameters
 	public int InitialInputVsizeAllocation { get; init; }
 	public int MaxVsizeCredentialValue { get; init; }
 	public int MaxVsizeAllocationPerAlice { get; init; }
-
-	public string CoordinationIdentifier { get; init; }
 
 	private static StandardTransactionPolicy StandardTransactionPolicy { get; } = new();
 
@@ -102,8 +98,7 @@ public record RoundParameters
 			wabiSabiConfig.ConnectionConfirmationTimeout,
 			wabiSabiConfig.OutputRegistrationTimeout,
 			wabiSabiConfig.TransactionSigningTimeout,
-			wabiSabiConfig.BlameInputRegistrationTimeout,
-			wabiSabiConfig.CoordinatorIdentifier);
+			wabiSabiConfig.BlameInputRegistrationTimeout);
 	}
 
 	public Transaction CreateTransaction()

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -120,10 +120,6 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "WW200CompatibleLoadBalancingInputSplit", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public double WW200CompatibleLoadBalancingInputSplit { get; set; } = 0.75;
 
-	[DefaultValue("wasabiwallet.io")]
-	[JsonProperty(PropertyName = "CoordinatorIdentifier", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public string CoordinatorIdentifier { get; set; } = "wasabiwallet.io";
-
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -94,7 +94,7 @@ public class AliceClient
 		{
 			var ownershipProof = keyChain.GetOwnershipProof(
 				coin,
-				new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Id));
+				new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", roundState.Id));
 
 			var (response, isPayingZeroCoordinationFee) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
 			aliceClient = new(response.Value, roundState, arenaClient, coin, ownershipProof, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isPayingZeroCoordinationFee);

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -17,18 +17,15 @@ public class ArenaClient
 	public ArenaClient(
 		WabiSabiClient amountCredentialClient,
 		WabiSabiClient vsizeCredentialClient,
-		string coordinatorIdentifier,
 		IWabiSabiApiRequestHandler requestHandler)
 	{
 		AmountCredentialClient = amountCredentialClient;
 		VsizeCredentialClient = vsizeCredentialClient;
-		CoordinatorIdentifier = coordinatorIdentifier;
 		RequestHandler = requestHandler;
 	}
 
 	public WabiSabiClient AmountCredentialClient { get; }
 	public WabiSabiClient VsizeCredentialClient { get; }
-	public string CoordinatorIdentifier { get; }
 	public IWabiSabiApiRequestHandler RequestHandler { get; }
 
 	public async Task<(ArenaResponse<Guid> ArenaResponse, bool IsPayingZeroCoordinationFee)> RegisterInputAsync(

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -41,7 +41,6 @@ public class CoinJoinClient
 		IKeyChain keyChain,
 		IDestinationProvider destinationProvider,
 		RoundStateUpdater roundStatusUpdater,
-		string coordinatorIdentifier,
 		int anonScoreTarget = int.MaxValue,
 		bool consolidationMode = false,
 		bool redCoinIsolation = false,
@@ -53,7 +52,6 @@ public class CoinJoinClient
 		DestinationProvider = destinationProvider;
 		RoundStatusUpdater = roundStatusUpdater;
 		AnonScoreTarget = anonScoreTarget;
-		CoordinatorIdentifier = coordinatorIdentifier;
 		ConsolidationMode = consolidationMode;
 		RedCoinIsolation = redCoinIsolation;
 		FeeRateMedianTimeFrame = feeRateMedianTimeFrame;
@@ -68,7 +66,6 @@ public class CoinJoinClient
 	private IKeyChain KeyChain { get; }
 	private IDestinationProvider DestinationProvider { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
-	public string CoordinatorIdentifier { get; }
 	public int AnonScoreTarget { get; }
 	private TimeSpan DoNotRegisterInLastMinuteTimeLimit { get; }
 
@@ -288,7 +285,6 @@ public class CoinJoinClient
 				var aliceArenaClient = new ArenaClient(
 					roundState.CreateAmountCredentialClient(SecureRandom),
 					roundState.CreateVsizeCredentialClient(SecureRandom),
-					CoordinatorIdentifier,
 					arenaRequestHandler);
 
 				var aliceClient = await AliceClient.CreateRegisterAndConfirmInputAsync(roundState, aliceArenaClient, coin, KeyChain, RoundStatusUpdater, linkedUnregisterCts.Token, linkedRegistrationsCts.Token, linkedConfirmationsCts.Token).ConfigureAwait(false);
@@ -382,7 +378,6 @@ public class CoinJoinClient
 			new(
 				roundState.CreateAmountCredentialClient(SecureRandom),
 				roundState.CreateVsizeCredentialClient(SecureRandom),
-				CoordinatorIdentifier,
 				arenaRequestHandler));
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -26,20 +26,18 @@ public class CoinJoinManager : BackgroundService
 	private record StartCoinJoinCommand(Wallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
 	private record StopCoinJoinCommand(Wallet Wallet) : CoinJoinCommand(Wallet);
 
-	public CoinJoinManager(WalletManager walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, ServiceConfiguration serviceConfiguration, string coordinatorIdentifier)
+	public CoinJoinManager(WalletManager walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, ServiceConfiguration serviceConfiguration)
 	{
 		WalletManager = walletManager;
 		HttpClientFactory = backendHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		ServiceConfiguration = serviceConfiguration;
-		CoordinatorIdentifier = coordinatorIdentifier;
 	}
 
 	public WalletManager WalletManager { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
 	public ServiceConfiguration ServiceConfiguration { get; }
-	public string CoordinatorIdentifier { get; }
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 	public bool IsUserInSendWorkflow { get; set; }
 
@@ -131,7 +129,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<Wallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
 	{
-		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, stoppingToken);
+		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, stoppingToken);
 
 		void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -12,19 +12,16 @@ public class CoinJoinTrackerFactory
 	public CoinJoinTrackerFactory(
 		IWasabiHttpClientFactory httpClientFactory,
 		RoundStateUpdater roundStatusUpdater,
-		string coordinatorIdentifier,
 		CancellationToken cancellationToken)
 	{
 		HttpClientFactory = httpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
-		CoordinatorIdentifier = coordinatorIdentifier;
 		CancellationToken = cancellationToken;
 	}
 
 	private IWasabiHttpClientFactory HttpClientFactory { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private CancellationToken CancellationToken { get; }
-	private string CoordinatorIdentifier { get; }
 
 	public CoinJoinTracker CreateAndStart(Wallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
 	{
@@ -33,7 +30,6 @@ public class CoinJoinTrackerFactory
 			new KeyChain(wallet.KeyManager, wallet.Kitchen),
 			new InternalDestinationProvider(wallet.KeyManager),
 			RoundStatusUpdater,
-			CoordinatorIdentifier,
 			wallet.KeyManager.AnonScoreTarget,
 			consolidationMode: false,
 			redCoinIsolation: wallet.KeyManager.RedCoinIsolation,

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -28,7 +28,6 @@ public static class RoundHasher
 			long maxVsizeCredentialValue,
 			long maxVsizeAllocationPerAlice,
 			long maxSuggestedAmount,
-			string coordinationIdentifier,
 			CredentialIssuerParameters amountCredentialIssuerParameters,
 			CredentialIssuerParameters vsizeCredentialIssuerParameters)
 	{
@@ -51,7 +50,6 @@ public static class RoundHasher
 					   .Append(ProtocolConstants.RoundMaxVsizeCredentialValueStrobeLabel, maxVsizeCredentialValue)
 					   .Append(ProtocolConstants.RoundMaxVsizePerAliceStrobeLabel, maxVsizeAllocationPerAlice)
 					   .Append(ProtocolConstants.RoundMaxSuggestedAmountLabel, maxSuggestedAmount)
-					   .Append(ProtocolConstants.RoundCoordinationIdentifier, coordinationIdentifier)
 					   .Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, amountCredentialIssuerParameters)
 					   .Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, vsizeCredentialIssuerParameters)
 					   .GetHash();

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -1,6 +1,5 @@
 using NBitcoin;
 using System.Linq;
-using WalletWasabi.Crypto;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -14,7 +13,8 @@ public record ConstructionState : MultipartyTransactionState
 	{
 	}
 
-	public ConstructionState AddInput(Coin coin, OwnershipProof ownershipProof, CoinJoinInputCommitmentData coinJoinInputCommitmentData)
+	// TODO ownership proofs and spend status also in scope
+	public ConstructionState AddInput(Coin coin)
 	{
 		var prevout = coin.TxOut;
 
@@ -61,12 +61,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
 		}
 
-		if (!OwnershipProof.VerifyCoinJoinInputProof(ownershipProof, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
-		{
-			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
-		}
-
-		return this with { Events = Events.Add(new InputAdded(coin, ownershipProof)) };
+		return this with { Events = Events.Add(new InputAdded(coin)) };
 	}
 
 	public ConstructionState AddOutput(TxOut output)

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using WalletWasabi.Crypto;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 
 namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
@@ -12,7 +11,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 public interface IEvent{};
 
 public record RoundCreated(RoundParameters RoundParameters) : IEvent;
-public record InputAdded (Coin Coin, OwnershipProof ownershipProof) : IEvent;
+public record InputAdded (Coin Coin) : IEvent;
 public record OutputAdded (TxOut Output) : IEvent;
 
 public abstract record MultipartyTransactionState

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -33,7 +33,6 @@ public static class ProtocolConstants
 	public const string RoundOutputRegistrationTimeoutStrobeLabel = "output-registration-timeout";
 	public const string RoundTransactionSigningTimeoutStrobeLabel = "transaction-signing-timeout";
 	public const string RoundMaxSuggestedAmountLabel = "maximum-suggested-amount";
-	public const string RoundCoordinationIdentifier = "coordination-identifier";
 
 	// Alice hashing labels
 	public const string AliceStrobeDomain = "alice-parameters";


### PR DESCRIPTION
Reverts zkSNACKs/WalletWasabi#8635

The reverted PR breaks client-coordinator compatibility in two ways:

1. It prevents clients on the master from coinjoining with the currently running coordinator. This would not mean there's something wrong with the PR, it'd just mean that the backend has to be deployed at the same time of merging the reverted PR. However...
2. It also prevents clients currently deployed to users from coinjoining with the coordinator running from the master. This must be fixed.