### PR TITLE
Add client side Prison to save banned coins to file (Take 2)

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -23,6 +23,7 @@ using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
+using WalletWasabi.WabiSabi.Client.Banning;
 
 namespace WalletWasabi.Tests.RegressionTests;
 
@@ -233,7 +234,7 @@ public class BuildTests
 			cache);
 
 		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir));
-		walletManager.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		walletManager.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider, new ClientPrison());
 
 		var baseTip = await rpc.GetBestBlockHashAsync();
 

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -21,6 +21,7 @@ using WalletWasabi.Tests.XunitConfiguration;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using Xunit;
+using WalletWasabi.WabiSabi.Client.Banning;
 
 namespace WalletWasabi.Tests.RegressionTests;
 
@@ -71,7 +72,7 @@ public class SendTests
 			cache);
 
 		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir));
-		walletManager.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		walletManager.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider, new ClientPrison());
 
 		// Get some money, make it confirm.
 		var key = keyManager.GetNextReceiveKey("foo label");
@@ -555,7 +556,7 @@ public class SendTests
 			cache);
 
 		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir));
-		walletManager.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		walletManager.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider, new ClientPrison());
 
 		// Get some money, make it confirm.
 		var key = keyManager.GetNextReceiveKey("foo label");

--- a/WalletWasabi.Tests/UnitTests/ClientPrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ClientPrisonTests.cs
@@ -1,0 +1,49 @@
+using NBitcoin;
+using System.IO;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Helpers;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Client.Banning;
+using Xunit;
+using System.Threading;
+
+namespace WalletWasabi.Tests.UnitTests;
+
+public class ClientPrisonTests
+{
+	[Fact]
+	public async Task CanCreateAndLoadPrisonClientDataTestAsync()
+	{
+		var workDir = Common.GetWorkDir();
+		ClientPrison cp = ClientPrison.CreateOrLoadFromFile(workDir);
+
+		var km = KeyManager.CreateNew(out _, "", Network.Main);
+		for (int i = 0; i < 5; i++)
+		{
+			var hpk = BitcoinFactory.CreateHdPubKey(km);
+			var sc = BitcoinFactory.CreateSmartCoin(hpk, 1m);
+			cp.AddCoin(sc, DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5));
+		}
+		Assert.Equal(5, cp.PrisonedCoins.Count);
+
+		// Call StartAsync to write to file
+		await cp.StartAsync(CancellationToken.None);
+		cp.Dispose();
+
+		cp = ClientPrison.CreateOrLoadFromFile(workDir);
+		Assert.Equal(5, cp.PrisonedCoins.Count);
+		await Task.Delay(5000);
+
+		// Call StartAsync to remove expired coins
+		await cp.StartAsync(CancellationToken.None);
+		Assert.Empty(cp.PrisonedCoins);
+
+		File.Delete(cp.FilePath);
+		cp.Dispose();
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -76,11 +76,7 @@ public class AliceClient
 
 			Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({aliceClient.AliceId}): Connection was confirmed.");
 		}
-		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode
-			is WabiSabiProtocolErrorCode.RoundNotFound
-			or WabiSabiProtocolErrorCode.WrongPhase
-			or WabiSabiProtocolErrorCode.AliceAlreadyRegistered
-			or WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection)
+		catch (WabiSabiProtocolException)
 		{
 			// Do not unregister.
 			throw;
@@ -92,15 +88,15 @@ public class AliceClient
 		}
 		catch (Exception) when (aliceClient is { })
 		{
-            var aliceWouldBeRemovedByBackendTime = aliceClient.LastSuccessfulInputConnectionConfirmation + roundState.CoinjoinState.Parameters.ConnectionConfirmationTimeout;
+			var aliceWouldBeRemovedByBackendTime = aliceClient.LastSuccessfulInputConnectionConfirmation + roundState.CoinjoinState.Parameters.ConnectionConfirmationTimeout;
 
-            // We only need to unregister if alice wouldn't be removed because of the connection confirmation timeout - otherwise just leave it there.
-            if (aliceWouldBeRemovedByBackendTime > roundState.InputRegistrationEnd)
-            {
-                // Unregistering coins is only possible before connection confirmation phase.
-                await aliceClient.TryToUnregisterAlicesAsync(unregisterCancellationToken).ConfigureAwait(false);
-            }
-            throw;
+			// We only need to unregister if alice wouldn't be removed because of the connection confirmation timeout - otherwise just leave it there.
+			if (aliceWouldBeRemovedByBackendTime > roundState.InputRegistrationEnd)
+			{
+				// Unregistering coins is only possible before connection confirmation phase.
+				await aliceClient.TryToUnregisterAlicesAsync(unregisterCancellationToken).ConfigureAwait(false);
+			}
+			throw;
 		}
 
 		return aliceClient;
@@ -109,61 +105,16 @@ public class AliceClient
 	private static async Task<AliceClient> RegisterInputAsync(RoundState roundState, ArenaClient arenaClient, SmartCoin coin, IKeyChain keyChain, CancellationToken cancellationToken)
 	{
 		AliceClient? aliceClient;
-		try
-		{
-			var ownershipProof = keyChain.GetOwnershipProof(
-				coin,
-				new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Id));
 
-			var (response, isCoordinationFeeExempted) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
-			aliceClient = new(response.Value, roundState, arenaClient, coin, ownershipProof, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isCoordinationFeeExempted);
-			coin.CoinJoinInProgress = true;
+		var ownershipProof = keyChain.GetOwnershipProof(
+			coin,
+			new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Id));
 
-			Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.Outpoint}.");
-		}
-		catch (WabiSabiProtocolException wpe)
-		{
-			switch (wpe.ErrorCode)
-			{
-				case WabiSabiProtocolErrorCode.InputSpent:
-					coin.SpentAccordingToBackend = true;
-					Logger.LogInfo($"{coin.Coin.Outpoint} is spent according to the backend. The wallet is not fully synchronized or corrupted.");
-					break;
+		var (response, isCoordinationFeeExempted) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
+		aliceClient = new(response.Value, roundState, arenaClient, coin, ownershipProof, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isCoordinationFeeExempted);
+		coin.CoinJoinInProgress = true;
 
-				case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
-					var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
-					if (inputBannedExData is null)
-					{
-						Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
-					}
-					coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
-					Logger.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
-					break;
-
-				case WabiSabiProtocolErrorCode.InputNotWhitelisted:
-					coin.SpentAccordingToBackend = false;
-					Logger.LogWarning($"{coin.Coin.Outpoint} cannot be registered in the blame round.");
-					break;
-
-				case WabiSabiProtocolErrorCode.AliceAlreadyRegistered:
-					Logger.LogInfo($"{coin.Coin.Outpoint} was already registered.");
-					break;
-
-				case WabiSabiProtocolErrorCode.WrongPhase:
-					Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late. Abort the rest of the registrations.");
-					break;
-
-				case WabiSabiProtocolErrorCode.RoundNotFound:
-					Logger.LogInfo($"{coin.Coin.Outpoint} arrived too late because the round doesn't exist anymore. Abort the rest of the registrations.");
-					break;
-
-				default:
-					Logger.LogInfo($"{coin.Coin.Outpoint} cannot be registered: '{wpe.ErrorCode}'.");
-					break;
-			}
-
-			throw;
-		}
+		Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.Outpoint}.");
 
 		return aliceClient;
 	}

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -76,7 +76,11 @@ public class AliceClient
 
 			Logger.LogInfo($"Round ({aliceClient.RoundId}), Alice ({aliceClient.AliceId}): Connection was confirmed.");
 		}
-		catch (WabiSabiProtocolException)
+		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode
+			is WabiSabiProtocolErrorCode.RoundNotFound
+			or WabiSabiProtocolErrorCode.WrongPhase
+			or WabiSabiProtocolErrorCode.AliceAlreadyRegistered
+			or WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection)
 		{
 			// Do not unregister.
 			throw;

--- a/WalletWasabi/WabiSabi/Client/Banning/ClientPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/ClientPrison.cs
@@ -52,6 +52,14 @@ public class ClientPrison : PeriodicRunner
 		}
 	}
 
+	public void AddCoins(List<(SmartCoin Coin, DateTimeOffset BannedUntil)> bannedCoins)
+	{
+		foreach (var item in bannedCoins)
+		{
+			AddCoin(item.Coin, item.BannedUntil);
+		}
+	}
+
 	private void ToFile()
 	{
 		if (string.IsNullOrWhiteSpace(FilePath))

--- a/WalletWasabi/WabiSabi/Client/Banning/ClientPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/ClientPrison.cs
@@ -1,0 +1,124 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Bases;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client.Banning;
+
+public class ClientPrison : PeriodicRunner
+{
+	public ClientPrison(string containingDirectory) : base(TimeSpan.FromSeconds(10))
+	{
+		FilePath = string.IsNullOrEmpty(containingDirectory) ? "" : Path.Combine(containingDirectory, "PrisonedCoins.json");
+
+		ChangeId = Guid.NewGuid();
+		LastKnownId = ChangeId;
+	}
+
+	public ClientPrison() : this("")
+	{
+	}
+
+	[JsonIgnore]
+	public string FilePath { get; set; }
+
+	[JsonIgnore]
+	public Guid ChangeId { get; private set; }
+
+	public Guid LastKnownId { get; private set; }
+	public List<PrisonedCoinRecord> PrisonedCoins { get; set; } = new();
+
+	private object PrisonedCoinsLock { get; } = new object();
+
+	public void AddCoin(SmartCoin coin, DateTimeOffset bannedUntil)
+	{
+		lock (PrisonedCoinsLock)
+		{
+			if (PrisonedCoins.Any(record => record.Outpoint == coin.Outpoint))
+			{
+				return;
+			}
+			PrisonedCoins.Add(new(coin.Outpoint, bannedUntil));
+			ChangeId = Guid.NewGuid();
+		}
+	}
+
+	private void ToFile()
+	{
+		if (string.IsNullOrWhiteSpace(FilePath))
+		{
+			return;
+		}
+
+		IoHelpers.EnsureFileExists(FilePath);
+		var json = JsonConvert.SerializeObject(PrisonedCoins, Formatting.Indented);
+		File.WriteAllText(FilePath, json);
+	}
+
+	public static ClientPrison CreateOrLoadFromFile(string containingDirectory)
+	{
+		string prisonFilePath = Path.Combine(containingDirectory, "PrisonedCoins.json");
+		List<PrisonedCoinRecord> prisonedCoinsRecord = new();
+		try
+		{
+			IoHelpers.EnsureFileExists(prisonFilePath);
+
+			string data = File.ReadAllText(prisonFilePath);
+			if (string.IsNullOrWhiteSpace(data))
+			{
+				Logger.LogDebug("Prisoned coins file is empty.");
+				return new(containingDirectory);
+			}
+			prisonedCoinsRecord = JsonConvert.DeserializeObject<List<PrisonedCoinRecord>>(data)
+				?? throw new InvalidDataException("Prisoned coins file is corrupted.");
+		}
+		catch (Exception exc)
+		{
+			Logger.LogError($"There was an error during loading {nameof(ClientPrison)}. Reseting file.", exc);
+			File.Delete(prisonFilePath);
+		}
+		return new(containingDirectory) { PrisonedCoins = prisonedCoinsRecord };
+	}
+
+	protected override Task ActionAsync(CancellationToken cancel)
+	{
+		lock (PrisonedCoinsLock)
+		{
+			bool shouldWriteToFile = LastKnownId != ChangeId;
+
+			if (PrisonedCoins.Any(record => DateTime.UtcNow > record.BannedUntil))
+			{
+				PrisonedCoins = PrisonedCoins.Where(record => DateTime.UtcNow < record.BannedUntil).ToList();
+				shouldWriteToFile = true;
+			}
+
+			if (shouldWriteToFile)
+			{
+				LastKnownId = ChangeId;
+				ToFile();
+			}
+		}
+		return Task.CompletedTask;
+	}
+
+	public void FindAndPrisonBannedCoins(IWallet iwallet)
+	{
+		Wallet? wallet = iwallet as Wallet;
+
+		var coinsToPrison = wallet?.Coins.Where(coin => coin.IsBanned) ?? new List<SmartCoin>();
+		foreach (var coin in coinsToPrison)
+		{
+			DateTimeOffset bannedUntil = coin.BannedUntilUtc ?? throw new InvalidOperationException($"Coin was banned but {nameof(coin.BannedUntilUtc)} was null. This is impossible.");
+			AddCoin(coin, bannedUntil);
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/Banning/PrisonedCoinRecord.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/PrisonedCoinRecord.cs
@@ -1,0 +1,19 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.JsonConverters;
+
+namespace WalletWasabi.WabiSabi.Client.Banning;
+
+public record PrisonedCoinRecord
+{
+	public PrisonedCoinRecord(OutPoint outpoint, DateTimeOffset bannedUntil)
+	{
+		Outpoint = outpoint;
+		BannedUntil = bannedUntil;
+	}
+
+	[JsonProperty]
+	[JsonConverter(typeof(OutPointJsonConverter))]
+	public OutPoint Outpoint { get; set; }
+	public DateTimeOffset BannedUntil { get; set; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -442,8 +442,10 @@ public class CoinJoinClient
 						{
 							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
 						}
-						coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
-						roundState.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
+						var banUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						coin.BannedUntilUtc = banUntilUtc;
+						roundState.LogInfo($"{coin.Coin.Outpoint} is banned until {banUntilUtc}.");
+						CoinJoinClientProgress.SafeInvoke(this, new CoinBanned(coin, banUntilUtc));
 						break;
 
 					case WabiSabiProtocolErrorCode.InputNotWhitelisted:

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -403,7 +403,7 @@ public class CoinJoinClient
 					case WabiSabiProtocolErrorCode.WrongPhase:
 						if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
 						{
-							roundState.LogInfo($"{coin.Coin.Outpoint} arrived too late. Abort the rest of the registrations.Aborting input registrations: '{WabiSabiProtocolErrorCode.WrongPhase}'.");
+							roundState.LogInfo($"{coin.Coin.Outpoint} arrived too late. Aborting input registrations: '{WabiSabiProtocolErrorCode.WrongPhase}'.");
 							if (wrongPhaseExceptionData.CurrentPhase != Phase.InputRegistration)
 							{
 								// Cancel all remaining pending input registrations because they will arrive late too.

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -364,7 +364,6 @@ public class CoinJoinClient
 		{
 			PersonCircuit? personCircuit = null;
 			bool disposeCircuit = true;
-
 			try
 			{
 				personCircuit = HttpClientFactory.NewHttpClientWithPersonCircuit(out Tor.Http.IHttpClient httpClient);
@@ -392,35 +391,69 @@ public class CoinJoinClient
 			}
 			catch (WabiSabiProtocolException wpe)
 			{
-				if (wpe.ErrorCode is WabiSabiProtocolErrorCode.RoundNotFound)
+				switch (wpe.ErrorCode)
 				{
-					// if the round does not exist then it ended/aborted.
-					registrationsCts.Cancel();
-					confirmationsCts.Cancel();
-					roundState.LogInfo($"Aborting input registrations: '{WabiSabiProtocolErrorCode.RoundNotFound}'.");
-				}
-				else if (wpe.ErrorCode is WabiSabiProtocolErrorCode.WrongPhase)
-				{
-					if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
-					{
-						roundState.LogInfo($"Aborting input registrations: '{WabiSabiProtocolErrorCode.WrongPhase}'.");
-						if (wrongPhaseExceptionData.CurrentPhase != Phase.InputRegistration)
-						{
-							// Cancel all remaining pending input registrations because they will arrive late too.
-							registrationsCts.Cancel();
+					case WabiSabiProtocolErrorCode.RoundNotFound:
+						// if the round does not exist then it ended/aborted.
+						roundState.LogInfo($"{coin.Coin.Outpoint} arrived too late because the round doesn't exist anymore. Aborting input registrations: '{WabiSabiProtocolErrorCode.RoundNotFound}'.");
+						registrationsCts.Cancel();
+						confirmationsCts.Cancel();
+						break;
 
-							if (wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation)
+					case WabiSabiProtocolErrorCode.WrongPhase:
+						if (wpe.ExceptionData is WrongPhaseExceptionData wrongPhaseExceptionData)
+						{
+							roundState.LogInfo($"{coin.Coin.Outpoint} arrived too late. Abort the rest of the registrations.Aborting input registrations: '{WabiSabiProtocolErrorCode.WrongPhase}'.");
+							if (wrongPhaseExceptionData.CurrentPhase != Phase.InputRegistration)
 							{
-								// Cancel all remaining pending connection confirmations because they will arrive late too.
-								confirmationsCts.Cancel();
+								// Cancel all remaining pending input registrations because they will arrive late too.
+								registrationsCts.Cancel();
+
+								if (wrongPhaseExceptionData.CurrentPhase != Phase.ConnectionConfirmation)
+								{
+									// Cancel all remaining pending connection confirmations because they will arrive late too.
+									confirmationsCts.Cancel();
+								}
 							}
 						}
-					}
-					else
-					{
-						throw new InvalidOperationException(
-							$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
-					}
+						else
+						{
+							throw new InvalidOperationException(
+								$"Unexpected condition. {nameof(WrongPhaseException)} doesn't contain a {nameof(WrongPhaseExceptionData)} data field.");
+						}
+						break;
+
+					case WabiSabiProtocolErrorCode.AliceAlreadyRegistered:
+						roundState.LogInfo($"{coin.Coin.Outpoint} was already registered.");
+						break;
+
+					case WabiSabiProtocolErrorCode.AliceAlreadyConfirmedConnection:
+						roundState.LogInfo($"{coin.Coin.Outpoint} already confirmed connection.");
+						break;
+
+					case WabiSabiProtocolErrorCode.InputSpent:
+						coin.SpentAccordingToBackend = true;
+						roundState.LogInfo($"{coin.Coin.Outpoint} is spent according to the backend. The wallet is not fully synchronized or corrupted.");
+						break;
+
+					case WabiSabiProtocolErrorCode.InputBanned or WabiSabiProtocolErrorCode.InputLongBanned:
+						var inputBannedExData = wpe.ExceptionData as InputBannedExceptionData;
+						if (inputBannedExData is null)
+						{
+							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
+						}
+						coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						roundState.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
+						break;
+
+					case WabiSabiProtocolErrorCode.InputNotWhitelisted:
+						coin.SpentAccordingToBackend = false;
+						Logger.LogWarning($"{coin.Coin.Outpoint} cannot be registered in the blame round.");
+						break;
+
+					default:
+						roundState.LogInfo($"{coin.Coin.Outpoint} cannot be registered: '{wpe.ErrorCode}'.");
+						break;
 				}
 			}
 			catch (OperationCanceledException ex)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, Banning.ClientPrison clientPrison)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -442,7 +442,7 @@ public class CoinJoinManager : BackgroundService
 		{
 			wallet.LogError($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
 		}
-
+		// Use Prison Client Here
 		NotifyCoinJoinCompletion(finishedCoinJoin);
 
 		// When to stop mixing:

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Client.Banning;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
@@ -23,7 +24,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, Banning.ClientPrison clientPrison)
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, ClientPrison clientPrison)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -31,6 +31,7 @@ public class CoinJoinManager : BackgroundService
 		HttpClientFactory = coordinatorHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
+		ClientPrison = clientPrison;
 	}
 
 	public event EventHandler<StatusChangedEventArgs>? StatusChanged;
@@ -41,6 +42,7 @@ public class CoinJoinManager : BackgroundService
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
 	public string CoordinatorIdentifier { get; }
+	public ClientPrison ClientPrison { get; }
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 
 	/// <summary>
@@ -443,7 +445,9 @@ public class CoinJoinManager : BackgroundService
 		{
 			wallet.LogError($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
 		}
-		// Use Prison Client Here
+
+		ClientPrison.AddCoins(finishedCoinJoin.BannedCoins);
+
 		NotifyCoinJoinCompletion(finishedCoinJoin);
 
 		// When to stop mixing:

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinBanned.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinBanned.cs
@@ -1,0 +1,15 @@
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
+
+public class CoinBanned : CoinJoinProgressEventArgs
+{
+	public CoinBanned(SmartCoin coin, DateTimeOffset banUntilUtc)
+	{
+		Coin = coin;
+		BanUntilUtc = banUntilUtc;
+	}
+
+	public SmartCoin Coin { get; }
+	public DateTimeOffset BanUntilUtc { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -43,6 +43,8 @@ public class CoinJoinTracker : IDisposable
 	public bool InCriticalCoinJoinState { get; private set; }
 	public bool IsStopped { get; private set; }
 
+	public List<(SmartCoin, DateTimeOffset)> BannedCoins { get; private set; } = new();
+
 	public void Stop()
 	{
 		IsStopped = true;
@@ -66,6 +68,10 @@ public class CoinJoinTracker : IDisposable
 
 			case RoundEnded roundEnded:
 				roundEnded.IsStopped = IsStopped;
+				break;
+
+			case CoinBanned coinBanned:
+				BannedCoins.Add((coinBanned.Coin, coinBanned.BanUntilUtc));
 				break;
 		}
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -247,6 +247,7 @@ public class Wallet : BackgroundService, IWallet
 					await LoadWalletStateAsync(cancel).ConfigureAwait(false);
 					await LoadDummyMempoolAsync().ConfigureAwait(false);
 					LoadExcludedCoins();
+					LoadPrisonedCoinsState();
 				}
 			}
 
@@ -258,6 +259,19 @@ public class Wallet : BackgroundService, IWallet
 		{
 			State = WalletState.Initialized;
 			throw;
+		}
+	}
+
+	private void LoadPrisonedCoinsState()
+	{
+		var prisonedCoinRecords = ClientPrison.PrisonedCoins;
+
+		foreach (var record in prisonedCoinRecords)
+		{
+			if (Coins.FirstOrDefault(coin => coin.Outpoint.Equals(record.Outpoint)) is { } coin)
+			{
+				coin.BannedUntilUtc = record.BannedUntil;
+			}
 		}
 	}
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -21,6 +21,7 @@ using WalletWasabi.Services;
 using WalletWasabi.Stores;
 using WalletWasabi.Userfacing;
 using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Client.Banning;
 using WalletWasabi.WebClients.PayJoin;
 
 namespace WalletWasabi.Wallets;
@@ -90,6 +91,7 @@ public class Wallet : BackgroundService, IWallet
 	public HybridFeeProvider FeeProvider { get; private set; }
 	public FilterModel LastProcessedFilter { get; private set; }
 	public IBlockProvider BlockProvider { get; private set; }
+	public ClientPrison ClientPrison { get; private set; }
 	private AsyncLock HandleFiltersLock { get; }
 
 	public bool IsLoggedIn { get; private set; }
@@ -184,7 +186,8 @@ public class Wallet : BackgroundService, IWallet
 		WasabiSynchronizer syncer,
 		ServiceConfiguration serviceConfiguration,
 		HybridFeeProvider feeProvider,
-		IBlockProvider blockProvider)
+		IBlockProvider blockProvider,
+		ClientPrison clientPrison)
 	{
 		if (State > WalletState.WaitingForInit)
 		{
@@ -197,6 +200,7 @@ public class Wallet : BackgroundService, IWallet
 			Synchronizer = Guard.NotNull(nameof(syncer), syncer);
 			ServiceConfiguration = Guard.NotNull(nameof(serviceConfiguration), serviceConfiguration);
 			FeeProvider = Guard.NotNull(nameof(feeProvider), feeProvider);
+			ClientPrison = clientPrison;
 
 			TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, KeyManager, ServiceConfiguration.DustThreshold);
 			Coins = TransactionProcessor.Coins;
@@ -544,7 +548,7 @@ public class Wallet : BackgroundService, IWallet
 	public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, string dataDir, ServiceConfiguration serviceConfiguration, HybridFeeProvider feeProvider, IBlockProvider blockProvider)
 	{
 		var wallet = new Wallet(dataDir, network, keyManager);
-		wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		wallet.RegisterServices(bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider, new ClientPrison());
 		return wallet;
 	}
 


### PR DESCRIPTION
Review with [whitespaces hidden](https://github.com/zkSNACKs/WalletWasabi/pull/10790/files?diff=split&w=1)
Instead of https://github.com/zkSNACKs/WalletWasabi/pull/10669
Built upon https://github.com/zkSNACKs/WalletWasabi/pull/10658
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/10582

This PR adds a new class, `ClientPrison` , and the adherent record, `PrisonedCoinRecord`.

`PrisonedCoinRecord` holds the banned coin's `OutPoint` and the date until it can't be coinjoined, and writes it to **PrisonedCoins.json** like the following:
```json
[
  {
    "Outpoint": "3053AD732AE6761EE8A92A18CC2E4ECCD219FE3CF6F2DFBD2A45004EBA87981A05000000",
    "BannedUntil": "2023-05-11T14:57:07.7955594+02:00"
  },
  {
    "Outpoint": "99DEB8C335D0449527F81AA13B695B866C2C91755549BA68D80DF2CD208166A902000000",
    "BannedUntil": "2023-05-11T14:59:08.0733863+02:00"
  }
]
```

Upon starting a Wallet, if a coin is banned, it will be read from here and `BannedUntil` be set, preventing to coinjoin it.

### Testing
You can easily test this PR on Regtest. Just insert these lines to `CoinVerifier.cs` **L188**:

```cs
var r = new CoinVerifyResult(coin, ShouldBan: true, ShouldRemove: true);
		item.SetResult(r);
		CoinBlacklisted?.SafeInvoke(this, coin);

		return true;
```
You should see that your coinjoin was ended, `Not enought participants`. 
Afterwards, when registering to the next round, you'll see your coin got banned. 
You can see the file has been written to. 
Restarting the wallet, you can see your coins are still banned.