### PR TITLE
Updated docs links

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -183,7 +183,7 @@
                                         </div>
                                         <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.msi" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .msi <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.msi.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#windows" target="_blank">guide</a></span>
+                                            .msi <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.msi.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/Download&Install.html#windows" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -195,7 +195,7 @@
                                         </div>
                                         <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/Download&Install.html#macos" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -207,7 +207,7 @@
                                         </div>
                                         <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4-arm64.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4-arm64.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4-arm64.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/Download&Install.html#macos" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -219,7 +219,7 @@
                                         </div>
                                         <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.deb" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .deb <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.deb.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu" target="_blank">guide</a></span>
+                                            .deb <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.deb.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/Download&Install.html#debian-and-ubuntu" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -231,7 +231,7 @@
                                         </div>
                                         <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.tar.gz" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .tar.gz <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.tar.gz.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#other-linux" target="_blank">guide</a></span>
+                                            .tar.gz <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.1.4/Wasabi-2.0.1.4.tar.gz.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/Download&Install.html#other-linux" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
On the docs the URLs have changed, so we have to update them on the website ASAP because they are running to a 404 page right now.