### PR TITLE
Enable "skip" for seed confirmation in debug mode

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -28,8 +28,11 @@ public partial class ConfirmRecoveryWordsViewModel : RoutableViewModel
 		string walletName)
 	{
 		_confirmationWordsSourceList = new SourceList<RecoveryWordViewModel>();
+# if RELEASE
 		_isSkipEnable = Services.WalletManager.Network != Network.Main || System.Diagnostics.Debugger.IsAttached;
-
+#else
+		_isSkipEnable = true;
+#endif
 		var nextCommandCanExecute =
 			_confirmationWordsSourceList
 			.Connect()


### PR DESCRIPTION
Fixes #9008 
I made it using preprocessor directives, these directives were already used in the codebase (for example in Logger.cs)
I kept `|| System.Diagnostics.Debugger.IsAttached` if someone wants to use debugguer in release mode.