### PR TITLE
[Backend] Use the actual outputs to calculate the difference

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -553,9 +553,9 @@ public partial class Arena : PeriodicRunner
 
 	private async Task<ConstructionState> TryAddBlameScriptAsync(Round round, ConstructionState coinjoin, bool allReady, Script blameScript, CancellationToken cancellationToken)
 	{
-		long aliceSum = round.Alices.Sum(x => x.CalculateRemainingAmountCredentials(round.Parameters.MiningFeeRate, round.Parameters.CoordinationFeeRate));
+		long inputsum = coinjoin.Inputs.Sum(input => input.EffectiveValue(round.Parameters.MiningFeeRate, CoordinationFeeRate.Zero));
 		long outputsum = coinjoin.Outputs.Sum(output => output.EffectiveCost(round.Parameters.MiningFeeRate));
-		var diff = aliceSum - outputsum;
+		var diff = inputsum - outputsum;
 
 		// If timeout we must fill up the outputs to build a reasonable transaction.
 		// This won't be signed by the alice who failed to provide output, so we know who to ban.

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -18,6 +18,7 @@ using System.Collections.Immutable;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
+
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
 public partial class Arena : PeriodicRunner
@@ -553,8 +554,8 @@ public partial class Arena : PeriodicRunner
 	private async Task<ConstructionState> TryAddBlameScriptAsync(Round round, ConstructionState coinjoin, bool allReady, Script blameScript, CancellationToken cancellationToken)
 	{
 		long aliceSum = round.Alices.Sum(x => x.CalculateRemainingAmountCredentials(round.Parameters.MiningFeeRate, round.Parameters.CoordinationFeeRate));
-		long bobSum = round.Bobs.Sum(x => x.CredentialAmount);
-		var diff = aliceSum - bobSum;
+		long outputsum = coinjoin.Outputs.Sum(output => output.EffectiveCost(round.Parameters.MiningFeeRate));
+		var diff = aliceSum - outputsum;
 
 		// If timeout we must fill up the outputs to build a reasonable transaction.
 		// This won't be signed by the alice who failed to provide output, so we know who to ban.
@@ -585,7 +586,7 @@ public partial class Arena : PeriodicRunner
 					round.LogInfo($"There were some leftover satoshis. Added amount to miner fees: '{diffMoney}'.");
 				}
 				else
-				{ 
+				{
 					round.LogWarning($"Some alices failed to signal ready. There were some leftover satoshis. Added amount to miner fees: '{diffMoney}'.");
 				}
 			}


### PR DESCRIPTION
WIP!!! I did not have time to finish this today - feel free to work on this. 

Currently, there is a tolerance set in the code - it is working fine. However, there should be a calculation error somewhere. This might be it. 


I noticed the failures only happen after we add an extra output here: 

https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs#L570

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/9323

Related:
https://github.com/zkSNACKs/WalletWasabi/pull/9556
https://github.com/zkSNACKs/WalletWasabi/pull/9531
https://github.com/zkSNACKs/WalletWasabi/pull/9530

Question
- Extra output and coordinator fee output using the same address? 
