### PR TITLE
[VDG] Privacy Ring Details Layout

### DIFF
--- a/WalletWasabi.Fluent/Controls/LabelsItemsPresenter.axaml
+++ b/WalletWasabi.Fluent/Controls/LabelsItemsPresenter.axaml
@@ -49,7 +49,7 @@
     </Setter>
     <Setter Property="ItemsPanel">
       <ItemsPanelTemplate>
-        <c:LabelsPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType={x:Type c:LabelsItemsPresenter}}}">
+        <c:LabelsPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
           <c:LabelsPanel.EllipsisControl>
             <Panel Margin="0 0 0 0">
               <Border Classes="label">

--- a/WalletWasabi.Fluent/Controls/LabelsItemsPresenter.axaml
+++ b/WalletWasabi.Fluent/Controls/LabelsItemsPresenter.axaml
@@ -34,6 +34,7 @@
   <Style Selector="c|LabelsItemsPresenter">
     <Setter Property="Margin" Value="0" />
     <Setter Property="VirtualizationMode" Value="Simple" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="ItemTemplate">
       <DataTemplate>
         <Panel Margin="0 0 4 0">
@@ -48,7 +49,7 @@
     </Setter>
     <Setter Property="ItemsPanel">
       <ItemsPanelTemplate>
-        <c:LabelsPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="Left">
+        <c:LabelsPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType={x:Type c:LabelsItemsPresenter}}}">
           <c:LabelsPanel.EllipsisControl>
             <Panel Margin="0 0 0 0">
               <Border Classes="label">
@@ -70,5 +71,4 @@
       </ItemsPanelTemplate>
     </Setter>
   </Style>
-
 </Styles>

--- a/WalletWasabi.Fluent/Converters/StringConverters.cs
+++ b/WalletWasabi.Fluent/Converters/StringConverters.cs
@@ -1,0 +1,9 @@
+using Avalonia.Data.Converters;
+
+namespace WalletWasabi.Fluent.Converters;
+
+public static class StringConverters
+{
+	public static readonly IValueConverter ToUpperCase =
+		new FuncValueConverter<string?, string?>(x => x?.ToUpperInvariant());
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
@@ -50,6 +50,8 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 		AmountText = $"{pocket.Amount.ToFormattedString()} BTC";
 		Unconfirmed = false;
 
+		PrivacyLevelText = GetPrivacyLevelDescription();
+
 		Reference = GetPrivacyLevelDescription();
 		Reference += " coins";
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
@@ -28,6 +28,8 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 		Unconfirmed = !coin.Confirmed;
 		Confirmations = coin.GetConfirmations();
 
+		PrivacyLevelText = GetPrivacyLevelDescription();
+
 		Reference = GetPrivacyLevelDescription();
 		Reference += " coin";
 		if (Unconfirmed)
@@ -62,6 +64,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem, IDisposable
 	public bool IsSemiPrivate { get; }
 	public bool IsNonPrivate { get; }
 	public string AmountText { get; }
+	public string PrivacyLevelText { get; }
 	public bool Unconfirmed { get; }
 	public int Confirmations { get; }
 	public string Reference { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -16,7 +16,7 @@ using WalletWasabi.Wallets;
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 
 [NavigationMetaData(
-	Title = "Wallet Coins",
+	Title = "Privacy Progress",
 	NavigationTarget = NavigationTarget.DialogScreen)]
 public partial class PrivacyRingViewModel : RoutableViewModel
 {

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml
@@ -3,33 +3,49 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:ir="clr-namespace:Avalonia.Xaml.Interactions.Responsive;assembly=Avalonia.Xaml.Interactions"
              xmlns:controls="clr-namespace:WalletWasabi.Fluent.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing.PrivacyRingDetailsView">
+  <UserControl.Styles>
+    <Style Selector="StackPanel.balance">
+      <Setter Property="Orientation" Value="Horizontal" />
+      <Setter Property="Spacing" Value="10" />
+    </Style>
+    <Style Selector="StackPanel.balance.small">
+      <Setter Property="Orientation" Value="Vertical" />
+      <Setter Property="Spacing" Value="5" />
+    </Style>
+  </UserControl.Styles>
   <DockPanel>
     <TextBlock Text="PRIVACY PROGRESS" DockPanel.Dock="Top" Classes="h8 bold" HorizontalAlignment="Center" />
 
     <StackPanel DockPanel.Dock="Bottom" Spacing="8" IsVisible="{Binding HasPrivateBalance}">
+      <i:Interaction.Behaviors>
+        <ir:AdaptiveBehavior>
+          <ir:AdaptiveClassSetter MinWidth="0" MaxWidth="190" MaxWidthOperator="LessThanOrEqual" ClassName="small" TargetControl="{Binding #Balance}" />
+        </ir:AdaptiveBehavior>
+      </i:Interaction.Behaviors>
+
       <Separator />
-      <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+
+      <StackPanel Opacity="0.8" HorizontalAlignment="Center" Classes="balance" x:Name="Balance">
+
         <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
-                BorderBrush="{StaticResource ButtonForeground}">
+                BorderBrush="{StaticResource ButtonForeground}" HorizontalAlignment="Center">
           <TextBlock
             Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
         </Border>
         <controls:PrivacyContentControl Classes="bold" NumberOfPrivacyChars="9"
-                                        VerticalAlignment="Center"
-
+                                        VerticalAlignment="Center" HorizontalAlignment="Center"
                                         Content="{Binding BalancePrivateBtc}" />
       </StackPanel>
     </StackPanel>
 
     <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 3">
-
       <Image Source="{StaticResource privacy_indicator_good}"
              VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 0 10 0"
              Height="36" Width="36" />
-
       <TextBlock
         VerticalAlignment="Center" HorizontalAlignment="Center"
         TextAlignment="Center"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml
@@ -1,0 +1,39 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:controls="clr-namespace:WalletWasabi.Fluent.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing.PrivacyRingDetailsView">
+  <DockPanel>
+    <TextBlock Text="PRIVACY PROGRESS" DockPanel.Dock="Top" Classes="h8 bold" HorizontalAlignment="Center" />
+
+    <StackPanel DockPanel.Dock="Bottom" Spacing="8" IsVisible="{Binding HasPrivateBalance}">
+      <Separator />
+      <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+        <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
+                BorderBrush="{StaticResource ButtonForeground}">
+          <TextBlock
+            Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
+        </Border>
+        <controls:PrivacyContentControl Classes="bold" NumberOfPrivacyChars="9"
+                                        VerticalAlignment="Center"
+
+                                        Content="{Binding BalancePrivateBtc}" />
+      </StackPanel>
+    </StackPanel>
+
+    <StackPanel VerticalAlignment="Center" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 3">
+
+      <Image Source="{StaticResource privacy_indicator_good}"
+             VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 0 10 0"
+             Height="36" Width="36" />
+
+      <TextBlock
+        VerticalAlignment="Center" HorizontalAlignment="Center"
+        TextAlignment="Center"
+        Text="{Binding PercentText}" Classes="h2" />
+    </StackPanel>
+  </DockPanel>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml
@@ -18,8 +18,6 @@
     </Style>
   </UserControl.Styles>
   <DockPanel>
-    <TextBlock Text="PRIVACY PROGRESS" DockPanel.Dock="Top" Classes="h8 bold" HorizontalAlignment="Center" />
-
     <StackPanel DockPanel.Dock="Bottom" Spacing="8" IsVisible="{Binding HasPrivateBalance}">
       <i:Interaction.Behaviors>
         <ir:AdaptiveBehavior>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingDetailsView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing;
+
+public partial class PrivacyRingDetailsView : UserControl
+{
+	public PrivacyRingDetailsView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
@@ -27,7 +27,7 @@
         </ir:AdaptiveBehavior>
       </i:Interaction.Behaviors>
 
-      <Separator />
+      <Separator IsVisible="{Binding !IsNonPrivate}"/>
       <StackPanel Opacity="0.8" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}" Classes="privacyLevel" x:Name="PrivacyLevel">
         <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
                 BorderBrush="{StaticResource ButtonForeground}">

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
@@ -1,0 +1,34 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:c="using:WalletWasabi.Fluent.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing.PrivacyRingItemDetailsView">
+  <DockPanel VerticalAlignment="Center">
+    <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
+    <StackPanel DockPanel.Dock="Bottom" Spacing="8">
+      <Separator />
+      <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+        <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}">
+          <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
+                  BorderBrush="{StaticResource ButtonForeground}">
+            <TextBlock
+              Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
+          </Border>
+        </StackPanel>
+        <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+      </StackPanel>
+    </StackPanel>
+
+    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
+      <Viewbox>
+        <TextBlock
+          VerticalAlignment="Center" HorizontalAlignment="Center"
+          TextAlignment="Center"
+          Text="{Binding AmountText}" Classes="h3" />
+      </Viewbox>
+      <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+    </StackPanel>
+  </DockPanel>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
@@ -18,34 +18,37 @@
       <Setter Property="Spacing" Value="5" />
     </Style>
   </UserControl.Styles>
-  <DockPanel VerticalAlignment="Center">
-    <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
-    <StackPanel DockPanel.Dock="Bottom" Spacing="8">
+  <StackPanel VerticalAlignment="Center">
+    <Viewbox Height="27" VerticalAlignment="Center" HorizontalAlignment="Center">
+      <TextBlock
+        VerticalAlignment="Center" HorizontalAlignment="Center"
+        TextAlignment="Center"
+        Text="{Binding AmountText}" Classes="h3" />
+    </Viewbox>
+
+    <StackPanel Spacing="8">
       <i:Interaction.Behaviors>
         <ir:AdaptiveBehavior>
           <ir:AdaptiveClassSetter MinWidth="0" MaxWidth="190" MaxWidthOperator="LessThanOrEqual" ClassName="small" TargetControl="{Binding #PrivacyLevel}" />
         </ir:AdaptiveBehavior>
       </i:Interaction.Behaviors>
 
-      <Separator IsVisible="{Binding !IsNonPrivate}"/>
-      <StackPanel Opacity="0.8" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}" Classes="privacyLevel" x:Name="PrivacyLevel">
-        <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
-                BorderBrush="{StaticResource ButtonForeground}">
-          <TextBlock
-            Text="{Binding PrivacyLevelText, Converter={x:Static conv:StringConverters.ToUpperCase}}" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
-        </Border>
-        <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+      <StackPanel IsVisible="{Binding !IsNonPrivate}">
+        <Separator Margin="0 3 0 9" />
+        <StackPanel Opacity="0.8" IsVisible="{Binding !IsNonPrivate}" Classes="privacyLevel" x:Name="PrivacyLevel" HorizontalAlignment="Center">
+          <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
+                  BorderBrush="{StaticResource ButtonForeground}">
+            <TextBlock
+              Text="{Binding PrivacyLevelText, Converter={x:Static conv:StringConverters.ToUpperCase}}" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
+          </Border>
+          <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+        </StackPanel>
+      </StackPanel>
+
+      <StackPanel IsVisible="{Binding IsNonPrivate}">
+        <Separator IsVisible="{Binding !Coin.SmartLabel.IsEmpty}" Margin="0 3 0 9" />
+        <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
       </StackPanel>
     </StackPanel>
-
-    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
-      <Viewbox MaxHeight="27">
-        <TextBlock
-          VerticalAlignment="Center" HorizontalAlignment="Center"
-          TextAlignment="Center"
-          Text="{Binding AmountText}" Classes="h3" />
-      </Viewbox>
-      <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
-    </StackPanel>
-  </DockPanel>
+  </StackPanel>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
@@ -4,26 +4,42 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:conv="using:WalletWasabi.Fluent.Converters"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:ir="clr-namespace:Avalonia.Xaml.Interactions.Responsive;assembly=Avalonia.Xaml.Interactions"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing.PrivacyRingItemDetailsView">
+  <UserControl.Styles>
+    <Style Selector="StackPanel.privacyLevel">
+      <Setter Property="Orientation" Value="Horizontal" />
+      <Setter Property="Spacing" Value="10" />
+    </Style>
+    <Style Selector="StackPanel.privacyLevel.small">
+      <Setter Property="Orientation" Value="Vertical" />
+      <Setter Property="Spacing" Value="5" />
+    </Style>
+  </UserControl.Styles>
   <DockPanel VerticalAlignment="Center">
     <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
     <StackPanel DockPanel.Dock="Bottom" Spacing="8">
+      <i:Interaction.Behaviors>
+        <ir:AdaptiveBehavior>
+          <ir:AdaptiveClassSetter MinWidth="0" MaxWidth="190" MaxWidthOperator="LessThanOrEqual" ClassName="small" TargetControl="{Binding #PrivacyLevel}" />
+        </ir:AdaptiveBehavior>
+      </i:Interaction.Behaviors>
+
       <Separator />
-      <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-        <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}">
-          <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
-                  BorderBrush="{StaticResource ButtonForeground}">
-            <TextBlock
-              Text="{Binding PrivacyLevelText, Converter={x:Static conv:StringConverters.ToUpperCase}}" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
-          </Border>
-        </StackPanel>
+      <StackPanel Opacity="0.8" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}" Classes="privacyLevel" x:Name="PrivacyLevel">
+        <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
+                BorderBrush="{StaticResource ButtonForeground}">
+          <TextBlock
+            Text="{Binding PrivacyLevelText, Converter={x:Static conv:StringConverters.ToUpperCase}}" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
+        </Border>
         <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
       </StackPanel>
     </StackPanel>
 
     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
-      <Viewbox>
+      <Viewbox MaxHeight="27">
         <TextBlock
           VerticalAlignment="Center" HorizontalAlignment="Center"
           TextAlignment="Center"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:conv="using:WalletWasabi.Fluent.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing.PrivacyRingItemDetailsView">
   <DockPanel VerticalAlignment="Center">
@@ -14,7 +15,7 @@
           <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
                   BorderBrush="{StaticResource ButtonForeground}">
             <TextBlock
-              Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
+              Text="{Binding PrivacyLevelText, Converter={x:Static conv:StringConverters.ToUpperCase}}" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
           </Border>
         </StackPanel>
         <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing;
+
+public partial class PrivacyRingItemDetailsView : UserControl
+{
+	public PrivacyRingItemDetailsView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -1,8 +1,9 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:ir="clr-namespace:Avalonia.Xaml.Interactions.Responsive;assembly=Avalonia.Xaml.Interactions"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:behaviors="using:WalletWasabi.Fluent.Behaviors"
              xmlns:tiles="using:WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles"
@@ -48,6 +49,14 @@
     <Style Selector="ListBoxItem:selected">
       <Setter Property="Background" Value="Red" />
     </Style>
+
+    <Style Selector="Carousel#Carousel">
+      <Setter Property="Width" Value="230" />
+    </Style>
+
+    <Style Selector="Carousel#Carousel.small">
+      <Setter Property="Width" Value="190" />
+    </Style>
   </UserControl.Styles>
   <c:ContentArea Title="{Binding Title}"
                  EnableNext="True" NextContent="Done"
@@ -89,6 +98,9 @@
           <behaviors:BoundsObserverBehavior Bounds="{Binding #Panel.Bounds, Mode=OneWay}"
                                             Width="{Binding Width, Mode=TwoWay}"
                                             Height="{Binding Height, Mode=TwoWay}" />
+          <ir:AdaptiveBehavior>
+            <ir:AdaptiveClassSetter MinHeight="0" MaxHeight="260" ClassName="small" TargetControl="{Binding #Carousel}" />
+          </ir:AdaptiveBehavior>
         </i:Interaction.Behaviors>
 
         <ListBox Items="{Binding Items}" ClipToBounds="False"
@@ -130,20 +142,21 @@
 
         <Carousel Items="{Binding PreviewItems}" IsVirtualized="False"
                   SelectedItem="{Binding SelectedItem, Mode=OneWay}"
-                  VerticalAlignment="Center" HorizontalAlignment="Center">
+                  VerticalAlignment="Center" HorizontalAlignment="Center"
+                  x:Name="Carousel">
           <Carousel.PageTransition>
             <CrossFade Duration="0.25" />
           </Carousel.PageTransition>
           <Carousel.DataTemplates>
             <DataTemplate DataType="{x:Type tiles:PrivacyControlTileViewModel}">
-              <ringView:PrivacyRingDetailsView IsEnabled="False" Height="90" Width="230">
+              <ringView:PrivacyRingDetailsView IsEnabled="False" VerticalAlignment="Center">
                 <i:Interaction.Behaviors>
                   <behaviors:FadeInBehavior InitialDelay="0:0:1" />
                 </i:Interaction.Behaviors>
               </ringView:PrivacyRingDetailsView>
             </DataTemplate>
             <DataTemplate DataType="{x:Type ring:PrivacyRingItemViewModel}">
-              <DockPanel Width="230" Height="90">
+              <DockPanel VerticalAlignment="Center">
                 <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
                 <StackPanel DockPanel.Dock="Bottom" Spacing="8">
                   <Separator />
@@ -160,11 +173,12 @@
                 </StackPanel>
 
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
-                  <TextBlock
-                    VerticalAlignment="Center" HorizontalAlignment="Center"
-                    TextAlignment="Center"
-                    Text="{Binding AmountText}" Classes="h3" />
-
+                  <Viewbox>
+                    <TextBlock
+                      VerticalAlignment="Center" HorizontalAlignment="Center"
+                      TextAlignment="Center"
+                      Text="{Binding AmountText}" Classes="h3" />
+                  </Viewbox>
                   <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </StackPanel>
               </DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -156,32 +156,7 @@
               </ringView:PrivacyRingDetailsView>
             </DataTemplate>
             <DataTemplate DataType="{x:Type ring:PrivacyRingItemViewModel}">
-              <DockPanel VerticalAlignment="Center">
-                <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
-                <StackPanel DockPanel.Dock="Bottom" Spacing="8">
-                  <Separator />
-                  <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-                    <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}">
-                      <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
-                              BorderBrush="{StaticResource ButtonForeground}">
-                        <TextBlock
-                          Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
-                      </Border>
-                    </StackPanel>
-                    <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                  </StackPanel>
-                </StackPanel>
-
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
-                  <Viewbox>
-                    <TextBlock
-                      VerticalAlignment="Center" HorizontalAlignment="Center"
-                      TextAlignment="Center"
-                      Text="{Binding AmountText}" Classes="h3" />
-                  </Viewbox>
-                  <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                </StackPanel>
-              </DockPanel>
+              <ringView:PrivacyRingItemDetailsView />
             </DataTemplate>
           </Carousel.DataTemplates>
         </Carousel>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -6,8 +6,8 @@
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:behaviors="using:WalletWasabi.Fluent.Behaviors"
              xmlns:tiles="using:WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles"
-             xmlns:tilesView="using:WalletWasabi.Fluent.Views.Wallets.Home.Tiles"
              xmlns:ring="using:WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing"
+             xmlns:ringView="using:WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyRing.PrivacyRingView"
              x:Name="View">
@@ -136,40 +136,38 @@
           </Carousel.PageTransition>
           <Carousel.DataTemplates>
             <DataTemplate DataType="{x:Type tiles:PrivacyControlTileViewModel}">
-              <tilesView:PrivacyControlTileView Width="300" Height="150" IsEnabled="False">
+              <ringView:PrivacyRingDetailsView IsEnabled="False" Height="90" Width="230">
                 <i:Interaction.Behaviors>
                   <behaviors:FadeInBehavior InitialDelay="0:0:1" />
                 </i:Interaction.Behaviors>
-              </tilesView:PrivacyControlTileView>
+              </ringView:PrivacyRingDetailsView>
             </DataTemplate>
             <DataTemplate DataType="{x:Type ring:PrivacyRingItemViewModel}">
-              <c:TileControl TileSize="Medium" Width="300" Height="150">
-                <DockPanel>
-                  <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
-                  <StackPanel DockPanel.Dock="Bottom" Height="25" Spacing="8">
-                    <Separator />
-                    <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-                      <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}">
-                        <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
-                                BorderBrush="{StaticResource ButtonForeground}">
-                          <TextBlock
-                            Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
-                        </Border>
-                      </StackPanel>
-                      <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+              <DockPanel Width="230" Height="90">
+                <c:LabelsItemsPresenter Items="{Binding Coin.SmartLabel}" DockPanel.Dock="Top" HorizontalAlignment="Center" />
+                <StackPanel DockPanel.Dock="Bottom" Spacing="8">
+                  <Separator />
+                  <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                    <StackPanel Opacity="0.8" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center" IsVisible="{Binding !IsNonPrivate}">
+                      <Border VerticalAlignment="Center" BorderThickness="1" CornerRadius="2"
+                              BorderBrush="{StaticResource ButtonForeground}">
+                        <TextBlock
+                          Text="PRIVATE" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Border>
                     </StackPanel>
+                    <TextBlock Text="{Binding Coin.AnonymitySet, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
                   </StackPanel>
+                </StackPanel>
 
-                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
-                    <TextBlock
-                      VerticalAlignment="Center" HorizontalAlignment="Center"
-                      TextAlignment="Center"
-                      Text="{Binding AmountText}" Classes="h3" />
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 3">
+                  <TextBlock
+                    VerticalAlignment="Center" HorizontalAlignment="Center"
+                    TextAlignment="Center"
+                    Text="{Binding AmountText}" Classes="h3" />
 
-                    <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                  </StackPanel>
-                </DockPanel>
-              </c:TileControl>
+                  <TextBlock Text="{Binding Coin.Confirmations, StringFormat='Confirmations: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                </StackPanel>
+              </DockPanel>
             </DataTemplate>
           </Carousel.DataTemplates>
         </Carousel>


### PR DESCRIPTION
 - Fixes bad layout problem in the privacy ring for minimal resolution where the center info is overlapping the ring segments
 - Fixes #9365
 - Closes #9032 

on Master:

![image](https://user-images.githubusercontent.com/98904713/197839056-73376c87-3502-4436-a074-ce4fc3f00619.png)

This PR:

![image](https://user-images.githubusercontent.com/98904713/197838746-ddc683b5-681f-45ff-b831-56380cba64ae.png)
