### PR TITLE
Introducing Pre-Decompositions to Enhance Decomposition Algorithms

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -220,6 +220,13 @@ public class AmountDecomposer
 		var naiveDecomp = CreateNaiveDecomposition(denoms, myInputSum, maxNumberOfOutputsAllowed);
 		setCandidates.Add(naiveDecomp.Key, naiveDecomp.Value);
 
+		// Create more pre-decompositions for sanity.
+		var preDecomps = CreatePreDecompositions(denoms, myInputSum, maxNumberOfOutputsAllowed);
+		foreach (var decomp in preDecomps)
+		{
+			setCandidates.TryAdd(decomp.Key, decomp.Value);
+		}
+
 		// Create many decompositions for optimization.
 		var changelessDecomps = CreateChangelessDecompositions(denoms, myInputSum, maxNumberOfOutputsAllowed);
 		foreach (var decomp in changelessDecomps)
@@ -309,6 +316,64 @@ public class AmountDecomposer
 
 				setCandidates.TryAdd(CalculateHash(finalDenoms), (finalDenoms, deficit));
 			}
+		}
+
+		return setCandidates;
+	}
+
+	private IDictionary<int, (IEnumerable<Output> Decomp, Money Cost)> CreatePreDecompositions(IEnumerable<Output> denoms, Money myInputSum, int maxNumberOfOutputsAllowed)
+	{
+		var setCandidates = new Dictionary<int, (IEnumerable<Output> Decomp, Money Cost)>();
+
+		for (int i = 0; i < 10_000; i++)
+		{
+			var remainingVsize = AvailableVsize;
+			var remaining = myInputSum;
+			List<Output> currentSet = new();
+			while (true)
+			{
+				var denom = denoms.Where(x => x.EffectiveCost <= remaining && x.EffectiveCost >= (remaining / 3)).RandomElement()
+					?? denoms.FirstOrDefault(x => x.EffectiveCost <= remaining);
+
+				// We can only let this go forward if at least 2 output can be added (denom + potential change)
+				if (denom is null || remaining < MinAllowedOutputAmount + ChangeFee || remainingVsize < denom.ScriptType.EstimateOutputVsize() + ChangeScriptType.EstimateOutputVsize())
+				{
+					break;
+				}
+
+				currentSet.Add(denom);
+				remaining -= denom.EffectiveCost;
+				remainingVsize -= denom.ScriptType.EstimateOutputVsize();
+
+				// Can't have more denoms than max - 1, where -1 is to account for possible change.
+				if (currentSet.Count >= maxNumberOfOutputsAllowed - 1)
+				{
+					break;
+				}
+			}
+
+			var loss = Money.Zero;
+			if (remaining >= MinAllowedOutputAmount + ChangeFee)
+			{
+				var change = Output.FromAmount(remaining, ChangeScriptType, FeeRate);
+				currentSet.Add(change);
+			}
+			else
+			{
+				// This goes to miners.
+				loss = remaining;
+			}
+
+			// This can happen when smallest denom is larger than the input sum.
+			if (currentSet.Count == 0)
+			{
+				var change = Output.FromAmount(remaining, ChangeScriptType, FeeRate);
+				currentSet.Add(change);
+			}
+
+			setCandidates.TryAdd(
+				CalculateHash(currentSet), // Create hash to ensure uniqueness.
+				(currentSet, loss + CalculateCost(currentSet)));
 		}
 
 		return setCandidates;

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -335,7 +335,7 @@ public class AmountDecomposer
 				var denom = denoms.Where(x => x.EffectiveCost <= remaining && x.EffectiveCost >= (remaining / 3)).RandomElement()
 					?? denoms.FirstOrDefault(x => x.EffectiveCost <= remaining);
 
-				// We can only let this go forward if at least 2 output can be added (denom + potential change)
+				// We can only let this go forward if at least 2 outputs can be added (denom + potential change)
 				if (denom is null || remaining < MinAllowedOutputAmount + ChangeFee || remainingVsize < denom.ScriptType.EstimateOutputVsize() + ChangeScriptType.EstimateOutputVsize())
 				{
 					break;


### PR DESCRIPTION
This PR builds on top of https://github.com/zkSNACKs/WalletWasabi/pull/10787 and I'll keep this as a draft until that is merged, so you don't get confused by the diff.

Sake equivalence: https://github.com/nopara73/Sake/pull/31

In extreme cases: when one cannot avoid creating a change output, there's only one decomposition to choose from. The solution proposed here involves introducing more decompositions via an intermediary pre-decomposition algorithm.

To put things into perspective, we currently use two decomposition algorithms which we'll refer to as: Naive decomp and Lucas decomp. While the Naive decomp is capable of generating only one decomp, the Lucas decomp generates decomps only when it can avoid creating change outputs.

However, there are scenarios (like when a user introduces 1000 btc into a small round) where we end up with just one possible decomp. This PR tackles such instances by including an additional pre-decomposition algorithm that runs in between the Naive and Lucas decomps, thereby creating a wider range of decomps.

The implementation involves a new function `CreatePreDecompositions` which is responsible for calculating multiple decompositions

Through the introduction of more decompositions, we aim to handle extreme cases more effectively, hence improving the flexibility and robustness of our system.

