### PR TITLE
[VDG] `CoinJoinStateViewModel` - Cleanup

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -131,7 +131,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				}
 			});
 
-		walletVm.Settings.WhenAnyValue(x => x.PlebStopThreshold)
+		walletVm.CoinJoinSettings.WhenAnyValue(x => x.PlebStopThreshold)
 			.SubscribeAsync(async _ =>
 			{
 				// Hack: we take the value from KeyManager but it is saved later.

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -63,9 +63,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		WalletVm = walletVm;
 		var wallet = walletVm.Wallet;
 
-		_countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-		_countdownTimer.Tick += OnTimerTick;
-
 		var coinJoinManager = Services.HostedServices.Get<CoinJoinManager>();
 
 		Observable.FromEventPattern<StatusChangedEventArgs>(coinJoinManager, nameof(coinJoinManager.StatusChanged))
@@ -145,6 +142,9 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			await coinJoinManager.StartAsync(wallet, stopWhenAllMixed: false, false, CancellationToken.None);
 			_autoCoinJoinStartTimer.Stop();
 		};
+
+		_countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+		_countdownTimer.Tick += (_, _) => _stateMachine.Fire(Trigger.Tick);
 
 		_stateMachine.Start();
 	}
@@ -404,10 +404,5 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		ElapsedTime = "";
 		RemainingTime = "";
 		ProgressValue = 0;
-	}
-
-	private void OnTimerTick(object? sender, EventArgs e)
-	{
-		_stateMachine.Fire(Trigger.Tick);
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -135,7 +135,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.SubscribeAsync(async _ =>
 			{
 				// Hack: we take the value from KeyManager but it is saved later.
-				// https://github.com/molnard/WalletWasabi/blob/master/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs#L105
 				await Task.Delay(1500);
 				_stateMachine.Fire(Trigger.PlebStopChanged);
 			});
@@ -186,7 +185,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 	private void ConfigureStateMachine()
 	{
-		// See diagram in the developer docs.
 		_stateMachine.Configure(State.Disabled);
 
 		_stateMachine.Configure(State.WaitingForAutoStart)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -1,4 +1,3 @@
-using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -108,11 +107,11 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			}
 		});
 
-		IsPauseButtonEnabled = this.WhenAnyValue(x => x.IsInCriticalPhase, x => x.PauseSpreading,
+		var topPauseCommandCanExecute = this.WhenAnyValue(x => x.IsInCriticalPhase, x => x.PauseSpreading,
 			(isInCriticalPhase, pauseSpreading) => !isInCriticalPhase && !pauseSpreading);
 
 		StopPauseCommand = ReactiveCommand.CreateFromTask(async () =>
-			await coinJoinManager.StopAsync(wallet, CancellationToken.None), IsPauseButtonEnabled);
+			await coinJoinManager.StopAsync(wallet, CancellationToken.None), topPauseCommandCanExecute);
 
 		AutoCoinJoinObservable = walletVm.CoinJoinSettings.WhenAnyValue(x => x.AutoCoinJoin);
 
@@ -173,8 +172,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	}
 
 	public IObservable<bool> AutoCoinJoinObservable { get; }
-
-	public IObservable<bool> IsPauseButtonEnabled { get; }
 
 	private bool IsCountDownFinished => GetRemainingTime() <= TimeSpan.Zero;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -34,6 +34,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private readonly string _waitingRoundMessage = "Waiting for a round";
 	private readonly string _plebStopMessage = "Coinjoining might be uneconomical";
 	private readonly string _plebStopMessageBelow = "Receive more funds or press play to bypass";
+	private readonly string _waitingForConfrmedFundsMessage = "Waiting for confirmed funds";
+	private readonly string _userInSendWorkflowMessage = "Waiting for closed send dialog";
+	private readonly string _allPrivateMessage = "Hurray! Your funds are private";
+	private readonly string _generalErrorMessage = "Waiting for valid conditions";
 
 	[AutoNotify] private bool _isAutoWaiting;
 	[AutoNotify] private bool _playVisible = true;
@@ -304,10 +308,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			case StartErrorEventArgs start:
 				CurrentStatus = start.Error switch
 				{
-					CoinjoinError.NoCoinsToMix => "Waiting for confirmed funds",
-					CoinjoinError.UserInSendWorkflow => "Waiting for closed send dialog",
-					CoinjoinError.AllCoinsPrivate => "Hurray! Your funds are private",
-					_ => "Waiting for valid conditions"
+					CoinjoinError.NoCoinsToMix => _waitingForConfrmedFundsMessage,
+					CoinjoinError.UserInSendWorkflow => _userInSendWorkflowMessage,
+					CoinjoinError.AllCoinsPrivate => _allPrivateMessage,
+					_ => _generalErrorMessage
 				};
 
 				break;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -105,11 +105,11 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			}
 		});
 
-		var topPauseCommandCanExecute = this.WhenAnyValue(x => x.IsInCriticalPhase, x => x.PauseSpreading,
+		var stopPauseCommandCanExecute = this.WhenAnyValue(x => x.IsInCriticalPhase, x => x.PauseSpreading,
 			(isInCriticalPhase, pauseSpreading) => !isInCriticalPhase && !pauseSpreading);
 
 		StopPauseCommand = ReactiveCommand.CreateFromTask(async () =>
-			await coinJoinManager.StopAsync(wallet, CancellationToken.None), topPauseCommandCanExecute);
+			await coinJoinManager.StopAsync(wallet, CancellationToken.None), stopPauseCommandCanExecute);
 
 		AutoCoinJoinObservable = walletVm.CoinJoinSettings.WhenAnyValue(x => x.AutoCoinJoin);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -47,8 +47,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	[AutoNotify] private string _currentStatus = "";
 	[AutoNotify] private bool _isProgressReversed;
 	[AutoNotify] private double _progressValue;
-	[AutoNotify] private string _elapsedTime = "";
-	[AutoNotify] private string _remainingTime = "";
+	[AutoNotify] private string _leftText = "";
+	[AutoNotify] private string _rightText = "";
 	[AutoNotify] private bool _isInCriticalPhase;
 	[AutoNotify] private bool _isCountDownDelayHappening;
 	[AutoNotify] private bool _areAllCoinsPrivate;
@@ -223,9 +223,9 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PauseSpreading = false;
 				StopVisible = false;
 				CurrentStatus = IsAutoCoinJoinEnabled ? PauseMessage : StoppedMessage;
-				ElapsedTime = "Press Play to start";
+				LeftText = "Press Play to start";
 			})
-			.OnExit(() => ElapsedTime = "");
+			.OnExit(() => LeftText = "");
 
 		_stateMachine.Configure(State.Playing)
 			.Permit(Trigger.WalletStoppedCoinJoin, State.StoppedOrPaused)
@@ -252,9 +252,9 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				StopVisible = false;
 
 				CurrentStatus = PlebStopMessage;
-				ElapsedTime = PlebStopMessageBelow;
+				LeftText = PlebStopMessageBelow;
 			})
-			.OnExit(() => ElapsedTime = "");
+			.OnExit(() => LeftText = "");
 	}
 
 	private void UpdateCountDown()
@@ -265,14 +265,14 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		// and the countdown has finished but the client hasn't received any new phase changed message.
 		if (IsCountDownDelayHappening)
 		{
-			ElapsedTime = "Waiting for response";
-			RemainingTime = "";
+			LeftText = "Waiting for response";
+			RightText = "";
 			return;
 		}
 
 		var format = @"hh\:mm\:ss";
-		ElapsedTime = $"{GetElapsedTime().ToString(format)}";
-		RemainingTime = $"-{GetRemainingTime().ToString(format)}";
+		LeftText = $"{GetElapsedTime().ToString(format)}";
+		RightText = $"-{GetRemainingTime().ToString(format)}";
 		ProgressValue = GetPercentage();
 	}
 
@@ -401,8 +401,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		IsCountDownDelayHappening = false;
 		_countDownStartTime = DateTimeOffset.MinValue;
 		_countDownEndTime = DateTimeOffset.MinValue;
-		ElapsedTime = "";
-		RemainingTime = "";
+		LeftText = "";
+		RightText = "";
 		ProgressValue = 0;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -21,23 +21,23 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private readonly DispatcherTimer _countdownTimer;
 	private readonly DispatcherTimer _autoCoinJoinStartTimer;
 
-	private readonly string _countDownMessage = "Waiting to auto-start coinjoin";
-	private readonly string _waitingMessage = "Waiting for coinjoin";
-	private readonly string _pauseMessage = "Coinjoin is paused";
-	private readonly string _stoppedMessage = "Coinjoin is stopped";
-	private readonly string _roundSucceedMessage = "Successful coinjoin! Continuing...";
-	private readonly string _roundFinishedMessage = "Round finished, waiting for next round";
-	private readonly string _abortedNotEnoughAlicesMessage = "Not enough participants, retrying...";
-	private readonly string _coinJoinInProgress = "Coinjoin in progress";
-	private readonly string _inputRegistrationMessage = "Waiting for other participants";
-	private readonly string _waitingForBlameRoundMessage = "Waiting for the blame round";
-	private readonly string _waitingRoundMessage = "Waiting for a round";
-	private readonly string _plebStopMessage = "Coinjoining might be uneconomical";
-	private readonly string _plebStopMessageBelow = "Receive more funds or press play to bypass";
-	private readonly string _waitingForConfrmedFundsMessage = "Waiting for confirmed funds";
-	private readonly string _userInSendWorkflowMessage = "Waiting for closed send dialog";
-	private readonly string _allPrivateMessage = "Hurray! Your funds are private";
-	private readonly string _generalErrorMessage = "Waiting for valid conditions";
+	private const string CountDownMessage = "Waiting to auto-start coinjoin";
+	private const string WaitingMessage = "Waiting for coinjoin";
+	private const string PauseMessage = "Coinjoin is paused";
+	private const string StoppedMessage = "Coinjoin is stopped";
+	private const string RoundSucceedMessage = "Successful coinjoin! Continuing...";
+	private const string RoundFinishedMessage = "Round finished, waiting for next round";
+	private const string AbortedNotEnoughAlicesMessage = "Not enough participants, retrying...";
+	private const string CoinJoinInProgress = "Coinjoin in progress";
+	private const string InputRegistrationMessage = "Waiting for other participants";
+	private const string WaitingForBlameRoundMessage = "Waiting for the blame round";
+	private const string WaitingRoundMessage = "Waiting for a round";
+	private const string PlebStopMessage = "Coinjoining might be uneconomical";
+	private const string PlebStopMessageBelow = "Receive more funds or press play to bypass";
+	private const string WaitingForConfirmedFundsMessage = "Waiting for confirmed funds";
+	private const string UserInSendWorkflowMessage = "Waiting for closed send dialog";
+	private const string AllPrivateMessage = "Hurray! Your funds are private";
+	private const string GeneralErrorMessage = "Waiting for valid conditions";
 
 	[AutoNotify] private bool _isAutoWaiting;
 	[AutoNotify] private bool _playVisible = true;
@@ -207,7 +207,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				var autoStartEnd = now + _autoCoinJoinStartTimer.Interval;
 				_autoCoinJoinStartTimer.Start();
 
-				StartCountDown(_countDownMessage, now, autoStartEnd);
+				StartCountDown(CountDownMessage, now, autoStartEnd);
 			})
 			.OnExit(() =>
 			{
@@ -227,7 +227,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PauseVisible = false;
 				PauseSpreading = false;
 				StopVisible = false;
-				CurrentStatus = IsAutoCoinJoinEnabled ? _pauseMessage : _stoppedMessage;
+				CurrentStatus = IsAutoCoinJoinEnabled ? PauseMessage : StoppedMessage;
 				ElapsedTime = "Press Play to start";
 			})
 			.OnExit(() => ElapsedTime = "");
@@ -241,7 +241,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PauseVisible = IsAutoCoinJoinEnabled;
 				StopVisible = !IsAutoCoinJoinEnabled;
 
-				CurrentStatus = _waitingMessage;
+				CurrentStatus = WaitingMessage;
 			})
 			.OnTrigger(Trigger.Tick, UpdateCountDown);
 
@@ -256,8 +256,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				PauseVisible = false;
 				StopVisible = false;
 
-				CurrentStatus = _plebStopMessage;
-				ElapsedTime = _plebStopMessageBelow;
+				CurrentStatus = PlebStopMessage;
+				ElapsedTime = PlebStopMessageBelow;
 			})
 			.OnExit(() => ElapsedTime = "");
 	}
@@ -308,10 +308,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			case StartErrorEventArgs start:
 				CurrentStatus = start.Error switch
 				{
-					CoinjoinError.NoCoinsToMix => _waitingForConfrmedFundsMessage,
-					CoinjoinError.UserInSendWorkflow => _userInSendWorkflowMessage,
-					CoinjoinError.AllCoinsPrivate => _allPrivateMessage,
-					_ => _generalErrorMessage
+					CoinjoinError.NoCoinsToMix => WaitingForConfirmedFundsMessage,
+					CoinjoinError.UserInSendWorkflow => UserInSendWorkflowMessage,
+					CoinjoinError.AllCoinsPrivate => AllPrivateMessage,
+					_ => GeneralErrorMessage
 				};
 
 				break;
@@ -335,9 +335,9 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				{
 					CurrentStatus = roundEnded.LastRoundState.EndRoundState switch
 					{
-						EndRoundState.TransactionBroadcasted => _roundSucceedMessage,
-						EndRoundState.AbortedNotEnoughAlices => _abortedNotEnoughAlicesMessage,
-						_ => _roundFinishedMessage
+						EndRoundState.TransactionBroadcasted => RoundSucceedMessage,
+						EndRoundState.AbortedNotEnoughAlices => AbortedNotEnoughAlicesMessage,
+						_ => RoundFinishedMessage
 					};
 					StopCountDown();
 				}
@@ -353,17 +353,17 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 			case EnteringInputRegistrationPhase inputRegPhase:
 				StartCountDown(
-					message: _inputRegistrationMessage,
+					message: InputRegistrationMessage,
 					start: inputRegPhase.TimeoutAt - inputRegPhase.RoundState.InputRegistrationTimeout,
 					end: inputRegPhase.TimeoutAt);
 				break;
 
 			case WaitingForBlameRound waitingForBlameRound:
-				StartCountDown(message: _waitingForBlameRoundMessage, start: DateTimeOffset.UtcNow, end: waitingForBlameRound.TimeoutAt);
+				StartCountDown(message: WaitingForBlameRoundMessage, start: DateTimeOffset.UtcNow, end: waitingForBlameRound.TimeoutAt);
 				break;
 
 			case WaitingForRound:
-				CurrentStatus = _waitingRoundMessage;
+				CurrentStatus = WaitingRoundMessage;
 				StopCountDown();
 				break;
 
@@ -375,7 +375,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 								   confirmationPhase.RoundState.CoinjoinState.Parameters.TransactionSigningTimeout;
 
 				StartCountDown(
-					message: _coinJoinInProgress,
+					message: CoinJoinInProgress,
 					start: startTime,
 					end: totalEndTime);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -40,15 +40,15 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string GeneralErrorMessage = "Waiting for valid conditions";
 
 	[AutoNotify] private bool _isAutoWaiting;
-	[AutoNotify] private bool _playVisible = true;
+	[AutoNotify] private bool _playVisible;
 	[AutoNotify] private bool _pauseVisible;
 	[AutoNotify] private bool _pauseSpreading;
 	[AutoNotify] private bool _stopVisible;
 	[AutoNotify] private string _currentStatus = "";
 	[AutoNotify] private bool _isProgressReversed;
 	[AutoNotify] private double _progressValue;
-	[AutoNotify] private string _elapsedTime;
-	[AutoNotify] private string _remainingTime;
+	[AutoNotify] private string _elapsedTime = "";
+	[AutoNotify] private string _remainingTime = "";
 	[AutoNotify] private bool _isInCriticalPhase;
 	[AutoNotify] private bool _isCountDownDelayHappening;
 	[AutoNotify] private bool _areAllCoinsPrivate;
@@ -62,9 +62,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	{
 		WalletVm = walletVm;
 		var wallet = walletVm.Wallet;
-
-		_elapsedTime = "";
-		_remainingTime = "";
 
 		_countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
 		_countdownTimer.Tick += OnTimerTick;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -21,26 +21,26 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private readonly DispatcherTimer _countdownTimer;
 	private readonly DispatcherTimer _autoCoinJoinStartTimer;
 
-	private readonly MusicStatusMessageViewModel _countDownMessage = new() { Message = "Waiting to auto-start coinjoin" };
-	private readonly MusicStatusMessageViewModel _waitingMessage = new() { Message = "Waiting for coinjoin" };
-	private readonly MusicStatusMessageViewModel _pauseMessage = new() { Message = "Coinjoin is paused" };
-	private readonly MusicStatusMessageViewModel _stoppedMessage = new() { Message = "Coinjoin is stopped" };
-	private readonly MusicStatusMessageViewModel _roundSucceedMessage = new() { Message = "Successful coinjoin! Continuing..." };
-	private readonly MusicStatusMessageViewModel _roundFinishedMessage = new() { Message = "Round finished, waiting for next round" };
-	private readonly MusicStatusMessageViewModel _abortedNotEnoughAlicesMessage = new() { Message = "Not enough participants, retrying..." };
-	private readonly MusicStatusMessageViewModel _coinJoinInProgress = new() { Message = "Coinjoin in progress" };
-	private readonly MusicStatusMessageViewModel _inputRegistrationMessage = new() { Message = "Waiting for other participants" };
-	private readonly MusicStatusMessageViewModel _waitingForBlameRoundMessage = new() { Message = "Waiting for the blame round" };
-	private readonly MusicStatusMessageViewModel _waitingRoundMessage = new() { Message = "Waiting for a round" };
-	private readonly MusicStatusMessageViewModel _plebStopMessage = new() { Message = "Coinjoining might be uneconomical" };
-	private readonly MusicStatusMessageViewModel _plebStopMessageBelow = new() { Message = "Receive more funds or press play to bypass" };
+	private readonly string _countDownMessage = "Waiting to auto-start coinjoin";
+	private readonly string _waitingMessage = "Waiting for coinjoin";
+	private readonly string _pauseMessage = "Coinjoin is paused";
+	private readonly string _stoppedMessage = "Coinjoin is stopped";
+	private readonly string _roundSucceedMessage = "Successful coinjoin! Continuing...";
+	private readonly string _roundFinishedMessage = "Round finished, waiting for next round";
+	private readonly string _abortedNotEnoughAlicesMessage = "Not enough participants, retrying...";
+	private readonly string _coinJoinInProgress = "Coinjoin in progress";
+	private readonly string _inputRegistrationMessage = "Waiting for other participants";
+	private readonly string _waitingForBlameRoundMessage = "Waiting for the blame round";
+	private readonly string _waitingRoundMessage = "Waiting for a round";
+	private readonly string _plebStopMessage = "Coinjoining might be uneconomical";
+	private readonly string _plebStopMessageBelow = "Receive more funds or press play to bypass";
 
 	[AutoNotify] private bool _isAutoWaiting;
 	[AutoNotify] private bool _playVisible = true;
 	[AutoNotify] private bool _pauseVisible;
 	[AutoNotify] private bool _pauseSpreading;
 	[AutoNotify] private bool _stopVisible;
-	[AutoNotify] private MusicStatusMessageViewModel? _currentStatus;
+	[AutoNotify] private string _currentStatus = "";
 	[AutoNotify] private bool _isProgressReversed;
 	[AutoNotify] private double _progressValue;
 	[AutoNotify] private string _elapsedTime;
@@ -253,7 +253,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				StopVisible = false;
 
 				CurrentStatus = _plebStopMessage;
-				ElapsedTime = _plebStopMessageBelow.Message!;
+				ElapsedTime = _plebStopMessageBelow;
 			})
 			.OnExit(() => ElapsedTime = "");
 	}
@@ -304,10 +304,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			case StartErrorEventArgs start:
 				CurrentStatus = start.Error switch
 				{
-					CoinjoinError.NoCoinsToMix => new() { Message = "Waiting for confirmed funds" },
-					CoinjoinError.UserInSendWorkflow => new() { Message = "Waiting for closed send dialog" },
-					CoinjoinError.AllCoinsPrivate => new() { Message = "Hurray! Your funds are private" },
-					_ => new() { Message = "Waiting for valid conditions" }
+					CoinjoinError.NoCoinsToMix => "Waiting for confirmed funds",
+					CoinjoinError.UserInSendWorkflow => "Waiting for closed send dialog",
+					CoinjoinError.AllCoinsPrivate => "Hurray! Your funds are private",
+					_ => "Waiting for valid conditions"
 				};
 
 				break;
@@ -387,7 +387,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		}
 	}
 
-	private void StartCountDown(MusicStatusMessageViewModel message, DateTimeOffset start, DateTimeOffset end)
+	private void StartCountDown(string message, DateTimeOffset start, DateTimeOffset end)
 	{
 		CurrentStatus = message;
 		_countDownStartTime = start;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/MusicStatusMessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/MusicStatusMessageViewModel.cs
@@ -1,6 +1,0 @@
-﻿namespace WalletWasabi.Fluent.ViewModels.Wallets;
-
-public partial class MusicStatusMessageViewModel : ViewModelBase
-{
-	[AutoNotify] private string? _message;
-}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -19,7 +19,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 public partial class WalletSettingsViewModel : RoutableViewModel
 {
 	private readonly Wallet _wallet;
-	[AutoNotify] private string _plebStopThreshold;
 	[AutoNotify] private bool _preferPsbtWorkflow;
 
 	public WalletSettingsViewModel(WalletViewModelBase walletViewModelBase)
@@ -29,8 +28,6 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		_preferPsbtWorkflow = _wallet.KeyManager.PreferPsbtWorkflow;
 		IsHardwareWallet = _wallet.KeyManager.IsHardwareWallet;
 		IsWatchOnly = _wallet.KeyManager.IsWatchOnly;
-		_plebStopThreshold = _wallet.KeyManager.PlebStopThreshold?.ToString() ??
-							 KeyManager.DefaultPlebStopThreshold.ToString();
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -58,8 +58,8 @@
                 <CrossFade Duration="0:0:0.125" FadeInEasing="0.4,0,0.6,1" FadeOutEasing="0.4,0,0.6,1" />
               </TransitioningContentControl.PageTransition>
               <TransitioningContentControl.DataTemplates>
-                <DataTemplate DataType="wallets:MusicStatusMessageViewModel">
-                  <TextBlock Text="{Binding Message}">
+                <DataTemplate DataType="x:String">
+                  <TextBlock Text="{Binding .}">
                     <TextBlock.OpacityMask>
                       <LinearGradientBrush StartPoint="100%,0%" EndPoint="90%,0%">
                         <LinearGradientBrush.GradientStops>

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -83,8 +83,8 @@
             </ProgressBar>
 
             <DockPanel LastChildFill="False">
-              <TextBlock Text="{Binding ElapsedTime}" />
-              <TextBlock Text="{Binding RemainingTime}" DockPanel.Dock="Right" />
+              <TextBlock Text="{Binding LeftText}" />
+              <TextBlock Text="{Binding RightText}" DockPanel.Dock="Right" />
             </DockPanel>
           </StackPanel>
 


### PR DESCRIPTION
- Removes `MusicStatusMessageViewModel` as we thought that would be needed, but since then it is clear `string` is enough.
- Fixes `PlebStopThreshold`. For some reason, it was duplicated on the wallet settings and the coinjoin settings too. It checked the wrong place.
- Cleanup (removes obsolete comment, reordering, unifying)
- Renames `ElapsedTime` and `RemainingTime` to `LeftText` and `RightText` as they don't only display time, but also messages.