### PR TITLE
Improve destination addresses algorithm

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -46,7 +46,7 @@ public class TransactionHistoryBuilder
 			{
 				var outputs = GetOutputs(containingTransaction, wallet.Network).ToList();
 				var inputs = GetInputs(containingTransaction).ToList();
-				var destinationAddresses = GetDestinationsAddresses(inputs, outputs);
+				var destinationAddresses = GetDestinationAddresses(inputs, outputs);
 
 				txRecordList.Add(new TransactionSummary
 				{
@@ -79,7 +79,7 @@ public class TransactionHistoryBuilder
 				{
 					var outputs = GetOutputs(spenderTransaction, wallet.Network).ToList();
 					var inputs = GetInputs(containingTransaction).ToList();
-					var destinationAddresses = GetDestinationsAddresses(inputs, outputs);
+					var destinationAddresses = GetDestinationAddresses(inputs, outputs);
 
 					txRecordList.Add(new TransactionSummary
 					{
@@ -102,7 +102,7 @@ public class TransactionHistoryBuilder
 		return txRecordList;
 	}
 
-	private IEnumerable<BitcoinAddress> GetDestinationsAddresses(ICollection<IInput> inputs, ICollection<Output> outputs)
+	private IEnumerable<BitcoinAddress> GetDestinationAddresses(ICollection<IInput> inputs, ICollection<Output> outputs)
 	{
 		var myOwnInputs = inputs.OfType<KnownInput>().ToList();
 		var foreignInputs = inputs.OfType<ForeignInput>().ToList();

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -118,6 +118,7 @@ public class TransactionHistoryBuilder
 				// Destination are the external addresses.
 				return myOwnOutputs.Where(x => !x.IsInternal).Select(x => x.DestinationAddress);
 			}
+
 			// Edge-case: self-spend to an internal address.
 			// We can't know the destination, return all the outputs.
 			return myOwnOutputs.Select(x => x.DestinationAddress);

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -46,7 +46,7 @@ public class TransactionHistoryBuilder
 			{
 				var outputs = GetOutputs(containingTransaction, wallet.Network).ToList();
 				var inputs = GetInputs(containingTransaction).ToList();
-				var destinationAddresses = GetDestinationAddresses(inputs, outputs);
+				var destinationAddresses = GetDestinationsAddresses(inputs, outputs);
 
 				txRecordList.Add(new TransactionSummary
 				{
@@ -79,7 +79,7 @@ public class TransactionHistoryBuilder
 				{
 					var outputs = GetOutputs(spenderTransaction, wallet.Network).ToList();
 					var inputs = GetInputs(containingTransaction).ToList();
-					var destinationAddresses = GetDestinationAddresses(inputs, outputs);
+					var destinationAddresses = GetDestinationsAddresses(inputs, outputs);
 
 					txRecordList.Add(new TransactionSummary
 					{
@@ -102,7 +102,7 @@ public class TransactionHistoryBuilder
 		return txRecordList;
 	}
 
-	private IEnumerable<BitcoinAddress> GetDestinationAddresses(ICollection<IInput> inputs, ICollection<Output> outputs)
+	private IEnumerable<BitcoinAddress> GetDestinationsAddresses(ICollection<IInput> inputs, ICollection<Output> outputs)
 	{
 		var myOwnInputs = inputs.OfType<KnownInput>().ToList();
 		var foreignInputs = inputs.OfType<ForeignInput>().ToList();
@@ -112,27 +112,27 @@ public class TransactionHistoryBuilder
 		// All inputs and outputs are my own, transaction is a self-spend.
 		if (!foreignInputs.Any() && !foreignOutputs.Any())
 		{
-			// Classic self-spend to an external address.
+			// Classic self-spend to one or more external addresses.
 			if (myOwnOutputs.Any(x => !x.IsInternal))
 			{
-				// Destination are the external addresses.
+				// Destinations are the external addresses.
 				return myOwnOutputs.Where(x => !x.IsInternal).Select(x => x.DestinationAddress);
 			}
 
-			// Edge-case: self-spend to an internal address.
-			// We can't know the destination, return all the outputs.
+			// Edge-case: self-spend to one or more internal addresses.
+			// We can't know the destinations, return all the outputs.
 			return myOwnOutputs.Select(x => x.DestinationAddress);
 		}
 
-		// All inputs are foreign but some outputs are my own, someone is sending a transaction to me.
+		// All inputs are foreign but some outputs are my own, someone is sending coins to me.
 		if (!myOwnInputs.Any() && myOwnOutputs.Any())
 		{
-			// All outputs that are my own are the destination.
+			// All outputs that are my own are the destinations.
 			return myOwnOutputs.Select(x => x.DestinationAddress);
 		}
 		
 		// I'm sending a transaction to someone else.
-		// All outputs that are not my own are the destination.
+		// All outputs that are not my own are the destinations.
 		return foreignOutputs.Select(x => x.DestinationAddress);
 	}
 


### PR DESCRIPTION
Fixes #10916

The comments are self-explanatory.
I can remove them from the code before merging, even if I think they help.
I believe this algo covers the standard cases correctly.
Sometimes if users make weird transactions, it might be incorrect, but I believe we don't care, as there is no way to know the user's intention anyway.