### PR TITLE
Fix removal of items when task is completed

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -169,8 +169,15 @@ public class CoinVerifier : IAsyncDisposable
 
 	public bool TryScheduleVerification(Coin coin, [NotNullWhen(true)] out CoinVerifyItem? coinVerifyItem, CancellationToken verificationCancellationToken, TimeSpan? delayedStart = null, bool oneHop = false, int? confirmations = null)
 	{
-		var item = new CoinVerifyItem();
 		coinVerifyItem = null;
+
+		if (CoinVerifyItems.TryGetValue(coin, out coinVerifyItem))
+		{
+			// Coin was already scheduled. It's OK.
+			return true;
+		}
+
+		var item = new CoinVerifyItem();
 
 		if (!CoinVerifyItems.TryAdd(coin, item))
 		{

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -125,7 +125,7 @@ public class CoinVerifier : IAsyncDisposable
 		var now = DateTimeOffset.UtcNow;
 		foreach (var (coin, item) in CoinVerifyItems)
 		{
-			if (now - item.ScheduleTime > AbsoluteScheduleSanityTimeout || item.Task.IsCompleted)
+			if (now - item.ScheduleTime > AbsoluteScheduleSanityTimeout)
 			{
 				CoinVerifyItems.TryRemove(coin, out var _);
 

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -53,7 +53,7 @@ public class CoinVerifier : IAsyncDisposable
 
 		// Booting up the results with the default value - ban: no, remove: yes.
 		Dictionary<Coin, CoinVerifyResult> coinVerifyItems = coinsToCheck.ToDictionary(
-			coin => coin, 
+			coin => coin,
 			coin => new CoinVerifyResult(coin, ShouldBan: false, ShouldRemove: true),
 			CoinEqualityComparer.Default);
 
@@ -125,7 +125,7 @@ public class CoinVerifier : IAsyncDisposable
 		var now = DateTimeOffset.UtcNow;
 		foreach (var (coin, item) in CoinVerifyItems)
 		{
-			if (now - item.ScheduleTime > AbsoluteScheduleSanityTimeout)
+			if (now - item.ScheduleTime > AbsoluteScheduleSanityTimeout || item.Task.IsCompleted)
 			{
 				CoinVerifyItems.TryRemove(coin, out var _);
 


### PR DESCRIPTION
Right now, I can see a bunch of these in the Logs.

```
WARNING	CoinVerifier.TryScheduleVerification (177)	Coin was already scheduled for verification.
WARNING	CoinVerifier.TryScheduleVerification (177)	Coin was already scheduled for verification.
WARNING	CoinVerifier.TryScheduleVerification (177)	Coin was already scheduled for verification.
```

Which means the coin was already scheduled for verification and most probably finished already, but we failed to remove it from the dictionary. (Not sure why we failed yet)

If the task is completed, the coin is either on the `Whitelist` or in the `Prison`, so we should remove completed tasks on `CleanUp()` calls.
