### PR TITLE
[WabiSabi] Do not ban inputs without valid ownership proof

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -44,7 +44,6 @@ public static class WabiSabiProtocolErrorCodeExtension
 	public static bool IsEvidencingClearMisbehavior(this WabiSabiProtocolErrorCode errorCode) =>
 		errorCode
 			is WabiSabiProtocolErrorCode.InputSpent
-			or WabiSabiProtocolErrorCode.WrongOwnershipProof
 			or WabiSabiProtocolErrorCode.ScriptNotAllowed
 			or WabiSabiProtocolErrorCode.NonStandardInput
 			or WabiSabiProtocolErrorCode.NonStandardOutput


### PR DESCRIPTION
This PR removes `WrongOwnershipProof` from the list of cheating reason.