### PR TITLE
[VDG] fix confusing wrong message about passphrase

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/ConnectHardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/ConnectHardwareWalletViewModel.cs
@@ -106,10 +106,7 @@ public partial class ConnectHardwareWalletViewModel : RoutableViewModel
 
 		try
 		{
-			using CancellationTokenSource cts = new();
-			AbandonedTasks.AddAndClearCompleted(CheckForPassphraseAsync(cts.Token));
 			var result = await HardwareWalletOperationHelpers.DetectAsync(Services.WalletManager.Network, cancel);
-			cts.Cancel();
 			EvaluateDetectionResult(result, cancel);
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
@@ -119,19 +116,6 @@ public partial class ConnectHardwareWalletViewModel : RoutableViewModel
 		finally
 		{
 			IsSearching = false;
-		}
-	}
-
-	private async Task CheckForPassphraseAsync(CancellationToken cancellationToken)
-	{
-		try
-		{
-			await Task.Delay(7000, cancellationToken);
-			Message = "Check your device and enter your passphrase, then click Rescan.";
-		}
-		catch (OperationCanceledException)
-		{
-			// ignored
 		}
 	}
 

--- a/WalletWasabi.Fluent/Views/AddWallet/HardwareWallet/ConnectHardwareWalletView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/HardwareWallet/ConnectHardwareWalletView.axaml
@@ -31,14 +31,20 @@
           <Image Height="100" Source="{Binding Generic, Converter={x:Static conv:WalletIconConverter.WalletTypeToImage}}" />
         </StackPanel>
       </Viewbox>
-      <Panel HorizontalAlignment="Center" VerticalAlignment="Center">
-        <DockPanel>
+      <Panel>
+
+        <DockPanel HorizontalAlignment="Center" VerticalAlignment="Center">
           <TextBlock Text="{Binding Message}" TextWrapping="Wrap" TextAlignment="Center" DockPanel.Dock="Top" />
           <Button IsVisible="{Binding ExistingWalletFound}" Margin="0 5 0 0" Command="{Binding NavigateToExistingWalletLoginCommand}" Content="Open wallet" Classes="h7 plain activeHyperLink" HorizontalAlignment="Center" VerticalAlignment="Bottom" DockPanel.Dock="Bottom" />
         </DockPanel>
-        <Viewbox IsVisible="{Binding !ConfirmationRequired}" MaxHeight="100" Margin="15">
-          <c:ProgressRing IsIndeterminate="True" Height="100" Width="100" />
-        </Viewbox>
+
+        <Panel IsVisible="{Binding !ConfirmationRequired}">
+          <Viewbox MaxHeight="100" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <c:ProgressRing IsIndeterminate="True" Height="100" Width="100" />
+          </Viewbox>
+          <c:InfoMessage Content="Enter your passphrase on the hardware wallet if needed." HorizontalAlignment="Center" VerticalAlignment="Bottom" Opacity="0.6"/>
+        </Panel>
+
       </Panel>
     </DockPanel>
   </c:ContentArea>


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9238

It is not possible to know during detection if it lasts too long or just a device requests a password... The previous solution assumed that if the detection lasts longer than 7 seconds then it is probably a password request. This is bad as it really depends on the computer...

Remove the hack and display a restrained message about the possible password.