### PR TITLE
[RPC] [TRIVIAL] listunspentcoins anonscore, not anonymityset

### DIFF
--- a/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Fluent/Rpc/WasabiJsonRpcService.cs
@@ -42,7 +42,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			txid = x.TransactionId.ToString(),
 			index = x.Index,
 			amount = x.Amount.Satoshi,
-			anonymitySet = x.HdPubKey.AnonymitySet,
+			anonscore = x.HdPubKey.AnonymitySet,
 			confirmed = x.Confirmed,
 			confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
 			label = x.HdPubKey.Label.ToString(),


### PR DESCRIPTION
anonymityset is an old concept, anonscore is 2.0 compatible.
This updates the table header of the RPC command.