### PR TITLE
State machine will follow the business logic

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -164,6 +164,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	{
 		Invalid = 0,
 		PlebStopActivated,
+		StartError,
 		BalanceChanged,
 		Tick,
 		PlebStopChanged,
@@ -195,6 +196,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.Permit(Trigger.WalletStartedCoinJoin, State.Playing)
 			.Permit(Trigger.AutoCoinJoinOff, State.StoppedOrPaused)
 			.Permit(Trigger.PlebStopActivated, State.PlebStopActive)
+			.Permit(Trigger.StartError, State.Playing)
+			.Permit(Trigger.StartError, State.Playing)
 			.OnEntry(() =>
 			{
 				PlayVisible = true;
@@ -305,6 +308,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				break;
 
 			case StartErrorEventArgs start:
+				_stateMachine.Fire(Trigger.StartError);
 				CurrentStatus = start.Error switch
 				{
 					CoinjoinError.NoCoinsToMix => new() { Message = "Waiting for confirmed funds" },
@@ -312,7 +316,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 					CoinjoinError.AllCoinsPrivate => new() { Message = "Hurray! Your funds are private" },
 					_ => new() { Message = "Waiting for valid conditions" }
 				};
-
 				break;
 
 			case CoinJoinStatusEventArgs coinJoinStatusEventArgs:

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -197,7 +197,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.Permit(Trigger.AutoCoinJoinOff, State.StoppedOrPaused)
 			.Permit(Trigger.PlebStopActivated, State.PlebStopActive)
 			.Permit(Trigger.StartError, State.Playing)
-			.Permit(Trigger.StartError, State.Playing)
 			.OnEntry(() =>
 			{
 				PlayVisible = true;
@@ -303,11 +302,13 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				_stateMachine.Fire(Trigger.WalletStoppedCoinJoin);
 				break;
 
-			case StartErrorEventArgs start when start.Error is CoinjoinError.NotEnoughUnprivateBalance:
-				_stateMachine.Fire(Trigger.PlebStopActivated);
-				break;
-
 			case StartErrorEventArgs start:
+				if (start.Error is CoinjoinError.NotEnoughUnprivateBalance)
+				{
+					_stateMachine.Fire(Trigger.PlebStopActivated);
+					break;
+				}
+
 				_stateMachine.Fire(Trigger.StartError);
 				CurrentStatus = start.Error switch
 				{


### PR DESCRIPTION
In auto coinjoin mode!

When you have unconfirmed coins only and you press the play button to override the initial coinjoin delay, it won't change the display to that the coinjoin is running and checking coins every 30 seconds. Another consequence is that the user cannot press pause, because only the play button is visible. 