### PR TITLE
Distinct Alices by Script when considering minimum input count in Coinjoin

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
@@ -14,7 +14,7 @@ public class StepConnectionConfirmationTests
 	[Fact]
 	public async Task AllConfirmedStepsAsync()
 	{
-		WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinInputCountByRoundMultiplier = 0.5 };
+		WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinUniqueInputCountByRound = 2 };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var a1 = WabiSabiFactory.CreateAlice(round);
 		var a2 = WabiSabiFactory.CreateAlice(round);
@@ -40,7 +40,7 @@ public class StepConnectionConfirmationTests
 	[Fact]
 	public async Task NotAllConfirmedStaysAsync()
 	{
-		WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinInputCountByRoundMultiplier = 0.5 };
+		WabiSabiConfig cfg = new() { MaxInputCountByRound = 4, MinUniqueInputCountByRound = 2 };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var a1 = WabiSabiFactory.CreateAlice(round);
 		var a2 = WabiSabiFactory.CreateAlice(round);
@@ -73,7 +73,7 @@ public class StepConnectionConfirmationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			ConnectionConfirmationTimeout = TimeSpan.Zero
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
@@ -110,7 +110,7 @@ public class StepConnectionConfirmationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 2,
 			ConnectionConfirmationTimeout = TimeSpan.Zero
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -15,7 +15,7 @@ public class StepInputRegistrationTests
 	[Fact]
 	public async Task RoundFullAsync()
 	{
-		WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
+		WabiSabiConfig cfg = new() { MaxInputCountByRound = 3, MinUniqueInputCountByRound = 1 };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
 
@@ -37,7 +37,7 @@ public class StepInputRegistrationTests
 	[Fact]
 	public async Task DetectSpentTxoBeforeSteppingIntoConnectionConfirmationAsync()
 	{
-		WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
+		WabiSabiConfig cfg = new() { MaxInputCountByRound = 3, MinUniqueInputCountByRound = 1 };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var offendingAlice = WabiSabiFactory.CreateAlice(round); // this Alice spent the coin after registration
 
@@ -68,7 +68,7 @@ public class StepInputRegistrationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 1
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var alice1 = WabiSabiFactory.CreateAlice(round);
@@ -103,7 +103,7 @@ public class StepInputRegistrationTests
 		{
 			StandardInputRegistrationTimeout = TimeSpan.Zero,
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 1
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
@@ -124,7 +124,7 @@ public class StepInputRegistrationTests
 			BlameInputRegistrationTimeout = TimeSpan.Zero,
 			StandardInputRegistrationTimeout = TimeSpan.FromHours(1), // Test that this is disregarded.
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 1
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var alice1 = WabiSabiFactory.CreateAlice(round);
@@ -151,7 +151,7 @@ public class StepInputRegistrationTests
 		{
 			StandardInputRegistrationTimeout = TimeSpan.Zero,
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 1
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
@@ -175,7 +175,7 @@ public class StepInputRegistrationTests
 			BlameInputRegistrationTimeout = TimeSpan.Zero,
 			StandardInputRegistrationTimeout = TimeSpan.FromHours(1), // Test that this is disregarded.
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 2
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var alice1 = WabiSabiFactory.CreateAlice(round);
@@ -200,7 +200,7 @@ public class StepInputRegistrationTests
 		{
 			StandardInputRegistrationTimeout = TimeSpan.FromHours(1),
 			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 1
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -30,7 +30,7 @@ public class StepOutputRegistrationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 		};
 		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
@@ -79,7 +79,7 @@ public class StepOutputRegistrationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			OutputRegistrationTimeout = TimeSpan.Zero,
 			CoordinationFeeRate = CoordinationFeeRate.Zero
 		};
@@ -119,7 +119,7 @@ public class StepOutputRegistrationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			OutputRegistrationTimeout = TimeSpan.Zero,
 			CoordinationFeeRate = CoordinationFeeRate.Zero
 		};
@@ -174,7 +174,7 @@ public class StepOutputRegistrationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5
+			MinUniqueInputCountByRound = 1
 		};
 		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 
@@ -250,7 +250,7 @@ public class StepOutputRegistrationTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			CoordinationFeeRate = CoordinationFeeRate.Zero
 		};
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -32,7 +32,7 @@ public class StepTransactionSigningTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 		};
 		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
@@ -67,7 +67,7 @@ public class StepTransactionSigningTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 		};
 		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
@@ -108,7 +108,7 @@ public class StepTransactionSigningTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 0.5,
+			MinUniqueInputCountByRound = 1,
 			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 		};
 
@@ -155,7 +155,7 @@ public class StepTransactionSigningTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 1,
+			MinUniqueInputCountByRound = 2,
 			TransactionSigningTimeout = TimeSpan.Zero,
 			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 		};
@@ -196,7 +196,7 @@ public class StepTransactionSigningTests
 		WabiSabiConfig cfg = new()
 		{
 			MaxInputCountByRound = 2,
-			MinInputCountByRoundMultiplier = 1,
+			MinUniqueInputCountByRound = 2,
 			TransactionSigningTimeout = TimeSpan.Zero,
 			OutputRegistrationTimeout = TimeSpan.Zero,
 			FailFastTransactionSigningTimeout = TimeSpan.Zero,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -159,7 +159,9 @@ public partial class Arena : PeriodicRunner
 					}
 				}
 
-				if (round.InputCount < Config.MinInputCountByRound)
+				var uniqueInputsByScript = round.Alices.DistinctBy(alice => alice.Coin.ScriptPubKey);
+
+				if (uniqueInputsByScript.Count() < Config.MinInputCountByRound)
 				{
 					if (!round.InputRegistrationTimeFrame.HasExpired)
 					{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -161,7 +161,7 @@ public partial class Arena : PeriodicRunner
 
 				var uniqueInputsByScript = round.Alices.DistinctBy(alice => alice.Coin.ScriptPubKey);
 
-				if (uniqueInputsByScript.Count() < Config.MinInputCountByRound)
+				if (uniqueInputsByScript.Count() < Config.MinUniqueInputCountByRound)
 				{
 					if (!round.InputRegistrationTimeFrame.HasExpired)
 					{
@@ -170,7 +170,7 @@ public partial class Arena : PeriodicRunner
 
 					MaxSuggestedAmountProvider.StepMaxSuggested(round, false);
 					EndRound(round, EndRoundState.AbortedNotEnoughAlices);
-					round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.InputRegistration)} phase. The minimum is ({Config.MinInputCountByRound}). {nameof(round.Parameters.MaxSuggestedAmount)} was '{round.Parameters.MaxSuggestedAmount}' BTC.");
+					round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.InputRegistration)} phase. The minimum is ({Config.MinUniqueInputCountByRound}). {nameof(round.Parameters.MaxSuggestedAmount)} was '{round.Parameters.MaxSuggestedAmount}' BTC.");
 				}
 				else if (round.IsInputRegistrationEnded(Config.MaxInputCountByRound))
 				{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -159,9 +159,7 @@ public partial class Arena : PeriodicRunner
 					}
 				}
 
-				var uniqueInputsByScript = round.Alices.DistinctBy(alice => alice.Coin.ScriptPubKey);
-
-				if (uniqueInputsByScript.Count() < Config.MinUniqueInputCountByRound)
+				if (round.UniqueScriptsCount < Config.MinUniqueInputCountByRound)
 				{
 					if (!round.InputRegistrationTimeFrame.HasExpired)
 					{
@@ -170,7 +168,7 @@ public partial class Arena : PeriodicRunner
 
 					MaxSuggestedAmountProvider.StepMaxSuggested(round, false);
 					EndRound(round, EndRoundState.AbortedNotEnoughAlices);
-					round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.InputRegistration)} phase. The minimum is ({Config.MinUniqueInputCountByRound}). {nameof(round.Parameters.MaxSuggestedAmount)} was '{round.Parameters.MaxSuggestedAmount}' BTC.");
+					round.LogInfo($"Not enough inputs with unique scripts ({round.UniqueScriptsCount}) in {nameof(Phase.InputRegistration)} phase. The minimum is ({Config.MinUniqueInputCountByRound}). {nameof(round.Parameters.MaxSuggestedAmount)} was '{round.Parameters.MaxSuggestedAmount}' BTC.");
 				}
 				else if (round.IsInputRegistrationEnded(Config.MaxInputCountByRound))
 				{
@@ -209,7 +207,7 @@ public partial class Arena : PeriodicRunner
 					// Once an input is confirmed and non-zero credentials are issued, it must be included and must provide a
 					// a signature for a valid transaction to be produced, therefore this is the last possible opportunity to
 					// remove any spent inputs.
-					if (round.InputCount >= Config.MinInputCountByRound)
+					if (round.UniqueScriptsCount >= Config.MinUniqueInputCountByRound)
 					{
 						await foreach (var offendingAlices in CheckTxoSpendStatusAsync(round, cancel).ConfigureAwait(false))
 						{
@@ -221,10 +219,10 @@ public partial class Arena : PeriodicRunner
 						}
 					}
 
-					if (round.InputCount < Config.MinInputCountByRound)
+					if (round.UniqueScriptsCount < Config.MinUniqueInputCountByRound)
 					{
 						EndRound(round, EndRoundState.AbortedNotEnoughAlices);
-						round.LogInfo($"Not enough inputs ({round.InputCount}) in {nameof(Phase.ConnectionConfirmation)} phase. The minimum is ({Config.MinInputCountByRound}).");
+						round.LogInfo($"Not enough inputs with unique scripts ({round.UniqueScriptsCount}) in {nameof(Phase.ConnectionConfirmation)} phase. The minimum is ({Config.MinUniqueInputCountByRound}).");
 					}
 					else
 					{
@@ -408,7 +406,7 @@ public partial class Arena : PeriodicRunner
 
 		round.LogInfo($"Removed {cnt} alices, because they didn't sign. Remaining: {round.InputCount}");
 
-		if (round.InputCount >= Config.MinInputCountByRound)
+		if (round.UniqueScriptsCount >= Config.MinUniqueInputCountByRound)
 		{
 			EndRound(round, EndRoundState.NotAllAlicesSign);
 			await CreateBlameRoundAsync(round, cancellationToken).ConfigureAwait(false);
@@ -442,7 +440,7 @@ public partial class Arena : PeriodicRunner
 		if (Config.WW200CompatibleLoadBalancing)
 		{
 			// Destroy the round when it reaches this input count and create 2 new ones instead.
-			var roundDestroyerInputCount = Config.MinInputCountByRound * 2 + Config.MinInputCountByRound / 2;
+			var roundDestroyerInputCount = Config.MinUniqueInputCountByRound * 2 + Config.MinUniqueInputCountByRound / 2;
 
 			foreach (var round in Rounds.Where(x =>
 				x.Phase == Phase.InputRegistration

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.Collections.Generic;
+using System.Linq;
 using WabiSabi.Crypto;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Crypto;
@@ -59,6 +60,7 @@ public class Round
 	public CredentialIssuerParameters VsizeCredentialIssuerParameters { get; }
 	public List<Alice> Alices { get; } = new();
 	public int InputCount => Alices.Count;
+	public int UniqueScriptsCount => Alices.DistinctBy(alice => alice.Coin.ScriptPubKey).Count();
 	public List<Bob> Bobs { get; } = new();
 
 	public Phase Phase { get; private set; } = Phase.InputRegistration;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -97,7 +97,7 @@ public record RoundParameters
 			miningFeeRate,
 			coordinationFeeRate,
 			maxSuggestedAmount,
-			wabiSabiConfig.MinInputCountByRound,
+			wabiSabiConfig.MinUniqueInputCountByRound,
 			wabiSabiConfig.MaxInputCountByRound,
 			new MoneyRange(wabiSabiConfig.MinRegistrableAmount, wabiSabiConfig.MaxRegistrableAmount),
 			new MoneyRange(wabiSabiConfig.MinRegistrableAmount, wabiSabiConfig.MaxRegistrableAmount),

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -91,15 +91,9 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "MaxInputCountByRound", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public int MaxInputCountByRound { get; set; } = 100;
 
-	[DefaultValue(0.5)]
-	[JsonProperty(PropertyName = "MinInputCountByRoundMultiplier", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public double MinInputCountByRoundMultiplier { get; set; } = 0.5;
-
 	[DefaultValue(150)]
 	[JsonProperty(PropertyName = "MinUniqueInputCountByRound", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public int MinUniqueInputCountByRound { get; set; } = 150;
-
-	public int MinInputCountByRound => Math.Max(1, (int)(MaxInputCountByRound * MinInputCountByRoundMultiplier));
 
 	[DefaultValueCoordinationFeeRate(0.003, 0.01)]
 	[JsonProperty(PropertyName = "CoordinationFeeRate", DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -95,6 +95,10 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "MinInputCountByRoundMultiplier", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public double MinInputCountByRoundMultiplier { get; set; } = 0.5;
 
+	[DefaultValue(150)]
+	[JsonProperty(PropertyName = "MinUniqueInputCountByRound", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public int MinUniqueInputCountByRound { get; set; } = 150;
+
 	public int MinInputCountByRound => Math.Max(1, (int)(MaxInputCountByRound * MinInputCountByRoundMultiplier));
 
 	[DefaultValueCoordinationFeeRate(0.003, 0.01)]


### PR DESCRIPTION
Fixes #10416

> Currently the minimum count of inputs is 150, regardless of the script used. Meaning if a user registers 10 inputs of the same address, the "effective" input count is only 140.
Instead, the coordinator should abort the round, when less than 150 unique scripts are on the input side.