### PR TITLE
`HttpMessageHelper`: Change exception being thrown

### DIFF
--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -430,34 +430,24 @@ public static class HttpMessageHelper
 		}
 	}
 
-	private static async Task<byte[]> ReadBytesTillLengthAsync(Stream stream, long length, CancellationToken ctsToken)
+	/// <seealso href="https://tools.ietf.org/html/rfc7230#section-3.3.3">See point 5.</seealso>
+	/// <seealso href="https://tools.ietf.org/html/rfc7230#section-3.4"/>
+	private static async Task<byte[]> ReadBytesTillLengthAsync(Stream stream, long contentLength, CancellationToken ctsToken)
 	{
-		try
+		if (contentLength < int.MinValue || contentLength > int.MaxValue)
 		{
-			Convert.ToInt32(length);
-		}
-		catch (OverflowException ex)
-		{
-			throw new NotSupportedException($"Content-Length too long: {length}.", ex);
+			throw new NotSupportedException($"Content-Length is out of range: {contentLength}.");
 		}
 
-		var allData = new byte[(int)length];
-		int num = await stream.ReadBlockAsync(allData, (int)length, ctsToken).ConfigureAwait(false);
-		if (num < (int)length)
+		int length = (int)contentLength;
+		byte[] allData = new byte[length];
+
+		int num = await stream.ReadBlockAsync(allData, length, ctsToken).ConfigureAwait(false);
+		if (num < length)
 		{
-			// https://tools.ietf.org/html/rfc7230#section-3.3.3
-			// If the sender closes the connection or
-			// the recipient times out before the indicated number of octets are
-			// received, the recipient MUST consider the message to be
-			// incomplete and close the connection.
-			// https://tools.ietf.org/html/rfc7230#section-3.4
-			// A client that receives an incomplete response message, which can
-			// occur when a connection is closed prematurely or when decoding a
-			// supposedly chunked transfer coding fails, MUST record the message as
-			// incomplete.Cache requirements for incomplete responses are defined
-			// in Section 3 of[RFC7234].
-			throw new NotSupportedException($"Incomplete message. Expected length: {length}. Actual: {num}.");
+			throw new TorConnectionReadException($"Incomplete message. A Tor circuit probably died. Expected length: {length}. Actual: {num}.");
 		}
+
 		return allData;
 	}
 

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -78,10 +78,7 @@ public class TorHttpPool : IDisposable
 	/// <param name="e">Tor exception.</param>
 	private void OnTorRequestFailed(Exception e)
 	{
-		if (TorDoesntWorkSince is null)
-		{
-			TorDoesntWorkSince = DateTimeOffset.UtcNow;
-		}
+		TorDoesntWorkSince ??= DateTimeOffset.UtcNow;
 
 		if (e is HttpRequestException)
 		{


### PR DESCRIPTION
Related to #6215

This PR changes the exception being thrown in `HttpMessageHelper` from `NotSupportedException` (denoting unexpected failure) to `TorConnectionReadException` (denoting failure that is expected to happen from time to time).

The reason for this change is this (combined) log:

```log
Jul 28 09:23:00.824 [info] circuit_launch_by_extend_info(): Cannibalizing circ 2258840194 (id: 249) for purpose 9 (Hidden service client: Establishing rendezvous point)
Jul 28 09:23:00.852 [info] connection_ap_handshake_attach_circuit(): Intro 3003528868 (id: 256) and rend circuit 2258840194 (id: 249) circuits are not both ready. Stalling conn. (0 sec old)
Jul 28 09:23:01.957 [info] connection_ap_handshake_attach_circuit(): Intro 3003528868 (id: 256) and rend circuit 2258840194 (id: 249) circuits are not both ready. Stalling conn. (1 sec old)
Jul 28 09:23:02.816 [info] connection_ap_handshake_attach_circuit(): Intro 3003528868 (id: 256) and rend circuit 2258840194 (id: 249) circuits are not both ready. Stalling conn. (2 sec old)
Jul 28 09:23:03.383 [info] connection_ap_handshake_attach_circuit(): ready rend circ 2258840194 (id: 249) already here. Nointro-ack yet on intro 3003528868 (id: 256). (stream 3 sec old)
Jul 28 09:23:03.383 [info] connection_ap_handshake_attach_circuit(): Found open intro circ 3003528868 (id: 256). Rend circuit 2258840194 (id: 249); Sending introduction. (stream 3 sec old)
Jul 28 09:23:03.837 [info] connection_ap_handshake_attach_circuit(): pending-join circ 2258840194 (id: 249) already here, with intro ack. Stalling. (stream 3 sec old)
Jul 28 09:23:04.127 [info] connection_ap_handshake_attach_circuit(): pending-join circ 2258840194 (id: 249) already here, with intro ack. Stalling. (stream 4 sec old)
Jul 28 09:23:04.173 [info] connection_ap_handshake_attach_circuit(): pending-join circ 2258840194 (id: 249) already here, with intro ack. Stalling. (stream 4 sec old)
Jul 28 09:23:05.219 [info] connection_ap_handshake_attach_circuit(): rend joined circ 2258840194 (id: 249) already here. Attaching. (stream 5 sec old)

Jul 28 09:27:51.836 [info] circuit_mark_for_close_(): Circuit 0 (id: 249) marked for close at circuitlist.c:1668 (orig reason: 520, new reason: 0)
Jul 28 09:27:51.836 [info] circuit_free_(): Circuit 0 (id: 249) has been freed.

2022-07-28 09:27:51.859 [86] TRACE	PipeReaderLineReaderExtension.ReadLineAsync (61)	Read message: '650 CIRC 249 CLOSED $EB71BDDA9686108C48C21F9A48403B2B0F793231~relay05V6Rocks,$D08660B6D70B6249A57D89BB7A8F2EA2C952BD35~SNTor,$0A592CE8A53AECDF9130D37245C6460B238728DF~Sturmvogel BUILD_FLAGS=IS_INTERNAL,NEED_CAPACITY,NEED_UPTIME PURPOSE=HS_CLIENT_REND HS_STATE=HSCR_JOINED REND_QUERY=wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad TIME_CREATED=2022-07-28T07:21:36.244723 SOCKS_USERNAME="H22AO0HUO0D61YES8MQZO" SOCKS_PASSWORD="H22AO0HUO0D61YES8MQZO" REASON=DESTROYED REMOTE_REASON=CHANNEL_CLOSED'
2022-07-28 09:27:51.860 [23] TRACE	TorHttpPool.ReportCircuitStatus (444)	Tor circuit was closed: #249 ('[PersonCircuit: H22AO0HUO0D61YES8MQZO]').

2022-07-28 09:27:51.891 [88] TRACE	TorHttpPool.SendAsync (195)	['PC#0004#H22AO0HUO0'] Could not get/read an HTTP response from Tor. Exception: WalletWasabi.Tor.Socks5.Exceptions.TorConnectionReadException: Could not read HTTP response.
 ---> System.NotSupportedException: Incomplete message. Expected length: 2275. Actual: 1987.
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.ReadBytesTillLengthAsync(Stream stream, Int64 length, CancellationToken ctsToken) in WalletWasabi\Tor\Http\Helpers\HttpMessageHelper.cs:line 459
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.GetDecodedChunkedContentBytesAsync(Stream stream, HttpRequestContentHeaders requestHeaders, HttpResponseContentHeaders responseHeaders, CancellationToken ctsToken) in WalletWasabi\Tor\Http\Helpers\HttpMessageHelper.cs:line 291
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.GetDecodedChunkedContentBytesAsync(Stream stream, HttpResponseContentHeaders headerStruct, CancellationToken ctsToken) in WalletWasabi\Tor\Http\Helpers\HttpMessageHelper.cs:line 240
   at WalletWasabi.Tor.Http.Helpers.HttpMessageHelper.GetContentBytesAsync(Stream stream, HttpResponseContentHeaders headerStruct, HttpMethod requestMethod, StatusLine statusLine, CancellationToken ctsToken) in WalletWasabi\Tor\Http\Helpers\HttpMessageHelper.cs:line 203
   at WalletWasabi.Tor.Http.Extensions.HttpResponseMessageExtensions.CreateNewAsync(Stream responseStream, HttpMethod requestMethod, CancellationToken cancellationToken) in WalletWasabi\Tor\Http\Extensions\HttpResponseMessageExtensions.cs:line 50
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 403
   --- End of inner exception stack trace ---
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendCoreAsync(TorTcpConnection connection, HttpRequestMessage request, CancellationToken token) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 407
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken) in WalletWasabi\Tor\Socks5\Pool\TorHttpPool.cs:line 169
```

Basically, some Tor circuit `249` was closed due to some network issue (was the relay terminated? or disconnected somehow? IDK) and as such we did not get all data back. 

Expected behavior is that `TorHttpPool` will catch the new `TorConnectionReadException` exception and repeat the request again.

## Resources

* https://github.com/torproject/torspec/blob/b5e2002983fc4682b88fedb73a9101cc8090b053/tor-spec.txt#L1538-L1554
* https://github.com/torproject/tor/blob/7528524aee3ffe3c9b7c69fa18f659e1993f59a3/src/core/or/circuitlist.c#L1668


cc @yahiheb (because he seemed to experience #6215 the most)