### PR TITLE
Remove unused `SmartCoin.Secret`

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -21,8 +21,6 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	private DateTimeOffset? _bannedUntilUtc;
 	private bool _spentAccordingToBackend;
 
-	private ISecret? _secret;
-
 	private bool _confirmed;
 	private bool _isBanned;
 	private bool _isExcludedFromCoinJoin;
@@ -112,16 +110,6 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	}
 
 	public HdPubKey HdPubKey { get; }
-
-	/// <summary>
-	/// It's a secret, so it's usually going to be null. Do not use it.
-	/// This will not get serialized, because that's a security risk.
-	/// </summary>
-	public ISecret? Secret
-	{
-		get => _secret;
-		set => RaiseAndSetIfChanged(ref _secret, value);
-	}
 
 	public bool Confirmed
 	{


### PR DESCRIPTION
I have noticed this while reviewing #10790.

## Questions

* Can it be used by a third party? 
* Should this PR be marked with some special label?

edit: Lucas mentioned in a Slack message: *Context: that was used in WW1.x as a side channel to pass the key material to the coinjoin client (i don't remember the name of that thing). WW2.x never used it and then once you removed the client-side code for WW1.x that thing remained unsued.*