### PR TITLE
Reduce log levels of common errors in the Log

### DIFF
--- a/WalletWasabi/Affiliation/AffiliateServerStatusUpdater.cs
+++ b/WalletWasabi/Affiliation/AffiliateServerStatusUpdater.cs
@@ -46,7 +46,7 @@ public class AffiliateServerStatusUpdater : PeriodicRunner
 		}
 		catch (Exception exception)
 		{
-			Logging.Logger.LogError(exception);
+			Logging.Logger.LogWarning(exception);
 			return false;
 		}
 	}

--- a/WalletWasabi/Extensions/EventHandlerExtensions.cs
+++ b/WalletWasabi/Extensions/EventHandlerExtensions.cs
@@ -12,7 +12,7 @@ public static class EventHandlerExtensions
 		}
 		catch (Exception e)
 		{
-			Logger.LogError(e);
+			Logger.LogWarning(e);
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -97,14 +97,14 @@ public class CoinVerifier : IAsyncDisposable
 		{
 			if (timeoutCancellationTokenSource.IsCancellationRequested)
 			{
-				Logger.LogError(ex);
+				Logger.LogWarning(ex);
 			}
 
 			// Otherwise just continue - the whole round was cancelled.
 		}
 		catch (Exception ex)
 		{
-			Logger.LogError(ex);
+			Logger.LogWarning(ex);
 		}
 
 		CleanUp();
@@ -129,7 +129,7 @@ public class CoinVerifier : IAsyncDisposable
 				// This should never happen.
 				if (!item.Task.IsCompleted)
 				{
-					Logger.LogError($"Unfinished task was removed for coin: '{coin.Outpoint}'.");
+					Logger.LogWarning($"Unfinished task was removed for coin: '{coin.Outpoint}'.");
 				}
 
 				item.Dispose();
@@ -231,7 +231,7 @@ public class CoinVerifier : IAsyncDisposable
 					// Sanity check.
 					if (delay > AbsoluteScheduleSanityTimeout)
 					{
-						Logger.LogError($"Start delay '{delay}' was more than the absolute maximum '{AbsoluteScheduleSanityTimeout}' for coin '{coin.Outpoint}'.");
+						Logger.LogWarning($"Start delay '{delay}' was more than the absolute maximum '{AbsoluteScheduleSanityTimeout}' for coin '{coin.Outpoint}'.");
 						delay = AbsoluteScheduleSanityTimeout;
 					}
 
@@ -276,7 +276,7 @@ public class CoinVerifier : IAsyncDisposable
 					item.SetResult(result);
 					VerifierAuditArchiver.LogVerificationResult(result, Reason.Exception, apiResponseItem: null, exception: ex);
 
-					Logger.LogError($"Coin verification has failed for coin '{coin.Outpoint}' with '{ex}'.");
+					Logger.LogWarning($"Coin verification has failed for coin '{coin.Outpoint}' with '{ex}'.");
 
 					// Do not throw an exception here - unobserved exception prevention.
 				}


### PR DESCRIPTION
Fixes: [#10849](https://github.com/zkSNACKs/WalletWasabi/issues/10849)

This PR reduces the log levels of several common errors in the backend log.

### Why?

> Whatever is not an error that prevents the coordinator to work properly should be a warning. Errors are suppose to be events that need our immediate attention and then the team should be notified on slack or in any other channel to take actions.

Reducing the severity from Error to Warning in the logs mean that we will still log them but they won't be sent to maintainers (if that will be introduced).