### PR TITLE
Tor: Increase `MaxCircuitDirtiness`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -23,6 +23,7 @@ public class TorSettingsTests
 			" ",
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
+			$"--MaxCircuitDirtiness 1800",
 			$"--SocksTimeout 30",
 			$"--CookieAuthentication 1",
 			$"--ControlPort 37151",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -97,6 +97,7 @@ public class TorSettings
 		{
 			$"--LogTimeGranularity 1",
 			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
+			$"--MaxCircuitDirtiness 1800", // 30 minutes. Default is 10 minutes.
 			$"--SocksTimeout 30", // Default is 2 minutes.
 			$"--CookieAuthentication 1",
 			$"--ControlPort {port}",


### PR DESCRIPTION
Additional question: Is the default value of [MaxClientCircuitsPending](https://github.com/torproject/tor/blob/01b0954b2335b8f1fe672c2d64666937876bb845/doc/man/tor.1.txt#L1309-L1312) (i.e. `32`) sufficient?
