### PR TITLE
Anonymity computation again

### DIFF
--- a/WalletWasabi.Tests/Helpers/AnalyzedTransaction/AnalyzedTransaction.cs
+++ b/WalletWasabi.Tests/Helpers/AnalyzedTransaction/AnalyzedTransaction.cs
@@ -1,0 +1,122 @@
+using NBitcoin;
+using System.Linq;
+using System.Collections.Generic;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Blockchain.Transactions;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
+using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.Analysis;
+
+namespace WalletWasabi.Tests.Helpers.AnalyzedTransaction;
+
+public class AnalyzedTransaction : SmartTransaction
+{
+	public AnalyzedTransaction()
+		: base(Transaction.Create(Network.Main), 0)
+	{
+	}
+
+	private static Key CreateKey(string? label = null)
+	{
+		if (label is null)
+		{
+			return new Key();
+		}
+		else
+		{
+			return new Key(Hashes.DoubleSHA256(Encoders.ASCII.DecodeData(label)).ToBytes());
+		}
+	}
+
+	private static Script CreateScript(string? label = null)
+	{
+		using var k = CreateKey(label);
+		return k.PubKey.WitHash.ScriptPubKey;
+	}
+
+	private static HdPubKey CreateHdPubKey(string? label = null)
+	{
+		using var k = CreateKey(label);
+		return new(k.PubKey, new KeyPath("0/0/0/0/0"), SmartLabel.Empty, KeyState.Clean);
+	}
+
+	public void AddForeignInput(ForeignOutput output)
+	{
+		Transaction.Inputs.Add(output.ToOutPoint());
+	}
+
+	public ForeignOutput AddForeignInput(decimal amount = 1, string? label = null)
+	{
+		ForeignOutput foreignOutput = ForeignOutput.Create(new Money(amount, MoneyUnit.BTC), CreateScript(label));
+		AddForeignInput(foreignOutput);
+		return foreignOutput;
+	}
+
+	private static AnalyzedTransaction CreateCoinjoin(int foreignInputs, int foreignOutputs)
+	{
+		AnalyzedTransaction transaction = new();
+		for (int i = 0; i < foreignInputs; i++)
+		{
+			transaction.AddForeignInput();
+		}
+		for (int i = 0; i < foreignOutputs; i++)
+		{
+			transaction.AddForeignOutput();
+		}
+		return transaction;
+	}
+
+	public void AddWalletInput(WalletOutput walletOutput)
+	{
+		AddForeignInput(walletOutput.ToForeignOutput());
+		TryAddWalletInput(walletOutput.ToSmartCoin());
+	}
+
+	public WalletOutput AddWalletInput(decimal amount = 1, string? label = null, int anonymity = 1)
+	{
+		AnalyzedTransaction coinjoinTransaction = CreateCoinjoin(anonymity - 1, anonymity - 1);
+		coinjoinTransaction.AddWalletInput(WalletOutput.Create(new Money(amount, MoneyUnit.BTC), CreateHdPubKey()));
+		WalletOutput walletOutput = coinjoinTransaction.AddWalletOutput(amount, label);
+		AddWalletInput(walletOutput);
+		return walletOutput;
+	}
+
+	public ForeignOutput AddForeignOutput(decimal amount = 1, string? label = null)
+	{
+		uint index = (uint)Transaction.Outputs.Count;
+		Transaction.Outputs.Add(new Money(amount, MoneyUnit.BTC), CreateScript(label));
+		return new ForeignOutput(Transaction, index);
+	}
+
+	public WalletOutput AddWalletOutput(decimal amount = 1, string? label = null)
+	{
+		ForeignOutput foreignOutput = AddForeignOutput(amount, label);
+		SmartCoin smartCoin = new(this, foreignOutput.Index, CreateHdPubKey(label));
+		TryAddWalletOutput(smartCoin);
+		return new WalletOutput(smartCoin);
+	}
+
+	public void AnalyzeRecursively()
+	{
+		var analyser = new BlockchainAnalyzer();
+		HashSet<SmartTransaction> analyzedTransactions = new();
+
+		// Analyze transactions in topological sorting
+		void AnalyzeRecursivelyHelper(SmartTransaction transaction)
+		{
+			if (!analyzedTransactions.Contains(transaction))
+			{
+				analyzedTransactions.Add(transaction);
+				foreach (SmartCoin walletInput in transaction.WalletInputs)
+				{
+					AnalyzeRecursivelyHelper(walletInput.Transaction);
+				}
+				analyser.Analyze(transaction);
+			}
+		}
+
+		AnalyzeRecursivelyHelper(this);
+	}
+}

--- a/WalletWasabi.Tests/Helpers/AnalyzedTransaction/ForeignOutput.cs
+++ b/WalletWasabi.Tests/Helpers/AnalyzedTransaction/ForeignOutput.cs
@@ -1,0 +1,17 @@
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+
+namespace WalletWasabi.Tests.Helpers.AnalyzedTransaction;
+
+public record ForeignOutput(Transaction Transaction, uint Index)
+{
+	public OutPoint ToOutPoint() => new OutPoint(Transaction, Index);
+
+	public static ForeignOutput Create(Money amount, Script scriptPubKey)
+	{
+		Transaction transaction = Transaction.Create(Network.Main);
+		TxOut txOut = new(amount, scriptPubKey);
+		transaction.Outputs.Add(txOut);
+		return new ForeignOutput(transaction, 0);
+	}
+}

--- a/WalletWasabi.Tests/Helpers/AnalyzedTransaction/WalletOutput.cs
+++ b/WalletWasabi.Tests/Helpers/AnalyzedTransaction/WalletOutput.cs
@@ -1,0 +1,27 @@
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Blockchain.Transactions;
+
+namespace WalletWasabi.Tests.Helpers.AnalyzedTransaction;
+
+public record WalletOutput(SmartCoin Coin)
+{
+	public double Anonymity => Coin.HdPubKey.AnonymitySet;
+
+	public SmartCoin ToSmartCoin() => Coin;
+
+	public ForeignOutput ToForeignOutput()
+	{
+		return new ForeignOutput(Coin.Transaction.Transaction, Coin.Index);
+	}
+
+	public static WalletOutput Create(Money amount, HdPubKey hdPubKey)
+	{
+		ForeignOutput output = ForeignOutput.Create(amount, hdPubKey.P2wpkhScript);
+		SmartTransaction smartTransaction = new(output.Transaction, 0);
+		SmartCoin smartCoin = new(smartTransaction, output.Index, hdPubKey);
+		smartTransaction.TryAddWalletOutput(smartCoin);
+		return new WalletOutput(smartCoin);
+	}
+}

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -69,11 +69,11 @@ public class BlockchainAnalyzer
 		// Consolidation in coinjoins is the only type of consolidation that's acceptable,
 		// because coinjoins are an exception from common input ownership heuristic.
 		// Calculate weighted average.
-		mixedAnonScore = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount));
-		mixedAnonScoreSanctioned = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min)) * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount);
+		mixedAnonScore = CoinjoinAnalyzer.WeightedAverage(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet, x.Amount)));
+		mixedAnonScoreSanctioned = CoinjoinAnalyzer.WeightedAverage(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min), x.Amount)));
 
-		nonMixedAnonScore = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet);
-		nonMixedAnonScoreSanctioned = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min));
+		nonMixedAnonScore = CoinjoinAnalyzer.Min(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet, x.Amount)));
+		nonMixedAnonScoreSanctioned = CoinjoinAnalyzer.Min(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min), x.Amount)));
 	}
 
 	private double AnalyzeSelfSpendWalletInputs(SmartTransaction tx)

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -70,10 +70,10 @@ public class BlockchainAnalyzer
 		// because coinjoins are an exception from common input ownership heuristic.
 		// Calculate weighted average.
 		mixedAnonScore = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount));
-		mixedAnonScoreSanctioned = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x)) * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount);
+		mixedAnonScoreSanctioned = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min)) * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount);
 
 		nonMixedAnonScore = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet);
-		nonMixedAnonScoreSanctioned = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x));
+		nonMixedAnonScoreSanctioned = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min));
 	}
 
 	private double AnalyzeSelfSpendWalletInputs(SmartTransaction tx)

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -70,7 +70,7 @@ public class BlockchainAnalyzer
 		// because coinjoins are an exception from common input ownership heuristic.
 		// Calculate weighted average.
 		mixedAnonScore = CoinjoinAnalyzer.WeightedAverage(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet, x.Amount)));
-		mixedAnonScoreSanctioned = CoinjoinAnalyzer.WeightedAverage(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min), x.Amount)));
+		mixedAnonScoreSanctioned = CoinjoinAnalyzer.WeightedAverage(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.WeightedAverage), x.Amount)));
 
 		nonMixedAnonScore = CoinjoinAnalyzer.Min(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet, x.Amount)));
 		nonMixedAnonScoreSanctioned = CoinjoinAnalyzer.Min(tx.WalletVirtualInputs.Select(x => new CoinjoinAnalyzer.AmountWithAnonymity(x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x, CoinjoinAnalyzer.Min), x.Amount)));

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -150,27 +150,31 @@ public class BlockchainAnalyzer
 			double anonymityGain = Math.Min(equalForeignOutputCount / (double)ownEqualOutputCount, foreignInputCount);
 
 			// If no anonset gain achieved on the output, then it's best to assume it's change.
+			double startingOutputAnonset;
 			double startingOutputAnonsetSanctioned;
 			if (anonymityGain < 1)
 			{
 				// When WW2 denom output isn't too large, then it's not change.
 				if (tx.IsWasabi2Cj is true && StdDenoms.Contains(virtualOutput.Amount.Satoshi) && virtualOutput.Amount < secondLargestOutputAmount)
 				{
+					startingOutputAnonset = startingMixedOutputAnonset;
 					startingOutputAnonsetSanctioned = startingMixedOutputAnonsetSanctioned;
 				}
 				else
 				{
+					startingOutputAnonset = startingNonMixedOutputAnonset;
 					startingOutputAnonsetSanctioned = startingNonMixedOutputAnonsetSanctioned;
 				}
 			}
 			else
 			{
+				startingOutputAnonset = startingMixedOutputAnonset;
 				startingOutputAnonsetSanctioned = startingMixedOutputAnonsetSanctioned;
 			}
 
 			// Account for the inherited anonymity set size from the inputs in the
 			// anonymity set size estimate.
-			double anonset = startingOutputAnonsetSanctioned + anonymityGain;
+			double anonset = new[] { startingOutputAnonsetSanctioned + anonymityGain, anonymityGain + 1, startingOutputAnonset }.Max();
 
 			foreach (var hdPubKey in virtualOutput.Coins.Select(x => x.HdPubKey).ToHashSet())
 			{

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -64,12 +64,14 @@ public class BlockchainAnalyzer
 
 	private static void AnalyzeCoinjoinWalletInputs(SmartTransaction tx, out double mixedAnonScore, out double nonMixedAnonScore)
 	{
+		CoinjoinAnalyzer cjAnal = new(tx);
+
 		// Consolidation in coinjoins is the only type of consolidation that's acceptable,
 		// because coinjoins are an exception from common input ownership heuristic.
 		// Calculate weighted average.
-		mixedAnonScore = tx.WalletInputs.Sum(x => x.HdPubKey.AnonymitySet * x.Amount.Satoshi) / tx.WalletInputs.Sum(x => x.Amount);
+		mixedAnonScore = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet - cjAnal.ComputeInputSanction(x)) * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount);
 
-		nonMixedAnonScore = tx.WalletInputs.Min(x => x.HdPubKey.AnonymitySet);
+		nonMixedAnonScore = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet - cjAnal.ComputeInputSanction(x));
 	}
 
 	private double AnalyzeSelfSpendWalletInputs(SmartTransaction tx)
@@ -142,10 +144,8 @@ public class BlockchainAnalyzer
 			var ownEqualOutputCount = indistinguishableWalletOutputs[virtualOutput.Amount];
 
 			// Anonset gain cannot be larger than others' input count.
-			double anonset = Math.Min(equalForeignOutputCount, foreignInputCount);
-
 			// Picking randomly an output would make our anonset: total/ours.
-			anonset /= ownEqualOutputCount;
+			double anonset = Math.Min(equalForeignOutputCount / (double)ownEqualOutputCount, foreignInputCount);
 
 			// If no anonset gain achieved on the output, then it's best to assume it's change.
 			double startingOutputAnonset;

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -147,30 +147,30 @@ public class BlockchainAnalyzer
 
 			// Anonset gain cannot be larger than others' input count.
 			// Picking randomly an output would make our anonset: total/ours.
-			double anonset = Math.Min(equalForeignOutputCount / (double)ownEqualOutputCount, foreignInputCount);
+			double anonymityGain = Math.Min(equalForeignOutputCount / (double)ownEqualOutputCount, foreignInputCount);
 
 			// If no anonset gain achieved on the output, then it's best to assume it's change.
-			double startingOutputAnonset;
-			if (anonset < 1)
+			double startingOutputAnonsetSanctioned;
+			if (anonymityGain < 1)
 			{
 				// When WW2 denom output isn't too large, then it's not change.
 				if (tx.IsWasabi2Cj is true && StdDenoms.Contains(virtualOutput.Amount.Satoshi) && virtualOutput.Amount < secondLargestOutputAmount)
 				{
-					startingOutputAnonset = startingMixedOutputAnonsetSanctioned;
+					startingOutputAnonsetSanctioned = startingMixedOutputAnonsetSanctioned;
 				}
 				else
 				{
-					startingOutputAnonset = startingNonMixedOutputAnonsetSanctioned;
+					startingOutputAnonsetSanctioned = startingNonMixedOutputAnonsetSanctioned;
 				}
 			}
 			else
 			{
-				startingOutputAnonset = startingMixedOutputAnonsetSanctioned;
+				startingOutputAnonsetSanctioned = startingMixedOutputAnonsetSanctioned;
 			}
 
 			// Account for the inherited anonymity set size from the inputs in the
 			// anonymity set size estimate.
-			anonset += startingOutputAnonset;
+			double anonset = startingOutputAnonsetSanctioned + anonymityGain;
 
 			foreach (var hdPubKey in virtualOutput.Coins.Select(x => x.HdPubKey).ToHashSet())
 			{
@@ -186,7 +186,7 @@ public class BlockchainAnalyzer
 				else if (tx.WalletVirtualInputs.Select(x => x.HdPubKey).Contains(hdPubKey))
 				{
 					// If it's a reuse of an input's pubkey, then intersection punishment is senseless.
-					hdPubKey.SetAnonymitySet(startingOutputAnonset, txid);
+					hdPubKey.SetAnonymitySet(startingOutputAnonsetSanctioned, txid);
 				}
 				else if (hdPubKey.OutputAnonSetReasons.Contains(txid))
 				{

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -70,10 +70,10 @@ public class BlockchainAnalyzer
 		// because coinjoins are an exception from common input ownership heuristic.
 		// Calculate weighted average.
 		mixedAnonScore = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount));
-		mixedAnonScoreSanctioned = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet - cjAnal.ComputeInputSanction(x)) * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount);
+		mixedAnonScoreSanctioned = tx.WalletVirtualInputs.Sum(x => (x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x)) * x.Amount.Satoshi) / tx.WalletVirtualInputs.Sum(x => x.Amount);
 
 		nonMixedAnonScore = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet);
-		nonMixedAnonScoreSanctioned = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet - cjAnal.ComputeInputSanction(x));
+		nonMixedAnonScoreSanctioned = tx.WalletVirtualInputs.Min(x => x.HdPubKey.AnonymitySet + cjAnal.ComputeInputSanction(x));
 	}
 
 	private double AnalyzeSelfSpendWalletInputs(SmartTransaction tx)

--- a/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
@@ -43,7 +43,7 @@ public class CoinjoinAnalyzer
 			// We are searching for any transaction inputs of analyzedTransaction that might have come from this transaction.
 			// If we find such remixed outputs, then we determine how much they contributed to our anonymity set.
 			SmartTransaction transaction = transactionOutput.Transaction;
-			double sanction = ComputeAnonymityContribution(transactionOutput, AnalyzedTransactionPrevOuts);
+			double sanction = -ComputeAnonymityContribution(transactionOutput, AnalyzedTransactionPrevOuts);
 
 			// Recursively branch out into all of the transaction inputs' histories and compute the sanction for each branch.
 			// Add the worst-case branch to the resulting sanction.

--- a/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
@@ -1,0 +1,77 @@
+using NBitcoin;
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Blockchain.Transactions;
+
+namespace WalletWasabi.Blockchain.Analysis;
+
+public class CoinjoinAnalyzer
+{
+	public CoinjoinAnalyzer(SmartTransaction transaction)
+	{
+		AnalyzedTransaction = transaction;
+		AnalyzedTransactionPrevOuts = AnalyzedTransaction.Transaction.Inputs.Select(input => input.PrevOut).ToHashSet();
+	}
+
+	private HashSet<OutPoint> AnalyzedTransactionPrevOuts { get; }
+	private Dictionary<SmartCoin, double> CachedInputSanctions { get; } = new();
+
+	public SmartTransaction AnalyzedTransaction { get; }
+
+	public double ComputeInputSanction(WalletVirtualInput virtualInput)
+		=> virtualInput.Coins.Select(ComputeInputSanction).Max();
+
+	public double ComputeInputSanction(SmartCoin transactionInput)
+	{
+		double ComputeInputSanctionHelper(SmartCoin transactionOutput)
+		{
+			// If we already analyzed the sanction for this output, then return the cached result.
+			if (CachedInputSanctions.ContainsKey(transactionOutput))
+			{
+				return CachedInputSanctions[transactionOutput];
+			}
+
+			// Look at the transaction containing transactionOutput.
+			// We are searching for any transaction inputs of analyzedTransaction that might have come from this transaction.
+			// If we find such remixed outputs, then we determine how much they contributed to our anonymity set.
+			SmartTransaction transaction = transactionOutput.Transaction;
+			double sanction = ComputeAnonymityContribution(transactionOutput, AnalyzedTransactionPrevOuts);
+
+			// Recursively branch out into all of the transaction inputs' histories and compute the sanction for each branch.
+			// Add the worst-case branch to the resulting sanction.
+			sanction += transaction.WalletInputs.Select(ComputeInputSanctionHelper).DefaultIfEmpty(0).Max();
+
+			// Cache the computed sanction in case we need it later.
+			CachedInputSanctions[transactionOutput] = sanction;
+			return sanction;
+		}
+
+		return ComputeInputSanctionHelper(transactionInput);
+	}
+
+	/// <summary>
+	/// Computes how much the foreign outputs of AnalyzedTransaction contribute to the anonymity of our transactionOutput.
+	/// Sometimes we are only interested in how much a certain subset of foreign outputs contributed.
+	/// This subset can be specified in relevantOutpoints, otherwise all outputs are considered relevant.
+	/// </summary>
+	public static double ComputeAnonymityContribution(SmartCoin transactionOutput, HashSet<OutPoint>? relevantOutpoints = null)
+	{
+		SmartTransaction transaction = transactionOutput.Transaction;
+		IEnumerable<WalletVirtualOutput> walletVirtualOutputs = transaction.WalletVirtualOutputs;
+		IEnumerable<ForeignVirtualOutput> foreignVirtualOutputs = transaction.ForeignVirtualOutputs;
+
+		Money amount = walletVirtualOutputs.Where(o => o.Coins.Select(c => c.OutPoint).Contains(transactionOutput.OutPoint)).First().Amount;
+		bool IsRelevantVirtualOutput(ForeignVirtualOutput output) => relevantOutpoints is null || relevantOutpoints.Intersect(output.OutPoints).Any();
+
+		// Count the outputs that have the same value as our transactionOutput.
+		var equalValueWalletVirtualOutputCount = walletVirtualOutputs.Where(o => o.Amount == amount).Count();
+		var equalValueForeignRelevantVirtualOutputCount = foreignVirtualOutputs.Where(o => o.Amount == amount).Where(IsRelevantVirtualOutput).Count();
+
+		// The anonymity set should increase by the number of equal-valued foreign ouputs.
+		// If we have multiple equal-valued wallet outputs, then we divide the increase evenly between them.
+		// The rationale behind this is that picking randomly an output would make our anonset:
+		// total/ours = 1 + foreign/ours, so the increase in anonymity is foreign/ours.
+		return (double)equalValueForeignRelevantVirtualOutputCount / equalValueWalletVirtualOutputCount;
+	}
+}

--- a/WalletWasabi/Blockchain/TransactionOutputs/WalletVirtualInput.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/WalletVirtualInput.cs
@@ -15,9 +15,11 @@ public class WalletVirtualInput
 		Id = id;
 		Coins = coins;
 		HdPubKey = coins.Select(x => x.HdPubKey).Distinct().Single();
+		Amount = coins.Sum(x => x.Amount);
 	}
 
 	public byte[] Id { get; }
 	public ISet<SmartCoin> Coins { get; }
 	public HdPubKey HdPubKey { get; }
+	public Money Amount { get; }
 }

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -208,4 +208,9 @@ public static class LinqExtensions
 			}
 		}
 	}
+
+	public static double WeightedAverage<T>(this IEnumerable<T> source, Func<T, double> value, Func<T, double> weight)
+	{
+		return source.Select(x => value(x) * weight(x)).Sum() / source.Select(weight).Sum();
+	}
 }


### PR DESCRIPTION
This PR builds on top of https://github.com/zkSNACKs/WalletWasabi/pull/8933 (which was reverted in https://github.com/zkSNACKs/WalletWasabi/pull/8948) and addresses issues that were the cause of the revert.

* https://github.com/zkSNACKs/WalletWasabi/commit/23b026326314e1b382c6d7a9d44687dd265f1b40 reapplies https://github.com/zkSNACKs/WalletWasabi/pull/8933.
* https://github.com/zkSNACKs/WalletWasabi/commit/ad2388e91728871bb8ebb85d6622b11341dbe74d limits the the recursion depth in `ComputeInputSanction` which should make the wallet loading faster.
* https://github.com/zkSNACKs/WalletWasabi/commit/50175442599d768a02dad4295953b2bc6c9870a3 and https://github.com/zkSNACKs/WalletWasabi/commit/14edd2bea018dfad8a1bafb2b5fdb6efa73da416 should solve the problem with the negative anonymity.
* Other commits are mere refactoring commits.

@nopara73 could you please test if it works well with your wallet?