### PR TITLE
[BLOCKS DL] Save block N to file system during block N+1 dl

### DIFF
--- a/WalletWasabi/Wallets/CachedBlockProvider.cs
+++ b/WalletWasabi/Wallets/CachedBlockProvider.cs
@@ -33,7 +33,7 @@ public class CachedBlockProvider : IBlockProvider
 		if (block is null)
 		{
 			block = await BlockSourceProvider.GetBlockAsync(hash, cancellationToken).ConfigureAwait(false);
-			await LastSaveBlockTask;
+			await LastSaveBlockTask.ConfigureAwait(false);
 			LastSaveBlockTask = BlockRepository.SaveAsync(block, cancellationToken).ConfigureAwait(false);
 		}
 		return block;

--- a/WalletWasabi/Wallets/CachedBlockProvider.cs
+++ b/WalletWasabi/Wallets/CachedBlockProvider.cs
@@ -34,7 +34,7 @@ public class CachedBlockProvider : IBlockProvider
 		{
 			block = await BlockSourceProvider.GetBlockAsync(hash, cancellationToken).ConfigureAwait(false);
 			await LastSaveBlockTask.ConfigureAwait(false);
-			LastSaveBlockTask = BlockRepository.SaveAsync(block, cancellationToken).ConfigureAwait(false);
+			LastSaveBlockTask = BlockRepository.SaveAsync(block, cancellationToken);
 		}
 		return block;
 	}

--- a/WalletWasabi/Wallets/CachedBlockProvider.cs
+++ b/WalletWasabi/Wallets/CachedBlockProvider.cs
@@ -17,6 +17,7 @@ public class CachedBlockProvider : IBlockProvider
 
 	public IRepository<uint256, Block> BlockRepository { get; }
 	public IBlockProvider BlockSourceProvider { get; }
+	private Task LastSaveBlockTask { get; set; } = Task.CompletedTask;
 
 	/// <summary>
 	/// Gets a bitcoin block. In case the requested block is not available in the repository it is returned
@@ -32,7 +33,8 @@ public class CachedBlockProvider : IBlockProvider
 		if (block is null)
 		{
 			block = await BlockSourceProvider.GetBlockAsync(hash, cancellationToken).ConfigureAwait(false);
-			await BlockRepository.SaveAsync(block, cancellationToken).ConfigureAwait(false);
+			await LastSaveBlockTask;
+			LastSaveBlockTask = BlockRepository.SaveAsync(block, cancellationToken).ConfigureAwait(false);
 		}
 		return block;
 	}


### PR DESCRIPTION
This PR is the first of a serie to improve block downloading speed.

This one is particularly trivial and the performance gain is not huge (but still present).
It just saves the block .json during the next block download. Once it starts writing to the FS, the task cannot be cancelled, so disposing should not be an issue
Thanks to @molnard for the clean code idea.