### PR TITLE
Randomize AS Target for Non-Privacy Profiles

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfileViewModelBase.cs
@@ -1,3 +1,5 @@
+using WalletWasabi.Crypto.Randomness;
+
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 public abstract class CoinJoinProfileViewModelBase : ViewModelBase
@@ -6,11 +8,16 @@ public abstract class CoinJoinProfileViewModelBase : ViewModelBase
 
 	public abstract string Description { get; }
 
-	public virtual int AnonScoreTarget { get; } = 5;
+	public virtual int AnonScoreTarget { get; }
 
 	public virtual bool RedCoinIsolation { get; } = false;
 
 	public virtual int FeeRateMedianTimeFrameHours { get; }
+
+	protected static int GetRandom(int minInclusive, int maxExclusive)
+	{
+		return SecureRandom.Instance.GetInt(minInclusive, maxExclusive);
+	}
 
 	public static bool operator ==(CoinJoinProfileViewModelBase x, CoinJoinProfileViewModelBase y)
 	{

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/CoinJoinProfilesViewModel.cs
@@ -46,10 +46,18 @@ public partial class CoinJoinProfilesViewModel : DialogViewModelBase<bool>
 		var currentProfile = new ManualCoinJoinProfileViewModel(keyManager);
 		var result = DefaultProfiles.FirstOrDefault(x => x == currentProfile) ?? currentProfile;
 
-		// Edge case: Update the PrivateCJProfile anonscore target, otherwise the randomly selected value will be displayed all time.
+		// Update the anonscore target, otherwise the randomly selected value will be displayed all time.
 		if (result is PrivateCoinJoinProfileViewModel)
 		{
 			result = new PrivateCoinJoinProfileViewModel(keyManager.AnonScoreTarget);
+		}
+		else if (result is SpeedyCoinJoinProfileViewModel)
+		{
+			result = new SpeedyCoinJoinProfileViewModel(keyManager.AnonScoreTarget);
+		}
+		else if (result is EconomicCoinJoinProfileViewModel)
+		{
+			result = new EconomicCoinJoinProfileViewModel(keyManager.AnonScoreTarget);
 		}
 
 		return result;

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomicCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomicCoinJoinProfileViewModel.cs
@@ -12,7 +12,7 @@ internal class EconomicCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public EconomicCoinJoinProfileViewModel()
 	{
-		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore);
+		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore + 1);
 	}
 
 	public override string Title => "Minimize Costs";

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomicCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/EconomicCoinJoinProfileViewModel.cs
@@ -2,9 +2,23 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 internal class EconomicCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
+	public const int MinAnonScore = 5;
+	public const int MaxAnonScore = 10;
+
+	public EconomicCoinJoinProfileViewModel(int anonScoreTarget)
+	{
+		AnonScoreTarget = anonScoreTarget;
+	}
+
+	public EconomicCoinJoinProfileViewModel()
+	{
+		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore);
+	}
+
 	public override string Title => "Minimize Costs";
 
 	public override string Description => "For savers. Only participates in coinjoins during the cheapest parts of the week.";
 
 	public override int FeeRateMedianTimeFrameHours => 168; // One week median.
+	public override int AnonScoreTarget { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -6,6 +6,7 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
 	// https://github.com/zkSNACKs/WalletWasabi/pull/10468#issuecomment-1506284198
 	public const int MinAnonScore = 27;
+
 	public const int MaxAnonScore = 76;
 
 	public PrivateCoinJoinProfileViewModel(int anonScoreTarget)
@@ -26,11 +27,6 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 	public override bool RedCoinIsolation { get; } = true;
 
 	public override int FeeRateMedianTimeFrameHours => 0;
-
-	private static int GetRandom(int minInclusive, int maxExclusive)
-	{
-		return SecureRandom.Instance.GetInt(minInclusive, maxExclusive);
-	}
 
 	public override bool Equals(object? obj)
 	{

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -7,7 +7,7 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 	// https://github.com/zkSNACKs/WalletWasabi/pull/10468#issuecomment-1506284198
 	public const int MinAnonScore = 27;
 
-	public const int MaxAnonScore = 76;
+	public const int MaxAnonScore = 75;
 
 	public PrivateCoinJoinProfileViewModel(int anonScoreTarget)
 	{
@@ -16,7 +16,7 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public PrivateCoinJoinProfileViewModel()
 	{
-		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore);
+		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore + 1);
 	}
 
 	public override string Title => "Maximize Privacy";

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfileViewModel.cs
@@ -2,9 +2,23 @@ namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
 internal class SpeedyCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
+	public const int MinAnonScore = 5;
+	public const int MaxAnonScore = 10;
+
+	public SpeedyCoinJoinProfileViewModel(int anonScoreTarget)
+	{
+		AnonScoreTarget = anonScoreTarget;
+	}
+
+	public SpeedyCoinJoinProfileViewModel()
+	{
+		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore);
+	}
+
 	public override string Title => "Maximize Speed";
 
 	public override string Description => "Getting things done. Geared towards speed and convenience.";
 
 	public override int FeeRateMedianTimeFrameHours => 0;
+	public override int AnonScoreTarget { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/SpeedyCoinJoinProfileViewModel.cs
@@ -12,7 +12,7 @@ internal class SpeedyCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public SpeedyCoinJoinProfileViewModel()
 	{
-		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore);
+		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore + 1);
 	}
 
 	public override string Title => "Maximize Speed";


### PR DESCRIPTION
This PR randomizes anonscore targets from 5 to 10 for economic and speedy profiles.  
This provides better privacy and narrows the gap between privacy and non-privacy profiles.  
Somewhat related recent conversations: https://github.com/zkSNACKs/WalletWasabi/issues/10567

I believe this slight tweak is a necessary improvement to prepare for the future, where profile selection will be removed from the wallet setup process.