### PR TITLE
[VDG] Close address displaying dialog when received funds

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
@@ -122,7 +122,7 @@ public partial class ReceiveAddressViewModel : RoutableViewModel
 			{
 				if (_wallet.KeyManager.GetKeys(x => x == _model && x.KeyState == KeyState.Used).Any())
 				{
-					Navigate().Back();
+					Navigate().Clear();
 				}
 			})
 			.DisposeWith(disposables);


### PR DESCRIPTION
fixes https://github.com/zkSNACKs/WalletWasabi/issues/9911

The previous solution (navigate back) was less intrusive, but honestly, it is better the close the dialog as that would be the first thing that the user does after noticing the new transaction.