### PR TITLE
[NoMerge] Performance test for CoinSelector for payments

### DIFF
--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -16,7 +16,7 @@ public class SmartCoinSelector : ICoinSelector
 		UnspentCoins = unspentCoins.Distinct().ToList();
 	}
 
-	private List<SmartCoin> UnspentCoins { get; }
+	private List<SmartCoin> UnspentCoins { get; set; }
 	private int IterationCount { get; set; }
 
 	/// <param name="suggestion">We use this to detect if NBitcoin tries to suggest something different and indicate the error.</param>
@@ -24,6 +24,8 @@ public class SmartCoinSelector : ICoinSelector
 	/// <remarks>Do not call this method repeatedly on a single <see cref="SmartCoinSelector"/> instance.</remarks>
 	public IEnumerable<ICoin> Select(IEnumerable<ICoin> suggestion, IMoney target)
 	{
+		var testCase = TransactionFactory.CurrentTestCase;
+		
 		var targetMoney = (Money)target;
 
 		long available = UnspentCoins.Sum(x => x.Amount);

--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -17,7 +17,7 @@ public class SmartCoinSelector : ICoinSelector
 		UnspentCoins = unspentCoins.Distinct().ToList();
 	}
 
-	private List<SmartCoin> UnspentCoins { get; set; }
+	private List<SmartCoin> UnspentCoins { get; }
 	private int IterationCount { get; set; }
 
 	/// <param name="suggestion">We use this to detect if NBitcoin tries to suggest something different and indicate the error.</param>

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -36,14 +36,16 @@ public class TransactionFactory
 	public string Password { get; }
 	public bool AllowUnconfirmed { get; }
 	private ITransactionStore TransactionStore { get; }
+	public static string CurrentTestCase { get; set; }
 
 	/// <inheritdoc cref="BuildTransaction(PaymentIntent, Func{FeeRate}, IEnumerable{OutPoint}?, Func{LockTime}?, IPayjoinClient?, bool)"/>
 	public BuildTransactionResult BuildTransaction(
 		PaymentIntent payments,
 		FeeRate feeRate,
 		IEnumerable<OutPoint>? allowedInputs = null,
-		IPayjoinClient? payjoinClient = null)
-		=> BuildTransaction(payments, () => feeRate, allowedInputs, () => LockTime.Zero, payjoinClient);
+		IPayjoinClient? payjoinClient = null,
+		string testCase = "")
+		=> BuildTransaction(payments, () => feeRate, allowedInputs, () => LockTime.Zero, payjoinClient, true, testCase);
 
 	/// <exception cref="ArgumentException"/>
 	/// <exception cref="ArgumentNullException"/>
@@ -54,8 +56,11 @@ public class TransactionFactory
 		IEnumerable<OutPoint>? allowedInputs = null,
 		Func<LockTime>? lockTimeSelector = null,
 		IPayjoinClient? payjoinClient = null,
-		bool tryToSign = true)
+		bool tryToSign = true,
+		string testCase = "")
 	{
+		CurrentTestCase = testCase;
+		
 		lockTimeSelector ??= () => LockTime.Zero;
 
 		long totalAmount = payments.TotalAmount.Satoshi;


### PR DESCRIPTION
This test (which could be better factored) build transactions from simulated wallets.
It tries to simulate common cases (wallet with many/few coins, big/small payment, big/small feerate, private/non-private...).
Then it creates the transactions for each simulated context with different versions of CoinSelector (`testCases`), then it ranks the results within 4 categories: MostPrivate, SmallestAmount, LessInputs, LessFees,
and finally computes the GlobalRank.
In every category, the smallest the number the better (as it's just the sum of ranks for each mocked transactions).

Commit https://github.com/zkSNACKs/WalletWasabi/commit/9643682d5cf8f7ac9e39e751abc5162a50e9d09f implements idea from https://github.com/zkSNACKs/WalletWasabi/pull/9625#issuecomment-1357295526.
@kiminuo, can you review this specific commit to see if I understood correctly your idea?