### PR TITLE
Get unconfirmed CoinJoins from the coordinator

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -21,12 +21,13 @@ namespace WalletWasabi.Backend.Controllers;
 [Route("api/v" + Constants.BackendMajorVersion + "/btc/[controller]")]
 public class BatchController : ControllerBase
 {
-	public BatchController(BlockchainController blockchainController, ChaumianCoinJoinController chaumianCoinJoinController, HomeController homeController, OffchainController offchainController, Global global)
+	public BatchController(BlockchainController blockchainController, ChaumianCoinJoinController chaumianCoinJoinController, HomeController homeController, OffchainController offchainController, WabiSabiController wabiSabiController, Global global)
 	{
 		BlockchainController = blockchainController;
 		ChaumianCoinJoinController = chaumianCoinJoinController;
 		HomeController = homeController;
 		OffchainController = offchainController;
+		WabiSabiController = wabiSabiController;
 		Global = global;
 	}
 
@@ -35,6 +36,7 @@ public class BatchController : ControllerBase
 	public ChaumianCoinJoinController ChaumianCoinJoinController { get; }
 	public HomeController HomeController { get; }
 	public OffchainController OffchainController { get; }
+	public WabiSabiController WabiSabiController { get; }
 
 	[HttpGet("synchronize")]
 	public async Task<IActionResult> GetSynchronizeAsync(
@@ -98,7 +100,7 @@ public class BatchController : ControllerBase
 
 		response.ExchangeRates = await OffchainController.GetExchangeRatesCollectionAsync(cancellationToken);
 
-		response.UnconfirmedCoinJoins = ChaumianCoinJoinController.GetUnconfirmedCoinJoinCollection().Concat(Global.CoinJoinMempoolManager.CoinJoinIds).Distinct();
+		response.UnconfirmedCoinJoins = ChaumianCoinJoinController.GetUnconfirmedCoinJoinCollection().Concat(WabiSabiController.GetUnconfirmedCoinJoinCollection()).Distinct();
 
 		return Ok(response);
 	}

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -98,7 +98,7 @@ public class BatchController : ControllerBase
 
 		response.ExchangeRates = await OffchainController.GetExchangeRatesCollectionAsync(cancellationToken);
 
-		response.UnconfirmedCoinJoins = ChaumianCoinJoinController.GetUnconfirmedCoinJoinCollection();
+		response.UnconfirmedCoinJoins = ChaumianCoinJoinController.GetUnconfirmedCoinJoinCollection().Concat(Global.CoinJoinMempoolManager.CoinJoinIds).Distinct();
 
 		return Ok(response);
 	}

--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -1,10 +1,13 @@
 using Microsoft.AspNetCore.Mvc;
+using NBitcoin;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Affiliation;
 using WalletWasabi.Backend.Filters;
 using WalletWasabi.Cache;
+using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Statistics;
@@ -19,12 +22,13 @@ namespace WalletWasabi.Backend.Controllers;
 [Produces("application/json")]
 public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 {
-	public WabiSabiController(IdempotencyRequestCache idempotencyRequestCache, Arena arena, CoinJoinFeeRateStatStore coinJoinFeeRateStatStore, AffiliationManager affiliationManager)
+	public WabiSabiController(IdempotencyRequestCache idempotencyRequestCache, Arena arena, CoinJoinFeeRateStatStore coinJoinFeeRateStatStore, AffiliationManager affiliationManager, CoinJoinMempoolManager coinJoinMempoolManager)
 	{
 		IdempotencyRequestCache = idempotencyRequestCache;
 		Arena = arena;
 		CoinJoinFeeRateStatStore = coinJoinFeeRateStatStore;
 		AffiliationManager = affiliationManager;
+		CoinJoinMempoolManager = coinJoinMempoolManager;
 	}
 
 	private static TimeSpan RequestTimeout { get; } = TimeSpan.FromMinutes(5);
@@ -32,6 +36,7 @@ public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 	private Arena Arena { get; }
 	private CoinJoinFeeRateStatStore CoinJoinFeeRateStatStore { get; }
 	private AffiliationManager AffiliationManager { get; }
+	public CoinJoinMempoolManager CoinJoinMempoolManager { get; }
 
 	[HttpPost("status")]
 	public async Task<RoundStateResponse> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
@@ -152,4 +157,19 @@ public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 
 		return new HumanMonitorResponse(response.ToArray());
 	}
+
+	/// <summary>
+	/// Gets the list of unconfirmed coinjoin transaction Ids.
+	/// </summary>
+	/// <returns>The list of coinjoin transactions in the mempool.</returns>
+	/// <response code="200">An array of transaction Ids</response>
+	[HttpGet("unconfirmed-coinjoins")]
+	[ProducesResponseType(200)]
+	public IActionResult GetUnconfirmedCoinjoins()
+	{
+		IEnumerable<string> unconfirmedCoinJoinString = GetUnconfirmedCoinJoinCollection().Select(x => x.ToString());
+		return Ok(unconfirmedCoinJoinString);
+	}
+
+	internal IEnumerable<uint256> GetUnconfirmedCoinJoinCollection() => CoinJoinMempoolManager.CoinJoinIds;
 }

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -251,7 +251,7 @@ public class Global : IDisposable
 					Logger.LogInfo($"{nameof(coordinator)} is disposed.");
 				}
 
-				CoinJoinMempoolManager?.Dispose();
+				CoinJoinMempoolManager.Dispose();
 
 				var stoppingTask = Task.Run(DisposeAsync);
 

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -51,6 +51,8 @@ public class Global : IDisposable
 
 		SegwitTaprootIndexBuilderService = new(IndexType.SegwitTaproot, RpcClient, HostedServices.Get<BlockNotifier>(), segwitTaprootIndexFilePath);
 		TaprootIndexBuilderService = new(IndexType.Taproot, RpcClient, HostedServices.Get<BlockNotifier>(), taprootIndexFilePath);
+
+		CoinJoinMempoolManager = new CoinJoinMempoolManager(CoinJoinIdStore);
 	}
 
 	public string DataDir { get; }
@@ -80,7 +82,7 @@ public class Global : IDisposable
 	public CoinJoinIdStore CoinJoinIdStore { get; }
 	public WabiSabiCoordinator? WabiSabiCoordinator { get; private set; }
 	private Whitelist? WhiteList { get; set; }
-	public CoinJoinMempoolManager? CoinJoinMempoolManager { get; private set; }
+	public CoinJoinMempoolManager CoinJoinMempoolManager { get; private set; }
 
 	public async Task InitializeAsync(CoordinatorRoundConfig roundConfig, CancellationToken cancel)
 	{
@@ -94,8 +96,8 @@ public class Global : IDisposable
 
 		HostedServices.Register<MempoolMirror>(() => new MempoolMirror(TimeSpan.FromSeconds(21), RpcClient, P2pNode), "Full Node Mempool Mirror");
 
-		CoinJoinMempoolManager = new CoinJoinMempoolManager(CoinJoinIdStore, HostedServices.Get<MempoolMirror>());
-		Logger.LogInfo($"{nameof(CoinJoinMempoolManager)} is successfully initialized and started synchronization.");
+		CoinJoinMempoolManager.RegisterMempoolProvider(HostedServices.Get<MempoolMirror>());
+		Logger.LogInfo($"{nameof(CoinJoinMempoolManager)} is successfully initialized.");
 
 		var blockNotifier = HostedServices.Get<BlockNotifier>();
 

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -52,7 +52,8 @@ public class Global : IDisposable
 		SegwitTaprootIndexBuilderService = new(IndexType.SegwitTaproot, RpcClient, HostedServices.Get<BlockNotifier>(), segwitTaprootIndexFilePath);
 		TaprootIndexBuilderService = new(IndexType.Taproot, RpcClient, HostedServices.Get<BlockNotifier>(), taprootIndexFilePath);
 
-		CoinJoinMempoolManager = new CoinJoinMempoolManager(CoinJoinIdStore);
+		MempoolMirror = new MempoolMirror(TimeSpan.FromSeconds(21), RpcClient, P2pNode);
+		CoinJoinMempoolManager = new CoinJoinMempoolManager(CoinJoinIdStore, MempoolMirror);
 	}
 
 	public string DataDir { get; }
@@ -82,6 +83,7 @@ public class Global : IDisposable
 	public CoinJoinIdStore CoinJoinIdStore { get; }
 	public WabiSabiCoordinator? WabiSabiCoordinator { get; private set; }
 	private Whitelist? WhiteList { get; set; }
+	private MempoolMirror MempoolMirror { get; }
 	public CoinJoinMempoolManager CoinJoinMempoolManager { get; private set; }
 
 	public async Task InitializeAsync(CoordinatorRoundConfig roundConfig, CancellationToken cancel)
@@ -94,10 +96,7 @@ public class Global : IDisposable
 		// Make sure P2P works.
 		await P2pNode.ConnectAsync(cancel).ConfigureAwait(false);
 
-		HostedServices.Register<MempoolMirror>(() => new MempoolMirror(TimeSpan.FromSeconds(21), RpcClient, P2pNode), "Full Node Mempool Mirror");
-
-		CoinJoinMempoolManager.RegisterMempoolProvider(HostedServices.Get<MempoolMirror>());
-		Logger.LogInfo($"{nameof(CoinJoinMempoolManager)} is successfully initialized.");
+		HostedServices.Register<MempoolMirror>(() => MempoolMirror, "Full Node Mempool Mirror");
 
 		var blockNotifier = HostedServices.Get<BlockNotifier>();
 

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -181,7 +181,7 @@ public class Global : IDisposable
 		CoinJoinIdStore!.TryAdd(transaction.GetHash());
 
 		// Trigger mempool refresh.
-		HostedServices.Get<MempoolMirror>().TriggerRound();
+		MempoolMirror.TriggerRound();
 	}
 
 	private async Task AssertRpcNodeFullyInitializedAsync(CancellationToken cancellationToken)

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -123,6 +123,11 @@ public class Startup
 			var coordinator = global.HostedServices.Get<WabiSabiCoordinator>();
 			return coordinator.AffiliationManager;
 		});
+		services.AddSingleton(serviceProvider =>
+		{
+			var global = serviceProvider.GetRequiredService<Global>();
+			return global.CoinJoinMempoolManager;
+		});
 		services.AddStartupTask<InitConfigStartupTask>();
 
 		services.AddResponseCompression();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinJoinMempoolManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinJoinMempoolManagerTests.cs
@@ -1,0 +1,77 @@
+using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.BitcoinCore.Mempool;
+using WalletWasabi.Services;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
+
+public class CoinJoinMempoolManagerTasks
+{
+	[Fact]
+	public async Task CoinJoinVisibleTestAsync()
+	{
+		var coreNode = await TestNodeBuilder.CreateAsync(nameof(CoinJoinMempoolManagerTasks), nameof(CoinJoinVisibleTestAsync));
+		using HostedServices services = new();
+		services.Register<MempoolMirror>(() => new MempoolMirror(TimeSpan.FromSeconds(2), coreNode.RpcClient, coreNode.P2pNode), "Mempool Mirror");
+		try
+		{
+			var rpc = coreNode.RpcClient;
+			var network = rpc.Network;
+			await services.StartAllAsync();
+			var mempoolInstance = services.Get<MempoolMirror>();
+
+			var walletName = "RandomWalletName";
+			await rpc.CreateWalletAsync(walletName);
+
+			var spendAmount = new Money(0.0004m, MoneyUnit.BTC);
+			await rpc.GenerateAsync(101);
+
+			var rpcMempoolBeforeSend = await rpc.GetRawMempoolAsync();
+			var localMempoolBeforeSend = mempoolInstance.GetMempoolHashes();
+			Assert.Equal(rpcMempoolBeforeSend.Length, localMempoolBeforeSend.Count);
+
+			await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(network), spendAmount);
+			while (!(await rpc.GetRawMempoolAsync()).Any())
+			{
+				await Task.Delay(50);
+			}
+
+			await mempoolInstance.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
+			var localMempoolAfterSend = mempoolInstance.GetMempoolHashes();
+			var coinjoinTx = localMempoolAfterSend.First();
+
+			CoinJoinIdStore coinjoinIdStore = new();
+			coinjoinIdStore.TryAdd(coinjoinTx);
+
+			using CoinJoinMempoolManager coinJoinMempoolManager = new(coinjoinIdStore);
+			coinJoinMempoolManager.RegisterMempoolProvider(mempoolInstance);
+			await mempoolInstance.TriggerAndWaitRoundAsync(CancellationToken.None);
+
+			Assert.Equal(coinjoinTx, coinJoinMempoolManager.CoinJoinIds.Single());
+
+			await rpc.GenerateAsync(1);
+			while ((await rpc.GetRawMempoolAsync()).Any())
+			{
+				await Task.Delay(50);
+			}
+			await mempoolInstance.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
+
+			Assert.Empty(coinJoinMempoolManager.CoinJoinIds);
+		}
+		finally
+		{
+			await services.StopAllAsync();
+			await coreNode.TryStopAsync();
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinJoinMempoolManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinJoinMempoolManagerTests.cs
@@ -1,3 +1,4 @@
+using Moq;
 using NBitcoin;
 using System;
 using System.Collections.Generic;
@@ -15,12 +16,12 @@ using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
 
-public class CoinJoinMempoolManagerTasks
+public class CoinJoinMempoolManagerTests
 {
 	[Fact]
 	public async Task CoinJoinVisibleTestAsync()
 	{
-		var coreNode = await TestNodeBuilder.CreateAsync(nameof(CoinJoinMempoolManagerTasks), nameof(CoinJoinVisibleTestAsync));
+		var coreNode = await TestNodeBuilder.CreateAsync(nameof(CoinJoinMempoolManagerTests), nameof(CoinJoinVisibleTestAsync));
 		using HostedServices services = new();
 		services.Register<MempoolMirror>(() => new MempoolMirror(TimeSpan.FromSeconds(2), coreNode.RpcClient, coreNode.P2pNode), "Mempool Mirror");
 		try
@@ -53,8 +54,7 @@ public class CoinJoinMempoolManagerTasks
 			CoinJoinIdStore coinjoinIdStore = new();
 			coinjoinIdStore.TryAdd(coinjoinTx);
 
-			using CoinJoinMempoolManager coinJoinMempoolManager = new(coinjoinIdStore);
-			coinJoinMempoolManager.RegisterMempoolProvider(mempoolInstance);
+			using CoinJoinMempoolManager coinJoinMempoolManager = new(coinjoinIdStore, mempoolInstance);
 			await mempoolInstance.TriggerAndWaitRoundAsync(CancellationToken.None);
 
 			Assert.Equal(coinjoinTx, coinJoinMempoolManager.CoinJoinIds.Single());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -28,6 +28,7 @@ using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.Wallets;
 using Xunit;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using WalletWasabi.BitcoinCore.Mempool;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
 
@@ -63,7 +64,7 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore(), new Mock<IMempoolMirror>().Object);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		var apiClient = new ArenaClient(null!, null!, config.CoordinatorIdentifier, wabiSabiApi);
@@ -106,7 +107,7 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore(), new Mock<IMempoolMirror>().Object);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		InsecureRandom rnd = InsecureRandom.Instance;
@@ -193,7 +194,7 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore(), new Mock<IMempoolMirror>().Object);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		var roundState = RoundState.FromRound(round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -27,6 +27,7 @@ using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.Wallets;
 using Xunit;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
 
@@ -62,7 +63,8 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager);
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		var apiClient = new ArenaClient(null!, null!, config.CoordinatorIdentifier, wabiSabiApi);
 
@@ -104,7 +106,8 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager);
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		InsecureRandom rnd = InsecureRandom.Instance;
 		var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, rnd, 4300000000000L);
@@ -190,7 +193,8 @@ public class ArenaClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager);
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		var roundState = RoundState.FromRound(round);
 		var aliceArenaClient = new ArenaClient(

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Affiliation;
 using WalletWasabi.Backend.Controllers;
+using WalletWasabi.BitcoinCore.Mempool;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Cache;
 using WalletWasabi.Crypto.Randomness;
@@ -52,7 +53,7 @@ public class BobClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore(), new Mock<IMempoolMirror>().Object);
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		InsecureRandom insecureRandom = InsecureRandom.Instance;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -16,6 +16,7 @@ using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using WalletWasabi.WabiSabi.Backend.Statistics;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -51,7 +52,8 @@ public class BobClientTests
 		using CoinJoinFeeRateStatStore coinJoinFeeRateStatStore = new(config, arena.Rpc);
 		Mock<IHttpClientFactory> mockIHttpClientFactory = new(MockBehavior.Strict);
 		using AffiliationManager affiliationManager = new(arena, config, mockIHttpClientFactory.Object);
-		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager);
+		using CoinJoinMempoolManager coinJoinMempoolManager = new(new CoinJoinIdStore());
+		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		InsecureRandom insecureRandom = InsecureRandom.Instance;
 		var roundState = RoundState.FromRound(round);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -67,6 +67,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddSingleton<CoinJoinFeeRateStatStore>();
 			services.AddHttpClient();
 			services.AddSingleton<AffiliationManager>();
+			services.AddSingleton<CoinJoinMempoolManager>();
 		});
 		builder.ConfigureLogging(o => o.SetMinimumLevel(LogLevel.Warning));
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -24,6 +24,7 @@ using WalletWasabi.WabiSabi.Backend.Statistics;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+using WalletWasabi.BitcoinCore.Mempool;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;
 
@@ -68,6 +69,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddHttpClient();
 			services.AddSingleton<AffiliationManager>();
 			services.AddSingleton<CoinJoinMempoolManager>();
+			services.AddSingleton(s => new Mock<IMempoolMirror>().Object);
 		});
 		builder.ConfigureLogging(o => o.SetMinimumLevel(LogLevel.Warning));
 	}

--- a/WalletWasabi/BitcoinCore/Mempool/IMempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/IMempoolMirror.cs
@@ -1,0 +1,9 @@
+using NBitcoin;
+using System.Collections.Generic;
+
+namespace WalletWasabi.BitcoinCore.Mempool;
+public interface IMempoolMirror
+{
+	public event EventHandler<TimeSpan>? Tick;
+	internal ISet<uint256> GetMempoolHashes();
+}

--- a/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/MempoolMirror.cs
@@ -11,7 +11,7 @@ using WalletWasabi.Logging;
 
 namespace WalletWasabi.BitcoinCore.Mempool;
 
-public class MempoolMirror : PeriodicRunner
+public class MempoolMirror : PeriodicRunner, IMempoolMirror
 {
 	/// <param name="period">How often to mirror the mempool.</param>
 	public MempoolMirror(TimeSpan period, IRPCClient rpc, P2pNode node) : base(period)
@@ -110,7 +110,7 @@ public class MempoolMirror : PeriodicRunner
 		}
 	}
 
-	internal ISet<uint256> GetMempoolHashes()
+	public ISet<uint256> GetMempoolHashes()
 	{
 		lock (MempoolLock)
 		{

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -49,11 +49,6 @@ public class CoinJoinProcessor : IDisposable
 
 				var txsNotKnownByAWallet = WalletManager.FilterUnknownCoinjoins(unconfirmedCoinJoinHashes);
 
-				if (!txsNotKnownByAWallet.Any())
-				{
-					return;
-				}
-
 				var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
 				var unconfirmedCoinJoins = await client.GetTransactionsAsync(Network, txsNotKnownByAWallet, CancellationToken.None).ConfigureAwait(false);
 

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -49,6 +49,11 @@ public class CoinJoinProcessor : IDisposable
 
 				var txsNotKnownByAWallet = WalletManager.FilterUnknownCoinjoins(unconfirmedCoinJoinHashes);
 
+				if (!txsNotKnownByAWallet.Any())
+				{
+					return;
+				}
+
 				var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
 				var unconfirmedCoinJoins = await client.GetTransactionsAsync(Network, txsNotKnownByAWallet, CancellationToken.None).ConfigureAwait(false);
 

--- a/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
+++ b/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
@@ -19,7 +19,7 @@ public class CoinJoinMempoolManager : IDisposable
 	}
 
 	private ICoinJoinIdStore CoinJoinIdStore { get; }
-	private MempoolMirror Mempool { get; set; }
+	private MempoolMirror? Mempool { get; set; }
 	public ImmutableArray<uint256> CoinJoinIds { get; private set; } = ImmutableArray.Create<uint256>();
 
 	public void RegisterMempoolProvider(MempoolMirror mempool)
@@ -30,7 +30,7 @@ public class CoinJoinMempoolManager : IDisposable
 
 	private void Mempool_Tick(object? sender, TimeSpan e)
 	{
-		var mempoolHashes = Mempool.GetMempoolHashes();
+		var mempoolHashes = Mempool?.GetMempoolHashes() ?? throw new InvalidOperationException("Mempool provider missing.");
 		var coinJoinsInMempool = mempoolHashes.Where(CoinJoinIdStore.Contains);
 		CoinJoinIds = coinJoinsInMempool.ToImmutableArray();
 	}
@@ -41,7 +41,10 @@ public class CoinJoinMempoolManager : IDisposable
 		{
 			if (disposing)
 			{
-				Mempool.Tick -= Mempool_Tick;
+				if (Mempool is { })
+				{
+					Mempool.Tick -= Mempool_Tick;
+				}
 			}
 
 			_disposedValue = true;

--- a/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
+++ b/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
@@ -26,7 +26,7 @@ public class CoinJoinMempoolManager : IDisposable
 
 	private void Mempool_Tick(object? sender, TimeSpan e)
 	{
-		var mempoolHashes = MempoolMirror?.GetMempoolHashes() ?? throw new InvalidOperationException("Mempool provider missing.");
+		var mempoolHashes = MempoolMirror.GetMempoolHashes();
 		var coinJoinsInMempool = mempoolHashes.Where(CoinJoinIdStore.Contains);
 		CoinJoinIds = coinJoinsInMempool.ToImmutableArray();
 	}

--- a/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
+++ b/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
@@ -13,16 +13,20 @@ public class CoinJoinMempoolManager : IDisposable
 {
 	private bool _disposedValue;
 
-	public CoinJoinMempoolManager(ICoinJoinIdStore coinJoinIdStore, MempoolMirror mempool)
+	public CoinJoinMempoolManager(ICoinJoinIdStore coinJoinIdStore)
 	{
 		CoinJoinIdStore = coinJoinIdStore;
-		Mempool = mempool;
-		Mempool.Tick += Mempool_Tick;
 	}
 
 	private ICoinJoinIdStore CoinJoinIdStore { get; }
-	public MempoolMirror Mempool { get; }
+	private MempoolMirror Mempool { get; set; }
 	public ImmutableArray<uint256> CoinJoinIds { get; private set; } = ImmutableArray.Create<uint256>();
+
+	public void RegisterMempoolProvider(MempoolMirror mempool)
+	{
+		Mempool = mempool;
+		Mempool.Tick += Mempool_Tick;
+	}
 
 	private void Mempool_Tick(object? sender, TimeSpan e)
 	{

--- a/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
+++ b/WalletWasabi/WabiSabi/Backend/CoinJoinMempoolManager.cs
@@ -1,0 +1,30 @@
+using NBitcoin;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Bases;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
+using System.Collections.Immutable;
+
+namespace WalletWasabi.WabiSabi.Backend;
+
+public class CoinJoinMempoolManager : PeriodicRunner
+{
+	public CoinJoinMempoolManager(ICoinJoinIdStore coinJoinIdStore, IRPCClient rpc) : base(TimeSpan.FromMinutes(1))
+	{
+		CoinJoinIdStore = coinJoinIdStore;
+		RpcClient = rpc;
+	}
+
+	private ICoinJoinIdStore CoinJoinIdStore { get; }
+	private IRPCClient RpcClient { get; }
+	public ImmutableArray<uint256> CoinJoinIds { get; private set; } = ImmutableArray.Create<uint256>();
+
+	protected override async Task ActionAsync(CancellationToken cancel)
+	{
+		uint256[] mempoolHashes = await RpcClient.GetRawMempoolAsync(cancel).ConfigureAwait(false);
+		var coinJoinsInMempool = mempoolHashes.Where(CoinJoinIdStore.Contains);
+		CoinJoinIds = coinJoinsInMempool.ToImmutableArray();
+	}
+}


### PR DESCRIPTION
Alternative to https://github.com/zkSNACKs/WalletWasabi/pull/10924

This solution uses the same feature what we had and still have for WW1. From time to time (30 secs) there is a sync request that contains all the unconfirmed CJ hashes. The list was not containing WW2 coinjoins, with this PR I added them. 

No change on the client side.

The concept is to make the clients know about the coinjoins in the coordinator's mempool. 

There is a difference to https://github.com/zkSNACKs/WalletWasabi/pull/10924 - this PR does not force the transactionprocessor to make the CJ replace double spend tx. In that case, the CJ will be rejected. 

Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/10629