### PR TITLE
[Deepsource] Don't compare against empty string

### DIFF
--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircuitInfo.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircuitInfo.cs
@@ -64,7 +64,7 @@ public record CircuitInfo
 		List<CircPath> circPaths = new();
 
 		// Optional arguments.
-		while (remainder != "")
+		while (!string.IsNullOrWhiteSpace(remainder))
 		{
 			// Read <PATH>.
 			if (remainder.StartsWith("$", StringComparison.Ordinal))

--- a/WalletWasabi/Tor/Control/Messages/Events/OrEvents/OrConnEvent.cs
+++ b/WalletWasabi/Tor/Control/Messages/Events/OrEvents/OrConnEvent.cs
@@ -51,7 +51,7 @@ public class OrConnEvent : IAsyncEvent
 		orStatus = Tokenizer.ParseEnumValue(value, OrStatus.UNKNOWN);
 
 		// Optional arguments.
-		while (remainder != "")
+		while (!string.IsNullOrWhiteSpace(remainder))
 		{
 			string key;
 			(key, value, remainder) = Tokenizer.ReadKeyValueAssignment(remainder, allowValueAsQuotedString: true);

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamInfo.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamInfo.cs
@@ -174,7 +174,7 @@ public record StreamInfo
 
 			if (key == "ISO_FIELDS")
 			{
-				if (value != "")
+				if (!string.IsNullOrWhiteSpace(value))
 				{
 					string[] flags = value.Split(',');
 					isoFields = flags.Select(x => Tokenizer.ParseEnumValue(x, IsoFieldFlag.UNKNOWN)).ToList();

--- a/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamInfo.cs
+++ b/WalletWasabi/Tor/Control/Messages/StreamStatus/StreamInfo.cs
@@ -124,7 +124,7 @@ public record StreamInfo
 		List<IsoFieldFlag> isoFields = new();
 
 		// Optional arguments.
-		while (remainder != "")
+		while (!string.IsNullOrWhiteSpace(remainder))
 		{
 			if (remainder.StartsWith("SOURCE=", StringComparison.Ordinal))
 			{

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -335,7 +335,7 @@ public class TorControlClient : IAsyncDisposable
 
 		if (sendCommand)
 		{
-			string command = subscribedEventNames == "" ? "SETEVENTS\r\n" : $"SETEVENTS {subscribedEventNames}\r\n";
+			string command = string.IsNullOrWhiteSpace(subscribedEventNames) ? "SETEVENTS\r\n" : $"SETEVENTS {subscribedEventNames}\r\n";
 			TorControlReply reply = await SendCommandNoLockAsync(command, cancellationToken).ConfigureAwait(false);
 
 			if (!reply.Success)

--- a/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
+++ b/WalletWasabi/Tor/Control/Utils/Tokenizer.cs
@@ -13,7 +13,7 @@ public static class Tokenizer
 	/// </summary>
 	public static (string token, string remainder) ReadUntilSeparator(string input)
 	{
-		if (input == "")
+		if (string.IsNullOrWhiteSpace(input))
 		{
 			throw new TorControlReplyParseException("Expected a token.");
 		}
@@ -73,7 +73,7 @@ public static class Tokenizer
 		input = ReadExactString("=", input);
 		(string value, string remainder) = ReadQuotedString(input);
 
-		if (remainder != "")
+		if (!string.IsNullOrWhiteSpace(remainder))
 		{
 			remainder = remainder[1..];
 		}


### PR DESCRIPTION
According to Deepsource:

> Comparing a string against an empty string literal is valid and is the preferred way in languages such as Go and Python. In C# however, it is recommended that you use the convenience methods such as string.IsNullOrWhiteSpace or string.IsNullOrEmpty as they offer slightly better performance when compared to other traditional/naive implementations.

I was able to do CJs, so the original behavior shouldn't change with this PR.


Here is a dotnet Fiddle link where I made sure that `string.IsNullOrWhiteSpace` also checks for empty strings:

https://dotnetfiddle.net/nMLHiB

_@kiminuo Feel free to close this PR if you think this doesn't add value to the codebase or if it makes the code harder to read._