### PR TITLE
PoC: Compress/Decompress filters in synchronization

### DIFF
--- a/WalletWasabi/Backend/Models/Responses/SynchronizeResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/SynchronizeResponse.cs
@@ -14,6 +14,7 @@ public class SynchronizeResponse
 	[JsonProperty(ItemConverterType = typeof(FilterModelJsonConverter))] // Do not use the default jsonifyer, because that's too much data.
 	public IEnumerable<FilterModel> Filters { get; set; } = new List<FilterModel>();
 
+	public byte[]? FiltersCompressed { get; set; }
 	public int BestHeight { get; set; }
 
 	public IEnumerable<RoundStateResponseBase> CcjRoundStates { get; set; } = new List<RoundStateResponseBase>();

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -37,7 +37,7 @@ public class WasabiClient
 	/// </remarks>
 	public async Task<SynchronizeResponse> GetSynchronizeAsync(uint256 bestKnownBlockHash, int count, EstimateSmartFeeMode? estimateMode = null, CancellationToken cancel = default)
 	{
-		string relativeUri = $"api/v{ApiVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}";
+		string relativeUri = $"api/v{ApiVersion}/btc/batch/synchronize?bestKnownBlockHash={bestKnownBlockHash}&maxNumberOfFilters={count}&zipResponse=true";
 		if (estimateMode is { })
 		{
 			relativeUri = $"{relativeUri}&estimateSmartFeeMode={estimateMode}";


### PR DESCRIPTION
This is a quick proof of concept, follow-up to #10608 
It's just to showcase that it's not really difficult to do and reduces data to download by more or less 40% (all filters weight 2.5 Gb (master) -> 1.5Gb (this PR), last 30k filters weight 700Mb (master) -> 400Mb (this PR))

Of course, for it to be a real feature, it needs better factoring, error handling, and caching.
You can test it on regtest but results are not as good on main because less redundancy (60% compression rate on my regtest vs 40% on main).