### PR TITLE
[Backend] Fix swagger 

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -317,8 +317,7 @@ public class BlockchainController : ControllerBase
 		return Ok(response);
 	}
 
-	[ApiExplorerSettings(IgnoreApi = true)]
-	public bool TryGetIndexer(string? indexType, [NotNullWhen(true)] out IndexBuilderService? indexer)
+	internal bool TryGetIndexer(string? indexType, [NotNullWhen(true)] out IndexBuilderService? indexer)
 	{
 		indexer = null;
 		if (indexType is null || indexType.Equals("segwittaproot", StringComparison.OrdinalIgnoreCase))

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -317,6 +317,7 @@ public class BlockchainController : ControllerBase
 		return Ok(response);
 	}
 
+	[ApiExplorerSettings(IgnoreApi = true)]
 	public bool TryGetIndexer(string? indexType, [NotNullWhen(true)] out IndexBuilderService? indexer)
 	{
 		indexer = null;


### PR DESCRIPTION
I found this while messing on RegTest.

Swagger documentation couldn't be generated because of `BlockchainController.TryGetIndexer()`

![image](https://user-images.githubusercontent.com/45069029/191923236-e9caff45-4e65-470e-b92d-49c0d288e954.png)


