### PR TITLE
Exception when closing the wallet fast

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -50,7 +50,10 @@ public class CoinJoinManager : BackgroundService
 	/// </summary>
 	private ConcurrentDictionary<string, byte> WalletsInSendWorkflow { get; } = new();
 
-	public CoinJoinClientState HighestCoinJoinClientState => CoinJoinClientStates.Values.MaxBy(s => (int)s);
+	public CoinJoinClientState HighestCoinJoinClientState => CoinJoinClientStates.Values.Any()
+		? CoinJoinClientStates.Values.MaxBy(s => (int)s)
+		: CoinJoinClientState.Idle;
+
 	private ImmutableDictionary<string, CoinJoinClientState> CoinJoinClientStates { get; set; } = ImmutableDictionary<string, CoinJoinClientState>.Empty;
 
 	private Channel<CoinJoinCommand> CommandChannel { get; } = Channel.CreateUnbounded<CoinJoinCommand>();


### PR DESCRIPTION
Discovered while looking into #10155.
Issue introduced in #10400 so this PR does not help with #10155.

This line https://github.com/zkSNACKs/WalletWasabi/blob/e12945e8c70b9b8ce85c1a9c5e9245adf7d265ef/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs#L53 throws the `InvalidOperationException` exception when `CoinJoinClientStates` is empty.

Log:

```
Exception type: System.InvalidOperationException

Message: Sequence contains no elements

Stack Trace:    at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.MaxBy[TSource,TKey](IEnumerable`1 source, Func`2 keySelector, IComparer`1 comparer)
   at System.Linq.Enumerable.MaxBy[TSource,TKey](IEnumerable`1 source, Func`2 keySelector)
   at WalletWasabi.WabiSabi.Client.CoinJoinManager.get_HighestCoinJoinClientState() in WalletWasabi\WabiSabi\Client\CoinJoinManager.cs:line 53
   at WalletWasabi.Fluent.ViewModels.ApplicationViewModel.CoinJoinCanShutdown() in WalletWasabi.Fluent\ViewModels\ApplicationViewModel.cs:line 102
   at WalletWasabi.Fluent.ViewModels.ApplicationViewModel.CanShutdown(Boolean restart) in WalletWasabi.Fluent\ViewModels\ApplicationViewModel.cs:line 88
   at WalletWasabi.Fluent.ApplicationStateManager.<CreateAndShowMainWindow>b__13_0(EventPattern`1 args) in WalletWasabi.Fluent\ApplicationStateManager.cs:line 129
   at System.Reactive.Linq.ObservableImpl.Select`2.Selector._.OnNext(TSource value) in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs:line 39
--- End of stack trace from previous location ---
   at System.Reactive.PlatformServices.ExceptionServicesImpl.Rethrow(Exception exception) in /_/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServicesImpl.cs:line 19
   at System.Reactive.ExceptionHelpers.Throw(Exception exception) in /_/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs:line 16
   at System.Reactive.Stubs.<>c.<.cctor>b__2_1(Exception ex) in /_/Rx.NET/Source/src/System.Reactive/Internal/Stubs.cs:line 16
   at System.Reactive.AnonymousSafeObserver`1.OnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/AnonymousSafeObserver.cs:line 62
   at System.Reactive.Sink`1.ForwardOnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 60
   at System.Reactive.Sink`2.OnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 94
   at System.Reactive.Sink`1.ForwardOnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 60
   at System.Reactive.Linq.ObservableImpl.Select`2.Selector._.OnNext(TSource value) in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs:line 43
   at System.Reactive.Subjects.Subject`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 141
   at System.Reactive.Linq.ObservableImpl.FromEventPattern.Handler`3.<>c__DisplayClass6_0.<GetHandler>b__0(TSender sender, TEventArgs eventArgs) in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs:line 93
   at Avalonia.Controls.Window.OnClosing(CancelEventArgs e) in /_/src/Avalonia.Controls/Window.cs:line 1030
   at Avalonia.Controls.Window.ShouldCancelClose(CancelEventArgs args) in /_/src/Avalonia.Controls/Window.cs:line 564
   at Avalonia.Controls.Window.Close(Boolean ignoreCancel) in /_/src/Avalonia.Controls/Window.cs:line 499
   at Avalonia.Controls.Window.Close() in /_/src/Avalonia.Controls/Window.cs:line 474
   at Avalonia.Controls.Chrome.CaptionButtons.OnClose() in /_/src/Avalonia.Controls/Chrome/CaptionButtons.cs:line 61
   at Avalonia.Controls.Chrome.CaptionButtons.<OnApplyTemplate>b__11_0(Object sender, PointerReleasedEventArgs e) in /_/src/Avalonia.Controls/Chrome/CaptionButtons.cs:line 98
   at Avalonia.Interactivity.EventRoute.RaiseEventImpl(RoutedEventArgs e) in /_/src/Avalonia.Interactivity/EventRoute.cs:line 118
   at Avalonia.Interactivity.EventRoute.RaiseEvent(IInteractive source, RoutedEventArgs e) in /_/src/Avalonia.Interactivity/EventRoute.cs:line 79
   at Avalonia.Interactivity.Interactive.RaiseEvent(RoutedEventArgs e) in /_/src/Avalonia.Interactivity/Interactive.cs:line 123
   at Avalonia.Input.MouseDevice.MouseUp(IMouseDevice device, UInt64 timestamp, IInputRoot root, Point p, PointerPointProperties props, KeyModifiers inputModifiers) in /_/src/Avalonia.Input/MouseDevice.cs:line 313
   at Avalonia.Input.MouseDevice.ProcessRawEvent(RawPointerEventArgs e) in /_/src/Avalonia.Input/MouseDevice.cs:line 179
   at Avalonia.Input.MouseDevice.ProcessRawEvent(RawInputEventArgs e) in /_/src/Avalonia.Input/MouseDevice.cs:line 90
   at Avalonia.Input.InputManager.ProcessInput(RawInputEventArgs e) in /_/src/Avalonia.Input/InputManager.cs:line 37
   at Avalonia.Win32.WindowImpl.AppWndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs:line 524
   at Avalonia.Win32.WindowImpl.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam) in /_/src/Windows/Avalonia.Win32/WindowImpl.WndProc.cs:line 33
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32Platform.RunLoop(CancellationToken cancellationToken) in /_/src/Windows/Avalonia.Win32/Win32Platform.cs:line 210
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 65
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 120
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop\Program.cs:line 110
```

This fix is invalid though because between:

```cs
public CoinJoinClientState HighestCoinJoinClientState => CoinJoinClientStates.Values.Any() // HERE
    ? CoinJoinClientStates.Values.MaxBy(s => (int)s) // AND HERE
    : CoinJoinClientState.Idle;
```
the value might change and we might get the exception anyway. I don't know about any other solution than using a `lock (lockObj)`.