### PR TITLE
When load balancing make 2.0.0 select the wrong round so newer versions prioritize the good one

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -100,29 +100,6 @@ public partial class Arena : PeriodicRunner
 						.ThenBy(x => x.InputCount)
 						.ToList();
 
-		var standardRegistrableRounds = rounds
-			.Where(x =>
-				x.Phase == Phase.InputRegistration
-				&& x is not BlameRound
-				&& !x.IsInputRegistrationEnded(Config.MaxInputCountByRound))
-			.ToArray();
-
-		// Let's make sure that newer clients prefer rounds that WW2.0.0 clients don't.
-		// In WW2.0.0 on client side we accidentally order rounds by calling .ToImmutableDictionary(x => x.Id, x => x)
-		// therefore whichever round ToImmutableDictionary would make to be the first round, we send it to the back of our list.
-		// With this we can make sure that WW2.0.0 and newer clients prefer different rounds in parallel round configuration.
-		if (standardRegistrableRounds.Any())
-		{
-			var firstRegistrableRoundAccordingToWW200 = standardRegistrableRounds
-				.ToImmutableDictionary(x => x.Id, x => x)
-				.First()
-				.Value;
-
-			// Remove from whatever WW2.0.0's most preferred round is, then add it back to the end of our list.
-			rounds.Remove(firstRegistrableRoundAccordingToWW200);
-			rounds.Add(firstRegistrableRoundAccordingToWW200);
-		}
-
 		RoundStates = rounds.Select(r => RoundState.FromRound(r, stateId: 0));
 	}
 


### PR DESCRIPTION
Fixes #9062 
Alternate of #9241 but backend side.

This is an hack of an hack of an hack, extremely bad code.
The only change is to call first `TryMine` for `smallRound` then for `bigRound`
The idea is to force 2.0.0 users to prefer the `bigRound` (so not the right one) instead of forcing `smallRound` so that newer clients will de-prioritize this one (due to behavior introduced in #8521) and therefore select the good round first (small inputs round)

All this weird behavior must be changed and probably compatibility with 2.0.0 completely dropped, it makes most of our rounds to fail.

Also, I would still suggest to set  `"WW200CompatibleLoadBalancingInputSplit": 0.925,` in `WabiSabiConfig.json` instead of `0.85`. (to have more clients in the small inputs round)
@nopara73 