### PR TITLE
Add file verifying to UpdateManager

### DIFF
--- a/WalletWasabi/Helpers/WasabiSignerHelpers.cs
+++ b/WalletWasabi/Helpers/WasabiSignerHelpers.cs
@@ -67,16 +67,9 @@ public class WasabiSignerHelpers
 	/// <exception cref="FileNotFoundException"></exception>
 	public static async Task<byte[]> GetShaComputedBytesOfFileAsync(string filePath, CancellationToken cancellationToken = default)
 	{
-		if (File.Exists(filePath))
-		{
-			byte[] bytes = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
-			using SHA256 sha = SHA256.Create();
-			byte[] computedHash = sha.ComputeHash(bytes);
-			return computedHash;
-		}
-		else
-		{
-			throw new FileNotFoundException($"Couldn't find file at {filePath}");
-		}
+		byte[] bytes = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
+		using SHA256 sha = SHA256.Create();
+		byte[] computedHash = sha.ComputeHash(bytes);
+		return computedHash;
 	}
 }

--- a/WalletWasabi/Helpers/WasabiSignerHelpers.cs
+++ b/WalletWasabi/Helpers/WasabiSignerHelpers.cs
@@ -3,6 +3,7 @@ using NBitcoin;
 using System.Threading.Tasks;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
 
 namespace WalletWasabi.Helpers;
 
@@ -10,9 +11,7 @@ public class WasabiSignerHelpers
 {
 	public static async Task SignSha256SumsFileAsync(string sha256SumsAscFilePath, Key wasabiPrivateKey)
 	{
-		var bytes = await File.ReadAllBytesAsync(sha256SumsAscFilePath).ConfigureAwait(false);
-		using SHA256 sha = SHA256.Create();
-		byte[] computedHash = sha.ComputeHash(bytes);
+		var computedHash = await GetShaComputedBytesOfFileAsync(sha256SumsAscFilePath).ConfigureAwait(false);
 
 		ECDSASignature signature = wasabiPrivateKey.Sign(new uint256(computedHash));
 
@@ -25,9 +24,7 @@ public class WasabiSignerHelpers
 	public static async Task VerifySha256SumsFileAsync(string sha256SumsAscFilePath)
 	{
 		// Read the content file
-		var bytes = await File.ReadAllBytesAsync(sha256SumsAscFilePath).ConfigureAwait(false);
-		using SHA256 sha = SHA256.Create();
-		byte[] hash = sha.ComputeHash(bytes);
+		byte[] hash = await GetShaComputedBytesOfFileAsync(sha256SumsAscFilePath).ConfigureAwait(false);
 
 		// Read the signature file
 		var wasabiSignatureFilePath = Path.ChangeExtension(sha256SumsAscFilePath, "wasabisig");
@@ -62,5 +59,25 @@ public class WasabiSignerHelpers
 		string keyFileContent = await File.ReadAllTextAsync(wasabiPrivateKeyFilePath).ConfigureAwait(false);
 		BitcoinSecret secret = new(keyFileContent, Network.Main);
 		return secret.PrivateKey;
+	}
+
+	/// <summary>
+	/// This function returns a SHA256 computed byte array of a file on the provided file path.
+	/// Used to generate uint256 hashes.
+	/// </summary>
+	/// <exception cref="FileNotFoundException"></exception>
+	public static async Task<byte[]> GetShaComputedBytesOfFileAsync(string filePath, CancellationToken cancellationToken = default)
+	{
+		if (File.Exists(filePath))
+		{
+			byte[] bytes = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
+			using SHA256 sha = SHA256.Create();
+			byte[] computedHash = sha.ComputeHash(bytes);
+			return computedHash;
+		}
+		else
+		{
+			throw new FileNotFoundException($"Couldn't find file at {filePath}");
+		}
 	}
 }

--- a/WalletWasabi/Helpers/WasabiSignerHelpers.cs
+++ b/WalletWasabi/Helpers/WasabiSignerHelpers.cs
@@ -63,7 +63,6 @@ public class WasabiSignerHelpers
 
 	/// <summary>
 	/// This function returns a SHA256 computed byte array of a file on the provided file path.
-	/// Used to generate uint256 hashes.
 	/// </summary>
 	/// <exception cref="FileNotFoundException"></exception>
 	public static async Task<byte[]> GetShaComputedBytesOfFileAsync(string filePath, CancellationToken cancellationToken = default)

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -1,4 +1,3 @@
-using NBitcoin;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -38,6 +38,7 @@ public class UpdateManager : IDisposable
 
 		if (!updateAvailable)
 		{
+			// After updating Wasabi, remove old installer file.
 			Cleanup();
 			return;
 		}

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -106,7 +106,7 @@ public class UpdateManager : IDisposable
 				Logger.LogInfo("Installer downloaded, copying...");
 
 				await CopyStreamContentToFileAsync(stream, filePath).ConfigureAwait(false);
-				VerifyInstallerHashAsync(installerFileName, filePath, newVersion);
+				await VerifyInstallerHashAsync(installerFileName, filePath, newVersion).ConfigureAwait(false);
 			}
 			catch (IOException)
 			{
@@ -118,7 +118,7 @@ public class UpdateManager : IDisposable
 		return (filePath, newVersion);
 	}
 
-	private async void VerifyInstallerHashAsync(string expectedFileName, string installerFilePath, Version version)
+	private async Task VerifyInstallerHashAsync(string expectedFileName, string installerFilePath, Version version)
 	{
 		var bytes = await WasabiSignerHelpers.GetShaComputedBytesOfFileAsync(installerFilePath, CancellationToken).ConfigureAwait(false);
 		string downloadedHash = Convert.ToHexString(bytes).ToLower();

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -225,7 +225,7 @@ public class UpdateManager : IDisposable
 			string message = "";
 			if (exc.StatusCode is HttpStatusCode.NotFound)
 			{
-				message = "Wasabi signature files was not found under the API.";
+				message = "Wasabi signature files were not found under the API.";
 			}
 			else
 			{

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -87,7 +87,7 @@ public class UpdateManager : IDisposable
 		var sha256SumsFilePath = Path.Combine(InstallerDir, "SHA256SUMS.asc");
 
 		// This will throw InvalidOperationException in case of invalid signature.
-		await DownloadAndValidateWasabiSignatureAsync(sha256SumsFilePath, result.WasabiSigUrl, result.Sha256SumsUrl).ConfigureAwait(false);
+		await DownloadAndValidateWasabiSignatureAsync(sha256SumsFilePath, result.Sha256SumsUrl, result.WasabiSigUrl).ConfigureAwait(false);
 
 		var installerFilePath = Path.Combine(InstallerDir, result.InstallerFileName);
 

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -206,14 +206,16 @@ public class UpdateManager : IDisposable
 
 		try
 		{
-			var stream = await httpClient.GetStreamAsync(sha256SumsUrl, CancellationToken).ConfigureAwait(false);
-			await CopyStreamContentToFileAsync(stream, sha256SumsFilePath).ConfigureAwait(false);
-			stream.Close();
-			Sha256SumsFilePath = sha256SumsFilePath;
+			using (var stream = await httpClient.GetStreamAsync(sha256SumsUrl, CancellationToken).ConfigureAwait(false))
+			{
+				await CopyStreamContentToFileAsync(stream, sha256SumsFilePath).ConfigureAwait(false);
+				Sha256SumsFilePath = sha256SumsFilePath;
+			}
 
-			stream = await httpClient.GetStreamAsync(wasabiSigUrl, CancellationToken).ConfigureAwait(false);
-			await CopyStreamContentToFileAsync(stream, wasabiSigFilePath).ConfigureAwait(false);
-			stream.Dispose();
+			using (var stream = await httpClient.GetStreamAsync(wasabiSigUrl, CancellationToken).ConfigureAwait(false))
+			{
+				await CopyStreamContentToFileAsync(stream, wasabiSigFilePath).ConfigureAwait(false);
+			}
 
 			await WasabiSignerHelpers.VerifySha256SumsFileAsync(sha256SumsFilePath).ConfigureAwait(false);
 			return true;
@@ -227,7 +229,7 @@ public class UpdateManager : IDisposable
 			}
 			else
 			{
-				message = "Something went wrong while geting Wasabi signature files.";
+				message = "Something went wrong while getting Wasabi signature files.";
 			}
 			throw new InvalidOperationException(message, exc);
 		}

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -125,7 +125,7 @@ public class UpdateManager : IDisposable
 		string expectedHash = await GetHashFromSha256SumsFileAsync(expectedFileName, version).ConfigureAwait(false);
 		if (expectedHash != downloadedHash)
 		{
-			throw new InvalidOperationException("Downloaded file hash doesn't match expected hash. Deleting invalid files.");
+			throw new InvalidOperationException("Downloaded file hash doesn't match expected hash.");
 		}
 	}
 
@@ -180,7 +180,7 @@ public class UpdateManager : IDisposable
 		bool isReleaseValid = await ValidateWasabiSignatureAsync(softwareVersion).ConfigureAwait(false);
 		if (!isReleaseValid)
 		{
-			throw new InvalidOperationException($"Downloading new release was cancelled, Wasabi signature was invalid.");
+			throw new InvalidOperationException($"Downloading new release was aborted, Wasabi signature was invalid.");
 		}
 		// Get all asset names and download urls to find the correct one.
 		List<JToken> assetsInfos = jsonResponse["assets"]?.Children().ToList() ?? throw new InvalidDataException("Missing assets from response.");
@@ -235,6 +235,7 @@ public class UpdateManager : IDisposable
 		}
 		catch (IOException)
 		{
+			// There's a chance to get IOException when closing Wasabi during stream copying. Throw OperationCancelledException instead.
 			CancellationToken.ThrowIfCancellationRequested();
 			throw;
 		}


### PR DESCRIPTION
Instead of #9259 

This PR adds different file verifying methods to the UpdateManager with the help of WasabiSignerHelpers, introduced in #9515 .

Once, upon a new release, it verifies the provided `SHA256SUMS.asc` file, with the _(also provided)_ `SHA256SUMS.wasabisig`.
Then, after the correct installer is downloaded, it verifies the hash of the downloaded file with the expected hash to be found in  `SHA256SUMS.asc`.