### PR TITLE
Tor: Implement partial parsing of "getinfo ns/all" responses

### DIFF
--- a/WalletWasabi/Tor/Control/Messages/RouterStatus/RouterNode.cs
+++ b/WalletWasabi/Tor/Control/Messages/RouterStatus/RouterNode.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Messages.CircuitStatus;
+using WalletWasabi.Tor.Control.Utils;
+
+namespace WalletWasabi.Tor.Control.Messages.RouterStatus;
+
+/// <seealso href="https://github.com/torproject/torspec/blob/e5cd03e38e25ddb10f3138ac25ec684890f97f00/dir-spec.txt#L2288-L2465"/>
+public record RouterNode(string Nickname, RouterNodeFlags[] Flags, long? Bandwidth)
+{
+	/// <summary>
+	/// Parses response of <c>getinfo ns/all</c> command.
+	/// </summary>
+	/// <returns>Rounter nodes in the same order as get from the <c>getinfo ns/all</c> command.</returns>
+	/// <exception cref="TorControlException">If the reply is not syntactically valid.</exception>
+	public static List<RouterNode> FromReply(TorControlReply reply)
+	{
+		if (!reply.Success)
+		{
+			throw new TorControlException("Failed to get router status info entries."); // This should never happen.
+		}
+
+		string? nickname = null;
+		RouterNodeFlags[]? flags = null;
+		long? bandwidth = null;
+
+		List<RouterNode> list = new();
+
+		foreach (string line in reply.ResponseLines)
+		{
+			if (line == "ns/all=")
+			{
+				continue;
+			}
+
+			// Either last line or new "r" record.
+			if (nickname is not null && (line == "." || line.StartsWith('r')))
+			{
+				if (flags is null)
+				{
+					throw new TorControlException("Unexpected state."); // This should never happen.
+				}
+
+				list.Add(new RouterNode(nickname, flags, bandwidth));
+
+				// We do not expect to get here without visiting a new "r" line.
+				nickname = null;
+				flags = null;
+				bandwidth = null;
+			}
+
+			// "r" record is present exactly once.
+			if (line.StartsWith('r'))
+			{
+				string[] rValues = line.Split(' ');
+				nickname = rValues[1];
+
+				continue;
+			}
+
+			// "s" record is present exactly once.
+			if (line.StartsWith('s'))
+			{
+				// Format of line is: "s" SP Flags NL
+				string[] sValues = line.Split(' ');
+
+				// Skip the initial "s" value and parse remaining flags.
+				flags = sValues.Skip(1).Select(x => Tokenizer.ParseEnumValue(x, RouterNodeFlags.UNKNOWN)).ToArray();
+			}
+
+			// "w" record is present AT MOST once.
+			if (line.StartsWith('w'))
+			{
+				// Format of line is: "w" SP "Bandwidth=" INT [SP "Measured=" INT] [SP "Unmeasured=1"] NL
+				string[] wValues = line.Split(' ');
+
+				(string key, string value, string _) = Tokenizer.ReadKeyValueAssignment(wValues[1]);
+
+				if (key != "Bandwidth")
+				{
+					throw new TorControlException("Invalid key name."); // This should never happen.
+				}
+
+				if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out long bandwidthValue))
+				{
+					throw new TorControlException("Bandwidth is not a number."); // This should never happen.
+				}
+
+				bandwidth = bandwidthValue;
+			}
+		}
+
+		return list;
+	}
+
+	/// <inheritdoc/>
+	public override string ToString()
+	{
+		string args = string.Join(
+		separator: ", ",
+			$"{nameof(Nickname)}='{Nickname}'",
+			$"{nameof(Flags)}='{string.Join('|', Flags)}'",
+			$"{nameof(Bandwidth)}={(Bandwidth.HasValue ? Bandwidth : "null")}");
+
+		return $"{nameof(RouterNode)}{{{args}}}";
+	}
+}

--- a/WalletWasabi/Tor/Control/Messages/RouterStatus/RouterNodeFlags.cs
+++ b/WalletWasabi/Tor/Control/Messages/RouterStatus/RouterNodeFlags.cs
@@ -1,0 +1,68 @@
+namespace WalletWasabi.Tor.Control.Messages.RouterStatus;
+
+/// <seealso href="https://github.com/torproject/torspec/blob/e5cd03e38e25ddb10f3138ac25ec684890f97f00/dir-spec.txt#L2327-L2365"/>
+public enum RouterNodeFlags
+{
+	/// <summary>If the router is a directory authority.</summary>
+	Authority,
+
+	/// <summary>
+	/// If the router is believed to be useless as an exit node
+	/// (because its ISP censors it, because it is behind a restrictive
+	/// proxy, or for some similar reason).
+	/// </summary>
+	BadExit,
+
+	/// <summary>
+	/// If the router is more useful for building general-purpose exit circuits
+	/// than for relay circuits. The path building algorithm uses this flag; see path-spec.txt.
+	/// </summary>
+	Exit,
+
+	/// <summary>If the router is suitable for high-bandwidth circuits.</summary>
+	Fast,
+
+	/// <summary>If the router is suitable for use as an entry guard.</summary>
+	Guard,
+
+	/// <summary>If the router is considered a v2 hidden service directory.</summary>
+	HSDir,
+
+	/// <summary>
+	/// If the router is considered unsuitable for usage other than as a middle relay.
+	/// Clients do not need to handle this option, since when it is present, the authorities
+	/// will automatically vote against flags that would make the router usable in other positions.
+	/// </summary>
+	MiddleOnly,
+
+	/// <summary>
+	/// If any Ed25519 key in the router's descriptor or microdescriptor does not reflect authority consensus.
+	/// </summary>
+	NoEdConsensus,
+
+	/// <summary>If the router is suitable for long-lived circuits.</summary>
+	Stable,
+
+	/// <summary>If the router should upload a new descriptor because the old one is too old.</summary>
+	StaleDesc,
+
+	/// <summary>
+	/// If the router is currently usable over all its published ORPorts.
+	/// (Authorities ignore IPv6 ORPorts unless configured to check IPv6 reachability.)
+	/// Relays without this flag are omitted from the consensus, and current clients (since 0.2.9.4-alpha)
+	/// assume that every listed relay has this flag.
+	/// </summary>
+	Running,
+
+	/// <summary>
+	/// If the router has been 'validated'. Relays without this flag are omitted
+	/// from the consensus, and current clients assume that every listed relay has this flag.
+	/// </summary>
+	Valid,
+
+	/// <summary>If the router implements the v2 directory protocol or higher.</summary>
+	V2Dir,
+
+	/// <summary>Reserved for unknown values.</summary>
+	UNKNOWN
+}


### PR DESCRIPTION
This PR implements parsing of `getinfo ns/all` (Tor control protocol command) which seems useful to automatically select good Tor exit nodes to route our HTTP requests through. Essentially, this is a quite natural follow-up to #9320 where there are fixed nodes.

By the way, the best exit nodes, given the following rules:

```cs
RouterNode[] bestExitNodes = list.Where(x => x.Flags.Contains(RouterNodeFlags.Exit) && x.Flags.Contains(RouterNodeFlags.Fast) && x.Flags.Contains(RouterNodeFlags.Stable))
	.Where(x => x.Bandwidth is not null)
	.OrderByDescending(x => x.Bandwidth!.Value)
	.ToArray();
```

are:

![image](https://user-images.githubusercontent.com/58662979/196111018-2801065c-4249-40d2-9fe2-a8616a009147.png)

In short, what we can do is that we introduce a loop which would:

1. Query `getinfo ns/all` to get best stable exit nodes with best bandwidth
2. Send command using Tor control protocol to set these exit nodes to be used.
3. Repeat after an hour (whatever suitable interval). Or possibly just do this once WW is started.

We have talked about the impact of various improvement ideas and sending multiple requests at once would have bigger impact (according to Clement's measurements) but selecting good exit nodes seems easier, nicer to Tor network and having non-negligible impact too.