### PR TITLE
Run Wasabi Wallet After Install 

### DIFF
--- a/WalletWasabi.WindowsInstaller/Components.wxs
+++ b/WalletWasabi.WindowsInstaller/Components.wxs
@@ -33,5 +33,16 @@
         <RemoveFolder Id="RemoveDesktop" Directory="DesktopFolder" On="uninstall" />
       </Component>
     </DirectoryRef>
+
+    <CustomAction Id="EXECUTE_AFTER_FINALIZE"
+        Execute="immediate" 
+        Impersonate="no"
+        Return="asyncNoWait"
+        Directory="INSTALLFOLDER"
+        ExeCommand="[INSTALLFOLDER]wassabee.exe" />
+
+    <InstallExecuteSequence>
+      <Custom Action="EXECUTE_AFTER_FINALIZE" After="InstallFinalize">NOT Installed</Custom>
+    </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/WalletWasabi.WindowsInstaller/Components.wxs
+++ b/WalletWasabi.WindowsInstaller/Components.wxs
@@ -33,16 +33,5 @@
         <RemoveFolder Id="RemoveDesktop" Directory="DesktopFolder" On="uninstall" />
       </Component>
     </DirectoryRef>
-
-    <CustomAction Id="EXECUTE_AFTER_FINALIZE"
-        Execute="immediate" 
-        Impersonate="no"
-        Return="asyncNoWait"
-        Directory="INSTALLFOLDER"
-        ExeCommand="[INSTALLFOLDER]wassabee.exe" />
-
-    <InstallExecuteSequence>
-      <Custom Action="EXECUTE_AFTER_FINALIZE" After="InstallFinalize">NOT Installed</Custom>
-    </InstallExecuteSequence>
   </Fragment>
 </Wix>

--- a/WalletWasabi.WindowsInstaller/Product.wxs
+++ b/WalletWasabi.WindowsInstaller/Product.wxs
@@ -60,9 +60,22 @@
             Event="NewDialog"
             Value="WelcomeDlg"
             Order="99">1</Publish>
+      <Publish Dialog="ExitDialog"
+            Control="Finish"
+            Event="DoAction"
+            Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
     </UI>
 
-    <!-- Define components, shortcuts, files, etc... for instealler. -->
+    <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Thank you for helping the world staying private." />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch Wasabi Wallet" />
+    <Property Id="WixShellExecTarget" Value="[INSTALLFOLDER]wassabee.exe" />
+
+    <CustomAction Id="LaunchApplication"
+        BinaryKey="WixCA"
+        DllEntry="WixShellExec"
+        Impersonate="yes" />
+
+    <!-- Define components, shortcuts, files, etc... for installer. -->
     <Feature Id="ProductFeature" Title="Wasabi" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
       <ComponentGroupRef Id="PublishedComponents" />


### PR DESCRIPTION
Fixes #4325

![image](https://user-images.githubusercontent.com/58662979/206655798-62018907-46f6-4a50-9b0a-4c6b5eab53f2.png)

## Notes

* It would be good to actually tick the checkbox by default. Not sure how to do it at the moment.
* The first commit shows how to run WW without any interaction whatsoever after the installation is done. This is slightly uncommon behavior though.
* The second commit adds the checkbox and fixes #4325. However, the checkbox is located in a gray rectangle. That's a known [WIX issue](https://github.com/wixtoolset/issues/issues/1687) and I have not found any workaround.

## Resources

* https://github.com/wixtoolset/issues/issues/1687 - text on exitdialog needs to be separate from checkbox 
  * https://github.com/wixtoolset/issues/issues/5430 - example 1
  * https://github.com/xenserver/xenadmin/pull/3018 - example 2
* https://wixtoolset.org/docs/v3/wixui/wixui_customizations/
