### PR TITLE
[PoC] Exclude Coins from CoinJoining

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinViewModel.cs
@@ -13,6 +13,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Advanced.WalletCoins;
 public partial class WalletCoinViewModel : ViewModelBase, IDisposable
 {
 	private readonly CompositeDisposable _disposables = new();
+	[AutoNotify] private bool _isExcludedFromCoinJoin;
 	[AutoNotify] private Money _amount = Money.Zero;
 	[AutoNotify] private int _anonymitySet;
 	[AutoNotify] private SmartLabel _smartLabel = "";
@@ -27,9 +28,10 @@ public partial class WalletCoinViewModel : ViewModelBase, IDisposable
 	{
 		Coin = coin;
 		Amount = Coin.Amount;
+		IsExcludedFromCoinJoin = coin.IsExcludedFromCoinJoin;
+		ToggleExcludeCommand = ReactiveCommand.Create(() => coin.IsExcludedFromCoinJoin = !coin.IsExcludedFromCoinJoin, canExecute: this.WhenAnyValue(x => x.CoinJoinInProgress).Select(x => !x));
 
-		ToggleSelectCommand = ReactiveCommand.Create(() => IsSelected = !IsSelected, canExecute: this.WhenAnyValue(x => x.CoinJoinInProgress).Select(x => !x));
-
+		Coin.WhenAnyValue(c => c.IsExcludedFromCoinJoin).Subscribe(x => IsExcludedFromCoinJoin = x).DisposeWith(_disposables);
 		Coin.WhenAnyValue(c => c.Confirmed).Subscribe(x => Confirmed = x).DisposeWith(_disposables);
 		Coin.WhenAnyValue(c => c.HdPubKey.Cluster.Labels).Subscribe(x => SmartLabel = x).DisposeWith(_disposables);
 		Coin.WhenAnyValue(c => c.HdPubKey.AnonymitySet).Subscribe(x => AnonymitySet = (int)x).DisposeWith(_disposables);
@@ -42,7 +44,7 @@ public partial class WalletCoinViewModel : ViewModelBase, IDisposable
 		this.WhenAnyValue(x => x.CoinJoinInProgress).Where(x => x).Subscribe(_ => IsSelected = false);
 	}
 
-	public ICommand ToggleSelectCommand { get; }
+	public ICommand ToggleExcludeCommand { get; }
 
 	public SmartCoin Coin { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -64,6 +64,9 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 			.Select(items => items.Any(t => t.IsSelected))
 			.ObserveOn(RxApp.MainThreadScheduler);
 
+		coinChanges.WhenPropertyChanged(x => x.IsExcludedFromCoinJoin, false)
+			.Subscribe(x => _walletVm.Wallet.UpdateExcludedCoinFromCoinJoin());
+
 		coinChanges
 			.DisposeMany()
 			.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/WalletCoinsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/WalletCoinsView.axaml
@@ -30,7 +30,7 @@
                          Background="Transparent"
                          x:CompileBindings="True" x:DataType="walletcoins:WalletCoinViewModel">
                 <i:Interaction.Behaviors>
-                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ToggleSelectCommand, Mode=OneWay}" />
+                  <behaviors:ExecuteCommandOnDoubleTapped Command="{Binding ToggleExcludeCommand, Mode=OneWay}" />
                 </i:Interaction.Behaviors>
                 <Border Name="PART_SelectionIndicator"
                         BorderThickness="2 0 0 0"

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -120,15 +120,15 @@ public class KeyManager
 
 	public static KeyPath GetAccountKeyPath(Network network, ScriptPubKeyType scriptPubKeyType) =>
 		new((network.Name, scriptPubKeyType) switch
-			{
-				("TestNet", ScriptPubKeyType.Segwit) => "m/84h/1h/0h",
-				("RegTest", ScriptPubKeyType.Segwit) => "m/84h/0h/0h",
-				("Main", ScriptPubKeyType.Segwit) => "m/84h/0h/0h",
-				("TestNet", ScriptPubKeyType.TaprootBIP86) => "m/86h/1h/0h",
-				("RegTest", ScriptPubKeyType.TaprootBIP86) => "m/86h/0h/0h",
-				("Main", ScriptPubKeyType.TaprootBIP86) => "m/86h/0h/0h",
-				_ => throw new ArgumentException($"Unknown account for network '{network}' and script type '{scriptPubKeyType}'.")
-			});
+		{
+			("TestNet", ScriptPubKeyType.Segwit) => "m/84h/1h/0h",
+			("RegTest", ScriptPubKeyType.Segwit) => "m/84h/0h/0h",
+			("Main", ScriptPubKeyType.Segwit) => "m/84h/0h/0h",
+			("TestNet", ScriptPubKeyType.TaprootBIP86) => "m/86h/1h/0h",
+			("RegTest", ScriptPubKeyType.TaprootBIP86) => "m/86h/0h/0h",
+			("Main", ScriptPubKeyType.TaprootBIP86) => "m/86h/0h/0h",
+			_ => throw new ArgumentException($"Unknown account for network '{network}' and script type '{scriptPubKeyType}'.")
+		});
 
 	public WpkhDescriptors GetOutputDescriptors(string password, Network network)
 	{
@@ -202,6 +202,9 @@ public class KeyManager
 
 	[JsonProperty(Order = 999, PropertyName = "HdPubKeys")]
 	private List<HdPubKey> HdPubKeys { get; } = new();
+
+	[JsonProperty(ItemConverterType = typeof(OutPointJsonConverter), PropertyName = "ExcludedCoinsFromCoinJoin")]
+	public List<OutPoint> ExcludedCoinsFromCoinJoin { get; private set; } = new();
 
 	public string? FilePath { get; private set; }
 
@@ -364,7 +367,7 @@ public class KeyManager
 		GetKeys(x =>
 				x.KeyState == KeyState.Locked &&
 				x.IsInternal == true);
-	
+
 	public IEnumerable<HdPubKey> GetKeys(Func<HdPubKey, bool>? wherePredicate)
 	{
 		// BIP44-ish derivation scheme
@@ -706,6 +709,12 @@ public class KeyManager
 
 	private static HdPubKey CreateHdPubKey((KeyPath KeyPath, ExtPubKey ExtPubKey) x) =>
 		new(x.ExtPubKey.PubKey, x.KeyPath, SmartLabel.Empty, KeyState.Clean);
+
+	internal void SetExcludedCoinsFromCoinJoin(IEnumerable<OutPoint> excludedOutpoints)
+	{
+		ExcludedCoinsFromCoinJoin = excludedOutpoints.ToList();
+		ToFile();
+	}
 }
 
 public static class KeyPathExtensions

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -173,7 +173,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	public bool IsSpent() => SpenderTransaction is not null;
 
 	/// <summary>
-	/// IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress AND !IsFrozen
+	/// IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress AND !IsExcludedFromCoinJoin
 	/// </summary>
 	public bool IsAvailable() => SpenderTransaction is null && !SpentAccordingToBackend && !CoinJoinInProgress && !IsExcludedFromCoinJoin;
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -25,6 +25,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 
 	private bool _confirmed;
 	private bool _isBanned;
+	private bool _isExcludedFromCoinJoin;
 
 	private Lazy<uint256> _transactionId;
 	private Lazy<OutPoint> _outPoint;
@@ -143,6 +144,12 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 		private set => RaiseAndSetIfChanged(ref _isBanned, value);
 	}
 
+	public bool IsExcludedFromCoinJoin
+	{
+		get => _isExcludedFromCoinJoin;
+		set => RaiseAndSetIfChanged(ref _isExcludedFromCoinJoin, value);
+	}
+
 	public bool IsImmature(int bestHeight)
 	{
 		return Transaction.Transaction.IsCoinBase && Height < bestHeight - 100;
@@ -166,9 +173,9 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	public bool IsSpent() => SpenderTransaction is not null;
 
 	/// <summary>
-	/// IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress
+	/// IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress AND !IsFrozen
 	/// </summary>
-	public bool IsAvailable() => SpenderTransaction is null && !SpentAccordingToBackend && !CoinJoinInProgress;
+	public bool IsAvailable() => SpenderTransaction is null && !SpentAccordingToBackend && !CoinJoinInProgress && !IsExcludedFromCoinJoin;
 
 	public bool IsReplaceable() => Transaction.IsRBF;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -224,6 +224,7 @@ public class Wallet : BackgroundService, IWallet
 				{
 					await LoadWalletStateAsync(cancel).ConfigureAwait(false);
 					await LoadDummyMempoolAsync().ConfigureAwait(false);
+					LoadExcludedCoins();
 				}
 			}
 
@@ -235,6 +236,27 @@ public class Wallet : BackgroundService, IWallet
 		{
 			State = WalletState.Initialized;
 			throw;
+		}
+	}
+
+	private void LoadExcludedCoins()
+	{
+		bool isUpdateRequired = false;
+		foreach (var excludedCoin in KeyManager.ExcludedCoinsFromCoinJoin)
+		{
+			var coin = Coins.SingleOrDefault(c => c.Outpoint == excludedCoin);
+			if (coin != null)
+			{
+				coin.IsExcludedFromCoinJoin = true;
+			}
+			else
+			{
+				isUpdateRequired = true;
+			}
+		}
+		if (isUpdateRequired)
+		{
+			UpdateExcludedCoinFromCoinJoin();
 		}
 	}
 
@@ -502,6 +524,12 @@ public class Wallet : BackgroundService, IWallet
 		var wallet = new Wallet(dataDir, network, keyManager);
 		wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
 		return wallet;
+	}
+
+	public void UpdateExcludedCoinFromCoinJoin()
+	{
+		var excludedOutpoints = Coins.Where(c => c.IsExcludedFromCoinJoin).Select(c => c.Outpoint);
+		KeyManager.SetExcludedCoinsFromCoinJoin(excludedOutpoints);
 	}
 
 	public bool IsMixable =>


### PR DESCRIPTION
## TL;DR
**Proof of Concept for https://github.com/zkSNACKs/WalletWasabi/issues/7487**

With this PR, one can ❄️"freeze"/exclude🧊 his or her coins from being selected for a **CoinJoin** by the `CoinJoinManager`.
You can achive it by double-clicking on a **Coin**🪙 in the **CoinList**🗒️_(CTRL+C+D)_.

## Description

As this PR is only but a **PoC**, there is still work to do, mainly on the UI side (\*wink\* @zkSNACKs/visual-design-group 😉 ).
Right now nothing indicates that a coin is excluded, you can check the Wallet file for the `"ExcludedCoinsFromCoinJoin" = [ ]`.
But the main concept in the bussiness logic is this.
- Select and/or exclude Coins from the coinlist;
- These Coins won't be participating in CoinJoins;
- These Coins's `Outpoint` will be saved in the `KeyManager` (including the `Wallet` file);
- Thanks to that, upon loading the `Wallet`, we also set by `Outpoint`, which Coins should still be excluded;
- This is good, as one might move his/her wallet to another computer, but don't have to re-select 10s if not 100s Coins.

## TODOs and Questions

- The UI should have an icon next to the Confirmation check and CoinJoining icon, indicationg if it's "frozen"? (maybe an icecube 🧊 , or snowflake ❄️)?
- Excluding a Coin should be a more obvious thing then double clicking _(wow)_.
- There needs to be a way to [select-deselect more coins in one step](https://github.com/zkSNACKs/WalletWasabi/issues/7487#issuecomment-1294373008).

### And the question:

If we add this feature, the proper place for it is the CoinList. Which all started as a developer feature, but as I heard, there were user complains about this, "why I need to come to GitHub to find out that this feature exists". Until now it's like they found an easter egg🥚. At this point, we need to reconsider making a dedicated button for the Coinlist in the Wallet.