### PR TITLE
[VDG] TreeDataGrid PrivacyTextCell - Add Transparent background

### DIFF
--- a/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
+++ b/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
@@ -23,7 +23,7 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 
 	public override void Realize(IElementFactory factory, ICell model, int columnIndex, int rowIndex)
 	{
-		var privacyTextCell = (PrivacyTextCell) model;
+		var privacyTextCell = (PrivacyTextCell)model;
 		var text = privacyTextCell.Value;
 
 		_numberOfPrivacyChars = privacyTextCell.NumberOfPrivacyChars;
@@ -40,6 +40,11 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 
 	public override void Render(DrawingContext context)
 	{
+		if (this.Background is { } background)
+		{
+			context.FillRectangle(background, new Rect(this.Bounds.Size));
+		}
+
 		if (_formattedText is null)
 		{
 			var placeHolder = new FormattedText(

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
@@ -117,6 +117,7 @@
           <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
           <Setter Property="FontSize" Value="15" />
           <Setter Property="Margin" Value="10 0" />
+          <Setter Property="Background" Value="Transparent" />
         </Style>
         <Style Selector="TreeDataGridRow /template/ Rectangle#PART_Separator">
           <Setter Property="Fill" Value="Transparent" />
@@ -152,7 +153,7 @@
                          Background="Transparent"
                          x:CompileBindings="True" x:DataType="historyItems:HistoryItemViewModelBase">
                 <i:Interaction.Behaviors>
-                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand, Mode=OneWay}"/>
+                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand, Mode=OneWay}" />
                 </i:Interaction.Behaviors>
                 <Border Name="PART_SelectionIndicator"
                         BorderThickness="2 0 0 0"
@@ -246,7 +247,7 @@
               <i:BehaviorCollection>
                 <behaviors:HistoryItemTypeClassBehavior />
                 <!-- TODO: The Command binding doesn't work in Avalonia 0.10.x -->
-                <!-- <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand, Mode=OneWay}"/> -->
+                <!-- <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ShowDetailsCommand, Mode=OneWay}" /> -->
               </i:BehaviorCollection>
             </i:BehaviorCollectionTemplate>
           </Setter>


### PR DESCRIPTION
 - Adds `Background` support in the rendering of `TreeDataGridPrivacyTextCell`
 - Sets the `Background` to `Transparent` for such cells in the `HistoryTable`
 - Fixes #9595
