### PR TITLE
Subscribe Tor Control `STREAM` events

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/Control/Messages/Events/StreamEventTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/Messages/Events/StreamEventTests.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+using WalletWasabi.Tor.Control.Messages;
+using WalletWasabi.Tor.Control.Messages.Events;
+using WalletWasabi.Tor.Control.Messages.StreamStatus;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Control.Messages.Events;
+
+/// <summary>
+/// Tests for <see cref="StreamEvent"/> class.
+/// </summary>
+public class StreamEventTests
+{
+	[Fact]
+	public async Task ParseStreamEventAsync()
+	{
+		string data = "650 STREAM 38 SENTCONNECT 36 94.204.133.221:8333 SOCKS_USERNAME=\"0QAAN5PBSOM5OXCTPXI0J\" SOCKS_PASSWORD=\"0QAAN5PBSOM5OXCTPXI0J\" CLIENT_PROTOCOL=SOCKS5 NYM_EPOCH=0 SESSION_GROUP=-4 ISO_FIELDS=SOCKS_USERNAME,SOCKS_PASSWORD,CLIENTADDR,SESSION_GROUP,NYM_EPOCH\r\n";
+
+		TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+		StreamEvent streamEvent = StreamEvent.FromReply(rawReply);
+
+		Assert.NotNull(streamEvent.StreamInfo);
+
+		StreamInfo info = streamEvent.StreamInfo;
+		Assert.Equal("38", info.StreamID);
+		Assert.Equal(StreamStatusFlag.SENTCONNECT, info.StreamStatus);
+		Assert.Equal("36", info.CircuitID);
+		Assert.Equal("94.204.133.221", info.TargetAddress);
+		Assert.Equal(8333, info.Port);
+		Assert.Null(info.Source);
+		Assert.Null(info.Purpose);
+		Assert.Equal("0QAAN5PBSOM5OXCTPXI0J", info.UserName);
+		Assert.Equal("0QAAN5PBSOM5OXCTPXI0J", info.UserPassword);
+		Assert.Equal(ClientProtocol.SOCKS5, info.ClientProtocol);
+		Assert.Equal(0, info.NymEpoch);
+		Assert.Equal(-4, info.SessionGroup);
+		Assert.Equal(new IsoFieldFlag[] { IsoFieldFlag.SOCKS_USERNAME, IsoFieldFlag.SOCKS_PASSWORD, IsoFieldFlag.CLIENTADDR, IsoFieldFlag.SESSION_GROUP, IsoFieldFlag.NYM_EPOCH }, info.IsoFields);
+	}
+
+	[Fact]
+	public async Task ParseStreamEvent2Async()
+	{
+		string data = "650 STREAM 34 NEW 0 175.32.128.126:8333 SOURCE_ADDR=127.0.0.1:25180 PURPOSE=USER SOCKS_USERNAME=\"YF98TC0IZD4PNMXE2RH0V\" SOCKS_PASSWORD=\"YF98TC0IZD4PNMXE2RH0V\" CLIENT_PROTOCOL=SOCKS5 NYM_EPOCH=0 SESSION_GROUP=-4 ISO_FIELDS=SOCKS_USERNAME,SOCKS_PASSWORD,CLIENTADDR,SESSION_GROUP,NYM_EPOCH\r\n";
+
+		TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+		StreamEvent streamEvent = StreamEvent.FromReply(rawReply);
+
+		Assert.NotNull(streamEvent.StreamInfo);
+
+		StreamInfo info = streamEvent.StreamInfo;
+		Assert.Equal("34", info.StreamID);
+		Assert.Equal(StreamStatusFlag.NEW, info.StreamStatus);
+		Assert.Equal("0", info.CircuitID);
+		Assert.Equal("175.32.128.126", info.TargetAddress);
+		Assert.Equal(8333, info.Port);
+		Assert.Equal("127.0.0.1:25180", info.SourceAddr);
+		Assert.Equal(Purpose.USER, info.Purpose);
+		Assert.Equal("YF98TC0IZD4PNMXE2RH0V", info.UserName);
+		Assert.Equal("YF98TC0IZD4PNMXE2RH0V", info.UserPassword);
+		Assert.Equal(ClientProtocol.SOCKS5, info.ClientProtocol);
+		Assert.Equal(0, info.NymEpoch);
+		Assert.Equal(-4, info.SessionGroup);
+		Assert.Equal(new IsoFieldFlag[] { IsoFieldFlag.SOCKS_USERNAME, IsoFieldFlag.SOCKS_PASSWORD, IsoFieldFlag.CLIENTADDR, IsoFieldFlag.SESSION_GROUP, IsoFieldFlag.NYM_EPOCH }, info.IsoFields);
+	}
+
+	[Fact]
+	public async Task ParseStreamEvent3Async()
+	{
+		string data = "650 STREAM 69 NEW 0 138.201.196.252.$AC7C88D67339B90F2C10FF7B702DCB1EF3B8D663.exit:9993 PURPOSE=DIR_FETCH CLIENT_PROTOCOL=UNKNOWN NYM_EPOCH=0 SESSION_GROUP=-2 ISO_FIELDS=\r\n";
+
+		TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+		StreamEvent streamEvent = StreamEvent.FromReply(rawReply);
+
+		Assert.NotNull(streamEvent.StreamInfo);
+
+		StreamInfo info = streamEvent.StreamInfo;
+		Assert.Equal("69", info.StreamID);
+		Assert.Equal(StreamStatusFlag.NEW, info.StreamStatus);
+		Assert.Equal("0", info.CircuitID);
+		Assert.Equal("138.201.196.252.$AC7C88D67339B90F2C10FF7B702DCB1EF3B8D663.exit", info.TargetAddress);
+		Assert.Equal(9993, info.Port);
+		Assert.Null(info.SourceAddr);
+		Assert.Equal(Purpose.DIR_FETCH, info.Purpose);
+		Assert.Null(info.UserName);
+		Assert.Null(info.UserPassword);
+		Assert.Equal(ClientProtocol.UNKNOWN, info.ClientProtocol);
+		Assert.Equal(0, info.NymEpoch);
+		Assert.Equal(-2, info.SessionGroup);
+		Assert.Empty(info.IsoFields);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/Utils/AsyncEventParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/Utils/AsyncEventParserTests.cs
@@ -45,4 +45,16 @@ public class AsyncEventParserTests
 		CircEvent @event = Assert.IsType<CircEvent>(asyncEvent);
 		Assert.NotNull(@event);
 	}
+
+	[Fact]
+	public async Task ParseStreamEventAsync()
+	{
+		string data = "650 STREAM 35 SUCCEEDED 34 103.47.192.15:8333 SOCKS_USERNAME=\"7NO8P91J0W7TLBS3JTP9F\" SOCKS_PASSWORD=\"7NO8P91J0W7TLBS3JTP9F\" CLIENT_PROTOCOL=SOCKS5 NYM_EPOCH=0 SESSION_GROUP=-4 ISO_FIELDS=SOCKS_USERNAME,SOCKS_PASSWORD,CLIENTADDR,SESSION_GROUP,NYM_EPOCH\r\n";
+
+		TorControlReply rawReply = await TorControlReplyReaderTest.ParseAsync(data);
+		IAsyncEvent asyncEvent = AsyncEventParser.Parse(rawReply);
+
+		StreamEvent @event = Assert.IsType<StreamEvent>(asyncEvent);
+		Assert.NotNull(@event);
+	}
 }

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/BuildFlag.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/BuildFlag.cs
@@ -2,18 +2,18 @@ namespace WalletWasabi.Tor.Control.Messages.CircuitStatus;
 
 public enum BuildFlag
 {
-	/// <summary>One-hop circuit, used for tunneled directory conns</summary>
+	/// <summary>One-hop circuit, used for tunneled directory conns.</summary>
 	ONEHOP_TUNNEL,
 
-	/// <summary>Internal circuit, not to be used for exiting streams</summary>
+	/// <summary>Internal circuit, not to be used for exiting streams.</summary>
 	IS_INTERNAL,
 
-	/// <summary>This circuit must use only high-capacity nodes</summary>
+	/// <summary>This circuit must use only high-capacity nodes.</summary>
 	NEED_CAPACITY,
 
-	/// <summary>This circuit must use only high-uptime nodes</summary>
+	/// <summary>This circuit must use only high-uptime nodes.</summary>
 	NEED_UPTIME,
 
-	/// <summary>Reserved for unknown values</summary>
-	UNKNOWN
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
 }

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircStatus.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircStatus.cs
@@ -3,24 +3,24 @@ namespace WalletWasabi.Tor.Control.Messages.CircuitStatus;
 /// <seealso href="https://github.com/torproject/torspec/blob/main/control-spec.txt">4.1.1. Circuit status changed</seealso>
 public enum CircStatus
 {
-	/// <summary>Circuit ID assigned to new circuit</summary>
+	/// <summary>Circuit ID assigned to new circuit.</summary>
 	LAUNCHED,
 
-	/// <summary>All hops finished, can now accept streams</summary>
+	/// <summary>All hops finished, can now accept streams.</summary>
 	BUILT,
 
-	/// <summary>All hops finished, waiting to see if a circuit with a better guard will be usable.</summary>
+	/// <summary>All hops finished, waiting to see if a circuit with a better guard will be usable..</summary>
 	GUARD_WAIT,
 
-	/// <summary>One more hop has been completed</summary>
+	/// <summary>One more hop has been completed.</summary>
 	EXTENDED,
 
-	/// <summary>Circuit closed (was not built)</summary>
+	/// <summary>Circuit closed (was not built).</summary>
 	FAILED,
 
-	/// <summary>Circuit closed (was built)</summary>
+	/// <summary>Circuit closed (was built).</summary>
 	CLOSED,
 
-	/// <summary>Reserved for unknown values</summary>
+	/// <summary>Reserved for unknown values.</summary>
 	UNKNOWN,
 }

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircuitInfo.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircuitInfo.cs
@@ -18,7 +18,7 @@ public record CircuitInfo
 		CircStatus = circStatus;
 	}
 
-	/// <summary>Unique circuit identifier</summary>
+	/// <summary>Unique circuit identifier.</summary>
 	/// <remarks>
 	/// Currently, Tor only uses digits, but this may change.
 	/// <para>String matches <c>^[a-zA-Z0-9]{1,16}$</c>.</para>

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/HsState.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/HsState.cs
@@ -4,38 +4,38 @@ public enum HsState
 {
 	// Client-side introduction-point circuit states
 
-	/// <summary>Connecting to intro point</summary>
+	/// <summary>Connecting to intro point.</summary>
 	HSCI_CONNECTING,
-	/// <summary>Sent INTRODUCE1; waiting for reply from IP (introduction point)</summary>
+	/// <summary>Sent INTRODUCE1; waiting for reply from IP (introduction point).</summary>
 	HSCI_INTRO_SENT,
-	/// <summary>Received reply from IP relay; closing</summary>
+	/// <summary>Received reply from IP relay; closing.</summary>
 	HSCI_DONE,
 
 	// Client-side rendezvous-point circuit states
 
-	/// <summary>Connecting to or waiting for reply from RP (rendezvous-point)</summary>
+	/// <summary>Connecting to or waiting for reply from RP (rendezvous-point).</summary>
 	HSCR_CONNECTING,
-	/// <summary>Established RP; waiting for introduction</summary>
+	/// <summary>Established RP; waiting for introduction.</summary>
 	HSCR_ESTABLISHED_IDLE,
-	/// <summary>Introduction sent to HS; waiting for rend</summary>
+	/// <summary>Introduction sent to HS; waiting for rend.</summary>
 	HSCR_ESTABLISHED_WAITING,
-	/// <summary>Connected to HS</summary>
+	/// <summary>Connected to HS.</summary>
 	HSCR_JOINED,
 
 	// Service-side introduction-point circuit states
 
-	/// <summary>Connecting to intro point</summary>
+	/// <summary>Connecting to intro point.</summary>
 	HSSI_CONNECTING,
-	/// <summary>Established intro point</summary>
+	/// <summary>Established intro point.</summary>
 	HSSI_ESTABLISHED,
 
 	// Service-side rendezvous-point circuit states
 
-	/// <summary>Connecting to client's rend point</summary>
+	/// <summary>Connecting to client's rend point.</summary>
 	HSSR_CONNECTING,
-	/// <summary>Connected to client's RP circuit</summary>
+	/// <summary>Connected to client's RP circuit.</summary>
 	HSSR_JOINED,
 
-	/// <summary>Reserved for unknown values</summary>
+	/// <summary>Reserved for unknown values.</summary>
 	UNKNOWN,
 }

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/Purpose.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/Purpose.cs
@@ -1,43 +1,44 @@
 namespace WalletWasabi.Tor.Control.Messages.CircuitStatus;
 
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4.1.1. Circuit status changed".</seealso>
 public enum Purpose
 {
-	/// <summary>Circuit for AP and/or directory request streams</summary>
+	/// <summary>Circuit for AP and/or directory request streams.</summary>
 	GENERAL,
 
-	/// <summary>HS client-side introduction-point circuit</summary>
+	/// <summary>HS client-side introduction-point circuit.</summary>
 	HS_CLIENT_INTRO,
 
-	/// <summary>HS client-side rendezvous circuit; carries AP streams</summary>
+	/// <summary>HS client-side rendezvous circuit; carries AP streams.</summary>
 	HS_CLIENT_REND,
 
-	/// <summary>Circuit is used for getting HS directories</summary>
+	/// <summary>Circuit is used for getting HS directories.</summary>
 	HS_CLIENT_HSDIR,
 
-	/// <summary>HS service-side introduction-point circuit</summary>
+	/// <summary>HS service-side introduction-point circuit.</summary>
 	HS_SERVICE_INTRO,
 
-	/// <summary>HS service-side rendezvous circuit</summary>
+	/// <summary>HS service-side rendezvous circuit.</summary>
 	HS_SERVICE_REND,
 
-	/// <summary>Reachability-testing circuit; carries no traffic</summary>
+	/// <summary>Reachability-testing circuit; carries no traffic.</summary>
 	TESTING,
 
-	/// <summary>Circuit built by a controller</summary>
+	/// <summary>Circuit built by a controller.</summary>
 	CONTROLLER,
 
-	/// <summary>Circuit being kept around to see how long it takes</summary>
+	/// <summary>Circuit being kept around to see how long it takes.</summary>
 	MEASURE_TIMEOUT,
 
-	/// <summary>Circuit created ahead of time when using HS vanguards, and later repurposed as needed</summary>
+	/// <summary>Circuit created ahead of time when using HS vanguards, and later repurposed as needed.</summary>
 	HS_VANGUARDS,
 
-	/// <summary>Circuit used to probe whether our circuits are being deliberately closed by an attacker</summary>
+	/// <summary>Circuit used to probe whether our circuits are being deliberately closed by an attacker.</summary>
 	PATH_BIAS_TESTING,
 
-	/// <summary>Circuit that is being held open to disguise its true close time</summary>
+	/// <summary>Circuit that is being held open to disguise its true close time.</summary>
 	CIRCUIT_PADDING,
 
-	/// <summary>Reserved for unknown values</summary>
-	UNKNOWN
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
 }

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/Reason.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/Reason.cs
@@ -1,5 +1,6 @@
 namespace WalletWasabi.Tor.Control.Messages.CircuitStatus;
 
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/tor-spec.txt">See section "5.4. Tearing down circuits".</seealso>
 public enum Reason
 {
 	/// <summary>No reason given.</summary>

--- a/WalletWasabi/Tor/Control/Messages/Events/StreamEvent.cs
+++ b/WalletWasabi/Tor/Control/Messages/Events/StreamEvent.cs
@@ -1,0 +1,38 @@
+using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Messages.CircuitStatus;
+using WalletWasabi.Tor.Control.Messages.StreamStatus;
+using WalletWasabi.Tor.Control.Utils;
+
+namespace WalletWasabi.Tor.Control.Messages.Events;
+
+/// <summary>Circuit event as specified in <c>4.1.2. Stream status changed</c> spec.</summary>
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt"/>
+public record StreamEvent : IAsyncEvent
+{
+	public const string EventName = "STREAM";
+
+	public StreamEvent(StreamInfo streamInfo)
+	{
+		StreamInfo = streamInfo;
+	}
+
+	public StreamInfo StreamInfo { get; }
+
+	/// <exception cref="TorControlReplyParseException"/>
+	public static StreamEvent FromReply(TorControlReply reply)
+	{
+		if (reply.StatusCode != StatusCode.AsynchronousEventNotify)
+		{
+			throw new TorControlReplyParseException($"StreamEvent: Expected {StatusCode.AsynchronousEventNotify} status code.");
+		}
+
+		(string value, string remainder) = Tokenizer.ReadUntilSeparator(reply.ResponseLines[0]);
+
+		if (value != EventName)
+		{
+			throw new TorControlReplyParseException($"StreamEvent: Expected '{EventName}' event name.");
+		}
+
+		return new StreamEvent(StreamInfo.ParseLine(remainder));
+	}
+}

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/ClientProtocol.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/ClientProtocol.cs
@@ -1,0 +1,27 @@
+namespace WalletWasabi.Tor.Control.Messages.StreamStatus;
+
+/// <remarks>
+/// The <see cref="ClientProtocol"/> indicates the protocol that was used by a client to initiate a stream.
+/// <para>
+/// Streams for clients connected with different protocols are isolated on separate circuits if the
+/// <c>IsolateClientProtocol</c> flag is active.
+/// </para>
+/// <para>Controllers MUST tolerate unrecognized client protocols.</para>
+/// </remarks>
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4.1.2. Stream status changed".</seealso>
+public enum ClientProtocol
+{
+	/// <summary>SOCKS version 4.</summary>
+	SOCKS4,
+
+	/// <summary>SOCKS version 5.</summary>
+	SOCKS5,
+
+	TRANS,
+	NATD,
+	DNS,
+	HTTPCONNECT,
+
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
+}

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/IsoFieldFlag.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/IsoFieldFlag.cs
@@ -1,0 +1,24 @@
+namespace WalletWasabi.Tor.Control.Messages.StreamStatus;
+
+/// <summary>
+/// The "ISO_FIELDS" field indicates the set of STREAM event fields for which stream
+/// isolation is enabled for the listener port that a client used to initiate this stream.
+/// </summary>
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4.1.2. Stream status changed".</seealso>
+public enum IsoFieldFlag
+{
+	SOCKS_USERNAME,
+	SOCKS_PASSWORD,
+	SESSION_GROUP,
+	CLIENT_PROTOCOL,
+	NYM_EPOCH,
+
+	// Special values follow.
+	CLIENTADDR,
+	CLIENTPORT,
+	DESTADDR,
+	DESTPORT,
+
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
+}

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/Purpose.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/Purpose.cs
@@ -1,0 +1,23 @@
+namespace WalletWasabi.Tor.Control.Messages.StreamStatus;
+
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4.1.2. Stream status changed".</seealso>
+public enum Purpose
+{
+	/// <summary>This stream is generated internally to Tor for fetching directory information.</summary>
+	DIR_FETCH,
+
+	/// <summary>An internal stream for uploading information to a directory authority.</summary>
+	DIR_UPLOAD,
+
+	/// <summary>A stream we're using to test our own directory port to make sure it's reachable.</summary>
+	DIRPORT_TEST,
+
+	/// <summary>A user-initiated DNS request.</summary>
+	DNS_REQUEST,
+
+	/// <summary>This stream is handling user traffic, OR it's internal to Tor, but it doesn't match one of the purposes above.</summary>
+	USER,
+
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
+}

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/Reason.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/Reason.cs
@@ -1,0 +1,50 @@
+namespace WalletWasabi.Tor.Control.Messages.StreamStatus;
+
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/tor-spec.txt">See section "6.3. Closing streams".</seealso>
+public enum Reason
+{
+	/// <summary>Catch-all for unlisted reasons.</summary>
+	MISC = 1,
+
+	/// <summary>Couldn't look up hostname.</summary>
+	RESOLVEFAILED = 2,
+
+	/// <summary>Remote host refused connection.</summary>
+	CONNECTREFUSED = 3,
+
+	/// <summary>OR refuses to connect to host or port.</summary>
+	EXITPOLICY = 4,
+
+	/// <summary>Circuit is being destroyed.</summary>
+	DESTROY = 5,
+
+	/// <summary>Anonymized TCP connection was closed.</summary>
+	DONE = 6,
+
+	/// <summary>Connection timed out, or OR timed out while connecting.</summary>
+	TIMEOUT = 7,
+
+	/// <summary>Routing error while attempting to contact destination.</summary>
+	NOROUTE = 8,
+
+	/// <summary>OR is temporarily hibernating.</summary>
+	HIBERNATING = 9,
+
+	/// <summary>Internal error at the OR.</summary>
+	INTERNAL = 10,
+
+	/// <summary>OR has no resources to fulfill request.</summary>
+	RESOURCELIMIT = 11,
+
+	/// <summary>Connection was unexpectedly reset.</summary>
+	CONNRESET = 12,
+
+	/// <summary>Sent when closing connection because of Tor protocol violations.</summary>
+	TORPROTOCOL = 13,
+
+	/// <summary>Client sent RELAY_BEGIN_DIR to a non-directory relay.</summary>
+	NOTDIRECTORY = 14,
+
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
+}

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamInfo.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamInfo.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using WalletWasabi.Logging;
+using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Utils;
+
+namespace WalletWasabi.Tor.Control.Messages.StreamStatus;
+
+/// <summary>Implemented as specified in <c>4.1.2. Stream status changed</c> spec.</summary>
+/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt"/>
+public record StreamInfo
+{
+	public StreamInfo(string streamID, StreamStatusFlag streamStatus, string circuitID, string targetAddress, int port)
+	{
+		StreamID = streamID;
+		StreamStatus = streamStatus;
+		CircuitID = circuitID;
+		TargetAddress = targetAddress;
+		Port = port;
+		IsoFields = Array.Empty<IsoFieldFlag>();
+	}
+
+	/// <summary>Unique stream identifier.</summary>
+	/// <remarks>
+	/// Currently, Tor only uses digits, but this may change.
+	/// <para>String matches <c>^[a-zA-Z0-9]{1,16}$</c>.</para>
+	/// </remarks>
+	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">2.4. General-use tokens</seealso>
+	public string StreamID { get; }
+
+	/// <summary>Status of the Tor stream.</summary>
+	public StreamStatusFlag StreamStatus { get; }
+
+	/// <summary>
+	/// The circuit ID designates which circuit this stream is attached to.
+	/// <para>If the stream is unattached, the circuit ID <c>0</c> is given.</para>
+	/// </summary>
+	/// <seealso cref="CircuitStatus.CircuitInfo.CircuitID"/>
+	public string CircuitID { get; }
+
+	/// <remarks>Parsed part of the original "target" value.</remarks>
+	public string TargetAddress { get; }
+
+	/// <remarks>Parsed part of the original "target" value.</remarks>
+	public int Port { get; }
+
+	public Reason? Reason { get; init; }
+	public Reason? RemoteReason { get; init; }
+
+	/// <remarks>Possible values are: <c>CACHE</c> or <c>EXIT</c>.</remarks>
+	public string? Source { get; init; }
+
+	/// <remarks>In form <c>Address:Port</c>.</remarks>
+	public string? SourceAddr { get; init; }
+	public Purpose? Purpose { get; init; }
+	public string? UserName { get; init; }
+	public string? UserPassword { get; init; }
+	public ClientProtocol? ClientProtocol { get; init; }
+
+	/// <summary>Field indicates the nym epoch that was active when a client initiated this stream.</summary>
+	/// <remarks>
+	/// The epoch increments when the <c>NEWNYM</c> signal is received.
+	/// Streams with different nym epochs are isolated on separate circuits.
+	/// <para>Value is a nonnegative integer.</para>
+	/// </remarks>
+	public int? NymEpoch { get; init; }
+
+	/// <summary>Field indicates the session group of the listener port that a client used to initiate this stream.</summary>
+	/// <remarks>
+	/// By default, the session group is different for each listener port, but this can be overridden for a listener 
+	/// via the <c>SessionGroup</c> option in <c>torrc</c>.
+	/// Streams with different session groups are isolated on separate circuits.
+	/// <para>Value can be any integer.</para>
+	/// </remarks>
+	public int? SessionGroup { get; init; }
+
+	/// <summary>
+	/// Field indicates the set of STREAM event fields for which stream isolation is enabled for the listener port
+	/// that a client used to initiate this stream.
+	/// </summary>
+	public IReadOnlyList<IsoFieldFlag> IsoFields { get; init; }
+
+	public static StreamInfo ParseLine(string line)
+	{
+		(string streamId, string remainder1) = Tokenizer.ReadUntilSeparator(line);
+		(string circuitStatus, string remainder2) = Tokenizer.ReadUntilSeparator(remainder1);
+		(string circuitId, string remainder3) = Tokenizer.ReadUntilSeparator(remainder2);
+		(string target, string remainder4) = Tokenizer.ReadUntilSeparator(remainder3);
+
+		int targetIndex = target.LastIndexOf(':');
+
+		if (targetIndex == -1)
+		{
+			throw new TorControlReplyParseException($"{nameof(StreamInfo)} should contain 'target' value with a colon (':').");
+		}
+
+		string targetAddress = target[0..targetIndex];
+
+		if (!int.TryParse(target[(targetIndex + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out int targetPort))
+		{
+			throw new TorControlReplyParseException($"{nameof(StreamInfo)} should contain 'target' with a valid port number.");
+		}
+
+		if (targetPort < 0 || targetPort > 65535)
+		{
+			throw new TorControlReplyParseException($"{nameof(StreamInfo)}: Port value ({targetPort} is out of range.");
+		}
+
+		StreamStatusFlag streamStatus = Tokenizer.ParseEnumValue(circuitStatus, StreamStatusFlag.UNKNOWN);
+
+		string remainder = remainder4;
+
+		Reason? reason = null;
+		Reason? remoteReason = null;
+		string? source = null;
+		string? sourceAddr = null;
+		Purpose? purpose = null;
+		string? userName = null;
+		string? userPassword = null;
+		ClientProtocol? clientProtocol = null;
+		int? nymEpoch = null;
+		int? sessionGroup = null;
+		List<IsoFieldFlag> isoFields = new();
+
+		// Optional arguments.
+		while (remainder != "")
+		{
+			if (remainder.StartsWith("SOURCE=", StringComparison.Ordinal))
+			{
+				(string _, source, remainder) = Tokenizer.ReadKeyValueAssignment(remainder);
+				continue;
+			}
+			else if (remainder.StartsWith("SOCKS_USERNAME=", StringComparison.Ordinal))
+			{
+				(userName, remainder) = Tokenizer.ReadKeyQuotedValueAssignment(key: "SOCKS_USERNAME", remainder);
+				continue;
+			}
+			else if (remainder.StartsWith("SOCKS_PASSWORD=", StringComparison.Ordinal))
+			{
+				(userPassword, remainder) = Tokenizer.ReadKeyQuotedValueAssignment(key: "SOCKS_PASSWORD", remainder);
+				continue;
+			}
+			else if (remainder.StartsWith("NYM_EPOCH=", StringComparison.Ordinal))
+			{
+				(_, string nymEpochStr, remainder) = Tokenizer.ReadKeyValueAssignment(remainder);
+
+				if (int.TryParse(nymEpochStr, out int nymEpochInt))
+				{
+					nymEpoch = nymEpochInt;
+				}
+
+				continue;
+			}
+			else if (remainder.StartsWith("SESSION_GROUP=", StringComparison.Ordinal))
+			{
+				(_, string sessionGroupStr, remainder) = Tokenizer.ReadKeyValueAssignment(remainder);
+
+				if (int.TryParse(sessionGroupStr, out int sessionGroupInt))
+				{
+					sessionGroup = sessionGroupInt;
+				}
+
+				continue;
+			}
+			else if (remainder.StartsWith("SOURCE_ADDR=", StringComparison.Ordinal))
+			{
+				(_, sourceAddr, remainder) = Tokenizer.ReadKeyValueAssignment(remainder);
+				continue;
+			}
+
+			// Read KEY=VALUE assignments.
+			(string key, string value, string rest) = Tokenizer.ReadKeyValueAssignment(remainder);
+
+			if (key == "ISO_FIELDS")
+			{
+				if (value != "")
+				{
+					string[] flags = value.Split(',');
+					isoFields = flags.Select(x => Tokenizer.ParseEnumValue(x, IsoFieldFlag.UNKNOWN)).ToList();
+				}
+			}
+			else if (key == "PURPOSE")
+			{
+				purpose = Tokenizer.ParseEnumValue(value, Messages.StreamStatus.Purpose.UNKNOWN);
+			}
+			else if (key == "REASON")
+			{
+				reason = Tokenizer.ParseEnumValue(value, Messages.StreamStatus.Reason.UNKNOWN);
+			}
+			else if (key == "REMOTE_REASON")
+			{
+				reason = Tokenizer.ParseEnumValue(value, Messages.StreamStatus.Reason.UNKNOWN);
+			}
+			else if (key == "CLIENT_PROTOCOL")
+			{
+				clientProtocol = Tokenizer.ParseEnumValue(value, Messages.StreamStatus.ClientProtocol.UNKNOWN);
+			}
+			else
+			{
+				Logger.LogError($"Unknown key '{key}'.");
+			}
+
+			remainder = rest;
+		}
+
+		StreamInfo circuitInfo = new(streamId, streamStatus, circuitId, targetAddress, targetPort)
+		{
+			Reason = reason,
+			RemoteReason = remoteReason,
+			Source = source,
+			SourceAddr = sourceAddr,
+			Purpose = purpose,
+			UserName = userName,
+			UserPassword = userPassword,
+			ClientProtocol = clientProtocol,
+			NymEpoch = nymEpoch,
+			SessionGroup = sessionGroup,
+			IsoFields = isoFields,
+		};
+
+		return circuitInfo;
+	}
+
+	/// <inheritdoc/>
+	public override string ToString()
+	{
+		string args = string.Join(
+			separator: ", ",
+			$"{nameof(StreamID)}={StreamID}",
+			$"{nameof(StreamStatus)}={StreamStatus}",
+			$"{nameof(CircuitID)}={CircuitID}",
+			$"{nameof(TargetAddress)}='{TargetAddress}'",
+			$"{nameof(Port)}={Port}",
+			$"{nameof(Reason)}={Reason?.ToString() ?? "null"}",
+			$"{nameof(RemoteReason)}={RemoteReason?.ToString() ?? "null"}",
+			$"{nameof(Source)}={Source ?? "null"}",
+			$"{nameof(Purpose)}={Purpose?.ToString() ?? "null"}",
+			$"{nameof(UserName)}='{UserName ?? "null"}'",
+			$"{nameof(UserPassword)}='{UserPassword ?? "null"}'",
+			$"{nameof(ClientProtocol)}={ClientProtocol?.ToString() ?? "null"}",
+			$"{nameof(NymEpoch)}={NymEpoch?.ToString() ?? "null"}",
+			$"{nameof(SessionGroup)}={SessionGroup?.ToString() ?? "null"}",
+			$"{nameof(IsoFields)}='{string.Join('|', IsoFields)}'"
+		);
+
+		return $"{nameof(StreamInfo)}{{{args}}}";
+	}
+}

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamStatusFlag.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamStatusFlag.cs
@@ -1,0 +1,56 @@
+namespace WalletWasabi.Tor.Control.Messages.StreamStatus;
+
+/// <summary>
+/// 
+/// </summary>
+public enum StreamStatusFlag
+{
+	/// <summary>New request to connect.</summary>
+	NEW,
+
+	/// <summary>New request to resolve an address.</summary>
+	NEWRESOLVE,
+
+	/// <summary>Address re-mapped to another.</summary>
+	REMAP,
+
+	/// <summary>Sent a connect cell along a circuit.</summary>
+	SENTCONNECT,
+
+	/// <summary>Sent a resolve cell along a circuit.</summary>
+	SENTRESOLVE,
+
+	/// <summary>Received a reply; stream established.</summary>
+	SUCCEEDED,
+
+	/// <summary>Stream failed and not retriable.</summary>
+	FAILED,
+
+	/// <summary>Stream closed.</summary>
+	CLOSED,
+
+	/// <summary>Detached from circuit; still retriable.</summary>
+	DETACHED,
+
+	/// <summary>Waiting for controller to use ATTACHSTREAM.</summary>
+	/// <remarks>New in 0.4.5.1-alpha.</remarks>
+	CONTROLLER_WAIT,
+
+	/// <summary>XOFF has been sent for this stream.</summary>
+	/// <remarks>New in 0.4.7.5-alpha.</remarks>
+	XOFF_SENT,
+	/// <summary>XOFF has been received for this stream.</summary>
+	/// <remarks>New in 0.4.7.5-alpha.</remarks>
+	XOFF_RECV,
+
+	/// <summary>XON has been sent for this stream.</summary>
+	/// <remarks>New in 0.4.7.5-alpha.</remarks>
+	XON_SENT,
+
+	/// <summary>XON has been received for this stream.</summary>
+	/// <remarks>New in 0.4.7.5-alpha.</remarks>
+	XON_RECV,
+
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN,
+}

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Control.Exceptions;
@@ -37,7 +36,7 @@ public class TorControlClientFactory
 	/// <summary>Connects to Tor Control endpoint and authenticates using safe-cookie mechanism.</summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.5</seealso>
 	/// <exception cref="TorControlException">If TCP connection cannot be established OR if authentication fails for some reason.</exception>
-	public async Task<TorControlClient> ConnectAndAuthenticateAsync(EndPoint endPoint, string cookieString, CancellationToken cancellationToken = default)
+	public async Task<TorControlClient> ConnectAndAuthenticateAsync(EndPoint endPoint, string cookieString, CancellationToken cancellationToken)
 	{
 		TcpClient tcpClient;
 		try
@@ -77,7 +76,7 @@ public class TorControlClientFactory
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.24 for SAFECOOKIE authentication.</seealso>
 	/// <seealso href="https://github.com/torproject/stem/blob/63a476056017dda5ede35efc4e4f7acfcc1d7d1a/stem/connection.py#L893">Python implementation.</seealso>
 	/// <exception cref="TorControlException">If authentication fails for some reason.</exception>
-	internal async Task<TorControlClient> AuthSafeCookieOrThrowAsync(TorControlClient controlClient, string cookieString, CancellationToken cancellationToken = default)
+	internal async Task<TorControlClient> AuthSafeCookieOrThrowAsync(TorControlClient controlClient, string cookieString, CancellationToken cancellationToken)
 	{
 		byte[] nonceBytes = new byte[32];
 		Random.GetBytes(nonceBytes);

--- a/WalletWasabi/Tor/Control/Utils/AsyncEventParser.cs
+++ b/WalletWasabi/Tor/Control/Utils/AsyncEventParser.cs
@@ -23,6 +23,7 @@ public static class AsyncEventParser
 		{
 			StatusEvent.EventNameStatusClient or StatusEvent.EventNameStatusServer or StatusEvent.EventNameStatusGeneral => StatusEvent.FromReply(reply),
 			CircEvent.EventName => CircEvent.FromReply(reply),
+			StreamEvent.EventName => StreamEvent.FromReply(reply),
 			NetworkLivenessEvent.EventName => NetworkLivenessEvent.FromReply(reply),
 			OrConnEvent.EventName => OrConnEvent.FromReply(reply),
 			_ => throw new NotSupportedException("This should never happen."),

--- a/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
+++ b/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
@@ -47,7 +47,11 @@ public static class Tokenizer
 		string remainder = input[(valueStartAt + 1)..];
 		string value;
 
-		if (allowValueAsQuotedString && remainder.Length > 0 && remainder[0] == '"')
+		if (remainder.Length == 0)
+		{
+			value = "";
+		} 
+		else if (allowValueAsQuotedString && remainder.Length > 0 && remainder[0] == '"')
 		{
 			(value, remainder) = ReadQuotedString(remainder);
 		}

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -34,6 +34,7 @@ public class TorMonitor : PeriodicRunner
 		StatusEvent.EventNameStatusClient,
 		StatusEvent.EventNameStatusServer,
 		CircEvent.EventName,
+		StreamEvent.EventName,
 		OrConnEvent.EventName,
 		NetworkLivenessEvent.EventName,
 	};


### PR DESCRIPTION
This PR implements receiving of async [`STREAM` Tor events](https://github.com/torproject/torspec/blob/79da008392caed38736c73d839df7aa80628b645/control-spec.txt#L2403) for debugging purposes. It actually should allow us to map Tor circuits to our Tor SOCKS5 TCP connections so that we will know easily what went wrong with a TCP connection. Unfortunately, we have not implemented this much sooner as it would allow us to debug the issues we were/are having easier.

This PR does not have any user visible effect. 

Event examples:

```
650 STREAM 24 CLOSED 13 [2600:1f11:b5e:2a00:c289:d72:428f:b3be]:8333 REASON=END REMOTE_REASON=DONE SOCKS_USERNAME="GNT18N1AGE9A96WX7U2O2" SOCKS_PASSWORD="GNT18N1AGE9A96WX7U2O2" CLIENT_PROTOCOL=SOCKS5 NYM_EPOCH=0 SESSION_GROUP=-4 ISO_FIELDS=SOCKS_USERNAME,SOCKS_PASSWORD,CLIENTADDR,SESSION_GROUP,NYM_EPOCH

650 STREAM 71 DETACHED 51 189.6.221.250:8333 REASON=END REMOTE_REASON=MISC SOCKS_USERNAME="8XQ6MKO6UV87DVOZV60XE" SOCKS_PASSWORD="8XQ6MKO6UV87DVOZV60XE" CLIENT_PROTOCOL=SOCKS5 NYM_EPOCH=0 SESSION_GROUP=-4 ISO_FIELDS=SOCKS_USERNAME,SOCKS_PASSWORD,CLIENTADDR,SESSION_GROUP,NYM_EPOCH

650 STREAM 66 CLOSED 0 p2ent3pvkifs2f7f3rsyrkxxb72giyzsmfak3x56dtmmiukstslayrqd.onion:8333 REASON=DONE SOCKS_USERNAME="76E0NQHNYX0UWSTTJIPWR" SOCKS_PASSWORD="76E0NQHNYX0UWSTTJIPWR" CLIENT_PROTOCOL=SOCKS5 NYM_EPOCH=0 SESSION_GROUP=-4 ISO_FIELDS=SOCKS_USERNAME,SOCKS_PASSWORD,CLIENTADDR,SESSION_GROUP,NYM_EPOCH
```