### PR TITLE
Make AliceClient handle Protocol exceptions

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -102,49 +102,47 @@ public class AliceClient
 
 			Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.OutPoint}.");
 		}
-		catch (System.Net.Http.HttpRequestException ex)
+		catch (WabiSabiProtocolException wpe)
 		{
-			if (ex.InnerException is WabiSabiProtocolException wpe)
+			switch (wpe.ErrorCode)
 			{
-				switch (wpe.ErrorCode)
-				{
-					case WabiSabiProtocolErrorCode.InputSpent:
-						coin.SpentAccordingToBackend = true;
-						Logger.LogInfo($"{coin.Coin.Outpoint} is spent according to the backend. The wallet is not fully synchronized or corrupted.");
-						break;
+				case WabiSabiProtocolErrorCode.InputSpent:
+					coin.SpentAccordingToBackend = true;
+					Logger.LogInfo($"{coin.Coin.Outpoint} is spent according to the backend. The wallet is not fully synchronized or corrupted.");
+					break;
 
-					case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
-						var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
-						if (inputBannedExData is null)
-						{
-							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
-						}
-						coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
-						Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
-						break;
+				case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
+					var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
+					if (inputBannedExData is null)
+					{
+						Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
+					}
+					coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+					Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
+					break;
 
-					case WabiSabiProtocolErrorCode.InputNotWhitelisted:
-						coin.SpentAccordingToBackend = false;
-						Logger.LogWarning($"{coin.Coin.Outpoint} cannot be registered in the blame round.");
-						break;
+				case WabiSabiProtocolErrorCode.InputNotWhitelisted:
+					coin.SpentAccordingToBackend = false;
+					Logger.LogWarning($"{coin.Coin.Outpoint} cannot be registered in the blame round.");
+					break;
 
-					case WabiSabiProtocolErrorCode.AliceAlreadyRegistered:
-						Logger.LogInfo($"{coin.Coin.Outpoint} was already registered.");
-						break;
+				case WabiSabiProtocolErrorCode.AliceAlreadyRegistered:
+					Logger.LogInfo($"{coin.Coin.Outpoint} was already registered.");
+					break;
 
-					case WabiSabiProtocolErrorCode.WrongPhase:
-						Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late. Abort the rest of the registrations.");
-						break;
+				case WabiSabiProtocolErrorCode.WrongPhase:
+					Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late. Abort the rest of the registrations.");
+					break;
 
-					case WabiSabiProtocolErrorCode.RoundNotFound:
-						Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late because the round doesn't exist anymore. Abort the rest of the registrations.");
-						break;
+				case WabiSabiProtocolErrorCode.RoundNotFound:
+					Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late because the round doesn't exist anymore. Abort the rest of the registrations.");
+					break;
 
-					default:
-						Logger.LogInfo($"{coin.Coin.Outpoint} cannot be registered: '{wpe.ErrorCode}'.");
-						break;
-				}
+				default:
+					Logger.LogInfo($"{coin.Coin.Outpoint} cannot be registered: '{wpe.ErrorCode}'.");
+					break;
 			}
+
 			throw;
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -327,14 +327,6 @@ public class CoinJoinClient
 							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
 					}
 				}
-				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.InputBanned || wpe.ErrorCode is WabiSabiProtocolErrorCode.InputLongBanned)
-				{
-					Logger.LogDebug($"Failed to register input: {wpe.Message}");
-				}
-				else
-				{
-					Logger.LogWarning(wpe);
-				}
 
 				personCircuit?.Dispose();
 				return (null, null);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -329,13 +329,7 @@ public class CoinJoinClient
 				}
 				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.InputBanned || wpe.ErrorCode is WabiSabiProtocolErrorCode.InputLongBanned)
 				{
-					var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
-					if (inputBannedExData is null)
-					{
-						Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
-					}
-					coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
-					Logger.LogWarning($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
+					Logger.LogDebug($"Failed to register input: {wpe.Message}");
 				}
 				else
 				{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -327,9 +327,15 @@ public class CoinJoinClient
 							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
 					}
 				}
-				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.InputBanned)
+				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.InputBanned || wpe.ErrorCode is WabiSabiProtocolErrorCode.InputLongBanned)
 				{
-					Logger.LogDebug($"Failed to register input: {wpe.Message}");
+					var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
+					if (inputBannedExData is null)
+					{
+						Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
+					}
+					coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+					Logger.LogWarning($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
 				}
 				else
 				{


### PR DESCRIPTION
Fixes: #8674

But this raises a big question.
We had these scenarios to handle the exceptions in the past. Worked quite well, when I implemented the client-side banning "feature".
https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/AliceClient.cs#L105-L145

But those cases are never ever hit anymore. Why?

What happened to them? Why aren't we catching and handling exceptions in `AliceClient` anymore?