### PR TITLE
TurboSync: Add missing `ConfigureAwait`s

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Wallet/MockNode.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/MockNode.cs
@@ -49,7 +49,7 @@ public class MockNode
 	public static async Task<MockNode> CreateNodeAsync()
 	{
 		var node = new MockNode();
-		await node.Wallet.GenerateAsync(101, CancellationToken.None);
+		await node.Wallet.GenerateAsync(101, CancellationToken.None).ConfigureAwait(false);
 		return node;
 	}
 
@@ -116,5 +116,5 @@ public class MockNode
 	}
 
 	public async Task GenerateBlockAsync(CancellationToken cancel) =>
-		await Rpc.GenerateToAddressAsync(1, Wallet.GetNextDestination().ScriptPubKey.GetDestinationAddress(Network)!, cancel);
+		await Rpc.GenerateToAddressAsync(1, Wallet.GetNextDestination().ScriptPubKey.GetDestinationAddress(Network)!, cancel).ConfigureAwait(false);
 }

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -58,9 +58,9 @@ public class WalletBuilder : IAsyncDisposable
 
 	public async Task<WalletWasabi.Wallets.Wallet> CreateRealWalletBasedOnTestWalletAsync(TestWallet wallet)
 	{
-		await BitcoinStore.InitializeAsync(); // StartingFilter already added to IndexStore after this line.
+		await BitcoinStore.InitializeAsync().ConfigureAwait(false); // StartingFilter already added to IndexStore after this line.
 
-		await BitcoinStore.IndexStore.AddNewFiltersAsync(Filters.Skip(1));
+		await BitcoinStore.IndexStore.AddNewFiltersAsync(Filters.Skip(1)).ConfigureAwait(false);
 		var keyManager = KeyManager.CreateNewWatchOnly(wallet.GetSegwitAccountExtPubKey(), null!);
 		keyManager.GetKeys(_ => true); // Make sure keys are asserted.
 
@@ -74,9 +74,9 @@ public class WalletBuilder : IAsyncDisposable
 
 	public async ValueTask DisposeAsync()
 	{
-		await IndexStore.DisposeAsync();
-		await TransactionStore.DisposeAsync();
-		await HttpClientFactory.DisposeAsync();
+		await IndexStore.DisposeAsync().ConfigureAwait(false);
+		await TransactionStore.DisposeAsync().ConfigureAwait(false);
+		await HttpClientFactory.DisposeAsync().ConfigureAwait(false);
 		Cache.Dispose();
 	}
 }


### PR DESCRIPTION
Follow-up to #10896

Add missing `ConfigureAwait(false)` and allow tests to fail (and give us info about what failed rather than CI timeout after an hour if something goes wrong).

I reported some other issues in #10946.