### PR TITLE
[PoC] Add Timeouts to StepTransactionSigningTests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -22,9 +22,14 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping;
 
 public class StepTransactionSigningTests
 {
+	private TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
+
 	[Fact]
 	public async Task EveryoneSignedAsync()
 	{
+		using CancellationTokenSource cancellationTokenSource = new(Timeout);
+		var token = cancellationTokenSource.Token;
+
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
@@ -37,26 +42,29 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
-		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
+		await aliceClient1.ReadyToSignAsync(token);
+		await aliceClient2.ReadyToSignAsync(token);
 
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
 
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.DoesNotContain(round, arena.GetActiveRounds());
 		Assert.Equal(Phase.Ended, round.Phase);
 
-		await arena.StopAsync(CancellationToken.None);
+		await arena.StopAsync(token);
 	}
 
 	[Fact]
 	public async Task FailsBroadcastAsync()
 	{
+		using CancellationTokenSource cancellationTokenSource = new(Timeout);
+		var token = cancellationTokenSource.Token;
+
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
@@ -73,28 +81,31 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
-		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
+		await aliceClient1.ReadyToSignAsync(token);
+		await aliceClient2.ReadyToSignAsync(token);
 
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
 
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Equal(Phase.Ended, round.Phase);
 		Assert.Equal(EndRoundState.TransactionBroadcastFailed, round.EndRoundState);
 		Assert.Empty(prison.GetInmates());
 
-		await arena.StopAsync(CancellationToken.None);
+		await arena.StopAsync(token);
 	}
 
 	[Fact]
 	public async Task AlicesSpentAsync()
 	{
+		using CancellationTokenSource cancellationTokenSource = new(Timeout);
+		var token = cancellationTokenSource.Token;
+
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
@@ -113,17 +124,17 @@ public class StepTransactionSigningTests
 
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
-		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
+		await aliceClient1.ReadyToSignAsync(token);
+		await aliceClient2.ReadyToSignAsync(token);
 
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
 
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Equal(Phase.Ended, round.Phase);
 		Assert.Equal(EndRoundState.TransactionBroadcastFailed, round.EndRoundState);
@@ -133,12 +144,15 @@ public class StepTransactionSigningTests
 		// the cost of spending the UTXO is the punishment instead.
 		Assert.Empty(prison.GetInmates());
 
-		await arena.StopAsync(CancellationToken.None);
+		await arena.StopAsync(token);
 	}
 
 	[Fact]
 	public async Task TimeoutInsufficientPeersAsync()
 	{
+		using CancellationTokenSource cancellationTokenSource = new(Timeout);
+		var token = cancellationTokenSource.Token;
+
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
@@ -156,27 +170,30 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(CancellationToken.None);
-		await aliceClient2.ReadyToSignAsync(CancellationToken.None);
+		await aliceClient1.ReadyToSignAsync(token);
+		await aliceClient2.ReadyToSignAsync(token);
 
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Equal(Phase.Ended, round.Phase);
 		Assert.Equal(EndRoundState.AbortedNotEnoughAlicesSigned, round.EndRoundState);
 		Assert.Empty(arena.Rounds.Where(x => x is BlameRound));
 		Assert.Contains(aliceClient2.SmartCoin.OutPoint, prison.GetInmates().Select(x => x.Utxo));
 
-		await arena.StopAsync(CancellationToken.None);
+		await arena.StopAsync(token);
 	}
 
 	[Fact]
 	public async Task TimeoutSufficientPeersAsync()
 	{
+		using CancellationTokenSource cancellationTokenSource = new(Timeout);
+		var token = cancellationTokenSource.Token;
+
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
@@ -202,13 +219,13 @@ public class StepTransactionSigningTests
 		alice3.ConfirmedConnection = true;
 		round.Alices.Add(alice3);
 		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
 		var signedCoinJoin = round.Assert<SigningState>().CreateTransaction();
-		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, CancellationToken.None);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await aliceClient1.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await aliceClient2.SignTransactionAsync(signedCoinJoin, keyChain, token);
+		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.DoesNotContain(round, arena.Rounds.Where(x => x.Phase != Phase.Ended));
 		Assert.Single(arena.Rounds.Where(x => x is BlameRound));
 		var badOutpoint = alice3.Coin.Outpoint;
@@ -224,28 +241,31 @@ public class StepTransactionSigningTests
 		Assert.Contains(aliceClient2.SmartCoin.OutPoint, whitelist);
 		Assert.DoesNotContain(badOutpoint, whitelist);
 
-		await arena.StopAsync(CancellationToken.None);
+		await arena.StopAsync(token);
 	}
 
 	private async Task<(Round Round, AliceClient AliceClient1, AliceClient AliceClient2)>
 			CreateRoundWithOutputsReadyToSignAsync(Arena arena, IKeyChain keyChain, SmartCoin coin1, SmartCoin coin2)
 	{
+		using CancellationTokenSource cancellationTokenSource = new(Timeout);
+		var token = cancellationTokenSource.Token;
+
 		// Create the round.
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+		await arena.TriggerAndWaitRoundAsync(token);
 
 		var round = Assert.Single(arena.Rounds);
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		// Register Alices.
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
-		await roundStateUpdater.StartAsync(CancellationToken.None);
+		await roundStateUpdater.StartAsync(token);
 
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None, CancellationToken.None);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, CancellationToken.None, CancellationToken.None, CancellationToken.None);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, token, token, token);
 
 		while (Phase.OutputRegistration != round.Phase)
 		{
-			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
+			await arena.TriggerAndWaitRoundAsync(token);
 		}
 
 		await Task.WhenAll(task1, task2);
@@ -261,15 +281,15 @@ public class StepTransactionSigningTests
 			destKey1.PubKey.WitHash.ScriptPubKey,
 			aliceClient1.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient1.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
-			CancellationToken.None).ConfigureAwait(false);
+			token).ConfigureAwait(false);
 
 		await bobClient.RegisterOutputAsync(
 			destKey1.PubKey.WitHash.ScriptPubKey,
 			aliceClient2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient2.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
-			CancellationToken.None).ConfigureAwait(false);
+			token).ConfigureAwait(false);
 
-		await roundStateUpdater.StopAsync(CancellationToken.None);
+		await roundStateUpdater.StopAsync(token);
 		return (round, aliceClient1, aliceClient2);
 	}
 }

--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -46,13 +46,19 @@ public abstract class PeriodicRunner : BackgroundService
 	/// <summary>
 	/// Triggers and waits for the action to execute.
 	/// </summary>
-	public async Task TriggerAndWaitRoundAsync(TimeSpan timeout)
+	public async Task TriggerAndWaitRoundAsync(CancellationToken cancellationToken)
 	{
 		EventAwaiter<TimeSpan> eventAwaiter = new(
 							h => Tick += h,
 							h => Tick -= h);
 		TriggerRound();
-		await eventAwaiter.WaitAsync(timeout).ConfigureAwait(false);
+		await eventAwaiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	public Task TriggerAndWaitRoundAsync(TimeSpan timeout)
+	{
+		using CancellationTokenSource cancellationTokenSource = new(timeout);
+		return TriggerAndWaitRoundAsync(cancellationTokenSource.Token);
 	}
 
 	/// <summary>

--- a/WalletWasabi/Helpers/EventAwaiter.cs
+++ b/WalletWasabi/Helpers/EventAwaiter.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System;
@@ -16,4 +17,7 @@ public class EventAwaiter<TEventArgs> : EventsAwaiter<TEventArgs>
 
 	public new async Task<TEventArgs> WaitAsync(TimeSpan timeout)
 		=> await Task.WithAwaitCancellationAsync(timeout).ConfigureAwait(false);
+
+	public new async Task<TEventArgs> WaitAsync(CancellationToken cancellationToken)
+		=> await Task.WithAwaitCancellationAsync(cancellationToken).ConfigureAwait(false);
 }

--- a/WalletWasabi/Helpers/EventsAwaiter.cs
+++ b/WalletWasabi/Helpers/EventsAwaiter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 
@@ -47,4 +48,7 @@ public class EventsAwaiter<TEventArgs>
 
 	public async Task<IEnumerable<TEventArgs>> WaitAsync(TimeSpan timeout)
 		=> await Task.WhenAll(Tasks).WithAwaitCancellationAsync(timeout).ConfigureAwait(false);
+
+	public async Task<IEnumerable<TEventArgs>> WaitAsync(CancellationToken cancellationToken)
+		=> await Task.WhenAll(Tasks).WithAwaitCancellationAsync(cancellationToken).ConfigureAwait(false);
 }


### PR DESCRIPTION
The concept for adding timeouts to specific tests, is to avoid infinite loops (60 minutes test).

Related issue: https://github.com/zkSNACKs/WalletWasabi/issues/8763#issue-1314937286