### PR TITLE
Add softwareexpiry=0 to knots parameters

### DIFF
--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -132,7 +132,8 @@ public class CoreNode
 					$"{configPrefix}.whitebind		= {whiteBindPermissionsPart}{coreNode.P2pEndPoint.ToString(coreNode.Network.DefaultPort)}",
 					$"{configPrefix}.rpcbind		= {rpcBindParameter}",
 					$"{configPrefix}.rpcallowip		= {IPAddress.Loopback}",
-					$"{configPrefix}.rpcport		= {rpcPortParameter}"
+					$"{configPrefix}.rpcport		= {rpcPortParameter}",
+					$"{configPrefix}.softwareexpiry	= 0",
 				};
 
 			if (!cookieAuth)


### PR DESCRIPTION
Fixes the CI and Knots for users who are using the full node integration. 