### PR TITLE
[PoC] Add sharedoverhead calculation

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
@@ -33,6 +33,9 @@ public class ConstructionStateTests
 		state = state.AddInput(coin, ownershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 		state = state.AddOutput(new TxOut(roundParameters.AllowedInputAmounts.Min, new Script("0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210"))).AsPayingForSharedOverhead();
 
+		Assert.Equal(0, state.RemainingUnpaidSharedOverheadVsize);
+		Assert.Equal(Money.Zero, state.RemainingUnpaidSharedOverheadCost);
+
 		var signingState = state.Finalize();
 		Assert.Equal(miningFeeRate, signingState.EffectiveFeeRate);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
@@ -28,12 +28,12 @@ public class ConstructionStateTests
 		var state = round.Assert<ConstructionState>();
 
 		var (coin, ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(
-			amount: roundParameters.AllowedInputAmounts.Min + miningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize),
+			amount: roundParameters.AllowedInputAmounts.Min + miningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize + Constants.P2wpkhOutputVirtualSize),
 			roundId: round.Id);
 		state = state.AddInput(coin, ownershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 		state = state.AddOutput(new TxOut(roundParameters.AllowedInputAmounts.Min, new Script("0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210") ));
 
-		var ex = Assert.Throws<WabiSabiProtocolException>(() => state.Finalize());
-		Assert.Equal(WabiSabiProtocolErrorCode.InsufficientFees, ex.ErrorCode);
+		var signingState = state.Finalize();
+		Assert.Equal(miningFeeRate, signingState.EffectiveFeeRate);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
@@ -28,10 +28,10 @@ public class ConstructionStateTests
 		var state = round.Assert<ConstructionState>();
 
 		var (coin, ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(
-			amount: roundParameters.AllowedInputAmounts.Min + miningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize + Constants.P2wpkhOutputVirtualSize),
+			amount: roundParameters.AllowedInputAmounts.Min + miningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize + Constants.P2wpkhOutputVirtualSize) + state.RemainingUnpaidSharedOverheadCost,
 			roundId: round.Id);
 		state = state.AddInput(coin, ownershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
-		state = state.AddOutput(new TxOut(roundParameters.AllowedInputAmounts.Min, new Script("0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210") ));
+		state = state.AddOutput(new TxOut(roundParameters.AllowedInputAmounts.Min, new Script("0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210"))).AsPayingForSharedOverhead();
 
 		var signingState = state.Finalize();
 		Assert.Equal(miningFeeRate, signingState.EffectiveFeeRate);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/ConstructionStateTests.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using WalletWasabi.Helpers;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Models;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Models;
+using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models;
+
+public class ConstructionStateTests
+{
+	[Fact]
+	public void ConstructionStateFeeRateCalculation()
+	{
+		var miningFeeRate = new FeeRate(8m);
+		var cfg = new WabiSabiConfig();
+		var roundParameters = RoundParameters.Create(
+				cfg,
+				Network.Main,
+				miningFeeRate,
+				cfg.CoordinationFeeRate,
+				Money.Coins(10));
+
+		var round = WabiSabiFactory.CreateRound(roundParameters);
+		var state = round.Assert<ConstructionState>();
+
+		var (coin, ownershipProof) = WabiSabiFactory.CreateCoinWithOwnershipProof(
+			amount: roundParameters.AllowedInputAmounts.Min + miningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize),
+			roundId: round.Id);
+		state = state.AddInput(coin, ownershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
+		state = state.AddOutput(new TxOut(roundParameters.AllowedInputAmounts.Min, new Script("0 bf3593d140d512eb607b3ddb5c5ee085f1e3a210") ));
+
+		var ex = Assert.Throws<WabiSabiProtocolException>(() => state.Finalize());
+		Assert.Equal(WabiSabiProtocolErrorCode.InsufficientFees, ex.ErrorCode);
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -554,7 +554,8 @@ public partial class Arena : PeriodicRunner
 	{
 		// If timeout we must fill up the outputs to build a reasonable transaction.
 		// This won't be signed by the alice who failed to provide output, so we know who to ban.
-		var diffMoney = coinjoin.Balance - round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize());
+		var estimatedBlameScriptCost = round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize() + MultipartyTransactionParameters.SharedOverhead); 
+		var diffMoney = coinjoin.Balance - coinjoin.EstimatedCost - estimatedBlameScriptCost;
 		if (diffMoney > round.Parameters.AllowedOutputAmounts.Min)
 		{
 			// If diff is smaller than max fee rate of a tx, then add it as fee.
@@ -563,7 +564,7 @@ public partial class Arena : PeriodicRunner
 			// ToDo: This condition could be more sophisticated by always trying to max out the miner fees to target 2 and only deal with the remaining diffMoney.
 			if (coinjoin.EffectiveFeeRate > highestFeeRate)
 			{
-				coinjoin = coinjoin.AddOutput(new TxOut(diffMoney, blameScript));
+				coinjoin = coinjoin.AddOutput(new TxOut(diffMoney, blameScript)).AsPayingForSharedOverhead();
 
 				if (allReady)
 				{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -552,13 +552,9 @@ public partial class Arena : PeriodicRunner
 
 	private async Task<ConstructionState> TryAddBlameScriptAsync(Round round, ConstructionState coinjoin, bool allReady, Script blameScript, CancellationToken cancellationToken)
 	{
-		long aliceSum = round.Alices.Sum(x => x.CalculateRemainingAmountCredentials(round.Parameters.MiningFeeRate, round.Parameters.CoordinationFeeRate));
-		long bobSum = round.Bobs.Sum(x => x.CredentialAmount);
-		var diff = aliceSum - bobSum;
-
 		// If timeout we must fill up the outputs to build a reasonable transaction.
 		// This won't be signed by the alice who failed to provide output, so we know who to ban.
-		var diffMoney = Money.Satoshis(diff) - round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize());
+		var diffMoney = coinjoin.Balance - round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize());
 		if (diffMoney > round.Parameters.AllowedOutputAmounts.Min)
 		{
 			// If diff is smaller than max fee rate of a tx, then add it as fee.

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -554,7 +554,7 @@ public partial class Arena : PeriodicRunner
 	{
 		// If timeout we must fill up the outputs to build a reasonable transaction.
 		// This won't be signed by the alice who failed to provide output, so we know who to ban.
-		var estimatedBlameScriptCost = round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize() + MultipartyTransactionParameters.SharedOverhead); 
+		var estimatedBlameScriptCost = round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize() + coinjoin.UnpaidSharedOverhead); 
 		var diffMoney = coinjoin.Balance - coinjoin.EstimatedCost - estimatedBlameScriptCost;
 		if (diffMoney > round.Parameters.AllowedOutputAmounts.Min)
 		{
@@ -604,11 +604,11 @@ public partial class Arena : PeriodicRunner
 		}
 		else
 		{
-			var effectiveCoordinationFee = coordinationFee - round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize());
+			var effectiveCoordinationFee = coordinationFee - round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize() + MultipartyTransactionParameters.SharedOverhead);
 
 			if (effectiveCoordinationFee > round.Parameters.AllowedOutputAmounts.Min)
 			{
-				coinjoin = coinjoin.AddOutput(new TxOut(effectiveCoordinationFee, coordinatorScriptPubKey));
+				coinjoin = coinjoin.AddOutput(new TxOut(effectiveCoordinationFee, coordinatorScriptPubKey)).AsPayingForSharedOverhead();
 			}
 			else
 			{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -604,7 +604,7 @@ public partial class Arena : PeriodicRunner
 		}
 		else
 		{
-			var effectiveCoordinationFee = coordinationFee - round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize() + MultipartyTransactionParameters.SharedOverhead);
+			var effectiveCoordinationFee = coordinationFee - round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize() + coinjoin.UnpaidSharedOverhead);
 
 			if (effectiveCoordinationFee > round.Parameters.AllowedOutputAmounts.Min)
 			{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -18,6 +18,7 @@ using System.Collections.Immutable;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
+
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
 public partial class Arena : PeriodicRunner
@@ -554,7 +555,7 @@ public partial class Arena : PeriodicRunner
 	{
 		// If timeout we must fill up the outputs to build a reasonable transaction.
 		// This won't be signed by the alice who failed to provide output, so we know who to ban.
-		var estimatedBlameScriptCost = round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize() + coinjoin.UnpaidSharedOverhead); 
+		var estimatedBlameScriptCost = round.Parameters.MiningFeeRate.GetFee(blameScript.EstimateOutputVsize());
 		var diffMoney = coinjoin.Balance - coinjoin.EstimatedCost - estimatedBlameScriptCost;
 		if (diffMoney > round.Parameters.AllowedOutputAmounts.Min)
 		{
@@ -582,7 +583,7 @@ public partial class Arena : PeriodicRunner
 					round.LogInfo($"There were some leftover satoshis. Added amount to miner fees: '{diffMoney}'.");
 				}
 				else
-				{ 
+				{
 					round.LogWarning($"Some alices failed to signal ready. There were some leftover satoshis. Added amount to miner fees: '{diffMoney}'.");
 				}
 			}
@@ -604,7 +605,7 @@ public partial class Arena : PeriodicRunner
 		}
 		else
 		{
-			var effectiveCoordinationFee = coordinationFee - round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize() + coinjoin.UnpaidSharedOverhead);
+			var effectiveCoordinationFee = coordinationFee - round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize()) - coinjoin.RemainingUnpaidSharedOverheadCost;
 
 			if (effectiveCoordinationFee > round.Parameters.AllowedOutputAmounts.Min)
 			{

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -105,10 +105,9 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.SizeLimitExceeded, $"Transaction size is {EstimatedVsize} bytes, which exceeds the limit of {Parameters.MaxTransactionSize} bytes.");
 		}
 
-		var minToleratedMiningFeeRate = new FeeRate(0.98m * Parameters.MiningFeeRate.SatoshiPerByte);
-		if (EffectiveFeeRate < minToleratedMiningFeeRate)
+		if (EffectiveFeeRate < Parameters.MiningFeeRate)
 		{
-			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InsufficientFees, $"Effective fee rate {EffectiveFeeRate} is less than required {minToleratedMiningFeeRate}.");
+			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InsufficientFees, $"Effective fee rate {EffectiveFeeRate} is less than required {Parameters.MiningFeeRate}.");
 		}
 
 		return new SigningState(Parameters, Events);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -111,10 +111,10 @@ public record ConstructionState : MultipartyTransactionState
 
 		return new SigningState(Parameters, Events);
 	}
-	
+
 	public ConstructionState AsPayingForSharedOverhead() =>
 		this with
 		{
-			UnpaidSharedOverhead = 0
+			RemainingUnpaidSharedOverheadVsize = 0
 		};
 }

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -97,7 +97,7 @@ public record ConstructionState : MultipartyTransactionState
 
 		return this with { Events = Events.Add(new OutputAdded(output)) };
 	}
-
+	
 	public SigningState Finalize()
 	{
 		if (EstimatedVsize > Parameters.MaxTransactionSize)
@@ -112,4 +112,10 @@ public record ConstructionState : MultipartyTransactionState
 
 		return new SigningState(Parameters, Events);
 	}
+	
+	public ConstructionState AsPayingForSharedOverhead() =>
+		this with
+		{
+			UnpaidSharedOverhead = 0
+		};
 }

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -97,7 +97,6 @@ public record ConstructionState : MultipartyTransactionState
 
 		return this with { Events = Events.Add(new OutputAdded(output)) };
 	}
-	
 	public SigningState Finalize()
 	{
 		if (EstimatedVsize > Parameters.MaxTransactionSize)

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -48,10 +48,6 @@ public abstract record MultipartyTransactionState
 
 	[JsonIgnore] protected int UnpaidSharedOverhead { get; init; } = MultipartyTransactionParameters.SharedOverhead;
 	
-	// With no coordinator fees we can't ensure that the shared overhead
-	// of the transaction also pays at the nominal feerate so this will have
-	// to do for now, but in the future EstimatedVsize should be used
-	// including the shared overhead
 	[JsonIgnore]
 	public FeeRate EffectiveFeeRate => new(Balance, EstimatedVsize - UnpaidSharedOverhead);
 

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -46,7 +46,8 @@ public abstract record MultipartyTransactionState
 	[JsonIgnore]
 	public Money EstimatedCost => Parameters.MiningFeeRate.GetFee(EstimatedVsize - UnpaidSharedOverhead);
 
-	[JsonIgnore] protected int UnpaidSharedOverhead { get; init; } = MultipartyTransactionParameters.SharedOverhead;
+	[JsonIgnore] 
+	public int UnpaidSharedOverhead { get; init; } = MultipartyTransactionParameters.SharedOverhead;
 	
 	[JsonIgnore]
 	public FeeRate EffectiveFeeRate => new(Balance, EstimatedVsize - UnpaidSharedOverhead);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -34,7 +34,7 @@ public abstract record MultipartyTransactionState
 	public IEnumerable<TxOut> Outputs => Events.OfType<OutputAdded>().Select(x => x.Output);
 
 	[JsonIgnore]
-	public Money Balance => Inputs.Sum(x => x.Amount) - Outputs.Sum(x => x.Value) - RemainingUnpaidSharedOverheadCost;
+	public Money Balance => Inputs.Sum(x => x.Amount) - Outputs.Sum(x => x.Value);
 	[JsonIgnore]
 	public int EstimatedInputsVsize => Inputs.Sum(x => x.TxOut.ScriptPubKey.EstimateInputVsize());
 	[JsonIgnore]
@@ -50,7 +50,7 @@ public abstract record MultipartyTransactionState
 	public int RemainingUnpaidSharedOverheadVsize { get; init; } = MultipartyTransactionParameters.SharedOverhead;
 
 	[JsonIgnore]
-	public Money RemainingUnpaidSharedOverheadCost => Parameters.MiningFeeRate.GetFee(RemainingUnpaidSharedOverheadVsize);
+	public Money RemainingUnpaidSharedOverheadCost => RemainingUnpaidSharedOverheadVsize == 0 ? Money.Zero : Parameters.MiningFeeRate.GetFee(RemainingUnpaidSharedOverheadVsize);
 
 	[JsonIgnore]
 	public FeeRate EffectiveFeeRate => new(Balance, EstimatedVsize);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -34,7 +34,7 @@ public abstract record MultipartyTransactionState
 	public IEnumerable<TxOut> Outputs => Events.OfType<OutputAdded>().Select(x => x.Output);
 
 	[JsonIgnore]
-	public Money Balance => Inputs.Sum(x => x.Amount) - Outputs.Sum(x => x.Value);
+	public Money Balance => Inputs.Sum(x => x.Amount) - Outputs.Sum(x => x.Value) - RemainingUnpaidSharedOverheadCost;
 	[JsonIgnore]
 	public int EstimatedInputsVsize => Inputs.Sum(x => x.TxOut.ScriptPubKey.EstimateInputVsize());
 	[JsonIgnore]
@@ -44,13 +44,16 @@ public abstract record MultipartyTransactionState
 	public int EstimatedVsize => MultipartyTransactionParameters.SharedOverhead + EstimatedInputsVsize + OutputsVsize;
 
 	[JsonIgnore]
-	public Money EstimatedCost => Parameters.MiningFeeRate.GetFee(EstimatedVsize - UnpaidSharedOverhead);
+	public Money EstimatedCost => Parameters.MiningFeeRate.GetFee(EstimatedVsize);
 
-	[JsonIgnore] 
-	public int UnpaidSharedOverhead { get; init; } = MultipartyTransactionParameters.SharedOverhead;
-	
 	[JsonIgnore]
-	public FeeRate EffectiveFeeRate => new(Balance, EstimatedVsize - UnpaidSharedOverhead);
+	public int RemainingUnpaidSharedOverheadVsize { get; init; } = MultipartyTransactionParameters.SharedOverhead;
+
+	[JsonIgnore]
+	public Money RemainingUnpaidSharedOverheadCost => Parameters.MiningFeeRate.GetFee(RemainingUnpaidSharedOverheadVsize);
+
+	[JsonIgnore]
+	public FeeRate EffectiveFeeRate => new(Balance, EstimatedVsize);
 
 	public ImmutableList<IEvent> Events { get; init; } = ImmutableList<IEvent>.Empty;
 

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -43,12 +43,17 @@ public abstract record MultipartyTransactionState
 	[JsonIgnore]
 	public int EstimatedVsize => MultipartyTransactionParameters.SharedOverhead + EstimatedInputsVsize + OutputsVsize;
 
+	[JsonIgnore]
+	public Money EstimatedCost => Parameters.MiningFeeRate.GetFee(EstimatedVsize - UnpaidSharedOverhead);
+
+	[JsonIgnore] protected int UnpaidSharedOverhead { get; init; } = MultipartyTransactionParameters.SharedOverhead;
+	
 	// With no coordinator fees we can't ensure that the shared overhead
 	// of the transaction also pays at the nominal feerate so this will have
 	// to do for now, but in the future EstimatedVsize should be used
 	// including the shared overhead
 	[JsonIgnore]
-	public FeeRate EffectiveFeeRate => new(Balance, EstimatedInputsVsize + OutputsVsize);
+	public FeeRate EffectiveFeeRate => new(Balance, EstimatedVsize - UnpaidSharedOverhead);
 
 	public ImmutableList<IEvent> Events { get; init; } = ImmutableList<IEvent>.Empty;
 


### PR DESCRIPTION
It was easier to address my review of https://github.com/zkSNACKs/WalletWasabi/pull/9558 as a PR. This PR is it.

Even if we take my suggestions from this PR it would be worth taking a look at why `ConstructionStateFeeRateCalculation` is failing with 

`WalletWasabi.WabiSabi.Backend.Models.WabiSabiProtocolException : Effective fee rate 7.993 Sat/B is less than required 8 Sat/B.`