### PR TITLE
Revert "Use lock when we remove Alices, fix backend bug"

### DIFF
--- a/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
+++ b/WalletWasabi/CoinJoin/Coordinator/Rounds/CoordinatorRound.cs
@@ -657,16 +657,16 @@ public class CoordinatorRound
 		}
 		catch (Exception exc)
 		{
-			Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({Alices.Count}).", exc);
+			Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({Alices.Count}).",exc);
 		}
 
 		var alicesToRemove = Alices.Where(alice => inputsToBan.Any(outpoint => alice.Inputs.Select(input => input.Outpoint).Contains(outpoint)));
-
-		RemoveAlicesBy(alicesToRemove.Select(alice => alice.UniqueId).ToArray());
-
-		await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, forceBan: true, inputsToBan.ToArray()).ConfigureAwait(false);
-
 		Logger.LogInfo($"Alices({alicesToRemove.Count()}) was force banned in round '{RoundId}'.");
+		foreach (var alice in alicesToRemove)
+		{
+			Alices.Remove(alice);
+		}
+		await UtxoReferee.BanUtxosAsync(1, DateTimeOffset.UtcNow, forceNoted: false, RoundId, forceBan: true, inputsToBan.ToArray()).ConfigureAwait(false);
 	}
 
 	private async Task MoveToInputRegistrationAsync()


### PR DESCRIPTION
This is not good. It results in a deadlock. `ExecuteNextPhaseAsync` also holds `RoundSynchronizerLock`