### PR TITLE
Use .NET 5's HEX function

### DIFF
--- a/WalletWasabi/Helpers/ByteHelpers.cs
+++ b/WalletWasabi/Helpers/ByteHelpers.cs
@@ -1,10 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace System;
 
 public static unsafe class ByteHelpers
 {
+	private static readonly uint[] Lookup32Unsafe = CreateLookup32Unsafe();
+	private static readonly uint* Lookup32UnsafeP = (uint*)GCHandle.Alloc(Lookup32Unsafe, GCHandleType.Pinned).AddrOfPinnedObject();
+
 	// https://stackoverflow.com/questions/415291/best-way-to-combine-two-or-more-byte-arrays-in-c-sharp
 	/// <summary>
 	/// Fastest byte array concatenation in C#
@@ -87,7 +91,21 @@ public static unsafe class ByteHelpers
 		}
 	}
 
-	/// <seealso cref="Convert.ToHexString(byte[])"/>
+	private static uint[] CreateLookup32Unsafe()
+	{
+		var result = new uint[256];
+		for (int i = 0; i < 256; i++)
+		{
+			string s = i.ToString("X2");
+			result[i] = BitConverter.IsLittleEndian ? s[0] + ((uint)s[1] << 16) : s[1] + ((uint)s[0] << 16);
+		}
+		return result;
+	}
+
+	// https://stackoverflow.com/a/24343727/2061103
+	/// <summary>
+	/// Fastest byte array to hex implementation in C#
+	/// </summary>
 	public static string ToHex(params byte[] bytes)
 	{
 		if (bytes.Length == 0)
@@ -95,7 +113,18 @@ public static unsafe class ByteHelpers
 			return "";
 		}
 
-		return Convert.ToHexString(bytes);
+		var lookupP = Lookup32UnsafeP;
+		var result = new string((char)0, bytes.Length * 2);
+		fixed (byte* bytesP = bytes)
+		fixed (char* resultP = result)
+		{
+			uint* resultP2 = (uint*)resultP;
+			for (int i = 0; i < bytes.Length; i++)
+			{
+				resultP2[i] = lookupP[bytesP[i]];
+			}
+		}
+		return result;
 	}
 
 	/// <seealso cref="Convert.FromHexString(string)"/>

--- a/WalletWasabi/Helpers/ByteHelpers.cs
+++ b/WalletWasabi/Helpers/ByteHelpers.cs
@@ -1,14 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace System;
 
 public static unsafe class ByteHelpers
 {
-	private static readonly uint[] Lookup32Unsafe = CreateLookup32Unsafe();
-	private static readonly uint* Lookup32UnsafeP = (uint*)GCHandle.Alloc(Lookup32Unsafe, GCHandleType.Pinned).AddrOfPinnedObject();
-
 	// https://stackoverflow.com/questions/415291/best-way-to-combine-two-or-more-byte-arrays-in-c-sharp
 	/// <summary>
 	/// Fastest byte array concatenation in C#
@@ -91,21 +87,7 @@ public static unsafe class ByteHelpers
 		}
 	}
 
-	private static uint[] CreateLookup32Unsafe()
-	{
-		var result = new uint[256];
-		for (int i = 0; i < 256; i++)
-		{
-			string s = i.ToString("X2");
-			result[i] = BitConverter.IsLittleEndian ? s[0] + ((uint)s[1] << 16) : s[1] + ((uint)s[0] << 16);
-		}
-		return result;
-	}
-
-	// https://stackoverflow.com/a/24343727/2061103
-	/// <summary>
-	/// Fastest byte array to hex implementation in C#
-	/// </summary>
+	/// <seealso cref="Convert.ToHexString(byte[])"/>
 	public static string ToHex(params byte[] bytes)
 	{
 		if (bytes.Length == 0)
@@ -113,25 +95,10 @@ public static unsafe class ByteHelpers
 			return "";
 		}
 
-		var lookupP = Lookup32UnsafeP;
-		var result = new string((char)0, bytes.Length * 2);
-		fixed (byte* bytesP = bytes)
-		fixed (char* resultP = result)
-		{
-			uint* resultP2 = (uint*)resultP;
-			for (int i = 0; i < bytes.Length; i++)
-			{
-				resultP2[i] = lookupP[bytesP[i]];
-			}
-		}
-		return result;
+		return Convert.ToHexString(bytes);
 	}
 
-	// https://stackoverflow.com/a/5919521/2061103
-	// https://stackoverflow.com/a/10048895/2061103
-	/// <summary>
-	/// Fastest hex to byte array implementation in C#
-	/// </summary>
+	/// <seealso cref="Convert.FromHexString(string)"/>
 	public static byte[] FromHex(string hex)
 	{
 		if (string.IsNullOrWhiteSpace(hex))
@@ -139,20 +106,6 @@ public static unsafe class ByteHelpers
 			return Array.Empty<byte>();
 		}
 
-		var bytes = new byte[hex.Length / 2];
-		var hexValue = new int[]
-		{
-				0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
-				0x06, 0x07, 0x08, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
-		};
-
-		for (int x = 0, i = 0; i < hex.Length; i += 2, x += 1)
-		{
-			bytes[x] = (byte)((hexValue[char.ToUpper(hex[i + 0]) - '0'] << 4) |
-				hexValue[char.ToUpper(hex[i + 1]) - '0']);
-		}
-
-		return bytes;
+		return Convert.FromHexString(hex);
 	}
 }


### PR DESCRIPTION
This PR aligns us with .NET and uses [`Convert.FromHexString`](https://learn.microsoft.com/en-us/dotnet/api/system.convert.fromhexstring?view=net-5.0) which is vectorized in .NET, so we should observe significant speedup (see https://github.com/MetacoSA/NBitcoin/pull/1149 for some numbers). 

Current master implementation

```
|  Method |      Mean |    Error |   StdDev |
|-------- |----------:|---------:|---------:|
|   ToHex |  25.19 ns | 0.501 ns | 1.355 ns |
| FromHex | 563.06 ns | 4.742 ns | 3.702 ns |
```

This PR: Only first commit:

```
|  Method |     Mean |    Error |   StdDev |
|-------- |---------:|---------:|---------:|
|   ToHex | 35.58 ns | 0.171 ns | 0.152 ns |
| FromHex | 71.38 ns | 0.650 ns | 0.576 ns |
```

This PR: All commits

```
|  Method |     Mean |    Error |   StdDev |
|-------- |---------:|---------:|---------:|
|   ToHex | 25.80 ns | 0.474 ns | 1.180 ns |
| FromHex | 75.86 ns | 1.552 ns | 1.963 ns |
```


Benchmark is [here](https://github.com/kiminuo/WalletWasabi/tree/feature/2022-11-17-fast-HEX-benchmark), use in `WalletWasabi.Tests` folder:

```s
dotnet run -c Release --framework net6.0 -- --runtimes net6.0
```


With this PR, we can replace https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Backend/Models/FilterModel.cs#L47 to use our new implementation and it can shave a bit of time from startup. Fundamentally, we should tackle it differently, but given current consensus, this is what we can do.