### PR TITLE
[VDG] Confirm recovery words - alphabetical instead of random

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/ConfirmRecoveryWordsViewModel.cs
@@ -73,7 +73,7 @@ public partial class ConfirmRecoveryWordsViewModel : RoutableViewModel
 		AvailableWords =
 			confirmationWordsSourceList.Items
 									   .Select(x => new RecoveryWordViewModel(x.Index, x.Word))
-									   .OrderBy(_ => Random.Shared.Next())
+									   .OrderBy(x => x.Word)
 									   .ToList();
 
 		var availableWordsSourceList = new SourceList<RecoveryWordViewModel>();


### PR DESCRIPTION
Small addition for https://github.com/zkSNACKs/WalletWasabi/pull/9816, that I was not sure about. So this PR is for discussing it too.

IMO it is better to show the words that the user can choose from, in alphabetical order instead of random. With this, the users can find the needed words much quicker.