### PR TITLE
[Test] BnB doesn't choose coins with same ScriptPubKey

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -326,6 +326,7 @@ public class BranchAndBoundTests
 			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
 			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1.1m),
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey,1m),
+			BitcoinFactory.CreateSmartCoin(constantHdPubKey,1m),
 			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
 			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
 		};
@@ -345,6 +346,7 @@ public class BranchAndBoundTests
 		await foreach (var coins in strategys)
 		{
 			int coinsWithExpectedScript = coins.Where(coin => coin.ScriptPubKey == expectedScript).Count();
+			Assert.Equal(3, coinsWithExpectedScript);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -340,7 +340,7 @@ public class BranchAndBoundTests
 		int maxInputCount = 3;
 		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
 
-		var strategys = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(availableCoins, feeRate, txOut, maxInputCount, cts.Token);
+		var strategies = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(availableCoins, feeRate, txOut, maxInputCount, cts.Token);
 
 		Script expectedScript = constantHdPubKey.GetAssumedScriptPubKey();
 		await foreach (var coins in strategys)

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -343,7 +343,7 @@ public class BranchAndBoundTests
 		var strategies = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(availableCoins, feeRate, txOut, maxInputCount, cts.Token);
 
 		Script expectedScript = constantHdPubKey.GetAssumedScriptPubKey();
-		await foreach (var coins in strategys)
+		await foreach (var coins in strategies)
 		{
 			int coinsWithExpectedScript = coins.Where(coin => coin.ScriptPubKey == expectedScript).Count();
 			Assert.Equal(3, coinsWithExpectedScript);

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/BranchAndBoundTests.cs
@@ -319,16 +319,16 @@ public class BranchAndBoundTests
 		// 3 coins coming from the same hdPubKey should be choosen for exact payment.
 		List<SmartCoin> availableCoins = new()
 		{
-			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1.1m),
-			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
-			BitcoinFactory.CreateSmartCoin(constantHdPubKey,1.1m),
-			BitcoinFactory.CreateSmartCoin(constantHdPubKey,1m),
-			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
-			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1.1m),
-			BitcoinFactory.CreateSmartCoin(constantHdPubKey,1m),
-			BitcoinFactory.CreateSmartCoin(constantHdPubKey,1m),
-			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
-			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km),1m),
+			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), 1.1m),
+			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), 1m),
+			BitcoinFactory.CreateSmartCoin(constantHdPubKey, 1.1m),
+			BitcoinFactory.CreateSmartCoin(constantHdPubKey, 1m),
+			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), 1m),
+			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), 1.1m),
+			BitcoinFactory.CreateSmartCoin(constantHdPubKey, 1m),
+			BitcoinFactory.CreateSmartCoin(constantHdPubKey, 1m),
+			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), 1m),
+			BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), 1m),
 		};
 
 		FeeRate feeRate = new(1m);


### PR DESCRIPTION
Addresses this [comment](https://github.com/zkSNACKs/WalletWasabi/issues/10060#issuecomment-1451570801) by @yahiheb.
Adding a **failing**🛑 test which prooves that the Branch and Bound doesn't choose coins together in case of same ScriptPubKey.