### PR TITLE
OptIn RBF in coinjoins in 2.1.0

### DIFF
--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
@@ -12,6 +12,8 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 public record SigningState : MultipartyTransactionState
 {
+	private static readonly Version OptInRbfVersion = new Version(2, 1, 0, 0);
+	
 	public SigningState(RoundParameters parameters, IEnumerable<IEvent> events)
 		: base(parameters)
 	{
@@ -85,11 +87,10 @@ public record SigningState : MultipartyTransactionState
 	{
 		var tx = Parameters.CreateTransaction();
 
+		var isRbf = Constants.ClientVersion >= OptInRbfVersion; 
 		foreach (var coin in SortedInputs)
 		{
-			// implied:
-			// nSequence = FINAL
-			tx.Inputs.Add(coin.Outpoint);
+			tx.Inputs.Add(coin.Outpoint, sequence: isRbf ? Sequence.OptInRBF : Sequence.Final);
 		}
 
 		foreach (var txout in SortedOutputs)


### PR DESCRIPTION
In [DoS mitigation by replacing transaction (full rbf is comming)](https://github.com/zkSNACKs/WalletWasabi/discussions/9540) we started discussing the usage of RBF to mitigate DoS attacks on coinjoins. You can read more about the topic in this the bitcoin-dev list [Why Full-RBF Makes DoS Attacks on Multiparty Protocols Significantly More Expensive](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-January/021322.html)

However, **full**-rbf is not really necessary here and we can do exactly the same by simply opt-in rbf explicitly with bip125 as suggested by Peter Todd [here](https://github.com/zkSNACKs/WalletWasabi/issues/9041#issuecomment-1338833341)

Unfortunately clients build the coinjoin transaction by themselves before signing and then they **all** must build the exact same transaction, this means that **all clients** (and the server too) must signal RBF at the same time. For this reason we need a coordination mechanism.

Currently the mechanism we have to enforce compatibility is the client versioning so, we can start signaling after a given version is released, in this case 2.1.0 (any other is equally good). Those who don't upgrade will be banned after a while. 