### PR TITLE
Decouple stuff from Amount Decomposer

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
@@ -50,7 +50,7 @@ public class AmountDecomposerTests
 		var theirCoinEffectiveValues = GenerateRandomCoins().Take(30).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
 		var allowedOutputAmountRange = new MoneyRange(Money.Satoshis(minOutputAmount), Money.Satoshis(ProtocolConstants.MaxAmountPerAlice));
 
-		var amountDecomposer = new AmountDecomposer(feeRate, allowedOutputAmountRange, availableVsize, isTaprootEnabled, Random);
+		var amountDecomposer = new AmountDecomposer(feeRate, allowedOutputAmountRange.Min, allowedOutputAmountRange.Max, availableVsize, isTaprootEnabled, Random);
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
 
 		var totalEffectiveValue = registeredCoinEffectiveValues.Sum(x => x);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -115,6 +115,9 @@ public record RoundParameters
 
 	public Transaction CreateTransaction()
 		=> Transaction.Create(Network);
+
+	/// <returns>Min output amount that's economically reasonable to be registered with current network conditions.</returns>
+	/// <remarks>It won't be smaller than min allowed output amount.</remarks>
 	public Money CalculateMinReasonableOutputAmount()
 	{
 		var minEconomicalOutput = MiningFeeRate.GetFee(

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -12,11 +12,11 @@ namespace WalletWasabi.WabiSabi.Client;
 public class AmountDecomposer
 {
 	/// <param name="feeRate">Bitcoin network fee rate the coinjoin is targeting.</param>
-	/// <param name="minReasonableOutputAmount">Min output amount that's economically reasonable to be registered.</param>
+	/// <param name="minAllowedOutputAmount">Min output amount that's allowed to be registered.</param>
 	/// <param name="maxAllowedOutputAmount">Max output amount that's allowed to be registered.</param>
 	/// <param name="availableVsize">Available virtual size for outputs.</param>
 	/// <param name="random">Allows testing by setting a seed value for the random number generator. Use <c>null</c> in production code.</param>
-	public AmountDecomposer(FeeRate feeRate, Money minReasonableOutputAmount, Money maxAllowedOutputAmount, int availableVsize, bool isTaprootAllowed, Random? random = null)
+	public AmountDecomposer(FeeRate feeRate, Money minAllowedOutputAmount, Money maxAllowedOutputAmount, int availableVsize, bool isTaprootAllowed, Random? random = null)
 	{
 		FeeRate = feeRate;
 
@@ -26,7 +26,7 @@ public class AmountDecomposer
 				Math.Max(
 					ScriptType.P2WPKH.EstimateInputVsize() + ScriptType.P2WPKH.EstimateOutputVsize(),
 					ScriptType.Taproot.EstimateInputVsize() + ScriptType.Taproot.EstimateOutputVsize()));
-		MinAllowedOutputAmount = Math.Max(minEconomicalOutput, minReasonableOutputAmount);
+		MinAllowedOutputAmount = Math.Max(minEconomicalOutput, minAllowedOutputAmount);
 		MaxAllowedOutputAmount = maxAllowedOutputAmount;
 
 		Random = random ?? Random.Shared;

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -22,11 +22,7 @@ public class AmountDecomposer
 
 		AvailableVsize = availableVsize;
 		IsTaprootAllowed = isTaprootAllowed;
-		var minEconomicalOutput = FeeRate.GetFee(
-				Math.Max(
-					ScriptType.P2WPKH.EstimateInputVsize() + ScriptType.P2WPKH.EstimateOutputVsize(),
-					ScriptType.Taproot.EstimateInputVsize() + ScriptType.Taproot.EstimateOutputVsize()));
-		MinAllowedOutputAmount = Math.Max(minEconomicalOutput, minAllowedOutputAmount);
+		MinAllowedOutputAmount = minAllowedOutputAmount;
 		MaxAllowedOutputAmount = maxAllowedOutputAmount;
 
 		Random = random ?? Random.Shared;

--- a/WalletWasabi/WabiSabi/Client/DenominationBuilder.cs
+++ b/WalletWasabi/WabiSabi/Client/DenominationBuilder.cs
@@ -1,0 +1,134 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+public static class DenominationBuilder
+{
+	public static IOrderedEnumerable<Output> CreateDenominations(Money minAllowedOutputAmount, Money maxAllowedOutputAmount, FeeRate feeRate, bool isTaprootAllowed, Random random)
+	{
+		var denominations = new HashSet<Output>();
+
+		Output CreateDenom(double sats)
+		{
+			var scriptType = AmountDecomposer.GetNextScriptType(isTaprootAllowed, random);
+			return Output.FromDenomination(Money.Satoshis((ulong)sats), scriptType, feeRate);
+		}
+
+		// Powers of 2
+		for (int i = 0; i < int.MaxValue; i++)
+		{
+			var denom = CreateDenom(Math.Pow(2, i));
+
+			if (denom.Amount < minAllowedOutputAmount)
+			{
+				continue;
+			}
+
+			if (denom.Amount > maxAllowedOutputAmount)
+			{
+				break;
+			}
+
+			denominations.Add(denom);
+		}
+
+		// Powers of 3
+		for (int i = 0; i < int.MaxValue; i++)
+		{
+			var denom = CreateDenom(Math.Pow(3, i));
+
+			if (denom.Amount < minAllowedOutputAmount)
+			{
+				continue;
+			}
+
+			if (denom.Amount > maxAllowedOutputAmount)
+			{
+				break;
+			}
+
+			denominations.Add(denom);
+		}
+
+		// Powers of 3 * 2
+		for (int i = 0; i < int.MaxValue; i++)
+		{
+			var denom = CreateDenom(Math.Pow(3, i) * 2);
+
+			if (denom.Amount < minAllowedOutputAmount)
+			{
+				continue;
+			}
+
+			if (denom.Amount > maxAllowedOutputAmount)
+			{
+				break;
+			}
+
+			denominations.Add(denom);
+		}
+
+		// Powers of 10 (1-2-5 series)
+		for (int i = 0; i < int.MaxValue; i++)
+		{
+			var denom = CreateDenom(Math.Pow(10, i));
+
+			if (denom.Amount < minAllowedOutputAmount)
+			{
+				continue;
+			}
+
+			if (denom.Amount > maxAllowedOutputAmount)
+			{
+				break;
+			}
+
+			denominations.Add(denom);
+		}
+
+		// Powers of 10 * 2 (1-2-5 series)
+		for (int i = 0; i < int.MaxValue; i++)
+		{
+			var denom = CreateDenom(Math.Pow(10, i) * 2);
+
+			if (denom.Amount < minAllowedOutputAmount)
+			{
+				continue;
+			}
+
+			if (denom.Amount > maxAllowedOutputAmount)
+			{
+				break;
+			}
+
+			denominations.Add(denom);
+		}
+
+		// Powers of 10 * 5 (1-2-5 series)
+		for (int i = 0; i < int.MaxValue; i++)
+		{
+			var denom = CreateDenom(Math.Pow(10, i) * 5);
+
+			if (denom.Amount < minAllowedOutputAmount)
+			{
+				continue;
+			}
+
+			if (denom.Amount > maxAllowedOutputAmount)
+			{
+				break;
+			}
+
+			denominations.Add(denom);
+		}
+
+		// Greedy decomposer will take the higher values first. Order in a way to prioritize cheaper denominations, this only matters in case of equality.
+		return denominations.OrderByDescending(x => x.EffectiveAmount);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/OutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/OutputProvider.cs
@@ -20,12 +20,7 @@ public class OutputProvider
 		IEnumerable<Money> theirCoinEffectiveValues,
 		int availableVsize)
 	{
-		AmountDecomposer amountDecomposer = new(
-			roundParameters.MiningFeeRate,
-			roundParameters.CalculateMinReasonableOutputAmount(),
-			roundParameters.AllowedOutputAmounts.Max,
-			availableVsize,
-			roundParameters.IsTaprootAllowed);
+		AmountDecomposer amountDecomposer = new(roundParameters.MiningFeeRate, roundParameters.CalculateMinReasonableOutputAmount(), roundParameters.AllowedOutputAmounts.Max, availableVsize, roundParameters.IsTaprootAllowed);
 
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues).ToArray();
 		return GetTxOuts(outputValues, DestinationProvider);

--- a/WalletWasabi/WabiSabi/Client/OutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/OutputProvider.cs
@@ -20,11 +20,12 @@ public class OutputProvider
 		IEnumerable<Money> theirCoinEffectiveValues,
 		int availableVsize)
 	{
-		// Get the output's size and its of the input that will spend it in the future.
-		// Here we assume all the outputs share the same scriptpubkey type.
-		var isTaprootAllowed = roundParameters.AllowedOutputTypes.Contains(ScriptType.Taproot);
-
-		AmountDecomposer amountDecomposer = new(roundParameters.MiningFeeRate, roundParameters.AllowedOutputAmounts, availableVsize, isTaprootAllowed);
+		AmountDecomposer amountDecomposer = new(
+			roundParameters.MiningFeeRate,
+			roundParameters.CalculateMinReasonableOutputAmount(),
+			roundParameters.AllowedOutputAmounts.Max,
+			availableVsize,
+			roundParameters.IsTaprootAllowed);
 
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues).ToArray();
 		return GetTxOuts(outputValues, DestinationProvider);


### PR DESCRIPTION
This is a preparation PR for https://github.com/zkSNACKs/WalletWasabi/pull/10830 to eventually resolve https://github.com/zkSNACKs/WalletWasabi/issues/10759

This does not change the behavior at all and is safe.

### What happened here?

- The main thing is I took `CreateDenominations` out of `AmountDecomposer` to `DenominationBuilder`.
- I pushed `IsTaprootAllowed` calculation to the `RoundParameters`
- I pushed the min economic output amount reasonability calculation into `RoundParameters`: `CalculateMinReasonableOutputAmount`

### ToDo:
- [x] @lontivero, @molnard, @onvej-sl are the 3 refactorings, mentioned above reasonable or would it break some API or something? They seem more than safe for me, but there can be unknown unknowns.
- [x] If ACKed, do the same changes in Sake before merge: https://github.com/nopara73/Sake/commit/1125b9a3db09a9cab1b8700642d0a60e569aba59