### PR TITLE
Use if-else instead of a switch statement when having 2 or fewer cases

### DIFF
--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -462,10 +462,8 @@ public class ChaumianCoinJoinController : ControllerBase
 			round.RemoveAlicesBy(uniqueIdGuid);
 			return NoContent();
 		}
-		else
-		{
-			return Gone($"Participation can be only unconfirmed from InputRegistration phase. Current phase: {phase}.");
-		}
+
+		return Gone($"Participation can be only unconfirmed from InputRegistration phase. Current phase: {phase}.");
 	}
 
 	/// <summary>
@@ -597,16 +595,12 @@ public class ChaumianCoinJoinController : ControllerBase
 			{
 				return Ok(hex);
 			}
-			else
-			{
-				return NotFound("Hex not found. This should never happen.");
-			}
+
+			return NotFound("Hex not found. This should never happen.");
 		}
-		else
-		{
-			TryLogLateRequest(roundId, RoundPhase.Signing);
-			return Conflict($"Coinjoin can only be requested from Signing phase. Current phase: {phase}.");
-		}
+
+		TryLogLateRequest(roundId, RoundPhase.Signing);
+		return Conflict($"Coinjoin can only be requested from Signing phase. Current phase: {phase}.");
 	}
 
 	/// <summary>
@@ -703,11 +697,9 @@ public class ChaumianCoinJoinController : ControllerBase
 
 			return NoContent();
 		}
-		else
-		{
-			TryLogLateRequest(roundId, RoundPhase.Signing);
-			return Conflict($"Coinjoin can only be requested from Signing phase. Current phase: {phase}.");
-		}
+
+		TryLogLateRequest(roundId, RoundPhase.Signing);
+		return Conflict($"Coinjoin can only be requested from Signing phase. Current phase: {phase}.");
 	}
 
 	/// <summary>

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -457,7 +457,7 @@ public class ChaumianCoinJoinController : ControllerBase
 		}
 
 		RoundPhase phase = round.Phase;
-		if (phase is RoundPhase.InputRegistration)
+		if (phase == RoundPhase.InputRegistration)
 		{
 			round.RemoveAlicesBy(uniqueIdGuid);
 			return NoContent();

--- a/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
+++ b/WalletWasabi.Backend/Controllers/ChaumianCoinJoinController.cs
@@ -650,7 +650,7 @@ public class ChaumianCoinJoinController : ControllerBase
 				foreach (var signaturePair in signatures)
 				{
 					int index = signaturePair.Key;
-					WitScript witness;
+					WitScript witness = new();
 					try
 					{
 						witness = new WitScript(signaturePair.Value);


### PR DESCRIPTION
This PR fixes the following deepsource issue reported in #10466:
https://deepsource.io/gh/zkSNACKs/WalletWasabi/run/75419cc3-9021-404c-ab5f-4cb5146e32a9/csharp/CS-R1116?listindex=1

> The primary use case of a switch statement is to handle different scenarios that cannot be easily handled using the traditional if-else statement. However, if a switch has 2 or fewer cases, consider falling back to the traditional if-else approach as it is easier to comprehend.

Plus that part of the code is less indented now.

The PR also fixes this deepsource issue: `Variable is uninitialized CS-W1022`

Please review with whitespace changes off: https://github.com/zkSNACKs/WalletWasabi/pull/10469/files?diff=unified&w=1