### PR TITLE
Make CoinjoinState consistent with Alices

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -238,8 +238,6 @@ public partial class Arena : IWabiSabiApiRequestHandler
 						await amountRealCredentialTask.ConfigureAwait(false),
 						await vsizeRealCredentialTask.ConfigureAwait(false));
 
-					// Update the coinjoin state, adding the confirmed input.
-					round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice.Coin, alice.OwnershipProof, round.CoinJoinInputCommitmentData);
 					alice.ConfirmedConnection = true;
 
 					return response;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -192,6 +192,7 @@ public partial class Arena : PeriodicRunner
 			{
 				if (round.Alices.All(x => x.ConfirmedConnection))
 				{
+					round.AddInputsToConstructionState();
 					SetRoundPhase(round, Phase.OutputRegistration);
 				}
 				else if (round.ConnectionConfirmationTimeFrame.HasExpired)
@@ -227,6 +228,7 @@ public partial class Arena : PeriodicRunner
 					else
 					{
 						round.OutputRegistrationTimeFrame = TimeFrame.Create(Config.FailFastOutputRegistrationTimeout);
+						round.AddInputsToConstructionState();
 						SetRoundPhase(round, Phase.OutputRegistration);
 					}
 				}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -131,6 +131,14 @@ public class Round
 		return InputRegistrationTimeFrame.HasExpired;
 	}
 
+	public void AddInputsToConstructionState()
+	{
+		foreach (var alice in Alices)
+		{
+			CoinjoinState = Assert<ConstructionState>().AddInput(alice.Coin, alice.OwnershipProof, CoinJoinInputCommitmentData);
+		}
+	}
+
 	public ConstructionState AddInput(Coin coin, OwnershipProof ownershipProof, CoinJoinInputCommitmentData coinJoinInputCommitmentData)
 		=> Assert<ConstructionState>().AddInput(coin, ownershipProof, coinJoinInputCommitmentData);
 


### PR DESCRIPTION
This is a hotfix that fixes the second part of https://github.com/zkSNACKs/WalletWasabi/issues/10900.