### PR TITLE
Use IDictionary.TryGetValue(TKey, out TValue) method

### DIFF
--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -832,9 +832,9 @@ public partial class LineChart : Control
 
 	private void UpdateSubscription(INotifyCollectionChanged? oldValue, INotifyCollectionChanged? newValue)
 	{
-		if (oldValue is { } && _collectionChangedSubscriptions.ContainsKey(oldValue))
+		if (oldValue is { } && _collectionChangedSubscriptions.TryGetValue(oldValue, out IDisposable value))
 		{
-			_collectionChangedSubscriptions[oldValue].Dispose();
+			value.Dispose();
 			_collectionChangedSubscriptions.Remove(oldValue);
 		}
 

--- a/WalletWasabi.Fluent/Controls/LineChart.cs
+++ b/WalletWasabi.Fluent/Controls/LineChart.cs
@@ -832,7 +832,7 @@ public partial class LineChart : Control
 
 	private void UpdateSubscription(INotifyCollectionChanged? oldValue, INotifyCollectionChanged? newValue)
 	{
-		if (oldValue is { } && _collectionChangedSubscriptions.TryGetValue(oldValue, out IDisposable value))
+		if (oldValue is { } && _collectionChangedSubscriptions.TryGetValue(oldValue, out IDisposable? value))
 		{
 			value.Dispose();
 			_collectionChangedSubscriptions.Remove(oldValue);

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -946,9 +946,9 @@ public static class DirectShow
 					.ToDictionary(x => (Guid)x.GetValue(null)!, x => x.Name);
 			}
 
-			if (NicknameCache.ContainsKey(guid))
+			if (NicknameCache.TryGetValue(guid, out string value))
 			{
-				var name = NicknameCache[guid];
+				var name = value;
 				var elem = name.Split('_');
 
 				if (elem.Length >= 2)

--- a/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
+++ b/WalletWasabi.Fluent/Models/Windows/DirectShow.cs
@@ -946,7 +946,7 @@ public static class DirectShow
 					.ToDictionary(x => (Guid)x.GetValue(null)!, x => x.Name);
 			}
 
-			if (NicknameCache.TryGetValue(guid, out string value))
+			if (NicknameCache.TryGetValue(guid, out string? value))
 			{
 				var name = value;
 				var elem = name.Split('_');

--- a/WalletWasabi.Fluent/State/StateMachine.cs
+++ b/WalletWasabi.Fluent/State/StateMachine.cs
@@ -46,7 +46,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 	private bool IsAncestorOf(TState state, TState parent)
 	{
-		if (_states.TryGetValue(state, out StateMachine<TState, TTrigger>.StateContext value))
+		if (_states.TryGetValue(state, out StateMachine<TState, TTrigger>.StateContext? value))
 		{
 			StateContext current = value;
 
@@ -84,7 +84,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 		{
 			var destination = _currentState.GetDestination(trigger);
 
-			if (_states.TryGetValue(destination, out StateMachine<TState, TTrigger>.StateContext value) && value.Parent is { } parent && !IsInState(parent.StateId))
+			if (_states.TryGetValue(destination, out StateMachine<TState, TTrigger>.StateContext? value) && value.Parent is { } parent && !IsInState(parent.StateId))
 			{
 				Goto(parent.StateId);
 			}
@@ -237,7 +237,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 		internal void Process(TTrigger trigger)
 		{
-			if (_triggerActions.TryGetValue(trigger, out List<Action> value) && value is { } actions)
+			if (_triggerActions.TryGetValue(trigger, out List<Action>? value) && value is { } actions)
 			{
 				foreach (var action in actions)
 				{

--- a/WalletWasabi.Fluent/State/StateMachine.cs
+++ b/WalletWasabi.Fluent/State/StateMachine.cs
@@ -46,9 +46,9 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 	private bool IsAncestorOf(TState state, TState parent)
 	{
-		if (_states.ContainsKey(state))
+		if (_states.TryGetValue(state, out StateMachine<TState, TTrigger>.StateContext value))
 		{
-			StateContext current = _states[state];
+			StateContext current = value;
 
 			while (true)
 			{
@@ -84,7 +84,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 		{
 			var destination = _currentState.GetDestination(trigger);
 
-			if (_states.ContainsKey(destination) && _states[destination].Parent is { } parent && !IsInState(parent.StateId))
+			if (_states.TryGetValue(destination, out StateMachine<TState, TTrigger>.StateContext value) && value.Parent is { } parent && !IsInState(parent.StateId))
 			{
 				Goto(parent.StateId);
 			}
@@ -237,7 +237,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 		internal void Process(TTrigger trigger)
 		{
-			if (_triggerActions.ContainsKey(trigger) && _triggerActions[trigger] is { } actions)
+			if (_triggerActions.TryGetValue(trigger, out List<Action> value) && value is { } actions)
 			{
 				foreach (var action in actions)
 				{

--- a/WalletWasabi.Fluent/Validation/Validations.cs
+++ b/WalletWasabi.Fluent/Validation/Validations.cs
@@ -87,9 +87,8 @@ public class Validations : ReactiveObject, IRegisterValidationMethod, IValidatio
 	{
 		if (!string.IsNullOrWhiteSpace(propertyName))
 		{
-			return ErrorsByPropertyName.ContainsKey(propertyName) && ErrorsByPropertyName[propertyName].Any()
-				? ErrorsByPropertyName[propertyName]
-				: ErrorDescriptors.Empty;
+			return ErrorsByPropertyName.TryGetValue(propertyName, out ErrorDescriptors value) && value.Any()
+				? value : ErrorDescriptors.Empty;
 		}
 		else
 		{

--- a/WalletWasabi.Fluent/Validation/Validations.cs
+++ b/WalletWasabi.Fluent/Validation/Validations.cs
@@ -87,7 +87,7 @@ public class Validations : ReactiveObject, IRegisterValidationMethod, IValidatio
 	{
 		if (!string.IsNullOrWhiteSpace(propertyName))
 		{
-			return ErrorsByPropertyName.TryGetValue(propertyName, out ErrorDescriptors value) && value.Any()
+			return ErrorsByPropertyName.TryGetValue(propertyName, out ErrorDescriptors? value) && value.Any()
 				? value : ErrorDescriptors.Empty;
 		}
 		else

--- a/WalletWasabi.Fluent/ViewModels/Navigation/NavigationManager.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/NavigationManager.cs
@@ -22,7 +22,7 @@ public static class NavigationManager
 
 	public static T? Get<T>() where T : ViewModelBase
 	{
-		if (TypeRegistry.ContainsKey(typeof(T)) && TypeRegistry[typeof(T)] is T vmb)
+		if (TypeRegistry.TryGetValue(typeof(T), out ViewModelBase value) && value is T vmb)
 		{
 			return vmb;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Navigation/NavigationManager.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/NavigationManager.cs
@@ -22,7 +22,7 @@ public static class NavigationManager
 
 	public static T? Get<T>() where T : ViewModelBase
 	{
-		if (TypeRegistry.TryGetValue(typeof(T), out ViewModelBase value) && value is T vmb)
+		if (TypeRegistry.TryGetValue(typeof(T), out ViewModelBase? value) && value is T vmb)
 		{
 			return vmb;
 		}

--- a/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
@@ -39,9 +39,9 @@ public class CoinjoinAnalyzer
 			}
 
 			// If we already analyzed the sanction for this output, then return the cached result.
-			if (CachedInputSanctions.ContainsKey(transactionOutput))
+			if (CachedInputSanctions.TryGetValue(transactionOutput, out double value))
 			{
-				return CachedInputSanctions[transactionOutput];
+				return value;
 			}
 
 			// Look at the transaction containing transactionOutput.

--- a/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
+++ b/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
@@ -27,9 +27,9 @@ public class RequestTimeStatista
 			var toDisplay = false;
 			lock (Lock)
 			{
-				if (Requests.ContainsKey(request))
+				if (Requests.TryGetValue(request, out List<(DateTimeOffset Time, TimeSpan Duration)> value))
 				{
-					Requests[request].Add((DateTimeOffset.UtcNow, duration));
+					value.Add((DateTimeOffset.UtcNow, duration));
 				}
 				else
 				{

--- a/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
+++ b/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
@@ -27,7 +27,7 @@ public class RequestTimeStatista
 			var toDisplay = false;
 			lock (Lock)
 			{
-				if (Requests.TryGetValue(request, out List<(DateTimeOffset Time, TimeSpan Duration)> value))
+				if (Requests.TryGetValue(request, out List<(DateTimeOffset Time, TimeSpan Duration)>? value))
 				{
 					value.Add((DateTimeOffset.UtcNow, duration));
 				}


### PR DESCRIPTION
To fix some VS warnings.

> CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
> Rule description
> When an element of an IDictionary is accessed, the indexer implementation checks for a null value by calling the IDictionary.ContainsKey method. If you also call IDictionary.ContainsKey in an if clause to guard a value lookup, two lookups are performed when only one is needed.

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1854
