### PR TITLE
Fix warning

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -45,4 +45,9 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 		return profile.AnonScoreTarget < MaxAnonScore && profile.AnonScoreTarget > MinAnonScore && profile.FeeRateMedianTimeFrameHours == FeeRateMedianTimeFrameHours && profile.RedCoinIsolation == RedCoinIsolation;
 	}
+
+	public override int GetHashCode()
+	{
+		return HashCode.Combine(AnonScoreTarget, FeeRateMedianTimeFrameHours, RedCoinIsolation);
+	}
 }


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2218

We override `Equals` method, but not yet the `GetHashCode`.
