### PR TITLE
Wallet Stats: rename locked to hidden

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletStatsView.axaml
@@ -60,7 +60,7 @@
                                  Content="{Binding GeneratedCleanKeyCount}" />
       </c:PreviewItem>
       <Separator />
-      <c:PreviewItem Label="Number of locked addresses"
+      <c:PreviewItem Label="Number of hidden addresses"
                      TextValue="{Binding GeneratedLockedKeyCount}">
         <c:PrivacyContentControl Classes="monoSpaced"
                                  Content="{Binding GeneratedLockedKeyCount}" />


### PR DESCRIPTION
to match wording: `hide address` at receive

(user asked what it means) it can be confusing if not the same wording.