### PR TITLE
[VDG] Add destination address to transaction summary

### DIFF
--- a/WalletWasabi.Fluent/Icons/Icons.axaml
+++ b/WalletWasabi.Fluent/Icons/Icons.axaml
@@ -70,10 +70,10 @@
       <PathIcon Data="{StaticResource arrow_sync_regular}" />
       <PathIcon Data="{StaticResource person_regular}" />
       <!-- Wallet icons -->
-      <!--<PathIcon Data="{StaticResource Ledger}" />
+      <PathIcon Data="{StaticResource Ledger}" />
       <PathIcon Data="{StaticResource Trezor}" />
       <PathIcon Data="{StaticResource Coldcard}" />
-      <PathIcon Data="{StaticResource General}" />-->
+      <PathIcon Data="{StaticResource General}" />
     </WrapPanel>
   </Design.PreviewWith>
   <Style>

--- a/WalletWasabi.Fluent/Icons/Icons.axaml
+++ b/WalletWasabi.Fluent/Icons/Icons.axaml
@@ -70,10 +70,10 @@
       <PathIcon Data="{StaticResource arrow_sync_regular}" />
       <PathIcon Data="{StaticResource person_regular}" />
       <!-- Wallet icons -->
-      <PathIcon Data="{StaticResource Ledger}" />
+      <!--<PathIcon Data="{StaticResource Ledger}" />
       <PathIcon Data="{StaticResource Trezor}" />
       <PathIcon Data="{StaticResource Coldcard}" />
-      <PathIcon Data="{StaticResource General}" />
+      <PathIcon Data="{StaticResource General}" />-->
     </WrapPanel>
   </Design.PreviewWith>
   <Style>

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
@@ -34,14 +35,17 @@ public partial class TransactionDetailsViewModel : RoutableViewModel
 
 		Fee = transactionSummary.Fee;
 		IsFeeVisible = transactionSummary.Fee != null && transactionSummary.Amount < Money.Zero;
-		DestinationAddress = transactionSummary.DestinationAddress.ToString();
+		DestinationAddresses = transactionSummary.DestinationAddresses;
+		DestinationAddressesList = string.Join(Environment.NewLine, transactionSummary.DestinationAddresses);
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		UpdateValues(transactionSummary);
 	}
 
-	public string DestinationAddress { get; set; }
+	public string DestinationAddressesList { get; set; }
+
+	public IEnumerable<BitcoinAddress> DestinationAddresses { get; set; }
 
 	public bool IsFeeVisible { get; set; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
@@ -43,13 +43,13 @@ public partial class TransactionDetailsViewModel : RoutableViewModel
 		UpdateValues(transactionSummary);
 	}
 
-	public string DestinationAddressesText { get; set; }
+	public string DestinationAddressesText { get; }
 
-	public IEnumerable<BitcoinAddress> DestinationAddresses { get; set; }
+	public IEnumerable<BitcoinAddress> DestinationAddresses { get; }
 
-	public bool IsFeeVisible { get; set; }
+	public bool IsFeeVisible { get; }
 
-	public Money? Fee { get; set; }
+	public Money? Fee { get; }
 
 	private void UpdateValues(TransactionSummary transactionSummary)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
@@ -34,11 +34,14 @@ public partial class TransactionDetailsViewModel : RoutableViewModel
 
 		Fee = transactionSummary.Fee;
 		IsFeeVisible = transactionSummary.Fee != null && transactionSummary.Amount < Money.Zero;
+		DestinationAddress = transactionSummary.DestinationAddress.ToString();
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		UpdateValues(transactionSummary);
 	}
+
+	public string DestinationAddress { get; set; }
 
 	public bool IsFeeVisible { get; set; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
@@ -36,14 +36,14 @@ public partial class TransactionDetailsViewModel : RoutableViewModel
 		Fee = transactionSummary.Fee;
 		IsFeeVisible = transactionSummary.Fee != null && transactionSummary.Amount < Money.Zero;
 		DestinationAddresses = transactionSummary.DestinationAddresses;
-		DestinationAddressesList = string.Join(Environment.NewLine, transactionSummary.DestinationAddresses);
+		DestinationAddressesText = string.Join(Environment.NewLine, transactionSummary.DestinationAddresses);
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
 		UpdateValues(transactionSummary);
 	}
 
-	public string DestinationAddressesList { get; set; }
+	public string DestinationAddressesText { get; set; }
 
 	public IEnumerable<BitcoinAddress> DestinationAddresses { get; set; }
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -35,6 +35,17 @@
 
       <Separator />
 
+      <!-- Amount -->
+      <c:PreviewItem Icon="{StaticResource person_regular}"
+                     Label="Destination address"
+                     CopyableContent="{Binding Amount}">
+        <c:PrivacyContentControl>
+          <TextBlock Text="{Binding DestinationAddress}" Classes="monoSpaced" />
+        </c:PrivacyContentControl>
+      </c:PreviewItem>
+
+      <Separator />
+
       <!-- Fee -->
       <c:PreviewItem IsVisible="{Binding IsFeeVisible}"
                      Icon="{StaticResource paper_cash_regular}"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -38,7 +38,7 @@
       <!-- Destination Address -->
       <c:PreviewItem Icon="{StaticResource transceive_regular}"
                      Label="Destination addresses"
-                     CopyableContent="{Binding DestinationAddressesList}">
+                     CopyableContent="{Binding DestinationAddressesText}">
         <ItemsControl Items="{Binding DestinationAddresses}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -36,12 +36,18 @@
       <Separator />
 
       <!-- Destination Address -->
-      <c:PreviewItem Icon="{StaticResource person_regular}"
-                     Label="Destination address"
-                     CopyableContent="{Binding DestinationAddress}">
-        <c:PrivacyContentControl>
-          <TextBlock Text="{Binding DestinationAddress}" Classes="monoSpaced" />
-        </c:PrivacyContentControl>
+      <c:PreviewItem Icon="{StaticResource transceive_regular}"
+                     Label="Destination addresses"
+                     CopyableContent="{Binding DestinationAddressesList}">
+        <ItemsControl Items="{Binding DestinationAddresses}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <c:PrivacyContentControl>
+                <TextBlock Text="{Binding}" Classes="monoSpaced" />
+              </c:PrivacyContentControl>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
       </c:PreviewItem>
 
       <Separator />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -35,10 +35,10 @@
 
       <Separator />
 
-      <!-- Amount -->
+      <!-- Destination Address -->
       <c:PreviewItem Icon="{StaticResource person_regular}"
                      Label="Destination address"
-                     CopyableContent="{Binding Amount}">
+                     CopyableContent="{Binding DestinationAddress}">
         <c:PrivacyContentControl>
           <TextBlock Text="{Binding DestinationAddress}" Classes="monoSpaced" />
         </c:PrivacyContentControl>

--- a/WalletWasabi/Blockchain/Transactions/Summary/ForeignOutput.cs
+++ b/WalletWasabi/Blockchain/Transactions/Summary/ForeignOutput.cs
@@ -1,0 +1,10 @@
+using NBitcoin;
+
+namespace WalletWasabi.Blockchain.Transactions.Summary;
+
+public class ForeignOutput : Output
+{
+	public ForeignOutput(Money amount, BitcoinAddress destinationAddress) : base(amount, destinationAddress)
+	{
+	}
+}

--- a/WalletWasabi/Blockchain/Transactions/Summary/Output.cs
+++ b/WalletWasabi/Blockchain/Transactions/Summary/Output.cs
@@ -2,9 +2,19 @@ using NBitcoin;
 
 namespace WalletWasabi.Blockchain.Transactions.Summary;
 
-public class Output
+public class OwnOutput : Output
 {
-	public Output(Money amount, BitcoinAddress destinationAddress)
+	public bool IsInternal { get; }
+
+	public OwnOutput(Money amount, BitcoinAddress destinationAddress, bool isInternal) : base(amount, destinationAddress)
+	{
+		IsInternal = isInternal;
+	}
+}
+
+public abstract class Output
+{
+	protected Output(Money amount, BitcoinAddress destinationAddress)
 	{
 		Amount = amount;
 		DestinationAddress = destinationAddress;
@@ -12,4 +22,11 @@ public class Output
 
 	public Money Amount { get; }
 	public BitcoinAddress DestinationAddress { get; }
+}
+
+public class ForeignOutput : Output
+{
+	public ForeignOutput(Money amount, BitcoinAddress destinationAddress) : base(amount, destinationAddress)
+	{
+	}
 }

--- a/WalletWasabi/Blockchain/Transactions/Summary/Output.cs
+++ b/WalletWasabi/Blockchain/Transactions/Summary/Output.cs
@@ -2,16 +2,6 @@ using NBitcoin;
 
 namespace WalletWasabi.Blockchain.Transactions.Summary;
 
-public class OwnOutput : Output
-{
-	public bool IsInternal { get; }
-
-	public OwnOutput(Money amount, BitcoinAddress destinationAddress, bool isInternal) : base(amount, destinationAddress)
-	{
-		IsInternal = isInternal;
-	}
-}
-
 public abstract class Output
 {
 	protected Output(Money amount, BitcoinAddress destinationAddress)
@@ -21,12 +11,6 @@ public abstract class Output
 	}
 
 	public Money Amount { get; }
-	public BitcoinAddress DestinationAddress { get; }
-}
 
-public class ForeignOutput : Output
-{
-	public ForeignOutput(Money amount, BitcoinAddress destinationAddress) : base(amount, destinationAddress)
-	{
-	}
+	public BitcoinAddress DestinationAddress { get; }
 }

--- a/WalletWasabi/Blockchain/Transactions/Summary/Output.cs
+++ b/WalletWasabi/Blockchain/Transactions/Summary/Output.cs
@@ -4,10 +4,12 @@ namespace WalletWasabi.Blockchain.Transactions.Summary;
 
 public class Output
 {
-	public Output(Money amount)
+	public Output(Money amount, BitcoinAddress destinationAddress)
 	{
 		Amount = amount;
+		DestinationAddress = destinationAddress;
 	}
 
 	public Money Amount { get; }
+	public BitcoinAddress DestinationAddress { get; }
 }

--- a/WalletWasabi/Blockchain/Transactions/Summary/OwnOutput.cs
+++ b/WalletWasabi/Blockchain/Transactions/Summary/OwnOutput.cs
@@ -1,0 +1,13 @@
+using NBitcoin;
+
+namespace WalletWasabi.Blockchain.Transactions.Summary;
+
+public class OwnOutput : Output
+{
+	public OwnOutput(Money amount, BitcoinAddress destinationAddress, bool isInternal) : base(amount, destinationAddress)
+	{
+		IsInternal = isInternal;
+	}
+
+	public bool IsInternal { get; }
+}

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -22,5 +22,5 @@ public class TransactionSummary
 	public Money OutputAmount => Outputs.Sum(x => x.Amount);
 	public Money? InputAmount => Inputs.Any(x => x.Amount == null) ? null : Inputs.Sum(x => x.Amount);
 	public Money? Fee => InputAmount != null ? InputAmount - OutputAmount : null;
-	public BitcoinAddress DestinationAddress { get; set; }
+	public IEnumerable<BitcoinAddress> DestinationAddresses { get; set; }
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -22,4 +22,5 @@ public class TransactionSummary
 	public Money OutputAmount => Outputs.Sum(x => x.Amount);
 	public Money? InputAmount => Inputs.Any(x => x.Amount == null) ? null : Inputs.Sum(x => x.Amount);
 	public Money? Fee => InputAmount != null ? InputAmount - OutputAmount : null;
+	public BitcoinAddress DestinationAddress { get; set; }
 }


### PR DESCRIPTION
This adds the destination address to the transaction summary.

I have calculated the destionation address by sorting by amount and taking the address of the first output. 
If this algorithm is incorrect, please tell me the correct way to do so :)

Also, I took the freedom to choose the icon 
![image](https://github.com/zkSNACKs/WalletWasabi/assets/3109851/a68a6890-62bd-45b6-a6b2-b7ba27d48a84). If it doesn't fit, please @editwentyone tell me which one to use 😁


Related: #8662, [#9014](https://github.com/zkSNACKs/WalletWasabi/issues/9014)