### PR TITLE
[VDG] Remove key gap fields from Wallet Stats

### DIFF
--- a/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
@@ -14,15 +14,4 @@ public static class KeyManagerExtensions
 
 	public static IEnumerable<SmartLabel> GetReceiveLabels(this KeyManager km) =>
 		km.GetKeys(isInternal: false).Select(x => x.Label);
-
-	public static int CountConsecutiveUnusedKeys(this KeyManager km, bool isInternal)
-	{
-		var view = km.GetView(isInternal, ScriptPubKeyType.Segwit);
-		var usedKeyIndexes = view.UsedKeys.Select(x => x.Index).OrderBy(x => x);
-		var auxPoints = usedKeyIndexes.Prepend(0).ToArray();
-		return auxPoints
-			.Zip(auxPoints[1..], (x, y) => y - x)
-			.Take(auxPoints.Length - 1)
-			.MaxOrDefault(0);
-	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletStatsViewModel.cs
@@ -24,8 +24,6 @@ public partial class WalletStatsViewModel : RoutableViewModel
 	[AutoNotify] private int _generatedCleanKeyCount;
 	[AutoNotify] private int _generatedLockedKeyCount;
 	[AutoNotify] private int _generatedUsedKeyCount;
-	[AutoNotify] private int _largestExternalKeyGap;
-	[AutoNotify] private int _largestInternalKeyGap;
 	[AutoNotify] private int _totalTransactionCount;
 	[AutoNotify] private int _nonCoinjointransactionCount;
 	[AutoNotify] private int _coinjoinTransactionCount;
@@ -68,9 +66,6 @@ public partial class WalletStatsViewModel : RoutableViewModel
 		GeneratedCleanKeyCount = _wallet.KeyManager.GetKeys(KeyState.Clean).Count();
 		GeneratedLockedKeyCount = _wallet.KeyManager.GetKeys(KeyState.Locked).Count();
 		GeneratedUsedKeyCount = _wallet.KeyManager.GetKeys(KeyState.Used).Count();
-
-		LargestExternalKeyGap = _wallet.KeyManager.CountConsecutiveUnusedKeys(isInternal: false);
-		LargestInternalKeyGap = _wallet.KeyManager.CountConsecutiveUnusedKeys(isInternal: true);
 
 		var singleCoinjoins = _walletViewModel.History.Transactions.OfType<CoinJoinHistoryItemViewModel>().ToList();
 		var groupedCoinjoins = _walletViewModel.History.Transactions.OfType<CoinJoinsHistoryItemViewModel>().ToList();

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
@@ -71,19 +71,6 @@
         <c:PrivacyContentControl Classes="monoSpaced"
                                  Content="{Binding GeneratedUsedKeyCount}" />
       </c:PreviewItem>
-
-      <Separator />
-      <c:PreviewItem Label="Largest receive key gap"
-                     TextValue="{Binding LargestExternalKeyGap}">
-        <c:PrivacyContentControl Classes="monoSpaced"
-                                 Content="{Binding LargestExternalKeyGap}" />
-      </c:PreviewItem>
-      <Separator />
-      <c:PreviewItem Label="Largest change key gap"
-                     TextValue="{Binding LargestInternalKeyGap}">
-        <c:PrivacyContentControl Classes="monoSpaced"
-                                 Content="{Binding LargestInternalKeyGap}" />
-      </c:PreviewItem>
     </StackPanel>
   </c:ContentArea>
 </UserControl>

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -195,30 +195,6 @@ public class KeyManagementTests
 		}
 	}
 
-	[Fact]
-	public void GapCountingTests()
-	{
-		var km = KeyManager.CreateNew(out _, "", Network.Main);
-		var hdPubKeys = Enumerable.Range(0, 100)
-			.Select(i => km.GenerateNewKey(SmartLabel.Empty, i % 2 == 0 ? KeyState.Clean : KeyState.Locked, true))
-			.ToArray();
-
-		km.SetKeyState(KeyState.Used, hdPubKeys[0]);
-		Assert.Equal(0, km.CountConsecutiveUnusedKeys(true));
-
-		km.SetKeyState(KeyState.Used, hdPubKeys[10]);
-		Assert.Equal(10, km.CountConsecutiveUnusedKeys(true));
-
-		km.SetKeyState(KeyState.Used, hdPubKeys[30]);
-		Assert.Equal(20, km.CountConsecutiveUnusedKeys(true));
-
-		km.SetKeyState(KeyState.Used, hdPubKeys[80]);
-		Assert.Equal(50, km.CountConsecutiveUnusedKeys(true));
-
-		km.SetKeyState(KeyState.Clean, hdPubKeys[30]);
-		Assert.Equal(70, km.CountConsecutiveUnusedKeys(true));
-	}
-
 	private static void DeleteFileAndDirectoryIfExists(string filePath)
 	{
 		var dir = Path.GetDirectoryName(filePath);


### PR DESCRIPTION
 - Removes `Largest receive key gap` and `Largest change key gap` from the `Wallet Stats` UI.
 - Removes the `KeyManagerExtensions.CountConsecutiveUnusedKeys()` extension method.
 - Removes Unit Tests for the method above.
 - Fixes #9733