### PR TITLE
Use less strict condition in anonymity computation

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -131,10 +131,6 @@ public class BlockchainAnalyzer
 
 		foreach (var virtualOutput in tx.WalletVirtualOutputs)
 		{
-			// Anonset gain cannot be larger than others' input count.
-			// Picking randomly an output would make our anonset: total/ours.
-			double anonymityGain = Math.Min(CoinjoinAnalyzer.ComputeAnonymityContribution(virtualOutput.Coins.First()), foreignInputCount);
-
 			double startingOutputAnonset;
 			double startingOutputAnonsetSanctioned;
 
@@ -158,6 +154,10 @@ public class BlockchainAnalyzer
 				startingOutputAnonset = startingMixedOutputAnonset;
 				startingOutputAnonsetSanctioned = startingMixedOutputAnonsetSanctioned;
 			}
+
+			// Anonset gain cannot be larger than others' input count.
+			// Picking randomly an output would make our anonset: total/ours.
+			double anonymityGain = Math.Min(CoinjoinAnalyzer.ComputeAnonymityContribution(virtualOutput.Coins.First()), foreignInputCount);
 
 			// Account for the inherited anonymity set size from the inputs in the
 			// anonymity set size estimate.

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -135,10 +135,11 @@ public class BlockchainAnalyzer
 			// Picking randomly an output would make our anonset: total/ours.
 			double anonymityGain = Math.Min(CoinjoinAnalyzer.ComputeAnonymityContribution(virtualOutput.Coins.First()), foreignInputCount);
 
-			// If no anonset gain achieved on the output, then it's best to assume it's change.
 			double startingOutputAnonset;
 			double startingOutputAnonsetSanctioned;
-			if (anonymityGain < 1)
+
+			// If the virtual output has a nonempty anonymity set
+			if (!tx.ForeignVirtualOutputs.Any(x => x.Amount == virtualOutput.Amount))
 			{
 				// When WW2 denom output isn't too large, then it's not change.
 				if (tx.IsWasabi2Cj is true && StdDenoms.Contains(virtualOutput.Amount.Satoshi) && virtualOutput.Amount < secondLargestOutputAmount)


### PR DESCRIPTION
This pull request slightly modifies the anonymity computation algorithm.

The anonymity score of a transaction output [is computed](https://github.com/zkSNACKs/WalletWasabi/blob/a695f7db82ba928ef994050defc8977d63fdb909/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs#L163) as an anonymity inherited from the inputs of the transaction belonging to the same person as the output plus an anonymity gained from the transaction itself. The inherited anonymity is either
  * [the average anonymity score of the inputs weighted by their values](https://github.com/zkSNACKs/WalletWasabi/blob/a695f7db82ba928ef994050defc8977d63fdb909/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs#L72) or
  * [the minimum anonymity score of the inputs](https://github.com/zkSNACKs/WalletWasabi/blob/a695f7db82ba928ef994050defc8977d63fdb909/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs#L75).

Usually the first formula [is used](https://github.com/zkSNACKs/WalletWasabi/blob/a695f7db82ba928ef994050defc8977d63fdb909/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs#L157). Nevertheless, if there is a suspicion that the coinjoin sudoku problem could be solvable for the output then the second formula [is used](https://github.com/zkSNACKs/WalletWasabi/blob/a695f7db82ba928ef994050defc8977d63fdb909/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs#L151).

The concept of using different formula depending on the supposed complexity of the coinjoin sudoku problem was introduced in https://github.com/zkSNACKs/WalletWasabi/commit/34e9d5d16eb3fc28f098ddfb6f0d13f12a12e195 (see the line `var startingOutputAnonset = anonset == 0 ? startingNonMixedOutputAnonset : startingMixedOutputAnonset;`) and extended in https://github.com/zkSNACKs/WalletWasabi/commit/e7e1711d73b922d71f8418a0962e49ff91bd0ff0 (see the line `if (anonset == 0)`). Starting from https://github.com/zkSNACKs/WalletWasabi/commit/d8b96fb98c2cbbb8dabb06ec3d0a68096bed7bd7, the anonymity score is of type `double` (instead of `int`) and the condition was changed to `if (anonset < 1)` which has remained until now.

It seems to me that this is not in compliance with the original idea which is summarized in the comment `// If no anonset gain achieved on the output, then it's best to assume it's change.`. Suppose for example there is a coinjoin transaction with 5 outputs of value 1 BTC, 2 of which are foreign and 3 belong to a wallet. The anonymity gain corresponding to the one of the wallet outputs is 2/3 which is less than 1. But in this case I don't think there is reason to use the minimum instead of the weighted average.

That is why I changed the condition to ` if (!tx.ForeignVirtualOutputs.Any(x => x.Amount == virtualOutput.Amount))` which is equivalent to `anonset == 0`.
