### PR TITLE
Use Func<> to get up-to-date coin candidates in CoinJoinClient

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -88,16 +88,13 @@ internal class Participant
 			return hdPubKey;
 		}
 
-		List<SmartCoin> GetCoinsCandidate()
-		{
-			return SplitTransaction.Transaction.Outputs.AsIndexedOutputs()
-		 	.Select(x => (IndexedTxOut: x, HdPubKey: Wallet.GetExtPubKey(x.TxOut.ScriptPubKey)))
-			.Select(x => new SmartCoin(SplitTransaction, x.IndexedTxOut.N, CreateHdPubKey(x.HdPubKey)))
-			.ToList();
-		}
+		var smartCoins = SplitTransaction.Transaction.Outputs.AsIndexedOutputs()
+					 .Select(x => (IndexedTxOut: x, HdPubKey: Wallet.GetExtPubKey(x.TxOut.ScriptPubKey)))
+					.Select(x => new SmartCoin(SplitTransaction, x.IndexedTxOut.N, CreateHdPubKey(x.HdPubKey)))
+					.ToList();
 
 		// Run the coinjoin client task.
-		var ret = await coinJoinClient.StartCoinJoinAsync(GetCoinsCandidate, cancellationToken).ConfigureAwait(false);
+		var ret = await coinJoinClient.StartCoinJoinAsync(() => smartCoins, cancellationToken).ConfigureAwait(false);
 
 		await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -89,9 +89,9 @@ internal class Participant
 		}
 
 		var smartCoins = SplitTransaction.Transaction.Outputs.AsIndexedOutputs()
-					 .Select(x => (IndexedTxOut: x, HdPubKey: Wallet.GetExtPubKey(x.TxOut.ScriptPubKey)))
-					.Select(x => new SmartCoin(SplitTransaction, x.IndexedTxOut.N, CreateHdPubKey(x.HdPubKey)))
-					.ToList();
+		   .Select(x => (IndexedTxOut: x, HdPubKey: Wallet.GetExtPubKey(x.TxOut.ScriptPubKey)))
+		   .Select(x => new SmartCoin(SplitTransaction, x.IndexedTxOut.N, CreateHdPubKey(x.HdPubKey)))
+		   .ToList();
 
 		// Run the coinjoin client task.
 		var ret = await coinJoinClient.StartCoinJoinAsync(() => smartCoins, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -86,13 +88,16 @@ internal class Participant
 			return hdPubKey;
 		}
 
-		var smartCoins = SplitTransaction.Transaction.Outputs.AsIndexedOutputs()
+		List<SmartCoin> GetCoinsCandidate()
+		{
+			return SplitTransaction.Transaction.Outputs.AsIndexedOutputs()
 		 	.Select(x => (IndexedTxOut: x, HdPubKey: Wallet.GetExtPubKey(x.TxOut.ScriptPubKey)))
 			.Select(x => new SmartCoin(SplitTransaction, x.IndexedTxOut.N, CreateHdPubKey(x.HdPubKey)))
 			.ToList();
+		}
 
 		// Run the coinjoin client task.
-		var ret = await coinJoinClient.StartCoinJoinAsync(smartCoins, cancellationToken).ConfigureAwait(false);
+		var ret = await coinJoinClient.StartCoinJoinAsync(GetCoinsCandidate, cancellationToken).ConfigureAwait(false);
 
 		await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -14,7 +14,6 @@ using WalletWasabi.Tor.Http;
 using WalletWasabi.Tor.Socks5.Pool.Circuits;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
-using WalletWasabi.WabiSabi.Backend.Banning;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -29,7 +28,6 @@ using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 using Xunit.Abstractions;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -120,7 +120,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			builder.AddMockRpcClient(
-				GetCoinsCandidate(),
+				coins,
 				rpc =>
 
 					// Make the coordinator believe that the transaction is being
@@ -147,7 +147,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				});
 
 				// Emulate that the first coin is coming from a coinjoin.
-				services.AddScoped(s => new InMemoryCoinJoinIdStore(new[] { GetCoinsCandidate()[0].Coin.Outpoint.Hash }));
+				services.AddScoped(s => new InMemoryCoinJoinIdStore(new[] { coins[0].Coin.Outpoint.Hash }));
 			})).CreateClient();
 
 		// Create the coinjoin client
@@ -214,7 +214,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			builder
-			.AddMockRpcClient(GetCoinsCandidate(), rpc => { })
+			.AddMockRpcClient(coins, rpc => { })
 			.ConfigureServices(services =>
 			{
 				// Instruct the coordinator DI container to use this scoped
@@ -415,7 +415,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		Assert.NotNull(broadcastedTx);
 
 		Assert.Equal(
-			GetCoinsCandidate().Select(x => x.Coin.Outpoint.ToString()).OrderBy(x => x),
+			coins.Select(x => x.Coin.Outpoint.ToString()).OrderBy(x => x),
 			broadcastedTx.Inputs.Select(x => x.PrevOut.ToString()).OrderBy(x => x));
 
 		await roundStateUpdater.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -111,11 +111,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		var coins = GenerateSmartCoins(keyManager, amounts, inputCount);
 
-		SmartCoin[] GetCoinsCandidate()
-		{
-			return coins;
-		}
-
 		_output.WriteLine("Coins were created successfully");
 
 		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
@@ -175,7 +170,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(mockHttpClientFactory.Object, keyManager, roundStateUpdater);
 
 		// Run the coinjoin client task.
-		var coinjoinResult = await coinJoinClient.StartCoinJoinAsync(GetCoinsCandidate, cts.Token);
+		var coinjoinResult = await coinJoinClient.StartCoinJoinAsync(() => coins, cts.Token);
 		Assert.True(coinjoinResult is SuccessfulCoinJoinResult);
 
 		var broadcastedTx = await transactionCompleted.Task; // wait for the transaction to be broadcasted.
@@ -198,11 +193,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		KeyManager keyManager = KeyManager.CreateNew(out var _, password: "", Network.Main);
 
 		var coins = GenerateSmartCoins(keyManager, amounts, inputCount);
-
-		SmartCoin[] GetCoinsCandidate()
-		{
-			return coins;
-		}
 
 		_output.WriteLine("Coins were created successfully");
 
@@ -276,7 +266,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			coinJoinClient.CoinJoinClientProgress += HandleCoinJoinProgress;
 
 			// Run the coinjoin client task.
-			await coinJoinClient.StartCoinJoinAsync(GetCoinsCandidate, cts.Token);
+			await coinJoinClient.StartCoinJoinAsync(() => coins, cts.Token);
 			throw new Exception("Coinjoin should have never finished successfully.");
 		}
 		catch (OperationCanceledException)
@@ -308,11 +298,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		var coins = GenerateSmartCoins(keyManager1, amounts, inputCount);
 		var badCoins = GenerateSmartCoins(keyManager2, amounts, inputCount);
-
-		SmartCoin[] GetCoinsCandidate()
-		{
-			return coins;
-		}
 
 		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 		builder.AddMockRpcClient(
@@ -374,7 +359,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(mockHttpClientFactory.Object, keyManager1, roundStateUpdater);
 
 		// Run the coinjoin client task.
-		var coinJoinTask = Task.Run(async () => await coinJoinClient.StartCoinJoinAsync(GetCoinsCandidate, cts.Token).ConfigureAwait(false), cts.Token);
+		var coinJoinTask = Task.Run(async () => await coinJoinClient.StartCoinJoinAsync(() => coins, cts.Token).ConfigureAwait(false), cts.Token);
 
 		// Creates a IBackendHttpClientFactory that creates an HttpClient that says everything is okay
 		// when a signature is sent but it doesn't really send it.

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -137,6 +137,9 @@ public class CoinJoinClient
 
 		do
 		{
+			// Sanity check if we would get coins at all otherwise this will throw.
+			var _ = coinCandidatesFunc();
+
 			currentRoundState = await WaitForRoundAsync(excludeRound, cancellationToken).ConfigureAwait(false);
 			RoundParameters roundParameteers = currentRoundState.CoinjoinState.Parameters;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -16,6 +16,7 @@ using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.CredentialDependencies;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
+using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.WebClients.Wasabi;
@@ -127,11 +128,12 @@ public class CoinJoinClient
 		return roundState;
 	}
 
-	public async Task<CoinJoinResult> StartCoinJoinAsync(IEnumerable<SmartCoin> coinCandidates, CancellationToken cancellationToken)
+	public async Task<CoinJoinResult> StartCoinJoinAsync(Func<IEnumerable<SmartCoin>> coinCandidatesFunc, CancellationToken cancellationToken)
 	{
 		RoundState? currentRoundState;
 		uint256 excludeRound = uint256.Zero;
 		ImmutableList<SmartCoin> coins;
+		var coinCandidates = coinCandidatesFunc();
 
 		do
 		{
@@ -140,6 +142,7 @@ public class CoinJoinClient
 
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameteers.MaxSuggestedAmount);
 			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameteers);
+
 			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, utxoSelectionParameters, ConsolidationMode, AnonScoreTarget, SemiPrivateThreshold, liquidityClue, SecureRandom);
 
 			if (!roundParameteers.AllowedInputTypes.Contains(ScriptType.P2WPKH) || !roundParameteers.AllowedOutputTypes.Contains(ScriptType.P2WPKH))

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -133,12 +133,14 @@ public class CoinJoinClient
 		RoundState? currentRoundState;
 		uint256 excludeRound = uint256.Zero;
 		ImmutableList<SmartCoin> coins;
-		var coinCandidates = coinCandidatesFunc();
+		IEnumerable<SmartCoin> coinCandidates;
 
 		do
 		{
 			currentRoundState = await WaitForRoundAsync(excludeRound, cancellationToken).ConfigureAwait(false);
 			RoundParameters roundParameteers = currentRoundState.CoinjoinState.Parameters;
+
+			coinCandidates = coinCandidatesFunc();
 
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameteers.MaxSuggestedAmount);
 			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameteers);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -14,7 +14,7 @@ public class CoinJoinTracker : IDisposable
 	public CoinJoinTracker(
 		IWallet wallet,
 		CoinJoinClient coinJoinClient,
-		IEnumerable<SmartCoin> coinCandidates,
+		Func<IEnumerable<SmartCoin>> coinCandidatesFunc,
 		bool stopWhenAllMixed,
 		bool overridePlebStop,
 		CancellationToken cancellationToken)
@@ -26,7 +26,7 @@ public class CoinJoinTracker : IDisposable
 		StopWhenAllMixed = stopWhenAllMixed;
 		OverridePlebStop = overridePlebStop;
 		CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		CoinJoinTask = coinJoinClient.StartCoinJoinAsync(coinCandidates, CancellationTokenSource.Token);
+		CoinJoinTask = coinJoinClient.StartCoinJoinAsync(coinCandidatesFunc, CancellationTokenSource.Token);
 	}
 
 	public event EventHandler<CoinJoinProgressEventArgs>? WalletCoinJoinProgressChanged;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -32,7 +32,7 @@ public class CoinJoinTrackerFactory
 	private string CoordinatorIdentifier { get; }
 	private LiquidityClueProvider LiquidityClueProvider { get; }
 
-	public async Task<CoinJoinTracker> CreateAndStartAsync(IWallet wallet, IEnumerable<SmartCoin> coinCandidates, bool stopWhenAllMixed, bool overridePlebStop)
+	public async Task<CoinJoinTracker> CreateAndStartAsync(IWallet wallet, Func<IEnumerable<SmartCoin>> coinCandidatesFunc, bool stopWhenAllMixed, bool overridePlebStop)
 	{
 		await LiquidityClueProvider.InitLiquidityClueAsync(wallet, CancellationToken).ConfigureAwait(false);
 
@@ -54,6 +54,6 @@ public class CoinJoinTrackerFactory
 			feeRateMedianTimeFrame: wallet.FeeRateMedianTimeFrame,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));
 
-		return new CoinJoinTracker(wallet, coinJoinClient, coinCandidates, stopWhenAllMixed, overridePlebStop, CancellationToken);
+		return new CoinJoinTracker(wallet, coinJoinClient, coinCandidatesFunc, stopWhenAllMixed, overridePlebStop, CancellationToken);
 	}
 }

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -25,7 +25,7 @@ public interface IWallet
 
 	Task<bool> IsWalletPrivateAsync();
 
-	Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync();
+	IEnumerable<SmartCoin> GetCoinjoinCoinCandidates();
 
 	Task<IEnumerable<SmartTransaction>> GetTransactionsAsync();
 }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -118,8 +118,6 @@ public class Wallet : BackgroundService, IWallet
 
 	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), AnonScoreTarget) >= 1;
 
-	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync() => Task.FromResult(GetCoinjoinCoinCandidates());
-
 	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(GetTransactions());
 
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates() => Coins;


### PR DESCRIPTION
Fixes: #10391

Built on top of https://github.com/zkSNACKs/WalletWasabi/pull/10403

The idea here is to only select coins in `CoinJoinClient` after we found a round.
So we are selecting from a more up-to-date list of coins.