### PR TITLE
`Guard.NotNull`: Make sure analyzers will know that T was not `null`

### DIFF
--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -28,7 +28,7 @@ public static class Guard
 	}
 
 	[return: NotNull]
-	public static T NotNull<T>(string parameterName, T value)
+	public static T NotNull<T>(string parameterName, [NotNull] T? value)
 	{
 		AssertCorrectParameterName(parameterName);
 		return value ?? throw new ArgumentNullException(parameterName, "Parameter cannot be null.");


### PR DESCRIPTION
This PR makes it so that the following snippet does not show a warning on the marked place:

```cs
Guard.NotNull(nameof(value), value);
writer.WriteValue(Convert.ToHexString(value /* no warning here */));
```

Inspired by https://github.com/xunit/assert.xunit/pull/36/files#diff-404187c76aea8c97952a33aade25a6e3a47480961b7d507e49d3c925a0919ba0R23