### PR TITLE
[BLOCKS DL] Match filters for blocks N+1 while block N is downloaded

### DIFF
--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -437,7 +437,7 @@ public class IndexStore : IAsyncDisposable
 	}
 	public async Task<FilterModel?> ReTryOnLastFiltersFound(Func<FilterModel, Task<bool>> todo, Height fromHeight, CancellationToken cancel = default)
 	{
-		FilterModel? result;
+		FilterModel? result = null;
 		foreach(var filter in IndexFilesLastFiltersFound.Where(x => x.Header.Height >= fromHeight))
 		{
 			if(await todo(filter).ConfigureAwait(false))


### PR DESCRIPTION
This is a basic yet very effective form of parallelization we can do on block downloading as both the iterations over `MatchAny` with a large keys set and `ProcessBlockAsync` can be very time consuming on their own.
It's based on #9080 (New modifications are in Wallet.cs)
Here's an execution example of what's happening, easier to understand:

```
current height = 0
HandleFiltersMatchBlockDownload

-> MatchAny (50 keys) -> 2s to execute
-> next block to dl is Height 100
-> start downloading block 100

-> MatchAny from height 101 (50 keys) -> 2s to execute
-> next block to dl is Height 110

-> block 100 finished downloading
-> process TXs, found 5 new keys
-> MatchAny from 102 to 110 (5 keys) ->0.1s
-> next block to dl is 102

-> compare both results and dl lower -> 102
-> recursively call HandleFiltersMatchBlockDownload with match 102
```

There are more efficient ways to parallelize, but each one I tried were downloading much more false positive blocks and using way more CPU, this PR is a good compromise.

It's draft because: 
- Need to try to remove recursion
- Syntax and naming
- Need to further test