### PR TITLE
[VDG] do not use same icon for coinjoin indicator and anonymity score indicator

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorDataGridSource.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorDataGridSource.cs
@@ -109,7 +109,7 @@ public static class CoinSelectorDataGridSource
 		return new PlainTextColumn<CoinControlItemViewModelBase>(
 			new AnonymityScoreHeaderView(),
 			node => node is PocketCoinControlItemViewModel ? "" : node.AnonymityScore.ToString(),
-			new GridLength(50, GridUnitType.Pixel),
+			new GridLength(55, GridUnitType.Pixel),
 			new TextColumnOptions<CoinControlItemViewModelBase>
 			{
 				CompareAscending = SortAscending<CoinControlItemViewModelBase, int?>(b => b.AnonymityScore),

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -240,7 +240,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 				CompareAscending = WalletCoinViewModel.SortAscending(x => x.AnonymitySet),
 				CompareDescending = WalletCoinViewModel.SortDescending(x => x.AnonymitySet)
 			},
-			width: new GridLength(50, GridUnitType.Pixel));
+			width: new GridLength(55, GridUnitType.Pixel));
 	}
 
 	private static IColumn<WalletCoinViewModel> LabelsColumn()

--- a/WalletWasabi.Fluent/Views/CoinControl/Core/Headers/AnonymityScoreHeaderView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinControl/Core/Headers/AnonymityScoreHeaderView.axaml
@@ -5,9 +5,5 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.CoinControl.Core.Headers.AnonymityScoreHeaderView">
-  <PathIcon Data="{StaticResource shield_regular}"
-            Opacity="0.6"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            ToolTip.Tip="Anonymity Score" />
+  <TextBlock Text="AS" ToolTip.Tip="Anonymity Score" />
 </UserControl>

--- a/WalletWasabi.Fluent/Views/CoinControl/Core/Headers/AnonymityScoreHeaderView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinControl/Core/Headers/AnonymityScoreHeaderView.axaml
@@ -5,5 +5,5 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.CoinControl.Core.Headers.AnonymityScoreHeaderView">
-  <TextBlock Text="AS" ToolTip.Tip="Anonymity Score" />
+  <TextBlock Text="AS" ToolTip.Tip="Anonymity Score" HorizontalAlignment="Center" />
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/AnonymitySetHeaderView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/AnonymitySetHeaderView.axaml
@@ -7,9 +7,5 @@
              x:DataType="walletcoins:WalletCoinViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Advanced.WalletCoins.Columns.AnonymitySetHeaderView">
-  <PathIcon Data="{StaticResource shield_regular}"
-            Opacity="0.6"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            ToolTip.Tip="Anonymity Score" />
+  <TextBlock Text="AS" ToolTip.Tip="Anonymity Score" />
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/AnonymitySetHeaderView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletCoins/Columns/AnonymitySetHeaderView.axaml
@@ -7,5 +7,5 @@
              x:DataType="walletcoins:WalletCoinViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Advanced.WalletCoins.Columns.AnonymitySetHeaderView">
-  <TextBlock Text="AS" ToolTip.Tip="Anonymity Score" />
+  <TextBlock Text="AS" ToolTip.Tip="Anonymity Score" HorizontalAlignment="Center" />
 </UserControl>


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9560

Simply use initials instead. ToolTip says the full title.