### PR TITLE
Start wallets automatically after daemon starts

### DIFF
--- a/WalletWasabi.Daemon/ArgumentHelpers.cs
+++ b/WalletWasabi.Daemon/ArgumentHelpers.cs
@@ -10,7 +10,7 @@ public static class ArgumentHelpers
 	{
 		var values = GetValues(key, args, converter);
 		value = values.FirstOrDefault();
-		return value != null;
+		return !Equals(value, default(T));
 	}
 
 	public static T[] GetValues<T>(string key, string[] args, Func<string, T> converter)

--- a/WalletWasabi.Daemon/ArgumentHelpers.cs
+++ b/WalletWasabi.Daemon/ArgumentHelpers.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace WalletWasabi.Daemon;
+
+public static class ArgumentHelpers
+{
+	public static bool TryGetValue<T>(string key, string[] args, Func<string, T> converter, [NotNullWhen(true)] out T? value)
+	{
+		var cliArgKey = "--" + key + "=";
+		var cliArgOrNull = args.FirstOrDefault(a => a.StartsWith(cliArgKey, StringComparison.InvariantCultureIgnoreCase));
+		if (cliArgOrNull is { } cliArg)
+		{
+			value = converter(cliArg[cliArgKey.Length..]);
+			return value != null;
+		}
+
+		value = default;
+		return false;
+	}
+}

--- a/WalletWasabi.Daemon/ArgumentHelpers.cs
+++ b/WalletWasabi.Daemon/ArgumentHelpers.cs
@@ -8,15 +8,17 @@ public static class ArgumentHelpers
 {
 	public static bool TryGetValue<T>(string key, string[] args, Func<string, T> converter, [NotNullWhen(true)] out T? value)
 	{
-		var cliArgKey = "--" + key + "=";
-		var cliArgOrNull = args.FirstOrDefault(a => a.StartsWith(cliArgKey, StringComparison.InvariantCultureIgnoreCase));
-		if (cliArgOrNull is { } cliArg)
-		{
-			value = converter(cliArg[cliArgKey.Length..]);
-			return value != null;
-		}
+		var values = GetValues(key, args, converter);
+		value = values.FirstOrDefault();
+		return value != null;
+	}
 
-		value = default;
-		return false;
+	public static T[] GetValues<T>(string key, string[] args, Func<string, T> converter)
+	{
+		var cliArgKey = "--" + key + "=";
+		return args
+			.Where(a => a.StartsWith(cliArgKey, StringComparison.InvariantCultureIgnoreCase))
+			.Select(x => converter(x[cliArgKey.Length..]))
+			.ToArray();
 	}
 }

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using NBitcoin;
 using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
@@ -106,11 +104,9 @@ public class Config
 
 	private static T GetEffectiveValue<T>(T valueInConfigFile, Func<string, T> converter, string[] args, string key)
 	{
-		var cliArgKey = "--" + key + "=";
-		var cliArgOrNull = args.FirstOrDefault(a => a.StartsWith(cliArgKey, StringComparison.InvariantCultureIgnoreCase));
-		if (cliArgOrNull is { } cliArg)
+		if (ArgumentHelpers.TryGetValue(key, args, converter, out var cliArg))
 		{
-			return converter(cliArg[cliArgKey.Length..]);
+			return cliArg;
 		}
 
 		var envKey = "WASABI-" + key.ToUpperInvariant();

--- a/WalletWasabi.Daemon/README.md
+++ b/WalletWasabi.Daemon/README.md
@@ -35,6 +35,7 @@ There are a few special switches that are not present in the `Config.json` file 
 * **LogLevel** to specify the level of detail used during logging
 * **DataDir** to specify the path to the directory used during runtime.
 * **BlockOnly** to instruct wasabi to ignore p2p transactions
+* **Wallet** to instruct wasabi to open a list of wallets automatically after started.
 
 ### Examples
 
@@ -48,4 +49,10 @@ Run Wasabi Daemon and connect to the testnet Bitcoin network.
 
 ```bash
 $ WASABI-NETWORK=testnet wasabi.daemon
+```
+
+Run Wasabi and open two wallets: AliceWallet and BobWallet
+
+```bash
+$ wasabi.daemon --wallet:AliceWallet,BobWallet
 ```

--- a/WalletWasabi.Daemon/README.md
+++ b/WalletWasabi.Daemon/README.md
@@ -35,7 +35,7 @@ There are a few special switches that are not present in the `Config.json` file 
 * **LogLevel** to specify the level of detail used during logging
 * **DataDir** to specify the path to the directory used during runtime.
 * **BlockOnly** to instruct wasabi to ignore p2p transactions
-* **Wallet** to instruct wasabi to open a list of wallets automatically after started.
+* **Wallet** to instruct wasabi to open a wallet automatically after started.
 
 ### Examples
 
@@ -54,5 +54,5 @@ $ WASABI-NETWORK=testnet wasabi.daemon
 Run Wasabi and open two wallets: AliceWallet and BobWallet
 
 ```bash
-$ wasabi.daemon --wallet:AliceWallet,BobWallet
+$ wasabi.daemon --wallet=AliceWallet --wallet=BobWallet
 ```

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -173,19 +173,20 @@ public static class WasabiAppExtensions
 		void ProcessCommands()
 		{
 			var arguments = app.AppConfig.Arguments;
-			string[] Split(string s) => s.Split(",", StringSplitOptions.RemoveEmptyEntries);
-			if (ArgumentHelpers.TryGetValue("wallet", arguments, (Func<string, string[]>) Split, out var walletNames))
+			var walletNames = ArgumentHelpers
+				.GetValues("wallet", arguments, x => x)
+				.Distinct();
+
+			foreach (var walletName in walletNames)
 			{
-				foreach (var walletName in walletNames)
+				try
 				{
-					try
-					{
-						app.Global!.WalletManager.GetWalletByName(walletName);
-					}
-					catch (InvalidOperationException)
-					{
-						Logger.LogWarning($"Wallet '{walletName}' was not found. Ignoring..." );
-					}
+					var wallet = app.Global!.WalletManager.GetWalletByName(walletName);
+					app.Global!.WalletManager.StartWalletAsync(wallet).ConfigureAwait(false);
+				}
+				catch (InvalidOperationException)
+				{
+					Logger.LogWarning($"Wallet '{walletName}' was not found. Ignoring..." );
 				}
 			}
 		}


### PR DESCRIPTION
This PR allows to specify one or more wallets to be opened automatically by the daemon after starting. For example:

```
$ ./wasabi.daemon --wallet:LucasWallet
```

Or many wallets separated by comma
```
$ ./wasabi.daemon --wallet:LucasWallet,DavidWallet,BalazzWallet
```

This is required to do things like:

* Start wallet automatically when computer starts,
* Specify wallet in the request path #10522 or,
* Implement `--coinjointo=`

