### PR TITLE
Use Wallet.AnonScoreTarget instead of KeyManager.AnonScoreTarget

### DIFF
--- a/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
@@ -70,5 +70,5 @@ public static class CoinPocketHelper
 		return pockets;
 	}
 
-	public static IEnumerable<Pocket> GetPockets(this Wallet wallet) => wallet.Coins.GetPockets(wallet.KeyManager.AnonScoreTarget).Select(x => new Pocket(x));
+	public static IEnumerable<Pocket> GetPockets(this Wallet wallet) => wallet.Coins.GetPockets(wallet.AnonScoreTarget).Select(x => new Pocket(x));
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -121,7 +121,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 			return;
 		}
 
-		var info = new TransactionInfo(address.Address, wallet.KeyManager.AnonScoreTarget)
+		var info = new TransactionInfo(address.Address, wallet.AnonScoreTarget)
 		{
 			Coins = selectedSmartCoins,
 			Amount = selectedSmartCoins.Sum(x => x.Amount),

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -25,8 +25,7 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 	{
 		_wallet = walletViewModelBase.Wallet;
 		_autoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
-		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
-							 KeyManager.DefaultPlebStopThreshold.ToString();
+		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ?? KeyManager.DefaultPlebStopThreshold.ToString();
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
@@ -95,7 +94,7 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 		IsCoinjoinProfileSelected = _wallet.KeyManager.IsCoinjoinProfileSelected;
 		SelectedCoinjoinProfileName =
 			(_wallet.KeyManager.IsCoinjoinProfileSelected,
-					CoinJoinProfilesViewModel.IdentifySelectedProfile(_wallet.KeyManager)) switch
+			CoinJoinProfilesViewModel.IdentifySelectedProfile(_wallet.KeyManager)) switch
 			{
 				(true, CoinJoinProfileViewModelBase x) => x.Title,
 				(false, _) => "None",

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinSettingsViewModel.cs
@@ -26,7 +26,7 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 		_wallet = walletViewModelBase.Wallet;
 		_autoCoinJoin = _wallet.KeyManager.AutoCoinJoin;
 		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
-		                     KeyManager.DefaultPlebStopThreshold.ToString();
+							 KeyManager.DefaultPlebStopThreshold.ToString();
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
@@ -59,7 +59,7 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 
 		SelectCoinjoinProfileCommand = ReactiveCommand.CreateFromTask(SelectCoinjoinProfileAsync);
 
-		_anonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
+		_anonScoreTarget = _wallet.AnonScoreTarget;
 
 		this.WhenAnyValue(x => x.AnonScoreTarget)
 			.ObserveOn(RxApp.TaskpoolScheduler)
@@ -90,17 +90,17 @@ public partial class CoinJoinSettingsViewModel : RoutableViewModel
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
 		PlebStopThreshold = _wallet.KeyManager.PlebStopThreshold.ToString();
-		AnonScoreTarget = _wallet.KeyManager.AnonScoreTarget;
+		AnonScoreTarget = _wallet.AnonScoreTarget;
 
 		IsCoinjoinProfileSelected = _wallet.KeyManager.IsCoinjoinProfileSelected;
 		SelectedCoinjoinProfileName =
 			(_wallet.KeyManager.IsCoinjoinProfileSelected,
 					CoinJoinProfilesViewModel.IdentifySelectedProfile(_wallet.KeyManager)) switch
-				{
-					(true, CoinJoinProfileViewModelBase x) => x.Title,
-					(false, _) => "None",
-					_ => "Unknown"
-				};
+			{
+				(true, CoinJoinProfileViewModelBase x) => x.Title,
+				(false, _) => "None",
+				_ => "Unknown"
+			};
 	}
 
 	private async Task SelectCoinjoinProfileAsync()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -55,7 +55,7 @@ public partial class PrivacyControlTileViewModel : TileViewModel, IPrivacyRingPr
 
 	private void Update()
 	{
-		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
+		var privateThreshold = _wallet.AnonScoreTarget;
 
 		var currentPrivacyScore = _wallet.Coins.Sum(x => x.Amount.Satoshi * Math.Min(x.HdPubKey.AnonymitySet - 1, privateThreshold - 1));
 		var maxPrivacyScore = _wallet.Coins.TotalAmount().Satoshi * (privateThreshold - 1);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarItemViewModel.cs
@@ -17,7 +17,7 @@ public class PrivacyBarItemViewModel : ViewModelBase, IDisposable
 	{
 		Coin = new WalletCoinViewModel(coin);
 
-		IsPrivate = coin.IsPrivate(parent.Wallet.KeyManager.AnonScoreTarget);
+		IsPrivate = coin.IsPrivate(parent.Wallet.AnonScoreTarget);
 		IsSemiPrivate = !IsPrivate && coin.IsSemiPrivate();
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 
@@ -29,7 +29,7 @@ public class PrivacyBarItemViewModel : ViewModelBase, IDisposable
 
 	public PrivacyBarItemViewModel(Pocket pocket, Wallet wallet, double start, double width)
 	{
-		IsPrivate = pocket.Coins.All(x => x.IsPrivate(wallet.KeyManager.AnonScoreTarget));
+		IsPrivate = pocket.Coins.All(x => x.IsPrivate(wallet.AnonScoreTarget));
 		IsSemiPrivate = !IsPrivate && pocket.Coins.All(x => x.IsSemiPrivate());
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
@@ -21,7 +21,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 
 		Data = CreateGeometry(start, end, OuterRadius);
 
-		IsPrivate = coin.IsPrivate(parent.Wallet.KeyManager.AnonScoreTarget);
+		IsPrivate = coin.IsPrivate(parent.Wallet.AnonScoreTarget);
 		IsSemiPrivate = !IsPrivate && coin.IsSemiPrivate();
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 		AmountText = $"{Coin.Amount.ToFormattedString()} BTC";
@@ -35,7 +35,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 
 		Data = CreateGeometry(start, end, OuterRadius);
 
-		IsPrivate = pocket.Coins.All(x => x.IsPrivate(parent.Wallet.KeyManager.AnonScoreTarget));
+		IsPrivate = pocket.Coins.All(x => x.IsPrivate(parent.Wallet.AnonScoreTarget));
 		IsSemiPrivate = !IsPrivate && pocket.Coins.All(x => x.IsSemiPrivate());
 		IsNonPrivate = !IsPrivate && !IsSemiPrivate;
 		AmountText = $"{pocket.Amount.ToFormattedString()} BTC";

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -64,7 +64,7 @@ public partial class WalletBalanceTileViewModel : TileViewModel
 
 		BalanceFiat = fiatAmount.GenerateFiatText("USD", fiatFormat).TrimEnd();
 
-		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
+		var privateThreshold = _wallet.AnonScoreTarget;
 		var privateCoins = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold);
 		var normalCoins = _wallet.Coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -45,7 +45,7 @@ public partial class PrivacyControlViewModel : DialogViewModelBase<IEnumerable<S
 
 	private void InitializeLabels()
 	{
-		var privateThreshold = _wallet.KeyManager.AnonScoreTarget;
+		var privateThreshold = _wallet.AnonScoreTarget;
 
 		LabelSelection.Reset(_wallet.Coins.GetPockets(privateThreshold).Select(x => new Pocket(x)).ToArray());
 		LabelSelection.SetUsedLabel(_usedCoins, privateThreshold);

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -89,7 +89,7 @@ public class Wallet : BackgroundService, IWallet
 
 	public Task<bool> IsWalletPrivateAsync() => Task.FromResult(IsWalletPrivate());
 
-	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), KeyManager.AnonScoreTarget) >= 1;
+	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), AnonScoreTarget) >= 1;
 
 	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync(int bestHeight) => Task.FromResult(GetCoinjoinCoinCandidates(bestHeight));
 


### PR DESCRIPTION
`AnonScoreTarget` property was added to the `Wallet` class in #8754 so now it can be used instead of `KeyManager.AnonScoreTarget`.