### PR TITLE
[PoC] Add package verifying tool

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -87,4 +87,20 @@ public class WasabiSignerToolsTests
 		Assert.Equal(fileHash, sameFileHash);
 		Assert.Equal(otherFileHash, otherFileSameHash);
 	}
+
+	[Fact]
+	public void CanSaveAndReadKeyFromFileTest()
+	{
+		var tmpFolder = Path.Combine(_installerFolder.FullName, "..");
+		var keyFilePath = Path.Combine(tmpFolder, "WasabiKey.txt");
+
+		WasabiSignerTools.SavePrivateKeyToFile(keyFilePath, _privateKey);
+		Assert.True(File.Exists(keyFilePath));
+		Assert.Throws<ArgumentException>(() => WasabiSignerTools.SavePrivateKeyToFile(keyFilePath, _privateKey));
+
+		bool canReadKey = WasabiSignerTools.TryGetKeyFromFile(keyFilePath, out Key? key);
+		Assert.True(canReadKey);
+		Assert.NotNull(key);
+		File.Delete(keyFilePath);
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -44,4 +44,29 @@ public class WasabiSignerToolsTests
 		bool isSignatureValid = WasabiSignerTools.VerifySHASumsFile(destinationPath, publicKey);
 		Assert.True(isSignatureValid);
 	}
+
+	[Fact]
+	public void WritingSHASumsThrowsErrorWithWrongArgumentTest()
+	{
+		string[] invalidFilePaths = new[] { "notAValidFilePath" };
+		string destinationPath = Path.Combine(_installerFolder.Parent!.FullName, WasabiSignerTools.SHASumsFileName);
+		Assert.Throws<FileNotFoundException>(() => WasabiSignerTools.SignAndSaveSHASumsFile(invalidFilePaths, destinationPath, _privateKey));
+	}
+
+	[Fact]
+	public void VerifyingSUMSFileWithInvalidArgumentsFailsTest()
+	{
+		string[] filepaths = _installerFolder.GetFiles().Select(file => file.FullName).ToArray();
+		string destinationPath = Path.Combine(_installerFolder.Parent!.FullName, WasabiSignerTools.SHASumsFileName);
+		WasabiSignerTools.SignAndSaveSHASumsFile(filepaths, destinationPath, _privateKey);
+		Assert.True(File.Exists(destinationPath));
+
+		PubKey goodPublicKey = WasabiSignerTools.GetPublicKey(_privateKey);
+		PubKey wrongPublicKey = WasabiSignerTools.GenerateKey().PubKey;
+
+		bool withWrongKey = WasabiSignerTools.VerifySHASumsFile(destinationPath, wrongPublicKey);
+		Assert.False(withWrongKey);
+		bool withWrongFile = WasabiSignerTools.VerifySHASumsFile(filepaths.First(), goodPublicKey);
+		Assert.False(withWrongFile);
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -1,0 +1,28 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Services;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Services;
+
+public class WasabiSignerToolsTests
+{
+	private Key _privateKey = WasabiSignerTools.GenerateKey();
+	private DirectoryInfo _tmpFolder = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "tmp"));
+
+	[Fact]
+	public void TestWritingAndSavingSHASums()
+	{
+		List<string> filenames = new();
+		string destinationPath = Path.Combine(_tmpFolder.FullName, WasabiSignerTools.SHASumsFileName);
+		//WasabiSignerTools.WriteAndSaveSHASumsFile(filenames, destinationPath, _privateKey);
+		File.WriteAllText(Path.Combine(_tmpFolder.FullName, "tmp.txt"), "temp");
+
+		string a = "10";
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -69,4 +69,22 @@ public class WasabiSignerToolsTests
 		bool withWrongFile = WasabiSignerTools.VerifySHASumsFile(filepaths.First(), goodPublicKey);
 		Assert.False(withWrongFile);
 	}
+
+	[Fact]
+	public void CanGenerateReadHashFromFileTest()
+	{
+		string[] filepaths = _installerFolder.GetFiles().Select(file => file.FullName).ToArray();
+
+		uint256 fileHash = WasabiSignerTools.GenerateHashFromFile(filepaths.First());
+		uint256 otherFileHash = WasabiSignerTools.GenerateHashFromFile(filepaths.ElementAt(1));
+
+		string destinationPath = Path.Combine(_installerFolder.Parent!.FullName, WasabiSignerTools.SHASumsFileName);
+		WasabiSignerTools.SignAndSaveSHASumsFile(filepaths, destinationPath, _privateKey);
+		Assert.True(File.Exists(destinationPath));
+
+		uint256 sameFileHash = WasabiSignerTools.ReadHashFromFile(destinationPath, filepaths.First().Split("\\").Last());
+		uint256 otherFileSameHash = WasabiSignerTools.ReadHashFromFile(destinationPath, filepaths.ElementAt(1).Split("\\").Last());
+		Assert.Equal(fileHash, sameFileHash);
+		Assert.Equal(otherFileHash, otherFileSameHash);
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -40,7 +40,7 @@ public class WasabiSignerToolsTests
 		WasabiSignerTools.SignAndSaveSHASumsFile(filepaths, destinationPath, _privateKey);
 		Assert.True(File.Exists(destinationPath));
 
-		PubKey publicKey = WasabiSignerTools.GetPublicKey(_privateKey);
+		PubKey publicKey = _privateKey.PubKey;
 		bool isSignatureValid = WasabiSignerTools.VerifySHASumsFile(destinationPath, publicKey);
 		Assert.True(isSignatureValid);
 	}
@@ -61,7 +61,7 @@ public class WasabiSignerToolsTests
 		WasabiSignerTools.SignAndSaveSHASumsFile(filepaths, destinationPath, _privateKey);
 		Assert.True(File.Exists(destinationPath));
 
-		PubKey goodPublicKey = WasabiSignerTools.GetPublicKey(_privateKey);
+		PubKey goodPublicKey = _privateKey.PubKey;
 		PubKey wrongPublicKey = WasabiSignerTools.GenerateKey().PubKey;
 
 		bool withWrongKey = WasabiSignerTools.VerifySHASumsFile(destinationPath, wrongPublicKey);

--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -13,16 +13,35 @@ namespace WalletWasabi.Tests.UnitTests.Services;
 public class WasabiSignerToolsTests
 {
 	private Key _privateKey = WasabiSignerTools.GenerateKey();
-	private DirectoryInfo _tmpFolder = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "tmp"));
+	private DirectoryInfo _installerFolder = CreateTestFolderWithFiles();
+
+	private static DirectoryInfo CreateTestFolderWithFiles()
+	{
+		var installerFolder = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "tmp", "installers"));
+		string[] filenames = new[] { "Wasabi.msi", "Wasabi.deb", "Wasabi.dmg", "Wasabi.tar.gz" };
+		string path;
+		for (int i = 0; i < filenames.Length; i++)
+		{
+			path = Path.Combine(installerFolder.FullName, filenames[i]);
+			if (!File.Exists(path))
+			{
+				File.WriteAllText(path, i.ToString());
+			}
+		}
+
+		return installerFolder;
+	}
 
 	[Fact]
-	public void TestWritingAndSavingSHASums()
+	public void WritingAndVerifyingSHASumsTest()
 	{
-		List<string> filenames = new();
-		string destinationPath = Path.Combine(_tmpFolder.FullName, WasabiSignerTools.SHASumsFileName);
-		//WasabiSignerTools.WriteAndSaveSHASumsFile(filenames, destinationPath, _privateKey);
-		File.WriteAllText(Path.Combine(_tmpFolder.FullName, "tmp.txt"), "temp");
+		string[] filepaths = _installerFolder.GetFiles().Select(file => file.FullName).ToArray();
+		string destinationPath = Path.Combine(_installerFolder.Parent!.FullName, WasabiSignerTools.SHASumsFileName);
+		WasabiSignerTools.SignAndSaveSHASumsFile(filepaths, destinationPath, _privateKey);
+		Assert.True(File.Exists(destinationPath));
 
-		string a = "10";
+		PubKey publicKey = WasabiSignerTools.GetPublicKey(_privateKey);
+		bool isSignatureValid = WasabiSignerTools.VerifySHASumsFile(destinationPath, publicKey);
+		Assert.True(isSignatureValid);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/WasabiSignerToolsTests.cs
@@ -82,8 +82,8 @@ public class WasabiSignerToolsTests
 		WasabiSignerTools.SignAndSaveSHASumsFile(filepaths, destinationPath, _privateKey);
 		Assert.True(File.Exists(destinationPath));
 
-		uint256 sameFileHash = WasabiSignerTools.ReadHashFromFile(destinationPath, filepaths.First().Split("\\").Last());
-		uint256 otherFileSameHash = WasabiSignerTools.ReadHashFromFile(destinationPath, filepaths.ElementAt(1).Split("\\").Last());
+		uint256 sameFileHash = WasabiSignerTools.ReadHashFromSHASumsFile(destinationPath, filepaths.First().Split("\\").Last());
+		uint256 otherFileSameHash = WasabiSignerTools.ReadHashFromSHASumsFile(destinationPath, filepaths.ElementAt(1).Split("\\").Last());
 		Assert.Equal(fileHash, sameFileHash);
 		Assert.Equal(otherFileHash, otherFileSameHash);
 	}

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -74,6 +74,9 @@ public static class Constants
 	// Defined in hours. Do not modify these values or the order!
 	public static readonly int[] CoinJoinFeeRateMedianTimeFrames = new[] { 24, 168, 720 };
 
+	// TODO: Use the signer Wasabi key's public key here
+	public static readonly PubKey WasabiPublicKey = new Key().PubKey;
+
 	public static readonly NodeRequirement NodeRequirements = new()
 	{
 		RequiredServices = NodeServices.NODE_WITNESS,

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -20,6 +20,7 @@ namespace WalletWasabi.Services;
 public class UpdateManager : IDisposable
 {
 	private string InstallerPath { get; set; } = "";
+	private string SHASumsFilePath { get; set; } = "";
 	private const byte MaxTries = 3;
 	private const string ReleaseURL = "https://api.github.com/repos/zkSNACKs/WalletWasabi/releases/latest";
 	private const string DownloadURL = "https://github.com/zkSNACKs/WalletWasabi/releases/download";
@@ -96,7 +97,7 @@ public class UpdateManager : IDisposable
 			await CopyStreamContentToFileAsync(stream, filePath).ConfigureAwait(false);
 
 			uint256 downloadedHash = WasabiSignerTools.GenerateHashFromFile(filePath);
-			uint256 expectedHash = WasabiSignerTools.ReadHashFromFile(SHASumsFilePath, fileName);
+			uint256 expectedHash = WasabiSignerTools.ReadHashFromSHASumsFile(SHASumsFilePath, fileName);
 			if (expectedHash != downloadedHash)
 			{
 				File.Delete(filePath);
@@ -143,7 +144,7 @@ public class UpdateManager : IDisposable
 		bool isReleaseValid = await ValidateWasabiSignatureAsync(softwareVersion).ConfigureAwait(false);
 		if (!isReleaseValid)
 		{
-			throw new OperationCanceledException($"Downloading release cancelled, signature of {WasabiSignerTools.SHASumsFileName} was invalid.");
+			throw new OperationCanceledException($"Downloading new release was canceled, signature of {WasabiSignerTools.SHASumsFileName} was invalid.");
 		}
 
 		// Get all asset names and download urls to find the correct one.
@@ -275,7 +276,6 @@ public class UpdateManager : IDisposable
 
 	private UpdateChecker? UpdateChecker { get; set; }
 	private CancellationToken CancellationToken { get; set; }
-	private string SHASumsFilePath { get; set; }
 
 	public void StartInstallingNewVersion()
 	{

--- a/WalletWasabi/Services/WasabiSignerTools.cs
+++ b/WalletWasabi/Services/WasabiSignerTools.cs
@@ -80,7 +80,7 @@ public static class WasabiSignerTools
 		}
 	}
 
-	public static uint256 ReadHashFromFile(string filepath, string installerName)
+	public static uint256 ReadHashFromSHASumsFile(string filepath, string installerName)
 	{
 		(string content, string _) = ReadSHASumsContent(filepath);
 		var lines = content.Split("\n");

--- a/WalletWasabi/Services/WasabiSignerTools.cs
+++ b/WalletWasabi/Services/WasabiSignerTools.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Services;
@@ -21,7 +22,7 @@ public static class WasabiSignerTools
 	public static Key GenerateKey() => new();
 
 	// PublicKey should be saved in Constants.cs later on
-	public static PubKey GetPublicKey(Key key) => key.PubKey;
+	public static PubKey GetPublicKey() => Constants.WasabiPublicKey;
 
 	public static bool TryGetKeyFromFile(string fileName, [NotNullWhen(true)] out Key? key)
 	{
@@ -149,7 +150,7 @@ public static class WasabiSignerTools
 		}
 	}
 
-	public static uint256 GenerateHashFromString(string content)
+	private static uint256 GenerateHashFromString(string content)
 	{
 		byte[] bytes = Encoding.UTF8.GetBytes(content);
 		using SHA256 sha = SHA256.Create();

--- a/WalletWasabi/Services/WasabiSignerTools.cs
+++ b/WalletWasabi/Services/WasabiSignerTools.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.DependencyInjection;
+using NBitcoin;
+using NBitcoin.Crypto;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Services;
+
+public static class WasabiSignerTools
+{
+	public static string SHASumsFileName { get; } = "SHA256SUMS.asc";
+
+	private static Key GenerateKey() => new();
+
+	public static PubKey GetPublicKey(Key key) => key.PubKey;
+
+	public static bool VerifySHASumsFile(string filepath, PubKey publicKey)
+	{
+		(string content, string base64Signature) = ReadSHASumsContent(filepath);
+
+		uint256 hash = GenerateHashFromString(content);
+
+		byte[] sigBytes = Convert.FromBase64String(base64Signature);
+		var wasabiSignature = ECDSASignature.FromDER(sigBytes);
+		return publicKey.Verify(hash, wasabiSignature);
+	}
+
+	private static (string content, string base64Signature) ReadSHASumsContent(string filepath)
+	{
+		bool endRequested = false;
+		string base64Signature = "";
+		StringBuilder stringBuilder = new();
+
+		using StreamReader reader = new(filepath);
+		while (!endRequested)
+		{
+			string? line = reader.ReadLine();
+			if (line is null)
+			{
+				endRequested = true;
+			}
+			else if (line.Contains("WASABI"))
+			{
+				string? nextLine = reader.ReadLine();
+
+				if (nextLine is not null)
+				{
+					base64Signature = nextLine;
+				}
+				endRequested = true;
+			}
+			else if (!line.Contains("-----"))
+			{
+				stringBuilder.AppendLine(line);
+			}
+		}
+		string content = stringBuilder.ToString();
+		return (content, base64Signature);
+	}
+
+	public static uint256 GenerateHashFromFile(string filePath)
+	{
+		if (File.Exists(filePath))
+		{
+			byte[] bytes = File.ReadAllBytes(filePath);
+			using SHA256 sha = SHA256.Create();
+			byte[] computedHash = sha.ComputeHash(bytes);
+			return new(computedHash);
+		}
+		else
+		{
+			throw new FileNotFoundException($"Couldn't find file at {filePath}.");
+		}
+	}
+
+	public static uint256 GenerateHashFromString(string content)
+	{
+		byte[] bytes = File.ReadAllBytes(content);
+		using SHA256 sha = SHA256.Create();
+		byte[] computedHash = sha.ComputeHash(bytes);
+		return new(computedHash);
+	}
+
+	public static void WriteAndSaveSHASumsFile(string[] filepaths, string destinationPath, Key key)
+	{
+		StringBuilder fileContent = new();
+		foreach (string filepath in filepaths)
+		{
+			uint256 fileHash = GenerateHashFromFile(filepath);
+			fileContent.AppendLine($"{fileHash} {filepath}");
+		}
+		uint256 contentHash = GenerateHashFromString(fileContent.ToString());
+
+		ECDSASignature signature = key.Sign(contentHash);
+		string base64Signature = Convert.ToBase64String(signature.ToDER());
+
+		fileContent.Insert(0, "-----BEGIN SIGNED CONTENT-----\n");
+		fileContent.AppendLine("-----END SIGNED CONTENT-----");
+		fileContent.AppendLine("-----BEGIN WASABI SIGNATURE-----");
+		fileContent.AppendLine(base64Signature);
+		fileContent.AppendLine("-----END WASABI SIGNATURE-----");
+		File.WriteAllText(destinationPath, fileContent.ToString());
+	}
+
+	public static void SavePrivateKeyToFile(string path, Key key)
+	{
+		if (File.Exists(path))
+		{
+			throw new InvalidOperationException("Private key file already exists.");
+		}
+		using StreamWriter streamWriter = new(path);
+		streamWriter.WriteLine("-----BEGIN WASABI PRIVATE KEY-----");
+		streamWriter.WriteLine(key.ToString(Network.Main));
+		streamWriter.WriteLine("-----END WASABI PRIVATE KEY-----");
+	}
+}


### PR DESCRIPTION
This PR introduces `WasabiSignerTools.cs` static class (👏**with tests**👏) to help both with the signing of new releases in the packager and verifying those files on client side.

Closes #8937 

### Important ❗ 
This is yet a proof of concept based on a plan, so some things might be removed/changed, mainly:
- `GenerateKey()`
- `GetPublicKey()`
- `Constants.WasabiPublicKey`

The packager will generate a `Key` when it runs the first time, which will get saved and later read from a file. This key is used to sign list of file hashes.
This same key's `PubKey` should be provided in the `Constants.cs` _(or an other place where it can be reached on client side, open for suggestions)_ so the clients can verify the downloaded files.

Im not sure about the implementation inside the packager, Im sure there are spots I missed, please review this carefully and help me out with that.

### TODOs: 🗒️ 

- [ ] Its on the future plans list to also sign the hash list(`SHA256SUMS.asc`) with PGP, this can be added in a later PR.
- [ ] Change `Constants.WasabiPublicKey` with the correct public key.
- [ ] Change or get rid of `GetPublicKey()`?
- [ ] Change or get rid of `GenerateKey()`?