### PR TITLE
Do not log `System.OperationCanceledException: The peer has been disconnected` on debug level

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -223,9 +223,14 @@ public class Program
 	{
 		ReadOnlyCollection<Exception> innerExceptions = e.Exception.Flatten().InnerExceptions;
 
-		// Until https://github.com/MetacoSA/NBitcoin/pull/1089 is resolved.
 		if (innerExceptions.Count == 1 && innerExceptions[0] is SocketException socketException && socketException.SocketErrorCode == SocketError.OperationAborted)
 		{
+			// Until https://github.com/MetacoSA/NBitcoin/pull/1089 is resolved.
+			Logger.LogTrace(e.Exception);
+		}
+		else if (innerExceptions.Count == 1 && innerExceptions[0] is OperationCanceledException ex && ex.Message == "The peer has been disconnected")
+		{
+			// Source of this exception is NBitcoin library.
 			Logger.LogTrace(e.Exception);
 		}
 		else


### PR DESCRIPTION
Fixes #8967

The end effect is that users won't see the mentioned exception in logs. No other user visible effect is expected.