### PR TITLE
Do not enforce identity change when connecting to p2p nodes

### DIFF
--- a/WalletWasabi/BestEffortEndpointConnector.cs
+++ b/WalletWasabi/BestEffortEndpointConnector.cs
@@ -19,12 +19,15 @@ public class BestEffortEndpointConnector : IEnpointConnector
 	{
 	}
 
-	private BestEffortEndpointConnector(EffortState state)
+	private BestEffortEndpointConnector(EffortState state, NetworkCredential? networkCredential = null)
 	{
 		State = state;
+		NetworkCredential = networkCredential ?? GenerateCredentials();
 	}
 
 	public EffortState State { get; private set; }
+
+	private NetworkCredential NetworkCredential { get; }
 
 	public void UpdateConnectedNodesCounter(int connectedNodes)
 	{
@@ -33,7 +36,7 @@ public class BestEffortEndpointConnector : IEnpointConnector
 
 	public IEnpointConnector Clone()
 	{
-		return new BestEffortEndpointConnector(State);
+		return new BestEffortEndpointConnector(State, NetworkCredential);
 	}
 
 	public virtual async Task ConnectSocket(Socket socket, EndPoint endpoint, NodeConnectionParameters nodeConnectionParameters, CancellationToken cancellationToken)
@@ -65,7 +68,7 @@ public class BestEffortEndpointConnector : IEnpointConnector
 
 		if (useSocks)
 		{
-			await SocksHelper.Handshake(socket, endpoint, GenerateCredentials(), cancellationToken).ConfigureAwait(false);
+			await SocksHelper.Handshake(socket, endpoint, NetworkCredential, cancellationToken).ConfigureAwait(false);
 		}
 	}
 


### PR DESCRIPTION
Attempts to do: *There was a Tor meeting 2 months ago where we decided not to enforce identity change between P2P Bitcoin nodes so we avoid using many circuits.*

This PR shows just the most strict approach. We would have only one Tor identity. 

I think it would be better to add a little bit of randomness to it. Lucas mentioned:

_you can also "reduce" the number of identities by deciding which one to use based on the endpoint.  Lets say you want to use only 3 circuits the you can do:_

```cs
var aThirdOfInt32 = Int32.MaxValue / 3;
var hash = Hash(endpoint);

Convert.ToInt32(hash[0..4]) switch {
   n when n < aThirdOfInt32 => "identity 1",
   n when n < 2 * aThirdOfInt32 => "identity 2"
   _ => "identity 3" }
```

another approach might be to have just one circuit but to change it after N minutes (10 / 30 / etc.)
