### PR TITLE
[VDG][Trivial] Simplify text of Preview Transaction dialog

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -53,7 +53,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 	{
 		_transaction = transactionResult;
 
-		ConfirmationTimeText = $"approximately {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
+		ConfirmationTimeText = $"{TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
 		var destinationAmount = _transaction.CalculateDestinationAmount();
 		AmountText = $"{destinationAmount.ToFormattedString()} BTC";

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -53,7 +53,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 	{
 		_transaction = transactionResult;
 
-		ConfirmationTimeText = $"{TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
+		ConfirmationTimeText = $"≈ {TextHelpers.TimeSpanToFriendlyString(info.ConfirmationTimeSpan)} ";
 
 		var destinationAmount = _transaction.CalculateDestinationAmount();
 		AmountText = $"{destinationAmount.ToFormattedString()} BTC";

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -26,7 +26,7 @@
         </Button.IsVisible>
       </Button>
       <c:PreviewItem Icon="{StaticResource btc_logo}"
-                     Label="a total of" HorizontalContentAlignment="Stretch"
+                     Label="amount" HorizontalContentAlignment="Stretch"
                      CopyableContent="{Binding Amount}">
         <TextBlock Classes="monoSpaced" Text="{Binding AmountText, FallbackValue=_ BTC (≈_ USD)}" />
       </c:PreviewItem>
@@ -35,7 +35,7 @@
 
     <!-- Recipient -->
     <c:PreviewItem Icon="{StaticResource person_regular}"
-                   Label="will be sent to"
+                   Label="receiver"
                    CopyableContent="{Binding Recipient}">
       <c:LabelsItemsPresenter Items="{Binding Recipient}"
                               HorizontalAlignment="Left"
@@ -45,12 +45,11 @@
 
     <!-- Address -->
     <c:PreviewItem Icon="{StaticResource transceive_regular}"
-                   Label="to the Bitcoin address"
+                   Label="address"
                    CopyableContent="{Binding AddressText}">
       <TextBlock Classes="monoSpaced" Text="{Binding AddressText, FallbackValue=btc029382398fkj34f98df239823}" />
     </c:PreviewItem>
     <Separator />
-
 
     <!-- Selected coin labels -->
     <DockPanel IsVisible="{Binding TransactionHasPockets}">
@@ -70,7 +69,7 @@
         </Viewbox>
       </Button>
       <c:PreviewItem Icon="{StaticResource nav_incognito_24_regular}"
-                     Label="other people or companies could know about this"
+                     Label="transaction known as yours by"
                      CopyableContent="{Binding Labels}">
         <c:LabelsItemsPresenter Items="{Binding Labels}"
                                 HorizontalAlignment="Left"
@@ -102,17 +101,16 @@
 
       <StackPanel Spacing="10">
         <c:PreviewItem Icon="{StaticResource timer_regular}"
-                       Label="your transaction should be confirmed within"
+                       Label="confirming within"
                        IsVisible="{Binding !IsCustomFeeUsed}">
           <TextBlock Text="{Binding ConfirmationTimeText, FallbackValue=~20 minutes }" />
         </c:PreviewItem>
         <c:PreviewItem Icon="{StaticResource paper_cash_regular}"
-                       Label="there will be an additional transaction fee of"
+                       Label="fee"
                        CopyableContent="{Binding Fee}">
           <TextBlock Classes="monoSpaced" Text="{Binding FeeText, FallbackValue=_ BTC (≈_ USD)}" />
         </c:PreviewItem>
       </StackPanel>
     </DockPanel>
-
   </StackPanel>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -35,7 +35,7 @@
 
     <!-- Recipient -->
     <c:PreviewItem Icon="{StaticResource person_regular}"
-                   Label="receiver"
+                   Label="recipient"
                    CopyableContent="{Binding Recipient}">
       <c:LabelsItemsPresenter Items="{Binding Recipient}"
                               HorizontalAlignment="Left"


### PR DESCRIPTION
The Transaction Preview dialog (when sending) is full of text and not user friendly imo.

This is a small PR with minimal effort to simplify the text and make the dialog less cluttered.

Master:

![1](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/b53faea8-fd3a-436a-b77c-33971bac2779)

PR:

![3](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/f72c586e-ef21-4499-b3d1-81c348e85312)
