### PR TITLE
Change default backend URIs to new API hostnames

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -188,6 +188,12 @@ public class Program
 		Config config = new(Path.Combine(dataDir, "Config.json"));
 		config.LoadFile(createIfMissing: true);
 
+		if (config.MigrateOldDefaultBackendUris())
+		{
+			Logger.LogInfo("Configuration file with the new coordinator API URIs was saved.");
+			config.ToFile();
+		}
+
 		return (uiConfig, config);
 	}
 

--- a/WalletWasabi.Fluent/Config.cs
+++ b/WalletWasabi.Fluent/Config.cs
@@ -218,4 +218,23 @@ public class Config : ConfigBase
 
 		ServiceConfiguration = new ServiceConfiguration(GetBitcoinP2pEndPoint(), DustThreshold);
 	}
+
+	public bool MigrateOldDefaultBackendUris()
+	{
+		bool hasChanged = false;
+
+		if (MainNetBackendUri == "https://wasabiwallet.io/")
+		{
+			MainNetBackendUri = "https://api.wasabiwallet.io/";
+			hasChanged = true;
+		}
+
+		if (TestNetBackendUri == "https://wasabiwallet.co/")
+		{
+			TestNetBackendUri = "https://api.wasabiwallet.co/";
+			hasChanged = true;
+		}
+
+		return hasChanged;
+	}
 }

--- a/WalletWasabi.Fluent/Config.cs
+++ b/WalletWasabi.Fluent/Config.cs
@@ -37,13 +37,13 @@ public class Config : ConfigBase
 	[JsonConverter(typeof(NetworkJsonConverter))]
 	public Network Network { get; internal set; } = Network.Main;
 
-	[DefaultValue("https://wasabiwallet.io/")]
+	[DefaultValue("https://api.wasabiwallet.io/")]
 	[JsonProperty(PropertyName = "MainNetBackendUri", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public string MainNetBackendUri { get; private set; } = "https://wasabiwallet.io/";
+	public string MainNetBackendUri { get; private set; } = "https://api.wasabiwallet.io/";
 
-	[DefaultValue("https://wasabiwallet.co/")]
+	[DefaultValue("https://api.wasabiwallet.co/")]
 	[JsonProperty(PropertyName = "TestNetClearnetBackendUri", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public string TestNetBackendUri { get; private set; } = "https://wasabiwallet.co/";
+	public string TestNetBackendUri { get; private set; } = "https://api.wasabiwallet.co/";
 
 	[DefaultValue("http://localhost:37127/")]
 	[JsonProperty(PropertyName = "RegTestBackendUri", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
New special hostnames are created for API requests. Part of longer term plan to separate backend from website. Old URLs are still working and will work for foreseeable future, but we want clients to start using new ones ASAP.