### PR TITLE
[WabiSabi] Verify ownership proof before any other policies

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputFailureTests.cs
@@ -43,11 +43,13 @@ public class RegisterInputFailureTests
 	public async Task WrongPhaseAsync()
 	{
 		WabiSabiConfig cfg = new();
-		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync();
+		using Key key = new();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync();
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		var round = arena.Rounds.First();
-		using Key key = new();
-		var req = WabiSabiFactory.CreateInputRegistrationRequest(round, key: key);
+		var req = WabiSabiFactory.CreateInputRegistrationRequest(round, key: key, coin.Outpoint);
 
 		foreach (Phase phase in Enum.GetValues(typeof(Phase)))
 		{
@@ -67,9 +69,11 @@ public class RegisterInputFailureTests
 		WabiSabiConfig cfg = new() { MaxInputCountByRound = 3 };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		using Key key = new();
+		var coin = WabiSabiFactory.CreateCoin(key);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 
-		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
@@ -78,7 +82,7 @@ public class RegisterInputFailureTests
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WrongPhaseException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), ownershipProof, CancellationToken.None));
+			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.WrongPhase, ex.ErrorCode);
 		Assert.Equal(Phase.InputRegistration, round.Phase);
 
@@ -91,10 +95,10 @@ public class RegisterInputFailureTests
 		WabiSabiConfig cfg = new() { StandardInputRegistrationTimeout = TimeSpan.Zero };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		using Key key = new();
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
-
 		var coin = WabiSabiFactory.CreateCoin(key);
 		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
+
 		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync();
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
@@ -114,22 +118,23 @@ public class RegisterInputFailureTests
 	public async Task InputBannedAsync()
 	{
 		using Key key = new();
-		var outpoint = BitcoinFactory.CreateOutPoint();
+		var coin = WabiSabiFactory.CreateCoin(key);
 
 		WabiSabiConfig cfg = new();
 		var round = WabiSabiFactory.CreateRound(cfg);
 
 		Prison prison = new();
-		using Arena arena = await ArenaBuilder.From(cfg, prison).CreateAndStartAsync(round);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+		using Arena arena = await ArenaBuilder.From(cfg, rpc, prison).CreateAndStartAsync(round);
 
-		prison.Punish(outpoint, Punishment.Banned, uint256.One);
+		prison.Punish(coin.Outpoint, Punishment.Banned, uint256.One);
 
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key);
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
+			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 
 		Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 		Assert.IsAssignableFrom<InputBannedExceptionData>(ex.ExceptionData);
@@ -141,22 +146,23 @@ public class RegisterInputFailureTests
 	public async Task InputLongBannedAsync()
 	{
 		using Key key = new();
-		var outpoint = BitcoinFactory.CreateOutPoint();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 
 		WabiSabiConfig cfg = new();
 		var round = WabiSabiFactory.CreateRound(cfg);
 
 		Prison prison = new();
-		using Arena arena = await ArenaBuilder.From(cfg, prison).CreateAndStartAsync(round);
+		using Arena arena = await ArenaBuilder.From(cfg, rpc, prison).CreateAndStartAsync(round);
 
-		prison.Punish(outpoint, Punishment.LongBanned, uint256.One);
+		prison.Punish(coin.Outpoint, Punishment.LongBanned, uint256.One);
 
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key);
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
+			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 
 		Assert.Equal(WabiSabiProtocolErrorCode.InputLongBanned, ex.ErrorCode);
 		Assert.IsAssignableFrom<InputBannedExceptionData>(ex.ExceptionData);
@@ -168,23 +174,23 @@ public class RegisterInputFailureTests
 	public async Task InputCanBeNotedAsync()
 	{
 		using Key key = new();
-		var outpoint = BitcoinFactory.CreateOutPoint();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 
 		WabiSabiConfig cfg = new();
 		var round = WabiSabiFactory.CreateRound(cfg);
 
 		Prison prison = new();
-		using Arena arena = await ArenaBuilder.From(cfg, prison).CreateAndStartAsync(round);
+		using Arena arena = await ArenaBuilder.From(cfg, rpc, prison).CreateAndStartAsync(round);
 
-		prison.Punish(outpoint, Punishment.Noted, uint256.One);
+		prison.Punish(coin.Outpoint, Punishment.Noted, uint256.One);
 
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key);
+		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
-		Assert.NotEqual(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
+		await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
+		// Noted inputs are allowed and should not throw any exception.
 
 		await arena.StopAsync(CancellationToken.None);
 	}
@@ -193,21 +199,22 @@ public class RegisterInputFailureTests
 	public async Task InputCantBeNotedAsync()
 	{
 		using Key key = new();
-		var outpoint = BitcoinFactory.CreateOutPoint();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 
 		WabiSabiConfig cfg = new() { AllowNotedInputRegistration = false };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
 		Prison prison = new();
-		using Arena arena = await ArenaBuilder.From(cfg, prison).CreateAndStartAsync(round);
+		using Arena arena = await ArenaBuilder.From(cfg, rpc, prison).CreateAndStartAsync(round);
 
-		prison.Punish(outpoint, Punishment.Noted, uint256.One);
+		prison.Punish(coin.Outpoint, Punishment.Noted, uint256.One);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
+			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.InputBanned, ex.ErrorCode);
 
 		await arena.StopAsync(CancellationToken.None);
@@ -287,35 +294,6 @@ public class RegisterInputFailureTests
 	}
 
 	[Fact]
-	public async Task ScriptNotAllowedAsync()
-	{
-		WabiSabiConfig cfg = new();
-		var round = WabiSabiFactory.CreateRound(cfg);
-		using Key key = new();
-		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
-
-		var mockRpc = new Mock<IRPCClient>();
-		mockRpc.Setup(rpc => rpc.GetTxOutAsync(It.IsAny<uint256>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new NBitcoin.RPC.GetTxOutResponse
-			{
-				Confirmations = 1,
-				TxOut = new(Money.Coins(1), key.PubKey.ScriptPubKey.Hash.GetAddress(Network.Main))
-			});
-
-		var prison = new Prison();
-		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync(round);
-
-		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
-
-		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), ownershipProof, CancellationToken.None));
-
-		Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, ex.ErrorCode);
-		Assert.Single(prison.GetInmates());
-		await arena.StopAsync(CancellationToken.None);
-	}
-
-	[Fact]
 	public async Task TaprootNotAllowedAsync()
 	{
 		WabiSabiConfig cfg = new() { AllowP2trInputs = false };
@@ -359,15 +337,19 @@ public class RegisterInputFailureTests
 	public async Task NotEnoughFundsAsync()
 	{
 		using Key key = new();
+		var txOut = new TxOut(Money.Coins(1.0m), key.GetScriptPubKey(ScriptPubKeyType.Segwit));
+		var outpoint = BitcoinFactory.CreateOutPoint();
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(new Coin(outpoint, txOut));
+
 		WabiSabiConfig cfg = new() { MinRegistrableAmount = Money.Coins(2) };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), ownershipProof, CancellationToken.None));
+			async () => await arenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.NotEnoughFunds, ex.ErrorCode);
 
 		await arena.StopAsync(CancellationToken.None);
@@ -377,15 +359,17 @@ public class RegisterInputFailureTests
 	public async Task TooMuchFundsAsync()
 	{
 		using Key key = new();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		var rpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
 		WabiSabiConfig cfg = new() { MaxRegistrableAmount = Money.Coins(0.9m) };
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
+		using Arena arena = await ArenaBuilder.From(cfg).With(rpc).CreateAndStartAsync(round);
 
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(
-			async () => await arenaClient.RegisterInputAsync(round.Id, BitcoinFactory.CreateOutPoint(), ownershipProof, CancellationToken.None));
+			async () => await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.TooMuchFunds, ex.ErrorCode);
 
 		await arena.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputToBlameRoundTests.cs
@@ -16,14 +16,16 @@ public class RegisterInputToBlameRoundTests
 	public async Task InputNotWhitelistedAsync()
 	{
 		WabiSabiConfig cfg = new();
+		using Key key = new();
+		var coin = WabiSabiFactory.CreateCoin(key);
+		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin);
+
 		var round = WabiSabiFactory.CreateRound(cfg);
 		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
 		Round blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
-		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round, blameRound);
-		using Key key = new();
-		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient();
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync(round, blameRound);
 
-		var req = WabiSabiFactory.CreateInputRegistrationRequest(round: blameRound);
+		var req = WabiSabiFactory.CreateInputRegistrationRequest(round: blameRound, key, coin.Outpoint);
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await arena.RegisterInputAsync(req, CancellationToken.None));
 		Assert.Equal(WabiSabiProtocolErrorCode.InputNotWhitelisted, ex.ErrorCode);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -70,11 +70,26 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 	{
 		using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(2));
 
-		var bannedOutPoint = BitcoinFactory.CreateOutPoint();
+		using var signingKey = new Key();
+		var coin = WabiSabiFactory .CreateCoin(signingKey);
+		var bannedOutPoint = coin.Outpoint;
 
 		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
 			builder.ConfigureServices(services =>
 			{
+				var rpc = BitcoinFactory.GetMockMinimalRpc();
+
+				// Make the coordinator believe that the coins are real and
+				// that they exist in the blockchain with many confirmations.
+				rpc.OnGetTxOutAsync = (_, _, _) => new()
+				{
+					Confirmations = 101,
+					IsCoinBase = false,
+					ScriptPubKeyType = "witness_v0_keyhash",
+					TxOut = coin.TxOut
+				};
+				services.AddScoped<IRPCClient>(s => rpc);
+
 				var inmate = new Inmate(bannedOutPoint, Punishment.LongBanned, DateTimeOffset.UtcNow, uint256.One);
 				services.AddScoped(_ => new Prison(new[] { inmate }));
 			})).CreateClient();
@@ -85,7 +100,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 
 		// If an output is not in the utxo dataset then it is not unspent, this
 		// means that the output is spent or simply doesn't even exist.
-		using var signingKey = new Key();
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
 
 		var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () =>

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Affiliation;
 using WabiSabi.CredentialRequesting;
 using WabiSabi.Crypto;
+using WalletWasabi.Crypto;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Models;
@@ -12,8 +13,6 @@ using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.Logging;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
-using WalletWasabi.WabiSabi.Backend.Events;
-using WalletWasabi.Extensions;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -40,6 +39,13 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		{
 			var round = GetRound(request.RoundId);
 
+			if (!OwnershipProof.VerifyCoinJoinInputProof(request.OwnershipProof, coin.ScriptPubKey, round.CoinJoinInputCommitmentData))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
+			}
+
+			CheckCoinIsNotBanned(coin.Outpoint);
+			
 			var registeredCoins = Rounds.Where(x => !(x.Phase == Phase.Ended && x.EndRoundState != EndRoundState.TransactionBroadcasted))
 				.SelectMany(r => r.Alices.Select(a => a.Coin));
 
@@ -368,23 +374,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	public async Task<(Coin coin, int Confirmations)> OutpointToCoinAsync(InputRegistrationRequest request, CancellationToken cancellationToken)
 	{
 		OutPoint input = request.Input;
-
-		if (Prison.TryGet(input, out var inmate))
-		{
-			DateTimeOffset bannedUntil;
-			if (inmate.Punishment == Punishment.LongBanned)
-			{
-				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan;
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
-			}
-
-			if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
-			{
-				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
-				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
-			}
-		}
-
+		
 		var txOutResponse = await Rpc.GetTxOutAsync(input.Hash, (int)input.N, includeMempool: true, cancellationToken).ConfigureAwait(false)
 			?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputSpent);
 		if (txOutResponse.Confirmations == 0)
@@ -415,6 +405,25 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		return Task.FromResult(new RoundStateResponse(responseRoundStates, Array.Empty<CoinJoinFeeRateMedian>(), Affiliation.Models.AffiliateInformation.Empty));
 	}
 
+	private void CheckCoinIsNotBanned(OutPoint input)
+	{
+		if (Prison.TryGet(input, out var inmate))
+		{
+			DateTimeOffset bannedUntil;
+			if (inmate.Punishment == Punishment.LongBanned)
+			{
+				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfterLongBan;
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputLongBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
+			}
+
+			if (!Config.AllowNotedInputRegistration || inmate.Punishment != Punishment.Noted)
+			{
+				bannedUntil = inmate.Started + Config.ReleaseUtxoFromPrisonAfter;
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputBanned, exceptionData: new InputBannedExceptionData(bannedUntil));
+			}
+		}
+	}
+	
 	private Round GetRound(uint256 roundId) =>
 		Rounds.FirstOrDefault(x => x.Id == roundId)
 		?? throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.RoundNotFound, $"Round ({roundId}) not found.");

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -19,6 +19,11 @@ public record ConstructionState : MultipartyTransactionState
 	{
 		var prevout = coin.TxOut;
 
+		if (!OwnershipProof.VerifyCoinJoinInputProof(ownershipProof, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
+		{
+			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
+		}
+
 		if (!StandardScripts.IsStandardScriptPubKey(prevout.ScriptPubKey))
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardInput);
@@ -55,11 +60,6 @@ public record ConstructionState : MultipartyTransactionState
 		if (Inputs.Any(x => x.Outpoint == coin.Outpoint))
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
-		}
-
-		if (!OwnershipProof.VerifyCoinJoinInputProof(ownershipProof, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
-		{
-			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongOwnershipProof);
 		}
 
 		return this with { Events = Events.Add(new InputAdded(coin, ownershipProof)) };


### PR DESCRIPTION
This PR is for checking ownership proofs before other acceptance criteria in order to act as an authentication mechanism for input registration.