### PR TITLE
Fix MempoolMirror's ArgumentException

### DIFF
--- a/WalletWasabi.Tests/UnitTests/MempoolMirrorTests/MempoolMirrorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/MempoolMirrorTests/MempoolMirrorTests.cs
@@ -1,7 +1,10 @@
+using Moq;
+using NBitcoin;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NBitcoin;
 using WalletWasabi.BitcoinCore.Mempool;
+using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Services;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
@@ -13,6 +16,86 @@ namespace WalletWasabi.Tests.UnitTests.MempoolMirrorTests;
 /// </summary>
 public class MempoolMirrorTests
 {
+	/// <summary>
+	/// Verifies that <see cref="MempoolMirror.GetSpenderTransactions(IEnumerable{OutPoint})"/>
+	/// returns correct distinct transactions from the mirrored mempool.
+	/// </summary>
+	[Fact]
+	public void GetSpenderTransactions()
+	{
+		Mock<IRPCClient> mockRpc = new(MockBehavior.Strict);
+		using MempoolMirror mempoolMirror = new(period: TimeSpan.FromSeconds(2), mockRpc.Object, node: null!);
+
+		// Empty mirrored mempool & no transaction outputs.
+		{
+			IEnumerable<OutPoint> txOuts = Enumerable.Empty<OutPoint>();
+			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(txOuts);
+
+			Assert.Empty(transactions);
+		}
+
+		// Empty mirrored mempool & a single transaction output.
+		{
+			OutPoint[] txOuts = new[] { new OutPoint(uint256.One, 1) };
+			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(txOuts);
+
+			Assert.Empty(transactions);
+		}
+
+		Transaction tx1;
+		OutPoint tx1prevOut1;
+		OutPoint tx1prevOut2;
+		TxOut tx1Out1;
+
+		// Add a single transaction to the mirrored mempool.
+		{
+			tx1 = Network.Main.CreateTransaction();
+			tx1prevOut1 = new(hashIn: new uint256(0x1), nIn: 0);
+			tx1.Inputs.Add(new TxIn(tx1prevOut1));
+
+			tx1prevOut2 = new(hashIn: new uint256(0x2), nIn: 0);
+			tx1.Inputs.Add(new TxIn(tx1prevOut2));
+
+			tx1Out1 = new TxOut(Money.Coins(0.1m), scriptPubKey: Script.Empty);
+			tx1.Outputs.Add(tx1Out1);
+
+			// Add the transaction.
+			Assert.Equal(1, mempoolMirror.AddTransactions(tx1));
+		}
+
+		// Mirrored mempool with tx1 & a non-existent prevOut.
+		{
+			OutPoint madeUpPrevOut = new(hashIn: new uint256(0x77777), nIn: 0);
+			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { madeUpPrevOut });
+
+			Assert.Empty(transactions);
+		}
+
+		// Mirrored mempool with tx1 & existing tx1prevOut1.
+		{
+			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut1 });
+
+			Transaction actualTx = Assert.Single(transactions);
+			Assert.Equal(tx1, actualTx);
+		}
+
+		// Mirrored mempool with tx1 & existing tx1prevOut2.
+		{
+			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut2 });
+
+			Transaction actualTx = Assert.Single(transactions);
+			Assert.Equal(tx1, actualTx);
+		}
+
+		// Mirrored mempool with tx1 & existing tx1prevOut1 and tx1prevOut2.
+		{
+			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut1, tx1prevOut2 });
+
+			Transaction actualTx = Assert.Single(transactions);
+			Assert.Equal(tx1, actualTx);
+		}
+	}
+
 	[Fact]
 	public async Task CanCopyMempoolFromRpcAsync()
 	{

--- a/WalletWasabi.Tests/UnitTests/MempoolMirrorTests/MempoolMirrorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/MempoolMirrorTests/MempoolMirrorTests.cs
@@ -66,14 +66,14 @@ public class MempoolMirrorTests
 		// Mirrored mempool with tx1 & a non-existent prevOut.
 		{
 			OutPoint madeUpPrevOut = new(hashIn: new uint256(0x77777), nIn: 0);
-			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { madeUpPrevOut });
+			IReadOnlySet<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { madeUpPrevOut });
 
 			Assert.Empty(transactions);
 		}
 
 		// Mirrored mempool with tx1 & existing tx1prevOut1.
 		{
-			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut1 });
+			IReadOnlySet<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut1 });
 
 			Transaction actualTx = Assert.Single(transactions);
 			Assert.Equal(tx1, actualTx);
@@ -81,7 +81,7 @@ public class MempoolMirrorTests
 
 		// Mirrored mempool with tx1 & existing tx1prevOut2.
 		{
-			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut2 });
+			IReadOnlySet<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut2 });
 
 			Transaction actualTx = Assert.Single(transactions);
 			Assert.Equal(tx1, actualTx);
@@ -89,7 +89,7 @@ public class MempoolMirrorTests
 
 		// Mirrored mempool with tx1 & existing tx1prevOut1 and tx1prevOut2.
 		{
-			IEnumerable<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut1, tx1prevOut2 });
+			IReadOnlySet<Transaction> transactions = mempoolMirror.GetSpenderTransactions(new[] { tx1prevOut1, tx1prevOut2 });
 
 			Transaction actualTx = Assert.Single(transactions);
 			Assert.Equal(tx1, actualTx);

--- a/WalletWasabi.Tests/UnitTests/MempoolMirrorTests/MempoolMirrorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/MempoolMirrorTests/MempoolMirrorTests.cs
@@ -8,7 +8,10 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.MempoolMirrorTests;
 
-public class MirrorMempoolTests
+/// <summary>
+/// Tests for <see cref="MempoolMirror"/>.
+/// </summary>
+public class MempoolMirrorTests
 {
 	[Fact]
 	public async Task CanCopyMempoolFromRpcAsync()

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -126,7 +126,6 @@ public class MempoolMirror : PeriodicRunner
 			return mempoolTxs.SelectMany(tx => tx.Inputs.Select(i => (tx, i.PrevOut)))
 				.Where(x => txOutsSet.Contains(x.PrevOut))
 				.Select(x => x.tx)
-				.Distinct()
 				.ToHashSet();
 		}
 	}

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -120,12 +120,13 @@ public class MempoolMirror : PeriodicRunner
 	{
 		lock (MempoolLock)
 		{
-			var mempool = Mempool.Values;
-			var txOutSet = txOuts.ToHashSet();
+			var mempoolTxs = Mempool.Values;
+			var txOutsSet = txOuts.ToHashSet();
 
-			return mempool.SelectMany(tx => tx.Inputs.Select(i => (tx, i.PrevOut)))
-				.Where(x => txOutSet.Contains(x.PrevOut))
-				.Select(x => x.tx);
+			return mempoolTxs.SelectMany(tx => tx.Inputs.Select(i => (tx, i.PrevOut)))
+				.Where(x => txOutsSet.Contains(x.PrevOut))
+				.Select(x => x.tx)
+				.Distinct();
 		}
 	}
 

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -116,7 +116,7 @@ public class MempoolMirror : PeriodicRunner
 		return added;
 	}
 
-	public IEnumerable<Transaction> GetSpenderTransactions(IEnumerable<OutPoint> txOuts)
+	public IReadOnlySet<Transaction> GetSpenderTransactions(IEnumerable<OutPoint> txOuts)
 	{
 		lock (MempoolLock)
 		{
@@ -126,7 +126,8 @@ public class MempoolMirror : PeriodicRunner
 			return mempoolTxs.SelectMany(tx => tx.Inputs.Select(i => (tx, i.PrevOut)))
 				.Where(x => txOutsSet.Contains(x.PrevOut))
 				.Select(x => x.tx)
-				.Distinct();
+				.Distinct()
+				.ToHashSet();
 		}
 	}
 

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -21,8 +21,8 @@ public class MempoolMirror : PeriodicRunner
 		Node = node;
 	}
 
-	public IRPCClient Rpc { get; }
-	public P2pNode Node { get; }
+	private IRPCClient Rpc { get; }
+	private P2pNode Node { get; }
 	private Dictionary<uint256, Transaction> Mempool { get; } = new();
 	private object MempoolLock { get; } = new();
 

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -66,7 +66,7 @@ public class MempoolMirror : PeriodicRunner
 		{
 			foreach (var tx in txs.Where(x => !Mempool.ContainsKey(x.GetHash())))
 			{
-				// Evict double spents.
+				// Evict double spends.
 				EvictSpendersNoLock(tx.Inputs.Select(x => x.PrevOut));
 
 				Mempool.Add(tx.GetHash(), tx);

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -57,7 +57,7 @@ public class MempoolMirror : PeriodicRunner
 		AddTransactions(stx.Transaction);
 	}
 
-	private int AddTransactions(params Transaction[] txs) => AddTransactions(txs as IEnumerable<Transaction>);
+	internal int AddTransactions(params Transaction[] txs) => AddTransactions(txs as IEnumerable<Transaction>);
 
 	private int AddTransactions(IEnumerable<Transaction> txs)
 	{

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -127,7 +127,10 @@ public class MempoolMirror : PeriodicRunner
 				{
 					if (mempoolTx.Value.Inputs.Select(x => x.PrevOut).Contains(input))
 					{
-						spenders.Add(mempoolTx.Key, mempoolTx.Value);
+						if (!spenders.TryAdd(mempoolTx.Key, mempoolTx.Value))
+						{
+							Logger.LogInfo("Transaction hash has already been added.");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
@lontivero found this bug

```
Oct 19 12:54:16 WalletWasabi walletwasabi-backend[3342266]:       System.ArgumentException: An item with the same key has already been added. Key: d33ac9c36fe99540b46a02c991aaed16a06a1681b6c1518760979687>
Oct 19 12:54:16 WalletWasabi walletwasabi-backend[3342266]:          at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
Oct 19 12:54:16 WalletWasabi walletwasabi-backend[3342266]:          at WalletWasabi.BitcoinCore.Mempool.MempoolMirror.GetSpenderTransactions(IEnumerable`1 txOuts)
Oct 19 12:54:16 WalletWasabi walletwasabi-backend[3342266]:          at WalletWasabi.Backend.Controllers.BlockchainController.BroadcastAsync(String hex)
```