### PR TITLE
[Trivial] Remove type specification

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -760,7 +760,7 @@ public class CoinJoinClient
 
 			var sw2 = Stopwatch.StartNew();
 			foreach (var group in orderedAllowedCoins
-				.Except(new TCoin[] { coin })
+				.Except(new[] { coin })
 				.CombinationsWithoutRepetition(inputCount - 1)
 				.Select(x => x.Concat(new[] { coin })))
 			{


### PR DESCRIPTION
This is useless as coin is already a `TCoin`, 2 lines after there's the same code where `TCoin` is not specified.