### PR TITLE
Revert "Disable Tor's `UseEntryGuards` feature"

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -24,7 +24,6 @@ public class TorSettingsTests
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--SocksTimeout 30",
-			$"--UseEntryGuards 0",
 			$"--CookieAuthentication 1",
 			$"--ControlPort 37151",
 			$"--CookieAuthFile \"{Path.Combine("temp", "tempDataDir", "control_auth_cookie")}\"",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -98,7 +98,6 @@ public class TorSettings
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--SocksTimeout 30", // Default is 2 minutes.
-			$"--UseEntryGuards 0", // Default is 1 (yes).
 			$"--CookieAuthentication 1",
 			$"--ControlPort {port}",
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",


### PR DESCRIPTION
Reverts #9240

See:

* https://github.com/zkSNACKs/WalletWasabi/pull/9240#issuecomment-1268256231
* https://github.com/zkSNACKs/WalletWasabi/pull/9240#issuecomment-1268653693
* https://blog.torproject.org/improving-tors-anonymity-changing-guard-parameters/

btw: https://lists.torproject.org/pipermail/tor-relays/2022-June/020682.html - the number of guards was increased from 1 to 2 via a consensus parameter to help mitigate the DDoS attack by the Tor developers. We don't need to change anything here.