### PR TITLE
Increase min required macOS version to macOs 11.6+

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -5,7 +5,7 @@ This document lists all the officially supported software and devices by Wasabi 
 # Officially Supported Operating Systems
 
 - Windows 10 1607+ (except 1703)
-- macOs 10.15+
+- macOs 11.6+
 - Ubuntu 16.04, 18.04, 20.04+
 - Fedora 33+
 - Debian 10+


### PR DESCRIPTION
I was not able to find out why macOS requires 11.6 to run Wasabi. 

https://github.com/zkSNACKs/WalletWasabi/discussions/7718
https://github.com/zkSNACKs/WalletWasabi/pull/8703#issuecomment-1252642416