### PR TITLE
Disable Tor's `UseEntryGuards` feature

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -24,6 +24,7 @@ public class TorSettingsTests
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--SocksTimeout 30",
+			$"--UseEntryGuards 0",
 			$"--CookieAuthentication 1",
 			$"--ControlPort 37151",
 			$"--CookieAuthFile \"{Path.Combine("temp", "tempDataDir", "control_auth_cookie")}\"",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -98,6 +98,7 @@ public class TorSettings
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--SocksTimeout 30", // Default is 2 minutes.
+			$"--UseEntryGuards 0", // Default is 1 (yes).
 			$"--CookieAuthentication 1",
 			$"--ControlPort {port}",
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",


### PR DESCRIPTION
This PR was discussed yesterday with @nopara73.

Why this might make sense? The reason is that Tor selects only a few guard nodes (first Tor circuit hops) and it does that because there are attacks that might lead to de-anonymizing the Tor user. The problem with selecting guard nodes in the strict way as Tor does it seems to be that if the guard nodes are overloaded we are having hard time to send requests. 

The balance here is: We should get more performance but we don't know how much privacy we might lose (how feasible is to achieve that Tor attacks). Certainly, this should be considered to be a temporary workaround as we are in a dumpster fire situation.

## Notes

* Ideally, we should measure it in the same way as we did it here: https://github.com/zkSNACKs/WalletWasabi/pull/9035#issuecomment-1266513997
* To avoid having too many experiments, we might consider deciding about #9035's fate first.