### PR TITLE
Abstractify enough to reuse Wabisabi without Wasabi wallet

### DIFF
--- a/WalletWasabi.Backend/docker-compose.yml
+++ b/WalletWasabi.Backend/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         deprecatedrpc=signrawtransaction
         fallbackfee=0.0002
         mempoolreplacement=fee,optin
+        txindex=1
     ports:
       - "18443:18443"
       - "18444:18444"

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -297,7 +297,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = HttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(5), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Config.ServiceConfiguration, Config.CoordinatorIdentifier), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Synchronizer, Config.CoordinatorIdentifier), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -51,8 +51,8 @@ public partial class WalletManagerViewModel : ViewModelBase
 					RemoveWallet(walletViewModel);
 				}
 				else if (walletViewModel is ClosedWalletViewModel { IsLoggedIn: true } cwvm &&
-				         ((cwvm.Wallet.KeyManager.SkipSynchronization && cwvm.Wallet.State == WalletState.Starting) ||
-				          cwvm.Wallet.State == WalletState.Started))
+						 ((cwvm.Wallet.KeyManager.SkipSynchronization && cwvm.Wallet.State == WalletState.Starting) ||
+						  cwvm.Wallet.State == WalletState.Started))
 				{
 					OpenClosedWallet(cwvm);
 				}
@@ -186,7 +186,7 @@ public partial class WalletManagerViewModel : ViewModelBase
 
 	private void EnumerateWallets()
 	{
-		foreach (var wallet in Services.WalletManager.GetWallets(true))
+		foreach (var wallet in Services.WalletManager.GetWallets())
 		{
 			InsertWallet(ClosedWalletViewModel.Create(wallet));
 		}

--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -186,7 +186,7 @@ public partial class WalletManagerViewModel : ViewModelBase
 
 	private void EnumerateWallets()
 	{
-		foreach (var wallet in Services.WalletManager.GetWallets())
+		foreach (var wallet in Services.WalletManager.GetWallets(true))
 		{
 			InsertWallet(ClosedWalletViewModel.Create(wallet));
 		}

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Crypto;
 using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Client;
@@ -132,6 +133,11 @@ public class TestWallet : IKeyChain, IDestinationProvider
 
 		transaction.Sign(extKey.PrivateKey.GetBitcoinSecret(Rpc.Network), coin);
 		return transaction;
+	}
+
+	public void NotifyScriptState(IEnumerable<Script> scripts, KeyState state)
+	{
+		// Test wallet doesn't care
 	}
 
 	public IEnumerable<IDestination> GetNextDestinations(int count) =>

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -135,7 +135,7 @@ public class TestWallet : IKeyChain, IDestinationProvider
 		return transaction;
 	}
 
-	public void NotifyScriptState(IEnumerable<Script> scripts, KeyState state)
+	public void TrySetScriptStates(KeyState state, IEnumerable<Script> scripts)
 	{
 		// Test wallet doesn't care
 	}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -13,12 +13,13 @@ using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Stores;
 using WalletWasabi.Tor.Socks5.Exceptions;
+using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Tor.Socks5.Models.Fields.OctetFields;
 using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services;
 
-public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvider
+public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvider, IWasabiBackendStatusProvider
 {
 	private const long StateNotStarted = 0;
 

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -116,7 +116,7 @@ public class TorProcessManager : IAsyncDisposable
 
 				if (isAlreadyRunning)
 				{
-					Logger.LogInfo($"Tor is already running on {Settings.SocksEndpoint.Address}:{Settings.SocksEndpoint.Port}.");
+					Logger.LogInfo($"Tor is already running on {Settings.SocksEndpoint}");
 					controlClient = await InitTorControlAsync(cancellationToken).ConfigureAwait(false);
 
 					// Tor process can crash even between these two commands too.

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -57,10 +57,10 @@ public class TorSettings
 	public string CookieAuthFilePath { get; }
 
 	/// <summary>Tor SOCKS5 endpoint.</summary>
-	public IPEndPoint SocksEndpoint { get; } = new(IPAddress.Loopback, 37150);
+	public EndPoint SocksEndpoint { get; set; } = new IPEndPoint(IPAddress.Loopback, 37150);
 
 	/// <summary>Tor control endpoint.</summary>
-	public IPEndPoint ControlEndpoint { get; } = new(IPAddress.Loopback, 37151);
+	public EndPoint ControlEndpoint { get; set; } = new IPEndPoint(IPAddress.Loopback, 37151);
 
 	private string GeoIpPath { get; }
 	private string GeoIp6Path { get; }
@@ -87,13 +87,15 @@ public class TorSettings
 	/// </seealso>
 	public string GetCmdArguments()
 	{
+		ControlEndpoint.TryGetPort(out var port);
+		
 		// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.
 		List<string> arguments = new()
 		{
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--CookieAuthentication 1",
-			$"--ControlPort {ControlEndpoint.Port}",
+			$"--ControlPort {port ?? 9051}",
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",
 			$"--DataDirectory \"{TorDataDir}\"",
 			$"--GeoIPFile \"{GeoIpPath}\"",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -57,7 +57,7 @@ public class TorSettings
 	public string CookieAuthFilePath { get; }
 
 	/// <summary>Tor SOCKS5 endpoint.</summary>
-	public EndPoint SocksEndpoint { get; set; } = new IPEndPoint(IPAddress.Loopback, 37150);
+	public EndPoint SocksEndpoint { get; } = new IPEndPoint(IPAddress.Loopback, 37150);
 
 	/// <summary>Tor control endpoint.</summary>
 	public EndPoint ControlEndpoint { get; set; } = new IPEndPoint(IPAddress.Loopback, 37151);
@@ -88,7 +88,7 @@ public class TorSettings
 	public string GetCmdArguments()
 	{
 		ControlEndpoint.TryGetPort(out var port);
-		
+
 		// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.
 		List<string> arguments = new()
 		{

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Crypto;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public abstract class BaseKeyChain : IKeyChain
+{
+	public BaseKeyChain(Kitchen kitchen)
+	{
+		Kitchen = kitchen;
+	}
+
+	protected Kitchen Kitchen { get; }
+
+	protected abstract Key GetMasterKey();
+
+	public OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData commitmentData)
+	{
+		var secret = GetBitcoinSecret(destination.ScriptPubKey);
+
+		var masterKey = GetMasterKey();
+		var identificationMasterKey = Slip21Node.FromSeed(masterKey.ToBytes());
+		var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019")
+			.DeriveChild("Ownership identification key").Key;
+
+		var signingKey = secret.PrivateKey;
+		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
+			signingKey,
+			new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
+			commitmentData);
+		return ownershipProof;
+	}
+
+	public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof)
+	{
+		transaction = transaction.Clone();
+		if (transaction.Inputs.Count == 0)
+		{
+			throw new ArgumentException("No inputs to sign.", nameof(transaction));
+		}
+
+		var txInput = transaction.Inputs.AsIndexedInputs().FirstOrDefault(input => input.PrevOut == coin.Outpoint);
+
+		if (txInput is null)
+		{
+			throw new InvalidOperationException("Missing input.");
+		}
+
+		var secret = GetBitcoinSecret(coin.ScriptPubKey);
+
+		transaction.Sign(secret, coin);
+		return transaction;
+	}
+
+	public abstract void NotifyScriptState(IEnumerable<Script> scripts, KeyState state);
+
+	protected abstract BitcoinSecret GetBitcoinSecret(Script scriptPubKey);
+}

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
 using WalletWasabi.Blockchain.Keys;
@@ -56,7 +56,7 @@ public abstract class BaseKeyChain : IKeyChain
 		return transaction;
 	}
 
-	public abstract void NotifyScriptState(IEnumerable<Script> scripts, KeyState state);
+	public abstract void TrySetScriptStates(KeyState state, IEnumerable<Script> scripts);
 
 	protected abstract BitcoinSecret GetBitcoinSecret(Script scriptPubKey);
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -11,7 +11,6 @@ using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
-using WalletWasabi.Models;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
@@ -22,23 +21,20 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	private record CoinJoinCommand(Wallet Wallet);
-	private record StartCoinJoinCommand(Wallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
-	private record StopCoinJoinCommand(Wallet Wallet) : CoinJoinCommand(Wallet);
+	private readonly IWasabiBackendStatusProvider _wasabiBackendStatusProvider;
 
-	public CoinJoinManager(WalletManager walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, ServiceConfiguration serviceConfiguration, string coordinatorIdentifier)
+	public CoinJoinManager(IWalletProvider walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
 	{
-		WalletManager = walletManager;
+		_wasabiBackendStatusProvider = wasabiBackendStatusProvider;
+		WalletProvider = walletProvider;
 		HttpClientFactory = backendHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
-		ServiceConfiguration = serviceConfiguration;
 		CoordinatorIdentifier = coordinatorIdentifier;
 	}
 
-	public WalletManager WalletManager { get; }
+	public IWalletProvider WalletProvider { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
-	public ServiceConfiguration ServiceConfiguration { get; }
 	public string CoordinatorIdentifier { get; }
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 	public bool IsUserInSendWorkflow { get; set; }
@@ -51,9 +47,9 @@ public class CoinJoinManager : BackgroundService
 
 	#region Public API (Start | Stop | )
 
-	public async Task StartAsync(Wallet wallet, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken cancellationToken)
+	public async Task StartAsync(IWallet wallet, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken cancellationToken)
 	{
-		if (overridePlebStop && !wallet.IsUnderPlebStop)
+		if (overridePlebStop && !wallet.CoinjoinEnabled)
 		{
 			// Turn off overriding if we went above the threshold meanwhile.
 			overridePlebStop = false;
@@ -86,18 +82,18 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task MonitorWalletsAsync(CancellationToken stoppingToken)
 	{
-		var trackedWallets = new Dictionary<string, Wallet>();
+		var trackedWallets = new Dictionary<string, IWallet>();
 		while (!stoppingToken.IsCancellationRequested)
 		{
 			var mixableWallets = RoundStatusUpdater.AnyRound
-				? GetMixableWallets()
-				: ImmutableDictionary<string, Wallet>.Empty;
+				? await GetMixableWallets().ConfigureAwait(false)
+				: ImmutableDictionary<string, IWallet>.Empty;
 
 			// Notifies when a wallet meets the criteria for participating in a coinjoin.
 			var openedWallets = mixableWallets.Where(x => !trackedWallets.ContainsKey(x.Key)).ToImmutableList();
 			foreach (var openedWallet in openedWallets.Select(x => x.Value))
 			{
-				trackedWallets.Add(openedWallet.WalletName, openedWallet);
+				trackedWallets.Add(openedWallet.Identifier, openedWallet);
 				NotifyMixableWalletLoaded(openedWallet);
 			}
 
@@ -107,7 +103,7 @@ public class CoinJoinManager : BackgroundService
 			{
 				//closedWallet.Cancel();
 				NotifyMixableWalletUnloaded(closedWallet);
-				trackedWallets.Remove(closedWallet.WalletName);
+				trackedWallets.Remove(closedWallet.Identifier);
 			}
 			await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken).ConfigureAwait(false);
 		}
@@ -118,7 +114,7 @@ public class CoinJoinManager : BackgroundService
 		// This is a shared resource and that's why it is concurrent. Alternatives are locking structures,
 		// using a single lock around its access or use a channel.
 		var trackedCoinJoins = new ConcurrentDictionary<string, CoinJoinTracker>();
-		var trackedAutoStarts = new ConcurrentDictionary<Wallet, TrackedAutoStart>();
+		var trackedAutoStarts = new ConcurrentDictionary<IWallet, TrackedAutoStart>();
 
 		var commandsHandlingTask = Task.Run(() => HandleCoinJoinCommandsAsync(trackedCoinJoins, trackedAutoStarts, stoppingToken), stoppingToken);
 		var monitorCoinJoinTask = Task.Run(() => MonitorAndHandlingCoinJoinFinallizationAsync(trackedCoinJoins, trackedAutoStarts, stoppingToken), stoppingToken);
@@ -129,14 +125,15 @@ public class CoinJoinManager : BackgroundService
 		await WaitAndHandleResultOfTasksAsync(nameof(monitorCoinJoinTask), monitorCoinJoinTask).ConfigureAwait(false);
 	}
 
-	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<Wallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
+	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
 	{
 		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, stoppingToken);
 
-		void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
+		async Task StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{
 			var walletToStart = startCommand.Wallet;
-			if (trackedCoinJoins.TryGetValue(walletToStart.WalletName, out var tracker))
+			
+			if (trackedCoinJoins.TryGetValue(walletToStart.Identifier, out var tracker))
 			{
 				if (startCommand.StopWhenAllMixed != tracker.StopWhenAllMixed)
 				{
@@ -162,7 +159,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			if (walletToStart.IsUnderPlebStop && !startCommand.OverridePlebStop)
+			if (!walletToStart.CoinjoinEnabled && !startCommand.OverridePlebStop)
 			{
 				walletToStart.LogDebug("PlebStop preventing coinjoin.");
 				ScheduleRestartAutomatically(walletToStart, trackedAutoStarts, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop, stoppingToken);
@@ -171,7 +168,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			if (WalletManager.Synchronizer?.LastResponse is not { } synchronizerResponse)
+			if (_wasabiBackendStatusProvider.LastResponse is not { } synchronizerResponse)
 			{
 				ScheduleRestartAutomatically(walletToStart, trackedAutoStarts, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop, stoppingToken);
 
@@ -179,7 +176,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			if (IsWalletPrivate(walletToStart))
+			if (await walletToStart.IsWalletPrivate())
 			{
 				walletToStart.LogDebug("All mixed!");
 				if (!startCommand.StopWhenAllMixed)
@@ -191,7 +188,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			var coinCandidates = SelectCandidateCoins(walletToStart, synchronizerResponse.BestHeight).ToArray();
+			var coinCandidates = (await SelectCandidateCoinsAsync(walletToStart, synchronizerResponse.BestHeight)).ToArray();
 			if (coinCandidates.Length == 0)
 			{
 				walletToStart.LogDebug("No candidate coins available to mix.");
@@ -203,7 +200,7 @@ public class CoinJoinManager : BackgroundService
 
 			var coinJoinTracker = coinJoinTrackerFactory.CreateAndStart(walletToStart, coinCandidates, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop);
 
-			if (!trackedCoinJoins.TryAdd(walletToStart.WalletName, coinJoinTracker))
+			if (!trackedCoinJoins.TryAdd(walletToStart.Identifier, coinJoinTracker))
 			{
 				// This should never happen.
 				walletToStart.LogError($"{nameof(CoinJoinTracker)} was already added.");
@@ -229,7 +226,7 @@ public class CoinJoinManager : BackgroundService
 
 			var autoStartRemoved = TryRemoveTrackedAutoStart(walletToStop);
 
-			if (trackedCoinJoins.TryGetValue(walletToStop.WalletName, out var coinJoinTrackerToStop))
+			if (trackedCoinJoins.TryGetValue(walletToStop.Identifier, out var coinJoinTrackerToStop))
 			{
 				coinJoinTrackerToStop.Stop();
 				if (coinJoinTrackerToStop.InCriticalCoinJoinState)
@@ -243,7 +240,7 @@ public class CoinJoinManager : BackgroundService
 			}
 		}
 
-		bool TryRemoveTrackedAutoStart(Wallet wallet)
+		bool TryRemoveTrackedAutoStart(IWallet wallet)
 		{
 			if (trackedAutoStarts.TryRemove(wallet, out var trackedAutoStart))
 			{
@@ -261,7 +258,7 @@ public class CoinJoinManager : BackgroundService
 			switch (command)
 			{
 				case StartCoinJoinCommand startCommand:
-					StartCoinJoinCommand(startCommand);
+					await StartCoinJoinCommand(startCommand);
 					break;
 
 				case StopCoinJoinCommand stopCommand:
@@ -279,7 +276,7 @@ public class CoinJoinManager : BackgroundService
 		await WaitAndHandleResultOfTasksAsync(nameof(trackedAutoStarts), trackedAutoStarts.Values.Select(x => x.Task).ToArray()).ConfigureAwait(false);
 	}
 
-	private void ScheduleRestartAutomatically(Wallet walletToStart, ConcurrentDictionary<Wallet, TrackedAutoStart> trackedAutoStarts, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken stoppingToken)
+	private void ScheduleRestartAutomatically(IWallet walletToStart, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken stoppingToken)
 	{
 		if (trackedAutoStarts.ContainsKey(walletToStart))
 		{
@@ -322,7 +319,7 @@ public class CoinJoinManager : BackgroundService
 		}
 	}
 
-	private async Task MonitorAndHandlingCoinJoinFinallizationAsync(ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<Wallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
+	private async Task MonitorAndHandlingCoinJoinFinallizationAsync(ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
 	{
 		while (!stoppingToken.IsCancellationRequested)
 		{
@@ -375,7 +372,7 @@ public class CoinJoinManager : BackgroundService
 			if (result.SuccessfulBroadcast)
 			{
 				CoinRefrigerator.Freeze(result.RegisteredCoins);
-				MarkDestinationsUsed(result.RegisteredOutputs);
+				await MarkDestinationsUsedAsync(result.RegisteredOutputs).ConfigureAwait(false);
 				wallet.LogInfo($"{nameof(CoinJoinClient)} finished. Coinjoin transaction was broadcast.");
 			}
 			else
@@ -416,7 +413,7 @@ public class CoinJoinManager : BackgroundService
 			wallet.LogError($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
 		}
 
-		if (!trackedCoinJoins.TryRemove(wallet.WalletName, out _))
+		if (!trackedCoinJoins.TryRemove(wallet.Identifier, out _))
 		{
 			wallet.LogWarning($"Was not removed from tracked wallet list. Will retry in a few seconds.");
 		}
@@ -430,35 +427,32 @@ public class CoinJoinManager : BackgroundService
 	/// <summary>
 	/// Mark all the outputs we had in any of our wallets used.
 	/// </summary>
-	private void MarkDestinationsUsed(ImmutableList<Script> outputs)
+	private async Task MarkDestinationsUsedAsync(ImmutableList<Script> outputs)
 	{
 		var hashSet = outputs.ToHashSet();
-
-		foreach (var k in WalletManager
-			.GetWallets(false)
-			.Select(w => w.KeyManager)
-			.SelectMany(k => k.GetKeys(k => hashSet.Contains(k.P2wpkhScript))))
+		var wallets = await WalletProvider.GetWallets().ConfigureAwait(false);
+		foreach (var k in wallets)
 		{
-			k.SetKeyState(KeyState.Used);
+			k.KeyChain.NotifyScriptState(hashSet, KeyState.Used);
 		}
 	}
 
-	private void NotifyWalletStartedCoinJoin(Wallet openedWallet) =>
+	private void NotifyWalletStartedCoinJoin(IWallet openedWallet) =>
 		StatusChanged.SafeInvoke(this, new WalletStartedCoinJoinEventArgs(openedWallet));
 
-	private void NotifyWalletStoppedCoinJoin(Wallet openedWallet) =>
+	private void NotifyWalletStoppedCoinJoin(IWallet openedWallet) =>
 	StatusChanged.SafeInvoke(this, new WalletStoppedCoinJoinEventArgs(openedWallet));
 
-	private void NotifyCoinJoinStarted(Wallet openedWallet, TimeSpan registrationTimeout) =>
+	private void NotifyCoinJoinStarted(IWallet openedWallet, TimeSpan registrationTimeout) =>
 		StatusChanged.SafeInvoke(this, new StartedEventArgs(openedWallet, registrationTimeout));
 
-	private void NotifyCoinJoinStartError(Wallet openedWallet, CoinjoinError error) =>
+	private void NotifyCoinJoinStartError(IWallet openedWallet, CoinjoinError error) =>
 		StatusChanged.SafeInvoke(this, new StartErrorEventArgs(openedWallet, error));
 
-	private void NotifyMixableWalletUnloaded(Wallet closedWallet) =>
+	private void NotifyMixableWalletUnloaded(IWallet closedWallet) =>
 		StatusChanged.SafeInvoke(this, new StoppedEventArgs(closedWallet, StopReason.WalletUnloaded));
 
-	private void NotifyMixableWalletLoaded(Wallet openedWallet) =>
+	private void NotifyMixableWalletLoaded(IWallet openedWallet) =>
 		StatusChanged.SafeInvoke(this, new LoadedEventArgs(openedWallet));
 
 	private void NotifyCoinJoinCompletion(CoinJoinTracker finishedCoinJoin) =>
@@ -472,54 +466,29 @@ public class CoinJoinManager : BackgroundService
 				_ => CompletionStatus.Unknown,
 			}));
 
-	private void NotifyCoinJoinStatusChanged(Wallet wallet, CoinJoinProgressEventArgs coinJoinProgressEventArgs) =>
+	private void NotifyCoinJoinStatusChanged(IWallet wallet, CoinJoinProgressEventArgs coinJoinProgressEventArgs) =>
 		StatusChanged.SafeInvoke(this, new CoinJoinStatusEventArgs(
 			wallet,
 			coinJoinProgressEventArgs));
 
-	private ImmutableDictionary<string, Wallet> GetMixableWallets() =>
-		WalletManager.GetWallets()
-			.Where(x => x.State == WalletState.Started // Only running wallets
-					&& !x.KeyManager.IsWatchOnly // that are not watch-only wallets
-					&& x.Kitchen.HasIngredients)
-			.ToImmutableDictionary(x => x.WalletName, x => x);
+	private async Task<ImmutableDictionary<string, IWallet>> GetMixableWallets() =>
+		(await WalletProvider.GetWallets().ConfigureAwait(false))
+			.Where(x => x.IsMixable)
+			.ToImmutableDictionary(x =>x.Identifier, x =>  x);
 
-	private bool IsWalletPrivate(Wallet wallet)
+	
+
+	private async Task<IEnumerable<SmartCoin>> SelectCandidateCoinsAsync(IWallet openedWallet, int bestHeight)
 	{
-		var coins = new CoinsView(wallet.Coins);
-
-		if (GetPrivacyPercentage(coins, wallet.KeyManager.AnonScoreTarget) >= 1)
-		{
-			return true;
-		}
-
-		return false;
-	}
-
-	private IEnumerable<SmartCoin> SelectCandidateCoins(Wallet openedWallet, int bestHeight)
-	{
-		var coins = new CoinsView(openedWallet.Coins
+		return new CoinsView(await openedWallet.GetCoinjoinCoinCandidates(bestHeight).ConfigureAwait(false))
 			.Available()
 			.Confirmed()
 			.Where(x => !x.IsImmature(bestHeight))
 			.Where(x => !x.IsBanned)
-			.Where(x => !CoinRefrigerator.IsFrozen(x)));
-
-		return coins;
+			.Where(x => !CoinRefrigerator.IsFrozen(x));
 	}
 
-	private double GetPrivacyPercentage(CoinsView coins, int privateThreshold)
-	{
-		var privateAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
-		var normalAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();
-
-		var privateDecimalAmount = privateAmount.ToDecimal(MoneyUnit.BTC);
-		var normalDecimalAmount = normalAmount.ToDecimal(MoneyUnit.BTC);
-		var totalDecimalAmount = privateDecimalAmount + normalDecimalAmount;
-
-		var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
-		return pcPrivate;
-	}
+	
 
 	private static async Task WaitAndHandleResultOfTasksAsync(string logPrefix, params Task[] tasks)
 	{
@@ -543,7 +512,7 @@ public class CoinJoinManager : BackgroundService
 
 	private void CoinJoinTracker_WalletCoinJoinProgressChanged(object? sender, CoinJoinProgressEventArgs e)
 	{
-		if (sender is not Wallet wallet)
+		if (sender is not IWallet wallet)
 		{
 			throw new InvalidOperationException("Sender must be a wallet.");
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -21,16 +21,17 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	private readonly IWasabiBackendStatusProvider _wasabiBackendStatusProvider;
 
 	public CoinJoinManager(IWalletProvider walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
 	{
-		_wasabiBackendStatusProvider = wasabiBackendStatusProvider;
+		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;
 		HttpClientFactory = backendHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
 	}
+
+	private IWasabiBackendStatusProvider WasabiBackendStatusProvide { get; }
 
 	public IWalletProvider WalletProvider { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
@@ -168,7 +169,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			if (_wasabiBackendStatusProvider.LastResponse is not { } synchronizerResponse)
+			if (WasabiBackendStatusProvide.LastResponse is not { } synchronizerResponse)
 			{
 				ScheduleRestartAutomatically(walletToStart, trackedAutoStarts, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop, stoppingToken);
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -21,8 +21,10 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-
-	public CoinJoinManager(IWalletProvider walletManager, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
+	private record CoinJoinCommand(IWallet Wallet);
+	private record StartCoinJoinCommand(IWallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
+	private record StopCoinJoinCommand(IWallet Wallet) : CoinJoinCommand(Wallet);
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;
@@ -199,7 +201,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			var coinJoinTracker = coinJoinTrackerFactory.CreateAndStart(walletToStart, coinCandidates, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop);
+			var coinJoinTracker = await coinJoinTrackerFactory.CreateAndStartAsync(walletToStart, coinCandidates, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop).ConfigureAwait(false);
 
 			if (!trackedCoinJoins.TryAdd(walletToStart.Identifier, coinJoinTracker))
 			{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -132,7 +132,7 @@ public class CoinJoinManager : BackgroundService
 		async Task StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{
 			var walletToStart = startCommand.Wallet;
-			
+
 			if (trackedCoinJoins.TryGetValue(walletToStart.Identifier, out var tracker))
 			{
 				if (startCommand.StopWhenAllMixed != tracker.StopWhenAllMixed)
@@ -176,7 +176,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			if (await walletToStart.IsWalletPrivate())
+			if (walletToStart.IsWalletPrivate())
 			{
 				walletToStart.LogDebug("All mixed!");
 				if (!startCommand.StopWhenAllMixed)
@@ -474,9 +474,7 @@ public class CoinJoinManager : BackgroundService
 	private async Task<ImmutableDictionary<string, IWallet>> GetMixableWallets() =>
 		(await WalletProvider.GetWallets().ConfigureAwait(false))
 			.Where(x => x.IsMixable)
-			.ToImmutableDictionary(x =>x.Identifier, x =>  x);
-
-	
+			.ToImmutableDictionary(x => x.Identifier, x => x);
 
 	private async Task<IEnumerable<SmartCoin>> SelectCandidateCoinsAsync(IWallet openedWallet, int bestHeight)
 	{
@@ -487,8 +485,6 @@ public class CoinJoinManager : BackgroundService
 			.Where(x => !x.IsBanned)
 			.Where(x => !CoinRefrigerator.IsFrozen(x));
 	}
-
-	
 
 	private static async Task WaitAndHandleResultOfTasksAsync(string logPrefix, params Task[] tasks)
 	{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -53,7 +53,7 @@ public class CoinJoinManager : BackgroundService
 
 	public async Task StartAsync(IWallet wallet, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken cancellationToken)
 	{
-		if (overridePlebStop && wallet.IsUnderPlebStop)
+		if (overridePlebStop && !wallet.IsUnderPlebStop)
 		{
 			// Turn off overriding if we went above the threshold meanwhile.
 			overridePlebStop = false;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -53,7 +53,7 @@ public class CoinJoinManager : BackgroundService
 
 	public async Task StartAsync(IWallet wallet, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken cancellationToken)
 	{
-		if (overridePlebStop && !wallet.CoinjoinEnabled)
+		if (overridePlebStop && wallet.IsUnderPlebStop)
 		{
 			// Turn off overriding if we went above the threshold meanwhile.
 			overridePlebStop = false;
@@ -163,7 +163,7 @@ public class CoinJoinManager : BackgroundService
 				return;
 			}
 
-			if (!walletToStart.CoinjoinEnabled && !startCommand.OverridePlebStop)
+			if (walletToStart.IsUnderPlebStop && !startCommand.OverridePlebStop)
 			{
 				walletToStart.LogDebug("PlebStop preventing coinjoin.");
 				ScheduleRestartAutomatically(walletToStart, trackedAutoStarts, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop, stoppingToken);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -24,6 +24,7 @@ public class CoinJoinManager : BackgroundService
 	private record CoinJoinCommand(IWallet Wallet);
 	private record StartCoinJoinCommand(IWallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
 	private record StopCoinJoinCommand(IWallet Wallet) : CoinJoinCommand(Wallet);
+
 	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
@@ -436,7 +437,7 @@ public class CoinJoinManager : BackgroundService
 		var wallets = await WalletProvider.GetWalletsAsync().ConfigureAwait(false);
 		foreach (var k in wallets)
 		{
-			k.KeyChain.NotifyScriptState(hashSet, KeyState.Used);
+			k.KeyChain.TrySetScriptStates(KeyState.Used, hashSet);
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -12,7 +12,7 @@ public class CoinJoinTracker : IDisposable
 	private bool _disposedValue;
 
 	public CoinJoinTracker(
-		Wallet wallet,
+		IWallet wallet,
 		CoinJoinClient coinJoinClient,
 		IEnumerable<SmartCoin> coinCandidates,
 		bool stopWhenAllMixed,
@@ -35,7 +35,7 @@ public class CoinJoinTracker : IDisposable
 	private CoinJoinClient CoinJoinClient { get; }
 	private CancellationTokenSource CancellationTokenSource { get; }
 
-	public Wallet Wallet { get; }
+	public IWallet Wallet { get; }
 	public Task<CoinJoinResult> CoinJoinTask { get; }
 	public IEnumerable<SmartCoin> CoinCandidates { get; }
 	public bool StopWhenAllMixed { get; set; }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -29,7 +29,7 @@ public class CoinJoinTrackerFactory
 	private CancellationToken CancellationToken { get; }
 	private string CoordinatorIdentifier { get; }
 
-	public CoinJoinTracker CreateAndStart(Wallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
+	public CoinJoinTracker CreateAndStart(IWallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
 	{
 		Money? liquidityClue = null;
 		if (CoinJoinClient.GetLiquidityClue() is null)
@@ -43,14 +43,14 @@ public class CoinJoinTrackerFactory
 
 		var coinJoinClient = new CoinJoinClient(
 			HttpClientFactory,
-			new KeyChain(wallet.KeyManager, wallet.Kitchen),
-			new InternalDestinationProvider(wallet.KeyManager),
+			wallet.KeyChain,
+			wallet.DestinationProvider,
 			RoundStatusUpdater,
 			CoordinatorIdentifier,
-			wallet.KeyManager.AnonScoreTarget,
-			consolidationMode: false,
-			redCoinIsolation: wallet.KeyManager.RedCoinIsolation,
-			feeRateMedianTimeFrame: TimeSpan.FromHours(wallet.KeyManager.FeeRateMedianTimeFrameHours),
+			wallet.AnonScoreTarget,
+			consolidationMode: wallet.ConsolidationMode,
+			redCoinIsolation: wallet.RedCoinIsolation,
+			feeRateMedianTimeFrame: wallet.FeeRateMedianTimeFrame,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1),
 			liquidityClue: liquidityClue);
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Extensions;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -29,12 +30,12 @@ public class CoinJoinTrackerFactory
 	private CancellationToken CancellationToken { get; }
 	private string CoordinatorIdentifier { get; }
 
-	public CoinJoinTracker CreateAndStart(IWallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
+	public async Task<CoinJoinTracker> CreateAndStartAsync(IWallet wallet, IEnumerable<SmartCoin> coinCandidates, bool restartAutomatically, bool overridePlebStop)
 	{
 		Money? liquidityClue = null;
 		if (CoinJoinClient.GetLiquidityClue() is null)
 		{
-			var lastCoinjoin = wallet.TransactionProcessor.TransactionStore.GetTransactions().OrderByBlockchain().LastOrDefault(x => x.IsOwnCoinjoin());
+			var lastCoinjoin = (await wallet.GetTransactionsAsync().ConfigureAwait(false)).OrderByBlockchain().LastOrDefault(x=> x.IsOwnCoinjoin());
 			if (lastCoinjoin is not null)
 			{
 				liquidityClue = CoinJoinClient.TryCalculateLiquidityClue(lastCoinjoin.Transaction, lastCoinjoin.WalletOutputs.Select(x => x.TxOut));

--- a/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
@@ -177,12 +177,9 @@ public class DependencyGraphTaskScheduler
 				}
 				catch (WabiSabiProtocolException ex) when (ex.ErrorCode == WabiSabiProtocolErrorCode.AlreadyRegisteredScript)
 				{
-					Logger.LogInfo($"Output registration error, code:'{ex.ErrorCode}' message:'{ex.Message}'.");
-					if (keyChain is KeyChain { KeyManager: var keyManager }
-						&& keyManager.TryGetKeyForScriptPubKey(txOut.ScriptPubKey, out var hdPubKey))
-					{
-						hdPubKey.SetKeyState(KeyState.Used);
-					}
+					Logger.LogDebug($"Output registration error, code:'{ex.ErrorCode}' message:'{ex.Message}'.");
+					keyChain.NotifyScriptState(new []{txOut.ScriptPubKey}, KeyState.Used);
+					
 				}
 				catch (Exception ex)
 				{

--- a/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
@@ -178,7 +178,7 @@ public class DependencyGraphTaskScheduler
 				catch (WabiSabiProtocolException ex) when (ex.ErrorCode == WabiSabiProtocolErrorCode.AlreadyRegisteredScript)
 				{
 					Logger.LogDebug($"Output registration error, code:'{ex.ErrorCode}' message:'{ex.Message}'.");
-					keyChain.NotifyScriptState(new []{txOut.ScriptPubKey}, KeyState.Used);
+					keyChain.TrySetScriptStates(KeyState.Used, new[] { txOut.ScriptPubKey });
 					
 				}
 				catch (Exception ex)

--- a/WalletWasabi/WabiSabi/Client/IKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/IKeyChain.cs
@@ -10,5 +10,6 @@ public interface IKeyChain
 	OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData committedData);
 
 	Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof);
-	void NotifyScriptState(IEnumerable<Script> scripts, KeyState state);
+
+	void TrySetScriptStates(KeyState state, IEnumerable<Script> scripts);
 }

--- a/WalletWasabi/WabiSabi/Client/IKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/IKeyChain.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Crypto;
 
 namespace WalletWasabi.WabiSabi.Client;
@@ -8,4 +10,5 @@ public interface IKeyChain
 	OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData committedData);
 
 	Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof);
+	void NotifyScriptState(IEnumerable<Script> scripts, KeyState state);
 }

--- a/WalletWasabi/WabiSabi/Client/IWalletProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IWalletProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using WalletWasabi.Wallets;
 
@@ -6,5 +6,5 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public interface IWalletProvider
 {
-	Task<IEnumerable<IWallet>> GetWallets();
+	IEnumerable<IWallet> GetWallets();
 }

--- a/WalletWasabi/WabiSabi/Client/IWalletProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IWalletProvider.cs
@@ -6,5 +6,5 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public interface IWalletProvider
 {
-	IEnumerable<IWallet> GetWallets();
+	Task<IEnumerable<IWallet>> GetWalletsAsync();
 }

--- a/WalletWasabi/WabiSabi/Client/IWalletProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IWalletProvider.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public interface IWalletProvider
+{
+	Task<IEnumerable<IWallet>> GetWallets();
+}

--- a/WalletWasabi/WabiSabi/Client/IWasabiBackendStatusProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IWasabiBackendStatusProvider.cs
@@ -1,0 +1,8 @@
+﻿using WalletWasabi.Backend.Models.Responses;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public interface IWasabiBackendStatusProvider
+{
+	SynchronizeResponse? LastResponse { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -8,25 +8,25 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class KeyChain : BaseKeyChain
 {
-	private readonly KeyManager _keyManager;
+	private KeyManager KeyManager { get; }
 
-	public KeyChain(KeyManager keyManager, Kitchen kitchen):base(kitchen)
+	public KeyChain(KeyManager keyManager, Kitchen kitchen) : base(kitchen)
 	{
 		if (keyManager.IsWatchOnly)
 		{
 			throw new ArgumentException("A watch-only keymanager cannot be used to initialize a keychain.");
 		}
-		_keyManager = keyManager;
+		KeyManager = keyManager;
 	}
 
 	protected override Key GetMasterKey()
 	{
-		return _keyManager.GetMasterExtKey(Kitchen.SaltSoup()).PrivateKey;
+		return KeyManager.GetMasterExtKey(Kitchen.SaltSoup()).PrivateKey;
 	}
 
 	public override void NotifyScriptState(IEnumerable<Script> scripts, KeyState state)
 	{
-		foreach (var hdPubKey in _keyManager.GetKeys(key => scripts.Any(key.ContainsScript)))
+		foreach (var hdPubKey in KeyManager.GetKeys(key => scripts.Any(key.ContainsScript)))
 		{
 			hdPubKey.SetKeyState(state);
 		}
@@ -35,7 +35,7 @@ public class KeyChain : BaseKeyChain
 	protected override BitcoinSecret GetBitcoinSecret(Script scriptPubKey)
 	{
 		{
-			var hdKey = _keyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKey).Single();
+			var hdKey = KeyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKey).Single();
 			if (hdKey is null)
 			{
 				throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
@@ -44,7 +44,7 @@ public class KeyChain : BaseKeyChain
 			{
 				throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
 			}
-			var secret = hdKey.PrivateKey.GetBitcoinSecret(_keyManager.GetNetwork());
+			var secret = hdKey.PrivateKey.GetBitcoinSecret(KeyManager.GetNetwork());
 			return secret;
 		}
 	}

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -24,7 +24,7 @@ public class KeyChain : BaseKeyChain
 		return KeyManager.GetMasterExtKey(Kitchen.SaltSoup()).PrivateKey;
 	}
 
-	public override void NotifyScriptState(IEnumerable<Script> scripts, KeyState state)
+	public override void TrySetScriptStates(KeyState state, IEnumerable<Script> scripts)
 	{
 		foreach (var hdPubKey in KeyManager.GetKeys(key => scripts.Any(key.ContainsScript)))
 		{

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -1,75 +1,51 @@
+using System.Collections.Generic;
 using NBitcoin;
 using System.Linq;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Crypto;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.WabiSabi.Client;
 
-public class KeyChain : IKeyChain
+public class KeyChain : BaseKeyChain
 {
-	public KeyChain(KeyManager keyManager, Kitchen kitchen)
+	private readonly KeyManager _keyManager;
+
+	public KeyChain(KeyManager keyManager, Kitchen kitchen):base(kitchen)
 	{
 		if (keyManager.IsWatchOnly)
 		{
 			throw new ArgumentException("A watch-only keymanager cannot be used to initialize a keychain.");
 		}
-		KeyManager = keyManager;
-		Kitchen = kitchen;
+		_keyManager = keyManager;
 	}
 
-	public KeyManager KeyManager { get; }
-	private Kitchen Kitchen { get; }
-
-	public OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData commitmentData)
+	protected override Key GetMasterKey()
 	{
-		var secret = GetBitcoinSecret(destination.ScriptPubKey);
-
-		var masterKey = KeyManager.GetMasterExtKey(Kitchen.SaltSoup()).PrivateKey;
-		var identificationMasterKey = Slip21Node.FromSeed(masterKey.ToBytes());
-		var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019").DeriveChild("Ownership identification key").Key;
-
-		var signingKey = secret.PrivateKey;
-		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
-				signingKey,
-				new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
-				commitmentData);
-		return ownershipProof;
+		return _keyManager.GetMasterExtKey(Kitchen.SaltSoup()).PrivateKey;
 	}
 
-	public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof)
+	public override void NotifyScriptState(IEnumerable<Script> scripts, KeyState state)
 	{
-		transaction = transaction.Clone();
-		if (transaction.Inputs.Count == 0)
+		foreach (var hdPubKey in _keyManager.GetKeys(key => scripts.Any(key.ContainsScript)))
 		{
-			throw new ArgumentException("No inputs to sign.", nameof(transaction));
+			hdPubKey.SetKeyState(state);
 		}
-
-		var txInput = transaction.Inputs.AsIndexedInputs().FirstOrDefault(input => input.PrevOut == coin.Outpoint);
-
-		if (txInput is null)
-		{
-			throw new InvalidOperationException("Missing input.");
-		}
-
-		var secret = GetBitcoinSecret(coin.ScriptPubKey);
-
-		transaction.Sign(secret, coin);
-		return transaction;
 	}
 
-	private BitcoinSecret GetBitcoinSecret(Script scriptPubKey)
+	protected override BitcoinSecret GetBitcoinSecret(Script scriptPubKey)
 	{
-		var hdKey = KeyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKey).Single();
-		if (hdKey is null)
 		{
-			throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
+			var hdKey = _keyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKey).Single();
+			if (hdKey is null)
+			{
+				throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
+			}
+			if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != scriptPubKey)
+			{
+				throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
+			}
+			var secret = hdKey.PrivateKey.GetBitcoinSecret(_keyManager.GetNetwork());
+			return secret;
 		}
-		if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != scriptPubKey)
-		{
-			throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
-		}
-		var secret = hdKey.PrivateKey.GetBitcoinSecret(KeyManager.GetNetwork());
-		return secret;
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -8,8 +8,6 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class KeyChain : BaseKeyChain
 {
-	private KeyManager KeyManager { get; }
-
 	public KeyChain(KeyManager keyManager, Kitchen kitchen) : base(kitchen)
 	{
 		if (keyManager.IsWatchOnly)
@@ -18,6 +16,8 @@ public class KeyChain : BaseKeyChain
 		}
 		KeyManager = keyManager;
 	}
+
+	private KeyManager KeyManager { get; }
 
 	protected override Key GetMasterKey()
 	{

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -34,18 +34,16 @@ public class KeyChain : BaseKeyChain
 
 	protected override BitcoinSecret GetBitcoinSecret(Script scriptPubKey)
 	{
+		var hdKey = KeyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKey).Single();
+		if (hdKey is null)
 		{
-			var hdKey = KeyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKey).Single();
-			if (hdKey is null)
-			{
-				throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
-			}
-			if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != scriptPubKey)
-			{
-				throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
-			}
-			var secret = hdKey.PrivateKey.GetBitcoinSecret(KeyManager.GetNetwork());
-			return secret;
+			throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
 		}
+		if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != scriptPubKey)
+		{
+			throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
+		}
+		var secret = hdKey.PrivateKey.GetBitcoinSecret(KeyManager.GetNetwork());
+		return secret;
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CoinJoinStatusEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CoinJoinStatusEventArgs.cs
@@ -5,7 +5,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class CoinJoinStatusEventArgs : StatusChangedEventArgs
 {
-	public CoinJoinStatusEventArgs(Wallet wallet, CoinJoinProgressEventArgs coinJoinProgressEventArgs) : base(wallet)
+	public CoinJoinStatusEventArgs(IWallet wallet, CoinJoinProgressEventArgs coinJoinProgressEventArgs) : base(wallet)
 	{
 		CoinJoinProgressEventArgs = coinJoinProgressEventArgs;
 	}

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CompletedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/CompletedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class CompletedEventArgs : StatusChangedEventArgs
 {
-	public CompletedEventArgs(Wallet wallet, CompletionStatus completionStatus)
+	public CompletedEventArgs(IWallet wallet, CompletionStatus completionStatus)
 		: base(wallet)
 	{
 		CompletionStatus = completionStatus;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/LoadedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/LoadedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class LoadedEventArgs : StatusChangedEventArgs
 {
-	public LoadedEventArgs(Wallet wallet)
+	public LoadedEventArgs(IWallet wallet)
 		: base(wallet)
 	{
 	}

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartErrorEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartErrorEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class StartErrorEventArgs : StatusChangedEventArgs
 {
-	public StartErrorEventArgs(Wallet wallet, CoinjoinError error)
+	public StartErrorEventArgs(IWallet wallet, CoinjoinError error)
 		: base(wallet)
 	{
 		Error = error;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StartedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class StartedEventArgs : StatusChangedEventArgs
 {
-	public StartedEventArgs(Wallet wallet, TimeSpan registrationTimeout)
+	public StartedEventArgs(IWallet wallet, TimeSpan registrationTimeout)
 		: base(wallet)
 	{
 		RegistrationTimeout = registrationTimeout;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StatusChangedEventArgs.cs
@@ -27,10 +27,10 @@ public enum CoinjoinError
 
 public class StatusChangedEventArgs : EventArgs
 {
-	public StatusChangedEventArgs(Wallet wallet)
+	public StatusChangedEventArgs(IWallet wallet)
 	{
 		Wallet = wallet;
 	}
 
-	public Wallet Wallet { get; }
+	public IWallet Wallet { get; }
 }

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StoppedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/StoppedEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class StoppedEventArgs : StatusChangedEventArgs
 {
-	public StoppedEventArgs(Wallet wallet, StopReason reason)
+	public StoppedEventArgs(IWallet wallet, StopReason reason)
 		: base(wallet)
 	{
 		Reason = reason;

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/WalletStartedCoinJoinEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/WalletStartedCoinJoinEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class WalletStartedCoinJoinEventArgs : StatusChangedEventArgs
 {
-	public WalletStartedCoinJoinEventArgs(Wallet wallet) : base(wallet)
+	public WalletStartedCoinJoinEventArgs(IWallet wallet) : base(wallet)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/StatusChangedEvents/WalletStoppedCoinJoinEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/StatusChangedEvents/WalletStoppedCoinJoinEventArgs.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 public class WalletStoppedCoinJoinEventArgs : StatusChangedEventArgs
 {
-	public WalletStoppedCoinJoinEventArgs(Wallet wallet) : base(wallet)
+	public WalletStoppedCoinJoinEventArgs(IWallet wallet) : base(wallet)
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/LoggerTools.cs
+++ b/WalletWasabi/WabiSabi/LoggerTools.cs
@@ -47,27 +47,27 @@ public static class LoggerTools
 		Log(roundState, LogLevel.Debug, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void Log(this Wallet wallet, LogLevel logLevel, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void Log(this IWallet wallet, LogLevel logLevel, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
-		Logger.Log(logLevel, $"Wallet ({wallet.WalletName}): {logMessage}", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
+		Logger.Log(logLevel, $"Wallet ({wallet.Identifier}): {logMessage}", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogInfo(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogInfo(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Info, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogDebug(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogDebug(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Debug, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogWarning(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogWarning(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Warning, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
-	public static void LogError(this Wallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	public static void LogError(this IWallet wallet, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 	{
 		Log(wallet, LogLevel.Error, logMessage, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -7,17 +7,17 @@ namespace WalletWasabi.Wallets;
 
 public interface IWallet
 {
-    string Identifier { get; }
-    bool CoinjoinEnabled { get; }
-    bool IsMixable { get; }
-    IKeyChain KeyChain { get; }
-    IDestinationProvider DestinationProvider { get; }
-    public int AnonScoreTarget { get; }
-    public bool ConsolidationMode { get; }
-    TimeSpan FeeRateMedianTimeFrame { get; }
-    bool RedCoinIsolation { get; }
+	string Identifier { get; }
+	bool CoinjoinEnabled { get; }
+	bool IsMixable { get; }
+	IKeyChain KeyChain { get; }
+	IDestinationProvider DestinationProvider { get; }
+	public int AnonScoreTarget { get; }
+	public bool ConsolidationMode { get; }
+	TimeSpan FeeRateMedianTimeFrame { get; }
+	bool RedCoinIsolation { get; }
 
-    bool IsWalletPrivate();
+	bool IsWalletPrivate();
 
-    Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight);
+	IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight);
 }

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.WabiSabi.Client;
 
 namespace WalletWasabi.Wallets;
@@ -20,4 +22,6 @@ public interface IWallet
 	Task<bool> IsWalletPrivateAsync();
 
 	Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight);
+
+	Task<IEnumerable<SmartTransaction>> GetTransactionsAsync();
 }

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -17,7 +17,7 @@ public interface IWallet
 	TimeSpan FeeRateMedianTimeFrame { get; }
 	bool RedCoinIsolation { get; }
 
-	bool IsWalletPrivate();
+	Task<bool> IsWalletPrivateAsync();
 
-	IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight);
+	Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight);
 }

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.WabiSabi.Client;
+
+namespace WalletWasabi.Wallets;
+
+public interface IWallet
+{
+	string Identifier { get; }
+	bool CoinjoinEnabled { get; }
+	bool IsMixable { get; }
+	IKeyChain KeyChain { get; }
+	IDestinationProvider DestinationProvider { get; }
+	public int AnonScoreTarget { get; }
+	public bool ConsolidationMode { get; }
+	TimeSpan FeeRateMedianTimeFrame { get; }
+	bool RedCoinIsolation { get; }
+
+	Task<bool> IsWalletPrivate();
+	Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight);
+}

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -10,7 +10,7 @@ namespace WalletWasabi.Wallets;
 public interface IWallet
 {
 	string Identifier { get; }
-	bool CoinjoinEnabled { get; }
+	bool IsUnderPlebStop { get; }
 	bool IsMixable { get; }
 	IKeyChain KeyChain { get; }
 	IDestinationProvider DestinationProvider { get; }

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.WabiSabi.Client;
@@ -7,16 +7,17 @@ namespace WalletWasabi.Wallets;
 
 public interface IWallet
 {
-	string Identifier { get; }
-	bool CoinjoinEnabled { get; }
-	bool IsMixable { get; }
-	IKeyChain KeyChain { get; }
-	IDestinationProvider DestinationProvider { get; }
-	public int AnonScoreTarget { get; }
-	public bool ConsolidationMode { get; }
-	TimeSpan FeeRateMedianTimeFrame { get; }
-	bool RedCoinIsolation { get; }
+    string Identifier { get; }
+    bool CoinjoinEnabled { get; }
+    bool IsMixable { get; }
+    IKeyChain KeyChain { get; }
+    IDestinationProvider DestinationProvider { get; }
+    public int AnonScoreTarget { get; }
+    public bool ConsolidationMode { get; }
+    TimeSpan FeeRateMedianTimeFrame { get; }
+    bool RedCoinIsolation { get; }
 
-	Task<bool> IsWalletPrivate();
-	Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight);
+    bool IsWalletPrivate();
+
+    Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight);
 }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -12,6 +12,7 @@ using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
@@ -88,6 +89,10 @@ public class Wallet : BackgroundService, IWallet
 	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), KeyManager.AnonScoreTarget) >= 1;
 
 	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
+	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync()
+	{
+		return Task.FromResult(TransactionProcessor.TransactionStore.GetTransactions());
+	}
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -90,10 +90,7 @@ public class Wallet : BackgroundService, IWallet
 
 	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
 
-	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync()
-	{
-		return Task.FromResult(TransactionProcessor.TransactionStore.GetTransactions());
-	}
+	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(TransactionProcessor.TransactionStore.GetTransactions());
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -90,7 +90,9 @@ public class Wallet : BackgroundService, IWallet
 
 	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
 
-	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync()
+	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(GetTransactions());
+
+	public IEnumerable<SmartTransaction> GetTransactions()
 	{
 		var walletTransactions = new List<SmartTransaction>();
 		var allCoins = ((CoinsRegistry)Coins).AsAllCoinsView();
@@ -102,8 +104,7 @@ public class Wallet : BackgroundService, IWallet
 				walletTransactions.Add(coin.SpenderTransaction);
 			}
 		}
-		walletTransactions = walletTransactions.OrderByBlockchain().ToList();
-		return Task.FromResult<IEnumerable<SmartTransaction>>(walletTransactions);
+		return walletTransactions.OrderByBlockchain().ToList();
 	}
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -83,17 +83,7 @@ public class Wallet : BackgroundService, IWallet
 
 	public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
 
-	public bool IsWalletPrivate()
-	{
-		var coins = new CoinsView(Coins);
-
-		if (GetPrivacyPercentage(coins, KeyManager.AnonScoreTarget) >= 1)
-		{
-			return true;
-		}
-
-		return false;
-	}
+	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), KeyManager.AnonScoreTarget) >= 1;
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -25,493 +25,490 @@ namespace WalletWasabi.Wallets;
 
 public class Wallet : BackgroundService, IWallet
 {
-    private volatile WalletState _state;
+	private volatile WalletState _state;
 
-    public Wallet(string dataDir, Network network, string filePath) : this(dataDir, network, KeyManager.FromFile(filePath))
-    {
-    }
+	public Wallet(string dataDir, Network network, string filePath) : this(dataDir, network, KeyManager.FromFile(filePath))
+	{
+	}
 
-    public Wallet(string dataDir, Network network, KeyManager keyManager)
-    {
-        Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
-        Network = Guard.NotNull(nameof(network), network);
-        KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+	public Wallet(string dataDir, Network network, KeyManager keyManager)
+	{
+		Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
+		Network = Guard.NotNull(nameof(network), network);
+		KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
 
-        RuntimeParams.SetDataDir(dataDir);
-        HandleFiltersLock = new AsyncLock();
-
-        KeyManager.AssertCleanKeysIndexed();
-        KeyChain = new KeyChain(KeyManager, Kitchen);
-        DestinationProvider = new InternalDestinationProvider(KeyManager);
-    }
-
-    public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
-
-    public static event EventHandler<bool>? InitializingChanged;
-
-    public event EventHandler<FilterModel>? NewFilterProcessed;
-
-    public event EventHandler<Block>? NewBlockProcessed;
-
-    public event EventHandler<WalletState>? StateChanged;
-
-    public WalletState State
-    {
-        get => _state;
-        private set
-        {
-            if (_state == value)
-            {
-                return;
-            }
-
-            _state = value;
-            StateChanged?.Invoke(this, _state);
-        }
-    }
-
-    public BitcoinStore BitcoinStore { get; private set; }
-    public KeyManager KeyManager { get; }
-    public WasabiSynchronizer Synchronizer { get; private set; }
-    public ServiceConfiguration ServiceConfiguration { get; private set; }
-    public string WalletName => KeyManager.WalletName;
-
-    /// <summary>
-    /// Unspent Transaction Outputs
-    /// </summary>
-    public ICoinsView Coins { get; private set; }
-
-    public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
-
-    public bool IsWalletPrivate()
-    {
-        var coins = new CoinsView(Coins);
-
-        if (GetPrivacyPercentage(coins, KeyManager.AnonScoreTarget) >= 1)
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight)
-    {
-        return Task.FromResult<IEnumerable<SmartCoin>>(Coins);
-    }
-
-    private double GetPrivacyPercentage(CoinsView coins, int privateThreshold)
-    {
-        var privateAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
-        var normalAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();
-
-        var privateDecimalAmount = privateAmount.ToDecimal(MoneyUnit.BTC);
-        var normalDecimalAmount = normalAmount.ToDecimal(MoneyUnit.BTC);
-        var totalDecimalAmount = privateDecimalAmount + normalDecimalAmount;
-
-        var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
-        return pcPrivate;
-    }
-
-    public Network Network { get; }
-    public TransactionProcessor TransactionProcessor { get; private set; }
-
-    public HybridFeeProvider FeeProvider { get; private set; }
-    public FilterModel LastProcessedFilter { get; private set; }
-    public IBlockProvider BlockProvider { get; private set; }
-    private AsyncLock HandleFiltersLock { get; }
-
-    public bool IsLoggedIn { get; private set; }
-
-    public Kitchen Kitchen { get; } = new();
-    public ICoinsView NonPrivateCoins => new CoinsView(Coins.Where(c => c.HdPubKey.AnonymitySet < KeyManager.AnonScoreTarget));
-
-    public bool IsUnderPlebStop => Coins.TotalAmount() <= KeyManager.PlebStopThreshold;
-
-    public bool TryLogin(string password, out string? compatibilityPasswordUsed)
-    {
-        compatibilityPasswordUsed = null;
-
-        if (KeyManager.IsWatchOnly)
-        {
-            IsLoggedIn = true;
-            Kitchen.Cook("");
-        }
-        else if (PasswordHelper.TryPassword(KeyManager, password, out compatibilityPasswordUsed))
-        {
-            IsLoggedIn = true;
-            Kitchen.Cook(compatibilityPasswordUsed ?? Guard.Correct(password));
-        }
-
-        return IsLoggedIn;
-    }
-
-    public void Logout()
-    {
-        Kitchen.CleanUp();
-        IsLoggedIn = false;
-    }
-
-    public void RegisterServices(
-        BitcoinStore bitcoinStore,
-        WasabiSynchronizer syncer,
-        ServiceConfiguration serviceConfiguration,
-        HybridFeeProvider feeProvider,
-        IBlockProvider blockProvider)
-    {
-        if (State > WalletState.WaitingForInit)
-        {
-            throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized} or {WalletState.WaitingForInit}. Current state: {State}.");
-        }
-
-        try
-        {
-            BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
-            Synchronizer = Guard.NotNull(nameof(syncer), syncer);
-            ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
-            FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
-
-            TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold);
-            Coins = TransactionProcessor.Coins;
-
-            TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;
-            BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
-            BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
-            BitcoinStore.MempoolService.TransactionReceived += Mempool_TransactionReceived;
-
-            BlockProvider = blockProvider;
-
-            State = WalletState.Initialized;
-        }
-        catch
-        {
-            State = WalletState.Uninitialized;
-            throw;
-        }
-    }
-
-    /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancel)
-    {
-        if (State != WalletState.Initialized)
-        {
-            throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Initialized}. Current state: {State}.");
-        }
-
-        try
-        {
-            State = WalletState.Starting;
-            InitializingChanged?.Invoke(this, true);
-
-            if (!Synchronizer.IsRunning)
-            {
-                throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
-            }
-
-            using (BenchmarkLogger.Measure())
-            {
-                await RuntimeParams.LoadAsync().ConfigureAwait(false);
-
-                using (await HandleFiltersLock.LockAsync(cancel).ConfigureAwait(false))
-                {
-                    await LoadWalletStateAsync(cancel).ConfigureAwait(false);
-                    await LoadDummyMempoolAsync().ConfigureAwait(false);
-                }
-            }
-
-            await base.StartAsync(cancel).ConfigureAwait(false);
-
-            State = WalletState.Started;
-        }
-        catch
-        {
-            State = WalletState.Initialized;
-            throw;
-        }
-        finally
-        {
-            InitializingChanged?.Invoke(this, false);
-        }
-    }
-
-    /// <inheritdoc />
-    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
-
-    /// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
-    /// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    public BuildTransactionResult BuildTransaction(
-        string password,
-        PaymentIntent payments,
-        FeeStrategy feeStrategy,
-        bool allowUnconfirmed = false,
-        IEnumerable<OutPoint>? allowedInputs = null,
-        IPayjoinClient? payjoinClient = null,
-        bool tryToSign = true)
-    {
-        var builder = new TransactionFactory(Network, KeyManager, Coins, BitcoinStore.TransactionStore, password, allowUnconfirmed);
-        return builder.BuildTransaction(
-            payments,
-            feeRateFetcher: () =>
-            {
-                if (feeStrategy.Type == FeeStrategyType.Target)
-                {
-                    return FeeProvider.AllFeeEstimate?.GetFeeRate(feeStrategy.Target.Value) ?? throw new InvalidOperationException("Cannot get fee estimations.");
-                }
-                else if (feeStrategy.Type == FeeStrategyType.Rate)
-                {
-                    return feeStrategy.Rate;
-                }
-                else
-                {
-                    throw new NotSupportedException(feeStrategy.Type.ToString());
-                }
-            },
-            allowedInputs,
-            lockTimeSelector: () =>
-            {
-                var currentTipHeight = BitcoinStore.SmartHeaderChain.TipHeight;
-                return LockTimeSelector.Instance.GetLockTimeBasedOnDistribution(currentTipHeight);
-            },
-            payjoinClient,
-            tryToSign: tryToSign);
-    }
-
-    /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancel)
-    {
-        try
-        {
-            var prevState = State;
-            State = WalletState.Stopping;
-
-            if (prevState < WalletState.Stopping)
-            {
-                await base.StopAsync(cancel).ConfigureAwait(false);
-
-                if (prevState >= WalletState.Initialized)
-                {
-                    BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
-                    BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
-                    BitcoinStore.MempoolService.TransactionReceived -= Mempool_TransactionReceived;
-                    TransactionProcessor.WalletRelevantTransactionProcessed -= TransactionProcessor_WalletRelevantTransactionProcessed;
-                }
-            }
-        }
-        finally
-        {
-            State = WalletState.Stopped;
-        }
-    }
-
-    private void TransactionProcessor_WalletRelevantTransactionProcessed(object? sender, ProcessedResult e)
-    {
-        try
-        {
-            WalletRelevantTransactionProcessed?.Invoke(this, e);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex);
-        }
-    }
-
-    private void Mempool_TransactionReceived(object? sender, SmartTransaction tx)
-    {
-        try
-        {
-            if (!TransactionProcessor.IsAware(tx.GetHash()))
-            {
-                TransactionProcessor.Process(tx);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex);
-        }
-    }
-
-    private async void IndexDownloader_ReorgedAsync(object? sender, FilterModel invalidFilter)
-    {
-        try
-        {
-            using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
-            {
-                uint256 invalidBlockHash = invalidFilter.Header.BlockHash;
-                if (BlockProvider is CachedBlockProvider blockCache)
-                {
-                    await blockCache.InvalidateAsync(invalidBlockHash, CancellationToken.None).ConfigureAwait(false);
-                }
-
-                KeyManager.SetMaxBestHeight(new Height(invalidFilter.Header.Height - 1));
-                TransactionProcessor.UndoBlock((int)invalidFilter.Header.Height);
-                BitcoinStore.TransactionStore.ReleaseToMempoolFromBlock(invalidBlockHash);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex);
-        }
-    }
-
-    private async void IndexDownloader_NewFilterAsync(object? sender, FilterModel filterModel)
-    {
-        try
-        {
-            using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
-            {
-                if (KeyManager.GetBestHeight() < filterModel.Header.Height)
-                {
-                    await ProcessFilterModelAsync(filterModel, CancellationToken.None).ConfigureAwait(false);
-                }
-            }
-
-            NewFilterProcessed?.Invoke(this, filterModel);
-
-            await Task.Delay(100).ConfigureAwait(false);
-
-            if (Synchronizer is null || BitcoinStore?.SmartHeaderChain is null)
-            {
-                return;
-            }
-
-            // Make sure fully synced and this filter is the latest filter.
-            if (BitcoinStore.SmartHeaderChain.HashesLeft != 0 || BitcoinStore.SmartHeaderChain.TipHash != filterModel.Header.BlockHash)
-            {
-                return;
-            }
-
-            var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer.HttpClientFactory);
-
-            if (task is { })
-            {
-                await task.ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex);
-        }
-    }
-
-    private async Task LoadWalletStateAsync(CancellationToken cancel)
-    {
-        KeyManager.AssertNetworkOrClearBlockState(Network);
-        Height bestKeyManagerHeight = KeyManager.GetBestHeight();
-
-        using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))
-        {
-            TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
-        }
-
-        // Go through the filters and queue to download the matches.
-        await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
-            new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
-    }
-
-    private async Task LoadDummyMempoolAsync()
-    {
-        if (BitcoinStore.TransactionStore.MempoolStore.IsEmpty())
-        {
-            return;
-        }
-
-        // Only clean the mempool if we're fully synchronized.
-        if (BitcoinStore.SmartHeaderChain.HashesLeft == 0)
-        {
-            try
-            {
-                var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
-                var compactness = 10;
-
-                var mempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
-
-                var txsToProcess = new List<SmartTransaction>();
-                foreach (var tx in BitcoinStore.TransactionStore.MempoolStore.GetTransactions())
-                {
-                    uint256 hash = tx.GetHash();
-                    if (mempoolHashes.Contains(hash.ToString()[..compactness]))
-                    {
-                        txsToProcess.Add(tx);
-                        Logger.LogInfo($"'{WalletName}': Transaction was successfully tested against the backend's mempool hashes: {hash}.");
-                    }
-                    else
-                    {
-                        BitcoinStore.TransactionStore.MempoolStore.TryRemove(tx.GetHash(), out _);
-                    }
-                }
-
-                TransactionProcessor.Process(txsToProcess);
-            }
-            catch (Exception ex)
-            {
-                // When there's a connection failure do not clean the transactions, add them to processing.
-                TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
-
-                Logger.LogWarning(ex);
-            }
-        }
-        else
-        {
-            TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
-        }
-    }
-
-    private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
-    {
-        var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
-        if (matchFound)
-        {
-            Block currentBlock = await BlockProvider.GetBlockAsync(filterModel.Header.BlockHash, cancel).ConfigureAwait(false); // Wait until not downloaded.
-            var height = new Height(filterModel.Header.Height);
-
-            var txsToProcess = new List<SmartTransaction>();
-            for (int i = 0; i < currentBlock.Transactions.Count; i++)
-            {
-                Transaction tx = currentBlock.Transactions[i];
-                txsToProcess.Add(new SmartTransaction(tx, height, currentBlock.GetHash(), i, firstSeen: currentBlock.Header.BlockTime, label: BitcoinStore.MempoolService.TryGetLabel(tx.GetHash())));
-            }
-
-            TransactionProcessor.Process(txsToProcess);
-            KeyManager.SetBestHeight(height);
-
-            NewBlockProcessed?.Invoke(this, currentBlock);
-        }
-
-        LastProcessedFilter = filterModel;
-    }
-
-    public void SetWaitingForInitState()
-    {
-        if (State != WalletState.Uninitialized)
-        {
-            throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized}. Current state: {State}.");
-        }
-
-        State = WalletState.WaitingForInit;
-    }
-
-    public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, string dataDir, ServiceConfiguration serviceConfiguration, HybridFeeProvider feeProvider, IBlockProvider blockProvider)
-    {
-        var wallet = new Wallet(dataDir, network, keyManager);
-        wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
-        return wallet;
-    }
-
-    public string Identifier => WalletName;
-    public bool CoinjoinEnabled => !IsUnderPlebStop;
-
-    public bool IsMixable =>
-        State == WalletState.Started // Only running wallets
-        && !KeyManager.IsWatchOnly // that are not watch-only wallets
-        && Kitchen.HasIngredients;
-
-    public IKeyChain KeyChain { get; }
-
-    public IDestinationProvider DestinationProvider { get; }
-    public int AnonScoreTarget => KeyManager.AnonScoreTarget;
-    public bool ConsolidationMode => false;
-    public TimeSpan FeeRateMedianTimeFrame => TimeSpan.FromHours(KeyManager.FeeRateMedianTimeFrameHours);
+		RuntimeParams.SetDataDir(dataDir);
+		HandleFiltersLock = new AsyncLock();
+
+		KeyManager.AssertCleanKeysIndexed();
+		KeyChain = new KeyChain(KeyManager, Kitchen);
+		DestinationProvider = new InternalDestinationProvider(KeyManager);
+	}
+
+	public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
+
+	public static event EventHandler<bool>? InitializingChanged;
+
+	public event EventHandler<FilterModel>? NewFilterProcessed;
+
+	public event EventHandler<Block>? NewBlockProcessed;
+
+	public event EventHandler<WalletState>? StateChanged;
+
+	public WalletState State
+	{
+		get => _state;
+		private set
+		{
+			if (_state == value)
+			{
+				return;
+			}
+
+			_state = value;
+			StateChanged?.Invoke(this, _state);
+		}
+	}
+
+	public BitcoinStore BitcoinStore { get; private set; }
+	public KeyManager KeyManager { get; }
+	public WasabiSynchronizer Synchronizer { get; private set; }
+	public ServiceConfiguration ServiceConfiguration { get; private set; }
+	public string WalletName => KeyManager.WalletName;
+
+	/// <summary>
+	/// Unspent Transaction Outputs
+	/// </summary>
+	public ICoinsView Coins { get; private set; }
+
+	public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
+
+	public bool IsWalletPrivate()
+	{
+		var coins = new CoinsView(Coins);
+
+		if (GetPrivacyPercentage(coins, KeyManager.AnonScoreTarget) >= 1)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;
+
+	private double GetPrivacyPercentage(CoinsView coins, int privateThreshold)
+	{
+		var privateAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
+		var normalAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();
+
+		var privateDecimalAmount = privateAmount.ToDecimal(MoneyUnit.BTC);
+		var normalDecimalAmount = normalAmount.ToDecimal(MoneyUnit.BTC);
+		var totalDecimalAmount = privateDecimalAmount + normalDecimalAmount;
+
+		var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
+		return pcPrivate;
+	}
+
+	public Network Network { get; }
+	public TransactionProcessor TransactionProcessor { get; private set; }
+
+	public HybridFeeProvider FeeProvider { get; private set; }
+	public FilterModel LastProcessedFilter { get; private set; }
+	public IBlockProvider BlockProvider { get; private set; }
+	private AsyncLock HandleFiltersLock { get; }
+
+	public bool IsLoggedIn { get; private set; }
+
+	public Kitchen Kitchen { get; } = new();
+	public ICoinsView NonPrivateCoins => new CoinsView(Coins.Where(c => c.HdPubKey.AnonymitySet < KeyManager.AnonScoreTarget));
+
+	public bool IsUnderPlebStop => Coins.TotalAmount() <= KeyManager.PlebStopThreshold;
+
+	public bool TryLogin(string password, out string? compatibilityPasswordUsed)
+	{
+		compatibilityPasswordUsed = null;
+
+		if (KeyManager.IsWatchOnly)
+		{
+			IsLoggedIn = true;
+			Kitchen.Cook("");
+		}
+		else if (PasswordHelper.TryPassword(KeyManager, password, out compatibilityPasswordUsed))
+		{
+			IsLoggedIn = true;
+			Kitchen.Cook(compatibilityPasswordUsed ?? Guard.Correct(password));
+		}
+
+		return IsLoggedIn;
+	}
+
+	public void Logout()
+	{
+		Kitchen.CleanUp();
+		IsLoggedIn = false;
+	}
+
+	public void RegisterServices(
+		BitcoinStore bitcoinStore,
+		WasabiSynchronizer syncer,
+		ServiceConfiguration serviceConfiguration,
+		HybridFeeProvider feeProvider,
+		IBlockProvider blockProvider)
+	{
+		if (State > WalletState.WaitingForInit)
+		{
+			throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized} or {WalletState.WaitingForInit}. Current state: {State}.");
+		}
+
+		try
+		{
+			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
+			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
+			FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
+
+			TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold);
+			Coins = TransactionProcessor.Coins;
+
+			TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;
+			BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
+			BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
+			BitcoinStore.MempoolService.TransactionReceived += Mempool_TransactionReceived;
+
+			BlockProvider = blockProvider;
+
+			State = WalletState.Initialized;
+		}
+		catch
+		{
+			State = WalletState.Uninitialized;
+			throw;
+		}
+	}
+
+	/// <inheritdoc/>
+	public override async Task StartAsync(CancellationToken cancel)
+	{
+		if (State != WalletState.Initialized)
+		{
+			throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Initialized}. Current state: {State}.");
+		}
+
+		try
+		{
+			State = WalletState.Starting;
+			InitializingChanged?.Invoke(this, true);
+
+			if (!Synchronizer.IsRunning)
+			{
+				throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
+			}
+
+			using (BenchmarkLogger.Measure())
+			{
+				await RuntimeParams.LoadAsync().ConfigureAwait(false);
+
+				using (await HandleFiltersLock.LockAsync(cancel).ConfigureAwait(false))
+				{
+					await LoadWalletStateAsync(cancel).ConfigureAwait(false);
+					await LoadDummyMempoolAsync().ConfigureAwait(false);
+				}
+			}
+
+			await base.StartAsync(cancel).ConfigureAwait(false);
+
+			State = WalletState.Started;
+		}
+		catch
+		{
+			State = WalletState.Initialized;
+			throw;
+		}
+		finally
+		{
+			InitializingChanged?.Invoke(this, false);
+		}
+	}
+
+	/// <inheritdoc />
+	protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+	/// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
+	/// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
+	/// <exception cref="ArgumentException"></exception>
+	/// <exception cref="ArgumentNullException"></exception>
+	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	public BuildTransactionResult BuildTransaction(
+		string password,
+		PaymentIntent payments,
+		FeeStrategy feeStrategy,
+		bool allowUnconfirmed = false,
+		IEnumerable<OutPoint>? allowedInputs = null,
+		IPayjoinClient? payjoinClient = null,
+		bool tryToSign = true)
+	{
+		var builder = new TransactionFactory(Network, KeyManager, Coins, BitcoinStore.TransactionStore, password, allowUnconfirmed);
+		return builder.BuildTransaction(
+			payments,
+			feeRateFetcher: () =>
+			{
+				if (feeStrategy.Type == FeeStrategyType.Target)
+				{
+					return FeeProvider.AllFeeEstimate?.GetFeeRate(feeStrategy.Target.Value) ?? throw new InvalidOperationException("Cannot get fee estimations.");
+				}
+				else if (feeStrategy.Type == FeeStrategyType.Rate)
+				{
+					return feeStrategy.Rate;
+				}
+				else
+				{
+					throw new NotSupportedException(feeStrategy.Type.ToString());
+				}
+			},
+			allowedInputs,
+			lockTimeSelector: () =>
+			{
+				var currentTipHeight = BitcoinStore.SmartHeaderChain.TipHeight;
+				return LockTimeSelector.Instance.GetLockTimeBasedOnDistribution(currentTipHeight);
+			},
+			payjoinClient,
+			tryToSign: tryToSign);
+	}
+
+	/// <inheritdoc/>
+	public override async Task StopAsync(CancellationToken cancel)
+	{
+		try
+		{
+			var prevState = State;
+			State = WalletState.Stopping;
+
+			if (prevState < WalletState.Stopping)
+			{
+				await base.StopAsync(cancel).ConfigureAwait(false);
+
+				if (prevState >= WalletState.Initialized)
+				{
+					BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
+					BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
+					BitcoinStore.MempoolService.TransactionReceived -= Mempool_TransactionReceived;
+					TransactionProcessor.WalletRelevantTransactionProcessed -= TransactionProcessor_WalletRelevantTransactionProcessed;
+				}
+			}
+		}
+		finally
+		{
+			State = WalletState.Stopped;
+		}
+	}
+
+	private void TransactionProcessor_WalletRelevantTransactionProcessed(object? sender, ProcessedResult e)
+	{
+		try
+		{
+			WalletRelevantTransactionProcessed?.Invoke(this, e);
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex);
+		}
+	}
+
+	private void Mempool_TransactionReceived(object? sender, SmartTransaction tx)
+	{
+		try
+		{
+			if (!TransactionProcessor.IsAware(tx.GetHash()))
+			{
+				TransactionProcessor.Process(tx);
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.LogWarning(ex);
+		}
+	}
+
+	private async void IndexDownloader_ReorgedAsync(object? sender, FilterModel invalidFilter)
+	{
+		try
+		{
+			using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
+			{
+				uint256 invalidBlockHash = invalidFilter.Header.BlockHash;
+				if (BlockProvider is CachedBlockProvider blockCache)
+				{
+					await blockCache.InvalidateAsync(invalidBlockHash, CancellationToken.None).ConfigureAwait(false);
+				}
+
+				KeyManager.SetMaxBestHeight(new Height(invalidFilter.Header.Height - 1));
+				TransactionProcessor.UndoBlock((int)invalidFilter.Header.Height);
+				BitcoinStore.TransactionStore.ReleaseToMempoolFromBlock(invalidBlockHash);
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.LogWarning(ex);
+		}
+	}
+
+	private async void IndexDownloader_NewFilterAsync(object? sender, FilterModel filterModel)
+	{
+		try
+		{
+			using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
+			{
+				if (KeyManager.GetBestHeight() < filterModel.Header.Height)
+				{
+					await ProcessFilterModelAsync(filterModel, CancellationToken.None).ConfigureAwait(false);
+				}
+			}
+
+			NewFilterProcessed?.Invoke(this, filterModel);
+
+			await Task.Delay(100).ConfigureAwait(false);
+
+			if (Synchronizer is null || BitcoinStore?.SmartHeaderChain is null)
+			{
+				return;
+			}
+
+			// Make sure fully synced and this filter is the latest filter.
+			if (BitcoinStore.SmartHeaderChain.HashesLeft != 0 || BitcoinStore.SmartHeaderChain.TipHash != filterModel.Header.BlockHash)
+			{
+				return;
+			}
+
+			var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer.HttpClientFactory);
+
+			if (task is { })
+			{
+				await task.ConfigureAwait(false);
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.LogWarning(ex);
+		}
+	}
+
+	private async Task LoadWalletStateAsync(CancellationToken cancel)
+	{
+		KeyManager.AssertNetworkOrClearBlockState(Network);
+		Height bestKeyManagerHeight = KeyManager.GetBestHeight();
+
+		using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))
+		{
+			TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
+		}
+
+		// Go through the filters and queue to download the matches.
+		await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
+			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
+	}
+
+	private async Task LoadDummyMempoolAsync()
+	{
+		if (BitcoinStore.TransactionStore.MempoolStore.IsEmpty())
+		{
+			return;
+		}
+
+		// Only clean the mempool if we're fully synchronized.
+		if (BitcoinStore.SmartHeaderChain.HashesLeft == 0)
+		{
+			try
+			{
+				var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
+				var compactness = 10;
+
+				var mempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
+
+				var txsToProcess = new List<SmartTransaction>();
+				foreach (var tx in BitcoinStore.TransactionStore.MempoolStore.GetTransactions())
+				{
+					uint256 hash = tx.GetHash();
+					if (mempoolHashes.Contains(hash.ToString()[..compactness]))
+					{
+						txsToProcess.Add(tx);
+						Logger.LogInfo($"'{WalletName}': Transaction was successfully tested against the backend's mempool hashes: {hash}.");
+					}
+					else
+					{
+						BitcoinStore.TransactionStore.MempoolStore.TryRemove(tx.GetHash(), out _);
+					}
+				}
+
+				TransactionProcessor.Process(txsToProcess);
+			}
+			catch (Exception ex)
+			{
+				// When there's a connection failure do not clean the transactions, add them to processing.
+				TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
+
+				Logger.LogWarning(ex);
+			}
+		}
+		else
+		{
+			TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
+		}
+	}
+
+	private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
+	{
+		var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
+		if (matchFound)
+		{
+			Block currentBlock = await BlockProvider.GetBlockAsync(filterModel.Header.BlockHash, cancel).ConfigureAwait(false); // Wait until not downloaded.
+			var height = new Height(filterModel.Header.Height);
+
+			var txsToProcess = new List<SmartTransaction>();
+			for (int i = 0; i < currentBlock.Transactions.Count; i++)
+			{
+				Transaction tx = currentBlock.Transactions[i];
+				txsToProcess.Add(new SmartTransaction(tx, height, currentBlock.GetHash(), i, firstSeen: currentBlock.Header.BlockTime, label: BitcoinStore.MempoolService.TryGetLabel(tx.GetHash())));
+			}
+
+			TransactionProcessor.Process(txsToProcess);
+			KeyManager.SetBestHeight(height);
+
+			NewBlockProcessed?.Invoke(this, currentBlock);
+		}
+
+		LastProcessedFilter = filterModel;
+	}
+
+	public void SetWaitingForInitState()
+	{
+		if (State != WalletState.Uninitialized)
+		{
+			throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized}. Current state: {State}.");
+		}
+
+		State = WalletState.WaitingForInit;
+	}
+
+	public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, string dataDir, ServiceConfiguration serviceConfiguration, HybridFeeProvider feeProvider, IBlockProvider blockProvider)
+	{
+		var wallet = new Wallet(dataDir, network, keyManager);
+		wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		return wallet;
+	}
+
+	public string Identifier => WalletName;
+	public bool CoinjoinEnabled => !IsUnderPlebStop;
+
+	public bool IsMixable =>
+		State == WalletState.Started // Only running wallets
+		&& !KeyManager.IsWatchOnly // that are not watch-only wallets
+		&& Kitchen.HasIngredients;
+
+	public IKeyChain KeyChain { get; }
+
+	public IDestinationProvider DestinationProvider { get; }
+	public int AnonScoreTarget => KeyManager.AnonScoreTarget;
+	public bool ConsolidationMode => false;
+	public TimeSpan FeeRateMedianTimeFrame => TimeSpan.FromHours(KeyManager.FeeRateMedianTimeFrameHours);
 }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -83,7 +83,11 @@ public class Wallet : BackgroundService, IWallet
 
 	public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
 
+	public Task<bool> IsWalletPrivateAsync() => Task.FromResult(IsWalletPrivate());
+
 	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), KeyManager.AnonScoreTarget) >= 1;
+
+	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -89,6 +89,7 @@ public class Wallet : BackgroundService, IWallet
 	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), KeyManager.AnonScoreTarget) >= 1;
 
 	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
+
 	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync()
 	{
 		return Task.FromResult(TransactionProcessor.TransactionStore.GetTransactions());
@@ -497,7 +498,6 @@ public class Wallet : BackgroundService, IWallet
 	}
 
 	public string Identifier => WalletName;
-	public bool CoinjoinEnabled => !IsUnderPlebStop;
 
 	public bool IsMixable =>
 		State == WalletState.Started // Only running wallets

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -90,7 +90,21 @@ public class Wallet : BackgroundService, IWallet
 
 	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
 
-	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(TransactionProcessor.TransactionStore.GetTransactions());
+	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync()
+	{
+		var walletTransactions = new List<SmartTransaction>();
+		var allCoins = ((CoinsRegistry)Coins).AsAllCoinsView();
+		foreach (SmartCoin coin in allCoins)
+		{
+			walletTransactions.Add(coin.Transaction);
+			if (coin.SpenderTransaction is not null)
+			{
+				walletTransactions.Add(coin.SpenderTransaction);
+			}
+		}
+		walletTransactions = walletTransactions.OrderByBlockchain().ToList();
+		return Task.FromResult<IEnumerable<SmartTransaction>>(walletTransactions);
+	}
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates(int bestHeight) => Coins;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -23,494 +23,495 @@ using WalletWasabi.WebClients.PayJoin;
 
 namespace WalletWasabi.Wallets;
 
-public class Wallet :  BackgroundService, IWallet
+public class Wallet : BackgroundService, IWallet
 {
-	private volatile WalletState _state;
-
-	public Wallet(string dataDir, Network network, string filePath) : this(dataDir, network, KeyManager.FromFile(filePath))
-	{
-	}
-
-	public Wallet(string dataDir, Network network, KeyManager keyManager)
-	{
-		Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
-		Network = Guard.NotNull(nameof(network), network);
-		KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-
-		RuntimeParams.SetDataDir(dataDir);
-		HandleFiltersLock = new AsyncLock();
-
-		KeyManager.AssertCleanKeysIndexed();
-		KeyChain = new KeyChain(KeyManager, Kitchen);
-		DestinationProvider = new InternalDestinationProvider(KeyManager);
-	}
-
-	public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
-
-	public static event EventHandler<bool>? InitializingChanged;
-
-	public event EventHandler<FilterModel>? NewFilterProcessed;
-
-	public event EventHandler<Block>? NewBlockProcessed;
-
-	public event EventHandler<WalletState>? StateChanged;
-
-	public WalletState State
-	{
-		get => _state;
-		private set
-		{
-			if (_state == value)
-			{
-				return;
-			}
-
-			_state = value;
-			StateChanged?.Invoke(this, _state);
-		}
-	}
-
-	public BitcoinStore BitcoinStore { get; private set; }
-	public KeyManager KeyManager { get; }
-	public WasabiSynchronizer Synchronizer { get; private set; }
-	public ServiceConfiguration ServiceConfiguration { get; private set; }
-	public string WalletName => KeyManager.WalletName;
-
-	/// <summary>
-	/// Unspent Transaction Outputs
-	/// </summary>
-	public ICoinsView Coins { get; private set; }
-
-	public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
-	public Task<bool> IsWalletPrivate()
-	{
-		var coins = new CoinsView(Coins);
-
-		if (GetPrivacyPercentage(coins, KeyManager.AnonScoreTarget) >= 1)
-		{
-			return Task.FromResult(true);
-		}
-
-		return Task.FromResult(false);
-	}
-
-	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight)
-	{
-		return Task.FromResult<IEnumerable<SmartCoin>>(Coins);
-	}
-
-	private double GetPrivacyPercentage(CoinsView coins, int privateThreshold)
-	{
-		var privateAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
-		var normalAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();
-
-		var privateDecimalAmount = privateAmount.ToDecimal(MoneyUnit.BTC);
-		var normalDecimalAmount = normalAmount.ToDecimal(MoneyUnit.BTC);
-		var totalDecimalAmount = privateDecimalAmount + normalDecimalAmount;
-
-		var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
-		return pcPrivate;
-	}
-	
-	public Network Network { get; }
-	public TransactionProcessor TransactionProcessor { get; private set; }
-
-	public HybridFeeProvider FeeProvider { get; private set; }
-	public FilterModel LastProcessedFilter { get; private set; }
-	public IBlockProvider BlockProvider { get; private set; }
-	private AsyncLock HandleFiltersLock { get; }
-
-	public bool IsLoggedIn { get; private set; }
-
-	public Kitchen Kitchen { get; } = new();
-	public ICoinsView NonPrivateCoins => new CoinsView(Coins.Where(c => c.HdPubKey.AnonymitySet < KeyManager.AnonScoreTarget));
-
-	public bool IsUnderPlebStop => Coins.TotalAmount() <= KeyManager.PlebStopThreshold;
-
-	public bool TryLogin(string password, out string? compatibilityPasswordUsed)
-	{
-		compatibilityPasswordUsed = null;
-
-		if (KeyManager.IsWatchOnly)
-		{
-			IsLoggedIn = true;
-			Kitchen.Cook("");
-		}
-		else if (PasswordHelper.TryPassword(KeyManager, password, out compatibilityPasswordUsed))
-		{
-			IsLoggedIn = true;
-			Kitchen.Cook(compatibilityPasswordUsed ?? Guard.Correct(password));
-		}
-
-		return IsLoggedIn;
-	}
-
-	public void Logout()
-	{
-		Kitchen.CleanUp();
-		IsLoggedIn = false;
-	}
-
-	public void RegisterServices(
-		BitcoinStore bitcoinStore,
-		WasabiSynchronizer syncer,
-		ServiceConfiguration serviceConfiguration,
-		HybridFeeProvider feeProvider,
-		IBlockProvider blockProvider)
-	{
-		if (State > WalletState.WaitingForInit)
-		{
-			throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized} or {WalletState.WaitingForInit}. Current state: {State}.");
-		}
-
-		try
-		{
-			BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
-			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
-			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
-			FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
-
-			TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold);
-			Coins = TransactionProcessor.Coins;
-
-			TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;
-			BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
-			BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
-			BitcoinStore.MempoolService.TransactionReceived += Mempool_TransactionReceived;
-
-			BlockProvider = blockProvider;
-
-			State = WalletState.Initialized;
-		}
-		catch
-		{
-			State = WalletState.Uninitialized;
-			throw;
-		}
-	}
-
-	/// <inheritdoc/>
-	public override async Task StartAsync(CancellationToken cancel)
-	{
-		if (State != WalletState.Initialized)
-		{
-			throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Initialized}. Current state: {State}.");
-		}
-
-		try
-		{
-			State = WalletState.Starting;
-			InitializingChanged?.Invoke(this, true);
-
-			if (!Synchronizer.IsRunning)
-			{
-				throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
-			}
-
-			using (BenchmarkLogger.Measure())
-			{
-				await RuntimeParams.LoadAsync().ConfigureAwait(false);
-
-				using (await HandleFiltersLock.LockAsync(cancel).ConfigureAwait(false))
-				{
-					await LoadWalletStateAsync(cancel).ConfigureAwait(false);
-					await LoadDummyMempoolAsync().ConfigureAwait(false);
-				}
-			}
-
-			await base.StartAsync(cancel).ConfigureAwait(false);
-
-			State = WalletState.Started;
-		}
-		catch
-		{
-			State = WalletState.Initialized;
-			throw;
-		}
-		finally
-		{
-			InitializingChanged?.Invoke(this, false);
-		}
-	}
-
-	/// <inheritdoc />
-	protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
-
-	/// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
-	/// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
-	/// <exception cref="ArgumentException"></exception>
-	/// <exception cref="ArgumentNullException"></exception>
-	/// <exception cref="ArgumentOutOfRangeException"></exception>
-	public BuildTransactionResult BuildTransaction(
-		string password,
-		PaymentIntent payments,
-		FeeStrategy feeStrategy,
-		bool allowUnconfirmed = false,
-		IEnumerable<OutPoint>? allowedInputs = null,
-		IPayjoinClient? payjoinClient = null,
-		bool tryToSign = true)
-	{
-		var builder = new TransactionFactory(Network, KeyManager, Coins, BitcoinStore.TransactionStore, password, allowUnconfirmed);
-		return builder.BuildTransaction(
-			payments,
-			feeRateFetcher: () =>
-			{
-				if (feeStrategy.Type == FeeStrategyType.Target)
-				{
-					return FeeProvider.AllFeeEstimate?.GetFeeRate(feeStrategy.Target.Value) ?? throw new InvalidOperationException("Cannot get fee estimations.");
-				}
-				else if (feeStrategy.Type == FeeStrategyType.Rate)
-				{
-					return feeStrategy.Rate;
-				}
-				else
-				{
-					throw new NotSupportedException(feeStrategy.Type.ToString());
-				}
-			},
-			allowedInputs,
-			lockTimeSelector: () =>
-			{
-				var currentTipHeight = BitcoinStore.SmartHeaderChain.TipHeight;
-				return LockTimeSelector.Instance.GetLockTimeBasedOnDistribution(currentTipHeight);
-			},
-			payjoinClient,
-			tryToSign: tryToSign);
-	}
-
-	/// <inheritdoc/>
-	public override async Task StopAsync(CancellationToken cancel)
-	{
-		try
-		{
-			var prevState = State;
-			State = WalletState.Stopping;
-
-			if (prevState < WalletState.Stopping)
-			{
-				await base.StopAsync(cancel).ConfigureAwait(false);
-
-				if (prevState >= WalletState.Initialized)
-				{
-					BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
-					BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
-					BitcoinStore.MempoolService.TransactionReceived -= Mempool_TransactionReceived;
-					TransactionProcessor.WalletRelevantTransactionProcessed -= TransactionProcessor_WalletRelevantTransactionProcessed;
-				}
-			}
-		}
-		finally
-		{
-			State = WalletState.Stopped;
-		}
-	}
-
-	private void TransactionProcessor_WalletRelevantTransactionProcessed(object? sender, ProcessedResult e)
-	{
-		try
-		{
-			WalletRelevantTransactionProcessed?.Invoke(this, e);
-		}
-		catch (Exception ex)
-		{
-			Logger.LogError(ex);
-		}
-	}
-
-	private void Mempool_TransactionReceived(object? sender, SmartTransaction tx)
-	{
-		try
-		{
-			if (!TransactionProcessor.IsAware(tx.GetHash()))
-			{
-				TransactionProcessor.Process(tx);
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger.LogWarning(ex);
-		}
-	}
-
-	private async void IndexDownloader_ReorgedAsync(object? sender, FilterModel invalidFilter)
-	{
-		try
-		{
-			using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
-			{
-				uint256 invalidBlockHash = invalidFilter.Header.BlockHash;
-				if (BlockProvider is CachedBlockProvider blockCache)
-				{
-					await blockCache.InvalidateAsync(invalidBlockHash, CancellationToken.None).ConfigureAwait(false);
-				}
-
-				KeyManager.SetMaxBestHeight(new Height(invalidFilter.Header.Height - 1));
-				TransactionProcessor.UndoBlock((int)invalidFilter.Header.Height);
-				BitcoinStore.TransactionStore.ReleaseToMempoolFromBlock(invalidBlockHash);
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger.LogWarning(ex);
-		}
-	}
-
-	private async void IndexDownloader_NewFilterAsync(object? sender, FilterModel filterModel)
-	{
-		try
-		{
-			using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
-			{
-				if (KeyManager.GetBestHeight() < filterModel.Header.Height)
-				{
-					await ProcessFilterModelAsync(filterModel, CancellationToken.None).ConfigureAwait(false);
-				}
-			}
-
-			NewFilterProcessed?.Invoke(this, filterModel);
-
-			await Task.Delay(100).ConfigureAwait(false);
-
-			if (Synchronizer is null || BitcoinStore?.SmartHeaderChain is null)
-			{
-				return;
-			}
-
-			// Make sure fully synced and this filter is the latest filter.
-			if (BitcoinStore.SmartHeaderChain.HashesLeft != 0 || BitcoinStore.SmartHeaderChain.TipHash != filterModel.Header.BlockHash)
-			{
-				return;
-			}
-
-			var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer.HttpClientFactory);
-
-			if (task is { })
-			{
-				await task.ConfigureAwait(false);
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger.LogWarning(ex);
-		}
-	}
-
-	private async Task LoadWalletStateAsync(CancellationToken cancel)
-	{
-		KeyManager.AssertNetworkOrClearBlockState(Network);
-		Height bestKeyManagerHeight = KeyManager.GetBestHeight();
-
-		using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))
-		{
-			TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
-		}
-
-		// Go through the filters and queue to download the matches.
-		await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
-			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
-	}
-
-	private async Task LoadDummyMempoolAsync()
-	{
-		if (BitcoinStore.TransactionStore.MempoolStore.IsEmpty())
-		{
-			return;
-		}
-
-		// Only clean the mempool if we're fully synchronized.
-		if (BitcoinStore.SmartHeaderChain.HashesLeft == 0)
-		{
-			try
-			{
-				var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
-				var compactness = 10;
-
-				var mempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
-
-				var txsToProcess = new List<SmartTransaction>();
-				foreach (var tx in BitcoinStore.TransactionStore.MempoolStore.GetTransactions())
-				{
-					uint256 hash = tx.GetHash();
-					if (mempoolHashes.Contains(hash.ToString()[..compactness]))
-					{
-						txsToProcess.Add(tx);
-						Logger.LogInfo($"'{WalletName}': Transaction was successfully tested against the backend's mempool hashes: {hash}.");
-					}
-					else
-					{
-						BitcoinStore.TransactionStore.MempoolStore.TryRemove(tx.GetHash(), out _);
-					}
-				}
-
-				TransactionProcessor.Process(txsToProcess);
-			}
-			catch (Exception ex)
-			{
-				// When there's a connection failure do not clean the transactions, add them to processing.
-				TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
-
-				Logger.LogWarning(ex);
-			}
-		}
-		else
-		{
-			TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
-		}
-	}
-
-	private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
-	{
-		var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
-		if (matchFound)
-		{
-			Block currentBlock = await BlockProvider.GetBlockAsync(filterModel.Header.BlockHash, cancel).ConfigureAwait(false); // Wait until not downloaded.
-			var height = new Height(filterModel.Header.Height);
-
-			var txsToProcess = new List<SmartTransaction>();
-			for (int i = 0; i < currentBlock.Transactions.Count; i++)
-			{
-				Transaction tx = currentBlock.Transactions[i];
-				txsToProcess.Add(new SmartTransaction(tx, height, currentBlock.GetHash(), i, firstSeen: currentBlock.Header.BlockTime, label: BitcoinStore.MempoolService.TryGetLabel(tx.GetHash())));
-			}
-
-			TransactionProcessor.Process(txsToProcess);
-			KeyManager.SetBestHeight(height);
-
-			NewBlockProcessed?.Invoke(this, currentBlock);
-		}
-
-		LastProcessedFilter = filterModel;
-	}
-
-	public void SetWaitingForInitState()
-	{
-		if (State != WalletState.Uninitialized)
-		{
-			throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized}. Current state: {State}.");
-		}
-
-		State = WalletState.WaitingForInit;
-	}
-
-	public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, string dataDir, ServiceConfiguration serviceConfiguration, HybridFeeProvider feeProvider, IBlockProvider blockProvider)
-	{
-		var wallet = new Wallet(dataDir, network, keyManager);
-		wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
-		return wallet;
-	}
-
-	public string Identifier => WalletName;
-	public bool CoinjoinEnabled => !IsUnderPlebStop;
-
-	public bool IsMixable =>
-		State == WalletState.Started // Only running wallets
-		&& !KeyManager.IsWatchOnly // that are not watch-only wallets
-		&& Kitchen.HasIngredients;
-
-	public IKeyChain KeyChain { get; }
-
-	public IDestinationProvider DestinationProvider { get; }
-	public int AnonScoreTarget => KeyManager.AnonScoreTarget;
-	public bool ConsolidationMode => false;
-	public TimeSpan FeeRateMedianTimeFrame => TimeSpan.FromHours(KeyManager.FeeRateMedianTimeFrameHours);
+    private volatile WalletState _state;
+
+    public Wallet(string dataDir, Network network, string filePath) : this(dataDir, network, KeyManager.FromFile(filePath))
+    {
+    }
+
+    public Wallet(string dataDir, Network network, KeyManager keyManager)
+    {
+        Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
+        Network = Guard.NotNull(nameof(network), network);
+        KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
+
+        RuntimeParams.SetDataDir(dataDir);
+        HandleFiltersLock = new AsyncLock();
+
+        KeyManager.AssertCleanKeysIndexed();
+        KeyChain = new KeyChain(KeyManager, Kitchen);
+        DestinationProvider = new InternalDestinationProvider(KeyManager);
+    }
+
+    public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
+
+    public static event EventHandler<bool>? InitializingChanged;
+
+    public event EventHandler<FilterModel>? NewFilterProcessed;
+
+    public event EventHandler<Block>? NewBlockProcessed;
+
+    public event EventHandler<WalletState>? StateChanged;
+
+    public WalletState State
+    {
+        get => _state;
+        private set
+        {
+            if (_state == value)
+            {
+                return;
+            }
+
+            _state = value;
+            StateChanged?.Invoke(this, _state);
+        }
+    }
+
+    public BitcoinStore BitcoinStore { get; private set; }
+    public KeyManager KeyManager { get; }
+    public WasabiSynchronizer Synchronizer { get; private set; }
+    public ServiceConfiguration ServiceConfiguration { get; private set; }
+    public string WalletName => KeyManager.WalletName;
+
+    /// <summary>
+    /// Unspent Transaction Outputs
+    /// </summary>
+    public ICoinsView Coins { get; private set; }
+
+    public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
+
+    public bool IsWalletPrivate()
+    {
+        var coins = new CoinsView(Coins);
+
+        if (GetPrivacyPercentage(coins, KeyManager.AnonScoreTarget) >= 1)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidates(int bestHeight)
+    {
+        return Task.FromResult<IEnumerable<SmartCoin>>(Coins);
+    }
+
+    private double GetPrivacyPercentage(CoinsView coins, int privateThreshold)
+    {
+        var privateAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
+        var normalAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();
+
+        var privateDecimalAmount = privateAmount.ToDecimal(MoneyUnit.BTC);
+        var normalDecimalAmount = normalAmount.ToDecimal(MoneyUnit.BTC);
+        var totalDecimalAmount = privateDecimalAmount + normalDecimalAmount;
+
+        var pcPrivate = totalDecimalAmount == 0M ? 1d : (double)(privateDecimalAmount / totalDecimalAmount);
+        return pcPrivate;
+    }
+
+    public Network Network { get; }
+    public TransactionProcessor TransactionProcessor { get; private set; }
+
+    public HybridFeeProvider FeeProvider { get; private set; }
+    public FilterModel LastProcessedFilter { get; private set; }
+    public IBlockProvider BlockProvider { get; private set; }
+    private AsyncLock HandleFiltersLock { get; }
+
+    public bool IsLoggedIn { get; private set; }
+
+    public Kitchen Kitchen { get; } = new();
+    public ICoinsView NonPrivateCoins => new CoinsView(Coins.Where(c => c.HdPubKey.AnonymitySet < KeyManager.AnonScoreTarget));
+
+    public bool IsUnderPlebStop => Coins.TotalAmount() <= KeyManager.PlebStopThreshold;
+
+    public bool TryLogin(string password, out string? compatibilityPasswordUsed)
+    {
+        compatibilityPasswordUsed = null;
+
+        if (KeyManager.IsWatchOnly)
+        {
+            IsLoggedIn = true;
+            Kitchen.Cook("");
+        }
+        else if (PasswordHelper.TryPassword(KeyManager, password, out compatibilityPasswordUsed))
+        {
+            IsLoggedIn = true;
+            Kitchen.Cook(compatibilityPasswordUsed ?? Guard.Correct(password));
+        }
+
+        return IsLoggedIn;
+    }
+
+    public void Logout()
+    {
+        Kitchen.CleanUp();
+        IsLoggedIn = false;
+    }
+
+    public void RegisterServices(
+        BitcoinStore bitcoinStore,
+        WasabiSynchronizer syncer,
+        ServiceConfiguration serviceConfiguration,
+        HybridFeeProvider feeProvider,
+        IBlockProvider blockProvider)
+    {
+        if (State > WalletState.WaitingForInit)
+        {
+            throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized} or {WalletState.WaitingForInit}. Current state: {State}.");
+        }
+
+        try
+        {
+            BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);
+            Synchronizer = Guard.NotNull(nameof(syncer), syncer);
+            ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
+            FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
+
+            TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold);
+            Coins = TransactionProcessor.Coins;
+
+            TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;
+            BitcoinStore.IndexStore.NewFilter += IndexDownloader_NewFilterAsync;
+            BitcoinStore.IndexStore.Reorged += IndexDownloader_ReorgedAsync;
+            BitcoinStore.MempoolService.TransactionReceived += Mempool_TransactionReceived;
+
+            BlockProvider = blockProvider;
+
+            State = WalletState.Initialized;
+        }
+        catch
+        {
+            State = WalletState.Uninitialized;
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async Task StartAsync(CancellationToken cancel)
+    {
+        if (State != WalletState.Initialized)
+        {
+            throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Initialized}. Current state: {State}.");
+        }
+
+        try
+        {
+            State = WalletState.Starting;
+            InitializingChanged?.Invoke(this, true);
+
+            if (!Synchronizer.IsRunning)
+            {
+                throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
+            }
+
+            using (BenchmarkLogger.Measure())
+            {
+                await RuntimeParams.LoadAsync().ConfigureAwait(false);
+
+                using (await HandleFiltersLock.LockAsync(cancel).ConfigureAwait(false))
+                {
+                    await LoadWalletStateAsync(cancel).ConfigureAwait(false);
+                    await LoadDummyMempoolAsync().ConfigureAwait(false);
+                }
+            }
+
+            await base.StartAsync(cancel).ConfigureAwait(false);
+
+            State = WalletState.Started;
+        }
+        catch
+        {
+            State = WalletState.Initialized;
+            throw;
+        }
+        finally
+        {
+            InitializingChanged?.Invoke(this, false);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+    /// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
+    /// <param name="allowedInputs">Only these inputs allowed to be used to build the transaction. The wallet must know the corresponding private keys.</param>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public BuildTransactionResult BuildTransaction(
+        string password,
+        PaymentIntent payments,
+        FeeStrategy feeStrategy,
+        bool allowUnconfirmed = false,
+        IEnumerable<OutPoint>? allowedInputs = null,
+        IPayjoinClient? payjoinClient = null,
+        bool tryToSign = true)
+    {
+        var builder = new TransactionFactory(Network, KeyManager, Coins, BitcoinStore.TransactionStore, password, allowUnconfirmed);
+        return builder.BuildTransaction(
+            payments,
+            feeRateFetcher: () =>
+            {
+                if (feeStrategy.Type == FeeStrategyType.Target)
+                {
+                    return FeeProvider.AllFeeEstimate?.GetFeeRate(feeStrategy.Target.Value) ?? throw new InvalidOperationException("Cannot get fee estimations.");
+                }
+                else if (feeStrategy.Type == FeeStrategyType.Rate)
+                {
+                    return feeStrategy.Rate;
+                }
+                else
+                {
+                    throw new NotSupportedException(feeStrategy.Type.ToString());
+                }
+            },
+            allowedInputs,
+            lockTimeSelector: () =>
+            {
+                var currentTipHeight = BitcoinStore.SmartHeaderChain.TipHeight;
+                return LockTimeSelector.Instance.GetLockTimeBasedOnDistribution(currentTipHeight);
+            },
+            payjoinClient,
+            tryToSign: tryToSign);
+    }
+
+    /// <inheritdoc/>
+    public override async Task StopAsync(CancellationToken cancel)
+    {
+        try
+        {
+            var prevState = State;
+            State = WalletState.Stopping;
+
+            if (prevState < WalletState.Stopping)
+            {
+                await base.StopAsync(cancel).ConfigureAwait(false);
+
+                if (prevState >= WalletState.Initialized)
+                {
+                    BitcoinStore.IndexStore.NewFilter -= IndexDownloader_NewFilterAsync;
+                    BitcoinStore.IndexStore.Reorged -= IndexDownloader_ReorgedAsync;
+                    BitcoinStore.MempoolService.TransactionReceived -= Mempool_TransactionReceived;
+                    TransactionProcessor.WalletRelevantTransactionProcessed -= TransactionProcessor_WalletRelevantTransactionProcessed;
+                }
+            }
+        }
+        finally
+        {
+            State = WalletState.Stopped;
+        }
+    }
+
+    private void TransactionProcessor_WalletRelevantTransactionProcessed(object? sender, ProcessedResult e)
+    {
+        try
+        {
+            WalletRelevantTransactionProcessed?.Invoke(this, e);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+        }
+    }
+
+    private void Mempool_TransactionReceived(object? sender, SmartTransaction tx)
+    {
+        try
+        {
+            if (!TransactionProcessor.IsAware(tx.GetHash()))
+            {
+                TransactionProcessor.Process(tx);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex);
+        }
+    }
+
+    private async void IndexDownloader_ReorgedAsync(object? sender, FilterModel invalidFilter)
+    {
+        try
+        {
+            using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
+            {
+                uint256 invalidBlockHash = invalidFilter.Header.BlockHash;
+                if (BlockProvider is CachedBlockProvider blockCache)
+                {
+                    await blockCache.InvalidateAsync(invalidBlockHash, CancellationToken.None).ConfigureAwait(false);
+                }
+
+                KeyManager.SetMaxBestHeight(new Height(invalidFilter.Header.Height - 1));
+                TransactionProcessor.UndoBlock((int)invalidFilter.Header.Height);
+                BitcoinStore.TransactionStore.ReleaseToMempoolFromBlock(invalidBlockHash);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex);
+        }
+    }
+
+    private async void IndexDownloader_NewFilterAsync(object? sender, FilterModel filterModel)
+    {
+        try
+        {
+            using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
+            {
+                if (KeyManager.GetBestHeight() < filterModel.Header.Height)
+                {
+                    await ProcessFilterModelAsync(filterModel, CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+
+            NewFilterProcessed?.Invoke(this, filterModel);
+
+            await Task.Delay(100).ConfigureAwait(false);
+
+            if (Synchronizer is null || BitcoinStore?.SmartHeaderChain is null)
+            {
+                return;
+            }
+
+            // Make sure fully synced and this filter is the latest filter.
+            if (BitcoinStore.SmartHeaderChain.HashesLeft != 0 || BitcoinStore.SmartHeaderChain.TipHash != filterModel.Header.BlockHash)
+            {
+                return;
+            }
+
+            var task = BitcoinStore.MempoolService?.TryPerformMempoolCleanupAsync(Synchronizer.HttpClientFactory);
+
+            if (task is { })
+            {
+                await task.ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex);
+        }
+    }
+
+    private async Task LoadWalletStateAsync(CancellationToken cancel)
+    {
+        KeyManager.AssertNetworkOrClearBlockState(Network);
+        Height bestKeyManagerHeight = KeyManager.GetBestHeight();
+
+        using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))
+        {
+            TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
+        }
+
+        // Go through the filters and queue to download the matches.
+        await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
+            new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
+    }
+
+    private async Task LoadDummyMempoolAsync()
+    {
+        if (BitcoinStore.TransactionStore.MempoolStore.IsEmpty())
+        {
+            return;
+        }
+
+        // Only clean the mempool if we're fully synchronized.
+        if (BitcoinStore.SmartHeaderChain.HashesLeft == 0)
+        {
+            try
+            {
+                var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
+                var compactness = 10;
+
+                var mempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
+
+                var txsToProcess = new List<SmartTransaction>();
+                foreach (var tx in BitcoinStore.TransactionStore.MempoolStore.GetTransactions())
+                {
+                    uint256 hash = tx.GetHash();
+                    if (mempoolHashes.Contains(hash.ToString()[..compactness]))
+                    {
+                        txsToProcess.Add(tx);
+                        Logger.LogInfo($"'{WalletName}': Transaction was successfully tested against the backend's mempool hashes: {hash}.");
+                    }
+                    else
+                    {
+                        BitcoinStore.TransactionStore.MempoolStore.TryRemove(tx.GetHash(), out _);
+                    }
+                }
+
+                TransactionProcessor.Process(txsToProcess);
+            }
+            catch (Exception ex)
+            {
+                // When there's a connection failure do not clean the transactions, add them to processing.
+                TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
+
+                Logger.LogWarning(ex);
+            }
+        }
+        else
+        {
+            TransactionProcessor.Process(BitcoinStore.TransactionStore.MempoolStore.GetTransactions());
+        }
+    }
+
+    private async Task ProcessFilterModelAsync(FilterModel filterModel, CancellationToken cancel)
+    {
+        var matchFound = filterModel.Filter.MatchAny(KeyManager.GetPubKeyScriptBytes(), filterModel.FilterKey);
+        if (matchFound)
+        {
+            Block currentBlock = await BlockProvider.GetBlockAsync(filterModel.Header.BlockHash, cancel).ConfigureAwait(false); // Wait until not downloaded.
+            var height = new Height(filterModel.Header.Height);
+
+            var txsToProcess = new List<SmartTransaction>();
+            for (int i = 0; i < currentBlock.Transactions.Count; i++)
+            {
+                Transaction tx = currentBlock.Transactions[i];
+                txsToProcess.Add(new SmartTransaction(tx, height, currentBlock.GetHash(), i, firstSeen: currentBlock.Header.BlockTime, label: BitcoinStore.MempoolService.TryGetLabel(tx.GetHash())));
+            }
+
+            TransactionProcessor.Process(txsToProcess);
+            KeyManager.SetBestHeight(height);
+
+            NewBlockProcessed?.Invoke(this, currentBlock);
+        }
+
+        LastProcessedFilter = filterModel;
+    }
+
+    public void SetWaitingForInitState()
+    {
+        if (State != WalletState.Uninitialized)
+        {
+            throw new InvalidOperationException($"{nameof(State)} must be {WalletState.Uninitialized}. Current state: {State}.");
+        }
+
+        State = WalletState.WaitingForInit;
+    }
+
+    public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, string dataDir, ServiceConfiguration serviceConfiguration, HybridFeeProvider feeProvider, IBlockProvider blockProvider)
+    {
+        var wallet = new Wallet(dataDir, network, keyManager);
+        wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+        return wallet;
+    }
+
+    public string Identifier => WalletName;
+    public bool CoinjoinEnabled => !IsUnderPlebStop;
+
+    public bool IsMixable =>
+        State == WalletState.Started // Only running wallets
+        && !KeyManager.IsWatchOnly // that are not watch-only wallets
+        && Kitchen.HasIngredients;
+
+    public IKeyChain KeyChain { get; }
+
+    public IDestinationProvider DestinationProvider { get; }
+    public int AnonScoreTarget => KeyManager.AnonScoreTarget;
+    public bool ConsolidationMode => false;
+    public TimeSpan FeeRateMedianTimeFrame => TimeSpan.FromHours(KeyManager.FeeRateMedianTimeFrameHours);
 }

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -109,8 +109,6 @@ public class WalletManager : IWalletProvider
 		}
 	}
 
-	public IEnumerable<IWallet> GetWallets() => GetWallets(true);
-
 	public bool HasWallet() => AnyWallet(_ => true);
 
 	public bool AnyWallet(Func<Wallet, bool> predicate)
@@ -249,7 +247,7 @@ public class WalletManager : IWalletProvider
 		WalletAdded?.Invoke(this, wallet);
 	}
 
-	public bool WalletExists(HDFingerprint? fingerprint) => GetWallets(true).Any(x => fingerprint is { } && x.KeyManager.MasterFingerprint == fingerprint);
+	public bool WalletExists(HDFingerprint? fingerprint) => GetWallets().Any(x => fingerprint is { } && x.KeyManager.MasterFingerprint == fingerprint);
 
 	private void TransactionProcessor_WalletRelevantTransactionProcessed(object? sender, ProcessedResult e)
 	{
@@ -286,7 +284,7 @@ public class WalletManager : IWalletProvider
 
 		using (await StartStopWalletLock.LockAsync(cancel).ConfigureAwait(false))
 		{
-			foreach (var wallet in GetWallets(true))
+			foreach (var wallet in GetWallets())
 			{
 				cancel.ThrowIfCancellationRequested();
 
@@ -386,7 +384,7 @@ public class WalletManager : IWalletProvider
 		FeeProvider = feeProvider;
 		BlockProvider = blockProvider;
 
-		foreach (var wallet in GetWallets(true).Where(w => w.State == WalletState.WaitingForInit))
+		foreach (var wallet in GetWallets().Where(w => w.State == WalletState.WaitingForInit))
 		{
 			wallet.RegisterServices(BitcoinStore, Synchronizer, ServiceConfiguration, FeeProvider, BlockProvider);
 		}

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -107,6 +107,8 @@ public class WalletManager : IWalletProvider
 		}
 	}
 
+	public IEnumerable<IWallet> GetWallets() => GetWallets(true);
+
 	public bool HasWallet() => AnyWallet(_ => true);
 
 	public bool AnyWallet(Func<Wallet, bool> predicate)
@@ -409,10 +411,5 @@ public class WalletManager : IWalletProvider
 		{
 			return Wallets.Single(x => x.KeyManager.WalletName == walletName);
 		}
-	}
-
-	public Task<IEnumerable<IWallet>> GetWallets()
-	{
-		return Task.FromResult<IEnumerable<IWallet>>(GetWallets(true));
 	}
 }

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -94,6 +94,8 @@ public class WalletManager : IWalletProvider
 		}
 	}
 
+	public Task<IEnumerable<IWallet>> GetWalletsAsync() => Task.FromResult<IEnumerable<IWallet>>(GetWallets(refreshWalletList: true));
+
 	public IEnumerable<Wallet> GetWallets(bool refreshWalletList = true)
 	{
 		if (refreshWalletList)


### PR DESCRIPTION
This PR introduces as few changes as possible to reuse wabisabi client code (including decomposer) without using Wasabi's blockchain indexer and wallet structure. 

Notable changes:
* New interface  `IWasabiBackendStatusProvider` : This allows me to fetch backend status without needing the synchronizer as I do not need the filters.
*  `TorControlClientFactory` now takes an `EndPoint` instead of only an IP, as wabisabi client / Tor are often running in docker containers which use DNS names (e.g. `tor:9050`)
* New interface `IWallet` which provides the coinjoin settings. This interface is probably the bulk of the changes as I had to replace direct usage of `Wallet`.
* New abstract class `BaseKeyChain`, as ownership proof magic code is reusable but not if it is coupled with `KeyManager`
* a fix to the new docker-compose that was missing txindex=1 setting