### PR TITLE
Fix state on empty list

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -50,7 +50,7 @@ public class CoinJoinManager : BackgroundService
 	/// </summary>
 	private ConcurrentDictionary<string, byte> WalletsInSendWorkflow { get; } = new();
 
-	public CoinJoinClientState HighestCoinJoinClientState => CoinJoinClientStates.Values.MaxBy(s => (int)s);
+	public CoinJoinClientState HighestCoinJoinClientState => CoinJoinClientStates.IsEmpty ? CoinJoinClientState.Idle : CoinJoinClientStates.Values.MaxBy(s => (int)s);
 	private ImmutableDictionary<string, CoinJoinClientState> CoinJoinClientStates { get; set; } = ImmutableDictionary<string, CoinJoinClientState>.Empty;
 
 	private Channel<CoinJoinCommand> CommandChannel { get; } = Channel.CreateUnbounded<CoinJoinCommand>();


### PR DESCRIPTION
Bug introduced by https://github.com/zkSNACKs/WalletWasabi/pull/10400

Credits @brizik 
Fixes: 

```
Exception type: System.InvalidOperationException
Message: Sequence contains no elements
Stack Trace:    at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.MaxBy[TSource,TKey](IEnumerable`1 source, Func`2 keySelector, IComparer`1 comparer)
   at WalletWasabi.WabiSabi.Client.CoinJoinManager.get_HighestCoinJoinClientState() in WalletWasabi/WabiSabi/Client/CoinJoinManager.cs:line 53
   at WalletWasabi.Fluent.ViewModels.ApplicationViewModel.CoinJoinCanShutdown() in WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs:line 102
   at WalletWasabi.Fluent.ViewModels.ApplicationViewModel.CanShutdown(Boolean restart) in WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs:line 88
   at WalletWasabi.Fluent.ApplicationStateManager.<CreateAndShowMainWindow>b__13_0(EventPattern`1 args) in WalletWasabi.Fluent/ApplicationStateManager.cs:line 129
   at System.Reactive.Linq.ObservableImpl.Select`2.Selector._.OnNext(TSource value) in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs:line 39
--- End of stack trace from previous location ---
   at System.Reactive.PlatformServices.ExceptionServicesImpl.Rethrow(Exception exception) in /_/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServicesImpl.cs:line 19
   at System.Reactive.ExceptionHelpers.Throw(Exception exception) in /_/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs:line 16
   at System.Reactive.Stubs.<>c.<.cctor>b__2_1(Exception ex) in /_/Rx.NET/Source/src/System.Reactive/Internal/Stubs.cs:line 16
   at System.Reactive.AnonymousSafeObserver`1.OnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/AnonymousSafeObserver.cs:line 62
   at System.Reactive.Sink`1.ForwardOnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 60
   at System.Reactive.Sink`2.OnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 94
   at System.Reactive.Sink`1.ForwardOnError(Exception error) in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 60
   at System.Reactive.Linq.ObservableImpl.Select`2.Selector._.OnNext(TSource value) in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs:line 43
   at System.Reactive.Subjects.Subject`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 141
   at Avalonia.Controls.Window.OnClosing(CancelEventArgs e) in /_/src/Avalonia.Controls/Window.cs:line 1030
   at Avalonia.Controls.Window.ShouldCancelClose(CancelEventArgs args) in /_/src/Avalonia.Controls/Window.cs:line 564
   at Avalonia.Controls.Window.HandleClosing() in /_/src/Avalonia.Controls/Window.cs:line 519
   at Avalonia.Native.WindowImpl.WindowEvents.Avalonia.Native.Interop.IAvnWindowEvents.Closing() in /_/src/Avalonia.Native/WindowImpl.cs:line 53
   at Avalonia.Native.Interop.Impl.__MicroComIAvnWindowEventsVTable.Closing(Void* this) in /_/src/Avalonia.Native/Interop.Generated.cs:line 4055
--- End of stack trace from previous location ---
   at Avalonia.Native.PlatformThreadingInterface.RunLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Native/PlatformThreadingInterface.cs:line 90
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken) in /_/src/Avalonia.Base/Threading/Dispatcher.cs:line 65
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 120
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop/Program.cs:line 110
Inner Exception:
```

