### PR TITLE
Remove Nonsensical EffectiveAmount

### DIFF
--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -335,7 +335,7 @@ public class AmountDecomposer
 		var secondLargestInput = inputEffectiveValues.OrderByDescending(x => x).Skip(1).First();
 		var demonsForBreakDown = Denominations
 			.Where(x => x.EffectiveCost <= secondLargestInput) // Take only affordable denominations.
-			.OrderByDescending(x => x.EffectiveAmount); // If the amount is the same, the cheaper to spend should be the first - so greedy will take that.
+			.OrderByDescending(x => x.EffectiveCost); // If the amount is the same, the cheaper to spend should be the first - so greedy will take that.
 
 		Dictionary<Output, long> denomFrequencies = new();
 		foreach (var input in inputEffectiveValues)

--- a/WalletWasabi/WabiSabi/Client/DenominationBuilder.cs
+++ b/WalletWasabi/WabiSabi/Client/DenominationBuilder.cs
@@ -130,6 +130,6 @@ public static class DenominationBuilder
 		}
 
 		// Greedy decomposer will take the higher values first. Order in a way to prioritize cheaper denominations, this only matters in case of equality.
-		return denominations.OrderByDescending(x => x.EffectiveAmount);
+		return denominations.OrderByDescending(x => x.EffectiveCost);
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/Output.cs
+++ b/WalletWasabi/WabiSabi/Client/Output.cs
@@ -18,7 +18,6 @@ public record Output
 
 	public Money Amount { get; }
 	public ScriptType ScriptType { get; }
-	public Money EffectiveAmount => Amount - Fee;
 	public Money EffectiveCost => Amount + Fee;
 	public Money InputFee { get; }
 	public Money Fee { get; }


### PR DESCRIPTION
What's the point of `EffectiveAmount`?

`EffectiveAmount = Amount - Fee`
`EffectiveCost = Amount + Fee`

In what way `- Fee` makes sense? We're talking about outputs, and the output amount will be `Amount`. However the cost of that is added onto the `Amount`, which would give us the `EffectiveCost`, but I don't understand when would it be necessary to take out the `Fee` from the `Amount`. So, could it be just removed or am I missing something?

Sake equivalence: https://github.com/nopara73/Sake/pull/41