### PR TITLE
Remove comma copy recovery words

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/RecoveryWordsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/RecoveryWordsViewModel.cs
@@ -56,7 +56,7 @@ public partial class RecoveryWordsViewModel : RoutableViewModel
 		var words =
 			MnemonicWords.Select(x => x.Word).ToArray();
 
-		var text = string.Join(", ", words);
+		var text = string.Join(" ", words);
 
 		await Application.Current.Clipboard.SetTextAsync(text);
 


### PR DESCRIPTION
Having a comma is non-standard; see #10523 

I also agree with the other point of #10523:

> The recovery words remain in the clipboard, which is risky.

And could make it in a following PR, but I believe that removing the commas shouldn't be controversial at all; hence I prefer to do it in 2 PRs.