### PR TITLE
Revert "Bump version to v2.0.3"

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -187,9 +187,9 @@
                                         <div class="my-4">
                                             <div class="system-text">WINDOWS 10+</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.msi" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.msi" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .msi <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.msi.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#windows" target="_blank">guide</a></span>
+                                            .msi <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.msi.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#windows" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -199,9 +199,9 @@
                                         <div class="my-4">
                                             <div class="system-text">MACOS 10.15+ INTEL</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -211,9 +211,9 @@
                                         <div class="my-4">
                                             <div class="system-text">MACOS 10.15+ M1, M2</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3-arm64.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2-arm64.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3-arm64.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2-arm64.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -223,9 +223,9 @@
                                         <div class="my-4">
                                             <div class="system-text">UBUNTU / DEBIAN</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.deb" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.deb" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .deb <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.deb.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu" target="_blank">guide</a></span>
+                                            .deb <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.deb.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -235,9 +235,9 @@
                                         <div class="my-4">
                                             <div class="system-text">OTHER LINUX</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.tar.gz" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.tar.gz" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .tar.gz <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.tar.gz.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#other-linux" target="_blank">guide</a></span>
+                                            .tar.gz <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.2.2/Wasabi-2.0.2.2.tar.gz.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#other-linux" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -68,7 +68,7 @@ public static class Constants
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 
-	public static readonly Version ClientVersion = new(2, 0, 3, 0);
+	public static readonly Version ClientVersion = new(2, 0, 2, 2);
 
 	public static readonly Version HwiVersion = new("2.1.1");
 	public static readonly Version BitcoinCoreVersion = new("21.2");


### PR DESCRIPTION
This will be released https://github.com/zkSNACKs/WalletWasabi/tree/v2030 
I wanted to have a commit to stick with. This might be the final version for the release. https://github.com/zkSNACKs/WalletWasabi/commit/dcac6090ffb83aa131674f5d3a785f60c21c13b9

With this PR, I am ensuring that the new version won't be deployed accidentally to the backend - because that would signal the latest version to everyone. 

Reverts zkSNACKs/WalletWasabi#10241