### PR TITLE
Save banned coins in file

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -206,6 +206,9 @@ public class KeyManager
 	[JsonProperty(ItemConverterType = typeof(OutPointJsonConverter), PropertyName = "ExcludedCoinsFromCoinJoin")]
 	public List<OutPoint> ExcludedCoinsFromCoinJoin { get; private set; } = new();
 
+	[JsonProperty(ItemConverterType = typeof(OutPointDateTimeJsonConverter), PropertyName = "BannedCoinsFromCoinJoin")]
+	public List<(OutPoint OutPoint, DateTimeOffset? BannedUntil)> BannedCoinsFromCoinJoin { get; private set; } = new();
+
 	public string? FilePath { get; private set; }
 
 	[MemberNotNullWhen(returnValue: false, nameof(EncryptedSecret))]
@@ -713,6 +716,12 @@ public class KeyManager
 	internal void SetExcludedCoinsFromCoinJoin(IEnumerable<OutPoint> excludedOutpoints)
 	{
 		ExcludedCoinsFromCoinJoin = excludedOutpoints.ToList();
+		ToFile();
+	}
+
+	internal void SetBannedCoinsFromCoinJoin(IEnumerable<(OutPoint OutPoint, DateTimeOffset? BannedUntil)> bannedOutpoints)
+	{
+		BannedCoinsFromCoinJoin = bannedOutpoints.ToList();
 		ToFile();
 	}
 }

--- a/WalletWasabi/JsonConverters/OutPointDateTimeJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/OutPointDateTimeJsonConverter.cs
@@ -1,0 +1,29 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.Extensions;
+
+namespace WalletWasabi.JsonConverters;
+
+internal class OutPointDateTimeJsonConverter : JsonConverter<(OutPoint OutPoint, DateTimeOffset? BannedUntil)>
+{
+	public override (OutPoint OutPoint, DateTimeOffset? BannedUntil) ReadJson(JsonReader reader, Type objectType, (OutPoint OutPoint, DateTimeOffset? BannedUntil) existingValue, bool hasExistingValue, JsonSerializer serializer)
+	{
+		if (reader.Value is string serialized)
+		{
+			var op = new OutPoint();
+			var date = DateTimeOffset.MinValue;
+			var splitValueArray = serialized.Split(":");
+			op.FromHex(splitValueArray[0]);
+			date = DateTimeOffset.Parse(splitValueArray[1]);
+			return (op, date);
+		}
+		throw new ArgumentException($"No valid serialized {nameof(OutPoint)} passed.");
+	}
+
+	public override void WriteJson(JsonWriter writer, (OutPoint OutPoint, DateTimeOffset? BannedUntil) value, JsonSerializer serializer)
+	{
+		string opHex = value.OutPoint?.ToHex() ?? throw new ArgumentNullException(nameof(value.OutPoint));
+		string date = value.BannedUntil?.ToString() ?? throw new ArgumentNullException(nameof(value.BannedUntil));
+		writer.WriteValue($"{opHex}:{date}");
+	}
+}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -243,6 +243,7 @@ public class Wallet : BackgroundService, IWallet
 					await LoadWalletStateAsync(cancel).ConfigureAwait(false);
 					await LoadDummyMempoolAsync().ConfigureAwait(false);
 					LoadExcludedCoins();
+					LoadBannedCoins();
 				}
 			}
 


### PR DESCRIPTION
**[WIP]**
Fixes #10582

My idea here is to save banned coins in the wallet file (`KeyManager`) the following way:
```
"BannedCoinsFromCoinJoin": [
   "outpointOfTheCoin:dateOfBannedUntil",
],
```

I added a new JsonConverter for reading/writing purposes.
These coins could be loaded similary as [excluded coins](https://github.com/zkSNACKs/WalletWasabi/pull/9925), my only problem is the code duplication, which I don't quite like.
Also, from the `AliceClient`, I'm not sure how to call `Wallet.UpdateBannedCoinsFromCoinJoin()`.