### PR TITLE
[Load Balancer] Avoid selecting existing large round if inputs won't be able to register in it

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -449,7 +449,7 @@ public partial class Arena : PeriodicRunner
 					.FirstOrDefault(x =>
 									x.Phase == Phase.InputRegistration
 									&& x is not BlameRound
-									&& (x.InputCount < 50 || roundDestroyerInputCount * 0.7 <= roundDestroyerInputCount - x.InputCount / (1 - (x.InputRegistrationTimeFrame.Remaining.TotalSeconds / x.InputRegistrationTimeFrame.Duration.TotalSeconds)))
+									&& (x.InputCount < 50 || roundDestroyerInputCount * 0.6 <= roundDestroyerInputCount - x.InputCount / (1 - (x.InputRegistrationTimeFrame.Remaining.TotalSeconds / x.InputRegistrationTimeFrame.Duration.TotalSeconds)))
 									&& x.Parameters.MaxSuggestedAmount >= allInputs.Max()
 									&& x.InputRegistrationTimeFrame.Remaining > TimeSpan.FromSeconds(150));
 				var largeRound = foundLargeRound ?? TryMineRound(parameters, roundWithoutThis.ToArray());

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -449,7 +449,7 @@ public partial class Arena : PeriodicRunner
 					.FirstOrDefault(x =>
 									x.Phase == Phase.InputRegistration
 									&& x is not BlameRound
-									&& roundDestroyerInputCount * 0.7 < x.InputCount / (1 - (x.InputRegistrationTimeFrame.Remaining.TotalSeconds / x.InputRegistrationTimeFrame.Duration.TotalSeconds))
+									&& x.InputCount < 50 || roundDestroyerInputCount * 0.7 <= roundDestroyerInputCount - x.InputCount / (1 - (x.InputRegistrationTimeFrame.Remaining.TotalSeconds / x.InputRegistrationTimeFrame.Duration.TotalSeconds))
 									&& x.Parameters.MaxSuggestedAmount >= allInputs.Max()
 									&& x.InputRegistrationTimeFrame.Remaining > TimeSpan.FromSeconds(150));
 				var largeRound = foundLargeRound ?? TryMineRound(parameters, roundWithoutThis.ToArray());

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -448,7 +448,7 @@ public partial class Arena : PeriodicRunner
 									&& x is not BlameRound
 									&& !x.IsInputRegistrationEnded(Config.MaxInputCountByRound)
 									&& x.Parameters.MaxSuggestedAmount >= allInputs.Max()
-									&& x.InputRegistrationTimeFrame.Remaining > TimeSpan.FromSeconds(60));
+									&& x.InputRegistrationTimeFrame.Remaining > TimeSpan.FromSeconds(150));
 				var largeRound = foundLargeRound ?? TryMineRound(parameters, roundWithoutThis.ToArray());
 
 				if (largeRound is not null)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -442,6 +442,7 @@ public partial class Arena : PeriodicRunner
 
 				var roundWithoutThis = Rounds.Except(new[] { round });
 				RoundParameters parameters = RoundParameterFactory.CreateRoundParameter(feeRate, largeSuggestion);
+
 				// Use an existing large round instead of creating a new one if there is one with enough time remaining
 				// and not already too crowded to support inputs inflow from next to be destroyed round
 				Round? foundLargeRound = roundWithoutThis

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -449,7 +449,7 @@ public partial class Arena : PeriodicRunner
 					.FirstOrDefault(x =>
 									x.Phase == Phase.InputRegistration
 									&& x is not BlameRound
-									&& x.InputCount < 50 || roundDestroyerInputCount * 0.7 <= roundDestroyerInputCount - x.InputCount / (1 - (x.InputRegistrationTimeFrame.Remaining.TotalSeconds / x.InputRegistrationTimeFrame.Duration.TotalSeconds))
+									&& (x.InputCount < 50 || roundDestroyerInputCount * 0.7 <= roundDestroyerInputCount - x.InputCount / (1 - (x.InputRegistrationTimeFrame.Remaining.TotalSeconds / x.InputRegistrationTimeFrame.Duration.TotalSeconds)))
 									&& x.Parameters.MaxSuggestedAmount >= allInputs.Max()
 									&& x.InputRegistrationTimeFrame.Remaining > TimeSpan.FromSeconds(150));
 				var largeRound = foundLargeRound ?? TryMineRound(parameters, roundWithoutThis.ToArray());


### PR DESCRIPTION
This PR solves 2 minor issues with the load balancer behavior to use an existing large round along with a new small round instead of creating both:
1) **Issue:** Sometimes it will select a round with not enough time to register inputs, therefore clients will register only part of their inputs and CJ will be sub-optimal. 

   **PR:** Don't select a large round if Its `InputRegistration` phase will finish in less than 2min30 (instead of 1min) 

   **Notes:**
   - This will be mitigated by implementing #9230 but it will still be an issue
   - Maybe the value should be set at 5min instead like `BlameRounds`

1) **Issue:** Sometimes it will select a round already too crowded so it will make it fail again

   **PR:** Don't select a large round if the number of inputs other Wasabi clients will register to it (estimated using the number of inputs already registered and the time remaining until the end of the `InputRegistration` phase) is already too high so the round is too crowded for the additional inputs load balanced (estimated to be 60% of the max inputs, our load balancing is not perfect and value will regularly be superior at this threshold but we also want to avoid splitting rounds for nothing to keep doing big rounds). If the round currently has less than 50 inputs registered, it can't be known if the round is too crowded so that calculation is not used.

   **Notes:**
   - This is not accounting for new clients that will choose this round, a more complex statistics model could be implemented but this one should be precise enough.
    - The implementation can be simplified by simply using `&& x.InputCount > roundDestroyerInputCount / 2` but with this simplification if `InputCount` is already really high early in the timeframe it will select it even if it's pretty sure it's too crowded