### PR TITLE
correct incoming notification

### DIFF
--- a/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
@@ -79,7 +79,7 @@ public static class NotificationHelpers
 				}
 				else if (incoming > Money.Zero)
 				{
-					message = $"{amountString} BTC received";
+					message = $"{amountString} BTC incoming";
 				}
 				else if (incoming < Money.Zero)
 				{


### PR DESCRIPTION
current is wrong
the user doesn't receive anything
as long as it's unconfirmed there is 0 certainty that you will receive the bitcoin

`X BTC incoming` is the best correct (newbie friendly) message, I think