### PR TITLE
catch OperationCanceledException properly

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -423,7 +423,7 @@ public class CoinJoinClient
 					}
 				}
 			}
-			catch (OperationCanceledException ex)
+			catch (Exception ex) when (ex is OperationCanceledException || (ex is AggregateException ae && ae.Flatten().InnerExceptions.All(e => e is OperationCanceledException)))
 			{
 				if (cancel.IsCancellationRequested)
 				{


### PR DESCRIPTION
When the round load is balanced (or aborted for any reason) the client in input registration will handle the situation correctly. However alarming error message appears in the logs. It seems like the code was not prepared to have `AggregateException` so I added that functionality. 

Fixes:
```
2023-03-18 23:17:29.992 [36] WARNING	CoinJoinClient.CreateRegisterAndConfirmCoinsAsync (452)	System.AggregateException: One or more errors occurred. (The operation was canceled.) (A task was canceled.)
 ---> System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Threading.CancellationToken.ThrowIfCancellationRequested()
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at WalletWasabi.Extensions.StreamExtensions.ReadByteAsync(Stream stream, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ReadRequestResponseAsync(NetworkStream stream, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.SendRequestAsync(TcpClient tcpClient, ByteArraySerializableBase request, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectToDestinationAsync(TcpClient tcpClient, String host, Int32 port, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectAsync(String host, Int32 port, Boolean useSsl, INamedCircuit circuit, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.TorTcpConnectionFactory.ConnectAsync(Uri requestUri, INamedCircuit circuit, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.CreateNewConnectionAsync(Uri requestUri, INamedCircuit circuit, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.ObtainFreeConnectionAsync(Uri requestUri, ICircuit circuit, CancellationToken token)
   at WalletWasabi.Tor.Socks5.Pool.TorHttpPool.SendAsync(HttpRequestMessage request, ICircuit circuit, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at WalletWasabi.Tor.Http.TorHttpClient.SendAsync(HttpMethod method, String relativeUri, HttpContent content, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken, Nullable`1 retryTimeout)
   --- End of inner exception stack trace ---
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken, Nullable`1 retryTimeout)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken, Nullable`1 retryTimeout)
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendAndReceiveAsync[TRequest,TResponse](RemoteAction action, TRequest request, CancellationToken cancellationToken, Nullable`1 retryTimeout)
   at WalletWasabi.WabiSabi.Client.ArenaClient.ConfirmConnectionAsync(uint256 roundId, Guid aliceId, IEnumerable`1 amountsToRequest, IEnumerable`1 vsizesToRequest, IEnumerable`1 amountCredentialsToPresent, IEnumerable`1 vsizeCredentialsToPresent, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.TryConfirmConnectionAsync(IEnumerable`1 amountsToRequest, IEnumerable`1 vsizesToRequest, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.ConfirmConnectionAsync(RoundStateUpdater roundStatusUpdater, CancellationToken cancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken)
   at WalletWasabi.WabiSabi.Client.AliceClient.CreateRegisterAndConfirmInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, RoundStateUpdater roundStatusUpdater, CancellationToken unregisterCancellationToken, CancellationToken registrationCancellationToken, CancellationToken confirmationCancellationToken)
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass55_0.<<CreateRegisterAndConfirmCoinsAsync>g__RegisterInputAsync|0>d.MoveNext()
 ---> (Inner Exception #1) System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync(RemoteAction action, String jsonString, CancellationToken cancellationToken, Nullable`1 retryTimeout)<---
2023-03-18 23:17:29.993 [36] INFO	CoinJoinClient.StartRoundAsync (268)	Round (9aef62f13ed28e462c12a42c96ddc9609ec60dfc32a91c94962e5863533f682c): Aborted. Load balancing registrations.
```