### PR TITLE
Increase max out from 8 to 10

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -212,7 +212,7 @@ public class AmountDecomposer
 		var myInputs = myInputCoinEffectiveValues.ToArray();
 		var myInputSum = myInputs.Sum();
 		var smallestScriptType = Math.Min(ScriptType.P2WPKH.EstimateOutputVsize(), ScriptType.Taproot.EstimateOutputVsize());
-		var maxNumberOfOutputsAllowed = Math.Min(AvailableVsize / smallestScriptType, 8); // The absolute max possible with the smallest script type.
+		var maxNumberOfOutputsAllowed = Math.Min(AvailableVsize / smallestScriptType, 10); // The absolute max possible with the smallest script type.
 
 		var setCandidates = new Dictionary<int, (IEnumerable<Output> Decomposition, Money Cost)>();
 
@@ -315,7 +315,7 @@ public class AmountDecomposer
 			foreach (var (sum, count, decomp) in Decomposer.Decompose(
 				target: (long)myInputSum,
 				tolerance: MinAllowedOutputAmount + FeeRate.GetFee(ScriptType.Taproot.EstimateOutputVsize()), // Assume script type with higher cost to be more permissive.
-				maxCount: maxNumberOfOutputsAllowed,
+				maxCount: Math.Min(maxNumberOfOutputsAllowed, 8), // Decomposer doesn't do more than 8.
 				stdDenoms: stdDenoms))
 			{
 				var currentSet = Decomposer.ToRealValuesArray(


### PR DESCRIPTION
Sake equivalence: https://github.com/nopara73/Sake/pull/33

ToDo: @turbolay @adamPetho can you do quick testing? (regtest, testnet, unit test, whatever you find the quickest)  
It needs to be tested if it works, namely what we're interested in is if there's any conditions outside of the decomposer that would limit our outputs to 8. There shouldn't be, but better to be safe than sorry. So if you succeeded to generate a regtest/testnet/unit test coinjoin with 9 or 10 outputs, then you're good. Note: you have to be big whale for that. If you're looking to test on testnet you may need @MaxHillebrand's whale coins for that. In Sake it does work, but I need slightly more guarantees.