### PR TITLE
Add option to send whole balance during Send

### DIFF
--- a/WalletWasabi.Fluent/Styles/Button.axaml
+++ b/WalletWasabi.Fluent/Styles/Button.axaml
@@ -7,6 +7,7 @@
         <Button Classes="plain" Content="Plain Button" />
         <Button Classes="function" Content="Function Button" />
         <Button Classes="invisible" Content="Invisible Button" />
+        <Button Classes="plainHyperlink" Content="Quick" />
       </StackPanel>
     </Border>
   </Design.PreviewWith>
@@ -31,7 +32,6 @@
   <Style Selector="Button.action:disabled /template/ ContentPresenter">
     <Setter Property="Background" Value="{DynamicResource ActionButtonDisabledBackgroundColor}" />
   </Style>
-
 
   <Style Selector="Button.plain">
     <Setter Property="VerticalAlignment" Value="Stretch" />
@@ -74,4 +74,22 @@
     <Setter Property="Background" Value="{DynamicResource InvisibleButtonPressedBackgroundColor}" />
   </Style>
 
+  <Style Selector="Button.plainHyperlink">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <Style Selector="Button.plainHyperlink:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="Transparent" />
+  </Style>
+  <Style Selector="Button.plainHyperlink:disabled /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="Transparent" />
+  </Style>
+  <Style Selector="Button.plainHyperlink:pointerover TextBlock">
+    <Setter Property="TextDecorations" Value="Underline" />
+  </Style>
+  <Style Selector="Button.plainHyperlink:pointerover AccessText">
+    <Setter Property="TextDecorations" Value="Underline" />
+  </Style>
 </Styles>

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -26,9 +26,6 @@ using WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles;
 using System.Reactive;
 using System.Collections.ObjectModel;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems;
-using Avalonia.Animation.Animators;
-using WalletWasabi.Exceptions;
-using DynamicData;
 using System.Linq;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -26,6 +26,10 @@ using WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles;
 using System.Reactive;
 using System.Collections.ObjectModel;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems;
+using Avalonia.Animation.Animators;
+using WalletWasabi.Exceptions;
+using DynamicData;
+using System.Linq;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 
@@ -93,6 +97,15 @@ public partial class SendViewModel : RoutableViewModel
 
 		PasteCommand = ReactiveCommand.CreateFromTask(async () => await OnPasteAsync());
 		AutoPasteCommand = ReactiveCommand.CreateFromTask(async () => await OnAutoPasteAsync());
+		InsertMaxCommand = ReactiveCommand.Create(() =>
+		{
+			if (Balance.BalanceBtc is not null)
+			{
+				string[] balanceStringParts = Balance.BalanceBtc.Split(" ");
+				string wholeBalance = string.Join("", balanceStringParts.SkipLast(1));
+				AmountBtc = decimal.Parse(wholeBalance);
+			}
+		});
 		QrCommand = ReactiveCommand.Create(async () =>
 		{
 			ShowQrCameraDialogViewModel dialog = new(_wallet.Network);
@@ -145,6 +158,8 @@ public partial class SendViewModel : RoutableViewModel
 	public ICommand AutoPasteCommand { get; }
 
 	public ICommand QrCommand { get; }
+
+	public ICommand InsertMaxCommand { get; }
 
 	public WalletBalanceTileViewModel Balance { get; }
 

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -22,11 +22,15 @@
         <TextBlock Text="Send" />
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" VerticalAlignment="Center">
           <!-- Balance -->
-          <c:PrivacyContentControl PrivacyReplacementMode="Text" DataContext="{Binding Balance}" DockPanel.Dock="Top" HorizontalAlignment="Center" NumberOfPrivacyChars="0">
+          <c:PrivacyContentControl PrivacyReplacementMode="Text" DockPanel.Dock="Top" HorizontalAlignment="Center" NumberOfPrivacyChars="0">
             <StackPanel Spacing="5" Orientation="Horizontal" VerticalAlignment="Top">
               <TextBlock Opacity="0.6" Classes="h8" Text="Balance: " />
-              <TextBlock Opacity="0.6" Classes="h8" Text="{Binding BalanceBtc}" />
-              <TextBlock Opacity="0.6" Classes="h8" Text="{Binding BalanceFiat}" />
+              <Button Focusable="False" Classes="plainHyperlink h8" Command="{Binding InsertMaxCommand}">
+                <Panel>
+                  <TextBlock Opacity="0.6" Classes="h8" Text="{Binding Balance.BalanceBtc}" />
+                </Panel>
+              </Button>
+              <TextBlock Opacity="0.6" Classes="h8" Text="{Binding Balance.BalanceFiat}" />
             </StackPanel>
           </c:PrivacyContentControl>
         </StackPanel>


### PR DESCRIPTION
Based on [comment](https://github.com/zkSNACKs/WalletWasabi/issues/9285#issuecomment-1274443752).

Clicking on BTC balance on the Send tab will instert the amount to the box.
Small but usefull feature that I've been craving for for a year.

Lowkey stole @SuperJMN's `plainHyperlink` button class, so half the respect for him. 👏 