### PR TITLE
Add `.editorconfig` to ignore errors in `MathNet` library

### DIFF
--- a/WalletWasabi.Fluent/MathNet/.editorconfig
+++ b/WalletWasabi.Fluent/MathNet/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*.cs]
+
+# Disable all .NET analyzers
+dotnet_analyzer_diagnostic.severity = none
+
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8601.severity = none
+dotnet_diagnostic.CS8603.severity = none
+dotnet_diagnostic.CS8604.severity = none
+dotnet_diagnostic.CS8618.severity = none
+dotnet_diagnostic.CS8625.severity = none
+dotnet_diagnostic.CS8765.severity = none
+dotnet_diagnostic.CS8767.severity = none


### PR DESCRIPTION
Similar to #7687. `MathNet` is a library we use, so its code style should not report any errors.