### PR TITLE
`ConnectedNode`: Dispose node properly

### DIFF
--- a/WalletWasabi/Wallets/BlockProvider/ConnectedNode.cs
+++ b/WalletWasabi/Wallets/BlockProvider/ConnectedNode.cs
@@ -72,6 +72,7 @@ public class ConnectedNode : IDisposable
 		if (Node is not null)
 		{
 			Node.StateChanged -= Node_StateChanged;
+			Node.Dispose();
 		}
 
 		DisconnectedCts.Dispose();


### PR DESCRIPTION
This PR contributes to #10155 but it's not a complete fix. 

On master, the app does not terminate on regtest for me. With this PR, it does[^1]. See https://github.com/zkSNACKs/WalletWasabi/issues/10155#issuecomment-1486401279. What this PR fixes is the connection to the local bitcoin fullnode. #10668 goes much deeper than this PR as it attempts to fix the issue with remote P2P nodes.

[^1]: Don't ask how many hours it took to write this one-line fix. :-| 
