### PR TITLE
Rename fallback to blame in music box

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -31,7 +31,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private readonly MusicStatusMessageViewModel _abortedNotEnoughAlicesMessage = new() { Message = "Not enough participants, retrying..." };
 	private readonly MusicStatusMessageViewModel _coinJoinInProgress = new() { Message = "Coinjoin in progress" };
 	private readonly MusicStatusMessageViewModel _inputRegistrationMessage = new() { Message = "Waiting for other participants" };
-	private readonly MusicStatusMessageViewModel _waitingForBlameRoundMessage = new() { Message = "Waiting for the fallback round" };
+	private readonly MusicStatusMessageViewModel _waitingForBlameRoundMessage = new() { Message = "Waiting for the blame round" };
 	private readonly MusicStatusMessageViewModel _waitingRoundMessage = new() { Message = "Waiting for a round" };
 	private readonly MusicStatusMessageViewModel _plebStopMessage = new() { Message = "Coinjoining might be uneconomical" };
 	private readonly MusicStatusMessageViewModel _plebStopMessageBelow = new() { Message = "Receive more funds or press play to bypass" };


### PR DESCRIPTION
Same as #9393 
Related https://github.com/zkSNACKs/WasabiDoc/pull/1413

I don't know the reasonning that led to label it "fallback round" in the UI, but we are referring to this concept as blame round, we are adding an entry in the doc about blame round, everywhere it's called blame round except here.

Imo it can bring confusion and make user think it's a different concept.
If there is a strong reason why it's bad to name it "blame" in the eyes of the users let's NACK and close this PR again but I think it's worth considering the change again now that we are adding a "blame round" entry in the doc.

Searching for "fallback" in the doc will only show an unrelated article: https://docs.wasabiwallet.io/using-wasabi/PayJoin.html#fallback-transaction