### PR TITLE
[Fix CI] Use the same port every time

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
@@ -13,23 +13,12 @@ namespace WalletWasabi.Tests.UnitTests.Clients;
 [Collection("Serial unit tests collection")]
 public class SingleInstanceCheckerTests
 {
-	private static Random Random { get; } = new();
-
-	/// <summary>
-	/// Global port may collide when several PRs are being tested on CI at the same time,
-	/// so we need some sort of non-determinism here (i.e. random numbers).
-	/// </summary>
-	private static int GenerateRandomPort()
-	{
-		return Random.Next(37128, 50000);
-	}
-
 	[Fact]
 	public async Task SingleInstanceTestsAsync()
 	{
-		int mainNetPort = GenerateRandomPort();
-		int testNetPort = mainNetPort + 1;
-		int regTestPort = testNetPort + 1;
+		int mainNetPort = 39900;
+		int testNetPort = 40000;
+		int regTestPort = 40001;
 
 		// Disposal test.
 		await using (SingleInstanceChecker sic = new(mainNetPort))
@@ -57,7 +46,7 @@ public class SingleInstanceCheckerTests
 	[Fact]
 	public async Task OtherInstanceStartedTestsAsync()
 	{
-		int mainNetPort = GenerateRandomPort();
+		int mainNetPort = 40003;
 
 		// Disposal test.
 		await using SingleInstanceChecker firstInstance = new(mainNetPort);


### PR DESCRIPTION
The following test randomly failing on win CI. Trying to fix it, I am not sure what is the problem. 

```
WalletWasabi.Tests.UnitTests.Clients.SingleInstanceCheckerTests.SingleInstanceTestsAsync
Assert.Throws() Failure
Expected: typeof(System.OperationCanceledException)
Actual:   typeof(System.InvalidOperationException): Wasabi is already running, but cannot be signaled, reason: 'System.IO.IOException: Unable to write data to the transport connection: An established connection was aborted by the software in your host machine..
           ---> System.Net.Sockets.SocketException (10053): An established connection was aborted by the software in your host machine.
             at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
             at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
             at System.Net.Sockets.NetworkStream.WriteAsync(ReadOnlyMemory`1 buffer, CancellationToken cancellationToken)
             at System.IO.StreamWriter.<FlushAsyncInternal>g__Core|76_0(Boolean flushStream, Boolean flushEncoder, CancellationToken cancellationToken)
             at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
             at System.IO.StreamWriter.FlushAsync()
             at WalletWasabi.Services.SingleInstanceChecker.EnsureSingleOrThrowAsync() in WalletWasabi\Services\SingleInstanceChecker.cs:line 96
             at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
             at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
             at System.Threading.ThreadPoolWorkQueue.Dispatch()
             at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
          --- End of stack trace from previous location ---
          
             --- End of inner exception stack trace ---
             at System.IO.StreamWriter.<FlushAsyncInternal>g__Core|76_0(Boolean flushStream, Boolean flushEncoder, CancellationToken cancellationToken)
             at WalletWasabi.Services.SingleInstanceChecker.EnsureSingleOrThrowAsync() in WalletWasabi\Services\SingleInstanceChecker.cs:line 96
             at WalletWasabi.Services.SingleInstanceChecker.EnsureSingleOrThrowAsync() in WalletWasabi\Services\SingleInstanceChecker.cs:line 97
             at WalletWasabi.Services.SingleInstanceChecker.EnsureSingleOrThrowAsync() in WalletWasabi\Services\SingleInstanceChecker.cs:line 97'
---- System.InvalidOperationException : Wasabi is already running, but cannot be signaled, reason: 'System.IO.IOException: Unable to write data to the transport connection: An established connection was aborted by the software in your host machine..
 ---> System.Net.Sockets.SocketException (10053): An established connection was aborted by the software in your host machine.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
   at System.Net.Sockets.NetworkStream.WriteAsync(ReadOnlyMemory`1 buffer, CancellationToken cancellationToken)
   at System.IO.StreamWriter.<FlushAsyncInternal>g__Core|76_0(Boolean flushStream, Boolean flushEncoder, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at System.IO.StreamWriter.FlushAsync()
   at WalletWasabi.Services.SingleInstanceChecker.EnsureSingleOrThrowAsync() in WalletWasabi\Services\SingleInstanceChecker.cs:line 96
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Threa
```