### PR TITLE
[Trivial] LogInfo for NoEstimationException

### DIFF
--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -90,6 +90,10 @@ public abstract class PeriodicRunner : BackgroundService
 			{
 				Logger.LogTrace(ex);
 			}
+			catch (NBitcoin.RPC.NoEstimationException ex)
+			{
+				Logger.LogInfo("Couldn't get fee estimation from Bitcoin Core, probably because it was not yet initialized");
+			}
 			catch (Exception ex)
 			{
 				// Exception encountered, process it.

--- a/WalletWasabi/Bases/PeriodicRunner.cs
+++ b/WalletWasabi/Bases/PeriodicRunner.cs
@@ -90,10 +90,6 @@ public abstract class PeriodicRunner : BackgroundService
 			{
 				Logger.LogTrace(ex);
 			}
-			catch (NBitcoin.RPC.NoEstimationException ex)
-			{
-				Logger.LogInfo("Couldn't get fee estimation from Bitcoin Core, probably because it was not yet initialized");
-			}
 			catch (Exception ex)
 			{
 				// Exception encountered, process it.

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -40,7 +40,7 @@ public class RpcFeeProvider : PeriodicRunner
 			}
 			InError = false;
 		}
-		catch(NoEstimationException ex)
+		catch (NoEstimationException ex)
 		{
 			Logging.Logger.LogInfo("Couldn't get fee estimation from the Bitcoin node, probably because it was not yet initialized.");
 			InError = true;

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -42,7 +42,7 @@ public class RpcFeeProvider : PeriodicRunner
 		}
 		catch(NoEstimationException ex)
 		{
-			Logging.Logger.LogInfo("Couldn't get fee estimation from Bitcoin Core, probably because it was not yet initialized.");
+			Logging.Logger.LogInfo("Couldn't get fee estimation from the Bitcoin node, probably because it was not yet initialized.");
 			InError = true;
 		}
 		catch

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -42,7 +42,7 @@ public class RpcFeeProvider : PeriodicRunner
 		}
 		catch(NoEstimationException ex)
 		{
-			Logging.Logger.LogInfo("Couldn't get fee estimation from Bitcoin Core, probably because it was not yet initialized");
+			Logging.Logger.LogInfo("Couldn't get fee estimation from Bitcoin Core, probably because it was not yet initialized.");
 			InError = true;
 		}
 		catch

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -40,6 +40,11 @@ public class RpcFeeProvider : PeriodicRunner
 			}
 			InError = false;
 		}
+		catch(NoEstimationException ex)
+		{
+			Logging.Logger.LogInfo("Couldn't get fee estimation from Bitcoin Core, probably because it was not yet initialized");
+			InError = true;
+		}
 		catch
 		{
 			InError = true;


### PR DESCRIPTION
Fixes #9010 
It can only be caught in the PeriodicRunner because all exceptions are logged as error right after, which is what we want to avoid.
Maybe it would be better in the message to add that fee estimation will be asked to the HybridFeeProvider?
A better fix would be to test upfront if Bitcoin Core is ready to provide the estimation to avoid the exception to be raised in the first place.