### PR TITLE
[Trivial] Update supported OS

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -4,7 +4,7 @@ This document lists all the officially supported software and devices by Wasabi 
 
 # Officially Supported Operating Systems
 
-- Windows 10 1607+ (except 1703)
+- Windows 10 1607+
 - macOs 10.15+
 - Ubuntu 16.04, 18.04, 20.04+
 - Fedora 33+


### PR DESCRIPTION
Windows 10 version 1703 is supported by .NET 6 according to: https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md