### PR TITLE
Add cancellation token to Controllers #1

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -4,6 +4,7 @@ using NBitcoin.RPC;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Backend.Models.Responses;
@@ -39,6 +40,7 @@ public class BatchController : ControllerBase
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,
 		[FromQuery, Required] int maxNumberOfFilters,
+		CancellationToken cancellationToken,
 		[FromQuery] string? estimateSmartFeeMode = nameof(EstimateSmartFeeMode.Conservative),
 		[FromQuery] string? indexType = null)
 	{
@@ -86,7 +88,7 @@ public class BatchController : ControllerBase
 		{
 			try
 			{
-				response.AllFeeEstimate = await BlockchainController.GetAllFeeEstimateAsync(mode);
+				response.AllFeeEstimate = await BlockchainController.GetAllFeeEstimateAsync(mode, cancellationToken);
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -40,9 +40,9 @@ public class BatchController : ControllerBase
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,
 		[FromQuery, Required] int maxNumberOfFilters,
-		CancellationToken cancellationToken,
 		[FromQuery] string? estimateSmartFeeMode = nameof(EstimateSmartFeeMode.Conservative),
-		[FromQuery] string? indexType = null)
+		[FromQuery] string? indexType = null,
+		CancellationToken cancellationToken = default)
 	{
 		bool estimateSmartFee = !string.IsNullOrWhiteSpace(estimateSmartFeeMode);
 		EstimateSmartFeeMode mode = EstimateSmartFeeMode.Conservative;

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -96,7 +96,7 @@ public class BatchController : ControllerBase
 			}
 		}
 
-		response.ExchangeRates = await OffchainController.GetExchangeRatesCollectionAsync();
+		response.ExchangeRates = await OffchainController.GetExchangeRatesCollectionAsync(cancellationToken);
 
 		response.UnconfirmedCoinJoins = ChaumianCoinJoinController.GetUnconfirmedCoinJoinCollection();
 

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -93,7 +93,7 @@ public class BlockchainController : ControllerBase
 	[ProducesResponseType(200)]
 	[ProducesResponseType(400)]
 	[ResponseCache(Duration = 3, Location = ResponseCacheLocation.Client)]
-	public async Task<IActionResult> GetMempoolHashesAsync(CancellationToken cancellationToken, [FromQuery] int compactness = 64)
+	public async Task<IActionResult> GetMempoolHashesAsync([FromQuery] int compactness = 64, CancellationToken cancellationToken = default)
 	{
 		if (compactness is < 1 or > 64)
 		{

--- a/WalletWasabi.Backend/Controllers/LegacyController.cs
+++ b/WalletWasabi.Backend/Controllers/LegacyController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace WalletWasabi.Backend.Controllers;
@@ -21,8 +22,8 @@ public class LegacyController : ControllerBase
 
 	[HttpGet("api/v3/btc/Blockchain/all-fees")]
 	[ResponseCache(Duration = 300, Location = ResponseCacheLocation.Client)]
-	public async Task<IActionResult> GetAllFeesV3Async([FromQuery, Required] string estimateSmartFeeMode)
-		=> await BlockchainController.GetAllFeesAsync(estimateSmartFeeMode);
+	public async Task<IActionResult> GetAllFeesV3Async([FromQuery, Required] string estimateSmartFeeMode, CancellationToken cancellationToken)
+		=> await BlockchainController.GetAllFeesAsync(estimateSmartFeeMode, cancellationToken);
 
 	[HttpGet("api/v3/btc/Offchain/exchange-rates")]
 	public async Task<IActionResult> GetExchangeRatesV3Async()

--- a/WalletWasabi.Backend/Controllers/LegacyController.cs
+++ b/WalletWasabi.Backend/Controllers/LegacyController.cs
@@ -26,6 +26,6 @@ public class LegacyController : ControllerBase
 		=> await BlockchainController.GetAllFeesAsync(estimateSmartFeeMode, cancellationToken);
 
 	[HttpGet("api/v3/btc/Offchain/exchange-rates")]
-	public async Task<IActionResult> GetExchangeRatesV3Async()
-		=> await OffchainController.GetExchangeRatesAsync();
+	public async Task<IActionResult> GetExchangeRatesV3Async(CancellationToken cancellationToken)
+		=> await OffchainController.GetExchangeRatesAsync(cancellationToken);
 }

--- a/WalletWasabi.Backend/Controllers/OffchainController.cs
+++ b/WalletWasabi.Backend/Controllers/OffchainController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Helpers;
@@ -34,9 +35,9 @@ public class OffchainController : ControllerBase
 	[HttpGet("exchange-rates")]
 	[ProducesResponseType(200)]
 	[ProducesResponseType(404)]
-	public async Task<IActionResult> GetExchangeRatesAsync()
+	public async Task<IActionResult> GetExchangeRatesAsync(CancellationToken cancellationToken)
 	{
-		IEnumerable<ExchangeRate> exchangeRates = await GetExchangeRatesCollectionAsync();
+		IEnumerable<ExchangeRate> exchangeRates = await GetExchangeRatesCollectionAsync(cancellationToken);
 
 		if (!exchangeRates.Any())
 		{
@@ -46,13 +47,13 @@ public class OffchainController : ControllerBase
 		return Ok(exchangeRates);
 	}
 
-	internal async Task<IEnumerable<ExchangeRate>> GetExchangeRatesCollectionAsync()
+	internal async Task<IEnumerable<ExchangeRate>> GetExchangeRatesCollectionAsync(CancellationToken cancellationToken)
 	{
 		var cacheKey = nameof(GetExchangeRatesCollectionAsync);
 
 		if (!Cache.TryGetValue(cacheKey, out IEnumerable<ExchangeRate> exchangeRates))
 		{
-			exchangeRates = await ExchangeRateProvider.GetExchangeRateAsync();
+			exchangeRates = await ExchangeRateProvider.GetExchangeRateAsync(cancellationToken);
 
 			if (exchangeRates.Any())
 			{

--- a/WalletWasabi.Backend/Controllers/OffchainController.cs
+++ b/WalletWasabi.Backend/Controllers/OffchainController.cs
@@ -53,7 +53,7 @@ public class OffchainController : ControllerBase
 
 		if (!Cache.TryGetValue(cacheKey, out IEnumerable<ExchangeRate> exchangeRates))
 		{
-			exchangeRates = await ExchangeRateProvider.GetExchangeRateAsync(cancellationToken);
+			exchangeRates = await ExchangeRateProvider.GetExchangeRateAsync(cancellationToken).ConfigureAwait(false);
 
 			if (exchangeRates.Any())
 			{

--- a/WalletWasabi.Backend/Controllers/WasabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WasabiController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Legal;
@@ -19,7 +20,7 @@ public class WasabiController : ControllerBase
 	/// <response code="200">Returns the legal documents.</response>
 	[HttpGet("legaldocuments")]
 	[ProducesResponseType(typeof(byte[]), 200)]
-	public async Task<IActionResult> GetLegalDocumentsAsync(string? id)
+	public async Task<IActionResult> GetLegalDocumentsAsync(string? id, CancellationToken cancellationToken)
 	{
 		string filePath;
 
@@ -37,7 +38,7 @@ public class WasabiController : ControllerBase
 				return NotFound();
 		}
 
-		var content = await System.IO.File.ReadAllBytesAsync(filePath);
+		var content = await System.IO.File.ReadAllBytesAsync(filePath, cancellationToken);
 		return File(content, "text/plain");
 	}
 }

--- a/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
@@ -41,7 +41,8 @@ public class ExternalApiTests
 
 	private async Task AssertProviderAsync(IExchangeRateProvider provider)
 	{
-		IEnumerable<ExchangeRate> rates = await provider.GetExchangeRateAsync(CancellationToken.None);
+		using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(3));
+		IEnumerable<ExchangeRate> rates = await provider.GetExchangeRateAsync(timeoutCts.Token);
 
 		var usdRate = Assert.Single(rates, x => x.Ticker == "USD");
 		Assert.NotEqual(0.0m, usdRate.Rate);

--- a/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
@@ -9,6 +9,7 @@ using WalletWasabi.WebClients.Gemini;
 using WalletWasabi.WebClients.ItBit;
 using Xunit;
 using WalletWasabi.Interfaces;
+using System.Threading;
 
 namespace WalletWasabi.Tests.IntegrationTests;
 
@@ -40,7 +41,7 @@ public class ExternalApiTests
 
 	private async Task AssertProviderAsync(IExchangeRateProvider provider)
 	{
-		IEnumerable<ExchangeRate> rates = await provider.GetExchangeRateAsync();
+		IEnumerable<ExchangeRate> rates = await provider.GetExchangeRateAsync(CancellationToken.None);
 
 		var usdRate = Assert.Single(rates, x => x.Ticker == "USD");
 		Assert.NotEqual(0.0m, usdRate.Rate);

--- a/WalletWasabi/Interfaces/IExchangeRateProvider.cs
+++ b/WalletWasabi/Interfaces/IExchangeRateProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 
@@ -6,5 +7,5 @@ namespace WalletWasabi.Interfaces;
 
 public interface IExchangeRateProvider
 {
-	Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync();
+	Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken);
 }

--- a/WalletWasabi/WebClients/Bitstamp/BitstampExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Bitstamp/BitstampExchangeRateProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Interfaces;
@@ -9,13 +10,13 @@ namespace WalletWasabi.WebClients.Bitstamp;
 
 public class BitstampExchangeRateProvider : IExchangeRateProvider
 {
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://www.bitstamp.net")
 		};
-		using var response = await httpClient.GetAsync("/api/v2/ticker/btcusd").ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("/api/v2/ticker/btcusd", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rate = await content.ReadAsJsonAsync<BitstampExchangeRate>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Interfaces;
@@ -9,13 +10,13 @@ namespace WalletWasabi.WebClients.BlockchainInfo;
 
 public class BlockchainInfoExchangeRateProvider : IExchangeRateProvider
 {
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://blockchain.info")
 		};
-		using var response = await httpClient.GetAsync("/ticker").ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("/ticker", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rates = await content.ReadAsJsonAsync<BlockchainInfoExchangeRates>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
@@ -21,9 +21,9 @@ public class BlockchainInfoExchangeRateProvider : IExchangeRateProvider
 		var rates = await content.ReadAsJsonAsync<BlockchainInfoExchangeRates>().ConfigureAwait(false);
 
 		var exchangeRates = new List<ExchangeRate>
-				{
-					new ExchangeRate { Rate = rates.USD.Sell, Ticker = "USD" }
-				};
+		{
+			new ExchangeRate { Rate = rates.USD.Sell, Ticker = "USD" }
+		};
 
 		return exchangeRates;
 	}

--- a/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Interfaces;
@@ -9,13 +10,13 @@ namespace WalletWasabi.WebClients.CoinGecko;
 
 public class CoinGeckoExchangeRateProvider : IExchangeRateProvider
 {
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.coingecko.com")
 		};
-		using var response = await httpClient.GetAsync("/api/v3/coins/markets?vs_currency=usd&ids=bitcoin").ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("/api/v3/coins/markets?vs_currency=usd&ids=bitcoin", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rates = await content.ReadAsJsonAsync<CoinGeckoExchangeRate[]>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
@@ -21,9 +21,9 @@ public class CoinbaseExchangeRateProvider : IExchangeRateProvider
 		var wrapper = await content.ReadAsJsonAsync<DataWrapper>().ConfigureAwait(false);
 
 		var exchangeRates = new List<ExchangeRate>
-				{
-					new ExchangeRate { Rate = wrapper.Data.Rates.USD, Ticker = "USD" }
-				};
+		{
+			new ExchangeRate { Rate = wrapper.Data.Rates.USD, Ticker = "USD" }
+		};
 
 		return exchangeRates;
 	}

--- a/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Interfaces;
@@ -9,13 +10,13 @@ namespace WalletWasabi.WebClients.Coinbase;
 
 public class CoinbaseExchangeRateProvider : IExchangeRateProvider
 {
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.coinbase.com")
 		};
-		using var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC").ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var wrapper = await content.ReadAsJsonAsync<DataWrapper>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -10,6 +10,7 @@ using WalletWasabi.WebClients.CoinGecko;
 using WalletWasabi.WebClients.Gemini;
 using WalletWasabi.WebClients.ItBit;
 using System.Linq;
+using System.Threading;
 
 namespace WalletWasabi.WebClients;
 
@@ -25,13 +26,13 @@ public class ExchangeRateProvider : IExchangeRateProvider
 			new ItBitExchangeRateProvider()
 		};
 
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		foreach (var provider in _exchangeRateProviders)
 		{
 			try
 			{
-				return await provider.GetExchangeRateAsync().ConfigureAwait(false);
+				return await provider.GetExchangeRateAsync(cancellationToken).ConfigureAwait(false);
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -18,13 +18,13 @@ public class ExchangeRateProvider : IExchangeRateProvider
 {
 	private readonly IExchangeRateProvider[] _exchangeRateProviders =
 	{
-			new BlockchainInfoExchangeRateProvider(),
-			new BitstampExchangeRateProvider(),
-			new CoinGeckoExchangeRateProvider(),
-			new CoinbaseExchangeRateProvider(),
-			new GeminiExchangeRateProvider(),
-			new ItBitExchangeRateProvider()
-		};
+		new BlockchainInfoExchangeRateProvider(),
+		new BitstampExchangeRateProvider(),
+		new CoinGeckoExchangeRateProvider(),
+		new CoinbaseExchangeRateProvider(),
+		new GeminiExchangeRateProvider(),
+		new ItBitExchangeRateProvider()
+	};
 
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{

--- a/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Interfaces;
@@ -9,13 +10,13 @@ namespace WalletWasabi.WebClients.Gemini;
 
 public class GeminiExchangeRateProvider : IExchangeRateProvider
 {
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.gemini.com")
 		};
-		using var response = await httpClient.GetAsync("/v1/pubticker/btcusd").ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("/v1/pubticker/btcusd", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var data = await content.ReadAsJsonAsync<GeminiExchangeRateInfo>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
@@ -21,9 +21,9 @@ public class GeminiExchangeRateProvider : IExchangeRateProvider
 		var data = await content.ReadAsJsonAsync<GeminiExchangeRateInfo>().ConfigureAwait(false);
 
 		var exchangeRates = new List<ExchangeRate>
-				{
-					new ExchangeRate { Rate = data.Bid, Ticker = "USD" }
-				};
+		{
+			new ExchangeRate { Rate = data.Bid, Ticker = "USD" }
+		};
 
 		return exchangeRates;
 	}

--- a/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Interfaces;
@@ -9,13 +10,13 @@ namespace WalletWasabi.WebClients.ItBit;
 
 public class ItBitExchangeRateProvider : IExchangeRateProvider
 {
-	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync()
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.itbit.com")
 		};
-		using var response = await httpClient.GetAsync("v1/markets/XBTUSD/ticker").ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("v1/markets/XBTUSD/ticker", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var data = await content.ReadAsJsonAsync<ItBitExchangeRateInfo>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/ItBit/ItBitExchangeRateProvider.cs
@@ -21,9 +21,9 @@ public class ItBitExchangeRateProvider : IExchangeRateProvider
 		var data = await content.ReadAsJsonAsync<ItBitExchangeRateInfo>().ConfigureAwait(false);
 
 		var exchangeRates = new List<ExchangeRate>
-				{
-					new ExchangeRate { Rate = data.Bid, Ticker = "USD" }
-				};
+		{
+			new ExchangeRate { Rate = data.Bid, Ticker = "USD" }
+		};
 
 		return exchangeRates;
 	}


### PR DESCRIPTION
Part of #9351

~~I didn't touch the exchange rate related methods because they don't (yet) support a cancellation token.~~
~~I will do that in a following PR.~~ Done.

I didn't touch `ChaumianController` because those methods modify states, and we don't want to halt that mid-way through IMO.
https://stackoverflow.com/a/58534523


It's easier to review commit by commit IMO.