### PR TITLE
Fix Common.fsx script for big amount values

### DIFF
--- a/Contrib/WalletDiagnostic/common.fsx
+++ b/Contrib/WalletDiagnostic/common.fsx
@@ -41,7 +41,7 @@ module Rpc =
   open FSharp.Data
   type ListCoinsRpcResponse = JsonProvider<"""{
     "result": [
-      {"txid":"73af1dd","index":0,"amount":2390000,"anonymitySet":"a1.0","confirmed":true,"confirmations":116,"keyPath":"84/0","address":"tb1q","spentBy":"2d7c3f"}
+      {"txid":"73af1dd","index":0,"amount":4300000000000,"anonymitySet":"a1.0","confirmed":true,"confirmations":116,"keyPath":"84/0","address":"tb1q","spentBy":"2d7c3f"}
     ]
   }""">
 


### PR DESCRIPTION
The model on master gives an `int`, but big amount need a `double` (or at least a `long` but IDK ho to do that).