### PR TITLE
Change WW2 monitor timeout from 1h to 3h

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -366,10 +366,11 @@ public class BlockchainController : ControllerBase
 		// Updating the status of WabiSabi coinjoin.
 		if (Global.WabiSabiCoordinator is { } wabiSabiCoordinator)
 		{
+			var ww2CjDownAfter = TimeSpan.FromHours(3);
 			var wabiSabiValidInterval = wabiSabiCoordinator.Config.StandardInputRegistrationTimeout * 2;
-			if (wabiSabiValidInterval < TimeSpan.FromHours(1))
+			if (wabiSabiValidInterval < ww2CjDownAfter)
 			{
-				wabiSabiValidInterval = TimeSpan.FromHours(1);
+				wabiSabiValidInterval = ww2CjDownAfter;
 			}
 			if (DateTimeOffset.UtcNow - wabiSabiCoordinator.LastSuccessfulCoinJoinTime < wabiSabiValidInterval)
 			{


### PR DESCRIPTION
We get a lot of notifications on our monitoring service, which is an annoyance. Also note that unlike in WW1 where a round happened every hour, in WW2 we aren't relying on such timeouts anymore, rather on reaching required input count instead.