### PR TITLE
`UpgradeTorBinaries`: Add support for GEOIP upgrade

### DIFF
--- a/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
+++ b/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
@@ -1,5 +1,19 @@
 ## How to upgrade bundled Tor version in Wallet Wasabi
 
+### Automatically
+
+Just invoke the following commands in your PowerShell 7+:
+
+```powershell
+cd WalletWasabi/Microservices/Binaries
+
+# See what the latest released Tor Browser version is here: https://dist.torproject.org/torbrowser/.
+# Suppose it is "11.5.2". Then one can just call:
+.\UpgradeTorBinaries.ps1 -version "11.5.2"
+```
+
+### Manually
+
 1. Check if there is a new Tor Browser version.
     * The Tor Browser changelog can be found here: https://gitweb.torproject.org/builders/tor-browser-build.git/plain/projects/tor-browser/Bundle-Data/Docs/ChangeLog.txt
     * The Tor changelog can be found here: https://gitweb.torproject.org/tor.git/plain/ChangeLog

--- a/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
+++ b/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
@@ -22,28 +22,28 @@ cd WalletWasabi/Microservices/Binaries
     * Linux x64
     * macOS x64 (macOS arm64 uses these binaries too)
 
-### Windows
+#### Windows
 
 1. Open `torbrowser-install-win64-<version>_en-US.exe` file in a zip decompressing tool (like 7zip).
 1. Navigate to `Browser\TorBrowser\Tor` folder in the archive.
 1. Unzip it to `WalletWasabi\Microservices\Binaries\win64\Tor` folder.
     * Do not copy the `PluggableTransports` folder.
 
-### Linux
+#### Linux
 
 1. Open `tor-browser-linux64-<version>_en-US.tar.xz` file in a zip decompressing tool (like 7zip).
 1. Navigate to `tor-browser_en-US\Browser\TorBrowser\Tor` folder in the archive.
 1. Unzip it to `WalletWasabi\Microservices\Binaries\lin64\Tor` folder.
     * Do not copy the `PluggableTransports` folder.
 
-### macOS
+#### macOS
 
 1. Open `TorBrowser-<version>-osx64_en-US.dmg` file in a zip decompressing tool (like 7zip).
 1. Navigate to `Tor Browser.app\Contents\MacOS\Tor` folder in the archive.
 1. Unzip it to `WalletWasabi\Microservices\Binaries\osx64\Tor` folder but preserve the `Tor` file!
     * Do not copy the `PluggableTransports` folder.
 
-### Upgrade Geoip files
+#### Upgrade Geoip files
 
 1. Open `torbrowser-install-win64-<version>_en-US.exe` file in a zip decompressing tool (like 7zip).
 1. Navigate to `Browser\TorBrowser\Data\Tor` folder in the archive.

--- a/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
+++ b/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
@@ -2,7 +2,7 @@
 
 ### Automatically
 
-Just invoke the following commands in your PowerShell 7+:
+Invoke the following commands in your PowerShell 7+:
 
 ```powershell
 cd WalletWasabi/Microservices/Binaries

--- a/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
+++ b/WalletWasabi.Documentation/Guides/UpgradeTorDaemons.md
@@ -7,7 +7,7 @@ Invoke the following commands in your PowerShell 7+:
 ```powershell
 cd WalletWasabi/Microservices/Binaries
 
-# See what the latest released Tor Browser version is here: https://dist.torproject.org/torbrowser/.
+# See what the latest released Tor Browser version is here: https://www.torproject.org/download/
 # Suppose it is "11.5.2". Then one can just call:
 .\UpgradeTorBinaries.ps1 -version "11.5.2"
 ```

--- a/WalletWasabi/Microservices/Binaries/UpgradeTorBinaries.ps1
+++ b/WalletWasabi/Microservices/Binaries/UpgradeTorBinaries.ps1
@@ -21,7 +21,8 @@ param(
   [Parameter(Mandatory=$false)][Switch]$skipDownloading,
   [Parameter(Mandatory=$false)][Switch]$skipExtractingBrowserArchives,
   [Parameter(Mandatory=$false)][Switch]$skipExtractingTorBinaries,
-  [Parameter(Mandatory=$false)][Switch]$skipReplacingTorBinaries)
+  [Parameter(Mandatory=$false)][Switch]$skipReplacingTorBinaries,
+  [Parameter(Mandatory=$false)][Switch]$skipReplacingGeoIpFiles)
 
 Set-StrictMode -Version 3
 $ErrorActionPreference = "Stop"
@@ -128,6 +129,14 @@ try {
       Remove-Item -Recurse -Force "$PSScriptRoot/$platform/Tor/*" -Exclude "LICENSE" -ErrorAction SilentlyContinue
       Copy-item -Recurse -Force -Path "Tor/$platform/*" -Destination "$PSScriptRoot/$platform/Tor/"
     }
+  }
+
+  if ($skipReplacingGeoIpFiles) {
+    Write-Output "# Skip replacing geoip files."
+  } else {
+    $destination = Join-Path -Resolve "$PSScriptRoot" ".." ".." "Tor" "Geoip"
+    Write-Output "# Replace geoip files in folder '$destination'."
+    Copy-item -Force -Path "TorBrowser/linux/tor-browser_en-US/Browser/TorBrowser/Data/Tor/geoip*" -Destination "$destination/"
   }
 
   Write-Output "# Done."


### PR DESCRIPTION
Fixes #9000

# Testing

```powershell
cd WalletWasabi/Microservices/Binaries

# To upgrade to the latest released Tor Browser version
.\UpgradeTorBinaries.ps1 -version "11.5.2"

# To test only geoip files upgrading
.\UpgradeTorBinaries.ps1 -version "11.5.2" -skipDownloading -skipExtractingBrowserArchives -skipExtractingTorBinaries -skipReplacingTorBinaries 
```