### PR TITLE
Packager: Rename Daemon + Fix for `Release` mode

### DIFF
--- a/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
+++ b/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
@@ -1,13 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<OutputType>Exe</OutputType>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<OutputType>WinExe</OutputType>
-	</PropertyGroup>
-
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<AnalysisLevel>latest</AnalysisLevel>
@@ -20,6 +12,7 @@
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Daemon</PathMap>
+		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -41,8 +34,8 @@
 		<Product>Wasabi Wallet Fluent Daemon</Product>
 	</PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\WalletWasabi\WalletWasabi.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\WalletWasabi\WalletWasabi.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -320,27 +320,19 @@ public static class Program
 				}
 			}
 
-			// Rename the final exe.
-			string oldExecutablePath;
-			string newExecutablePath;
-			if (target.StartsWith("win"))
-			{
-				oldExecutablePath = Path.Combine(currentBinDistDirectory, "WalletWasabi.Fluent.Desktop.exe");
-				newExecutablePath = Path.Combine(currentBinDistDirectory, $"{ExecutableName}.exe");
-
-				// Delete unused executables.
-				File.Delete(Path.Combine(currentBinDistDirectory, "WalletWasabi.Fluent.exe"));
-			}
-			else // Linux & OSX
-			{
-				oldExecutablePath = Path.Combine(currentBinDistDirectory, "WalletWasabi.Fluent.Desktop");
-				newExecutablePath = Path.Combine(currentBinDistDirectory, ExecutableName);
-
-				// Delete unused executables.
-				File.Delete(Path.Combine(currentBinDistDirectory, "WalletWasabi.Fluent"));
-			}
-
+			// Rename WalletWasabi.Fluent.Desktop(.exe) -> wassabee(.exe).
+			string executableExtension = target.StartsWith("win") ? ".exe" : "";
+			string oldExecutablePath = Path.Combine(currentBinDistDirectory, $"WalletWasabi.Fluent.Desktop{executableExtension}");
+			string newExecutablePath = Path.Combine(currentBinDistDirectory, $"{ExecutableName}{executableExtension}");
 			File.Move(oldExecutablePath, newExecutablePath);
+
+			// Rename WalletWasabi.Daemon(.exe) -> wassabeed(.exe).
+			oldExecutablePath = Path.Combine(currentBinDistDirectory, $"WalletWasabi.Daemon{executableExtension}");
+			newExecutablePath = Path.Combine(currentBinDistDirectory, $"{DaemonExecutableName}{executableExtension}");
+			File.Move(oldExecutablePath, newExecutablePath);
+
+			// Delete unused executables.
+			File.Delete(Path.Combine(currentBinDistDirectory, $"WalletWasabi.Fluent{executableExtension}"));
 
 			// IF IT'S IN ONLYBINARIES MODE DON'T DO ANYTHING FANCY PACKAGING AFTER THIS!!!
 			if (OnlyBinaries)

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -25,6 +25,8 @@ namespace WalletWasabi.Packager;
 public static class Program
 {
 	public const string PfxPath = "C:\\digicert.pfx";
+
+	public const string DaemonExecutableName = Constants.DaemonExecutableName;
 	public const string ExecutableName = Constants.ExecutableName;
 
 	private const string WasabiPrivateKeyFilePath = @"C:\wasabi\Wasabi.privkey";
@@ -413,7 +415,7 @@ public static class Program
 				Console.WriteLine($"# Move '{publishedFolder}' to '{newFolderPath}'.");
 				Directory.Move(publishedFolder, newFolderPath);
 				publishedFolder = newFolderPath;
-				string chmodExecutablesArgs = "-type f \\( -name 'wassabee' -o -name 'hwi' -o -name 'bitcoind' -o -name 'tor' \\) -exec chmod +x {} \\;";
+				string chmodExecutablesArgs = $$"""-type f \( -name '{{ExecutableName}}' -o -name '{{DaemonExecutableName}}' -o -name 'hwi' -o -name 'bitcoind' -o -name 'tor' \) -exec chmod +x {} \;""";
 
 				string[] commands = new string[]
 				{

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -60,7 +60,12 @@ public static class Constants
 	public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
+	/// <summary>Executable file name of Wasabi Wallet Daemon application (without extension).</summary>
+	public const string DaemonExecutableName = $"{ExecutableName}d";
+
+	/// <summary>Executable file name of Wasabi Wallet UI application (without extension).</summary>
 	public const string ExecutableName = "wassabee";
+
 	public const string AppName = "Wasabi Wallet";
 	public const string BuiltinBitcoinNodeName = "Bitcoin Knots";
 


### PR DESCRIPTION
Addresses

> Lucas Ontivero 3 days ago I think the next release is not shipping the daemon. It will be there but the packager doesn't remaned it as wassabeed as i think it should

from https://github.com/orgs/zkSNACKs/projects/27/views/1

## Testing

```bash
# Package for all platforms
cd C:\WasabiWallet\WalletWasabi\WalletWasabi.Packager
dotnet restore && dotnet build && dotnet run # or: dotnet restore && dotnet build && dotnet run -- --onlybinaries

# Result is placed here
cd C:\WalletWasabi\WalletWasabi.Fluent.Desktop\bin\dist\win7-x64
wassabeed.exe
```

<s>I'm not exactly why this leads to starting the Daemon process but not waiting for user input (pressing CTRL+C). I tried to add `Console.Read()` command but it did not help. Investigating. Maybe I'm doing something trivially wrong.</s> Fixed by bc2a139f643d9b3610ab6b31709fcc78f9ae433d.

Help is welcome.

edit: Testing the same on macOS works OK for me. So it's only on Win11 that `wassabeed.exe` does not wait for console input (on my machine at least).

edit: edit: Fixed.