### PR TITLE
Calculate the min feerate

### DIFF
--- a/WalletWasabi.Tests/Helpers/MempoolInfoGenerator.cs
+++ b/WalletWasabi.Tests/Helpers/MempoolInfoGenerator.cs
@@ -26,7 +26,7 @@ public class MempoolInfoGenerator
 
 		var realSizesHistogram = new[]
 		{
-			// Extrated from mempool.space (May 8th)
+			// Extracted from mempool.space (May 8th)
 			26912900, 39041211, 11497886, 12630137, 5215539, 5346874, 4165246, 6182007, 22028761, 10532242,
 			7840968, 4766683, 5323740, 3866718, 4380467, 3821845, 2669088, 1594671, 3365674, 3032493,
 			3489014, 2257412, 5913665, 798395, 457517, 251187, 392587, 540874, 132731, 36160, 11657, 6884,
@@ -43,7 +43,7 @@ public class MempoolInfoGenerator
 				Sizes = (uint)size * 4,
 				From = new FeeRate((decimal)range.from),
 				To = new FeeRate((decimal)range.to),
-				Fees = Money.Satoshis(avgFeeRate * (decimal)size),
+				Fees = Money.Satoshis(avgFeeRate * size),
 				Group = range.from
 			};
 		}

--- a/WalletWasabi.Tests/Helpers/MempoolInfoGenerator.cs
+++ b/WalletWasabi.Tests/Helpers/MempoolInfoGenerator.cs
@@ -6,33 +6,82 @@ namespace WalletWasabi.Tests.Helpers;
 
 public class MempoolInfoGenerator
 {
-	private static readonly int[] FeeLimits = new[]
+	private static readonly int[] FeeLimits =
 	{
-			1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 17, 20, 25, 30, 40, 50, 60, 70, 80,
-			100, 120, 140, 170, 200, 250, 300, 400, 500, 600, 700, 800, 1000,
-			1200, 1400, 1700, 2000, 2500, 3000, 4000, 5000, 6000, 7000, 8000, 10000
-		};
+		1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 17, 20, 25, 30, 40, 50, 60, 70, 80,
+		100, 120, 140, 170, 200, 250, 300, 400, 500, 600, 700, 800, 1000,
+		1200, 1400, 1700, 2000, 2500, 3000, 4000, 5000, 6000, 7000, 8000, 10000
+	};
 
 	public static (int from, int to)[] FeeRanges { get; } = FeeLimits.Zip(FeeLimits.Skip(1), (from, to) => (from, to)).ToArray();
 
-	public static FeeRate GenerateFeeRateForTarget(int target)
-		=> new((decimal)(4_000 / (target * target) * Random.Shared.Gaussian(1.0, 0.2)));
+	public static MemPoolInfo GenerateRealMempoolInfo()
+	{
+		var mempoolInfoFeeLimits = new[]
+		{
+			// The fee scale used by mempool.space
+			1, 2, 3, 4, 5, 6, 8, 10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 100, 125,
+			150, 175, 200, 250, 300, 350, 400, 500, 600, 700, 800, 900, 1000
+		};
+
+		var realSizesHistogram = new[]
+		{
+			// Extrated from mempool.space (May 8th)
+			26912900, 39041211, 11497886, 12630137, 5215539, 5346874, 4165246, 6182007, 22028761, 10532242,
+			7840968, 4766683, 5323740, 3866718, 4380467, 3821845, 2669088, 1594671, 3365674, 3032493,
+			3489014, 2257412, 5913665, 798395, 457517, 251187, 392587, 540874, 132731, 36160, 11657, 6884,
+			4554, 1066, 244, 116, 664, 1056
+		};
+
+		static FeeRateGroup ToFeeRateGroup((int from, int to) range, int size)
+		{
+			var count = size / Math.Max(300, Random.Shared.Gaussian(500, 100));
+			var avgFeeRate = range.from + (range.to - range.from) / 2.0m;
+			return new FeeRateGroup
+			{
+				Count = (uint)count,
+				Sizes = (uint)size * 4,
+				From = new FeeRate((decimal)range.from),
+				To = new FeeRate((decimal)range.to),
+				Fees = Money.Satoshis(avgFeeRate * (decimal)size),
+				Group = range.from
+			};
+		}
+
+		var histogram = mempoolInfoFeeLimits
+			.Zip(mempoolInfoFeeLimits.Skip(1), (from, to) => (from, to))
+			.Zip(realSizesHistogram)
+			.Select(x => ToFeeRateGroup(x.First, x.Second))
+			.ToArray();
+
+		var totalSize = (ulong)histogram.Sum(x => (decimal)x.Sizes);
+		var txCount = (ulong)histogram.Sum(x => (decimal)x.Count);
+
+		return new MemPoolInfo
+		{
+			Histogram = histogram,
+			MemPoolMinFee = 0.00001000,
+			Bytes = (int)totalSize,
+			Size = (int)txCount,
+			MinRelayTxFee = 0.00001000,
+			MaxMemPool = 1_000_000_000
+		};
+	}
 
 	public static MemPoolInfo GenerateMempoolInfo()
 	{
 		var histogram = GenerateHistogram().ToArray();
 		var totalSize = (ulong)histogram.Sum(x => (decimal)x.Sizes);
 		var txCount = (ulong)histogram.Sum(x => (decimal)x.Count);
-		var isMemPoolAlmostFull = totalSize > 250_000_000;
 
 		return new MemPoolInfo
 		{
 			Histogram = histogram,
-			MemPoolMinFee = isMemPoolAlmostFull ? 0.00004000 : 0.00001000,
+			MemPoolMinFee = 0.00001000,
 			Bytes = (int)totalSize,
 			Size = (int)txCount,
 			MinRelayTxFee = 0.00001000,
-			MaxMemPool = 300_000_000
+			MaxMemPool = 1_000_000_000
 		};
 	}
 
@@ -41,15 +90,16 @@ public class MempoolInfoGenerator
 
 	private static FeeRateGroup GenerateFeeRateGroup(int from, int to)
 	{
-		var count = Math.Max(1, Random.Shared.Gaussian(10_000 - 5 * to, 1_000));
-		var sizes = count * Math.Max(250, Random.Shared.Gaussian(500, 100));
+		var count = 100_000 / (to - from);
+		var sizes = count * Math.Max(300, Random.Shared.Gaussian(500, 100));
+		var avgFeeRate = from + ((to - from) / 2.0m);
 		return new FeeRateGroup
 		{
 			Count = (uint)count,
 			Sizes = (uint)sizes,
 			From = new FeeRate((decimal)from),
 			To = new FeeRate((decimal)to),
-			Fees = Money.Satoshis((decimal)((to - from) / 2.0 * sizes)),
+			Fees = Money.Satoshis(avgFeeRate * (decimal)sizes),
 			Group = from
 		};
 	}

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -278,7 +278,7 @@ public class AllFeeEstimateTests
 		foreach (var _ in Enumerable.Range(0, 100))
 		{
 			var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
-			var mempoolInfo = MempoolInfoGenerator.GenerateRealMempoolInfo();
+			var mempoolInfo = MempoolInfoGenerator.GenerateMempoolInfo();
 			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(mempoolInfo);
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 120m));
 			var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -275,10 +275,10 @@ public class AllFeeEstimateTests
 	[Fact]
 	public async Task ExhaustiveMempoolEstimationsAsync()
 	{
-		foreach (var i in Enumerable.Range(0, 1000))
+		foreach (var _ in Enumerable.Range(0, 100))
 		{
 			var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
-			var mempoolInfo = MempoolInfoGenerator.GenerateMempoolInfo();
+			var mempoolInfo = MempoolInfoGenerator.GenerateRealMempoolInfo();
 			mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(mempoolInfo);
 			mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative, It.IsAny<CancellationToken>())).ReturnsAsync(FeeRateResponse(2, 120m));
 			var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
@@ -289,6 +289,21 @@ public class AllFeeEstimateTests
 			Assert.Equal(estimations.Values, estimations.Values.OrderByDescending(x => x));
 			Assert.All(estimations, (e) => Assert.True(e.Value >= mempoolInfo.MemPoolMinFee * 100_000));
 		}
+	}
+
+	[Fact]
+	public async Task RealWorldMempoolMinFeeAsync()
+	{
+		var mockRpc = CreateAndConfigureRpcClient(hasPeersInfo: true);
+		var mempoolInfo = MempoolInfoGenerator.GenerateRealMempoolInfo();
+		mockRpc.Setup(rpc => rpc.GetMempoolInfoAsync(It.IsAny<CancellationToken>())).ReturnsAsync(mempoolInfo);
+		mockRpc.Setup(rpc => rpc.EstimateSmartFeeAsync(It.IsAny<int>(), EstimateSmartFeeMode.Conservative, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(FeeRateResponse(2, 0m)); // all estimations a 0 s/b so, only estimations based on mempool.
+		var feeRates = await mockRpc.Object.EstimateAllFeeAsync(EstimateSmartFeeMode.Conservative);
+		var estimations = feeRates.Estimations;
+		var minFee = estimations.Min(x => x.Value);
+
+		Assert.Equal(30, minFee); // this is the calculated MempoolMinFee needed to be in the top 200MB
 	}
 
 	private static Mock<IRPCClient> CreateAndConfigureRpcClient(bool isSynchronized = true, bool hasPeersInfo = false, double memPoolMinFee = 0.00001000)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -80,8 +80,7 @@ public static class RPCClientExtensions
 
 		var rpcStatus = await rpc.GetRpcStatusAsync(cancel).ConfigureAwait(false);
 
-		var (minEstimatedMempoolFee, minEstimations) = GetFeeEstimationsFromMempoolInfo(mempoolInfo);
-		var sanityFeeRate = FeeRate.Max(minEstimatedMempoolFee, mempoolInfo.GetSanityFeeRate());
+		var (sanityFeeRate, minEstimations) = GetFeeEstimationsFromMempoolInfo(mempoolInfo);
 
 		var fixedEstimations = smartEstimations
 			.GroupJoin(
@@ -205,7 +204,10 @@ public static class RPCClientExtensions
 		var feeRateByConfirmationTarget = consolidatedFeeGroupByTarget
 			.ToDictionary(x => x.Target, x => (int)Math.Ceiling(x.FeeRate));
 
-		return (top200Mb ?? FeeRate.Zero, feeRateByConfirmationTarget);
+		var top200MbFeeRate = top200Mb ?? FeeRate.Zero; 
+		var sanityFeeRate = FeeRate.Max(top200MbFeeRate, mempoolInfo.GetSanityFeeRate());
+		
+		return (sanityFeeRate, feeRateByConfirmationTarget);
 	}
 
 	public static async Task<RpcStatus> GetRpcStatusAsync(this IRPCClient rpc, CancellationToken cancel)


### PR DESCRIPTION
Here we calculate the minimum fee rate needed to be in the top 200Mb of the mempool.

It is tested with real world data extracted from mempool.space (May 8th) and the result (30s/b) seems reasonable.

![image](https://github.com/zkSNACKs/WalletWasabi/assets/127973/9311eb2b-a2d2-4295-b26d-4aef7af4e664)
