### PR TITLE
`HttpContentExtensions`: Cleanup + `CoinVerifierApiClient` cleanup

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/Http/Extensions/HttpContentExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Http/Extensions/HttpContentExtensionsTests.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json;
+using System.Net.Http;
+using System.Threading.Tasks;
+using WalletWasabi.Tor.Http.Extensions;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Tor.Http.Extensions;
+
+/// <summary>
+/// Tests for <see cref="HttpContentExtensions"/>.
+/// </summary>
+public class HttpContentExtensionsTests
+{
+	[Fact]
+	public async Task ReadAsJsonAsync()
+	{
+		// null is valid JSON value but we are interested only in deserialized objects that are non-null.
+		{
+			using StringContent content = new(content: "null");
+			await Assert.ThrowsAsync<InvalidOperationException>(content.ReadAsJsonAsync<TestClass>);
+		}
+
+		// Invalid JSON. We should throw an exception that inherits from `JsonException`.
+		{
+			using StringContent content = new(content: """{ "property" : error-here """);
+			await Assert.ThrowsAnyAsync<JsonException>(content.ReadAsJsonAsync<TestClass>);
+		}
+	}
+
+	private class TestClass
+	{
+		[JsonProperty(PropertyName = "blockHeight")]
+		public int BlockHeight { get; set; }
+	}
+}

--- a/WalletWasabi/Tor/Http/Extensions/HttpContentExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpContentExtensions.cs
@@ -8,19 +8,17 @@ namespace WalletWasabi.Tor.Http.Extensions;
 
 public static class HttpContentExtensions
 {
+	private static JsonSerializerSettings Settings = new()
+	{
+		Converters = new[] { new RoundStateResponseJsonConverter(WasabiClient.ApiVersion) }
+	};
+
+	/// <exception cref="JsonException">If JSON deserialization fails for any reason.</exception>
+	/// <exception cref="InvalidOperationException">If the JSON string is <c>"null"</c> (valid value but forbiden in this implementation).</exception>
 	public static async Task<T> ReadAsJsonAsync<T>(this HttpContent me)
 	{
-		if (me is null)
-		{
-			throw new ArgumentNullException(nameof(me));
-		}
-
-		var settings = new JsonSerializerSettings
-		{
-			Converters = new[] { new RoundStateResponseJsonConverter(WasabiClient.ApiVersion) }
-		};
 		var jsonString = await me.ReadAsStringAsync().ConfigureAwait(false);
-		return JsonConvert.DeserializeObject<T>(jsonString, settings)
-			?? throw new InvalidOperationException($"Deserialization failed. Received json: {jsonString}");
+		return JsonConvert.DeserializeObject<T>(jsonString, Settings)
+			?? throw new InvalidOperationException("'null' is forbidden.");
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
@@ -73,7 +73,7 @@ public class CoinVerifierApiClient : IAsyncDisposable
 				var duration = DateTimeOffset.UtcNow - before;
 				RequestTimeStatista.Instance.Add("verifier-request", duration);
 
-				if (response is { } && response.StatusCode == HttpStatusCode.OK)
+				if (response.StatusCode == HttpStatusCode.OK)
 				{
 					// Successful request, break the iteration.
 					break;

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs
@@ -1,10 +1,10 @@
 using NBitcoin;
-using Newtonsoft.Json;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
+using WalletWasabi.Tor.Http.Extensions;
 using WalletWasabi.WabiSabi.Backend.Statistics;
 
 namespace WalletWasabi.WabiSabi.Backend.Banning;
@@ -78,10 +78,8 @@ public class CoinVerifierApiClient : IAsyncDisposable
 					// Successful request, break the iteration.
 					break;
 				}
-				else
-				{
-					throw new InvalidOperationException($"Response was either null or response.{nameof(HttpStatusCode)} was {response?.StatusCode.ToString() ?? "Null"}.");
-				}
+
+				throw new InvalidOperationException($"HTTP status code was {response.StatusCode}.");
 			}
 			catch (OperationCanceledException)
 			{
@@ -95,7 +93,7 @@ public class CoinVerifierApiClient : IAsyncDisposable
 			}
 		}
 
-		// Throw proper exceptions - if needed - according to the latest response.
+		// Handle the HTTP response, if there is any.
 		if (response?.StatusCode == HttpStatusCode.Forbidden)
 		{
 			throw new UnauthorizedAccessException("User roles access forbidden.");
@@ -105,11 +103,7 @@ public class CoinVerifierApiClient : IAsyncDisposable
 			throw new InvalidOperationException($"API request failed. {nameof(HttpStatusCode)} was {response?.StatusCode}.");
 		}
 
-		string responseString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-
-		ApiResponseItem deserializedRecord = JsonConvert.DeserializeObject<ApiResponseItem>(responseString)
-			?? throw new JsonSerializationException($"Failed to deserialize API response, response string was: '{responseString}'");
-		return deserializedRecord;
+		return await response.Content.ReadAsJsonAsync<ApiResponseItem>().ConfigureAwait(false);
 	}
 
 	/// <inheritdoc/>


### PR DESCRIPTION
This PR is an alternative to #10310 and pulls the good parts from that PR.

If the PR is merged, the next step should be to move `HttpContentExtensions` out of `WalletWasabi.Tor.Http.Extensions` namespace to a better one (e.g. `WalletWasabi.Http.Extensions`)