### PR TITLE
Maximize parallel request to 30

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
@@ -59,14 +59,14 @@ public class CoinVerifierApiClient
 
 		HttpResponseMessage? response = null;
 
-		lock (ParallelRequestCounterLock)
-		{
-			CurrentParallelRequestCount++;
-		}
-
 		while (CurrentParallelRequestCount >= MaxParallelRequestCount)
 		{
 			await Task.Delay(delay, linkedTokenSource.Token).ConfigureAwait(false);
+		}
+
+		lock (ParallelRequestCounterLock)
+		{
+			CurrentParallelRequestCount++;
 		}
 
 		do


### PR DESCRIPTION
API provider recommended that we maximize the number of parallel requests we send at a given time.