### PR TITLE
Auto-add discussions to project board

### DIFF
--- a/.github/workflows/auto-add-to-projcet.yml
+++ b/.github/workflows/auto-add-to-projcet.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types:
       - opened
+  discussion:
+    types:
+      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
This is not tested, similar to https://github.com/zkSNACKs/WalletWasabi/pull/9497/, but for discussions.