### PR TITLE
Fix IndexStore on RegTest

### DIFF
--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -41,15 +41,12 @@ public class IndexStore : IAsyncDisposable
 			File.Delete(indexFilePath);
 			throw;
 		}
-
-		if (network == Network.RegTest)
-		{
-			IndexStorage.Clear(); // RegTest is not a global ledger, better to delete it.
-		}
 	}
 
 	public event EventHandler<FilterModel>? Reorged;
+
 	public event EventHandler<FilterModel>? NewFilter;
+
 	public SmartHeaderChain SmartHeaderChain { get; }
 
 	/// <summary>Filter disk storage.</summary>


### PR DESCRIPTION
Fixes: #10568

I'm not sure if this was leftover code or did it have any purpose in the past,
but removing it fixes the client synchronization on RegTest.