### PR TITLE
[easy] `IndexStore`: Unify CT param names and use test deadlines in tests

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -51,6 +51,8 @@ public class WalletTests
 	[Fact]
 	public async Task FilterDownloaderTestAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		(_, IRPCClient rpc, _, _, _, BitcoinStore bitcoinStore, _) = await Common.InitializeTestEnvironmentAsync(RegTestFixture, 1);
 
 		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
@@ -98,7 +100,7 @@ public class WalletTests
 				filterList.Add(x);
 				await Task.CompletedTask;
 			},
-			new Height(0));
+			new Height(0), testDeadlineCts.Token);
 			FilterModel[] filters = filterList.ToArray();
 			for (int i = 0; i < 101; i++)
 			{
@@ -118,6 +120,8 @@ public class WalletTests
 	[Fact]
 	public async Task ReorgTestAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		(string password, IRPCClient rpc, Network network, _, _, BitcoinStore bitcoinStore, Backend.Global global) = await Common.InitializeTestEnvironmentAsync(RegTestFixture, 1);
 
 		var keyManager = KeyManager.CreateNew(out _, password, network);
@@ -178,7 +182,7 @@ public class WalletTests
 				filterList.Add(x);
 				await Task.CompletedTask;
 			},
-			new Height(0));
+			new Height(0), testDeadlineCts.Token);
 			var filterTip = filterList.Last();
 			Assert.Equal(tip, filterTip.Header.BlockHash);
 
@@ -191,7 +195,7 @@ public class WalletTests
 				filterList.Add(x);
 				await Task.CompletedTask;
 			},
-			new Height(0));
+			new Height(0), testDeadlineCts.Token);
 			FilterModel[] filters = filterList.ToArray();
 			for (int i = 0; i < blockCountIncludingGenesis; i++)
 			{

--- a/WalletWasabi.Tests/UnitTests/Stores/IndexStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Stores/IndexStoreTests.cs
@@ -22,6 +22,8 @@ public class IndexStoreTests
 	[Fact]
 	public async Task IndexStoreTestsAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		var network = Network.Main;
 
 		var dir = (await GetIndexStorePathsAsync()).dir;
@@ -30,12 +32,14 @@ public class IndexStoreTests
 			Directory.Delete(dir, true);
 		}
 		await using var indexStore = new IndexStore(dir, network, new SmartHeaderChain());
-		await indexStore.InitializeAsync();
+		await indexStore.InitializeAsync(testDeadlineCts.Token);
 	}
 
 	[Fact]
 	public async Task InconsistentMatureIndexAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		var (dir, matureFilters, _) = await GetIndexStorePathsAsync();
 
 		var network = Network.Main;
@@ -52,7 +56,7 @@ public class IndexStoreTests
 			};
 		await File.WriteAllLinesAsync(matureFilters, matureIndexStoreContent.Select(x => x.ToLine()));
 
-		await Assert.ThrowsAsync<InvalidOperationException>(async () => await indexStore.InitializeAsync());
+		await Assert.ThrowsAsync<InvalidOperationException>(async () => await indexStore.InitializeAsync(testDeadlineCts.Token));
 		Assert.Equal(new uint256(3), headersChain.TipHash);
 		Assert.Equal(2u, headersChain.TipHeight);
 
@@ -63,6 +67,8 @@ public class IndexStoreTests
 	[Fact]
 	public async Task InconsistentImmatureIndexAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		var (dir, _, immatureFilters) = await GetIndexStorePathsAsync();
 
 		var network = Network.Main;
@@ -80,7 +86,7 @@ public class IndexStoreTests
 			};
 		await File.WriteAllLinesAsync(immatureFilters, immatureIndexStoreContent.Select(x => x.ToLine()));
 
-		await Assert.ThrowsAsync<InvalidOperationException>(async () => await indexStore.InitializeAsync());
+		await Assert.ThrowsAsync<InvalidOperationException>(async () => await indexStore.InitializeAsync(testDeadlineCts.Token));
 		Assert.Equal(new uint256(3), headersChain.TipHash);
 		Assert.Equal(startingFilter.Header.Height + 2u, headersChain.TipHeight);
 
@@ -91,6 +97,8 @@ public class IndexStoreTests
 	[Fact]
 	public async Task GapInIndexAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		var (dir, matureFilters, immatureFilters) = await GetIndexStorePathsAsync();
 
 		var network = Network.Main;
@@ -112,7 +120,7 @@ public class IndexStoreTests
 			};
 		await File.WriteAllLinesAsync(immatureFilters, immatureIndexStoreContent.Select(x => x.ToLine()));
 
-		await Assert.ThrowsAsync<InvalidOperationException>(async () => await indexStore.InitializeAsync());
+		await Assert.ThrowsAsync<InvalidOperationException>(async () => await indexStore.InitializeAsync(testDeadlineCts.Token));
 		Assert.Equal(new uint256(3), headersChain.TipHash);
 		Assert.Equal(2u, headersChain.TipHeight);
 
@@ -123,6 +131,8 @@ public class IndexStoreTests
 	[Fact]
 	public async Task ReceiveNonMatchingFilterAsync()
 	{
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
+
 		var (dir, matureFilters, immatureFilters) = await GetIndexStorePathsAsync();
 
 		var network = Network.Main;
@@ -138,7 +148,7 @@ public class IndexStoreTests
 			};
 		await File.WriteAllLinesAsync(matureFilters, matureIndexStoreContent.Select(x => x.ToLine()));
 
-		await indexStore.InitializeAsync();
+		await indexStore.InitializeAsync(testDeadlineCts.Token);
 		Assert.Equal(new uint256(3), headersChain.TipHash);
 		Assert.Equal(2u, headersChain.TipHeight);
 

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -64,13 +64,13 @@ public class IndexStore : IAsyncDisposable
 	private uint StartingHeight => StartingFilter.Header.Height;
 	private List<FilterModel> ImmatureFilters { get; } = new(150);
 
-	public async Task InitializeAsync(CancellationToken cancel = default)
+	public async Task InitializeAsync(CancellationToken cancellationToken)
 	{
 		using IDisposable _ = BenchmarkLogger.Measure();
 
-		using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
-		using (await MatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
-		using (await ImmatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
+		using (await IndexLock.LockAsync(cancellationToken).ConfigureAwait(false))
+		using (await MatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
+		using (await ImmatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
 			if (Network == Network.RegTest)
 			{
@@ -78,20 +78,20 @@ public class IndexStore : IAsyncDisposable
 				ImmatureIndexFileManager.DeleteMe();
 			}
 
-			cancel.ThrowIfCancellationRequested();
+			cancellationToken.ThrowIfCancellationRequested();
 
 			if (!MatureIndexFileManager.Exists())
 			{
 				await MatureIndexFileManager.WriteAllLinesAsync(new[] { StartingFilter.ToLine() }, CancellationToken.None).ConfigureAwait(false);
 			}
 
-			cancel.ThrowIfCancellationRequested();
+			cancellationToken.ThrowIfCancellationRequested();
 
-			await InitializeFiltersAsync(cancel).ConfigureAwait(false);
+			await InitializeFiltersAsync(cancellationToken).ConfigureAwait(false);
 		}
 	}
 
-	private async Task InitializeFiltersAsync(CancellationToken cancel)
+	private async Task InitializeFiltersAsync(CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -107,7 +107,7 @@ public class IndexStore : IAsyncDisposable
 						while (true)
 						{
 							i++;
-							cancel.ThrowIfCancellationRequested();
+							cancellationToken.ThrowIfCancellationRequested();
 							string? line = await sr.ReadLineAsync(CancellationToken.None).ConfigureAwait(false);
 
 							if (line is null)
@@ -134,16 +134,16 @@ public class IndexStore : IAsyncDisposable
 			throw;
 		}
 
-		cancel.ThrowIfCancellationRequested();
+		cancellationToken.ThrowIfCancellationRequested();
 
 		try
 		{
 			if (ImmatureIndexFileManager.Exists())
 			{
-				foreach (var line in await ImmatureIndexFileManager.ReadAllLinesAsync(cancel).ConfigureAwait(false)) // We can load ImmatureIndexFileManager to the memory, no problem.
+				foreach (var line in await ImmatureIndexFileManager.ReadAllLinesAsync(cancellationToken).ConfigureAwait(false)) // We can load ImmatureIndexFileManager to the memory, no problem.
 				{
 					ProcessLine(line, enqueue: true);
-					cancel.ThrowIfCancellationRequested();
+					cancellationToken.ThrowIfCancellationRequested();
 				}
 			}
 		}
@@ -198,7 +198,7 @@ public class IndexStore : IAsyncDisposable
 	private bool IsWrongFilter(FilterModel filter) =>
 		Network == Network.Main && filter.Header.Height == 627278 && filter.ToLine() == "627278:00000000000000000002edea14cfbbcde1cdb6a14275d9ad36491aa5d8862747:fd4b018270de28c44316c049e4e4050d8a7de5746c7bb31d093831c56196e5f5464956c9ab7142b998a93cb80149b09353cb5d46dfeb44ecb0c8255fb0eb64247a405ab2305713e3418707be4fe87286b467ac86603749aeeac6c182022f0105b6c547b22b89608d0b57eaee2767150bff2354e4cdecef069d1a7f9356e5972ac7323c907b2e42775d032b4a12cc45e96eaa86d232e14808beca91f21c09003734bf77005d2dbfdfeaf19108e971f99b91046db0a021a128bb17b91c83766c65e924bb48af50c473f80e8e8569fd68aaba856b9e4f60efba08519d4ca0f1c0453e60f50a86398b11c860607f049e2bc5e1b6201470f5383601fcfbbea766f510768bac3145dc33443131e50d41bdfb92f5b3d9affc0bbaa85a4c40be2d9e582c3ca0c82251d191ec83dbd197cc1a9f070e6754d84c8ca1c0258d21264619cb523a9bda5556aded4f82e9a8955180c8c8772304bb5f2a5498d15f28b3f0d5d0b22aba14a18be7c8a100bb35b73385ce2b410126ac614f2260557444c3279b73dab148cd14e8800815a1248fa802901a4430817b59d936ceb3e1594d002c1b8d88ec8641f2b2d9827a42948c61c888fc32f070eeba19dda8f773c6cef04485575652f3e929507a9e24dcee53bdc548a317f1e019fbc7ac87c5314548cca6c0b85ebbca79bed2685ed7024a21349189d9a6c92b05aa53a7e241b6885575a19bd737040c263ac05b9920d2e31568afff3c545a827338e103096fbd8fb60ef317e55146b74260577064627bba812c7ca06c39b45d291d7bb9142c338012ccb97330873a0e256ca8aaff778348085e1c9e9942cd10a8444f0c708a798c1d701b4e1879d78ee51f3044ee0012e9929c6e5bfddba40ed04872065373af111ebe53a832f5563078ef274cd39a6b77c8155d8996b6a5617c2ff447dcf4a37a84bfbd1ab34b8a4012f0ccb82c8085668a52e722f8a59a63a07420d2fc67a4da39209fc0cdcd335b2b4670817218f92aee62c8d0e3e895d7aa0f3c69ba36687c9559cf38adfef8ef0ec90128d1efc3b69006ed2c026a1a904bdd1bc0aa1924c74e05b4fdd8316a4cc400d9ced30eaf0ed01f82a6ab59bdf1fbd7a7c6f7186e33411140b57673a0075946902c5890e5647df67183a84f5b2001be152a23741582b529116e2d3bd9964968b40080173e5339018edf609199f25021c757ff3b8d1add3731002784c4da7176cd8b201e3931c61272d17e4e58a2487666510889935d054f0b72817700:000000000000000000028dbd5c398fa064b00e07805af0a8806e6f3b6ffce2c0:1587639149";
 
-	public async Task AddNewFiltersAsync(IEnumerable<FilterModel> filters, CancellationToken cancel)
+	public async Task AddNewFiltersAsync(IEnumerable<FilterModel> filters, CancellationToken cancellationToken)
 	{
 		var successAny = false;
 
@@ -206,7 +206,7 @@ public class IndexStore : IAsyncDisposable
 		{
 			var success = false;
 
-			using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
+			using (await IndexLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
 				success = TryProcessFilter(filter, enqueue: true);
 			}
@@ -221,15 +221,15 @@ public class IndexStore : IAsyncDisposable
 
 		if (successAny)
 		{
-			AbandonedTasks.AddAndClearCompleted(TryCommitToFileAsync(TimeSpan.FromSeconds(3), cancel));
+			AbandonedTasks.AddAndClearCompleted(TryCommitToFileAsync(TimeSpan.FromSeconds(3), cancellationToken));
 		}
 	}
 
-	public async Task<FilterModel> RemoveLastFilterAsync(CancellationToken cancel)
+	public async Task<FilterModel> RemoveLastFilterAsync(CancellationToken cancellationToken)
 	{
 		FilterModel? filter = null;
 
-		using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
+		using (await IndexLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
 			filter = ImmatureFilters.Last();
 			ImmatureFilters.RemoveLast();
@@ -242,15 +242,15 @@ public class IndexStore : IAsyncDisposable
 
 		Reorged?.Invoke(this, filter);
 
-		AbandonedTasks.AddAndClearCompleted(TryCommitToFileAsync(TimeSpan.FromSeconds(3), cancel));
+		AbandonedTasks.AddAndClearCompleted(TryCommitToFileAsync(TimeSpan.FromSeconds(3), cancellationToken));
 
 		return filter;
 	}
 
-	public async Task<IEnumerable<FilterModel>> RemoveAllImmatureFiltersAsync(CancellationToken cancel, bool deleteAndCrashIfMature = false)
+	public async Task<IEnumerable<FilterModel>> RemoveAllImmatureFiltersAsync(CancellationToken cancellationToken, bool deleteAndCrashIfMature = false)
 	{
 		var removed = new List<FilterModel>();
-		using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
+		using (await IndexLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
 			if (ImmatureFilters.Any())
 			{
@@ -264,8 +264,8 @@ public class IndexStore : IAsyncDisposable
 				{
 					Logger.LogCritical($"Deleting all filters and crashing the software...");
 
-					using (await MatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
-					using (await ImmatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
+					using (await MatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
+					using (await ImmatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 					{
 						ImmatureIndexFileManager.DeleteMe();
 						MatureIndexFileManager.DeleteMe();
@@ -278,7 +278,7 @@ public class IndexStore : IAsyncDisposable
 
 		while (ImmatureFilters.Any())
 		{
-			removed.Add(await RemoveLastFilterAsync(cancel).ConfigureAwait(false));
+			removed.Add(await RemoveLastFilterAsync(cancellationToken).ConfigureAwait(false));
 		}
 
 		return removed;
@@ -288,7 +288,7 @@ public class IndexStore : IAsyncDisposable
 	/// It'll LogError the exceptions.
 	/// If cancelled, it'll LogTrace the exception.
 	/// </summary>
-	private async Task TryCommitToFileAsync(TimeSpan throttle, CancellationToken cancel)
+	private async Task TryCommitToFileAsync(TimeSpan throttle, CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -300,7 +300,7 @@ public class IndexStore : IAsyncDisposable
 
 				if (incremented < 21)
 				{
-					await Task.Delay(throttle, cancel).ConfigureAwait(false);
+					await Task.Delay(throttle, cancellationToken).ConfigureAwait(false);
 				}
 
 				// If the _throttleId is still the incremented value, then I am the latest CommitToFileAsync request.
@@ -317,9 +317,9 @@ public class IndexStore : IAsyncDisposable
 				Interlocked.Exchange(ref _throttleId, 0); // So to notify the currently throttled threads that they do not have to run.
 			}
 
-			using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
-			using (await MatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
-			using (await ImmatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
+			using (await IndexLock.LockAsync(cancellationToken).ConfigureAwait(false))
+			using (await MatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
+			using (await ImmatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 			{
 				// Do not feed the cancellationToken here I always want this to finish running for safety.
 				var currentImmatureLines = ImmatureFilters.Select(x => x.ToLine()).ToArray(); // So we do not read on ImmatureFilters while removing them.
@@ -353,10 +353,10 @@ public class IndexStore : IAsyncDisposable
 		}
 	}
 
-	public async Task ForeachFiltersAsync(Func<FilterModel, Task> todo, Height fromHeight, CancellationToken cancel = default)
+	public async Task ForeachFiltersAsync(Func<FilterModel, Task> todo, Height fromHeight, CancellationToken cancellationToken)
 	{
-		using (await IndexLock.LockAsync(cancel).ConfigureAwait(false))
-		using (await MatureIndexAsyncLock.LockAsync(cancel).ConfigureAwait(false))
+		using (await IndexLock.LockAsync(cancellationToken).ConfigureAwait(false))
+		using (await MatureIndexAsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
 			var firstImmatureHeight = ImmatureFilters.FirstOrDefault()?.Header?.Height;
 			if (!firstImmatureHeight.HasValue || firstImmatureHeight.Value > fromHeight)


### PR DESCRIPTION
This PR is just a minor refactoring:

* Changes `cancel` -> `cancellationToken`
* Changes `Cancellation cancellationToken = default` to `Cancellation cancellationToken`

A part of work on #7324.