### PR TITLE
wix3: Bugfix to avoid VS2022 crash

### DIFF
--- a/WalletWasabi.WindowsInstaller/WalletWasabi.WindowsInstaller.wixproj
+++ b/WalletWasabi.WindowsInstaller/WalletWasabi.WindowsInstaller.wixproj
@@ -62,7 +62,8 @@
       <DefineConstants>BuildVersion=%(AssemblyVersion.Version);BasePath=..\WalletWasabi.Fluent.Desktop\bin\dist\win7-x64</DefineConstants>
     </PropertyGroup>
     <!-- Harvest file components from publish folder. -->
-    <HeatDirectory OutputFile="ComponentsGenerated.wxs" DirectoryRefId="INSTALLFOLDER" ComponentGroupName="PublishedComponents" SuppressCom="true" Directory="..\WalletWasabi.Fluent.Desktop\bin\dist\win7-x64" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" AutoGenerateGuids="false" GenerateGuidsNow="true" ToolPath="$(WixToolPath)" PreprocessorVariable="var.BasePath" />
+    <!-- See https://github.com/wixtoolset/issues/issues/6636#issuecomment-984886136 for the reason why RunAsSeparateProcess="True" was added. -->
+    <HeatDirectory RunAsSeparateProcess="True" OutputFile="ComponentsGenerated.wxs" DirectoryRefId="INSTALLFOLDER" ComponentGroupName="PublishedComponents" SuppressCom="true" Directory="..\WalletWasabi.Fluent.Desktop\bin\dist\win7-x64" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" AutoGenerateGuids="false" GenerateGuidsNow="true" ToolPath="$(WixToolPath)" PreprocessorVariable="var.BasePath" />
   </Target>
   <Target Name="AfterBuild">
   </Target>


### PR DESCRIPTION
Currently building `WalletWasabi.WindowsInstaller` leads to crashing of VS2022. With the help of [this workaround](https://github.com/wixtoolset/issues/issues/6636#issuecomment-984886136), it seems it works. 

I'm not sure if it behaves as it used to work because it's not something I've been involved in a lot. 