### PR TITLE
[VDG] Add support for double-click to show details

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/ExecuteCommandOnDoubleTapped.cs
+++ b/WalletWasabi.Fluent/Behaviors/ExecuteCommandOnDoubleTapped.cs
@@ -20,21 +20,18 @@ public class ExecuteCommandOnDoubleTapped : DisposingBehavior<Control>
 
 	protected override void OnAttached(CompositeDisposable disposables)
 	{
-		if (AssociatedObject is { })
-		{
-			Gestures.DoubleTappedEvent.AddClassHandler<InputElement>(
-					(x, _) =>
+		Gestures.DoubleTappedEvent.AddClassHandler<InputElement>(
+				(x, _) =>
+				{
+					if (Equals(x, AssociatedObject))
 					{
-						if (Equals(x, AssociatedObject))
+						if (Command is { } cmd && cmd.CanExecute(default))
 						{
-							if (Command is { } cmd && cmd.CanExecute(default))
-							{
-								cmd.Execute(default);
-							}
+							cmd.Execute(default);
 						}
-					},
-					RoutingStrategies.Tunnel | RoutingStrategies.Bubble)
-				.DisposeWith(disposables);
-		}
+					}
+				},
+				RoutingStrategies.Tunnel | RoutingStrategies.Bubble)
+			.DisposeWith(disposables);
 	}
 }

--- a/WalletWasabi.Fluent/Behaviors/ExecuteCommandOnDoubleTapped.cs
+++ b/WalletWasabi.Fluent/Behaviors/ExecuteCommandOnDoubleTapped.cs
@@ -1,0 +1,40 @@
+﻿using System.Reactive.Disposables;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace WalletWasabi.Fluent.Behaviors;
+
+public class ExecuteCommandOnDoubleTapped : DisposingBehavior<Control>
+{
+	public static readonly StyledProperty<ICommand?> CommandProperty =
+		AvaloniaProperty.Register<ExecuteCommandOnDoubleTapped, ICommand?>(nameof(Command));
+
+	public ICommand? Command
+	{
+		get => GetValue(CommandProperty);
+		set => SetValue(CommandProperty, value);
+	}
+
+	protected override void OnAttached(CompositeDisposable disposables)
+	{
+		if (AssociatedObject is { })
+		{
+			Gestures.DoubleTappedEvent.AddClassHandler<InputElement>(
+					(x, _) =>
+					{
+						if (Equals(x, AssociatedObject))
+						{
+							if (Command is { } cmd && cmd.CanExecute(default))
+							{
+								cmd.Execute(default);
+							}
+						}
+					},
+					RoutingStrategies.Tunnel | RoutingStrategies.Bubble)
+				.DisposeWith(disposables);
+		}
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinViewModel.cs
@@ -3,6 +3,7 @@ using ReactiveUI;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Helpers;
@@ -27,6 +28,8 @@ public partial class WalletCoinViewModel : ViewModelBase, IDisposable
 		Coin = coin;
 		Amount = Coin.Amount;
 
+		ToggleSelectCommand = ReactiveCommand.Create(() => IsSelected = !IsSelected);
+
 		Coin.WhenAnyValue(c => c.Confirmed).Subscribe(x => Confirmed = x).DisposeWith(_disposables);
 		Coin.WhenAnyValue(c => c.HdPubKey.Cluster.Labels).Subscribe(x => SmartLabel = x).DisposeWith(_disposables);
 		Coin.WhenAnyValue(c => c.HdPubKey.AnonymitySet).Subscribe(x => AnonymitySet = (int)x).DisposeWith(_disposables);
@@ -35,6 +38,8 @@ public partial class WalletCoinViewModel : ViewModelBase, IDisposable
 		Coin.WhenAnyValue(c => c.BannedUntilUtc).WhereNotNull().Subscribe(x => BannedUntilUtcToolTip = $"Can't participate in coinjoin until: {x:g}").DisposeWith(_disposables);
 		Coin.WhenAnyValue(c => c.Height).Select(_ => Coin.GetConfirmations()).Subscribe(x => ConfirmedToolTip = $"{x} confirmation{TextHelpers.AddSIfPlural(x)}").DisposeWith(_disposables);
 	}
+
+	public ICommand ToggleSelectCommand { get; }
 
 	public SmartCoin Coin { get; }
 

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/WalletCoinsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/WalletCoinsView.axaml
@@ -2,7 +2,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:behaviors="clr-namespace:WalletWasabi.Fluent.Behaviors"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:walletcoins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Advanced.WalletCoins"
              x:DataType="walletcoins:WalletCoinsViewModel"
@@ -22,6 +24,28 @@
         <Style Selector="TreeDataGridRow">
           <Setter Property="Focusable" Value="False" />
           <Setter Property="Height" Value="47.5" />
+          <Setter Property="Template">
+            <ControlTemplate>
+              <DockPanel LastChildFill="True"
+                         Background="Transparent"
+                         x:CompileBindings="True" x:DataType="walletcoins:WalletCoinViewModel">
+                <i:Interaction.Behaviors>
+                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ToggleSelectCommand, Mode=OneWay}"/>
+                </i:Interaction.Behaviors>
+                <Border Name="PART_SelectionIndicator"
+                        BorderThickness="2 0 0 0"
+                        DockPanel.Dock="Left"
+                        VerticalAlignment="Stretch" />
+                <Panel>
+                  <Rectangle Name="BackgroundRectangle" />
+                  <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
+                                              ElementFactory="{TemplateBinding ElementFactory}"
+                                              Items="{TemplateBinding Columns}"
+                                              Rows="{TemplateBinding Rows}" />
+                </Panel>
+              </DockPanel>
+            </ControlTemplate>
+          </Setter>
         </Style>
       </TreeDataGrid.Styles>
     </TreeDataGrid>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
@@ -148,14 +148,18 @@
           <Setter Property="Height" Value="37.5" />
           <Setter Property="Template">
             <ControlTemplate>
-              <DockPanel LastChildFill="True">
+              <DockPanel LastChildFill="True"
+                         Background="Transparent"
+                         x:CompileBindings="True" x:DataType="historyItems:HistoryItemViewModelBase">
+                <i:Interaction.Behaviors>
+                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand, Mode=OneWay}"/>
+                </i:Interaction.Behaviors>
                 <Border Name="PART_SelectionIndicator"
                         BorderThickness="2 0 0 0"
                         DockPanel.Dock="Left"
                         VerticalAlignment="Stretch" />
                 <Panel>
                   <Rectangle Name="BackgroundRectangle"
-                             x:CompileBindings="False"
                              Classes.selectAnimation="{Binding IsFlashing}" />
                   <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
                                               ElementFactory="{TemplateBinding ElementFactory}"
@@ -241,7 +245,8 @@
             <i:BehaviorCollectionTemplate>
               <i:BehaviorCollection>
                 <behaviors:HistoryItemTypeClassBehavior />
-                <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand}"/>
+                <!-- TODO: The Command binding doesn't work in Avalonia 0.10.x -->
+                <!-- <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand, Mode=OneWay}"/> -->
               </i:BehaviorCollection>
             </i:BehaviorCollectionTemplate>
           </Setter>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
@@ -111,9 +111,6 @@
             <i:BehaviorCollectionTemplate>
               <i:BehaviorCollection>
                 <behaviors:PendingHistoryItemSeparatorBehavior />
-                <iac:RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.DoubleTappedEvent}" >
-                  <ia:InvokeCommandAction Command="{Binding ShowDetailsCommand}" x:DataType="historyItems:HistoryItemViewModelBase"/>
-                </iac:RoutedEventTriggerBehavior>
               </i:BehaviorCollection>
             </i:BehaviorCollectionTemplate>
           </Setter>
@@ -246,6 +243,9 @@
             <i:BehaviorCollectionTemplate>
               <i:BehaviorCollection>
                 <behaviors:HistoryItemTypeClassBehavior />
+                <iac:RoutedEventTriggerBehavior RoutingStrategies="Bubble, Tunnel" RoutedEvent="{x:Static InputElement.DoubleTappedEvent}" >
+                  <ia:InvokeCommandAction Command="{Binding ShowDetailsCommand}" x:DataType="historyItems:HistoryItemViewModelBase"/>
+                </iac:RoutedEventTriggerBehavior>
               </i:BehaviorCollection>
             </i:BehaviorCollectionTemplate>
           </Setter>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
@@ -3,8 +3,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
-             xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
-             xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:history="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.History"
              xmlns:historyItems="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems"
@@ -238,14 +236,12 @@
           <Setter Property="IsVisible" Value="False" />
         </Style>
 
-        <Style Selector="TreeDataGridRow">
+        <Style Selector="TreeDataGridRow" x:CompileBindings="True" x:DataType="historyItems:HistoryItemViewModelBase">
           <Setter Property="(i:Interaction.Behaviors)">
             <i:BehaviorCollectionTemplate>
               <i:BehaviorCollection>
                 <behaviors:HistoryItemTypeClassBehavior />
-                <iac:RoutedEventTriggerBehavior RoutingStrategies="Bubble, Tunnel" RoutedEvent="{x:Static InputElement.DoubleTappedEvent}" >
-                  <ia:InvokeCommandAction Command="{Binding ShowDetailsCommand}" x:DataType="historyItems:HistoryItemViewModelBase"/>
-                </iac:RoutedEventTriggerBehavior>
+                <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand}"/>
               </i:BehaviorCollection>
             </i:BehaviorCollectionTemplate>
           </Setter>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
@@ -3,6 +3,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
+             xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              xmlns:history="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.History"
              xmlns:historyItems="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems"
@@ -109,6 +111,9 @@
             <i:BehaviorCollectionTemplate>
               <i:BehaviorCollection>
                 <behaviors:PendingHistoryItemSeparatorBehavior />
+                <iac:RoutedEventTriggerBehavior RoutedEvent="{x:Static InputElement.DoubleTappedEvent}" >
+                  <ia:InvokeCommandAction Command="{Binding ShowDetailsCommand}" x:DataType="historyItems:HistoryItemViewModelBase"/>
+                </iac:RoutedEventTriggerBehavior>
               </i:BehaviorCollection>
             </i:BehaviorCollectionTemplate>
           </Setter>

--- a/WalletWasabi.Fluent/Views/Wallets/Receive/ReceiveAddressesView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Receive/ReceiveAddressesView.axaml
@@ -2,7 +2,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:behaviors="clr-namespace:WalletWasabi.Fluent.Behaviors"
              xmlns:receive="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Receive"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="receive:ReceiveAddressesViewModel"
@@ -18,6 +20,28 @@
         <Style Selector="TreeDataGridRow">
           <Setter Property="Focusable" Value="False" />
           <Setter Property="Height" Value="37.5" />
+          <Setter Property="Template">
+            <ControlTemplate>
+              <DockPanel LastChildFill="True"
+                         Background="Transparent"
+                         x:CompileBindings="True" x:DataType="receive:AddressViewModel">
+                <i:Interaction.Behaviors>
+                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding NavigateCommand, Mode=OneWay}"/>
+                </i:Interaction.Behaviors>
+                <Border Name="PART_SelectionIndicator"
+                        BorderThickness="2 0 0 0"
+                        DockPanel.Dock="Left"
+                        VerticalAlignment="Stretch" />
+                <Panel>
+                  <Rectangle Name="BackgroundRectangle" />
+                  <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
+                                              ElementFactory="{TemplateBinding ElementFactory}"
+                                              Items="{TemplateBinding Columns}"
+                                              Rows="{TemplateBinding Rows}" />
+                </Panel>
+              </DockPanel>
+            </ControlTemplate>
+          </Setter>
         </Style>
         <Style Selector="c|AnimatedButton.addressActionButton">
           <Setter Property="DockPanel.Dock" Value="Right" />


### PR DESCRIPTION
Fixes: #9532

- HistoryTable - Show transaction details
- ReceiveAddressesView - Navigate to address QR code
- WalletCoinsView - Selected/deselect coin