### PR TITLE
MinOutputMultiplier config to change min output without changing min input

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -100,7 +100,7 @@ public record RoundParameters
 			wabiSabiConfig.MinInputCountByRound,
 			wabiSabiConfig.MaxInputCountByRound,
 			new MoneyRange(wabiSabiConfig.MinRegistrableAmount, wabiSabiConfig.MaxRegistrableAmount),
-			new MoneyRange(wabiSabiConfig.MinRegistrableAmount, wabiSabiConfig.MaxRegistrableAmount),
+			new MoneyRange(Money.Satoshis(wabiSabiConfig.MinRegistrableAmount.Satoshi * wabiSabiConfig.MinOutputMultiplier), wabiSabiConfig.MaxRegistrableAmount),
 			wabiSabiConfig.AllowedInputTypes,
 			wabiSabiConfig.AllowedOutputTypes,
 			wabiSabiConfig.StandardInputRegistrationTimeout,

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -44,6 +44,13 @@ public class WabiSabiConfig : ConfigBase
 	public Money MinRegistrableAmount { get; set; } = Money.Coins(0.00005m);
 
 	/// <summary>
+	/// Minimum output in a round = MinRegistrableAmount * MinOutputMultiplier
+	/// </summary>
+	[DefaultValue(1.0)]
+	[JsonProperty(PropertyName = "MinOutputMultiplier", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public decimal MinOutputMultiplier { get; set; } = 1.0m;
+	
+	/// <summary>
 	/// The width of the range proofs are calculated from this, so don't choose stupid numbers.
 	/// </summary>
 	[DefaultValueMoneyBtc("43000")]


### PR DESCRIPTION
Config item to quickly change the minimum output registrable without changing the minimum input.
Even if don't really like this, I implemented as a multiplier so I don't have to deal with sanity checks, and it's really easy to review this PR + to manually change and adapt the multiplier.

If cACK for decoupling `MinInput` and `MinOutput` but NACK for using a multiplier, I will implement a new config field  especially for `MinOutput`.
Naming will just be a bit bad (as I don't want to change existing name `MinRegistrableAmount`) and diff larger with the sanity checks.