### PR TITLE
Stop and Restart Coinjoins properly when entered Send Workflow

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -127,6 +127,11 @@ public partial class SendViewModel : RoutableViewModel
 					SubtractFee = amount == _wallet.Coins.TotalAmount() && !(IsFixedAmount || IsPayJoin)
 				};
 
+				if (_coinJoinManager is { } coinJoinManager)
+				{
+					await coinJoinManager.WalletEnteredTxPreviewAsync(_wallet);
+				}
+
 				Navigate().To(new TransactionPreviewViewModel(walletVm, transactionInfo));
 			},
 			nextCommandCanExecute);
@@ -328,7 +333,7 @@ public partial class SendViewModel : RoutableViewModel
 
 			if (_coinJoinManager is { } coinJoinManager)
 			{
-				coinJoinManager.WalletEnteredSendWorkflow(_wallet.WalletName);
+				coinJoinManager.WalletEnteredSendWorkflow(_wallet.WalletName, WalletStatus.InSendWorkFlow);
 			}
 		}
 
@@ -350,7 +355,7 @@ public partial class SendViewModel : RoutableViewModel
 
 		if (!isInHistory && _coinJoinManager is { } coinJoinManager)
 		{
-			coinJoinManager.WalletLeftSendWorkflow(_wallet.WalletName);
+			Task.Run(async () => await coinJoinManager.WalletLeftSendWorkflowAsync(_wallet));
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -582,4 +582,5 @@ public class CoinJoinManager : BackgroundService
 	private record StopCoinJoinCommand(IWallet Wallet) : CoinJoinCommand(Wallet);
 
 	private record TrackedAutoStart(Task Task, bool StopWhenAllMixed, bool OverridePlebStop, CancellationTokenSource CancellationTokenSource);
+	private record CoinJoinClientStateHolder(CoinJoinClientState CoinJoinClientState, bool StopWhenAllMixed, bool OverridePlebStop);
 }

--- a/WalletWasabi/WabiSabi/Client/WalletStatus.cs
+++ b/WalletWasabi/WabiSabi/Client/WalletStatus.cs
@@ -1,0 +1,8 @@
+namespace WalletWasabi.WabiSabi.Client;
+
+public enum WalletStatus
+{
+	Idle,
+	InSendWorkFlow,
+	NeedsToRestartAfterSend
+}


### PR DESCRIPTION
First part of #9972

https://github.com/zkSNACKs/WalletWasabi/issues/9972#issuecomment-1498862591

What this PR does:

If the user clicks on the `Send` tab and fills out the address - amount - label fields and presses `Next`, we assume the user's intention to send is serious.

So, if the CjClient is in input registration, we command the CjManager to stop participating in the round.
Once, the user is finished with the sending (either sends the tx or closes the Send dialog) we restart the coinjoin according to the original state when it was stopped.

_I need to refactor this, it's ugly._

