### PR TITLE
Use block height of the response

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -311,7 +311,7 @@ public class ChaumianCoinJoinController : ControllerBase
 
 				foreach (var coin in alice.Inputs)
 				{
-					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, out _, CancellationToken.None, false, coinAndTxOutResponses[coin].Confirmations, currentHeight);
+					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, out _, coinAndTxOutResponses[coin].Confirmations, currentHeight, CancellationToken.None);
 				}
 
 				round.AddAlice(alice);

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -307,9 +307,11 @@ public class ChaumianCoinJoinController : ControllerBase
 					round.RemoveAlicesBy(aliceToRemove);
 				}
 
+				var currentHeight = await RpcClient.GetBlockCountAsync().ConfigureAwait(false);
+
 				foreach (var coin in alice.Inputs)
 				{
-					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, out _, CancellationToken.None, false, coinAndTxOutResponses[coin].Confirmations);
+					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, out _, CancellationToken.None, false, coinAndTxOutResponses[coin].Confirmations, currentHeight);
 				}
 
 				round.AddAlice(alice);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
@@ -20,6 +20,8 @@ public class CoinVerifierTests
 
 	private WabiSabiConfig _wabisabiTestConfig = new() { RiskFlags = new List<int>() { 11 } };
 
+	private int _mockBlockchainHeight = 733947; // Same as the example JSON report block height, otherwise we kick out.
+
 	[Fact]
 	public async Task CanHandleBlacklistedUtxosTestAsync()
 	{
@@ -234,7 +236,7 @@ public class CoinVerifierTests
 	{
 		foreach (Coin coin in coins)
 		{
-			coinVerifier.TryScheduleVerification(coin, out _, CancellationToken.None, delay, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations);
+			coinVerifier.TryScheduleVerification(coin, out _, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations, _mockBlockchainHeight, CancellationToken.None);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -222,7 +222,7 @@ public class CoinVerifier : IAsyncDisposable
 
 		if (coin.Amount >= WabiSabiConfig.CoinVerifierRequiredConfirmationAmount)
 		{
-			if (confirmations is null || confirmations < WabiSabiConfig.CoinVerifierRequiredConfirmations)
+			if (confirmations < WabiSabiConfig.CoinVerifierRequiredConfirmations)
 			{
 				var result = new CoinVerifyResult(coin, ShouldBan: false, ShouldRemove: true);
 				item.SetResult(result);

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -142,7 +142,7 @@ public class CoinVerifier : IAsyncDisposable
 		}
 	}
 
-	private (bool ShouldBan, bool ShouldRemove) CheckVerifierResult(ApiResponseItem response, int? confirmatons, int? blockchainHeight)
+	private (bool ShouldBan, bool ShouldRemove) CheckVerifierResult(ApiResponseItem response, int? confirmations, int? blockchainHeight)
 	{
 		if (WabiSabiConfig.RiskFlags is null)
 		{
@@ -160,7 +160,7 @@ public class CoinVerifier : IAsyncDisposable
 		bool shouldBan = flagIds.Any(id => WabiSabiConfig.RiskFlags.Contains(id));
 
 		// When to remove: if we ban it OR if address_used is false, API provider doesn't know about it OR if the report doesn't include the block in which the script is used to receive the coin.
-		bool shouldRemove = shouldBan || !response.Report_info_section.Address_used || blockchainHeight - (confirmatons - 1) > response.Report_info_section.Report_block_height;
+		bool shouldRemove = shouldBan || !response.Report_info_section.Address_used || blockchainHeight - (confirmations - 1) > response.Report_info_section.Report_block_height;
 		return (shouldBan, shouldRemove);
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -159,19 +159,23 @@ public class CoinVerifier : IAsyncDisposable
 
 		bool shouldBan = flagIds.Any(id => WabiSabiConfig.RiskFlags.Contains(id));
 
-		// When to remove: if we ban it OR if address_used is false, API provider doesn't know about it OR if the report doesn't include the block in which the script is used to receive the coin.
+		/* When to remove:
+		 - if we ban it
+		 - OR if address_used is false (API provider doesn't know about it)
+		 - OR if the report doesn't include the block in which the script is used to receive the coin.
+		 */
 		bool shouldRemove = shouldBan || !response.Report_info_section.Address_used || blockchainHeight - (confirmations - 1) > response.Report_info_section.Report_block_height;
 		return (shouldBan, shouldRemove);
 	}
 
-	public bool TryScheduleVerification(Coin coin, DateTimeOffset inputRegistrationEndTime, [NotNullWhen(true)] out CoinVerifyItem? coinVerifyItem, CancellationToken cancellationToken, bool oneHop = false, int? confirmations = null, int? bestBlockHeight = null)
+	public bool TryScheduleVerification(Coin coin, DateTimeOffset inputRegistrationEndTime, [NotNullWhen(true)] out CoinVerifyItem? coinVerifyItem, CancellationToken cancellationToken, bool oneHop = false, int confirmations = 0, int bestBlockHeight = 0)
 	{
 		var startTime = inputRegistrationEndTime - WabiSabiConfig.CoinVerifierStartBefore;
 		var delayUntilStart = startTime - DateTimeOffset.UtcNow;
 		return TryScheduleVerification(coin, out coinVerifyItem, cancellationToken, delayUntilStart, oneHop, confirmations, bestBlockHeight);
 	}
 
-	public bool TryScheduleVerification(Coin coin, [NotNullWhen(true)] out CoinVerifyItem? coinVerifyItem, CancellationToken verificationCancellationToken, TimeSpan? delayedStart = null, bool oneHop = false, int? confirmations = null, int? bestBlockHeight = null)
+	public bool TryScheduleVerification(Coin coin, [NotNullWhen(true)] out CoinVerifyItem? coinVerifyItem, CancellationToken verificationCancellationToken, TimeSpan? delayedStart = null, bool oneHop = false, int confirmations = 0, int? bestBlockHeight = null)
 	{
 		coinVerifyItem = null;
 

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierLogger.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierLogger.cs
@@ -56,6 +56,7 @@ public class CoinVerifierLogger : IAsyncDisposable
 		if (apiResponseItem is not null)
 		{
 			var reportId = apiResponseItem?.Report_info_section.Report_id;
+			var reportHeight = apiResponseItem?.Report_info_section.Report_block_height.ToString();
 			var reportType = apiResponseItem?.Report_info_section.Report_type;
 			var ids = apiResponseItem?.Cscore_section.Cscore_info?.Select(x => x.Id) ?? Enumerable.Empty<int>();
 			var categories = apiResponseItem?.Cscore_section.Cscore_info.Select(x => x.Name) ?? Enumerable.Empty<string>();
@@ -64,13 +65,14 @@ public class CoinVerifierLogger : IAsyncDisposable
 			var detailsArray = new string[]
 			{
 					reportId ?? "ReportID None",
+					reportHeight ?? "ReportHeight None",
 					reportType ?? "ReportType None",
 					addressUsed ? "Address used" : "Address not used",
 					ids.Any() ? string.Join(' ', ids) : "FlagIds None",
 					categories.Any() ? string.Join(' ', categories) : "Risk categories None"
 			};
 
-			// Separate the different values of the ApiResponseItem with ';', so the details will be one value in the CSV file.
+			// Separate the different values of the ApiResponseItem with '|', so the details will be one value in the CSV file.
 			details = string.Join("|", detailsArray);
 		}
 		else if (exception is not null)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -119,7 +119,9 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 			round.Alices.Add(alice);
 
-			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, out _, cancellationToken, oneHop, confirmations);
+			int currentBlockchainHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
+
+			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, out _, cancellationToken, oneHop, confirmations, currentBlockchainHeight);
 
 			return new(alice.Id,
 				commitAmountCredentialResponse,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -119,9 +119,18 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 			round.Alices.Add(alice);
 
-			int currentBlockchainHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
+			int currentBlockchainHeight = 0;
 
-			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, out _, cancellationToken, oneHop, confirmations, currentBlockchainHeight);
+			try
+			{
+				currentBlockchainHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError($"Couldn't get current blockchain height. Exception: {ex}");
+			}
+
+			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, out _, confirmations, currentBlockchainHeight, cancellationToken, oneHop);
 
 			return new(alice.Id,
 				commitAmountCredentialResponse,


### PR DESCRIPTION
I didn't (yet) find a better way to use the report's block height.

Explanation of this `blockchainHeight - (confirmations - 1) > response.Report_info_section.Report_block_height;` with an example:

For simplicity let's say at the time of the input registration request
- `blockchainHeight = 1000;`
- `confirmations = 4`
- `Report_block_height = 995`

`Report_block_height` indicates which is the last block the API provider analyzed.

`confirmations = 4` means the coin is in the 997 block. Since being in the latest block means we are in the 1000 block, but the confirmations would be 1, we need to extract 1 out of the confirmations variable.

So in this example, we would remove the coin, because the coin is in the 997. block, which is bigger than the `Report_block_height`.

_Previously we used only the address_used property for this. API Provider said that's a clever solution, but using the Report_block_height is more accurate. Especially in case of address reuses._