### PR TITLE
[MusicBox] Don't display "Round finished..." when user presses pause during InputRegPhase

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -41,7 +41,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	[AutoNotify] private bool _isAutoWaiting;
 	[AutoNotify] private bool _playVisible = true;
 	[AutoNotify] private bool _pauseVisible;
-	[AutoNotify] private bool _pauseLoading;
+	[AutoNotify] private bool _pauseSpreading;
 	[AutoNotify] private bool _stopVisible;
 	[AutoNotify] private MusicStatusMessageViewModel? _currentStatus;
 	[AutoNotify] private bool _isProgressReversed;
@@ -104,8 +104,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			}
 		});
 
-		IsPauseButtonEnabled = this.WhenAnyValue(x => x.IsInCriticalPhase, x => x.PauseLoading,
-			(isInCriticalPhase,pauseLoading) => !isInCriticalPhase && !pauseLoading);
+		IsPauseButtonEnabled = this.WhenAnyValue(x => x.IsInCriticalPhase, x => x.PauseSpreading,
+			(isInCriticalPhase,pauseSpreading) => !isInCriticalPhase && !pauseSpreading);
 			
 		StopPauseCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
@@ -221,7 +221,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				StopCountDown();
 				PlayVisible = true;
 				PauseVisible = false;
-				PauseLoading = false;
+				PauseSpreading = false;
 				StopVisible = false;
 				CurrentStatus = IsAutoCoinJoinEnabled ? _pauseMessage : _stoppedMessage;
 				ElapsedTime = "Press Play to start";
@@ -330,7 +330,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			case RoundEnded roundEnded:
 				if (roundEnded.IsStopped)
 				{
-					PauseLoading = true;
+					PauseSpreading = true;
 				}
 				else
 				{ 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -320,18 +320,20 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	{
 		switch (coinJoinProgress)
 		{
-			case RoundEndedUserPressedPause:
-				StopCountDown();
-				_stateMachine.Fire(Trigger.WalletStoppedCoinJoin);
-				break;
-
 			case RoundEnded roundEnded:
-				CurrentStatus = roundEnded.LastRoundState.EndRoundState switch
+				if (roundEnded.IsStopped)
 				{
-					EndRoundState.TransactionBroadcasted => _roundSucceedMessage,
-					EndRoundState.AbortedNotEnoughAlices => _abortedNotEnoughAlicesMessage,
-					_ => _roundFinishedMessage
-				};
+					_stateMachine.Fire(Trigger.WalletStoppedCoinJoin);
+				}
+				else
+				{ 
+					CurrentStatus = roundEnded.LastRoundState.EndRoundState switch
+					{
+						EndRoundState.TransactionBroadcasted => _roundSucceedMessage,
+						EndRoundState.AbortedNotEnoughAlices => _abortedNotEnoughAlicesMessage,
+						_ => _roundFinishedMessage
+					};
+				}
 				StopCountDown();
 				break;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -320,6 +320,11 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	{
 		switch (coinJoinProgress)
 		{
+			case RoundEndedUserPressedPause:
+				StopCountDown();
+				_stateMachine.Fire(Trigger.WalletStoppedCoinJoin);
+				break;
+
 			case RoundEnded roundEnded:
 				CurrentStatus = roundEnded.LastRoundState.EndRoundState switch
 				{

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -92,14 +92,12 @@
           </Button>
 
           <Button Classes="plain"
-                  IsEnabled="{Binding !IsInCriticalPhase}"
                   IsVisible="{Binding PauseVisible}"
                   Command="{Binding StopPauseCommand}">
             <PathIcon Data="{StaticResource pause_regular}" />
           </Button>
 
           <Button Classes="plain"
-                  IsEnabled="{Binding !IsInCriticalPhase}"
                   IsVisible="{Binding StopVisible}"
                   Command="{Binding StopPauseCommand}">
             <PathIcon Data="{StaticResource stop_regular}" />

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -231,10 +231,6 @@ public class CoinJoinClient
 
 				registeredAliceClientAndCircuits = await ProceedWithInputRegAndConfirmAsync(smartCoins, roundState, linkedCts.Token).ConfigureAwait(false);
 			}
-			catch(OperationCanceledException ex)
-			{
-				return new CoinJoinResult(false);
-			}
 			catch (UnexpectedRoundPhaseException ex)
 			{
 				roundState = ex.RoundState;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -231,6 +231,10 @@ public class CoinJoinClient
 
 				registeredAliceClientAndCircuits = await ProceedWithInputRegAndConfirmAsync(smartCoins, roundState, linkedCts.Token).ConfigureAwait(false);
 			}
+			catch(OperationCanceledException ex)
+			{
+				return new CoinJoinResult(false);
+			}
 			catch (UnexpectedRoundPhaseException ex)
 			{
 				roundState = ex.RoundState;
@@ -1089,9 +1093,12 @@ public class CoinJoinClient
 			throw new InvalidOperationException($"Round '{roundState.Id}' is missing.");
 		}
 
-		// Be aware: at this point we are already in connection confirmation and all the coins got their first confirmation, so this is not exactly the starting time of the phase.
-		var estimatedRemainingFromConnectionConfirmation = DateTimeOffset.UtcNow + roundState.CoinjoinState.Parameters.ConnectionConfirmationTimeout;
-		CoinJoinClientProgress.SafeInvoke(this, new EnteringConnectionConfirmationPhase(newRoundState, estimatedRemainingFromConnectionConfirmation));
+		if(!result.IsDefaultOrEmpty)
+		{
+			// Be aware: at this point we are already in connection confirmation and all the coins got their first confirmation, so this is not exactly the starting time of the phase.
+			var estimatedRemainingFromConnectionConfirmation = DateTimeOffset.UtcNow + roundState.CoinjoinState.Parameters.ConnectionConfirmationTimeout;
+			CoinJoinClientProgress.SafeInvoke(this, new EnteringConnectionConfirmationPhase(newRoundState, estimatedRemainingFromConnectionConfirmation));
+		}
 
 		return result;
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEnded.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEnded.cs
@@ -10,4 +10,5 @@ public class RoundEnded : CoinJoinProgressEventArgs
 	}
 
 	public RoundState LastRoundState { get; }
+	public bool IsStopped { get; set; }
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEndedUserPressedPause.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEndedUserPressedPause.cs
@@ -1,9 +1,0 @@
-using WalletWasabi.WabiSabi.Models;
-namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
-
-public class RoundEndedUserPressedPause : RoundEnded
-{
-	public RoundEndedUserPressedPause(RoundState lastRoundState) : base(lastRoundState)
-	{
-	}
-}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEndedUserPressedPause.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/RoundEndedUserPressedPause.cs
@@ -1,0 +1,9 @@
+using WalletWasabi.WabiSabi.Models;
+namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
+
+public class RoundEndedUserPressedPause : RoundEnded
+{
+	public RoundEndedUserPressedPause(RoundState lastRoundState) : base(lastRoundState)
+	{
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -66,9 +66,10 @@ public class CoinJoinTracker : IDisposable
 				InCriticalCoinJoinState = false;
 				break;
 			case RoundEnded roundEnded:
-				coinJoinProgressEventArgs = IsStopped
-					? new RoundEndedUserPressedPause(roundEnded.LastRoundState)
-					: coinJoinProgressEventArgs;
+				if (IsStopped)
+				{
+					coinJoinProgressEventArgs = new RoundEndedUserPressedPause(roundEnded.LastRoundState);
+				}
 				break;
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -65,6 +65,11 @@ public class CoinJoinTracker : IDisposable
 			case LeavingCriticalPhase:
 				InCriticalCoinJoinState = false;
 				break;
+			case RoundEnded roundEnded:
+				coinJoinProgressEventArgs = IsStopped
+					? new RoundEndedUserPressedPause(roundEnded.LastRoundState)
+					: coinJoinProgressEventArgs;
+				break;
 		}
 
 		WalletCoinJoinProgressChanged?.Invoke(Wallet, coinJoinProgressEventArgs);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -66,10 +66,7 @@ public class CoinJoinTracker : IDisposable
 				InCriticalCoinJoinState = false;
 				break;
 			case RoundEnded roundEnded:
-				if (IsStopped)
-				{
-					coinJoinProgressEventArgs = new RoundEndedUserPressedPause(roundEnded.LastRoundState);
-				}
+				roundEnded.IsStopped = IsStopped;
 				break;
 		}
 


### PR DESCRIPTION
First of a several PRs to fix the messages of the MusicBox.
This one fixes #8769 

`if(!result.IsDefaultOrEmpty){...}` at the end of `CoinJoinClient` is to avoid having the message "Peparing CoinJoin" displayed for a small time if pause is pressed after the registration of the inputs.

Some "questions" on this:
1) Maybe `RoundEndedUserPressedPause` could have a better name? Even a proper folder (I will probably have to add another class heriting `RoundEnded` in another PR)? Or should I add a parameter to RoundEnd instead of creating an herited class?
2) Maybe I should add some logs? The obvious place is in `CoinJoinClient:236` but it's not really possible to know what caused the `OperationCanceledException` there.
3) `_stateMachine.Fire(Trigger.WalletStoppedCoinJoin);` will be ran twice (firstly after `RoundEndedUserPressedPause` and then after `WalletStoppedCoinJoinEventArgs`). I don't think this is a problem, and it can be avoided by deleting `CoinJoinStateViewModel:325` but it creates a small "lag":
<details>
<summary>See the lag when deleting CoinJoinStateViewModel:325</summary>

![WalletWasabi Fluent Desktop_oNiYu8V5yr](https://user-images.githubusercontent.com/16029533/186509516-aa40ed58-297a-418f-92ba-55487abae243.gif)
</details>