### PR TITLE
Make sure to filter affiliated info for remixes

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Affiliation/RoundDataTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Affiliation/RoundDataTests.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using WalletWasabi.Affiliation;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
+using Xunit;
+using System.Linq;
+
+namespace WalletWasabi.Tests.UnitTests.Affiliation;
+
+public class RoundDataTests
+{
+	[Fact]
+	public void DoNotShareAffiliationOfRemixes()
+	{
+		var roundData = new RoundData(WabiSabiFactory.CreateRoundParameters(new WabiSabiConfig()));
+		var unmixedCoin = WabiSabiFactory.CreateCoin(amount: Money.Coins(1));
+		var mixedCoin = WabiSabiFactory.CreateCoin(amount: Money.Coins(3));
+
+		roundData.AddInputCoin(unmixedCoin, isCoordinationFeeExempted: false);
+		roundData.AddInputCoin(mixedCoin, isCoordinationFeeExempted: true);
+		roundData.AddInputAffiliationId(unmixedCoin, "bluewallet");
+		roundData.AddInputAffiliationId(mixedCoin, "bluewallet");
+
+		var cj = Network.Main.CreateTransaction();
+		cj.Inputs.Add(unmixedCoin.Outpoint);
+		cj.Inputs.Add(mixedCoin.Outpoint);
+		cj.Outputs.Add(Money.Coins(2.9999M), BitcoinFactory.CreateScript());
+
+		var transactionData = roundData.FinalizeRoundData(cj);
+		var txNotificationForBlueWallet = transactionData.GetAffiliationData("bluewallet");
+		var reportedAffiliatedCoin = Assert.Single(txNotificationForBlueWallet.Inputs.Where(x => x.IsAffiliated));
+
+		Assert.Equal(unmixedCoin.Outpoint.Hash.ToBytes(), reportedAffiliatedCoin.Prevout.Hash);
+		Assert.Equal(unmixedCoin.Outpoint.N, reportedAffiliatedCoin.Prevout.Index);
+
+		var txNotificationForUnknownWallet = transactionData.GetAffiliationData("unknown");
+		Assert.Empty(txNotificationForUnknownWallet.Inputs.Where(x => x.IsAffiliated));
+	}
+}

--- a/WalletWasabi/Affiliation/Models/CoinjoinNotification/Input.cs
+++ b/WalletWasabi/Affiliation/Models/CoinjoinNotification/Input.cs
@@ -16,7 +16,7 @@ public record Input(Outpoint Prevout, byte[] ScriptPubkey, bool IsAffiliated, bo
 		return new(
 			Outpoint.FromOutPoint(affiliateInput.Prevout),
 			affiliateInput.ScriptPubKey.ToBytes(),
-			isAffiliated,
+			isAffiliated && !affiliateInput.IsNoFee,
 			affiliateInput.IsNoFee);
 	}
 }


### PR DESCRIPTION
This PR adds an extra mechanism for ensuring no affiliation info is attached to inputs that pay no fee.