### PR TITLE
`SingleInstanceCheckerTests.OtherInstanceStartedTestsAsync`: Add missing test multiplier

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Clients/SingleInstanceCheckerTests.cs
@@ -58,7 +58,7 @@ public class SingleInstanceCheckerTests
 		int mainNetPort = GenerateRandomPort();
 
 		// Disposal test.
-		await using SingleInstanceChecker firstInstance = new(mainNetPort);
+		await using SingleInstanceChecker firstInstance = new(mainNetPort, TimeoutMultiplier);
 		long eventCalled = 0;
 
 		firstInstance.OtherInstanceStarted += SetCalled;


### PR DESCRIPTION
I have noticed that the test has been failing recently. I'm not sure if this fixes the issue but it might be the reason why it fails.