### PR TITLE
Reduce MaxAnonScore of PrivateCoinJoinProfile for new wallets

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -5,7 +5,7 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
 	public const int MinAnonScore = 50;
-	public const int MaxAnonScore = 101;
+	public const int MaxAnonScore = 61;
 
 	public PrivateCoinJoinProfileViewModel(int anonScoreTarget)
 	{

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -4,7 +4,7 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
-	public const int MinAnonScore = 50;
+	public const int MinAnonScore = 27;
 	public const int MaxAnonScore = 76;
 
 	public PrivateCoinJoinProfileViewModel(int anonScoreTarget)

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -5,7 +5,7 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
 	public const int MinAnonScore = 50;
-	public const int MaxAnonScore = 61;
+	public const int MaxAnonScore = 76;
 
 	public PrivateCoinJoinProfileViewModel(int anonScoreTarget)
 	{

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -4,6 +4,7 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
+	// https://github.com/zkSNACKs/WalletWasabi/pull/10468#issuecomment-1506284198
 	public const int MinAnonScore = 27;
 	public const int MaxAnonScore = 76;
 


### PR DESCRIPTION
This PR reduces the `MaxAnonScore` of `PrivateCoinJoinProfile` from 100 to 60.  
It covers both ideas mentioned in #10462:
> - lower the privacy scores of Maximize Privacy profile, it's a terrible overkill
> - Reduce the impact of randomness

Old wallets with `PrivacyProfile` selected would now see that they have a `Custom` profile if their AS is between 61 and 100, but nothing would change for them.

I didn't implement retro-compatibility (set `AnonScoreTarget` (AST) lower for old wallets with `PrivacyProfile` selected) in case of a NACK because there are several things to add. Still, if it's preferred to have retro-compatibility, I will add the following behavior, so please give your opinion in the comments:
- Add the name of the `CoinJoinProfile` selected to the wallet json file
- While constructing the `KeyManager` from the file, perform these actions, for example, using a `JsonConverter`
   1) If no profile name is saved in the file and `50 <= AST < 101` (i.e., an old client with `PrivacyProfile` selected launching wallet for the first time after update), set AST  at `Random(50,61)`
   2) Save the selected profile name to the wallet file if different from what's saved.

Unfortunately, this "complexity" seems necessary for retro-compatibility because of the case where a client would deliberately set his `AnonScore` > 60 and < 101. In that case, we don't want to set back the AST to `Random(50,61)` every time he relaunches the wallet. Also, if an old wallet deliberately chose AST > 60 and < 101, it will be set back to `Random(50,61)`, which is not expected.

Bonus question: Why is this in a ViewModel??