### PR TITLE
[PoC] Add creating circuits in advance

### DIFF
--- a/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
@@ -24,7 +24,7 @@ public class DependencyGraphTaskScheduler
 		DependencyTasks = allInEdges.ToDictionary(edge => edge, _ => new TaskCompletionSource<Credential>(TaskCreationOptions.RunContinuationsAsynchronously));
 	}
 
-	private DependencyGraph Graph { get; }
+	public DependencyGraph Graph { get; }
 	private Dictionary<CredentialDependency, TaskCompletionSource<Credential>> DependencyTasks { get; }
 
 	private async Task CompleteConnectionConfirmationAsync(IEnumerable<AliceClient> aliceClients, BobClient bobClient, CancellationToken cancellationToken)


### PR DESCRIPTION
Related: https://github.com/zkSNACKs/WalletWasabi/pull/8827

I am not sure how this should work but besides that... 

I still think this can backfire. Can pre-creating circuits take away circuits from actual requests? 

What if we just create 50 circuits upfront right after we jump into conn confirm? Because from that point we will use a lot of PerRequest Tor circuits - at that point we have time but we don't know the exact number of requests. Later we will know the exact number but we won't have time to prebuild. 

