### PR TITLE
[VDG] Add ability to sort coins in Coin List by indicators

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -137,8 +137,8 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 					{
 						CanUserResizeColumn = false,
 						CanUserSortColumn = true,
-						CompareAscending = WalletCoinViewModel.SortAscending(x => x.CoinJoinInProgress),
-						CompareDescending = WalletCoinViewModel.SortDescending(x => x.CoinJoinInProgress),
+						CompareAscending = WalletCoinViewModel.SortAscending(x => GetOrderingPriority(x)),
+						CompareDescending = WalletCoinViewModel.SortDescending(x => GetOrderingPriority(x)),
 					},
 					width: new GridLength(0, GridUnitType.Auto)),
 
@@ -193,6 +193,26 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 			.Select(_ => GetCoins())
 			.Subscribe(RefreshCoinsList)
 			.DisposeWith(disposables);
+	}
+
+	private static int GetOrderingPriority(WalletCoinViewModel x)
+	{
+		if (x.Confirmed)
+		{
+			return 1;
+		}
+
+		if (x.CoinJoinInProgress)
+		{
+			return 2;
+		}
+
+		if (x.IsBanned)
+		{
+			return 3;
+		}
+
+		return 0;
 	}
 
 	private ICoinsView GetCoins()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -197,17 +197,17 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 
 	private static int GetOrderingPriority(WalletCoinViewModel x)
 	{
-		if (x.Confirmed)
+		if (x.CoinJoinInProgress)
 		{
 			return 1;
 		}
 
-		if (x.CoinJoinInProgress)
+		if (x.IsBanned)
 		{
 			return 2;
 		}
 
-		if (x.IsBanned)
+		if (!x.Confirmed)
 		{
 			return 3;
 		}


### PR DESCRIPTION
A set of priorities have been assigned to the different indicators. This enables sorting for the indicators column:

These are the values:

```
1: Coinjoining
2: Banned
3: Unconfirmed (!Confirmed)
```

This is just a value to discriminate the possible states, so the sorting can know which elements are grouped. 

Different priority values give similar results in the GUI, but I have considered these are giving the desired outcome.

Fixes #8758