### PR TITLE
Downgrade warning message to debug

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -213,23 +213,12 @@ public class AliceClient
 		{
 			Logger.LogTrace(e);
 		}
+		catch (Exception e) when (e is HttpRequestException or WabiSabiProtocolException)
+		{
+			Logger.LogDebug($"Unregistration failed for coin '{SmartCoin.Coin.Outpoint}'.", e);
+		}
 		catch (Exception e)
 		{
-			if (e is HttpRequestException && e.InnerException is WabiSabiProtocolException wpe)
-			{
-				switch (wpe.ErrorCode)
-				{
-					case WabiSabiProtocolErrorCode.RoundNotFound:
-						SmartCoin.CoinJoinInProgress = false;
-						Logger.LogInfo($"{SmartCoin.Coin.Outpoint} the round was not found. Nothing to unregister.");
-						break;
-
-					case WabiSabiProtocolErrorCode.WrongPhase:
-						Logger.LogInfo($"{SmartCoin.Coin.Outpoint} could not be unregistered at this phase (too late).");
-						break;
-				}
-			}
-
 			// Log and swallow the exception because there is nothing else that can be done here.
 			Logger.LogWarning($"{SmartCoin.Coin.Outpoint} unregistration failed with {e}.");
 		}


### PR DESCRIPTION
Fixes message in the log.

```
2023-03-18 23:17:29.991 [36] WARNING	AliceClient.TryToUnregisterAlicesAsync (234)	709c87bb14ef0cd40626b687ff01778decb7ecc9dddf8b1541aff67c5fa55a54-264 unregistration failed with WalletWasabi.WabiSabi.Backend.Models.WabiSabiProtocolException: Round (9aef62f13ed28e462c12a42c96ddc9609ec60dfc32a91c94962e5863533f682c): Wrong phase (Ended).
   at WalletWasabi.Tor.Http.Extensions.HttpResponseMessageExtensions.ThrowUnwrapExceptionFromContentAsync(HttpResponseMessage me, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken, Nullable`1 retryTimeout)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendAndReceiveAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken, Nullable`1 retryTimeout)
   at WalletWasabi.WabiSabi.Client.ArenaClient.RemoveInputAsync(uint256 roundId, Guid aliceId, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.RemoveInputAsync(CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.TryToUnregisterAlicesAsync(CancellationToken cancellationToken).
```

According to the log message we did not catch `WabiSabiProtocolException`, thus it was generating a Warning message in the log. WabiSabiProtocolException is OK to have and enough to have Debug level message. 