### PR TITLE
[Trivial] Bump VS version

### DIFF
--- a/WalletWasabi.sln
+++ b/WalletWasabi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32819.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalletWasabi.Backend", "WalletWasabi.Backend\WalletWasabi.Backend.csproj", "{A378E063-1660-472F-9CB2-0A3E96A56A63}"
 EndProject


### PR DESCRIPTION
https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/solution-dot-sln-file?view=vs-2022

> The full version of Visual Studio that (most recently) saved the solution file. If the solution file is saved by a newer version of Visual Studio that has the same major version, this value is not updated so as to lessen churn in the file.

Bumped VS solution version to the one that VS2022 creates as a template by default