### PR TITLE
`PasswordConsole`: Remove Win7 workaround

### DIFF
--- a/WalletWasabi/Userfacing/PasswordConsole.cs
+++ b/WalletWasabi/Userfacing/PasswordConsole.cs
@@ -9,38 +9,31 @@ public static class PasswordConsole
 	/// </summary>
 	public static string ReadPassword()
 	{
-		try
+		var sb = new StringBuilder();
+		while (true)
 		{
-			var sb = new StringBuilder();
-			while (true)
+			ConsoleKeyInfo cki = Console.ReadKey(true);
+			if (cki.Key == ConsoleKey.Enter)
 			{
-				ConsoleKeyInfo cki = Console.ReadKey(true);
-				if (cki.Key == ConsoleKey.Enter)
-				{
-					Console.WriteLine();
-					break;
-				}
-
-				if (cki.Key == ConsoleKey.Backspace)
-				{
-					if (sb.Length > 0)
-					{
-						Console.Write("\b \b");
-						sb.Length--;
-					}
-
-					continue;
-				}
-
-				Console.Write('*');
-				sb.Append(cki.KeyChar);
+				Console.WriteLine();
+				break;
 			}
 
-			return sb.ToString();
+			if (cki.Key == ConsoleKey.Backspace)
+			{
+				if (sb.Length > 0)
+				{
+					Console.Write("\b \b");
+					sb.Length--;
+				}
+
+				continue;
+			}
+
+			Console.Write('*');
+			sb.Append(cki.KeyChar);
 		}
-		catch (InvalidOperationException)
-		{
-			return Console.ReadLine() ?? "";
-		}
+
+		return sb.ToString();
 	}
 }


### PR DESCRIPTION
edit: Reverts #3268 because we no longer support Windows 7.