### PR TITLE
Add `catch IOException` to UpdateManager

### DIFF
--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -56,6 +56,11 @@ public class UpdateManager : IDisposable
 					Logger.LogTrace($"Getting new update was canceled.", ex);
 					break;
 				}
+				catch (IOException ex)
+				{
+					Logger.LogError("Getting new update from the web ended unintentionally.", ex);
+					break;
+				}
 				catch (Exception ex)
 				{
 					Logger.LogError($"Getting new update failed with error.", ex);


### PR DESCRIPTION
Closes #9419 

Addressing [comment](https://github.com/zkSNACKs/WalletWasabi/issues/9419#issuecomment-1310011627):
> Look. This needs not to be reproduced. Read the code and find where there's no cancellation token. Then add one.

I can add no more cancellation token, there is a token in every function where it's possible.

Reading the exception:
``` lua
2022-10-28 11:52:27.652 [29] ERROR      UpdateManager.UpdateChecker_UpdateStatusChangedAsync (61)       Geting new update failed with error. Exception: System.IO.IOException: The response ended prematurely.
   at System.Net.Http.HttpConnection.FillAsync(Boolean async) -- There is no CancellationToken in this method.--
   at System.Net.Http.HttpConnection.CopyToContentLengthAsync(Stream destination, Boolean async, UInt64 length, Int32 bufferSize, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnection.ContentLengthReadStream.CompleteCopyToAsync(Task copyTask, CancellationToken cancellationToken)
   at WalletWasabi.Services.UpdateManager.GetInstallerAsync(Version targetVersion) in WalletWasabi\Services\UpdateManager.cs:line 96
   at WalletWasabi.Services.UpdateManager.UpdateChecker_UpdateStatusChangedAsync(Object sender, UpdateStatus updateStatus) in WalletWasabi\Services\UpdateManager.cs:line 47
```
there is no CancellationToken in `System.Net.Http.HttpConnection.FillAsync(Boolean async)`. It's possible that it throws an `IOException` instead of `OperationCancelled`.

As I'm not a microsoft developer, I can't put CTS in this method, so best to do is catch it.