### PR TITLE
Remove backward compatibility code

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
@@ -79,7 +79,7 @@ public class AllTransactionStoreTests
 	{
 		var dir = PrepareWorkDir();
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		Assert.NotNull(txStore.ConfirmedStore);
 		Assert.NotNull(txStore.MempoolStore);
@@ -139,7 +139,7 @@ public class AllTransactionStoreTests
 		await File.WriteAllLinesAsync(txFile, txFileContent);
 
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		Assert.Equal(6, txStore.GetTransactions().Count());
 		Assert.Equal(6, txStore.GetTransactionHashes().Count());
@@ -197,7 +197,7 @@ public class AllTransactionStoreTests
 		await File.WriteAllLinesAsync(txFile, txFileContent);
 
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		Assert.Equal(6, txStore.GetTransactions().Count());
 		Assert.Equal(6, txStore.GetTransactionHashes().Count());
@@ -232,7 +232,7 @@ public class AllTransactionStoreTests
 		await File.WriteAllLinesAsync(txFile, txFileContent);
 
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		Assert.Equal(6, txStore.GetTransactions().Count());
 		Assert.Equal(2, txStore.MempoolStore.GetTransactions().Count());
@@ -270,7 +270,7 @@ public class AllTransactionStoreTests
 		await File.WriteAllLinesAsync(txFile, txFileContent);
 
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		Assert.Equal(6, txStore.GetTransactions().Count());
 		Assert.Equal(2, txStore.MempoolStore.GetTransactions().Count());
@@ -322,7 +322,7 @@ public class AllTransactionStoreTests
 
 		await using (var txStore = new AllTransactionStore(dir, network))
 		{
-			await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+			await txStore.InitializeAsync();
 
 			var txs = txStore.GetTransactions();
 			var txHashes = txStore.GetTransactionHashes();
@@ -333,7 +333,7 @@ public class AllTransactionStoreTests
 
 		await using (var txStore = new AllTransactionStore(PrepareWorkDir(), network))
 		{
-			await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+			await txStore.InitializeAsync();
 
 			txStore.AddOrUpdate(uTx3);
 			txStore.AddOrUpdate(uTx1);
@@ -355,7 +355,7 @@ public class AllTransactionStoreTests
 	public async Task DoesntUpdateAsync(Network network)
 	{
 		await using var txStore = new AllTransactionStore(PrepareWorkDir(), network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		var tx = BitcoinFactory.CreateSmartTransaction();
 		Assert.False(txStore.TryUpdate(tx));
@@ -408,7 +408,7 @@ public class AllTransactionStoreTests
 		await File.WriteAllLinesAsync(txFile, txFileContent);
 
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		// Two transactions are in the mempool store and unconfirmed.
 		Assert.True(txStore.MempoolStore.TryGetTransaction(uTx1.GetHash(), out var myUnconfirmedTx1));
@@ -454,7 +454,7 @@ public class AllTransactionStoreTests
 
 		var network = Network.Main;
 		await using var txStore = new AllTransactionStore(dir, network);
-		await txStore.InitializeAsync(ensureBackwardsCompatibility: false);
+		await txStore.InitializeAsync();
 
 		foreach (var height in Enumerable.Range(1, blocks))
 		{

--- a/WalletWasabi/Blockchain/Transactions/AllTransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/AllTransactionStore.cs
@@ -1,10 +1,8 @@
 using NBitcoin;
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Analysis.Clustering;
@@ -36,7 +34,7 @@ public class AllTransactionStore : ITransactionStore, IAsyncDisposable
 	public TransactionStore ConfirmedStore { get; }
 	private object Lock { get; } = new object();
 
-	public async Task InitializeAsync(bool ensureBackwardsCompatibility = true, CancellationToken cancel = default)
+	public async Task InitializeAsync(CancellationToken cancel = default)
 	{
 		using (BenchmarkLogger.Measure())
 		{
@@ -48,62 +46,6 @@ public class AllTransactionStore : ITransactionStore, IAsyncDisposable
 
 			await Task.WhenAll(initTasks).ConfigureAwait(false);
 			EnsureConsistency();
-
-			if (ensureBackwardsCompatibility)
-			{
-				cancel.ThrowIfCancellationRequested();
-				EnsureBackwardsCompatibility();
-			}
-		}
-	}
-
-	private void EnsureBackwardsCompatibility()
-	{
-		try
-		{
-			// Before Wasabi 1.1.7
-			var networkIndependentTransactionsFolderPath = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client")), "Transactions");
-			if (Directory.Exists(networkIndependentTransactionsFolderPath))
-			{
-				var oldTransactionsFolderPath = Path.Combine(networkIndependentTransactionsFolderPath, Network.Name);
-				if (Directory.Exists(oldTransactionsFolderPath))
-				{
-					lock (Lock)
-					{
-						foreach (var filePath in Directory.EnumerateFiles(oldTransactionsFolderPath))
-						{
-							try
-							{
-								string jsonString = File.ReadAllText(filePath, Encoding.UTF8);
-								var allWalletTransactions = JsonConvert.DeserializeObject<IEnumerable<SmartTransaction>>(jsonString)?.OrderByBlockchain() ?? Enumerable.Empty<SmartTransaction>();
-								foreach (var tx in allWalletTransactions)
-								{
-									AddOrUpdateNoLock(tx);
-								}
-
-								File.Delete(filePath);
-							}
-							catch (Exception ex)
-							{
-								Logger.LogTrace(ex);
-							}
-						}
-
-						Directory.Delete(oldTransactionsFolderPath, recursive: true);
-					}
-				}
-
-				// If all networks successfully migrated, too, then delete the transactions folder, too.
-				if (!Directory.EnumerateFileSystemEntries(networkIndependentTransactionsFolderPath).Any())
-				{
-					Directory.Delete(networkIndependentTransactionsFolderPath, recursive: true);
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger.LogWarning("Backwards compatibility could not be ensured.");
-			Logger.LogWarning(ex);
 		}
 	}
 

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -71,8 +71,6 @@ public class IndexStore : IAsyncDisposable
 			using (await MatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
 			using (await ImmatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
 			{
-				await EnsureBackwardsCompatibilityAsync().ConfigureAwait(false);
-
 				if (Network == Network.RegTest)
 				{
 					MatureIndexFileManager.DeleteMe(); // RegTest is not a global ledger, better to delete it.
@@ -90,27 +88,6 @@ public class IndexStore : IAsyncDisposable
 
 				await InitializeFiltersAsync(cancel).ConfigureAwait(false);
 			}
-		}
-	}
-
-	private async Task DeleteIfDeprecatedAsync(DigestableSafeIoManager ioManager)
-	{
-		string? firstLine;
-		using (var content = ioManager.OpenText())
-		{
-			firstLine = await content.ReadLineAsync().ConfigureAwait(false);
-		}
-
-		try
-		{
-			FilterModel.FromLine(firstLine);
-		}
-		catch
-		{
-			Logger.LogWarning("Old Index file detected. Deleting it.");
-			MatureIndexFileManager.DeleteMe();
-			ImmatureIndexFileManager.DeleteMe();
-			Logger.LogWarning("Successfully deleted old Index file.");
 		}
 	}
 
@@ -218,67 +195,6 @@ public class IndexStore : IAsyncDisposable
 	/// </summary>
 	private bool IsWrongFilter(FilterModel filter) =>
 		Network == Network.Main && filter.Header.Height == 627278 && filter.ToLine() == "627278:00000000000000000002edea14cfbbcde1cdb6a14275d9ad36491aa5d8862747:fd4b018270de28c44316c049e4e4050d8a7de5746c7bb31d093831c56196e5f5464956c9ab7142b998a93cb80149b09353cb5d46dfeb44ecb0c8255fb0eb64247a405ab2305713e3418707be4fe87286b467ac86603749aeeac6c182022f0105b6c547b22b89608d0b57eaee2767150bff2354e4cdecef069d1a7f9356e5972ac7323c907b2e42775d032b4a12cc45e96eaa86d232e14808beca91f21c09003734bf77005d2dbfdfeaf19108e971f99b91046db0a021a128bb17b91c83766c65e924bb48af50c473f80e8e8569fd68aaba856b9e4f60efba08519d4ca0f1c0453e60f50a86398b11c860607f049e2bc5e1b6201470f5383601fcfbbea766f510768bac3145dc33443131e50d41bdfb92f5b3d9affc0bbaa85a4c40be2d9e582c3ca0c82251d191ec83dbd197cc1a9f070e6754d84c8ca1c0258d21264619cb523a9bda5556aded4f82e9a8955180c8c8772304bb5f2a5498d15f28b3f0d5d0b22aba14a18be7c8a100bb35b73385ce2b410126ac614f2260557444c3279b73dab148cd14e8800815a1248fa802901a4430817b59d936ceb3e1594d002c1b8d88ec8641f2b2d9827a42948c61c888fc32f070eeba19dda8f773c6cef04485575652f3e929507a9e24dcee53bdc548a317f1e019fbc7ac87c5314548cca6c0b85ebbca79bed2685ed7024a21349189d9a6c92b05aa53a7e241b6885575a19bd737040c263ac05b9920d2e31568afff3c545a827338e103096fbd8fb60ef317e55146b74260577064627bba812c7ca06c39b45d291d7bb9142c338012ccb97330873a0e256ca8aaff778348085e1c9e9942cd10a8444f0c708a798c1d701b4e1879d78ee51f3044ee0012e9929c6e5bfddba40ed04872065373af111ebe53a832f5563078ef274cd39a6b77c8155d8996b6a5617c2ff447dcf4a37a84bfbd1ab34b8a4012f0ccb82c8085668a52e722f8a59a63a07420d2fc67a4da39209fc0cdcd335b2b4670817218f92aee62c8d0e3e895d7aa0f3c69ba36687c9559cf38adfef8ef0ec90128d1efc3b69006ed2c026a1a904bdd1bc0aa1924c74e05b4fdd8316a4cc400d9ced30eaf0ed01f82a6ab59bdf1fbd7a7c6f7186e33411140b57673a0075946902c5890e5647df67183a84f5b2001be152a23741582b529116e2d3bd9964968b40080173e5339018edf609199f25021c757ff3b8d1add3731002784c4da7176cd8b201e3931c61272d17e4e58a2487666510889935d054f0b72817700:000000000000000000028dbd5c398fa064b00e07805af0a8806e6f3b6ffce2c0:1587639149";
-
-	private async Task EnsureBackwardsCompatibilityAsync()
-	{
-		try
-		{
-			// Before Wasabi 1.1.5
-			var oldIndexFilePath = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client")), $"Index{Network}.dat");
-
-			// Before Wasabi 1.1.6
-			var oldFileNames = new[]
-			{
-				"ImmatureIndex.dat" ,
-				"ImmatureIndex.dat.dig",
-				"MatureIndex.dat",
-				"MatureIndex.dat.dig"
-			};
-
-			var oldIndexFolderPath = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client")), "BitcoinStore", Network.ToString());
-
-			foreach (var fileName in oldFileNames)
-			{
-				var oldFilePath = Path.Combine(oldIndexFolderPath, fileName);
-				if (File.Exists(oldFilePath))
-				{
-					string newFilePath = oldFilePath.Replace(oldIndexFolderPath, WorkFolderPath);
-					if (File.Exists(newFilePath))
-					{
-						File.Delete(newFilePath);
-					}
-
-					File.Move(oldFilePath, newFilePath);
-				}
-			}
-
-			if (File.Exists(oldIndexFilePath))
-			{
-				string[] allLines = await File.ReadAllLinesAsync(oldIndexFilePath).ConfigureAwait(false);
-				var matureLines = allLines.SkipLast(100);
-				var immatureLines = allLines.TakeLast(100);
-
-				await MatureIndexFileManager.WriteAllLinesAsync(matureLines).ConfigureAwait(false);
-				await ImmatureIndexFileManager.WriteAllLinesAsync(immatureLines).ConfigureAwait(false);
-
-				File.Delete(oldIndexFilePath);
-			}
-
-			if (MatureIndexFileManager.Exists())
-			{
-				await DeleteIfDeprecatedAsync(MatureIndexFileManager).ConfigureAwait(false);
-			}
-
-			if (ImmatureIndexFileManager.Exists())
-			{
-				await DeleteIfDeprecatedAsync(ImmatureIndexFileManager).ConfigureAwait(false);
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger.LogWarning($"Backwards compatibility could not be ensured. Exception: {ex}.");
-		}
-	}
 
 	public async Task AddNewFiltersAsync(IEnumerable<FilterModel> filters, CancellationToken cancel)
 	{

--- a/WalletWasabi/Wallets/FileSystemBlockRepository.cs
+++ b/WalletWasabi/Wallets/FileSystemBlockRepository.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Wallets;
@@ -25,123 +24,13 @@ public class FileSystemBlockRepository : IRepository<uint256, Block>
 			BlocksFolderPath = blocksFolderPath;
 			Network = network;
 			CreateFolders();
-			EnsureBackwardsCompatibility();
 			Prune(targetBlocksFolderSizeMb);
 		}
 	}
 
 	public string BlocksFolderPath { get; }
 	private Network Network { get; }
-	private AsyncLock BlockFolderLock { get; } = new AsyncLock();
-
-	/// <summary>
-	/// Copies files one by one from <c>BlocksNETWORK_NAME</c> folder to <c>BitcoinStore/NETWORK_NAME/Blocks</c> if not already migrated.
-	/// </summary>
-	private void EnsureBackwardsCompatibility()
-	{
-		Logger.LogTrace(">");
-
-		try
-		{
-			string dataDir = EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client"));
-			string wrongGlobalBlockFolderPath = Path.Combine(dataDir, "Blocks");
-			string[] wrongBlockFolderPaths = new[]
-			{
-					// Before Wasabi 1.1.13
-					Path.Combine(dataDir, $"Blocks{Network}"),
-					Path.Combine(wrongGlobalBlockFolderPath, Network.Name)
-				};
-
-			foreach (string wrongBlockFolderPath in wrongBlockFolderPaths.Where(x => Directory.Exists(x)))
-			{
-				MigrateBlocks(wrongBlockFolderPath);
-			}
-
-			if (Directory.Exists(wrongGlobalBlockFolderPath))
-			{
-				// If all networks successfully migrated, too, then delete the transactions folder, too.
-				if (!Directory.EnumerateFileSystemEntries(wrongGlobalBlockFolderPath).Any())
-				{
-					Directory.Delete(wrongGlobalBlockFolderPath, recursive: true);
-					Logger.LogInfo($"Deleted '{wrongGlobalBlockFolderPath}' folder.");
-				}
-				else
-				{
-					Logger.LogTrace($"Cannot delete '{wrongGlobalBlockFolderPath}' folder as it is not empty.");
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger.LogWarning("Backwards compatibility could not be ensured.");
-			Logger.LogWarning(ex);
-		}
-
-		Logger.LogTrace("<");
-	}
-
-	private void MigrateBlocks(string blockFolderPath)
-	{
-		Logger.LogTrace($"Initiate migration of '{blockFolderPath}'");
-
-		int cntSuccess = 0;
-		int cntRedundant = 0;
-		int cntFailure = 0;
-
-		foreach (string oldBlockFilePath in Directory.EnumerateFiles(blockFolderPath))
-		{
-			try
-			{
-				MigrateBlock(oldBlockFilePath, ref cntSuccess, ref cntRedundant);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogDebug($"'{oldBlockFilePath}' failed to migrate.");
-				Logger.LogDebug(ex);
-				cntFailure++;
-			}
-		}
-
-		Directory.Delete(blockFolderPath, recursive: true);
-
-		if (cntSuccess > 0)
-		{
-			Logger.LogInfo($"Successfully migrated {cntSuccess} blocks to '{BlocksFolderPath}'.");
-		}
-
-		if (cntRedundant > 0)
-		{
-			Logger.LogInfo($"{cntRedundant} blocks were already in '{BlocksFolderPath}'.");
-		}
-
-		if (cntFailure > 0)
-		{
-			Logger.LogDebug($"Failed to migrate {cntFailure} blocks to '{BlocksFolderPath}'.");
-		}
-
-		Logger.LogInfo($"Deleted '{blockFolderPath}' folder.");
-	}
-
-	private void MigrateBlock(string blockFilePath, ref int cntSuccess, ref int cntRedundant)
-	{
-		string fileName = Path.GetFileName(blockFilePath);
-		string newFilePath = Path.Combine(BlocksFolderPath, fileName);
-
-		if (!File.Exists(newFilePath))
-		{
-			Logger.LogTrace($"Migrate '{blockFilePath}' -> '{newFilePath}'.");
-
-			// Unintuitively File.Move overwrite: false throws an IOException if the file already exists.
-			// https://docs.microsoft.com/en-us/dotnet/api/system.io.file.move?view=netcore-3.1
-			File.Move(sourceFileName: blockFilePath, destFileName: newFilePath, overwrite: false);
-			cntSuccess++;
-		}
-		else
-		{
-			Logger.LogTrace($"'{newFilePath}' already exists. Skip migrating.");
-			cntRedundant++;
-		}
-	}
+	private AsyncLock BlockFolderLock { get; } = new();
 
 	/// <summary>
 	/// Prunes <see cref="BlocksFolderPath"/> so that its size is at most <paramref name="maxFolderSizeMb"/> MB.


### PR DESCRIPTION
This PR removes code that ensures backward compatibility. I'm aware that the policy is not to break BC but there are some considerations that might make it reasonably in this case.

* The [code](https://github.com/zkSNACKs/WalletWasabi/commit/29ca098abb58ad98aec9b330c2330e43b1713ccb) was added 2 years ago.
* https://github.com/zkSNACKs/WalletWasabi/pull/9528#issuecomment-1328857058 - David plans to write a note about backward compatibility anyway

So 2 years is a long time and there were many new WW1 versions after that. So the removed code is only useful for people who are on a very old WW1 versions and did not upgrade to the latest WW1 also did not install WW2 and also did not need [Trezor T hotfix](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v1.1.12.7), probably use an oldish Tor version, etc. Moreover, .NET Core 3.1 reaches [EOF](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/) in a week. 

So overall, maybe there is an old software collector who is running her old WW version but it's pretty unlikely. Adding a release note that if you are on a very old WW1 client, you need to upgrade to the current released WW2 build first and then to the latest WW2 version covers even those potentially affected.

Is there anything I'm missing?

btw: We don't need to merge this now. We can say that we'll warn users for the next 1 or 2 releases and then merge this PR. An alternative is to have the code there forever, I don't find sufficient reason for it and also it's not a common [software practice](https://github.com/zkSNACKs/WalletWasabi/pull/9528#discussion_r1023160146).