### PR TITLE
Don't send GetStatus requests when no wallet is CJing

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -19,7 +19,7 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.WabiSabi.Client;
 
-public class CoinJoinManager : BackgroundService
+public class CoinJoinManager : BackgroundService, IHighestCoinJoinClientStateProvider
 {
 	private record CoinJoinCommand(IWallet Wallet);
 	private record StartCoinJoinCommand(IWallet Wallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
@@ -32,6 +32,7 @@ public class CoinJoinManager : BackgroundService
 		HttpClientFactory = backendHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
+		roundStatusUpdater.SetHighestCoinJoinClientStateProvider(this);
 	}
 
 	private IWasabiBackendStatusProvider WasabiBackendStatusProvide { get; }

--- a/WalletWasabi/WabiSabi/Client/IHighestCoinJoinClientStateProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IHighestCoinJoinClientStateProvider.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.WabiSabi.Client;
+
+public interface IHighestCoinJoinClientStateProvider
+{
+	CoinJoinClientState HighestCoinJoinClientState { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -28,8 +28,15 @@ public class RoundStateUpdater : PeriodicRunner
 
 	public bool AnyRound => RoundStates.Any();
 
+	public IHighestCoinJoinClientStateProvider? HighestCoinJoinClientStateProvider { get; private set; }
+
 	protected override async Task ActionAsync(CancellationToken cancellationToken)
 	{
+		if (HighestCoinJoinClientStateProvider?.HighestCoinJoinClientState is CoinJoinClientState.Idle)
+		{
+			return;
+		}
+
 		var request = new RoundStateRequest(
 			RoundStates.Select(x => new RoundStateCheckpoint(x.Key, x.Value.CoinjoinState.Events.Count)).ToImmutableList());
 
@@ -120,5 +127,10 @@ public class RoundStateUpdater : PeriodicRunner
 			}
 		}
 		return base.StopAsync(cancellationToken);
+	}
+
+	public void SetHighestCoinJoinClientStateProvider(IHighestCoinJoinClientStateProvider provider)
+	{
+		HighestCoinJoinClientStateProvider = provider;
 	}
 }


### PR DESCRIPTION
The idea is not to send `GetStatus` requests if no wallet is coinjoining.
Don't spam our server when it's not necessary.

Idea came from @molnard 