### PR TITLE
`IndexStore`: Simplify `ForeachFiltersAsync`

### DIFF
--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -109,7 +109,7 @@ public class IndexStore : IAsyncDisposable
 						{
 							i++;
 							cancel.ThrowIfCancellationRequested();
-							string? line = await sr.ReadLineAsync().ConfigureAwait(false);
+							string? line = await sr.ReadLineAsync(CancellationToken.None).ConfigureAwait(false);
 
 							if (line is null)
 							{
@@ -362,48 +362,19 @@ public class IndexStore : IAsyncDisposable
 				{
 					uint height = StartingHeight;
 					using var sr = MatureIndexFileManager.OpenText();
-					if (!sr.EndOfStream)
+
+					while (true)
 					{
-						var lineTask = sr.ReadLineAsync();
-						Task tTask = Task.CompletedTask;
-						string? line = null;
-						while (lineTask is { })
-						{
-							if (firstImmatureHeight == height)
-							{
-								break; // Let's use our the immature filters from here on. The content is the same, just someone else modified the file.
-							}
-
-							line ??= await lineTask.ConfigureAwait(false);
-
-							lineTask = sr.EndOfStream ? null : sr.ReadLineAsync();
-
-							if (height < fromHeight.Value)
-							{
-								height++;
-								line = null;
-								continue;
-							}
-
-							var filter = FilterModel.FromLine(line);
-
-							await tTask.ConfigureAwait(false);
-							tTask = todo(filter);
-
-							height++;
-
-							line = null;
-						}
-						await tTask.ConfigureAwait(false);
-					}
-
-					while (!sr.EndOfStream)
-					{
-						var line = await sr.ReadLineAsync().ConfigureAwait(false);
-
 						if (firstImmatureHeight == height)
 						{
 							break; // Let's use our the immature filters from here on. The content is the same, just someone else modified the file.
+						}
+
+						string? line = await sr.ReadLineAsync(CancellationToken.None).ConfigureAwait(false);
+
+						if (line is null)
+						{
+							break;
 						}
 
 						if (height < fromHeight.Value)
@@ -412,7 +383,7 @@ public class IndexStore : IAsyncDisposable
 							continue;
 						}
 
-						var filter = FilterModel.FromLine(line);
+						FilterModel filter = FilterModel.FromLine(line);
 
 						await todo(filter).ConfigureAwait(false);
 						height++;

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Hosting;
 using NBitcoin;
 using Nito.AsyncEx;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -411,14 +410,9 @@ public class Wallet : BackgroundService, IWallet
 			TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
 		}
 
-		Logger.LogInfo($"XXX START");
-		Stopwatch sw = Stopwatch.StartNew();
-
 		// Go through the filters and queue to download the matches.
 		await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
 			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
-
-		Logger.LogInfo($"XXX END | {sw.ElapsedMilliseconds} ms");
 	}
 
 	private async Task LoadDummyMempoolAsync()

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Hosting;
 using NBitcoin;
 using Nito.AsyncEx;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -410,9 +411,14 @@ public class Wallet : BackgroundService, IWallet
 			TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestKeyManagerHeight));
 		}
 
+		Logger.LogInfo($"XXX START");
+		Stopwatch sw = Stopwatch.StartNew();
+
 		// Go through the filters and queue to download the matches.
 		await BitcoinStore.IndexStore.ForeachFiltersAsync(async (filterModel) => await ProcessFilterModelAsync(filterModel, cancel).ConfigureAwait(false),
 			new Height(bestKeyManagerHeight.Value + 1), cancel).ConfigureAwait(false);
+
+		Logger.LogInfo($"XXX END | {sw.ElapsedMilliseconds} ms");
 	}
 
 	private async Task LoadDummyMempoolAsync()


### PR DESCRIPTION
This PR fixes a few warning regarding not propagating cancellation tokens. 

Also it simplifies the algorithm used in `ForeachFiltersAsync` and it's actually slightly faster on my machine because instead of using `ReadLineAsync` that returns `Task`, we use the overload that returns `ValueTask` so we don't need to allocate that much.

Additionaly, about 12 warnings is shaved off.