### PR TITLE
Add affiliation id to coinjoin notification header

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Affiliation/CanonicalSerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Affiliation/CanonicalSerializationTests.cs
@@ -36,7 +36,7 @@ public class CanonicalSerializationTests
 	public void TransactionSerialization()
 	{
 		var transaction = new Payload(
-			Header.Instance,
+			Header.Create("WalletWasabi"),
 			new Body(
 					Inputs: new List<Input>()
 					{
@@ -56,7 +56,7 @@ public class CanonicalSerializationTests
 					NoFeeThreshold: 1000000,
 					MinRegistrableAmount: 5000,
 					Timestamp: 0));
-		string expected_json = """{"body":{"fee_rate":300000,"inputs":[{"is_affiliated":true,"is_no_fee":false,"prevout":{"hash":"e5b7e21b5ba720e81efd6bfa9f854ababdcddc75a43bfa60bf0fe069cfd1bb8a","index":0},"script_pubkey":"5120b3a2750e21facec36b2a56d76cca6019bf517a5c45e2ea8e5b4ed191090f3003"},{"is_affiliated":true,"is_no_fee":false,"prevout":{"hash":"f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a","index":1},"script_pubkey":"51202f436892d90fb2665519efa3d9f0f5182859124f179486862c2cd7a78ea9ac19"}],"min_registrable_amount":5000,"no_fee_threshold":1000000,"outputs":[{"amount":50000,"script_pubkey":"5120e0458118b80a08042d84c4f0356d86863fe2bffc034e839c166ad4e8da7e26ef"},{"amount":50000,"script_pubkey":"5120bdb100a4e7ba327d364642dc653b9e6b51783bde6ea0df2ccbc1a78e3cc13295"},{"amount":7202065,"script_pubkey":"5120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e"},{"amount":49010,"script_pubkey":"512062fdf14323b9ccda6f5b03c5c2c28e35839a3909a2e14d32b595c63d53c7b88f"},{"amount":36945,"script_pubkey":"76a914a579388225827d9f2fe9014add644487808c695d88ac"}],"slip44_coin_type":1,"timestamp":0},"header":{"title":"coinjoin notification","version":1}}""";
+		string expected_json = """{"body":{"fee_rate":300000,"inputs":[{"is_affiliated":true,"is_no_fee":false,"prevout":{"hash":"e5b7e21b5ba720e81efd6bfa9f854ababdcddc75a43bfa60bf0fe069cfd1bb8a","index":0},"script_pubkey":"5120b3a2750e21facec36b2a56d76cca6019bf517a5c45e2ea8e5b4ed191090f3003"},{"is_affiliated":true,"is_no_fee":false,"prevout":{"hash":"f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a","index":1},"script_pubkey":"51202f436892d90fb2665519efa3d9f0f5182859124f179486862c2cd7a78ea9ac19"}],"min_registrable_amount":5000,"no_fee_threshold":1000000,"outputs":[{"amount":50000,"script_pubkey":"5120e0458118b80a08042d84c4f0356d86863fe2bffc034e839c166ad4e8da7e26ef"},{"amount":50000,"script_pubkey":"5120bdb100a4e7ba327d364642dc653b9e6b51783bde6ea0df2ccbc1a78e3cc13295"},{"amount":7202065,"script_pubkey":"5120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e"},{"amount":49010,"script_pubkey":"512062fdf14323b9ccda6f5b03c5c2c28e35839a3909a2e14d32b595c63d53c7b88f"},{"amount":36945,"script_pubkey":"76a914a579388225827d9f2fe9014add644487808c695d88ac"}],"slip44_coin_type":1,"timestamp":0},"header":{"affiliation_id":"WalletWasabi","title":"coinjoin notification","version":1}}""";
 
 		string json = JsonConvert.SerializeObject(transaction, CanonicalJsonSerializationOptions.Settings);
 		Assert.Equal(expected_json, json);

--- a/WalletWasabi/Affiliation/AffiliateDataUpdater.cs
+++ b/WalletWasabi/Affiliation/AffiliateDataUpdater.cs
@@ -95,7 +95,7 @@ public class AffiliateDataUpdater : BackgroundService
 		try
 		{
 			Body body = builtTransactionData.GetAffiliationData(affiliationId);
-			byte[] result = await GetCoinJoinRequestAsync(affiliateServerHttpApiClient, body, cancellationToken).ConfigureAwait(false);
+			byte[] result = await GetCoinJoinRequestAsync(affiliateServerHttpApiClient, affiliationId, body, cancellationToken).ConfigureAwait(false);
 
 			RegisterReceivedCoinJoinRequest(roundId, affiliationId, result);
 		}
@@ -121,9 +121,9 @@ public class AffiliateDataUpdater : BackgroundService
 		}
 	}
 
-	private async Task<byte[]> GetCoinJoinRequestAsync(AffiliateServerHttpApiClient client, Body body, CancellationToken cancellationToken)
+	private async Task<byte[]> GetCoinJoinRequestAsync(AffiliateServerHttpApiClient client, string affiliationId, Body body, CancellationToken cancellationToken)
 	{
-		Payload payload = new(Header.Instance, body);
+		Payload payload = new(Header.Create(affiliationId), body);
 		byte[] signature = Signer.Sign(payload.GetCanonicalSerialization());
 		CoinJoinNotificationRequest coinJoinRequestRequest = new(body, signature);
 

--- a/WalletWasabi/Affiliation/Models/CoinjoinNotification/Header.cs
+++ b/WalletWasabi/Affiliation/Models/CoinjoinNotification/Header.cs
@@ -1,6 +1,6 @@
 namespace WalletWasabi.Affiliation.Models.CoinJoinNotification;
 
-public record Header(string Title, int Version)
+public record Header(string Title, string AffiliationId, int Version)
 {
-	public static readonly Header Instance = new(Title: "coinjoin notification", Version: 1);
+	public static Header Create(string affiliationId) => new(Title: "coinjoin notification", AffiliationId: affiliationId, Version: 1);
 }


### PR DESCRIPTION
This pull request adds affiliation id to the coinjoin notification header. The header is part of the data that is signed by the coordinator.

This pull request makes coinjoin notifications non-transferable from one affiliate server to another. In other words, an affiliate server that receives a coinjoin notification can eventually prove that the coinjoin notification was addressed to them.

Since the new format of the header is not compatible with the old one, deployment of this change requires coordinated deployment of affiliate servers as well (unless affiliate servers temporarily accept both formats).