### PR TITLE
[VDG] [Trivial] Use ObserveOn correctly

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -57,12 +57,12 @@ public partial class WalletViewModel : WalletViewModelBase
 					nameof(Wallet.TransactionProcessor.WalletRelevantTransactionProcessed))
 				.Select(_ => Unit.Default)
 				.Merge(Observable.FromEventPattern(Wallet, nameof(Wallet.NewFilterProcessed))
-					.Select(_ => Unit.Default))
+						.Select(_ => Unit.Default))
 				.Merge(Services.UiConfig.WhenAnyValue(x => x.PrivacyMode).Select(_ => Unit.Default))
 				.Merge(Wallet.Synchronizer.WhenAnyValue(x => x.UsdExchangeRate).Select(_ => Unit.Default))
 				.Merge(CoinJoinSettings.WhenAnyValue(x => x.AnonScoreTarget).Select(_ => Unit.Default).Skip(1).Throttle(TimeSpan.FromMilliseconds(3000))
-				.Throttle(TimeSpan.FromSeconds(0.1))
-				.ObserveOn(RxApp.MainThreadScheduler));
+					.Throttle(TimeSpan.FromSeconds(0.1)))
+				.ObserveOn(RxApp.MainThreadScheduler);
 
 		History = new HistoryViewModel(this, balanceChanged);
 


### PR DESCRIPTION
The original goal of this ObserveOn call is to execute subscribed code in the UI thread. Please, notice how it's placed incorrectly.

This is dangerous. For example, this will use a different thread:

```csharp
Observable.FromEventPattern(Wallet, nameof(Wallet.NewFilterProcessed)
```

Consumers of this sequence could incorrectly assume that subscriptions will use the UI thread, it it won't in some cases (like the one above).

This PR fixes that.