### PR TITLE
[VDG] Fix for focus loss after window becomes inactive

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/SearchBarBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/SearchBarBehavior.cs
@@ -67,18 +67,6 @@ public class SearchBarBehavior : AttachedToVisualTreeBehavior<Control>
 				.DisposeWith(disposables);
 		}
 
-		if (visualRoot is WindowBase window)
-		{
-			Observable
-				.FromEventPattern(window, nameof(WindowBase.Deactivated))
-				.Subscribe(_ =>
-				{
-					FocusManager.Instance?.Focus(null);
-					HideFlyout();
-				})
-				.DisposeWith(disposables);
-		}
-
 		if (SearchBox is { } && SearchPanel is { })
 		{
 			Observable


### PR DESCRIPTION
A workaround we introduced for W10 causes focus to be lost when the application window is deactivated.

With this PR, it should no longer happen. 
Presumably fixes #8733