### PR TITLE
[VDG] Temporarily Disable Navbar dragging

### DIFF
--- a/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
+++ b/WalletWasabi.Fluent/Views/NavBar/NavBar.axaml
@@ -116,7 +116,6 @@
     <Style Selector="c|NavBarItem:selected PathIcon" x:CompileBindings="False">
       <Setter Property="Data" Value="{Binding IconNameFocused, Converter={x:Static conv:NavBarIconConverter.Instance}}" />
     </Style>
-
   </UserControl.Styles>
 
   <DockPanel Margin="0 -5 0 5">
@@ -153,7 +152,7 @@
                        SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                        ReSelectSelectedItem="False"
                        Name="ItemsListBox"
-                       Classes="vertical draggable narrowItemPadding"
+                       Classes="vertical narrowItemPadding"
                        VerticalAlignment="Stretch">
         <c:NavBarListBox.DataTemplates>
           <DataTemplate DataType="vmw:WalletViewModelBase">


### PR DESCRIPTION
 - Removes the ability for the end user to change ordering of wallets in the Navbar by dragging them
 - This is a temporary fix to prevent a crash that is currently occurring.
 - Proper implementation of dragging functionality requires modification of Avalonia.Xaml.Interactivity (@wieslawsoltes)
 - Fixes #9058 