### PR TITLE
[VDG] [Trivial] Add trigger to monitor coinjoin status changes

### DIFF
--- a/WalletWasabi.Fluent/Models/UiTriggers.cs
+++ b/WalletWasabi.Fluent/Models/UiTriggers.cs
@@ -55,9 +55,9 @@ public class UiTriggers
 	/// <summary>
 	/// Triggers when any of the coins starts/stops participating in a coinjoin
 	/// </summary>
-	public IObservable<Unit> WalletCoinsCoinjoinTrigger => Observable.Interval(TimeSpan.FromSeconds(0.5), RxApp.MainThreadScheduler)
-		.Select(_ => _wallet.Coins.ToArray().Where(x => x.CoinJoinInProgress))
+	public IObservable<Unit> WalletCoinsCoinjoinTrigger => Observable.Interval(TimeSpan.FromSeconds(1), RxApp.MainThreadScheduler)
+		.Select(_ => _wallet.Coins.Where(x => x.CoinJoinInProgress).ToList())
 		.Buffer(2, 1)
-		.Where(list => !new HashSet<SmartCoin>(list[0]).SetEquals(new HashSet<SmartCoin>(list[0])))
+		.Where(list => !new HashSet<SmartCoin>(list[0]).SetEquals(new HashSet<SmartCoin>(list[1])))
 		.ToSignal();
 }

--- a/WalletWasabi.Fluent/Models/UiTriggers.cs
+++ b/WalletWasabi.Fluent/Models/UiTriggers.cs
@@ -1,6 +1,9 @@
-﻿using System.Reactive;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
 using ReactiveUI;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.ViewModels.Wallets;
@@ -48,4 +51,13 @@ public class UiTriggers
 	/// Triggers on subscription and when a transaction is processed to the wallet or the anon score target changed.
 	/// </summary>
 	public IObservable<Unit> PrivacyProgressUpdateTrigger => TransactionsUpdateTrigger.Merge(AnonScoreTargetChanged).Skip(1);
+
+	/// <summary>
+	/// Triggers when any of the coins starts/stops participating in a coinjoin
+	/// </summary>
+	public IObservable<Unit> WalletCoinsCoinjoinTrigger => Observable.Interval(TimeSpan.FromSeconds(0.5), RxApp.MainThreadScheduler)
+		.Select(_ => _wallet.Coins.ToArray().Where(x => x.CoinJoinInProgress))
+		.Buffer(2, 1)
+		.Where(list => !new HashSet<SmartCoin>(list[0]).SetEquals(new HashSet<SmartCoin>(list[0])))
+		.ToSignal();
 }


### PR DESCRIPTION
Adds a trigger when any of the coins in a given wallet starts/stops participating in a coinjoin.
Can be used to calculate the available balance correctly.

Please, read this for more context: https://github.com/zkSNACKs/WalletWasabi/pull/9706#issuecomment-1359223363

**Beware: testing on this has been quite limited.**