### PR TITLE
Reduce number of decimals for AS display in RPC

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -32,7 +32,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	private Wallet? ActiveWallet { get; set; }
 
 	[JsonRpcMethod("listunspentcoins")]
-	public object[] GetUnspentCoinList()
+	public object[] GetUnspentCoinList(int anonScoreDecimals = 2)
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
@@ -44,7 +44,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 				txid = x.TransactionId.ToString(),
 				index = x.Index,
 				amount = x.Amount.Satoshi,
-				anonymityScore = x.HdPubKey.AnonymitySet,
+				anonymityScore = Math.Round(x.HdPubKey.AnonymitySet, anonScoreDecimals),
 				confirmed = x.Confirmed,
 				confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
 				label = x.HdPubKey.Labels.ToString(),
@@ -54,7 +54,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("listcoins")]
-	public object[] GetCoinList()
+	public object[] GetCoinList(int anonScoreDecimals = 2)
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
@@ -70,7 +70,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 				txid = x.TransactionId.ToString(),
 				index = x.Index,
 				amount = x.Amount.Satoshi,
-				anonymityScore = x.HdPubKey.AnonymitySet,
+				anonymityScore = Math.Round(x.HdPubKey.AnonymitySet, anonScoreDecimals),
 				confirmed = x.Confirmed,
 				confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
 				keyPath = x.HdPubKey.FullKeyPath.ToString(),


### PR DESCRIPTION
Closes #10847 

I made the PR, but I'm not convinced about the idea because, for reproducibility reasons, we might want this to reflect by default what the software has, whether it's user-friendly or not.

@lontivero please check and decide if:
- PR is OK
- Optional parameters should be removed
- The default value for `anonScoreDecimals` should be higher to return by default what the code has.
- Close PR/Issue and neverminds