### PR TITLE
[VDG] Remove OAPH from SearchBar

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
@@ -12,7 +12,6 @@ namespace WalletWasabi.Fluent.ViewModels.SearchBar;
 public partial class SearchBarViewModel : ReactiveObject
 {
 	private readonly ReadOnlyObservableCollection<SearchItemGroup> _groups;
-	private readonly ObservableAsPropertyHelper<bool> _hasResults;
 	[AutoNotify] private bool _isSearchListVisible;
 	[AutoNotify] private string _searchText = "";
 
@@ -29,7 +28,10 @@ public partial class SearchBarViewModel : ReactiveObject
 			.Filter(filterPredicate);
 
 		filteredItems
-			.Transform(item => item is ActionableItem i ? new AutocloseActionableItem(i, () => IsSearchListVisible = false) : item)
+			.Transform(
+				item => item is ActionableItem i
+					? new AutocloseActionableItem(i, () => IsSearchListVisible = false)
+					: item)
 			.Group(s => s.Category)
 			.Transform(group => new SearchItemGroup(group.Key, group.Cache))
 			.Bind(out _groups)
@@ -37,13 +39,14 @@ public partial class SearchBarViewModel : ReactiveObject
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe();
 
-		_hasResults = filteredItems
+		HasResults = filteredItems
 			.Count()
 			.Select(i => i > 0)
-			.ToProperty(this, x => x.HasResults);
+			.Replay()
+			.RefCount();
 	}
 
-	public bool HasResults => _hasResults.Value;
+	public IObservable<bool> HasResults { get; }
 
 	public ReadOnlyObservableCollection<SearchItemGroup> Groups => _groups;
 

--- a/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
+++ b/WalletWasabi.Fluent/Views/SearchBar/SearchBarDropdown.axaml
@@ -101,8 +101,8 @@
   </UserControl.DataTemplates>
 
   <Panel VerticalAlignment="Center">
-    <TextBlock IsVisible="{Binding !HasResults, FallbackValue=False}" Margin="10">No results</TextBlock>
-    <ItemsControl IsVisible="{Binding HasResults}" Items="{Binding Groups}">
+    <TextBlock IsVisible="{Binding !HasResults^, FallbackValue=False}" Margin="10">No results</TextBlock>
+    <ItemsControl IsVisible="{Binding HasResults^}" Items="{Binding Groups}">
       <ItemsControl.ItemTemplate>
         <DataTemplate DataType="{x:Type sb:SearchItemGroup}">
           <DockPanel Margin="0 0 0 10">


### PR DESCRIPTION
No longer need to use RxUI ObservableAsPropertyHelper.