### PR TITLE
`P2pBlockProvider`: Do not always disconnect 

### DIFF
--- a/WalletWasabi/Wallets/P2pBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2pBlockProvider.cs
@@ -117,8 +117,10 @@ public class P2pBlockProvider : IBlockProvider
 					{
 						DisconnectNode(node, $"Disconnected node: {node.RemoteSocketAddress}. Block ({block.GetCoinbaseHeight()}) downloaded: {block.GetHash()}.");
 					}
-
-					await UpdateNodeTimeoutsAsync(increase: false).ConfigureAwait(false);
+					else
+					{
+						await UpdateNodeTimeoutsAsync(increase: false).ConfigureAwait(false);
+					}
 				}
 				catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
 				{


### PR DESCRIPTION
<s>Depends on #9851</s>

Addresses Nopara's request: *There was a Tor meeting 2 months ago where we decided not to enforce identity change between P2P Bitcoin nodes so we avoid using many circuits.*