### PR TITLE
[PoC] Improve stopping of software after logging to a wallet

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -169,7 +169,7 @@ public static class WasabiAppExtensions
 				Logger.LogSoftwareStarted("Wasabi GUI");
 				bool runGuiInBackground = app.AppConfig.Arguments.Any(arg => arg.Contains(StartupHelper.SilentArgument));
 				UiConfig uiConfig = LoadOrCreateUiConfig(Config.DataDir);
-				Services.Initialize(app.Global!, uiConfig, app.SingleInstanceChecker);
+				Services.Initialize(app.Global!, uiConfig, app.SingleInstanceChecker, app.TerminateService.TerminationRequested.Task);
 
 				AppBuilder
 					.Configure(() => new App(

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -1,7 +1,9 @@
+using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionBroadcasting;
 using WalletWasabi.Daemon;
 using WalletWasabi.Helpers;
 using WalletWasabi.Services;
+using WalletWasabi.Services.Terminate;
 using WalletWasabi.Stores;
 using WalletWasabi.Tor;
 using WalletWasabi.Tor.StatusChecker;
@@ -38,6 +40,7 @@ public static class Services
 
 	public static TorStatusChecker TorStatusChecker { get; private set; } = null!;
 	public static UpdateManager? UpdateManager { get; private set; }
+	public static Task TerminationRequestedTask { get; private set; } = null!;
 
 	public static bool IsInitialized { get; private set; }
 
@@ -46,7 +49,7 @@ public static class Services
 	/// </summary>
 	/// <param name="global">The global instance.</param>
 	/// <param name="singleInstanceChecker">The singleInstanceChecker instance.</param>
-	public static void Initialize(Global global, UiConfig uiConfig, SingleInstanceChecker singleInstanceChecker)
+	public static void Initialize(Global global, UiConfig uiConfig, SingleInstanceChecker singleInstanceChecker, Task terminationRequestedTask)
 	{
 		Guard.NotNull(nameof(global.DataDir), global.DataDir);
 		Guard.NotNull(nameof(global.TorSettings), global.TorSettings);
@@ -75,6 +78,7 @@ public static class Services
 		SingleInstanceChecker = singleInstanceChecker;
 		TorStatusChecker = global.TorStatusChecker;
 		UpdateManager = global.UpdateManager;
+		TerminationRequestedTask = terminationRequestedTask;
 
 		IsInitialized = true;
 	}


### PR DESCRIPTION
The PR was created with #10844 in mind. However, this PR fixes a different issue where stopping software after trying to open a wallet. Not before.

Notes:

* Relevant [comment](https://github.com/zkSNACKs/WalletWasabi/issues/10844#issuecomment-1576366143). Even though I agree with the comment, it would make it sort of impossible to fix "stopping of software" for the next release as rewriting Synchronizer is a big task.
* This PR also ignores the UI decoupling effort for now. If the PR is deemed useful, we should take it into account.

cc @MarnixCroes 