### PR TITLE
Add SemiPrivateThreshold constant

### DIFF
--- a/WalletWasabi.Fluent/Helpers/CoinHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/CoinHelpers.cs
@@ -1,5 +1,6 @@
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.Helpers;
@@ -13,7 +14,7 @@ public static class CoinHelpers
 
 	public static bool IsSemiPrivate(this SmartCoin coin)
 	{
-		return coin.HdPubKey.AnonymitySet >= 2;
+		return coin.HdPubKey.AnonymitySet >= Constants.SemiPrivateThreshold;
 	}
 
 	public static SmartLabel GetLabels(this SmartCoin coin, int privateThreshold)

--- a/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Models;
+using WalletWasabi.Helpers;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.Helpers;
@@ -18,7 +19,7 @@ public static class CoinPocketHelper
 		List<(SmartLabel SmartLabel, ICoinsView Coins)> pockets = new();
 		var clusters = new Dictionary<SmartLabel, List<SmartCoin>>();
 
-		foreach (SmartCoin coin in allCoins.Where(x => x.HdPubKey.AnonymitySet < 2))
+		foreach (SmartCoin coin in allCoins.Where(x => x.HdPubKey.AnonymitySet < Constants.SemiPrivateThreshold))
 		{
 			var cluster = coin.HdPubKey.Cluster.Labels;
 
@@ -61,7 +62,7 @@ public static class CoinPocketHelper
 			pockets.Add(new(PrivateFundsText, privateCoins));
 		}
 
-		var semiPrivateCoins = new CoinsView(allCoins.Where(x => x.HdPubKey.AnonymitySet >= 2 && x.HdPubKey.AnonymitySet < privateAnonSetThreshold));
+		var semiPrivateCoins = new CoinsView(allCoins.Where(x => x.HdPubKey.AnonymitySet >= Constants.SemiPrivateThreshold && x.HdPubKey.AnonymitySet < privateAnonSetThreshold));
 		if (semiPrivateCoins.Any())
 		{
 			pockets.Add(new(SemiPrivateFundsText, semiPrivateCoins));

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -270,7 +270,7 @@ public class BlockchainAnalyzer
 			// Forget clusters when no unique outputs created in coinjoins,
 			// otherwise in half mixed wallets all the labels quickly gravitate into a single cluster
 			// making pocket selection unusable.
-			if (newCoin.HdPubKey.AnonymitySet < 2)
+			if (newCoin.HdPubKey.AnonymitySet < Constants.SemiPrivateThreshold)
 			{
 				// Set clusters.
 				foreach (var spentCoin in tx.WalletInputs)

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -38,6 +38,8 @@ public static class Constants
 
 	public const decimal MaximumNumberOfBitcoins = 20999999.9769m;
 
+	public const int SemiPrivateThreshold = 2;
+
 	public const int FastestConfirmationTarget = 1;
 	public const int TwentyMinutesConfirmationTarget = 2;
 	public const int OneDayConfirmationTarget = 144;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -602,10 +602,10 @@ public class CoinJoinClient
 			.Where(x => x.HdPubKey.AnonymitySet >= anonScoreTarget)
 			.ToArray();
 		var semiPrivateCoins = filteredCoins
-			.Where(x => x.HdPubKey.AnonymitySet < anonScoreTarget && x.HdPubKey.AnonymitySet >= 2)
+			.Where(x => x.HdPubKey.AnonymitySet < anonScoreTarget && x.HdPubKey.AnonymitySet >= Constants.SemiPrivateThreshold)
 			.ToArray();
 		var redCoins = filteredCoins
-			.Where(x => x.HdPubKey.AnonymitySet < 2)
+			.Where(x => x.HdPubKey.AnonymitySet < Constants.SemiPrivateThreshold)
 			.ToArray();
 
 		if (semiPrivateCoins.Length + redCoins.Length == 0)


### PR DESCRIPTION
Add a constant to avoid making mistakes.

The value of this const (2) was first introduced in #8255 to hide/forget clusters/lables when no unique outputs created in coinjoins.