### PR TITLE
[PoC] Don’t test already used internal keys

### DIFF
--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -84,6 +84,9 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 
 	[JsonProperty(Order = 4)]
 	public KeyState KeyState { get; private set; }
+	
+	[JsonProperty(Order = 5)]
+	public int FirstUsedHeight { get; set; }
 
 	public Script P2pkScript { get; }
 	public Script P2pkhScript { get; }

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -523,6 +523,10 @@ public class KeyManager
 			}
 		}
 	}
+	public void SetFirstSeenKeyHeight(int height, HdPubKey hdPubKey)
+	{
+		hdPubKey.FirstUsedHeight = height;
+	}
 
 	private HdPubKeyGenerator? GetHdPubKeyGenerator(bool isInternal, ScriptPubKeyType scriptPubKeyType) =>
 		(isInternal, scriptPubKeyType) switch

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -220,6 +220,10 @@ public class TransactionProcessor
 				}
 
 				KeyManager.SetKeyState(KeyState.Used, foundKey);
+				if (foundKey.FirstUsedHeight > tx.Height || foundKey.FirstUsedHeight == 0)
+				{
+					KeyManager.SetFirstSeenKeyHeight(tx.Height, foundKey);
+				}
 				var areWeSending = myInputs.Any();
 				if (output.Value <= DustThreshold && !areWeSending)
 				{


### PR DESCRIPTION
> **Warning**
> Please note that this PoC add information in the .json wallet file. These lines are ignored on master, but still you will have extra lines if you test that

This PoC is made as a showcase to demostrate the time saved to load big wallets when old internal keys are not retested.
First it needs to find a Transaction, until then it's useless so if you resync try to set a height close to your first TX.

It's useful when a wallet has lot of derived keys. The main advantage is that if you didn't use an extremely big wallet during let's say 1 month, on Master it can take several minutes/hours but with this PoC it will be pretty much instant.

When a key is used in a TX, the height of the TX is saved for the `HdPubKey` in the wallet json file. When a filter is tested against keys, it will be tested only in a gap of keys around the last key used at this height. 
Eg: If key `84/1/0/1/123` matches against filter height 100, filter height 101 will only be tested against keys `[84/1/0/1/123 - MinGapLimit, 84/1/0/1/123 + MinGapLimit]`

As long as the `MinGapLimit` has always been respected and old internal keys were never reused it should sync correctly, but maybe there are some bugs causing wrong sync, don't use on Mainet. It's made for contributors that need to test regularly on big wallets (cc @wieslawsoltes).
If your balance is incorrect after first sync, just resync the wallet.

This change is the most interesting one for the whole wallet loading workflow. To further work on this, we need first to implement [Wallet Labels Export Format (BIP329)](https://github.com/zkSNACKs/WalletWasabi/discussions/9980)