### PR TITLE
Verify back Installer's hashes in Packager

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -201,7 +201,7 @@ public static class Program
 		await WasabiSignerHelpers.VerifySha256SumsFileAsync(sha256sumAscFilePath).ConfigureAwait(false);
 
 		// Verify back Wasabi installer's hashes
-		await WasabiSignerHelpers.VerifyInstallerFileHashesAsync(finalFiles, sha256SumsFilePath).ConfigureAwait(false);
+		await WasabiSignerHelpers.VerifyInstallerFileHashesAsync(finalFiles, sha256sumAscFilePath).ConfigureAwait(false);
 
 		IoHelpers.OpenFolderInFileExplorer(BinDistDirectory);
 	}

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Userfacing;

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -198,10 +198,10 @@ public static class Program
 		await WasabiSignerHelpers.SignSha256SumsFileAsync(sha256sumAscFilePath, key).ConfigureAwait(false);
 
 		// Verify back the signature file.
-		await WasabiSignerHelpers.VerifySha256SumsFileAsync(sha256sumAscFilePath);
+		await WasabiSignerHelpers.VerifySha256SumsFileAsync(sha256sumAscFilePath).ConfigureAwait(false);
 
 		// Verify back Wasabi installer's hashes
-		await VerifyInstallerFileHashesAsync(finalFiles, sha256SumsFilePath);
+		await VerifyInstallerFileHashesAsync(finalFiles, sha256SumsFilePath).ConfigureAwait(false);
 
 		IoHelpers.OpenFolderInFileExplorer(BinDistDirectory);
 	}

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -201,7 +201,7 @@ public static class Program
 		await WasabiSignerHelpers.VerifySha256SumsFileAsync(sha256sumAscFilePath).ConfigureAwait(false);
 
 		// Verify back Wasabi installer's hashes
-		await VerifyInstallerFileHashesAsync(finalFiles, sha256SumsFilePath).ConfigureAwait(false);
+		await WasabiSignerHelpers.VerifyInstallerFileHashesAsync(finalFiles, sha256SumsFilePath).ConfigureAwait(false);
 
 		IoHelpers.OpenFolderInFileExplorer(BinDistDirectory);
 	}
@@ -585,26 +585,6 @@ public static class Program
 			// Use Bash on other platforms.
 			string arguments = string.Join(" && ", commands);
 			StartProcessAndWaitForExit("bash", BinDistDirectory, arguments: $"-c \"{arguments}\"");
-		}
-	}
-
-	private static async Task VerifyInstallerFileHashesAsync(string[] finalFiles, string sha256SumsFilePath)
-	{
-		string[] lines = await File.ReadAllLinesAsync(sha256SumsFilePath).ConfigureAwait(false);
-		var hashWithFileNameLines = lines.Where(line => line.Contains("Wasabi-"));
-
-		foreach (var installerFilePath in finalFiles)
-		{
-			string installerName = Path.GetFileName(installerFilePath);
-			string installerExpectedHash = hashWithFileNameLines.Single(line => line.Contains(installerName)).Split(" ")[0];
-
-			var bytes = await WasabiSignerHelpers.GetShaComputedBytesOfFileAsync(installerFilePath).ConfigureAwait(false);
-			string installerRealHash = Convert.ToHexString(bytes).ToLower();
-
-			if (installerExpectedHash != installerRealHash)
-			{
-				throw new InvalidOperationException("Installer file's hash doesn't match expected hash.");
-			}
 		}
 	}
 


### PR DESCRIPTION
Simple addition to #9535, requested by @molnard :
At the very end, check back if the created installer file's match the ones in `SHA256SUMS.asc`.