### PR TITLE
If there are changeless candidates, don't even consider ones with change

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -310,6 +310,13 @@ public class AmountDecomposer
 
 		var denomHashSet = denoms.ToHashSet();
 		var preCandidates = setCandidates.Select(x => x.Value).ToList();
+
+		// If there are changeless candidates, don't even consider ones with change.
+		var changelessCandidates = preCandidates.Where(x => x.Decomposition.All(y => denomHashSet.Contains(y))).ToList();
+		if (changelessCandidates.Any())
+		{
+			preCandidates = changelessCandidates;
+		}
 		preCandidates.Shuffle();
 
 		var orderedCandidates = preCandidates


### PR DESCRIPTION
Nobrainer. Although we do sort orderedCandidates by change first, later on `costTolerance` logic would still prefer them. 

https://github.com/nopara73/Sake/commit/639295b6b44f4904843c1b1311090bf13f75f3a0