### PR TITLE
[Payment in Coinjoin] Output provider

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -300,7 +300,7 @@ public static class WabiSabiFactory
 		return CreateTestCoinJoinClient(
 			httpClientFactory,
 			new KeyChain(keyManager, new Kitchen("")),
-			new InternalDestinationProvider(keyManager),
+			new OutputProvider(new InternalDestinationProvider(keyManager)),
 			roundStateUpdater,
 			keyManager.RedCoinIsolation);
 	}
@@ -308,20 +308,20 @@ public static class WabiSabiFactory
 	public static CoinJoinClient CreateTestCoinJoinClient(
 		IWasabiHttpClientFactory httpClientFactory,
 		IKeyChain keyChain,
-		IDestinationProvider destinationProvider,
+		OutputProvider outputProvider,
 		RoundStateUpdater roundStateUpdater,
 		bool redCoinIsolation)
 	{
+		var semiPrivateThreshold = redCoinIsolation ? Constants.SemiPrivateThreshold : 0;
+		var coinSelector = new CoinJoinCoinSelector(consolidationMode: true, anonScoreTarget: int.MaxValue, semiPrivateThreshold, SecureRandom.Instance);
 		var mock = new Mock<CoinJoinClient>(
 			httpClientFactory,
 			keyChain,
-			destinationProvider,
+			outputProvider,
 			roundStateUpdater,
 			"CoinJoinCoordinatorIdentifier",
+			coinSelector,
 			new LiquidityClueProvider(),
-			int.MaxValue,
-			true,
-			redCoinIsolation,
 			TimeSpan.Zero,
 			TimeSpan.Zero);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinClientTests.cs
@@ -72,7 +72,7 @@ public class CoinJoinClientTests
 		var km = ServiceFactory.CreateKeyManager(password, true);
 		var destinationProvider = new InternalDestinationProvider(km);
 
-		var txOuts = CoinJoinClient.GetTxOuts(outputs, destinationProvider);
+		var txOuts = OutputProvider.GetTxOuts(outputs, destinationProvider);
 
 		// All the outputs were generated.
 		Assert.Equal(txOuts.Count(), outputs.Length);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -18,14 +18,11 @@ public class CoinJoinCoinSelectionTests
 	public void SelectNothingFromEmptySetOfCoins()
 	{
 		// This test is to make sure no coins are selected when there are no coins.
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: 10, semiPrivateThreshold: 0, ConfigureRng(5));
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: Enumerable.Empty<SmartCoin>(),
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
-			consolidationMode: false,
-			anonScoreTarget: 10,
-			semiPrivateThreshold: 0,
-			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
-			ConfigureRng(5));
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
 	}
@@ -41,14 +38,11 @@ public class CoinJoinCoinSelectionTests
 			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
 			.ToList();
 
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, ConfigureRng(5));
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
-			consolidationMode: false,
-			anonScoreTarget: AnonymitySet,
-			semiPrivateThreshold: 0,
-			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
-			ConfigureRng(5));
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
 	}
@@ -66,14 +60,11 @@ public class CoinJoinCoinSelectionTests
 			.Prepend(smallerAnonCoin)
 			.ToList();
 
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: true, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, ConfigureRng(5));
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
-			consolidationMode: true,
-			anonScoreTarget: AnonymitySet,
-			semiPrivateThreshold: 0,
-			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
-			ConfigureRng(5));
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Contains(smallerAnonCoin, coins);
 		Assert.Equal(10, coins.Count);
@@ -90,14 +81,11 @@ public class CoinJoinCoinSelectionTests
 			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet - 1))
 			.ToList();
 
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, ConfigureRng(1));
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
-			consolidationMode: false,
-			anonScoreTarget: AnonymitySet,
-			semiPrivateThreshold: 0,
-			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
-			ConfigureRng(1));
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Single(coins);
 	}
@@ -115,14 +103,11 @@ public class CoinJoinCoinSelectionTests
 			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet - 1))
 			.ToList();
 
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, ConfigureRng(1));
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
-			consolidationMode: false,
-			anonScoreTarget: AnonymitySet,
-			semiPrivateThreshold: 0,
-			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
-			ConfigureRng(1));
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Equal(2, coins.Count);
 	}
@@ -139,14 +124,11 @@ public class CoinJoinCoinSelectionTests
 			.Prepend(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet - 1))
 			.ToList();
 
-		var coins = CoinJoinCoinSelector.SelectCoinsForRound(
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: true, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, ConfigureRng(1));
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
-			consolidationMode: true,
-			anonScoreTarget: AnonymitySet,
-			semiPrivateThreshold: 0,
-			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney,
-			ConfigureRng(1));
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Equal(2, coins.Count);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -79,7 +79,8 @@ internal class Participant
 		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(3), apiClient);
 		await roundStateUpdater.StartAsync(cancellationToken).ConfigureAwait(false);
 
-		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(HttpClientFactory, Wallet, Wallet, roundStateUpdater, false);
+		var outputProvider = new OutputProvider(Wallet);
+		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(HttpClientFactory, Wallet, outputProvider, roundStateUpdater, false);
 
 		static HdPubKey CreateHdPubKey(ExtPubKey extPubKey)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -43,10 +43,8 @@ public class CoinJoinClient
 		IDestinationProvider destinationProvider,
 		RoundStateUpdater roundStatusUpdater,
 		string coordinatorIdentifier,
+		CoinJoinCoinSelector coinJoinCoinSelector,
 		LiquidityClueProvider liquidityClueProvider,
-		int anonScoreTarget = int.MaxValue,
-		bool consolidationMode = false,
-		bool redCoinIsolation = false,
 		TimeSpan feeRateMedianTimeFrame = default,
 		TimeSpan doNotRegisterInLastMinuteTimeLimit = default)
 	{
@@ -54,11 +52,9 @@ public class CoinJoinClient
 		KeyChain = keyChain;
 		DestinationProvider = destinationProvider;
 		RoundStatusUpdater = roundStatusUpdater;
-		AnonScoreTarget = anonScoreTarget;
 		CoordinatorIdentifier = coordinatorIdentifier;
 		LiquidityClueProvider = liquidityClueProvider;
-		ConsolidationMode = consolidationMode;
-		SemiPrivateThreshold = redCoinIsolation ? Constants.SemiPrivateThreshold : 0;
+		CoinJoinCoinSelector = coinJoinCoinSelector;
 		FeeRateMedianTimeFrame = feeRateMedianTimeFrame;
 		SecureRandom = new SecureRandom();
 		DoNotRegisterInLastMinuteTimeLimit = doNotRegisterInLastMinuteTimeLimit;
@@ -73,12 +69,9 @@ public class CoinJoinClient
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private string CoordinatorIdentifier { get; }
 	private LiquidityClueProvider LiquidityClueProvider { get; }
-	private int AnonScoreTarget { get; }
+	private CoinJoinCoinSelector CoinJoinCoinSelector { get; } 
 	private TimeSpan DoNotRegisterInLastMinuteTimeLimit { get; }
 
-	private bool ConsolidationMode { get; set; }
-	private bool RedCoinIsolation { get; }
-	private int SemiPrivateThreshold { get; }
 	private TimeSpan FeeRateMedianTimeFrame { get; }
 	private TimeSpan MaxWaitingTimeForRound { get; } = TimeSpan.FromMinutes(10);
 
@@ -154,7 +147,7 @@ public class CoinJoinClient
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameters.MaxSuggestedAmount);
 			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters);
 
-			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, utxoSelectionParameters, ConsolidationMode, AnonScoreTarget, SemiPrivateThreshold, liquidityClue, SecureRandom);
+			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, utxoSelectionParameters, liquidityClue);
 
 			if (!roundParameters.AllowedInputTypes.Contains(ScriptType.P2WPKH) || !roundParameters.AllowedOutputTypes.Contains(ScriptType.P2WPKH))
 			{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -10,39 +10,51 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.Wallets;
+using SecureRandom = WabiSabi.Crypto.Randomness.SecureRandom;
 
 namespace WalletWasabi.WabiSabi.Client;
 
-public static class CoinJoinCoinSelector
+public class CoinJoinCoinSelector
 {
 	private const int MaxInputsRegistrableByWallet = 10; // how many
 	private const int MaxWeightedAnonLoss = 3; // Maximum tolerable WeightedAnonLoss.
-
+	
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>
 	/// <param name="semiPrivateThreshold">Minimum anonymity of coins that can be selected together.</param>
-	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
-	public static ImmutableList<TCoin> SelectCoinsForRound<TCoin>(
-		IEnumerable<TCoin> coins,
-		UtxoSelectionParameters parameters,
+	public CoinJoinCoinSelector(
 		bool consolidationMode,
 		int anonScoreTarget,
 		int semiPrivateThreshold,
-		Money liquidityClue,
 		WasabiRandom rnd)
+	{
+		ConsolidationMode = consolidationMode;
+		AnonScoreTarget = anonScoreTarget;
+		SemiPrivateThreshold = semiPrivateThreshold;
+		Rnd = rnd;
+	}
+
+	public bool ConsolidationMode { get; }
+	public int AnonScoreTarget { get; }
+	public int SemiPrivateThreshold { get; }
+	private WasabiRandom Rnd { get; }
+	
+	public static CoinJoinCoinSelector FromWallet(IWallet wallet) =>
+		new (
+			wallet.ConsolidationMode,
+			wallet.AnonScoreTarget,
+			wallet.RedCoinIsolation ? Constants.SemiPrivateThreshold : 0,
+			SecureRandom.Instance);
+	
+	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
+	public ImmutableList<TCoin> SelectCoinsForRound<TCoin>(IEnumerable<TCoin> coins, UtxoSelectionParameters parameters, Money liquidityClue)
 		where TCoin : class, ISmartCoin, IEquatable<TCoin>
 	{
-		if (semiPrivateThreshold < 0)
-		{
-			throw new ArgumentException("Cannot be negative", nameof(semiPrivateThreshold));
-		}
-
-		// Sanity check.
-		if (liquidityClue <= Money.Zero)
-		{
-			liquidityClue = Constants.MaximumNumberOfBitcoinsMoney;
-		}
-
+		liquidityClue = liquidityClue > Money.Zero
+			? liquidityClue
+			: Constants.MaximumNumberOfBitcoinsMoney;
+			
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputScriptTypes.Contains(x.ScriptType))
@@ -50,15 +62,15 @@ public static class CoinJoinCoinSelector
 			.ToArray();
 
 		var privateCoins = filteredCoins
-			.Where(x => x.IsPrivate(anonScoreTarget))
+			.Where(x => x.IsPrivate(AnonScoreTarget))
 			.ToArray();
 		var semiPrivateCoins = filteredCoins
-			.Where(x => x.IsSemiPrivate(anonScoreTarget, semiPrivateThreshold))
+			.Where(x => x.IsSemiPrivate(AnonScoreTarget, SemiPrivateThreshold))
 			.ToArray();
 
 		// redCoins will only fill up if redCoinIsolaton is turned on. Otherwise the coin will be in semiPrivateCoins.
 		var redCoins = filteredCoins
-			.Where(x => x.IsRedCoin(semiPrivateThreshold))
+			.Where(x => x.IsRedCoin(SemiPrivateThreshold))
 			.ToArray();
 
 		if (semiPrivateCoins.Length + redCoins.Length == 0)
@@ -86,8 +98,8 @@ public static class CoinJoinCoinSelector
 
 		int inputCount = Math.Min(
 			privateCoins.Length + allowedNonPrivateCoins.Count,
-			consolidationMode ? MaxInputsRegistrableByWallet : GetInputTarget(rnd));
-		if (consolidationMode)
+			ConsolidationMode ? MaxInputsRegistrableByWallet : GetInputTarget(Rnd));
+		if (ConsolidationMode)
 		{
 			Logger.LogDebug($"Consolidation mode is on.");
 		}
@@ -169,7 +181,7 @@ public static class CoinJoinCoinSelector
 		var selectedNonPrivateCoin = remainingLargestNonPrivateCoins.RandomElement(); // Select randomly at first just to have a starting value.
 		foreach (var coin in remainingLargestNonPrivateCoins.OrderByDescending(x => x.Amount))
 		{
-			if (rnd.GetInt(1, 101) <= 50)
+			if (Rnd.GetInt(1, 101) <= 50)
 			{
 				selectedNonPrivateCoin = coin;
 				break;
@@ -225,7 +237,7 @@ public static class CoinJoinCoinSelector
 			percent = 80;
 		}
 
-		int sameTxAllowance = GetRandomBiasedSameTxAllowance(rnd, percent);
+		int sameTxAllowance = GetRandomBiasedSameTxAllowance(Rnd, percent);
 
 		List<TCoin> winner = new()
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -42,10 +42,11 @@ public class CoinJoinTrackerFactory
 		}
 
 		var coinSelector = CoinJoinCoinSelector.FromWallet(wallet);
+		var outputProvider = new OutputProvider(wallet.DestinationProvider); 
 		var coinJoinClient = new CoinJoinClient(
 			HttpClientFactory,
 			wallet.KeyChain,
-			wallet.DestinationProvider,
+			outputProvider,
 			RoundStatusUpdater,
 			CoordinatorIdentifier,
 			coinSelector,

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTrackerFactory.cs
@@ -41,16 +41,15 @@ public class CoinJoinTrackerFactory
 			throw new NotSupportedException("Wallet has no key chain.");
 		}
 
+		var coinSelector = CoinJoinCoinSelector.FromWallet(wallet);
 		var coinJoinClient = new CoinJoinClient(
 			HttpClientFactory,
 			wallet.KeyChain,
 			wallet.DestinationProvider,
 			RoundStatusUpdater,
 			CoordinatorIdentifier,
+			coinSelector,
 			LiquidityClueProvider,
-			wallet.AnonScoreTarget,
-			consolidationMode: wallet.ConsolidationMode,
-			redCoinIsolation: wallet.RedCoinIsolation,
 			feeRateMedianTimeFrame: wallet.FeeRateMedianTimeFrame,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));
 

--- a/WalletWasabi/WabiSabi/Client/OutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/OutputProvider.cs
@@ -1,0 +1,54 @@
+using NBitcoin;
+using System.Linq;
+using System.Collections.Generic;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public class OutputProvider
+{
+	public OutputProvider(IDestinationProvider destinationProvider)
+	{
+		DestinationProvider = destinationProvider;
+	}
+
+	private IDestinationProvider DestinationProvider { get; }
+
+	public virtual IEnumerable<TxOut> GetOutputs(
+		RoundParameters roundParameters,
+		IEnumerable<Money> registeredCoinEffectiveValues,
+		IEnumerable<Money> theirCoinEffectiveValues,
+		int availableVsize)
+	{
+		// Get the output's size and its of the input that will spend it in the future.
+		// Here we assume all the outputs share the same scriptpubkey type.
+		var isTaprootAllowed = roundParameters.AllowedOutputTypes.Contains(ScriptType.Taproot);
+
+		AmountDecomposer amountDecomposer = new(roundParameters.MiningFeeRate, roundParameters.AllowedOutputAmounts, availableVsize, isTaprootAllowed);
+		
+		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues).ToArray();
+		return GetTxOuts(outputValues, DestinationProvider);
+	}
+	
+	internal static IEnumerable<TxOut> GetTxOuts(IEnumerable<Output> outputValues, IDestinationProvider destinationProvider)
+	{
+		// Get as many destinations as outputs we need.
+		var taprootOutputCount = outputValues.Count(output => output.ScriptType is ScriptType.Taproot);
+		var taprootScripts = new Stack<IDestination>(destinationProvider.GetNextDestinations(taprootOutputCount, preferTaproot: true));
+		var segwitOutputCount = outputValues.Count(output => output.ScriptType is ScriptType.P2WPKH);
+		var segwitScripts = new Stack<IDestination>(destinationProvider.GetNextDestinations(segwitOutputCount, preferTaproot: false));
+
+		List<TxOut> outputTxOuts = new();
+		foreach (var output in outputValues)
+		{
+			var destinationStack = output.ScriptType is ScriptType.Taproot
+				? taprootScripts
+				: segwitScripts;
+
+			var destination = destinationStack.Pop();
+			var txOut = new TxOut(output.Amount, destination.ScriptPubKey);
+			outputTxOuts.Add(txOut);
+		}
+		return outputTxOuts;
+	}
+}


### PR DESCRIPTION
This PR contain two commits that simplify the `CoinJoinClient` interface and improve the code many ways. Extracting the logic for outputs generation allows us to implement a much cleaner solution for payments in coinjoins because a PIC is not  other thing that providing and registering the right output in a coinjoin round.

The PR should be reviewed commit by commit. Each commit contains the explanation of what and why the changes are for. 