### PR TITLE
[VDG] Reduce Privacy Ring Preview Delay

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -95,7 +95,7 @@
                  SelectedItem="{Binding SelectedItem}"
                  x:Name="Ring" Margin="{Binding Margin}">
           <i:Interaction.Behaviors>
-            <behaviors:ListBoxPreviewBehavior PreviewItem="{Binding SelectedItem, Mode=TwoWay}" Delay="1000" />
+            <behaviors:ListBoxPreviewBehavior PreviewItem="{Binding SelectedItem, Mode=TwoWay}" Delay="250" />
             <behaviors:ItemsControlAnimationBehavior />
           </i:Interaction.Behaviors>
           <ListBox.Template>


### PR DESCRIPTION
 - Workaround for #9340 
 - Reduces coin details preview delay, making it much harder (but not impossible if you try really hard) to reproduce the bug.
 