### PR TITLE
[trivial] improve TransactionSizeException message

### DIFF
--- a/WalletWasabi/Exceptions/TransactionSizeException.cs
+++ b/WalletWasabi/Exceptions/TransactionSizeException.cs
@@ -5,7 +5,7 @@ namespace WalletWasabi.Exceptions;
 public class TransactionSizeException : Exception
 {
 	public TransactionSizeException(Money target, Money maximumPossible)
-		: base($"Transaction size over the limit. Needed {target.ToString(false, true)} BTC. The maximum amount you can spend is {maximumPossible.ToString(false, true)} BTC at the moment.")
+		: base($"Transaction size is over the limit, {target.ToString(false, true)} BTC was needed. Currently, the maximum amount you can spend is {maximumPossible.ToString(false, true)} BTC.")
 	{
 		Target = target ?? Money.Zero;
 		MaximumPossible = maximumPossible ?? Money.Zero;


### PR DESCRIPTION
for logs current was ok, this is mainly a more user friendly message for the GUI

![image](https://user-images.githubusercontent.com/93143998/191944752-890cf745-002f-4a21-bd9d-1b6d63417bc0.png)

