### PR TITLE
remove backend deployment instructions link from backend README

### DIFF
--- a/WalletWasabi.Backend/README.md
+++ b/WalletWasabi.Backend/README.md
@@ -4,10 +4,6 @@
 - TestNet: http://testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion/swagger
 - Main: http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/swagger
 
-## Related Documents:
-
-[Backend Deployment And Update Instructions](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/BackendDeployment.md)
-
 ## HTTP
 
   Requests and Responses are JSON.


### PR DESCRIPTION
dead link
it was removed 4c95e03e75fe0736f52f58089ce237201253216a