### PR TITLE
UnexpectedRoundPhaseException shouldn't be a warning

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -287,7 +287,7 @@ public class CoinJoinClient
 	{
 		int eventInvokedAlready = 0;
 
-		UnexpectedRoundPhaseException? lastAbortedNotEnoughAlicesException = null;
+		UnexpectedRoundPhaseException? lastUnexpectedRoundPhaseException = null;
 
 		var remainingInputRegTime = roundState.InputRegistrationEnd - DateTimeOffset.UtcNow;
 
@@ -378,9 +378,9 @@ public class CoinJoinClient
 					Logger.LogDebug(ex);
 				}
 			}
-			catch (UnexpectedRoundPhaseException ex) when (ex.RoundState.EndRoundState is EndRoundState.AbortedNotEnoughAlices)
+			catch (UnexpectedRoundPhaseException ex)
 			{
-				lastAbortedNotEnoughAlicesException = ex;
+				lastUnexpectedRoundPhaseException = ex;
 				Logger.LogTrace(ex);
 			}
 			catch (Exception ex)
@@ -424,10 +424,10 @@ public class CoinJoinClient
 			.Select(r => (r.AliceClient!, r.PersonCircuit!))
 			.ToImmutableArray();
 
-		if (!successfulAlices.Any() && lastAbortedNotEnoughAlicesException is { })
+		if (!successfulAlices.Any() && lastUnexpectedRoundPhaseException is { })
 		{
 			// In this case the coordinator aborted the round - throw only one exception and log outside.
-			throw lastAbortedNotEnoughAlicesException;
+			throw lastUnexpectedRoundPhaseException;
 		}
 
 		return successfulAlices;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -358,9 +358,6 @@ public class CoinJoinClient
 							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
 					}
 				}
-
-				personCircuit?.Dispose();
-				return (null, null);
 			}
 			catch (OperationCanceledException ex)
 			{
@@ -380,23 +377,20 @@ public class CoinJoinClient
 				{
 					Logger.LogDebug(ex);
 				}
-
-				personCircuit?.Dispose();
-				return (null, null);
 			}
 			catch (UnexpectedRoundPhaseException ex) when (ex.RoundState.EndRoundState is EndRoundState.AbortedNotEnoughAlices)
 			{
 				lastAbortedNotEnoughAlicesException = ex;
 				Logger.LogTrace(ex);
-				personCircuit?.Dispose();
-				return (null, null);
 			}
 			catch (Exception ex)
 			{
 				Logger.LogWarning(ex);
-				personCircuit?.Dispose();
-				return (null, null);
 			}
+
+			// In case of any exception.
+			personCircuit?.Dispose();
+			return (null, null);
 		}
 
 		// Gets the list of scheduled dates/time in the remaining available time frame when each alice has to be registered.
@@ -484,7 +478,6 @@ public class CoinJoinClient
 				{
 					Logger.LogDebug("Signature was already sent - bypassing error.", ex);
 				}
-
 			})
 			.ToImmutableArray();
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -305,6 +305,8 @@ public class CoinJoinClient
 		async Task<(AliceClient? AliceClient, PersonCircuit? PersonCircuit)> RegisterInputAsync(SmartCoin coin)
 		{
 			PersonCircuit? personCircuit = null;
+			bool disposeCircuit = true;
+
 			try
 			{
 				personCircuit = HttpClientFactory.NewHttpClientWithPersonCircuit(out Tor.Http.IHttpClient httpClient);
@@ -326,6 +328,8 @@ public class CoinJoinClient
 					CoinJoinClientProgress.SafeInvoke(this, new EnteringCriticalPhase());
 				}
 
+				// Do not dispose the circuit, it will be used later.
+				disposeCircuit = false;
 				return (aliceClient, personCircuit);
 			}
 			catch (WabiSabiProtocolException wpe)
@@ -387,9 +391,15 @@ public class CoinJoinClient
 			{
 				Logger.LogWarning(ex);
 			}
+			finally
+			{
+				if (disposeCircuit)
+				{
+					personCircuit?.Dispose();
+				}
+			}
 
 			// In case of any exception.
-			personCircuit?.Dispose();
 			return (null, null);
 		}
 


### PR DESCRIPTION
During the input and conn-conf phase, UnexpectedRoundPhaseException can happen because of not enough inputs or LoadBalancing. Neither is a warning message. 

The PR will dismiss these messages from the logs

```
2022-10-25 08:14:03.239 [55] WARNING	CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (396)	WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 2bb1275b9d62fbfbdea1815eb786535ef0c5186409e96c6ebb6ff7fec3e80180 unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedLoadBalancing'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass56_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 321
2022-10-25 08:14:03.239 [98] WARNING	CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (396)	WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 2bb1275b9d62fbfbdea1815eb786535ef0c5186409e96c6ebb6ff7fec3e80180 unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedLoadBalancing'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass56_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 321
2022-10-25 08:14:03.239 [26] WARNING	CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (396)	WalletWasabi.WabiSabi.Client.RoundStateAwaiters.UnexpectedRoundPhaseException: Round 2bb1275b9d62fbfbdea1815eb786535ef0c5186409e96c6ebb6ff7fec3e80180 unexpected phase change. Waiting for 'ConnectionConfirmation' but the round is in 'Ended' - ErrorCode:'AbortedLoadBalancing'.
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 165
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken) in WalletWasabi\WabiSabi\Client\AliceClient.cs:line 73
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass56_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext() in WalletWasabi\WabiSabi\Client\CoinJoinClient.cs:line 321
```

 and we will have only one info severity message from here

https://github.com/molnard/WalletWasabi/blob/1e673d9028b438f30de36953c9138ec2aab7ccc7/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs#L415