### PR TITLE
`TorHttpPool`: Do not log OperationCancelledException

### DIFF
--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -242,6 +242,10 @@ public class TorHttpPool : IAsyncDisposable
 					TorConnectionException innerException = new("Connection was refused.", e);
 					throw new HttpRequestException("Failed to handle the HTTP request via Tor.", innerException);
 				}
+				catch (OperationCanceledException)
+				{
+					throw;
+				}
 				catch (Exception e)
 				{
 					Logger.LogTrace($"['{connection}'] Exception occurred.", e);


### PR DESCRIPTION
Trivial PR not to log `OperationCancelledException`. It adds no value and adds noise when reading logs