### PR TITLE
[Documentation] [Trivial] Update manual steps for RegTest setup

### DIFF
--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -108,6 +108,7 @@ Todo:
 10. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
 11. Send 1 BTC to that address.
 12. Now in both instance go to CoinJoin tab and enqueue. CoinJoin should happen.
-13. If you see Waiting for confirmation in the Wasabi CoinList you can generate a block in Bitcoin Knots to continue coinjoining. You can do it with the command: `generatetoaddress 1 <replace_with_your_address_here>`
+13. If you see Waiting for confirmation in the Wasabi CoinList you can generate a block in Bitcoin Knots to continue coinjoining. 
+    - You can do it with the console command `generatetoaddress 1 <replace_with_your_address_here>`
 
 Happy CoinJoin!

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -81,7 +81,7 @@ Linux: "/home/{your username}/.walletwasabi/backend"
 ```
 "AnonymitySet": 2,
 ```
-7. Start Bitcoin Core in RegTest.
+7. Start Bitcoin Knots in RegTest (command to run is explained above).
 8. Go to WalletWasabi folder
 9. Open the command line and enter. This will build all the projects under this directory. 
 `dotnet build`

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -96,7 +96,7 @@ Todo:
 1. Go to `WalletWasabi\WalletWasabi.Fluent.Desktop` folder.
 2. Open the command line and run the Wasabi Client with:
 `dotnet run --no-build`
-3. Go to Tools/Settings and set the network to RegTest
+3. Go to Settings/Bitcoin and set the network to RegTest
 4. Close Wasabi and restart it with:
 `dotnet run --no-build`
 5. Generate a wallet in Wasabi named: R1.
@@ -107,8 +107,8 @@ Todo:
 9. Generate a wallet in Wasabi named: R2.
 10. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
 11. Send 1 BTC to that address.
-12. Now in both instance go to CoinJoin tab and enqueue. CoinJoin should happen.
-13. If you see Waiting for confirmation in the Wasabi CoinList you can generate a block in Bitcoin Knots to continue coinjoining. 
+12. Now let the coinjoin happen automatically in both instances.
+13. If you see `Waiting for confirmed funds` in the music box you can generate a block in Bitcoin Knots to continue coinjoining.
     - You can do it with the console command `generatetoaddress 1 <replace_with_your_address_here>`
 
 Happy CoinJoin!

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -18,7 +18,7 @@ Windows: "C:\Program Files\Bitcoin\bitcoin-qt.exe" -regtest
 macOS: "/Applications/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt" -regtest
 Linux:
 ```
-3. Go to Bitcoin Core data directory. If the directory is missing run core bitcoin-qt, then quit immediately. In this way the data directory and the config files will be generated.
+3. Go to Bitcoin Knots data directory. If the directory is missing run core bitcoin-qt, then quit immediately. In this way the data directory and the config files will be generated.
 ```
 Windows: %APPDATA%\Bitcoin\
 macOS: $HOME/Library/Application Support/Bitcoin/
@@ -36,7 +36,7 @@ regtest.rpcuser = 7c9b6473600fbc9be1120ae79f1622f42c32e5c78d
 regtest.rpcpassword = 309bc9961d01f388aed28b630ae834379296a8c8e3
 ```
 5. Save it.
-6. Start Bitcoin Core with: bitcoin-qt.exe -regtest.
+6. Start Bitcoin Knots with: bitcoin-qt.exe -regtest.
 7. Do not worry about "Syncing Headers" just press the Hide button. Because you run on Regtest, no Mainnet blocks will be downloaded.
 8. Go to menu *File / Create* wallet and create a wallet with the name you prefer. Use the default options.
 9. Go to menu *Window / Console*.
@@ -100,14 +100,14 @@ Todo:
 4. Close Wasabi and restart it with:
 `dotnet run --no-build`
 5. Generate a wallet in Wasabi named: R1.
-6. Generate a receive address in Wasabi, now go to Bitcoin Core gui to the Send tab.
+6. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
 7. Send 1 BTC to that address.
 8. Open another Wasabi instance from another command line:
 `dotnet run --no-build`
 9. Generate a wallet in Wasabi named: R2.
-10. Generate a receive address in Wasabi, now go to Bitcoin Core gui to the Send tab.
+10. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
 11. Send 1 BTC to that address.
 12. Now in both instance go to CoinJoin tab and enqueue. CoinJoin should happen.
-13. If you see Waiting for confirmation in the Wasabi CoinList you can generate a block in Bitcoin Core to continue coinjoining.
+13. If you see Waiting for confirmation in the Wasabi CoinList you can generate a block in Bitcoin Knots to continue coinjoining. You can do it with the command: `generatetoaddress 1 <replace_with_your_address_here>`
 
 Happy CoinJoin!

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -102,13 +102,11 @@ Todo:
 5. Generate a wallet in Wasabi named: R1.
 6. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
 7. Send 1 BTC to that address.
-8. Open another Wasabi instance from another command line:
-`dotnet run --no-build`
-9. Generate a wallet in Wasabi named: R2.
-10. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
-11. Send 1 BTC to that address.
-12. Now let the coinjoin happen automatically in both instances.
-13. If you see `Waiting for confirmed funds` in the music box you can generate a block in Bitcoin Knots to continue coinjoining.
+8. Generate a wallet in Wasabi named: R2.
+9. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
+10. Send 1 BTC to that address.
+11. Now let the coinjoin happen automatically in both instances.
+12. If you see `Waiting for confirmed funds` in the music box you can generate a block in Bitcoin Knots to continue coinjoining.
     - You can do it with the console command `generatetoaddress 1 <replace_with_your_address_here>`
 
 Happy CoinJoin!

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -24,7 +24,7 @@ Windows: %APPDATA%\Bitcoin\
 macOS: $HOME/Library/Application Support/Bitcoin/
 Linux: $HOME/.bitcoin/
 ```
-4. Edit bitcoin.conf file and add these lines there:
+4. Add a file called **bitcoin.conf** and add these lines:
 ```C#
 regtest.server = 1
 regtest.listen = 1
@@ -35,14 +35,15 @@ regtest.rpcport = 18443
 regtest.rpcuser = 7c9b6473600fbc9be1120ae79f1622f42c32e5c78d
 regtest.rpcpassword = 309bc9961d01f388aed28b630ae834379296a8c8e3
 ```
-5. Start Bitcoin Core with: bitcoin-qt.exe -regtest.
-6. Do not worry about "Syncing Headers" just press the Hide button. Because you run on Regtest, no Mainnet blocks will be downloaded.
-7. Go to MainMenu / Window / Console.
-8. Generate a new address with:
+5. Save it.
+6. Start Bitcoin Core with: bitcoin-qt.exe -regtest.
+7. Do not worry about "Syncing Headers" just press the Hide button. Because you run on Regtest, no Mainnet blocks will be downloaded.
+8. Go to MainMenu / Window / Console.
+9. Generate a new address with:
 `getnewaddress`
-9. Generate the first 101 blocks with:
+10. Generate the first 101 blocks with:
 `generatetoaddress 101 <replace_new_address_here>`
-10. Now you have your own Bitcoin blockchain and you are a God there - try to resist the insurmountable temptation to start your own shit coin, remember there is only one true coin. You can create transactions with the Send button and confirm with:
+11. Now you have your own Bitcoin blockchain and you are a God there - try to resist the insurmountable temptation to start your own shit coin, remember there is only one true coin. You can create transactions with the Send button and confirm with:
 `generatetoaddress 1 <replace_new_address_here>`
 
 You can force rebuilding the txindex with the `-reindex` command line argument.

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -105,7 +105,7 @@ Todo:
 8. Generate a wallet in Wasabi named: R2.
 9. Generate a receive address in Wasabi, now go to Bitcoin Knots to the Send tab.
 10. Send 1 BTC to that address.
-11. Now let the coinjoin happen automatically in both instances.
+11. Now let the coinjoin happen automatically in both wallets.
 12. If you see `Waiting for confirmed funds` in the music box you can generate a block in Bitcoin Knots to continue coinjoining.
     - You can do it with the console command `generatetoaddress 1 <replace_with_your_address_here>`
 

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -38,12 +38,13 @@ regtest.rpcpassword = 309bc9961d01f388aed28b630ae834379296a8c8e3
 5. Save it.
 6. Start Bitcoin Core with: bitcoin-qt.exe -regtest.
 7. Do not worry about "Syncing Headers" just press the Hide button. Because you run on Regtest, no Mainnet blocks will be downloaded.
-8. Go to MainMenu / Window / Console.
-9. Generate a new address with:
+8. Go to menu *File / Create* wallet and create a wallet with the name you prefer. Use the default options.
+9. Go to menu *Window / Console*.
+10. Generate a new address with:
 `getnewaddress`
-10. Generate the first 101 blocks with:
+11. Generate the first 101 blocks with:
 `generatetoaddress 101 <replace_new_address_here>`
-11. Now you have your own Bitcoin blockchain and you are a God there - try to resist the insurmountable temptation to start your own shit coin, remember there is only one true coin. You can create transactions with the Send button and confirm with:
+12. Now you have your own Bitcoin blockchain and you are a God there - try to resist the insurmountable temptation to start your own shit coin, remember there is only one true coin. You can create transactions with the Send button and confirm with:
 `generatetoaddress 1 <replace_new_address_here>`
 
 You can force rebuilding the txindex with the `-reindex` command line argument.


### PR DESCRIPTION
Updates the doc:
- Reflect that **bitcoin.conf** won't exist after setup. It needs to be created first.
- Can't start more than 1 instance of Wasabi Wallet.
- Minor corrections.