### PR TITLE
[test] return same script type in GetNextReceiveKey()

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -360,10 +360,11 @@ public class KeyManager
 			x.IsInternal == true &&
 			x.FullKeyPath.GetScriptTypeFromKeyPath() == ScriptPubKeyType.Segwit).First();
 
-	public IEnumerable<HdPubKey> GetNextCoinJoinKeys() =>
+	public IEnumerable<HdPubKey> GetNextCoinJoinKeys(bool preferTaproot) =>
 		GetKeys(x =>
-				x.KeyState == KeyState.Locked &&
-				x.IsInternal == true);
+			x.KeyState == KeyState.Locked &&
+			x.IsInternal == true &&
+			preferTaproot == (x.FullKeyPath.GetScriptTypeFromKeyPath() == ScriptPubKeyType.TaprootBIP86));
 	
 	public IEnumerable<HdPubKey> GetKeys(Func<HdPubKey, bool>? wherePredicate)
 	{

--- a/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
@@ -19,14 +19,7 @@ public class InternalDestinationProvider : IDestinationProvider
 		// Get all locked internal keys we have and assert we have enough.
 		KeyManager.AssertLockedInternalKeysIndexedAndPersist(count, preferTaproot);
 
-		var allKeys = KeyManager.GetNextCoinJoinKeys().ToList();
-		var taprootKeys = allKeys
-			.Where(x => x.FullKeyPath.GetScriptTypeFromKeyPath() == ScriptPubKeyType.TaprootBIP86)
-			.ToList();
-		
-		var destinations = preferTaproot && taprootKeys.Count >= count
-			? taprootKeys
-			: allKeys;
-		return destinations.Select(x => x.GetAddress(KeyManager.GetNetwork()));
+		var keys = KeyManager.GetNextCoinJoinKeys(preferTaproot).ToList();
+		return keys.Select(x => x.GetAddress(KeyManager.GetNetwork()));
 	}
 }


### PR DESCRIPTION
Fixes `CoinJoinWithBlameRoundTestAsync` by forcing `KeyManager.GetNextReceiveKey()` to return only `destinations` of same script type to make this comment true again:
https://github.com/zkSNACKs/WalletWasabi/blob/286922118f1848e76d2573a7e49cddfb241ebc12/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs#L1075

It's only a PR made to investigate the #9964 as it fixes the test, not to be merged as it changes the behavior