### PR TITLE
Specify wallet in the request path

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -77,7 +77,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		}).ToArray();
 	}
 
-	[JsonRpcMethod("createwallet")]
+	[JsonRpcMethod("createwallet", initializable: false)]
 	public object CreateWallet(string walletName, string password)
 	{
 		var walletGenerator = new WalletGenerator(Global.WalletManager.WalletDirectories.WalletsDir, Global.Network);
@@ -128,7 +128,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		};
 	}
 
-	[JsonRpcMethod("getstatus")]
+	[JsonRpcMethod("getstatus", initializable: false)]
 	public object GetStatus()
 	{
 		var sync = Global.Synchronizer;
@@ -198,7 +198,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		};
 	}
 
-	[JsonRpcMethod("broadcast")]
+	[JsonRpcMethod("broadcast", initializable: false)]
 	public async Task<object> SendRawTransactionAsync(string txHex)
 	{
 		txHex = Guard.Correct(txHex);
@@ -272,7 +272,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		coinJoinManager.StopAsync(activeWallet, CancellationToken.None).ConfigureAwait(false);
 	}
 
-	[JsonRpcMethod("selectwallet")]
+	[JsonRpcMethod("selectwallet", initializable: false)]
 	public void SelectWallet(string walletName)
 	{
 		walletName = Guard.NotNullOrEmptyOrWhitespace(nameof(walletName), walletName);
@@ -292,7 +292,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		}
 	}
 
-	[JsonRpcMethod("stop")]
+	[JsonRpcMethod("stop", initializable: false)]
 	public async Task StopAsync()
 	{
 		// RPC terminating itself so it should not block this call while the RPC interface is stopping.
@@ -301,9 +301,13 @@ public class WasabiJsonRpcService : IJsonRpcService
 
 	private void AssertWalletIsLoaded()
 	{
-		if (ActiveWallet is null || ActiveWallet.State != WalletState.Started)
+		if (ActiveWallet is null)
 		{
 			throw new InvalidOperationException("There is no wallet loaded.");
+		}
+		if (ActiveWallet.State < WalletState.Started)
+		{
+			throw new InvalidOperationException("Wallet is not fully loaded yet.");
 		}
 	}
 
@@ -312,6 +316,21 @@ public class WasabiJsonRpcService : IJsonRpcService
 		if (!activeWallet.IsLoggedIn && !activeWallet.TryLogin(password, out _))
 		{
 			throw new Exception($"'{activeWallet.WalletName}' wallet requires the password to start coinjoining.");
+		}
+	}
+
+	[JsonRpcInitialization]
+	public void Initialize(string path, bool needsWallet)
+	{
+		var parts = path.Split("/", StringSplitOptions.RemoveEmptyEntries);
+		var walletName = parts.Length == 1 ? parts[0] : string.Empty;
+		if (needsWallet && !string.IsNullOrEmpty(walletName))
+		{
+			SelectWallet(walletName);
+		}
+		else
+		{
+			throw new InvalidOperationException("Wallet name is invalid or not allowed.");
 		}
 	}
 }

--- a/WalletWasabi.Tests/RpcTests.cs
+++ b/WalletWasabi.Tests/RpcTests.cs
@@ -94,7 +94,7 @@ public class RpcTests
 	{
 		var handler = new JsonRpcRequestHandler<TestableRpcService>(new TestableRpcService());
 
-		var response = await handler.HandleAsync(request, CancellationToken.None);
+		var response = await handler.HandleAsync("", request, CancellationToken.None);
 		Assert.Equal(expectedResponse, response);
 	}
 

--- a/WalletWasabi/Rpc/JsonRpcInitializationAttribute.cs
+++ b/WalletWasabi/Rpc/JsonRpcInitializationAttribute.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.Rpc;
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class JsonRpcInitializationAttribute : Attribute
+{
+}

--- a/WalletWasabi/Rpc/JsonRpcMethodAttribute.cs
+++ b/WalletWasabi/Rpc/JsonRpcMethodAttribute.cs
@@ -6,10 +6,12 @@ namespace WalletWasabi.Rpc;
 [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
 public sealed class JsonRpcMethodAttribute : Attribute
 {
-	public JsonRpcMethodAttribute(string name)
+	public JsonRpcMethodAttribute(string name, bool initializable = true)
 	{
 		Name = name;
+		Initializable = initializable;
 	}
 
 	public string Name { get; }
+	public bool Initializable { get; }
 }

--- a/WalletWasabi/Rpc/JsonRpcMethodMetadata.cs
+++ b/WalletWasabi/Rpc/JsonRpcMethodMetadata.cs
@@ -8,16 +8,17 @@ namespace WalletWasabi.Rpc;
 /// </summary>
 public class JsonRpcMethodMetadata
 {
-	public JsonRpcMethodMetadata(string name, MethodInfo mi, List<(string name, Type type, bool isOptional, object defaultValue)> parameters)
+	public JsonRpcMethodMetadata(string name, MethodInfo mi, bool ri, List<(string name, Type type, bool isOptional, object defaultValue)> parameters)
 	{
 		Name = name;
+		RequiresInitialization = ri;
 		MethodInfo = mi;
 		Parameters = parameters;
 	}
 
 	// The name of the remote procedure. This is NOT the name of the method to be invoked.
 	public string Name { get; }
-
 	public MethodInfo MethodInfo { get; }
+	public bool RequiresInitialization { get; } 
 	public List<(string name, Type type, bool isOptional, object defaultValue)> Parameters { get; }
 }

--- a/WalletWasabi/Rpc/JsonRpcRequestHandler.cs
+++ b/WalletWasabi/Rpc/JsonRpcRequestHandler.cs
@@ -46,7 +46,7 @@ public class JsonRpcRequestHandler<TService>
 	/// <param name="body">The raw RPC request.</param>
 	/// <param name="cancellationToken">The cancellation token that will be past to the service handler in case it expects/accepts one.</param>
 	/// <returns>The response that, after serialization, is returned as response.</returns>
-	public async Task<string> HandleAsync(string body, CancellationToken cancellationToken)
+	public async Task<string> HandleAsync(string path, string body, CancellationToken cancellationToken)
 	{
 		if (!JsonRpcRequest.TryParse(body, out var jsonRpcRequests, out var isBatch))
 		{
@@ -56,12 +56,12 @@ public class JsonRpcRequestHandler<TService>
 		foreach (var jsonRpcRequest in jsonRpcRequests)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			results.Add(await HandleRequestAsync(jsonRpcRequest, cancellationToken).ConfigureAwait(false));
+			results.Add(await HandleRequestAsync(path, jsonRpcRequest, cancellationToken).ConfigureAwait(false));
 		}
 		return isBatch ? $"[{string.Join(",", results)}]" : results[0];
 	}
 
-	private async Task<string> HandleRequestAsync(JsonRpcRequest jsonRpcRequest, CancellationToken cancellationToken)
+	private async Task<string> HandleRequestAsync(string path, JsonRpcRequest jsonRpcRequest, CancellationToken cancellationToken)
 	{
 		var methodName = jsonRpcRequest.Method;
 
@@ -122,6 +122,12 @@ public class JsonRpcRequestHandler<TService>
 
 			var missingParameters = methodParameters.Count - parameters.Count;
 			parameters.AddRange(methodParameters.TakeLast(missingParameters).Select(x => x.defaultValue));
+		
+			if (procedureMetadata.RequiresInitialization && MetadataProvider.TryGetInitializer(out var initializer))
+			{
+				initializer.Invoke(Service, new object[] { path, procedureMetadata.RequiresInitialization });
+			}
+			
 			var result = procedureMetadata.MethodInfo.Invoke(Service, parameters.ToArray());
 
 			if (jsonRpcRequest.IsNotification) // the client is not interested in getting a response

--- a/WalletWasabi/Rpc/JsonRpcServer.cs
+++ b/WalletWasabi/Rpc/JsonRpcServer.cs
@@ -57,7 +57,8 @@ public class JsonRpcServer : BackgroundService
 
 					if (IsAuthorized(context))
 					{
-						var result = await handler.HandleAsync(body, stoppingToken).ConfigureAwait(false);
+						var path = request.Url?.LocalPath ?? string.Empty;
+						var result = await handler.HandleAsync(path, body, stoppingToken).ConfigureAwait(false);
 
 						// result is null only when the request is a notification.
 						if (!string.IsNullOrEmpty(result))

--- a/WalletWasabi/Rpc/JsonRpcService.cs
+++ b/WalletWasabi/Rpc/JsonRpcService.cs
@@ -18,8 +18,10 @@ public class JsonRpcServiceMetadataProvider
 {
 	// Keeps the directory of procedures' metadata
 	private Dictionary<string, JsonRpcMethodMetadata> _proceduresDirectory =
-			new();
+		new();
 
+	private MethodInfo? _initializer = null;
+	
 	public JsonRpcServiceMetadataProvider(Type serviceType)
 	{
 		ServiceType = serviceType;
@@ -37,16 +39,25 @@ public class JsonRpcServiceMetadataProvider
 		{
 			LoadServiceMetadata();
 		}
+
 		if (!_proceduresDirectory.TryGetValue(methodName, out metadata))
 		{
 			metadata = null;
 			return false;
 		}
+
 		return true;
 	}
 
+	public bool TryGetInitializer([NotNullWhen(true)] out MethodInfo? info)
+	{
+		info = _initializer;
+		return info is not null;
+	}
+	
 	private void LoadServiceMetadata()
 	{
+		_initializer = GetInitializationMethod();	
 		foreach (var info in EnumerateServiceInfo())
 		{
 			_proceduresDirectory.Add(info.Name, info);
@@ -68,10 +79,33 @@ public class JsonRpcServiceMetadataProvider
 					{
 						parameters.Add((p.Name, p.ParameterType, p.IsOptional, p.DefaultValue));
 					}
+
 					var jsonRpcMethodAttr = attribute;
-					yield return new JsonRpcMethodMetadata(jsonRpcMethodAttr.Name, methodInfo, parameters);
+					yield return new JsonRpcMethodMetadata(
+						jsonRpcMethodAttr.Name,
+						methodInfo,
+						jsonRpcMethodAttr.Initializable,
+						parameters);
 				}
 			}
 		}
+	}
+
+	internal MethodInfo? GetInitializationMethod()
+	{
+		var publicMethods = ServiceType.GetMethods();
+		foreach (var methodInfo in publicMethods)
+		{
+			var attrs = methodInfo.GetCustomAttributes();
+			foreach (Attribute attr in attrs)
+			{
+				if (attr is JsonRpcInitializationAttribute)
+				{
+					return methodInfo;
+				}
+			}
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
This PR allows to specify the wallet to use in the url path. 

```bash
curl -s
  \ --data-binary '{"jsonrpc":"2.0", "id":"curltext", "method":"listcoins", "params":[]}' 
  \ -H 'content-type: text/plain;'
  \ 'http://127.0.0.1:37128/MyWallet'
```

Before it was required to use two calls: `SelectWallet` first and then the wanted method.

