### PR TITLE
[Tor] `HeaderSection`: Remove unused `ToString(bool endWithTwoCRLF)`

### DIFF
--- a/WalletWasabi/Tor/Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpRequestMessageExtensions.cs
@@ -65,7 +65,7 @@ public static class HttpRequestMessageExtensions
 		if (request.Headers.NotNullAndNotEmpty())
 		{
 			var headerSection = HeaderSection.CreateNew(request.Headers);
-			headers += headerSection.ToString(endWithTwoCRLF: false);
+			headers += headerSection.ToString();
 		}
 
 		string messageBody = "";
@@ -74,7 +74,7 @@ public static class HttpRequestMessageExtensions
 			if (request.Content.Headers.NotNullAndNotEmpty())
 			{
 				var headerSection = HeaderSection.CreateNew(request.Content.Headers);
-				headers += headerSection.ToString(endWithTwoCRLF: false);
+				headers += headerSection.ToString();
 			}
 
 			messageBody = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Tor/Http/Models/HeaderSection.cs
+++ b/WalletWasabi/Tor/Http/Models/HeaderSection.cs
@@ -13,23 +13,15 @@ public class HeaderSection
 {
 	public List<HeaderField> Fields { get; private set; } = new List<HeaderField>();
 
-	public string ToString(bool endWithTwoCRLF)
+	public override string ToString()
 	{
 		StringBuilder sb = new();
 		foreach (var field in Fields)
 		{
 			sb.Append(field.ToString(endWithCRLF: true));
 		}
-		if (endWithTwoCRLF)
-		{
-			sb.Append(CRLF);
-		}
-		return sb.ToString();
-	}
 
-	public override string ToString()
-	{
-		return ToString(false);
+		return sb.ToString();
 	}
 
 	public static async Task<HeaderSection> CreateNewAsync(string headersString)


### PR DESCRIPTION
`ToString(bool endWithTwoCRLF)` is always called with `false` as the parameter of the calls