### PR TITLE
[VDG] [Trivial] Coin control. Fix bad confirmation count

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinControl/Core/PocketCoinControlItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/Core/PocketCoinControlItemViewModel.cs
@@ -7,9 +7,10 @@ public class PocketCoinControlItemViewModel : CoinControlItemViewModelBase
 {
 	public PocketCoinControlItemViewModel(Pocket pocket)
 	{
-		var confirmedCount = pocket.Coins.Count();
+		var coinCount = pocket.Coins.Count();
 		var unconfirmedCount = pocket.Coins.Count(x => !x.Confirmed);
-		var allConfirmed = confirmedCount == unconfirmedCount;
+		var confirmedCount = coinCount - unconfirmedCount;
+		var allConfirmed = coinCount == confirmedCount;
 		ConfirmationStatus = allConfirmed ? "All coins are confirmed" : $"{unconfirmedCount} coins are waiting for confirmation";
 		IsBanned = pocket.Coins.Any(x => x.IsBanned);
 		BannedUntilUtcToolTip = IsBanned ? "Some coins can't participate in coinjoin" : null;

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/Core/PocketCoinControlItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/Core/PocketCoinControlItemViewModel.cs
@@ -7,15 +7,12 @@ public class PocketCoinControlItemViewModel : CoinControlItemViewModelBase
 {
 	public PocketCoinControlItemViewModel(Pocket pocket)
 	{
-		var coinCount = pocket.Coins.Count();
 		var unconfirmedCount = pocket.Coins.Count(x => !x.Confirmed);
-		var confirmedCount = coinCount - unconfirmedCount;
-		var allConfirmed = coinCount == confirmedCount;
-		ConfirmationStatus = allConfirmed ? "All coins are confirmed" : $"{unconfirmedCount} coins are waiting for confirmation";
+		IsConfirmed = unconfirmedCount == 0;
+		ConfirmationStatus = IsConfirmed ? "All coins are confirmed" : $"{unconfirmedCount} coins are waiting for confirmation";
 		IsBanned = pocket.Coins.Any(x => x.IsBanned);
 		BannedUntilUtcToolTip = IsBanned ? "Some coins can't participate in coinjoin" : null;
 		Amount = pocket.Amount;
-		IsConfirmed = allConfirmed;
 		IsCoinjoining = pocket.Coins.Any(x => x.CoinJoinInProgress);
 		AnonymityScore = (int) pocket.Coins.Max(x => x.HdPubKey.AnonymitySet);
 		Labels = pocket.Labels;


### PR DESCRIPTION
Calculation was wrong. This showed pockets as being unconfirmed. Not it's fixed.