### PR TITLE
Tor: Proper matching of `TorTcpConnection`s and Tor's streams (circuits)

### DIFF
--- a/WalletWasabi/Tor/Socks5/TorTcpConnection.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnection.cs
@@ -15,23 +15,19 @@ public class TorTcpConnection : IDisposable
 {
 	private volatile bool _disposedValue = false;
 
-	/// <summary>ID generator.</summary>
-	private static long LastId;
-
 	/// <param name="tcpClient">TCP client connected to Tor SOCKS5 endpoint.</param>
 	/// <param name="transportStream">Transport stream to actually send the data to Tor SOCKS5 endpoint (the difference is SSL).</param>
 	/// <param name="circuit">Tor circuit under which we operate with this TCP connection.</param>
 	/// <param name="allowRecycling">Whether it is allowed to re-use this Tor TCP connection.</param>
 	public TorTcpConnection(TcpClient tcpClient, Stream transportStream, ICircuit circuit, bool allowRecycling)
 	{
-		long id = Interlocked.Increment(ref LastId);
 		string prefix = circuit switch
 		{
 			DefaultCircuit _ => "DC",
 			PersonCircuit _ => "PC",
 			_ => "UC" // Unknown circuit type.
 		};
-		Name = $"{prefix}#{id:0000}#{circuit.Name[0..10]}";
+		Name = $"{prefix}#{circuit.Name[0..5]}";
 
 		TcpClient = tcpClient;
 		TransportStream = transportStream;

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -11,6 +11,7 @@ using WalletWasabi.Tor.Control.Messages.CircuitStatus;
 using WalletWasabi.Tor.Control.Messages.Events;
 using WalletWasabi.Tor.Control.Messages.Events.OrEvents;
 using WalletWasabi.Tor.Control.Messages.Events.StatusEvents;
+using WalletWasabi.Tor.Control.Messages.StreamStatus;
 using WalletWasabi.Tor.Control.Utils;
 using WalletWasabi.Tor.Http;
 using WalletWasabi.Tor.Socks5.Exceptions;
@@ -158,10 +159,14 @@ public class TorMonitor : PeriodicRunner
 						Logger.LogInfo("Tor circuit was established.");
 						circuitEstablished = true;
 					}
+				}
+				else if (asyncEvent is StreamEvent streamEvent)
+				{
+					StreamInfo info = streamEvent.StreamInfo;
 
-					if ((info.CircStatus is CircStatus.BUILT or CircStatus.CLOSED) && info.UserName is not null)
+					if (info.UserName is not null)
 					{
-						TorHttpPool.ReportCircuitStatus(info.CircStatus, info.CircuitID, info.UserName);
+						TorHttpPool.ReportCircuitStatus(streamUsername: info.UserName, streamStatus: info.StreamStatus, circuitID: info.CircuitID);
 					}
 				}
 			}


### PR DESCRIPTION
This PR is meant to fix `SocketException`s that we have kept seeing:

```log
2022-07-29 09:13:02.042 [76] TRACE	TorHttpPool.SendAsync (199)	['PC#0008#GETZVMTKJG'] Could not get/read an HTTP response from Tor. Exception: WalletWasabi.Tor.Socks5.Exceptions.TorConnectionReadException: Could not read HTTP response.
 ---> System.IO.IOException: Unable to read data from the transport connection: An established connection was aborted by the software in your host machine..
 ---> System.Net.Sockets.SocketException (10053): An established connection was aborted by the software in your host machine.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
```

before #8846 was merged.