### PR TITLE
Fix CjManager Notification flow

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -4,7 +4,6 @@ using NBitcoin;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.Rounds;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -42,7 +42,7 @@ public class CoinJoinCoinSelectionTests
 			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
 			.ToList();
 
-		var selectCoinsTask = () => CoinJoinCoinSelector.SelectCoinsForRound(
+		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			consolidationMode: false,
@@ -51,7 +51,7 @@ public class CoinJoinCoinSelectionTests
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
 			ConfigureRng(5));
 
-		Assert.Throws<CoinJoinClientException>(selectCoinsTask);
+		Assert.Empty(coins);
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -4,6 +4,7 @@ using NBitcoin;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -41,7 +42,7 @@ public class CoinJoinCoinSelectionTests
 			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
 			.ToList();
 
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var selectCoinsTask = () => CoinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			consolidationMode: false,
@@ -50,7 +51,7 @@ public class CoinJoinCoinSelectionTests
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
 			ConfigureRng(5));
 
-		Assert.Empty(coins);
+		Assert.Throws<CoinJoinClientException>(selectCoinsTask);
 	}
 
 	[Fact]

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -45,16 +45,16 @@ public static class CoinJoinCoinSelector
 			liquidityClue = Constants.MaximumNumberOfBitcoinsMoney;
 		}
 
-		if (!coins.Any())
-		{
-			return ImmutableList<TCoin>.Empty;
-		}
-
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputScriptTypes.Contains(x.ScriptType))
 			.Where(x => x.EffectiveValue(parameters.MiningFeeRate) > Money.Zero)
 			.ToArray();
+
+		if (!filteredCoins.Any())
+		{
+			return ImmutableList<TCoin>.Empty;
+		}
 
 		var privateCoins = filteredCoins
 			.Where(x => x.IsPrivate(anonScoreTarget))

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -51,8 +51,10 @@ public static class CoinJoinCoinSelector
 			.Where(x => x.EffectiveValue(parameters.MiningFeeRate) > Money.Zero)
 			.ToArray();
 
+		// Sanity check.
 		if (!filteredCoins.Any())
 		{
+			Logger.LogInfo("No suitable coins for this round.");
 			return ImmutableList<TCoin>.Empty;
 		}
 
@@ -70,7 +72,8 @@ public static class CoinJoinCoinSelector
 
 		if (semiPrivateCoins.Length + redCoins.Length == 0)
 		{
-			throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate, "No red coins or semi private coins in the wallet.");
+			Logger.LogInfo("No suitable coins for this round.");
+			return ImmutableList<TCoin>.Empty;
 		}
 
 		Logger.LogDebug($"Coin selection started:");

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -45,6 +45,11 @@ public static class CoinJoinCoinSelector
 			liquidityClue = Constants.MaximumNumberOfBitcoinsMoney;
 		}
 
+		if (!coins.Any())
+		{
+			return ImmutableList<TCoin>.Empty;
+		}
+
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputScriptTypes.Contains(x.ScriptType))

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -5,12 +5,10 @@ using System.Diagnostics;
 using System.Linq;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Rounds;
-using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 namespace WalletWasabi.WabiSabi.Client;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -6,10 +6,12 @@ using System.Linq;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 
 namespace WalletWasabi.WabiSabi.Client;
 
@@ -63,8 +65,7 @@ public static class CoinJoinCoinSelector
 
 		if (semiPrivateCoins.Length + redCoins.Length == 0)
 		{
-			// Let's not mess up the logs when this function gets called many times.
-			return ImmutableList<TCoin>.Empty;
+			throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate, "No red coins or semi private coins in the wallet.");
 		}
 
 		Logger.LogDebug($"Coin selection started:");

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Crypto.Randomness;
-using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -450,11 +450,14 @@ public class CoinJoinManager : BackgroundService
 		{
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
-
-		// - If there was a CjClient exception, for example PlebStop or no coins to mix.
+		else if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false) && finishedCoinJoin.StopWhenAllMixed)
+		{
+			NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);
+		}
 		else if (cjClientException is not null)
 		{
-			// Keep trying, so CJ start automatically when the wallet becomes mixable again.
+			// - If there was a CjClient exception, for example PlebStop or no coins to mix,
+			// Keep trying, so CJ starts automatically when the wallet becomes mixable again.
 			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);
 			NotifyCoinJoinStartError(wallet, cjClientException.CoinjoinError);
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -455,7 +455,7 @@ public class CoinJoinManager : BackgroundService
 		}
 		else
 		{
-			finishedCoinJoin.Wallet.LogInfo($"{nameof(CoinJoinClient)} restart automatically.");
+			wallet.LogInfo($"{nameof(CoinJoinClient)} restart automatically.");
 
 			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);
 		}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -450,6 +450,7 @@ public class CoinJoinManager : BackgroundService
 		{
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
+
 		// - If there was a CjClient exception, for example PlebStop or no coins to mix.
 		else if (cjClientException is not null)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -443,7 +443,7 @@ public class CoinJoinManager : BackgroundService
 		if (finishedCoinJoin.IsStopped  // If stop was requested by user.
 			|| cancellationToken.IsCancellationRequested)    // If cancellation was requested.
 		{
-			NotifyWalletStoppedCoinJoin(finishedCoinJoin.Wallet);
+			NotifyWalletStoppedCoinJoin(wallet);
 		}
 		else if (wallet.IsUnderPlebStop && !finishedCoinJoin.OverridePlebStop)  // If wallet is under PlebStop threshold and user do not override it.
 		{
@@ -457,7 +457,7 @@ public class CoinJoinManager : BackgroundService
 		{
 			finishedCoinJoin.Wallet.LogInfo($"{nameof(CoinJoinClient)} restart automatically.");
 
-			ScheduleRestartAutomatically(finishedCoinJoin.Wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);
+			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);
 		}
 
 		if (!trackedCoinJoins.TryRemove(wallet.WalletName, out _))

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -442,15 +442,19 @@ public class CoinJoinManager : BackgroundService
 
 		NotifyCoinJoinCompletion(finishedCoinJoin);
 
-		// When to stop mixing.
-		if (finishedCoinJoin.IsStopped  // If stop was requested by user.
-			|| cancellationToken.IsCancellationRequested)    // If cancellation was requested.
+		// When to stop mixing:
+		// - If stop was requested by user.
+		// - If cancellation was requested.
+		if (finishedCoinJoin.IsStopped
+			|| cancellationToken.IsCancellationRequested)
 		{
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
-		else if (cjClientException is not null)	// If there was a CjClient exception, for example PlebStop or no coins to mix.
+		// - If there was a CjClient exception, for example PlebStop or no coins to mix.
+		else if (cjClientException is not null)
 		{
-			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);	// Keep trying, so CJ start automatically when the wallet becomes mixable again.
+			// Keep trying, so CJ start automatically when the wallet becomes mixable again.
+			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);
 			NotifyCoinJoinStartError(wallet, cjClientException.CoinjoinError);
 		}
 		else

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -179,7 +179,7 @@ public class CoinJoinManager : BackgroundService
 				}
 
 				// If all coins are already private, then don't mix.
-				if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false) && startCommand.StopWhenAllMixed)
+				if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false))
 				{
 					walletToStart.LogTrace("All mixed!");
 
@@ -450,9 +450,14 @@ public class CoinJoinManager : BackgroundService
 		{
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
-		else if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false) && finishedCoinJoin.StopWhenAllMixed)
+		else if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false))
 		{
 			NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);
+			if (!finishedCoinJoin.StopWhenAllMixed)
+			{
+				// In auto CJ mode we never stop trying.
+				ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, cancellationToken);
+			}
 		}
 		else if (cjClientException is not null)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -200,11 +200,12 @@ public class CoinJoinManager : BackgroundService
 					throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate, $"All coin candidates are already private and {nameof(startCommand.StopWhenAllMixed)} was {startCommand.StopWhenAllMixed}");
 				}
 
+				NotifyWalletStartedCoinJoin(walletToStart);
+
 				return coinCandidates;
 			}
 
 			var coinJoinTracker = await coinJoinTrackerFactory.CreateAndStartAsync(walletToStart, SanityChecksAndGetCoinCandidatesFunc, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop).ConfigureAwait(false);
-			NotifyWalletStartedCoinJoin(walletToStart);
 
 			if (!trackedCoinJoins.TryAdd(walletToStart.WalletName, coinJoinTracker))
 			{


### PR DESCRIPTION
Fixes: #10521

It got messed up in https://github.com/zkSNACKs/WalletWasabi/pull/10441

Previously:
We notified the `MusicBox` about the `PlebStop`, but right after that, we overwrote the `MusicBox` status and the user couldn't override the `PlebStop`.

With this:
User get to decide if he wants to override the PlebStop or not. Just as before my mistake.


Please test this PR and look out for edge cases.
