### PR TITLE
Fix relative path in uri

### DIFF
--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -60,7 +60,7 @@ public class RegTestFixture : IDisposable
 			.Build();
 		BackendEndPoint = $"http://localhost:{CryptoHelpers.RandomInt(37130, 37999)}/";
 		BackendEndPointUri = new Uri(BackendEndPoint);
-		BackendEndPointApiUri = new Uri(BackendEndPointUri, $"/api/v{Constants.BackendMajorVersion}/");
+		BackendEndPointApiUri = new Uri(BackendEndPointUri, $"api/v{Constants.BackendMajorVersion}/");
 
 		BackendHost = Host.CreateDefaultBuilder()
 				.ConfigureWebHostDefaults(webBuilder => webBuilder

--- a/WalletWasabi/WebClients/Bitstamp/BitstampExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Bitstamp/BitstampExchangeRateProvider.cs
@@ -16,7 +16,7 @@ public class BitstampExchangeRateProvider : IExchangeRateProvider
 		{
 			BaseAddress = new Uri("https://www.bitstamp.net")
 		};
-		using var response = await httpClient.GetAsync("/api/v2/ticker/btcusd", cancellationToken).ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("api/v2/ticker/btcusd", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rate = await content.ReadAsJsonAsync<BitstampExchangeRate>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
@@ -16,7 +16,7 @@ public class CoinGeckoExchangeRateProvider : IExchangeRateProvider
 		{
 			BaseAddress = new Uri("https://api.coingecko.com")
 		};
-		using var response = await httpClient.GetAsync("/api/v3/coins/markets?vs_currency=usd&ids=bitcoin", cancellationToken).ConfigureAwait(false);
+		using var response = await httpClient.GetAsync("api/v3/coins/markets?vs_currency=usd&ids=bitcoin", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rates = await content.ReadAsJsonAsync<CoinGeckoExchangeRate[]>().ConfigureAwait(false);
 

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -37,7 +37,7 @@ public class WasabiClient
 	/// </remarks>
 	public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
 	{
-		string relativeUri = $"/api/v{ApiVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
+		string relativeUri = $"api/v{ApiVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
 		if (estimateMode is { })
 		{
 			relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";
@@ -67,7 +67,7 @@ public class WasabiClient
 	{
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
-			$"/api/v{ApiVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
+			$"api/v{ApiVersion}/btc/blockchain/filters?bestKnownBlockHash={bestKnownBlockHash}&count={count}",
 			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode == HttpStatusCode.NoContent)
@@ -103,7 +103,7 @@ public class WasabiClient
 
 			using HttpResponseMessage response = await HttpClient.SendAsync(
 				HttpMethod.Get,
-				$"/api/v{ApiVersion}/btc/blockchain/transaction-hexes?&transactionIds={string.Join("&transactionIds=", chunk.Select(x => x.ToString()))}",
+				$"api/v{ApiVersion}/btc/blockchain/transaction-hexes?&transactionIds={string.Join("&transactionIds=", chunk.Select(x => x.ToString()))}",
 				cancellationToken: cancel).ConfigureAwait(false);
 
 			if (response.StatusCode != HttpStatusCode.OK)
@@ -140,7 +140,7 @@ public class WasabiClient
 	public async Task BroadcastAsync(string hex)
 	{
 		using var content = new StringContent($"'{hex}'", Encoding.UTF8, "application/json");
-		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Post, $"/api/v{ApiVersion}/btc/blockchain/broadcast", content).ConfigureAwait(false);
+		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Post, $"api/v{ApiVersion}/btc/blockchain/broadcast", content).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
@@ -162,7 +162,7 @@ public class WasabiClient
 	{
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
-			$"/api/v{ApiVersion}/btc/blockchain/mempool-hashes",
+			$"api/v{ApiVersion}/btc/blockchain/mempool-hashes",
 			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
@@ -185,7 +185,7 @@ public class WasabiClient
 	{
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
-			$"/api/v{ApiVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
+			$"api/v{ApiVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
 			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
@@ -205,7 +205,7 @@ public class WasabiClient
 
 	public async Task<(Version ClientVersion, ushort BackendMajorVersion, Version LegalDocumentsVersion)> GetVersionsAsync(CancellationToken cancel)
 	{
-		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, "/api/software/versions", cancellationToken: cancel).ConfigureAwait(false);
+		using HttpResponseMessage response = await HttpClient.SendAsync(HttpMethod.Get, "api/software/versions", cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
 		{
@@ -242,7 +242,7 @@ public class WasabiClient
 	{
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
-			$"/api/v{ApiVersion}/wasabi/legaldocuments?id=ww2",
+			$"api/v{ApiVersion}/wasabi/legaldocuments?id=ww2",
 			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)


### PR DESCRIPTION
When the base url has a subpath, and the relative url has a leading "/", the subpath of the base url is ignored. Initially ran into this in #9904, and @kiminuo showed me the correct usage. Since I was only testing with the wabisabi client, it all worked fine. Now, I was testing with the full wasabi client ans the api calls in `WasabiClient` all have a leading "/", causing the same issue. This PR removes all leading "/" in HttpClient Send requests.