### PR TITLE
Better log messages when round aborted with not enough alices

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -321,6 +321,8 @@ public class CoinJoinClient
 	{
 		int eventInvokedAlready = 0;
 
+		UnexpectedRoundPhaseException? lastAbortedNotEnoughAlicesException = null;
+
 		var remainingInputRegTime = roundState.InputRegistrationEnd - DateTimeOffset.UtcNow;
 
 		using CancellationTokenSource strictInputRegTimeoutCts = new(remainingInputRegTime);
@@ -419,6 +421,13 @@ public class CoinJoinClient
 				personCircuit?.Dispose();
 				return (null, null);
 			}
+			catch (UnexpectedRoundPhaseException ex) when (ex.RoundState.EndRoundState is EndRoundState.AbortedNotEnoughAlices)
+			{
+				lastAbortedNotEnoughAlicesException = ex;
+				Logger.LogTrace(ex);
+				personCircuit?.Dispose();
+				return (null, null);
+			}
 			catch (Exception ex)
 			{
 				Logger.LogWarning(ex);
@@ -452,11 +461,19 @@ public class CoinJoinClient
 
 		await Task.WhenAll(aliceClients).ConfigureAwait(false);
 
-		return aliceClients
+		var successfulAlices = aliceClients
 			.Select(x => x.Result)
 			.Where(r => r.AliceClient is not null && r.PersonCircuit is not null)
 			.Select(r => (r.AliceClient!, r.PersonCircuit!))
 			.ToImmutableArray();
+
+		if (!successfulAlices.Any() && lastAbortedNotEnoughAlicesException is { })
+		{
+			// In this case the coordinator aborted the round - throw only one exception and log outside.
+			throw lastAbortedNotEnoughAlicesException;
+		}
+
+		return successfulAlices;
 	}
 
 	private BobClient CreateBobClient(RoundState roundState)


### PR DESCRIPTION
When the backend aborts the round with Not enough inputs - on the client side the log contains warnings for every input. However, nothing to warn about is just a new round. 

### Before this PR:

```
2022-08-09 09:30:42.053 [49] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (100)        Received a response for ConfirmConnection in 0.9s.
2022-08-09 09:30:45.392 [49] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (100)        Received a response for ConfirmConnection in 0.67s.
2022-08-09 09:30:47.497 [49] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (100)        Received a response for ConfirmConnection in 1.32s.
2022-08-09 09:30:49.978 [49] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (100)        Received a response for ConfirmConnection in 0.66s.
2022-08-09 09:30:54.306 [49] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (100)        Received a response for ConfirmConnection in 0.28s.
2022-08-09 09:31:03.584 [74] WARNING    CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (424) WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 1d21918a80a404143ae511e831f690d36f1b94224ee19f7294533755a3ed66ab unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedNotEnoughAlices'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass55_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 356
2022-08-09 09:31:03.584 [75] WARNING    CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (424) WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 1d21918a80a404143ae511e831f690d36f1b94224ee19f7294533755a3ed66ab unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedNotEnoughAlices'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass55_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 356
2022-08-09 09:31:03.584 [21] WARNING    CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (424) WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 1d21918a80a404143ae511e831f690d36f1b94224ee19f7294533755a3ed66ab unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedNotEnoughAlices'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass55_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 356
2022-08-09 09:31:03.584 [80] WARNING    CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (424) WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 1d21918a80a404143ae511e831f690d36f1b94224ee19f7294533755a3ed66ab unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedNotEnoughAlices'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass55_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 356
2022-08-09 09:31:03.584 [39] WARNING    CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (424) WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 1d21918a80a404143ae511e831f690d36f1b94224ee19f7294533755a3ed66ab unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedNotEnoughAlices'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass55_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 356
2022-08-09 09:31:04.216 [39] INFO       CoinJoinManager.HandleCoinJoinFinalizationAsync (384)   Wallet (WalletTestMain): CoinJoinClient finished. Coinjoin transaction was not broadcast.
```

### After: 

```
2022-08-09 10:41:21.195 [55] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (95) Received a response for RegisterInput in 0.01s.
2022-08-09 10:41:21.210 [55] INFO       AliceClient.RegisterInputAsync (104)    Round (17692725884b09ecb55ceda2a779a26e338011c66a809f5faf799fd1cac2c1bb), Alice (845039e6-c9ea-bea0-6fbc-1a7c2c24e92c): Registered d71d64d9c61d2953ac75f571c9b2d0ae3e71f13d17bffbc6c10552d6002a8de1-5.
2022-08-09 10:41:32.219 [55] DEBUG      WabiSabiHttpApiClient.SendWithRetriesAsync (95) Received a response for RegisterInput in 0.01s.
2022-08-09 10:41:32.232 [55] INFO       AliceClient.RegisterInputAsync (104)    Round (17692725884b09ecb55ceda2a779a26e338011c66a809f5faf799fd1cac2c1bb), Alice (3b865ebe-a380-ac85-93da-6fde3f11a411): Registered 5136cdebc8ac6f63dca2817440bb92be6824154757b44147e2fd778044bafc03-0.
2022-08-09 10:42:40.599 [11] INFO       CoinJoinClient.StartRoundAsync (227)    Round (17692725884b09ecb55ceda2a779a26e338011c66a809f5faf799fd1cac2c1bb): Not enough participants in the round to continue. Waiting for a new round.
2022-08-09 10:42:41.118 [47] INFO       CoinJoinManager.HandleCoinJoinFinalizationAsync (384)   Wallet (Random Wallet): CoinJoinClient finished. Coinjoin transaction was not broadcast.
```