### PR TITLE
Fix the impossible :)

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -142,7 +142,6 @@ public partial class Arena : PeriodicRunner
 					{
 						// This should never happen.
 
-						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}) for Round({round.Id}).", exc);
 						CoinVerifier.VerifierAuditArchiver.LogException(round.Id, exc);
 						throw;
 					}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -142,9 +142,9 @@ public partial class Arena : PeriodicRunner
 					{
 						// This should never happen.
 
-						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}).", exc);
+						Logger.LogError($"{nameof(CoinVerifier)} has failed to verify all Alices({round.Alices.Count}) for Round({round.Id}).", exc);
 						CoinVerifier.VerifierAuditArchiver.LogException(round.Id, exc);
-						round.EndRound(EndRoundState.AbortedWithError);
+						throw;
 					}
 				}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -141,7 +141,6 @@ public partial class Arena : PeriodicRunner
 					catch (Exception exc)
 					{
 						// This should never happen.
-
 						CoinVerifier.VerifierAuditArchiver.LogException(round.Id, exc);
 						throw;
 					}


### PR DESCRIPTION
Throw the exception to the outer try-catch block otherwise we can resurrect ended rounds.

Exmaple:

```
Round.SetPhase (90)	Round (34c600b6a1d8b3135ad7ef527c462c8d657951f37a3e7f6bacfcfc0ccde6d200): Phase changed: InputRegistration -> Ended
Round.SetPhase (90)	Round (34c600b6a1d8b3135ad7ef527c462c8d657951f37a3e7f6bacfcfc0ccde6d200): Phase changed: Ended -> ConnectionConfirmation
Arena.StepConnectionConfirmationPhaseAsync (194)	Round (34c600b6a1d8b3135ad7ef527c462c8d657951f37a3e7f6bacfcfc0ccde6d200): 2 alices removed because they didn't confirm.
Round.SetPhase (90)	Round (34c600b6a1d8b3135ad7ef527c462c8d657951f37a3e7f6bacfcfc0ccde6d200): Phase changed: ConnectionConfirmation -> OutputRegistration

```