### PR TITLE
Fix coins dialog on address reuse

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -53,7 +53,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 		var coins = CreateCoinsObservable(_walletVm.UiTriggers.TransactionsUpdateTrigger);
 
 		var coinChanges = coins
-			.ToObservableChangeSet(c => c.HdPubKey.GetHashCode())
+			.ToObservableChangeSet(c => c.Outpoint.GetHashCode())
 			.AsObservableCache()
 			.Connect()
 			.TransformWithInlineUpdate(x => new WalletCoinViewModel(x))


### PR DESCRIPTION
If you address reuse the coins dialog is missing utxos.

Master:
![image](https://user-images.githubusercontent.com/45069029/216363747-6ef1e030-2851-4dd5-9aff-fd5803a34068.png)


This PR:
![image](https://user-images.githubusercontent.com/45069029/216364038-a7f89524-67da-4b1e-8a3e-0e502da61b8c.png)
