### PR TITLE
[VDG] rename pending to unconfirmed

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
@@ -56,7 +56,7 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 	private void Update()
 	{
 		Date = _coinJoin.DateString;
-		Status = _coinJoin.IsConfirmed ? "Confirmed" : "Pending";
+		Status = _coinJoin.IsConfirmed ? "Confirmed" : "Unconfirmed";
 		CoinJoinFee = _coinJoin.OutgoingAmount;
 		CoinJoinFeeString = CoinJoinFee.ToFeeDisplayUnitString() ?? "Unknown";
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinsDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinsDetailsViewModel.cs
@@ -59,7 +59,7 @@ public partial class CoinJoinsDetailsViewModel : RoutableViewModel
 	private void Update()
 	{
 		Date = _coinJoinGroup.DateString;
-		Status = _coinJoinGroup.IsConfirmed ? "Confirmed" : "Pending";
+		Status = _coinJoinGroup.IsConfirmed ? "Confirmed" : "Unconfirmed";
 		CoinJoinFee = _coinJoinGroup.OutgoingAmount;
 		CoinJoinFeeString = CoinJoinFee.ToFeeDisplayUnitString() ?? "Unknown";
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -86,7 +86,7 @@ public partial class WalletBalanceTileViewModel : TileViewModel
 
 			RecentTransactionName = isIncoming ? "Incoming" : "Outgoing";
 			RecentTransactionDate = recent.DateString;
-			RecentTransactionStatus = $"{(isIncoming ? recent.IncomingAmount : recent.OutgoingAmount)} BTC - {(recent.IsConfirmed ? "Confirmed" : "Pending")}";
+			RecentTransactionStatus = $"{(isIncoming ? recent.IncomingAmount : recent.OutgoingAmount)} BTC - {(recent.IsConfirmed ? "Confirmed" : "Unconfirmed")}";
 
 			ShowRecentTransaction = true;
 		}

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/IndicatorsColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/IndicatorsColumnView.axaml
@@ -16,12 +16,12 @@
                 Foreground="{DynamicResource SystemAccentColor}"
                 Height="11"
                 ToolTip.Tip="{Binding ConfirmedToolTip}" />
-      <!-- Pending -->
+      <!-- Unconfirmed -->
       <PathIcon IsVisible="{Binding !Confirmed}"
                 Data="{StaticResource clock_regular}"
                 Height="14"
                 Opacity="0.6"
-                ToolTip.Tip="Pending" />
+                ToolTip.Tip="Unconfirmed" />
     </Panel>
 
     <Panel IsVisible="{Binding !IsBanned}">

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Columns/IndicatorsColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Columns/IndicatorsColumnView.axaml
@@ -25,12 +25,12 @@
                 Height="11"
                 Opacity="0.6"
                 ToolTip.Tip="{Binding ConfirmedToolTip}" />
-      <!-- Pending -->
+      <!-- Unconfirmed -->
       <PathIcon IsVisible="{Binding !IsConfirmed}"
                 Data="{StaticResource clock_regular}"
                 Height="14"
                 Opacity="0.6"
-                ToolTip.Tip="Pending" />
+                ToolTip.Tip="Unconfirmed" />
     </Panel>
 
     <!-- Type -->

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -39,7 +39,7 @@
         <StackPanel Orientation="Horizontal">
           <Panel>
             <TextBlock Text="Confirmed" IsVisible="{Binding IsConfirmed}" />
-            <TextBlock Text="Pending" IsVisible="{Binding !IsConfirmed}" />
+            <TextBlock Text="Unconfirmed" IsVisible="{Binding !IsConfirmed}" />
           </Panel>
           <TextBlock IsVisible="{Binding IsConfirmed}" Margin="4 0 0 0 " Text="{Binding Confirmations, StringFormat='({0} confirmations)'}" />
         </StackPanel>


### PR DESCRIPTION
-unconfirmed is technically the correct verb here
-for consistency in the software (like PrivacyRing already uses unconfirmed)
-_pending_ can cause custodial shivers :)