### PR TITLE
Adjust Timeouts + fix backend bug

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -82,7 +82,7 @@ public class CoinVerifier
 
 		var coinDictionary = coinsToCheck.ToDictionary(c => c.ScriptPubKey);
 
-		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(7));
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(30));
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken);
 
 		var lastChangeId = Whitelist.ChangeId;

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
@@ -42,7 +42,7 @@ public class CoinVerifierApiClient
 
 		var address = script.GetDestinationAddress(Network.Main); // API provider don't accept testnet/regtest addresses.
 
-		using CancellationTokenSource timeoutTokenSource = new(TimeSpan.FromSeconds(20));
+		using CancellationTokenSource timeoutTokenSource = new(TimeSpan.FromSeconds(15));
 		using CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutTokenSource.Token);
 		using var content = new HttpRequestMessage(HttpMethod.Get, $"{HttpClient.BaseAddress}{address}");
 		content.Headers.Authorization = new("Bearer", ApiToken);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -149,14 +149,14 @@ public partial class Arena : PeriodicRunner
 					try
 					{
 						int banCounter = 0;
-						var aliceDictionary = round.Alices.Where(x => !x.IsPayingZeroCoordinationFee).ToDictionary(a => a.Coin.ScriptPubKey, a => a);
+						var aliceDictionary = round.Alices.Where(x => !x.IsPayingZeroCoordinationFee).ToDictionary(a => a.Coin.Outpoint, a => a);
 						IEnumerable<Coin> coinsToCheck = aliceDictionary.Values.Select(x => x.Coin);
 						await foreach (var coinVerifyInfo in CoinVerifier.VerifyCoinsAsync(coinsToCheck, cancel, round.Id.ToString()).ConfigureAwait(false))
 						{
 							if (coinVerifyInfo.ShouldBan)
 							{
 								banCounter++;
-								Alice aliceToPunish = aliceDictionary[coinVerifyInfo.Coin.ScriptPubKey];
+								Alice aliceToPunish = aliceDictionary[coinVerifyInfo.Coin.Outpoint];
 								Prison.Ban(aliceToPunish, round.Id, isLongBan: true);
 								round.Alices.Remove(aliceToPunish);
 							}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -149,14 +149,14 @@ public partial class Arena : PeriodicRunner
 					try
 					{
 						int banCounter = 0;
-						var aliceDictionary = round.Alices.Where(x => !x.IsPayingZeroCoordinationFee).ToDictionary(a => a.Coin.Outpoint, a => a);
+						var aliceDictionary = round.Alices.Where(x => !x.IsPayingZeroCoordinationFee).ToDictionary(a => a.Coin, a => a);
 						IEnumerable<Coin> coinsToCheck = aliceDictionary.Values.Select(x => x.Coin);
 						await foreach (var coinVerifyInfo in CoinVerifier.VerifyCoinsAsync(coinsToCheck, cancel, round.Id.ToString()).ConfigureAwait(false))
 						{
 							if (coinVerifyInfo.ShouldBan)
 							{
 								banCounter++;
-								Alice aliceToPunish = aliceDictionary[coinVerifyInfo.Coin.Outpoint];
+								Alice aliceToPunish = aliceDictionary[coinVerifyInfo.Coin];
 								Prison.Ban(aliceToPunish, round.Id, isLongBan: true);
 								round.Alices.Remove(aliceToPunish);
 							}


### PR DESCRIPTION
The bug:
```
2022-08-19 18:26:35.320 [280] ERROR     Arena.StepInputRegistrationPhaseAsync (168)     System.ArgumentException: An item with the same key has already been added. Key: 0 a83cebbe930033ff4899bd6b4efd19074ccbb377
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](List`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at WalletWasabi.WabiSabi.Backend.Rounds.Arena.StepInputRegistrationPhaseAsync(CancellationToken cancel)
```

I made a mistake, when I thought `ScriptPubKey` will always be unique.

This commit https://github.com/zkSNACKs/WalletWasabi/pull/8981/commits/545f1a5fbf71605524ed2aec22b224196756bfbf fixes this by using `Coin` instead of `ScriptPK`

PR also adjust the Cancellation Token timeouts. 7 seconds is not enough IMO (and according to the backend logs). 