### PR TITLE
[VDG] Trace all info in exception on app crash

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -103,7 +103,7 @@ public class Program
 
 					Logger.LogError(ex);
 
-					RxApp.MainThreadScheduler.Schedule(() => throw ex);
+					RxApp.MainThreadScheduler.Schedule(() => throw new ApplicationException("Command execution crashed", ex));
 				});
 
 			Logger.LogSoftwareStarted("Wasabi GUI");

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -103,7 +103,7 @@ public class Program
 
 					Logger.LogError(ex);
 
-					RxApp.MainThreadScheduler.Schedule(() => throw new ApplicationException("Command execution crashed", ex));
+					RxApp.MainThreadScheduler.Schedule(() => throw new ApplicationException("Exception has been thrown in unobserved ThrownExceptions", ex));
 				});
 
 			Logger.LogSoftwareStarted("Wasabi GUI");

--- a/WalletWasabi.Fluent/CrashReport/ViewModels/CrashReportWindowViewModel.cs
+++ b/WalletWasabi.Fluent/CrashReport/ViewModels/CrashReportWindowViewModel.cs
@@ -40,8 +40,7 @@ public class CrashReportWindowViewModel : ViewModelBase
 
 	public string Caption => $"A problem has occurred and Wasabi is unable to continue.";
 
-	public string Trace => $"{SerializedException.Message}{Environment.NewLine}" +
-						   $"{Environment.NewLine}{SerializedException.StackTrace}";
+	public string Trace => SerializedException.ToString();
 
 	public string Title => "Wasabi has crashed";
 }

--- a/WalletWasabi/Models/SerializableException.cs
+++ b/WalletWasabi/Models/SerializableException.cs
@@ -50,4 +50,14 @@ public record SerializableException
 		var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64String));
 		return JsonConvert.DeserializeObject<SerializableException>(json);
 	}
+
+	public override string ToString()
+	{
+		return string.Join(
+			Environment.NewLine + Environment.NewLine,
+			$"Exception type: {ExceptionType}",
+			$"Message: {Message}",
+			$"Stack Trace: {StackTrace}",
+			$"Inner Exception: {InnerException}");
+	}
 }


### PR DESCRIPTION
I made modifications so we don't lose important information when a crash happens.

The stack trace was being ovewritten, so we never had the chance to see what really happened.

To illustrate the fix, here is what the Crash Reporter shows to the user with and without this fix.

## Without the fix

> Wallet with the same name was already added: Wallet 24.
> 
>    at WalletWasabi.Fluent.Desktop.Program.<>c__DisplayClass1_1.<Main>b__4() in WalletWasabi.Fluent.Desktop\Program.cs:line 106
>    at System.Reactive.Concurrency.Scheduler.Invoke(Action action) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 253
>    at System.Reactive.Concurrency.Scheduler.<>c.<Schedule>b__74_0(IScheduler _, Action a) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 37
>    at Avalonia.Threading.AvaloniaScheduler.Schedule[TState](TState state, TimeSpan dueTime, Func`3 action) in /_/src/Avalonia.Base/Threading/AvaloniaScheduler.cs:line 73
>    at System.Reactive.Concurrency.LocalScheduler.Schedule[TState](TState state, Func`3 action) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.cs:line 32
>    at System.Reactive.Concurrency.Scheduler.Schedule(IScheduler scheduler, Action action) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 37
>    at WalletWasabi.Fluent.Desktop.Program.<>c.<Main>b__1_1(Exception ex) in WalletWasabi.Fluent.Desktop\Program.cs:line 106
>    at System.Reactive.AnonymousSafeObserver`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousSafeObserver.cs:line 54
>    at System.Reactive.ObserveOnObserverNew`1.DrainStep(ConcurrentQueue`1 q) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 561
>    at System.Reactive.ObserveOnObserverNew`1.DrainShortRunning(IScheduler recursiveScheduler) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 507
>    at System.Reactive.ObserveOnObserverNew`1.<>c.<.cctor>b__17_0(IScheduler scheduler, ObserveOnObserverNew`1 self) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 497
>    at Avalonia.Threading.AvaloniaScheduler.<>c__DisplayClass4_1`1.<Schedule>b__1() in /_/src/Avalonia.Base/Threading/AvaloniaScheduler.cs:line 47
>    at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
>    at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 283
>    at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
>    at Avalonia.Win32.Win32Platform.RunLoop(CancellationToken cancellationToken) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 210
>    at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 65
>    at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 120
>    at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
>    at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop\Program.cs:line 110

## This PR
> Exception type: System.ApplicationException
> 
> Message: Command execution crashed
> 
> Stack Trace:    at WalletWasabi.Fluent.Desktop.Program.<>c__DisplayClass1_1.<Main>b__4() in WalletWasabi.Fluent.Desktop\Program.cs:line 106
>    at System.Reactive.Concurrency.Scheduler.Invoke(Action action) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 253
>    at System.Reactive.Concurrency.Scheduler.<>c.<Schedule>b__74_0(IScheduler _, Action a) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 37
>    at Avalonia.Threading.AvaloniaScheduler.Schedule[TState](TState state, TimeSpan dueTime, Func`3 action) in /_/src/Avalonia.Base/Threading/AvaloniaScheduler.cs:line 89
>    at System.Reactive.Concurrency.Scheduler.Schedule(IScheduler scheduler, Action action) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 37
>    at WalletWasabi.Fluent.Desktop.Program.<>c.<Main>b__1_1(Exception ex) in WalletWasabi.Fluent.Desktop\Program.cs:line 106
>    at System.Reactive.AnonymousSafeObserver`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousSafeObserver.cs:line 54
>    at System.Reactive.ObserveOnObserverNew`1.DrainStep(ConcurrentQueue`1 q) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 561
>    at System.Reactive.ObserveOnObserverNew`1.DrainShortRunning(IScheduler recursiveScheduler) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 507
>    at System.Reactive.ObserveOnObserverNew`1.<>c.<.cctor>b__17_0(IScheduler scheduler, ObserveOnObserverNew`1 self) in /_/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs:line 497
>    at Avalonia.Threading.AvaloniaScheduler.<>c__DisplayClass4_1`1.<Schedule>b__1() in /_/src/Avalonia.Base/Threading/AvaloniaScheduler.cs:line 45
>    at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
>    at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 283
>    at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
>    at Avalonia.Win32.Win32Platform.RunLoop(CancellationToken cancellationToken) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 210
>    at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 65
>    at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 120
>    at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
>    at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop\Program.cs:line 110
> 
> Inner Exception: Exception type: System.InvalidOperationException
> 
> Message: Wallet with the same name was already added: Wallet 23.
> 
> Stack Trace:    at WalletWasabi.Wallets.WalletManager.AddWallet(Wallet wallet) in WalletWasabi\Wallets\WalletManager.cs:line 231
>    at WalletWasabi.Wallets.WalletManager.AddWallet(KeyManager keyManager) in WalletWasabi\Wallets\WalletManager.cs:line 182
>    at WalletWasabi.Fluent.ViewModels.AddWallet.AddedWalletPageViewModel.OnNavigatedTo(Boolean isInHistory, CompositeDisposable disposables) in WalletWasabi.Fluent\ViewModels\AddWallet\AddedWalletPageViewModel.cs:line 55
>    at WalletWasabi.Fluent.ViewModels.Navigation.RoutableViewModel.DoNavigateTo(Boolean isInHistory) in WalletWasabi.Fluent\ViewModels\Navigation\RoutableViewModel.cs:line 54
>    at WalletWasabi.Fluent.ViewModels.Navigation.RoutableViewModel.OnNavigatedTo(Boolean isInHistory) in WalletWasabi.Fluent\ViewModels\Navigation\RoutableViewModel.cs:line 115
>    at WalletWasabi.Fluent.ViewModels.Navigation.NavigationStack`1.NavigationOperation(T oldPage, Boolean oldInStack, T newPage, Boolean newInStack) in WalletWasabi.Fluent\ViewModels\Navigation\NavigationStack.cs:line 47
>    at WalletWasabi.Fluent.ViewModels.Navigation.NavigationStack`1.Back() in WalletWasabi.Fluent\ViewModels\Navigation\NavigationStack.cs:line 172
>    at WalletWasabi.Fluent.ViewModels.Navigation.RoutableViewModel.NavigateDialogAsync[TResult](DialogViewModelBase`1 dialog, NavigationTarget target, NavigationMode navigationMode) in WalletWasabi.Fluent\ViewModels\Navigation\RoutableViewModel.cs:line 149
>    at WalletWasabi.Fluent.ViewModels.Navigation.RoutableViewModel.ShowErrorAsync(String title, String message, String caption) in WalletWasabi.Fluent\ViewModels\Navigation\RoutableViewModel.cs:line 162
>    at WalletWasabi.Fluent.ViewModels.AddWallet.WalletNamePageViewModel.ImportWalletAsync(String walletName, String filePath) in WalletWasabi.Fluent\ViewModels\AddWallet\WalletNamePageViewModel.cs:line 76
>    at WalletWasabi.Fluent.ViewModels.AddWallet.WalletNamePageViewModel.OnNextAsync(String walletName, WalletCreationOption creationOption) in WalletWasabi.Fluent\ViewModels\AddWallet\WalletNamePageViewModel.cs:line 59
>    at WalletWasabi.Fluent.ViewModels.AddWallet.WalletNamePageViewModel.<>c__DisplayClass2_0.<<-ctor>b__2>d.MoveNext() in WalletWasabi.Fluent\ViewModels\AddWallet\WalletNamePageViewModel.cs:line 37
> 
> Inner Exception: 

Please, notice how the current code doesn't show the correct stack trace. 
The new code shows the exception and the inner exception, that contains all the relevant information we need to track down the issues like https://github.com/zkSNACKs/WalletWasabi/issues/8783

# Verifying the fix
To help you reproduce the issue, please download the following .zip file, extract the wallet (.json) and try to import it into Wasabi. 