### PR TITLE
Fix dust attack prevention logic

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -831,22 +831,22 @@ public class TransactionProcessorTests
 	[Fact]
 	public async Task ReceiveTransactionWithDustForWalletAsync()
 	{
-		static void AssertCoin(ProcessedResult e, bool expectDust)
+		static void AssertCoin(ProcessedResult result, bool expectDust)
 		{
 			if (!expectDust)
 			{
-				Assert.Empty(e.ReceivedDusts);
-				Assert.NotEmpty(e.ReceivedCoins);
-				Assert.NotEmpty(e.NewlyReceivedCoins);
+				Assert.Empty(result.ReceivedDusts);
+				Assert.NotEmpty(result.ReceivedCoins);
+				Assert.NotEmpty(result.NewlyReceivedCoins);
 			}
 			else
 			{
-				Assert.NotEmpty(e.ReceivedDusts);
-				Assert.Empty(e.ReceivedCoins);
-				Assert.Empty(e.NewlyReceivedCoins);
+				Assert.NotEmpty(result.ReceivedDusts);
+				Assert.Empty(result.ReceivedCoins);
+				Assert.Empty(result.NewlyReceivedCoins);
 			}
-			Assert.True(e.IsNews);
-			Assert.Empty(e.NewlyConfirmedReceivedCoins);
+			Assert.True(result.IsNews);
+			Assert.Empty(result.NewlyConfirmedReceivedCoins);
 		}
 
 		await using var txStore = await CreateTransactionStoreAsync();
@@ -858,7 +858,7 @@ public class TransactionProcessorTests
 
 		// It is relevant even when all the coins can be dust.
 		AssertCoin(relevant, expectDust: false);
-		Assert.NotEmpty(transactionProcessor.Coins);
+		Assert.Single(transactionProcessor.Coins);
 
 		// Transaction store assertions
 		var mempool = transactionProcessor.TransactionStore.MempoolStore.GetTransactions();
@@ -869,10 +869,10 @@ public class TransactionProcessorTests
 
 		var attackTx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(0.000099m));
 
-		relevant = transactionProcessor.Process(attackTx);
+		var result = transactionProcessor.Process(attackTx);
 
 		// It is relevant even when all the coins can be dust.
-		AssertCoin(relevant, expectDust: true);
+		AssertCoin(result, expectDust: true);
 		Assert.Single(transactionProcessor.Coins); // the dust coin used is not added to the coin registry
 	}
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -831,36 +831,34 @@ public class TransactionProcessorTests
 	[Fact]
 	public async Task ReceiveTransactionWithDustForWalletAsync()
 	{
-		static void WhenVerySmallCoinIsProcessed(object? s, ProcessedResult e)
+		static void AssertCoin(ProcessedResult e, bool expectDust)
 		{
-			// The dust coin should raise an event, but it shouldn't be fully processed.
-			Assert.Empty(e.ReceivedDusts);
-			Assert.NotEmpty(e.ReceivedCoins);
-			Assert.NotEmpty(e.NewlyReceivedCoins);
-			Assert.Empty(e.NewlyConfirmedReceivedCoins);
-		}
-
-		static void WhenDustCoinIsProcessed(object? s, ProcessedResult e)
-		{
-			// The dust coin should raise an event, but it shouldn't be fully processed.
-			Assert.NotEmpty(e.ReceivedDusts);
-			Assert.Empty(e.ReceivedCoins);
-			Assert.Empty(e.NewlyReceivedCoins);
+			if (!expectDust)
+			{
+				Assert.Empty(e.ReceivedDusts);
+				Assert.NotEmpty(e.ReceivedCoins);
+				Assert.NotEmpty(e.NewlyReceivedCoins);
+			}
+			else
+			{
+				Assert.NotEmpty(e.ReceivedDusts);
+				Assert.Empty(e.ReceivedCoins);
+				Assert.Empty(e.NewlyReceivedCoins);
+			}
+			Assert.True(e.IsNews);
 			Assert.Empty(e.NewlyConfirmedReceivedCoins);
 		}
 
 		await using var txStore = await CreateTransactionStoreAsync();
 		var transactionProcessor = CreateTransactionProcessor(txStore);
-		transactionProcessor.WalletRelevantTransactionProcessed += WhenVerySmallCoinIsProcessed;
 		var keys = transactionProcessor.KeyManager.GetKeys();
 		var tx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(0.000099m));
 
 		var relevant = transactionProcessor.Process(tx);
 
 		// It is relevant even when all the coins can be dust.
-		Assert.True(relevant.IsNews);
+		AssertCoin(relevant, expectDust: false);
 		Assert.NotEmpty(transactionProcessor.Coins);
-		transactionProcessor.WalletRelevantTransactionProcessed -= WhenVerySmallCoinIsProcessed;
 
 		// Transaction store assertions
 		var mempool = transactionProcessor.TransactionStore.MempoolStore.GetTransactions();
@@ -869,15 +867,13 @@ public class TransactionProcessorTests
 		var matureTxs = transactionProcessor.TransactionStore.ConfirmedStore.GetTransactions().ToArray();
 		Assert.Empty(matureTxs);
 
-		transactionProcessor.WalletRelevantTransactionProcessed += WhenDustCoinIsProcessed;
 		var attackTx = CreateCreditingTransaction(keys.First().P2wpkhScript, Money.Coins(0.000099m));
 
 		relevant = transactionProcessor.Process(attackTx);
 
 		// It is relevant even when all the coins can be dust.
-		Assert.True(relevant.IsNews);
+		AssertCoin(relevant, expectDust: true);
 		Assert.Single(transactionProcessor.Coins); // the dust coin used is not added to the coin registry
-		transactionProcessor.WalletRelevantTransactionProcessed -= WhenVerySmallCoinIsProcessed;
 	}
 
 	[Fact]

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -281,7 +281,7 @@ public class TransactionProcessor
 	private bool CanBeConsideredDustAttack(TxOut output, HdPubKey hdPubKey, bool weAreAmongTheSender) =>
 		output.Value <= DustThreshold // the value received is under the dust threshold
 		&& !weAreAmongTheSender // we are not one of the senders (it is not a self-spending tx or coinjoin)
-		&& hdPubKey.KeyState == KeyState.Used; // the destination address has already been used (address reuse)
+		&& Coins.Any(c => c.HdPubKey == hdPubKey); // the destination address has already been used (address reuse)
 	
 	public void UndoBlock(Height blockHeight)
 	{

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -219,9 +219,10 @@ public class TransactionProcessor
 					tx.Label = SmartLabel.Merge(tx.Label, foundKey.Label);
 				}
 
-				KeyManager.SetKeyState(KeyState.Used, foundKey);
 				var areWeSending = myInputs.Any();
-				if (output.Value <= DustThreshold && !areWeSending)
+				var isReusingAddress = foundKey.KeyState == KeyState.Used; 
+				KeyManager.SetKeyState(KeyState.Used, foundKey);
+				if (output.Value <= DustThreshold && !areWeSending && isReusingAddress)
 				{
 					result.ReceivedDusts.Add(output);
 					continue;

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -281,7 +281,7 @@ public class TransactionProcessor
 	private bool CanBeConsideredDustAttack(TxOut output, HdPubKey hdPubKey, bool weAreAmongTheSender) =>
 		output.Value <= DustThreshold // the value received is under the dust threshold
 		&& !weAreAmongTheSender // we are not one of the senders (it is not a self-spending tx or coinjoin)
-		&& hdPubKey.KeyState == KeyState.Used; // the destination address has already been used (address reuse) 
+		&& hdPubKey.KeyState == KeyState.Used; // the destination address has already been used (address reuse)
 	
 	public void UndoBlock(Height blockHeight)
 	{


### PR DESCRIPTION
Closes #10044

A small coin is not an attack on the user if it was not sent by someone to an already used address. A coins should be filtered when:

1. it is smaller than the _dust attack prevention threshold_,
2. the sender and the receiver are not the same person and,
3. the coin is sent to an already used address. 