### PR TITLE
Simplify LINQ calls

### DIFF
--- a/WalletWasabi.Packager/ArgsProcessor.cs
+++ b/WalletWasabi.Packager/ArgsProcessor.cs
@@ -49,7 +49,7 @@ public class ArgsProcessor
 
 		try
 		{
-			var appleidArg = Args.Where(a => a.Contains("appleid", StringComparison.InvariantCultureIgnoreCase)).First();
+			var appleidArg = Args.First(a => a.Contains("appleid", StringComparison.InvariantCultureIgnoreCase));
 			var parameters = appleidArg.Split("=")[1];
 			var idAndPassword = parameters.Split(":");
 			appleId = idAndPassword[0];

--- a/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/CoinjoinAnalyzer.cs
@@ -73,12 +73,12 @@ public class CoinjoinAnalyzer
 		IEnumerable<WalletVirtualOutput> walletVirtualOutputs = transaction.WalletVirtualOutputs;
 		IEnumerable<ForeignVirtualOutput> foreignVirtualOutputs = transaction.ForeignVirtualOutputs;
 
-		Money amount = walletVirtualOutputs.Where(o => o.Coins.Select(c => c.Outpoint).Contains(transactionOutput.Outpoint)).First().Amount;
+		Money amount = walletVirtualOutputs.First(o => o.Coins.Select(c => c.Outpoint).Contains(transactionOutput.Outpoint)).Amount;
 		bool IsRelevantVirtualOutput(ForeignVirtualOutput output) => relevantOutpoints is null || relevantOutpoints.Intersect(output.OutPoints).Any();
 
 		// Count the outputs that have the same value as our transactionOutput.
-		var equalValueWalletVirtualOutputCount = walletVirtualOutputs.Where(o => o.Amount == amount).Count();
-		var equalValueForeignRelevantVirtualOutputCount = foreignVirtualOutputs.Where(o => o.Amount == amount).Where(IsRelevantVirtualOutput).Count();
+		var equalValueWalletVirtualOutputCount = walletVirtualOutputs.Count(o => o.Amount == amount);
+		var equalValueForeignRelevantVirtualOutputCount = foreignVirtualOutputs.Count(o => o.Amount == amount && IsRelevantVirtualOutput(o));
 
 		// The anonymity set should increase by the number of equal-valued foreign outputs.
 		// If we have multiple equal-valued wallet outputs, then we divide the increase evenly between them.

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -186,8 +186,8 @@ public class UpdateManager : IDisposable
 			assetDownloadUrls.Add(asset["browser_download_url"]?.ToString() ?? throw new InvalidDataException("Missing download url from response."));
 		}
 
-		string sha256SumsUrl = assetDownloadUrls.Where(url => url.Contains("SHA256SUMS.asc")).First();
-		string wasabiSigUrl = assetDownloadUrls.Where(url => url.Contains("SHA256SUMS.wasabisig")).First();
+		string sha256SumsUrl = assetDownloadUrls.First(url => url.Contains("SHA256SUMS.asc"));
+		string wasabiSigUrl = assetDownloadUrls.First(url => url.Contains("SHA256SUMS.wasabisig"));
 
 		(string url, string fileName) = GetAssetToDownload(assetDownloadUrls);
 
@@ -239,7 +239,7 @@ public class UpdateManager : IDisposable
 	{
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
-			var url = urls.Where(url => url.Contains(".msi")).First();
+			var url = urls.First(url => url.Contains(".msi"));
 			return (url, url.Split("/").Last());
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -247,10 +247,10 @@ public class UpdateManager : IDisposable
 			var cpu = RuntimeInformation.ProcessArchitecture;
 			if (cpu.ToString() == "Arm64")
 			{
-				var arm64url = urls.Where(url => url.Contains("arm64.dmg")).First();
+				var arm64url = urls.First(url => url.Contains("arm64.dmg"));
 				return (arm64url, arm64url.Split("/").Last());
 			}
-			var url = urls.Where(url => url.Contains(".dmg") && !url.Contains("arm64")).First();
+			var url = urls.First(url => url.Contains(".dmg") && !url.Contains("arm64"));
 			return (url, url.Split("/").Last());
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
`First()` and `Count()` accept predicates, so we can drop the `Where()` part and move the predicates right into those calls.