### PR TITLE
Fix "Bitcoin Knots doesn't work" issue

### DIFF
--- a/WalletWasabi.Fluent/Global.cs
+++ b/WalletWasabi.Fluent/Global.cs
@@ -256,6 +256,7 @@ public class Global
 							EndPointStrategy.Default(Network, EndPointType.Rpc),
 							txIndex: null,
 							prune: null,
+							disableWallet: 1,
 							mempoolReplacement: "fee,optin",
 							userAgent: $"/WasabiClient:{Constants.ClientVersion}/",
 							fallbackFee: null, // ToDo: Maybe we should have it, not only for tests?

--- a/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/TestNodeBuilder.cs
@@ -46,6 +46,7 @@ public static class TestNodeBuilder
 				EndPointStrategy.Random,
 				txIndex: 1,
 				prune: 0,
+				disableWallet: 0,
 				mempoolReplacement: "fee,optin",
 				userAgent: $"/WasabiClient:{Constants.ClientVersion}/",
 				fallbackFee: Money.Coins(0.0002m), // https://github.com/bitcoin/bitcoin/pull/16524

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -129,7 +129,7 @@ public class CoreNode
 					$"{configPrefix}.server			= 1",
 					$"{configPrefix}.listen			= 1",
 					$"{configPrefix}.daemon			= 0", // https://github.com/zkSNACKs/WalletWasabi/issues/3588
-					$"{configPrefix}.disablewallet	= 1",
+					$"{configPrefix}.disablewallet	= 1", // https://github.com/zkSNACKs/WalletWasabi/pull/9714
 					$"{configPrefix}.whitebind		= {whiteBindPermissionsPart}{coreNode.P2pEndPoint.ToString(coreNode.Network.DefaultPort)}",
 					$"{configPrefix}.rpcbind		= {rpcBindParameter}",
 					$"{configPrefix}.rpcallowip		= {IPAddress.Loopback}",

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -129,6 +129,7 @@ public class CoreNode
 					$"{configPrefix}.server			= 1",
 					$"{configPrefix}.listen			= 1",
 					$"{configPrefix}.daemon			= 0", // https://github.com/zkSNACKs/WalletWasabi/issues/3588
+					$"{configPrefix}.disablewallet	= 1",
 					$"{configPrefix}.whitebind		= {whiteBindPermissionsPart}{coreNode.P2pEndPoint.ToString(coreNode.Network.DefaultPort)}",
 					$"{configPrefix}.rpcbind		= {rpcBindParameter}",
 					$"{configPrefix}.rpcallowip		= {IPAddress.Loopback}",

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -129,7 +129,6 @@ public class CoreNode
 					$"{configPrefix}.server			= 1",
 					$"{configPrefix}.listen			= 1",
 					$"{configPrefix}.daemon			= 0", // https://github.com/zkSNACKs/WalletWasabi/issues/3588
-					$"{configPrefix}.disablewallet	= 1", // https://github.com/zkSNACKs/WalletWasabi/pull/9714
 					$"{configPrefix}.whitebind		= {whiteBindPermissionsPart}{coreNode.P2pEndPoint.ToString(coreNode.Network.DefaultPort)}",
 					$"{configPrefix}.rpcbind		= {rpcBindParameter}",
 					$"{configPrefix}.rpcallowip		= {IPAddress.Loopback}",
@@ -150,6 +149,11 @@ public class CoreNode
 			if (coreNodeParams.Prune is { })
 			{
 				desiredConfigLines.Add($"{configPrefix}.prune = {coreNodeParams.Prune}");
+			}
+
+			if (coreNodeParams.DisableWallet is { })
+			{
+				desiredConfigLines.Add($"{configPrefix}.disablewallet = {coreNodeParams.DisableWallet}");
 			}
 
 			if (coreNodeParams.MempoolReplacement is { })

--- a/WalletWasabi/BitcoinCore/CoreNodeParams.cs
+++ b/WalletWasabi/BitcoinCore/CoreNodeParams.cs
@@ -18,6 +18,7 @@ public class CoreNodeParams
 		EndPointStrategy rpcEndPointStrategy,
 		int? txIndex,
 		int? prune,
+		int? disableWallet,
 		string mempoolReplacement,
 		string userAgent,
 		Money? fallbackFee,
@@ -32,6 +33,7 @@ public class CoreNodeParams
 		RpcEndPointStrategy = Guard.NotNull(nameof(rpcEndPointStrategy), rpcEndPointStrategy);
 		TxIndex = txIndex;
 		Prune = prune;
+		DisableWallet = disableWallet;
 		MempoolReplacement = mempoolReplacement;
 		UserAgent = Guard.NotNullOrEmptyOrWhitespace(nameof(userAgent), userAgent, trim: true);
 		FallbackFee = fallbackFee;
@@ -45,6 +47,7 @@ public class CoreNodeParams
 	public bool TryDeleteDataDir { get; }
 	public int? TxIndex { get; }
 	public int? Prune { get; }
+	public int? DisableWallet { get; }
 	public string MempoolReplacement { get; }
 	public string UserAgent { get; }
 	public Money? FallbackFee { get; }


### PR DESCRIPTION
This PR disables wallet for Bitcoin Knots when starting it. The reasons are the following:

1. We don't need it.
2. It probably makes startup faster.
3. It makes Knots work on my machine.

Let me elaborate on point (3):

I recently changed computers and noticed Wasabi Wallet cannot start Bitcoin Knots. It fails with the following message:

```
2022-12-08 11:14:49.945 [22] ERROR	Global.StartLocalBitcoinNodeAsync (272)	WalletWasabi.BitcoinCore.Processes.BitcoindException: Failed to start daemon, location: 'C:\Users\user\Desktop\WalletWasabi\WalletWasabi.Fluent.Desktop\bin\Debug\net7.0\Microservices\Binaries\win64\bitcoind.exe -regtest=0 -testnet=0 -datadir="C:\Users\user\AppData\Roaming\Bitcoin" -printtoconsole=0'
 ---> System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it. (127.0.0.1:8332)
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
   at System.Net.Sockets.Socket.<ConnectAsync>g__WaitForConnectWithCancellation|281_0(AwaitableSocketAsyncEventArgs saea, ValueTask connectTask, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.HttpConnectionWaiter`1.WaitForConnectionAsync(Boolean async, CancellationToken requestCancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at NBitcoin.RPC.RPCClient.SendCommandAsync(RPCRequest request, CancellationToken cancellationToken)
   at NBitcoin.RPC.RPCClient.UptimeAsync(CancellationToken cancellationToken)
   at WalletWasabi.BitcoinCore.Rpc.RpcClientBase.UptimeAsync(CancellationToken cancellationToken) in WalletWasabi\BitcoinCore\Rpc\RpcClientBase.cs:line 131
   at WalletWasabi.BitcoinCore.Processes.BitcoindRpcProcessBridge.StartAsync(CancellationToken cancel) in WalletWasabi\BitcoinCore\Processes\BitcoindRpcProcessBridge.cs:line 71
   --- End of inner exception stack trace ---
   at WalletWasabi.BitcoinCore.Processes.BitcoindRpcProcessBridge.StartAsync(CancellationToken cancel) in WalletWasabi\BitcoinCore\Processes\BitcoindRpcProcessBridge.cs:line 91
   at WalletWasabi.BitcoinCore.CoreNode.CreateAsync(CoreNodeParams coreNodeParams, CancellationToken cancel) in WalletWasabi\BitcoinCore\CoreNode.cs:line 242
   at WalletWasabi.Fluent.Global.StartLocalBitcoinNodeAsync(CancellationToken cancel) in WalletWasabi.Fluent\Global.cs:line 247
```

So I checked Bitcoin Knots' logs and found this to be the reason why it fails to start:
```
2022-12-08T10:14:46Z Error: Unknown address type 'bech32m'
```

My theory is that Wasabi ships older Knots version (LTS) than what I have installed on my computer (I won't check it, don't even ask. A good programmer maximizes work not done.)
So figured if that's the case, then I should just disable the wallet and it should work. And it did. We should do this anyway as elaborated in (1) and (2).

This change should make Wasabi's full node more robust against future Bitcoin Core changes.