### PR TITLE
[trivial] use https instead of http

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 **Visual Studio IDE:**
 
-**DO** use [CodeMaid](http://www.codemaid.net/), a Visual Studio extension to automatically clean up your code on saving the file.
+**DO** use [CodeMaid](https://www.codemaid.net/), a Visual Studio extension to automatically clean up your code on saving the file.
 CodeMaid is a non-intrusive code cleanup tool.
 
 Wasabi's CodeMaid settings [can be found in the root of the repository](https://github.com/zkSNACKs/WalletWasabi/blob/master/CodeMaid.config). They are automatically picked up by Visual Studio when you open the project, assuming the CodeMaid extension is installed. Unfortunately CodeMaid has no Visual Studio Code extension yet. You can check out the progress on this [under this GitHub issue](https://github.com/codecadwallader/codemaid/issues/273).

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -11,7 +11,7 @@ Bitcoin Knots is working very similarly to Bitcoin Core. You can get a grasp wit
 
 Todo:
 
-1. Install [Bitcoin Knots](http://bitcoinknots.org/) on your computer. Verify the PGP - there is a tutorial [here](http://bitcoinknots.org/)
+1. Install [Bitcoin Knots](https://bitcoinknots.org/) on your computer. Verify the PGP - there is a tutorial [here](https://bitcoinknots.org/)
 2. Start Bitcoin Knots with: bitcoin-qt.exe -regtest then quit immediately. In this way the data directory and the config files will be generated.
 ```
 Windows: "C:\Program Files\Bitcoin\bitcoin-qt.exe" -regtest


### PR DESCRIPTION
All remaining http ones are namespaces, localhosts, .onion links, copyrights and licences.
So I didn't touch those