### PR TITLE
[VDG] Fix splash animation

### DIFF
--- a/WalletWasabi.Fluent/Controls/Spectrum/AuraSpectrumDataSource.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/AuraSpectrumDataSource.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace WalletWasabi.Fluent.Controls.Spectrum;
+﻿namespace WalletWasabi.Fluent.Controls.Spectrum;
 
 public class AuraSpectrumDataSource : SpectrumDataSource
 {
@@ -11,18 +9,11 @@ public class AuraSpectrumDataSource : SpectrumDataSource
 		_random = new Random(DateTime.Now.Millisecond);
 	}
 
-	public bool IsActive { get; set; }
-
 	protected override void OnMixData()
 	{
 		for (int i = 0; i < NumBins; i++)
 		{
-			Bins[i] = IsActive ? _random.NextSingle() : Bins[i] - 0.1F;
-		}
-
-		if (!IsActive && Bins.All(f => f <= 0))
-		{
-			Stop();
+			Bins[i] = _random.NextSingle();
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
@@ -85,9 +85,9 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 		set => SetValue(IsDockEffectVisibleProperty, value);
 	}
 
-	private void OnGeneratingDataStateChanged(object? sender, bool isGenerating)
+	private void OnGeneratingDataStateChanged(object? sender, EventArgs e)
 	{
-		_isGenerating = isGenerating;
+		_isGenerating = _auraSpectrumDataSource.IsGenerating || _splashEffectDataSource.IsGenerating;
 
 		if (_isGenerating)
 		{
@@ -147,7 +147,9 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 			source.Render(ref _data);
 		}
 
-		if (!_isGenerating && _data.All(f => f <= 0)) // there is nothing to render.
+		// Even if the data generation is finished, let's wait until the animation finishes to disappear.
+		// Only stop the rendering once it fully disappeared. (== there is nothing to render)
+		if (!_isGenerating && _data.All(f => f <= 0))
 		{
 			_invalidationTimer.Stop();
 		}

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
@@ -46,7 +46,6 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 
 	public SpectrumControl()
 	{
-		SetVisibility();
 		_data = new float[NumBins];
 		_auraSpectrumDataSource = new AuraSpectrumDataSource(NumBins);
 		_splashEffectDataSource = new SplashEffectDataSource(NumBins);
@@ -88,18 +87,27 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 	private void OnSplashGeneratingDataStateChanged(object? sender, bool e)
 	{
 		_isSplashActive = e;
-		SetVisibility();
+		EvaluateInvalidationTimer();
 	}
 
 	private void OnAuraGeneratingDataStateChanged(object? sender, bool e)
 	{
 		_isAuraActive = e;
-		SetVisibility();
+		EvaluateInvalidationTimer();
 	}
 
-	private void SetVisibility()
+	private void EvaluateInvalidationTimer()
 	{
-		IsVisible = _isSplashActive || _isAuraActive;
+		var startInvalidation = _isSplashActive || _isAuraActive;
+
+		if (startInvalidation)
+		{
+			_invalidationTimer.Start();
+		}
+		else
+		{
+			_invalidationTimer.Stop();
+		}
 	}
 
 	private void OnIsActiveChanged()
@@ -109,11 +117,6 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 		if (IsActive)
 		{
 			_auraSpectrumDataSource.Start();
-			_invalidationTimer.Start();
-		}
-		else
-		{
-			_invalidationTimer.Stop();
 		}
 	}
 

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
@@ -24,6 +24,8 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 
 	private float[] _data;
 
+	private bool _isGenerating;
+
 	private readonly SKPaint _blur = new()
 	{
 		ImageFilter = SKImageFilter.CreateBlur(24, 24, SKShaderTileMode.Clamp),
@@ -84,7 +86,9 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 
 	private void OnGeneratingDataStateChanged(object? sender, bool isGenerating)
 	{
-		if (isGenerating)
+		_isGenerating = isGenerating;
+
+		if (_isGenerating)
 		{
 			_invalidationTimer.Start();
 		}
@@ -92,11 +96,13 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 
 	private void OnIsActiveChanged()
 	{
-		_auraSpectrumDataSource.IsActive = IsActive;
-
 		if (IsActive)
 		{
 			_auraSpectrumDataSource.Start();
+		}
+		else
+		{
+			_auraSpectrumDataSource.Stop();
 		}
 	}
 
@@ -140,7 +146,7 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 			source.Render(ref _data);
 		}
 
-		if (_data.All(f => f <= 0)) // there is nothing to render.
+		if (!_isGenerating && _data.All(f => f <= 0)) // there is nothing to render.
 		{
 			_invalidationTimer.Stop();
 		}

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumControl.cs
@@ -14,17 +14,13 @@ namespace WalletWasabi.Fluent.Controls.Spectrum;
 public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 {
 	private const int NumBins = 64;
+	private const double TextureHeight = 32;
+	private const double TextureWidth = 32;
 
 	private readonly AuraSpectrumDataSource _auraSpectrumDataSource;
 	private readonly SplashEffectDataSource _splashEffectDataSource;
 
 	private readonly SpectrumDataSource[] _sources;
-
-	private IBrush? _lineBrush;
-
-	private float[] _data;
-
-	private bool _isGenerating;
 
 	private readonly SKPaint _blur = new()
 	{
@@ -32,11 +28,16 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 		FilterQuality = SKFilterQuality.Low
 	};
 
+	private readonly DispatcherTimer _invalidationTimer;
+
+	private IBrush? _lineBrush;
+
+	private float[] _data;
+
+	private bool _isGenerating;
+
 	private SKColor _lineColor;
 	private SKSurface? _surface;
-	private readonly DispatcherTimer _invalidationTimer;
-	private const double TextureHeight = 32;
-	private const double TextureWidth = 32;
 
 	public static readonly StyledProperty<bool> IsActiveProperty =
 		AvaloniaProperty.Register<SpectrumControl, bool>(nameof(IsActive));
@@ -231,7 +232,8 @@ public class SpectrumControl : TemplatedControl, ICustomDrawOperation
 		skia.SkCanvas.DrawImage(
 			snapshot,
 			new SKRect(0, 0, (float)TextureWidth, (float)TextureHeight),
-			new SKRect(0, 0, (float)bounds.Width, (float)bounds.Height), _blur);
+			new SKRect(0, 0, (float)bounds.Width, (float)bounds.Height),
+			_blur);
 	}
 
 	bool IEquatable<ICustomDrawOperation>.Equals(ICustomDrawOperation? other) => false;

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
@@ -46,7 +46,7 @@ public abstract class SpectrumDataSource
 			_averaged[i] -= _averaged[i] / NumAverages;
 			_averaged[i] += Bins[i] / NumAverages;
 
-			data[i] = Math.Max(data[i], _averaged[i]);
+			data[i] = Math.Max(data[i], (float)Math.Round(_averaged[i], 3));
 		}
 	}
 

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
@@ -22,7 +22,7 @@ public abstract class SpectrumDataSource
 		NumAverages = numAverages;
 	}
 
-	public event EventHandler<bool>? GeneratingDataStateChanged;
+	public event EventHandler? GeneratingDataStateChanged;
 
 	public int NumAverages { get; }
 
@@ -32,7 +32,7 @@ public abstract class SpectrumDataSource
 
 	protected int MidPointBins => NumBins / 2;
 
-	private bool IsGenerating => _timer.IsEnabled;
+	public bool IsGenerating => _timer.IsEnabled;
 
 	private void TimerOnTick(object? sender, EventArgs e)
 	{
@@ -63,17 +63,17 @@ public abstract class SpectrumDataSource
 	{
 		_averaged = new float[_averaged.Length];
 		_timer.Start();
-		OnGeneratingDataStateChanged(isGenerating: true);
+		OnGeneratingDataStateChanged();
 	}
 
 	public void Stop()
 	{
 		_timer.Stop();
-		OnGeneratingDataStateChanged(isGenerating: false);
+		OnGeneratingDataStateChanged();
 	}
 
-	private void OnGeneratingDataStateChanged(bool isGenerating)
+	private void OnGeneratingDataStateChanged()
 	{
-		GeneratingDataStateChanged?.Invoke(this, isGenerating);
+		GeneratingDataStateChanged?.Invoke(this, EventArgs.Empty);
 	}
 }

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
@@ -32,6 +32,8 @@ public abstract class SpectrumDataSource
 
 	protected int MidPointBins => NumBins / 2;
 
+	private bool IsGenerating => _timer.IsEnabled;
+
 	private void TimerOnTick(object? sender, EventArgs e)
 	{
 		OnMixData();
@@ -43,10 +45,17 @@ public abstract class SpectrumDataSource
 	{
 		for (int i = 0; i < NumBins; i++)
 		{
-			_averaged[i] -= _averaged[i] / NumAverages;
-			_averaged[i] += Bins[i] / NumAverages;
+			if (IsGenerating)
+			{
+				_averaged[i] -= _averaged[i] / NumAverages;
+				_averaged[i] += Bins[i] / NumAverages;
+			}
+			else
+			{
+				_averaged[i] -= 0.03f;
+			}
 
-			data[i] = Math.Max(data[i], (float)Math.Round(_averaged[i], 3));
+			data[i] = Math.Max(data[i], _averaged[i]);
 		}
 	}
 

--- a/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SpectrumDataSource.cs
@@ -61,6 +61,7 @@ public abstract class SpectrumDataSource
 
 	public void Start()
 	{
+		_averaged = new float[_averaged.Length];
 		_timer.Start();
 		OnGeneratingDataStateChanged(isGenerating: true);
 	}

--- a/WalletWasabi.Fluent/Controls/Spectrum/SplashEffectDataSource.cs
+++ b/WalletWasabi.Fluent/Controls/Spectrum/SplashEffectDataSource.cs
@@ -13,11 +13,10 @@ public class SplashEffectDataSource : SpectrumDataSource
 		Bins[MidPointBins - _currentEffectIndex] = 1;
 		Bins[MidPointBins + _currentEffectIndex] = 1;
 
-		if (_currentEffectIndex >= 8)
+		for (int i = _currentEffectIndex; i > 0; i--)
 		{
-			var index = _currentEffectIndex - 8;
-			Bins[MidPointBins - index] = 0;
-			Bins[MidPointBins + index] = 0;
+			Bins[MidPointBins - i] -= 0.1f;
+			Bins[MidPointBins + i] -= 0.1f;
 		}
 
 		_currentEffectIndex++;


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9189

The animation was broken on the master. This PR fixes while trying to simplify the rendering logic.
It will keep calling `Render` until there is something to draw.

Expected behavior:
- The greeting "splash" animation should appear when a wallet's home screen gets opened.
   - it should not appear when CJing animation is visible.
- The MainWindow should be refreshed when there is no animation.
   - Press F12 to pop Avalonia debugger. enable FPS counter from the Options. It should be 0 when there is no animation (and of course if there is nothing on the screen that is moving)
   - Whenever the animation is finished the FPS counter should go back to 0.
- Splash animation and CJing animation should not happen at the same time.