### PR TITLE
Sanity checks before and after we found a round

### DIFF
--- a/WalletWasabi/Exceptions/CoinJoinClientException.cs
+++ b/WalletWasabi/Exceptions/CoinJoinClientException.cs
@@ -1,0 +1,13 @@
+using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
+
+namespace WalletWasabi.Exceptions;
+
+public class CoinJoinClientException : Exception
+{
+	public CoinJoinClientException(CoinjoinError coinjoinError, string? message = null) : base($"Coinjoin aborted with error: {coinjoinError}. {message}")
+	{
+		CoinjoinError = coinjoinError;
+	}
+
+	public CoinjoinError CoinjoinError { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -172,7 +173,7 @@ public class CoinJoinClient
 
 		if (coins.IsEmpty)
 		{
-			throw new NoCoinsToMixException($"No coin was selected from '{coinCandidates.Count()}' number of coins. Probably it was not economical, total amount of coins were: {Money.Satoshis(coinCandidates.Sum(c => c.Amount))} BTC.");
+			throw new CoinJoinClientException(CoinjoinError.NoCoinsToMix, $"No coin was selected from '{coinCandidates.Count()}' number of coins. Probably it was not economical, total amount of coins were: {Money.Satoshis(coinCandidates.Sum(c => c.Amount))} BTC.");
 		}
 
 		// Keep going to blame round until there's none, so CJs won't be DDoS-ed.
@@ -315,7 +316,7 @@ public class CoinJoinClient
 			registeredAliceClientAndCircuits = await ProceedWithInputRegAndConfirmAsync(smartCoins, roundState, cancellationToken).ConfigureAwait(false);
 			if (!registeredAliceClientAndCircuits.Any())
 			{
-				throw new NoCoinsToMixException($"The coordinator rejected all {smartCoins.Count()} inputs.");
+				throw new CoinJoinClientException(CoinjoinError.NoCoinsToMix, $"The coordinator rejected all {smartCoins.Count()} inputs.");
 			}
 
 			roundState.LogInfo($"Successfully registered {registeredAliceClientAndCircuits.Length} inputs.");

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -420,33 +420,8 @@ public class CoinJoinManager : BackgroundService
 		}
 		catch (CoinJoinClientException clientException)
 		{
-			switch (clientException.CoinjoinError)
-			{
-				case CoinjoinError.UserInSendWorkflow:
-					NotifyCoinJoinStartError(wallet, CoinjoinError.UserInSendWorkflow);
-					break;
-
-				case CoinjoinError.NotEnoughUnprivateBalance:
-					NotifyCoinJoinStartError(wallet, CoinjoinError.NotEnoughUnprivateBalance);
-					break;
-
-				case CoinjoinError.BackendNotSynchronized:
-					NotifyCoinJoinStartError(wallet, CoinjoinError.BackendNotSynchronized);
-					break;
-
-				case CoinjoinError.AllCoinsPrivate:
-					NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);
-					break;
-
-				case CoinjoinError.NoCoinsToMix:
-					NotifyCoinJoinStartError(wallet, CoinjoinError.NoCoinsToMix);
-					Logger.LogDebug(clientException);
-					break;
-
-				default:
-					wallet.LogError($"Unkown {nameof(CoinjoinError)}. {nameof(CoinJoinClient)} failed with exception: '{clientException}'");
-					break;
-			}
+			Logger.LogDebug(clientException);
+			NotifyCoinJoinStartError(wallet, clientException.CoinjoinError);
 		}
 		catch (InvalidOperationException ioe)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -356,7 +356,7 @@ public class CoinJoinManager : BackgroundService
 
 				NotifyCoinJoinCompletion(finishedCoinJoin);
 
-				if (!finishedCoinJoin.IsStopped && !stoppingToken.IsCancellationRequested)
+				if (!finishedCoinJoin.IsStopped && !stoppingToken.IsCancellationRequested && !(finishedCoinJoin.Wallet.IsWalletPrivate() && finishedCoinJoin.StopWhenAllMixed))
 				{
 					finishedCoinJoin.Wallet.LogInfo($"{nameof(CoinJoinClient)} restart automatically.");
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -352,7 +352,7 @@ public class CoinJoinManager : BackgroundService
 			var finishedCoinJoins = trackedCoinJoins.Where(x => x.Value.IsCompleted).Select(x => x.Value).ToImmutableArray();
 			foreach (var finishedCoinJoin in finishedCoinJoins)
 			{
-				await HandleCoinJoinFinalizationAsync(finishedCoinJoin, trackedCoinJoins, trackedAutoStarts, stoppingToken).ConfigureAwait(false);
+				await HandleCoinJoinFinalizationAsync(finishedCoinJoin, trackedCoinJoins, stoppingToken).ConfigureAwait(false);
 
 				NotifyCoinJoinCompletion(finishedCoinJoin);
 
@@ -401,7 +401,7 @@ public class CoinJoinManager : BackgroundService
 		return coinJoinClientStates.ToImmutable();
 	}
 
-	private async Task HandleCoinJoinFinalizationAsync(CoinJoinTracker finishedCoinJoin, ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken cancellationToken)
+	private async Task HandleCoinJoinFinalizationAsync(CoinJoinTracker finishedCoinJoin, ConcurrentDictionary<string, CoinJoinTracker> trackedCoinJoins, CancellationToken cancellationToken)
 	{
 		var wallet = finishedCoinJoin.Wallet;
 		try

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -356,15 +356,18 @@ public class CoinJoinManager : BackgroundService
 
 				NotifyCoinJoinCompletion(finishedCoinJoin);
 
-				if (!finishedCoinJoin.IsStopped && !stoppingToken.IsCancellationRequested && !(finishedCoinJoin.Wallet.IsWalletPrivate() && finishedCoinJoin.StopWhenAllMixed))
+				// When to stop mixing.
+				if (finishedCoinJoin.IsStopped  // If stop was requested by user.
+					|| stoppingToken.IsCancellationRequested    // If cancellation was requested.
+					|| (finishedCoinJoin.Wallet.IsWalletPrivate() && finishedCoinJoin.StopWhenAllMixed))  // If wallet is private and the wallet needs to stop mixing when it becomes private.
+				{
+					NotifyWalletStoppedCoinJoin(finishedCoinJoin.Wallet);
+				}
+				else
 				{
 					finishedCoinJoin.Wallet.LogInfo($"{nameof(CoinJoinClient)} restart automatically.");
 
 					ScheduleRestartAutomatically(finishedCoinJoin.Wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, stoppingToken);
-				}
-				else
-				{
-					NotifyWalletStoppedCoinJoin(finishedCoinJoin.Wallet);
 				}
 			}
 

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/NoCoinsToMixException.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/NoCoinsToMixException.cs
@@ -1,8 +1,0 @@
-namespace WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
-
-public class NoCoinsToMixException : InvalidOperationException
-{
-	public NoCoinsToMixException(string? message) : base(message)
-	{
-	}
-}

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -23,7 +23,7 @@ public interface IWallet
 	TimeSpan FeeRateMedianTimeFrame { get; }
 	bool RedCoinIsolation { get; }
 
-	Task<bool> IsWalletPrivateAsync();
+	bool IsWalletPrivate();
 
 	IEnumerable<SmartCoin> GetCoinjoinCoinCandidates();
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -112,8 +112,6 @@ public class Wallet : BackgroundService, IWallet
 
 	public bool IsUnderPlebStop => Coins.TotalAmount() <= KeyManager.PlebStopThreshold;
 
-	public Task<bool> IsWalletPrivateAsync() => Task.FromResult(IsWalletPrivate());
-
 	public bool IsWalletPrivate() => GetPrivacyPercentage(new CoinsView(Coins), AnonScoreTarget) >= 1;
 
 	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(GetTransactions());


### PR DESCRIPTION
Idea come from @molnard 

What this PR tries to achieve:

Since waiting for a round can take some time, this PR runs a couple of sanity checks before AND after we find a round.

Sanity checks:

- Wallet got into the Send workflow while waiting
- Wallet balance fall below the `PlebStop` while waiting
- Backend become unresponsive
- Wallet become fully private meanwhile (not sure how could this happen)

This PR also adds a new exception called `CoinJoinClientException`, which is thrown by the sanity checks.
This exception can be used to make `NoCoinsToMixException` useless. So that's got removed.
