### PR TITLE
[FILTERS] wip: Birthday concept

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -82,7 +82,8 @@ public partial class ConfirmRecoveryWordsViewModel : RoutableViewModel
 						Services.WalletManager.WalletDirectories.WalletsDir,
 						Services.WalletManager.Network)
 					{
-						TipHeight = Services.BitcoinStore.SmartHeaderChain.TipHeight
+						TipHeight = Services.BitcoinStore.SmartHeaderChain.TipHeight,
+						ServerTipHeight = Services.BitcoinStore.SmartHeaderChain.ServerTipHeight
 					};
 					return walletGenerator.GenerateWallet(walletName, password, mnemonics);
 				});

--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -51,7 +51,7 @@ public partial class WalletManagerViewModel : ViewModelBase
 					RemoveWallet(walletViewModel);
 				}
 				else if (walletViewModel is ClosedWalletViewModel { IsLoggedIn: true } cwvm &&
-						 ((cwvm.Wallet.KeyManager.SkipSynchronization && cwvm.Wallet.State == WalletState.Starting) ||
+						 (((cwvm.Wallet.KeyManager.SkipSynchronization || Services.BitcoinStore.SmartHeaderChain.TipHeight < cwvm.Wallet.KeyManager.GetFirstRelevantHeight()) && cwvm.Wallet.State == WalletState.Starting) ||
 						  cwvm.Wallet.State == WalletState.Started))
 				{
 					OpenClosedWallet(cwvm);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
@@ -101,7 +101,7 @@ public partial class LoadingViewModel : ActivatableViewModel
 
 		await SetInitValuesAsync(isBackendAvailable).ConfigureAwait(false);
 
-		while (isBackendAvailable && RemainingFiltersToDownload > 0 && !_wallet.KeyManager.SkipSynchronization)
+		while (isBackendAvailable && RemainingFiltersToDownload > 0 && !_wallet.KeyManager.SkipSynchronization && Services.BitcoinStore.SmartHeaderChain.TipHeight >= _wallet.KeyManager.GetFirstRelevantHeight())
 		{
 			await Task.Delay(1000).ConfigureAwait(false);
 		}

--- a/WalletWasabi/Blockchain/BlockFilters/FilterProcessor.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/FilterProcessor.cs
@@ -26,7 +26,6 @@ public class FilterProcessor
 			using (await AsyncLock.LockAsync().ConfigureAwait(false))
 			{
 				var hashChain = BitcoinStore.SmartHeaderChain;
-				hashChain.SetServerTipHeight(serverBestHeight);
 
 				if (filtersResponseState == FiltersResponseState.NewFilters)
 				{

--- a/WalletWasabi/Blockchain/Keys/BlockchainState.cs
+++ b/WalletWasabi/Blockchain/Keys/BlockchainState.cs
@@ -32,4 +32,8 @@ public class BlockchainState
 	[JsonProperty]
 	[JsonConverter(typeof(HeightJsonConverter))]
 	public Height Height { get; set; }
+
+	[JsonProperty]
+	[JsonConverter(typeof(HeightJsonConverter))]
+	public Height FirstRelevantHeight { get; set; }
 }

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -136,6 +136,10 @@ public class KeyManager
 	[JsonProperty(PropertyName = "PreferPsbtWorkflow")]
 	public bool PreferPsbtWorkflow { get; set; }
 
+	[JsonProperty(PropertyName = "FirstRelevantHeight")]
+	[JsonConverter(typeof(HeightJsonConverter))]
+	public Height FirstRelevantHeight { get; set; } = new Height(0);
+
 	[JsonProperty(PropertyName = "AutoCoinJoin")]
 	public bool AutoCoinJoin { get; set; } = DefaultAutoCoinjoin;
 
@@ -684,6 +688,11 @@ public class KeyManager
 		return res;
 	}
 
+	public Height GetFirstRelevantHeight()
+	{
+		return FirstRelevantHeight;
+	}
+
 	public Network GetNetwork()
 	{
 		lock (BlockchainStateLock)
@@ -699,6 +708,12 @@ public class KeyManager
 			BlockchainState.Height = height;
 			ToFileNoBlockchainStateLock();
 		}
+	}
+
+	public void SetFirstRelevantHeight(Height height)
+	{
+		FirstRelevantHeight = height;
+		ToFile();
 	}
 
 	public void SetMaxBestHeight(Height height)

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -38,7 +38,7 @@ public class WalletGenerator
 			: KeyManager.CreateNew(mnemonic, password, Network);
 		km.AutoCoinJoin = true;
 		km.SetBestHeight(new Height(TipHeight));
-		km.SetFirstRelevantHeight(new Height(ServerTipHeight));
+		km.SetFirstRelevantHeight(new Height(ServerTipHeight - 100));
 		km.SetFilePath(walletFilePath);
 		return (km, mnemonic);
 	}

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -24,6 +24,7 @@ public class WalletGenerator
 	public string WalletsDir { get; private set; }
 	public Network Network { get; private set; }
 	public uint TipHeight { get; set; }
+	public uint ServerTipHeight { get; set; }
 
 	public (KeyManager, Mnemonic) GenerateWallet(string walletName, string password, Mnemonic? mnemonic = null)
 	{
@@ -32,11 +33,12 @@ public class WalletGenerator
 		// Here we are not letting anything that will be autocorrected later. We need to generate the wallet exactly with the entered password because of compatibility.
 		PasswordHelper.Guard(password);
 
-		var km = mnemonic is null 
+		var km = mnemonic is null
 			? KeyManager.CreateNew(out mnemonic, password, Network)
 			: KeyManager.CreateNew(mnemonic, password, Network);
 		km.AutoCoinJoin = true;
 		km.SetBestHeight(new Height(TipHeight));
+		km.SetFirstRelevantHeight(new Height(ServerTipHeight));
 		km.SetFilePath(walletFilePath);
 		return (km, mnemonic);
 	}

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -38,7 +38,7 @@ public class WalletGenerator
 			: KeyManager.CreateNew(mnemonic, password, Network);
 		km.AutoCoinJoin = true;
 		km.SetBestHeight(new Height(TipHeight));
-		km.SetFirstRelevantHeight(new Height(ServerTipHeight - 100));
+		km.SetFirstRelevantHeight(new Height(ServerTipHeight));
 		km.SetFilePath(walletFilePath);
 		return (km, mnemonic);
 	}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -109,9 +109,9 @@ public class TransactionProcessor
 		if (ret.IsNews)
 		{
 			var firstRelevantHeight = KeyManager.GetFirstRelevantHeight();
-			if (firstRelevantHeight == 0 || firstRelevantHeight > tx.Height)
+			if (firstRelevantHeight == 0 || firstRelevantHeight > tx.Height - 100)
 			{
-				KeyManager.SetFirstRelevantHeight(tx.Height);
+				KeyManager.SetFirstRelevantHeight(tx.Height - 100);
 			}
 			WalletRelevantTransactionProcessed?.Invoke(this, ret);
 		}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -108,6 +108,11 @@ public class TransactionProcessor
 		}
 		if (ret.IsNews)
 		{
+			var firstRelevantHeight = KeyManager.GetFirstRelevantHeight();
+			if (firstRelevantHeight == 0 || firstRelevantHeight > tx.Height)
+			{
+				KeyManager.SetFirstRelevantHeight(tx.Height);
+			}
 			WalletRelevantTransactionProcessed?.Invoke(this, ret);
 		}
 		return ret;

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -108,10 +108,9 @@ public class TransactionProcessor
 		}
 		if (ret.IsNews)
 		{
-			var firstRelevantHeight = KeyManager.GetFirstRelevantHeight();
-			if (firstRelevantHeight == 0 || firstRelevantHeight > tx.Height - 100)
+			if (KeyManager.IsLowerThanFirstRelevantHeight(tx.Height))
 			{
-				KeyManager.SetFirstRelevantHeight(tx.Height - 100);
+				KeyManager.SetFirstRelevantHeight(tx.Height);
 			}
 			WalletRelevantTransactionProcessed?.Invoke(this, ret);
 		}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -145,6 +145,8 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 								.GetSynchronizeAsync(BitcoinStore.SmartHeaderChain.TipHash, maxFiltersToSyncAtInitialization, EstimateSmartFeeMode.Conservative, StopCts.Token)
 								.ConfigureAwait(false);
 
+							BitcoinStore.SmartHeaderChain.SetServerTipHeight((uint)response.BestHeight);
+
 							// NOT GenSocksServErr
 							BackendStatus = BackendStatus.Connected;
 							TorStatus = TorStatus.Running;

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -369,7 +369,7 @@ public class Wallet : BackgroundService, IWallet
 		{
 			using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
 			{
-				if (KeyManager.GetBestHeight() < filterModel.Header.Height && KeyManager.GetFirstRelevantHeight() <= filterModel.Header.Height)
+				if (KeyManager.GetBestHeight() < filterModel.Header.Height)
 				{
 					await ProcessFilterModelAsync(filterModel, CancellationToken.None).ConfigureAwait(false);
 				}
@@ -415,7 +415,7 @@ public class Wallet : BackgroundService, IWallet
 
 		// Go through the filters and queue to download the matches.
 		await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
-			new Height(Math.Max(bestKeyManagerHeight.Value + 1, KeyManager.GetFirstRelevantHeight())), cancel).ConfigureAwait(false);
+			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
 	}
 
 	private async Task LoadDummyMempoolAsync()

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -369,7 +369,7 @@ public class Wallet : BackgroundService, IWallet
 		{
 			using (await HandleFiltersLock.LockAsync().ConfigureAwait(false))
 			{
-				if (KeyManager.GetBestHeight() < filterModel.Header.Height)
+				if (KeyManager.GetBestHeight() < filterModel.Header.Height && KeyManager.GetFirstRelevantHeight() <= filterModel.Header.Height)
 				{
 					await ProcessFilterModelAsync(filterModel, CancellationToken.None).ConfigureAwait(false);
 				}
@@ -415,7 +415,7 @@ public class Wallet : BackgroundService, IWallet
 
 		// Go through the filters and queue to download the matches.
 		await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
-			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
+			new Height(Math.Max(bestKeyManagerHeight.Value + 1, KeyManager.GetFirstRelevantHeight())), cancel).ConfigureAwait(false);
 	}
 
 	private async Task LoadDummyMempoolAsync()


### PR DESCRIPTION
This concept aims to completely bypass wallet loading time for a user which first action with wasabi is to create a new wallet

It saves the current server BestHeight (i.e. blockchain height) at the time of creation to the wallet .json file.
By doing so, wallet can start and filters are downloaded in the background, but they are not matched against keys before reaching creation height (as its not possible to haveTX before wallet creation it would only return false or false positives anyway).

Please discuss the concept.
Even if that specific solution is not accepted I think a similar one is the key to solve WW loading time short term as everything would happen in the background and implementation is relatively easy. 

A companion solution proposed by @lontivero is to save wallet TXs in the .json wallet file (or create an export function to have wallet info + its TXs). That way it will basically be instant to import a wallet.

**TODO:**
- Renaming, if TXs are exported with the wallet it can be named something like "BlockchainHeightAtCreation"
- Currently if a user goes really really fast (or if tor takes a lot of time to load) he can create his wallet before Synchronizer have first response and so FirstRelevantHeight is set at 0.
- New filters must be saved in memory and used while the other ones are downloading

Fixes #9002