### PR TITLE
Add missing equality comparer

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -19,6 +19,7 @@ using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -128,7 +129,7 @@ public partial class Arena : PeriodicRunner
 				{
 					try
 					{
-						var coinAliceDictionary = round.Alices.ToDictionary(alice => alice.Coin, alice => alice);
+						var coinAliceDictionary = round.Alices.ToDictionary(alice => alice.Coin, alice => alice, CoinEqualityComparer.Default);
 						foreach (var coinVerifyInfo in await CoinVerifier.VerifyCoinsAsync(coinAliceDictionary.Keys, cancel).ConfigureAwait(false))
 						{
 							if (coinVerifyInfo.ShouldRemove)


### PR DESCRIPTION
Missing from #10088

Found this in the Logs

```
Exception: System.Collections.Generic.KeyNotFoundException: The given key 'NBitcoin.Coin' was not present in the dictionary.
   at WalletWasabi.WabiSabi.Backend.Rounds.Arena.StepInputRegistrationPhaseAsync(CancellationToken cancel)
```