### PR TITLE
[VDG] Privacy bar and Privacy Ring render threshold

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/UIConstants.cs
+++ b/WalletWasabi.Fluent/ViewModels/UIConstants.cs
@@ -3,4 +3,5 @@ namespace WalletWasabi.Fluent.ViewModels;
 public static class UIConstants
 {
 	public const char PrivacyChar = '#';
+	public const int PrivacyRingMaxItemCount = 100;
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
@@ -1,8 +1,11 @@
 using Avalonia;
 using Avalonia.Media;
+using System.Linq;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Wallets.Advanced.WalletCoins;
+using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 
@@ -24,11 +27,11 @@ public class PrivacyBarItemViewModel : ViewModelBase, IDisposable
 		};
 	}
 
-	public PrivacyBarItemViewModel(bool isPrivate, bool isSemiPrivate, bool isNonPrivate, double start, double width)
+	public PrivacyBarItemViewModel(Pocket pocket, Wallet wallet, double start, double width)
 	{
-		IsPrivate = isPrivate;
-		IsSemiPrivate = isSemiPrivate;
-		IsNonPrivate = isNonPrivate;
+		IsPrivate = pocket.Coins.First().IsPrivate(wallet.KeyManager.AnonScoreTarget);
+		IsSemiPrivate = !IsPrivate && pocket.Coins.First().IsSemiPrivate();
+		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 
 		Data = new RectangleGeometry
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
@@ -6,23 +6,45 @@ using WalletWasabi.Fluent.ViewModels.Wallets.Advanced.WalletCoins;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 
-public class PrivacyBarItemViewModel : WalletCoinViewModel
+public class PrivacyBarItemViewModel : ViewModelBase, IDisposable
 {
-	public PrivacyBarItemViewModel(PrivacyBarViewModel parent, SmartCoin coin, double start, double width) : base(coin)
+	public const double BarHeight = 10;
+
+	public PrivacyBarItemViewModel(PrivacyBarViewModel parent, SmartCoin coin, double start, double width)
 	{
+		Coin = new WalletCoinViewModel(coin);
+
 		IsPrivate = coin.IsPrivate(parent.Wallet.KeyManager.AnonScoreTarget);
 		IsSemiPrivate = !IsPrivate && coin.IsSemiPrivate();
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 
 		Data = new RectangleGeometry
 		{
-			Rect = new Rect((double)start, 0, (double)width, 10)
+			Rect = new Rect(start, 0, width, BarHeight)
+		};
+	}
+
+	public PrivacyBarItemViewModel(bool isPrivate, bool isSemiPrivate, bool isNonPrivate, double start, double width)
+	{
+		IsPrivate = isPrivate;
+		IsSemiPrivate = isSemiPrivate;
+		IsNonPrivate = isNonPrivate;
+
+		Data = new RectangleGeometry
+		{
+			Rect = new Rect(start, 0, width, BarHeight)
 		};
 	}
 
 	public RectangleGeometry Data { get; }
+	public WalletCoinViewModel? Coin { get; }
 
 	public bool IsPrivate { get; }
 	public bool IsSemiPrivate { get; }
 	public bool IsNonPrivate { get; }
+
+	public void Dispose()
+	{
+		Coin?.Dispose();
+	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
@@ -29,8 +29,8 @@ public class PrivacyBarItemViewModel : ViewModelBase, IDisposable
 
 	public PrivacyBarItemViewModel(Pocket pocket, Wallet wallet, double start, double width)
 	{
-		IsPrivate = pocket.Coins.First().IsPrivate(wallet.KeyManager.AnonScoreTarget);
-		IsSemiPrivate = !IsPrivate && pocket.Coins.First().IsSemiPrivate();
+		IsPrivate = pocket.Coins.All(x => x.IsPrivate(wallet.KeyManager.AnonScoreTarget));
+		IsSemiPrivate = !IsPrivate && pocket.Coins.All(x => x.IsSemiPrivate());
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 
 		Data = new RectangleGeometry

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -89,7 +89,12 @@ public partial class PrivacyBarViewModel : ViewModelBase
 
 		var usableWidth = Width - (coinCount * 2);
 
-		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		var usablePockets =
+				pockets.Where(x => x.Coins.Any())
+					   .OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet)
+					   .ToList();
+
+		foreach (var pocket in usablePockets)
 		{
 			var pocketCoins = pocket.Coins.OrderByDescending(x => x.Amount).ToList();
 
@@ -120,7 +125,12 @@ public partial class PrivacyBarViewModel : ViewModelBase
 
 		var usableWidth = Width - (pockets.Count() * 2);
 
-		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		var usablePockets =
+				pockets.Where(x => x.Coins.Any())
+					   .OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet)
+					   .ToList();
+
+		foreach (var pocket in usablePockets)
 		{
 			var margin = 2;
 			var amount = pocket.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -16,7 +16,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 
 public partial class PrivacyBarViewModel : ViewModelBase
 {
-	private const int MaximumCoinCount = 100;
 	private readonly SourceList<PrivacyBarItemViewModel> _itemsSourceList = new();
 	private IObservable<Unit> _coinsUpdated;
 
@@ -69,7 +68,7 @@ public partial class PrivacyBarViewModel : ViewModelBase
 
 		var result = Enumerable.Empty<PrivacyBarItemViewModel>();
 
-		if (coinCount < MaximumCoinCount)
+		if (coinCount < UIConstants.PrivacyRingMaxItemCount)
 		{
 			result = CreateCoinSegments(pockets, coinCount);
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -1,9 +1,9 @@
 using Avalonia;
-using Avalonia.Media;
 using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -16,6 +16,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 
 public partial class PrivacyBarViewModel : ViewModelBase
 {
+	private const int MaximumCoinCount = 100;
 	private readonly SourceList<PrivacyBarItemViewModel> _itemsSourceList = new();
 	private IObservable<Unit> _coinsUpdated;
 
@@ -51,45 +52,94 @@ public partial class PrivacyBarViewModel : ViewModelBase
 
 	private void RefreshCoinsList(IEnumerable<Pocket> pockets)
 	{
-		_itemsSourceList.Edit(list =>
+		_itemsSourceList.Edit(list => CreateSegments(list, pockets));
+	}
+
+	[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "items are disposed of together with _itemsSourceList.")]
+	private void CreateSegments(IExtendedList<PrivacyBarItemViewModel> list, IEnumerable<Pocket> pockets)
+	{
+		list.Clear();
+
+		if (Width == 0d)
 		{
-			list.Clear();
+			return;
+		}
 
-			if (Width == 0d)
+		var coinCount = pockets.SelectMany(x => x.Coins).Count();
+
+		var result = Enumerable.Empty<PrivacyBarItemViewModel>();
+
+		if (coinCount < MaximumCoinCount)
+		{
+			result = CreateCoinSegments(pockets, coinCount);
+		}
+		else
+		{
+			result = CreatePocketSegments(pockets);
+		}
+
+		foreach (var item in result)
+		{
+			list.Add(item);
+		}
+	}
+
+	private IEnumerable<PrivacyBarItemViewModel> CreateCoinSegments(IEnumerable<Pocket> pockets, int coinCount)
+	{
+		var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
+		var start = 0.0m;
+
+		var usableWidth = Width - (coinCount * 2);
+
+		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		{
+			var pocketCoins = pocket.Coins.OrderByDescending(x => x.Amount).ToList();
+
+			foreach (var coin in pocketCoins)
 			{
-				return;
-			}
+				var margin = 2;
+				var amount = coin.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC);
+				var width = Math.Abs((decimal)usableWidth * amount / total);
 
-			var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
-			var start = 0.0m;
-
-			var usableWidth = Width - (pockets.SelectMany(x => x.Coins).Count() * 2);
-
-			foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
-			{
-				var pocketCoins = pocket.Coins.OrderByDescending(x => x.Amount).ToList();
-
-				foreach (var coin in pocketCoins)
+				// Artificially enlarge segments smaller than 2 px in order to make them visible.
+				if (width < 2)
 				{
-					var margin = 2;
-					var amount = coin.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC);
-					var width = Math.Abs((decimal)usableWidth * amount / total);
-
-					// Artificially enlarge UTXOs smaller than 2 px in order to make them visible.
-					if (width < 2)
-					{
-						width++;
-						margin--;
-					}
-
-					var item = new PrivacyBarItemViewModel(this, coin, (double)start, (double)width);
-
-					list.Add(item);
-
-					start += width + margin;
+					width++;
+					margin--;
 				}
+
+				yield return new PrivacyBarItemViewModel(this, coin, (double)start, (double)width);
+
+				start += width + margin;
 			}
-		});
+		}
+	}
+
+	private IEnumerable<PrivacyBarItemViewModel> CreatePocketSegments(IEnumerable<Pocket> pockets)
+	{
+		var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
+		var start = 0.0m;
+
+		var usableWidth = Width - (pockets.Count() * 2);
+
+		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		{
+			var margin = 2;
+			var amount = pocket.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC);
+
+			var width = Math.Abs((decimal)usableWidth * amount / total);
+
+			// Artificially enlarge segments smaller than 2 px in order to make them visible.
+			if (width < 2)
+			{
+				width++;
+				margin--;
+			}
+
+			yield return new PrivacyBarItemViewModel(pocket, Wallet, (double)start, (double)width);
+
+			start += width + margin;
+		}
 	}
 
 	public void Dispose()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -54,7 +54,6 @@ public partial class PrivacyBarViewModel : ViewModelBase
 		_itemsSourceList.Edit(list => CreateSegments(list, pockets));
 	}
 
-	[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "items are disposed of together with _itemsSourceList.")]
 	private void CreateSegments(IExtendedList<PrivacyBarItemViewModel> list, IEnumerable<Pocket> pockets)
 	{
 		list.Clear();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
@@ -35,8 +35,8 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 
 		Data = CreateGeometry(start, end, OuterRadius);
 
-		IsPrivate = pocket.Coins.First().IsPrivate(parent.Wallet.KeyManager.AnonScoreTarget);
-		IsSemiPrivate = !IsPrivate && pocket.Coins.First().IsSemiPrivate();
+		IsPrivate = pocket.Coins.All(x => x.IsPrivate(parent.Wallet.KeyManager.AnonScoreTarget));
+		IsSemiPrivate = !IsPrivate && pocket.Coins.All(x => x.IsSemiPrivate());
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 		AmountText = $"{pocket.Amount.ToFormattedString()} BTC";
 		Unconfirmed = false;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
@@ -42,6 +42,19 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 		Unconfirmed = false;
 	}
 
+	public WalletCoinViewModel? Coin { get; }
+
+	public PathGeometry Data { get; private set; }
+
+	public double OuterRadius { get; private set; }
+
+	public bool IsPrivate { get; }
+	public bool IsSemiPrivate { get; }
+	public bool IsNonPrivate { get; }
+	public string AmountText { get; }
+	public bool Unconfirmed { get; }
+	public int Confirmations { get; }
+
 	private PathGeometry CreateGeometry(double start, double end, double outerRadius)
 	{
 		var innerRadius = outerRadius - SegmentWidth;
@@ -91,19 +104,6 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 			}
 		};
 	}
-
-	public WalletCoinViewModel? Coin { get; }
-
-	public PathGeometry Data { get; private set; }
-
-	public double OuterRadius { get; private set; }
-
-	public bool IsPrivate { get; }
-	public bool IsSemiPrivate { get; }
-	public bool IsNonPrivate { get; }
-	public string AmountText { get; }
-	public bool Unconfirmed { get; }
-	public int Confirmations { get; }
 
 	private Point GetAnglePoint(double r, double angle)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -120,7 +120,12 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 		var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
 		var start = 0.0m;
 
-		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		var usablePockets =
+				pockets.Where(x => x.Coins.Any())
+					   .OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet)
+					   .ToList();
+
+		foreach (var pocket in usablePockets)
 		{
 			var pocketCoins = pocket.Coins.OrderByDescending(x => x.Amount).ToList();
 
@@ -142,7 +147,12 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 		var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
 		var start = 0.0m;
 
-		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		var usablePockets =
+				pockets.Where(x => x.Coins.Any())
+					   .OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet)
+					   .ToList();
+
+		foreach (var pocket in usablePockets)
 		{
 			var end = start + (Math.Abs(pocket.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)) / total);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -81,38 +81,84 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 
 	private void RefreshCoinsList(IEnumerable<Pocket> pockets)
 	{
-		_itemsSourceList.Edit(list =>
+		_itemsSourceList.Edit(list => CreateSegments(pockets, list));
+	}
+
+	private void CreateSegments(IEnumerable<Pocket> pockets, IExtendedList<PrivacyRingItemViewModel> list)
+	{
+		list.Clear();
+
+		if (Width == 0d)
 		{
-			list.Clear();
+			return;
+		}
 
-			var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
-			var start = 0.0m;
+		var coinCount = pockets.SelectMany(x => x.Coins).Count();
 
-			foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		var result = Enumerable.Empty<PrivacyRingItemViewModel>();
+
+		if (coinCount < UIConstants.PrivacyRingMaxItemCount)
+		{
+			result = CreateCoinSegments(pockets);
+		}
+		else
+		{
+			result = CreatePocketSegments(pockets);
+		}
+
+		foreach (var item in result)
+		{
+			list.Add(item);
+		}
+
+		PreviewItems.RemoveRange(1, PreviewItems.Count - 1);
+		PreviewItems.AddRange(list);
+	}
+
+	private IEnumerable<PrivacyRingItemViewModel> CreateCoinSegments(IEnumerable<Pocket> pockets)
+	{
+		var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
+		var start = 0.0m;
+
+		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		{
+			var pocketCoins = pocket.Coins.OrderByDescending(x => x.Amount).ToList();
+
+			foreach (var coin in pocketCoins)
 			{
-				var pocketCoins = pocket.Coins.OrderByDescending(x => x.Amount).ToList();
+				var end = start + (Math.Abs(coin.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)) / total);
 
-				foreach (var coin in pocketCoins)
-				{
-					var end = start + (Math.Abs(coin.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)) / total);
+				var item = new PrivacyRingItemViewModel(this, coin, (double)start, (double)end);
 
-					var item = new PrivacyRingItemViewModel(this, coin, (double)start, (double)end);
+				yield return item;
 
-					list.Add(item);
-
-					_disposables.Add(item);
-
-					start = end;
-				}
+				start = end;
 			}
+		}
+	}
 
-			PreviewItems.RemoveRange(1, PreviewItems.Count - 1);
-			PreviewItems.AddRange(list);
-		});
+	private IEnumerable<PrivacyRingItemViewModel> CreatePocketSegments(IEnumerable<Pocket> pockets)
+	{
+		var total = pockets.Sum(x => Math.Abs(x.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)));
+		var start = 0.0m;
+
+		foreach (var pocket in pockets.OrderByDescending(x => x.Coins.First().HdPubKey.AnonymitySet))
+		{
+			var end = start + (Math.Abs(pocket.Amount.ToDecimal(NBitcoin.MoneyUnit.BTC)) / total);
+
+			var item = new PrivacyRingItemViewModel(this, pocket, (double)start, (double)end);
+
+			yield return item;
+
+			_disposables.Add(item);
+
+			start = end;
+		}
 	}
 
 	public void Dispose()
 	{
+		_itemsSourceList?.Dispose();
 		_disposables.Dispose();
 	}
 }

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyBar/PrivacyBar.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyBar/PrivacyBar.axaml
@@ -1,0 +1,50 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:controls="clr-namespace:WalletWasabi.Fluent.Controls"
+             xmlns:tiles="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles"
+             xmlns:behaviors="using:WalletWasabi.Fluent.Behaviors"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyBar">
+  <Panel x:Name="Panel" DockPanel.Dock="Bottom" Margin="0 0 0 8">
+    <i:Interaction.Behaviors>
+      <behaviors:BoundsObserverBehavior Bounds="{Binding #Panel.Bounds, Mode=OneWay}"
+                                        Width="{Binding PrivacyBar.Width, Mode=TwoWay}"
+                                        x:CompileBindings="False" />
+    </i:Interaction.Behaviors>
+
+    <Button Classes="plain" Command="{Binding ShowDetailsCommand}"
+            ToolTip.Tip="Show Details">
+      <ItemsControl Items="{Binding PrivacyBar.Items}" Height="10">
+        <ItemsControl.Styles>
+          <Style Selector="Path.private">
+            <Setter Property="Fill" Value="{DynamicResource PrivacyLevelStrongBrush}" />
+          </Style>
+
+          <Style Selector="Path.semiPrivate">
+            <Setter Property="Fill" Value="{DynamicResource PrivacyLevelMediumBrush}" />
+          </Style>
+
+          <Style Selector="Path.nonPrivate">
+            <Setter Property="Fill" Value="{DynamicResource PrivacyLevelNoneBrush}" />
+          </Style>
+        </ItemsControl.Styles>
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <Panel />
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <Path Data="{Binding Data}"
+                  Classes.private="{Binding IsPrivate}"
+                  Classes.semiPrivate="{Binding IsSemiPrivate}"
+                  Classes.nonPrivate="{Binding IsNonPrivate}" />
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </Button>
+  </Panel>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyBar/PrivacyBar.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyBar/PrivacyBar.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets.Home.Tiles;
+
+public partial class PrivacyBar : UserControl
+{
+	public PrivacyBar()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
@@ -5,6 +5,7 @@
              xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:controls="clr-namespace:WalletWasabi.Fluent.Controls"
              xmlns:tiles="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles"
+             xmlns:tilesView="clr-namespace:WalletWasabi.Fluent.Views.Wallets.Home.Tiles"
              xmlns:behaviors="using:WalletWasabi.Fluent.Behaviors"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:CompileBindings="True" x:DataType="tiles:PrivacyControlTileViewModel"
@@ -28,46 +29,8 @@
         </StackPanel>
       </StackPanel>
 
-      <Panel x:Name="Panel" DockPanel.Dock="Bottom" Margin="0 0 0 8"
-             IsVisible="{Binding ShowPrivacyBar}">
-        <i:Interaction.Behaviors>
-          <behaviors:BoundsObserverBehavior Bounds="{Binding #Panel.Bounds, Mode=OneWay}"
-                                            Width="{Binding PrivacyBar.Width, Mode=TwoWay}"
-                                            x:CompileBindings="False" />
-        </i:Interaction.Behaviors>
-
-        <Button Classes="plain" Command="{Binding ShowDetailsCommand}"
-                ToolTip.Tip="Show Details">
-          <ItemsControl Items="{Binding PrivacyBar.Items}" Height="10">
-            <ItemsControl.Styles>
-              <Style Selector="Path.private">
-                <Setter Property="Fill" Value="{DynamicResource PrivacyLevelStrongBrush}" />
-              </Style>
-
-              <Style Selector="Path.semiPrivate">
-                <Setter Property="Fill" Value="{DynamicResource PrivacyLevelMediumBrush}" />
-              </Style>
-
-              <Style Selector="Path.nonPrivate">
-                <Setter Property="Fill" Value="{DynamicResource PrivacyLevelNoneBrush}" />
-              </Style>
-            </ItemsControl.Styles>
-            <ItemsControl.ItemsPanel>
-              <ItemsPanelTemplate>
-                <Panel />
-              </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <Path Data="{Binding Data}"
-                      Classes.private="{Binding IsPrivate}"
-                      Classes.semiPrivate="{Binding IsSemiPrivate}"
-                      Classes.nonPrivate="{Binding IsNonPrivate}" />
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
-        </Button>
-      </Panel>
+      <tilesView:PrivacyBar DockPanel.Dock="Bottom" Margin="0 0 0 8"
+                            IsVisible="{Binding ShowPrivacyBar}" />
 
       <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 3">
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -117,7 +117,7 @@
           <DataTemplate DataType="{x:Type ring:PrivacyRingItemViewModel}">
             <c:TileControl TileSize="Medium" Width="300" Height="150">
               <DockPanel>
-                <c:LabelsItemsPresenter Items="{Binding SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
+                <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
                 <StackPanel DockPanel.Dock="Bottom" Height="25" Spacing="8">
                   <Separator />
                   <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
@@ -128,7 +128,7 @@
                           Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
                       </Border>
                     </StackPanel>
-                    <TextBlock Text="{Binding AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                    <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
                   </StackPanel>
                 </StackPanel>
 
@@ -138,7 +138,7 @@
                     TextAlignment="Center"
                     Text="{Binding AmountText}" Classes="h3" />
 
-                  <TextBlock Text="{Binding Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                  <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </StackPanel>
               </DockPanel>
             </c:TileControl>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/98904713/189903421-ae99a115-7768-44f4-8f6c-6013ac11c105.png)

- Establishes a maximum coin count of 100 to render the Privacy Bar and Privacy Ring
- If this maximum is exceeded, renders one segment per pocket, instead of one segment per coin
- Prevents the UI from hanging when trying to render too many segments for wallets with a very high number of coins
- Code cleanup and best practices: removes inheritance of bar and ring item viewmodels from `WalletCoinViewModel` and uses composition instead
- Fixes #9055 
- Fixes #9056
- Fixes #9101 