### PR TITLE
Remove segwit limitation for change outputs

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -357,8 +357,8 @@ public class KeyManager
 	public HdPubKey GetNextChangeKey() =>
 		GetKeys(x =>
 			x.KeyState == KeyState.Clean &&
-			x.IsInternal == true &&
-			x.FullKeyPath.GetScriptTypeFromKeyPath() == ScriptPubKeyType.Segwit).First();
+			x.IsInternal == true)
+			.First();
 
 	public IEnumerable<HdPubKey> GetKeys(Func<HdPubKey, bool>? wherePredicate)
 	{


### PR DESCRIPTION
Reverts the change introduced before release to limit the output scripts for change outputs to segwit only. 