### PR TITLE
Remove `default` CTs from Tor code

### DIFF
--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -92,7 +92,7 @@ public class TorControlClient : IAsyncDisposable
 	/// Gets protocol info (for version 1).
 	/// </summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">3.21. PROTOCOLINFO</seealso>
-	public async Task<ProtocolInfoReply> GetProtocolInfoAsync(CancellationToken cancellationToken = default)
+	public async Task<ProtocolInfoReply> GetProtocolInfoAsync(CancellationToken cancellationToken)
 	{
 		// Grammar: "PROTOCOLINFO" *(SP PIVERSION) CRLF
 		// Note: PIVERSION is there in case we drastically change the syntax one day. For now it should always be "1".
@@ -105,7 +105,7 @@ public class TorControlClient : IAsyncDisposable
 	/// Gets process ID belonging to the main Tor process.
 	/// </summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">3.9. GETINFO</seealso>
-	public async Task<int> GetTorProcessIdAsync(CancellationToken cancellationToken = default)
+	public async Task<int> GetTorProcessIdAsync(CancellationToken cancellationToken)
 	{
 		TorControlReply reply = await SendCommandAsync("GETINFO process/pid\r\n", cancellationToken).ConfigureAwait(false);
 
@@ -130,7 +130,7 @@ public class TorControlClient : IAsyncDisposable
 	/// Gets Tor's circuits that are currently available.
 	/// </summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">3.9. GETINFO, and 4.1.1. Circuit status changed.</seealso>
-	public async Task<GetInfoCircuitStatusReply> GetCircuitStatusAsync(CancellationToken cancellationToken = default)
+	public async Task<GetInfoCircuitStatusReply> GetCircuitStatusAsync(CancellationToken cancellationToken)
 	{
 		TorControlReply reply = await SendCommandAsync("GETINFO circuit-status\r\n", cancellationToken).ConfigureAwait(false);
 
@@ -141,7 +141,7 @@ public class TorControlClient : IAsyncDisposable
 	/// Instructs Tor to shut down when this control connection is closed.
 	/// </summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See 3.23. TAKEOWNERSHIP.</seealso>
-	public Task<TorControlReply> TakeOwnershipAsync(CancellationToken cancellationToken = default)
+	public Task<TorControlReply> TakeOwnershipAsync(CancellationToken cancellationToken)
 		=> SendCommandAsync("TAKEOWNERSHIP\r\n", cancellationToken);
 
 	/// <summary>
@@ -149,7 +149,7 @@ public class TorControlClient : IAsyncDisposable
 	/// </summary>
 	/// <remarks>If server is a client (OP), exit immediately. If it's a relay (OR), close listeners and exit after <c>ShutdownWaitLength</c> seconds.</remarks>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See 3.7. SIGNAL.</seealso>
-	public async Task<TorControlReply> SignalShutdownAsync(CancellationToken cancellationToken = default)
+	public async Task<TorControlReply> SignalShutdownAsync(CancellationToken cancellationToken)
 	{
 		using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
 
@@ -171,20 +171,20 @@ public class TorControlClient : IAsyncDisposable
 	/// </summary>
 	/// <remarks>If TAKEOWNERSHIP command is sent, Tor will still exit when the control connection ends.</remarks>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See 3.2. RESETCONF and 3.23. TAKEOWNERSHIP.</seealso>
-	public Task<TorControlReply> ResetOwningControllerProcessConfAsync(CancellationToken cancellationToken = default)
+	public Task<TorControlReply> ResetOwningControllerProcessConfAsync(CancellationToken cancellationToken)
 		=> SendCommandAsync("RESETCONF __OwningControllerProcess\r\n", cancellationToken);
 
 	/// <summary>Sends a command to Tor.</summary>
 	/// <remarks>This is meant as a low-level API method, if needed for some reason.</remarks>
 	/// <param name="command">A Tor control command which must end with <c>\r\n</c>.</param>
-	public async Task<TorControlReply> SendCommandAsync(string command, CancellationToken cancellationToken = default)
+	public async Task<TorControlReply> SendCommandAsync(string command, CancellationToken cancellationToken)
 	{
 		using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
 		return await SendCommandNoLockAsync(command, cancellationToken).ConfigureAwait(false);
 	}
 
 	/// <remarks>Lock <see cref="MessageLock"/> must be acquired by the caller.</remarks>
-	private async Task<TorControlReply> SendCommandNoLockAsync(string command, CancellationToken cancellationToken = default)
+	private async Task<TorControlReply> SendCommandNoLockAsync(string command, CancellationToken cancellationToken)
 	{
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ReaderCts.Token, cancellationToken);
 
@@ -208,7 +208,7 @@ public class TorControlClient : IAsyncDisposable
 	/// }
 	/// </code> 
 	/// </example>
-	public async IAsyncEnumerable<TorControlReply> ReadEventsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+	public async IAsyncEnumerable<TorControlReply> ReadEventsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
 	{
 		Channel<TorControlReply> channel = Channel.CreateUnbounded<TorControlReply>(Options);
 		List<Channel<TorControlReply>> newList;
@@ -259,7 +259,7 @@ public class TorControlClient : IAsyncDisposable
 	/// <param name="cancellationToken">
 	/// Useful when the whole Tor process stops. Otherwise, the internal state of this object may get corrupted.
 	/// </param>
-	public async Task SubscribeEventsAsync(IEnumerable<string> names, CancellationToken cancellationToken = default)
+	public async Task SubscribeEventsAsync(IEnumerable<string> names, CancellationToken cancellationToken)
 	{
 		using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
 
@@ -302,7 +302,7 @@ public class TorControlClient : IAsyncDisposable
 	/// <param name="cancellationToken">
 	/// Useful when the whole application stops. Otherwise, the internal state of this object may get corrupted.
 	/// </param>
-	public async Task UnsubscribeEventsAsync(string[] names, CancellationToken cancellationToken = default)
+	public async Task UnsubscribeEventsAsync(string[] names, CancellationToken cancellationToken)
 	{
 		using IDisposable _ = await MessageLock.LockAsync(cancellationToken).ConfigureAwait(false);
 

--- a/WalletWasabi/Tor/Control/TorControlReplyReader.cs
+++ b/WalletWasabi/Tor/Control/TorControlReplyReader.cs
@@ -22,7 +22,7 @@ public class TorControlReplyReader
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section "4. Replies".</seealso>
 	/// <seealso href="https://github.com/lontivero/Torino/blob/d891616777ed596ef54dbf1d86c9b4771e45e8f3/src/Reply.cs#L72"/>
 	/// <seealso href="https://github.com/torproject/stem/blob/master/stem/response/__init__.py"/>
-	public static async Task<TorControlReply> ReadReplyAsync(PipeReader reader, CancellationToken cancellationToken = default)
+	public static async Task<TorControlReply> ReadReplyAsync(PipeReader reader, CancellationToken cancellationToken)
 	{
 		string line;
 
@@ -68,8 +68,10 @@ public class TorControlReplyReader
 			return new TorControlReply((StatusCode)code, responseLines: new List<string>() { line });
 		}
 
-		List<string> responses = new();
-		responses.Add(line[1..]);
+		List<string> responses = new()
+		{
+			line[1..]
+		};
 
 		while (true)
 		{

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.Tor.Http.Extensions;
 
 public static class HttpResponseMessageExtensions
 {
-	public static async Task<HttpResponseMessage> CreateNewAsync(Stream responseStream, HttpMethod requestMethod, CancellationToken cancellationToken = default)
+	public static async Task<HttpResponseMessage> CreateNewAsync(Stream responseStream, HttpMethod requestMethod, CancellationToken cancellationToken)
 	{
 		// https://tools.ietf.org/html/rfc7230#section-3
 		// The normal procedure for parsing an HTTP message is to read the
@@ -59,7 +59,7 @@ public static class HttpResponseMessageExtensions
 		return response;
 	}
 
-	public static async Task ThrowUnwrapExceptionFromContentAsync(this HttpResponseMessage me, CancellationToken cancellationToken = default)
+	public static async Task ThrowUnwrapExceptionFromContentAsync(this HttpResponseMessage me, CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -71,7 +71,7 @@ public static class HttpResponseMessageExtensions
 		}
 	}
 
-	public static async Task ThrowRequestExceptionFromContentAsync(this HttpResponseMessage me, CancellationToken cancellationToken = default)
+	public static async Task ThrowRequestExceptionFromContentAsync(this HttpResponseMessage me, CancellationToken cancellationToken)
 	{
 		var errorMessage = "";
 

--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.Tor.Http.Helpers;
 
 public static class HttpMessageHelper
 {
-	public static async Task<string> ReadStartLineAsync(Stream stream, CancellationToken ctsToken = default)
+	public static async Task<string> ReadStartLineAsync(Stream stream, CancellationToken cancellationToken)
 	{
 		// https://tools.ietf.org/html/rfc7230#section-3
 		// A recipient MUST parse an HTTP message as a sequence of octets in an
@@ -34,7 +34,7 @@ public static class HttpMessageHelper
 		int read = 0;
 		while (read >= 0)
 		{
-			read = await stream.ReadByteAsync(ctsToken).ConfigureAwait(false);
+			read = await stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
 
 			// End of stream has been reached.
 			if (read == -1)

--- a/WalletWasabi/Tor/Http/IHttpClient.cs
+++ b/WalletWasabi/Tor/Http/IHttpClient.cs
@@ -14,15 +14,15 @@ public interface IHttpClient
 
 	/// <summary>Sends an HTTP(s) request.</summary>
 	/// <param name="request">HTTP request message to send.</param>
-	/// <param name="token">Cancellation token to cancel the asynchronous operation.</param>
+	/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
 	/// <exception cref="HttpRequestException"/>
 	/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
-	Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default);
+	Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
 
 	/// <exception cref="HttpRequestException"/>
 	/// <exception cref="InvalidOperationException"/>
 	/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
-	async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent? content = null, CancellationToken cancel = default)
+	async Task<HttpResponseMessage> SendAsync(HttpMethod method, string relativeUri, HttpContent? content = null, CancellationToken cancellationToken = default)
 	{
 		if (BaseUriGetter is null)
 		{
@@ -44,6 +44,6 @@ public interface IHttpClient
 			httpRequestMessage.Content = content;
 		}
 
-		return await SendAsync(httpRequestMessage, cancel).ConfigureAwait(false);
+		return await SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
+++ b/WalletWasabi/Tor/Socks5/TorTcpConnectionFactory.cs
@@ -49,13 +49,13 @@ public class TorTcpConnectionFactory
 	/// Creates a new connected TCP client connected to Tor SOCKS5 endpoint.
 	/// </summary>
 	/// <inheritdoc cref="ConnectAsync(string, int, bool, ICircuit, CancellationToken)"/>
-	public virtual async Task<TorTcpConnection> ConnectAsync(Uri requestUri, ICircuit circuit, CancellationToken token = default)
+	public virtual async Task<TorTcpConnection> ConnectAsync(Uri requestUri, ICircuit circuit, CancellationToken cancellationToken)
 	{
 		bool useSsl = requestUri.Scheme == Uri.UriSchemeHttps;
 		string host = requestUri.DnsSafeHost;
 		int port = requestUri.Port;
 
-		return await ConnectAsync(host, port, useSsl, circuit, token).ConfigureAwait(false);
+		return await ConnectAsync(host, port, useSsl, circuit, cancellationToken).ConfigureAwait(false);
 	}
 
 	/// <summary>
@@ -68,7 +68,7 @@ public class TorTcpConnectionFactory
 	/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
 	/// <returns>New <see cref="TorTcpConnection"/> instance.</returns>
 	/// <exception cref="TorConnectionException">When <see cref="TcpClientSocks5Connector.ConnectAsync"/> fails.</exception>
-	public async Task<TorTcpConnection> ConnectAsync(string host, int port, bool useSsl, ICircuit circuit, CancellationToken cancellationToken = default)
+	public async Task<TorTcpConnection> ConnectAsync(string host, int port, bool useSsl, ICircuit circuit, CancellationToken cancellationToken)
 	{
 		TcpClient? tcpClient = null;
 		Stream? transportStream = null;
@@ -280,7 +280,7 @@ public class TorTcpConnectionFactory
 	/// <returns>Reply</returns>
 	/// <exception cref="ArgumentException">When <paramref name="request"/> is not supported.</exception>
 	/// <exception cref="TorConnectionException">When we receive no response from Tor or the response is invalid.</exception>
-	private async Task<byte[]> SendRequestAsync(TcpClient tcpClient, ByteArraySerializableBase request, CancellationToken cancellationToken = default)
+	private async Task<byte[]> SendRequestAsync(TcpClient tcpClient, ByteArraySerializableBase request, CancellationToken cancellationToken)
 	{
 		try
 		{

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -361,7 +361,7 @@ public class TorProcessManager : IAsyncDisposable
 			// > SHUTDOWN" and wait for the Tor process to close.)
 			if (Settings.TerminateOnExit)
 			{
-				await torControlClient.SignalShutdownAsync().ConfigureAwait(false);
+				await torControlClient.SignalShutdownAsync(CancellationToken.None).ConfigureAwait(false);
 			}
 
 			// Leads to Tor termination because we sent TAKEOWNERSHIP command.

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -44,7 +44,7 @@ public class WasabiClient
 			relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";
 		}
 
-		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, relativeUri, cancel: cancel).ConfigureAwait(false);
+		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, relativeUri, cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
@@ -69,7 +69,7 @@ public class WasabiClient
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
 			$"/api/v{ApiVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
-			cancel: cancel).ConfigureAwait(false);
+			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode == HttpStatusCode.NoContent)
 		{
@@ -105,7 +105,7 @@ public class WasabiClient
 			using HttpResponseMessage response = await HttpClient.SendAsync(
 				HttpMethod.Get,
 				$"/api/v{ApiVersion}/btc/blockchain/transaction-hexes?&transactionIds={string.Join("&transactionIds=", chunk.Select(x => x.ToString()))}",
-				cancel: cancel).ConfigureAwait(false);
+				cancellationToken: cancel).ConfigureAwait(false);
 
 			if (response.StatusCode != HttpStatusCode.OK)
 			{
@@ -145,7 +145,7 @@ public class WasabiClient
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
-			await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+			await response.ThrowRequestExceptionFromContentAsync(CancellationToken.None).ConfigureAwait(false);
 		}
 	}
 
@@ -164,7 +164,7 @@ public class WasabiClient
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
 			$"/api/v{ApiVersion}/btc/blockchain/mempool-hashes",
-			cancel: cancel).ConfigureAwait(false);
+			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
@@ -187,7 +187,7 @@ public class WasabiClient
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
 			$"/api/v{ApiVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
-			cancel: cancel).ConfigureAwait(false);
+			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
@@ -210,7 +210,7 @@ public class WasabiClient
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
-			await response.ThrowRequestExceptionFromContentAsync().ConfigureAwait(false);
+			await response.ThrowRequestExceptionFromContentAsync(CancellationToken.None).ConfigureAwait(false);
 		}
 
 		using HttpContent content = response.Content;
@@ -225,7 +225,7 @@ public class WasabiClient
 
 	public async Task<(Version ClientVersion, ushort BackendMajorVersion, Version LegalDocumentsVersion)> GetVersionsAsync(CancellationToken cancel)
 	{
-		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, "/api/software/versions", cancel: cancel).ConfigureAwait(false);
+		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, "/api/software/versions", cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
@@ -263,7 +263,7 @@ public class WasabiClient
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
 			$"/api/v{ApiVersion}/wasabi/legaldocuments?id=ww2",
-			cancel: cancel).ConfigureAwait(false);
+			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{


### PR DESCRIPTION
Follow-up to https://github.com/zkSNACKs/WalletWasabi/pull/8979#discussion_r951224641 so that it's hard to *not propagate* a cancellation token all the way down.

And unifies:

* `CancellationToken cancel` -> `CancellationToken cancellationToken`
* `CancellationToken token` -> `CancellationToken cancellationToken`

in Tor code. I find `CancellationToken cancel` weird because `cancel` is a verb and the thing is a noun (a token).