### PR TITLE
Start CJ with only pending coins

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -503,7 +503,6 @@ public class CoinJoinManager : BackgroundService
 	private async Task<IEnumerable<SmartCoin>> SelectCandidateCoinsAsync(IWallet openedWallet, int bestHeight)
 		=> new CoinsView(await openedWallet.GetCoinjoinCoinCandidatesAsync().ConfigureAwait(false))
 			.Available()
-			.Confirmed()
 			.Where(coin => !coin.IsExcludedFromCoinJoin)
 			.Where(coin => !coin.IsImmature(bestHeight))
 			.Where(coin => !coin.IsBanned)


### PR DESCRIPTION
Closes #9936 (see https://github.com/zkSNACKs/WalletWasabi/issues/9936#issuecomment-1405969523)
I don't think it makes any difference in the behavior as wallet will wait for the coins to confirm anyway.
Not sure if we want to do that, please NACK if no.

Please also note that this doesn't help for #9957, even if the issues are similar
To fix both issues we could remove these lines: 
https://github.com/zkSNACKs/WalletWasabi/blob/919c88e21d4a33f9d339afdf2649e7b8f5444d32/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs#L199-L206