### PR TITLE
Optimized SmartLabel type

### DIFF
--- a/WalletWasabi.Fluent/Helpers/LabelHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/LabelHelpers.cs
@@ -13,7 +13,7 @@ public static class LabelHelpers
 
 		// Make recent and receive labels count more for the current wallet
 		var multiplier = 100;
-		foreach (var label in wallet.KeyManager.GetReceiveLabels().Reverse().SelectMany(x => x.Labels))
+		foreach (var label in wallet.KeyManager.GetReceiveLabels().Reverse().SelectMany(x => x))
 		{
 			var score = (intent == Intent.Receive ? 100 : 1) * multiplier;
 			if (!labelPool.TryAdd(label, score))
@@ -28,7 +28,7 @@ public static class LabelHelpers
 		}
 
 		// Receive addresses should be more dominant.
-		foreach (var label in WalletHelpers.GetReceiveAddressLabels().SelectMany(x => x.Labels))
+		foreach (var label in WalletHelpers.GetReceiveAddressLabels().SelectMany(x => x))
 		{
 			var score = intent == Intent.Receive ? 100 : 1;
 			if (!labelPool.TryAdd(label, score))
@@ -38,7 +38,7 @@ public static class LabelHelpers
 		}
 
 		// Change addresses shouldn't be much dominant, but should be present.
-		foreach (var label in WalletHelpers.GetChangeAddressLabels().SelectMany(x => x.Labels))
+		foreach (var label in WalletHelpers.GetChangeAddressLabels().SelectMany(x => x))
 		{
 			var score = 1;
 			if (!labelPool.TryAdd(label, score))
@@ -48,7 +48,7 @@ public static class LabelHelpers
 		}
 
 		multiplier = 100; // Make recent labels count more.
-		foreach (var label in WalletHelpers.GetTransactionLabels().SelectMany(x => x.Labels).Reverse())
+		foreach (var label in WalletHelpers.GetTransactionLabels().SelectMany(x => x).Reverse())
 		{
 			var score = (intent == Intent.Send ? 100 : 1) * multiplier;
 			if (!labelPool.TryAdd(label, score))

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/LabelEntryDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/LabelEntryDialogViewModel.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using DynamicData;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Fluent.Extensions;
@@ -21,7 +20,7 @@ public partial class LabelEntryDialogViewModel : DialogViewModelBase<SmartLabel?
 		_wallet = wallet;
 		SuggestionLabels = new SuggestionLabelsViewModel(wallet.KeyManager, Intent.Send, 3)
 		{
-			Labels = { label.Labels }
+			Labels = { label }
 		};
 
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Labels/SuggestionLabelsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Labels/SuggestionLabelsViewModel.cs
@@ -48,7 +48,7 @@ public partial class SuggestionLabelsViewModel : ViewModelBase
 
 		// Make recent and receive labels count more for the current wallet
 		var multiplier = 100;
-		foreach (var label in KeyManager.GetReceiveLabels().Reverse().SelectMany(x => x.Labels))
+		foreach (var label in KeyManager.GetReceiveLabels().Reverse().SelectMany(x => x))
 		{
 			var score = (Intent == Intent.Receive ? 100 : 1) * multiplier;
 			if (!labelPool.TryAdd(label, score))
@@ -63,7 +63,7 @@ public partial class SuggestionLabelsViewModel : ViewModelBase
 		}
 
 		// Receive addresses should be more dominant.
-		foreach (var label in WalletHelpers.GetReceiveAddressLabels().SelectMany(x => x.Labels))
+		foreach (var label in WalletHelpers.GetReceiveAddressLabels().SelectMany(x => x))
 		{
 			var score = Intent == Intent.Receive ? 100 : 1;
 			if (!labelPool.TryAdd(label, score))
@@ -73,7 +73,7 @@ public partial class SuggestionLabelsViewModel : ViewModelBase
 		}
 
 		// Change addresses shouldn't be much dominant, but should be present.
-		foreach (var label in WalletHelpers.GetChangeAddressLabels().SelectMany(x => x.Labels))
+		foreach (var label in WalletHelpers.GetChangeAddressLabels().SelectMany(x => x))
 		{
 			var score = 1;
 			if (!labelPool.TryAdd(label, score))
@@ -83,7 +83,7 @@ public partial class SuggestionLabelsViewModel : ViewModelBase
 		}
 
 		multiplier = 100; // Make recent labels count more.
-		foreach (var label in WalletHelpers.GetTransactionLabels().SelectMany(x => x.Labels).Reverse())
+		foreach (var label in WalletHelpers.GetTransactionLabels().SelectMany(x => x).Reverse())
 		{
 			var score = (Intent == Intent.Send ? 100 : 1) * multiplier;
 			if (!labelPool.TryAdd(label, score))

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -76,7 +76,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		TransactionHasChange =
 			_transaction.InnerWalletOutputs.Any(x => x.ScriptPubKey != info.Destination.ScriptPubKey);
 
-		Labels = new SmartLabel(transactionResult.SpentCoins.SelectMany(x => x.GetLabels(info.PrivateCoinThreshold)).Except(info.Recipient.Labels));
+		Labels = new SmartLabel(transactionResult.SpentCoins.SelectMany(x => x.GetLabels(info.PrivateCoinThreshold)).Except(info.Recipient));
 		TransactionHasPockets = Labels.Any();
 
 		Recipient = info.Recipient;

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -397,17 +397,17 @@ public class SendTests
 
 			Assert.Single(res.InnerWalletOutputs);
 			Assert.Equal(2, res.OuterWalletOutputs.Count());
-			IEnumerable<string> change = res.InnerWalletOutputs.Single().HdPubKey.Label.Labels;
+			IEnumerable<string> change = res.InnerWalletOutputs.Single().HdPubKey.Label;
 			Assert.Contains("outgoing", change);
 			Assert.Contains("outgoing2", change);
 
 			await broadcaster.SendTransactionAsync(res.Transaction);
 
 			IEnumerable<SmartCoin> unconfirmedCoins = wallet.Coins.Where(x => x.Height == Height.Mempool).ToArray();
-			IEnumerable<string> unconfirmedCoinLabels = unconfirmedCoins.SelectMany(x => x.HdPubKey.Label.Labels).ToArray();
+			IEnumerable<string> unconfirmedCoinLabels = unconfirmedCoins.SelectMany(x => x.HdPubKey.Label).ToArray();
 			Assert.Contains("outgoing", unconfirmedCoinLabels);
 			Assert.Contains("outgoing2", unconfirmedCoinLabels);
-			IEnumerable<string> allKeyLabels = keyManager.GetKeys().SelectMany(x => x.Label.Labels);
+			IEnumerable<string> allKeyLabels = keyManager.GetKeys().SelectMany(x => x.Label);
 			Assert.Contains("outgoing", allKeyLabels);
 			Assert.Contains("outgoing2", allKeyLabels);
 
@@ -416,10 +416,10 @@ public class SendTests
 			await Common.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 1);
 
 			var bestHeight = new Height(bitcoinStore.SmartHeaderChain.TipHeight);
-			IEnumerable<string> confirmedCoinLabels = wallet.Coins.Where(x => x.Height == bestHeight).SelectMany(x => x.HdPubKey.Label.Labels);
+			IEnumerable<string> confirmedCoinLabels = wallet.Coins.Where(x => x.Height == bestHeight).SelectMany(x => x.HdPubKey.Label);
 			Assert.Contains("outgoing", confirmedCoinLabels);
 			Assert.Contains("outgoing2", confirmedCoinLabels);
-			allKeyLabels = keyManager.GetKeys().SelectMany(x => x.Label.Labels);
+			allKeyLabels = keyManager.GetKeys().SelectMany(x => x.Label);
 			Assert.Contains("outgoing", allKeyLabels);
 			Assert.Contains("outgoing2", allKeyLabels);
 

--- a/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartLabelTests.cs
@@ -102,12 +102,12 @@ public class SmartLabelTests
 
 		label2 = new SmartLabel("qux", "bar");
 		label = SmartLabel.Merge(label, label2);
-		Assert.Equal(4, label.Labels.Count());
+		Assert.Equal(4, label.Labels.Length);
 		Assert.Equal("bar, buz, foo, qux", label);
 
 		label2 = new SmartLabel("Qux", "Bar");
 		label = SmartLabel.Merge(label, label2, null!);
-		Assert.Equal(4, label.Labels.Count());
+		Assert.Equal(4, label.Labels.Length);
 		Assert.Equal("bar, buz, foo, qux", label);
 	}
 

--- a/WalletWasabi/Blockchain/Analysis/Clustering/SmartLabel.cs
+++ b/WalletWasabi/Blockchain/Analysis/Clustering/SmartLabel.cs
@@ -1,153 +1,168 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace WalletWasabi.Blockchain.Analysis.Clustering;
 
-public class SmartLabel : IEquatable<SmartLabel>, IEquatable<string>, IEnumerable<string>, IComparable<SmartLabel>
+public readonly struct SmartLabel : IEquatable<SmartLabel>, IComparable<SmartLabel>, IEnumerable<string>
 {
+	private readonly string[]? _labels;
+	
 	public SmartLabel(params string[] labels) : this(labels as IEnumerable<string>)
 	{
 	}
 
-	public SmartLabel(IEnumerable<string> labels)
+	public SmartLabel(IEnumerable<string>? labels)
 	{
-		labels ??= Enumerable.Empty<string>();
-		Labels = labels
-			   .SelectMany(x => x?.Split(Separators, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>())
-			   .Select(x => x.Trim())
-			   .Where(x => x.Length != 0)
-			   .Distinct(StringComparer.OrdinalIgnoreCase)
-			   .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-			   .ToArray();
-
-		IsEmpty = !Labels.Any();
-
-		LabelString = string.Join(", ", Labels);
+		_labels = (labels ?? Array.Empty<string>())
+		   .SelectMany(x => x?.Split(Separators, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>())
+		   .Select(x => x.Trim())
+		   .Where(x => x.Length != 0)
+		   .Distinct(StringComparer.OrdinalIgnoreCase)
+		   .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+		   .ToArray();
 	}
 
-	public static SmartLabel Empty { get; } = new SmartLabel();
+	public static SmartLabel Empty { get; } = new();
 	public static char[] Separators { get; } = new[] { ',', ':' };
-	public IEnumerable<string> Labels { get; }
-	public bool IsEmpty { get; }
+	
+	public ReadOnlySpan<string> Labels => _labels;
+	public bool IsEmpty => Labels.IsEmpty;
 
-	private string LabelString { get; }
-
-	public override string ToString() => LabelString;
-
-	public static SmartLabel Merge(IEnumerable<SmartLabel> labels)
+	public override string ToString()
 	{
-		labels ??= Enumerable.Empty<SmartLabel>();
-
-		IEnumerable<string> labelStrings = labels
-			.SelectMany(x => x?.Labels ?? Enumerable.Empty<string>())
-			.Where(x => x is { });
-
-		return new SmartLabel(labelStrings);
-	}
-
-	public static SmartLabel Merge(params SmartLabel[] labels) => Merge(labels as IEnumerable<SmartLabel>);
-
-	public IEnumerator<string> GetEnumerator() => Labels.GetEnumerator();
-
-	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-	#region Equality
-
-	public int CompareTo(SmartLabel? other)
-	{
-		if (other is null)
+		const string Separator = ", ";
+		int length = 0;
+		
+		foreach (var label in this)
 		{
-			return -1;
+			length += label.Length + Separator.Length;
 		}
 
-		return string.Compare(this, other, StringComparison.OrdinalIgnoreCase);
-	}
-
-	public override bool Equals(object? obj) => Equals(obj as SmartLabel) || Equals(obj as string);
-
-	public bool Equals(SmartLabel? other) => AreEquivalent(this, other);
-
-	public bool Equals(string? other) => AreEquivalent(other, this);
-
-	public bool Equals(string? other, StringComparison comparison) => AreEquivalent(other, this, comparison);
-
-	public bool Equals(SmartLabel? other, IEqualityComparer<string> comparer) => AreEquivalent(this, other, comparer);
-
-	public override int GetHashCode() => ((IStructuralEquatable)Labels).GetHashCode(EqualityComparer<string>.Default);
-
-	private static bool AreEquivalent(SmartLabel? x, SmartLabel? y, IEqualityComparer<string>? comparer = null)
-	{
-		if (x is null)
+		if (length == 0)
 		{
-			if (y is null)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return string.Empty;
 		}
-		else
+		
+		return string.Create(length - Separator.Length, this, static (span, self) =>
 		{
-			if (y is null)
-			{
-				return false;
-			}
-			else
-			{
-				return x.Labels.SequenceEqual(y.Labels, comparer);
-			}
-		}
-	}
+			var index = 0;
 
-	private static bool AreEquivalent(string? x, SmartLabel? y, StringComparison? comparison = null)
-	{
-		if (x is null)
-		{
-			if (y is null)
+			foreach (var label in self)
 			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-		else
-		{
-			if (y is null)
-			{
-				return false;
-			}
-			else
-			{
-				if (comparison is { })
-				{
-					return string.Equals(x, y.LabelString, comparison.Value);
+				label.CopyTo(span[index..]);
+				index += label.Length;
+
+				if (index < span.Length)
+				{					
+					Separator.CopyTo(span[index..]);
+					index += Separator.Length;
 				}
-
-				return x == y.LabelString;
 			}
+		});
+	}
+
+	public override int GetHashCode()
+	{
+		var hashCode = new HashCode();
+		
+		foreach (var label in Labels)
+		{
+			hashCode.Add(label);
+		}
+
+		return hashCode.ToHashCode();
+	}
+
+	public override bool Equals(object? other)
+	{
+		return other is SmartLabel label && label.Equals(this);
+	}
+
+	public bool Equals(SmartLabel other) =>
+		Labels.SequenceEqual(other.Labels);
+
+	public bool Equals(SmartLabel other, IEqualityComparer<string> comparer) =>
+		Labels.SequenceEqual(other.Labels, comparer);
+
+	public bool Equals(string? other) =>
+		ToString().Equals(other);
+
+	public bool Equals(string? other, StringComparison comparison) =>
+		ToString().Equals(other, comparison);
+
+	public int CompareTo(SmartLabel other) =>
+		Labels.SequenceCompareTo(other.Labels);
+
+	public int CompareTo(SmartLabel other, IComparer<string> comparer)
+	{
+		if (comparer is null)
+		{
+			return CompareTo(other);
+		}
+
+		// The following code repears what .NET could
+		// if it has SequenceCompareTo accepting a comparer.
+		var thisLabels = Labels;
+		var otherLabels = other.Labels;
+		
+		return CompareToSlow(
+			ref MemoryMarshal.GetReference(thisLabels),
+			thisLabels.Length,
+			ref MemoryMarshal.GetReference(otherLabels),
+			otherLabels.Length,
+			comparer);
+
+		static int CompareToSlow(ref string first, int firstLength, ref string second, int secondLength, IComparer<string> comparer)
+		{
+			int minLength = firstLength;
+            if (minLength > secondLength)
+			{
+                minLength = secondLength;
+			}
+			
+            for (int i = 0; i < minLength; i++)
+            {
+                int result = comparer.Compare(
+					Unsafe.Add(ref first, i),
+					Unsafe.Add(ref second, i));
+					
+                if (result != 0)
+                    return result;
+            }
+			
+            return firstLength.CompareTo(secondLength);
 		}
 	}
 
-	public static bool operator ==(SmartLabel? x, SmartLabel? y) => AreEquivalent(x, y);
+	public int CompareTo(string? other) =>
+		string.Compare(ToString(), other);
 
-	public static bool operator ==(string? x, SmartLabel? y) => AreEquivalent(x, y);
+	public int CompareTo(string? other, StringComparison comparison) =>
+		string.Compare(ToString(), other, comparison);
 
-	public static bool operator ==(SmartLabel? x, string? y) => y == x;
+	public ReadOnlySpan<string>.Enumerator GetEnumerator() =>
+		Labels.GetEnumerator();
 
-	public static bool operator !=(SmartLabel? x, SmartLabel? y) => !(x == y);
+	IEnumerator<string> IEnumerable<string>.GetEnumerator() => GetEnumeratorAllocating();
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumeratorAllocating();
 
-	public static bool operator !=(string? x, SmartLabel? y) => !(x == y);
+	private IEnumerator<string> GetEnumeratorAllocating() =>
+		(_labels ?? Enumerable.Empty<string>()).GetEnumerator();
+	
+	public static SmartLabel Merge(params SmartLabel[] labels) =>
+		Merge(labels as IEnumerable<SmartLabel>);
 
-	public static bool operator !=(SmartLabel? x, string? y) => !(x == y);
+	public static SmartLabel Merge(IEnumerable<SmartLabel> labels) =>
+		new(labels?.SelectMany(x => x));
+
+	public static bool operator ==(SmartLabel x, SmartLabel y) => x.Equals(y);
+
+	public static bool operator !=(SmartLabel x, SmartLabel y) => !(x == y);
 
 	public static implicit operator SmartLabel(string labels) => new(labels);
 
-	public static implicit operator string(SmartLabel label) => label?.LabelString;
-
-	#endregion Equality
+	public static implicit operator string(SmartLabel label) => label.ToString();
 }

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -111,8 +111,6 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 
 	public void SetLabel(SmartLabel label, KeyManager? kmToFile = null)
 	{
-		label ??= SmartLabel.Empty;
-
 		if (Label == label)
 		{
 			return;

--- a/WalletWasabi/JsonConverters/SmartLabelJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/SmartLabelJsonConverter.cs
@@ -6,7 +6,7 @@ namespace WalletWasabi.JsonConverters;
 public class SmartLabelJsonConverter : JsonConverter<SmartLabel>
 {
 	/// <inheritdoc />
-	public override SmartLabel? ReadJson(JsonReader reader, Type objectType, SmartLabel? existingValue, bool hasExistingValue, JsonSerializer serializer)
+	public override SmartLabel ReadJson(JsonReader reader, Type objectType, SmartLabel existingValue, bool hasExistingValue, JsonSerializer serializer)
 	{
 		if (reader.Value is string serialized)
 		{
@@ -17,9 +17,9 @@ public class SmartLabelJsonConverter : JsonConverter<SmartLabel>
 	}
 
 	/// <inheritdoc />
-	public override void WriteJson(JsonWriter writer, SmartLabel? value, JsonSerializer serializer)
+	public override void WriteJson(JsonWriter writer, SmartLabel value, JsonSerializer serializer)
 	{
 		var label = value;
-		writer.WriteValue(label ?? "");
+		writer.WriteValue(label);
 	}
 }


### PR DESCRIPTION
This PR turn the `SmartLabel` type into a slim wrapper around a backing array, so the type can fit into a single register. Additionally I changed `Labels` property type from `IEnumerable<string>` to `ReadOnlySpan<string>` which allows no allocating iteration over elements. The same happens when `foreach` loop is used over an instance itself because `GetEnumerator` returns `ReadOnlySpan<string>.Enumerator` while `IEnumerable<string` interface is implemented explicitly.

The only controversial thing I see here is the type of `Labels` property or maybe its existence. A better option, I guess, would be a method named `AsSpan()`.