### PR TITLE
Add CodeOwners file

### DIFF
--- a/.github/CODEOWNERS.txt
+++ b/.github/CODEOWNERS.txt
@@ -1,0 +1,2 @@
+WalletWasabi/Wallets/IWallet.cs @onvej-sl @andrewkozlik
+WalletWasabi/Wallets/Wallet.cs @onvej-sl @andrewkozlik


### PR DESCRIPTION
 - Adds a CodeOwners file to enable automatic review requests to third parties.
 - This is a first step towards fixing #10516 
 - @andrewkozlik and @onvej-sl can you provide a list of specific files that you consider important to add here? I will mark this PR as draft until we can agree on that.