### PR TITLE
Make software update flow better

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -145,7 +145,7 @@ public class Program
 
 		Logger.LogSoftwareStopped("Wasabi");
 
-		if (Services.UpdateManager.UpdateOnClose)
+		if (Services.UpdateManager.DoUpdateOnClose)
 		{
 			bool installed = Services.UpdateManager.InstallNewVersion();
 			if (installed)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -147,11 +147,7 @@ public class Program
 
 		if (Services.UpdateManager.DoUpdateOnClose)
 		{
-			bool installed = Services.UpdateManager.InstallNewVersion();
-			if (installed)
-			{
-				AppLifetimeHelper.Restart();
-			}
+			Services.UpdateManager.InstallNewVersion();
 		}
 
 		return exceptionToReport is { } ? 1 : 0;

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -145,6 +145,11 @@ public class Program
 
 		Logger.LogSoftwareStopped("Wasabi");
 
+		if (Services.UpdateManager.UpdateOnClose)
+		{
+			Services.UpdateManager.InstallNewVersion();
+		}
+
 		return exceptionToReport is { } ? 1 : 0;
 	}
 

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -147,7 +147,11 @@ public class Program
 
 		if (Services.UpdateManager.UpdateOnClose)
 		{
-			Services.UpdateManager.InstallNewVersion();
+			bool installed = Services.UpdateManager.InstallNewVersion();
+			if (installed)
+			{
+				AppLifetimeHelper.Restart();
+			}
 		}
 
 		return exceptionToReport is { } ? 1 : 0;

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -139,16 +139,15 @@ public class Program
 			// Trigger the CrashReport process if required.
 			CrashReporter.Invoke(exceptionToReport);
 		}
+		else if (Services.UpdateManager.DoUpdateOnClose)
+		{
+			Services.UpdateManager.StartInstallingNewVersion();
+		}
 
 		AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
 		TaskScheduler.UnobservedTaskException -= TaskScheduler_UnobservedTaskException;
 
 		Logger.LogSoftwareStopped("Wasabi");
-
-		if (Services.UpdateManager.DoUpdateOnClose)
-		{
-			Services.UpdateManager.StartInstallingNewVersion();
-		}
 
 		return exceptionToReport is { } ? 1 : 0;
 	}

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -147,7 +147,7 @@ public class Program
 
 		if (Services.UpdateManager.DoUpdateOnClose)
 		{
-			Services.UpdateManager.InstallNewVersion();
+			Services.UpdateManager.StartInstallingNewVersion();
 		}
 
 		return exceptionToReport is { } ? 1 : 0;

--- a/WalletWasabi.Fluent/Config.cs
+++ b/WalletWasabi.Fluent/Config.cs
@@ -69,6 +69,10 @@ public class Config : ConfigBase
 	[JsonProperty(PropertyName = "TerminateTorOnExit", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool TerminateTorOnExit { get; internal set; } = false;
 
+	[DefaultValue(true)]
+	[JsonProperty(PropertyName = "DownloadNewVersion", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool DownloadNewVersion { get; internal set; } = true;
+
 	[DefaultValue(false)]
 	[JsonProperty(PropertyName = "StartLocalBitcoinCoreOnStartup", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool StartLocalBitcoinCoreOnStartup { get; internal set; } = false;

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -146,8 +146,7 @@ public class Global
 
 				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer, UpdateManager), "Software Update Checker");
 
-				var updateChecker = HostedServices.Get<UpdateChecker>();
-				await LegalChecker.InitializeAsync(updateChecker).ConfigureAwait(false);
+				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
 
 				cancel.ThrowIfCancellationRequested();
 

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -103,7 +103,7 @@ public class Global
 
 			Synchronizer = new WasabiSynchronizer(BitcoinStore, HttpClientFactory);
 			LegalChecker = new(DataDir);
-			UpdateManager = new(DataDir, HttpClientFactory.NewHttpClient(Mode.DefaultCircuit));
+			UpdateManager = new(DataDir, Config.DownloadNewVersion, HttpClientFactory.NewHttpClient(Mode.DefaultCircuit));
 			TransactionBroadcaster = new TransactionBroadcaster(Network, BitcoinStore, HttpClientFactory, WalletManager);
 			TorStatusChecker = new TorStatusChecker(TimeSpan.FromHours(6), HttpClientFactory.NewHttpClient(Mode.DefaultCircuit), new XmlIssueListParser());
 

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -144,11 +144,10 @@ public class Global
 			{
 				var bstoreInitTask = BitcoinStore.InitializeAsync(cancel);
 
-				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer), "Software Update Checker");
+				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer, UpdateManager), "Software Update Checker");
 
 				var updateChecker = HostedServices.Get<UpdateChecker>();
 				await LegalChecker.InitializeAsync(updateChecker).ConfigureAwait(false);
-				UpdateManager.Initialize(updateChecker);
 
 				cancel.ThrowIfCancellationRequested();
 
@@ -405,11 +404,6 @@ public class Global
 				{
 					cache.Dispose();
 					Logger.LogInfo($"{nameof(Cache)} is disposed.");
-				}
-
-				if (UpdateManager is { } updateManager)
-				{
-					updateManager.Unsubscribe();
 				}
 
 				try

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -144,7 +144,7 @@ public class Global
 			{
 				var bstoreInitTask = BitcoinStore.InitializeAsync(cancel);
 
-				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer, UpdateManager), "Software Update Checker");
+				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer), "Software Update Checker");
 				var updateChecker = HostedServices.Get<UpdateChecker>();
 
 				UpdateManager.Initialize(updateChecker);

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -54,6 +54,7 @@ public class Global
 	private TorProcessManager? TorManager { get; set; }
 	public CoreNode? BitcoinCoreNode { get; private set; }
 	public TorStatusChecker TorStatusChecker { get; set; }
+	public UpdateManager UpdateManager { get; set; }
 	public HostedServices HostedServices { get; }
 
 	public UiConfig UiConfig { get; }
@@ -102,6 +103,7 @@ public class Global
 
 			Synchronizer = new WasabiSynchronizer(BitcoinStore, HttpClientFactory);
 			LegalChecker = new(DataDir);
+			UpdateManager = new(DataDir);
 			TransactionBroadcaster = new TransactionBroadcaster(Network, BitcoinStore, HttpClientFactory, WalletManager);
 			TorStatusChecker = new TorStatusChecker(TimeSpan.FromHours(6), HttpClientFactory.NewHttpClient(Mode.DefaultCircuit), new XmlIssueListParser());
 
@@ -145,6 +147,8 @@ public class Global
 				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer), "Software Update Checker");
 
 				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
+				UpdateManager.Initialize(HostedServices.Get<UpdateChecker>());
+
 				cancel.ThrowIfCancellationRequested();
 
 				await StartTorProcessManagerAsync(cancel).ConfigureAwait(false);

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -145,8 +145,10 @@ public class Global
 				var bstoreInitTask = BitcoinStore.InitializeAsync(cancel);
 
 				HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromMinutes(7), Synchronizer, UpdateManager), "Software Update Checker");
+				var updateChecker = HostedServices.Get<UpdateChecker>();
 
-				await LegalChecker.InitializeAsync(HostedServices.Get<UpdateChecker>()).ConfigureAwait(false);
+				UpdateManager.Initialize(updateChecker);
+				await LegalChecker.InitializeAsync(updateChecker).ConfigureAwait(false);
 
 				cancel.ThrowIfCancellationRequested();
 
@@ -331,6 +333,12 @@ public class Global
 				catch (Exception ex)
 				{
 					Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
+				}
+
+				if (UpdateManager is { } updateManager)
+				{
+					UpdateManager.Dispose();
+					Logger.LogInfo($"{nameof(UpdateManager)} is stopped.", nameof(Global));
 				}
 
 				if (RpcServer is { } rpcServer)

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -36,9 +36,10 @@ public static class Services
 	public static SingleInstanceChecker SingleInstanceChecker { get; private set; } = null!;
 
 	public static TorStatusChecker TorStatusChecker { get; private set; } = null!;
+	public static UpdateManager UpdateManager { get; private set; } = null!;
 
 	public static bool IsInitialized { get; private set; }
-	
+
 	/// <summary>
 	/// Initializes global services used by fluent project.
 	/// </summary>
@@ -57,6 +58,7 @@ public static class Services
 		Guard.NotNull(nameof(global.HostedServices), global.HostedServices);
 		Guard.NotNull(nameof(global.UiConfig), global.UiConfig);
 		Guard.NotNull(nameof(global.TorStatusChecker), global.TorStatusChecker);
+		Guard.NotNull(nameof(global.UpdateManager), global.UpdateManager);
 
 		DataDir = global.DataDir;
 		TorSettings = global.TorSettings;
@@ -71,6 +73,7 @@ public static class Services
 		UiConfig = global.UiConfig;
 		SingleInstanceChecker = singleInstanceChecker;
 		TorStatusChecker = global.TorStatusChecker;
+		UpdateManager = global.UpdateManager;
 
 		IsInitialized = true;
 	}

--- a/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/GeneralSettingsTabViewModel.cs
@@ -31,6 +31,7 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 	[AutoNotify] private bool _hideOnClose;
 	[AutoNotify] private bool _useTor;
 	[AutoNotify] private bool _terminateTorOnExit;
+	[AutoNotify] private bool _downloadNewVersion;
 
 	public GeneralSettingsTabViewModel()
 	{
@@ -45,6 +46,7 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 			: FeeDisplayUnit.Satoshis;
 		_useTor = Services.Config.UseTor;
 		_terminateTorOnExit = Services.Config.TerminateTorOnExit;
+		_downloadNewVersion = Services.Config.DownloadNewVersion;
 
 		this.WhenAnyValue(x => x.DarkModeEnabled)
 			.Skip(1)
@@ -97,7 +99,8 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 
 		this.WhenAnyValue(
 				x => x.UseTor,
-				x => x.TerminateTorOnExit)
+				x => x.TerminateTorOnExit,
+				x => x.DownloadNewVersion)
 			.ObserveOn(RxApp.TaskpoolScheduler)
 			.Throttle(TimeSpan.FromMilliseconds(ThrottleTime))
 			.Skip(1)
@@ -113,5 +116,6 @@ public partial class GeneralSettingsTabViewModel : SettingsTabViewModelBase
 	{
 		config.UseTor = UseTor;
 		config.TerminateTorOnExit = TerminateTorOnExit;
+		config.DownloadNewVersion = DownloadNewVersion;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
@@ -41,13 +41,12 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 		ManualUpdateCommand = ReactiveCommand.CreateFromTask(() => IoHelpers.OpenBrowserAsync("https://wasabiwallet.io/#download"));
 		UpdateCommand = ReactiveCommand.Create(() =>
 		{
-			Services.UpdateManager.UpdateOnClose = true;
+			Services.UpdateManager.DoUpdateOnClose = true;
 			UpdateAvailable = false;
 		});
 
 		AskMeLaterCommand = ReactiveCommand.Create(() =>
 		{
-			Services.UpdateManager.UpdateOnClose = false;
 			UpdateAvailable = false;
 		});
 

--- a/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
@@ -43,7 +43,6 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 		UpdateCommand = ReactiveCommand.Create(() =>
 		{
 			Services.UpdateManager.DoUpdateOnClose = true;
-			UpdateAvailable = false;
 			AppLifetimeHelper.Shutdown();
 		});
 

--- a/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
@@ -27,6 +27,7 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 	[AutoNotify] private int _peers;
 	[AutoNotify] private bool _updateAvailable;
 	[AutoNotify] private bool _criticalUpdateAvailable;
+	[AutoNotify] private bool _isReadyToInstall;
 	[AutoNotify] private bool _isConnectionIssueDetected;
 	[AutoNotify] private string? _versionText;
 	private readonly ObservableAsPropertyHelper<ICollection<Issue>> _torIssues;
@@ -37,9 +38,20 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 		TorStatus = UseTor ? Services.Synchronizer.TorStatus : TorStatus.TurnedOff;
 		UseBitcoinCore = Services.Config.StartLocalBitcoinCoreOnStartup;
 
-		UpdateCommand = ReactiveCommand.CreateFromTask( () =>  IoHelpers.OpenBrowserAsync("https://wasabiwallet.io/#download"));
+		ManualUpdateCommand = ReactiveCommand.CreateFromTask(() => IoHelpers.OpenBrowserAsync("https://wasabiwallet.io/#download"));
+		UpdateCommand = ReactiveCommand.Create(() =>
+		{
+			Services.UpdateManager.UpdateOnClose = true;
+			UpdateAvailable = false;
+		});
+
+		AskMeLaterCommand = ReactiveCommand.Create(() =>
+		{
+			Services.UpdateManager.UpdateOnClose = false;
+			UpdateAvailable = false;
+		});
+
 		OpenTorStatusSiteCommand = ReactiveCommand.CreateFromTask(() => IoHelpers.OpenBrowserAsync("https://status.torproject.org"));
-		AskMeLaterCommand = ReactiveCommand.Create(() => UpdateAvailable = false);
 
 		this.WhenAnyValue(
 				x => x.TorStatus,
@@ -76,6 +88,7 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 	public ICommand OpenTorStatusSiteCommand { get; }
 
 	public ICommand UpdateCommand { get; }
+	public ICommand ManualUpdateCommand { get; }
 
 	public ICommand AskMeLaterCommand { get; }
 
@@ -126,6 +139,7 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 		var synchronizer = Services.Synchronizer;
 		var rpcMonitor = Services.HostedServices.GetOrDefault<RpcMonitor>();
 		var updateChecker = Services.HostedServices.Get<UpdateChecker>();
+		var updateManager = Services.UpdateManager;
 
 		BitcoinCoreStatus = rpcMonitor?.RpcStatus ?? RpcStatus.Unresponsive;
 
@@ -168,7 +182,7 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 				.DisposeWith(Disposables);
 		}
 
-		Observable.FromEventPattern<UpdateStatus>(updateChecker, nameof(updateChecker.UpdateStatusChanged))
+		Observable.FromEventPattern<UpdateStatus>(updateManager, nameof(updateManager.UpdateAvailableToGet))
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(e =>
 			{
@@ -176,10 +190,15 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 
 				UpdateAvailable = !updateStatus.ClientUpToDate;
 				CriticalUpdateAvailable = !updateStatus.BackendCompatible;
+				IsReadyToInstall = updateStatus.IsReadyToInstall;
 
 				if (CriticalUpdateAvailable)
 				{
 					VersionText = $"Critical update required";
+				}
+				else if (IsReadyToInstall)
+				{
+					VersionText = $"Version {updateStatus.ClientVersion} is now ready to install";
 				}
 				else if (UpdateAvailable)
 				{

--- a/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
@@ -10,6 +10,7 @@ using ReactiveUI;
 using WalletWasabi.BitcoinCore.Monitoring;
 using WalletWasabi.BitcoinP2p;
 using WalletWasabi.Fluent.AppServices.Tor;
+using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
@@ -43,6 +44,7 @@ public partial class StatusIconViewModel : IStatusIconViewModel, IDisposable
 		{
 			Services.UpdateManager.DoUpdateOnClose = true;
 			UpdateAvailable = false;
+			AppLifetimeHelper.Shutdown();
 		});
 
 		AskMeLaterCommand = ReactiveCommand.Create(() =>

--- a/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/GeneralSettingsTabView.axaml
@@ -52,6 +52,11 @@
       <ToggleSwitch IsChecked="{Binding TerminateTorOnExit}" />
     </DockPanel>
 
+    <DockPanel>
+      <TextBlock Text="Auto download new version" />
+      <ToggleSwitch IsChecked="{Binding DownloadNewVersion}" />
+    </DockPanel>
+
     <StackPanel Spacing="10">
       <TextBlock Text="Fee display unit" />
       <ComboBox HorizontalAlignment="Stretch" Items="{Binding FeeDisplayUnits}" SelectedItem="{Binding SelectedFeeDisplayUnit}">
@@ -62,6 +67,5 @@
         </ComboBox.ItemTemplate>
       </ComboBox>
     </StackPanel>
-
   </StackPanel>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
@@ -37,7 +37,6 @@
       <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
       <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
     </Style>
-
   </UserControl.Styles>
   <Panel>
 
@@ -128,10 +127,16 @@
                 <PathIcon Data="{StaticResource arrow_clockwise_regular}" />
               </c:StatusItem.Icon>
             </c:StatusItem>
-            <Button Classes="activeHyperLink" Command="{Binding UpdateCommand}">
+            <Button IsVisible="{Binding IsReadyToInstall}" Classes="activeHyperLink" Command="{Binding UpdateCommand}">
               <StackPanel Spacing="5" Orientation="Horizontal">
                 <PathIcon Data="{StaticResource arrow_download_regular}" Height="13" />
-                <AccessText Text="Update now" />
+                <AccessText Text="Update on Close" />
+              </StackPanel>
+            </Button>
+            <Button IsVisible="{Binding !IsReadyToInstall}" Classes="activeHyperLink" Command="{Binding ManualUpdateCommand}">
+              <StackPanel Spacing="5" Orientation="Horizontal">
+                <PathIcon Data="{StaticResource arrow_download_regular}" Height="13" />
+                <AccessText Text="Update" />
               </StackPanel>
             </Button>
 
@@ -175,6 +180,5 @@
       IsVisible="{Binding CurrentState, Converter={x:Static converters:StatusIconStateVisibilityConverter.Instance}, ConverterParameter={x:Static models:StatusIconState.Loading}}"
       Data="{StaticResource arrow_sync_regular}"
       Classes.rotate="{Binding $self.IsVisible}" />
-
   </Panel>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
@@ -130,7 +130,7 @@
             <Button IsVisible="{Binding IsReadyToInstall}" Classes="activeHyperLink" Command="{Binding UpdateCommand}">
               <StackPanel Spacing="5" Orientation="Horizontal">
                 <PathIcon Data="{StaticResource arrow_download_regular}" Height="13" />
-                <AccessText Text="Update on Close" />
+                <AccessText Text="Close and Update" />
               </StackPanel>
             </Button>
             <Button IsVisible="{Binding !IsReadyToInstall}" Classes="activeHyperLink" Command="{Binding ManualUpdateCommand}">

--- a/WalletWasabi/Models/UpdateStatus.cs
+++ b/WalletWasabi/Models/UpdateStatus.cs
@@ -13,7 +13,7 @@ public class UpdateStatus : IEquatable<UpdateStatus>
 
 	public bool ClientUpToDate { get; }
 	public bool BackendCompatible { get; }
-	public bool IsReadyToInstall { get; set; } = false;
+	public bool IsReadyToInstall { get; set; }
 
 	public Version LegalDocumentsVersion { get; }
 	public ushort CurrentBackendMajorVersion { get; }

--- a/WalletWasabi/Models/UpdateStatus.cs
+++ b/WalletWasabi/Models/UpdateStatus.cs
@@ -13,6 +13,7 @@ public class UpdateStatus : IEquatable<UpdateStatus>
 
 	public bool ClientUpToDate { get; }
 	public bool BackendCompatible { get; }
+	public bool IsReadyToInstall { get; set; } = false;
 
 	public Version LegalDocumentsVersion { get; }
 	public ushort CurrentBackendMajorVersion { get; }

--- a/WalletWasabi/Models/UpdateStatus.cs
+++ b/WalletWasabi/Models/UpdateStatus.cs
@@ -18,7 +18,7 @@ public class UpdateStatus : IEquatable<UpdateStatus>
 	public Version LegalDocumentsVersion { get; }
 	public ushort CurrentBackendMajorVersion { get; }
 
-	public Version ClientVersion { get; }
+	public Version ClientVersion { get; set; }
 
 	#region EqualityAndComparison
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -19,8 +19,6 @@ public class UpdateChecker : PeriodicRunner
 
 	public event EventHandler<UpdateStatus>? UpdateStatusChanged;
 
-	public event EventHandler? CleanupAfterUpdate;
-
 	private WasabiSynchronizer Synchronizer { get; }
 	public UpdateStatus UpdateStatus { get; private set; }
 	public WasabiClient WasabiClient { get; }
@@ -42,10 +40,6 @@ public class UpdateChecker : PeriodicRunner
 		{
 			UpdateStatus = newUpdateStatus;
 			UpdateStatusChanged?.Invoke(this, newUpdateStatus);
-		}
-		else if (UpdateStatus.ClientUpToDate)
-		{
-			CleanupAfterUpdate?.Invoke(this, EventArgs.Empty);
 		}
 	}
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -20,6 +20,8 @@ public class UpdateChecker : PeriodicRunner
 
 	public event EventHandler<UpdateStatus>? UpdateStatusChanged;
 
+	public event EventHandler? CleanupAfterUpdate;
+
 	private WasabiSynchronizer Synchronizer { get; }
 	public UpdateStatus UpdateStatus { get; private set; }
 	public WasabiClient WasabiClient { get; }
@@ -41,11 +43,11 @@ public class UpdateChecker : PeriodicRunner
 		if (newUpdateStatus != UpdateStatus)
 		{
 			UpdateStatus = newUpdateStatus;
-			UpdateManager.UpdateStatusChangedAsync(newUpdateStatus);
+			UpdateStatusChanged?.Invoke(this, newUpdateStatus);
 		}
 		else if (UpdateStatus.ClientUpToDate)
 		{
-			UpdateManager.DeletePossibleLefotver();
+			CleanupAfterUpdate?.Invoke(this, EventArgs.Empty);
 		}
 	}
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -9,12 +9,11 @@ namespace WalletWasabi.Services;
 
 public class UpdateChecker : PeriodicRunner
 {
-	public UpdateChecker(TimeSpan period, WasabiSynchronizer synchronizer, UpdateManager updateManager) : base(period)
+	public UpdateChecker(TimeSpan period, WasabiSynchronizer synchronizer) : base(period)
 	{
 		Synchronizer = synchronizer;
 		UpdateStatus = new UpdateStatus(true, true, new Version(), 0, new Version());
 		WasabiClient = Synchronizer.HttpClientFactory.SharedWasabiClient;
-		UpdateManager = updateManager;
 		Synchronizer.PropertyChanged += Synchronizer_PropertyChanged;
 	}
 
@@ -25,7 +24,6 @@ public class UpdateChecker : PeriodicRunner
 	private WasabiSynchronizer Synchronizer { get; }
 	public UpdateStatus UpdateStatus { get; private set; }
 	public WasabiClient WasabiClient { get; }
-	public UpdateManager UpdateManager { get; }
 
 	private void Synchronizer_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -1,75 +1,152 @@
-using System;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using WalletWasabi.Logging;
 using WalletWasabi.Microservices;
 using WalletWasabi.Models;
+using WalletWasabi.Tor.Http;
 
 namespace WalletWasabi.Services;
 
 public class UpdateManager
 {
-	public UpdateManager(string dataDir)
+	private string InstallerName { get; set; } = "";
+
+	public UpdateManager(string dataDir, IHttpClient httpClient)
 	{
 		DataDir = dataDir;
+		HttpClient = httpClient;
 	}
 
-	private void UpdateChecker_UpdateStatusChanged(object? sender, UpdateStatus updateStatus)
+	private async void UpdateChecker_UpdateStatusChangedAsync(object? sender, UpdateStatus updateStatus)
 	{
-		bool updateAvailable = !updateStatus.ClientUpToDate || !updateStatus.BackendCompatible;
-		if (updateAvailable)
+		try
 		{
-			try
+			bool updateAvailable = !updateStatus.ClientUpToDate || !updateStatus.BackendCompatible;
+			if (!updateAvailable)
 			{
-				// TODO: download MSI to DataDir/downloads
-				bool downloadSuccessful = GetInstaller(updateStatus);
-				updateStatus.IsReadyToInstall = downloadSuccessful;
+				return;
 			}
-			catch (Exception)
+
+			// TODO: download MSI to DataDir/downloads
+			Version targetVersion = updateStatus.ClientVersion;
+			bool downloadSuccessful = await GetInstallerAsync(targetVersion).ConfigureAwait(false);
+			updateStatus.IsReadyToInstall = downloadSuccessful;
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError("Geting new version failed with error.", ex);
+		}
+
+		UpdateAvailableToGet?.Invoke(this, updateStatus);
+	}
+
+	private async Task<bool> GetInstallerAsync(Version targetVersion)
+	{
+		using HttpRequestMessage message = new(HttpMethod.Get, "https://api.github.com/repos/zkSNACKs/WalletWasabi/releases/latest");
+		message.Headers.UserAgent.Add(new("WalletWasabi", "2.0"));
+		var resp = await HttpClient.SendAsync(message).ConfigureAwait(false);
+
+		JObject jsonResponse = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
+
+		string softwareVersion = jsonResponse["tag_name"]?.ToString();
+		if (string.IsNullOrEmpty(softwareVersion))
+		{
+			throw new InvalidDataException("");
+		}
+
+		Version githubVersion = new(softwareVersion[1..]);
+		Version shortGithubVersion = new(githubVersion.Major, githubVersion.Minor, githubVersion.Build);
+		if (targetVersion != shortGithubVersion)
+		{
+			throw new InvalidDataException("");
+		}
+
+		List<JToken> assetsInfos = jsonResponse["assets"].Children().ToList();
+		List<string> assetDownloadUrls = new();
+		foreach (JToken asset in assetsInfos)
+		{
+			assetDownloadUrls.Add(asset["browser_download_url"].ToString());
+		}
+
+		(string url, string fileName) = GetAssetToDownload(softwareVersion, assetDownloadUrls);
+
+		var installerPath = Path.Combine(DataDir, "Downloads");
+		IoHelpers.EnsureDirectoryExists(installerPath);
+
+		using System.Net.Http.HttpClient httpClient = new();
+		using HttpRequestMessage newMessage = new(HttpMethod.Get, url);
+		message.Headers.UserAgent.Add(new("WalletWasabi", "2.0"));
+
+		var stream = await httpClient.GetStreamAsync(url).ConfigureAwait(false);
+		using var file = File.OpenWrite(Path.Combine(installerPath, fileName));
+		await stream.CopyToAsync(file).ConfigureAwait(false);
+		InstallerName = fileName;
+
+		return true;
+	}
+
+	private (string url, string fileName) GetAssetToDownload(string softwareVersion, List<string> urls)
+	{
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			var url = urls.Where(url => url.Contains(".msi")).First();
+			return (url, url.Split("/").Last());
+		}
+		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+		{
+			var url = urls.Where(url => url.Contains("arm64.dmg")).First();
+			return (url, url.Split("/").Last());
+		}
+		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			if (RuntimeInformation.OSDescription.Contains("Ubuntu"))
 			{
-				throw;
+				var url = urls.Where(url => url.Contains(".deb")).First();
+				return (url, url.Split("/").Last());
 			}
-			finally
+			else
 			{
-				UpdateAvailableToGet?.Invoke(this, updateStatus);
+				throw new InvalidOperationException("For Linux, get the correct update manually.");
 			}
 		}
-	}
-
-	private bool GetInstaller(UpdateStatus updateStatus)
-	{
-		var resp = GetInstallerAsync(updateStatus);
-		return resp.Result;
-	}
-
-	private async Task<bool> GetInstallerAsync(UpdateStatus updateStatus)
-	{
-		await Task.Delay(5000).ConfigureAwait(false);
-		// Download installer here
-		// based on target OS
-		return true;
+		else
+		{
+			throw new InvalidOperationException("OS not recognized, download manually.");
+		}
 	}
 
 	public event EventHandler<UpdateStatus>? UpdateAvailableToGet;
 
 	public string DataDir { get; }
+	public IHttpClient HttpClient { get; }
 	public bool UpdateOnClose { get; set; }
-
-	public void Initialize(UpdateChecker updateChecker)
-	{
-		updateChecker.UpdateStatusChanged += UpdateChecker_UpdateStatusChanged;
-	}
+	public UpdateChecker? UpdateChecker { get; set; }
 
 	public void InstallNewVersion()
 	{
-		var installerPath = Path.Combine(DataDir, "Downloads", "<downloaded_installer_name>");
+		var installerPath = Path.Combine(DataDir, "Downloads", InstallerName);
 		if (File.Exists(installerPath))
 		{
 			ProcessStartInfo startInfo = ProcessStartInfoFactory.Make(installerPath, "");
+			// Throws exception rn
 			using Process? p = Process.Start(startInfo);
 		}
+	}
+
+	public void Initialize(UpdateChecker updateChecker)
+	{
+		UpdateChecker = updateChecker;
+		updateChecker.UpdateStatusChanged += UpdateChecker_UpdateStatusChangedAsync;
+	}
+
+	public void Unsubscribe()
+	{
+		UpdateChecker!.UpdateStatusChanged -= UpdateChecker_UpdateStatusChangedAsync;
 	}
 }

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -114,8 +114,8 @@ public class UpdateManager
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
 		{
-			var cpu = System.Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-			Logger.LogWarning(cpu);
+			var cpu = RuntimeInformation.ProcessArchitecture;
+			Logger.LogWarning(cpu.ToString());
 			var url = urls.Where(url => url.Contains("arm64.dmg")).First();
 			return (url, url.Split("/").Last());
 		}

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -47,6 +47,7 @@ public class UpdateManager : IDisposable
 					InstallerPath = installerPath;
 					Logger.LogInfo($"Version {newVersion} downloaded successfuly.");
 					updateStatus.IsReadyToInstall = true;
+					updateStatus.ClientVersion = newVersion;
 					break;
 				}
 				catch (Exception ex)
@@ -129,7 +130,7 @@ public class UpdateManager : IDisposable
 
 	private bool TryGetDownloadedInstaller(string fileName)
 	{
-		IoHelpers.EnsureContainingDirectoryExists(InstallerDir);
+		IoHelpers.EnsureDirectoryExists(InstallerDir);
 		DirectoryInfo folder = new(InstallerDir);
 		if (folder.Exists)
 		{

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -190,7 +190,7 @@ public class UpdateManager
 			}
 			else
 			{
-				Logger.LogError("Wasabi installer was terminated.");
+				Logger.LogError($"Wasabi installer was terminated with exit code {p.ExitCode}.");
 			}
 		}
 		catch (Exception ex)
@@ -206,20 +206,15 @@ public class UpdateManager
 		var folder = new DirectoryInfo(DownloadsDir);
 		if (folder.Exists)
 		{
-			var files = folder.GetFileSystemInfos();
-			if (files.Length == 0)
+			FileSystemInfo[] files = folder.GetFileSystemInfos();
+
+			FileSystemInfo? file = files.Where(file => file.Name.Contains("Wasabi")).FirstOrDefault();
+			if (file is { })
 			{
-				return false;
+				InstallerName = file.Name;
+				return true;
 			}
-			return files.Any(file =>
-			{
-				if (file.Name.Contains("Wasabi"))
-				{
-					InstallerName = file.Name;
-					return true;
-				}
-				return false;
-			});
+			return false;
 		}
 		else
 		{

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -174,11 +174,13 @@ public class UpdateManager : IDisposable
 	private void EnsureToRemoveCorruptedFiles()
 	{
 		DirectoryInfo folder = new(InstallerDir);
-
-		IEnumerable<FileSystemInfo> corruptedFiles = folder.GetFileSystemInfos().Where(file => file.Name.Contains("tmp"));
-		foreach (var file in corruptedFiles)
+		if (folder.Exists)
 		{
-			File.Delete(file.FullName);
+			IEnumerable<FileSystemInfo> corruptedFiles = folder.GetFileSystemInfos().Where(file => file.Name.Contains("tmp"));
+			foreach (var file in corruptedFiles)
+			{
+				File.Delete(file.FullName);
+			}
 		}
 	}
 

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -151,7 +151,7 @@ public class UpdateManager
 	public string DownloadsDir { get; }
 	public IHttpClient HttpClient { get; }
 
-	///<summary>Comes from config file.</summary>
+	///<summary> Comes from config file. Decides Wasabi should download the new installer in the background or not.</summary>
 	public bool DownloadNewVersion { get; set; }
 
 	///<summary>User's answer if installing new version on shutdown is needed.</summary>

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -119,15 +119,7 @@ public class UpdateManager
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 		{
-			if (RuntimeInformation.OSDescription.Contains("Ubuntu"))
-			{
-				var url = urls.Where(url => url.Contains(".deb")).First();
-				return (url, url.Split("/").Last());
-			}
-			else
-			{
-				throw new InvalidOperationException("For Linux, get the correct update manually.");
-			}
+			throw new InvalidOperationException("For Linux, get the correct update manually.");
 		}
 		else
 		{
@@ -141,7 +133,6 @@ public class UpdateManager
 	public string DownloadsDir { get; }
 	public IHttpClient HttpClient { get; }
 	public bool UpdateOnClose { get; set; }
-	public UpdateChecker? UpdateChecker { get; set; }
 
 	public void InstallNewVersion()
 	{
@@ -157,7 +148,7 @@ public class UpdateManager
 			{
 				startInfo = ProcessStartInfoFactory.Make(installerPath, "", true);
 			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			else
 			{
 				startInfo = new()
 				{
@@ -165,10 +156,6 @@ public class UpdateManager
 					UseShellExecute = true,
 					WindowStyle = ProcessWindowStyle.Normal
 				};
-			}
-			else
-			{
-				startInfo = new(installerPath);
 			}
 
 			using Process? p = Process.Start(startInfo);

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -115,8 +115,12 @@ public class UpdateManager
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
 		{
 			var cpu = RuntimeInformation.ProcessArchitecture;
-			Logger.LogWarning(cpu.ToString());
-			var url = urls.Where(url => url.Contains("arm64.dmg")).First();
+			if (cpu.ToString() == "Arm64")
+			{
+				var arm64url = urls.Where(url => url.Contains("arm64.dmg")).First();
+				return (arm64url, arm64url.Split("/").Last());
+			}
+			var url = urls.Where(url => url.Contains(".dmg") && !url.Contains("arm64")).First();
 			return (url, url.Split("/").Last());
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -114,6 +114,8 @@ public class UpdateManager
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
 		{
+			var cpu = System.Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+			Logger.LogWarning(cpu);
 			var url = urls.Where(url => url.Contains("arm64.dmg")).First();
 			return (url, url.Split("/").Last());
 		}

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -154,7 +154,7 @@ public class UpdateManager
 	///<summary> Comes from config file. Decides Wasabi should download the new installer in the background or not.</summary>
 	public bool DownloadNewVersion { get; set; }
 
-	///<summary>User's answer if installing new version on shutdown is needed.</summary>
+	///<summary> Install new version on shutdown or not.</summary>
 	public bool DoUpdateOnClose { get; set; } = false;
 
 	public bool InstallNewVersion()

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Microservices;
+using WalletWasabi.Models;
+
+namespace WalletWasabi.Services;
+
+public class UpdateManager
+{
+	public UpdateManager(string dataDir)
+	{
+		DataDir = dataDir;
+	}
+
+	private void UpdateChecker_UpdateStatusChanged(object? sender, UpdateStatus updateStatus)
+	{
+		bool updateAvailable = !updateStatus.ClientUpToDate || !updateStatus.BackendCompatible;
+		if (updateAvailable)
+		{
+			try
+			{
+				// TODO: download MSI to DataDir/downloads
+				bool downloadSuccessful = GetInstaller(updateStatus);
+				updateStatus.IsReadyToInstall = downloadSuccessful;
+			}
+			catch (Exception)
+			{
+				throw;
+			}
+			finally
+			{
+				UpdateAvailableToGet?.Invoke(this, updateStatus);
+			}
+		}
+	}
+
+	private bool GetInstaller(UpdateStatus updateStatus)
+	{
+		var resp = GetInstallerAsync(updateStatus);
+		return resp.Result;
+	}
+
+	private async Task<bool> GetInstallerAsync(UpdateStatus updateStatus)
+	{
+		await Task.Delay(5000).ConfigureAwait(false);
+		// Download installer here
+		// based on target OS
+		return true;
+	}
+
+	public event EventHandler<UpdateStatus>? UpdateAvailableToGet;
+
+	public string DataDir { get; }
+	public bool UpdateOnClose { get; set; }
+
+	public void Initialize(UpdateChecker updateChecker)
+	{
+		updateChecker.UpdateStatusChanged += UpdateChecker_UpdateStatusChanged;
+	}
+
+	public void InstallNewVersion()
+	{
+		var installerPath = Path.Combine(DataDir, "Downloads", "<downloaded_installer_name>");
+		if (File.Exists(installerPath))
+		{
+			ProcessStartInfo startInfo = ProcessStartInfoFactory.Make(installerPath, "");
+			using Process? p = Process.Start(startInfo);
+		}
+	}
+}

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -134,7 +134,7 @@ public class UpdateManager
 	public IHttpClient HttpClient { get; }
 	public bool UpdateOnClose { get; set; }
 
-	public void InstallNewVersion()
+	public bool InstallNewVersion()
 	{
 		try
 		{
@@ -179,6 +179,7 @@ public class UpdateManager
 				{
 					Logger.LogInfo("Succesfuly installed new version. Deleting installer.");
 					Directory.Delete(DownloadsDir, true);
+					return true;
 				}
 			}
 			else
@@ -191,6 +192,7 @@ public class UpdateManager
 			Logger.LogError("Failed to install latest release. File might be corrupted. Deleting...", ex);
 			Directory.Delete(DownloadsDir, true);
 		}
+		return false;
 	}
 
 	public bool CheckIfInstallerDownloaded()

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -83,13 +83,16 @@ public class UpdateManager : IDisposable
 
 			// Get file stream and copy it to downloads folder to access.
 			using var stream = await httpClient.GetStreamAsync(url).ConfigureAwait(false);
-			Logger.LogInfo("Installer stream downloaded, copying...");
+			Logger.LogInfo("Installer downloaded, copying...");
 			IoHelpers.EnsureContainingDirectoryExists(tmpFilePath);
-			using var file = File.OpenWrite(tmpFilePath);
-			await stream.CopyToAsync(file).ConfigureAwait(false);
+			using (var file = File.OpenWrite(tmpFilePath))
+			{
+				await stream.CopyToAsync(file).ConfigureAwait(false);
 
-			// Closing the file to rename.
-			file.Close();
+				// Closing the file to rename.
+				file.Close();
+			};
+
 			File.Move(tmpFilePath, newFilePath);
 		}
 

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -20,6 +20,7 @@ public class UpdateManager
 	public UpdateManager(string dataDir, IHttpClient httpClient)
 	{
 		DataDir = dataDir;
+		DownloadsDir = Path.Combine(DataDir, "Downloads");
 		HttpClient = httpClient;
 	}
 
@@ -33,10 +34,9 @@ public class UpdateManager
 				return;
 			}
 
-			// TODO: download MSI to DataDir/downloads
 			Version targetVersion = updateStatus.ClientVersion;
-			bool downloadSuccessful = await GetInstallerAsync(targetVersion).ConfigureAwait(false);
-			updateStatus.IsReadyToInstall = downloadSuccessful;
+			bool isReadyToInstall = await GetInstallerAsync(targetVersion).ConfigureAwait(false);
+			updateStatus.IsReadyToInstall = isReadyToInstall;
 		}
 		catch (Exception ex)
 		{
@@ -48,25 +48,38 @@ public class UpdateManager
 
 	private async Task<bool> GetInstallerAsync(Version targetVersion)
 	{
+		try
+		{
+			if (CheckIfInstallerDownloaded())
+			{
+				return true;
+			}
+		}
+		catch (DirectoryNotFoundException)
+		{
+			IoHelpers.EnsureDirectoryExists(DownloadsDir);
+		}
+
 		using HttpRequestMessage message = new(HttpMethod.Get, "https://api.github.com/repos/zkSNACKs/WalletWasabi/releases/latest");
 		message.Headers.UserAgent.Add(new("WalletWasabi", "2.0"));
-		var resp = await HttpClient.SendAsync(message).ConfigureAwait(false);
+		var response = await HttpClient.SendAsync(message).ConfigureAwait(false);
 
-		JObject jsonResponse = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
-
+		JObject jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 		string softwareVersion = jsonResponse["tag_name"]?.ToString();
 		if (string.IsNullOrEmpty(softwareVersion))
 		{
-			throw new InvalidDataException("");
+			throw new InvalidDataException("Endpoint gave back wrong json data or it's changed.");
 		}
 
+		// If the version we are looking for is not the one on github, somethings wrong.
 		Version githubVersion = new(softwareVersion[1..]);
 		Version shortGithubVersion = new(githubVersion.Major, githubVersion.Minor, githubVersion.Build);
 		if (targetVersion != shortGithubVersion)
 		{
-			throw new InvalidDataException("");
+			throw new InvalidDataException("Target version from backend does not match with the latest github release. This should be impossible.");
 		}
 
+		// Get all asset names and download urls to find the correct one.
 		List<JToken> assetsInfos = jsonResponse["assets"].Children().ToList();
 		List<string> assetDownloadUrls = new();
 		foreach (JToken asset in assetsInfos)
@@ -74,24 +87,23 @@ public class UpdateManager
 			assetDownloadUrls.Add(asset["browser_download_url"].ToString());
 		}
 
-		(string url, string fileName) = GetAssetToDownload(softwareVersion, assetDownloadUrls);
+		(string url, string fileName) = GetAssetToDownload(assetDownloadUrls);
 
-		var installerPath = Path.Combine(DataDir, "Downloads");
-		IoHelpers.EnsureDirectoryExists(installerPath);
-
+		// This should also be done using Tor.
 		using System.Net.Http.HttpClient httpClient = new();
 		using HttpRequestMessage newMessage = new(HttpMethod.Get, url);
 		message.Headers.UserAgent.Add(new("WalletWasabi", "2.0"));
 
+		// Get file stream and copy it to downloads folder to access.
 		var stream = await httpClient.GetStreamAsync(url).ConfigureAwait(false);
-		using var file = File.OpenWrite(Path.Combine(installerPath, fileName));
+		using var file = File.OpenWrite(Path.Combine(DownloadsDir, fileName));
 		await stream.CopyToAsync(file).ConfigureAwait(false);
 		InstallerName = fileName;
 
 		return true;
 	}
 
-	private (string url, string fileName) GetAssetToDownload(string softwareVersion, List<string> urls)
+	private (string url, string fileName) GetAssetToDownload(List<string> urls)
 	{
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
@@ -124,19 +136,68 @@ public class UpdateManager
 	public event EventHandler<UpdateStatus>? UpdateAvailableToGet;
 
 	public string DataDir { get; }
+	public string DownloadsDir { get; }
 	public IHttpClient HttpClient { get; }
 	public bool UpdateOnClose { get; set; }
 	public UpdateChecker? UpdateChecker { get; set; }
 
 	public void InstallNewVersion()
 	{
-		var installerPath = Path.Combine(DataDir, "Downloads", InstallerName);
-		if (File.Exists(installerPath))
+		try
 		{
-			ProcessStartInfo startInfo = ProcessStartInfoFactory.Make(installerPath, "");
-			// Throws exception rn
-			using Process? p = Process.Start(startInfo);
+			var installerPath = Path.Combine(DataDir, "Downloads", InstallerName);
+			if (File.Exists(installerPath))
+			{
+				ProcessStartInfo startInfo = ProcessStartInfoFactory.Make(installerPath, "", true);
+
+				using Process? p = Process.Start(startInfo);
+				p!.WaitForExit();
+
+				// Exit code -- Reason
+				//	___________________
+				//	1602	 -- Canceled
+				//	1		 -- Terminated
+				//	0		 -- Finished
+				if (p.ExitCode == 0)
+				{
+					Logger.LogInfo("Succesfuly installed new version. Deleting installer.");
+					Directory.Delete(DownloadsDir, true);
+				}
+				else
+				{
+					Logger.LogError("Wasabi installer was terminated.");
+				}
+			}
 		}
+		catch (Exception ex)
+		{
+			Logger.LogError("Failed to install latest release. File might be corrupted. Deleting...", ex);
+			Directory.Delete(DownloadsDir, true);
+		}
+	}
+
+	public bool CheckIfInstallerDownloaded()
+	{
+		var folder = new DirectoryInfo(DownloadsDir);
+		if (folder.Exists)
+		{
+			var files = folder.GetFileSystemInfos();
+			if (files.Length == 0)
+			{
+				return false;
+			}
+			return files.Any(file =>
+			{
+				if (file.Name.Contains("Wasabi"))
+				{
+					InstallerName = file.Name;
+					return true;
+				}
+				return false;
+			});
+		}
+
+		throw new DirectoryNotFoundException();
 	}
 
 	public void Initialize(UpdateChecker updateChecker)


### PR DESCRIPTION
This PR implements an `UpdateManager.cs` class which makes updating after a new release easier.

**Old flow:**
1. In case of new version, Wasabi indicates to "Update".
2. Click on "Update" button.
3. Get redirected to Wasabi website.
4. Find your version to download based on OS.
5. Install manualy.

**New flow** is somewhat simpler:
1. In case of new version, Wasabi downloads the version you need in the background, then indicates "Close and Update".
2. Click on "Close and Update".
3. Upon closing, the installer will start automatically.

## How to test
1. Find `WalletWasabi/Helpers/Constants.cs`.
2. Change `ClientVersion` to: `new(2, 0, 0, 1)` or any other version thats smaller then current.
3. Start Wasabi and go through the steps above.
4. You can also double check logs and see if `Roaming\WalletWasabi\Client\Downloads` folder gets deleted after succesful install.

Tested on Windows. ✅ 
Tested on M1 MacOS. ✅ 
Tested on non-M1 MacOS. ✅ 
Does not support other linuxes currently, sorry Max.

## TODOs

- [x] Use .tmp file format until download finished.
- [x] Add "Update on close" to settings (config file, default: `true`).
- [x] Check if works on non-M1 Mac.
- [ ] ~Use tor for downloading installer as well.~ _Not prio, will be added later, a PR will be opened for this not to be forgotten._
- [ ] ~Restart Wasabi after updating(?)~ _Bumped, best way IMO is to add a "Start Wasabi" checkable option at the end of the installer._
- [ ] ~Download `.asc` and verify GPG as well.~ _In later PR so this PR don't get overwhelmed_
- [ ] ~Terminate Tor on close if "Update on close" is `true`.~ _Later in different PR, need to add `ShutDownTor` method to TorProcessManager_