### PR TITLE
Unifying the source of keys in `KeyManager`

### DIFF
--- a/WalletWasabi/Blockchain/Keys/HdPubKeyRegistry.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKeyRegistry.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NBitcoin;
+
+namespace WalletWasabi.Blockchain.Keys;
+
+public record HdPubKeyEx(HdPubKey HdPubKey, byte[] ScriptPubKeyBytes);
+
+public class HdPubKeyRegistry : IEnumerable<HdPubKeyEx>
+{
+	private Dictionary<Script, HdPubKeyEx> KeyExtendedDataByScript { get; } = new ();
+
+	public void AddKey(HdPubKey hdPubKey, ScriptPubKeyType scriptPubKeyType)
+	{
+		var scriptPubKey = hdPubKey.PubKey.GetScriptPubKey(scriptPubKeyType);
+		KeyExtendedDataByScript.AddOrReplace(scriptPubKey, new HdPubKeyEx(hdPubKey, scriptPubKey.ToCompressedBytes()));
+	}
+
+	public bool TryGetPubkey(Script destination, [NotNullWhen(true)] out HdPubKeyEx? hdPubKeyEx) =>
+		KeyExtendedDataByScript.TryGetValue(destination, out hdPubKeyEx);
+
+	public void AddRangeKeys(IEnumerable<HdPubKey> keys)
+	{
+		foreach (var key in keys)
+		{
+			AddKey(key, ScriptPubKeyType.Segwit);
+		}
+	}
+
+	public IEnumerator<HdPubKeyEx> GetEnumerator() =>
+		KeyExtendedDataByScript.Values.DistinctBy(x => x.HdPubKey).GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() =>
+		GetEnumerator();
+}


### PR DESCRIPTION
This PR is the first one to start separating the keys by script type. The unification of the list of keys and its encoded as a byte array in only one data structure makes easier to keep the state synchronized.