### PR TITLE
[FireProofing] Don't allow to burn more than 30% of coins effective value in CJs

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -58,7 +58,7 @@ public class CoinJoinCoinSelector
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputScriptTypes.Contains(x.ScriptType))
-			.Where(x => x.EffectiveValue(parameters.MiningFeeRate).Satoshi > x.Amount.Satoshi * MaxEffectiveValueLossTolerance)
+			.Where(x => x.EffectiveValue(parameters.MiningFeeRate).Satoshi > x.Amount.Satoshi * (1 - MaxEffectiveValueLossTolerance)
 			.ToArray();
 
 		// Sanity check.

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -16,9 +16,9 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinCoinSelector
 {
-	private static readonly double MaxEffectiveValueLossTolerance = 0.3; // Maximum tolerable effective value loss.
 	private const int MaxInputsRegistrableByWallet = 10; // how many
 	private const int MaxWeightedAnonLoss = 3; // Maximum tolerable WeightedAnonLoss.
+	private static readonly double MaxEffectiveValueLossTolerance = 0.3; // Maximum tolerable effective value loss.
 
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -18,7 +18,8 @@ public class CoinJoinCoinSelector
 {
 	private const int MaxInputsRegistrableByWallet = 10; // how many
 	private const int MaxWeightedAnonLoss = 3; // Maximum tolerable WeightedAnonLoss.
-	
+	private const double MaxEffectiveValueLossTolerance = 0.3; // Maximum tolerable effective value loss.
+
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>
 	/// <param name="semiPrivateThreshold">Minimum anonymity of coins that can be selected together.</param>
@@ -38,14 +39,14 @@ public class CoinJoinCoinSelector
 	public int AnonScoreTarget { get; }
 	public int SemiPrivateThreshold { get; }
 	private WasabiRandom Rnd { get; }
-	
+
 	public static CoinJoinCoinSelector FromWallet(IWallet wallet) =>
-		new (
+		new(
 			wallet.ConsolidationMode,
 			wallet.AnonScoreTarget,
 			wallet.RedCoinIsolation ? Constants.SemiPrivateThreshold : 0,
 			SecureRandom.Instance);
-	
+
 	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
 	public ImmutableList<TCoin> SelectCoinsForRound<TCoin>(IEnumerable<TCoin> coins, UtxoSelectionParameters parameters, Money liquidityClue)
 		where TCoin : class, ISmartCoin, IEquatable<TCoin>
@@ -53,11 +54,11 @@ public class CoinJoinCoinSelector
 		liquidityClue = liquidityClue > Money.Zero
 			? liquidityClue
 			: Constants.MaximumNumberOfBitcoinsMoney;
-			
+
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputScriptTypes.Contains(x.ScriptType))
-			.Where(x => x.EffectiveValue(parameters.MiningFeeRate) > Money.Zero)
+			.Where(x => x.EffectiveValue(parameters.MiningFeeRate).Satoshi > x.Amount.Satoshi * MaxEffectiveValueLossTolerance)
 			.ToArray();
 
 		// Sanity check.

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -58,7 +58,7 @@ public class CoinJoinCoinSelector
 		var filteredCoins = coins
 			.Where(x => parameters.AllowedInputAmounts.Contains(x.Amount))
 			.Where(x => parameters.AllowedInputScriptTypes.Contains(x.ScriptType))
-			.Where(x => x.EffectiveValue(parameters.MiningFeeRate).Satoshi > x.Amount.Satoshi * (1 - MaxEffectiveValueLossTolerance)
+			.Where(x => x.EffectiveValue(parameters.MiningFeeRate).Satoshi > x.Amount.Satoshi * (1 - MaxEffectiveValueLossTolerance))
 			.ToArray();
 
 		// Sanity check.

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -18,7 +18,7 @@ public class CoinJoinCoinSelector
 {
 	private const int MaxInputsRegistrableByWallet = 10; // how many
 	private const int MaxWeightedAnonLoss = 3; // Maximum tolerable WeightedAnonLoss.
-	private static readonly double MaxEffectiveValueLossTolerance = 0.3; // Maximum tolerable effective value loss.
+	private const double MaxEffectiveValueLossTolerance = 0.3; // Maximum tolerable effective value loss.
 
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>


### PR DESCRIPTION
First action item we could think of for fixing https://github.com/zkSNACKs/WalletWasabi/issues/10675

Idea:

Client should not register small coins that are loosing more than 30% of their effective values.
This check is only useful in high fee enviroment.

`0.3` was from the top of my head. Feel free to suggest other values.