### PR TITLE
Set HTTP status codes

### DIFF
--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -100,7 +100,7 @@ public static class HttpResponseMessageExtensions
 
 			if (innerException is not null)
 			{
-				throw new HttpRequestException("Remote coordinator responded with an error.", innerException, me.StatusCode);
+				throw new HttpRequestException("Remote coordinator responded with an error.", innerException, statusCode: me.StatusCode);
 			}
 
 			// Remove " from beginning and end to ensure backwards compatibility and it's kind of trash, too.
@@ -115,6 +115,6 @@ public static class HttpResponseMessageExtensions
 			}
 		}
 
-		throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}");
+		throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}", inner: null, statusCode: me.StatusCode);
 	}
 }

--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -480,7 +480,7 @@ public static class HttpMessageHelper
 		{
 			if (contentHeaders.ContentLength < 0)
 			{
-				throw new HttpRequestException("Content-Length MUST be greater than or equal to zero.");
+				throw new HttpRequestException("Content-Length MUST be greater than or equal to zero.", inner: null, statusCode: HttpStatusCode.BadGateway);
 			}
 		}
 	}

--- a/WalletWasabi/Tor/Http/Models/RequestLine.cs
+++ b/WalletWasabi/Tor/Http/Models/RequestLine.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using static WalletWasabi.Tor.Http.Constants;
 
@@ -15,7 +16,7 @@ public class RequestLine : StartLine
 		// A sender MUST NOT generate an "http" URI with an empty host identifier.
 		if (string.IsNullOrEmpty(uri.DnsSafeHost))
 		{
-			throw new HttpRequestException("Host identifier is empty.");
+			throw new HttpRequestException("Host identifier is empty.", inner: null, statusCode: HttpStatusCode.BadGateway);
 		}
 
 		URI = uri;


### PR DESCRIPTION
Alternative to #10536 

This PR attempts to set HTTP status code for all `HttpRequestException`[^1]

[^1]: [These two](https://github.com/zkSNACKs/WalletWasabi/blob/a5d3ea3af5b95866d7a97610864f0c6a4d9e6285/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifierApiClient.cs#L25-L32) should not be imo `HttpRequestException` but rather `ArgumentException`s.