### PR TITLE
Filter out uneconomical denoms client-side

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -205,10 +205,9 @@ public class AmountDecomposer
 			currentLength--;
 		}
 		
-		// Filter out denominations that will cost too much in fees to create.
-		var biggestScriptTypeVsize = Math.Max(ScriptType.P2WPKH.EstimateOutputVsize(), ScriptType.Taproot.EstimateOutputVsize());
-		var maxFeeOutputCreation = FeeRate.GetFee(biggestScriptTypeVsize).ToUnit(MoneyUnit.BTC);
-		denoms = denoms.Where(x => x.Amount.ToUnit(MoneyUnit.BTC) * (MaxOutputLossInFeePercentage) >= maxFeeOutputCreation).ToList();
+		// Filter out denominations that will cost too much in fees to remix/spend.
+		var biggestInputVSize = Math.Max(ScriptType.P2WPKH.EstimateInputVsize(), ScriptType.Taproot.EstimateInputVsize());
+		denoms = denoms.Where(x => x.Amount.ToUnit(MoneyUnit.BTC) * (MaxOutputLossInFeePercentage) >= FeeRate.GetFee(biggestInputVSize).ToUnit(MoneyUnit.BTC)).ToList();
 
 		return denoms;
 	}

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -11,6 +11,8 @@ namespace WalletWasabi.WabiSabi.Client;
 /// </summary>
 public class AmountDecomposer
 {
+	private const decimal MaxOutputLossInFeePercentage = 0.3m;
+
 	/// <param name="feeRate">Bitcoin network fee rate the coinjoin is targeting.</param>
 	/// <param name="allowedOutputAmount">Range of output amount that's allowed to be registered.</param>
 	/// <param name="availableVsize">Available virtual size for outputs.</param>
@@ -202,6 +204,11 @@ public class AmountDecomposer
 			}
 			currentLength--;
 		}
+		
+		// Filter out denominations that will cost too much in fees to create.
+		var biggestScriptTypeVsize = Math.Max(ScriptType.P2WPKH.EstimateOutputVsize(), ScriptType.Taproot.EstimateOutputVsize());
+		var maxFeeOutputCreation = FeeRate.GetFee(biggestScriptTypeVsize).ToUnit(MoneyUnit.BTC);
+		denoms = denoms.Where(x => x.Amount.ToUnit(MoneyUnit.BTC) * (MaxOutputLossInFeePercentage) >= maxFeeOutputCreation).ToList();
 
 		return denoms;
 	}


### PR DESCRIPTION
Closes #10675 

This PR would avoid clients to create denominations that costs more than 30% of their value in fees. EDIT: to remix
It always takes the worst case scenario: ~~Taproot output cost~~ EDIT: Segwit INPUT cost, to avoid some clients choosing a denom and not other because of `ScriptType` randomness.

With this, old clients might be the only ones creating low value outputs during high fees, which could be a problem.
Change could still be created below the threshold.