### PR TITLE
Coinjoin payment batching

### DIFF
--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -9,6 +9,7 @@ using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Crypto;
 using WalletWasabi.Helpers;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 
 namespace WalletWasabi.Tests.UnitTests;
@@ -139,8 +140,8 @@ public class TestWallet : IKeyChain, IDestinationProvider
 		// Test wallet doesn't care
 	}
 
-	public IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot) =>
-		Enumerable.Range(0, count).Select(_ => CreateNewAddress());
+	public Task<IEnumerable<IDestination>> GetNextDestinationsAsync(int count, bool preferTaproot) =>
+		Task.FromResult<IEnumerable<IDestination>>(Enumerable.Range(0, count).Select(_ => CreateNewAddress()));
 
 	private void ScanTransaction(Transaction tx)
 	{
@@ -154,4 +155,9 @@ public class TestWallet : IKeyChain, IDestinationProvider
 
 	private ExtKey CreateNewKey() =>
 		ExtKey.Derive(NextKeyIndex++);
+
+	public Task<IEnumerable<PendingPayment>> GetPendingPaymentsAsync(UtxoSelectionParameters roundParameters)
+	{
+		return Task.FromResult(Enumerable.Empty<PendingPayment>());
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -79,7 +79,7 @@ public class ArenaClientTests
 		var keyChain = new KeyChain(km, new Kitchen(password));
 		var destinationProvider = new InternalDestinationProvider(km);
 
-		var coins = destinationProvider.GetNextDestinations(2, false)
+		var coins = (await destinationProvider.GetNextDestinationsAsync(2, false))
 			.Select(dest => (
 				Coin: new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(1.0m), dest)),
 				OwnershipProof: keyChain.GetOwnershipProof(dest, WabiSabiFactory.CreateCommitmentData(round.Id))))

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Linq;
+using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Client;
@@ -11,13 +12,13 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
 public class KeyChainTests
 {
 	[Fact]
-	public void SignTransactionTest()
+	public async Task SignTransactionTest()
 	{
 		var keyManager = KeyManager.CreateNew(out _, "", Network.Main);
 		var destinationProvider = new InternalDestinationProvider(keyManager);
 		var keyChain = new KeyChain(keyManager, new Kitchen(""));
 
-		var coinDestination = destinationProvider.GetNextDestinations(1, false).First();
+		var coinDestination = (await destinationProvider.GetNextDestinationsAsync(1, false)).First();
 		var coin = new Coin(BitcoinFactory.CreateOutPoint(), new TxOut(Money.Coins(1.0m), coinDestination));
 
 		var transaction = Transaction.Create(Network.Main); // the transaction doesn't contain the input that we request to be signed.

--- a/WalletWasabi/WabiSabi/Backend/Rounds/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/UtxoSelectionParameters.cs
@@ -9,7 +9,8 @@ public record UtxoSelectionParameters(
 	MoneyRange AllowedOutputAmounts,
 	CoordinationFeeRate CoordinationFeeRate,
 	FeeRate MiningFeeRate,
-	ImmutableSortedSet<ScriptType> AllowedInputScriptTypes)
+	ImmutableSortedSet<ScriptType> AllowedInputScriptTypes,
+	ImmutableSortedSet<ScriptType> AllowedOutputScriptTypes)
 {
 	public static UtxoSelectionParameters FromRoundParameters(RoundParameters roundParameters) =>
 		new(
@@ -17,5 +18,6 @@ public record UtxoSelectionParameters(
 			roundParameters.AllowedOutputAmounts,
 			roundParameters.CoordinationFeeRate,
 			roundParameters.MiningFeeRate,
-			roundParameters.AllowedInputTypes);
+			roundParameters.AllowedInputTypes,
+			roundParameters.AllowedOutputTypes);
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinResult.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinResult.cs
@@ -9,4 +9,5 @@ public record CoinJoinResult(
 	bool SuccessfulBroadcast,
 	ImmutableList<SmartCoin> RegisteredCoins,
 	ImmutableList<Script> RegisteredOutputs,
-	Transaction? UnsignedCoinJoin);
+	ImmutableDictionary<TxOut, PendingPayment> HandledPayments,
+	Transaction UnsignedCoinJoin, uint256 RoundId);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -52,7 +52,8 @@ public class CoinJoinTrackerFactory
 			consolidationMode: wallet.ConsolidationMode,
 			redCoinIsolation: wallet.RedCoinIsolation,
 			feeRateMedianTimeFrame: wallet.FeeRateMedianTimeFrame,
-			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));
+			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1),
+			wallet.BatchPayments );
 
 		return new CoinJoinTracker(wallet, coinJoinClient, coinCandidates, stopWhenAllMixed, overridePlebStop, CancellationToken);
 	}

--- a/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/DependencyGraphTaskScheduler.cs
@@ -145,7 +145,7 @@ public class DependencyGraphTaskScheduler
 		}
 	}
 
-	public async Task StartOutputRegistrationsAsync(IEnumerable<TxOut> txOuts, BobClient bobClient, IKeyChain keyChain, ImmutableList<DateTimeOffset> outputRegistrationScheduledDates, CancellationToken cancellationToken)
+	public async Task<Dictionary<TxOut, Exception?>> StartOutputRegistrationsAsync(IEnumerable<TxOut> txOuts, BobClient bobClient, IKeyChain keyChain, ImmutableList<DateTimeOffset> outputRegistrationScheduledDates, CancellationToken cancellationToken)
 	{
 		using CancellationTokenSource ctsOnError = new();
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ctsOnError.Token);
@@ -163,7 +163,7 @@ public class DependencyGraphTaskScheduler
 			return smartRequestNode;
 		});
 
-		var tasks = txOuts.Zip(nodes, outputRegistrationScheduledDates,
+		var tasks = txOuts.Zip(nodes, outputRegistrationScheduledDates.AsEnumerable(),
 			async (txOut, smartRequestNode, scheduledDate) =>
 			{
 				try
@@ -173,21 +173,30 @@ public class DependencyGraphTaskScheduler
 					{
 						await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 					}
-					await smartRequestNode.StartOutputRegistrationAsync(bobClient, txOut.ScriptPubKey, cancellationToken).ConfigureAwait(false);
+
+					await smartRequestNode
+						.StartOutputRegistrationAsync(bobClient, txOut.ScriptPubKey, cancellationToken)
+						.ConfigureAwait(false);
 				}
-				catch (WabiSabiProtocolException ex) when (ex.ErrorCode == WabiSabiProtocolErrorCode.AlreadyRegisteredScript)
+				catch (WabiSabiProtocolException ex)
 				{
 					Logger.LogDebug($"Output registration error, code:'{ex.ErrorCode}' message:'{ex.Message}'.");
 					keyChain.TrySetScriptStates(KeyState.Used, new[] { txOut.ScriptPubKey });
+					
+					return (txOut, ex);
 				}
 				catch (Exception ex)
 				{
 					Logger.LogInfo($"Output registration error message:'{ex.Message}'.");
+					
+					return (txOut, ex);
 				}
+				
+				return (txOut, null)!;
 			}
 		).ToImmutableArray();
-
-		await Task.WhenAll(tasks).ConfigureAwait(false);
+		var result = await Task.WhenAll(tasks).ConfigureAwait(false);
+		return result.Where(tuple => tuple.ex is { }).ToDictionary(tuple => tuple.txOut, tuple => tuple.ex);
 	}
 
 	private IEnumerable<(AliceClient AliceClient, InputNode Node)> PairAliceClientAndRequestNodes(IEnumerable<AliceClient> aliceClients, DependencyGraph graph)

--- a/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
@@ -1,16 +1,20 @@
 using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 
 namespace WalletWasabi.WabiSabi.Client;
 
 public interface IDestinationProvider
 {
-	IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot);
+	Task<IEnumerable<IDestination>> GetNextDestinationsAsync(int count, bool preferTaproot);
+	
+	Task<IEnumerable<PendingPayment>> GetPendingPaymentsAsync(UtxoSelectionParameters roundParameters);
 }
 
 public static class DestinationProviderExtensions
 {
 	public static Script Peek(this IDestinationProvider me, bool preferTaproot) =>
-		me.GetNextDestinations(1, preferTaproot).First().ScriptPubKey;
+		me.GetNextDestinationsAsync(1, preferTaproot).Result.First().ScriptPubKey;
 }

--- a/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
@@ -1,7 +1,9 @@
 using NBitcoin;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 
 namespace WalletWasabi.WabiSabi.Client;
 
@@ -14,7 +16,7 @@ public class InternalDestinationProvider : IDestinationProvider
 
 	private KeyManager KeyManager { get; }
 
-	public IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot)
+	public Task<IEnumerable<IDestination>> GetNextDestinationsAsync(int count, bool preferTaproot)
 	{
 		// Get all locked internal keys we have and assert we have enough.
 		KeyManager.AssertLockedInternalKeysIndexedAndPersist(count, preferTaproot);
@@ -27,6 +29,11 @@ public class InternalDestinationProvider : IDestinationProvider
 		var destinations = preferTaproot && taprootKeys.Count >= count
 			? taprootKeys
 			: allKeys;
-		return destinations.Select(x => x.GetAddress(KeyManager.GetNetwork()));
+		return Task.FromResult(destinations.Select(x => (IDestination) x.GetAddress(KeyManager.GetNetwork())));
+	}
+
+	public Task<IEnumerable<PendingPayment>> GetPendingPaymentsAsync(UtxoSelectionParameters roundParameters)
+	{
+		return Task.FromResult(Enumerable.Empty<PendingPayment>());
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/PendingPayment.cs
+++ b/WalletWasabi/WabiSabi/Client/PendingPayment.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public class PendingPayment
+{
+	public IDestination Destination { get; set; }
+	public Money Value { get; set; }
+	public Func<Task<bool>> PaymentStarted { get; set; }
+	public Action PaymentFailed { get; set; }
+	public Action<(uint256 roundId, uint256 transactionId, int outputIndex)> PaymentSucceeded { get; set; }
+	public string Identifier { get; set; }
+
+	public TxOut ToTxOut()
+	{
+		return new TxOut(Value, Destination);
+	}
+}

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -22,6 +22,7 @@ public interface IWallet
 	bool ConsolidationMode { get; }
 	TimeSpan FeeRateMedianTimeFrame { get; }
 	bool RedCoinIsolation { get; }
+	bool BatchPayments { get; }
 
 	Task<bool> IsWalletPrivateAsync();
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -84,6 +84,7 @@ public class Wallet : BackgroundService, IWallet
 	public ICoinsView Coins { get; private set; }
 
 	public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
+	public bool BatchPayments { get; } = false;
 
 	public Task<bool> IsWalletPrivateAsync() => Task.FromResult(IsWalletPrivate());
 


### PR DESCRIPTION
This PR introduces support to the internals to allow payment batching. The destination provider supplies a list of `PendingPayment`. The `IWallet` has a new bool that signals its intent to batch payments to the coinjoin client. Please note that for this to  be efficient in payments, wasabi wallet needs to:
* not stop the coinjoin client when all mixed if payments are enabled
* the coin selector needs to factor in any payments it wants to do
* the coordinator needs to remove its output script type limitations