### PR TITLE
Separate wasabi and wabisabi clients

### DIFF
--- a/WalletWasabi.Fluent/Config.cs
+++ b/WalletWasabi.Fluent/Config.cs
@@ -21,6 +21,7 @@ public class Config : ConfigBase
 	public static readonly Money DefaultDustThreshold = Money.Coins(Constants.DefaultDustThreshold);
 
 	private Uri? _backendUri;
+	private Uri? _coordinatorUri;
 
 	/// <summary>
 	/// Constructor for config population using Newtonsoft.JSON.
@@ -50,6 +51,15 @@ public class Config : ConfigBase
 	[DefaultValue("http://localhost:37127/")]
 	[JsonProperty(PropertyName = "RegTestBackendUri", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public string RegTestBackendUri { get; private set; } = "http://localhost:37127/";
+
+	[JsonProperty(PropertyName = "MainNetCoordinatorUri", DefaultValueHandling = DefaultValueHandling.Ignore)]
+	public string? MainNetCoordinatorUri { get; private set; }
+
+	[JsonProperty(PropertyName = "TestNetCoordinatorUri", DefaultValueHandling = DefaultValueHandling.Ignore)]
+	public string? TestNetCoordinatorUri { get; private set; }
+
+	[JsonProperty(PropertyName = "RegTestCoordinatorUri", DefaultValueHandling = DefaultValueHandling.Ignore)]
+	public string? RegTestCoordinatorUri { get; private set; }
 
 	[DefaultValue(true)]
 	[JsonProperty(PropertyName = "UseTor", DefaultValueHandling = DefaultValueHandling.Populate)]
@@ -143,6 +153,25 @@ public class Config : ConfigBase
 		}
 
 		return _backendUri;
+	}
+
+	public Uri GetCoordinatorUri()
+	{
+		if (_coordinatorUri is { })
+		{
+			return _coordinatorUri;
+		}
+
+		var result = Network switch
+		{
+			{ } n when n == Network.Main => MainNetCoordinatorUri,
+			{ } n when n == Network.TestNet => TestNetCoordinatorUri,
+			{ } n when n == Network.RegTest => RegTestCoordinatorUri,
+			_ => throw new NotSupportedNetworkException(Network)
+		};
+
+		_coordinatorUri = result is null ? GetBackendUri() : new Uri(result);
+		return _coordinatorUri;
 	}
 
 	public EndPoint GetBitcoinP2pEndPoint()

--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -92,13 +92,11 @@ public class Global
 		HttpClientFactory = new HttpClientFactory(
 			Config.UseTor ? TorSettings.SocksEndpoint : null,
 			backendUriGetter: () => Config.GetBackendUri());
-			
-			
-			CoordinatorHttpClientFactory = new HttpClientFactory(
+
+		CoordinatorHttpClientFactory = new HttpClientFactory(
 			Config.UseTor ? TorSettings.SocksEndpoint : null,
 			backendUriGetter: () => Config.GetCoordinatorUri());
-
-
+		
 		Synchronizer = new WasabiSynchronizer(BitcoinStore, HttpClientFactory);
 		LegalChecker = new(DataDir);
 		UpdateManager = new(DataDir, Config.DownloadNewVersion, HttpClientFactory.NewHttpClient(Mode.DefaultCircuit));
@@ -382,7 +380,7 @@ public class Global
 				}
 				if (CoordinatorHttpClientFactory is { } coordinatorHttpClientFactory)
 				{
-					coordinatorHttpClientFactory.Dispose();
+					await coordinatorHttpClientFactory.DisposeAsync().ConfigureAwait(false);
 					Logger.LogInfo($"{nameof(CoordinatorHttpClientFactory)} is disposed.");
 				}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -26,11 +26,11 @@ public class CoinJoinManager : BackgroundService
 	private record StartCoinJoinCommand(IWallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
 	private record StopCoinJoinCommand(IWallet Wallet) : CoinJoinCommand(Wallet);
 
-	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory backendHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;
-		HttpClientFactory = backendHttpClientFactory;
+		HttpClientFactory = coordinatorHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
 	}


### PR DESCRIPTION
This PR attempts to separate the coordinator http client from the wasabi http client. The idea is that not all coordinators would provide block filters, currency rates, etc so wasabi wallet should be able to connect to two endpoints: a backend and a coordinator