### PR TITLE
Use HttpFactory in Global

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -115,11 +115,13 @@ public class Global : IDisposable
 					throw new ArgumentException($"Risk indicators were not provided in {nameof(WabiSabiConfig)}.");
 				}
 
-				HttpClient.BaseAddress = url;
-				HttpClient.Timeout = CoinVerifierApiClient.ApiRequestTimeout;
+				var cvHttpClient = HttpClientFactory.CreateClient(nameof(CoinVerifier));
+
+				cvHttpClient.BaseAddress = url;
+				cvHttpClient.Timeout = CoinVerifierApiClient.ApiRequestTimeout;
 
 				WhiteList = await Whitelist.CreateAndLoadFromFileAsync(CoordinatorParameters.WhitelistFilePath, wabiSabiConfig, cancel).ConfigureAwait(false);
-				CoinVerifierApiClient = new CoinVerifierApiClient(CoordinatorParameters.RuntimeCoordinatorConfig.CoinVerifierApiAuthToken, HttpClient);
+				CoinVerifierApiClient = new CoinVerifierApiClient(CoordinatorParameters.RuntimeCoordinatorConfig.CoinVerifierApiAuthToken, cvHttpClient);
 				CoinVerifier = new(CoinJoinIdStore, CoinVerifierApiClient, WhiteList, CoordinatorParameters.RuntimeCoordinatorConfig, auditsDirectoryPath: Path.Combine(CoordinatorParameters.CoordinatorDataDir, "CoinVerifierAudits"));
 
 				Logger.LogInfo("CoinVerifier created successfully.");

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -33,7 +33,6 @@ public class Global : IDisposable
 		RpcClient = rpcClient;
 		Config = config;
 		HostedServices = new();
-		HttpClient = new();
 		HttpClientFactory = httpClientFactory;
 
 		CoordinatorParameters = new(DataDir);
@@ -63,8 +62,6 @@ public class Global : IDisposable
 
 	public IndexBuilderService SegwitTaprootIndexBuilderService { get; }
 	public IndexBuilderService TaprootIndexBuilderService { get; }
-
-	private HttpClient HttpClient { get; }
 	private IHttpClientFactory HttpClientFactory { get; }
 
 	public Coordinator? Coordinator { get; private set; }
@@ -235,8 +232,6 @@ public class Global : IDisposable
 		{
 			if (disposing)
 			{
-				HttpClient.Dispose();
-
 				if (Coordinator is { } coordinator)
 				{
 					coordinator.CoinJoinBroadcasted -= Coordinator_CoinJoinBroadcasted;


### PR DESCRIPTION
Found this while reviewing.

In the future, someone can easily think they can use the `HttpClient` in `Global.cs` for anything.
That's not true at all! 
The `HttpClient` is a specific client for one feature.

In order to not make this mistake in the future, this PR cleans it up.

About disposing:
> It is generally not necessary to dispose of the `HttpClient` as the `IHttpClientFactory` tracks and disposes resources used by the `HttpClient`.

My only concern is this:

> HttpClient instances created by IHttpClientFactory are intended to be **short-lived**.
Recycling and recreating HttpMessageHandler's when their lifetime expires is essential for IHttpClientFactory to ensure the handlers react to DNS changes. HttpClient is tied to a specific handler instance upon its creation, so new HttpClient instances should be requested in a timely manner to ensure the client will get the updated handler.

Maybe we should just let it be as it was before? I'm not sure.

https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory