### PR TITLE
`TorMonitor`: Report that "we are no longer confident that we can build Tor circuits"

### DIFF
--- a/WalletWasabi/Tor/Control/Messages/Events/StatusEvents/StatusEvent.cs
+++ b/WalletWasabi/Tor/Control/Messages/Events/StatusEvents/StatusEvent.cs
@@ -49,6 +49,14 @@ public record StatusEvent : IAsyncEvent
 	/// </remarks>
 	public const string ActionCircuitEstablished = "CIRCUIT_ESTABLISHED";
 
+	/// <remarks>
+	/// From spec: We are no longer confident that we can build circuits. The "reason" keyword provides an explanation:
+	/// which other status event type caused our lack of confidence.
+	/// <para>Suggested use: Controllers may want to use this event to decide when to indicate progress
+	/// to their users, but should not interrupt the user's browsing to do so.</para>
+	/// </remarks>
+	public const string ActionCircuitNotEstablished = "CIRCUIT_NOT_ESTABLISHED";
+
 	public StatusEvent(string action, Dictionary<string, string> arguments)
 	{
 		Action = action;

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -141,6 +141,12 @@ public class TorMonitor : PeriodicRunner
 						Logger.LogInfo("Tor circuit was established.");
 						circuitEstablished = true;
 					}
+
+					if (statusEvent.Action == StatusEvent.ActionCircuitNotEstablished)
+					{
+						_ = statusEvent.Arguments.TryGetValue("REASON", out string? reason);
+						Logger.LogError($"Tor circuit failed to be established: {(reason ?? "unknown reason")}.");
+					}
 				}
 				else if (asyncEvent is CircEvent circEvent)
 				{


### PR DESCRIPTION
This PR is meant to improve our understanding that something is wrong with Tor circuit building.

I did not add any rate limiting because it looks to me that the event should be reported only once in (long) while.