### PR TITLE
Don't swallow exception

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -329,7 +329,7 @@ public class CoinJoinClient
 				}
 				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.InputBanned)
 				{
-					Logger.LogInfo($"Failed to register input: {wpe.Message}");
+					Logger.LogDebug($"Failed to register input: {wpe.Message}");
 				}
 				else
 				{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -327,6 +327,8 @@ public class CoinJoinClient
 							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
 					}
 				}
+
+				Logger.LogWarning(wpe);
 				personCircuit?.Dispose();
 				return (null, null);
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -327,8 +327,15 @@ public class CoinJoinClient
 							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
 					}
 				}
+				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.InputBanned)
+				{
+					Logger.LogInfo($"Failed to register input: {wpe.Message}");
+				}
+				else
+				{
+					Logger.LogWarning(wpe);
+				}
 
-				Logger.LogWarning(wpe);
 				personCircuit?.Dispose();
 				return (null, null);
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -330,8 +330,9 @@ public class CoinJoinClient
 				personCircuit?.Dispose();
 				return (null, null);
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
+				Logger.LogWarning(ex);
 				personCircuit?.Dispose();
 				return (null, null);
 			}


### PR DESCRIPTION
When input registration is unsuccessful we don't know why (or even that it was unsuccessful) from the logs.  

I am experiencing an issue that only a portion of my input registrations go through and I have no idea why. This should tell me. 

Update: The issue I was experiencing: https://github.com/zkSNACKs/WalletWasabi/issues/8674