### PR TITLE
[VDG] Debounce focus changes that break the Flyout in Win10

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/ShowAttachedFlyoutWhenFocusedBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/ShowAttachedFlyoutWhenFocusedBehavior.cs
@@ -30,7 +30,7 @@ public class ShowAttachedFlyoutWhenFocusedBehavior : AttachedToVisualTreeBehavio
 
 	protected override void OnAttachedToVisualTree(CompositeDisposable disposable)
 	{
-		if (AssociatedObject?.GetVisualRoot() is not Control visualRoot)
+		if (AssociatedObject?.GetVisualRoot() is not Window visualRoot)
 		{
 			return;
 		}
@@ -108,7 +108,7 @@ public class ShowAttachedFlyoutWhenFocusedBehavior : AttachedToVisualTreeBehavio
 		var mergedFocused = isAssociatedObjectFocused.Merge(isPopupFocused);
 
 		var weAreFocused = mergedFocused
-			.Throttle(TimeSpan.FromSeconds(0.1))
+			.Throttle(TimeSpan.FromSeconds(0.1), RxApp.MainThreadScheduler)
 			.DistinctUntilChanged();
 
 		return weAreFocused


### PR DESCRIPTION
Somewhat, in Windows 10, the focus changes are unstable for some time and break the Flyout under some circumnstances. 
This throttle should fix that problem.

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/7752
Might fix: https://github.com/zkSNACKs/WalletWasabi/issues/9454