### PR TITLE
Simplify `TorHttpPool.CreateNewConnectionAsync`

### DIFF
--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -281,12 +281,7 @@ public class TorHttpPool : IDisposable
 
 	private async Task<TorTcpConnection> CreateNewConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
 	{
-		DateTime start = DateTime.UtcNow;
-		TorTcpConnection connection = await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
-		Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Created new Tor SOCKS5 connection in {DateTime.UtcNow - start}.");
-
-		Logger.LogTrace($"< connection='{connection}'");
-		return connection;
+		return await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
 	}
 
 	/// <exception cref="TorConnectionWriteException">When a failure during sending our HTTP(s) request to Tor SOCKS5 occurs.</exception>

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -279,30 +279,11 @@ public class TorHttpPool : IDisposable
 		while (true);
 	}
 
-	private async Task<TorTcpConnection?> CreateNewConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
+	private async Task<TorTcpConnection> CreateNewConnectionAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
 	{
-		TorTcpConnection? connection;
-
-		try
-		{
-			connection = await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
-			Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Created new Tor SOCKS5 connection.");
-		}
-		catch (TorException e)
-		{
-			Logger.LogDebug($"['{request.RequestUri}'][ERROR] Failed to create a new pool connection.", e);
-			throw;
-		}
-		catch (OperationCanceledException)
-		{
-			Logger.LogTrace($"['{request.RequestUri}'] Operation was canceled.");
-			throw;
-		}
-		catch (Exception e)
-		{
-			Logger.LogTrace($"['{request.RequestUri}'][EXCEPTION] {e}");
-			throw;
-		}
+		DateTime start = DateTime.UtcNow;
+		TorTcpConnection connection = await TcpConnectionFactory.ConnectAsync(request.RequestUri!, circuit, cancellationToken).ConfigureAwait(false);
+		Logger.LogTrace($"[NEW {connection}]['{request.RequestUri}'] Created new Tor SOCKS5 connection in {DateTime.UtcNow - start}.");
 
 		Logger.LogTrace($"< connection='{connection}'");
 		return connection;


### PR DESCRIPTION
These exceptions are being logged in `TorHttpPool.SendAsync` so we log them twice and logs look worse than they are.

Allows us to see how long it takes to create a new Tor SOCKS5 connection:

```log
2022-08-03 00:13:25.630 [34] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW DC#0001#NLV34Q4JQ4]['https://status.torproject.org/index.xml'] Created new Tor SOCKS5 connection in 00:00:01.8913407.
2022-08-03 00:13:41.658 [34] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0002#66NZVM1LC9]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/status'] Created new Tor SOCKS5 connection in 00:00:17.8907451.
2022-08-03 00:13:42.081 [34] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW DC#0003#NLV34Q4JQ4]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/software/versions'] Created new Tor SOCKS5 connection in 00:00:18.3728742.
2022-08-03 00:13:42.081 [19] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW DC#0004#NLV34Q4JQ4]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/v4/btc/batch/synchronize?bestKnownBlockHash=00000000000000000009454e195b471b1f8b3136586a9fc13582695cbf2d5dde&maxNumberOfFilters=1000&estimateSmartFeeMode=Conservative'] Created new Tor SOCKS5 connection in 00:00:18.2960207.
2022-08-03 00:14:34.196 [34] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0005#QQ7WR7S9DM]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:07.1390869.
2022-08-03 00:14:41.255 [34] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0006#CO5IF35QGG]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:23.0012451.
2022-08-03 00:15:51.670 [34] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0007#66NZVM1LC9]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/status'] Created new Tor SOCKS5 connection in 00:00:07.0042848.
2022-08-03 00:16:50.014 [86] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0008#CWZJMILQNA]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:03.3213155.
2022-08-03 00:17:23.216 [86] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0009#X1VRK6II33]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:06.2196037.
2022-08-03 00:18:05.981 [64] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0010#8SPL58TWQY]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:05.1364841.
2022-08-03 00:18:11.776 [64] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0011#DIF38H22BE]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:05.9773944.
2022-08-03 00:18:15.196 [64] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0012#RFMI13DEQH]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/input-registration'] Created new Tor SOCKS5 connection in 00:00:02.1219571.
2022-08-03 00:18:57.895 [66] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0013#DIF38H22BE]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/connection-confirmation'] Created new Tor SOCKS5 connection in 00:00:00.3530233.
2022-08-03 00:21:49.309 [77] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0014#NYZMQ7T3Y2]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:03.2274238.
2022-08-03 00:21:50.205 [84] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0015#13V4W6BXQM]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:03.8059443.
2022-08-03 00:21:51.219 [77] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0016#O2DPHHKTIK]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:04.0223026.
2022-08-03 00:21:55.218 [66] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0017#HFRG75IBD9]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:07.5078009.
2022-08-03 00:21:55.719 [66] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0018#KBAVRBSPHQ]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:09.0598520.
2022-08-03 00:21:56.060 [66] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0019#QP0IDJLUDU]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:09.1378345.
2022-08-03 00:22:03.852 [77] TRACE	TorHttpPool.CreateNewConnectionAsync (286)	[NEW PC#0020#1G9U1XR9ZN]['http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/wabisabi/credential-issuance'] Created new Tor SOCKS5 connection in 00:00:07.5437085.
```

edit: No, we already log that so it can be simplified even further.