### PR TITLE
[VDG] MusicBox CoinjoinProfile Selector

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/BindableFlyoutOpenBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/BindableFlyoutOpenBehavior.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia;
@@ -12,10 +13,19 @@ public class BindableFlyoutOpenBehavior : DisposingBehavior<Control>
 	public static readonly StyledProperty<bool> IsOpenProperty =
 		AvaloniaProperty.Register<BindableFlyoutOpenBehavior, bool>(nameof(IsOpen));
 
+	public static readonly StyledProperty<bool> AutoOpenOnPointerOverProperty =
+		AvaloniaProperty.Register<BindableFlyoutOpenBehavior, bool>(nameof(AutoOpenOnPointerOver), defaultValue: true);
+
 	public bool IsOpen
 	{
 		get => GetValue(IsOpenProperty);
 		set => SetValue(IsOpenProperty, value);
+	}
+
+	public bool AutoOpenOnPointerOver
+	{
+		get => GetValue(AutoOpenOnPointerOverProperty);
+		set => SetValue(AutoOpenOnPointerOverProperty, value);
 	}
 
 	protected override void OnAttached(CompositeDisposable disposable)
@@ -25,10 +35,13 @@ public class BindableFlyoutOpenBehavior : DisposingBehavior<Control>
 			return;
 		}
 
-		Observable
-			.FromEventPattern(AssociatedObject, nameof(AssociatedObject.PointerEnter))
-			.Subscribe(_ => IsOpen = true)
-			.DisposeWith(disposable);
+		if (AutoOpenOnPointerOver)
+		{
+			Observable
+				.FromEventPattern(AssociatedObject, nameof(AssociatedObject.PointerEnter))
+				.Subscribe(_ => IsOpen = true)
+				.DisposeWith(disposable);
+		}
 
 		this.WhenAnyValue(x => x.IsOpen)
 			.Subscribe(isOpen =>

--- a/WalletWasabi.Fluent/Controls/TileButton.axaml
+++ b/WalletWasabi.Fluent/Controls/TileButton.axaml
@@ -22,9 +22,7 @@
                         Height="{TemplateBinding IconSize}" />
 
               <ContentPresenter x:Name="PART_ContentPresenter"
-                                Content="{TemplateBinding Content}"
-                                Height="{TemplateBinding IconSize}"
-                                Width="{TemplateBinding IconSize}" />
+                                Content="{TemplateBinding Content}" />
             </Panel>
           </DockPanel>
         </Border>
@@ -40,8 +38,6 @@
   </Style>
 
   <Style Selector="c|TileButton /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="HorizontalAlignment" Value="Center" />
-    <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Margin" Value="0 0 0 15" />
   </Style>
 

--- a/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
-using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 namespace WalletWasabi.Fluent.Helpers;
 
@@ -14,4 +14,14 @@ public static class KeyManagerExtensions
 
 	public static IEnumerable<SmartLabel> GetReceiveLabels(this KeyManager km) =>
 		km.GetKeys(isInternal: false).Select(x => x.Label);
+
+	public static void SetCoinjoinProfile(this KeyManager km, CoinJoinProfileViewModelBase profile)
+	{
+		km.RedCoinIsolation = profile.RedCoinIsolation;
+		km.SetAnonScoreTarget(profile.AnonScoreTarget, toFile: false);
+		km.SetFeeRateMedianTimeFrame(profile.FeeRateMedianTimeFrameHours, toFile: false);
+		km.IsCoinjoinProfileSelected = true;
+
+		km.ToFile();
+	}
 }

--- a/WalletWasabi.Fluent/Styles/FlyoutPresenter.axaml
+++ b/WalletWasabi.Fluent/Styles/FlyoutPresenter.axaml
@@ -30,7 +30,7 @@
     <Setter Property="CornerRadius" Value="8 8 8 8" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Panel MaxHeight="500">
+        <Panel>
           <Border Name="LayoutRoot" Margin="3 20 3 0"
                   Classes.IsActive="{Binding IsActive, FallbackValue=false}"
                   BoxShadow="0 0 5 0 #7F000000"
@@ -68,5 +68,9 @@
         </Panel>
       </ControlTemplate>
     </Setter>
+  </Style>
+
+  <Style Selector="FlyoutPresenter > Panel">
+    <Setter Property="MaxHeight" Value="500" />
   </Style>
 </Styles>

--- a/WalletWasabi.Fluent/ViewModels/Wallets/MusicBoxCoinjoinProfileSelectorViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/MusicBoxCoinjoinProfileSelectorViewModel.cs
@@ -1,0 +1,82 @@
+using ReactiveUI;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+using WalletWasabi.Fluent.ViewModels.Dialogs;
+using WalletWasabi.Fluent.ViewModels.Navigation;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets;
+
+[NavigationMetaData(Title = "Coinjoin Profiles")]
+public partial class MusicBoxCoinjoinProfileSelectorViewModel : RoutableViewModel
+{
+	[AutoNotify] private CoinJoinProfileViewModelBase? _selectedProfile;
+	[AutoNotify] private bool _isFlyoutOpen;
+
+	public MusicBoxCoinjoinProfileSelectorViewModel(KeyManager keyManager)
+	{
+		Profiles = DefaultProfiles.ToList();
+		Profiles.Add(new ManualCoinJoinProfileViewModel(keyManager));
+
+		_selectedProfile = IdentifySelectedProfile(keyManager);
+
+		OpenFlyoutCommand = ReactiveCommand.Create(() =>
+		{
+			IsFlyoutOpen = false;
+			IsFlyoutOpen = true;
+		});
+		SelectProfileCommand = ReactiveCommand.CreateFromTask<CoinJoinProfileViewModelBase>(async p => await OnCoinjoinProfileSelectedAsync(keyManager, p));
+	}
+
+	public ICommand OpenFlyoutCommand { get; }
+	public ICommand SelectProfileCommand { get; }
+
+	private async Task OnCoinjoinProfileSelectedAsync(KeyManager keyManager, CoinJoinProfileViewModelBase profile)
+	{
+		IsFlyoutOpen = false;
+
+		if (profile is ManualCoinJoinProfileViewModel)
+		{
+			var dialog = new ManualCoinJoinProfileDialogViewModel(profile);
+
+			var dialogResult = await NavigateDialogAsync(dialog, NavigationTarget.CompactDialogScreen);
+
+			if (dialogResult.Result is { } result)
+			{
+				profile = result.Profile;
+			}
+		}
+
+		SelectedProfile = null;
+		SelectedProfile = profile;
+		keyManager.SetCoinjoinProfile(profile);
+	}
+
+	public static CoinJoinProfileViewModelBase IdentifySelectedProfile(KeyManager keyManager)
+	{
+		var currentProfile = new ManualCoinJoinProfileViewModel(keyManager);
+		var result = DefaultProfiles.FirstOrDefault(x => x == currentProfile) ?? currentProfile;
+
+		// Edge case: Update the PrivateCJProfile anonscore target, otherwise the randomly selected value will be displayed all time.
+		if (result is PrivateCoinJoinProfileViewModel)
+		{
+			result = new PrivateCoinJoinProfileViewModel(keyManager.AnonScoreTarget);
+		}
+
+		return result;
+	}
+
+	private static CoinJoinProfileViewModelBase[] DefaultProfiles { get; } = new CoinJoinProfileViewModelBase[]
+	{
+		new PrivateCoinJoinProfileViewModel(),
+		new SpeedyCoinJoinProfileViewModel(),
+		new EconomicCoinJoinProfileViewModel(),
+	};
+
+	public List<CoinJoinProfileViewModelBase> Profiles { get; }
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -41,6 +41,7 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		Settings = new WalletSettingsViewModel(this);
 		CoinJoinSettings = new CoinJoinSettingsViewModel(this);
+		MusicBoxCoinjoinProfileSelector = new MusicBoxCoinjoinProfileSelectorViewModel(wallet.KeyManager);
 		UiTriggers = new UiTriggers(this);
 		History = new HistoryViewModel(this);
 
@@ -120,6 +121,8 @@ public partial class WalletViewModel : WalletViewModelBase
 	public UiTriggers UiTriggers { get; }
 
 	public CoinJoinSettingsViewModel CoinJoinSettings { get; }
+
+	public MusicBoxCoinjoinProfileSelectorViewModel MusicBoxCoinjoinProfileSelector { get; }
 
 	public bool IsWatchOnly => Wallet.KeyManager.IsWatchOnly;
 

--- a/WalletWasabi.Fluent/Views/Wallets/MusicBoxCoinjoinProfileSelector.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicBoxCoinjoinProfileSelector.axaml
@@ -1,0 +1,154 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:c="using:WalletWasabi.Fluent.Controls"
+             xmlns:profiles="using:WalletWasabi.Fluent.ViewModels.CoinJoinProfiles"
+             xmlns:behaviors="clr-namespace:WalletWasabi.Fluent.Behaviors"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.MusicBoxCoinjoinProfileSelector">
+  <UserControl.Styles>
+    <Style Selector="FlyoutPresenter">
+      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+      <Setter Property="Height" Value="580" />
+      <Setter Property="MaxHeight" Value="580" />
+    </Style>
+
+    <Style Selector="FlyoutPresenter > Panel">
+      <Setter Property="Height" Value="520" />
+      <Setter Property="MaxHeight" Value="520" />
+    </Style>
+  </UserControl.Styles>
+  <UserControl.DataTemplates>
+    <DataTemplate DataType="profiles:EconomicCoinJoinProfileViewModel">
+      <PathIcon Data="{StaticResource coinjoin_cost}" Foreground="{StaticResource SystemAccentColor}" />
+    </DataTemplate>
+    <DataTemplate DataType="profiles:SpeedyCoinJoinProfileViewModel">
+      <PathIcon Data="{StaticResource coinjoin_speed}" Foreground="{StaticResource SystemAccentColor}" />
+    </DataTemplate>
+    <DataTemplate DataType="profiles:PrivateCoinJoinProfileViewModel">
+      <PathIcon Data="{StaticResource coinjoin_privacy}" Foreground="{StaticResource SystemAccentColor}" />
+    </DataTemplate>
+    <DataTemplate DataType="profiles:ManualCoinJoinProfileViewModel">
+      <PathIcon Data="{StaticResource wallet_action_advanced}" Foreground="{StaticResource SystemAccentColor}" />
+    </DataTemplate>
+  </UserControl.DataTemplates>
+  <Button Classes="plain"
+          Command="{Binding OpenFlyoutCommand}">
+    <Interaction.Behaviors>
+      <behaviors:BindableFlyoutOpenBehavior IsOpen="{Binding IsFlyoutOpen}" AutoOpenOnPointerOver="False" />
+    </Interaction.Behaviors>
+
+    <Panel>
+      <ContentPresenter Content="{Binding}" DataContext="{Binding SelectedProfile}"
+                        Height="35" Width="35" VerticalAlignment="Center" HorizontalAlignment="Center" />
+
+      <Image IsVisible="{Binding SelectedProfile, Converter={x:Static ObjectConverters.IsNull}}"
+             Height="35" Width="35" VerticalAlignment="Center" HorizontalAlignment="Center"
+             Source="{DynamicResource wasabi_logo_dynamic}" />
+    </Panel>
+    <FlyoutBase.AttachedFlyout>
+      <Flyout Placement="Top" ShowMode="Transient">
+        <DockPanel>
+          <TextBlock Text="Select your profile" Margin="0 5 0 5"
+                     DockPanel.Dock="Top" />
+          <ItemsControl Items="{Binding Profiles}">
+            <ItemsControl.Styles>
+              <Style Selector="c|TileButton">
+                <Setter Property="Margin" Value="10" />
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="Width" Value="300" />
+                <Setter Property="Height" Value="90" />
+                <Setter Property="Foreground" Value="{DynamicResource TextForegroundColor}" />
+                <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="1" />
+              </Style>
+              <Style Selector="c|TileButton:pointerover">
+                <Setter Property="BorderBrush" Value="{DynamicResource TextForegroundColor}" />
+              </Style>
+              <Style Selector="Viewbox">
+                <Setter Property="DockPanel.Dock" Value="Left" />
+                <Setter Property="Margin" Value="10" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Stretch" Value="Uniform" />
+              </Style>
+              <Style Selector="Viewbox > PathIcon">
+                <Setter Property="ClipToBounds" Value="False" />
+              </Style>
+            </ItemsControl.Styles>
+            <ItemsControl.DataTemplates>
+
+              <!-- Private -->
+              <DataTemplate DataType="profiles:PrivateCoinJoinProfileViewModel">
+                <c:TileButton Command="{Binding $parent[UserControl].DataContext.SelectProfileCommand}"
+                              CommandParameter="{Binding}">
+                  <DockPanel>
+                    <Viewbox>
+                      <PathIcon Data="{StaticResource coinjoin_privacy}" />
+                    </Viewbox>
+
+                    <StackPanel VerticalAlignment="Center" Spacing="2">
+                      <TextBlock Text="Maximum Privacy" TextAlignment="Center" />
+                      <TextBlock Text="Choice of the paranoid" TextAlignment="Center" />
+                    </StackPanel>
+                  </DockPanel>
+                </c:TileButton>
+              </DataTemplate>
+
+              <!-- Speedy -->
+              <DataTemplate DataType="profiles:SpeedyCoinJoinProfileViewModel">
+                <c:TileButton Command="{Binding $parent[UserControl].DataContext.SelectProfileCommand}"
+                              CommandParameter="{Binding}">
+                  <DockPanel>
+                    <Viewbox>
+                      <PathIcon Data="{StaticResource coinjoin_speed}" />
+                    </Viewbox>
+
+                    <StackPanel>
+                      <TextBlock Text="Maximum Speed" TextAlignment="Center" />
+                      <TextBlock Text="Privacy Faster" TextAlignment="Center" />
+                    </StackPanel>
+                  </DockPanel>
+                </c:TileButton>
+              </DataTemplate>
+
+              <!-- Economic -->
+              <DataTemplate DataType="profiles:EconomicCoinJoinProfileViewModel">
+                <c:TileButton Command="{Binding $parent[UserControl].DataContext.SelectProfileCommand}"
+                              CommandParameter="{Binding}">
+                  <DockPanel>
+                    <Viewbox>
+                      <PathIcon Data="{StaticResource coinjoin_cost}" />
+                    </Viewbox>
+
+                    <TextBlock Text="Economic Mode" TextAlignment="Center" VerticalAlignment="Center" />
+                  </DockPanel>
+                </c:TileButton>
+              </DataTemplate>
+
+              <!-- Custom -->
+              <DataTemplate DataType="profiles:ManualCoinJoinProfileViewModel">
+                <c:TileButton Command="{Binding $parent[UserControl].DataContext.SelectProfileCommand}"
+                              CommandParameter="{Binding}">
+                  <DockPanel>
+                    <Viewbox>
+                      <PathIcon Data="{StaticResource wallet_action_advanced}" />
+                    </Viewbox>
+
+                    <StackPanel>
+                      <TextBlock Text="Custom" TextAlignment="Center" />
+                      <TextBlock Text="Maximum Control" TextAlignment="Center" />
+                    </StackPanel>
+                  </DockPanel>
+                </c:TileButton>
+              </DataTemplate>
+            </ItemsControl.DataTemplates>
+          </ItemsControl>
+        </DockPanel>
+      </Flyout>
+    </FlyoutBase.AttachedFlyout>
+  </Button>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/MusicBoxCoinjoinProfileSelector.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicBoxCoinjoinProfileSelector.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets;
+
+public class MusicBoxCoinjoinProfileSelector : UserControl
+{
+	public MusicBoxCoinjoinProfileSelector()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:wallets="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets"
+             xmlns:walletViews="clr-namespace:WalletWasabi.Fluent.Views.Wallets"
              Background="Transparent"
              IsPointerOver="{Binding IsPointerOver, Mode=OneWayToSource}"
              x:DataType="wallets:WalletViewModel"
@@ -39,7 +40,7 @@
             CornerRadius="4 4 0 0"
             BorderBrush="{DynamicResource GlassEdgeColor}"
             BorderThickness="1,1,1,0">
-      <Panel DataContext="{Binding CoinJoinStateViewModel}">
+      <Panel>
         <Panel Background="{DynamicResource TileRegionColor}" Opacity="0.35" />
         <StackPanel Margin="10 5" Orientation="Horizontal" Spacing="20">
           <StackPanel.Styles>
@@ -47,82 +48,89 @@
               <Setter Property="Foreground" Value="{DynamicResource TextControlForegroundDisabled}" />
             </Style>
           </StackPanel.Styles>
-          <Image Height="35" Width="35" VerticalAlignment="Center" HorizontalAlignment="Center" Source="{DynamicResource wasabi_logo_dynamic}" />
-          <StackPanel Spacing="5">
-            <TransitioningContentControl MinWidth="350" MaxWidth="350" MinHeight="18" Content="{Binding CurrentStatus}">
-              <TransitioningContentControl.PageTransition>
-                <CrossFade Duration="0:0:0.125" FadeInEasing="0.4,0,0.6,1" FadeOutEasing="0.4,0,0.6,1" />
-              </TransitioningContentControl.PageTransition>
-              <TransitioningContentControl.DataTemplates>
-                <DataTemplate DataType="wallets:MusicStatusMessageViewModel">
-                  <TextBlock Text="{Binding Message}">
-                    <TextBlock.OpacityMask>
-                      <LinearGradientBrush StartPoint="100%,0%" EndPoint="90%,0%">
-                        <LinearGradientBrush.GradientStops>
-                          <GradientStop Color="#00FFFFFF" Offset="0.1" />
-                          <GradientStop Color="#FFFFFFFF" Offset="1" />
-                        </LinearGradientBrush.GradientStops>
-                      </LinearGradientBrush>
-                    </TextBlock.OpacityMask>
-                  </TextBlock>
-                </DataTemplate>
-              </TransitioningContentControl.DataTemplates>
-            </TransitioningContentControl>
 
-            <ProgressBar Minimum="0" Maximum="100" IsIndeterminate="{Binding IsCountDownDelayHappening}" Value="{Binding ProgressValue}">
-              <ProgressBar.Foreground>
-                <SolidColorBrush Color="{DynamicResource SystemBaseMediumColor}" />
-              </ProgressBar.Foreground>
-              <ProgressBar.Background>
-                <SolidColorBrush Color="{DynamicResource SystemBaseMediumColor}" Opacity="0.5" />
-              </ProgressBar.Background>
-            </ProgressBar>
+          <walletViews:MusicBoxCoinjoinProfileSelector DataContext="{Binding MusicBoxCoinjoinProfileSelector}"
+                                                       Height="35" Width="35"
+                                                       VerticalAlignment="Center"
+                                                       HorizontalAlignment="Center" />
 
-            <DockPanel LastChildFill="False">
-              <TextBlock Text="{Binding ElapsedTime}" />
-              <TextBlock Text="{Binding RemainingTime}" DockPanel.Dock="Right" />
-            </DockPanel>
+          <StackPanel Orientation="Horizontal" Spacing="20" Margin="0 5" DataContext="{Binding CoinJoinStateViewModel}">
+            <StackPanel Spacing="5">
+              <TransitioningContentControl MinWidth="350" MaxWidth="350" MinHeight="18" Content="{Binding CurrentStatus}">
+                <TransitioningContentControl.PageTransition>
+                  <CrossFade Duration="0:0:0.125" FadeInEasing="0.4,0,0.6,1" FadeOutEasing="0.4,0,0.6,1" />
+                </TransitioningContentControl.PageTransition>
+                <TransitioningContentControl.DataTemplates>
+                  <DataTemplate DataType="wallets:MusicStatusMessageViewModel">
+                    <TextBlock Text="{Binding Message}">
+                      <TextBlock.OpacityMask>
+                        <LinearGradientBrush StartPoint="100%,0%" EndPoint="90%,0%">
+                          <LinearGradientBrush.GradientStops>
+                            <GradientStop Color="#00FFFFFF" Offset="0.1" />
+                            <GradientStop Color="#FFFFFFFF" Offset="1" />
+                          </LinearGradientBrush.GradientStops>
+                        </LinearGradientBrush>
+                      </TextBlock.OpacityMask>
+                    </TextBlock>
+                  </DataTemplate>
+                </TransitioningContentControl.DataTemplates>
+              </TransitioningContentControl>
+
+              <ProgressBar Minimum="0" Maximum="100" IsIndeterminate="{Binding IsCountDownDelayHappening}" Value="{Binding ProgressValue}">
+                <ProgressBar.Foreground>
+                  <SolidColorBrush Color="{DynamicResource SystemBaseMediumColor}" />
+                </ProgressBar.Foreground>
+                <ProgressBar.Background>
+                  <SolidColorBrush Color="{DynamicResource SystemBaseMediumColor}" Opacity="0.5" />
+                </ProgressBar.Background>
+              </ProgressBar>
+
+              <DockPanel LastChildFill="False">
+                <TextBlock Text="{Binding ElapsedTime}" />
+                <TextBlock Text="{Binding RemainingTime}" DockPanel.Dock="Right" />
+              </DockPanel>
+            </StackPanel>
+
+            <Separator Classes="vertical" />
+
+            <Button Classes="plain"
+                    IsVisible="{Binding PlayVisible}"
+                    Command="{Binding PlayCommand}">
+              <PathIcon Data="{StaticResource play_regular}" />
+            </Button>
+
+            <Button Classes="plain"
+                    IsVisible="{Binding PauseVisible}"
+                    Command="{Binding StopPauseCommand}">
+              <PathIcon Data="{StaticResource pause_regular}" />
+            </Button>
+
+            <Button Classes="plain"
+                    IsVisible="{Binding StopVisible}"
+                    Command="{Binding StopPauseCommand}">
+              <PathIcon Data="{StaticResource stop_regular}" />
+            </Button>
+
+            <Ellipse Height="12" Width="12"
+                     Classes.disabled="{Binding !AutoCoinJoinObservable^}"
+                     Classes.waiting="{Binding IsAutoWaiting}">
+              <Ellipse.Styles>
+                <Style Selector="Ellipse">
+                  <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
+                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
+                </Style>
+                <Style Selector="Ellipse.waiting">
+                  <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
+                  <Setter Property="ToolTip.Tip"
+                          Value="Auto-start coinjoin enabled. Press Play to start immediately." />
+                </Style>
+                <Style Selector="Ellipse.disabled">
+                  <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
+                  <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
+                </Style>
+              </Ellipse.Styles>
+            </Ellipse>
           </StackPanel>
-
-          <Separator Classes="vertical" />
-
-          <Button Classes="plain"
-                  IsVisible="{Binding PlayVisible}"
-                  Command="{Binding PlayCommand}">
-            <PathIcon Data="{StaticResource play_regular}" />
-          </Button>
-
-          <Button Classes="plain"
-                  IsVisible="{Binding PauseVisible}"
-                  Command="{Binding StopPauseCommand}">
-            <PathIcon Data="{StaticResource pause_regular}" />
-          </Button>
-
-          <Button Classes="plain"
-                  IsVisible="{Binding StopVisible}"
-                  Command="{Binding StopPauseCommand}">
-            <PathIcon Data="{StaticResource stop_regular}" />
-          </Button>
-
-          <Ellipse Height="12" Width="12"
-                   Classes.disabled="{Binding !AutoCoinJoinObservable^}"
-                   Classes.waiting="{Binding IsAutoWaiting}">
-            <Ellipse.Styles>
-              <Style Selector="Ellipse">
-                <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
-                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin enabled" />
-              </Style>
-              <Style Selector="Ellipse.waiting">
-                <Setter Property="Fill" Value="{DynamicResource CoinjoinActiveColor}" />
-                <Setter Property="ToolTip.Tip"
-                        Value="Auto-start coinjoin enabled. Press Play to start immediately." />
-              </Style>
-              <Style Selector="Ellipse.disabled">
-                <Setter Property="Fill" Value="{DynamicResource SystemBaseMediumColor}" />
-                <Setter Property="ToolTip.Tip" Value="Auto-start coinjoin disabled" />
-              </Style>
-            </Ellipse.Styles>
-          </Ellipse>
         </StackPanel>
       </Panel>
     </Border>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/98904713/208247178-21707ff4-c147-4733-a6aa-6f947e10181d.png)

 - Makes the icon in the MusicBox clickable and pops up the above UI.
 - Allows single-click selection of Coinjoin Profiles.
 - For the Custom one, shows the usual "Coinjoin Strategy Settings" UI.
 - Wording differs from the previous Coinjoin Profiles UI, as specified in the [Lunacy design](https://lun-eu.icons8.com/d/7eAOKr3Q5U-fd8dqUwaBAQ?page=7uAOKr3Q5U-fd8dqUwaBAQ&vp=2387,9296,2298,1701)
 - Icons are placeholders, these are not the final ones.
 - PR marked as draft until @Bodnaralexa creates the final icons.