### PR TITLE
[VDG] fix condition in `TryHandleInsufficientBalanceCaseAsync`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -335,7 +335,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				? feeRate
 				: FeeRate.Zero;
 
-		if (differenceOfFeePercentage is > 0 and TransactionFeeHelper.FeePercentageThreshold ||
+		if (differenceOfFeePercentage is > 0 and < TransactionFeeHelper.FeePercentageThreshold ||
 			(differenceOfFeePercentage > 0 && reason == BuildTransactionReason.FeeChanged))
 		{
 			_info.MaximumPossibleFeeRate = maximumPossibleFeeRate;


### PR DESCRIPTION
The condition should be true when the value is between `0` and `Threshold` and not when it is greater than `0` and equal to `Threshold`.