### PR TITLE
Consider composability when analyzing coinjoin transactions

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -256,4 +256,20 @@ public class CoinJoinAnonScoreTests
 		// 10 participants, 1 is you, your anonset would be 10 normally and now too:
 		Assert.Equal(10, tx.WalletOutputs.First().HdPubKey.AnonymitySet);
 	}
+
+	[Fact]
+	public void SmallerSumAdded()
+	{
+		var analyser = new BlockchainAnalyzer();
+		var tx = BitcoinFactory.CreateSmartTransaction(50, Enumerable.Repeat(Money.Coins(1m), 9), new[] { (Money.Coins(2.1m), 1) }, new[] { (Money.Coins(2m), HdPubKey.DefaultHighAnonymitySet) });
+
+		analyser.Analyze(tx);
+
+		Assert.Equal(1, tx.WalletInputs.First().HdPubKey.AnonymitySet);
+
+		// 10 participants, 1 is you with 2BTC, 9 are others with 1BTC:
+		// Out of 9 1BTC outputs we can assume 4 2BTC outputs, which would add 4/2 AS:
+		// So the final AS would be 2 + 1 = 3.
+		Assert.Equal(3, tx.WalletOutputs.First().HdPubKey.AnonymitySet);
+	}
 }

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -148,9 +148,9 @@ public class BlockchainAnalyzer
 				// Take outputs those aren't on the same level as any of our outputs.
 				var combinableOutputs = indistinguishableOutputs
 					.Where(x => !tx.WalletOutputs.Any(y => y.Amount.Satoshi == x.Key) && StdDenoms.Contains(x.Key))
-					.SelectMany(x => Enumerable.Repeat(new LongHolder(x.Key), x.Value))
+					.SelectMany(x => Enumerable.Repeat(x.Key, x.Value).Select(y => new LongHolder(y)))
 					.ToArray();
-				equalOutputCount += CalculateSumAnonScoreGain(output.Value, combinableOutputs, usedOutputs, 10, DateTimeOffset.UtcNow + TimeSpan.FromMinutes(10));
+				equalOutputCount += CalculateSumAnonScoreGain(output.Value, combinableOutputs, usedOutputs, 10, DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(10));
 			}
 
 			// Anonset gain cannot be larger than others' input count.
@@ -228,14 +228,7 @@ public class BlockchainAnalyzer
 	private double CalculateSumAnonScoreGain(long outputValue, IEnumerable<LongHolder> combinableOutputs, List<LongHolder> usedOutputs, int comboCount, int largestComboCount, DateTimeOffset timeoutAt)
 	{
 		var asGain = 0d;
-		var remainingOutputs = new List<LongHolder>();
-		foreach (var o in combinableOutputs)
-		{
-			if (!usedOutputs.Any(x => ReferenceEquals(x, o)))
-			{
-				remainingOutputs.Add(o);
-			}
-		}
+		var remainingOutputs = combinableOutputs.Except(usedOutputs);
 
 		foreach (var combo in remainingOutputs.CombinationsWithoutRepetition(comboCount))
 		{

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -146,6 +146,7 @@ public class BlockchainAnalyzer
 			if (isWasabi2Cj)
 			{
 				// Take outputs those aren't on the same level as any of our outputs.
+				// https://github.com/zkSNACKs/WalletWasabi/pull/8604#issuecomment-1197894226
 				var combinableOutputs = indistinguishableOutputs
 					.Where(x => !tx.WalletOutputs.Any(y => y.Amount.Satoshi == x.Key) && StdDenoms.Contains(x.Key))
 					.SelectMany(x => Enumerable.Repeat(x.Key, x.Value).Select(y => new LongHolder(y)))

--- a/WalletWasabi/Blockchain/Analysis/LongHolder.cs
+++ b/WalletWasabi/Blockchain/Analysis/LongHolder.cs
@@ -11,12 +11,12 @@ namespace WalletWasabi.Blockchain.Analysis;
 /// </summary>
 public class LongHolder
 {
-	public long Long { get; }
-
 	public LongHolder(long l)
 	{
 		Long = l;
 	}
+
+	public long Long { get; }
 
 	public override string ToString() => Long.ToString();
 }

--- a/WalletWasabi/Blockchain/Analysis/LongHolder.cs
+++ b/WalletWasabi/Blockchain/Analysis/LongHolder.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Blockchain.Analysis;
+
+/// <summary>
+/// Helper class that holds a long, but intentionally does not implement equality and comparability.
+/// </summary>
+public class LongHolder
+{
+	public long Long { get; }
+
+	public LongHolder(long l)
+	{
+		Long = l;
+	}
+
+	public override string ToString() => Long.ToString();
+}


### PR DESCRIPTION
Proof of Concept of https://github.com/zkSNACKs/WalletWasabi/pull/8604#issuecomment-1197894226

ToDo: it's ugly and slow and has only one unit test

Retults: the gains aren't impressing me. Adds 1% to my privacy percentage