### PR TITLE
Tor SOCKS5: Remove "keepalive" functionality

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
@@ -43,7 +43,7 @@ public class TorProcessManagerTests
 
 		// Set up Tor process manager.
 		Mock<TorTcpConnectionFactory> mockTcpConnectionFactory = new(MockBehavior.Strict, DummyTorControlEndpoint);
-		mockTcpConnectionFactory.Setup(c => c.IsTorRunningAsync(CancellationToken.None))
+		mockTcpConnectionFactory.Setup(c => c.IsTorRunningAsync(It.IsAny<CancellationToken>()))
 			.ReturnsAsync(false);
 
 		// Mock TorProcessManager.

--- a/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
+++ b/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
@@ -11,7 +11,7 @@ public static class TcpClientSocks5Connector
 	/// <summary>
 	/// Establishes TCP connection with Tor SOCKS5 endpoint.
 	/// </summary>
-	/// <exception cref="ArgumentException">This should never happen.</exception>
+	/// <exception cref="NotSupportedException">This should never happen.</exception>
 	/// <exception cref="TorException">When connection to Tor SOCKS5 endpoint fails.</exception>
 	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken)
 	{

--- a/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
+++ b/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
@@ -13,11 +13,11 @@ public static class TcpClientSocks5Connector
 	/// </summary>
 	/// <exception cref="ArgumentException">This should never happen.</exception>
 	/// <exception cref="TorException">When connection to Tor SOCKS5 endpoint fails.</exception>
-	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancel)
+	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken)
 	{
 		try
 		{
-			return await TcpClientConnector.ConnectAsync(endPoint, cancel).ConfigureAwait(false);
+			return await TcpClientConnector.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
 		}
 		catch (SocketException ex) when (ex.ErrorCode is 10061 or 111 or 61)
 		{

--- a/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
+++ b/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Tor.Socks5.Exceptions;
@@ -15,14 +11,13 @@ public static class TcpClientSocks5Connector
 	/// <summary>
 	/// Establishes TCP connection with Tor SOCKS5 endpoint.
 	/// </summary>
-	/// <param name="builder">Runs in between creation of TCP client and connection to the end point.</param>
 	/// <exception cref="ArgumentException">This should never happen.</exception>
 	/// <exception cref="TorException">When connection to Tor SOCKS5 endpoint fails.</exception>
-	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancel, Action<TcpClient>? builder = null)
+	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancel)
 	{
 		try
 		{
-			return await TcpClientConnector.ConnectAsync(endPoint, cancel, builder).ConfigureAwait(false);
+			return await TcpClientConnector.ConnectAsync(endPoint, cancel).ConfigureAwait(false);
 		}
 		catch (SocketException ex) when (ex.ErrorCode is 10061 or 111 or 61)
 		{

--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -74,25 +74,7 @@ public class TorTcpConnectionFactory
 
 		try
 		{
-			tcpClient = await TcpClientSocks5Connector.ConnectAsync(TorSocks5EndPoint, cancellationToken, client =>
-			{
-				client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-
-				// Windows 7 does not support the API we use.
-				if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version.Major < 10))
-				{
-					try
-					{
-						client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 30);
-						client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 5);
-						client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 5);
-					}
-					catch (SocketException ex) when (ex.ErrorCode is 10042)
-					{
-						Logger.LogWarning("KeepAlive settings are not allowed by your OS. Ignoring.");
-					}
-				}
-			}).ConfigureAwait(false);
+			tcpClient = await TcpClientSocks5Connector.ConnectAsync(TorSocks5EndPoint, cancellationToken).ConfigureAwait(false);
 
 			transportStream = tcpClient.GetStream();
 			await HandshakeAsync(tcpClient, circuit, cancellationToken).ConfigureAwait(false);
@@ -125,7 +107,7 @@ public class TorTcpConnectionFactory
 		try
 		{
 			// Internal TCP client may close, so we need a new instance here.
-			using var tcpClient = await TcpClientSocks5Connector.ConnectAsync(TorSocks5EndPoint, cancellationToken).ConfigureAwait(false);
+			using TcpClient tcpClient = await TcpClientSocks5Connector.ConnectAsync(TorSocks5EndPoint, cancellationToken).ConfigureAwait(false);
 			await HandshakeAsync(tcpClient, DefaultCircuit.Instance, cancellationToken).ConfigureAwait(false);
 
 			return true;

--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -120,13 +120,13 @@ public class TorTcpConnectionFactory
 	/// <summary>
 	/// Checks whether communication can be established with Tor over <see cref="TorSocks5EndPoint"/> endpoint.
 	/// </summary>
-	public virtual async Task<bool> IsTorRunningAsync(CancellationToken cancel)
+	public virtual async Task<bool> IsTorRunningAsync(CancellationToken cancellationToken)
 	{
 		try
 		{
 			// Internal TCP client may close, so we need a new instance here.
-			using var tcpClient = await TcpClientSocks5Connector.ConnectAsync(TorSocks5EndPoint, cancel).ConfigureAwait(false);
-			await HandshakeAsync(tcpClient, DefaultCircuit.Instance, cancel).ConfigureAwait(false);
+			using var tcpClient = await TcpClientSocks5Connector.ConnectAsync(TorSocks5EndPoint, cancellationToken).ConfigureAwait(false);
+			await HandshakeAsync(tcpClient, DefaultCircuit.Instance, cancellationToken).ConfigureAwait(false);
 
 			return true;
 		}

--- a/WalletWasabi/Tor/TcpClientConnector.cs
+++ b/WalletWasabi/Tor/TcpClientConnector.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,24 +10,32 @@ public static class TcpClientConnector
 	/// <summary>
 	/// Connects to end point using a TCP client.
 	/// </summary>
-	/// <param name="builder">Runs in between creation of TCP client and connection to the end point.</param>
-	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancel, Action<TcpClient>? builder = null)
+	public static async Task<TcpClient> ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken)
 	{
-		TcpClient tcpClient = new(endPoint.AddressFamily);
-		builder?.Invoke(tcpClient);
-		switch (endPoint)
+		TcpClient? client = null;
+
+		try
 		{
-			case DnsEndPoint dnsEndPoint:
-				await tcpClient.ConnectAsync(dnsEndPoint.Host, dnsEndPoint.Port, cancel).ConfigureAwait(false);
-				break;
+			client = new(endPoint.AddressFamily);
 
-			case IPEndPoint ipEndPoint:
-				await tcpClient.ConnectAsync(ipEndPoint, cancel).ConfigureAwait(false);
-				break;
-
-			default:
-				throw new ArgumentOutOfRangeException(nameof(endPoint));
+			switch (endPoint)
+			{
+				case DnsEndPoint dnsEndPoint:
+					await client.ConnectAsync(dnsEndPoint.Host, dnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
+					break;
+				case IPEndPoint ipEndPoint:
+					await client.ConnectAsync(ipEndPoint, cancellationToken).ConfigureAwait(false);
+					break;
+				default:
+					throw new NotSupportedException($"Endpoint of type '{endPoint.GetType().FullName}' is not supported.");
+			}
 		}
-		return tcpClient;
+		catch (Exception)
+		{
+			client?.Dispose();
+			throw;
+		}
+
+		return client;
 	}
 }

--- a/WalletWasabi/Tor/TcpClientConnector.cs
+++ b/WalletWasabi/Tor/TcpClientConnector.cs
@@ -16,16 +16,18 @@ public static class TcpClientConnector
 
 		try
 		{
-			client = new(endPoint.AddressFamily);
-
 			switch (endPoint)
 			{
 				case DnsEndPoint dnsEndPoint:
+					client = new();
 					await client.ConnectAsync(dnsEndPoint.Host, dnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
 					break;
+
 				case IPEndPoint ipEndPoint:
+					client = new(endPoint.AddressFamily);
 					await client.ConnectAsync(ipEndPoint, cancellationToken).ConfigureAwait(false);
 					break;
+
 				default:
 					throw new NotSupportedException($"Endpoint of type '{endPoint.GetType().FullName}' is not supported.");
 			}

--- a/WalletWasabi/Tor/TcpClientConnector.cs
+++ b/WalletWasabi/Tor/TcpClientConnector.cs
@@ -32,7 +32,7 @@ public static class TcpClientConnector
 					throw new NotSupportedException($"Endpoint of type '{endPoint.GetType().FullName}' is not supported.");
 			}
 		}
-		catch (Exception)
+		catch
 		{
 			client?.Dispose();
 			throw;


### PR DESCRIPTION
Follow-up to #8851 and #8888
<s>Contains #8896 changes (just a test fix)</s>
Contains some changes from https://github.com/kiminuo/WalletWasabi/commit/23f26d718c021fbf9b67951b4ecb695139d934fe

Tor team responded to our [question](https://gitlab.torproject.org/tpo/core/tor/-/issues/40653) and we specifically asked whether it makes sense to use keep-alive functionality and:

>> Is it necessary to specify that keep-alive options? Is it recommended? Is it useless?
>
> I'm going to go with 'no', 'no', and 'unclear'.

So this PR removes that. The code for doing keep-alives were added with the hope that it changes something but nobody was able to say why it should improve anything (long story short: it cannot really). I actually did some test runs and I could not spot any difference with and without keep-alives, so removing that simplifies code.