### PR TITLE
[VDG] Don't show flyout when main window is not active

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/ShowAttachedFlyoutWhenFocusedBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/ShowAttachedFlyoutWhenFocusedBehavior.cs
@@ -94,6 +94,9 @@ public class ShowAttachedFlyoutWhenFocusedBehavior : AttachedToVisualTreeBehavio
 	{
 		return this
 			.WhenAnyValue(x => x.IsFlyoutOpen)
+			.CombineLatest(ApplicationHelper.MainWindowActivated, (isFlyoutOpen, isActivated) => (isFlyoutOpen, isActivated ))
+			.Where(x => x.isActivated)
+			.Select(x => x.isFlyoutOpen)
 			.Do(controller.SetIsForcedOpen)
 			.Subscribe();
 	}


### PR DESCRIPTION
- Without this PR, the Search Bar flyout can appear on top of other windows.
- This PR: The flyout should no longer appear on top of other windows.

Should fix https://github.com/zkSNACKs/WalletWasabi/issues/10181