### PR TITLE
Tor: Fix use of `AnyOneOffCircuit`

### DIFF
--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamStatusFlag.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamStatusFlag.cs
@@ -39,6 +39,7 @@ public enum StreamStatusFlag
 	/// <summary>XOFF has been sent for this stream.</summary>
 	/// <remarks>New in 0.4.7.5-alpha.</remarks>
 	XOFF_SENT,
+
 	/// <summary>XOFF has been received for this stream.</summary>
 	/// <remarks>New in 0.4.7.5-alpha.</remarks>
 	XOFF_RECV,

--- a/WalletWasabi/Tor/Socks5/Pool/Circuits/AnyOneOffCircuit.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/Circuits/AnyOneOffCircuit.cs
@@ -19,4 +19,10 @@ public class AnyOneOffCircuit : ICircuit
 
 	/// <inheritdoc/>
 	public string? Purpose { get; }
+
+	/// <inheritdoc/>
+	public override string ToString()
+	{
+		return $"[{nameof(AnyOneOffCircuit)}]";
+	}
 }

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -137,7 +137,7 @@ public class TorHttpPool : IAsyncDisposable
 	/// </summary>
 	/// <exception cref="HttpRequestException">When <paramref name="request"/> fails to be processed.</exception>
 	/// <exception cref="OperationCanceledException">When the operation was canceled.</exception>
-	public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken = default)
+	public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
 	{
 		int i = 0;
 		int attemptsNo = 3;

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -71,7 +71,7 @@ public class TorProcessManager : IAsyncDisposable
 		{
 			try
 			{
-				Logger.LogDebug($"Attempt #{i} to start Tor.");
+				Logger.LogDebug($"Attempt #{i + 1} to start Tor.");
 				return await WaitForNextAttemptAsync(cancellationToken).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException)


### PR DESCRIPTION
This PR fixes uses of `AnyOneOffCircuit`. The bug was introduced in #8827. 