### PR TITLE
Quick fix for incorrect fee issue

### DIFF
--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -105,9 +105,16 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.SizeLimitExceeded, $"Transaction size is {EstimatedVsize} bytes, which exceeds the limit of {Parameters.MaxTransactionSize} bytes.");
 		}
 
-		if (EffectiveFeeRate < Parameters.MiningFeeRate)
+		var minToleratedMiningFeeRate = new FeeRate(0.95m * Parameters.MiningFeeRate.SatoshiPerByte);
+		if (EffectiveFeeRate < minToleratedMiningFeeRate)
 		{
-			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InsufficientFees, $"Effective fee rate {EffectiveFeeRate} is less than required {Parameters.MiningFeeRate}.");
+			var state = new SigningState(Parameters, Events);
+			var tx = state.CreateUnsignedTransaction();
+			var txHex = tx.ToHex();
+
+			throw new WabiSabiProtocolException(
+				WabiSabiProtocolErrorCode.InsufficientFees,
+				$"Effective fee rate {EffectiveFeeRate} is less than required {minToleratedMiningFeeRate}. RawTx: {txHex}");
 		}
 
 		return new SigningState(Parameters, Events);


### PR DESCRIPTION
Adds a safety margin of tolerance for mining fee paid by coinjoins and add log the offending transaction to see what elements are the one disrupting the round 