### PR TITLE
Retry in case of exception/timeout of HttpClient

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -113,7 +113,6 @@ public class Global : IDisposable
 				}
 
 				HttpClient.BaseAddress = url;
-				HttpClient.Timeout = TimeSpan.FromMinutes(2);
 
 				var coinVerifierApiClient = new CoinVerifierApiClient(CoordinatorParameters.RuntimeCoordinatorConfig.CoinVerifierApiAuthToken, RpcClient.Network, HttpClient);
 				var whitelist = await Whitelist.CreateAndLoadFromFileAsync(CoordinatorParameters.WhitelistFilePath, wabiSabiConfig, cancel).ConfigureAwait(false);

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -113,6 +113,7 @@ public class Global : IDisposable
 				}
 
 				HttpClient.BaseAddress = url;
+				HttpClient.Timeout = TimeSpan.FromMinutes(2);
 
 				var coinVerifierApiClient = new CoinVerifierApiClient(CoordinatorParameters.RuntimeCoordinatorConfig.CoinVerifierApiAuthToken, RpcClient.Network, HttpClient);
 				var whitelist = await Whitelist.CreateAndLoadFromFileAsync(CoordinatorParameters.WhitelistFilePath, wabiSabiConfig, cancel).ConfigureAwait(false);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
@@ -66,6 +66,8 @@ public class CoinVerifierTests
 			.ReturnsAsync(cleanResponse)
 			.ReturnsAsync(cleanResponse)
 			.ThrowsAsync(new InvalidOperationException())
+			.ThrowsAsync(new InvalidOperationException())   // Because of the retry mechanism, we need to fail 3 times to kick out the coin.
+			.ThrowsAsync(new InvalidOperationException())
 			.ReturnsAsync(cleanResponse)
 			.ReturnsAsync(cleanResponse)
 			.ReturnsAsync(cleanResponse)
@@ -94,7 +96,7 @@ public class CoinVerifierTests
 			{
 				naughtyCoins.Add(item.Coin);
 			}
-			else if (item.ShouldRemove)
+			if (item.ShouldRemove)
 			{
 				removedCoins.Add(item.Coin);
 			}

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
@@ -48,6 +48,7 @@ public class CoinVerifierApiClient
 		using CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutTokenSource.Token);
 
 		int tries = 3;
+		var delay = TimeSpan.FromSeconds(2);
 
 		HttpResponseMessage? response = null;
 
@@ -58,28 +59,36 @@ public class CoinVerifierApiClient
 			using var content = new HttpRequestMessage(HttpMethod.Get, $"{HttpClient.BaseAddress}{address}");
 			content.Headers.Authorization = new("Bearer", ApiToken);
 
-			response = await HttpClient.SendAsync(content, linkedTokenSource.Token).ConfigureAwait(false);
+			try
+			{
+				response = await HttpClient.SendAsync(content, linkedTokenSource.Token).ConfigureAwait(false);
 
-			if (response.StatusCode == HttpStatusCode.OK)
-			{
-				// Successful request, break the iteration.
-				break;
+				if (response is { } && response.StatusCode == HttpStatusCode.OK)
+				{
+					// Successful request, break the iteration.
+					break;
+				}
+				else
+				{
+					Logger.LogWarning($"API request failed. {nameof(HttpStatusCode)} was {response?.StatusCode}.");
+				}
 			}
-			else
+			catch (Exception ex)
 			{
-				Logger.LogWarning($"API request failed. {nameof(HttpStatusCode)} was {response.StatusCode}.");
+				Logger.LogError($"API request failed for script: {script}. Remaining tries: {tries}.", ex);
+				await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 			}
 		}
 		while (tries > 0);
 
 		// Throw proper exceptions - if needed - according to the latest response.
-		if (response.StatusCode == HttpStatusCode.Forbidden)
+		if (response?.StatusCode == HttpStatusCode.Forbidden)
 		{
 			throw new UnauthorizedAccessException("User roles access forbidden.");
 		}
-		else if (response.StatusCode != HttpStatusCode.OK)
+		else if (response?.StatusCode != HttpStatusCode.OK)
 		{
-			throw new InvalidOperationException($"API request failed. {nameof(HttpStatusCode)} was {response.StatusCode}.");
+			throw new InvalidOperationException($"API request failed. {nameof(HttpStatusCode)} was {response?.StatusCode}.");
 		}
 
 		string responseString = await response.Content.ReadAsStringAsync(linkedTokenSource.Token).ConfigureAwait(false);

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
@@ -70,12 +70,12 @@ public class CoinVerifierApiClient
 				}
 				else
 				{
-					Logger.LogWarning($"API request failed. {nameof(HttpStatusCode)} was {response?.StatusCode}.");
+					throw new InvalidOperationException($"Response was either null or response.{nameof(HttpStatusCode)} was {response?.StatusCode}.");
 				}
 			}
 			catch (Exception ex)
 			{
-				Logger.LogError($"API request failed for script: {script}. Remaining tries: {tries}.", ex);
+				Logger.LogWarning($"API request failed for script: {script}. Remaining tries: {tries}. Exception: {ex}.");
 				await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 			}
 		}


### PR DESCRIPTION
I'm seeing a lot of these in the Logs

```
2023-02-07 09:37:19.048 [518] ERROR	xxx.TryScheduleVerification (265)	xxx was failed with 'System.Threading.Tasks.TaskCanceledException: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
 ---> System.TimeoutException: The operation was canceled.
 ---> System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: Operation canceled.
 ---> System.Net.Sockets.SocketException (125): Operation canceled
   --- End of inner exception stack trace ---
```

~~With this PR, the `cancellation token` and the `HttpClient.Timeout` is the same time interval.~~

_I know this is only mitigating the issue._