### PR TITLE
Fix: relative url overwrites the path of base url in wasabi's http client

### DIFF
--- a/WalletWasabi/Tor/Http/IHttpClient.cs
+++ b/WalletWasabi/Tor/Http/IHttpClient.cs
@@ -19,6 +19,13 @@ public interface IHttpClient
 	/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
 	Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
 
+	public static string Combine(string uri1, string uri2)
+	{
+		uri1 = uri1.TrimEnd('/');
+		uri2 = uri2.TrimStart('/');
+		return string.Format("{0}/{1}", uri1, uri2);
+	}
+	
 	/// <exception cref="HttpRequestException"/>
 	/// <exception cref="InvalidOperationException"/>
 	/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
@@ -36,7 +43,7 @@ public interface IHttpClient
 			throw new InvalidOperationException("Base URI is not set.");
 		}
 
-		Uri requestUri = new(baseUri, relativeUri);
+		Uri requestUri = new Uri(Combine(baseUri.ToString(), relativeUri));
 		using HttpRequestMessage httpRequestMessage = new(method, requestUri);
 
 		if (content is { })


### PR DESCRIPTION
when `google.com/test, subpath/other `
expected = `google.com/test/subpath/other`
current = `google.com/subpath/other`