### PR TITLE
[VDG] Disable ToggleSwitch knobs transitions to fix delay of switch toggle as settings

### DIFF
--- a/WalletWasabi.Fluent/Styles/ToggleSwitch.axaml
+++ b/WalletWasabi.Fluent/Styles/ToggleSwitch.axaml
@@ -3,4 +3,10 @@
   <Style Selector="ToggleSwitch">
     <Setter Property="Cursor" Value="Hand" />
   </Style>
+  <Style Selector="ToggleSwitch:not(:dragging) /template/ Grid#MovingKnobs">
+    <Setter Property="Transitions">
+      <Transitions>
+      </Transitions>
+    </Setter>
+  </Style>
 </Styles>

--- a/WalletWasabi.Fluent/Styles/ToggleSwitch.axaml
+++ b/WalletWasabi.Fluent/Styles/ToggleSwitch.axaml
@@ -3,6 +3,8 @@
   <Style Selector="ToggleSwitch">
     <Setter Property="Cursor" Value="Hand" />
   </Style>
+
+  <!-- Fix for https://github.com/zkSNACKs/WalletWasabi/issues/9436 -->
   <Style Selector="ToggleSwitch:not(:dragging) /template/ Grid#MovingKnobs">
     <Setter Property="Transitions">
       <Transitions>


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/9436

The ToggleSwitch has Transitions set for knonbs when IsChecked property value changes (true/false). When initial value of IsChecked=true and view is first time showed the transition is activated so it may be perceived as delay.

https://github.com/AvaloniaUI/Avalonia/blob/401bc521d2947bf7699a530f3d6e43e7a32c6baf/src/Avalonia.Themes.Fluent/Controls/ToggleSwitch.xaml#L116-L125

https://github.com/AvaloniaUI/Avalonia/blob/401bc521d2947bf7699a530f3d6e43e7a32c6baf/src/Avalonia.Themes.Fluent/Controls/ToggleSwitch.xaml#L162-L168

https://github.com/AvaloniaUI/Avalonia/blob/401bc521d2947bf7699a530f3d6e43e7a32c6baf/src/Avalonia.Controls/ToggleSwitch.cs#L242-L255

In this PR I just disabled the transition, another option would be enable transition only after ToggleSwitch  was attached to visual tree.
