### PR TITLE
Use lock when we remove Alices, fix backend bug

### DIFF
--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -657,16 +657,16 @@ public class CoordinatorRound
 		}
 		catch (Exception exc)
 		{
-			Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({Alices.Count}).",exc);
+			Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({Alices.Count}).", exc);
 		}
 
 		var alicesToRemove = Alices.Where(alice => inputsToBan.Any(outpoint => alice.Inputs.Select(input => input.Outpoint).Contains(outpoint)));
-		Logger.LogInfo($"Alices({alicesToRemove.Count()}) was force banned in round '{RoundId}'.");
-		foreach (var alice in alicesToRemove)
-		{
-			Alices.Remove(alice);
-		}
+
+		RemoveAlicesBy(alicesToRemove.Select(alice => alice.UniqueId).ToArray());
+
 		await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, forceBan: true, inputsToBan.ToArray()).ConfigureAwait(false);
+
+		Logger.LogInfo($"Alices({alicesToRemove.Count()}) was force banned in round '{RoundId}'.");
 	}
 
 	private async Task MoveToInputRegistrationAsync()


### PR DESCRIPTION
The bug:
```
2022-09-27 12:45:45.762 [510] ERROR	CoordinatorRound.ExecuteNextPhaseAsync (290)	System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at WalletWasabi.CoinJoin.Coordinator.Rounds.CoordinatorRound.RemoveAliceIfCoinsAreNaughtyAsync()
   at WalletWasabi.CoinJoin.Coordinator.Rounds.CoordinatorRound.MoveToConnectionConfirmationAsync()
   at WalletWasabi.CoinJoin.Coordinator.Rounds.CoordinatorRound.ExecuteNextPhaseAsync(RoundPhase expectedPhase)
2022-09-27 12:45:45.762 [510] WARNING	CoordinatorRound.KickTimeout (398)	Round (55420): InputRegistration timeout failed.
```

Stupid mistake.
We removed `Alices` without the `RoundSynchronizerLock`, which is used every place we touch `Alices`.

With this PR, we use the `RemoveAlicesBy` method to remove Alices, which acquires the lock.