### PR TITLE
[VDG] reset empty local BTC core path when enabled

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -53,6 +53,11 @@ public partial class BitcoinTabSettingsViewModel : SettingsTabViewModelBase
 			.Throttle(TimeSpan.FromMilliseconds(ThrottleTime))
 			.Skip(1)
 			.Subscribe(_ => Save());
+
+		this.WhenAnyValue(x => x.StartLocalBitcoinCoreOnStartup)
+			.Skip(1)
+			.Where(value => value && string.IsNullOrEmpty(LocalBitcoinCoreDataDir))
+			.Subscribe(_ => LocalBitcoinCoreDataDir = EnvironmentHelpers.GetDefaultBitcoinCoreDataDirOrEmptyString());
 	}
 
 	public Version BitcoinCoreVersion => Constants.BitcoinCoreVersion;


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/8735

The thing is empty string is allowed in case it doesn't find the directory. This solution still allows the string to be empty, but when the user turns the feature off/on it will try to find again the default path.