### PR TITLE
Fixed view model constructors according guidelines

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Dialogs/AddressEntryDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/AddressEntryDialogViewModel.cs
@@ -30,7 +30,7 @@ public partial class AddressEntryDialogViewModel : DialogViewModelBase<BitcoinUr
 	private bool _amountUrlFound;
 	private BitcoinUrlBuilder? _resultToReturn;
 
-	public AddressEntryDialogViewModel(Network network)
+	private AddressEntryDialogViewModel(Network network)
 	{
 		_network = network;
 		IsQrButtonVisible = WebcamQrReader.IsOsPlatformSupported;
@@ -47,7 +47,7 @@ public partial class AddressEntryDialogViewModel : DialogViewModelBase<BitcoinUr
 		AutoPasteCommand = ReactiveCommand.CreateFromTask(async () => await OnAutoPasteAsync());
 		QrCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
-			ShowQrCameraDialogViewModel dialog = new(_network);
+			ShowQrCameraDialogViewModel dialog = new(UiContext, _network);
 			var result = await NavigateDialogAsync(dialog, NavigationTarget.CompactDialogScreen);
 			if (!string.IsNullOrWhiteSpace(result.Result))
 			{

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/ShowQrCameraDialogViewModel.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Threading;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Models;
+using WalletWasabi.Fluent.Models.UI;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 
 namespace WalletWasabi.Fluent.ViewModels.Dialogs;
@@ -19,10 +20,11 @@ public partial class ShowQrCameraDialogViewModel : DialogViewModelBase<string?>
 	[AutoNotify] private string _errorMessage = "";
 	[AutoNotify] private string _qrContent = "";
 
-	public ShowQrCameraDialogViewModel(Network network)
+	public ShowQrCameraDialogViewModel(UiContext context, Network network)
 	{
 		_qrReader = new(network);
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
+		UiContext = context;
 	}
 
 	private CancellationTokenSource CancellationTokenSource { get; } = new();

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -217,7 +217,7 @@ public partial class MainViewModel : ViewModelBase
 		{
 			if (UiServices.WalletManager.TryGetSelectedAndLoggedInWalletViewModel(out var walletViewModel))
 			{
-				return new WalletCoinsViewModel(walletViewModel);
+				return new WalletCoinsViewModel(UiContext, walletViewModel);
 			}
 
 			return null;
@@ -286,7 +286,7 @@ public partial class MainViewModel : ViewModelBase
 			if (UiServices.WalletManager.TryGetSelectedAndLoggedInWalletViewModel(out var walletViewModel))
 			{
 				// TODO: Check if we can send?
-				return new SendViewModel(walletViewModel);
+				return new SendViewModel(UiContext, walletViewModel);
 			}
 
 			return null;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -39,7 +39,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 	[AutoNotify]
 	private FlatTreeDataGridSource<WalletCoinViewModel> _source = new(Enumerable.Empty<WalletCoinViewModel>());
 
-	public WalletCoinsViewModel(WalletViewModel walletVm)
+	private WalletCoinsViewModel(WalletViewModel walletVm)
 	{
 		_walletVm = walletVm;
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
@@ -131,7 +131,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 		var wallet = _walletVm.Wallet;
 		var selectedSmartCoins = Source.Items.Where(x => x.IsSelected).Select(x => x.Coin).ToImmutableArray();
 
-		var addressDialog = new AddressEntryDialogViewModel(wallet.Network);
+		var addressDialog = new AddressEntryDialogViewModel(UiContext, wallet.Network);
 		var addressResult = await NavigateDialogAsync(addressDialog, NavigationTarget.CompactDialogScreen);
 		if (addressResult.Result is not { } address || address.Address is null)
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -55,7 +55,7 @@ public partial class SendViewModel : RoutableViewModel
 	[AutoNotify] private string? _payJoinEndPoint;
 	[AutoNotify] private bool _conversionReversed;
 
-	public SendViewModel(WalletViewModel walletVm)
+	private SendViewModel(WalletViewModel walletVm)
 	{
 		WalletVm = walletVm;
 		_to = "";
@@ -89,7 +89,7 @@ public partial class SendViewModel : RoutableViewModel
 		InsertMaxCommand = ReactiveCommand.Create(() => AmountBtc = _wallet.Coins.TotalAmount().ToDecimal(MoneyUnit.BTC));
 		QrCommand = ReactiveCommand.Create(async () =>
 		{
-			ShowQrCameraDialogViewModel dialog = new(_wallet.Network);
+			ShowQrCameraDialogViewModel dialog = new(UiContext, _wallet.Network);
 			var result = await NavigateDialogAsync(dialog, NavigationTarget.CompactDialogScreen);
 			if (!string.IsNullOrWhiteSpace(result.Result))
 			{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -84,7 +84,7 @@ public partial class WalletViewModel : WalletViewModelBase
 					return (isSelected && !isWalletBalanceZero && (!areAllCoinsPrivate || pointerOver)) && !wallet.KeyManager.IsWatchOnly;
 				});
 
-		SendCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new SendViewModel(this)));
+		SendCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new SendViewModel(UiContext, this)));
 
 		ReceiveCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new ReceiveViewModel(wallet)));
 
@@ -108,7 +108,7 @@ public partial class WalletViewModel : WalletViewModelBase
 
 		WalletSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(Settings));
 
-		WalletCoinsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletCoinsViewModel(this)));
+		WalletCoinsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new WalletCoinsViewModel(UiContext, this)));
 
 		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(CoinJoinSettings), Observable.Return(!wallet.KeyManager.IsWatchOnly));
 


### PR DESCRIPTION
No idea why no constructor for `ShowQrCameraDialogViewModel` is generated automatically while making it private, but keeping it public there's an error, so I ended up with a public constructor taking `UiContext`.

Required to fix #10479.