### PR TITLE
Add support for Ledger Nano S+

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
@@ -23,7 +23,7 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 		Type = device.Model switch
 		{
 			HardwareWalletModels.Coldcard or HardwareWalletModels.Coldcard_Simulator => WalletType.Coldcard,
-			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X => WalletType.Ledger,
+			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => WalletType.Ledger,
 			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator => WalletType.Trezor,
 			_ => WalletType.Hardware
 		};

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -291,6 +291,89 @@ public class HwiKatas
 	}
 
 	[Fact]
+	public async Task LedgerNanoSPlusKataAsync()
+	{
+		// --- USER INTERACTIONS ---
+		//
+		// Connect and initialize your Nano S+ with the following seed phrase:
+		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// Run this test.
+		// displayaddress request(derivation path): approve
+		// displayaddress request: reject
+		// displayaddress request(derivation path): approve
+		// displayaddress request: approve
+		// displayaddress request(derivation path): approve
+		// displayaddress request: approve
+		// signtx request: reject
+		// signtx request: accept
+		// confirm transaction: accept and send
+		//
+		// --- USER INTERACTIONS ---
+
+		var network = Network.Main;
+		var client = new HwiClient(network);
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		var enumerate = await client.EnumerateAsync(cts.Token);
+		HwiEnumerateEntry entry = Assert.Single(enumerate);
+		Assert.NotNull(entry.Path);
+		Assert.Equal(HardwareWalletModels.Ledger_Nano_S_Plus, entry.Model);
+		Assert.NotNull(entry.Fingerprint);
+		Assert.Null(entry.Code);
+		Assert.Null(entry.Error);
+		Assert.Null(entry.SerialNumber);
+		Assert.False(entry.NeedsPassphraseSent);
+		Assert.False(entry.NeedsPinSent);
+
+		string devicePath = entry.Path;
+		HardwareWalletModels deviceType = entry.Model;
+		HDFingerprint fingerprint = entry.Fingerprint!.Value;
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+
+		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network).Derive("0/0");
+		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network).Derive("0/1");
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		Assert.NotNull(xpub1);
+		Assert.NotNull(xpub2);
+		Assert.NotEqual(xpub1, xpub2);
+
+		// USER SHOULD REFUSE ACTION
+		await Assert.ThrowsAsync<HwiException>(async () => await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token));
+
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(fingerprint, keyPath2, cts.Token);
+		Assert.NotNull(address1);
+		Assert.NotNull(address2);
+		Assert.NotEqual(address1, address2);
+		var expectedAddress1 = xpub1.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		var expectedAddress2 = xpub2.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+
+		// USER: REFUSE
+		var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token));
+		Assert.Equal(HwiErrorCode.UnknownError, ex.ErrorCode);
+
+		// USER: CONFIRM
+		PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token);
+
+		Transaction signedTx = signedPsbt.GetOriginalTransaction();
+		Assert.Equal(Psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
+
+		var checkResult = signedTx.Check();
+		Assert.Equal(TransactionCheckResult.Success, checkResult);
+	}
+
+	[Fact]
 	public async Task LedgerNanoXKataAsync()
 	{
 		// --- USER INTERACTIONS ---

--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -31,6 +31,9 @@ public enum HardwareWalletModels
 	[FriendlyName("Ledger Nano S")]
 	Ledger_Nano_S,
 
+	[FriendlyName("Ledger Nano S Plus")]
+	Ledger_Nano_S_Plus,
+
 	[FriendlyName("Ledger Nano X")]
 	Ledger_Nano_X,
 


### PR DESCRIPTION
This PR aims to add support for the new Ledger Nano S+, enabled by the #7791 HWI Update PR.

![image](https://user-images.githubusercontent.com/16554748/181482620-cb024517-2cdd-455e-8ca1-f4dff09187fc.png)
![image](https://user-images.githubusercontent.com/16554748/181482978-63553708-05af-4bf9-9a09-9539844a8803.png)
![image](https://user-images.githubusercontent.com/16554748/181483074-616a4ee2-449e-42ca-a55e-b30467782381.png)


cc @nopara73 @Szpoti @zkSNACKs/code-team 