### PR TITLE
[PoC] Lower reorg protection

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -656,8 +656,8 @@ public class KeyManager
 	private void ToFileNoLock(string filePath)
 	{
 		IoHelpers.EnsureContainingDirectoryExists(filePath);
-		// Remove the last 100 blocks to ensure verification on the next run. This is needed of reorg.
-		int maturity = 101;
+		// Remove the last 12 blocks to ensure verification on the next run. This is needed of reorg.
+		int maturity = 13;
 		Height prevHeight = BlockchainState.Height;
 		int matureHeight = Math.Max(0, prevHeight.Value - maturity);
 

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -61,7 +61,7 @@ public class IndexStore : IAsyncDisposable
 
 	private FilterModel StartingFilter { get; }
 	private uint StartingHeight => StartingFilter.Header.Height;
-	private List<FilterModel> ImmatureFilters { get; } = new(150);
+	private List<FilterModel> ImmatureFilters { get; } = new(18);
 
 	public async Task InitializeAsync(CancellationToken cancel = default)
 	{
@@ -255,8 +255,8 @@ public class IndexStore : IAsyncDisposable
 			if (File.Exists(oldIndexFilePath))
 			{
 				string[] allLines = await File.ReadAllLinesAsync(oldIndexFilePath).ConfigureAwait(false);
-				var matureLines = allLines.SkipLast(100);
-				var immatureLines = allLines.TakeLast(100);
+				var matureLines = allLines.SkipLast(12);
+				var immatureLines = allLines.TakeLast(12);
 
 				await MatureIndexFileManager.WriteAllLinesAsync(matureLines).ConfigureAwait(false);
 				await ImmatureIndexFileManager.WriteAllLinesAsync(immatureLines).ConfigureAwait(false);


### PR DESCRIPTION
This PR was made to discuss the concept of setting reorg protection to N blocks (in the PR set as 12) instead of 100.
Last time a reorg >12 blocks happened was in 2013, and currently on WW people lose some time having to match and download last 100 blocks all the time, especially if they re-open the software right after closing it which feels weird.

### Notes
- Binance uses a standard protection of 2 conf for BTC. Reorgs >1 block almost never happen nowadays.
- In case of a big event like [these](https://bitcoin.stackexchange.com/a/92981), or more basically to solve [synchronization issues](https://github.com/zkSNACKs/WalletWasabi/discussions/9420#discussioncomment-4016224), we should consider making an UI to perform a [partial resync](https://github.com/zkSNACKs/WalletWasabi/issues/9485#issuecomment-1304576321). @yahiheb (and others) what do you think of this UI concept?
- On `TestNet` reorgs are bigger so we might need something special in that case.