### PR TITLE
[PoC] Migrate `SmartCoin.IsBanned` to `CoinsRegistry` 1/n

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -322,7 +322,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Config.CoordinatorIdentifier), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -1,8 +1,8 @@
-using System;
-using System.IO;
 using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using Nito.AsyncEx;
+using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,9 +12,11 @@ using WalletWasabi.BitcoinCore.Mempool;
 using WalletWasabi.BitcoinCore.Monitoring;
 using WalletWasabi.BitcoinP2p;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.TransactionBroadcasting;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.CoinJoin.Client;
 using WalletWasabi.Helpers;
@@ -31,7 +33,6 @@ using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.BlockstreamInfo;
 using WalletWasabi.WebClients.Wasabi;
-using WalletWasabi.Blockchain.BlockFilters;
 
 namespace WalletWasabi.Daemon;
 
@@ -56,6 +57,7 @@ public class Global
 		var mempoolService = new MempoolService();
 		var blocks = new FileSystemBlockRepository(Path.Combine(networkWorkFolderPath, "Blocks"), Network);
 
+		CoinsRegistry = new();
 		BitcoinStore = new BitcoinStore(IndexStore, AllTransactionStore, mempoolService, blocks);
 		HttpClientFactory = BuildHttpClientFactory(() => Config.GetBackendUri());
 		CoordinatorHttpClientFactory = BuildHttpClientFactory(() => Config.GetCoordinatorUri());
@@ -88,6 +90,7 @@ public class Global
 
 	public string DataDir { get; }
 	public TorSettings TorSettings { get; }
+	private CoinsRegistry CoinsRegistry { get; }
 	public BitcoinStore BitcoinStore { get; }
 
 	/// <summary>HTTP client factory for sending HTTP requests.</summary>
@@ -322,7 +325,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(CoinsRegistry, WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -62,6 +62,19 @@ public class CoinsRegistry : ICoinsView
 		}
 	}
 
+	public ICoinsView AsAvailableForCoinJoinCoinsView(int bestHeight)
+	{
+		lock (Lock)
+		{
+			return new CoinsView(AsCoinsViewNoLock()
+				.Available()
+				.Confirmed()
+				.Where(coin => !coin.IsExcludedFromCoinJoin)
+				.Where(coin => !coin.IsImmature(bestHeight))
+				.Where(coin => !IsBanned(coin)));
+		}
+	}
+
 	private CoinsView AsSpentCoinsView()
 	{
 		lock (Lock)

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -150,6 +150,17 @@ public class CoinsRegistry : ICoinsView
 		return coinsToRemove;
 	}
 
+	public bool IsBanned(SmartCoin coin)
+	{
+		return IsBanned(coin, out _);
+	}
+
+	public bool IsBanned(SmartCoin coin, out DateTimeOffset? bannedUntilUtc)
+	{
+		bannedUntilUtc = coin.BannedUntilUtc;
+		return coin.IsBanned;
+	}
+
 	public void Spend(SmartCoin spentCoin, SmartTransaction tx)
 	{
 		tx.TryAddWalletInput(spentCoin);

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -160,7 +160,9 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	[MemberNotNullWhen(returnValue: true, nameof(SpenderTransaction))]
 	public bool IsSpent() => SpenderTransaction is not null;
 
-	/// <summary>IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress</summary>
+	/// <summary>
+	/// IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress
+	/// </summary>
 	public bool IsAvailable() => SpenderTransaction is null && !SpentAccordingToBackend && !CoinJoinInProgress;
 
 	public bool IsReplaceable() => Transaction.IsRBF;

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -172,9 +172,7 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	[MemberNotNullWhen(returnValue: true, nameof(SpenderTransaction))]
 	public bool IsSpent() => SpenderTransaction is not null;
 
-	/// <summary>
-	/// IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress
-	/// </summary>
+	/// <summary>IsUnspent() AND !SpentAccordingToBackend AND !CoinJoinInProgress</summary>
 	public bool IsAvailable() => SpenderTransaction is null && !SpentAccordingToBackend && !CoinJoinInProgress;
 
 	public bool IsReplaceable() => Transaction.IsRBF;

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -28,7 +28,7 @@ public class TransactionHistoryBuilder
 			return txRecordList;
 		}
 
-		var allCoins = ((CoinsRegistry)wallet.Coins).AsAllCoinsView();
+		var allCoins = wallet.Coins.AsAllCoinsView();
 		foreach (SmartCoin coin in allCoins)
 		{
 			var containingTransaction = coin.Transaction;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -16,6 +16,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
+using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 
@@ -23,16 +24,9 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	public CoinJoinManager(
-		CoinsRegistry coinsRegistry,
-		IWalletProvider walletProvider,
-		RoundStateUpdater roundStatusUpdater,
-		IWasabiHttpClientFactory coordinatorHttpClientFactory,
-		IWasabiBackendStatusProvider wasabiBackendStatusProvider,
-		string coordinatorIdentifier)
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
-		CoinsRegistry = coinsRegistry;
 		WalletProvider = walletProvider;
 		HttpClientFactory = coordinatorHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
@@ -42,7 +36,7 @@ public class CoinJoinManager : BackgroundService
 	public event EventHandler<StatusChangedEventArgs>? StatusChanged;
 
 	private IWasabiBackendStatusProvider WasabiBackendStatusProvide { get; }
-	private CoinsRegistry CoinsRegistry { get; }
+
 	public IWalletProvider WalletProvider { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
@@ -576,7 +570,7 @@ public class CoinJoinManager : BackgroundService
 			.Confirmed()
 			.Where(coin => !coin.IsExcludedFromCoinJoin)
 			.Where(coin => !coin.IsImmature(bestHeight))
-			.Where(coin => !CoinsRegistry.IsBanned(coin))
+			.Where(coin => !coin.IsBanned)
 			.Where(coin => !CoinRefrigerator.IsFrozen(coin));
 
 	private static async Task WaitAndHandleResultOfTasksAsync(string logPrefix, params Task[] tasks)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -16,7 +16,6 @@ using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
-using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 
@@ -24,9 +23,16 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier)
+	public CoinJoinManager(
+		CoinsRegistry coinsRegistry,
+		IWalletProvider walletProvider,
+		RoundStateUpdater roundStatusUpdater,
+		IWasabiHttpClientFactory coordinatorHttpClientFactory,
+		IWasabiBackendStatusProvider wasabiBackendStatusProvider,
+		string coordinatorIdentifier)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
+		CoinsRegistry = coinsRegistry;
 		WalletProvider = walletProvider;
 		HttpClientFactory = coordinatorHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
@@ -36,7 +42,7 @@ public class CoinJoinManager : BackgroundService
 	public event EventHandler<StatusChangedEventArgs>? StatusChanged;
 
 	private IWasabiBackendStatusProvider WasabiBackendStatusProvide { get; }
-
+	private CoinsRegistry CoinsRegistry { get; }
 	public IWalletProvider WalletProvider { get; }
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
@@ -570,7 +576,7 @@ public class CoinJoinManager : BackgroundService
 			.Confirmed()
 			.Where(coin => !coin.IsExcludedFromCoinJoin)
 			.Where(coin => !coin.IsImmature(bestHeight))
-			.Where(coin => !coin.IsBanned)
+			.Where(coin => !CoinsRegistry.IsBanned(coin))
 			.Where(coin => !CoinRefrigerator.IsFrozen(coin));
 
 	private static async Task WaitAndHandleResultOfTasksAsync(string logPrefix, params Task[] tasks)

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -25,7 +25,11 @@ public interface IWallet
 
 	Task<bool> IsWalletPrivateAsync();
 
-	Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync();
+	/// <summary>
+	/// Coinjoin candidate coins are those coins that are: available, confirmed, mature enough, not explicitly excluded, and not banned.
+	/// </summary>
+	/// <returns><c>null</c> is returned when Backend is not synchronized yet.</returns>
+	Task<IEnumerable<SmartCoin>?> GetCoinjoinCoinCandidatesAsync();
 
 	Task<IEnumerable<SmartTransaction>> GetTransactionsAsync();
 }

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -118,9 +118,10 @@ public class Wallet : BackgroundService, IWallet
 
 	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(GetTransactions());
 
-	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync() => Task.FromResult(GetCoinjoinCoinCandidates());
-
-	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates() => Coins;
+	/// <inheritdoc/>
+	public Task<IEnumerable<SmartCoin>?> GetCoinjoinCoinCandidatesAsync() => (Synchronizer.LastResponse is { } lastResponse)
+			? Task.FromResult<IEnumerable<SmartCoin>?>(Coins.AsAvailableForCoinJoinCoinsView(lastResponse.BestHeight))
+			: Task.FromResult<IEnumerable<SmartCoin>?>(null);
 
 	public IEnumerable<SmartTransaction> GetTransactions()
 	{

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -80,7 +80,7 @@ public class Wallet : BackgroundService, IWallet
 	public string WalletName => KeyManager.WalletName;
 
 	/// <summary>Unspent Transaction Outputs</summary>
-	public ICoinsView Coins { get; private set; }
+	public CoinsRegistry Coins { get; private set; }
 
 	public bool RedCoinIsolation => KeyManager.RedCoinIsolation;
 
@@ -125,7 +125,7 @@ public class Wallet : BackgroundService, IWallet
 	public IEnumerable<SmartTransaction> GetTransactions()
 	{
 		var walletTransactions = new List<SmartTransaction>();
-		var allCoins = ((CoinsRegistry)Coins).AsAllCoinsView();
+		var allCoins = Coins.AsAllCoinsView();
 		foreach (SmartCoin coin in allCoins)
 		{
 			walletTransactions.Add(coin.Transaction);


### PR DESCRIPTION
This PR is an idea how to remove `SmartCoin.IsBanned` (and other properties) and use `CoinsRegistry` instead. This was discussed here:

* https://github.com/zkSNACKs/WalletWasabi/pull/10790#issuecomment-1564697065, and
* https://github.com/zkSNACKs/WalletWasabi/pull/10790#issuecomment-1566269245

The end goal is to implement what #10790 implements but with more sound API design. That in turn would remove the arbitrariness how we deal with `SmartCoin` instances.

So the idea of this PR is: *Wrap `SmartCoin.IsBanned` property in `CoinsRegistry` and then remove all uses of `SmartCoin.IsBanned` until there is no instance and we can actually remove `SmartCoin.IsBanned`.* Basically, `CoinsRegistry` would be a singleton and it would be a source of truth regarding coins.

WDYT? @lontivero @molnard 