### PR TITLE
CoinHelpers and starting CJ with empty coins consistency

### DIFF
--- a/WalletWasabi/Helpers/CoinHelpers.cs
+++ b/WalletWasabi/Helpers/CoinHelpers.cs
@@ -1,0 +1,25 @@
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.Helpers;
+
+public static class CoinHelpers
+{
+	public static bool IsPrivate<TCoin>(this TCoin coin, int privateThreshold)
+		where TCoin : class, ISmartCoin, IEquatable<TCoin>
+	{
+		return coin.AnonymitySet >= privateThreshold;
+	}
+
+	public static bool IsSemiPrivate<TCoin>(this TCoin coin, int privateThreshold, int semiPrivateThreshold = Constants.SemiPrivateThreshold)
+		where TCoin : class, ISmartCoin, IEquatable<TCoin>
+	{
+		var anonymitySet = coin.AnonymitySet;
+		return anonymitySet >= semiPrivateThreshold && anonymitySet < privateThreshold;
+	}
+	
+	public static bool IsRedCoin<TCoin>(this TCoin coin, int semiPrivateThreshold = Constants.SemiPrivateThreshold)
+		where TCoin : class, ISmartCoin, IEquatable<TCoin>
+	{
+		return coin.AnonymitySet < semiPrivateThreshold;
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -680,13 +680,13 @@ public class CoinJoinClient
 			.ToArray();
 
 		var privateCoins = filteredCoins
-			.Where(x => x.AnonymitySet >= anonScoreTarget)
+			.Where(x => x.IsPrivate(anonScoreTarget))
 			.ToArray();
 		var semiPrivateCoins = filteredCoins
-			.Where(x => x.AnonymitySet < anonScoreTarget && x.AnonymitySet >= semiPrivateThreshold)
+			.Where(x => x.IsSemiPrivate(anonScoreTarget, semiPrivateThreshold))
 			.ToArray();
 		var redCoins = filteredCoins
-			.Where(x => x.AnonymitySet < semiPrivateThreshold)
+			.Where(x => x.IsRedCoin(semiPrivateThreshold))
 			.ToArray();
 
 		if (semiPrivateCoins.Length + redCoins.Length == 0)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -503,6 +503,7 @@ public class CoinJoinManager : BackgroundService
 	private async Task<IEnumerable<SmartCoin>> SelectCandidateCoinsAsync(IWallet openedWallet, int bestHeight)
 		=> new CoinsView(await openedWallet.GetCoinjoinCoinCandidatesAsync().ConfigureAwait(false))
 			.Available()
+			.Confirmed()
 			.Where(coin => !coin.IsExcludedFromCoinJoin)
 			.Where(coin => !coin.IsImmature(bestHeight))
 			.Where(coin => !coin.IsBanned)

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -112,8 +112,8 @@ public class Wallet : BackgroundService, IWallet
 
 	private double GetPrivacyPercentage(CoinsView coins, int privateThreshold)
 	{
-		var privateAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet >= privateThreshold).TotalAmount();
-		var normalAmount = coins.FilterBy(x => x.HdPubKey.AnonymitySet < privateThreshold).TotalAmount();
+		var privateAmount = coins.FilterBy(x => x.IsPrivate(privateThreshold)).TotalAmount();
+		var normalAmount = coins.FilterBy(x => !x.IsPrivate(privateThreshold)).TotalAmount();
 
 		var privateDecimalAmount = privateAmount.ToDecimal(MoneyUnit.BTC);
 		var normalDecimalAmount = normalAmount.ToDecimal(MoneyUnit.BTC);


### PR DESCRIPTION
Result of a meeting with @molnard 

This PR does 3 things:
1) 7d0398b41a22aedc49283ffef7a5bd46269ba656: Create `WalletWasabi.Helpers.CoinHelpers` which is inspired from [WalletWasabi.Fluent.Helpers.CoinHelpers](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Fluent/Helpers/CoinHelpers.cs) and implements privacy status checks for `TCoin`. I chose to use `TCoin` as it's the same type used in `SelectCoinsForRounds`. It would probably be cleaner to create a file for this class.

2) 32aa212291ef2632f595f69adaae6245d7e5dc27: Reverts #10008

3) 4b68c87c0120677bdda238207f061cfb315a6adc: Throw `StartError NoCoinsToMix` when the wallet is 100% private but has pending incoming coins.

-> So the behavior is always consistent: When no coins are available to mix in auto mode, don't start the process but keep checking for confirmation.

#9936 issue is narrowed down as a `MusicBox`/`StateMachine` issue: 

When no coins are available to mix but there are incoming pending coins
- In auto-coinjoin mode: The user has to wait for its transaction to confirm if he doesn't want these incoming coins to be coinjoined (or disable auto-cj)
- In manual mode: If the user click play, but then changes his mind and doesn't want to CJ the incoming coins, he has to either close the software either wait for its coin to confirm.

In both cases the problem is the lack of `Pause` button when CJ is not started and the messages displayed in the `MusicBox` which are incorrect.