### PR TITLE
`MempollMirror`: Improve effectiveness of `EvictSpendersNoLock`

### DIFF
--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -83,18 +83,18 @@ public class MempoolMirror : PeriodicRunner
 					if (PrevOutsIndex.TryGetValue(txInput.PrevOut, out Transaction? mempoolTx))
 					{
 						// Remove the old transaction from our mempool snapshot.
-						RemoveTransactionLocked(mempoolTx.GetHash());
+						RemoveTransactionNoLock(mempoolTx.GetHash());
 					}
 				}
 
-				AddTransactionLocked(tx);
+				AddTransactionNoLock(tx);
 				added++;
 			}
 		}
 		return added;
 	}
 
-	private void AddTransactionLocked(Transaction tx)
+	private void AddTransactionNoLock(Transaction tx)
 	{
 		Mempool.Add(tx.GetHash(), tx);
 
@@ -104,7 +104,7 @@ public class MempoolMirror : PeriodicRunner
 		}
 	}
 
-	private void RemoveTransactionLocked(uint256 txHash)
+	private void RemoveTransactionNoLock(uint256 txHash)
 	{
 		if (Mempool.Remove(txHash, out Transaction? transaction))
 		{
@@ -123,12 +123,12 @@ public class MempoolMirror : PeriodicRunner
 		IEnumerable<uint256> missingHashes;
 		lock (MempoolLock)
 		{
-			var mempoolKeys = Mempool.Keys.ToImmutableArray();
+			var mempoolKeys = Mempool.Keys.ToArray();
 			missingHashes = mempoolHashes.Except(mempoolKeys);
 
-			foreach (var txid in mempoolKeys.Except(mempoolHashes).ToHashSet())
+			foreach (var txid in mempoolKeys.Except(mempoolHashes).ToArray())
 			{
-				RemoveTransactionLocked(txid);
+				RemoveTransactionNoLock(txid);
 			}
 		}
 

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -139,14 +139,12 @@ public class MempoolMirror : PeriodicRunner
 
 	public IReadOnlySet<Transaction> GetSpenderTransactions(IEnumerable<OutPoint> txOuts)
 	{
+		HashSet<OutPoint> txOutsSet = txOuts.ToHashSet();
+
 		lock (MempoolLock)
 		{
-			var mempoolTxs = Mempool.Values;
-			var txOutsSet = txOuts.ToHashSet();
-
-			return mempoolTxs.SelectMany(tx => tx.Inputs.Select(i => (tx, i.PrevOut)))
-				.Where(x => txOutsSet.Contains(x.PrevOut))
-				.Select(x => x.tx)
+			return PrevOutsIndex.Where(x => txOutsSet.Contains(x.Key))
+				.Select(x => x.Value)
 				.ToHashSet();
 		}
 	}

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -143,8 +143,8 @@ public class MempoolMirror : PeriodicRunner
 
 		lock (MempoolLock)
 		{
-			return PrevOutsIndex.Where(x => txOutsSet.Contains(x.Key))
-				.Select(x => x.Value)
+			return txOutsSet.Where(prevOut => PrevOutsIndex.ContainsKey(prevOut))
+				.Select(prevOut => PrevOutsIndex[prevOut])
 				.ToHashSet();
 		}
 	}

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -74,7 +74,7 @@ public class MempoolMirror : PeriodicRunner
 		lock (MempoolLock)
 		{
 			// Loop through the newly received transactions expect those that are already present in our mempool snapshot.
-			foreach (Transaction tx in txs.Where(x => !Mempool.ContainsKey(x.GetHash())))
+			foreach (Transaction tx in txs.Where(x => !Mempool.ContainsKey(x.GetHash())).ToArray())
 			{
 				// Evict double spends.
 				foreach (TxIn txInput in tx.Inputs)


### PR DESCRIPTION
Fixes #9446 (hopefully)

https://github.com/zkSNACKs/WalletWasabi/issues/9446#issue-1431471722 proposes to modify `EvictSpendersNoLock` like this:

```cs
var txos = Mempool.Values
	.SelectMany(x => x.Inputs.Select(y => (PrevOut: y.PrevOut, TxId: x.GetHash())))
	.ToDictionary(x => x.PrevOut, x => x.TxId);

foreach (var input in txOuts)
{
	if (txos.TryGetValue(input, out var txid))
	{
		Mempool.Remove(txid);
	}
}
```

but this PR does not implement that idea because I don't see too much value in recomputing prevouts for the mempool transactions *with every received new mempool transaction* because we can do it once and then just update the data. So this PR removes `EvictSpendersNoLock` and adds an index (`PrevOutsIndex`) that allows to detect double spends easily.