### PR TITLE
Small changes in `KeyManager`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/RecoverWalletViewModel.cs
@@ -81,7 +81,6 @@ public partial class RecoverWalletViewModel : RoutableViewModel
 							MinGapLimit);
 
 						result.AutoCoinJoin = true;
-						result.SetNetwork(Services.WalletManager.Network);
 
 						// Set the filepath but we will only write the file later when the Ui workflow is done.
 						result.SetFilePath(walletFilePath);

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -677,16 +677,7 @@ public class KeyManager
 		}
 		return res;
 	}
-
-	public void SetNetwork(Network network)
-	{
-		lock (BlockchainStateLock)
-		{
-			BlockchainState.Network = network;
-			ToFileNoBlockchainStateLock();
-		}
-	}
-
+	
 	public Network GetNetwork()
 	{
 		lock (BlockchainStateLock)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -115,7 +115,8 @@ public class KeyManager
 	[JsonConverter(typeof(ExtPubKeyJsonConverter))]
 	public ExtPubKey ExtPubKey { get; }
 
-	[JsonProperty(Order = 5)] public bool SkipSynchronization { get; private set; } = false;
+	[JsonProperty(Order = 5)] 
+	public bool SkipSynchronization { get; private set; } = false;
 
 	[JsonProperty(Order = 6)]
 	public int MinGapLimit { get; private set; }
@@ -123,14 +124,6 @@ public class KeyManager
 	[JsonProperty(Order = 7)]
 	[JsonConverter(typeof(KeyPathJsonConverter))]
 	public KeyPath AccountKeyPath { get; private set; }
-
-	public string? FilePath { get; private set; }
-
-	[MemberNotNullWhen(returnValue: false, nameof(EncryptedSecret))]
-	public bool IsWatchOnly => EncryptedSecret is null;
-
-	[MemberNotNullWhen(returnValue: true, nameof(MasterFingerprint))]
-	public bool IsHardwareWallet => EncryptedSecret is null && MasterFingerprint is not null;
 
 	[JsonProperty(Order = 8)]
 	private BlockchainState BlockchainState { get; }
@@ -166,6 +159,14 @@ public class KeyManager
 	[JsonProperty(Order = 999)] 
 	private List<HdPubKey> HdPubKeys { get; } = new ();
 
+	public string? FilePath { get; private set; }
+
+	[MemberNotNullWhen(returnValue: false, nameof(EncryptedSecret))]
+	public bool IsWatchOnly => EncryptedSecret is null;
+
+	[MemberNotNullWhen(returnValue: true, nameof(MasterFingerprint))]
+	public bool IsHardwareWallet => EncryptedSecret is null && MasterFingerprint is not null;
+	
 	private object BlockchainStateLock { get; } = new ();
 
 	private object HdPubKeysLock { get; } = new ();

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -32,9 +32,10 @@ public class WalletGenerator
 		// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password because of compatibility.
 		PasswordHelper.Guard(password);
 
-		var km = mnemonic is null ? KeyManager.CreateNew(out mnemonic, password, Network) : KeyManager.CreateNew(mnemonic, password, Network);
+		var km = mnemonic is null 
+			? KeyManager.CreateNew(out mnemonic, password, Network)
+			: KeyManager.CreateNew(mnemonic, password, Network);
 		km.AutoCoinJoin = true;
-		km.SetNetwork(Network);
 		km.SetBestHeight(new Height(TipHeight));
 		km.SetFilePath(walletFilePath);
 		return (km, mnemonic);


### PR DESCRIPTION
The first commit removes the `SetNetwork` method because the network should never be changed and it is always known.
The second commit just move a block of properties.