### PR TITLE
Remove unused `OwnershipProof` from `IKeyChain`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -124,7 +124,7 @@ public class TestWallet : IKeyChain, IDestinationProvider
 	}
 
 	/// <remarks>Test wallet assumes that the ownership proof is always correct.</remarks>
-	public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof, PrecomputedTransactionData precomputeTransactionData)
+	public Transaction Sign(Transaction transaction, Coin coin, PrecomputedTransactionData precomputeTransactionData)
 	{
 		if (!ScriptPubKeys.TryGetValue(coin.ScriptPubKey, out var extKey))
 		{

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -123,7 +123,6 @@ public class TestWallet : IKeyChain, IDestinationProvider
 				ScriptPubKeyType.Segwit);
 	}
 
-	/// <remarks>Test wallet assumes that the ownership proof is always correct.</remarks>
 	public Transaction Sign(Transaction transaction, Coin coin, PrecomputedTransactionData precomputeTransactionData)
 	{
 		if (!ScriptPubKeys.TryGetValue(coin.ScriptPubKey, out var extKey))

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -115,14 +115,14 @@ public class ArenaClientTests
 
 		// No inputs in the coinjoin.
 		await Assert.ThrowsAsync<ArgumentException>(async () =>
-				await apiClient.SignTransactionAsync(round.Id, alice1.Coin, coins[0].OwnershipProof, keyChain, finalizedEmptyState.CreateUnsignedTransactionWithPrecomputedData(), CancellationToken.None));
+				await apiClient.SignTransactionAsync(round.Id, alice1.Coin, keyChain, finalizedEmptyState.CreateUnsignedTransactionWithPrecomputedData(), CancellationToken.None));
 
 		var oneInput = emptyState.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData).Finalize();
 		round.CoinjoinState = oneInput;
 
 		// Trying to sign coins those are not in the coinjoin.
 		await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-				await apiClient.SignTransactionAsync(round.Id, alice2.Coin, coins[1].OwnershipProof, keyChain, oneInput.CreateUnsignedTransactionWithPrecomputedData(), CancellationToken.None));
+				await apiClient.SignTransactionAsync(round.Id, alice2.Coin, keyChain, oneInput.CreateUnsignedTransactionWithPrecomputedData(), CancellationToken.None));
 
 		var twoInputs = emptyState
 			.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData)
@@ -133,13 +133,13 @@ public class ArenaClientTests
 		Assert.False(round.Assert<SigningState>().IsFullySigned);
 		var unsigned = round.Assert<SigningState>().CreateUnsignedTransactionWithPrecomputedData();
 
-		await apiClient.SignTransactionAsync(round.Id, alice1.Coin, coins[0].OwnershipProof, keyChain, unsigned, CancellationToken.None);
+		await apiClient.SignTransactionAsync(round.Id, alice1.Coin, keyChain, unsigned, CancellationToken.None);
 		Assert.True(round.Assert<SigningState>().IsInputSigned(alice1.Coin.Outpoint));
 		Assert.False(round.Assert<SigningState>().IsInputSigned(alice2.Coin.Outpoint));
 
 		Assert.False(round.Assert<SigningState>().IsFullySigned);
 
-		await apiClient.SignTransactionAsync(round.Id, alice2.Coin, coins[1].OwnershipProof, keyChain, unsigned, CancellationToken.None);
+		await apiClient.SignTransactionAsync(round.Id, alice2.Coin, keyChain, unsigned, CancellationToken.None);
 		Assert.True(round.Assert<SigningState>().IsInputSigned(alice2.Coin.Outpoint));
 
 		Assert.True(round.Assert<SigningState>().IsFullySigned);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
@@ -1,7 +1,6 @@
 using NBitcoin;
 using System.Linq;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Crypto;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
@@ -20,14 +19,13 @@ public class KeyChainTests
 
 		var coinDestination = destinationProvider.GetNextDestinations(1, false).First();
 		var coin = new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(1.0m), coinDestination));
-		var ownershipProof = keyChain.GetOwnershipProof(coinDestination, new CoinJoinInputCommitmentData("test", uint256.One));
 
 		var transaction = Transaction.Create(Network.Main); // the transaction doesn't contain the input that we request to be signed.
 
-		Assert.Throws<ArgumentException>(() => keyChain.Sign(transaction, coin, ownershipProof, transaction.PrecomputeTransactionData()));
+		Assert.Throws<ArgumentException>(() => keyChain.Sign(transaction, coin, transaction.PrecomputeTransactionData()));
 
 		transaction.Inputs.Add(coin.Outpoint);
-		var signedTx = keyChain.Sign(transaction, coin, ownershipProof, transaction.PrecomputeTransactionData(new[] { coin }));
+		var signedTx = keyChain.Sign(transaction, coin, transaction.PrecomputeTransactionData(new[] { coin }));
 		Assert.True(signedTx.HasWitness);
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -249,7 +249,7 @@ public class AliceClient
 
 	public async Task SignTransactionAsync(TransactionWithPrecomputedData unsignedCoinJoin, IKeyChain keyChain, CancellationToken cancellationToken)
 	{
-		await ArenaClient.SignTransactionAsync(RoundId, SmartCoin.Coin, OwnershipProof, keyChain, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
+		await ArenaClient.SignTransactionAsync(RoundId, SmartCoin.Coin, keyChain, unsignedCoinJoin, cancellationToken).ConfigureAwait(false);
 
 		Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Posted a signature.");
 	}

--- a/WalletWasabi/WabiSabi/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/ArenaClient.cs
@@ -195,12 +195,11 @@ public class ArenaClient
 	public async Task SignTransactionAsync(
 		uint256 roundId,
 		Coin coin,
-		OwnershipProof ownershipProof,
-		IKeyChain keyChain,
+		IKeyChain keyChain, // unused now
 		TransactionWithPrecomputedData unsignedCoinJoin,
 		CancellationToken cancellationToken)
 	{
-		var signedCoinJoin = keyChain.Sign(unsignedCoinJoin.Transaction, coin, ownershipProof, unsignedCoinJoin.PrecomputedTransactionData);
+		var signedCoinJoin = keyChain.Sign(unsignedCoinJoin.Transaction, coin, unsignedCoinJoin.PrecomputedTransactionData);
 		var txInput = signedCoinJoin.Inputs.AsIndexedInputs().First(input => input.PrevOut == coin.Outpoint);
 		if (!txInput.VerifyScript(coin, ScriptVerify.Standard, unsignedCoinJoin.PrecomputedTransactionData, out var error))
 		{

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -58,7 +58,7 @@ public abstract class BaseKeyChain : IKeyChain
 		TransactionBuilder builder = Network.Main.CreateTransactionBuilder();
 		builder.AddKeys(secret);
 		builder.AddCoins(coin);
-		builder.SetSigningOptions(new SigningOptions(TaprootSigHash.All, precomputedTransactionData as TaprootReadyPrecomputedTransactionData));
+		builder.SetSigningOptions(new SigningOptions(TaprootSigHash.All, (TaprootReadyPrecomputedTransactionData)precomputedTransactionData));
 		builder.SignTransactionInPlace(transaction);
 		
 		return transaction;

--- a/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs
@@ -38,7 +38,7 @@ public abstract class BaseKeyChain : IKeyChain
 		return ownershipProof;
 	}
 
-	public Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof, PrecomputedTransactionData precomputedTransactionData)
+	public Transaction Sign(Transaction transaction, Coin coin, PrecomputedTransactionData precomputedTransactionData)
 	{
 		transaction = transaction.Clone();
 		if (transaction.Inputs.Count == 0)

--- a/WalletWasabi/WabiSabi/Client/IKeyChain.cs
+++ b/WalletWasabi/WabiSabi/Client/IKeyChain.cs
@@ -9,7 +9,7 @@ public interface IKeyChain
 {
 	OwnershipProof GetOwnershipProof(IDestination destination, CoinJoinInputCommitmentData committedData);
 
-	Transaction Sign(Transaction transaction, Coin coin, OwnershipProof ownershipProof, PrecomputedTransactionData precomputeTransactionData);
+	Transaction Sign(Transaction transaction, Coin coin, PrecomputedTransactionData precomputeTransactionData);
 
 	void TrySetScriptStates(KeyState state, IEnumerable<Script> scripts);
 }


### PR DESCRIPTION
Follow-up to the slack discussion:

> Is there a reason why `IKeyChain.Sign` has ownershipProof [parameter](https://github.com/zkSNACKs/WalletWasabi/blob/97f07b778b886b43207519bbc34ed348062a11e6/WalletWasabi/WabiSabi/Client/IKeyChain.cs#L12)? Both implementations of IKeyChain:
>
> *  https://github.com/zkSNACKs/WalletWasabi/blob/97f07b778b886b43207519bbc34ed348062a11e6/WalletWasabi.Tests/UnitTests/TestWallet.cs#L127-L136
>  * https://github.com/zkSNACKs/WalletWasabi/blob/97f07b778b886b43207519bbc34ed348062a11e6/WalletWasabi/WabiSabi/Client/BaseKeyChain.cs#L41-L65
>
> do not seem to use the parameter.

Lucas's response:

> Yes. The idea is to abstract the signer. IKeyChain tries to be that abstraction, it should be good enough to abstract smart devices that know their UTXO set as well as dumb devices that know nothing else than their keys. "Dumb" devices can be fooled to sign wrong transactions because of that. So, if one day we make coinjoins with hardware wallets or other kind of signers that have no access to the utxo/blockchain, we will need it.Currently we don't need it. We can remove it and it can be added back in the future when the time comes.