### PR TITLE
`TorSettings`: Use `KeepAliveIsolateSOCKSAuth` flag

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -22,7 +22,7 @@ public class TorSettingsTests
 		string expected = string.Join(
 			" ",
 			$"--LogTimeGranularity 1",
-			$"--SOCKSPort \"127.0.0.1:37150 KeepAliveIsolateSOCKSAuth ExtendedErrors\"",
+			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--CookieAuthentication 1",
 			$"--ControlPort 37151",
 			$"--CookieAuthFile \"{Path.Combine("temp", "tempDataDir", "control_auth_cookie")}\"",

--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -22,7 +22,7 @@ public class TorSettingsTests
 		string expected = string.Join(
 			" ",
 			$"--LogTimeGranularity 1",
-			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors\"",
+			$"--SOCKSPort \"127.0.0.1:37150 KeepAliveIsolateSOCKSAuth ExtendedErrors\"",
 			$"--CookieAuthentication 1",
 			$"--ControlPort 37151",
 			$"--CookieAuthFile \"{Path.Combine("temp", "tempDataDir", "control_auth_cookie")}\"",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -81,6 +81,10 @@ public class TorSettings
 		return platform == OSPlatform.OSX ? $"{TorBinaryFileName}.real" : TorBinaryFileName;
 	}
 
+	/// <seealso href="https://github.com/torproject/tor/blob/7528524aee3ffe3c9b7c69fa18f659e1993f59a3/doc/man/tor.1.txt#L1505-L1509">For <c>KeepAliveIsolateSOCKSAuth</c> explanation.</seealso>
+	/// <seealso href="https://github.com/torproject/tor/blob/22cb4c23d0d23dfda2c91817bac74a01831f94af/doc/man/tor.1.txt#L1298-L1305">
+	/// Explains <c>MaxCircuitDirtiness</c> parameter which is affected by the <c>KeepAliveIsolateSOCKSAuth</c> flag.
+	/// </seealso>
 	public string GetCmdArguments()
 	{
 		// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -87,7 +87,7 @@ public class TorSettings
 		List<string> arguments = new()
 		{
 			$"--LogTimeGranularity 1",
-			$"--SOCKSPort \"{SocksEndpoint} KeepAliveIsolateSOCKSAuth ExtendedErrors\"",
+			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--CookieAuthentication 1",
 			$"--ControlPort {ControlEndpoint.Port}",
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -87,7 +87,7 @@ public class TorSettings
 		List<string> arguments = new()
 		{
 			$"--LogTimeGranularity 1",
-			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors\"",
+			$"--SOCKSPort \"{SocksEndpoint} KeepAliveIsolateSOCKSAuth ExtendedErrors\"",
 			$"--CookieAuthentication 1",
 			$"--ControlPort {ControlEndpoint.Port}",
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",


### PR DESCRIPTION
My hope is that we might alleviate the signing issue with this PR. The change is trivial but the implications might affect privacy so please review carefully.

## Intro

This is the signing issue as I can see it in logs:

```log
2022-07-29 18:25:16.953 [29] TRACE	TorHttpPool.ReportCircuitStatus (436)	Tor circuit was built: #531 ('[PersonCircuit: TQ98BYW60WN3E5GYEZL91]').
// NOTE THAT TEN MINUTES ELAPSED!
2022-07-29 18:35:37.116 [52] TRACE	TorHttpPool.ObtainFreeConnectionAsync (281)	> request='http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/transaction-signature', circuit=[PersonCircuit: TQ98BYW60WN3E5GYEZL91]
2022-07-29 18:35:37.116 [52] TRACE	TorHttpPool.ObtainFreeConnectionAsync (297)	[OLD PC#0089#TQ98BYW60W]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/transaction-signature'] Re-use existing Tor SOCKS5 connection.
2022-07-29 18:35:37.117 [52] TRACE	TorHttpPool.SendAsync (165)	['PC#0089#TQ98BYW60W'][Attempt #1] About to send request.
2022-07-29 18:35:37.118 [52] TRACE	TorHttpPool.SendAsync (189)	['PC#0089#TQ98BYW60W'] TCP connection from the pool is probably dead as we can't write data to the connection. Exception: WalletWasabi.Tor.Socks5.Exceptions.TorConnectionWriteException: Could not use transport stream to write data.
 ---> System.IO.IOException: Unable to write data to the transport connection: An established connection was aborted by the software in your host machine..
 ---> System.Net.Sockets.SocketException (10053): An established connection was aborted by the software in your host machine.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
```

And so what seems to happen is that we create a Tor circuit that is supposed to live for some time (e.g. `PersonCircuit`) and we keep re-using the Tor circuit to hit the [10 minutes dirtiness timeout](https://github.com/torproject/tor/blob/22cb4c23d0d23dfda2c91817bac74a01831f94af/doc/man/tor.1.txt#L1298-L1305). Note in the logs above that it fails after about 10 minutes. 

So the idea is to avoid this Tor circuit closing when the Tor circuit is in use. 

Current behavior: 

* You create a Tor circuit
* You send some HTTP requests
* After ten minutes the Tor circuit is destroyed always

New behavior:

* You create a Tor circuit
* You send some HTTP requests
* **Ten minutes after the last HTTP request is sent, the Tor circuit is destroyed.**

## Tor man

https://github.com/torproject/tor/blob/22cb4c23d0d23dfda2c91817bac74a01831f94af/doc/man/tor.1.txt#L1505-L1509

>     **KeepAliveIsolateSOCKSAuth**;;
>         If **IsolateSOCKSAuth** is enabled, keep alive circuits while they have
>         at least one stream with SOCKS authentication active. After such a
>         circuit is idle for more than MaxCircuitDirtiness seconds, it can be
>         closed.
(Note that [IsolateSOCKSAuth](https://github.com/torproject/tor/blob/22cb4c23d0d23dfda2c91817bac74a01831f94af/doc/man/tor.1.txt#L1488-L1493) is ON by default.)

https://github.com/torproject/tor/blob/22cb4c23d0d23dfda2c91817bac74a01831f94af/doc/man/tor.1.txt#L1298-L1305

> [[MaxCircuitDirtiness]] **MaxCircuitDirtiness** __NUM__::
>     Feel free to reuse a circuit that was first used at most NUM seconds ago,
>     but never attach a new stream to a circuit that is too old.  For hidden
>     services, this applies to the __last__ time a circuit was used, not the
>     first. Circuits with streams constructed with SOCKS authentication via
>     SocksPorts that have **KeepAliveIsolateSOCKSAuth** also remain alive
>     for MaxCircuitDirtiness seconds after carrying the last such stream.
>     (Default: 10 minutes) 
