### PR TITLE
[VDG] Use ItemTemplate instead of DataTemplates

### DIFF
--- a/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinJoinProfiles/CoinJoinProfilesView.axaml
@@ -78,13 +78,13 @@
             <UniformGrid Rows="1" />
           </ItemsPanelTemplate>
         </ListBox.ItemsPanel>
-        <ListBox.DataTemplates>
+        <ListBox.ItemTemplate>
           <DataTemplate>
             <c:SuggestionItem MaxHeight="280">
               <prof:CoinJoinProfileControl />
             </c:SuggestionItem>
           </DataTemplate>
-        </ListBox.DataTemplates>
+        </ListBox.ItemTemplate>
       </ListBox>
     </DockPanel>
   </c:ContentArea>


### PR DESCRIPTION
When using DataTemplate without DataType we should use ItemTemplate instead of DataTemplates i(n Avalonia 11 it will throw exception).