### PR TITLE
[Backend] Remove unnecessary check

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -105,10 +105,6 @@ public class Global : IDisposable
 				{
 					throw new ArgumentException($"Blacklist API token was not provided in {nameof(WabiSabiConfig)}.");
 				}
-				if (CoordinatorParameters.RuntimeCoordinatorConfig.RiskFlags is null || !CoordinatorParameters.RuntimeCoordinatorConfig.RiskFlags.Any())
-				{
-					throw new ArgumentException($"Risk indicators were not provided in {nameof(WabiSabiConfig)}.");
-				}
 
 				HttpClient.BaseAddress = url;
 


### PR DESCRIPTION
Let the verifier be built, even if we don't specify the flags.

Also, we can change the flags on the fly, so we shouldn't block the creation of the object, just because the flags are missing.