### PR TITLE
add the word `blocks` to fee provider log message

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/HybridFeeProvider.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/HybridFeeProvider.cs
@@ -129,7 +129,7 @@ public class HybridFeeProvider : IHostedService
 				var accuracy = fees.IsAccurate ? "Accurate" : "Inaccurate";
 				var from = fees.Estimations.First();
 				var to = fees.Estimations.Last();
-				Logger.LogInfo($"{accuracy} fee rates are acquired from {sender?.GetType()?.Name} ranging from target {from.Key} at {from.Value} sat/vByte to target {to.Key} at {to.Value} sat/vByte.");
+				Logger.LogInfo($"{accuracy} fee rates are acquired from {sender?.GetType()?.Name} ranging from target {from.Key} blocks at {from.Value} sat/vByte to target {to.Key} blocks at {to.Value} sat/vByte.");
 				AllFeeEstimateChanged?.Invoke(this, fees);
 			}
 		}


### PR DESCRIPTION
master
`INFO	HybridFeeProvider.OnAllFeeEstimateArrived (132)	Accurate fee rates are acquired from WasabiSynchronizer ranging from target 2 at 2 sat/vByte to target 1008 at 21 sat/vByte.`

PR
`INFO	HybridFeeProvider.OnAllFeeEstimateArrived (132)	Accurate fee rates are acquired from WasabiSynchronizer ranging from target 2 blocks at 2 sat/vByte to target 1008 blocks at 21 sat/vByte.`

if you don't know what the `2` stands for it's kinda useless