### PR TITLE
`IdempotencyRequestCache`: Add test: 2 requests, first one throws an ex…

### DIFF
--- a/WalletWasabi/Cache/IdempotencyRequestCache.cs
+++ b/WalletWasabi/Cache/IdempotencyRequestCache.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.Caching.Memory;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.WabiSabi.Backend.Models;
-using WalletWasabi.WabiSabi.Crypto;
 
 namespace WalletWasabi.Cache;
 


### PR DESCRIPTION
…ception, second one throws the same exception.

Related to #9469

So unfortunately, my idea of the bug was not correct and this test proves it. The test seems useful so I think it's worthy of merging.