### PR TITLE
Remove unused Wallet.InitializingChanged static event

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -53,8 +53,6 @@ public class Wallet : BackgroundService, IWallet
 
 	public event EventHandler<ProcessedResult>? WalletRelevantTransactionProcessed;
 
-	public static event EventHandler<bool>? InitializingChanged;
-
 	public event EventHandler<FilterModel>? NewFilterProcessed;
 
 	public event EventHandler<Block>? NewBlockProcessed;
@@ -215,7 +213,6 @@ public class Wallet : BackgroundService, IWallet
 		try
 		{
 			State = WalletState.Starting;
-			InitializingChanged?.Invoke(this, true);
 
 			if (!Synchronizer.IsRunning)
 			{
@@ -241,10 +238,6 @@ public class Wallet : BackgroundService, IWallet
 		{
 			State = WalletState.Initialized;
 			throw;
-		}
-		finally
-		{
-			InitializingChanged?.Invoke(this, false);
 		}
 	}
 


### PR DESCRIPTION
The Wallet InitializingChanged static event is not used anymore, for initialization we have StateChanged event.