### PR TITLE
Removed duplicating company properties from projects

### DIFF
--- a/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
+++ b/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
@@ -33,7 +33,6 @@
 		<Copyright>MIT</Copyright>
 		<PackageId>Wasabi Wallet Daemon</PackageId>
 		<AssemblyTitle>Wasabi Wallet Daemon</AssemblyTitle>
-		<Company>zkSNACKs</Company>
 		<PackageTags>bitcoin-wallet;privacy;bitcoin;dotnet;nbitcoin;cross-platform;zerolink;wallet;tumbler;coin;tor</PackageTags>
 		<PackageProjectUrl>https://github.com/zkSNACKs/WalletWasabi/</PackageProjectUrl>
 		<PackageLicenseUrl>https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -34,7 +34,6 @@
 		<Copyright>MIT</Copyright>
 		<PackageId>Wasabi Wallet Fluent</PackageId>
 		<AssemblyTitle>Wasabi Wallet</AssemblyTitle>
-		<Company>zkSNACKs</Company>
 		<PackageTags>bitcoin-wallet;privacy;bitcoin;dotnet;nbitcoin;cross-platform;zerolink;wallet;tumbler;coin;tor</PackageTags>
 		<PackageProjectUrl>https://github.com/zkSNACKs/WalletWasabi/</PackageProjectUrl>
 		<PackageLicenseUrl>https://github.com/zkSNACKs/WalletWasabi/blob/master/LICENSE.md</PackageLicenseUrl>


### PR DESCRIPTION
The removed `Company` properties were duplicates of those which are located a few lines above in both modified files with a single difference. The removed values were without `Ltd`.