### PR TITLE
[VDG] Add Coinjoin Settings dialog

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -31,7 +31,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 
 	public WalletCoinsViewModel(WalletViewModel walletViewModel, IObservable<Unit> balanceChanged)
 	{
-		SetupCancel(false, true, true);
+		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 		NextCommand = CancelCommand;
 		_walletViewModel = walletViewModel;
 		_balanceChanged = balanceChanged;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -1,18 +1,143 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using NBitcoin;
+using ReactiveUI;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Fluent.Validation;
+using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 using WalletWasabi.Fluent.ViewModels.Navigation;
+using WalletWasabi.Models;
+using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
-public class CoinJoinSettingsViewModel : RoutableViewModel
+public partial class CoinJoinSettingsViewModel : RoutableViewModel
 {
-	public CoinJoinSettingsViewModel()
+	[AutoNotify] private bool _preferPsbtWorkflow;
+	[AutoNotify] private bool _autoCoinJoin;
+	[AutoNotify] private string _plebStopThreshold;
+	[AutoNotify] private string? _selectedCoinjoinProfileName;
+	[AutoNotify] private bool _isCoinjoinProfileSelected;
+
+	private Wallet _wallet;
+
+	public CoinJoinSettingsViewModel(WalletViewModelBase walletViewModelBase)
 	{
+		_wallet = walletViewModelBase.Wallet;
+		Title = $"{_wallet.WalletName} - Coinjoin Settings";
+		_preferPsbtWorkflow = _wallet.KeyManager.PreferPsbtWorkflow;
+		_autoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
+		IsHardwareWallet = _wallet.KeyManager.IsHardwareWallet;
+		IsWatchOnly = _wallet.KeyManager.IsWatchOnly;
+		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ?? KeyManager.DefaultPlebStopThreshold.ToString();
+
+		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
+
+		NextCommand = CancelCommand;
+
+		VerifyRecoveryWordsCommand = ReactiveCommand.Create(() => Navigate().To(new VerifyRecoveryWordsViewModel(_wallet)));
+
+		this.WhenAnyValue(x => x.PreferPsbtWorkflow)
+			.Skip(1)
+			.Subscribe(value =>
+			{
+				_wallet.KeyManager.PreferPsbtWorkflow = value;
+				_wallet.KeyManager.ToFile();
+				walletViewModelBase.RaisePropertyChanged(nameof(walletViewModelBase.PreferPsbtWorkflow));
+			});
+
+		SetAutoCoinJoin = ReactiveCommand.CreateFromTask(async () =>
+		{
+			if (_wallet.KeyManager.IsCoinjoinProfileSelected)
+			{
+				AutoCoinJoin = !AutoCoinJoin;
+			}
+			else
+			{
+				await NavigateDialogAsync(new CoinJoinProfilesViewModel(_wallet.KeyManager, false), NavigationTarget.DialogScreen);
+			}
+
+			if (_wallet.KeyManager.IsCoinjoinProfileSelected)
+			{
+				_wallet.KeyManager.AutoCoinJoin = AutoCoinJoin;
+				_wallet.KeyManager.ToFile();
+			}
+			else
+			{
+				AutoCoinJoin = false;
+			}
+		});
+
+		SelectCoinjoinProfileCommand = ReactiveCommand.CreateFromTask(SelectCoinjoinProfileAsync);
+
+		this.ValidateProperty(x => x.PlebStopThreshold, ValidatePlebStopThreshold);
+
+		this.WhenAnyValue(x => x.PlebStopThreshold)
+			.Skip(1)
+			.Throttle(TimeSpan.FromMilliseconds(1000))
+			.ObserveOn(RxApp.TaskpoolScheduler)
+			.Subscribe(x =>
+			{
+				if (Money.TryParse(x, out Money result) && result != _wallet.KeyManager.PlebStopThreshold)
+				{
+					_wallet.KeyManager.PlebStopThreshold = result;
+					_wallet.KeyManager.ToFile();
+				}
+			});
 	}
 
-	public string Text => "Greetings";
+	public bool IsHardwareWallet { get; }
 
-	public override string Title
+	public bool IsWatchOnly { get; }
+
+	public override sealed string Title { get; protected set; }
+
+	public ICommand SetAutoCoinJoin { get; }
+
+	public ICommand SelectCoinjoinProfileCommand { get; }
+
+	public ICommand VerifyRecoveryWordsCommand { get; }
+
+	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
-		get => "Coinjoin Settings";
-		protected set { }
+		base.OnNavigatedTo(isInHistory, disposables);
+		PlebStopThreshold = _wallet.KeyManager.PlebStopThreshold.ToString();
+
+		IsCoinjoinProfileSelected = _wallet.KeyManager.IsCoinjoinProfileSelected;
+		SelectedCoinjoinProfileName =
+			(_wallet.KeyManager.IsCoinjoinProfileSelected, CoinJoinProfilesViewModel.IdentifySelectedProfile(_wallet.KeyManager)) switch
+			{
+				(true, CoinJoinProfileViewModelBase x) => x.Title,
+				(false, _) => "None",
+				_ => "Unknown"
+			};
+	}
+
+	private async Task SelectCoinjoinProfileAsync()
+	{
+		await NavigateDialogAsync(new CoinJoinProfilesViewModel(_wallet.KeyManager, false), NavigationTarget.DialogScreen);
+		AutoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
+	}
+
+	private void ValidatePlebStopThreshold(IValidationErrors errors) =>
+		ValidatePlebStopThreshold(errors, PlebStopThreshold);
+
+	private static void ValidatePlebStopThreshold(IValidationErrors errors, string plebStopThreshold)
+	{
+		if (string.IsNullOrWhiteSpace(plebStopThreshold) || string.IsNullOrEmpty(plebStopThreshold))
+		{
+			return;
+		}
+
+		if (plebStopThreshold.Contains(',', StringComparison.InvariantCultureIgnoreCase))
+		{
+			errors.Add(ErrorSeverity.Error, "Use decimal point instead of comma.");
+		}
+		else if (!decimal.TryParse(plebStopThreshold, out _))
+		{
+			errors.Add(ErrorSeverity.Error, "Invalid coinjoin threshold.");
+		}
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -1,0 +1,18 @@
+using WalletWasabi.Fluent.ViewModels.Navigation;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets;
+
+public class CoinJoinSettingsViewModel : RoutableViewModel
+{
+	public CoinJoinSettingsViewModel()
+	{
+	}
+
+	public string Text => "Greetings";
+
+	public override string Title
+	{
+		get => "Coinjoin Settings";
+		protected set { }
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -15,7 +15,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
 public partial class CoinJoinSettingsViewModel : RoutableViewModel
 {
-	[AutoNotify] private bool _preferPsbtWorkflow;
 	[AutoNotify] private bool _autoCoinJoin;
 	[AutoNotify] private string _plebStopThreshold;
 	[AutoNotify] private string? _selectedCoinjoinProfileName;
@@ -27,26 +26,12 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 	{
 		_wallet = walletViewModelBase.Wallet;
 		Title = $"{_wallet.WalletName} - Coinjoin Settings";
-		_preferPsbtWorkflow = _wallet.KeyManager.PreferPsbtWorkflow;
 		_autoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
-		IsHardwareWallet = _wallet.KeyManager.IsHardwareWallet;
-		IsWatchOnly = _wallet.KeyManager.IsWatchOnly;
 		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ?? KeyManager.DefaultPlebStopThreshold.ToString();
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		NextCommand = CancelCommand;
-
-		VerifyRecoveryWordsCommand = ReactiveCommand.Create(() => Navigate().To(new VerifyRecoveryWordsViewModel(_wallet)));
-
-		this.WhenAnyValue(x => x.PreferPsbtWorkflow)
-			.Skip(1)
-			.Subscribe(value =>
-			{
-				_wallet.KeyManager.PreferPsbtWorkflow = value;
-				_wallet.KeyManager.ToFile();
-				walletViewModelBase.RaisePropertyChanged(nameof(walletViewModelBase.PreferPsbtWorkflow));
-			});
 
 		SetAutoCoinJoin = ReactiveCommand.CreateFromTask(async () =>
 		{
@@ -88,17 +73,11 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 			});
 	}
 
-	public bool IsHardwareWallet { get; }
-
-	public bool IsWatchOnly { get; }
-
 	public override sealed string Title { get; protected set; }
 
 	public ICommand SetAutoCoinJoin { get; }
 
 	public ICommand SelectCoinjoinProfileCommand { get; }
-
-	public ICommand VerifyRecoveryWordsCommand { get; }
 
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -15,12 +15,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
 public partial class CoinJoinSettingsViewModel : RoutableViewModel
 {
+	private readonly Wallet _wallet;
 	[AutoNotify] private bool _autoCoinJoin;
 	[AutoNotify] private bool _isCoinjoinProfileSelected;
 	[AutoNotify] private string _plebStopThreshold;
 	[AutoNotify] private string? _selectedCoinjoinProfileName;
-
-	private readonly Wallet _wallet;
 
 	public CoinJoinSettingsViewModel(WalletViewModelBase walletViewModelBase)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -36,7 +36,7 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
 		                     KeyManager.DefaultPlebStopThreshold.ToString();
 
-		SetupCancel(false, true, true);
+		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		NextCommand = CancelCommand;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -13,6 +13,14 @@ using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
+[NavigationMetaData(
+	Title = "Coinjoin Settings",
+	Category = "Coinjoin",
+	Caption = "Coinjoin Settings",
+	IconName = "wallet_action_coinjoin",
+	Keywords = new [] { "Coinjoin", "Settings", "Options", "Pleb", "Auto" },
+	Searchable = true)
+]
 public partial class CoinJoinSettingsViewModel : RoutableViewModel
 {
 	private readonly Wallet _wallet;
@@ -24,7 +32,6 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 	public CoinJoinSettingsViewModel(WalletViewModelBase walletViewModelBase)
 	{
 		_wallet = walletViewModelBase.Wallet;
-		Title = $"{_wallet.WalletName} - Coinjoin Settings";
 		_autoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
 		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
 		                     KeyManager.DefaultPlebStopThreshold.ToString();
@@ -76,8 +83,6 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 					}
 				});
 	}
-
-	public sealed override string Title { get; protected set; }
 
 	public ICommand SetAutoCoinJoin { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -5,10 +5,8 @@ using System.Windows.Input;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Fluent.Validation;
 using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 using WalletWasabi.Fluent.ViewModels.Navigation;
-using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets;
@@ -67,8 +65,6 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 
 		SelectCoinjoinProfileCommand = ReactiveCommand.CreateFromTask(SelectCoinjoinProfileAsync);
 
-		this.ValidateProperty(x => x.PlebStopThreshold, ValidatePlebStopThreshold);
-
 		this.WhenAnyValue(x => x.PlebStopThreshold)
 			.Skip(1)
 			.Throttle(TimeSpan.FromMilliseconds(1000))
@@ -104,33 +100,11 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 				};
 	}
 
-	private static void ValidatePlebStopThreshold(IValidationErrors errors, string plebStopThreshold)
-	{
-		if (string.IsNullOrWhiteSpace(plebStopThreshold) || string.IsNullOrEmpty(plebStopThreshold))
-		{
-			return;
-		}
-
-		if (plebStopThreshold.Contains(',', StringComparison.InvariantCultureIgnoreCase))
-		{
-			errors.Add(ErrorSeverity.Error, "Use decimal point instead of comma.");
-		}
-		else if (!decimal.TryParse(plebStopThreshold, out _))
-		{
-			errors.Add(ErrorSeverity.Error, "Invalid coinjoin threshold.");
-		}
-	}
-
 	private async Task SelectCoinjoinProfileAsync()
 	{
 		await NavigateDialogAsync(
 			new CoinJoinProfilesViewModel(_wallet.KeyManager, false),
 			NavigationTarget.DialogScreen);
 		AutoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
-	}
-
-	private void ValidatePlebStopThreshold(IValidationErrors errors)
-	{
-		ValidatePlebStopThreshold(errors, PlebStopThreshold);
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -16,7 +16,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 	Category = "Coinjoin",
 	Caption = "Coinjoin Settings",
 	IconName = "wallet_action_coinjoin",
-	Keywords = new [] { "Coinjoin", "Settings", "Options", "Pleb", "Auto" },
+	Keywords = new[] { "Coinjoin", "Settings", "Options", "Pleb", "Auto" },
 	Searchable = true)
 ]
 public partial class CoinJoinSettingsViewModel : RoutableViewModel

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -11,14 +11,7 @@ using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
-[NavigationMetaData(
-	Title = "Coinjoin Settings",
-	Category = "Coinjoin",
-	Caption = "Coinjoin Settings",
-	IconName = "wallet_action_coinjoin",
-	Keywords = new[] { "Coinjoin", "Settings", "Options", "Pleb", "Auto" },
-	Searchable = true)
-]
+[NavigationMetaData(Title = "Coinjoin Settings")]
 public partial class CoinJoinSettingsViewModel : RoutableViewModel
 {
 	private readonly Wallet _wallet;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -53,7 +53,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private DateTimeOffset _countDownStartTime;
 	private DateTimeOffset _countDownEndTime;
 
-	public bool IsAutoCoinJoinEnabled => WalletVm.Settings.AutoCoinJoin;
+	public bool IsAutoCoinJoinEnabled => WalletVm.CoinJoinSettings.AutoCoinJoin;
 
 	public CoinJoinStateViewModel(WalletViewModel walletVm, IObservable<Unit> balanceChanged)
 	{
@@ -74,7 +74,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(StatusChanged);
 
-		var initialState = walletVm.Settings.AutoCoinJoin
+		var initialState = walletVm.CoinJoinSettings.AutoCoinJoin
 			? State.WaitingForAutoStart
 			: State.StoppedOrPaused;
 
@@ -108,7 +108,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			await coinJoinManager.StopAsync(wallet, CancellationToken.None);
 		});
 
-		AutoCoinJoinObservable = walletVm.Settings.WhenAnyValue(x => x.AutoCoinJoin);
+		AutoCoinJoinObservable = walletVm.CoinJoinSettings.WhenAnyValue(x => x.AutoCoinJoin);
 
 		AutoCoinJoinObservable
 			.Skip(1) // The first one is triggered at the creation.

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendFeeViewModel.cs
@@ -35,7 +35,7 @@ public partial class SendFeeViewModel : DialogViewModelBase<FeeRate>
 
 		FeeChart = new FeeChartViewModel();
 
-		SetupCancel(false, true, false);
+		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: false);
 		EnableBack = true;
 
 		NextCommand = ReactiveCommand.Create(() =>

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -10,11 +10,10 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 
 public partial class WalletSettingsViewModel : RoutableViewModel
 {
-	[AutoNotify] private bool _preferPsbtWorkflow;
+	private readonly Wallet _wallet;
 	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private string _plebStopThreshold;
-
-	private readonly Wallet _wallet;
+	[AutoNotify] private bool _preferPsbtWorkflow;
 
 	public WalletSettingsViewModel(WalletViewModelBase walletViewModelBase)
 	{
@@ -23,22 +22,25 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		_preferPsbtWorkflow = _wallet.KeyManager.PreferPsbtWorkflow;
 		IsHardwareWallet = _wallet.KeyManager.IsHardwareWallet;
 		IsWatchOnly = _wallet.KeyManager.IsWatchOnly;
-		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ?? KeyManager.DefaultPlebStopThreshold.ToString();
+		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
+		                     KeyManager.DefaultPlebStopThreshold.ToString();
 
-		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
+		SetupCancel(false, true, true);
 
 		NextCommand = CancelCommand;
 
-		VerifyRecoveryWordsCommand = ReactiveCommand.Create(() => Navigate().To(new VerifyRecoveryWordsViewModel(_wallet)));
+		VerifyRecoveryWordsCommand =
+			ReactiveCommand.Create(() => Navigate().To(new VerifyRecoveryWordsViewModel(_wallet)));
 
 		this.WhenAnyValue(x => x.PreferPsbtWorkflow)
 			.Skip(1)
-			.Subscribe(value =>
-			{
-				_wallet.KeyManager.PreferPsbtWorkflow = value;
-				_wallet.KeyManager.ToFile();
-				walletViewModelBase.RaisePropertyChanged(nameof(walletViewModelBase.PreferPsbtWorkflow));
-			});
+			.Subscribe(
+				value =>
+				{
+					_wallet.KeyManager.PreferPsbtWorkflow = value;
+					_wallet.KeyManager.ToFile();
+					walletViewModelBase.RaisePropertyChanged(nameof(walletViewModelBase.PreferPsbtWorkflow));
+				});
 
 		_anonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
 
@@ -53,7 +55,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 
 	public bool IsWatchOnly { get; }
 
-	public override sealed string Title { get; protected set; }
+	public sealed override string Title { get; protected set; }
 
 	public ICommand VerifyRecoveryWordsCommand { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -1,10 +1,8 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Windows.Input;
-using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Fluent.Validation;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Wallets;
 
@@ -16,7 +14,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private string _plebStopThreshold;
 
-	private Wallet _wallet;
+	private readonly Wallet _wallet;
 
 	public WalletSettingsViewModel(WalletViewModelBase walletViewModelBase)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -1,16 +1,11 @@
-using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.Validation;
-using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
-using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Fluent.ViewModels.Navigation;
-using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets;
@@ -18,11 +13,8 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 public partial class WalletSettingsViewModel : RoutableViewModel
 {
 	[AutoNotify] private bool _preferPsbtWorkflow;
-	[AutoNotify] private bool _autoCoinJoin;
 	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private string _plebStopThreshold;
-	[AutoNotify] private string? _selectedCoinjoinProfileName;
-	[AutoNotify] private bool _isCoinjoinProfileSelected;
 
 	private Wallet _wallet;
 
@@ -31,7 +23,6 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		_wallet = walletViewModelBase.Wallet;
 		Title = $"{_wallet.WalletName} - Wallet Settings";
 		_preferPsbtWorkflow = _wallet.KeyManager.PreferPsbtWorkflow;
-		_autoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
 		IsHardwareWallet = _wallet.KeyManager.IsHardwareWallet;
 		IsWatchOnly = _wallet.KeyManager.IsWatchOnly;
 		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ?? KeyManager.DefaultPlebStopThreshold.ToString();
@@ -51,30 +42,6 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 				walletViewModelBase.RaisePropertyChanged(nameof(walletViewModelBase.PreferPsbtWorkflow));
 			});
 
-		SetAutoCoinJoin = ReactiveCommand.CreateFromTask(async () =>
-		{
-			if (_wallet.KeyManager.IsCoinjoinProfileSelected)
-			{
-				AutoCoinJoin = !AutoCoinJoin;
-			}
-			else
-			{
-				await NavigateDialogAsync(new CoinJoinProfilesViewModel(_wallet.KeyManager, false), NavigationTarget.DialogScreen);
-			}
-
-			if (_wallet.KeyManager.IsCoinjoinProfileSelected)
-			{
-				_wallet.KeyManager.AutoCoinJoin = AutoCoinJoin;
-				_wallet.KeyManager.ToFile();
-			}
-			else
-			{
-				AutoCoinJoin = false;
-			}
-		});
-
-		SelectCoinjoinProfileCommand = ReactiveCommand.CreateFromTask(SelectCoinjoinProfileAsync);
-
 		_anonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
 
 		this.WhenAnyValue(x => x.AnonScoreTarget)
@@ -82,21 +49,6 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 			.Throttle(TimeSpan.FromMilliseconds(1000))
 			.Skip(1)
 			.Subscribe(_ => _wallet.KeyManager.SetAnonScoreTarget(AnonScoreTarget));
-
-		this.ValidateProperty(x => x.PlebStopThreshold, ValidatePlebStopThreshold);
-
-		this.WhenAnyValue(x => x.PlebStopThreshold)
-			.Skip(1)
-			.Throttle(TimeSpan.FromMilliseconds(1000))
-			.ObserveOn(RxApp.TaskpoolScheduler)
-			.Subscribe(x =>
-			{
-				if (Money.TryParse(x, out Money result) && result != _wallet.KeyManager.PlebStopThreshold)
-				{
-					_wallet.KeyManager.PlebStopThreshold = result;
-					_wallet.KeyManager.ToFile();
-				}
-			});
 	}
 
 	public bool IsHardwareWallet { get; }
@@ -105,51 +57,11 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 
 	public override sealed string Title { get; protected set; }
 
-	public ICommand SetAutoCoinJoin { get; }
-
-	public ICommand SelectCoinjoinProfileCommand { get; }
-
 	public ICommand VerifyRecoveryWordsCommand { get; }
 
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
-		PlebStopThreshold = _wallet.KeyManager.PlebStopThreshold.ToString();
 		AnonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
-
-		IsCoinjoinProfileSelected = _wallet.KeyManager.IsCoinjoinProfileSelected;
-		SelectedCoinjoinProfileName =
-			(_wallet.KeyManager.IsCoinjoinProfileSelected, CoinJoinProfilesViewModel.IdentifySelectedProfile(_wallet.KeyManager)) switch
-			{
-				(true, CoinJoinProfileViewModelBase x) => x.Title,
-				(false, _) => "None",
-				_ => "Unknown"
-			};
-	}
-
-	private async Task SelectCoinjoinProfileAsync()
-	{
-		await NavigateDialogAsync(new CoinJoinProfilesViewModel(_wallet.KeyManager, false), NavigationTarget.DialogScreen);
-		AutoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
-	}
-
-	private void ValidatePlebStopThreshold(IValidationErrors errors) =>
-		ValidatePlebStopThreshold(errors, PlebStopThreshold);
-
-	private static void ValidatePlebStopThreshold(IValidationErrors errors, string plebStopThreshold)
-	{
-		if (string.IsNullOrWhiteSpace(plebStopThreshold) || string.IsNullOrEmpty(plebStopThreshold))
-		{
-			return;
-		}
-
-		if (plebStopThreshold.Contains(',', StringComparison.InvariantCultureIgnoreCase))
-		{
-			errors.Add(ErrorSeverity.Error, "Use decimal point instead of comma.");
-		}
-		else if (!decimal.TryParse(plebStopThreshold, out _))
-		{
-			errors.Add(ErrorSeverity.Error, "Invalid coinjoin threshold.");
-		}
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -25,7 +25,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
 		                     KeyManager.DefaultPlebStopThreshold.ToString();
 
-		SetupCancel(false, true, true);
+		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		NextCommand = CancelCommand;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -159,6 +159,8 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		WalletCoinsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletCoinsViewModel(this, balanceChanged)));
 
+		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new CoinJoinSettingsViewModel()));
+
 		CoinJoinStateViewModel = new CoinJoinStateViewModel(this, balanceChanged);
 	}
 
@@ -182,7 +184,9 @@ public partial class WalletViewModel : WalletViewModelBase
 
 	public ICommand WalletCoinsCommand { get; }
 
-	private CompositeDisposable Disposables { get; set; }
+	public ICommand CoinJoinSettingsCommand { get; }
+
+	private CompositeDisposable Disposables { get; }
 
 	public HistoryViewModel History { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -49,6 +49,7 @@ public partial class WalletViewModel : WalletViewModelBase
 			: throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
 		Settings = new WalletSettingsViewModel(this);
+		CoinJoinSettings = new CoinJoinSettingsViewModel(this);
 
 		var balanceChanged =
 			Observable.FromEventPattern(
@@ -159,12 +160,14 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		WalletCoinsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletCoinsViewModel(this, balanceChanged)));
 
-		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new CoinJoinSettingsViewModel(this)), Observable.Return(!wallet.KeyManager.IsWatchOnly));
+		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(CoinJoinSettings), Observable.Return(!wallet.KeyManager.IsWatchOnly));
 
 		CoinJoinStateViewModel = new CoinJoinStateViewModel(this, balanceChanged);
 
 		IsWatchOnly = wallet.KeyManager.IsWatchOnly;
 	}
+
+	public CoinJoinSettingsViewModel CoinJoinSettings { get; }
 
 	public bool IsWatchOnly { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -163,13 +163,11 @@ public partial class WalletViewModel : WalletViewModelBase
 		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(CoinJoinSettings), Observable.Return(!wallet.KeyManager.IsWatchOnly));
 
 		CoinJoinStateViewModel = new CoinJoinStateViewModel(this, balanceChanged);
-
-		IsWatchOnly = wallet.KeyManager.IsWatchOnly;
 	}
 
 	public CoinJoinSettingsViewModel CoinJoinSettings { get; }
 
-	public bool IsWatchOnly { get; }
+	public bool IsWatchOnly => Wallet.KeyManager.IsWatchOnly;
 
 	public IObservable<bool> IsMusicBoxVisible { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -189,7 +189,7 @@ public partial class WalletViewModel : WalletViewModelBase
 
 	public ICommand WalletCoinsCommand { get; }
 
-	public ReactiveCommand<Unit, Unit> CoinJoinSettingsCommand { get; }
+	public ICommand CoinJoinSettingsCommand { get; }
 
 	private CompositeDisposable Disposables { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -159,7 +159,7 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		WalletCoinsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletCoinsViewModel(this, balanceChanged)));
 
-		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new CoinJoinSettingsViewModel()));
+		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new CoinJoinSettingsViewModel(this)));
 
 		CoinJoinStateViewModel = new CoinJoinStateViewModel(this, balanceChanged);
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -159,10 +159,14 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		WalletCoinsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletCoinsViewModel(this, balanceChanged)));
 
-		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new CoinJoinSettingsViewModel(this)));
+		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new CoinJoinSettingsViewModel(this)), Observable.Return(!wallet.KeyManager.IsWatchOnly));
 
 		CoinJoinStateViewModel = new CoinJoinStateViewModel(this, balanceChanged);
+
+		IsWatchOnly = wallet.KeyManager.IsWatchOnly;
 	}
+
+	public bool IsWatchOnly { get; }
 
 	public IObservable<bool> IsMusicBoxVisible { get; }
 
@@ -184,7 +188,7 @@ public partial class WalletViewModel : WalletViewModelBase
 
 	public ICommand WalletCoinsCommand { get; }
 
-	public ICommand CoinJoinSettingsCommand { get; }
+	public ReactiveCommand<Unit, Unit> CoinJoinSettingsCommand { get; }
 
 	private CompositeDisposable Disposables { get; }
 

--- a/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml
@@ -22,20 +22,12 @@
         </DockPanel>
 
         <StackPanel Spacing="10"
-                    ToolTip.Tip="Coinjoin will not automatically start if the non-private wallet balance is less than this."
-                    IsVisible="{Binding !IsWatchOnly}">
+                    ToolTip.Tip="Coinjoin will not automatically start if the non-private wallet balance is less than this.">
           <TextBlock Text="Auto-start coinjoin threshold" />
           <c:CurrencyEntryBox Text="{Binding PlebStopThreshold}" CurrencyCode="BTC" />
         </StackPanel>
 
         <DockPanel>
-          <DockPanel.IsVisible>
-            <MultiBinding Converter="{x:Static BoolConverters.And}">
-              <Binding Path="IsCoinjoinProfileSelected" />
-              <Binding Path="IsWatchOnly" Converter="{x:Static BoolConverters.Not}" />
-            </MultiBinding>
-          </DockPanel.IsVisible>
-
           <TextBlock Text="Coinjoin strategy:" VerticalAlignment="Center" DockPanel.Dock="Left" Margin="0" />
           <Button Content="Change" Command="{Binding SelectCoinjoinProfileCommand}" DockPanel.Dock="Right" />
           <TextBlock Text="{Binding SelectedCoinjoinProfileName}" VerticalAlignment="Center" MinWidth="120" Margin="10 0 10 0" />

--- a/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml
@@ -6,14 +6,42 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:wallets="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets"
              x:DataType="wallets:CoinJoinSettingsViewModel"
-             x:CompileBindings="True"
-             x:Class="WalletWasabi.Fluent.Views.Wallets.CoinJoinSettingsView">
+             x:Class="WalletWasabi.Fluent.Views.Wallets.CoinJoinSettingsView"
+             x:CompileBindings="True">
   <c:ContentArea Title="{Binding Title}"
                  EnableNext="True" NextContent="Done"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}">
+    <StackPanel Spacing="20" Margin="0 30">
 
-    <TextBlock>Greetings</TextBlock>
+      <StackPanel Classes="settingsLayout">
 
+        <DockPanel>
+          <TextBlock Text="Automatically start coinjoin" />
+          <ToggleSwitch IsChecked="{Binding AutoCoinJoin, Mode=OneWay}" Command="{Binding SetAutoCoinJoin}" />
+        </DockPanel>
+
+        <StackPanel Spacing="10"
+                    ToolTip.Tip="Coinjoin will not automatically start if the non-private wallet balance is less than this."
+                    IsVisible="{Binding !IsWatchOnly}">
+          <TextBlock Text="Auto-start coinjoin threshold" />
+          <c:CurrencyEntryBox Text="{Binding PlebStopThreshold}" CurrencyCode="BTC" />
+        </StackPanel>
+
+        <DockPanel>
+          <DockPanel.IsVisible>
+            <MultiBinding Converter="{x:Static BoolConverters.And}">
+              <Binding Path="IsCoinjoinProfileSelected" />
+              <Binding Path="IsWatchOnly" Converter="{x:Static BoolConverters.Not}" />
+            </MultiBinding>
+          </DockPanel.IsVisible>
+
+          <TextBlock Text="Coinjoin strategy:" VerticalAlignment="Center" DockPanel.Dock="Left" Margin="0" />
+          <Button Content="Change" Command="{Binding SelectCoinjoinProfileCommand}" DockPanel.Dock="Right" />
+          <TextBlock Text="{Binding SelectedCoinjoinProfileName}" VerticalAlignment="Center" MinWidth="120" Margin="10 0 10 0" />
+        </DockPanel>
+      </StackPanel>
+
+    </StackPanel>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:c="using:WalletWasabi.Fluent.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:wallets="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets"
+             x:DataType="wallets:CoinJoinSettingsViewModel"
+             x:CompileBindings="True"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.CoinJoinSettingsView">
+  <c:ContentArea Title="{Binding Title}"
+                 EnableNext="True" NextContent="Done"
+                 EnableCancel="{Binding EnableCancel}"
+                 EnableBack="{Binding EnableBack}">
+
+    <TextBlock>Greetings</TextBlock>
+
+  </c:ContentArea>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/CoinJoinSettingsView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets;
+
+public class CoinJoinSettingsView : UserControl
+{
+	public CoinJoinSettingsView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -105,40 +105,40 @@
             <PathIcon Data="{StaticResource stop_regular}" />
           </Button>
 
-          <Panel>
-            <Ellipse Height="12" Width="12"
-                     Classes.disabled="{Binding !CoinJoinStateViewModel.AutoCoinJoinObservable^}"
-                     Classes.waiting="{Binding CoinJoinStateViewModel.IsAutoWaiting}">
-              <Ellipse.Styles>
-                <Style Selector="Ellipse">
-                  <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
-                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
-                </Style>
-                <Style Selector="Ellipse.waiting">
-                  <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
-                  <Setter Property="ToolTip.Tip"
-                          Value="Auto-start coinjoin enabled. Press Play to start immediately." />
-                </Style>
-                <Style Selector="Ellipse.disabled">
-                  <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
-                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
-                </Style>
-              </Ellipse.Styles>
-            </Ellipse>
-
-            <Button DockPanel.Dock="Top" Opacity="0.6"
-                    Background="Transparent"
-                    Padding="0"
-                    Command="{Binding CoinJoinSettingsCommand}"
-                    VerticalAlignment="Top"
-                    HorizontalAlignment="Right">
-              <Button.Content>
-                <PathIcon Height="12" Data="{StaticResource settings_general_regular}" />
-              </Button.Content>
-            </Button>
-
-          </Panel>
+          <Ellipse Height="12" Width="12"
+                   Classes.disabled="{Binding !CoinJoinStateViewModel.AutoCoinJoinObservable^}"
+                   Classes.waiting="{Binding CoinJoinStateViewModel.IsAutoWaiting}">
+            <Ellipse.Styles>
+              <Style Selector="Ellipse">
+                <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
+                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
+              </Style>
+              <Style Selector="Ellipse.waiting">
+                <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
+                <Setter Property="ToolTip.Tip"
+                        Value="Auto-start coinjoin enabled. Press Play to start immediately." />
+              </Style>
+              <Style Selector="Ellipse.disabled">
+                <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
+                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
+              </Style>
+            </Ellipse.Styles>
+          </Ellipse>
         </StackPanel>
+
+        <Button DockPanel.Dock="Top"
+                Opacity="0.6"
+                Margin="0 4 0 0"
+                Background="Transparent"
+                Padding="0"
+                Command="{Binding CoinJoinSettingsCommand}"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Right">
+          <Button.Content>
+            <PathIcon Height="12" Data="{StaticResource settings_general_regular}" />
+          </Button.Content>
+        </Button>
+
       </Panel>
     </Border>
   </Border>

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -38,7 +38,7 @@
             CornerRadius="4 4 0 0"
             BorderBrush="{DynamicResource GlassEdgeColor}"
             BorderThickness="1,1,1,0">
-      <Panel DataContext="{Binding CoinJoinStateViewModel}">
+      <Panel>
         <Panel Background="{DynamicResource TileRegionColor}" Opacity="0.35" />
         <StackPanel Margin="10 5" Orientation="Horizontal" Spacing="20">
           <StackPanel.Styles>
@@ -48,7 +48,7 @@
           </StackPanel.Styles>
           <Image Height="35" Width="35" VerticalAlignment="Center" HorizontalAlignment="Center" Source="{DynamicResource wasabi_logo_dynamic}" />
           <StackPanel Spacing="5">
-            <TransitioningContentControl MinWidth="350" MaxWidth="350" MinHeight="18" Content="{Binding CurrentStatus}">
+            <TransitioningContentControl MinWidth="350" MaxWidth="350" MinHeight="18" Content="{Binding CoinJoinStateViewModel.CurrentStatus}">
               <TransitioningContentControl.PageTransition>
                 <CrossFade Duration="0:0:0.125" FadeInEasing="0.4,0,0.6,1" FadeOutEasing="0.4,0,0.6,1" />
               </TransitioningContentControl.PageTransition>
@@ -68,7 +68,7 @@
               </TransitioningContentControl.DataTemplates>
             </TransitioningContentControl>
 
-            <ProgressBar Minimum="0" Maximum="100" IsIndeterminate="{Binding IsCountDownDelayHappening}" Value="{Binding ProgressValue}">
+            <ProgressBar Minimum="0" Maximum="100" IsIndeterminate="{Binding CoinJoinStateViewModel.IsCountDownDelayHappening}" Value="{Binding CoinJoinStateViewModel.ProgressValue}">
               <ProgressBar.Foreground>
                 <SolidColorBrush Color="{DynamicResource SystemBaseMediumColor}" />
               </ProgressBar.Foreground>
@@ -78,52 +78,66 @@
             </ProgressBar>
 
             <DockPanel LastChildFill="False">
-              <TextBlock Text="{Binding ElapsedTime}" />
-              <TextBlock Text="{Binding RemainingTime}" DockPanel.Dock="Right" />
+              <TextBlock Text="{Binding CoinJoinStateViewModel.ElapsedTime}" />
+              <TextBlock Text="{Binding CoinJoinStateViewModel.RemainingTime}" DockPanel.Dock="Right" />
             </DockPanel>
           </StackPanel>
 
           <Separator Classes="vertical" />
 
           <Button Classes="plain"
-                  IsVisible="{Binding PlayVisible}"
-                  Command="{Binding PlayCommand}">
+                  IsVisible="{Binding CoinJoinStateViewModel.PlayVisible}"
+                  Command="{Binding CoinJoinStateViewModel.PlayCommand}">
             <PathIcon Data="{StaticResource play_regular}" />
           </Button>
 
           <Button Classes="plain"
-                  IsEnabled="{Binding !IsInCriticalPhase}"
-                  IsVisible="{Binding PauseVisible}"
-                  Command="{Binding StopPauseCommand}">
+                  IsEnabled="{Binding !CoinJoinStateViewModel.IsInCriticalPhase}"
+                  IsVisible="{Binding CoinJoinStateViewModel.PauseVisible}"
+                  Command="{Binding CoinJoinStateViewModel.StopPauseCommand}">
             <PathIcon Data="{StaticResource pause_regular}" />
           </Button>
 
           <Button Classes="plain"
-                  IsEnabled="{Binding !IsInCriticalPhase}"
-                  IsVisible="{Binding StopVisible}"
-                  Command="{Binding StopPauseCommand}">
+                  IsEnabled="{Binding !CoinJoinStateViewModel.IsInCriticalPhase}"
+                  IsVisible="{Binding CoinJoinStateViewModel.StopVisible}"
+                  Command="{Binding CoinJoinStateViewModel.StopPauseCommand}">
             <PathIcon Data="{StaticResource stop_regular}" />
           </Button>
 
-          <Ellipse Height="12" Width="12"
-                   Classes.disabled="{Binding !AutoCoinJoinObservable^}"
-                   Classes.waiting="{Binding IsAutoWaiting}">
-            <Ellipse.Styles>
-              <Style Selector="Ellipse">
-                <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
-                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
-              </Style>
-              <Style Selector="Ellipse.waiting">
-                <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
-                <Setter Property="ToolTip.Tip"
-                        Value="Auto-start coinjoin enabled. Press Play to start immediately." />
-              </Style>
-              <Style Selector="Ellipse.disabled">
-                <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
-                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
-              </Style>
-            </Ellipse.Styles>
-          </Ellipse>
+          <Panel>
+            <Ellipse Height="12" Width="12"
+                     Classes.disabled="{Binding !CoinJoinStateViewModel.AutoCoinJoinObservable^}"
+                     Classes.waiting="{Binding CoinJoinStateViewModel.IsAutoWaiting}">
+              <Ellipse.Styles>
+                <Style Selector="Ellipse">
+                  <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
+                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
+                </Style>
+                <Style Selector="Ellipse.waiting">
+                  <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
+                  <Setter Property="ToolTip.Tip"
+                          Value="Auto-start coinjoin enabled. Press Play to start immediately." />
+                </Style>
+                <Style Selector="Ellipse.disabled">
+                  <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
+                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
+                </Style>
+              </Ellipse.Styles>
+            </Ellipse>
+
+            <Button DockPanel.Dock="Top" Opacity="0.6"
+                    Background="Transparent"
+                    Padding="0"
+                    Command="{Binding CoinJoinSettingsCommand}"
+                    VerticalAlignment="Top"
+                    HorizontalAlignment="Right">
+              <Button.Content>
+                <PathIcon Height="12" Data="{StaticResource settings_general_regular}" />
+              </Button.Content>
+            </Button>
+
+          </Panel>
         </StackPanel>
       </Panel>
     </Border>

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -38,7 +38,7 @@
             CornerRadius="4 4 0 0"
             BorderBrush="{DynamicResource GlassEdgeColor}"
             BorderThickness="1,1,1,0">
-      <Panel>
+      <Panel DataContext="{Binding CoinJoinStateViewModel}">
         <Panel Background="{DynamicResource TileRegionColor}" Opacity="0.35" />
         <StackPanel Margin="10 5" Orientation="Horizontal" Spacing="20">
           <StackPanel.Styles>
@@ -48,7 +48,7 @@
           </StackPanel.Styles>
           <Image Height="35" Width="35" VerticalAlignment="Center" HorizontalAlignment="Center" Source="{DynamicResource wasabi_logo_dynamic}" />
           <StackPanel Spacing="5">
-            <TransitioningContentControl MinWidth="350" MaxWidth="350" MinHeight="18" Content="{Binding CoinJoinStateViewModel.CurrentStatus}">
+            <TransitioningContentControl MinWidth="350" MaxWidth="350" MinHeight="18" Content="{Binding CurrentStatus}">
               <TransitioningContentControl.PageTransition>
                 <CrossFade Duration="0:0:0.125" FadeInEasing="0.4,0,0.6,1" FadeOutEasing="0.4,0,0.6,1" />
               </TransitioningContentControl.PageTransition>
@@ -68,7 +68,7 @@
               </TransitioningContentControl.DataTemplates>
             </TransitioningContentControl>
 
-            <ProgressBar Minimum="0" Maximum="100" IsIndeterminate="{Binding CoinJoinStateViewModel.IsCountDownDelayHappening}" Value="{Binding CoinJoinStateViewModel.ProgressValue}">
+            <ProgressBar Minimum="0" Maximum="100" IsIndeterminate="{Binding IsCountDownDelayHappening}" Value="{Binding ProgressValue}">
               <ProgressBar.Foreground>
                 <SolidColorBrush Color="{DynamicResource SystemBaseMediumColor}" />
               </ProgressBar.Foreground>
@@ -78,66 +78,52 @@
             </ProgressBar>
 
             <DockPanel LastChildFill="False">
-              <TextBlock Text="{Binding CoinJoinStateViewModel.ElapsedTime}" />
-              <TextBlock Text="{Binding CoinJoinStateViewModel.RemainingTime}" DockPanel.Dock="Right" />
+              <TextBlock Text="{Binding ElapsedTime}" />
+              <TextBlock Text="{Binding RemainingTime}" DockPanel.Dock="Right" />
             </DockPanel>
           </StackPanel>
 
           <Separator Classes="vertical" />
 
           <Button Classes="plain"
-                  IsVisible="{Binding CoinJoinStateViewModel.PlayVisible}"
-                  Command="{Binding CoinJoinStateViewModel.PlayCommand}">
+                  IsVisible="{Binding PlayVisible}"
+                  Command="{Binding PlayCommand}">
             <PathIcon Data="{StaticResource play_regular}" />
           </Button>
 
           <Button Classes="plain"
-                  IsEnabled="{Binding !CoinJoinStateViewModel.IsInCriticalPhase}"
-                  IsVisible="{Binding CoinJoinStateViewModel.PauseVisible}"
-                  Command="{Binding CoinJoinStateViewModel.StopPauseCommand}">
+                  IsEnabled="{Binding !IsInCriticalPhase}"
+                  IsVisible="{Binding PauseVisible}"
+                  Command="{Binding StopPauseCommand}">
             <PathIcon Data="{StaticResource pause_regular}" />
           </Button>
 
           <Button Classes="plain"
-                  IsEnabled="{Binding !CoinJoinStateViewModel.IsInCriticalPhase}"
-                  IsVisible="{Binding CoinJoinStateViewModel.StopVisible}"
-                  Command="{Binding CoinJoinStateViewModel.StopPauseCommand}">
+                  IsEnabled="{Binding !IsInCriticalPhase}"
+                  IsVisible="{Binding StopVisible}"
+                  Command="{Binding StopPauseCommand}">
             <PathIcon Data="{StaticResource stop_regular}" />
           </Button>
 
-          <Panel>
-            <Ellipse Height="12" Width="12"
-                     Classes.disabled="{Binding !CoinJoinStateViewModel.AutoCoinJoinObservable^}"
-                     Classes.waiting="{Binding CoinJoinStateViewModel.IsAutoWaiting}">
-              <Ellipse.Styles>
-                <Style Selector="Ellipse">
-                  <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
-                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
-                </Style>
-                <Style Selector="Ellipse.waiting">
-                  <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
-                  <Setter Property="ToolTip.Tip"
-                          Value="Auto-start coinjoin enabled. Press Play to start immediately." />
-                </Style>
-                <Style Selector="Ellipse.disabled">
-                  <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
-                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
-                </Style>
-              </Ellipse.Styles>
-            </Ellipse>
-
-            <Button DockPanel.Dock="Top" Opacity="0.6"
-                    Background="Transparent"
-                    Padding="0"
-                    Command="{Binding CoinJoinSettingsCommand}"
-                    VerticalAlignment="Top"
-                    HorizontalAlignment="Right">
-              <Button.Content>
-                <PathIcon Height="12" Data="{StaticResource settings_general_regular}" />
-              </Button.Content>
-            </Button>
-
-          </Panel>
+          <Ellipse Height="12" Width="12"
+                   Classes.disabled="{Binding !AutoCoinJoinObservable^}"
+                   Classes.waiting="{Binding IsAutoWaiting}">
+            <Ellipse.Styles>
+              <Style Selector="Ellipse">
+                <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
+                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
+              </Style>
+              <Style Selector="Ellipse.waiting">
+                <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
+                <Setter Property="ToolTip.Tip"
+                        Value="Auto-start coinjoin enabled. Press Play to start immediately." />
+              </Style>
+              <Style Selector="Ellipse.disabled">
+                <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
+                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
+              </Style>
+            </Ellipse.Styles>
+          </Ellipse>
         </StackPanel>
       </Panel>
     </Border>

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -105,40 +105,40 @@
             <PathIcon Data="{StaticResource stop_regular}" />
           </Button>
 
-          <Ellipse Height="12" Width="12"
-                   Classes.disabled="{Binding !CoinJoinStateViewModel.AutoCoinJoinObservable^}"
-                   Classes.waiting="{Binding CoinJoinStateViewModel.IsAutoWaiting}">
-            <Ellipse.Styles>
-              <Style Selector="Ellipse">
-                <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
-                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
-              </Style>
-              <Style Selector="Ellipse.waiting">
-                <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
-                <Setter Property="ToolTip.Tip"
-                        Value="Auto-start coinjoin enabled. Press Play to start immediately." />
-              </Style>
-              <Style Selector="Ellipse.disabled">
-                <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
-                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
-              </Style>
-            </Ellipse.Styles>
-          </Ellipse>
+          <Panel>
+            <Ellipse Height="12" Width="12"
+                     Classes.disabled="{Binding !CoinJoinStateViewModel.AutoCoinJoinObservable^}"
+                     Classes.waiting="{Binding CoinJoinStateViewModel.IsAutoWaiting}">
+              <Ellipse.Styles>
+                <Style Selector="Ellipse">
+                  <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
+                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
+                </Style>
+                <Style Selector="Ellipse.waiting">
+                  <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
+                  <Setter Property="ToolTip.Tip"
+                          Value="Auto-start coinjoin enabled. Press Play to start immediately." />
+                </Style>
+                <Style Selector="Ellipse.disabled">
+                  <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
+                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
+                </Style>
+              </Ellipse.Styles>
+            </Ellipse>
+
+            <Button DockPanel.Dock="Top" Opacity="0.6"
+                    Background="Transparent"
+                    Padding="0"
+                    Command="{Binding CoinJoinSettingsCommand}"
+                    VerticalAlignment="Top"
+                    HorizontalAlignment="Right">
+              <Button.Content>
+                <PathIcon Height="12" Data="{StaticResource settings_general_regular}" />
+              </Button.Content>
+            </Button>
+
+          </Panel>
         </StackPanel>
-
-        <Button DockPanel.Dock="Top"
-                Opacity="0.6"
-                Margin="0 4 0 0"
-                Background="Transparent"
-                Padding="0"
-                Command="{Binding CoinJoinSettingsCommand}"
-                VerticalAlignment="Top"
-                HorizontalAlignment="Right">
-          <Button.Content>
-            <PathIcon Height="12" Data="{StaticResource settings_general_regular}" />
-          </Button.Content>
-        </Button>
-
       </Panel>
     </Border>
   </Border>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -12,37 +12,13 @@
                  EnableNext="True" NextContent="Done"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}">
+
     <StackPanel Spacing="20" Margin="0 30">
-      <!-- TODO: It is getting messy... A separate settings page should be created for HW wallets. -->
+
       <StackPanel Classes="settingsLayout">
         <DockPanel IsVisible="{Binding IsHardwareWallet}">
           <TextBlock Text="PSBT workflow" />
           <ToggleSwitch IsChecked="{Binding PreferPsbtWorkflow}" />
-        </DockPanel>
-
-        <DockPanel IsVisible="{Binding !IsWatchOnly}">
-          <TextBlock Text="Automatically start coinjoin" />
-          <ToggleSwitch IsChecked="{Binding AutoCoinJoin, Mode=OneWay}" Command="{Binding SetAutoCoinJoin}" />
-        </DockPanel>
-
-        <StackPanel Spacing="10"
-                    ToolTip.Tip="Coinjoin will not automatically start if the non-private wallet balance is less than this."
-                    IsVisible="{Binding !IsWatchOnly}">
-          <TextBlock Text="Auto-start coinjoin threshold" />
-          <c:CurrencyEntryBox Text="{Binding PlebStopThreshold}" CurrencyCode="BTC" />
-        </StackPanel>
-
-        <DockPanel>
-          <DockPanel.IsVisible>
-            <MultiBinding Converter="{x:Static BoolConverters.And}">
-              <Binding Path="IsCoinjoinProfileSelected" />
-              <Binding Path="IsWatchOnly" Converter="{x:Static BoolConverters.Not}" />
-            </MultiBinding>
-          </DockPanel.IsVisible>
-
-          <TextBlock Text="Coinjoin strategy:" VerticalAlignment="Center" DockPanel.Dock="Left" Margin="0" />
-          <Button Content="Change" Command="{Binding SelectCoinjoinProfileCommand}" DockPanel.Dock="Right" />
-          <TextBlock Text="{Binding SelectedCoinjoinProfileName}" VerticalAlignment="Center" MinWidth="120" Margin="10 0 10 0" />
         </DockPanel>
       </StackPanel>
 
@@ -57,6 +33,8 @@
           </DockPanel>
         </c:InfoMessage>
       </StackPanel>
+
     </StackPanel>
+
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -22,8 +22,6 @@
         </DockPanel>
       </StackPanel>
 
-      <Separator IsVisible="{Binding !IsWatchOnly}" />
-
       <StackPanel Spacing="20" IsVisible="{Binding !IsWatchOnly}">
         <TextBlock Classes="h6" Text="Have you checked your wallet backup?" />
         <c:InfoMessage>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -64,6 +64,11 @@
                       <PathIcon Data="{StaticResource stats_wallet_regular}" />
                     </MenuItem.Icon>
                   </MenuItem>
+                  <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}">
+                    <MenuItem.Icon>
+                      <PathIcon Data="{StaticResource stats_wallet_regular}" />
+                    </MenuItem.Icon>
+                  </MenuItem>
                 </MenuFlyout>
               </Button.Flyout>
               <PathIcon Data="{StaticResource more_regular}" Foreground="{DynamicResource TextForegroundColor}" />

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -66,7 +66,7 @@
                   </MenuItem>
                   <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}" IsVisible="{Binding !IsWatchOnly}">
                     <MenuItem.Icon>
-                      <PathIcon Data="{StaticResource stats_wallet_regular}" />
+                      <PathIcon Data="{StaticResource wallet_action_coinjoin}" />
                     </MenuItem.Icon>
                   </MenuItem>
                 </MenuFlyout>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -64,7 +64,7 @@
                       <PathIcon Data="{StaticResource stats_wallet_regular}" />
                     </MenuItem.Icon>
                   </MenuItem>
-                  <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}">
+                  <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}" IsVisible="{Binding !IsWatchOnly}">
                     <MenuItem.Icon>
                       <PathIcon Data="{StaticResource stats_wallet_regular}" />
                     </MenuItem.Icon>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -59,14 +59,14 @@
                       <PathIcon Data="{StaticResource settings_wallet_regular}" />
                     </MenuItem.Icon>
                   </MenuItem>
-                  <MenuItem Header="Wallet Statistics" Command="{Binding WalletStatisticsCommand}">
-                    <MenuItem.Icon>
-                      <PathIcon Data="{StaticResource stats_wallet_regular}" />
-                    </MenuItem.Icon>
-                  </MenuItem>
                   <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}" IsVisible="{Binding !IsWatchOnly}">
                     <MenuItem.Icon>
                       <PathIcon Data="{StaticResource wallet_action_coinjoin}" />
+                    </MenuItem.Icon>
+                  </MenuItem>
+                  <MenuItem Header="Wallet Statistics" Command="{Binding WalletStatisticsCommand}">
+                    <MenuItem.Icon>
+                      <PathIcon Data="{StaticResource stats_wallet_regular}" />
                     </MenuItem.Icon>
                   </MenuItem>
                 </MenuFlyout>


### PR DESCRIPTION
**Adds a separate Coinjoin Settings page** as a new dialog.
*As requested in the WW2.0 meeting held on 01/08/2022.*

- Moves every coinjoin related setting from the Wallet Settings to this new Coinjoin Settings.
- For watch-only wallets (hardware wallets are included, they are also watch-only wallets) it's not visible.
- Reachable from the ... menu next to the Send and Receive button.

~~Bonus: A tiny faded/semi-transparent settings icon on the MusicBox. Please, check how it looks. It is just an idea yet.~~