### PR TITLE
Fix Max Privacy profile equality

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -43,7 +43,7 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 			return false;
 		}
 
-		return profile.AnonScoreTarget < MaxAnonScore && profile.AnonScoreTarget > MinAnonScore && profile.FeeRateMedianTimeFrameHours == FeeRateMedianTimeFrameHours && profile.RedCoinIsolation == RedCoinIsolation;
+		return profile.AnonScoreTarget < MaxAnonScore && profile.AnonScoreTarget >= MinAnonScore && profile.FeeRateMedianTimeFrameHours == FeeRateMedianTimeFrameHours && profile.RedCoinIsolation == RedCoinIsolation;
 	}
 
 	public override int GetHashCode()


### PR DESCRIPTION
Fixes: #9587

Max Privacy + 50 anon score target gives back `Custom` coinjoin profile falsely.
This PR fixes this.