### PR TITLE
[Taproot support] Separate persistent methods

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -116,7 +116,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		var hdkey = activeWallet.KeyManager
-			.GenerateNewKey(new SmartLabel(label), KeyState.Clean, isInternal: false);
+			.GenerateNewPersistentKey(new SmartLabel(label), KeyState.Clean, isInternal: false);
 		return new
 		{
 			address = hdkey.GetP2wpkhAddress(Global.Network).ToString(),

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -27,7 +27,7 @@ public static class ServiceFactory
 		var toGenerate = coinArray.Length - generated;
 		for (int i = 0; i < toGenerate; i++)
 		{
-			keyManager.GenerateNewKey("", KeyState.Clean, false, false);
+			keyManager.GenerateNewKey("", KeyState.Clean, false);
 		}
 
 		var keys = keyManager.GetKeys().Take(coinArray.Length).ToArray();

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -80,7 +80,7 @@ public class KeyManagementTests
 		Assert.NotEqual(manager.ExtPubKey, differentManager.ExtPubKey);
 
 		differentManager.AssertCleanKeysIndexed();
-		var newKey = differentManager.GenerateNewKey("some-label", KeyState.Clean, true, false);
+		var newKey = differentManager.GenerateNewKey("some-label", KeyState.Clean, true);
 		Assert.Equal(newKey.Index, differentManager.MinGapLimit);
 		Assert.Equal("999'/999'/999'/1/55", newKey.FullKeyPath.ToString());
 	}
@@ -122,7 +122,7 @@ public class KeyManagementTests
 			var isInternal = Random.Shared.Next(2) == 0;
 			var label = RandomString.AlphaNumeric(21);
 			var keyState = (KeyState)Random.Shared.Next(3);
-			manager.GenerateNewKey(label, keyState, isInternal, toFile: false);
+			manager.GenerateNewKey(label, keyState, isInternal);
 		}
 		manager.ToFile();
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -184,7 +184,7 @@ public class TransactionFactoryTests
 
 		keyManager.AssertCleanKeysIndexed();
 
-		HdPubKey NewKey(string label) => keyManager.GenerateNewKey(label, KeyState.Used, true, false);
+		HdPubKey NewKey(string label) => keyManager.GenerateNewKey(label, KeyState.Used, true);
 		var scoins = new[]
 		{
 				BitcoinFactory.CreateSmartCoin(NewKey("Pablo"), 0.9m),

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/LabelTestExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/LabelTestExtensions.cs
@@ -28,7 +28,7 @@ internal static class LabelTestExtensions
 
 	public static HdPubKey NewKey(string label = "", int anonymitySet = 1)
 	{
-		var key = KeyManager.GenerateNewKey(label, KeyState.Used, true, false);
+		var key = KeyManager.GenerateNewKey(label, KeyState.Used, true);
 		key.SetAnonymitySet(anonymitySet);
 		key.SetLabel(label);
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -237,7 +237,7 @@ public class TransactionProcessor
 					result.NewlyReceivedCoins.Add(newCoin);
 
 					// Make sure there's always 21 clean keys generated and indexed.
-					KeyManager.AssertCleanKeysIndexed(isInternal: foundKey.IsInternal);
+					KeyManager.AssertCleanKeysIndexedAndPersist(isInternal: foundKey.IsInternal);
 				}
 				else // If we had this coin already.
 				{

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -143,7 +143,7 @@ public class TransactionFactory
 		}
 		else
 		{
-			KeyManager.AssertCleanKeysIndexed(isInternal: true);
+			KeyManager.AssertCleanKeysIndexedAndPersist(isInternal: true);
 			changeHdPubKey = KeyManager.GetKeys(KeyState.Clean, true).First();
 
 			builder.SetChange(changeHdPubKey.P2wpkhScript);

--- a/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
@@ -17,7 +17,7 @@ public class InternalDestinationProvider : IDestinationProvider
 	public IEnumerable<IDestination> GetNextDestinations(int count)
 	{
 		// Get all locked internal keys we have and assert we have enough.
-		KeyManager.AssertLockedInternalKeysIndexed(count);
+		KeyManager.AssertLockedInternalKeysIndexedAndPersist(count);
 		return KeyManager.GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked).Select(x => x.PubKey.WitHash);
 	}
 }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -41,7 +41,7 @@ public class Wallet : BackgroundService, IWallet
 		RuntimeParams.SetDataDir(dataDir);
 		HandleFiltersLock = new AsyncLock();
 
-		KeyManager.AssertCleanKeysIndexed();
+		KeyManager.AssertCleanKeysIndexedAndPersist();
 
 		if (!KeyManager.IsWatchOnly)
 		{


### PR DESCRIPTION
This PR is the one of a sequence of PRs to add support for taproot. The idea is simplify the `KeyManager` in little steps in order to make the real implementation simpler and less risky by doing all these small changes before.

In this case we remove redundant calls to `ToFile()`. In tests we almost never want to persist the keys so, no need to call persistent methods.