### PR TITLE
[VDG] make PrivacyBar not clickable when wallet is empty

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -43,7 +43,7 @@ public partial class PrivacyBarViewModel : ViewModelBase
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(RefreshCoinsList);
 	
-	IsEmpty = this.WhenAnyValue(x => x.Items.Count).Select(count => count == 0);
+		IsEmpty = this.WhenAnyValue(x => x.Items.Count).Select(count => count == 0);
 	}
 
 	public ObservableCollectionExtended<PrivacyBarItemViewModel> Items { get; } = new();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -43,10 +43,14 @@ public partial class PrivacyBarViewModel : ViewModelBase
 			.Select(_ => walletViewModel.Wallet.GetPockets())
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(RefreshCoinsList);
+	
+	IsEmpty = this.WhenAnyValue(x => x.Items.Count).Select(count => count == 0);
 	}
 
 	public ObservableCollectionExtended<PrivacyBarItemViewModel> Items { get; } = new();
 
+	public IObservable<bool> IsEmpty { get; }
+	
 	public Wallet Wallet { get; }
 
 	private void RefreshCoinsList(IEnumerable<Pocket> pockets)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -3,7 +3,6 @@ using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyBar/PrivacyBar.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyBar/PrivacyBar.axaml
@@ -16,7 +16,8 @@
     </i:Interaction.Behaviors>
 
     <Button Classes="plain" Command="{Binding ShowDetailsCommand}"
-            ToolTip.Tip="Show Details">
+            ToolTip.Tip="Show Details"
+            IsVisible="{Binding !PrivacyBar.IsEmpty^}">
       <ItemsControl Items="{Binding PrivacyBar.Items}" Height="10">
         <ItemsControl.Styles>
           <Style Selector="Path.private">


### PR DESCRIPTION
currently when the user has an empty wallet, the PrivacyBar is not visible, but it is still clickable:
![image](https://user-images.githubusercontent.com/93143998/190994786-e62f9cfd-76c0-4608-8cfa-11246e89d963.png)

this PR fixes this (making invisible PrivacyBar not clickable) 

thanks @soosr for the help