### PR TITLE
Friendly exception tor.real wrong arch on silicon

### DIFF
--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -195,7 +195,7 @@ public class TorProcessManager : IAsyncDisposable
 			}
 			catch (Win32Exception ex)
 			{
-				var message = (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+				string message = (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
 					? "Tor process cannot be started. Please check that you have installed Rosetta 2 (https://support.apple.com/en-us/HT211861) if you use Apple Silicon machine."
 					: "Failed to start the Tor process.";
 				Logger.LogError(message, ex);


### PR DESCRIPTION
Related #9878

It would be much better to trigger the crash reporter and display the exception there, if anyone know if it's possible to do that it'd be great.
Waiting for a better handling, this friendly log message might still help. I repro the crash and it's displayed close to the end of the messages.