### PR TITLE
Use block height from response (take 2)

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -307,9 +307,11 @@ public class ChaumianCoinJoinController : ControllerBase
 					round.RemoveAlicesBy(aliceToRemove);
 				}
 
+				var blockHeight = await RpcClient.GetBlockCountAsync().ConfigureAwait(false);
+
 				foreach (var coin in alice.Inputs)
 				{
-					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, coinAndTxOutResponses[coin].Confirmations, oneHop: false, CancellationToken.None);
+					CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimesout, coinAndTxOutResponses[coin].Confirmations, oneHop: false, currentBlockHeight: blockHeight, CancellationToken.None);
 				}
 
 				round.AddAlice(alice);

--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -134,7 +134,7 @@ public static class BitcoinFactory
 				FeeRate = new FeeRate(Money.Satoshis(5000))
 			});
 
-		// We don't need use the result, but we need to not throw NotImplementedException.
+		// We don't use the result, but we need not to throw NotImplementedException.
 		mockRpc.OnGetBlockCountAsync = () => Task.FromResult(0);
 
 		mockRpc.OnGetTxOutAsync = (_, _, _) => null;

--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -134,6 +134,9 @@ public static class BitcoinFactory
 				FeeRate = new FeeRate(Money.Satoshis(5000))
 			});
 
+		// We don't need use the result, but we need to not throw NotImplementedException.
+		mockRpc.OnGetBlockCountAsync = () => Task.FromResult(0);
+
 		mockRpc.OnGetTxOutAsync = (_, _, _) => null;
 
 		return mockRpc;

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -24,6 +24,7 @@ public class MockRpcClient : IRPCClient
 	public Func<int, EstimateSmartFeeMode, Task<EstimateSmartFeeResponse>>? OnEstimateSmartFeeAsync { get; set; }
 	public Func<Task<PeerInfo[]>>? OnGetPeersInfoAsync { get; set; }
 	public Func<int, BitcoinAddress, Task<uint256[]>>? OnGenerateToAddressAsync { get; set; }
+	public Func<Task<int>>? OnGetBlockCountAsync { get; set; }
 	public Network Network { get; set; } = Network.RegTest;
 	public RPCCredentialString CredentialString => new();
 
@@ -52,7 +53,7 @@ public class MockRpcClient : IRPCClient
 
 	public Task<int> GetBlockCountAsync(CancellationToken cancellationToken = default)
 	{
-		throw new NotImplementedException();
+		return OnGetBlockCountAsync?.Invoke() ?? NotImplementedTask<int>(nameof(GetBlockCountAsync));
 	}
 
 	public Task<uint256> GetBlockHashAsync(int height, CancellationToken cancellationToken = default)

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinVerifierTests.cs
@@ -20,6 +20,8 @@ public class CoinVerifierTests
 
 	private WabiSabiConfig _wabisabiTestConfig = new() { RiskFlags = new List<int>() { 11 } };
 
+	private int _mockBlockchainHeight = 733947; // Same as the example JSON report block height, otherwise we kick out the coin.
+
 	[Fact]
 	public async Task CanHandleBlacklistedUtxosTestAsync()
 	{
@@ -234,7 +236,7 @@ public class CoinVerifierTests
 	{
 		foreach (Coin coin in coins)
 		{
-			coinVerifier.TryScheduleVerification(coin, delayedStart: TimeSpan.Zero, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations, oneHop: false, CancellationToken.None);
+			coinVerifier.TryScheduleVerification(coin, delayedStart: TimeSpan.Zero, confirmations: _wabisabiTestConfig.CoinVerifierRequiredConfirmations, oneHop: false, currentBlockHeight: _mockBlockchainHeight, CancellationToken.None);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -155,9 +155,9 @@ public class CoinVerifier : IAsyncDisposable
 		bool shouldBan = flagIds.Any(id => WabiSabiConfig.RiskFlags.Contains(id));
 
 		// When to remove:
-		bool shouldRemove = shouldBan ||    // If we ban it.
-			!response.Report_info_section.Address_used ||   // If address_used is false (API provider doesn't know about it).
-			blockchainHeightOfCoin > response.Report_info_section.Report_block_height;  // If the report_block_height is less than the block height of the coin. This means that the API provider didn't processed it, yet. On equal or if the report_height is bigger,then the API provider processed that block for sure.
+		bool shouldRemove = shouldBan || // If we ban it.
+			!response.Report_info_section.Address_used || // If address_used is false (API provider doesn't know about it).
+			blockchainHeightOfCoin > response.Report_info_section.Report_block_height; // If the report_block_height is less than the block height of the coin. This means that the API provider didn't processed it, yet. On equal or if the report_height is bigger,then the API provider processed that block for sure.
 
 		return (shouldBan, shouldRemove);
 	}

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -155,9 +155,9 @@ public class CoinVerifier : IAsyncDisposable
 		bool shouldBan = flagIds.Any(id => WabiSabiConfig.RiskFlags.Contains(id));
 
 		// When to remove:
-		bool shouldRemove = shouldBan ||                    // if we ban it OR
-			!response.Report_info_section.Address_used ||   // if address_used is false (API provider doesn't know about it) OR
-			blockchainHeightOfCoin > response.Report_info_section.Report_block_height; // if the report_block_height is less than the block height of the coin. This means that the API provider didn't processed it, yet. On equal or if the report_height is bigger,then the API provider processed that block for sure.
+		bool shouldRemove = shouldBan ||    // If we ban it.
+			!response.Report_info_section.Address_used ||   // If address_used is false (API provider doesn't know about it).
+			blockchainHeightOfCoin > response.Report_info_section.Report_block_height;  // If the report_block_height is less than the block height of the coin. This means that the API provider didn't processed it, yet. On equal or if the report_height is bigger,then the API provider processed that block for sure.
 
 		return (shouldBan, shouldRemove);
 	}

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -252,9 +252,11 @@ public class CoinVerifier : IAsyncDisposable
 
 					var apiResponseItem = await CoinVerifierApiClient.SendRequestAsync(coin.ScriptPubKey, linkedCts.Token).ConfigureAwait(false);
 
-					int blockHeightOfTransaction = currentBlockHeight - (confirmations - 1);
+					// This calculates in which block the coin got into the blockchain.
+					// So we can compare it to the latest block height that the API provider has already processed.
+					int blockchainHeightOfCoin = currentBlockHeight - (confirmations - 1);
 
-					(bool shouldBan, bool shouldRemove) = CheckVerifierResult(apiResponseItem, blockHeightOfTransaction);
+					(bool shouldBan, bool shouldRemove) = CheckVerifierResult(apiResponseItem, blockchainHeightOfCoin);
 
 					// We got a definitive answer.
 					if (shouldBan)

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierLogger.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierLogger.cs
@@ -56,6 +56,7 @@ public class CoinVerifierLogger : IAsyncDisposable
 		if (apiResponseItem is not null)
 		{
 			var reportId = apiResponseItem?.Report_info_section.Report_id;
+			var reportHeight = apiResponseItem?.Report_info_section.Report_block_height.ToString();
 			var reportType = apiResponseItem?.Report_info_section.Report_type;
 			var ids = apiResponseItem?.Cscore_section.Cscore_info?.Select(x => x.Id) ?? Enumerable.Empty<int>();
 			var categories = apiResponseItem?.Cscore_section.Cscore_info.Select(x => x.Name) ?? Enumerable.Empty<string>();
@@ -64,13 +65,14 @@ public class CoinVerifierLogger : IAsyncDisposable
 			var detailsArray = new string[]
 			{
 					reportId ?? "ReportID None",
+					reportHeight ?? "ReportHeight None",
 					reportType ?? "ReportType None",
 					addressUsed ? "Address used" : "Address not used",
 					ids.Any() ? string.Join(' ', ids) : "FlagIds None",
 					categories.Any() ? string.Join(' ', categories) : "Risk categories None"
 			};
 
-			// Separate the different values of the ApiResponseItem with ';', so the details will be one value in the CSV file.
+			// Separate the different values of the ApiResponseItem with '|', so the details will be one value in the CSV file.
 			details = string.Join("|", detailsArray);
 		}
 		else if (exception is not null)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -119,7 +119,19 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 			round.Alices.Add(alice);
 
-			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, confirmations, oneHop: oneHop, cancellationToken);
+			int currentBlockHeight = 0;
+
+			// We need the try-catch block, otherwise the tests will fail.
+			try
+			{
+				currentBlockHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError($"Couldn't get current blockchain height. Exception: {ex}");
+			}
+
+			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, confirmations, oneHop: oneHop, currentBlockHeight, cancellationToken);
 
 			return new(alice.Id,
 				commitAmountCredentialResponse,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -119,17 +119,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
 			round.Alices.Add(alice);
 
-			int currentBlockHeight = 0;
-
-			// We need the try-catch block, otherwise the tests will fail.
-			try
-			{
-				currentBlockHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError($"Couldn't get current blockchain height. Exception: {ex}");
-			}
+			int currentBlockHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
 
 			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, confirmations, oneHop: oneHop, currentBlockHeight, cancellationToken);
 


### PR DESCRIPTION
Explanation of this `blockchainHeight - (confirmations - 1)` with an example:

For simplicity let's say at the time of the input registration request

blockchainHeight = 1000;
confirmations = 4
Report_block_height = 995 (Report_block_height indicates which is the last block the API provider analyzed.)

confirmations = 4 means the coin is in the 997 block.
Since being in the latest block means we are in the 1000 block, but the confirmations would be 1, we need to extract 1 out of the confirmations variable.

So in this example, we would remove the coin, because the coin is in the 997. block, which is bigger than the Report_block_height.