### PR TITLE
[Test][Don't merge] Try fix CI by increasing timeout

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -68,7 +68,7 @@ public class P2pBasedTests
 			}
 
 			// Wait until the mempool service receives all the sent transactions.
-			IEnumerable<SmartTransaction> mempoolSmartTxs = await eventAwaiter.WaitAsync(TimeSpan.FromMinutes(5));
+			IEnumerable<SmartTransaction> mempoolSmartTxs = await eventAwaiter.WaitAsync(TimeSpan.FromMinutes(10));
 
 			// Check that all the received transaction hashes are in the set of sent transaction hashes.
 			foreach (SmartTransaction tx in mempoolSmartTxs)

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -68,7 +68,7 @@ public class P2pBasedTests
 			}
 
 			// Wait until the mempool service receives all the sent transactions.
-			IEnumerable<SmartTransaction> mempoolSmartTxs = await eventAwaiter.WaitAsync(TimeSpan.FromMinutes(4));
+			IEnumerable<SmartTransaction> mempoolSmartTxs = await eventAwaiter.WaitAsync(TimeSpan.FromMinutes(5));
 
 			// Check that all the received transaction hashes are in the set of sent transaction hashes.
 			foreach (SmartTransaction tx in mempoolSmartTxs)


### PR DESCRIPTION
Just testing, I'm curious about the CI.

`P2pBasedTests.MempoolNotifiesAsync()` fails consistently on Linux 
with `System.OperationCanceledException : Timed out.`.