### PR TITLE
Upgrade NBitcoin version from 7.0.14 to 7.0.24

### DIFF
--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -310,8 +310,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "7.0.14",
-        "contentHash": "P5M1IeJbFuClYo0v4dzgf3MGA/z03EaL+HzfCsQRm70l2irTN8RonEuRX5QSuUOPc4oUbKFPR+K7OTGMT/gL4Q==",
+        "resolved": "7.0.24",
+        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -664,7 +664,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.14, )",
+          "NBitcoin": "[7.0.24, )",
           "NBitcoin.Secp256k1": "[3.0.1, )"
         }
       },

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -278,8 +278,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "7.0.14",
-        "contentHash": "P5M1IeJbFuClYo0v4dzgf3MGA/z03EaL+HzfCsQRm70l2irTN8RonEuRX5QSuUOPc4oUbKFPR+K7OTGMT/gL4Q==",
+        "resolved": "7.0.24",
+        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -591,7 +591,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.14, )",
+          "NBitcoin": "[7.0.24, )",
           "NBitcoin.Secp256k1": "[3.0.1, )"
         }
       }

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -59,8 +59,8 @@
       },
       "NBitcoin": {
         "type": "Transitive",
-        "resolved": "7.0.14",
-        "contentHash": "P5M1IeJbFuClYo0v4dzgf3MGA/z03EaL+HzfCsQRm70l2irTN8RonEuRX5QSuUOPc4oUbKFPR+K7OTGMT/gL4Q==",
+        "resolved": "7.0.24",
+        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -275,7 +275,7 @@
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.14, )",
+          "NBitcoin": "[7.0.24, )",
           "NBitcoin.Secp256k1": "[3.0.1, )"
         }
       }

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -349,7 +349,7 @@ public class TransactionFactoryTests
 				new DestinationRequest(key3, Money.Coins(0.3m))
 			});
 		var feeRate = new FeeRate(20m);
-		var ex = Assert.Throws<NotEnoughFundsException>(() => transactionFactory.BuildTransaction(payment, feeRate));
+		var ex = Assert.Throws<OutputTooSmallException>(() => transactionFactory.BuildTransaction(payment, feeRate));
 
 		Assert.Equal(Money.Satoshis(3240), ex.Missing);
 	}

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -30,7 +30,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
-		<PackageReference Include="NBitcoin" Version="7.0.14" />
+		<PackageReference Include="NBitcoin" Version="7.0.24" />
 		<PackageReference Include="NBitcoin.Secp256k1" Version="3.0.1" />
 	</ItemGroup>
 

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -21,9 +21,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[7.0.14, )",
-        "resolved": "7.0.14",
-        "contentHash": "P5M1IeJbFuClYo0v4dzgf3MGA/z03EaL+HzfCsQRm70l2irTN8RonEuRX5QSuUOPc4oUbKFPR+K7OTGMT/gL4Q==",
+        "requested": "[7.0.24, )",
+        "resolved": "7.0.24",
+        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"


### PR DESCRIPTION
NBitcoin 7.0.14 doesn't allow elements larger than 1MiB what prevents us to deal with transactions containing NFTs or other large witness data.

See: https://github.com/MetacoSA/NBitcoin/issues/1162