### PR TITLE
Change HdPubKey Labels after Transaction is sent

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -442,7 +442,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				var finalTransaction =
 					await GetFinalTransactionAsync(transactionAuthorizationInfo.Transaction, _info);
 				await SendTransactionAsync(finalTransaction);
-				_wallet.UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithLabels);
+				_wallet.UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithNewLabels);
 				_cancellationTokenSource?.Cancel();
 				Navigate().To(new SendSuccessViewModel(_wallet, finalTransaction));
 			}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -442,7 +442,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				var finalTransaction =
 					await GetFinalTransactionAsync(transactionAuthorizationInfo.Transaction, _info);
 				await SendTransactionAsync(finalTransaction);
-				UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithLabels);
+				_wallet.UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithLabels);
 				_cancellationTokenSource?.Cancel();
 				Navigate().To(new SendSuccessViewModel(_wallet, finalTransaction));
 			}
@@ -456,14 +456,6 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			}
 
 			IsBusy = false;
-		}
-	}
-
-	private void UpdateUsedHdPubKeysLabels(Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels)
-	{
-		foreach (var item in hdPubKeysWithLabels)
-		{
-			item.Key.SetLabel(item.Value);
 		}
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using NBitcoin;
 using ReactiveUI;
+using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
@@ -440,6 +442,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				var finalTransaction =
 					await GetFinalTransactionAsync(transactionAuthorizationInfo.Transaction, _info);
 				await SendTransactionAsync(finalTransaction);
+				UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithLabels);
 				_cancellationTokenSource?.Cancel();
 				Navigate().To(new SendSuccessViewModel(_wallet, finalTransaction));
 			}
@@ -453,6 +456,14 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			}
 
 			IsBusy = false;
+		}
+	}
+
+	private void UpdateUsedHdPubKeysLabels(Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels)
+	{
+		foreach (var item in hdPubKeysWithLabels)
+		{
+			item.Key.SetLabel(item.Value);
 		}
 	}
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -80,6 +80,9 @@ public class TransactionFactoryTests
 
 		var changeCoin = Assert.Single(result.InnerWalletOutputs);
 		Assert.True(changeCoin.HdPubKey.IsInternal);
+
+		var changeCoinAndLabelPair = result.HdPubKeysWithLabels.First(x => x.Key == changeCoin.HdPubKey);
+		Assert.Equal("Sophie", changeCoinAndLabelPair.Value);
 	}
 
 	[Fact]
@@ -107,6 +110,9 @@ public class TransactionFactoryTests
 
 		var changeCoin = Assert.Single(result.InnerWalletOutputs);
 		Assert.True(changeCoin.HdPubKey.IsInternal);
+
+		var changeCoinAndLabelPair = result.HdPubKeysWithLabels.First(x => x.Key == changeCoin.HdPubKey);
+		Assert.Equal("Joseph, Sophie", changeCoinAndLabelPair.Value);
 	}
 
 	[Fact]
@@ -164,6 +170,8 @@ public class TransactionFactoryTests
 		Assert.Equal(Money.Coins(0.14m), result.SpentCoins.Select(x => x.Amount).Sum());
 
 		var changeCoin = Assert.Single(result.InnerWalletOutputs);
+		var changeCoinAndLabelPair = result.HdPubKeysWithLabels.First(x => x.Key == changeCoin.HdPubKey);
+		Assert.Equal("Daniel, Maria, Sophie", changeCoinAndLabelPair.Value);
 
 		var tx = result.Transaction.Transaction;
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -81,7 +81,7 @@ public class TransactionFactoryTests
 		var changeCoin = Assert.Single(result.InnerWalletOutputs);
 		Assert.True(changeCoin.HdPubKey.IsInternal);
 
-		var changeCoinAndLabelPair = result.HdPubKeysWithLabels.First(x => x.Key == changeCoin.HdPubKey);
+		var changeCoinAndLabelPair = result.HdPubKeysWithNewLabels.First(x => x.Key == changeCoin.HdPubKey);
 		Assert.Equal("Sophie", changeCoinAndLabelPair.Value);
 	}
 
@@ -111,7 +111,7 @@ public class TransactionFactoryTests
 		var changeCoin = Assert.Single(result.InnerWalletOutputs);
 		Assert.True(changeCoin.HdPubKey.IsInternal);
 
-		var changeCoinAndLabelPair = result.HdPubKeysWithLabels.First(x => x.Key == changeCoin.HdPubKey);
+		var changeCoinAndLabelPair = result.HdPubKeysWithNewLabels.First(x => x.Key == changeCoin.HdPubKey);
 		Assert.Equal("Joseph, Sophie", changeCoinAndLabelPair.Value);
 	}
 
@@ -170,7 +170,7 @@ public class TransactionFactoryTests
 		Assert.Equal(Money.Coins(0.14m), result.SpentCoins.Select(x => x.Amount).Sum());
 
 		var changeCoin = Assert.Single(result.InnerWalletOutputs);
-		var changeCoinAndLabelPair = result.HdPubKeysWithLabels.First(x => x.Key == changeCoin.HdPubKey);
+		var changeCoinAndLabelPair = result.HdPubKeysWithNewLabels.First(x => x.Key == changeCoin.HdPubKey);
 		Assert.Equal("Daniel, Maria, Sophie", changeCoinAndLabelPair.Value);
 
 		var tx = result.Transaction.Transaction;

--- a/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
@@ -10,14 +10,14 @@ namespace WalletWasabi.Blockchain.TransactionBuilding;
 
 public class BuildTransactionResult
 {
-	public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent, Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels)
+	public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent, Dictionary<HdPubKey, SmartLabel> hdPubKeysWithNewLabels)
 	{
 		Transaction = transaction;
 		Psbt = psbt;
 		Signed = signed;
 		Fee = fee;
 		FeePercentOfSent = feePercentOfSent;
-		HdPubKeysWithLabels = hdPubKeysWithLabels;
+		HdPubKeysWithNewLabels = hdPubKeysWithNewLabels;
 	}
 
 	public SmartTransaction Transaction { get; }
@@ -30,7 +30,7 @@ public class BuildTransactionResult
 	public IEnumerable<SmartCoin> InnerWalletOutputs => Transaction.WalletOutputs;
 	public IEnumerable<SmartCoin> SpentCoins => Transaction.WalletInputs;
 
-	public Dictionary<HdPubKey, SmartLabel> HdPubKeysWithLabels { get; }
+	public Dictionary<HdPubKey, SmartLabel> HdPubKeysWithNewLabels { get; }
 
 	public IEnumerable<Coin> OuterWalletOutputs
 	{

--- a/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
@@ -1,6 +1,8 @@
 using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
+using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 
@@ -8,13 +10,14 @@ namespace WalletWasabi.Blockchain.TransactionBuilding;
 
 public class BuildTransactionResult
 {
-	public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent)
+	public BuildTransactionResult(SmartTransaction transaction, PSBT psbt, bool signed, Money fee, decimal feePercentOfSent, Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels)
 	{
 		Transaction = transaction;
 		Psbt = psbt;
 		Signed = signed;
 		Fee = fee;
 		FeePercentOfSent = feePercentOfSent;
+		HdPubKeysWithLabels = hdPubKeysWithLabels;
 	}
 
 	public SmartTransaction Transaction { get; }
@@ -27,6 +30,7 @@ public class BuildTransactionResult
 	public IEnumerable<SmartCoin> InnerWalletOutputs => Transaction.WalletOutputs;
 	public IEnumerable<SmartCoin> SpentCoins => Transaction.WalletInputs;
 
+	public Dictionary<HdPubKey, SmartLabel> HdPubKeysWithLabels { get;}
 	public IEnumerable<Coin> OuterWalletOutputs
 	{
 		get

--- a/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
@@ -30,7 +30,8 @@ public class BuildTransactionResult
 	public IEnumerable<SmartCoin> InnerWalletOutputs => Transaction.WalletOutputs;
 	public IEnumerable<SmartCoin> SpentCoins => Transaction.WalletInputs;
 
-	public Dictionary<HdPubKey, SmartLabel> HdPubKeysWithLabels { get;}
+	public Dictionary<HdPubKey, SmartLabel> HdPubKeysWithLabels { get; }
+
 	public IEnumerable<Coin> OuterWalletOutputs
 	{
 		get

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -252,6 +252,7 @@ public class TransactionFactory
 				smartTransaction.TryAddWalletOutput(smartCoin);
 			}
 		}
+		Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels = new();
 
 		foreach (var coin in smartTransaction.WalletOutputs)
 		{
@@ -261,18 +262,18 @@ public class TransactionFactory
 			// The foundkeylabel has already been added previously, so no need to concatenate.
 			if (foundPaymentRequest is null) // Then it's autochange.
 			{
-				coin.HdPubKey.SetLabel(label);
+				hdPubKeysWithLabels.Add(coin.HdPubKey, label);
 			}
 			else
 			{
-				coin.HdPubKey.SetLabel(SmartLabel.Merge(coin.HdPubKey.Label, foundPaymentRequest.Label));
+				hdPubKeysWithLabels.Add(coin.HdPubKey, SmartLabel.Merge(coin.HdPubKey.Label, foundPaymentRequest.Label));
 			}
 		}
 
 		Logger.LogDebug($"Built tx: {totalOutgoingAmountNoFee.ToString(fplus: false, trimExcessZero: true)} BTC. Fee: {fee.Satoshi} sats. Vsize: {vSize} vBytes. Fee/Total ratio: {feePercentage:0.#}%. Tx hash: {tx.GetHash()}.");
 
 		var sign = !KeyManager.IsWatchOnly;
-		return new BuildTransactionResult(smartTransaction, psbt, sign, fee, feePercentage);
+		return new BuildTransactionResult(smartTransaction, psbt, sign, fee, feePercentage, hdPubKeysWithLabels);
 	}
 
 	private PSBT TryNegotiatePayjoin(IPayjoinClient payjoinClient, TransactionBuilder builder, PSBT psbt, HdPubKey changeHdPubKey)

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -252,6 +252,7 @@ public class TransactionFactory
 				smartTransaction.TryAddWalletOutput(smartCoin);
 			}
 		}
+
 		// New labels will be added to the HdPubKey only when tx will be succesfully broadcasted.
 		Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels = new();
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -254,7 +254,7 @@ public class TransactionFactory
 		}
 
 		// New labels will be added to the HdPubKey only when tx will be succesfully broadcasted.
-		Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels = new();
+		Dictionary<HdPubKey, SmartLabel> hdPubKeysWithNewLabels = new();
 
 		foreach (var coin in smartTransaction.WalletOutputs)
 		{
@@ -264,18 +264,18 @@ public class TransactionFactory
 			// The foundkeylabel has already been added previously, so no need to concatenate.
 			if (foundPaymentRequest is null) // Then it's autochange.
 			{
-				hdPubKeysWithLabels.Add(coin.HdPubKey, label);
+				hdPubKeysWithNewLabels.Add(coin.HdPubKey, label);
 			}
 			else
 			{
-				hdPubKeysWithLabels.Add(coin.HdPubKey, SmartLabel.Merge(coin.HdPubKey.Label, foundPaymentRequest.Label));
+				hdPubKeysWithNewLabels.Add(coin.HdPubKey, SmartLabel.Merge(coin.HdPubKey.Label, foundPaymentRequest.Label));
 			}
 		}
 
 		Logger.LogDebug($"Built tx: {totalOutgoingAmountNoFee.ToString(fplus: false, trimExcessZero: true)} BTC. Fee: {fee.Satoshi} sats. Vsize: {vSize} vBytes. Fee/Total ratio: {feePercentage:0.#}%. Tx hash: {tx.GetHash()}.");
 
 		var sign = !KeyManager.IsWatchOnly;
-		return new BuildTransactionResult(smartTransaction, psbt, sign, fee, feePercentage, hdPubKeysWithLabels);
+		return new BuildTransactionResult(smartTransaction, psbt, sign, fee, feePercentage, hdPubKeysWithNewLabels);
 	}
 
 	private PSBT TryNegotiatePayjoin(IPayjoinClient payjoinClient, TransactionBuilder builder, PSBT psbt, HdPubKey changeHdPubKey)

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -558,9 +558,16 @@ public class Wallet : BackgroundService, IWallet
 
 	public void UpdateUsedHdPubKeysLabels(Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels)
 	{
+		if (!hdPubKeysWithLabels.Any())
+		{
+			return;
+		}
+
 		foreach (var item in hdPubKeysWithLabels)
 		{
 			item.Key.SetLabel(item.Value);
 		}
+
+		KeyManager.ToFile();
 	}
 }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -555,4 +555,12 @@ public class Wallet : BackgroundService, IWallet
 		var excludedOutpoints = Coins.Where(c => c.IsExcludedFromCoinJoin).Select(c => c.Outpoint);
 		KeyManager.SetExcludedCoinsFromCoinJoin(excludedOutpoints);
 	}
+
+	public void UpdateUsedHdPubKeysLabels(Dictionary<HdPubKey, SmartLabel> hdPubKeysWithLabels)
+	{
+		foreach (var item in hdPubKeysWithLabels)
+		{
+			item.Key.SetLabel(item.Value);
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9377

On **master**:
0. Create an address labeled "First". Send 50 USD to wallet (from other client).
1. Ctrl+C+D.
2. Select 1 coin, click Send selected coins.
3. Enter "First" address.
4. Enter label "Random".
5. Cancel transaction.
6. Ctrl+C+D.

See that the coin now has "First" and "Random" labels. Restarting the Wallet solves this issue as it's all in memory.

**Additional problem**: If you create a new address labeled "Second", and want to self spend, if you give a recepient label, e.g: "Test", but cancel the transaction, "Test" will appear next to "Second" as a label in the Unused Receive Addresses tab.
If you do this a more than once, you can stack up unused Labels. If you eventually send the transaction, all the unused labels will appear permanently. Restarting the Wallet solves this issue as well.

**CRUCIAL problem however** : If during this time, the coin gets confirmed, KeyManager's ToFile will write these new, incorrect labels into the Wallet file, staying there permanently.

This PR fixes these.
