### PR TITLE
[Trivial] Add indentation preference in .editorconfig files

### DIFF
--- a/WalletWasabi.Fluent/MathNet/.editorconfig
+++ b/WalletWasabi.Fluent/MathNet/.editorconfig
@@ -2,6 +2,8 @@ root = true
 
 [*.cs]
 
+charset = utf-8
+
 # Use hard tabs for indentation
 indent_style = tab
 indent_size = 4

--- a/WalletWasabi.Fluent/MathNet/.editorconfig
+++ b/WalletWasabi.Fluent/MathNet/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*.cs]
 
-# use hard tabs for indentation
+# Use hard tabs for indentation
 indent_style = tab
 indent_size = 4
 

--- a/WalletWasabi.Fluent/MathNet/.editorconfig
+++ b/WalletWasabi.Fluent/MathNet/.editorconfig
@@ -2,6 +2,10 @@ root = true
 
 [*.cs]
 
+# use hard tabs for indentation
+indent_style = tab
+indent_size = 4
+
 # Disable all .NET analyzers
 dotnet_analyzer_diagnostic.severity = none
 

--- a/WalletWasabi.Fluent/Models/Windows/.editorconfig
+++ b/WalletWasabi.Fluent/Models/Windows/.editorconfig
@@ -2,6 +2,8 @@ root = true
 
 [*.cs]
 
+charset = utf-8
+
 # Use hard tabs for indentation
 indent_style = tab
 indent_size = 4

--- a/WalletWasabi.Fluent/Models/Windows/.editorconfig
+++ b/WalletWasabi.Fluent/Models/Windows/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*.cs]
 
-# use hard tabs for indentation
+# Use hard tabs for indentation
 indent_style = tab
 indent_size = 4
 

--- a/WalletWasabi.Fluent/Models/Windows/.editorconfig
+++ b/WalletWasabi.Fluent/Models/Windows/.editorconfig
@@ -2,6 +2,10 @@ root = true
 
 [*.cs]
 
+# use hard tabs for indentation
+indent_style = tab
+indent_size = 4
+
 # Disable all .NET analyzers
 dotnet_analyzer_diagnostic.severity = none
 

--- a/WalletWasabi/Gma/.editorconfig
+++ b/WalletWasabi/Gma/.editorconfig
@@ -2,6 +2,8 @@ root = true
 
 [*.cs]
 
+charset = utf-8
+
 # Use hard tabs for indentation
 indent_style = tab
 indent_size = 4

--- a/WalletWasabi/Gma/.editorconfig
+++ b/WalletWasabi/Gma/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*.cs]
 
-# use hard tabs for indentation
+# Use hard tabs for indentation
 indent_style = tab
 indent_size = 4
 

--- a/WalletWasabi/Gma/.editorconfig
+++ b/WalletWasabi/Gma/.editorconfig
@@ -2,6 +2,10 @@ root = true
 
 [*.cs]
 
+# use hard tabs for indentation
+indent_style = tab
+indent_size = 4
+
 # Disable all .NET analyzers
 dotnet_analyzer_diagnostic.severity = none
 

--- a/WalletWasabi/Nito/.editorconfig
+++ b/WalletWasabi/Nito/.editorconfig
@@ -2,6 +2,8 @@ root = true
 
 [*.cs]
 
+charset = utf-8
+
 # Use hard tabs for indentation
 indent_style = tab
 indent_size = 4

--- a/WalletWasabi/Nito/.editorconfig
+++ b/WalletWasabi/Nito/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*.cs]
 
-# use hard tabs for indentation
+# Use hard tabs for indentation
 indent_style = tab
 indent_size = 4
 

--- a/WalletWasabi/Nito/.editorconfig
+++ b/WalletWasabi/Nito/.editorconfig
@@ -2,6 +2,10 @@ root = true
 
 [*.cs]
 
+# use hard tabs for indentation
+indent_style = tab
+indent_size = 4
+
 # Disable all .NET analyzers
 dotnet_analyzer_diagnostic.severity = none
 


### PR DESCRIPTION
Because these .editorconfig files have `root = true` the search for .editorconfig files will stop and therefore not use the .editoconfig file at the root of the repository.

This change prevents the use of spaces when editing any file in the directory of the .editorconfig file or in any child directory.