### PR TITLE
simplify onboarding screens

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -141,7 +141,7 @@
         <Grid ColumnDefinitions="Auto,*">
           <DockPanel Grid.Column="1" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi is a Bitcoin wallet. You can simply receive and send money with it.&#10;&#10;Securely and privately." />
+                       Text="Wasabi is a Bitcoin wallet. You can easily receive and send money with it.&#10;&#10;Securely and privately." />
             <TextBlock Text="Welcome to Wasabi"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -141,7 +141,7 @@
         <Grid ColumnDefinitions="Auto,*">
           <DockPanel Grid.Column="1" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi is a Bitcoin wallet. You can receive and send money with it.&#10;&#10;Simple yet powerful.&#10;&#10;Securely and privately." />
+                       Text="Wasabi is a Bitcoin wallet. You can simply receive and send money with it.&#10;&#10;Securely and privately." />
             <TextBlock Text="Welcome to Wasabi"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -243,7 +243,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can breach your privacy.&#10;&#10;And for that you pay a fee to the Wasabi backend." />
+                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can breach your privacy.&#10;&#10;For that you pay a fee of 0.3%." />
             <TextBlock Text="Anonymous"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -243,7 +243,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can find out how much money you have, or where you spend it.&#10;&#10;For that you pay a fee of 0.3%." />
+                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can find out how much money you have, or where you spend it." />
             <TextBlock Text="Anonymous"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -243,7 +243,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi provides privacy by default, it protects your important financial information.&#10;&#10;Neither the public nor the developers can breach your privacy.&#10;&#10;To protect your privacy, you pay a fee to the Bitcoin network and the Wasabi backend." />
+                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can breach your privacy.&#10;&#10;And for that you pay a fee to the Wasabi backend." />
             <TextBlock Text="Anonymous"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -317,7 +317,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi is free, open-source and deterministically reproducible software.&#10;&#10;You can verify exactly what's going on." />
+                       Text="Wasabi is open-source.&#10;&#10;You can verify exactly what's going on under the hood, and help us make it better." />
             <TextBlock Text="Open-Source"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -141,7 +141,7 @@
         <Grid ColumnDefinitions="Auto,*">
           <DockPanel Grid.Column="1" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Satoshi brought scarcity, while Wasabi is bringing fungibility. As inflation is running rampant, vigilant individuals are opting out.&#10;Bitcoin is rapidly becoming the world's reserve currency, but its fungibility - a property of good money - is still unsatisfactory.&#10;&#10;Wasabi Wallet is a bastion of hope in the quest to qualitatively improve the money of the future." />
+                       Text="Wasabi is a Bitcoin wallet. You can receive and send money with it.&#10;&#10;Securely and privately." />
             <TextBlock Text="Welcome to Wasabi"
                        Classes="title" />
           </DockPanel>
@@ -177,7 +177,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="If you don't control your private keys, then you are not the true owner of your funds.&#10;&#10;Wasabi is non-custodial: the developers cannot steal or freeze your funds." />
+                       Text="With Wasabi only you know the keys to spend your money.&#10;&#10;Nobody can steal from you." />
             <TextBlock Text="Non-Custodial"
                        Classes="title" />
           </DockPanel>
@@ -243,7 +243,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi provides privacy by default, it protects your financial information through coinjoins, client-side block filtering and communication over the Tor anonymity network.&#10;&#10;Neither the public nor the developers can breach your privacy." />
+                       Text="Wasabi provides privacy by default, it protects your important financial information.&#10;&#10;Neither the public nor the developers can breach your privacy.&#10;&#10;To protect your privacy, you pay a fee to the Bitcoin network and the Wasabi backend." />
             <TextBlock Text="Anonymous"
                        Classes="title" />
           </DockPanel>
@@ -317,7 +317,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="To ensure the code - running on your computer - can indeed protect you from the developers and the public, Wasabi is free, open-source and deterministically reproducible software." />
+                       Text="Wasabi is free, open-source and deterministically reproducible software.&#10;&#10;You can verify exactly what's going on." />
             <TextBlock Text="Open-Source"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -177,7 +177,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="With Wasabi only you know the keys to spend your money.&#10;&#10;Nobody can steal from you." />
+                       Text="With Wasabi only you are in full control of your money.&#10;&#10;Nobody can steal from you." />
             <TextBlock Text="Non-Custodial"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -243,7 +243,7 @@
           </Viewbox>
           <DockPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can breach your privacy.&#10;&#10;For that you pay a fee of 0.3%." />
+                       Text="Wasabi provides privacy by default.&#10;&#10;Nobody can find out how much money you have, or where you spend it.&#10;&#10;For that you pay a fee of 0.3%." />
             <TextBlock Text="Anonymous"
                        Classes="title" />
           </DockPanel>

--- a/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/WelcomePageView.axaml
@@ -141,7 +141,7 @@
         <Grid ColumnDefinitions="Auto,*">
           <DockPanel Grid.Column="1" VerticalAlignment="Center">
             <TextBlock Classes="text"
-                       Text="Wasabi is a Bitcoin wallet. You can receive and send money with it.&#10;&#10;Securely and privately." />
+                       Text="Wasabi is a Bitcoin wallet. You can receive and send money with it.&#10;&#10;Simple yet powerful.&#10;&#10;Securely and privately." />
             <TextBlock Text="Welcome to Wasabi"
                        Classes="title" />
           </DockPanel>


### PR DESCRIPTION
There is too much unneccesary text in the initial onboarding screens.

Here is a big simpolification. Arguably this can be improved even more by changing the design, but this is a minor actionable improvement.