### PR TITLE
Select coins from reused address

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs
@@ -11,7 +11,7 @@ public interface ISmartCoin
 	/// <remarks>Note there might be a new script type that even NBitcoin does not support.</remarks>
 	ScriptType ScriptType { get; }
 
-	HdPubKey HdPubKey { get; }
+	Script ScriptPubKey { get; }
 
 	double AnonymitySet { get; }
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
 
 namespace WalletWasabi.Blockchain.TransactionOutputs;
 
@@ -9,6 +10,8 @@ public interface ISmartCoin
 	/// <summary>Script type if available, throw an exception if it is not available.</summary>
 	/// <remarks>Note there might be a new script type that even NBitcoin does not support.</remarks>
 	ScriptType ScriptType { get; }
+
+	HdPubKey HdPubKey { get; }
 
 	double AnonymitySet { get; }
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -903,9 +903,15 @@ public class CoinJoinClient
 				.GroupBy(x => x.HdPubKey)
 				.OrderByDescending(g => g.Count())
 				.SelectMany(g => g)
-				.Take(MaxInputsRegistrableByWallet - winner.Count);
+				.Take(MaxInputsRegistrableByWallet - winner.Count)
+				.ToList();
 			
 			winner.AddRange(nonSelectedCoinsOnSameAddresses);
+
+			if (nonSelectedCoinsOnSameAddresses.Count > 0)
+			{
+				Logger.LogInfo($"{nonSelectedCoinsOnSameAddresses.Count} coins were added to the selection because they are on same public addresses than some selected coins.");
+			}
 		}
 
 		return winner.ToShuffled().ToImmutableList();

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -893,19 +893,18 @@ public class CoinJoinClient
 
 		if (winner.Count < MaxInputsRegistrableByWallet)
 		{
-			
 			// If the address of a winner contains other coins (address reuse, same HdPubKey) that are available but not selected,
 			// complete the selection with them until MaxInputsRegistrableByWallet threshold.
 			// Order by most to least reused to try not splitting coins from same address into several rounds.
 			var nonSelectedCoinsOnSameAddresses = filteredCoins
 				.Except(winner)
-				.Where(x => winner.Any(y => y.HdPubKey == x.HdPubKey))
-				.GroupBy(x => x.HdPubKey)
+				.Where(x => winner.Any(y => y.ScriptPubKey == x.ScriptPubKey))
+				.GroupBy(x => x.ScriptPubKey)
 				.OrderByDescending(g => g.Count())
 				.SelectMany(g => g)
 				.Take(MaxInputsRegistrableByWallet - winner.Count)
 				.ToList();
-			
+
 			winner.AddRange(nonSelectedCoinsOnSameAddresses);
 
 			if (nonSelectedCoinsOnSameAddresses.Count > 0)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -910,7 +910,7 @@ public class CoinJoinClient
 
 			if (nonSelectedCoinsOnSameAddresses.Count > 0)
 			{
-				Logger.LogInfo($"{nonSelectedCoinsOnSameAddresses.Count} coins were added to the selection because they are on same public addresses than some selected coins.");
+				Logger.LogInfo($"{nonSelectedCoinsOnSameAddresses.Count} coins were added to the selection because they are on the same addresses of some selected coins.");
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -897,16 +897,15 @@ public class CoinJoinClient
 			// If the address of a winner contains other coins (address reuse, same HdPubKey) that are available but not selected,
 			// complete the selection with them until MaxInputsRegistrableByWallet threshold.
 			// Order by most to least reused to try not splitting coins from same address into several rounds.
-			var nonSelectedCoinsOnSameAddresses = semiPrivateCoins
-				.Union(redCoins)
+			var nonSelectedCoinsOnSameAddresses = filteredCoins
 				.Except(winner)
 				.Where(x => winner.Any(y => y.HdPubKey == x.HdPubKey))
 				.GroupBy(x => x.HdPubKey)
 				.OrderByDescending(g => g.Count())
 				.SelectMany(g => g)
-				.ToList();
+				.Take(MaxInputsRegistrableByWallet - winner.Count);
 			
-			winner.AddRange(nonSelectedCoinsOnSameAddresses.Take(MaxInputsRegistrableByWallet - winner.Count));
+			winner.AddRange(nonSelectedCoinsOnSameAddresses);
 		}
 
 		return winner.ToShuffled().ToImmutableList();

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -891,20 +891,21 @@ public class CoinJoinClient
 			Logger.LogDebug($"{nameof(winner)}: {winner.Count} coins, {string.Join(", ", winner.Select(x => x.Amount.ToString(false, true)).ToArray())} BTC.");
 		}
 
-		// If the address of a winner contains other coins (address reuse, same HdPubKey) that are available but not selected,
-		// complete the selection with them until MaxInputsRegistrableByWallet threshold.
-		// Order by most to least reused to try not splitting coins from same address into several rounds.
-		var nonSelectedCoinsOnSameAddresses = semiPrivateCoins
-			.Union(redCoins)
-			.Except(winner)
-			.Where(x => winner.Any(y => y.HdPubKey == x.HdPubKey))
-			.GroupBy(x => x.HdPubKey)
-			.OrderByDescending(g => g.Count())
-			.SelectMany(g => g)
-			.ToList();
-
 		if (winner.Count < MaxInputsRegistrableByWallet)
 		{
+			
+			// If the address of a winner contains other coins (address reuse, same HdPubKey) that are available but not selected,
+			// complete the selection with them until MaxInputsRegistrableByWallet threshold.
+			// Order by most to least reused to try not splitting coins from same address into several rounds.
+			var nonSelectedCoinsOnSameAddresses = semiPrivateCoins
+				.Union(redCoins)
+				.Except(winner)
+				.Where(x => winner.Any(y => y.HdPubKey == x.HdPubKey))
+				.GroupBy(x => x.HdPubKey)
+				.OrderByDescending(g => g.Count())
+				.SelectMany(g => g)
+				.ToList();
+			
 			winner.AddRange(nonSelectedCoinsOnSameAddresses.Take(MaxInputsRegistrableByWallet - winner.Count));
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -672,7 +672,7 @@ public class CoinJoinClient
 			.GroupBy(x => x.HdPubKey)
 			.Select(x => x.ToList())
 			.Where(x => x.Count > 1)
-			.OrderBy(x => x.Count);
+			.OrderByDescending(x => x.Count);
 
 		if (sameAddressCoins.Any())
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -891,14 +891,12 @@ public class CoinJoinClient
 			Logger.LogDebug($"{nameof(winner)}: {winner.Count} coins, {string.Join(", ", winner.Select(x => x.Amount.ToString(false, true)).ToArray())} BTC.");
 		}
 
-		// If the address of a winner contains other coins (address reuse, same HdPubKey),
+		// If the address of a winner contains other coins (address reuse, same HdPubKey) that are available but not selected,
 		// complete the selection with them until MaxInputsRegistrableByWallet threshold.
-		var nonSelectedCoins = semiPrivateCoins
-			.Union(redCoins)
-			.Except(winner);
-
 		// Order by most to least reused to try not splitting coins from same address into several rounds.
-		var nonSelectedCoinsOnSameAddresses = nonSelectedCoins
+		var nonSelectedCoinsOnSameAddresses = semiPrivateCoins
+			.Union(redCoins)
+			.Except(winner)
 			.Where(x => winner.Any(y => y.HdPubKey == x.HdPubKey))
 			.GroupBy(x => x.HdPubKey)
 			.OrderByDescending(g => g.Count())


### PR DESCRIPTION
Fixes #9770

There are several ways of doing this concept, I implemented 2:

1) Commits [ea17538-46aa327](https://github.com/zkSNACKs/WalletWasabi/pull/9782/files/46aa327e7916b9cb11e8b4bc9f03ad13da4ec5cc): At the beginning of the coin selection, if some coins are on the same `HdPubKey`, group and select `MaxInputsRegistrableByWallet` of them.
If not that much are available, does not complete the selection with other coins.

2) [83473d3](https://github.com/zkSNACKs/WalletWasabi/pull/9782/files/83473d3a505adb57f15de1e44a1d372a10d44d3d): At the end of the selection, check if the winners coins have other coins on their `HdPubKey` and if so select them but respecting the number of `MaxInputsRegistrableByWallet`.
