### PR TITLE
Reduce Non-Standard Changes

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -312,8 +312,8 @@ public class AmountDecomposer
 		preCandidates.Shuffle();
 
 		var orderedCandidates = preCandidates
-			.OrderBy(x => x.Cost) // Less cost is better.
-			.ThenBy(x => x.Decomposition.All(x => denomHashSet.Contains(x)) ? 0 : 1) // Prefer no change.
+			.OrderBy(x => x.Decomposition.All(x => denomHashSet.Contains(x)) ? 0 : 1) // Prefer no change.
+			.ThenBy(x => x.Cost) // Less cost is better.
 			.ThenBy(x => x.Decomposition.Any(d => d.ScriptType == ScriptType.Taproot) && x.Decomposition.Any(d => d.ScriptType == ScriptType.P2WPKH) ? 0 : 1) // Prefer mixed scripts types.
 			.Select(x => x).ToList();
 


### PR DESCRIPTION
- Credit goes to @turbolay for the idea here: https://github.com/zkSNACKs/WalletWasabi/issues/10708#issuecomment-1553033121
- Equivalent commit in Sake: https://github.com/nopara73/Sake/commit/a6cc7c3a65f69623bbfbfcfdb48589f4f0780c7a
- This improves upon (probably a lot) on https://github.com/zkSNACKs/WalletWasabi/issues/10708#issuecomment-1553033121
- This also solves a user's issue I've been hunting for 3 weeks at this point: his anonymity score went down after creating a non-standard (not the largest one, mind you!) output. Although I've been hunting it for 3 weeks, this information came to light today. (Thanks for @SuperJMN's PRs: https://github.com/zkSNACKs/WalletWasabi/pull/10680, https://github.com/zkSNACKs/WalletWasabi/pull/10679)

**So what does this PR do?** It changes preference of amount organization from cost minimization to non-std change minimization.

**Is there a compromise or is it a clean bug fix?** Although it may seem like there's a tradeoff here, but that's not actually the case when we zoom out of a single transaction and look at the coinjoin system as a whole: creating non-standard change is expensive, because it comes with anonymity punishment, making the user having to mix a lot more. Compared to this cost, whatever micro satoshis we'd have gained in the transaction at hand is insignificant. Therefore I conclude, this PR is trivial.

**Ok, but does it make a difference?** I tested with [Sake](https://github.com/nopara73/Sake) (recently updated Sake with 2.0 data) and it has arrived to the following average non-standard change creation numbers:

Without the modification I ran Sake 100 + 100 + 100 + 100 times and the averages were: `0,52, 0,59, 0,53, 0,48`.
With the modification I ran Sake 100 times and the average was `0,16`, which is a huge improvement.