### PR TITLE
[GitHub Action] Add issues automatically to the project board

### DIFF
--- a/.github/workflows/auto-add-to-projcet.yml
+++ b/.github/workflows/auto-add-to-projcet.yml
@@ -1,0 +1,21 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.AUTO_ADD_TO_PROJECT_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues to project board
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/zkSNACKs/projects/18'
+        column_name: 'Title'   

--- a/.github/workflows/auto-add-to-projcet.yml
+++ b/.github/workflows/auto-add-to-projcet.yml
@@ -18,4 +18,4 @@ jobs:
       if: github.event.action == 'opened'
       with:
         project: 'https://github.com/orgs/zkSNACKs/projects/18'
-        column_name: 'Title'   
+        column_name: 'Title'

--- a/.github/workflows/auto-add-to-projcet.yml
+++ b/.github/workflows/auto-add-to-projcet.yml
@@ -1,21 +1,16 @@
-name: Auto Assign to Project(s)
+name: Add issues to project board
 
 on:
   issues:
-    types: [opened]
-  issue_comment:
-    types: [created]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.AUTO_ADD_TO_PROJECT_TOKEN }}
+    types:
+      - opened
 
 jobs:
-  assign_one_project:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-latest
-    name: Assign to One Project
     steps:
-    - name: Assign NEW issues to project board
-      uses: srggrs/assign-one-project-github-action@1.3.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/zkSNACKs/projects/18'
-        column_name: 'Title'
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/zkSNACKs/projects/18
+          github-token: ${{ secrets.AUTO_ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
This action should add all the new issues to the Prioritization project board automatically.

Keep in mind the organization should have a token that called `AUTO_ADD_TO_PROJECT_TOKEN` with the right privileges in order to make the action work. I don't have the right to create one so someone should do it.
It only requires reading access to the projects:
![image](https://user-images.githubusercontent.com/16364053/184681667-9e041d3a-6b46-4da4-873a-a7ebe63e770c.png)


More info here: https://github.com/marketplace/actions/add-to-github-projects