### PR TITLE
[DRAFT] Quit application: Stop P2P faster

### DIFF
--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -74,10 +74,10 @@
         "resolved": "7.0.0",
         "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
       },
-      "NBitcoin": {
+      "NBitcoin.Kimi": {
         "type": "Transitive",
-        "resolved": "7.0.24",
-        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
+        "resolved": "7.0.25.1",
+        "contentHash": "kQECjHNKxSZycPLLuFu9iqtg9IKa12Vhz/b+4Bk6SOQRGxPnsS0Ot7dM8c/7YzbB9f0q+xlDzYQKXqvUbnz6TQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -336,7 +336,7 @@
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Data.Sqlite": "[7.0.3, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.24, )",
+          "NBitcoin.Kimi": "[7.0.25.1, )",
           "WabiSabi": "[1.0.1.2, )"
         }
       }

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -325,10 +325,10 @@
         "resolved": "7.0.0",
         "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
       },
-      "NBitcoin": {
+      "NBitcoin.Kimi": {
         "type": "Transitive",
-        "resolved": "7.0.24",
-        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
+        "resolved": "7.0.25.1",
+        "contentHash": "kQECjHNKxSZycPLLuFu9iqtg9IKa12Vhz/b+4Bk6SOQRGxPnsS0Ot7dM8c/7YzbB9f0q+xlDzYQKXqvUbnz6TQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -726,7 +726,7 @@
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Data.Sqlite": "[7.0.3, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.24, )",
+          "NBitcoin.Kimi": "[7.0.25.1, )",
           "WabiSabi": "[1.0.1.2, )"
         }
       },

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -290,10 +290,10 @@
         "resolved": "7.0.0",
         "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
       },
-      "NBitcoin": {
+      "NBitcoin.Kimi": {
         "type": "Transitive",
-        "resolved": "7.0.24",
-        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
+        "resolved": "7.0.25.1",
+        "contentHash": "kQECjHNKxSZycPLLuFu9iqtg9IKa12Vhz/b+4Bk6SOQRGxPnsS0Ot7dM8c/7YzbB9f0q+xlDzYQKXqvUbnz6TQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -644,7 +644,7 @@
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Data.Sqlite": "[7.0.3, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.24, )",
+          "NBitcoin.Kimi": "[7.0.25.1, )",
           "WabiSabi": "[1.0.1.2, )"
         }
       },

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -74,10 +74,10 @@
         "resolved": "7.0.0",
         "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
       },
-      "NBitcoin": {
+      "NBitcoin.Kimi": {
         "type": "Transitive",
-        "resolved": "7.0.24",
-        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
+        "resolved": "7.0.25.1",
+        "contentHash": "kQECjHNKxSZycPLLuFu9iqtg9IKa12Vhz/b+4Bk6SOQRGxPnsS0Ot7dM8c/7YzbB9f0q+xlDzYQKXqvUbnz6TQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"
@@ -336,7 +336,7 @@
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[7.0.0, )",
           "Microsoft.Data.Sqlite": "[7.0.3, )",
           "Microsoft.Win32.SystemEvents": "[7.0.0, )",
-          "NBitcoin": "[7.0.24, )",
+          "NBitcoin.Kimi": "[7.0.25.1, )",
           "WabiSabi": "[1.0.1.2, )"
         }
       }

--- a/WalletWasabi/BitcoinP2p/P2pNetwork.cs
+++ b/WalletWasabi/BitcoinP2p/P2pNetwork.cs
@@ -89,6 +89,7 @@ public class P2pNetwork : BackgroundService
 			connectionParameters.TemplateBehaviors.Add(BitcoinStore.CreateUntrustedP2pBehavior());
 			connectionParameters.TemplateBehaviors.Add(addressManagerBehavior);
 			connectionParameters.EndpointConnector = new BestEffortEndpointConnector(MaximumNodeConnections / 2);
+			connectionParameters.ConnectCancellation = ConnectCts.Token;
 
 			if (torSocks5EndPoint is not null)
 			{
@@ -110,6 +111,7 @@ public class P2pNetwork : BackgroundService
 	private Node? RegTestMempoolServingNode { get; set; }
 	private string AddressManagerFilePath { get; }
 	private AddressManager? AddressManager { get; set; }
+	private CancellationTokenSource ConnectCts { get; } = new();
 
 	/// <inheritdoc />
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -163,6 +165,8 @@ public class P2pNetwork : BackgroundService
 
 		cancellationToken.ThrowIfCancellationRequested();
 
+		ConnectCts.Cancel();
+
 		Nodes.Disconnect();
 		while (Nodes.ConnectedNodes.Any(x => x.IsConnected))
 		{
@@ -189,6 +193,7 @@ public class P2pNetwork : BackgroundService
 		}
 
 		Nodes.Dispose();
+		ConnectCts.Dispose();
 		base.Dispose();
 	}
 }

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -31,7 +31,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.3" />
 		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
-		<PackageReference Include="NBitcoin" Version="7.0.24" />
+		<PackageReference Include="NBitcoin.Kimi" Version="7.0.25.1" />
+		<!--<PackageReference Include="NBitcoin" Version="7.0.24" />-->
 		<PackageReference Include="WabiSabi" Version="1.0.1.2" />
 	</ItemGroup>
 

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -29,11 +29,11 @@
         "resolved": "7.0.0",
         "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
       },
-      "NBitcoin": {
+      "NBitcoin.Kimi": {
         "type": "Direct",
-        "requested": "[7.0.24, )",
-        "resolved": "7.0.24",
-        "contentHash": "+K8o9WH09/o8oTl0aV/IR2y+1leR7e1vvZ2S6A7IozvMsWGh/Wi3TYWhasAskEYryQJr2f4gQsy67eAO7YExAg==",
+        "requested": "[7.0.25.1, )",
+        "resolved": "7.0.25.1",
+        "contentHash": "kQECjHNKxSZycPLLuFu9iqtg9IKa12Vhz/b+4Bk6SOQRGxPnsS0Ot7dM8c/7YzbB9f0q+xlDzYQKXqvUbnz6TQ==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"


### PR DESCRIPTION
Fixes #10155

There are 2 commits:

1. 80b8a7197524e2c10339e8df7bcca2e1406cca4d - I think we should have this connect cancellation in place.
2. 0bf965321cf053f763a97c334e31cf1b2256c653 corresponds with https://github.com/kiminuo/NBitcoin/commit/46dfc4b25fd480bb55094d7b211960c08ba09767 commit (`NBitcoin.Kimi` fork `7.0.25.1`)

## Explanation

Now what is happening. We have P2pNetwork.cs where we initialize a `NodesGroup`:

https://github.com/zkSNACKs/WalletWasabi/blob/969b6bb354b9bc07475b8ae43c80779a77f85359/WalletWasabi/BitcoinP2p/P2pNetwork.cs#L97

so on NBitcoin's side we start [NodesGroup.StartConnecting()](https://github.com/MetacoSA/NBitcoin/blob/fb13874fa43b881b55db9325b1e92a3d77e0bdbb/NBitcoin/Protocol/NodesGroup.cs#L139-L207). So far so good. 

The process of stopping `P2pNetwork` relies on [NodesGroup.Disconnect()](https://github.com/zkSNACKs/WalletWasabi/blob/969b6bb354b9bc07475b8ae43c80779a77f85359/WalletWasabi/BitcoinP2p/P2pNetwork.cs#L166) and there is a slight issue in the [NBitcoin impl](https://github.com/MetacoSA/NBitcoin/blob/fb13874fa43b881b55db9325b1e92a3d77e0bdbb/NBitcoin/Protocol/NodesGroup.cs#L130-L134):

```cs
/// <summary>
/// Drop connection to all connected nodes
/// </summary>
public void Disconnect()
{
	_Disconnect.Cancel();
	_ConnectedNodes.DisconnectAll();
}
```

... and the issue is that NBitcoin does not cancel connecting of a *not-yet-connected* node (if there is one) in [NodesGroup.StartConnecting](https://github.com/MetacoSA/NBitcoin/blob/fb13874fa43b881b55db9325b1e92a3d77e0bdbb/NBitcoin/Protocol/NodesGroup.cs#L175-L181). How is that possible? One would expect that:

1. `_Disconnect.Cancel();` stops connecting to any not-yet-connected node, and
2. that `_ConnectedNodes.DisconnectAll();` disconnects all connected nodes.

The issue seems to be in 

* https://github.com/MetacoSA/NBitcoin/blob/fb13874fa43b881b55db9325b1e92a3d77e0bdbb/NBitcoin/Protocol/Node.cs#L838
* https://github.com/MetacoSA/NBitcoin/blob/fb13874fa43b881b55db9325b1e92a3d77e0bdbb/NBitcoin/Protocol/Node.cs#L851 (notice that this is the same method as @soosr observed in https://github.com/zkSNACKs/WalletWasabi/issues/10155#issue-1594928722)

and the issue is that `_Connection` (`NodeConnection`) has its [own cancellation token](https://github.com/MetacoSA/NBitcoin/blob/fb13874fa43b881b55db9325b1e92a3d77e0bdbb/NBitcoin/Protocol/Node.cs#L183) that is not being cancelled by `NodesGroup.Disconnect()` ([here](https://github.com/zkSNACKs/WalletWasabi/blob/969b6bb354b9bc07475b8ae43c80779a77f85359/WalletWasabi/BitcoinP2p/P2pNetwork.cs#L166)).

And that's why https://github.com/kiminuo/NBitcoin/commit/46dfc4b25fd480bb55094d7b211960c08ba09767 makes sense to me. 
