### PR TITLE
Preloading BitcoinSecrets

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Extensions;
@@ -454,6 +455,11 @@ public class CoinJoinClient
 		// Decrease the available time, so the clients hurry up.
 		var safetyBuffer = TimeSpan.FromMinutes(1);
 		var scheduledDates = GetScheduledDates(smartCoins.Count(), roundState.InputRegistrationEnd - safetyBuffer);
+
+		if (KeyChain is KeyChain keyChain)
+		{
+			keyChain.PreloadBitcoinSecrets(smartCoins.Select(c => c.ScriptPubKey));
+		}
 
 		// Creates scheduled tasks (tasks that wait until the specified date/time and then perform the real registration)
 		var aliceClients = smartCoins.Zip(

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -458,7 +458,10 @@ public class CoinJoinClient
 
 		if (KeyChain is KeyChain keyChain)
 		{
-			keyChain.PreloadBitcoinSecrets(smartCoins.Select(c => c.ScriptPubKey));
+			using (BenchmarkLogger.Measure(operationName: nameof(keyChain.PreloadBitcoinSecrets)))
+			{
+				keyChain.PreloadBitcoinSecrets(smartCoins.Select(c => c.ScriptPubKey));
+			}
 		}
 
 		// Creates scheduled tasks (tasks that wait until the specified date/time and then perform the real registration)

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -32,6 +32,10 @@ public class KeyChain : BaseKeyChain
 		MasterKey = KeyManager.GetMasterExtKey(Kitchen.SaltSoup());
 	}
 
+	/// <summary>
+	/// Do the CPU intense operations for specified scripts.
+	/// </summary>
+	/// <param name="scriptPubKeys"></param>
 	public void PreloadBitcoinSecrets(IEnumerable<Script> scriptPubKeys)
 	{
 		BitcoinSecrets.Clear();

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -33,11 +33,12 @@ public class KeyChain : BaseKeyChain
 	{
 		BitcoinSecrets.Clear();
 
-		var hdKeyAndScripPubs = KeyManager.GetSecrets(Kitchen.SaltSoup(), scriptPubKeys.ToArray()).Zip(scriptPubKeys);
+		var secretAndhdPubs = KeyManager.GetSecretsAndPubKeyPairs(Kitchen.SaltSoup(), scriptPubKeys.ToArray());
 
-		foreach (var (hdKey, scriptPubKey) in hdKeyAndScripPubs)
+		foreach (var (secret, hdPub) in secretAndhdPubs)
 		{
-			BitcoinSecrets.Add(scriptPubKey, GetBitcoinSecret(scriptPubKey, hdKey));
+			var scriptPubKey = hdPub.GetAssumedScriptPubKey();
+			BitcoinSecrets.Add(scriptPubKey, GetBitcoinSecret(scriptPubKey, secret));
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Client/KeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/KeyChain.cs
@@ -33,7 +33,7 @@ public class KeyChain : BaseKeyChain
 	}
 
 	/// <summary>
-	/// Do the CPU intense operations for specified scripts.
+	/// Do the CPU intense operations for specified scripts. With every call the previously stored data cleared.
 	/// </summary>
 	/// <param name="scriptPubKeys"></param>
 	public void PreloadBitcoinSecrets(IEnumerable<Script> scriptPubKeys)


### PR DESCRIPTION
We are overloading the CPU right before the signing. The calculations are CPU bound. There are two places, this PR takes the highest-level approach and adds a "cache" at the beginning of every round. 

It can be done more performant, right now I am looking for a concept ACK from @lontivero.
Currently, the calculations take about 20-40 seconds. 

I made tests and proved to solve the problem in the issue below, but this was a source of many other random coinjoin failures and timeouts on any computer. 

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/9339

Closes: https://github.com/zkSNACKs/WalletWasabi/pull/9767 https://github.com/zkSNACKs/WalletWasabi/pull/9728 https://github.com/zkSNACKs/WalletWasabi/pull/9537

Might be related: https://github.com/zkSNACKs/WalletWasabi/issues/9370

TODO:
- [ ] GetSecretsAndPubKeyPairs recalculating the masterkey.
- [ ] Add cancellation to Parallel.Foreach.
