### PR TITLE
Pay to miners the exact committed fee rate

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -458,7 +458,7 @@ public class MultipartyTransactionTests
 		var coordinatorScript = BitcoinFactory.CreateScript();
 		var round = WabiSabiFactory.CreateRound(parameters);
 
-		// Make sure the the highest fee rate is low, so coordinator script will be added.
+		// Make sure the highest fee rate is low, so coordinator script will be added.
 		var coinjoinWithCoordinatorScript = Arena.AddCoordinationFee(round, coinjoin, coordinatorScript);
 		coinjoinWithCoordinatorScript.Finalize();
 		Assert.NotSame(coinjoinWithCoordinatorScript, coinjoin);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -455,13 +455,12 @@ public class MultipartyTransactionTests
 		}
 		while (coinjoin.Balance > tenPercent);
 
-		var blameScript = BitcoinFactory.CreateScript();
+		var coordinatorScript = BitcoinFactory.CreateScript();
 		var round = WabiSabiFactory.CreateRound(parameters);
 
-		// Make sure the the highest fee rate is low, so blame script will be added.
-		var highestFeeRateTask = () => Task.FromResult(new FeeRate(1m));
-		var coinjoinWithBlame = await Arena.TryAddBlameScriptAsync(round, coinjoin, false, blameScript, highestFeeRateTask);
-		coinjoinWithBlame.Finalize();
-		Assert.NotSame(coinjoinWithBlame, coinjoin);
+		// Make sure the the highest fee rate is low, so coordinator script will be added.
+		var coinjoinWithCoordinatorScript = Arena.AddCoordinationFee(round, coinjoin, coordinatorScript);
+		coinjoinWithCoordinatorScript.Finalize();
+		Assert.NotSame(coinjoinWithCoordinatorScript, coinjoin);
 	}
 }


### PR DESCRIPTION
Wasabi only takes the exact coordination fee rate and in some situations when there are small amounts that are uneconomical it gives those amounts to miners. This PR changes that to pay the exact committed mining feerate to the miners and no more.