### PR TITLE
Fix CI - Wait a bit more for the CoinJoin

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -66,7 +66,7 @@ internal class Participant
 		SplitTransaction = new SmartTransaction(splitTx, new Height(1));
 	}
 
-	public async Task StartParticipatingAsync(CancellationToken cancellationToken)
+	public async Task<CoinJoinResult> StartParticipatingAsync(CancellationToken cancellationToken)
 	{
 		if (SplitTransaction is null)
 		{
@@ -92,8 +92,10 @@ internal class Participant
 			.ToList();
 
 		// Run the coinjoin client task.
-		await coinJoinClient.StartCoinJoinAsync(smartCoins, cancellationToken).ConfigureAwait(false);
+		var ret = await coinJoinClient.StartCoinJoinAsync(smartCoins, cancellationToken).ConfigureAwait(false);
 
 		await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
+
+		return ret;
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -27,7 +27,6 @@ using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 using Xunit.Abstractions;
-using System.Diagnostics;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
 
@@ -522,7 +521,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 						continue;
 					}
 
-					if (DateTimeOffset.UtcNow - allTaskCompletedTime > TimeSpan.FromSeconds(10))
+					if (DateTimeOffset.UtcNow - allTaskCompletedTime > TimeSpan.FromSeconds(30))
 					{
 						throw new Exception("All participants finished, but CoinJoin still not in the mempool.");
 					}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -543,11 +543,11 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 						var mempool = await rpc.GetRawMempoolAsync();
 						Assert.Single(mempool);
 					}
-					else if(participantsFinishedSuccessully.All(x => x.GoForBlameRound == false && x.SuccessfulBroadcast == false))
+					else if (participantsFinishedSuccessully.All(x => x.GoForBlameRound == false && x.SuccessfulBroadcast == false))
 					{
 						throw new Exception("All participants finished, but CoinJoin still not in the mempool (no more blame rounds).");
 					}
-					else if(!participantsFinishedSuccessully.Any() && !cts.IsCancellationRequested)
+					else if (!participantsFinishedSuccessully.Any() && !cts.IsCancellationRequested)
 					{
 						var exceptions = tasks
 							.Where(x => x.IsFaulted)
@@ -564,7 +564,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				{
 					throw new Exception("This is not so possible.");
 				}
-
 			}
 			catch (OperationCanceledException e)
 			{
@@ -616,26 +615,18 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 	public class TesteableRpcClient : RpcClientBase
 	{
-		public Action<Transaction>? AfterSendRawTransaction { get; set; }
-
 		public TesteableRpcClient(RpcClientBase rpc)
 			: base(rpc.Rpc)
 		{
 		}
 
+		public Action<Transaction>? AfterSendRawTransaction { get; set; }
+
 		public override async Task<uint256> SendRawTransactionAsync(Transaction transaction, CancellationToken cancellationToken = default)
 		{
-			try
-			{
-				var ret = await base.SendRawTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
-				AfterSendRawTransaction?.Invoke(transaction);
-				return ret;
-			}
-			catch (Exception e)
-			{
-				Console.WriteLine(e);
-				throw;
-			}
+			var ret = await base.SendRawTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
+			AfterSendRawTransaction?.Invoke(transaction);
+			return ret;
 		}
 	}
 }

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -21,7 +21,7 @@ public class RpcClientBase : IRPCClient
 
 	public Network Network => Rpc.Network;
 
-	private RPCClient Rpc { get; }
+	protected internal RPCClient Rpc { get; }
 
 	public RPCCredentialString CredentialString => Rpc.CredentialString;
 


### PR DESCRIPTION
This is fixing MultiClientsCoinJoinTestAsync for the CI. 
The test is good, just need to wait a bit more for the CoinJoin to be propagated into the mempool. 