### PR TITLE
Don't wait indefinitely for a Round

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -81,13 +81,13 @@ public class CoinJoinClient
 	private bool RedCoinIsolation { get; }
 	private int SemiPrivateThreshold { get; }
 	private TimeSpan FeeRateMedianTimeFrame { get; }
-	private TimeSpan MaxWaitingTimeSpanForRound { get; } = TimeSpan.FromMinutes(10);
+	private TimeSpan MaxWaitingTimeForRound { get; } = TimeSpan.FromMinutes(10);
 
 	private async Task<RoundState> WaitForRoundAsync(uint256 excludeRound, CancellationToken token)
 	{
 		CoinJoinClientProgress.SafeInvoke(this, new WaitingForRound());
 
-		using CancellationTokenSource cts = new(MaxWaitingTimeSpanForRound);
+		using CancellationTokenSource cts = new(MaxWaitingTimeForRound);
 		using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, cts.Token);
 
 		return await RoundStatusUpdater


### PR DESCRIPTION
Edit:

~The idea here is to break the `WaitForRoundAsync` call, which can wait for a long time as described in the issue.~

> The economy profile could wait for a coinjoin hours/days or even a week according to the user's selection. During this period, coins could confirm, got unbanned, or generally change state.

~By breaking out of the `WaitForRoundAsync` with an `OperationCancelledException`, we force the `CoinJoinManager` to re-build the `CoinJoinTracker` class,
and more importantly to update the coin candidates.~

Just don't wait indefinitely.
This can be still useful IMO.
