### PR TITLE
Suport taproot

### DIFF
--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -105,11 +105,11 @@ public static class BitcoinFactory
 		if (key is null)
 		{
 			using Key k = new();
-			return k.PubKey.WitHash.ScriptPubKey;
+			return k.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 		}
 		else
 		{
-			return key.PubKey.WitHash.ScriptPubKey;
+			return key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 		}
 	}
 

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -53,7 +53,8 @@ public static class WabiSabiFactory
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			GetOwnershipIdentifier(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
-			new CoinJoinInputCommitmentData(CoordinatorIdentifier, roundHash ?? BitcoinFactory.CreateUint256()));
+			new CoinJoinInputCommitmentData(CoordinatorIdentifier, roundHash ?? BitcoinFactory.CreateUint256()),
+			ScriptPubKeyType.Segwit);
 
 	public static OwnershipIdentifier GetOwnershipIdentifier(Script scriptPubKey)
 	{

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -34,7 +34,7 @@ public static class WabiSabiFactory
 	{
 		key ??= new();
 		amount ??= Money.Coins(1);
-		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.WitHash.ScriptPubKey));
+		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)));
 	}
 
 	public static Tuple<Coin, OwnershipProof> CreateCoinWithOwnershipProof(Key? key = null, Money? amount = null, uint256? roundId = null)
@@ -52,7 +52,7 @@ public static class WabiSabiFactory
 	public static OwnershipProof CreateOwnershipProof(Key key, uint256? roundHash = null)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
-			GetOwnershipIdentifier(key.PubKey.WitHash.ScriptPubKey),
+			GetOwnershipIdentifier(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
 			new CoinJoinInputCommitmentData(CoordinatorIdentifier, roundHash ?? BitcoinFactory.CreateUint256()));
 
 	public static OwnershipIdentifier GetOwnershipIdentifier(Script scriptPubKey)

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -30,17 +30,17 @@ namespace WalletWasabi.Tests.Helpers;
 
 public static class WabiSabiFactory
 {
-	public static Coin CreateCoin(Key? key = null, Money? amount = null)
+	public static Coin CreateCoin(Key? key = null, Money? amount = null, ScriptPubKeyType scriptPubKeyType = ScriptPubKeyType.Segwit)
 	{
 		key ??= new();
 		amount ??= Money.Coins(1);
-		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)));
+		return new(new OutPoint(Hashes.DoubleSHA256(key.PubKey.ToBytes()), 0), new TxOut(amount, key.PubKey.GetScriptPubKey(scriptPubKeyType)));
 	}
 
-	public static Tuple<Coin, OwnershipProof> CreateCoinWithOwnershipProof(Key? key = null, Money? amount = null, uint256? roundId = null)
+	public static Tuple<Coin, OwnershipProof> CreateCoinWithOwnershipProof(Key? key = null, Money? amount = null, uint256? roundId = null, ScriptPubKeyType scriptPubKeyType = ScriptPubKeyType.Segwit)
 	{
 		key = key ?? new();
-		var coin = WabiSabiFactory.CreateCoin(key, amount);
+		var coin = WabiSabiFactory.CreateCoin(key, amount, scriptPubKeyType);
 		roundId ??= uint256.One;
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, roundId);
 		return new Tuple<Coin, OwnershipProof>(coin, ownershipProof);
@@ -49,12 +49,12 @@ public static class WabiSabiFactory
 	public static CoinJoinInputCommitmentData CreateCommitmentData(uint256? RoundId = null)
 		=> new CoinJoinInputCommitmentData(CoordinatorIdentifier, RoundId ?? uint256.One);
 
-	public static OwnershipProof CreateOwnershipProof(Key key, uint256? roundHash = null)
+	public static OwnershipProof CreateOwnershipProof(Key key, uint256? roundHash = null, ScriptPubKeyType scriptPubKeyType = ScriptPubKeyType.Segwit)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
-			GetOwnershipIdentifier(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
+			GetOwnershipIdentifier(key.PubKey.GetScriptPubKey(scriptPubKeyType)),
 			new CoinJoinInputCommitmentData(CoordinatorIdentifier, roundHash ?? BitcoinFactory.CreateUint256()),
-			ScriptPubKeyType.Segwit);
+			scriptPubKeyType);
 
 	public static OwnershipIdentifier GetOwnershipIdentifier(Script scriptPubKey)
 	{
@@ -124,8 +124,8 @@ public static class WabiSabiFactory
 	public static Alice CreateAlice(Coin coin, OwnershipProof ownershipProof, Round round)
 		=> new(coin, ownershipProof, round, Guid.NewGuid(), false) { Deadline = DateTimeOffset.UtcNow + TimeSpan.FromHours(1) };
 
-	public static Alice CreateAlice(Key key, Money amount, Round round)
-		=> CreateAlice(CreateCoin(key, amount), CreateOwnershipProof(key, round.Id), round);
+	public static Alice CreateAlice(Key key, Money amount, Round round, ScriptPubKeyType scriptPubKeyType = ScriptPubKeyType.Segwit)
+		=> CreateAlice(CreateCoin(key, amount, scriptPubKeyType), CreateOwnershipProof(key, round.Id, scriptPubKeyType), round);
 
 	public static Alice CreateAlice(Money amount, Round round)
 	{
@@ -133,8 +133,8 @@ public static class WabiSabiFactory
 		return CreateAlice(key, amount, round);
 	}
 
-	public static Alice CreateAlice(Key key, Round round)
-		=> CreateAlice(key, Money.Coins(1), round);
+	public static Alice CreateAlice(Key key, Round round, ScriptPubKeyType scriptPubKeyType = ScriptPubKeyType.Segwit)
+		=> CreateAlice(key, Money.Coins(1), round, scriptPubKeyType);
 
 	public static Alice CreateAlice(Round round)
 	{

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -588,7 +588,7 @@ public class SendTests
 			Assert.Equal(2, tx1Res.OuterWalletOutputs.Count());
 
 			// Spend the unconfirmed coin (send it to ourself)
-			operations = new PaymentIntent(key.PubKey.WitHash.ScriptPubKey, Money.Coins(0.5m));
+			operations = new PaymentIntent(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(0.5m));
 			tx1Res = wallet.BuildTransaction(password, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy, allowUnconfirmed: true);
 			eventAwaiter = new EventAwaiter<ProcessedResult>(
 				h => wallet.TransactionProcessor.WalletRelevantTransactionProcessed += h,
@@ -612,7 +612,7 @@ public class SendTests
 			Assert.Equal((1 * Money.COIN) - tx1Res.Fee.Satoshi, totalWallet);
 
 			// Spend the unconfirmed and unspent coin (send it to ourself)
-			operations = new PaymentIntent(key.PubKey.WitHash.ScriptPubKey, Money.Coins(0.6m), subtractFee: true);
+			operations = new PaymentIntent(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(0.6m), subtractFee: true);
 			var tx2Res = wallet.BuildTransaction(password, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy, allowUnconfirmed: true);
 
 			eventAwaiter = new EventAwaiter<ProcessedResult>(

--- a/WalletWasabi.Tests/UnitTests/Crypto/Bip322SignatureTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/Bip322SignatureTest.cs
@@ -65,4 +65,53 @@ public class Bip322SignatureTest
 		invalidBip322Signature = new Bip322Signature(bip322Signature.ScriptSig, new WitScript(new List<byte[]> { signature, invalidPubKey }));
 		Assert.False(invalidBip322Signature.Verify(message, scriptPubKey));
 	}
+
+	[Fact]
+	public void P2trBip322SignatureEncodingDecoding()
+	{
+		// [all all all all all all all all all all all all]/86'/0'/0'/1/0
+		using var key = new Key(Encoders.Hex.DecodeData("E4E13C6ACF002C94D5EE25E89F419531A52A39F93B00B71349C4889E046BBA3C"));
+		var message = new uint256(Encoders.Hex.DecodeData("BB06B6D65C9F4A1D245F203EB039A735D94D3ECA3E19B04DA59956413F5D5C8F"), false);
+		var bip322Signature = Bip322Signature.Generate(key, message, ScriptPubKeyType.TaprootBIP86);
+
+		var bip322SignatureBytes = Encoders.Hex.DecodeData("000140671520C782E52D070309579BA1FEE3889EB32D2E812A32B4899193233E5856E824014C17F68AB354BC4964AABBC957FE33AC557E2B3386923F3ED7A019DCC0C6");
+
+		Assert.True(bip322SignatureBytes.SequenceEqual(bip322Signature.ToBytes()));
+		var bip322SignatureDeserialized = Bip322Signature.FromBytes(bip322SignatureBytes);
+		Assert.True(bip322SignatureBytes.SequenceEqual(bip322SignatureDeserialized.ToBytes()));
+	}
+
+	[Fact]
+	public void P2trBip322SignatureVerification()
+	{
+		// [all all all all all all all all all all all all]/86'/0'/0'/1/0
+		using var key = new Key(Encoders.Hex.DecodeData("E4E13C6ACF002C94D5EE25E89F419531A52A39F93B00B71349C4889E046BBA3C"));
+		var message = new uint256(Encoders.Hex.DecodeData("BB06B6D65C9F4A1D245F203EB039A735D94D3ECA3E19B04DA59956413F5D5C8F"), false);
+
+		var bip322Signature = Bip322Signature.Generate(key, message, ScriptPubKeyType.TaprootBIP86);
+		var signature = bip322Signature.Witness[0];
+		var scriptPubKey = key.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86);
+
+		// Valid signature
+		Assert.True(bip322Signature.Verify(message, scriptPubKey));
+
+		byte[] invalidSignature;
+		Bip322Signature invalidBip322Signature;
+
+		// Invalid signature, modified scriptsig
+		invalidBip322Signature = new Bip322Signature(new Script(new byte[] { 0x00 }), bip322Signature.Witness);
+		Assert.False(invalidBip322Signature.Verify(message, scriptPubKey));
+
+		// Invalid signature, modified length field of signature in witness
+		invalidSignature = signature.ToArray();
+		invalidSignature[2] = 30;
+		invalidBip322Signature = new Bip322Signature(bip322Signature.ScriptSig, new WitScript(new List<byte[]> { invalidSignature }));
+		Assert.False(invalidBip322Signature.Verify(message, scriptPubKey));
+
+		// Invalid signature, Modified r part of signature in witness
+		invalidSignature = signature.ToArray();
+		invalidSignature[4] ^= 1;
+		invalidBip322Signature = new Bip322Signature(bip322Signature.ScriptSig, new WitScript(new List<byte[]> { invalidSignature }));
+		Assert.False(invalidBip322Signature.Verify(message, scriptPubKey));
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Crypto/Bip322SignatureTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/Bip322SignatureTest.cs
@@ -10,7 +10,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto;
 public class Bip322SignatureTest
 {
 	[Fact]
-	public void Bip322SignatureEncodingDecoding()
+	public void P2wpkhBip322SignatureEncodingDecoding()
 	{
 		// [all all all all all all all all all all all all]/84'/0'/0'/1/0
 		using var key = new Key(Encoders.Hex.DecodeData("3460814214450E864EC722FF1F84F96C41746CD6BBE2F1C09B33972761032E9F"));
@@ -25,7 +25,7 @@ public class Bip322SignatureTest
 	}
 
 	[Fact]
-	public void Bip322SignatureVerification()
+	public void P2wpkhBip322SignatureVerification()
 	{
 		// [all all all all all all all all all all all all]/84'/0'/0'/1/0
 		using var key = new Key(Encoders.Hex.DecodeData("3460814214450E864EC722FF1F84F96C41746CD6BBE2F1C09B33972761032E9F"));

--- a/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
@@ -25,7 +25,6 @@ public class OwnershipProofTest
 
 		var commitmentData = Array.Empty<byte>();
 		var ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, false, ScriptPubKeyType.Segwit);
-		var scriptPubKey = key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 		var ownershipProofBytes = Encoders.Hex.DecodeData("534c00190001a122407efc198211c81af4450f40b235d54775efd934d16b9e31c6ce9bad57070002483045022100c0dc28bb563fc5fea76cacff75dba9cb4122412faae01937cdebccfb065f9a7002202e980bfbd8a434a7fc4cd2ca49da476ce98ca097437f8159b1a386b41fcdfac50121032ef68318c8f6aaa0adec0199c69901f0db7d3485eb38d9ad235221dc3d61154b");
 

--- a/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
@@ -97,4 +97,92 @@ public class OwnershipProofTest
 
 		Assert.False(invalidOwnershipProof.VerifyOwnership(scriptPubKey, commitmentData, false));
 	}
+
+	[Fact]
+	public void P2trOwnershipProofEncodingDecoding()
+	{
+		// SLIP-19 test vector
+		// See https://github.com/satoshilabs/slips/blob/846a0a6c1dfc29f8b90fd90a9309b1174b7d91e8/slip-0019.md#test-vector-5-p2tr
+		// [all all all all all all all all all all all all]/86'/0'/0'/1/0
+		var allMnemonic = new Mnemonic("all all all all all all all all all all all all");
+		var identificationMasterKey = Slip21Node.FromSeed(allMnemonic.DeriveSeed());
+		var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019").DeriveChild("Ownership identification key").Key;
+		using var key = new Key(Encoders.Hex.DecodeData("E4E13C6ACF002C94D5EE25E89F419531A52A39F93B00B71349C4889E046BBA3C"));
+
+		var ownershipIdentifier = new OwnershipIdentifier(identificationKey, key.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86));
+		var ownershipIdentifierBytes = Encoders.Hex.DecodeData("DC18066224B9E30E306303436DC18AB881C7266C13790350A3FE415E438135EC");
+		Assert.True(ownershipIdentifierBytes.SequenceEqual(ownershipIdentifier.ToBytes()));
+
+		var commitmentData = Array.Empty<byte>();
+		var ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, false, ScriptPubKeyType.TaprootBIP86);
+		var ownershipProofBytes = Encoders.Hex.DecodeData("534C00190001DC18066224B9E30E306303436DC18AB881C7266C13790350A3FE415E438135EC000140647D6AF883107A870417E808ABE424882BD28EE04A28BA85A7E99400E1B9485075733695964C2A0FA02D4439AB80830E9566CCBD10F2597F5513EFF9F03A0497");
+
+		Assert.True(ownershipProofBytes.SequenceEqual(ownershipProof.ToBytes()));
+		var deserializedOwnershipProof = OwnershipProof.FromBytes(ownershipProofBytes);
+		Assert.True(ownershipProofBytes.SequenceEqual(deserializedOwnershipProof.ToBytes()));
+	}
+
+	[Fact]
+	public void P2trOwnershipProofVerification()
+	{
+		OwnershipProof ownershipProof, invalidOwnershipProof;
+		Script scriptPubKey;
+		byte[] commitmentData;
+
+		// SLIP-19 test vector
+		// See https://github.com/satoshilabs/slips/blob/846a0a6c1dfc29f8b90fd90a9309b1174b7d91e8/slip-0019.md#test-vector-5-p2tr
+		commitmentData = Encoders.Hex.DecodeData("");
+		scriptPubKey = Script.FromHex("51204102897557DE0CAFEA0A8401EA5B59668ECCB753E4B100AEBE6A19609F3CC79F");
+		var ownershipProofBytes = Encoders.Hex.DecodeData("534C00190001DC18066224B9E30E306303436DC18AB881C7266C13790350A3FE415E438135EC0001401B553E5B9CC787B531BBC78417AEA901272B4EA905136A2BABC4D6CA471549743B5E0E39DDC14E620B254E42FAA7F6D5BD953E97AA231D764D21BC5A58E8B7D9");
+		ownershipProof = OwnershipProof.FromBytes(ownershipProofBytes);
+		Assert.True(ownershipProof.VerifyOwnership(scriptPubKey, commitmentData, false));
+
+		// [all all all all all all all all all all all all]/86'/0'/0'/1/0
+		using var key = new Key(Encoders.Hex.DecodeData("E4E13C6ACF002C94D5EE25E89F419531A52A39F93B00B71349C4889E046BBA3C"));
+		var ownershipIdentifier = new OwnershipIdentifier(Encoders.Hex.DecodeData("DC18066224B9E30E306303436DC18AB881C7266C13790350A3FE415E438135EC"));
+		commitmentData = Encoders.Hex.DecodeData("A42E38EF564D4B05B65575D22553BB1F264332D77F8A61159ABF3E6179B0317C");
+		scriptPubKey = key.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86);
+
+		// Valid proofs
+		ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, true, ScriptPubKeyType.TaprootBIP86);
+		Assert.True(ownershipProof.VerifyOwnership(scriptPubKey, commitmentData, false));
+		Assert.True(ownershipProof.VerifyOwnership(scriptPubKey, commitmentData, true));
+
+		ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, false, ScriptPubKeyType.TaprootBIP86);
+		Assert.True(ownershipProof.VerifyOwnership(scriptPubKey, commitmentData, false));
+
+		// Valid proof, modified user confirmation flag
+		Assert.False(ownershipProof.VerifyOwnership(scriptPubKey, commitmentData, true));
+
+		// Valid proof, modified commitment data
+		var invalidCommitmentData = commitmentData.ToArray();
+		invalidCommitmentData[0] ^= 1;
+		Assert.False(ownershipProof.VerifyOwnership(scriptPubKey, invalidCommitmentData, false));
+
+		// Valid proof, invalid scriptPubKey
+		// [all all all all all all all all all all all all]/84'/0'/0'/1/1
+		using var invalidKey = new Key(Encoders.Hex.DecodeData("7B041DD735E7202D3C1B9592147894ED24DA6355F0CD66573C273C0DF1AFA78A"));
+		var invalidScriptPubKey = invalidKey.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86);
+		Assert.False(ownershipProof.VerifyOwnership(invalidScriptPubKey, commitmentData, false));
+
+		// Invalid proof, modified ownership identifier
+		var invalidOwnershipIdentifierBytes = ownershipIdentifier.ToBytes();
+		invalidOwnershipIdentifierBytes[0] ^= 1;
+
+		invalidOwnershipProof = new OwnershipProof(
+			new ProofBody(ownershipProof.ProofBody.Flags, new OwnershipIdentifier(invalidOwnershipIdentifierBytes)),
+			ownershipProof.ProofSignature);
+
+		Assert.False(invalidOwnershipProof.VerifyOwnership(scriptPubKey, commitmentData, false));
+
+		// Invalid proof, modified r part of signature in witness
+		var invalidSignature = ownershipProof.ProofSignature.Witness[0].ToArray();
+		invalidSignature[4] ^= 1;
+
+		invalidOwnershipProof = new OwnershipProof(
+			ownershipProof.ProofBody,
+			new Bip322Signature(ownershipProof.ProofSignature.ScriptSig, new WitScript(new byte[][] { invalidSignature })));
+
+		Assert.False(invalidOwnershipProof.VerifyOwnership(scriptPubKey, commitmentData, false));
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
@@ -18,7 +18,7 @@ public class OwnershipProofTest
 		var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019").DeriveChild("Ownership identification key").Key;
 		using var key = new Key(Encoders.Hex.DecodeData("3460814214450E864EC722FF1F84F96C41746CD6BBE2F1C09B33972761032E9F"));
 
-		var ownershipIdentifier = new OwnershipIdentifier(identificationKey, key.PubKey.WitHash.ScriptPubKey);
+		var ownershipIdentifier = new OwnershipIdentifier(identificationKey, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
 		var commitmentData = Array.Empty<byte>();
 		var ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, false, ScriptPubKeyType.Segwit);
 		var scriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(key.PubKey);

--- a/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
@@ -26,7 +26,7 @@ public class OwnershipProofTest
 		var commitmentData = Array.Empty<byte>();
 		var ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, false, ScriptPubKeyType.Segwit);
 
-		var ownershipProofBytes = Encoders.Hex.DecodeData("534c00190001a122407efc198211c81af4450f40b235d54775efd934d16b9e31c6ce9bad57070002483045022100c0dc28bb563fc5fea76cacff75dba9cb4122412faae01937cdebccfb065f9a7002202e980bfbd8a434a7fc4cd2ca49da476ce98ca097437f8159b1a386b41fcdfac50121032ef68318c8f6aaa0adec0199c69901f0db7d3485eb38d9ad235221dc3d61154b");
+		var ownershipProofBytes = Encoders.Hex.DecodeData("534C00190001A122407EFC198211C81AF4450F40B235D54775EFD934D16B9E31C6CE9BAD57070002483045022100C0DC28BB563FC5FEA76CACFF75DBA9CB4122412FAAE01937CDEBCCFB065F9A7002202E980BFBD8A434A7FC4CD2CA49DA476CE98CA097437F8159B1A386B41FCDFAC50121032EF68318C8F6AAA0ADEC0199C69901F0DB7D3485EB38D9AD235221DC3D61154B");
 
 		Assert.True(ownershipProofBytes.SequenceEqual(ownershipProof.ToBytes()));
 		var deserializedOwnershipProof = OwnershipProof.FromBytes(ownershipProofBytes);
@@ -72,7 +72,7 @@ public class OwnershipProofTest
 
 		// Valid proof, invalid scriptPubKey
 		// [all all all all all all all all all all all all]/84'/0'/0'/1/1
-		using var invalidKey = new Key(Encoders.Hex.DecodeData("7b041dd735e7202d3c1b9592147894ed24da6355f0cd66573c273c0df1afa78a"));
+		using var invalidKey = new Key(Encoders.Hex.DecodeData("7B041DD735E7202D3C1B9592147894ED24DA6355F0CD66573C273C0DF1AFA78A"));
 		var invalidScriptPubKey = invalidKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 		Assert.False(ownershipProof.VerifyOwnership(invalidScriptPubKey, commitmentData, false));

--- a/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.Tests.UnitTests.Crypto;
 public class OwnershipProofTest
 {
 	[Fact]
-	public void OwnershipProofEncodingDecoding()
+	public void P2wpkhOwnershipProofEncodingDecoding()
 	{
 		// SLIP-19 test vector
 		// See https://github.com/satoshilabs/slips/blob/846a0a6c1dfc29f8b90fd90a9309b1174b7d91e8/slip-0019.md#test-vector-1-p2wpkh
@@ -34,7 +34,7 @@ public class OwnershipProofTest
 	}
 
 	[Fact]
-	public void OwnershipProofVerification()
+	public void P2wpkhOwnershipProofVerification()
 	{
 		OwnershipProof ownershipProof, invalidOwnershipProof;
 		Script scriptPubKey;

--- a/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Crypto/OwnershipProofTest.cs
@@ -21,7 +21,7 @@ public class OwnershipProofTest
 		var ownershipIdentifier = new OwnershipIdentifier(identificationKey, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
 		var commitmentData = Array.Empty<byte>();
 		var ownershipProof = OwnershipProof.Generate(key, ownershipIdentifier, commitmentData, false, ScriptPubKeyType.Segwit);
-		var scriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(key.PubKey);
+		var scriptPubKey = key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 		var ownershipProofBytes = Encoders.Hex.DecodeData("534c00190001a122407efc198211c81af4450f40b235d54775efd934d16b9e31c6ce9bad57070002483045022100c0dc28bb563fc5fea76cacff75dba9cb4122412faae01937cdebccfb065f9a7002202e980bfbd8a434a7fc4cd2ca49da476ce98ca097437f8159b1a386b41fcdfac50121032ef68318c8f6aaa0adec0199c69901f0db7d3485eb38d9ad235221dc3d61154b");
 
@@ -37,7 +37,7 @@ public class OwnershipProofTest
 		using var key = new Key(Encoders.Hex.DecodeData("3460814214450E864EC722FF1F84F96C41746CD6BBE2F1C09B33972761032E9F"));
 		var ownershipIdentifier = new OwnershipIdentifier(Encoders.Hex.DecodeData("A122407EFC198211C81AF4450F40B235D54775EFD934D16B9E31C6CE9BAD5707"));
 		var commitmentData = Encoders.Hex.DecodeData("A42E38EF564D4B05B65575D22553BB1F264332D77F8A61159ABF3E6179B0317C");
-		var scriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(key.PubKey);
+		var scriptPubKey = key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 		OwnershipProof ownershipProof, invalidOwnershipProof;
 
@@ -60,7 +60,8 @@ public class OwnershipProofTest
 		// Valid proof, invalid scriptPubKey
 		// [all all all all all all all all all all all all]/84'/0'/0'/1/1
 		using var invalidKey = new Key(Encoders.Hex.DecodeData("7b041dd735e7202d3c1b9592147894ed24da6355f0cd66573c273c0df1afa78a"));
-		var invalidScriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(invalidKey.PubKey);
+		var invalidScriptPubKey = invalidKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
+
 		Assert.False(ownershipProof.VerifyOwnership(invalidScriptPubKey, commitmentData, false));
 
 		// Invalid proof, modified ownership identifier

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -120,7 +120,8 @@ public class TestWallet : IKeyChain, IDestinationProvider
 		return OwnershipProof.GenerateCoinJoinInputProof(
 				extKey.PrivateKey,
 				new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
-				committedData);
+				committedData,
+				ScriptPubKeyType.Segwit);
 	}
 
 	/// <remarks>Test wallet assumes that the ownership proof is always correct.</remarks>

--- a/WalletWasabi.Tests/UnitTests/Transactions/PayjoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/PayjoinTests.cs
@@ -22,7 +22,7 @@ public class PayjoinTests
 		var key = new Key();
 		var tx =
 			Network.Main.CreateTransactionBuilder()
-			.AddCoins(Coin(0.5m, key.PubKey.WitHash.ScriptPubKey))
+			.AddCoins(Coin(0.5m, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)))
 			.AddKeys(key)
 			.Send(BitcoinFactory.CreateScript(), Money.Coins(0.5m))
 			.BuildPSBT(true);
@@ -116,7 +116,7 @@ public class PayjoinTests
 					input.WitScript = WitScript.Empty;
 				}
 				var serverCoinKey = new Key();
-				var serverCoin = Coin(0.345m, serverCoinKey.PubKey.WitHash.ScriptPubKey);
+				var serverCoin = Coin(0.345m, serverCoinKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
 				clientTx.Inputs.Add(serverCoin.Outpoint);
 				var paymentOutput = clientTx.Outputs.First(x => x.Value == amountToPay);
 				paymentOutput.Value += (Money)serverCoin.Amount;

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -98,7 +98,7 @@ public class TransactionProcessorTests
 		// An unconfirmed segwit transaction for us
 		var hdPubKey = transactionProcessor.KeyManager.GetKeys().First();
 
-		var tx1 = CreateCreditingTransaction(hdPubKey.PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+		var tx1 = CreateCreditingTransaction(hdPubKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(1.0m));
 		var blockHeight = new Height(77551);
 		var tx2 = new SmartTransaction(tx1.Transaction, blockHeight);
 		var tx3 = CreateSpendingTransaction(tx2.Transaction.Outputs.AsCoins().First(), BitcoinFactory.CreateScript());
@@ -176,7 +176,7 @@ public class TransactionProcessorTests
 		// An unconfirmed segwit transaction for us
 		var hdPubKey = transactionProcessor.KeyManager.GetKeys().First();
 
-		var tx = CreateCreditingTransaction(hdPubKey.PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+		var tx = CreateCreditingTransaction(hdPubKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(1.0m));
 		transactionProcessor.Process(tx);
 
 		Assert.True(transactionProcessor.TransactionStore.ConfirmedStore.IsEmpty());
@@ -211,15 +211,15 @@ public class TransactionProcessorTests
 		var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
 
 		// An unconfirmed segwit transaction for us
-		var tx0 = CreateCreditingTransaction(keys[0].PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+		var tx0 = CreateCreditingTransaction(keys[0].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(1.0m));
 
 		var createdCoin = tx0.Transaction.Outputs.AsCoins().First();
 
 		// Spend the received coin
-		var tx1 = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
+		var tx1 = CreateSpendingTransaction(createdCoin, keys[1].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
 
 		// Spend the same coin again
-		var tx2 = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey);
+		var tx2 = CreateSpendingTransaction(createdCoin, keys[2].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
 		var relevant = transactionProcessor.Process(tx0, tx1, tx2).Last();
 
 		Assert.False(relevant.IsNews);
@@ -251,7 +251,7 @@ public class TransactionProcessorTests
 				var coin = Assert.Single(doubleSpents);
 
 				// Double spend to ourselves but to a different address. So checking the address.
-				Assert.Equal(keys[1].PubKey.WitHash.ScriptPubKey, coin.ScriptPubKey);
+				Assert.Equal(keys[1].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), coin.ScriptPubKey);
 
 				doubleSpendReceived++;
 			}
@@ -266,9 +266,9 @@ public class TransactionProcessorTests
 			{
 				switch (coinReceivedCalled)
 				{
-					case 0: Assert.Equal(keys[0].PubKey.WitHash.ScriptPubKey, c.ScriptPubKey); break;
-					case 1: Assert.Equal(keys[1].PubKey.WitHash.ScriptPubKey, c.ScriptPubKey); break;
-					case 2: Assert.Equal(keys[2].PubKey.WitHash.ScriptPubKey, c.ScriptPubKey); break;
+					case 0: Assert.Equal(keys[0].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), c.ScriptPubKey); break;
+					case 1: Assert.Equal(keys[1].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), c.ScriptPubKey); break;
+					case 2: Assert.Equal(keys[2].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), c.ScriptPubKey); break;
 					default:
 						throw new InvalidOperationException();
 				};
@@ -278,17 +278,17 @@ public class TransactionProcessorTests
 		};
 
 		// An unconfirmed segwit transaction for us
-		var tx0 = CreateCreditingTransaction(keys[0].PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m), height: 54321);
+		var tx0 = CreateCreditingTransaction(keys[0].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(1.0m), height: 54321);
 
 		var createdCoin = tx0.Transaction.Outputs.AsCoins().First();
 
 		// Spend the received coin
-		var tx1 = CreateSpendingTransaction(createdCoin, keys[1].PubKey.WitHash.ScriptPubKey);
+		var tx1 = CreateSpendingTransaction(createdCoin, keys[1].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
 
 		Assert.Equal(0, doubleSpendReceived);
 
 		// Spend the coin
-		var tx2 = CreateSpendingTransaction(createdCoin, keys[2].PubKey.WitHash.ScriptPubKey, height: 54321);
+		var tx2 = CreateSpendingTransaction(createdCoin, keys[2].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), height: 54321);
 		var relevant = transactionProcessor.Process(tx0, tx1, tx2).Last();
 		Assert.Equal(1, doubleSpendReceived);
 
@@ -512,7 +512,7 @@ public class TransactionProcessorTests
 		};
 
 		// A confirmed segwit transaction for us
-		var tx1 = CreateCreditingTransaction(keys[0].PubKey.WitHash.ScriptPubKey, Money.Coins(1.0m));
+		var tx1 = CreateCreditingTransaction(keys[0].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(1.0m));
 		var results = transactionProcessor.Process(tx1, tx1).ToArray();
 		var res1 = results[0];
 		var res2a = results[1];

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -38,14 +38,14 @@ public class StepOutputRegistrationTests
 		var bobClient = new BobClient(round.Id, arenaClient);
 		using var destKey1 = new Key();
 		await bobClient.RegisterOutputAsync(
-			destKey1.PubKey.WitHash.ScriptPubKey,
+			destKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			amountCredentials1.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials1.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None);
 
 		using var destKey2 = new Key();
 		await bobClient.RegisterOutputAsync(
-			destKey2.PubKey.WitHash.ScriptPubKey,
+			destKey2.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			amountCredentials2.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials2.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None);
@@ -86,7 +86,7 @@ public class StepOutputRegistrationTests
 		var bobClient = new BobClient(round.Id, arenaClient);
 		using var destKey = new Key();
 		await bobClient.RegisterOutputAsync(
-			destKey.PubKey.WitHash.ScriptPubKey,
+			destKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			amountCredentials1.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials1.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None);
@@ -124,13 +124,13 @@ public class StepOutputRegistrationTests
 		using var destKey1 = new Key();
 		using var destKey2 = new Key();
 		await bobClient.RegisterOutputAsync(
-			destKey1.PubKey.WitHash.ScriptPubKey,
+			destKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			amountCredentials1.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials1.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None);
 
 		await bobClient.RegisterOutputAsync(
-			destKey2.PubKey.WitHash.ScriptPubKey,
+			destKey2.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			amountCredentials2.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials2.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None);
@@ -173,7 +173,7 @@ public class StepOutputRegistrationTests
 		var bobClient = new BobClient(round.Id, arenaClient);
 		using var destKey = new Key();
 		await bobClient.RegisterOutputAsync(
-			destKey.PubKey.WitHash.ScriptPubKey,
+			destKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			amountCredentials1.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials1.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -258,13 +258,13 @@ public class StepTransactionSigningTests
 		using var destKey1 = new Key();
 		using var destKey2 = new Key();
 		await bobClient.RegisterOutputAsync(
-			destKey1.PubKey.WitHash.ScriptPubKey,
+			destKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			aliceClient1.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient1.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None).ConfigureAwait(false);
 
 		await bobClient.RegisterOutputAsync(
-			destKey2.PubKey.WitHash.ScriptPubKey,
+			destKey2.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			aliceClient2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient2.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
 			CancellationToken.None).ConfigureAwait(false);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -330,7 +330,7 @@ public class RegisterInputFailureTests
 	[Fact]
 	public async Task WrongCoordinatorIdentifierInOwnershipProofAsync()
 	{
-		await TestOwnershipProof((key, roundId) => OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", roundId)));
+		await TestOwnershipProof((key, roundId) => OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", roundId), ScriptPubKeyType.Segwit));
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -330,7 +330,7 @@ public class RegisterInputFailureTests
 	[Fact]
 	public async Task WrongCoordinatorIdentifierInOwnershipProofAsync()
 	{
-		await TestOwnershipProof((key, roundId) => OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey), new CoinJoinInputCommitmentData("test", roundId)));
+		await TestOwnershipProof((key, roundId) => OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", roundId)));
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -68,7 +68,7 @@ public class RegisterInputSuccessTests
 			roundState.CreateVsizeCredentialClient(random),
 			"test",
 			arena);
-		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", round.Id));
+		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", round.Id), ScriptPubKeyType.Segwit);
 
 		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -68,7 +68,7 @@ public class RegisterInputSuccessTests
 			roundState.CreateVsizeCredentialClient(random),
 			"test",
 			arena);
-		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey), new CoinJoinInputCommitmentData("test", round.Id));
+		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", round.Id));
 
 		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -25,6 +26,40 @@ public class RegisterOutputTests
 		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round);
 		await arena.RegisterOutputAsync(req, CancellationToken.None);
 		Assert.NotEmpty(round.Bobs);
+
+		await arena.StopAsync(CancellationToken.None);
+	}
+
+	[Fact]
+	public async Task TaprootSuccessAsync()
+	{
+		WabiSabiConfig cfg = new() { AllowP2trOutputs = true };
+		var round = WabiSabiFactory.CreateRound(cfg);
+		round.SetPhase(Phase.OutputRegistration);
+		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
+
+		using Key privKey = new();
+		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, privKey.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86), Constants.P2trOutputVirtualSize);
+		await arena.RegisterOutputAsync(req, CancellationToken.None);
+		Assert.NotEmpty(round.Bobs);
+
+		await arena.StopAsync(CancellationToken.None);
+	}
+
+	[Fact]
+	public async Task TaprootNotAllowedAsync()
+	{
+		WabiSabiConfig cfg = new() { AllowP2trOutputs = false };
+		var round = WabiSabiFactory.CreateRound(cfg);
+		round.SetPhase(Phase.OutputRegistration);
+		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
+		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
+
+		using Key privKey = new();
+		var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, privKey.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86), Constants.P2trOutputVirtualSize);
+		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.RegisterOutputAsync(req, CancellationToken.None));
+		Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, ex.ErrorCode);
 
 		await arena.StopAsync(CancellationToken.None);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -91,7 +91,7 @@ public class ArenaClientTests
 
 		using var destinationKey1 = new Key();
 		using var destinationKey2 = new Key();
-		var p2wpkhScriptSize = (long)destinationKey1.PubKey.WitHash.ScriptPubKey.EstimateOutputVsize();
+		var p2wpkhScriptSize = (long)destinationKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit).EstimateOutputVsize();
 
 		var vsizesToRequest = new[] { round.Parameters.MaxVsizeAllocationPerAlice - (inputVsize + 2 * p2wpkhScriptSize), 2 * p2wpkhScriptSize };
 
@@ -151,14 +151,14 @@ public class ArenaClientTests
 
 		await bobArenaClient.RegisterOutputAsync(
 			round.Id,
-			destinationKey1.PubKey.WitHash.ScriptPubKey,
+			destinationKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			new[] { amountCred1, zeroAmountCred1 },
 			new[] { vsizeCred1, zeroVsizeCred1 },
 			CancellationToken.None);
 
 		await bobArenaClient.RegisterOutputAsync(
 			round.Id,
-			destinationKey2.PubKey.WitHash.ScriptPubKey,
+			destinationKey2.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
 			new[] { amountCred2, zeroAmountCred2 },
 			new[] { vsizeCred2, zeroVsizeCred2 },
 			CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -31,146 +31,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
 public class ArenaClientTests
 {
 	[Fact]
-	public async Task FullCoinjoinAsyncTestAsync()
+	public async Task FullP2wpkhCoinjoinTestAsync()
 	{
-		var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
-		var round = WabiSabiFactory.CreateRound(WabiSabiFactory.CreateRoundParameters(config));
-		using var key = new Key();
-		var outpoint = BitcoinFactory.CreateOutPoint();
-		var mockRpc = new Mock<IRPCClient>();
-		mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true, It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
-			{
-				IsCoinBase = false,
-				Confirmations = 200,
-				TxOut = new TxOut(Money.Coins(1m), key.PubKey.WitHash.GetAddress(Network.Main)),
-			});
-		mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new EstimateSmartFeeResponse
-			{
-				Blocks = 1000,
-				FeeRate = new FeeRate(10m)
-			});
-		mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new MemPoolInfo
-			{
-				MinRelayTxFee = 1
-			});
-		mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
-		mockRpc.Setup(rpc => rpc.SendBatchAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-		mockRpc.Setup(rpc => rpc.GetRawTransactionAsync(It.IsAny<uint256>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-				.ReturnsAsync(BitcoinFactory.CreateTransaction());
-
-		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
-
-		using var memoryCache = new MemoryCache(new MemoryCacheOptions());
-		var idempotencyRequestCache = new IdempotencyRequestCache(memoryCache);
-
-		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
-		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore);
-
-		var insecureRandom = new InsecureRandom();
-		var roundState = RoundState.FromRound(round);
-		var aliceArenaClient = new ArenaClient(
-			roundState.CreateAmountCredentialClient(insecureRandom),
-			roundState.CreateVsizeCredentialClient(insecureRandom),
-			config.CoordinatorIdentifier,
-			wabiSabiApi);
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
-
-		var (inputRegistrationResponse, _) = await aliceArenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None);
-		var aliceId = inputRegistrationResponse.Value;
-
-		var inputVsize = Constants.P2wpkhInputVirtualSize;
-		var amountsToRequest = new[]
-		{
-			Money.Coins(.75m) - round.Parameters.MiningFeeRate.GetFee(inputVsize) - round.Parameters.CoordinationFeeRate.GetFee(Money.Coins(1m)),
-			Money.Coins(.25m),
-		}.Select(x => x.Satoshi).ToArray();
-
-		using var destinationKey1 = new Key();
-		using var destinationKey2 = new Key();
-		var p2wpkhScriptSize = (long)destinationKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit).EstimateOutputVsize();
-
-		var vsizesToRequest = new[] { round.Parameters.MaxVsizeAllocationPerAlice - (inputVsize + 2 * p2wpkhScriptSize), 2 * p2wpkhScriptSize };
-
-		// Phase: Input Registration
-		Assert.Equal(Phase.InputRegistration, round.Phase);
-
-		var connectionConfirmationResponse1 = await aliceArenaClient.ConfirmConnectionAsync(
-			round.Id,
-			aliceId,
-			amountsToRequest,
-			vsizesToRequest,
-			inputRegistrationResponse.IssuedAmountCredentials,
-			inputRegistrationResponse.IssuedVsizeCredentials,
-			CancellationToken.None);
-
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
-		Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
-
-		// Phase: Connection Confirmation
-		var connectionConfirmationResponse2 = await aliceArenaClient.ConfirmConnectionAsync(
-			round.Id,
-			aliceId,
-			amountsToRequest,
-			vsizesToRequest,
-			connectionConfirmationResponse1.IssuedAmountCredentials,
-			connectionConfirmationResponse1.IssuedVsizeCredentials,
-			CancellationToken.None);
-
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(1));
-
-		// Phase: Output Registration
-		Assert.Equal(Phase.OutputRegistration, round.Phase);
-
-		var bobArenaClient = new ArenaClient(
-			roundState.CreateAmountCredentialClient(insecureRandom),
-			roundState.CreateVsizeCredentialClient(insecureRandom),
-			config.CoordinatorIdentifier,
-			wabiSabiApi);
-
-		var reissuanceResponse = await bobArenaClient.ReissueCredentialAsync(
-			round.Id,
-			amountsToRequest,
-			Enumerable.Repeat(p2wpkhScriptSize, 2),
-			connectionConfirmationResponse2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
-			connectionConfirmationResponse2.IssuedVsizeCredentials.Skip(1).Take(ProtocolConstants.CredentialNumber), // first amount is the leftover value
-			CancellationToken.None);
-
-		Credential amountCred1 = reissuanceResponse.IssuedAmountCredentials.ElementAt(0);
-		Credential amountCred2 = reissuanceResponse.IssuedAmountCredentials.ElementAt(1);
-		Credential zeroAmountCred1 = reissuanceResponse.IssuedAmountCredentials.ElementAt(2);
-		Credential zeroAmountCred2 = reissuanceResponse.IssuedAmountCredentials.ElementAt(3);
-
-		Credential vsizeCred1 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(0);
-		Credential vsizeCred2 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(1);
-		Credential zeroVsizeCred1 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(2);
-		Credential zeroVsizeCred2 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(3);
-
-		await bobArenaClient.RegisterOutputAsync(
-			round.Id,
-			destinationKey1.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
-			new[] { amountCred1, zeroAmountCred1 },
-			new[] { vsizeCred1, zeroVsizeCred1 },
-			CancellationToken.None);
-
-		await bobArenaClient.RegisterOutputAsync(
-			round.Id,
-			destinationKey2.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
-			new[] { amountCred2, zeroAmountCred2 },
-			new[] { vsizeCred2, zeroVsizeCred2 },
-			CancellationToken.None);
-
-		await aliceArenaClient.ReadyToSignAsync(round.Id, aliceId, CancellationToken.None);
-
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
-		Assert.Equal(Phase.TransactionSigning, round.Phase);
-
-		var tx = round.Assert<SigningState>().CreateTransaction();
-		Assert.Single(tx.Inputs);
-		Assert.Equal(2 + 1, tx.Outputs.Count); // +1 because it pays coordination fees
+		await TestFullCoinjoinAsync(ScriptPubKeyType.Segwit, Constants.P2wpkhInputVirtualSize);
 	}
 
 	[Fact]
@@ -271,5 +134,146 @@ public class ArenaClientTests
 		Assert.True(round.Assert<SigningState>().IsInputSigned(alice2.Coin.Outpoint));
 
 		Assert.True(round.Assert<SigningState>().IsFullySigned);
+	}
+
+	private async Task TestFullCoinjoinAsync(ScriptPubKeyType scriptPubKeyType, int inputVirtualSize)
+	{
+		var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
+		var round = WabiSabiFactory.CreateRound(WabiSabiFactory.CreateRoundParameters(config));
+		using var key = new Key();
+		var outpoint = BitcoinFactory.CreateOutPoint();
+		var mockRpc = new Mock<IRPCClient>();
+		mockRpc.Setup(rpc => rpc.GetTxOutAsync(outpoint.Hash, (int)outpoint.N, true, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
+			{
+				IsCoinBase = false,
+				Confirmations = 200,
+				TxOut = new TxOut(Money.Coins(1m), key.PubKey.GetAddress(scriptPubKeyType, Network.Main)),
+			});
+		mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new EstimateSmartFeeResponse
+			{
+				Blocks = 1000,
+				FeeRate = new FeeRate(10m)
+			});
+		mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new MemPoolInfo
+			{
+				MinRelayTxFee = 1
+			});
+		mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
+		mockRpc.Setup(rpc => rpc.SendBatchAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+		mockRpc.Setup(rpc => rpc.GetRawTransactionAsync(It.IsAny<uint256>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(BitcoinFactory.CreateTransaction());
+
+		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
+
+		using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+		var idempotencyRequestCache = new IdempotencyRequestCache(memoryCache);
+
+		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
+		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore);
+
+		var insecureRandom = new InsecureRandom();
+		var roundState = RoundState.FromRound(round);
+		var aliceArenaClient = new ArenaClient(
+			roundState.CreateAmountCredentialClient(insecureRandom),
+			roundState.CreateVsizeCredentialClient(insecureRandom),
+			config.CoordinatorIdentifier,
+			wabiSabiApi);
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id, scriptPubKeyType);
+
+		var (inputRegistrationResponse, _) = await aliceArenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None);
+		var aliceId = inputRegistrationResponse.Value;
+
+		var amountsToRequest = new[]
+		{
+			Money.Coins(.75m) - round.Parameters.MiningFeeRate.GetFee(inputVirtualSize) - round.Parameters.CoordinationFeeRate.GetFee(Money.Coins(1m)),
+			Money.Coins(.25m),
+		}.Select(x => x.Satoshi).ToArray();
+
+		using var destinationKey1 = new Key();
+		using var destinationKey2 = new Key();
+		var scriptSize = (long)destinationKey1.PubKey.GetScriptPubKey(scriptPubKeyType).EstimateOutputVsize();
+
+		var vsizesToRequest = new[] { round.Parameters.MaxVsizeAllocationPerAlice - (inputVirtualSize + 2 * scriptSize), 2 * scriptSize };
+
+		// Phase: Input Registration
+		Assert.Equal(Phase.InputRegistration, round.Phase);
+
+		var connectionConfirmationResponse1 = await aliceArenaClient.ConfirmConnectionAsync(
+			round.Id,
+			aliceId,
+			amountsToRequest,
+			vsizesToRequest,
+			inputRegistrationResponse.IssuedAmountCredentials,
+			inputRegistrationResponse.IssuedVsizeCredentials,
+			CancellationToken.None);
+
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
+		Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
+
+		// Phase: Connection Confirmation
+		var connectionConfirmationResponse2 = await aliceArenaClient.ConfirmConnectionAsync(
+			round.Id,
+			aliceId,
+			amountsToRequest,
+			vsizesToRequest,
+			connectionConfirmationResponse1.IssuedAmountCredentials,
+			connectionConfirmationResponse1.IssuedVsizeCredentials,
+			CancellationToken.None);
+
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(1));
+
+		// Phase: Output Registration
+		Assert.Equal(Phase.OutputRegistration, round.Phase);
+
+		var bobArenaClient = new ArenaClient(
+			roundState.CreateAmountCredentialClient(insecureRandom),
+			roundState.CreateVsizeCredentialClient(insecureRandom),
+			config.CoordinatorIdentifier,
+			wabiSabiApi);
+
+		var reissuanceResponse = await bobArenaClient.ReissueCredentialAsync(
+			round.Id,
+			amountsToRequest,
+			Enumerable.Repeat(scriptSize, 2),
+			connectionConfirmationResponse2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
+			connectionConfirmationResponse2.IssuedVsizeCredentials.Skip(1).Take(ProtocolConstants.CredentialNumber), // first amount is the leftover value
+			CancellationToken.None);
+
+		Credential amountCred1 = reissuanceResponse.IssuedAmountCredentials.ElementAt(0);
+		Credential amountCred2 = reissuanceResponse.IssuedAmountCredentials.ElementAt(1);
+		Credential zeroAmountCred1 = reissuanceResponse.IssuedAmountCredentials.ElementAt(2);
+		Credential zeroAmountCred2 = reissuanceResponse.IssuedAmountCredentials.ElementAt(3);
+
+		Credential vsizeCred1 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(0);
+		Credential vsizeCred2 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(1);
+		Credential zeroVsizeCred1 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(2);
+		Credential zeroVsizeCred2 = reissuanceResponse.IssuedVsizeCredentials.ElementAt(3);
+
+		await bobArenaClient.RegisterOutputAsync(
+			round.Id,
+			destinationKey1.PubKey.GetScriptPubKey(scriptPubKeyType),
+			new[] { amountCred1, zeroAmountCred1 },
+			new[] { vsizeCred1, zeroVsizeCred1 },
+			CancellationToken.None);
+
+		await bobArenaClient.RegisterOutputAsync(
+			round.Id,
+			destinationKey2.PubKey.GetScriptPubKey(scriptPubKeyType),
+			new[] { amountCred2, zeroAmountCred2 },
+			new[] { vsizeCred2, zeroVsizeCred2 },
+			CancellationToken.None);
+
+		await aliceArenaClient.ReadyToSignAsync(round.Id, aliceId, CancellationToken.None);
+
+		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
+		Assert.Equal(Phase.TransactionSigning, round.Phase);
+
+		var tx = round.Assert<SigningState>().CreateTransaction();
+		Assert.Single(tx.Inputs);
+		Assert.Equal(2 + 1, tx.Outputs.Count); // +1 because it pays coordination fees
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -37,6 +37,12 @@ public class ArenaClientTests
 	}
 
 	[Fact]
+	public async Task FullP2trCoinjoinTestAsync()
+	{
+		await TestFullCoinjoinAsync(ScriptPubKeyType.TaprootBIP86, Constants.P2trInputVirtualSize);
+	}
+
+	[Fact]
 	public async Task RemoveInputAsyncTestAsync()
 	{
 		var config = new WabiSabiConfig();
@@ -138,7 +144,7 @@ public class ArenaClientTests
 
 	private async Task TestFullCoinjoinAsync(ScriptPubKeyType scriptPubKeyType, int inputVirtualSize)
 	{
-		var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
+		var config = new WabiSabiConfig { MaxInputCountByRound = 1, AllowP2trInputs = true, AllowP2trOutputs = true };
 		var round = WabiSabiFactory.CreateRound(WabiSabiFactory.CreateRoundParameters(config));
 		using var key = new Key();
 		var outpoint = BitcoinFactory.CreateOutPoint();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -73,7 +73,7 @@ public class BobClientTests
 		Assert.Equal(Phase.OutputRegistration, round.Phase);
 
 		using var destinationKey = new Key();
-		var destination = destinationKey.PubKey.WitHash.ScriptPubKey;
+		var destination = destinationKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 		var bobClient = new BobClient(round.Id, bobArenaClient);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
@@ -39,5 +39,6 @@ public class OwnershipProofTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
-			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash));
+			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash),
+			ScriptPubKeyType.Segwit);
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Crypto/OwnershipProofTests.cs
@@ -38,6 +38,6 @@ public class OwnershipProofTests
 	public static OwnershipProof CreateOwnershipProof(Key key, uint256 roundHash)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
-			new OwnershipIdentifier(key, key.PubKey.WitHash.ScriptPubKey),
+			new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
 			new CoinJoinInputCommitmentData("wasabiwallet.io", roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -203,7 +203,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		keyManager.AssertLockedInternalKeysIndexed(14);
 		var outputScriptCandidates = keyManager
 			.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked)
-			.Select(x => x.PubKey.WitHash.ScriptPubKey)
+			.Select(x => x.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit))
 			.ToImmutableArray();
 
 		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
@@ -534,7 +534,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		using Key signingKey = new();
 		Coin coinToRegister = new(
 			fromOutpoint: BitcoinFactory.CreateOutPoint(),
-			fromTxOut: new TxOut(Money.Coins(1), signingKey.PubKey.WitHash.ScriptPubKey));
+			fromTxOut: new TxOut(Money.Coins(1), signingKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)));
 
 		using HttpClient httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			builder.ConfigureServices(services =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
@@ -122,6 +122,6 @@ public class InputRegistrationRequestTests
 	public static OwnershipProof CreateOwnershipProof(Key key, uint256 roundHash)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
-			new OwnershipIdentifier(Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main), key.PubKey.WitHash.ScriptPubKey),
+			new OwnershipIdentifier(Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main), key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
 			WabiSabiFactory.CreateCommitmentData(roundHash));
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/InputRegistrationRequestTests.cs
@@ -123,5 +123,6 @@ public class InputRegistrationRequestTests
 		=> OwnershipProof.GenerateCoinJoinInputProof(
 			key,
 			new OwnershipIdentifier(Key.Parse("5KbdaBwc9Eit2LrmDp1WfZd815StNstwHanbRrPpGGN6wWJKyHe", Network.Main), key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)),
-			WabiSabiFactory.CreateCommitmentData(roundHash));
+			WabiSabiFactory.CreateCommitmentData(roundHash),
+			ScriptPubKeyType.Segwit);
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -255,7 +255,7 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void OnlyAllowedInputTypes()
 	{
-		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
+		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputScriptTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
 		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
 		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddInput(coin, ownershipProof, commitmentData));
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -253,7 +253,7 @@ public class MultipartyTransactionTests
 	// TODO nonstandard input
 
 	[Fact]
-	public void OnlyAllowedInputTypes()
+	public void OnlyAllowedInputScriptTypes()
 	{
 		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedInputScriptTypes = ImmutableSortedSet.Create<ScriptType>(ScriptType.P2PKH) });
 		(var coin, var ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof();
@@ -303,7 +303,7 @@ public class MultipartyTransactionTests
 	}
 
 	[Fact]
-	public void OnlyAllowedOutputTypes()
+	public void OnlyAllowedOutputScriptTypes()
 	{
 		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedOutputScriptTypes = ImmutableSortedSet<ScriptType>.Empty.Add(ScriptType.P2PKH) });
 		var p2wpkh = BitcoinFactory.CreateScript();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -305,7 +305,7 @@ public class MultipartyTransactionTests
 	[Fact]
 	public void OnlyAllowedOutputTypes()
 	{
-		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedOutputTypes = ImmutableSortedSet<ScriptType>.Empty.Add(ScriptType.P2PKH) });
+		var legacyOnly = new ConstructionState(DefaultParameters with { AllowedOutputScriptTypes = ImmutableSortedSet<ScriptType>.Empty.Add(ScriptType.P2PKH) });
 		var p2wpkh = BitcoinFactory.CreateScript();
 		ThrowsProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, () => legacyOnly.AddOutput(new TxOut(Money.Coins(1), p2wpkh)));
 	}

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -29,7 +29,7 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 
 		P2pkScript = PubKey.ScriptPubKey;
 		P2pkhScript = PubKey.Hash.ScriptPubKey;
-		P2wpkhScript = PubKey.WitHash.ScriptPubKey;
+		P2wpkhScript = PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 		P2shOverP2wpkhScript = P2wpkhScript.Hash.ScriptPubKey;
 
 		PubKeyHash = PubKey.Hash;

--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRoundConfig.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRoundConfig.cs
@@ -81,7 +81,7 @@ public class CoordinatorRoundConfig : ConfigBase
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
-	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;
+	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 	public void MakeNextCoordinatorScriptDirty()
 	{

--- a/WalletWasabi/Crypto/Bip322Signature.cs
+++ b/WalletWasabi/Crypto/Bip322Signature.cs
@@ -41,7 +41,7 @@ public record Bip322Signature : IBitcoinSerializable
 		NBitcoinExtensions.FromBytes<Bip322Signature>(bip322SignatureBytes);
 
 	public bool Verify(uint256 hash, Script scriptPubKey) =>
-		scriptPubKey.GetScriptType() switch
+		scriptPubKey.TryGetScriptType() switch
 		{
 			ScriptType.P2WPKH => VerifyP2wpkh(hash, scriptPubKey),
 			ScriptType.Taproot => VerifyP2tr(hash, scriptPubKey),

--- a/WalletWasabi/Crypto/Bip322Signature.cs
+++ b/WalletWasabi/Crypto/Bip322Signature.cs
@@ -43,7 +43,7 @@ public record Bip322Signature : IBitcoinSerializable
 	public bool Verify(uint256 hash, Script scriptPubKey) =>
 		scriptPubKey.GetScriptType() switch
 		{
-			ScriptType.P2WPKH => VerifySegwit(hash, scriptPubKey),
+			ScriptType.P2WPKH => VerifyP2wpkh(hash, scriptPubKey),
 			_ => throw new NotImplementedException("Only P2WPKH scripts are supported.")
 		};
 
@@ -58,7 +58,7 @@ public record Bip322Signature : IBitcoinSerializable
 			_ => throw new NotImplementedException("Only P2WPKH scripts are supported.")
 		};
 
-	private bool VerifySegwit(uint256 hash, Script scriptPubKey)
+	private bool VerifyP2wpkh(uint256 hash, Script scriptPubKey)
 	{
 		if (ScriptSig != Script.Empty)
 		{

--- a/WalletWasabi/Crypto/Bip322Signature.cs
+++ b/WalletWasabi/Crypto/Bip322Signature.cs
@@ -41,10 +41,10 @@ public record Bip322Signature : IBitcoinSerializable
 		NBitcoinExtensions.FromBytes<Bip322Signature>(bip322SignatureBytes);
 
 	public bool Verify(uint256 hash, Script scriptPubKey) =>
-		scriptPubKey.IsScriptType(ScriptType.P2WPKH) switch
+		scriptPubKey.GetScriptType() switch
 		{
-			true => VerifySegwit(hash, scriptPubKey),
-			false => throw new NotImplementedException("Only P2WPKH scripts are supported.")
+			ScriptType.P2WPKH => VerifySegwit(hash, scriptPubKey),
+			_ => throw new NotImplementedException("Only P2WPKH scripts are supported.")
 		};
 
 	public static Bip322Signature Generate(Key key, uint256 hash, ScriptPubKeyType scriptPubKeyType) =>

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -47,7 +47,7 @@ public record OwnershipProof : IBitcoinSerializable
 			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.GetScriptPubKey(scriptPubKeyType), commitmentData), scriptPubKeyType));
 
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
-		scriptPubKey.GetScriptType() switch
+		scriptPubKey.TryGetScriptType() switch
 		{
 			ScriptType.P2WPKH or ScriptType.Taproot => VerifyOwnershipProof(scriptPubKey, commitmentData, requireUserConfirmation),
 			_ => throw new NotImplementedException("Only P2WPKH and P2TR scripts are supported."),

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -38,7 +38,7 @@ public record OwnershipProof : IBitcoinSerializable
 		scriptPubKeyType switch
 		{
 			ScriptPubKeyType.Segwit => GenerateOwnershipProofSegwit(key, commitmentData, new ProofBody(userConfirmation ? ProofBodyFlags.UserConfirmation : 0, ownershipIdentifiers.ToArray())),
-			_ => throw new NotImplementedException()
+			_ => throw new NotImplementedException("Only P2WPKH script is supported."),
 		};
 
 	private static OwnershipProof GenerateOwnershipProofSegwit(Key key, byte[] commitmentData, ProofBody proofBody) =>
@@ -50,7 +50,7 @@ public record OwnershipProof : IBitcoinSerializable
 		scriptPubKey.GetScriptType() switch
 		{
 			ScriptType.P2WPKH => VerifyOwnershipProofSegwit(scriptPubKey, commitmentData, requireUserConfirmation),
-			_ => throw new NotImplementedException(),
+			_ => throw new NotImplementedException("Only P2WPKH script is supported."),
 		};
 
 	private bool VerifyOwnershipProofSegwit(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation)

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -47,10 +47,10 @@ public record OwnershipProof : IBitcoinSerializable
 			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.WitHash.ScriptPubKey, commitmentData), ScriptPubKeyType.Segwit));
 
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
-		scriptPubKey.IsScriptType(ScriptType.P2WPKH) switch
+		scriptPubKey.GetScriptType() switch
 		{
-			true => VerifyOwnershipProofSegwit(scriptPubKey, commitmentData, requireUserConfirmation),
-			false => throw new NotImplementedException()
+			ScriptType.P2WPKH => VerifyOwnershipProofSegwit(scriptPubKey, commitmentData, requireUserConfirmation),
+			_ => throw new NotImplementedException("Only P2WPKH scripts are supported."),
 		};
 
 	private bool VerifyOwnershipProofSegwit(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation)

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -44,7 +44,7 @@ public record OwnershipProof : IBitcoinSerializable
 	private static OwnershipProof GenerateOwnershipProof(Key key, byte[] commitmentData, ProofBody proofBody, ScriptPubKeyType scriptPubKeyType) =>
 		new(
 			proofBody,
-			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), commitmentData), scriptPubKeyType));
+			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.GetScriptPubKey(scriptPubKeyType), commitmentData), scriptPubKeyType));
 
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
 		scriptPubKey.GetScriptType() switch
@@ -65,11 +65,11 @@ public record OwnershipProof : IBitcoinSerializable
 		return _proofSignature.Verify(hash, scriptPubKey);
 	}
 
-	public static OwnershipProof GenerateCoinJoinInputProof(Key key, OwnershipIdentifier ownershipIdentifier, CoinJoinInputCommitmentData coinJoinInputsCommitmentData) =>
-		Generate(key, new[] { ownershipIdentifier }, coinJoinInputsCommitmentData.ToBytes(), true, ScriptPubKeyType.Segwit);
+	public static OwnershipProof GenerateCoinJoinInputProof(Key key, OwnershipIdentifier ownershipIdentifier, CoinJoinInputCommitmentData coinJoinInputsCommitmentData, ScriptPubKeyType scriptPubKeyType) =>
+		Generate(key, new[] { ownershipIdentifier }, coinJoinInputsCommitmentData.ToBytes(), true, scriptPubKeyType);
 
-	public static OwnershipProof GenerateCoinJoinInputProof(Key key, IEnumerable<OwnershipIdentifier> ownershipIdentifiers, CoinJoinInputCommitmentData coinJoinInputsCommitmentData) =>
-		Generate(key, ownershipIdentifiers, coinJoinInputsCommitmentData.ToBytes(), true, ScriptPubKeyType.Segwit);
+	public static OwnershipProof GenerateCoinJoinInputProof(Key key, IEnumerable<OwnershipIdentifier> ownershipIdentifiers, CoinJoinInputCommitmentData coinJoinInputsCommitmentData, ScriptPubKeyType scriptPubKeyType) =>
+		Generate(key, ownershipIdentifiers, coinJoinInputsCommitmentData.ToBytes(), true, scriptPubKeyType);
 
 	public static bool VerifyCoinJoinInputProof(OwnershipProof ownershipProofBytes, Script scriptPubKey, CoinJoinInputCommitmentData coinJoinInputsCommitmentData) =>
 		ownershipProofBytes.VerifyOwnership(scriptPubKey, coinJoinInputsCommitmentData.ToBytes(), true);

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -49,11 +49,11 @@ public record OwnershipProof : IBitcoinSerializable
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
 		scriptPubKey.GetScriptType() switch
 		{
-			ScriptType.P2WPKH => VerifyOwnershipProofSegwit(scriptPubKey, commitmentData, requireUserConfirmation),
+			ScriptType.P2WPKH => VerifyOwnershipProof(scriptPubKey, commitmentData, requireUserConfirmation),
 			_ => throw new NotImplementedException("Only P2WPKH script is supported."),
 		};
 
-	private bool VerifyOwnershipProofSegwit(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation)
+	private bool VerifyOwnershipProof(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation)
 	{
 		if (requireUserConfirmation && !_proofBody.Flags.HasFlag(ProofBodyFlags.UserConfirmation))
 		{

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -37,8 +37,8 @@ public record OwnershipProof : IBitcoinSerializable
 	public static OwnershipProof Generate(Key key, IEnumerable<OwnershipIdentifier> ownershipIdentifiers, byte[] commitmentData, bool userConfirmation, ScriptPubKeyType scriptPubKeyType) =>
 		scriptPubKeyType switch
 		{
-			ScriptPubKeyType.Segwit => GenerateOwnershipProof(key, commitmentData, new ProofBody(userConfirmation ? ProofBodyFlags.UserConfirmation : 0, ownershipIdentifiers.ToArray()), scriptPubKeyType),
-			_ => throw new NotImplementedException("Only P2WPKH script is supported."),
+			ScriptPubKeyType.Segwit or ScriptPubKeyType.TaprootBIP86 => GenerateOwnershipProof(key, commitmentData, new ProofBody(userConfirmation ? ProofBodyFlags.UserConfirmation : 0, ownershipIdentifiers.ToArray()), scriptPubKeyType),
+			_ => throw new NotImplementedException("Only P2WPKH and P2TR scripts are supported."),
 		};
 
 	private static OwnershipProof GenerateOwnershipProof(Key key, byte[] commitmentData, ProofBody proofBody, ScriptPubKeyType scriptPubKeyType) =>
@@ -49,8 +49,8 @@ public record OwnershipProof : IBitcoinSerializable
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
 		scriptPubKey.GetScriptType() switch
 		{
-			ScriptType.P2WPKH => VerifyOwnershipProof(scriptPubKey, commitmentData, requireUserConfirmation),
-			_ => throw new NotImplementedException("Only P2WPKH script is supported."),
+			ScriptType.P2WPKH or ScriptType.Taproot => VerifyOwnershipProof(scriptPubKey, commitmentData, requireUserConfirmation),
+			_ => throw new NotImplementedException("Only P2WPKH and P2TR scripts are supported."),
 		};
 
 	private bool VerifyOwnershipProof(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation)

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -44,13 +44,13 @@ public record OwnershipProof : IBitcoinSerializable
 	private static OwnershipProof GenerateOwnershipProofSegwit(Key key, byte[] commitmentData, ProofBody proofBody) =>
 		new(
 			proofBody,
-			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.WitHash.ScriptPubKey, commitmentData), ScriptPubKeyType.Segwit));
+			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), commitmentData), ScriptPubKeyType.Segwit));
 
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
 		scriptPubKey.GetScriptType() switch
 		{
 			ScriptType.P2WPKH => VerifyOwnershipProofSegwit(scriptPubKey, commitmentData, requireUserConfirmation),
-			_ => throw new NotImplementedException("Only P2WPKH scripts are supported."),
+			_ => throw new NotImplementedException(),
 		};
 
 	private bool VerifyOwnershipProofSegwit(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation)

--- a/WalletWasabi/Crypto/OwnershipProof.cs
+++ b/WalletWasabi/Crypto/OwnershipProof.cs
@@ -37,14 +37,14 @@ public record OwnershipProof : IBitcoinSerializable
 	public static OwnershipProof Generate(Key key, IEnumerable<OwnershipIdentifier> ownershipIdentifiers, byte[] commitmentData, bool userConfirmation, ScriptPubKeyType scriptPubKeyType) =>
 		scriptPubKeyType switch
 		{
-			ScriptPubKeyType.Segwit => GenerateOwnershipProofSegwit(key, commitmentData, new ProofBody(userConfirmation ? ProofBodyFlags.UserConfirmation : 0, ownershipIdentifiers.ToArray())),
+			ScriptPubKeyType.Segwit => GenerateOwnershipProof(key, commitmentData, new ProofBody(userConfirmation ? ProofBodyFlags.UserConfirmation : 0, ownershipIdentifiers.ToArray()), scriptPubKeyType),
 			_ => throw new NotImplementedException("Only P2WPKH script is supported."),
 		};
 
-	private static OwnershipProof GenerateOwnershipProofSegwit(Key key, byte[] commitmentData, ProofBody proofBody) =>
+	private static OwnershipProof GenerateOwnershipProof(Key key, byte[] commitmentData, ProofBody proofBody, ScriptPubKeyType scriptPubKeyType) =>
 		new(
 			proofBody,
-			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), commitmentData), ScriptPubKeyType.Segwit));
+			Bip322Signature.Generate(key, proofBody.SignatureHash(key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), commitmentData), scriptPubKeyType));
 
 	public bool VerifyOwnership(Script scriptPubKey, byte[] commitmentData, bool requireUserConfirmation) =>
 		scriptPubKey.GetScriptType() switch

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -355,7 +355,7 @@ public static class NBitcoinExtensions
 
 	public static ScriptType? GetScriptType(this Script script)
 	{
-		foreach (ScriptType scriptType in new ScriptType[] { ScriptType.P2WPKH })
+		foreach (ScriptType scriptType in new ScriptType[] { ScriptType.P2WPKH, ScriptType.Taproot })
 		{
 			if (script.IsScriptType(scriptType))
 			{

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -475,10 +475,10 @@ public static class NBitcoinExtensions
 		new TxOut(Money.Zero, scriptPubKey).GetSerializedSize();
 
 	public static int EstimateInputVsize(this Script scriptPubKey) =>
-		scriptPubKey.IsScriptType(ScriptType.P2WPKH) switch
+		scriptPubKey.GetScriptType() switch
 		{
-			true => Constants.P2wpkhInputVirtualSize,
-			false => throw new NotImplementedException($"Size estimation isn't implemented for provided script type.")
+			ScriptType.P2WPKH => Constants.P2wpkhInputVirtualSize,
+			_ => throw new NotImplementedException($"Size estimation isn't implemented for provided script type.")
 		};
 
 	public static Money EffectiveCost(this TxOut output, FeeRate feeRate) =>

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -478,6 +478,7 @@ public static class NBitcoinExtensions
 		scriptPubKey.GetScriptType() switch
 		{
 			ScriptType.P2WPKH => Constants.P2wpkhInputVirtualSize,
+			ScriptType.Taproot => Constants.P2trInputVirtualSize,
 			_ => throw new NotImplementedException($"Size estimation isn't implemented for provided script type.")
 		};
 

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -353,19 +353,6 @@ public static class NBitcoinExtensions
 		}
 	}
 
-	public static ScriptType? GetScriptType(this Script script)
-	{
-		foreach (ScriptType scriptType in new ScriptType[] { ScriptType.P2WPKH, ScriptType.Taproot })
-		{
-			if (script.IsScriptType(scriptType))
-			{
-				return scriptType;
-			}
-		}
-
-		return null;
-	}
-
 	public static ScriptPubKeyType? GetInputScriptPubKeyType(this PSBTInput i)
 	{
 		if (i.WitnessUtxo is null)
@@ -475,7 +462,7 @@ public static class NBitcoinExtensions
 		new TxOut(Money.Zero, scriptPubKey).GetSerializedSize();
 
 	public static int EstimateInputVsize(this Script scriptPubKey) =>
-		scriptPubKey.GetScriptType() switch
+		scriptPubKey.TryGetScriptType() switch
 		{
 			ScriptType.P2WPKH => Constants.P2wpkhInputVirtualSize,
 			ScriptType.Taproot => Constants.P2trInputVirtualSize,

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -353,6 +353,19 @@ public static class NBitcoinExtensions
 		}
 	}
 
+	public static ScriptType? GetScriptType(this Script script)
+	{
+		foreach (ScriptType scriptType in new ScriptType[] { ScriptType.P2WPKH })
+		{
+			if (script.IsScriptType(scriptType))
+			{
+				return scriptType;
+			}
+		}
+
+		return null;
+	}
+
 	public static ScriptPubKeyType? GetInputScriptPubKeyType(this PSBTInput i)
 	{
 		if (i.WitnessUtxo is null)

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -22,6 +22,9 @@ public static class Constants
 	public const int P2pkhInputSizeInBytes = 145;
 	public const int P2wpkhOutputVirtualSize = 31;
 
+	public const int P2trInputVirtualSize = 58;
+	public const int P2trOutputVirtualSize = 43;
+
 	/// <summary>
 	/// OBSOLATED, USE SPECIFIC TYPE
 	/// </summary>

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -17,6 +17,8 @@ public static class Constants
 
 	public const uint ProtocolVersionWitnessVersion = 70012;
 
+	public const int InputBaseSizeInBytes = 41;
+
 	public const int P2wpkhInputSizeInBytes = 41;
 	public const int P2wpkhInputVirtualSize = 69;
 	public const int P2pkhInputSizeInBytes = 145;

--- a/WalletWasabi/Helpers/ScriptSizeHelpers.cs
+++ b/WalletWasabi/Helpers/ScriptSizeHelpers.cs
@@ -1,0 +1,10 @@
+namespace WalletWasabi.Helpers;
+
+public static class ScriptSizeHelpers
+{
+	public const int NonSegwitByteInWeightUnits = 4;
+	public const int SegwitByteInWeightUnits = 1;
+	public const int VirtualByteInWeightUnits = 4;
+	public static int WeightUnitsToVirtualSize(int WeightUnits) => WeightUnits / VirtualByteInWeightUnits + (WeightUnits % VirtualByteInWeightUnits == 0 ? 0 : 1); // ceiling(VirtualSize / VirtualByteInWeightUnits)
+	public static int VirtualSize(int nonSegwitBytes, int segwitBytes) => WeightUnitsToVirtualSize(NonSegwitByteInWeightUnits * nonSegwitBytes + SegwitByteInWeightUnits * segwitBytes);
+}

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -35,7 +35,8 @@ public enum WabiSabiProtocolErrorCode
 	CryptoException,
 	AliceAlreadySignalled,
 	AliceAlreadyConfirmedConnection,
-	AlreadyRegisteredScript
+	AlreadyRegisteredScript,
+	SignatureTooLong,
 }
 
 public static class WabiSabiProtocolErrorCodeExtension

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -147,7 +147,7 @@ public class Round
 				OutputRegistrationTimeFrame.Duration,
 				TransactionSigningTimeFrame.Duration,
 				Parameters.AllowedInputAmounts,
-				Parameters.AllowedInputTypes,
+				Parameters.AllowedInputScriptTypes,
 				Parameters.AllowedOutputAmounts,
 				Parameters.AllowedOutputTypes,
 				Parameters.Network,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -149,7 +149,7 @@ public class Round
 				Parameters.AllowedInputAmounts,
 				Parameters.AllowedInputScriptTypes,
 				Parameters.AllowedOutputAmounts,
-				Parameters.AllowedOutputTypes,
+				Parameters.AllowedOutputScriptTypes,
 				Parameters.Network,
 				Parameters.MiningFeeRate.FeePerK,
 				Parameters.CoordinationFeeRate,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -60,7 +60,7 @@ public record RoundParameters
 	public TimeSpan TransactionSigningTimeout { get; init; }
 	public TimeSpan BlameInputRegistrationTimeout { get; init; }
 
-	public ImmutableSortedSet<ScriptType> AllowedInputTypes { get; init; } = OnlyP2WPKH;
+	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; init; } = OnlyP2WPKH;
 	public ImmutableSortedSet<ScriptType> AllowedOutputTypes { get; init; } = OnlyP2WPKH;
 
 	public Money MinAmountCredentialValue => AllowedInputAmounts.Min;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Immutable;
 using NBitcoin;
 using NBitcoin.Policy;
+using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
@@ -19,6 +21,8 @@ public record RoundParameters
 		int maxInputCountByRound,
 		MoneyRange allowedInputAmounts,
 		MoneyRange allowedOutputAmounts,
+		ImmutableSortedSet<ScriptType> allowedInputScriptTypes,
+		ImmutableSortedSet<ScriptType> allowedOutputScriptTypes,
 		TimeSpan standardInputRegistrationTimeout,
 		TimeSpan connectionConfirmationTimeout,
 		TimeSpan outputRegistrationTimeout,
@@ -34,6 +38,8 @@ public record RoundParameters
 		MaxInputCountByRound = maxInputCountByRound;
 		AllowedInputAmounts = allowedInputAmounts;
 		AllowedOutputAmounts = allowedOutputAmounts;
+		AllowedInputScriptTypes = allowedInputScriptTypes;
+		AllowedOutputScriptTypes = allowedOutputScriptTypes;
 		StandardInputRegistrationTimeout = standardInputRegistrationTimeout;
 		ConnectionConfirmationTimeout = connectionConfirmationTimeout;
 		OutputRegistrationTimeout = outputRegistrationTimeout;
@@ -54,14 +60,13 @@ public record RoundParameters
 	public int MaxInputCountByRound { get; init; }
 	public MoneyRange AllowedInputAmounts { get; init; }
 	public MoneyRange AllowedOutputAmounts { get; init; }
+	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; init; }
+	public ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes { get; init; }
 	public TimeSpan StandardInputRegistrationTimeout { get; init; }
 	public TimeSpan ConnectionConfirmationTimeout { get; init; }
 	public TimeSpan OutputRegistrationTimeout { get; init; }
 	public TimeSpan TransactionSigningTimeout { get; init; }
 	public TimeSpan BlameInputRegistrationTimeout { get; init; }
-
-	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; init; } = OnlyP2WPKH;
-	public ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes { get; init; } = OnlyP2WPKH;
 
 	public Money MinAmountCredentialValue => AllowedInputAmounts.Min;
 	public Money MaxAmountCredentialValue => AllowedInputAmounts.Max;
@@ -98,6 +103,8 @@ public record RoundParameters
 			wabiSabiConfig.MaxInputCountByRound,
 			new MoneyRange(wabiSabiConfig.MinRegistrableAmount, wabiSabiConfig.MaxRegistrableAmount),
 			new MoneyRange(wabiSabiConfig.MinRegistrableAmount, wabiSabiConfig.MaxRegistrableAmount),
+			wabiSabiConfig.AllowedInputScriptTypes,
+			wabiSabiConfig.AllowedOutputScriptTypes,
 			wabiSabiConfig.StandardInputRegistrationTimeout,
 			wabiSabiConfig.ConnectionConfirmationTimeout,
 			wabiSabiConfig.OutputRegistrationTimeout,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -61,7 +61,7 @@ public record RoundParameters
 	public TimeSpan BlameInputRegistrationTimeout { get; init; }
 
 	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; init; } = OnlyP2WPKH;
-	public ImmutableSortedSet<ScriptType> AllowedOutputTypes { get; init; } = OnlyP2WPKH;
+	public ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes { get; init; } = OnlyP2WPKH;
 
 	public Money MinAmountCredentialValue => AllowedInputAmounts.Min;
 	public Money MaxAmountCredentialValue => AllowedInputAmounts.Max;

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -1,5 +1,7 @@
 using NBitcoin;
 using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using WalletWasabi.Bases;
 using WalletWasabi.Helpers;
@@ -124,6 +126,18 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "CoordinatorIdentifier", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public string CoordinatorIdentifier { get; set; } = "CoinJoinCoordinatorIdentifier";
 
+	[DefaultValue(true)]
+	[JsonProperty(PropertyName = "AllowP2wpkhInputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2wpkhInputs { get; set; } = true;
+
+	[DefaultValue(true)]
+	[JsonProperty(PropertyName = "AllowP2wpkhOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2wpkhOutputs { get; set; } = true;
+
+	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes => GetScriptTypes(AllowP2wpkhInputs);
+
+	public ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes => GetScriptTypes(AllowP2wpkhOutputs);
+
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
@@ -135,5 +149,19 @@ public class WabiSabiConfig : ConfigBase
 		{
 			ToFile();
 		}
+	}
+
+	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh)
+	{
+		var scriptTypes = new List<ScriptType>();
+		if (p2wpkh)
+		{
+			scriptTypes.Add(ScriptType.P2WPKH);
+		}
+
+		// When adding new script types, please see
+		// https://github.com/zkSNACKs/WalletWasabi/issues/5440
+
+		return scriptTypes.ToImmutableSortedSet();
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -130,13 +130,21 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "AllowP2wpkhInputs", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool AllowP2wpkhInputs { get; set; } = true;
 
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2trInputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2trInputs { get; set; } = false;
+
 	[DefaultValue(true)]
 	[JsonProperty(PropertyName = "AllowP2wpkhOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool AllowP2wpkhOutputs { get; set; } = true;
 
-	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes => GetScriptTypes(AllowP2wpkhInputs);
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2trOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2trOutputs { get; set; } = false;
 
-	public ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes => GetScriptTypes(AllowP2wpkhOutputs);
+	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs);
+
+	public ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs);
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
@@ -151,12 +159,16 @@ public class WabiSabiConfig : ConfigBase
 		}
 	}
 
-	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh)
+	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr)
 	{
 		var scriptTypes = new List<ScriptType>();
 		if (p2wpkh)
 		{
 			scriptTypes.Add(ScriptType.P2WPKH);
+		}
+		if (p2tr)
+		{
+			scriptTypes.Add(ScriptType.Taproot);
 		}
 
 		// When adding new script types, please see

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -126,7 +126,7 @@ public class WabiSabiConfig : ConfigBase
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
-	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.WitHash.ScriptPubKey;
+	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);
 
 	public void MakeNextCoordinatorScriptDirty()
 	{

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -32,8 +32,7 @@ public abstract class BaseKeyChain : IKeyChain
 			signingKey,
 			new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
 			commitmentData,
-			ScriptPubKeyType.TaprootBIP86
-			);
+			ScriptPubKeyType.TaprootBIP86);
 		return ownershipProof;
 	}
 

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -31,7 +31,9 @@ public abstract class BaseKeyChain : IKeyChain
 		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(
 			signingKey,
 			new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
-			commitmentData);
+			commitmentData,
+			ScriptPubKeyType.TaprootBIP86
+			);
 		return ownershipProof;
 	}
 

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -32,7 +32,7 @@ public abstract class BaseKeyChain : IKeyChain
 			signingKey,
 			new OwnershipIdentifier(identificationKey, destination.ScriptPubKey),
 			commitmentData,
-			ScriptPubKeyType.TaprootBIP86);
+			ScriptPubKeyType.Segwit);
 		return ownershipProof;
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -603,7 +603,7 @@ public class CoinJoinClient
 
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
-			.Where(x => parameters.AllowedInputTypes.Any(t => x.ScriptPubKey.IsScriptType(t)))
+			.Where(x => parameters.AllowedInputScriptTypes.Any(t => x.ScriptPubKey.IsScriptType(t)))
 			.Where(x => x.EffectiveValue(parameters.MiningFeeRate) > Money.Zero)
 			.ToArray();
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -161,6 +161,14 @@ public class CoinJoinClient
 
 			coins = SelectCoinsForRound(coinCandidates, roundParameteers, ConsolidationMode, AnonScoreTarget, RedCoinIsolation, liquidityClue, SecureRandom);
 
+			if (!roundParameteers.AllowedInputScriptTypes.Contains(ScriptType.P2WPKH) || !roundParameteers.AllowedOutputScriptTypes.Contains(ScriptType.P2WPKH))
+			{
+				excludeRound = currentRoundState.Id;
+				currentRoundState.LogInfo($"Skipping the round since it doesn't support P2WPKH inputs and outputs.");
+
+				continue;
+			}
+
 			if (roundParameteers.MaxSuggestedAmount != default && coins.Any(c => c.Amount > roundParameteers.MaxSuggestedAmount))
 			{
 				excludeRound = currentRoundState.Id;

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -39,7 +39,7 @@ public class KeyChain : BaseKeyChain
 		{
 			throw new InvalidOperationException($"The signing key for '{scriptPubKey}' was not found.");
 		}
-		if (hdKey.PrivateKey.PubKey.WitHash.ScriptPubKey != scriptPubKey)
+		if (hdKey.PrivateKey.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit) != scriptPubKey)
 		{
 			throw new InvalidOperationException("The key cannot generate the utxo scriptpubkey. This could happen if the wallet password is not the correct one.");
 		}

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -41,7 +41,7 @@ public static class RoundHasher
 					   .Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
 					   .Append(ProtocolConstants.RoundAllowedInputScriptTypesStrobeLabel, allowedInputTypes)
 					   .Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)
-					   .Append(ProtocolConstants.RoundAllowedOutputTypesStrobeLabel, allowedOutputTypes)
+					   .Append(ProtocolConstants.RoundAllowedOutputScriptTypesStrobeLabel, allowedOutputTypes)
 					   .Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())
 					   .Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
 					   .Append(ProtocolConstants.RoundCoordinationFeeRateStrobeLabel, coordinationFeeRate)

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -39,7 +39,7 @@ public static class RoundHasher
 					   .Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, outputRegistrationTimeout)
 					   .Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, transactionSigningTimeout)
 					   .Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
-					   .Append(ProtocolConstants.RoundAllowedInputTypesStrobeLabel, allowedInputTypes)
+					   .Append(ProtocolConstants.RoundAllowedInputScriptTypesStrobeLabel, allowedInputTypes)
 					   .Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)
 					   .Append(ProtocolConstants.RoundAllowedOutputTypesStrobeLabel, allowedOutputTypes)
 					   .Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -16,7 +16,7 @@ public static class RoundHasher
 			TimeSpan outputRegistrationTimeout,
 			TimeSpan transactionSigningTimeout,
 			MoneyRange allowedInputAmounts,
-			ImmutableSortedSet<ScriptType> allowedInputTypes,
+			ImmutableSortedSet<ScriptType> allowedInputScriptTypes,
 			MoneyRange allowedOutputAmounts,
 			ImmutableSortedSet<ScriptType> allowedOutputTypes,
 			Network network,
@@ -39,7 +39,7 @@ public static class RoundHasher
 					   .Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, outputRegistrationTimeout)
 					   .Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, transactionSigningTimeout)
 					   .Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
-					   .Append(ProtocolConstants.RoundAllowedInputScriptTypesStrobeLabel, allowedInputTypes)
+					   .Append(ProtocolConstants.RoundAllowedInputScriptTypesStrobeLabel, allowedInputScriptTypes)
 					   .Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)
 					   .Append(ProtocolConstants.RoundAllowedOutputScriptTypesStrobeLabel, allowedOutputTypes)
 					   .Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -18,7 +18,7 @@ public static class RoundHasher
 			MoneyRange allowedInputAmounts,
 			ImmutableSortedSet<ScriptType> allowedInputScriptTypes,
 			MoneyRange allowedOutputAmounts,
-			ImmutableSortedSet<ScriptType> allowedOutputTypes,
+			ImmutableSortedSet<ScriptType> allowedOutputScriptTypes,
 			Network network,
 			long feePerK,
 			CoordinationFeeRate coordinationFeeRate,
@@ -41,7 +41,7 @@ public static class RoundHasher
 					   .Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
 					   .Append(ProtocolConstants.RoundAllowedInputScriptTypesStrobeLabel, allowedInputScriptTypes)
 					   .Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)
-					   .Append(ProtocolConstants.RoundAllowedOutputScriptTypesStrobeLabel, allowedOutputTypes)
+					   .Append(ProtocolConstants.RoundAllowedOutputScriptTypesStrobeLabel, allowedOutputScriptTypes)
 					   .Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())
 					   .Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
 					   .Append(ProtocolConstants.RoundCoordinationFeeRateStrobeLabel, coordinationFeeRate)

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -29,11 +29,6 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
 		}
 
-		if (!prevout.ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
-		{
-			throw new NotImplementedException(); // See #5440
-		}
-
 		if (prevout.Value < Parameters.AllowedInputAmounts.Min)
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -95,7 +95,7 @@ public record ConstructionState : MultipartyTransactionState
 		// Only one OP_RETURN is allowed per standard transaction, but this
 		// check is not implemented since there is no OP_RETURN ScriptType,
 		// which means no OP_RETURN outputs can be registered at all.
-		if (!Parameters.AllowedOutputTypes.Any(x => output.ScriptPubKey.IsScriptType(x)))
+		if (!Parameters.AllowedOutputScriptTypes.Any(x => output.ScriptPubKey.IsScriptType(x)))
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
 		}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -24,7 +24,7 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardInput);
 		}
 
-		if (!Parameters.AllowedInputTypes.Any(x => prevout.ScriptPubKey.IsScriptType(x)))
+		if (!Parameters.AllowedInputScriptTypes.Any(x => prevout.ScriptPubKey.IsScriptType(x)))
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
 		}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
@@ -72,7 +72,8 @@ public record SigningState : MultipartyTransactionState
 		IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
 
 		// 6. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
-		if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
+		var precomputedTransactionData = cjCopy.PrecomputeTransactionData(SortedInputs.Select(x => x.TxOut).ToArray());
+		if (!currentIndexedInput.VerifyScript(registeredCoin, ScriptVerify.Standard, precomputedTransactionData, out ScriptError error))
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongCoinjoinSignature); // TODO keep script error
 		}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using WalletWasabi.Extensions;
 using System.Linq;
 using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -52,19 +53,25 @@ public record SigningState : MultipartyTransactionState
 		}
 
 		// Verify witness.
-		// 1. Copy UnsignedCoinJoin.
-		Transaction cjCopy = CreateUnsignedTransaction();
-
-		// 2. Sign the copy.
-		cjCopy.Inputs[index].WitScript = witness;
-
-		// 3. Convert the current input to IndexedTxIn.
-		IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
-
-		// 4. Find the corresponding registered input.
+		// 1. Find the corresponding registered input.
 		Coin registeredCoin = SortedInputs[index];
 
-		// 5. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
+		// 2. Check the witness is not too long.
+		if (ScriptSizeHelpers.VirtualSize(Constants.InputBaseSizeInBytes, witness.ToBytes().Length) > registeredCoin.ScriptPubKey.EstimateInputVsize())
+		{
+			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.SignatureTooLong);
+		}
+
+		// 3. Copy UnsignedCoinJoin.
+		Transaction cjCopy = CreateUnsignedTransaction();
+
+		// 4. Sign the copy.
+		cjCopy.Inputs[index].WitScript = witness;
+
+		// 5. Convert the current input to IndexedTxIn.
+		IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
+
+		// 6. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
 		if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongCoinjoinSignature); // TODO keep script error

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -14,8 +14,8 @@ public static class ProtocolConstants
 
 	public const string RoundAllowedInputAmountsStrobeLabel = "allowed-input-amounts";
 	public const string RoundAllowedOutputAmountsStrobeLabel = "allowed-output-amounts";
-	public const string RoundAllowedInputScriptTypesStrobeLabel = "allowed-input-types";
-	public const string RoundAllowedOutputScriptTypesStrobeLabel = "allowed-output-types";
+	public const string RoundAllowedInputScriptTypesStrobeLabel = "allowed-input-script-types";
+	public const string RoundAllowedOutputScriptTypesStrobeLabel = "allowed-output-script-types";
 	public const string RoundNetworkStrobeLabel = "network";
 	public const string RoundMaxTransactionSizeStrobeLabel = "max-transaction-size";
 	public const string RoundMinRelayTxFeeStrobeLabel = "min-relay-tx-fee";

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -14,7 +14,7 @@ public static class ProtocolConstants
 
 	public const string RoundAllowedInputAmountsStrobeLabel = "allowed-input-amounts";
 	public const string RoundAllowedOutputAmountsStrobeLabel = "allowed-output-amounts";
-	public const string RoundAllowedInputTypesStrobeLabel = "allowed-input-types";
+	public const string RoundAllowedInputScriptTypesStrobeLabel = "allowed-input-types";
 	public const string RoundAllowedOutputTypesStrobeLabel = "allowed-output-types";
 	public const string RoundNetworkStrobeLabel = "network";
 	public const string RoundMaxTransactionSizeStrobeLabel = "max-transaction-size";

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -15,7 +15,7 @@ public static class ProtocolConstants
 	public const string RoundAllowedInputAmountsStrobeLabel = "allowed-input-amounts";
 	public const string RoundAllowedOutputAmountsStrobeLabel = "allowed-output-amounts";
 	public const string RoundAllowedInputScriptTypesStrobeLabel = "allowed-input-types";
-	public const string RoundAllowedOutputTypesStrobeLabel = "allowed-output-types";
+	public const string RoundAllowedOutputScriptTypesStrobeLabel = "allowed-output-types";
 	public const string RoundNetworkStrobeLabel = "network";
 	public const string RoundMaxTransactionSizeStrobeLabel = "max-transaction-size";
 	public const string RoundMinRelayTxFeeStrobeLabel = "min-relay-tx-fee";


### PR DESCRIPTION
This PR makes the wabisabi coordinator support [P2TR](https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki) scripts, which includes the support of taproot in ownership proofs.

The support has to be turned on by setting `"AllowP2trInputs" : true` and `"AllowP2trOutputs" : true` in `WabiSabiConfig.json`.