### PR TITLE
Limit parallels reissuance requests to 10

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinClient
 {
-	private const int MaxInputsRegistrableByWallet = 10; // how many
+	public const int MaxInputsRegistrableByWallet = 10; // how many
 	private const int MaxWeightedAnonLoss = 3; // Maximum tolerable WeightedAnonLoss.
 
 	private static readonly Money MinimumOutputAmountSanity = Money.Coins(0.0001m); // ignore rounds with too big minimum denominations

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -24,7 +24,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinClient
 {
-	public const int MaxInputsRegistrableByWallet = 10; // how many
+	private const int MaxInputsRegistrableByWallet = 10; // how many
 	private const int MaxWeightedAnonLoss = 3; // Maximum tolerable WeightedAnonLoss.
 
 	private static readonly Money MinimumOutputAmountSanity = Money.Coins(0.0001m); // ignore rounds with too big minimum denominations

--- a/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
+++ b/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
@@ -10,6 +10,9 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class SmartRequestNode
 {
+	// Limit reissuance requests at the same time when coinjoining with multiple wallets to avoid overloading tor.
+	private static SemaphoreSlim SemaphoreSlim = new(CoinJoinClient.MaxInputsRegistrableByWallet);
+	
 	public SmartRequestNode(
 		IEnumerable<Task<Credential>> inputAmountCredentialTasks,
 		IEnumerable<Task<Credential>> inputVsizeCredentialTasks,
@@ -35,12 +38,16 @@ public class SmartRequestNode
 		var amountsToRequest = AddExtraCredentialRequests(amounts, inputAmountCredentials.Sum(x => x.Value));
 		var vsizesToRequest = AddExtraCredentialRequests(vsizes, inputVsizeCredentials.Sum(x => x.Value));
 
+		await SemaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
+		
 		(IEnumerable<Credential> RealAmountCredentials, IEnumerable<Credential> RealVsizeCredentials) result = await bobClient.ReissueCredentialsAsync(
 			amountsToRequest,
 			vsizesToRequest,
 			inputAmountCredentials,
 			inputVsizeCredentials,
 			cancellationToken).ConfigureAwait(false);
+
+		SemaphoreSlim.Release();
 
 		// TODO keep the credentials that were not needed by the graph
 		var (amountCredentials, _) = SeparateExtraCredentials(result.RealAmountCredentials, amounts);

--- a/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
+++ b/WalletWasabi/WabiSabi/Client/SmartRequestNode.cs
@@ -11,8 +11,8 @@ namespace WalletWasabi.WabiSabi.Client;
 public class SmartRequestNode
 {
 	// Limit reissuance requests at the same time when coinjoining with multiple wallets to avoid overloading tor.
-	private static readonly int MaxInputsRegistrableByWallet = 10;
-	private static SemaphoreSlim SemaphoreSlim = new(MaxInputsRegistrableByWallet);
+	private static readonly int MaxParallelReissuanceRequests = 10;
+	private static readonly SemaphoreSlim SemaphoreSlim = new(MaxParallelReissuanceRequests);
 	
 	public SmartRequestNode(
 		IEnumerable<Task<Credential>> inputAmountCredentialTasks,


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9370

I've tested many ways to mitigate the problem as best as possible; this solution is the most efficient. I tested it extensively to the limits of the wallet (20 wallets coinjoining at the same time), I had no problem and could make coinjoins with 70+ TXs easily.

It has no effect if someone is conjoining with only one wallet.
Otherwise, requests are just waiting for others to finish before starting, keeping the load constant on Tor, increasing the number of requests that can be sent in the phase time window.

Using `15` as the max number of parallel requests is also possible and better on my machine, but I chose `10` for safety reasons because I can't test on old hardware.