### PR TITLE
`WabiSabiHttpApiClient`: Remove extra `catch`

### DIFF
--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -214,12 +214,12 @@ public class TorHttpPool : IDisposable
 		}
 		catch (OperationCanceledException)
 		{
-			Logger.LogTrace($"[{connection}] Request was canceled: '{request.RequestUri}'.");
+			Logger.LogTrace($"['{connection}'] Request was canceled: '{request.RequestUri}'.");
 			throw;
 		}
 		catch (Exception e)
 		{
-			Logger.LogTrace($"[{connection}] Request failed with exception", e);
+			Logger.LogTrace($"['{connection}'] Request failed with exception", e);
 			OnTorRequestFailed(e);
 			throw;
 		}


### PR DESCRIPTION
`IHttpClient.SendAsync(..)` is not allowed to throw any `TorException`s. All such exceptions are wrapped in `HttpRequestException`.