### PR TITLE
[Trivial] Hide overwhelming `SocketExceptions`

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -23,6 +23,7 @@ using WalletWasabi.Wallets;
 using LogLevel = WalletWasabi.Logging.LogLevel;
 using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Fluent.Desktop.Extensions;
+using System.Net.Sockets;
 
 namespace WalletWasabi.Fluent.Desktop;
 
@@ -219,7 +220,17 @@ public class Program
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
-		Logger.LogDebug(e.Exception);
+		foreach (var exc in e.Exception.Flatten().InnerExceptions)
+		{
+			if (exc is SocketException)
+			{
+				Logger.LogTrace(exc);
+			}
+			else
+			{
+				Logger.LogDebug(exc);
+			}
+		}
 	}
 
 	private static void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -220,16 +220,13 @@ public class Program
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
-		foreach (var exc in e.Exception.Flatten().InnerExceptions)
+		if (e.Exception.Flatten().InnerException is SocketException exc)
 		{
-			if (exc is SocketException)
-			{
-				Logger.LogTrace(exc);
-			}
-			else
-			{
-				Logger.LogDebug(exc);
-			}
+			Logger.LogTrace(exc);
+		}
+		else
+		{
+			Logger.LogDebug(e.Exception);
 		}
 	}
 

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -220,6 +220,7 @@ public class Program
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
+		// Until https://github.com/MetacoSA/NBitcoin/pull/1089 is resolved.
 		if (e.Exception.Flatten().InnerException is SocketException exc)
 		{
 			Logger.LogTrace(exc);

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -24,6 +24,7 @@ using LogLevel = WalletWasabi.Logging.LogLevel;
 using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Fluent.Desktop.Extensions;
 using System.Net.Sockets;
+using System.Collections.ObjectModel;
 
 namespace WalletWasabi.Fluent.Desktop;
 
@@ -220,10 +221,12 @@ public class Program
 
 	private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
 	{
+		ReadOnlyCollection<Exception> innerExceptions = e.Exception.Flatten().InnerExceptions;
+
 		// Until https://github.com/MetacoSA/NBitcoin/pull/1089 is resolved.
-		if (e.Exception.Flatten().InnerException is SocketException exc)
+		if (innerExceptions.Count == 1 && innerExceptions[0] is SocketException)
 		{
-			Logger.LogTrace(exc);
+			Logger.LogTrace(e.Exception);
 		}
 		else
 		{

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -224,7 +224,7 @@ public class Program
 		ReadOnlyCollection<Exception> innerExceptions = e.Exception.Flatten().InnerExceptions;
 
 		// Until https://github.com/MetacoSA/NBitcoin/pull/1089 is resolved.
-		if (innerExceptions.Count == 1 && innerExceptions[0] is SocketException)
+		if (innerExceptions.Count == 1 && innerExceptions[0] is SocketException socketException && socketException.SocketErrorCode == SocketError.OperationAborted)
 		{
 			Logger.LogTrace(e.Exception);
 		}


### PR DESCRIPTION
This simple PR TraceLogs all unobserved `SocketExceptions`, e.g. when a peer disconects, so it won't get overwhelmed in the logs during debuging.
Until better handling gets added on NBitcoin's side, this is the best way not to get burried alive in these exceptions.