### PR TITLE
Make SmartCoin aware of Critical Phase

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -85,12 +85,6 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 		set => RaiseAndSetIfChanged(ref _spenderTransaction, value);
 	}
 
-	public bool RegisterToHdPubKey()
-		=> HdPubKey.Coins.Add(this);
-
-	public bool UnregisterFromHdPubKey()
-		=> HdPubKey.Coins.Remove(this);
-
 	public bool CoinJoinInProgress
 	{
 		get => _coinJoinInProgress;
@@ -168,6 +162,12 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	{
 		return Transaction.Transaction.IsCoinBase && Height < bestHeight - 100;
 	}
+
+	public bool RegisterToHdPubKey()
+		=> HdPubKey.Coins.Add(this);
+
+	public bool UnregisterFromHdPubKey()
+		=> HdPubKey.Coins.Remove(this);
 
 	public bool RefreshAndGetIsBanned()
 	{

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -18,6 +18,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	private Height _height;
 	private SmartTransaction? _spenderTransaction;
 	private bool _coinJoinInProgress;
+	private bool _coinJoinInCriticalPhase;
 	private DateTimeOffset? _bannedUntilUtc;
 	private bool _spentAccordingToBackend;
 
@@ -93,7 +94,20 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	public bool CoinJoinInProgress
 	{
 		get => _coinJoinInProgress;
-		set => RaiseAndSetIfChanged(ref _coinJoinInProgress, value);
+		set
+		{
+			if (value is false)
+			{
+				CoinJoinInCriticalPhase = false;
+			}
+			RaiseAndSetIfChanged(ref _coinJoinInProgress, value);
+		}
+	}
+
+	public bool CoinJoinInCriticalPhase
+	{
+		get => _coinJoinInCriticalPhase;
+		set => RaiseAndSetIfChanged(ref _coinJoinInCriticalPhase, value);
 	}
 
 	public DateTimeOffset? BannedUntilUtc

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -692,6 +692,11 @@ public class CoinJoinClient
 
 		CoinJoinClientProgress.SafeInvoke(this, new EnteringOutputRegistrationPhase(roundState, outputRegistrationPhaseEndTime));
 
+		foreach (var aliceClient in registeredAliceClients)
+		{
+			aliceClient.SmartCoin.CoinJoinInCriticalPhase = true;
+		}
+
 		using CancellationTokenSource phaseTimeoutCts = new(remainingTime + ExtraPhaseTimeoutMargin);
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, phaseTimeoutCts.Token);
 


### PR DESCRIPTION
I need this, so I can continue working on #9972.

This PR gives another property to `SmartCoin` called `CoinJoinInCriticalPhase`.

We are setting it to `true` after we invoke `CoinJoinClientProgress` with `EnteringOutputRegistrationPhase` event arguments.

We are setting it to `false` when `CoinJoinInProgress` is set to `false` (end of the round).