### PR TITLE
Add RPC `Start` and `Stop` coinjoin

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
 using WalletWasabi.BitcoinP2p;
@@ -12,6 +13,7 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Rpc;
 using WalletWasabi.Services.Terminate;
+using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.Rpc;
@@ -245,6 +247,28 @@ public class WasabiJsonRpcService : IJsonRpcService
 			pubKeyHash = x.PubKeyHash.ToString(),
 			address = x.GetP2wpkhAddress(Global.Network).ToString()
 		}).ToArray();
+	}
+
+	[JsonRpcMethod("startcoinjoin")]
+	public void StartCoinJoining(bool stopWhenAllMixed, bool overridePlebStop)
+	{
+		var coinJoinManager = Global.HostedServices.Get<CoinJoinManager>();
+		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
+
+		AssertWalletIsLoaded();
+
+		coinJoinManager.StartAsync(activeWallet, stopWhenAllMixed, overridePlebStop, CancellationToken.None).ConfigureAwait(false);
+	}
+
+	[JsonRpcMethod("stopcoinjoin")]
+	public void StopCoinJoining()
+	{
+		var coinJoinManager = Global.HostedServices.Get<CoinJoinManager>();
+		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
+
+		AssertWalletIsLoaded();
+
+		coinJoinManager.StopAsync(activeWallet, CancellationToken.None).ConfigureAwait(false);
 	}
 
 	[JsonRpcMethod("selectwallet")]

--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -250,7 +250,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("startcoinjoin")]
-	public void StartCoinJoining(bool stopWhenAllMixed, bool overridePlebStop)
+	public void StartCoinJoining(bool stopWhenAllMixed = true, bool overridePlebStop = true)
 	{
 		var coinJoinManager = Global.HostedServices.Get<CoinJoinManager>();
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);


### PR DESCRIPTION
Closes #8942

This PR add two new RPC calls `startcoinjoin` and `stopcoinjoin`. As all other rpc methods, these work at a wallet level so, the user has to select the wallet first with `selectwallet` and then call the new methods. 


![](https://i.imgur.com/bXHJf0W.gif)

## Testing

The easiest way to test it is by using the [wcli.sh](https://github.com/lontivero/Wiki/blob/master/src/wasabi/wcli.md) 
Here is a session:

```
[lontivero@nixos:~/Projects/WalletWasabi]$ ~/wcli.sh selectwallet TestNet
null

[lontivero@nixos:~/Projects/WalletWasabi]$ ~/wcli.sh startcoinjoin 
2 parameters were expected but 0 were received.

[lontivero@nixos:~/Projects/WalletWasabi]$ ~/wcli.sh startcoinjoin true true
null

[lontivero@nixos:~/Projects/WalletWasabi]$ ~/wcli.sh stopcoinjoin
null
```

# Open discussion

The `startcoinjoin` takes to parameters: `stopWhenAllMixed` and `overridePlebStop`, should we remove them from the definition of the service?