### PR TITLE
[PoC] `Logger`: Improve performance and prepare for scoped logger

### DIFF
--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -17,7 +17,7 @@ public class InitConfigStartupTask : IStartupTask
 
 	public async Task ExecuteAsync(CancellationToken cancellationToken)
 	{
-		Logger.InitializeDefaults(Path.Combine(Global.DataDir, "Logs.txt"));
+		Logger.Initialize(Path.Combine(Global.DataDir, "Logs.txt"));
 		Logger.LogSoftwareStarted("Wasabi Backend");
 
 		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;

--- a/WalletWasabi.Backend/InitConfigStartupTask.cs
+++ b/WalletWasabi.Backend/InitConfigStartupTask.cs
@@ -17,7 +17,7 @@ public class InitConfigStartupTask : IStartupTask
 
 	public async Task ExecuteAsync(CancellationToken cancellationToken)
 	{
-		Logger.Initialize(Path.Combine(Global.DataDir, "Logs.txt"));
+		Logger.Initialize(isEnabled: true, filePath: Path.Combine(Global.DataDir, "Logs.txt"));
 		Logger.LogSoftwareStarted("Wasabi Backend");
 
 		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -175,7 +175,7 @@ public class Program
 			}
 		}
 
-		Logger.Initialize(Path.Combine(dataDir, "Logs.txt"), minimumLogLevel);
+		Logger.Initialize(isEnabled: true, Path.Combine(dataDir, "Logs.txt"), minimumLogLevel);
 	}
 
 	private static (UiConfig uiConfig, Config config) LoadOrCreateConfigs(string dataDir)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -159,7 +159,7 @@ public class Program
 	/// <example>Start Wasabi Wallet with <c>./wassabee --LogLevel=trace</c> to set <see cref="LogLevel.Trace"/>.</example>
 	private static void SetupLogger(string dataDir, string[] args)
 	{
-		LogLevel? logLevel = null;
+		LogLevel? minimumLogLevel = null;
 
 		foreach (string arg in args)
 		{
@@ -169,13 +169,13 @@ public class Program
 
 				if (Enum.TryParse(value, ignoreCase: true, out LogLevel parsedLevel))
 				{
-					logLevel = parsedLevel;
+					minimumLogLevel = parsedLevel;
 					break;
 				}
 			}
 		}
 
-		Logger.InitializeDefaults(Path.Combine(dataDir, "Logs.txt"), logLevel);
+		Logger.Initialize(Path.Combine(dataDir, "Logs.txt"), minimumLogLevel);
 	}
 
 	private static (UiConfig uiConfig, Config config) LoadOrCreateConfigs(string dataDir)

--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -12,9 +12,7 @@ public static class Common
 {
 	static Common()
 	{
-		Logger.SetFilePath(Path.Combine(DataDir, "Logs.txt"));
-		Logger.SetMinimumLevel(LogLevel.Info);
-		Logger.SetModes(LogMode.Debug, LogMode.File);
+		Logger.Initialize(filePath: Path.Combine(DataDir, "Logs.txt"), minimumLogLevel: LogLevel.Info, LogMode.Debug, LogMode.File);
 	}
 
 	public static EndPoint TorSocks5Endpoint => new IPEndPoint(IPAddress.Loopback, 37150);

--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -12,7 +12,7 @@ public static class Common
 {
 	static Common()
 	{
-		Logger.Initialize(filePath: Path.Combine(DataDir, "Logs.txt"), minimumLogLevel: LogLevel.Info, LogMode.Debug, LogMode.File);
+		Logger.Initialize(isEnabled: true, filePath: Path.Combine(DataDir, "Logs.txt"), minimumLogLevel: LogLevel.Info, LogMode.Debug, LogMode.File);
 	}
 
 	public static EndPoint TorSocks5Endpoint => new IPEndPoint(IPAddress.Loopback, 37150);

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -77,13 +77,9 @@ public class BackendTests
 		var tx = await rpc.GetRawTransactionAsync(utxo.OutPoint.Hash);
 		using StringContent content = new($"'{tx.ToHex()}'", Encoding.UTF8, "application/json");
 
-		Logger.TurnOff();
-
 		using var response = await BackendApiHttpClient.SendAsync(HttpMethod.Post, "btc/blockchain/broadcast", content);
 		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 		Assert.Equal("Transaction is already in the blockchain.", await response.Content.ReadAsJsonAsync<string>());
-
-		Logger.TurnOn();
 	}
 
 	[Fact]
@@ -93,15 +89,11 @@ public class BackendTests
 
 		using StringContent content = new($"''", Encoding.UTF8, "application/json");
 
-		Logger.TurnOff();
-
 		using var response = await BackendApiHttpClient.SendAsync(HttpMethod.Post, "btc/blockchain/broadcast", content);
 
 		Assert.NotEqual(HttpStatusCode.OK, response.StatusCode);
 		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 		Assert.Contains("The hex field is required.", await response.Content.ReadAsStringAsync());
-
-		Logger.TurnOn();
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -77,8 +77,6 @@ public class BuildTests
 			new DestinationRequest(scp, Money.Satoshis(long.MaxValue)),
 			new DestinationRequest(scp, Money.Satoshis(5))));
 
-		Logger.TurnOff();
-
 		// toSend cannot have a zero element
 		Assert.Throws<ArgumentException>(() => wallet.BuildTransaction("", new PaymentIntent(Array.Empty<DestinationRequest>()), FeeStrategy.SevenDaysConfirmationTargetStrategy));
 
@@ -173,8 +171,6 @@ public class BuildTests
 					new DestinationRequest(scp, MoneyRequest.CreateAllRemaining()),
 					new DestinationRequest(scp, MoneyRequest.CreateAllRemaining())),
 				FeeStrategy.TwentyMinutesConfirmationTargetStrategy));
-
-			Logger.TurnOn();
 
 			operations = new PaymentIntent(scp, Money.Coins(0.5m));
 			btx = wallet.BuildTransaction(password, operations, FeeStrategy.TwentyMinutesConfirmationTargetStrategy);

--- a/WalletWasabi.Tests/RegressionTests/LoggerPerfTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/LoggerPerfTests.cs
@@ -8,10 +8,10 @@ namespace WalletWasabi.Tests.RegressionTests;
 /// <summary>
 /// Stress tests for <see cref="IdempotencyRequestCache"/>.
 /// </summary>
-public class LoggerStressTests
+public class LoggerPerfTests
 {
 	[Fact]
-	public void StressTest()
+	public void NoLoggingPerfTest()
 	{
 		const int IterationCount = 1_000_000;
 
@@ -34,6 +34,26 @@ public class LoggerStressTests
 		sw2.Stop();
 		Debug.WriteLine(sw1.ElapsedMilliseconds);
 		Debug.WriteLine(sw2.ElapsedMilliseconds);
+		Debug.WriteLine("DONE");
+	}
+
+	[Fact]
+	public void FileLoggingPerfTest()
+	{
+		const int IterationCount = 10_000;
+
+		Logger.Initialize(isEnabled: true, "C:\\temp\\stressTest.log", minimumLogLevel: LogLevel.Debug, LogMode.File);
+		Stopwatch sw1 = Stopwatch.StartNew();
+
+		for (int i = 0; i < IterationCount; i++)
+		{
+			Logger.LogDebug(message: "Test message");
+		}
+
+		sw1.Stop();
+
+		// 2s without optimizations.
+		Debug.WriteLine(sw1.ElapsedMilliseconds);
 		Debug.WriteLine("DONE");
 	}
 }

--- a/WalletWasabi.Tests/RegressionTests/LoggerPerfTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/LoggerPerfTests.cs
@@ -50,6 +50,7 @@ public class LoggerPerfTests
 			Logger.LogDebug(message: "Test message");
 		}
 
+		Logger.FlushAndClose();
 		sw1.Stop();
 
 		// 2s without optimizations.

--- a/WalletWasabi.Tests/RegressionTests/LoggerStressTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/LoggerStressTests.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using WalletWasabi.Cache;
+using WalletWasabi.Logging;
+using Xunit;
+
+namespace WalletWasabi.Tests.RegressionTests;
+
+/// <summary>
+/// Stress tests for <see cref="IdempotencyRequestCache"/>.
+/// </summary>
+public class LoggerStressTests
+{
+	[Fact]
+	public void StressTest()
+	{
+		const int IterationCount = 1_000_000;
+
+		Stopwatch sw1 = Stopwatch.StartNew();
+
+		for (int i = 0; i < IterationCount; i++)
+		{
+			Logger.LogTrace(message: $"{new string((char)i, 500)}");
+		}
+
+		sw1.Stop();
+		Stopwatch sw2 = Stopwatch.StartNew();
+
+		for (int i = 0; i < IterationCount; i++)
+		{
+			string message = $"{new string((char)i, 500)}";
+			Logger.LogTrace(message);
+		}
+
+		sw2.Stop();
+		Debug.WriteLine(sw1.ElapsedMilliseconds);
+		Debug.WriteLine(sw2.ElapsedMilliseconds);
+		Debug.WriteLine("DONE");
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -39,9 +39,7 @@ public class KeyManagementTests
 
 		var sameManager = new KeyManager(manager.EncryptedSecret, manager.ChainCode, manager.MasterFingerprint, manager.ExtPubKey, true, null, new BlockchainState(Network.Main));
 		var sameManager2 = new KeyManager(manager.EncryptedSecret, manager.ChainCode, password, Network.Main);
-		Logger.TurnOff();
 		Assert.Throws<SecurityException>(() => new KeyManager(manager.EncryptedSecret, manager.ChainCode, "differentPassword", Network.Main));
-		Logger.TurnOn();
 
 		Assert.Equal(manager.ChainCode, sameManager.ChainCode);
 		Assert.Equal(manager.EncryptedSecret, sameManager.EncryptedSecret);
@@ -106,9 +104,7 @@ public class KeyManagementTests
 		var filePath = Path.Combine(Common.GetWorkDir(), "Wallet.json");
 		DeleteFileAndDirectoryIfExists(filePath);
 
-		Logger.TurnOff();
 		Assert.Throws<FileNotFoundException>(() => KeyManager.FromFile(filePath));
-		Logger.TurnOn();
 
 		var manager = KeyManager.CreateNew(out _, password, Network.Main, filePath);
 		KeyManager.FromFile(filePath);

--- a/WalletWasabi.Tests/UnitTests/Userfacing/PasswordTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/PasswordTests.cs
@@ -25,9 +25,7 @@ public class PasswordTests
 		{
 			var original = pairs.Key;
 			var desired = pairs.Value;
-			Logger.TurnOff();
 			var results = PasswordHelper.GetPossiblePasswords(original);
-			Logger.TurnOn();
 			var foundCorrectPassword = false;
 
 			foreach (var pw in results)
@@ -51,8 +49,6 @@ public class PasswordTests
 
 		// Creating a wallet with buggy password.
 		var keyManager = KeyManager.CreateNew(out _, Guard.Correct(buggy), Network.Main); // Every wallet was created with Guard.Correct before.
-
-		Logger.TurnOff();
 
 		// Password will be trimmed inside.
 		PasswordHelper.GetMasterExtKey(keyManager, original, out _);
@@ -78,8 +74,6 @@ public class PasswordTests
 
 		// This should not throw format exception but pw is not correct.
 		Assert.Throws<SecurityException>(() => PasswordHelper.GetMasterExtKey(keyManager, badPassword!, out _));
-
-		Logger.TurnOn();
 	}
 
 	[Fact]
@@ -97,7 +91,6 @@ public class PasswordTests
 
 		Assert.True(PasswordHelper.IsTrimmable(original, out original));
 
-		Logger.TurnOff();
 		Assert.False(PasswordHelper.TryPassword(keyManager, "falsepassword", out _));
 
 		// This should pass
@@ -108,7 +101,6 @@ public class PasswordTests
 
 		Assert.True(PasswordHelper.TryPassword(keyManager, original!, out var compatiblePassword));
 		Assert.Equal(buggy, compatiblePassword);
-		Logger.TurnOn();
 	}
 
 	[Fact]
@@ -117,10 +109,8 @@ public class PasswordTests
 		string emptyPw = "";
 		string? nullPw = null;
 
-		Logger.TurnOff();
 		var emptyPws = PasswordHelper.GetPossiblePasswords(emptyPw);
 		var nullPws = PasswordHelper.GetPossiblePasswords(nullPw);
-		Logger.TurnOn();
 
 		var emptyPwRes = Assert.Single(emptyPws);
 		var nullPwRes = Assert.Single(nullPws);

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -247,4 +246,7 @@ public static class Logger
 	/// <example>Examples: Data loss scenarios, out of disk space, etc.</example>
 	public static void LogCritical(Exception exception, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
 		=> Implementation.Value.Log(LogLevel.Critical, StandardExceptionMessage, exception, callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
+
+	public static void FlushAndClose()
+		=> Implementation.Value.FlushAndClose();
 }

--- a/WalletWasabi/Logging/LoggerImpl.cs
+++ b/WalletWasabi/Logging/LoggerImpl.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.Logging;
+
+public class LoggerImpl
+{
+	public static string EntrySeparator { get; } = Environment.NewLine;
+
+	public LoggerImpl(bool isEnabled, string filePath, LogLevel minimumLevel, IReadOnlySet<LogMode> modes, long maximumLogFileSize)
+	{
+		IsEnabled = isEnabled;
+		FilePath = filePath;
+		MinimumLevel = minimumLevel;
+		Modes = ImmutableHashSet.Create(modes.ToArray());
+		MaximumLogFileSize = maximumLogFileSize;
+	}
+
+	private object Lock { get; } = new();
+	public bool IsEnabled { get; }
+	public string FilePath { get; init; }
+	public long MaximumLogFileSize { get; }
+	public LogLevel MinimumLevel { get; init; }
+
+	public IImmutableSet<LogMode> Modes { get; init; }
+	private bool IsEnabledOnLevel(LogLevel level)
+		=> IsEnabled && Modes.Count > 0 && level >= MinimumLevel;
+
+	public void Log(LogLevel level, string message, Exception? ex = null, int additionalEntrySeparators = 0, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	{
+		if (!IsEnabledOnLevel(level))
+		{
+			return;
+		}
+
+		LogCore(level, message, ex, additionalEntrySeparators, callerFilePath, callerMemberName, callerLineNumber);
+	}
+
+	public void Log(LogLevel level, DefaultInterpolatedStringHandler builder, Exception? ex = null, int additionalEntrySeparators = 0, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	{
+		if (!IsEnabledOnLevel(level))
+		{
+			return;
+		}
+
+		LogCore(level, builder.ToStringAndClear(), ex, additionalEntrySeparators, callerFilePath, callerMemberName, callerLineNumber);
+	}
+
+	private void LogCore(LogLevel level, string message, Exception? exception = null, int additionalEntrySeparators = 0, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)
+	{
+		try
+		{
+			string category = string.IsNullOrWhiteSpace(callerFilePath)
+				? ""
+				: $"{EnvironmentHelpers.ExtractFileName(callerFilePath)}.{callerMemberName} ({callerLineNumber})";
+
+			var messageBuilder = new StringBuilder();
+			messageBuilder.Append($"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId}] {level.ToString().ToUpperInvariant()}\t");
+
+			if (message.Length == 0)
+			{
+				if (category.Length == 0) // If both empty. It probably never happens though.
+				{
+					messageBuilder.Append(EntrySeparator);
+				}
+				else // If only the message is empty.
+				{
+					messageBuilder.Append($"{category}{EntrySeparator}");
+				}
+			}
+			else
+			{
+				if (category.Length == 0) // If only the category is empty.
+				{
+					if (exception is not null)
+					{
+						messageBuilder.Append($"{message} Exception: {exception}{EntrySeparator}");
+					}
+					else
+					{
+						messageBuilder.Append($"{message}{EntrySeparator}");
+					}
+				}
+				else // If none of them empty.
+				{
+					messageBuilder.Append($"{category}\t{message}{EntrySeparator}");
+				}
+			}
+
+			var finalMessage = messageBuilder.ToString();
+
+			for (int i = 0; i < additionalEntrySeparators; i++)
+			{
+				messageBuilder.Insert(0, EntrySeparator);
+			}
+
+			var finalFileMessage = messageBuilder.ToString();
+
+			lock (Lock)
+			{
+				if (Modes.Contains(LogMode.Console))
+				{
+					lock (Console.Out)
+					{
+						var color = Console.ForegroundColor;
+						switch (level)
+						{
+							case LogLevel.Warning:
+								color = ConsoleColor.Yellow;
+								break;
+
+							case LogLevel.Error:
+							case LogLevel.Critical:
+								color = ConsoleColor.Red;
+								break;
+
+							default:
+								break; // Keep original color.
+						}
+
+						Console.ForegroundColor = color;
+						Console.Write(finalMessage);
+						Console.ResetColor();
+					}
+				}
+
+				if (Modes.Contains(LogMode.Debug))
+				{
+					Debug.Write(finalMessage);
+				}
+
+				if (!Modes.Contains(LogMode.File))
+				{
+					return;
+				}
+
+				IoHelpers.EnsureContainingDirectoryExists(FilePath);
+
+				if (MaximumLogFileSize > 0)
+				{
+					if (File.Exists(FilePath))
+					{
+						var sizeInBytes = new FileInfo(FilePath).Length;
+						if (sizeInBytes > 1000 * MaximumLogFileSize)
+						{
+							File.Delete(FilePath);
+						}
+					}
+				}
+
+				File.AppendAllText(FilePath, finalFileMessage);
+			}
+		}
+		catch
+		{
+			// Ignore.
+		}
+	}
+}

--- a/WalletWasabi/Services/Terminate/TerminateService.cs
+++ b/WalletWasabi/Services/Terminate/TerminateService.cs
@@ -132,5 +132,6 @@ public class TerminateService
 		Interlocked.Exchange(ref _terminateStatus, TerminateStatusFinished);
 
 		Logger.LogSoftwareStopped("Wasabi");
+		Logger.FlushAndClose();
 	}
 }


### PR DESCRIPTION
`Logger` is a class that we use for logging but it has some properties that are not nice:

1. We use `File.AppendAllText` to [write](https://github.com/zkSNACKs/WalletWasabi/blob/f619e14040da1ccc427a53c944824d3ece98f110/WalletWasabi/Logging/Logger.cs#L234) each new log line in a file. This is inefficient.
    * This seems innoncent but in my measurements it took 2 seconds to log 1000 messages. I have an SSD disk, people with older disks may see even worse throughput. We don't log typically many messages but then when I debug Tor, I turn on `LogLevel.Trace` and then there are many messages and the logging is much slower than it needs to be.
    * Mobile devices are constrained and storage might be slower than on a computer.
    * SSD disk suffers. AFAIK, SSD disks have a limited number of writes. By forcing the disk to store each and every line and forcing disk to write that change immediately, we decrease lifetimes of disks.
2. We materialize strings (allocate) that we end up *not logging*.
    * For example, we [keep creating](https://github.com/zkSNACKs/WalletWasabi/blob/f619e14040da1ccc427a53c944824d3ece98f110/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs#L213) strings like `$"Created {Enum.GetName(IndexType)} filter for block: {nextHeight}."` in Release mode, even if `Debug` log level is *not* enabled.
    * That's why alternative logging libraries use patterns like `Logger.LogLevel("Created {0} filter for block {1}.", 
Enum.GetName(IndexType), nextHeight)` (it's not perfect but at least the message string is not allocated).
    * .NET provides a very nice feature to avoid creating (interpolated) strings if they are not necessary: https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/interpolated-string-handler (my tests indicates that logging is then 2x faster for not-end-up-being-written-anywhere log commands).
3. [not addressed] Logging creates unneeded contention between unrelated parts of code.
    * If you put a log line in two separate places and both log lines are about to be executed they are processed in serial fashion because there is a lock here: https://github.com/zkSNACKs/WalletWasabi/blob/f619e14040da1ccc427a53c944824d3ece98f110/WalletWasabi/Logging/Logger.cs#L182-L235. So even if we parallelize some parts of code, we might lose a lot of performance on waiting for all the disk writes.
    * I have an idea how to fix this.
4. [not addressed] We end up writing [wrapper classes](https://github.com/zkSNACKs/WalletWasabi/blob/f619e14040da1ccc427a53c944824d3ece98f110/WalletWasabi/WabiSabi/LoggerTools.cs) because `Logger` does not support scopes. I think the boilerplate code should be removed and we should do it properly. It should be less code and it might be easier to work with.

This PR is by design very brave. Hence it's a PoC.

edit: Having ASP.NET logger would be the option. I think.