### PR TITLE
[VDG] Fix LabelsPanel not displaying all items

### DIFF
--- a/WalletWasabi.Fluent/Controls/LabelsPanel.cs
+++ b/WalletWasabi.Fluent/Controls/LabelsPanel.cs
@@ -87,6 +87,8 @@ public class LabelsPanel : VirtualizingStackPanel
 			var child = Children[i];
 			var childWidth = child.DesiredSize.Width;
 
+			height = Math.Max(height, child.DesiredSize.Height);
+
 			if (width + childWidth > finalWidth)
 			{
 				while (true)
@@ -121,7 +123,6 @@ public class LabelsPanel : VirtualizingStackPanel
 			}
 
 			width += child.DesiredSize.Width + spacing;
-			height = Math.Max(height, child.DesiredSize.Height);
 			count++;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8331

The issue was with long labels no item height was taken into calculation of ellipsis control so it had height equal zero, this PR fixes that and takes first label item height to arrange ellipsis control.

Now with long labels the ellipsis control is displayed correctly each time.