### PR TITLE
More friendly HWI error message on timeout

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
@@ -86,10 +86,10 @@ public partial class ReceiveAddressViewModel : RoutableViewModel
 
 		await Task.Run(async () =>
 		{
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 			try
 			{
 				var client = new HwiClient(network);
-				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
 				await client.DisplayAddressAsync(masterFingerprint.Value, model.FullKeyPath, cts.Token);
 			}
@@ -101,7 +101,8 @@ public partial class ReceiveAddressViewModel : RoutableViewModel
 			catch (Exception ex)
 			{
 				Logger.LogError(ex);
-				await ShowErrorAsync(Title, ex.ToUserFriendlyString(), "Unable to send the address to the device");
+				var exMessage = cts.IsCancellationRequested ? "User response didn't arrive in time." : ex.ToUserFriendlyString();
+				await ShowErrorAsync(Title, exMessage, "Unable to send the address to the device");
 			}
 		});
 	}
@@ -130,6 +131,7 @@ public partial class ReceiveAddressViewModel : RoutableViewModel
 			})
 			.DisposeWith(disposables);
 	}
+
 	private void GenerateQrCode()
 	{
 		try

--- a/WalletWasabi/Extensions/ExceptionExtensions.cs
+++ b/WalletWasabi/Extensions/ExceptionExtensions.cs
@@ -35,7 +35,11 @@ public static class ExceptionExtensions
 		}
 		else
 		{
-			if (ex is HwiException hwiEx)
+			if (ex is OperationCanceledException exception)
+			{
+				return exception.Message;
+			}
+			else if (ex is HwiException hwiEx)
 			{
 				if (hwiEx.ErrorCode == HwiErrorCode.DeviceConnError)
 				{
@@ -44,6 +48,10 @@ public static class ExceptionExtensions
 				else if (hwiEx.ErrorCode == HwiErrorCode.ActionCanceled)
 				{
 					return "The transaction was canceled on the device.";
+				}
+				else if (hwiEx.ErrorCode == HwiErrorCode.UnknownError)
+				{
+					return "Unknown error.\nMake sure the device is connected and isn't busy, then try again.";
 				}
 			}
 

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -10,7 +10,6 @@ using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Hwi.Parsers;
 using WalletWasabi.Hwi.ProcessBridge;
-using WalletWasabi.Logging;
 
 namespace WalletWasabi.Hwi;
 
@@ -56,7 +55,7 @@ public class HwiClient
 		}
 		catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
 		{
-			throw new OperationCanceledException($"'hwi {arguments}' operation is canceled.");
+			throw new OperationCanceledException($"'hwi {arguments}' operation is canceled.", ex);
 		}
 		//// HWI is inconsistent with error codes here.
 		catch (HwiException ex) when (ex.ErrorCode is HwiErrorCode.DeviceConnError or HwiErrorCode.DeviceNotReady)

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -56,8 +56,7 @@ public class HwiClient
 		}
 		catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
 		{
-			Logger.LogError($"'hwi {arguments}' operation is canceled.", ex);
-			throw new OperationCanceledException("User response didn't arrive in time.");
+			throw new OperationCanceledException($"'hwi {arguments}' operation is canceled.");
 		}
 		//// HWI is inconsistent with error codes here.
 		catch (HwiException ex) when (ex.ErrorCode is HwiErrorCode.DeviceConnError or HwiErrorCode.DeviceNotReady)

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -10,6 +10,7 @@ using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Hwi.Parsers;
 using WalletWasabi.Hwi.ProcessBridge;
+using WalletWasabi.Logging;
 
 namespace WalletWasabi.Hwi;
 
@@ -55,7 +56,8 @@ public class HwiClient
 		}
 		catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
 		{
-			throw new OperationCanceledException($"'hwi {arguments}' operation is canceled.", ex);
+			Logger.LogError($"'hwi {arguments}' operation is canceled.", ex);
+			throw new OperationCanceledException("Confirmation response didn't arrive in time.");
 		}
 		//// HWI is inconsistent with error codes here.
 		catch (HwiException ex) when (ex.ErrorCode is HwiErrorCode.DeviceConnError or HwiErrorCode.DeviceNotReady)

--- a/WalletWasabi/Hwi/HwiClient.cs
+++ b/WalletWasabi/Hwi/HwiClient.cs
@@ -57,7 +57,7 @@ public class HwiClient
 		catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
 		{
 			Logger.LogError($"'hwi {arguments}' operation is canceled.", ex);
-			throw new OperationCanceledException("Confirmation response didn't arrive in time.");
+			throw new OperationCanceledException("User response didn't arrive in time.");
 		}
 		//// HWI is inconsistent with error codes here.
 		catch (HwiException ex) when (ex.ErrorCode is HwiErrorCode.DeviceConnError or HwiErrorCode.DeviceNotReady)


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/9781

This is how I would imagine a more user friendly but talkitive error message, pls suggest something if you find that better.

But to be perfectly honest, this isn't really an error, I can imagine this be usefull as somekind of a software-freeze prevention. Is there a main reason to happen like this?
What if we just handle this timeout in the background, but don't show it on the UI? Or increase the timespan to 120 sec?
One problem I can think of is that the user might click on some command (send, show address etc.) again, but if one didn't respond to the previous command on the HW, we throw an error anyway that the HW is busy. ⬅️ Maybe that error message needs a lil user-friendly tweak? 