### PR TITLE
RpcBasedTests: Fix a few warnings

### DIFF
--- a/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
+++ b/WalletWasabi.Tests/Helpers/BitcoinFactory.cs
@@ -144,7 +144,8 @@ public static class BitcoinFactory
 
 	public static BitcoinAddress CreateBitcoinAddress(Network network, Key? key = null)
 	{
-		return CreateScript(key).GetDestinationAddress(network);
+		// Segwit script has always a destination address, so it cannot be null.
+		return CreateScript(key).GetDestinationAddress(network)!;
 	}
 
 	public static Transaction CreateTransaction() => CreateSmartTransaction(1, 0, 0, 1).Transaction;

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -286,7 +286,7 @@ public class RpcBasedTests
 
 			await rpc.CreateWalletAsync("wallet");
 			await rpc.GenerateAsync(101);
-			var txid = await rpc.SendToAddressAsync(BitcoinFactory.CreateScript().GetDestinationAddress(Network.RegTest), Money.Coins(1));
+			var txid = await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(Network.RegTest), Money.Coins(1));
 
 			txs = await rpc.GetRawTransactionsAsync(new[] { txid }, CancellationToken.None);
 			Assert.Single(txs);
@@ -294,7 +294,7 @@ public class RpcBasedTests
 			List<uint256> txids = new();
 			for (int i = 0; i < 2; i++)
 			{
-				var txid2 = await rpc.SendToAddressAsync(BitcoinFactory.CreateScript().GetDestinationAddress(Network.RegTest), Money.Coins(1));
+				var txid2 = await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(Network.RegTest), Money.Coins(1));
 				txids.Add(txid2);
 			}
 
@@ -304,7 +304,7 @@ public class RpcBasedTests
 			txids = new();
 			for (int i = 0; i < 20; i++)
 			{
-				var txid2 = await rpc.SendToAddressAsync(BitcoinFactory.CreateScript().GetDestinationAddress(Network.RegTest), Money.Coins(1));
+				var txid2 = await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(Network.RegTest), Money.Coins(1));
 				txids.Add(txid2);
 			}
 


### PR DESCRIPTION
Follow-up to #10196

NBitcoin changed its API so that some methods can return a null. This PR fixes a trivial case.