### PR TITLE
Add the logic of cancelling operations if the round ends prematurely

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -235,8 +235,6 @@ public class CoinJoinClient
 			try
 			{
 				using CancellationTokenSource timeUntilOutputRegCts = new(timeUntilOutputReg + ExtraPhaseTimeoutMargin);
-				using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSourceWithRoundEnded.Token, timeUntilOutputRegCts.Token);
-
 				registeredAliceClientAndCircuits = await ProceedWithInputRegAndConfirmAsync(smartCoins, roundState, cancellationTokenSourceWithRoundEnded.Token).ConfigureAwait(false);
 			}
 			catch (UnexpectedRoundPhaseException ex)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -181,15 +181,7 @@ public class CoinJoinClient
 
 			using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, coinJoinRoundTimeoutCts.Token);
 
-			CoinJoinResult result;
-			try
-			{
-				result = await StartRoundAsync(coins, currentRoundState, linkedCts.Token).ConfigureAwait(false);
-			}
-			finally
-			{
-				cancelRoundEndedTaskCts.Cancel();
-			}
+			CoinJoinResult result = await StartRoundAsync(coins, currentRoundState, linkedCts.Token).ConfigureAwait(false);
 
 			if (!result.GoForBlameRound)
 			{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -391,6 +391,10 @@ public class CoinJoinManager : BackgroundService
 			NotifyCoinJoinStartError(wallet, CoinjoinError.NoCoinsToMix);
 			Logger.LogDebug(x);
 		}
+		catch (RoundEndedPrematurelyException e)
+		{
+			wallet.LogInfo($"{nameof(CoinJoinClient)} round: '{e}' ended prematurely - most likely the coordinator aborted it.");
+		}
 		catch (InvalidOperationException ioe)
 		{
 			Logger.LogWarning(ioe);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -393,7 +393,7 @@ public class CoinJoinManager : BackgroundService
 		}
 		catch (RoundEndedPrematurelyException e)
 		{
-			wallet.LogInfo($"{nameof(CoinJoinClient)} round: '{e}' ended prematurely - most likely the coordinator aborted it.");
+			wallet.LogInfo($"{nameof(CoinJoinClient)} round: '{e.RoundId}' ended prematurely - most likely the coordinator aborted it.");
 		}
 		catch (InvalidOperationException ioe)
 		{

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundEndedPrematurelyException.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundEndedPrematurelyException.cs
@@ -1,0 +1,13 @@
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
+
+public class RoundEndedPrematurelyException : InvalidOperationException
+{
+	public RoundEndedPrematurelyException(uint256 roundId, Exception? innerException = null) : base(null, innerException)
+	{
+		RoundId = roundId;
+	}
+
+	public uint256 RoundId { get; }
+}


### PR DESCRIPTION
This will speed up the reaction time of the clients in case of load balancing. 

Sometimes the coordinator cuts the round short by aborting it. For example when load balancing happens. But there can be other reasons as well. If the client is in a delay operation (for example delaying the request to fulfil poison distribution) - it won't notice the phase change only after the delay. In input registration, this delay can be 8 minutes until the client is stuck and won't jump into the next round. 
This PR fixes this by creating a sentinel task that triggers a cancellation in all the operations before waiting until the end of the round. 