### PR TITLE
[VDG] Make error messages more user friendly

### DIFF
--- a/WalletWasabi.Fluent/Extensions/FriendlyExceptionMessageExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/FriendlyExceptionMessageExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
@@ -24,6 +25,11 @@ public static class FriendlyExceptionMessageExtensions
 		if (ex is HwiException hwiEx)
 		{
 			return GetFriendlyHwiExceptionMessage(hwiEx);
+		}
+
+		if (ex is HttpRequestException httpEx)
+		{
+			return  $"An unexpected network error occured.\n{httpEx}\nTry again.";
 		}
 
 		foreach (KeyValuePair<string, string> pair in RpcErrorTools.ErrorTranslations)

--- a/WalletWasabi.Fluent/Extensions/FriendlyExceptionMessageExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/FriendlyExceptionMessageExtensions.cs
@@ -6,7 +6,7 @@ using WalletWasabi.Hwi.Exceptions;
 
 namespace WalletWasabi.Fluent.Extensions;
 
-public static class UserFriendlyExceptionExtensions
+public static class FriendlyExceptionMessageExtensions
 {
 	public static string ToUserFriendlyString(this Exception ex)
 	{

--- a/WalletWasabi.Fluent/Extensions/UserFriendlyExceptionExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/UserFriendlyExceptionExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Extensions;
+using WalletWasabi.Helpers;
+using WalletWasabi.Hwi.Exceptions;
+
+namespace WalletWasabi.Fluent.Extensions;
+
+public static class UserFriendlyExceptionExtensions
+{
+	public static string ToUserFriendlyString(this Exception ex)
+	{
+		var trimmed = Guard.Correct(ex.Message);
+		if (trimmed.Length == 0)
+		{
+			return ex.ToTypeMessageString();
+		}
+		else
+		{
+			if (ex is OperationCanceledException exception)
+			{
+				return exception.Message;
+			}
+			else if (ex is HwiException hwiEx)
+			{
+				if (hwiEx.ErrorCode == HwiErrorCode.DeviceConnError)
+				{
+					return "Could not find the hardware wallet.\nMake sure it is connected.";
+				}
+				else if (hwiEx.ErrorCode == HwiErrorCode.ActionCanceled)
+				{
+					return "The transaction was canceled on the device.";
+				}
+				else if (hwiEx.ErrorCode == HwiErrorCode.UnknownError)
+				{
+					return "Unknown error.\nMake sure the device is connected and isn't busy, then try again.";
+				}
+			}
+
+			foreach (KeyValuePair<string, string> pair in RpcErrorTools.ErrorTranslations)
+			{
+				if (trimmed.Contains(pair.Key, StringComparison.InvariantCultureIgnoreCase))
+				{
+					return pair.Value;
+				}
+			}
+
+			return ex.ToTypeMessageString();
+		}
+	}
+}

--- a/WalletWasabi.Fluent/Extensions/UserFriendlyExceptionExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/UserFriendlyExceptionExtensions.cs
@@ -15,37 +15,36 @@ public static class UserFriendlyExceptionExtensions
 		{
 			return ex.ToTypeMessageString();
 		}
-		else
+
+		if (ex is OperationCanceledException exception)
 		{
-			if (ex is OperationCanceledException exception)
-			{
-				return exception.Message;
-			}
-			else if (ex is HwiException hwiEx)
-			{
-				if (hwiEx.ErrorCode == HwiErrorCode.DeviceConnError)
-				{
-					return "Could not find the hardware wallet.\nMake sure it is connected.";
-				}
-				else if (hwiEx.ErrorCode == HwiErrorCode.ActionCanceled)
-				{
-					return "The transaction was canceled on the device.";
-				}
-				else if (hwiEx.ErrorCode == HwiErrorCode.UnknownError)
-				{
-					return "Unknown error.\nMake sure the device is connected and isn't busy, then try again.";
-				}
-			}
-
-			foreach (KeyValuePair<string, string> pair in RpcErrorTools.ErrorTranslations)
-			{
-				if (trimmed.Contains(pair.Key, StringComparison.InvariantCultureIgnoreCase))
-				{
-					return pair.Value;
-				}
-			}
-
-			return ex.ToTypeMessageString();
+			return exception.Message;
 		}
+
+		if (ex is HwiException hwiEx)
+		{
+			return GetFriendlyHwiExceptionMessage(hwiEx);
+		}
+
+		foreach (KeyValuePair<string, string> pair in RpcErrorTools.ErrorTranslations)
+		{
+			if (trimmed.Contains(pair.Key, StringComparison.InvariantCultureIgnoreCase))
+			{
+				return pair.Value;
+			}
+		}
+
+		return ex.ToTypeMessageString();
+	}
+
+	private static string GetFriendlyHwiExceptionMessage(HwiException hwiEx)
+	{
+		return hwiEx.ErrorCode switch
+		{
+			HwiErrorCode.DeviceConnError => "Could not find the hardware wallet.\nMake sure it is connected.",
+			HwiErrorCode.ActionCanceled => "The transaction was canceled on the device.",
+			HwiErrorCode.UnknownError => "Unknown error.\nMake sure the device is connected and isn't busy, then try again.",
+			_ => hwiEx.Message
+		};
 	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/Address.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/Address.cs
@@ -6,7 +6,7 @@ using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Hwi;
 using WalletWasabi.Logging;
 

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
@@ -4,7 +4,7 @@ using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using ReactiveUI;
-using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using ReactiveUI;
 using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Helpers;
 using WalletWasabi.Hwi.Models;

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/WalletNamePageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/WalletNamePageViewModel.cs
@@ -12,7 +12,7 @@ using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Helpers;
 using NBitcoin;
-using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 
 namespace WalletWasabi.Fluent.ViewModels.AddWallet;
 

--- a/WalletWasabi.Fluent/ViewModels/TransactionBroadcasting/LoadTransactionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/TransactionBroadcasting/LoadTransactionViewModel.cs
@@ -7,6 +7,7 @@ using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Logging;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/HardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/HardwareWalletViewModel.cs
@@ -1,5 +1,5 @@
 using ReactiveUI;
-using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.ViewModels.TransactionBroadcasting;
 using WalletWasabi.Logging;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressViewModel.cs
@@ -11,7 +11,7 @@ using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Extensions;
+using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Hwi;
 using WalletWasabi.Logging;

--- a/WalletWasabi/Extensions/ExceptionExtensions.cs
+++ b/WalletWasabi/Extensions/ExceptionExtensions.cs
@@ -26,47 +26,6 @@ public static class ExceptionExtensions
 		}
 	}
 
-	public static string ToUserFriendlyString(this Exception ex)
-	{
-		var trimmed = Guard.Correct(ex.Message);
-		if (trimmed.Length == 0)
-		{
-			return ex.ToTypeMessageString();
-		}
-		else
-		{
-			if (ex is OperationCanceledException exception)
-			{
-				return exception.Message;
-			}
-			else if (ex is HwiException hwiEx)
-			{
-				if (hwiEx.ErrorCode == HwiErrorCode.DeviceConnError)
-				{
-					return "Could not find the hardware wallet.\nMake sure it is connected.";
-				}
-				else if (hwiEx.ErrorCode == HwiErrorCode.ActionCanceled)
-				{
-					return "The transaction was canceled on the device.";
-				}
-				else if (hwiEx.ErrorCode == HwiErrorCode.UnknownError)
-				{
-					return "Unknown error.\nMake sure the device is connected and isn't busy, then try again.";
-				}
-			}
-
-			foreach (KeyValuePair<string, string> pair in RpcErrorTools.ErrorTranslations)
-			{
-				if (trimmed.Contains(pair.Key, StringComparison.InvariantCultureIgnoreCase))
-				{
-					return pair.Value;
-				}
-			}
-
-			return ex.ToTypeMessageString();
-		}
-	}
-
 	public static SerializableException ToSerializableException(this Exception ex)
 	{
 		return new SerializableException(ex);


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9907

This PR moves `ToUserFriendlyString()` method to the UI side, as all the references were from the UI and this is more like a UI concept than a business. 
The actual fix is [this commit](https://github.com/zkSNACKs/WalletWasabi/commit/c10c924cb86a1d6fce6b8b7b55b9be5061bd1d34). Basically, just adjust the message to be more friendly. (I am not even sure if the exception message is needed though).
The idea is to slowly add more and more exceptions here and thus the error dialogs can give messages that are understandable for nontech guys.