### PR TITLE
[VDG] Privacy Ring + Privacy Bar improvements

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -20,21 +20,26 @@ public partial class PrivacyControlTileViewModel : TileViewModel, IPrivacyRingPr
 	[AutoNotify] private string _percentText = "";
 	[AutoNotify] private string _balancePrivateBtc = "";
 	[AutoNotify] private bool _hasPrivateBalance;
+	[AutoNotify] private bool _showPrivacyBar;
 
-	public PrivacyControlTileViewModel(WalletViewModel walletVm, IObservable<Unit> balanceChanged)
+	public PrivacyControlTileViewModel(WalletViewModel walletVm, IObservable<Unit> balanceChanged, bool showPrivacyBar = true)
 	{
 		_wallet = walletVm.Wallet;
 		_walletVm = walletVm;
 		_balanceChanged = balanceChanged;
+		_showPrivacyBar = showPrivacyBar;
 
 		ShowDetailsCommand = ReactiveCommand.Create(ShowDetails);
 
-		PrivacyBar = new PrivacyBarViewModel(_walletVm, _balanceChanged);
+		if (_showPrivacyBar)
+		{
+			PrivacyBar = new PrivacyBarViewModel(_walletVm, _balanceChanged);
+		}
 	}
 
 	public ICommand ShowDetailsCommand { get; }
 
-	public PrivacyBarViewModel PrivacyBar { get; }
+	public PrivacyBarViewModel? PrivacyBar { get; }
 
 	protected override void OnActivated(CompositeDisposable disposables)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -5,6 +5,7 @@ using ReactiveUI;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
@@ -21,6 +22,7 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 {
 	private readonly SourceList<PrivacyRingItemViewModel> _itemsSourceList = new();
 	private IObservable<Unit> _coinsUpdated;
+	private readonly CompositeDisposable _disposables = new();
 	[AutoNotify] private PrivacyRingItemViewModel? _selectedItem;
 	[AutoNotify] private double _height;
 	[AutoNotify] private double _width;
@@ -32,8 +34,10 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 		Wallet = walletViewModel.Wallet;
 
 		NextCommand = CancelCommand;
+		PrivacyTile = new PrivacyControlTileViewModel(walletViewModel, balanceChanged, false);
+		PrivacyTile.Activate(_disposables);
 
-		PreviewItems.Add(walletViewModel.Tiles.OfType<PrivacyControlTileViewModel>().First());
+		PreviewItems.Add(PrivacyTile);
 
 		_itemsSourceList
 			.Connect()
@@ -53,6 +57,8 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(RefreshCoinsList);
 
+		_disposables.Add(_itemsSourceList);
+
 		this.WhenAnyValue(x => x.Width, x => x.Height)
 			.Subscribe(x =>
 			{
@@ -65,6 +71,8 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 	}
+
+	public PrivacyControlTileViewModel PrivacyTile { get; }
 
 	public ObservableCollectionExtended<PrivacyRingItemViewModel> Items { get; } = new();
 	public ObservableCollectionExtended<IPrivacyRingPreviewItem> PreviewItems { get; } = new();
@@ -92,6 +100,8 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 
 					list.Add(item);
 
+					_disposables.Add(item);
+
 					start = end;
 				}
 			}
@@ -103,11 +113,6 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 
 	public void Dispose()
 	{
-		foreach (var item in Items)
-		{
-			item.Dispose();
-		}
-
-		_itemsSourceList.Dispose();
+		_disposables.Dispose();
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -20,9 +20,9 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 	NavigationTarget = NavigationTarget.DialogScreen)]
 public partial class PrivacyRingViewModel : RoutableViewModel
 {
+	private readonly CompositeDisposable _disposables = new();
 	private readonly SourceList<PrivacyRingItemViewModel> _itemsSourceList = new();
 	private IObservable<Unit> _coinsUpdated;
-	private readonly CompositeDisposable _disposables = new();
 	[AutoNotify] private PrivacyRingItemViewModel? _selectedItem;
 	[AutoNotify] private double _height;
 	[AutoNotify] private double _width;

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
@@ -28,7 +28,8 @@
         </StackPanel>
       </StackPanel>
 
-      <Panel x:Name="Panel" DockPanel.Dock="Bottom" Margin="0 0 0 8">
+      <Panel x:Name="Panel" DockPanel.Dock="Bottom" Margin="0 0 0 8"
+             IsVisible="{Binding ShowPrivacyBar}">
         <i:Interaction.Behaviors>
           <behaviors:BoundsObserverBehavior Bounds="{Binding #Panel.Bounds, Mode=OneWay}"
                                             Width="{Binding PrivacyBar.Width, Mode=TwoWay}"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -117,7 +117,7 @@
           <DataTemplate DataType="{x:Type ring:PrivacyRingItemViewModel}">
             <c:TileControl TileSize="Medium" Width="300" Height="150">
               <DockPanel>
-                <c:LabelsItemsPresenter Items="{Binding SmartLabel}" DockPanel.Dock="Top" />
+                <c:LabelsItemsPresenter Items="{Binding SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
                 <StackPanel DockPanel.Dock="Bottom" Height="25" Spacing="8">
                   <Separator />
                   <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">


### PR DESCRIPTION
 - Fixes [layout glitch](https://github.com/zkSNACKs/WalletWasabi/pull/8956#issuecomment-1220490343) caused by reuse of tile viewmodel
 
 - Removes the Privacy Bar inside the Privacy ring (as per [this comment](https://github.com/zkSNACKs/WalletWasabi/pull/9032#pullrequestreview-1091562897))

 - Centers the Labels inside the coin tile (as per [this comment](https://github.com/zkSNACKs/WalletWasabi/pull/8832#issuecomment-1229210693))