### PR TITLE
Make Wasabi work with pruned nodes (client side included)

### DIFF
--- a/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
@@ -44,8 +44,8 @@ public static class TestNodeBuilder
 				tryDeleteDataDir: true,
 				EndPointStrategy.Random,
 				EndPointStrategy.Random,
-				txIndex: 1,
-				prune: 0,
+				txIndex: 0,
+				prune: 1,
 				mempoolReplacement: "fee,optin",
 				userAgent: $"/WasabiClient:{Constants.ClientVersion}/",
 				fallbackFee: Money.Coins(0.0002m), // https://github.com/bitcoin/bitcoin/pull/16524

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -101,7 +101,7 @@ public static class WabiSabiFactory
 					TxOut = coin.TxOut,
 				});
 
-			mockRpc.Setup(rpc => rpc.GetRawTransactionAsync(coin.Outpoint.Hash, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+			mockRpc.Setup(rpc => rpc.GetRawTransactionAsync(coin.Outpoint.Hash,  It.IsAny<uint256>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(BitcoinFactory.CreateTransaction());
 		}
 		mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), It.IsAny<EstimateSmartFeeMode>(), It.IsAny<CancellationToken>()))

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -13,6 +13,7 @@ public class MockRpcClient : IRPCClient
 	public Func<Task<uint256>>? OnGetBestBlockHashAsync { get; set; }
 	public Func<uint256, int, bool, GetTxOutResponse?>? OnGetTxOutAsync { get; set; }
 	public Func<uint256, Task<Block>>? OnGetBlockAsync { get; set; }
+	public Func<Task<int>>? OnGetBlockCountAsync { get; set; }
 	public Func<int, Task<uint256>>? OnGetBlockHashAsync { get; set; }
 	public Func<uint256, Task<BlockHeader>>? OnGetBlockHeaderAsync { get; set; }
 	public Func<Task<BlockchainInfo>>? OnGetBlockchainInfoAsync { get; set; }
@@ -20,7 +21,7 @@ public class MockRpcClient : IRPCClient
 	public Func<Transaction, uint256>? OnSendRawTransactionAsync { get; set; }
 	public Func<Task<MemPoolInfo>>? OnGetMempoolInfoAsync { get; set; }
 	public Func<Task<uint256[]>>? OnGetRawMempoolAsync { get; set; }
-	public Func<uint256, bool, Task<Transaction>>? OnGetRawTransactionAsync { get; set; }
+	public Func<uint256, uint256, bool, Task<Transaction>>? OnGetRawTransactionAsync { get; set; }
 	public Func<int, EstimateSmartFeeMode, Task<EstimateSmartFeeResponse>>? OnEstimateSmartFeeAsync { get; set; }
 	public Func<Task<PeerInfo[]>>? OnGetPeersInfoAsync { get; set; }
 	public Func<int, BitcoinAddress, Task<uint256[]>>? OnGenerateToAddressAsync { get; set; }
@@ -52,7 +53,7 @@ public class MockRpcClient : IRPCClient
 
 	public Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default)
 	{
-		throw new NotImplementedException();
+		return OnGetBlockCountAsync?.Invoke() ?? NotImplementedTask<int>(nameof(GetBlockCountAsync));
 	}
 
 	public Task<uint256> GetBlockHashAsync(int height, CancellationToken cancellationToken = default)
@@ -90,9 +91,9 @@ public class MockRpcClient : IRPCClient
 		return OnGetRawMempoolAsync?.Invoke() ?? NotImplementedTask<uint256[]>(nameof(GetRawMempoolAsync));
 	}
 
-	public Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
+	public Task<Transaction> GetRawTransactionAsync(uint256 txid, uint256? blockHash = null, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 	{
-		return OnGetRawTransactionAsync?.Invoke(txid, throwIfNotFound) ?? NotImplementedTask<Transaction>(nameof(GetRawTransactionAsync));
+		return OnGetRawTransactionAsync?.Invoke(txid, blockHash, throwIfNotFound) ?? NotImplementedTask<Transaction>(nameof(GetRawTransactionAsync));
 	}
 
 	public Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancellationToken = default)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -58,7 +58,7 @@ public class ArenaClientTests
 			});
 		mockRpc.Setup(rpc => rpc.PrepareBatch()).Returns(mockRpc.Object);
 		mockRpc.Setup(rpc => rpc.SendBatchAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-		mockRpc.Setup(rpc => rpc.GetRawTransactionAsync(It.IsAny<uint256>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+		mockRpc.Setup(rpc => rpc.GetRawTransactionAsync(It.IsAny<uint256>(),  It.IsAny<uint256>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
 				.ReturnsAsync(BitcoinFactory.CreateTransaction());
 
 		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/IWebHostBuilderExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/IWebHostBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class IWebHostBuilderExtensions
 			TxOut = coins.Single(x => x.TransactionId == txId && x.Index == idx).TxOut
 		};
 
-		rpc.OnGetRawTransactionAsync = (txid, throwIfNotFound) =>
+		rpc.OnGetRawTransactionAsync = (txid, blockHash, throwIfNotFound) =>
 		{
 			var tx = coins.First(coin => coin.TransactionId == txid)?.Transaction?.Transaction;
 
@@ -36,6 +36,9 @@ public static class IWebHostBuilderExtensions
 
 			return Task.FromResult(tx);
 		};
+
+		rpc.OnGetBlockCountAsync = () => Task.FromResult(100);
+		rpc.OnGetBlockHashAsync = (height) => Task.FromResult(uint256.One);
 
 		options(rpc);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -520,7 +520,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			var mempool = await rpc.GetRawMempoolAsync();
 			var coinjoin = await rpc.GetRawTransactionAsync(mempool.Single());
 
-			Assert.True(coinjoin.Outputs.Count <= ExpectedInputNumber);
+			Assert.NotNull(coinjoin);
 		}
 		finally
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -318,7 +318,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			Enumerable.Concat(coins, badCoins).ToArray(),
 			rpc =>
 			{
-				rpc.OnGetRawTransactionAsync = (txid, throwIfNotFound) =>
+				rpc.OnGetRawTransactionAsync = (txid, blockHash, throwIfNotFound) =>
 				{
 					var tx = Transaction.Create(Network.Main);
 					return Task.FromResult(tx);
@@ -547,7 +547,9 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					ScriptPubKeyType = "witness_v0_keyhash",
 					TxOut = coinToRegister.TxOut
 				};
-				rpc.OnGetRawTransactionAsync = (txid, throwIfNotFound) =>
+				rpc.OnGetBlockCountAsync = () => Task.FromResult(100);
+				rpc.OnGetBlockHashAsync = (_) => Task.FromResult(uint256.One);
+				rpc.OnGetRawTransactionAsync = (txid, blockHash, throwIfNotFound) =>
 				{
 					var tx = Transaction.Create(Network.Main);
 					return Task.FromResult(tx);

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -61,11 +61,6 @@ public class P2pNode
 		Node = await Node.ConnectAsync(Network, EndPoint, parameters).ConfigureAwait(false);
 		Node.VersionHandshake(cancel);
 
-		if (Node.PeerVersion.StartHeight > SmartHeader.GetStartingHeader(Network).Height)
-		{
-		 	throw new InvalidOperationException("Wasabi cannot use the local node it doesn't have all the blocks since segwit activation.");
-		}
-
 		if (!Node.IsConnected)
 		{
 			throw new InvalidOperationException(

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Monitoring;
 using WalletWasabi.BitcoinP2p;
+using WalletWasabi.Blockchain.BlockFilters;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -59,9 +61,9 @@ public class P2pNode
 		Node = await Node.ConnectAsync(Network, EndPoint, parameters).ConfigureAwait(false);
 		Node.VersionHandshake(cancel);
 
-		if (!Node.PeerVersion.Services.HasFlag(NodeServices.Network))
+		if (Node.PeerVersion.StartHeight > SmartHeader.GetStartingHeader(Network).Height)
 		{
-			throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
+		 	throw new InvalidOperationException("Wasabi cannot use the local node it doesn't have all the blocks since segwit activation.");
 		}
 
 		if (!Node.IsConnected)

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -56,7 +56,7 @@ public interface IRPCClient
 
 	Task<BumpResponse> BumpFeeAsync(uint256 txid, CancellationToken cancellationToken = default);
 
-	Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default);
+	Task<Transaction> GetRawTransactionAsync(uint256 txid, uint256? blockHash = null, bool throwIfNotFound = true, CancellationToken cancellationToken = default);
 
 	Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel);
 

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -185,9 +185,9 @@ public class RpcClientBase : IRPCClient
 		return await Rpc.BumpFeeAsync(txid, cancellationToken).ConfigureAwait(false);
 	}
 
-	public virtual async Task<Transaction> GetRawTransactionAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
+	public virtual async Task<Transaction> GetRawTransactionAsync(uint256 txid, uint256? blockHash = null, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 	{
-		return await Rpc.GetRawTransactionAsync(txid, throwIfNotFound, cancellationToken).ConfigureAwait(false);
+		return await Rpc.GetRawTransactionAsync(txid, blockHash, throwIfNotFound, cancellationToken).ConfigureAwait(false);
 	}
 
 	public virtual async Task<IEnumerable<Transaction>> GetRawTransactionsAsync(IEnumerable<uint256> txids, CancellationToken cancel)
@@ -200,7 +200,7 @@ public class RpcClientBase : IRPCClient
 			List<Task<Transaction>> tasks = new();
 			foreach (var txid in txidsChunk)
 			{
-				tasks.Add(batchingRpc.GetRawTransactionAsync(txid, throwIfNotFound: false, cancel));
+				tasks.Add(batchingRpc.GetRawTransactionAsync(txid, blockHash:null /*mempool only*/, throwIfNotFound: false, cancel));
 			}
 
 			await batchingRpc.SendBatchAsync(cancel).ConfigureAwait(false);


### PR DESCRIPTION
In its current state Wasabi can work with pruned nodes if they contain **all** the blocks after segwit activation height. However, pruned nodes cannot keep a transaction index and for that reason it is not possible for them to find a transaction by `id`. This is necessary for one and only one feature: `one hop transactions don't pay`.

Fortunately if we know the hash of the block that contains the wanted transaction, and that block is available, a pruned node can return the transaction as before.

# Changes in WabiSabi

So, given an outpoint, how can we know the hash of the block where the transaction referred by that outpoint was mined?
 
After this PR when Alice registers an input (outpoint) the coordinator uses the number of confirmations returned by `gettxout` RPC response to calculate the block height (and then get the block hash) of the block containing the utxo. 

So, the Alice's coins that used to be a tuple `(outpoint, txout)` are now `(outpoint, txout, blockhash)` and the new property is used in the `GetRawTransaction` RPC call request. Here is all the magic.

# Changes in the client code

The limitation in the client that prevented the client to connect to pruned nodes was also removed ~but the client needs to have all the blocks after segwit activation anyway (this is only possible with **manual prunning**)~

# Others

This addition that looks only necessary to work with pruned nodes is in fact good because we need to return the block hash of each coins to the clients in order to allow them to verify the coordinator is not laying to them in a cheapest way. See https://github.com/zkSNACKs/WalletWasabi/pull/8661

**Note:** the block height calculation works in this draft but we need to review it. Basically the questions to answer is what happens if a new block is received immediately after the `gettxout` returned? 
