### PR TITLE
`ProcessAsync`: Cleanup

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/BaseInhibitorTaskTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/BaseInhibitorTaskTests.cs
@@ -19,7 +19,7 @@ public class BaseInhibitorTaskTests
 	public async Task CancelBehaviorAsync()
 	{
 		Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
-		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
 			.Returns((CancellationToken cancellationToken, bool killOnCancel) => Task.Delay(Timeout.Infinite, cancellationToken));
 		mockProcess.Setup(p => p.HasExited).Returns(false);
 		mockProcess.Setup(p => p.Kill(It.IsAny<bool>()));

--- a/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/BaseInhibitorTaskTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/BaseInhibitorTaskTests.cs
@@ -20,7 +20,7 @@ public class BaseInhibitorTaskTests
 	{
 		Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
 		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
-			.Returns((CancellationToken cancellationToken, bool killOnCancel) => Task.Delay(Timeout.Infinite, cancellationToken));
+			.Returns((CancellationToken cancellationToken) => Task.Delay(Timeout.Infinite, cancellationToken));
 		mockProcess.Setup(p => p.HasExited).Returns(false);
 		mockProcess.Setup(p => p.Kill(It.IsAny<bool>()));
 

--- a/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
@@ -38,7 +38,7 @@ public class TorProcessManagerTests
 
 		// Mock Tor process.
 		Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
-		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
 			.Returns((CancellationToken cancellationToken, bool killOnCancel) => Task.Delay(torProcessCrashPeriod, cancellationToken));
 		mockProcess.Setup(p => p.Dispose());
 

--- a/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
@@ -39,7 +39,7 @@ public class TorProcessManagerTests
 		// Mock Tor process.
 		Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
 		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
-			.Returns((CancellationToken cancellationToken, bool killOnCancel) => Task.Delay(torProcessCrashPeriod, cancellationToken));
+			.Returns((CancellationToken cancellationToken) => Task.Delay(torProcessCrashPeriod, cancellationToken));
 		mockProcess.Setup(p => p.Dispose());
 
 		// Set up Tor process manager.

--- a/WalletWasabi/Microservices/ProcessAsync.cs
+++ b/WalletWasabi/Microservices/ProcessAsync.cs
@@ -7,7 +7,7 @@ using WalletWasabi.Logging;
 namespace WalletWasabi.Microservices;
 
 /// <summary>
-/// Async wrapper class for <see cref="System.Diagnostics.Process"/> class that implements <see cref="WaitForExitAsync(CancellationToken, bool)"/>
+/// Async wrapper class for <see cref="System.Diagnostics.Process"/> class that implements <see cref="WaitForExitAsync(CancellationToken)"/>
 /// to asynchronously wait for a process to exit.
 /// </summary>
 public class ProcessAsync : IDisposable
@@ -77,9 +77,8 @@ public class ProcessAsync : IDisposable
 	/// Waits until the process either finishes on its own or when user cancels the action.
 	/// </summary>
 	/// <param name="cancellationToken">Cancellation token.</param>
-	/// <param name="killOnCancel">If <c>true</c> the process will be killed (with entire process tree) when this asynchronous action is canceled via <paramref name="cancellationToken"/> token.</param>
 	/// <returns><see cref="Task"/>.</returns>
-	public virtual async Task WaitForExitAsync(CancellationToken cancellationToken, bool killOnCancel = false)
+	public virtual async Task WaitForExitAsync(CancellationToken cancellationToken)
 	{
 		if (Process.HasExited)
 		{
@@ -97,23 +96,6 @@ public class ProcessAsync : IDisposable
 		catch (OperationCanceledException ex)
 		{
 			Logger.LogTrace("User canceled waiting for process exit.");
-
-			if (killOnCancel)
-			{
-				if (!Process.HasExited)
-				{
-					try
-					{
-						Logger.LogTrace("Kill process.");
-						Process.Kill(entireProcessTree: true);
-					}
-					catch (Exception e)
-					{
-						Logger.LogError($"Could not kill process: {e}.");
-					}
-				}
-			}
-
 			throw new TaskCanceledException("Waiting for process exiting was canceled.", ex, cancellationToken);
 		}
 	}


### PR DESCRIPTION
Remove unused code. At this point, we need `ProcessAsync` only for mocking purposes. Originally, `ProcessAsync` was implemented because `Process.WaitForExitAsync` was not implemented in .NET. 

Imho our encapsulation of `Process` should be as thin as possible.