### PR TITLE
Refactor Schedule method

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -309,7 +309,7 @@ public class ChaumianCoinJoinController : ControllerBase
 
 				foreach (var coin in alice.Inputs)
 				{
-					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, out _, CancellationToken.None, false, coinAndTxOutResponses[coin].Confirmations);
+					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, coinAndTxOutResponses[coin].Confirmations, oneHop: false, CancellationToken.None);
 				}
 
 				round.AddAlice(alice);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
@@ -86,7 +86,7 @@ public class CoinVerifierTests
 		List<Coin> removedCoins = new();
 		List<Coin> checkedCoins = new();
 
-		ScheduleVerifications(coinVerifier, generatedCoins, TimeSpan.FromSeconds(2));
+		ScheduleVerifications(coinVerifier, generatedCoins);
 		coinVerifier.CancelSchedule(generatedCoins[9]);
 
 		foreach (var item in await coinVerifier.VerifyCoinsAsync(generatedCoins, CancellationToken.None))
@@ -230,11 +230,11 @@ public class CoinVerifierTests
 		return coins;
 	}
 
-	private void ScheduleVerifications(CoinVerifier coinVerifier, IEnumerable<Coin> coins, TimeSpan? delay = null)
+	private void ScheduleVerifications(CoinVerifier coinVerifier, IEnumerable<Coin> coins)
 	{
 		foreach (Coin coin in coins)
 		{
-			coinVerifier.TryScheduleVerification(coin, out _, CancellationToken.None, delay, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations);
+			coinVerifier.TryScheduleVerification(coin, TimeSpan.Zero, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations, oneHop: false, CancellationToken.None);
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
@@ -234,7 +234,7 @@ public class CoinVerifierTests
 	{
 		foreach (Coin coin in coins)
 		{
-			coinVerifier.TryScheduleVerification(coin, TimeSpan.Zero, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations, oneHop: false, CancellationToken.None);
+			coinVerifier.TryScheduleVerification(coin, delayedStart: TimeSpan.Zero, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations, oneHop: false, CancellationToken.None);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -71,7 +71,7 @@ public class CoinVerifier : IAsyncDisposable
 			}
 			else
 			{
-				Logger.LogWarning($"Coin {coin.Outpoint} is missing scheduled verification, but it is inside the round. Removing it.");
+				Logger.LogWarning($"Coin {coin.Outpoint} is missing scheduled verification. Ignoring it.");
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -119,7 +119,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 			round.Alices.Add(alice);
 
-			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, out _, cancellationToken, oneHop, confirmations);
+			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, confirmations, oneHop: oneHop, cancellationToken);
 
 			return new(alice.Id,
 				commitAmountCredentialResponse,


### PR DESCRIPTION
Extracted from #10208 and improved a bit.

- removed nullability from parameters
- `[NotNullWhen(true)] out CoinVerifyItem? coinVerifyItem` was removed since no one used it.
- Removed "fast-scheduling", see my [reasons](https://github.com/zkSNACKs/WalletWasabi/pull/10266#issuecomment-1461693272)