### PR TITLE
Don't send GetStatus requests when ClientState is Idle (2nd edition)

### DIFF
--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -297,8 +297,9 @@ public class Global
 	private void RegisterCoinJoinComponents()
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = HttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
-		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Synchronizer, Config.CoordinatorIdentifier), "CoinJoin Manager");
+		CoinJoinClientStateProvider cjStateProvider = new();
+		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient), cjStateProvider), "Round info updater");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), HttpClientFactory, Synchronizer, Config.CoordinatorIdentifier, cjStateProvider), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
@@ -65,7 +65,7 @@ public partial class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 
 		if (cjManager is { })
 		{
-			return cjManager.HighestCoinJoinClientState switch
+			return cjManager.CoinJoinClientStateProvider.HighestCoinJoinState switch
 			{
 				CoinJoinClientState.InCriticalPhase => false,
 				CoinJoinClientState.Idle or CoinJoinClientState.InProgress => true,

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -20,7 +20,6 @@ public class CachedRpcClient : RpcClientBase
 
 	private object CancellationTokenSourceLock { get; } = new object();
 
-	// SizeLimit is not set, so cache size set on the entry will be ignored.
 	public IMemoryCache Cache { get; }
 
 	private CancellationTokenSource TipChangeCancellationTokenSource
@@ -55,7 +54,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(10, 300),
+			CacheOptions(10, 4),
 			() => base.GetBlockAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -65,7 +64,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(10, 300),
+			CacheOptions(10, 4),
 			() => base.GetBlockAsync(blockHeight, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -75,7 +74,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(20, 300),
+			CacheOptions(20, 4),
 			() => base.GetVerboseBlockAsync(blockId, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -85,7 +84,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(2, 300),
+			CacheOptions(2, 4),
 			() => base.GetBlockHeaderAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -135,7 +134,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(1, 60, true),
+			CacheOptions(1, 10, true),
 			() => base.EstimateSmartFeeAsync(confirmationTarget, estimateMode, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -159,14 +158,12 @@ public class CachedRpcClient : RpcClientBase
 			() => base.GetTxOutAsync(txid, index, includeMempool, cancellationToken)).ConfigureAwait(false);
 	}
 
-	// Only used in Regtest mode or in tests.
 	public override async Task<uint256[]> GenerateAsync(int blockCount, CancellationToken cancellationToken = default)
 	{
 		TipChangeCancellationTokenSource.Cancel();
 		return await base.GenerateAsync(blockCount, cancellationToken).ConfigureAwait(false);
 	}
 
-	// Only used in Regtest mode or in tests.
 	public override async Task InvalidateBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 	{
 		TipChangeCancellationTokenSource.Cancel();

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -20,6 +20,7 @@ public class CachedRpcClient : RpcClientBase
 
 	private object CancellationTokenSourceLock { get; } = new object();
 
+	// SizeLimit is not set, so cache size set on the entry will be ignored.
 	public IMemoryCache Cache { get; }
 
 	private CancellationTokenSource TipChangeCancellationTokenSource
@@ -54,7 +55,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(10, 4),
+			CacheOptions(10, 300),
 			() => base.GetBlockAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -64,7 +65,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(10, 4),
+			CacheOptions(10, 300),
 			() => base.GetBlockAsync(blockHeight, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -74,7 +75,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(20, 4),
+			CacheOptions(20, 300),
 			() => base.GetVerboseBlockAsync(blockId, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -84,7 +85,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(2, 4),
+			CacheOptions(2, 300),
 			() => base.GetBlockHeaderAsync(blockHash, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -134,7 +135,7 @@ public class CachedRpcClient : RpcClientBase
 
 		return await Cache.AtomicGetOrCreateAsync(
 			cacheKey,
-			CacheOptions(1, 10, true),
+			CacheOptions(1, 60, true),
 			() => base.EstimateSmartFeeAsync(confirmationTarget, estimateMode, cancellationToken)).ConfigureAwait(false);
 	}
 
@@ -158,12 +159,14 @@ public class CachedRpcClient : RpcClientBase
 			() => base.GetTxOutAsync(txid, index, includeMempool, cancellationToken)).ConfigureAwait(false);
 	}
 
+	// Only used in Regtest mode or in tests.
 	public override async Task<uint256[]> GenerateAsync(int blockCount, CancellationToken cancellationToken = default)
 	{
 		TipChangeCancellationTokenSource.Cancel();
 		return await base.GenerateAsync(blockCount, cancellationToken).ConfigureAwait(false);
 	}
 
+	// Only used in Regtest mode or in tests.
 	public override async Task InvalidateBlockAsync(uint256 blockHash, CancellationToken cancellationToken = default)
 	{
 		TipChangeCancellationTokenSource.Cancel();

--- a/WalletWasabi/Services/SleepInhibitor.cs
+++ b/WalletWasabi/Services/SleepInhibitor.cs
@@ -70,7 +70,7 @@ public class SleepInhibitor : PeriodicRunner
 
 	protected override async Task ActionAsync(CancellationToken cancel)
 	{
-		var highestCoinJoinClientState = CoinJoinManager.HighestCoinJoinClientState;
+		var highestCoinJoinClientState = CoinJoinManager.CoinJoinClientStateProvider.HighestCoinJoinState;
 		switch (highestCoinJoinClientState)
 		{
 			case CoinJoinClientState.Idle:

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClientStateProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClientStateProvider.cs
@@ -1,0 +1,25 @@
+namespace WalletWasabi.WabiSabi.Client;
+
+public class CoinJoinClientStateProvider
+{
+	private CoinJoinClientState _highestCoinJoinState;
+	private object HighestCoinJoinStateLock { get; } = new object();
+
+	public CoinJoinClientState HighestCoinJoinState
+	{
+		get
+		{
+			lock (HighestCoinJoinStateLock)
+			{
+				return _highestCoinJoinState;
+			}
+		}
+		set
+		{
+			lock (HighestCoinJoinStateLock)
+			{
+				_highestCoinJoinState = value;
+			}
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -14,12 +14,14 @@ namespace WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 
 public class RoundStateUpdater : PeriodicRunner
 {
-	public RoundStateUpdater(TimeSpan requestInterval, IWabiSabiApiRequestHandler arenaRequestHandler) : base(requestInterval)
+	public RoundStateUpdater(TimeSpan requestInterval, IWabiSabiApiRequestHandler arenaRequestHandler, CoinJoinClientStateProvider? clientStateProvider = null) : base(requestInterval)
 	{
 		ArenaRequestHandler = arenaRequestHandler;
+		CoinJoinClientStateProvider = clientStateProvider;
 	}
 
 	private IWabiSabiApiRequestHandler ArenaRequestHandler { get; }
+	private CoinJoinClientStateProvider? CoinJoinClientStateProvider { get; }
 	private IDictionary<uint256, RoundState> RoundStates { get; set; } = new Dictionary<uint256, RoundState>();
 	public Dictionary<TimeSpan, FeeRate> CoinJoinFeeRateMedians { get; private set; } = new();
 

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -32,6 +32,11 @@ public class RoundStateUpdater : PeriodicRunner
 
 	protected override async Task ActionAsync(CancellationToken cancellationToken)
 	{
+		if (CoinJoinClientStateProvider is not null && CoinJoinClientStateProvider.HighestCoinJoinState is CoinJoinClientState.Idle)
+		{
+			return;
+		}
+
 		var request = new RoundStateRequest(
 			RoundStates.Select(x => new RoundStateCheckpoint(x.Key, x.Value.CoinjoinState.Events.Count)).ToImmutableList());
 


### PR DESCRIPTION
Alternative version of #9300

The idea is not to send GetStatus requests if no wallet is coinjoining.

Implementation based on Kimi's [comment](https://github.com/zkSNACKs/WalletWasabi/pull/9300?notification_referrer_id=NT_kwDOAq-y5bM0NTgzNDAyMDI1OjQ1MDY5MDI5#issuecomment-1277427778).