### PR TITLE
[PoC] Upgrade `SmartCoinSelector`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorDataGridSource.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorDataGridSource.cs
@@ -9,6 +9,7 @@ using WalletWasabi.Fluent.TreeDataGrid;
 using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 using WalletWasabi.Fluent.Views.CoinControl.Core.Cells;
 using WalletWasabi.Fluent.Views.CoinControl.Core.Headers;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinControl;
 

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorViewModel.cs
@@ -10,9 +10,9 @@ using DynamicData.Binding;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 using WalletWasabi.Fluent.ViewModels.Wallets;
+using WalletWasabi.Helpers;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinControl;

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/Core/CoinCoinControlItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/Core/CoinCoinControlItemViewModel.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.Models;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/Core/CoinControlItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/Core/CoinControlItemViewModelBase.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
-using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/Core/PocketCoinControlItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/Core/PocketCoinControlItemViewModel.cs
@@ -3,7 +3,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData;
 using ReactiveUI;
-using WalletWasabi.Fluent.Models;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
@@ -7,7 +7,8 @@ using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.Models;
+using WalletWasabi.Helpers;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -7,9 +7,9 @@ using Avalonia.Threading;
 using ReactiveUI;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Extensions;
-using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
+using WalletWasabi.Helpers;
+using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacyControlViewModel.cs
@@ -19,17 +19,15 @@ public partial class PrivacyControlViewModel : DialogViewModelBase<IEnumerable<S
 {
 	private readonly Wallet _wallet;
 	private readonly TransactionInfo _transactionInfo;
-	private readonly bool _isSilent;
 	private readonly IEnumerable<SmartCoin>? _usedCoins;
 
-	public PrivacyControlViewModel(Wallet wallet, TransactionInfo transactionInfo, IEnumerable<SmartCoin>? usedCoins, bool isSilent)
+	public PrivacyControlViewModel(Wallet wallet, TransactionInfo transactionInfo, IEnumerable<SmartCoin>? usedCoins)
 	{
 		_wallet = wallet;
 		_transactionInfo = transactionInfo;
-		_isSilent = isSilent;
 		_usedCoins = usedCoins;
 
-		LabelSelection = new LabelSelectionViewModel(wallet.KeyManager, wallet.Kitchen.SaltSoup(), _transactionInfo, isSilent);
+		LabelSelection = new LabelSelectionViewModel(wallet.KeyManager, wallet.Kitchen.SaltSoup(), _transactionInfo);
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: false);
 		EnableBack = true;
@@ -71,13 +69,6 @@ public partial class PrivacyControlViewModel : DialogViewModelBase<IEnumerable<S
 			if (!isInHistory)
 			{
 				await InitializeLabelsAsync();
-			}
-
-			if (_isSilent)
-			{
-				var autoSelectedPockets = await LabelSelection.AutoSelectPocketsAsync();
-
-				Complete(autoSelectedPockets);
 			}
 
 			IsBusy = false;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using DynamicData;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Fluent.Extensions;
-using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Wallets;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -21,6 +21,7 @@ using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.CoinControl;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Fluent.ViewModels.Navigation;
+using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/LabelTestExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/LabelTestExtensions.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Wallets.Send;
+using WalletWasabi.Models;
 using WalletWasabi.Tests.Helpers;
 
 namespace WalletWasabi.Tests.UnitTests.UserInterfaceTest;

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/LabelTestExtensions.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/LabelTestExtensions.cs
@@ -35,9 +35,9 @@ internal static class LabelTestExtensions
 		return key;
 	}
 
-	public static SmartCoin CreateCoin(decimal amount, string label = "", int anonymitySet = 1)
+	public static SmartCoin CreateCoin(decimal amount, string label = "", int anonymitySet = 1, bool isConfirmed = true)
 	{
-		var coin = BitcoinFactory.CreateSmartCoin(NewKey(label: label, anonymitySet: anonymitySet), amount);
+		var coin = BitcoinFactory.CreateSmartCoin(NewKey(label: label, anonymitySet: anonymitySet), amount, isConfirmed);
 		coin.HdPubKey.SetAnonymitySet(anonymitySet);
 
 		return coin;

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
@@ -5,9 +5,9 @@ using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Wallets.Send;
+using WalletWasabi.Helpers;
+using WalletWasabi.Models;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
@@ -31,7 +31,7 @@ public class PocketSelectionTests
 			Recipient = recipient
 		};
 
-		return new LabelSelectionViewModel(km, pw, info, isSilent: false);
+		return new LabelSelectionViewModel(km, pw, info);
 	}
 
 	[Fact]
@@ -468,262 +468,6 @@ public class PocketSelectionTests
 	}
 
 	[Fact]
-	public async Task AutoSelectOnlyPrivatePocketAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("0.7"), "Dan");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.8M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(0.6M, out var pocket2, "Dan");
-		pockets.AddPocket(0.7M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.7M, out var pocket4, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.DoesNotContain(pocket4, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectPrivateAndSemiPrivatePocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("0.7"), "Dan");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.4M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(0.6M, out var pocket2, "Dan");
-		pockets.AddPocket(0.7M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.4M, out var pocket4, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectPrivateAndSemiPrivateAndKnownPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), "Dan");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.3M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(0.5M, out var pocket2, "Dan");
-		pockets.AddPocket(0.4M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.3M, out var pocket4, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.Contains(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectPrivateAndSemiPrivateAndUnknownPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), "Dan");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.3M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(0.1M, out var pocket2, "Dan");
-		pockets.AddPocket(0.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.4M, out var pocket4, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.Contains(pocket3, output);
-		Assert.Contains(pocket4, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectAllPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("2.0"), "Dan");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.8M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(0.3M, out var pocket2, "Dan");
-		pockets.AddPocket(0.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.5M, out var pocket4, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.Contains(pocket2, output);
-		Assert.Contains(pocket3, output);
-		Assert.Contains(pocket4, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectOnlyKnownByRecipientPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), "David, Lucas");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(1.0M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(1.1M, out var pocket2, "Dan");
-		pockets.AddPocket(0.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(1.1M, out var pocket4, "David", "Lucas");
-		pockets.AddPocket(1.1M, out var pocket5, "David");
-		pockets.AddPocket(1.1M, out var pocket6, "Lucas");
-		pockets.AddPocket(1.1M, out var pocket7, "David", "Lucas", "Dan");
-		pockets.AddPocket(1.0M, out var pocket8, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.DoesNotContain(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-		Assert.DoesNotContain(pocket5, output);
-		Assert.DoesNotContain(pocket6, output);
-		Assert.DoesNotContain(pocket7, output);
-		Assert.DoesNotContain(pocket8, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectOnlyKnownByRecipientPocketsCaseInsensitiveAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), "dAN");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(2.8M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(1.1M, out var pocket2, "Dan");
-		pockets.AddPocket(1.1M, out var pocket3, "Lucas", "Dan");
-		pockets.AddPocket(1.1M, out var pocket4, "dan");
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.DoesNotContain(pocket1, output);
-		Assert.Contains(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectKnownByRecipientPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.9"), "David");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.8M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(1.1M, out var pocket2, "Dan");
-		pockets.AddPocket(1.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(1.1M, out var pocket4, "David", "Lucas");
-		pockets.AddPocket(0.1M, out var pocket5, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-		Assert.Contains(pocket5, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectKnownByMultipleRecipientPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.9"), "David, Lucas");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.8M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(1.1M, out var pocket2, "Dan");
-		pockets.AddPocket(0.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(1.1M, out var pocket4, "David", "Lucas", "Dan");
-		pockets.AddPocket(1.1M, out var pocket5, "David");
-		pockets.AddPocket(1.1M, out var pocket6, "Lucas");
-		pockets.AddPocket(1.1M, out var pocket7, "David", "Lucas", "Dan", "Roland");
-		pockets.AddPocket(1.1M, out var pocket8, "David", "Dan");
-		pockets.AddPocket(0.1M, out var pocket9, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-		Assert.DoesNotContain(pocket5, output);
-		Assert.DoesNotContain(pocket6, output);
-		Assert.DoesNotContain(pocket7, output);
-		Assert.DoesNotContain(pocket8, output);
-		Assert.Contains(pocket9, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectMultipleKnownByMultipleRecipientPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), "David, Lucas");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.2M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(1.1M, out var pocket2, "Dan");
-		pockets.AddPocket(0.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.4M, out var pocket4, "David", "Lucas", "Dan");
-		pockets.AddPocket(0.6M, out var pocket5, "David");
-		pockets.AddPocket(0.5M, out var pocket6, "Lucas");
-		pockets.AddPocket(0.5M, out var pocket7, "David", "Lucas", "Dan", "Roland");
-		pockets.AddPocket(0.5M, out var pocket8, "David", "Dan");
-		pockets.AddPocket(0.1M, out var pocket9, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-		Assert.Contains(pocket5, output);
-		Assert.DoesNotContain(pocket6, output);
-		Assert.DoesNotContain(pocket7, output);
-		Assert.DoesNotContain(pocket8, output);
-		Assert.Contains(pocket9, output);
-	}
-
-	[Fact]
-	public async Task AutoSelectRequiredKnownByRecipientPocketsAsync()
-	{
-		var selection = CreateLabelSelectionViewModel(Money.Parse("1.3"), "David");
-
-		var pockets = new List<Pocket>();
-		pockets.AddPocket(0.2M, out var pocket1, CoinPocketHelper.PrivateFundsText);
-		pockets.AddPocket(1.1M, out var pocket2, "Dan");
-		pockets.AddPocket(1.5M, out var pocket3, CoinPocketHelper.UnlabelledFundsText);
-		pockets.AddPocket(0.5M, out var pocket4, "David");
-		pockets.AddPocket(0.4M, out var pocket5, "David", "Max");
-		pockets.AddPocket(0.6M, out var pocket6, "David", "Lucas", "Dan");
-		pockets.AddPocket(0.1M, out var pocket7, CoinPocketHelper.SemiPrivateFundsText);
-
-		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
-		Assert.DoesNotContain(pocket3, output);
-		Assert.Contains(pocket4, output);
-		Assert.DoesNotContain(pocket5, output);
-		Assert.Contains(pocket6, output);
-		Assert.Contains(pocket7, output);
-	}
-
-	[Fact]
 	public async Task NotEnoughSelectedWhenSameLabelFoundInSeveralPocketsAsync()
 	{
 		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), SmartLabel.Empty);
@@ -749,14 +493,10 @@ public class PocketSelectionTests
 		var selection = CreateLabelSelectionViewModel(Money.Parse("1.0"), "Dan");
 
 		var pockets = new List<Pocket>();
-		pockets.AddPocket(1.2M, out var pocket1, "Dan");
-		pockets.AddPocket(1.2M, out var pocket2, "Lucas");
+		pockets.AddPocket(1.2M, out _, "Dan");
+		pockets.AddPocket(1.2M, out _, "Lucas");
 
 		await selection.ResetAsync(pockets.ToArray());
-
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.Contains(pocket1, output);
-		Assert.DoesNotContain(pocket2, output);
 
 		var hdpk = LabelTestExtensions.NewKey("dan");
 		var usedCoin = BitcoinFactory.CreateSmartCoin(hdpk, 1.0M);
@@ -785,9 +525,7 @@ public class PocketSelectionTests
 
 		await selection.ResetAsync(pockets.ToArray());
 
-		var output = await selection.AutoSelectPocketsAsync();
-
-		await selection.SetUsedLabelAsync(output.SelectMany(x => x.Coins), privateThreshold: 10);
+		await selection.SetUsedLabelAsync(pockets.SelectMany(x => x.Coins), privateThreshold: 10);
 
 		Assert.True(selection.EnoughSelected);
 	}
@@ -811,9 +549,7 @@ public class PocketSelectionTests
 
 		await selection.ResetAsync(pockets.ToArray());
 
-		var output = await selection.AutoSelectPocketsAsync();
-
-		await selection.SetUsedLabelAsync(output.SelectMany(x => x.Coins), privateThreshold: 10);
+		await selection.SetUsedLabelAsync(pockets.SelectMany(x => x.Coins), privateThreshold: 10);
 
 		Assert.True(selection.EnoughSelected);
 	}
@@ -846,9 +582,7 @@ public class PocketSelectionTests
 
 		await selection.ResetAsync(pockets.ToArray());
 
-		var output = await selection.AutoSelectPocketsAsync();
-
-		await selection.SetUsedLabelAsync(output.SelectMany(x => x.Coins), privateThreshold: 10);
+		await selection.SetUsedLabelAsync(pockets.SelectMany(x => x.Coins), privateThreshold: 10);
 
 		Assert.True(selection.EnoughSelected);
 	}
@@ -856,59 +590,45 @@ public class PocketSelectionTests
 	[Fact]
 	public async Task IsOtherSelectionPossibleCasesAsync()
 	{
-		var pockets = new List<Pocket>();
-
 		var privatePocket = LabelTestExtensions.CreateSingleCoinPocket(1.0m, CoinPocketHelper.PrivateFundsText, anonSet: 999);
 		var semiPrivatePocket = LabelTestExtensions.CreateSingleCoinPocket(1.0m, CoinPocketHelper.SemiPrivateFundsText, anonSet: 2);
-
-		pockets.Add(LabelTestExtensions.CreateSingleCoinPocket(1.0m, "Dan"));
-		pockets.Add(LabelTestExtensions.CreateSingleCoinPocket(1.0m, "Dan, Lucas"));
+		var danPocket = LabelTestExtensions.CreateSingleCoinPocket(1.0m, "Dan");
+		var danLucasPocket = LabelTestExtensions.CreateSingleCoinPocket(1.0m, "Dan, Lucas");
 
 		// Other pocket can be used case.
 		var recipient = "Lucas";
 		var selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
-		await selection.ResetAsync(pockets.ToArray());
-		var output = await selection.AutoSelectPocketsAsync();
-		Assert.True(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		await selection.ResetAsync(new[] { danPocket, danLucasPocket });
+		Assert.True(selection.IsOtherSelectionPossible(danLucasPocket.Coins, recipient));
 
 		// No other pocket can be used case.
 		recipient = "Adam";
 		selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
-		output = await selection.AutoSelectPocketsAsync();
-		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		var usedCoins = Pocket.Merge(danPocket, danLucasPocket).Coins;
+		Assert.False(selection.IsOtherSelectionPossible(usedCoins, recipient));
 
 		// Exact match. Recipient == pocket, no better selection.
 		recipient = "Dan";
 		selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
-		await selection.ResetAsync(pockets.ToArray());
-		output = await selection.AutoSelectPocketsAsync();
-		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		Assert.False(selection.IsOtherSelectionPossible(danPocket.Coins, recipient));
 
-		pockets.Add(privatePocket);
-		await selection.ResetAsync(pockets.ToArray());
+		await selection.ResetAsync(new[] { privatePocket, danPocket, danLucasPocket });
 
 		// Private funds are enough for the payment, no better selection.
 		recipient = "Doesn't matter, it will use private coins";
 		selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
-		await selection.ResetAsync(pockets.ToArray());
-		output = await selection.AutoSelectPocketsAsync();
-		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		Assert.False(selection.IsOtherSelectionPossible(privatePocket.Coins, recipient));
 
-		pockets.Remove(privatePocket);
-		pockets.Add(semiPrivatePocket);
-		selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
-		await selection.ResetAsync(pockets.ToArray());
+		await selection.ResetAsync(new[] { semiPrivatePocket, danPocket, danLucasPocket });
 
 		// Semi funds are enough for the payment, no better selection.
-		output = await selection.AutoSelectPocketsAsync();
-		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		Assert.False(selection.IsOtherSelectionPossible(semiPrivatePocket.Coins, recipient));
 
-		pockets.Add(privatePocket);
 		selection = CreateLabelSelectionViewModel(Money.Parse("3.5"), recipient);
-		await selection.ResetAsync(pockets.ToArray());
+		await selection.ResetAsync(new[] { privatePocket, semiPrivatePocket, danPocket, danLucasPocket });
 
 		// Private and semi funds are enough for the payment, no better selection.
-		output = await selection.AutoSelectPocketsAsync();
-		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		usedCoins = Pocket.Merge(privatePocket, semiPrivatePocket).Coins;
+		Assert.False(selection.IsOtherSelectionPossible(usedCoins, recipient));
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketTests.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using WalletWasabi.Fluent.Models;
+using WalletWasabi.Models;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.UserInterfaceTest;

--- a/WalletWasabi.Tests/UnitTests/Wallet/SmartCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/SmartCoinSelectorTests.cs
@@ -7,6 +7,7 @@ using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Tests.Helpers;
+using WalletWasabi.Tests.UnitTests.UserInterfaceTest;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Wallet;
@@ -31,7 +32,7 @@ public class SmartCoinSelectorTests
 		decimal target = 0.3m;
 		List<SmartCoin> availableCoins = GenerateSmartCoins(Enumerable.Range(0, 9).Select(i => ("Juan", 0.1m * (i + 1))));
 
-		SmartCoinSelector selector = new(availableCoins);
+		SmartCoinSelector selector = new(availableCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		IEnumerable<ICoin> coinsToSpend = selector.Select(suggestion: EmptySuggestion, Money.Coins(target));
 
 		Coin theOnlyOne = Assert.Single(coinsToSpend.Cast<Coin>());
@@ -44,7 +45,7 @@ public class SmartCoinSelectorTests
 		Money target = Money.Coins(4m);
 		List<SmartCoin> availableCoins = GenerateSmartCoins(Enumerable.Range(0, 10).Select(i => ("Juan", 0.1m * (i + 1))));
 
-		SmartCoinSelector selector = new(availableCoins);
+		SmartCoinSelector selector = new(availableCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		List<Coin> coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		Assert.Equal(5, coinsToSpend.Count);
@@ -57,7 +58,7 @@ public class SmartCoinSelectorTests
 		Money target = Money.Coins(0.3m);
 		List<SmartCoin> availableCoins = GenerateSmartCoins(("Besos", 0.2m), ("Besos", 0.2m), ("Juan", 0.1m), ("Juan", 0.1m));
 
-		SmartCoinSelector selector = new(availableCoins);
+		SmartCoinSelector selector = new(availableCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		List<Coin> coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		// We do NOT expect an exact match, because that would mix the clusters.
@@ -70,7 +71,7 @@ public class SmartCoinSelectorTests
 		Money target = Money.Coins(0.3m);
 		List<SmartCoin> availableCoins = GenerateSmartCoins(("Besos", 0.2m), ("Juan", 0.1m), ("Adam", 0.2m), ("Eve", 0.1m));
 
-		SmartCoinSelector selector = new(availableCoins);
+		SmartCoinSelector selector = new(availableCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		List<Coin> coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		Assert.Equal(2, coinsToSpend.Count);
@@ -83,7 +84,7 @@ public class SmartCoinSelectorTests
 		Money target = Money.Coins(0.3m);
 		List<SmartCoin> availableCoins = GenerateDuplicateSmartCoins(("Juan", 0.1m), count: 10);
 
-		SmartCoinSelector selector = new(availableCoins);
+		SmartCoinSelector selector = new(availableCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		List<Coin> coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		Assert.Equal(3, coinsToSpend.Count);
@@ -97,7 +98,7 @@ public class SmartCoinSelectorTests
 		List<SmartCoin> availableCoins = GenerateDuplicateSmartCoins(("Juan", 0.1m), count: 11);
 		availableCoins.Add(GenerateDuplicateSmartCoins(("Beto", 0.2m), count: 5));
 
-		SmartCoinSelector selector = new(availableCoins);
+		SmartCoinSelector selector = new(availableCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		List<Coin> coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		Assert.Equal(5, coinsToSpend.Count);
@@ -112,7 +113,7 @@ public class SmartCoinSelectorTests
 		smartCoins.Add(BitcoinFactory.CreateSmartCoin(smartCoins[0].HdPubKey, 0.11m));
 		var someCoins = smartCoins.Select(x => x.Coin);
 
-		var selector = new SmartCoinSelector(smartCoins);
+		var selector = new SmartCoinSelector(smartCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		var coinsToSpend = selector.Select(someCoins, target);
 
 		var theOnlyOne = Assert.Single(coinsToSpend.Cast<Coin>());
@@ -126,7 +127,7 @@ public class SmartCoinSelectorTests
 		var smartCoins = GenerateSmartCoins(Enumerable.Repeat(("Juan", 0.2m), 12)).ToList();
 		smartCoins.Add(BitcoinFactory.CreateSmartCoin(smartCoins[0].HdPubKey, 0.11m));
 
-		var selector = new SmartCoinSelector(smartCoins);
+		var selector = new SmartCoinSelector(smartCoins, recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		Assert.Equal(2, coinsToSpend.Count);
@@ -141,11 +142,345 @@ public class SmartCoinSelectorTests
 		var coinsKnownByJuan = GenerateSmartCoins(Enumerable.Repeat(("Juan", 0.2m), 5));
 		var coinsKnownByBeto = GenerateSmartCoins(Enumerable.Repeat(("Beto", 0.2m), 2));
 
-		var selector = new SmartCoinSelector(coinsKnownByJuan.Concat(coinsKnownByBeto).ToList());
+		var selector = new SmartCoinSelector(coinsKnownByJuan.Concat(coinsKnownByBeto).ToList(), recipient: "Jose", privateThreshold: 999, semiPrivateThreshold: 2);
 		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
 
 		Assert.Equal(2, coinsToSpend.Count);
 		Assert.Equal(0.4m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Fact]
+	public void PreferPrivatePocket()
+	{
+		Money target = Money.Coins(0.3m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.4m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.5m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.6m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Single(coinsToSpend);
+		Assert.Equal(0.4m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Fact]
+	public void PreferSemiPrivatePocket()
+	{
+		Money target = Money.Coins(0.5m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.4m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.5m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.6m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Single(coinsToSpend);
+		Assert.Equal(0.5m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Fact]
+	public void PreferPrivateAndSemiPrivatePocket()
+	{
+		Money target = Money.Coins(0.9m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.4m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.5m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.6m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(2, coinsToSpend.Count);
+		Assert.Equal(0.9m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Fact]
+	public void AvoidUnlabelledPocket()
+	{
+		Money target = Money.Coins(0.7m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(3, coinsToSpend.Count);
+		Assert.Equal(0.7m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Fact]
+	public void PreferPocketKnownByRecipient()
+	{
+		Money target = Money.Coins(0.7m);
+
+		var knownByJoseCoin = LabelTestExtensions.CreateCoin(0.3m, "Jose", anonymitySet: 1);
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas", anonymitySet: 1),
+			knownByJoseCoin,
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(3, coinsToSpend.Count);
+		Assert.Equal(0.7m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+		Assert.Contains(knownByJoseCoin.Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void PreferUnlabelledPocketWhenKnownIsUnnecessary()
+	{
+		Money target = Money.Coins(0.7m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(3, coinsToSpend.Count);
+		Assert.Equal(0.7m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Fact]
+	public void UseAllPockets()
+	{
+		Money target = Money.Coins(0.7m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.1m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Jose", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(4, coinsToSpend.Count);
+		Assert.Equal(0.7m, coinsToSpend.Sum(x => x.Amount.ToUnit(MoneyUnit.BTC)));
+	}
+
+	[Theory]
+	[InlineData("Jose, Lucas", "Jose, Lucas")]
+	[InlineData("jOSE, lUCAS", "Jose, Lucas")]
+	[InlineData("Jose, Lucas", "jOSE, lUCAS")]
+	public void SelectOnlyKnownByRecipientPocketTests(string label, string recipient)
+	{
+		Money target = Money.Coins(0.1m);
+
+		var knownByJoseLucasCoin = LabelTestExtensions.CreateCoin(0.5m, label, anonymitySet: 1);
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose, Lucas, Federico", anonymitySet: 1),
+			knownByJoseLucasCoin,
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: recipient, privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Single(coinsToSpend);
+		Assert.Contains(knownByJoseLucasCoin.Coin, coinsToSpend);
+	}
+
+	[Theory]
+	[InlineData("David, Lucas", "David")]
+	[InlineData("David, Lucas, Jose", "David, Lucas")]
+	public void SelectKnownByRecipientPocketTests(string label, string recipient)
+	{
+		Money target = Money.Coins(0.41m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.1m, label, anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose, Lucas, Federico", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: recipient, privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(3, coinsToSpend.Count);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+		Assert.Contains(coins[1].Coin, coinsToSpend);
+		Assert.Contains(coins[2].Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void PreferKnownByRecipientPocket()
+	{
+		Money target = Money.Coins(0.71m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.1m, "David, Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose, Lucas, Federico", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Lucas", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(4, coinsToSpend.Count);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+		Assert.Contains(coins[1].Coin, coinsToSpend);
+		Assert.Contains(coins[2].Coin, coinsToSpend);
+		Assert.Contains(coins[3].Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void OnlySelectNecessaryKnownByRecipientPocket()
+	{
+		Money target = Money.Coins(1m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 10), // Private pocket
+			LabelTestExtensions.CreateCoin(0.2m, "", anonymitySet: 4), // Semi-private pocket
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.1m, "Lucas, David", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Lucas, David, Jose", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.3m, "Jose, Lucas, Federico", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(0.7m, "", anonymitySet: 1), // Unlabelled pocket
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "Lucas", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(4, coinsToSpend.Count);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+		Assert.Contains(coins[1].Coin, coinsToSpend);
+		Assert.Contains(coins[2].Coin, coinsToSpend);
+		Assert.Contains(coins[4].Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void PreferConfirmedPocket()
+	{
+		Money target = Money.Coins(1m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(1.1m, "Lucas", anonymitySet: 1),
+			LabelTestExtensions.CreateCoin(1m, "Jose", anonymitySet: 1, isConfirmed: false),
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "David", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Single(coinsToSpend);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void AvoidUnconfirmedPrivateCoins()
+	{
+		Money target = Money.Coins(1m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.5m, anonymitySet: 999),
+			LabelTestExtensions.CreateCoin(0.5m, anonymitySet: 999),
+			LabelTestExtensions.CreateCoin(1m, anonymitySet: 999, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(1m, anonymitySet: 999, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(1m, anonymitySet: 999, isConfirmed: false),
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "David", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(2, coinsToSpend.Count);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+		Assert.Contains(coins[1].Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void AvoidUnconfirmedSemiPrivateCoins()
+	{
+		Money target = Money.Coins(1m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.5m, anonymitySet: 4),
+			LabelTestExtensions.CreateCoin(0.5m, anonymitySet: 4),
+			LabelTestExtensions.CreateCoin(1m, anonymitySet: 4, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(1m, anonymitySet: 4, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(1m, anonymitySet: 4, isConfirmed: false),
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "David", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(2, coinsToSpend.Count);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+		Assert.Contains(coins[1].Coin, coinsToSpend);
+	}
+
+	[Fact]
+	public void IncludeUnconfirmedCoins()
+	{
+		Money target = Money.Coins(1m);
+
+		var coins = new List<SmartCoin>
+		{
+			LabelTestExtensions.CreateCoin(0.25m, anonymitySet: 999, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(0.25m, anonymitySet: 4, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(0.25m, "Lucas", anonymitySet: 1, isConfirmed: false),
+			LabelTestExtensions.CreateCoin(0.25m, "Jose", anonymitySet: 1, isConfirmed: false),
+		};
+
+		var selector = new SmartCoinSelector(coins, recipient: "David", privateThreshold: 5, semiPrivateThreshold: 2);
+		var coinsToSpend = selector.Select(suggestion: EmptySuggestion, target).Cast<Coin>().ToList();
+
+		Assert.Equal(4, coinsToSpend.Count);
+		Assert.Contains(coins[0].Coin, coinsToSpend);
+		Assert.Contains(coins[1].Coin, coinsToSpend);
+		Assert.Contains(coins[2].Coin, coinsToSpend);
+		Assert.Contains(coins[3].Coin, coinsToSpend);
 	}
 
 	private List<SmartCoin> GenerateDuplicateSmartCoins((string Cluster, decimal amount) coin, int count)

--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -6,6 +6,8 @@ using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using System.Collections.Immutable;
 using WalletWasabi.Extensions;
+using WalletWasabi.Helpers;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Blockchain.TransactionBuilding;
 
@@ -59,53 +61,20 @@ public class SmartCoinSelector : ICoinSelector
 			}
 		}
 
-		// Get unique clusters.
-		IEnumerable<Cluster> uniqueClusters = UnspentCoins
-			.Select(coin => coin.HdPubKey.Cluster)
-			.Distinct();
+		var coins = FilterUnnecessaryPrivateAndSemiPrivateUnconfirmedCoins(UnspentCoins, targetMoney);
+		var pockets = coins.ToPockets(PrivateThreshold).ToArray();
+		var bestPocket = GetBestCombination(pockets, targetMoney);
+		var bestPocketCoins = bestPocket.Coins;
 
-		// Build all the possible coin clusters, except when it's computationally too expensive.
-		List<List<SmartCoin>> coinClusters = uniqueClusters.Count() < 10
-			? uniqueClusters
-				.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
-				.Select(clusterCombination => UnspentCoins
-					.Where(coin => clusterCombination.Contains(coin.HdPubKey.Cluster))
-					.ToList())
-				.ToList()
-			: new List<List<SmartCoin>>();
-
-		coinClusters.Add(UnspentCoins);
-
-		// This operation is doing super advanced grouping on the coin clusters and adding properties to each of them.
-		var sayajinCoinClusters = coinClusters
-			.Select(coins => (Coins: coins, Privacy: 1.0m / (1 + coins.Sum(x => x.HdPubKey.Cluster.Labels.Count))))
-			.Select(group => (
-				Coins: group.Coins,
-				Unconfirmed: group.Coins.Any(x => !x.Confirmed),    // If group has an unconfirmed, then the whole group is unconfirmed.
-				AnonymitySet: group.Coins.Min(x => x.HdPubKey.AnonymitySet), // The group is as anonymous as its weakest member.
-				ClusterPrivacy: group.Privacy, // The number people/entities that know the cluster.
-				Amount: group.Coins.Sum(x => x.Amount)
-			));
-
-		// Find the best coin cluster that we are going to use.
-		IEnumerable<SmartCoin> bestCoinCluster = sayajinCoinClusters
-			.Where(group => group.Amount >= targetMoney)
-			.OrderBy(group => group.Unconfirmed)
-			.ThenByDescending(group => group.AnonymitySet)     // Always try to spend/merge the largest anonset coins first.
-			.ThenByDescending(group => group.ClusterPrivacy)   // Select lesser-known coins.
-			.ThenBy(group => group.Amount)           // Once we order them by cluster-privacy, we want to be as close to the target as we can.
-			.First()
-			.Coins;
-
-		var coinsInBestClusterByScript = bestCoinCluster
+		var coinsInBestPocketByScript = bestPocketCoins
 			.GroupBy(c => c.ScriptPubKey)
 			.Select(group => (ScriptPubKey: group.Key, Coins: group.ToList()))
 			.OrderByDescending(x => x.Coins.Sum(c => c.Amount))
 			.ToImmutableList();
 
 		// {1} {2} ... {n} {1, 2} {1, 2, 3} {1, 2, 3, 4} ... {1, 2, 3, 4, 5 ... n}
-		var coinsGroup = coinsInBestClusterByScript.Select(x => ImmutableList.Create(x))
-				.Concat(coinsInBestClusterByScript.Scan(ImmutableList<(Script ScriptPubKey, List<SmartCoin> Coins)>.Empty, (acc, coinGroup) => acc.Add(coinGroup)));
+		var coinsGroup = coinsInBestPocketByScript.Select(x => ImmutableList.Create(x))
+			.Concat(coinsInBestPocketByScript.Scan(ImmutableList<(Script ScriptPubKey, List<SmartCoin> Coins)>.Empty, (acc, coinGroup) => acc.Add(coinGroup)));
 
 		// Flattens the groups of coins and filters out the ones that are too small.
 		// Finally it sorts the solutions by amount and coins (those with less coins on the top).
@@ -120,5 +89,91 @@ public class SmartCoinSelector : ICoinSelector
 
 		// Select the best solution.
 		return candidates.First().Coins.Select(x => x.Coin);
+	}
+
+	/// <summary>
+	/// Removes the unconfirmed Private and Semi-Private coins if they are not required.
+	/// Since those two pockets are a mix of coins from different clusters,
+	/// it is not mandatory to spend them as a whole pocket, so unconfirmed coins can be skipped.
+	/// </summary>
+	private IEnumerable<SmartCoin> FilterUnnecessaryPrivateAndSemiPrivateUnconfirmedCoins(IEnumerable<SmartCoin> unspentCoins, Money targetAmount)
+	{
+		SmartCoin[] FilterIfUnnecessary(SmartCoin[] allCoins, SmartCoin[] coinsToFilter)
+		{
+			return allCoins.Sum(x => x.Amount) - coinsToFilter.Sum(x => x.Amount) >= targetAmount
+				? allCoins.Except(coinsToFilter).ToArray()
+				: allCoins;
+		}
+
+		var unconfirmedSemiPrivateCoins = UnspentCoins.Where(x => x.IsSemiPrivate(PrivateThreshold, SemiPrivateThreshold) && !x.Confirmed).ToArray();
+		var unconfirmedPrivateCoins = UnspentCoins.Where(x => x.IsPrivate(PrivateThreshold) && !x.Confirmed).ToArray();
+		var coins = unspentCoins.ToArray();
+
+		coins = FilterIfUnnecessary(coins, unconfirmedSemiPrivateCoins);
+		coins = FilterIfUnnecessary(coins, unconfirmedPrivateCoins);
+
+		return coins;
+	}
+
+	/// <summary>
+	/// Calculates the best combination from the gives pocket that can cover the target amount,
+	/// if the calculation is not expensive.
+	/// Otherwise it returns a combination fromm all pockets.
+	/// </summary>
+	private Pocket GetBestCombination(Pocket[] pockets, Money targetMoney)
+	{
+		if (pockets.Length >= 10)
+		{
+			return Pocket.Merge(pockets);
+		}
+
+		return pockets
+			.CombinationsWithoutRepetition(ofLength: 1, upToLength: 6)
+			.Select(pocketCombination =>
+				(Score: pocketCombination.Max(GetPrivacyScore),
+					Pocket: Pocket.Merge(pocketCombination.ToArray()),
+					Unconfirmed: pocketCombination.Any(x => x.IsUnconfirmed())))
+			.Where(x => x.Pocket.Amount >= targetMoney)
+			.OrderBy(x => x.Unconfirmed)
+			.ThenBy(x => x.Score)
+			.ThenByDescending(x => x.Pocket.Coins.Sum(x => x.HdPubKey.AnonymitySet) / x.Pocket.Coins.Count())
+			.ThenBy(x => x.Pocket.Amount)
+			.First()
+			.Pocket;
+	}
+
+	/// <summary>
+	/// Scores the given pocket from a privacy acceptance perspective.
+	/// </summary>
+	private decimal GetPrivacyScore(Pocket pocket)
+	{
+		if (Recipient.Equals(pocket.Labels, StringComparer.OrdinalIgnoreCase))
+		{
+			return 1;
+		}
+
+		if (pocket.IsPrivate(PrivateThreshold))
+		{
+			return 2;
+		}
+
+		if (pocket.IsSemiPrivate(PrivateThreshold, SemiPrivateThreshold))
+		{
+			return 3;
+		}
+
+		if (pocket.IsUnknown(SemiPrivateThreshold))
+		{
+			return 8;
+		}
+
+		var containedRecipientLabelsCount = pocket.Labels.Count(label => Recipient.Contains(label, StringComparer.OrdinalIgnoreCase));
+		if (containedRecipientLabelsCount > 0)
+		{
+			var index = ((decimal)containedRecipientLabelsCount / pocket.Labels.Count) + ((decimal)containedRecipientLabelsCount / Recipient.Count);
+			return 4 + (2 - index);
+		}
+
+		return 7 + (1 - 1M / pocket.Labels.Count);
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/SmartCoinSelector.cs
@@ -11,12 +11,18 @@ namespace WalletWasabi.Blockchain.TransactionBuilding;
 
 public class SmartCoinSelector : ICoinSelector
 {
-	public SmartCoinSelector(List<SmartCoin> unspentCoins)
+	public SmartCoinSelector(List<SmartCoin> unspentCoins, SmartLabel recipient, int privateThreshold, int semiPrivateThreshold)
 	{
 		UnspentCoins = unspentCoins.Distinct().ToList();
+		Recipient = recipient;
+		PrivateThreshold = privateThreshold;
+		SemiPrivateThreshold = semiPrivateThreshold;
 	}
 
 	private List<SmartCoin> UnspentCoins { get; }
+	public SmartLabel Recipient { get; }
+	public int PrivateThreshold { get; }
+	public int SemiPrivateThreshold { get; }
 	private int IterationCount { get; set; }
 	private Exception? LastTransactionSizeException { get; set; }
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -101,7 +101,7 @@ public class TransactionFactory
 		}
 
 		TransactionBuilder builder = Network.CreateTransactionBuilder();
-		builder.SetCoinSelector(new SmartCoinSelector(allowedSmartCoinInputs));
+		builder.SetCoinSelector(new SmartCoinSelector(allowedSmartCoinInputs, new SmartLabel(payments.Requests.SelectMany(x => x.Label)), KeyManager.AnonScoreTarget, Constants.SemiPrivateThreshold));
 		builder.AddCoins(allowedSmartCoinInputs.Select(c => c.Coin));
 		builder.SetLockTime(lockTimeSelector());
 

--- a/WalletWasabi/Helpers/CoinPocketHelper.cs
+++ b/WalletWasabi/Helpers/CoinPocketHelper.cs
@@ -2,11 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Fluent.Models;
-using WalletWasabi.Helpers;
+using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 
-namespace WalletWasabi.Fluent.Helpers;
+namespace WalletWasabi.Helpers;
 
 public static class CoinPocketHelper
 {

--- a/WalletWasabi/Helpers/CoinPocketHelper.cs
+++ b/WalletWasabi/Helpers/CoinPocketHelper.cs
@@ -71,4 +71,12 @@ public static class CoinPocketHelper
 	}
 
 	public static IEnumerable<Pocket> GetPockets(this Wallet wallet) => wallet.Coins.GetPockets(wallet.AnonScoreTarget).Select(x => new Pocket(x));
+
+	public static IEnumerable<Pocket> ToPockets(this IEnumerable<SmartCoin> coins, int anonScoreTarget)
+	{
+		var coinsView = new CoinsView(coins);
+		var pockets = coinsView.GetPockets(anonScoreTarget).Select(x => new Pocket(x));
+
+		return pockets;
+	}
 }

--- a/WalletWasabi/Models/Pocket.cs
+++ b/WalletWasabi/Models/Pocket.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Models;
 
@@ -20,6 +21,30 @@ public class Pocket
 	public ICoinsView Coins { get; }
 
 	public static Pocket Empty => new((SmartLabel.Empty, new CoinsView(Enumerable.Empty<SmartCoin>())));
+
+	public bool IsPrivate(int privateThreshold)
+	{
+		return Coins.All(x => x.IsPrivate(privateThreshold));
+	}
+
+	public bool IsSemiPrivate(int privateThreshold, int semiPrivateThreshold)
+	{
+		return Coins.All(x => x.IsSemiPrivate(privateThreshold, semiPrivateThreshold));
+	}
+
+	public bool IsUnknown(int semiPrivateThreshold)
+	{
+		var allLabel = Coins.SelectMany(x => x.HdPubKey.Cluster.Labels);
+		var isAllCoinNonPrivate = Coins.All(x => x.HdPubKey.AnonymitySet < semiPrivateThreshold);
+		var mergedLabels = new SmartLabel(allLabel);
+
+		return mergedLabels.IsEmpty && isAllCoinNonPrivate;
+	}
+
+	public bool IsUnconfirmed()
+	{
+		return Coins.Any(x => !x.Confirmed);
+	}
 
 	public static Pocket Merge(params Pocket[] pockets)
 	{

--- a/WalletWasabi/Models/Pocket.cs
+++ b/WalletWasabi/Models/Pocket.cs
@@ -2,9 +2,8 @@ using System.Linq;
 using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Extensions;
 
-namespace WalletWasabi.Fluent.Models;
+namespace WalletWasabi.Models;
 
 public class Pocket
 {


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/9985 (which means the user will get the same result by using the automatic algorithm or manually selecting every coin on the coin control page)

##

This PR adds the `Recipient` label and `PrivateThreshold` and `SemiPrivateThreshold` to the class so that it can take them into account during coin selection. The goal was mainly to move the code from the UI side to the business side, although it required some logic modification too. I added tests to check the logic.

##

Benefit on the UI side: https://github.com/zkSNACKs/WalletWasabi/commit/d0feb0c2716881278020115680cd7a6cff2ad065 It makes the ViewModels simpler which is a huge advantage before the UI decoupling process.

##

Note:
IMO the handling of Unconfirmed coins should be rethought. As currently (on master and in this PR) if a Pocket (cluster) has at least one unconfirmed coin the algorithm will try to avoid it. But it would be better if it did it only when the given pocket wouldn't be enough to cover the target amount.

Example:
The target amount is 1 BTC. Pocket A has 2 BTC worth of coins in it, and 0.5 is unconfirmed.  In this case, it is safe to use Pocket A because the remaining amount (1.5 BTC) can cover the target amount, and either way, some BTC would remain in the pocket. 

The target amount is 1 BTC. Pocket B has 2 BTC worth of coins in it, and 1.5 is unconfirmed. In this case, it is better to avoid Pocket B as we don't want to use unconfirmed coins and the remaining 0.5 is not enough for the target amount and it isn't worth mixing it with another pocket. 


