### PR TITLE
[BnB] Spend address re-used coins together

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -141,7 +141,7 @@ public class ChangelessTransactionCoinSelectorTests
 
 		await foreach (var coins in suggestions)
 		{
-			var selectedScripts = coins.GroupBy(coin => coin.ScriptPubKey.Hash);
+			var selectedScripts = coins.GroupBy(coin => coin.ScriptPubKey);
 			Assert.Single(selectedScripts); // Single, so we are sending the address reused coins together and we don't mix them with other scripts.
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -135,7 +135,7 @@ public class ChangelessTransactionCoinSelectorTests
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey2, Money.Satoshis(5000)),
 		};
 
-		// First test case where we show that no mixing of script pub keys is not if BnB can find such a solution.
+		// First test case where we show that we are not mixing the script pub keys and we spend the address reused coins together.
 		{
 			Money target = Money.Satoshis(30000);
 			TxOut txOut = new(target, scriptPubKey: BitcoinFactory.CreateScript());
@@ -149,12 +149,12 @@ public class ChangelessTransactionCoinSelectorTests
 
 				long sumOfCoins = coins.Sum(coin => coin.Amount);
 
-				if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))  // First case: Less-selection strategy
+				if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))  // Less-selection strategy
 				{
 					Assert.Equal(30_000, sumOfCoins);
 					Assert.Equal(3, coins.Count);
 				}
-				else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))   // Second case: More-selection strategy
+				else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))   // More-selection strategy
 				{
 					Assert.Equal(35_000, sumOfCoins);
 					Assert.Equal(4, coins.Count);

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -129,7 +129,7 @@ public class ChangelessTransactionCoinSelectorTests
 		TxOut txOut = new(target, destination);
 		int maxInputCount = 6;
 
-		// Coins with same ScriptPubKey should be considered one coin, thus be chosen together.
+		// Coins with the same ScriptPubKey should be considered one coin, thus be chosen together.
 		List<SmartCoin> availableCoins = new()
 		{
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey, Money.Satoshis(10000)),

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -142,7 +142,27 @@ public class ChangelessTransactionCoinSelectorTests
 		await foreach (var coins in suggestions)
 		{
 			var selectedScripts = coins.GroupBy(coin => coin.ScriptPubKey);
+
 			Assert.Single(selectedScripts); // Single, so we are sending the address reused coins together and we don't mix them with other scripts.
+
+			var sumOfCoins = coins.Sum(coin => coin.Amount);
+
+			// First case: Lesser strategy
+			if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))
+			{
+				Assert.Equal(30_000, sumOfCoins);
+				Assert.Equal(3, coins.Count());
+			}
+			// Second case: More strategy
+			else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))
+			{
+				Assert.Equal(35_000, sumOfCoins);
+				Assert.Equal(4, coins.Count());
+			}
+			else
+			{
+				Assert.Fail("Mixed scripts in coin selection!");
+			}
 		}
 	}
 

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -147,14 +147,12 @@ public class ChangelessTransactionCoinSelectorTests
 
 			var sumOfCoins = coins.Sum(coin => coin.Amount);
 
-			// First case: Lesser strategy
-			if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))
+			if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))  // First case: Lesser strategy
 			{
 				Assert.Equal(30_000, sumOfCoins);
 				Assert.Equal(3, coins.Count());
 			}
-			// Second case: More strategy
-			else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))
+			else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))    // Second case: More strategy
 			{
 				Assert.Equal(35_000, sumOfCoins);
 				Assert.Equal(4, coins.Count());

--- a/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelectorTests.cs
@@ -24,12 +24,12 @@ public class ChangelessTransactionCoinSelectorTests
 	public void GoodSuggestion()
 	{
 		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(1));
-		KeyManager km = ServiceFactory.CreateKeyManager();
 
+		KeyManager km = ServiceFactory.CreateKeyManager();
 		IEnumerable<SmartCoin> coins = GenerateDummySmartCoins(km, 6_025, 6_561, 8_192, 13_122, 50_000, 100_000, 196_939, 524_288);
 
 		var coinsByScript = coins
-			.GroupBy(coin => coin.ScriptPubKey.Hash)
+			.GroupBy(coin => coin.ScriptPubKey)
 			.OrderByDescending(group => group.Sum(coin => coin.Amount))
 			.ToList();
 
@@ -54,12 +54,12 @@ public class ChangelessTransactionCoinSelectorTests
 	public void Good_LesserSuggestion()
 	{
 		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(1));
-		KeyManager km = ServiceFactory.CreateKeyManager();
 
+		KeyManager km = ServiceFactory.CreateKeyManager();
 		List<SmartCoin> coins = GenerateDummySmartCoins(km, 6_025, 6_561, 8_192, 13_122, 50_000, 100_000, 196_939, 524_288);
 
 		var coinsByScript = coins
-			.GroupBy(coin => coin.ScriptPubKey.Hash)
+			.GroupBy(coin => coin.ScriptPubKey)
 			.OrderByDescending(group => group.Sum(coin => coin.Amount))
 			.ToList();
 
@@ -86,12 +86,12 @@ public class ChangelessTransactionCoinSelectorTests
 	public void TooExpensiveSolution()
 	{
 		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(1));
-		KeyManager km = ServiceFactory.CreateKeyManager();
 
+		KeyManager km = ServiceFactory.CreateKeyManager();
 		List<SmartCoin> coins = GenerateDummySmartCoins(km, 150_000);
 
 		var coinsByScript = coins
-			.GroupBy(coin => coin.ScriptPubKey.Hash)
+			.GroupBy(coin => coin.ScriptPubKey)
 			.OrderByDescending(group => group.Sum(coin => coin.Amount))
 			.ToList();
 
@@ -108,58 +108,85 @@ public class ChangelessTransactionCoinSelectorTests
 		Assert.False(found);
 	}
 
+	/// <summary>
+	/// BnB algorithm chooses coins in the way that either all coins with the same scriptPubKey are selected or no coin with that scriptPubKey is selected.
+	/// </summary>
 	[Fact]
-	public async void BnBChoosesCoinsWithSameScriptPubKeyAsync()
+	public async void BnBRespectScriptPubKeyPrivacyRuleAsync()
 	{
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(300));
+		using CancellationTokenSource testDeadlineCts = new(TimeSpan.FromMinutes(5));
 
 		KeyManager km = ServiceFactory.CreateKeyManager();
 		HdPubKey constantHdPubKey = BitcoinFactory.CreateHdPubKey(km);
 		HdPubKey constantHdPubKey2 = BitcoinFactory.CreateHdPubKey(km);
 
-		Money target = Money.Satoshis(30000);
-
-		FeeRate feeRate = new(0m);
-		Script destination = BitcoinFactory.CreateScript();
-
-		TxOut txOut = new(target, destination);
-		int maxInputCount = 6;
-
 		// Coins with the same ScriptPubKey should be considered one coin, thus be chosen together.
 		List<SmartCoin> availableCoins = new()
 		{
+			// Group #1.
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey, Money.Satoshis(10000)),
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey, Money.Satoshis(10000)),
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey, Money.Satoshis(10000)),
+
+			// Group #2.
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey2, Money.Satoshis(10000)),
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey2, Money.Satoshis(10000)),
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey2, Money.Satoshis(10000)),
 			BitcoinFactory.CreateSmartCoin(constantHdPubKey2, Money.Satoshis(5000)),
 		};
 
-		var suggestions = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(availableCoins, feeRate, txOut, maxInputCount, cts.Token);
-
-		await foreach (var coins in suggestions)
+		// First test case where we show that no mixing of script pub keys is not if BnB can find such a solution.
 		{
-			var selectedScripts = coins.GroupBy(coin => coin.ScriptPubKey);
+			Money target = Money.Satoshis(30000);
+			TxOut txOut = new(target, scriptPubKey: BitcoinFactory.CreateScript());
 
-			Assert.Single(selectedScripts); // Single, so we are sending the address reused coins together and we don't mix them with other scripts.
+			var suggestions = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(availableCoins, FeeRate.Zero, txOut, maxInputCount: 6, testDeadlineCts.Token);
 
-			var sumOfCoins = coins.Sum(coin => coin.Amount);
-
-			if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))  // First case: Lesser strategy
+			await foreach (var coins in suggestions)
 			{
-				Assert.Equal(30_000, sumOfCoins);
-				Assert.Equal(3, coins.Count());
+				// We expect all address-reused coins to be selected together.
+				Assert.Single(coins.GroupBy(coin => coin.ScriptPubKey));
+
+				long sumOfCoins = coins.Sum(coin => coin.Amount);
+
+				if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript))  // First case: Less-selection strategy
+				{
+					Assert.Equal(30_000, sumOfCoins);
+					Assert.Equal(3, coins.Count);
+				}
+				else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))   // Second case: More-selection strategy
+				{
+					Assert.Equal(35_000, sumOfCoins);
+					Assert.Equal(4, coins.Count);
+				}
+				else
+				{
+					Assert.Fail("Mixed scripts in coin selection!");
+				}
 			}
-			else if (coins.All(coin => coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript))    // Second case: More strategy
+		}
+
+		// Second test case where we show that a final selection can contain coins with multiple script pub keys.
+		{
+			Money target = Money.Satoshis(60_000);
+			TxOut txOut = new(target, scriptPubKey: BitcoinFactory.CreateScript());
+
+			var suggestions = ChangelessTransactionCoinSelector.GetAllStrategyResultsAsync(availableCoins, FeeRate.Zero, txOut, maxInputCount: 10, testDeadlineCts.Token);
+
+			await foreach (var coins in suggestions)
 			{
-				Assert.Equal(35_000, sumOfCoins);
-				Assert.Equal(4, coins.Count());
-			}
-			else
-			{
-				Assert.Fail("Mixed scripts in coin selection!");
+				long sumOfCoins = coins.Sum(coin => coin.Amount);
+
+				if (sumOfCoins == 65_000) // Second case: More-selection strategy.
+				{
+					Assert.True(coins.All(coin => coin.ScriptPubKey == constantHdPubKey.P2wpkhScript || coin.ScriptPubKey == constantHdPubKey2.P2wpkhScript));
+					Assert.Equal(65_000, coins.Sum(coin => coin.Amount));
+					Assert.Equal(7, coins.Count);
+				}
+				else
+				{
+					Assert.Fail("Unexpected selection!");
+				}
 			}
 		}
 	}
@@ -167,8 +194,6 @@ public class ChangelessTransactionCoinSelectorTests
 	/// <remarks>These smart coins are from an invalid transaction but we are interested only in smart coins' amounts.</remarks>
 	private List<SmartCoin> GenerateDummySmartCoins(KeyManager km, params long[] values)
 	{
-		Network network = Network.Main;
-
 		List<SmartCoin> result = new(capacity: values.Length);
 
 		for (uint i = 0; i < values.Length; i++)

--- a/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
@@ -26,8 +26,8 @@ public static class ChangelessTransactionCoinSelector
 
 		// Group coins by their script pub key and sort the groups in the descending order. Each coin group is considered to be a single coin for the purposes of the algorithm.
 		// All coins in a single group have the same script pub key so all the coins should be spent together or not spent at all.
-		IOrderedEnumerable<IGrouping<ScriptId, SmartCoin>> coinsByScript = availableCoins
-			.GroupBy(coin => coin.ScriptPubKey.Hash)
+		IOrderedEnumerable<IGrouping<Script, SmartCoin>> coinsByScript = availableCoins
+			.GroupBy(coin => coin.ScriptPubKey)
 			.OrderByDescending(group => group.Sum(coin => coin.EffectiveValue(feeRate).Satoshi));
 
 		// How much it costs to spend each coin group.

--- a/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
@@ -55,16 +55,16 @@ public static class ChangelessTransactionCoinSelector
 						return coins;
 					}
 
-					return Array.Empty<SmartCoin>();
+					return null;
 				},
 				cancellationToken))
 			.ToArray();
 
 		foreach (var task in tasks)
 		{
-			IReadOnlyList<SmartCoin> smartCoins = await task.ConfigureAwait(false);
+			IReadOnlyList<SmartCoin>? smartCoins = await task.ConfigureAwait(false);
 
-			if (smartCoins.Any())
+			if (smartCoins is not null)
 			{
 				yield return smartCoins;
 			}

--- a/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
@@ -55,16 +55,16 @@ public static class ChangelessTransactionCoinSelector
 						return coins;
 					}
 
-					return null;
+					return Array.Empty<SmartCoin>();
 				},
 				cancellationToken))
 			.ToArray();
 
 		foreach (var task in tasks)
 		{
-			IReadOnlyList<SmartCoin>? smartCoins = await task.ConfigureAwait(false);
+			IReadOnlyList<SmartCoin> smartCoins = await task.ConfigureAwait(false);
 
-			if (smartCoins is not null)
+			if (smartCoins.Any())
 			{
 				yield return smartCoins;
 			}


### PR DESCRIPTION
Co-pilot @Szpoti 

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/10060

Test taken from https://github.com/zkSNACKs/WalletWasabi/pull/10233

BnB should choose coins with same `ScriptPubKey` together and calculates with them as ONE coin. BnB doesn't prioritize them over non-address-reused coins.

All this PR does is making sure to spend the address reused coins together.
Also, improves the tests by a lot.
