### PR TITLE
[Trivial] Correct link for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     Documentation
   </a>
   <span> | </span>
-  <a href="https://docs.wasabiwallet.io/building-wasabi/TechnicalOverview.html#v-general-wallet-features">
+  <a href="https://wasabiwallet.io/swagger/index.html">
     API
   </a>
   <span> | </span>


### PR DESCRIPTION
I guess it was mistake to link to the docs about the technical overview of wasabi which will be removed maybe. https://github.com/zkSNACKs/WasabiDoc/pull/1417