### PR TITLE
Add retry timeouts to CoinJoin requests

### DIFF
--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -66,7 +66,9 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 		var exceptions = new Dictionary<Exception, int>();
 		var start = DateTime.UtcNow;
 
-		using CancellationTokenSource absoluteTimeoutCts = new(TimeSpan.FromMinutes(30));
+		var totalTimeout = TimeSpan.FromMinutes(30);
+
+		using CancellationTokenSource absoluteTimeoutCts = new(totalTimeout);
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, absoluteTimeoutCts.Token);
 		var combinedToken = linkedCts.Token;
 
@@ -77,7 +79,7 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 			{
 				using StringContent content = new(jsonString, Encoding.UTF8, "application/json");
 
-				using CancellationTokenSource requestTimeoutCts = new(retryTimeout is { } timeout ? timeout : TimeSpan.MaxValue);
+				using CancellationTokenSource requestTimeoutCts = new(retryTimeout is { } timeout ? timeout : totalTimeout);
 				using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(combinedToken, requestTimeoutCts.Token);
 
 				// Any transport layer errors will throw an exception here.

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -38,30 +38,30 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 	}
 
 	public Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<InputRegistrationRequest, InputRegistrationResponse>(RemoteAction.RegisterInput, request, cancellationToken);
+		SendAndReceiveAsync<InputRegistrationRequest, InputRegistrationResponse>(RemoteAction.RegisterInput, request, cancellationToken, TimeSpan.FromSeconds(30));
 
 	public Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<ConnectionConfirmationRequest, ConnectionConfirmationResponse>(RemoteAction.ConfirmConnection, request, cancellationToken);
+		SendAndReceiveAsync<ConnectionConfirmationRequest, ConnectionConfirmationResponse>(RemoteAction.ConfirmConnection, request, cancellationToken, TimeSpan.FromSeconds(30));
 
 	public Task RegisterOutputAsync(OutputRegistrationRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<OutputRegistrationRequest>(RemoteAction.RegisterOutput, request, cancellationToken);
+		SendAndReceiveAsync<OutputRegistrationRequest>(RemoteAction.RegisterOutput, request, cancellationToken, TimeSpan.FromSeconds(30));
 
 	public Task<ReissueCredentialResponse> ReissuanceAsync(ReissueCredentialRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<ReissueCredentialRequest, ReissueCredentialResponse>(RemoteAction.ReissueCredential, request, cancellationToken);
+		SendAndReceiveAsync<ReissueCredentialRequest, ReissueCredentialResponse>(RemoteAction.ReissueCredential, request, cancellationToken, TimeSpan.FromSeconds(30));
 
 	public Task RemoveInputAsync(InputsRemovalRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<InputsRemovalRequest>(RemoteAction.RemoveInput, request, cancellationToken);
+		SendAndReceiveAsync<InputsRemovalRequest>(RemoteAction.RemoveInput, request, cancellationToken, TimeSpan.FromSeconds(30));
 
 	public virtual Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<TransactionSignaturesRequest>(RemoteAction.SignTransaction, request, cancellationToken);
+		SendAndReceiveAsync<TransactionSignaturesRequest>(RemoteAction.SignTransaction, request, cancellationToken, TimeSpan.FromSeconds(30));
 
 	public Task<RoundStateResponse> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken) =>
 		SendAndReceiveAsync<RoundStateRequest, RoundStateResponse>(RemoteAction.GetStatus, request, cancellationToken);
 
 	public Task ReadyToSignAsync(ReadyToSignRequestRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken);
+		SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken, TimeSpan.FromSeconds(30));
 
-	private async Task<HttpResponseMessage> SendWithRetriesAsync(RemoteAction action, string jsonString, CancellationToken cancellationToken)
+	private async Task<HttpResponseMessage> SendWithRetriesAsync(RemoteAction action, string jsonString, CancellationToken cancellationToken, TimeSpan? retryTimeout = null)
 	{
 		var exceptions = new Dictionary<Exception, int>();
 		var start = DateTime.UtcNow;
@@ -77,9 +77,12 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 			{
 				using StringContent content = new(jsonString, Encoding.UTF8, "application/json");
 
+				using CancellationTokenSource requestTimeoutCts = new(retryTimeout is { } timeout ? timeout : TimeSpan.MaxValue);
+				using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(combinedToken, requestTimeoutCts.Token);
+
 				// Any transport layer errors will throw an exception here.
 				HttpResponseMessage response = await _client
-					.SendAsync(HttpMethod.Post, GetUriEndPoint(action), content, combinedToken).ConfigureAwait(false);
+					.SendAsync(HttpMethod.Post, GetUriEndPoint(action), content, requestCts.Token).ConfigureAwait(false);
 
 				TimeSpan totalTime = DateTime.UtcNow - start;
 
@@ -160,9 +163,9 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 		}
 	}
 
-	private async Task<string> SendWithRetriesAsync<TRequest>(RemoteAction action, TRequest request, CancellationToken cancellationToken) where TRequest : class
+	private async Task<string> SendWithRetriesAsync<TRequest>(RemoteAction action, TRequest request, CancellationToken cancellationToken, TimeSpan? retryTimeout = null) where TRequest : class
 	{
-		using var response = await SendWithRetriesAsync(action, Serialize(request), cancellationToken).ConfigureAwait(false);
+		using var response = await SendWithRetriesAsync(action, Serialize(request), cancellationToken, retryTimeout).ConfigureAwait(false);
 
 		if (!response.IsSuccessStatusCode)
 		{
@@ -172,14 +175,14 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 		return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 	}
 
-	private async Task SendAndReceiveAsync<TRequest>(RemoteAction action, TRequest request, CancellationToken cancellationToken) where TRequest : class
+	private async Task SendAndReceiveAsync<TRequest>(RemoteAction action, TRequest request, CancellationToken cancellationToken, TimeSpan? retryTimeout = null) where TRequest : class
 	{
-		await SendWithRetriesAsync(action, request, cancellationToken).ConfigureAwait(false);
+		await SendWithRetriesAsync(action, request, cancellationToken, retryTimeout).ConfigureAwait(false);
 	}
 
-	private async Task<TResponse> SendAndReceiveAsync<TRequest, TResponse>(RemoteAction action, TRequest request, CancellationToken cancellationToken) where TRequest : class
+	private async Task<TResponse> SendAndReceiveAsync<TRequest, TResponse>(RemoteAction action, TRequest request, CancellationToken cancellationToken, TimeSpan? retryTimeout = null) where TRequest : class
 	{
-		var jsonString = await SendWithRetriesAsync(action, request, cancellationToken).ConfigureAwait(false);
+		var jsonString = await SendWithRetriesAsync(action, request, cancellationToken, retryTimeout).ConfigureAwait(false);
 		return Deserialize<TResponse>(jsonString);
 	}
 

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -80,7 +80,7 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 				using StringContent content = new(jsonString, Encoding.UTF8, "application/json");
 
 				using CancellationTokenSource requestTimeoutCts = new(retryTimeout is { } timeout ? timeout : totalTimeout);
-				using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(combinedToken, requestTimeoutCts.Token);
+				using CancellationTokenSource requestCts = CancellationTokenSource.CreateLinkedTokenSource(combinedToken, requestTimeoutCts.Token);
 
 				// Any transport layer errors will throw an exception here.
 				HttpResponseMessage response = await _client

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -38,28 +38,28 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 	}
 
 	public Task<InputRegistrationResponse> RegisterInputAsync(InputRegistrationRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<InputRegistrationRequest, InputRegistrationResponse>(RemoteAction.RegisterInput, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<InputRegistrationRequest, InputRegistrationResponse>(RemoteAction.RegisterInput, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public Task<ConnectionConfirmationResponse> ConfirmConnectionAsync(ConnectionConfirmationRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<ConnectionConfirmationRequest, ConnectionConfirmationResponse>(RemoteAction.ConfirmConnection, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<ConnectionConfirmationRequest, ConnectionConfirmationResponse>(RemoteAction.ConfirmConnection, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public Task RegisterOutputAsync(OutputRegistrationRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<OutputRegistrationRequest>(RemoteAction.RegisterOutput, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<OutputRegistrationRequest>(RemoteAction.RegisterOutput, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public Task<ReissueCredentialResponse> ReissuanceAsync(ReissueCredentialRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<ReissueCredentialRequest, ReissueCredentialResponse>(RemoteAction.ReissueCredential, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<ReissueCredentialRequest, ReissueCredentialResponse>(RemoteAction.ReissueCredential, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public Task RemoveInputAsync(InputsRemovalRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<InputsRemovalRequest>(RemoteAction.RemoveInput, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<InputsRemovalRequest>(RemoteAction.RemoveInput, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public virtual Task SignTransactionAsync(TransactionSignaturesRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<TransactionSignaturesRequest>(RemoteAction.SignTransaction, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<TransactionSignaturesRequest>(RemoteAction.SignTransaction, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public Task<RoundStateResponse> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<RoundStateRequest, RoundStateResponse>(RemoteAction.GetStatus, request, cancellationToken);
+		SendAndReceiveAsync<RoundStateRequest, RoundStateResponse>(RemoteAction.GetStatus, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	public Task ReadyToSignAsync(ReadyToSignRequestRequest request, CancellationToken cancellationToken) =>
-		SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken, TimeSpan.FromSeconds(30));
+		SendAndReceiveAsync<ReadyToSignRequestRequest>(RemoteAction.ReadyToSign, request, cancellationToken, retryTimeout: TimeSpan.FromSeconds(30));
 
 	private async Task<HttpResponseMessage> SendWithRetriesAsync(RemoteAction action, string jsonString, CancellationToken cancellationToken, TimeSpan? retryTimeout = null)
 	{


### PR DESCRIPTION
Continuation of https://github.com/zkSNACKs/WalletWasabi/pull/8878

Tests result from https://github.com/zkSNACKs/WalletWasabi/pull/8878#issuecomment-1207759447

```
2022-08-08 09:14:00.816 [108] INFO      RequestTimeStatista2.Display (61)       Response times for the last 3862 minutes:
2022-08-08 09:14:00.821 [108] INFO      RequestTimeStatista2.Display (72)       Responded to 'XXX-API-OK-GetStatus'      21060 times. Median: 0.7s Average: 1.0s Largest 40.0s SuccessRatio: 1 FatalFails: 17
2022-08-08 09:14:00.824 [108] INFO      RequestTimeStatista2.Display (72)       Responded to 'XXX-API-OK-ConfirmConnection'      9033 times. Median: 0.9s Average: 1.7s Largest 212.4s SuccessRatio: 1 FatalFails: 9
2022-08-08 09:14:00.825 [108] INFO      RequestTimeStatista2.Display (72)       Responded to 'XXX-API-OK-ReissueCredential'      2660 times. Median: 3.4s Average: 5.3s Largest 293.6s SuccessRatio: 1 FatalFails: 0
2022-08-08 09:14:00.826 [108] INFO      RequestTimeStatista2.Display (72)       Responded to 'XXX-API-OK-RegisterInput'  2128 times. Median: 2.1s Average: 3.8s Largest 89.3s SuccessRatio: 1 FatalFails: 16
2022-08-08 09:14:00.827 [108] INFO      RequestTimeStatista2.Display (72)       Responded to 'XXX-API-OK-ReadyToSign'    1680 times. Median: 2.4s Average: 3.8s Largest 204.0s SuccessRatio: 1 FatalFails: 7
```

### Conclusion

Sometimes request hangs there for a couple of minutes without retries. With this PR a timeout is added per request level, so at least some retries will be done before the final failure. 