### PR TITLE
[VDG] [Trivial] Replace coinjoin icon

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/IndicatorsColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/IndicatorsColumnView.axaml
@@ -27,13 +27,13 @@
     <Panel IsVisible="{Binding !IsBanned}">
       <!-- CJ active -->
       <PathIcon IsVisible="{Binding CoinJoinInProgress}"
-                Data="{StaticResource link_filled}"
+                Data="{StaticResource wallet_action_coinjoin}"
                 Foreground="{DynamicResource SystemAccentColor}"
                 Height="9"
                 ToolTip.Tip="Coinjoining" />
       <!-- CJ inactive -->
       <PathIcon IsVisible="{Binding !CoinJoinInProgress}"
-                Data="{StaticResource link_filled}"
+                Data="{StaticResource wallet_action_coinjoin}"
                 Height="9"
                 Opacity="0.3"
                 ToolTip.Tip="Not coinjoining" />

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/IndicatorsColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/IndicatorsColumnView.axaml
@@ -29,12 +29,12 @@
       <PathIcon IsVisible="{Binding CoinJoinInProgress}"
                 Data="{StaticResource wallet_action_coinjoin}"
                 Foreground="{DynamicResource SystemAccentColor}"
-                Height="9"
+                Height="15"
                 ToolTip.Tip="Coinjoining" />
       <!-- CJ inactive -->
       <PathIcon IsVisible="{Binding !CoinJoinInProgress}"
                 Data="{StaticResource wallet_action_coinjoin}"
-                Height="9"
+                Height="15"
                 Opacity="0.3"
                 ToolTip.Tip="Not coinjoining" />
     </Panel>


### PR DESCRIPTION
The only usage remaining seems to be the indicator column in Coin List.

Fixes #6986