### PR TITLE
[PoC] Aggressive signing retry when running out of time

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -560,7 +560,7 @@ public class CoinJoinClient
 					for (var i = 0; i < 3; i++)
 					{
 						// Too many parallel requests, don't add more.
-						// ToDo: Replace older requests with ne ones. 
+						// ToDo: Replace older requests with new ones. 
 						if (tasks.Count() > 20)
 						{
 							break;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -569,6 +569,8 @@ public class CoinJoinClient
 						tasks = tasks.Union(myMissingSignatures.Select(aliceClient => aliceClient.SignTransactionAsync(unsignedCoinJoinTransaction, KeyChain, cancellationToken)).ToList());
 						await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 					}
+
+					break;
 				}
 			}
 			catch (InvalidOperationException)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -571,7 +571,7 @@ public class CoinJoinClient
 					}
 				}
 			}
-			catch (InvalidOperationException ex)
+			catch (InvalidOperationException)
 			{
 				Logger.LogDebug($"Current state was not SigningState");
 				break;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -573,7 +573,8 @@ public class CoinJoinClient
 			}
 			catch (InvalidOperationException ex)
 			{
-				// Ignore
+				Logger.LogDebug($"Current state was not SigningState");
+				break;
 			}
 
 			await Task.Delay(1000, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Concept: If we still have unsigned inputs but the round will end soon (so we are going to disrupt the round), send parallel requests and be more aggressive in general with remaining requests to try all we can to not disrupt the round.

The code is not ideal as it recomputes `Signing` all the time instead of just sending new requests.

The point is to discuss the concept and potentially run a test to see if a client have better performances with this.