### PR TITLE
[BLOCKS DL] IndexStore modifications

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -96,6 +96,7 @@ public class WalletTests
 			{
 				filterList.Add(x);
 				await Task.CompletedTask;
+				return false;
 			},
 			new Height(0));
 			FilterModel[] filters = filterList.ToArray();
@@ -176,6 +177,7 @@ public class WalletTests
 			{
 				filterList.Add(x);
 				await Task.CompletedTask;
+				return false;
 			},
 			new Height(0));
 			var filterTip = filterList.Last();
@@ -189,6 +191,7 @@ public class WalletTests
 			{
 				filterList.Add(x);
 				await Task.CompletedTask;
+				return false;
 			},
 			new Height(0));
 			FilterModel[] filters = filterList.ToArray();

--- a/WalletWasabi/Backend/Models/ForeachFiltersResults.cs
+++ b/WalletWasabi/Backend/Models/ForeachFiltersResults.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace WalletWasabi.Backend.Models;
+
+public class ForeachFiltersResults
+{
+	[Required]
+	public bool HasMatched { get; set; }
+
+	[Required]
+	public List<FilterModel> BufferFiltersRead { get; } = new();
+}


### PR DESCRIPTION
_This PR is a new version of #9080 with clean commit history_

These modifications allows `LoadWalletStateAsync` to stop `ForeachFiltersAsync` execution using a `Channel` to perform actions on last filter that matched a `Task<bool>`. It also includes a function to retry the `Task<bool>` on each filters found during the last iteration of the execution without re-reading the stream. This will make parallelizations presented in #9082 and #9083 possible for a small cost of RAM (the maximum is set at 50.000 filters in memory x2. Maybe a config parameter could be created).

It's ready for reviews