### PR TITLE
rename and change order WalletView menu items

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
@@ -10,7 +10,7 @@ using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced;
 
-[NavigationMetaData(Title = "Wallet Statistics")]
+[NavigationMetaData(Title = "Wallet Stats")]
 public partial class WalletStatsViewModel : RoutableViewModel
 {
 	private readonly Wallet _wallet;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -144,7 +144,7 @@ public partial class WalletViewModel : WalletViewModelBase
 			Navigate(NavigationTarget.DialogScreen).To(new WalletInfoViewModel(this));
 		});
 
-		WalletStatisticsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletStatsViewModel(this)));
+		WalletStatsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletStatsViewModel(this)));
 
 		WalletSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(Settings));
 
@@ -177,7 +177,7 @@ public partial class WalletViewModel : WalletViewModelBase
 
 	public ICommand WalletSettingsCommand { get; }
 
-	public ICommand WalletStatisticsCommand { get; }
+	public ICommand WalletStatsCommand { get; }
 
 	public ICommand WalletCoinsCommand { get; }
 

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -64,7 +64,7 @@
                       <PathIcon Data="{StaticResource wallet_action_coinjoin}" />
                     </MenuItem.Icon>
                   </MenuItem>
-                  <MenuItem Header="Wallet Statistics" Command="{Binding WalletStatisticsCommand}">
+                  <MenuItem Header="Wallet Stats" Command="{Binding WalletStatsCommand}">
                     <MenuItem.Icon>
                       <PathIcon Data="{StaticResource stats_wallet_regular}" />
                     </MenuItem.Icon>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -49,9 +49,9 @@
             <Button Classes="function">
               <Button.Flyout>
                 <MenuFlyout Placement="Bottom">
-                  <MenuItem Header="Wallet Info" Command="{Binding WalletInfoCommand}">
+                  <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}" IsVisible="{Binding !IsWatchOnly}">
                     <MenuItem.Icon>
-                      <PathIcon Data="{StaticResource info_regular}" />
+                      <PathIcon Data="{StaticResource wallet_action_coinjoin}" />
                     </MenuItem.Icon>
                   </MenuItem>
                   <MenuItem Header="Wallet Settings" Command="{Binding WalletSettingsCommand}">
@@ -59,9 +59,9 @@
                       <PathIcon Data="{StaticResource settings_wallet_regular}" />
                     </MenuItem.Icon>
                   </MenuItem>
-                  <MenuItem Header="Coinjoin Settings" Command="{Binding CoinJoinSettingsCommand}" IsVisible="{Binding !IsWatchOnly}">
+                  <MenuItem Header="Wallet Info" Command="{Binding WalletInfoCommand}">
                     <MenuItem.Icon>
-                      <PathIcon Data="{StaticResource wallet_action_coinjoin}" />
+                      <PathIcon Data="{StaticResource info_regular}" />
                     </MenuItem.Icon>
                   </MenuItem>
                   <MenuItem Header="Wallet Stats" Command="{Binding WalletStatsCommand}">


### PR DESCRIPTION
closes https://github.com/zkSNACKs/WalletWasabi/issues/9441
-rename Wallet Statistics to Wallet Stats
-change order of items

![image](https://user-images.githubusercontent.com/93143998/199527593-f97cec0d-b206-466b-99d5-a4e45a64289a.png)