### PR TITLE
`WasabiSynchronizer`: Fix exception being handled.

### DIFF
--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -219,7 +219,7 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 					{
 						Logger.LogInfo("Wasabi Synchronizer execution was canceled.");
 					}
-					catch (TorConnectionException ex)
+					catch (HttpRequestException ex) when (ex.InnerException is TorConnectionException)
 					{
 						// When stopping, we do not want to wait.
 						if (!IsRunning)


### PR DESCRIPTION
Yahia's [comment ](https://github.com/zkSNACKs/WalletWasabi/pull/8810#issuecomment-1200053304) shows that we do not handle proper exception and thus when stopping WW we might show an exception stacktrace when it's not needed. 

This PR should correct that slightly.