### PR TITLE
Reduce Non-Standard Changes: Follow-up

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -332,13 +332,13 @@ public class AmountDecomposer
 		var costTolerance = Money.Coins(bestCandidateCost.ToUnit(MoneyUnit.BTC) * 1.2m);
 
 
-		// Change can only be max between: 100.000 satoshis, 10% of the inputs sum or 10% more than the best candidate change
+		// Change can only be max between: 100.000 satoshis, 10% of the inputs sum or 20% more than the best candidate change
 		var bestCandidateChange = CalculateChange(orderedCandidates.First().Decomposition, denomHashSet);
 		var changeTolerance = Money.Coins(
 			Math.Max(
 				Math.Max(
 					myInputSum.ToUnit(MoneyUnit.BTC) * 0.10m,
-					bestCandidateChange.ToUnit(MoneyUnit.BTC) * 1.1m),
+					bestCandidateChange.ToUnit(MoneyUnit.BTC) * 1.2m),
 				Money.Satoshis(100000).ToUnit(MoneyUnit.BTC)));
 		
 		var finalCandidates = orderedCandidates.Where(x => x.Cost <= costTolerance && CalculateChange(x.Decomposition, denomHashSet) <= changeTolerance).ToArray();


### PR DESCRIPTION
While testing #10736 I realized that sometimes big non-standard change was still created, causing `AnonymityLoss`, so I took the concept a bit further with 3 possible improvements, listed in the order they appear in the diff:
- `maxDenomUsage` being per denom instead of global. Considering the naming and position of the variables, this seems like a bug fix. While the change is still too big (more than 100.000 sats or 10% of the inputs), the naive decomposer will keep creating outputs by going on to the next denomination. Maybe some randomness has to be added here to avoid being too deterministic. The reason behind this change is that on master sometimes you are only allowed really few denominations and it can make you to create a really big change. An alternate is to have `maxDenomUsage = Random.Next(4, 8);` instead of `2,8`. The first commit included a simpler version that was always going to the next denomination without checking the change but then I was afraid of crumbling.
- Prefer lower change instead of preferring no change. This is the modification I'm least sure about, it's to still improve a bit in case there is no decomposition without change.
- Introduce `changeTolerance`, similar to `costTolerance`. This is the most important improvement because sometimes with #10736 randomness can make you to choose a really bad decomposition. This pre-filters decompositions to exclude those that create too much change so they won't be chosen. I used as threshold the maximum between: 100.000 sats (the idea is that small change is not a big problem), 10% of the coins (so if 100 BTC in total is registered, we accept a change of 10 BTC) or +10% of the change of `bestCandidate` decomposition.

I'm not sure about any of the changes, maybe they have consequences I didn't think about like too much determinism, it's just to show an axis of work and give additional ideas.

This PR completely removes the issue of AnonymityLoss except in one case: All other inputs/outputs in the round are significantly lower than mine (lone whale)