### PR TITLE
crash report: correct link to post GH issue tracker

### DIFF
--- a/WalletWasabi.Fluent/CrashReport/ViewModels/CrashReportWindowViewModel.cs
+++ b/WalletWasabi.Fluent/CrashReport/ViewModels/CrashReportWindowViewModel.cs
@@ -17,7 +17,7 @@ public class CrashReportWindowViewModel : ViewModelBase
 		CancelCommand = ReactiveCommand.Create(() => AppLifetimeHelper.Shutdown(withShutdownPrevention: false, restart: true));
 		NextCommand = ReactiveCommand.Create(() => AppLifetimeHelper.Shutdown(withShutdownPrevention: false, restart: false));
 
-		OpenGitHubRepoCommand = ReactiveCommand.CreateFromTask(async () => await IoHelpers.OpenBrowserAsync(AboutViewModel.UserSupportLink));
+		OpenGitHubRepoCommand = ReactiveCommand.CreateFromTask(async () => await IoHelpers.OpenBrowserAsync(AboutViewModel.BugReportLink));
 
 		CopyTraceCommand = ReactiveCommand.CreateFromTask(async () =>
 		{


### PR DESCRIPTION
current link goes to https://github.com/zkSNACKs/WalletWasabi/discussions/5185, which is not the right place to report a crash/bug