### PR TITLE
Store banned coins in file

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -32,6 +32,7 @@ using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.BlockstreamInfo;
 using WalletWasabi.WebClients.Wasabi;
 using WalletWasabi.Blockchain.BlockFilters;
+using WalletWasabi.WabiSabi.Client.Banning;
 
 namespace WalletWasabi.Daemon;
 
@@ -220,7 +221,7 @@ public class Global
 					new P2PBlockProvider(Network, HostedServices.Get<P2pNetwork>().Nodes, HttpClientFactory.IsTorEnabled),
 					Cache);
 
-				WalletManager.RegisterServices(HostedServices.Get<HybridFeeProvider>(), blockProvider);
+				WalletManager.RegisterServices(HostedServices.Get<HybridFeeProvider>(), blockProvider, CoinPrison.CreateOrLoadFromFile(Config.DataDir));
 			}
 			finally
 			{

--- a/WalletWasabi.Tests/RegressionTests/BuildTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTests.cs
@@ -250,7 +250,7 @@ public class BuildTests : IClassFixture<RegTestFixture>
 			cache);
 
 		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, serviceConfiguration);
-		walletManager.RegisterServices(feeProvider, blockProvider);
+		walletManager.RegisterServices(feeProvider, blockProvider, new(""));
 
 		var baseTip = await rpc.GetBestBlockHashAsync();
 
@@ -354,7 +354,7 @@ public class BuildTests : IClassFixture<RegTestFixture>
 			// Spend the inputs of the tx so we know
 			var success = bitcoinStore.TransactionStore.TryGetTransaction(fundingTxId, out var invalidSmartTransaction);
 			Assert.True(success);
-			var invalidCoin = Assert.Single(((CoinsRegistry)wallet.Coins).AsAllCoinsView().CreatedBy(invalidSmartTransaction!.GetHash()));
+			var invalidCoin = Assert.Single(wallet.Coins.AsAllCoinsView().CreatedBy(invalidSmartTransaction!.GetHash()));
 			Assert.NotNull(invalidCoin.SpenderTransaction);
 			Assert.True(invalidCoin.Confirmed);
 

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -80,7 +80,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 			cache);
 
 		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, serviceConfiguration);
-		walletManager.RegisterServices(feeProvider, blockProvider);
+		walletManager.RegisterServices(feeProvider, blockProvider, new(""));
 
 		// Get some money, make it confirm.
 		var key = keyManager.GetNextReceiveKey("foo label");
@@ -587,7 +587,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 			cache);
 
 		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, serviceConfiguration);
-		walletManager.RegisterServices(feeProvider, blockProvider);
+		walletManager.RegisterServices(feeProvider, blockProvider, new(""));
 
 		// Get some money, make it confirm.
 		var key = keyManager.GetNextReceiveKey("foo label");

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -14,6 +14,7 @@ using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Client.Banning;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Transactions;
@@ -1429,6 +1430,7 @@ public class TransactionProcessorTests
 		return new TransactionProcessor(
 			transactionStore,
 			keyManager,
-			Money.Coins(0.0001m));
+			Money.Coins(0.0001m),
+			new CoinsRegistry(new CoinPrison("")));
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -6,6 +6,7 @@ using NBitcoin;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Models;
 using WalletWasabi.WabiSabi.Client.Banning;
+using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 
 namespace WalletWasabi.Blockchain.TransactionOutputs;
 
@@ -289,11 +290,11 @@ public class CoinsRegistry : ICoinsView
 		return CoinPrison.TryGetOrRemoveBannedCoin(coin, when, out bannedUntil);
 	}
 
-	public void BanCoins(List<(SmartCoin Coin, DateTimeOffset BannedUntilUtc)> bannedCoins)
+	public void BanCoins(List<CoinBanned> bannedCoins)
 	{
 		foreach (var banInfo in bannedCoins)
 		{
-			CoinPrison.Add(banInfo.Coin, banInfo.BannedUntilUtc);
+			CoinPrison.Add(banInfo.Coin, banInfo.BanUntilUtc);
 		}
 	}
 }

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -18,12 +18,13 @@ public class TransactionProcessor
 	public TransactionProcessor(
 		AllTransactionStore transactionStore,
 		KeyManager keyManager,
-		Money dustThreshold)
+		Money dustThreshold,
+		CoinsRegistry coinRegistry)
 	{
 		TransactionStore = Guard.NotNull(nameof(transactionStore), transactionStore);
 		KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
 		DustThreshold = Guard.NotNull(nameof(dustThreshold), dustThreshold);
-		Coins = new();
+		Coins = coinRegistry;
 		BlockchainAnalyzer = new();
 	}
 

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -18,6 +18,7 @@ public class CoinPrison
 
 	public List<PrisonedCoinRecord> BannedCoins { get; set; } = new();
 	public string FilePath { get; set; }
+	private object Lock { get; set; } = new();
 
 	public bool TryGetOrRemoveBannedCoin(SmartCoin coin, DateTimeOffset when, [NotNullWhen(true)] out DateTimeOffset? bannedUntil)
 	{
@@ -62,6 +63,8 @@ public class CoinPrison
 
 	private void ToFile()
 	{
+		lock (Lock)
+		{
 		if (string.IsNullOrWhiteSpace(FilePath))
 		{
 			return;
@@ -70,6 +73,7 @@ public class CoinPrison
 		IoHelpers.EnsureFileExists(FilePath);
 		string json = JsonConvert.SerializeObject(BannedCoins, Formatting.Indented);
 		File.WriteAllText(FilePath, json);
+	}
 	}
 
 	public static CoinPrison CreateOrLoadFromFile(string containingDirectory)

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -1,0 +1,99 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.WabiSabi.Client.Banning;
+
+public class CoinPrison
+{
+	public CoinPrison(string filePath)
+	{
+		FilePath = filePath;
+	}
+
+	public List<PrisonedCoinRecord> BannedCoins { get; set; } = new();
+	public string FilePath { get; set; }
+
+	public bool TryGetOrRemoveBannedCoin(SmartCoin coin, DateTimeOffset when, [NotNullWhen(true)] out DateTimeOffset? bannedUntil)
+	{
+		bannedUntil = null;
+		if (BannedCoins.SingleOrDefault(record => record.Outpoint == coin.Outpoint) is { } record)
+		{
+			if (when < record.BannedUntil)
+			{
+				bannedUntil = record.BannedUntil;
+				return true;
+			}
+			RemoveBannedCoin(coin);
+		}
+		return false;
+	}
+
+	public void Add(SmartCoin coin, DateTimeOffset until)
+	{
+		if (BannedCoins.SingleOrDefault(record => record.Outpoint == coin.Outpoint) is { } record)
+		{
+			if (record.BannedUntil >= until)
+			{
+				return;
+			}
+		}
+		BannedCoins.Add(new(coin.Outpoint, until));
+		ToFile();
+	}
+
+	public void RemoveBannedCoin(SmartCoin coin)
+	{
+		var recordToRemove = BannedCoins.SingleOrDefault(record => coin.Outpoint == record.Outpoint);
+		if (recordToRemove == null)
+		{
+			Logger.LogError($"Tried to remove {nameof(coin)} from {nameof(BannedCoins)}, but {nameof(coin)} was null.");
+			return;
+		}
+		BannedCoins.Remove(recordToRemove);
+		coin.BannedUntilUtc = null;
+		ToFile();
+	}
+
+	private void ToFile()
+	{
+		if (string.IsNullOrWhiteSpace(FilePath))
+		{
+			return;
+		}
+
+		IoHelpers.EnsureFileExists(FilePath);
+		string json = JsonConvert.SerializeObject(BannedCoins, Formatting.Indented);
+		File.WriteAllText(FilePath, json);
+	}
+
+	public static CoinPrison CreateOrLoadFromFile(string containingDirectory)
+	{
+		string prisonFilePath = Path.Combine(containingDirectory, "PrisonedCoins.json");
+		List<PrisonedCoinRecord> prisonedCoinsRecord = new();
+		try
+		{
+			IoHelpers.EnsureFileExists(prisonFilePath);
+
+			string data = File.ReadAllText(prisonFilePath);
+			if (string.IsNullOrWhiteSpace(data))
+			{
+				Logger.LogDebug("Prisoned coins file is empty.");
+				return new(prisonFilePath);
+			}
+			prisonedCoinsRecord = JsonConvert.DeserializeObject<List<PrisonedCoinRecord>>(data)
+				?? throw new InvalidDataException("Prisoned coins file is corrupted.");
+		}
+		catch (Exception exc)
+		{
+			Logger.LogError($"There was an error during loading {nameof(CoinPrison)}. Reseting file.", exc);
+			File.Delete(prisonFilePath);
+		}
+		return new(prisonFilePath) { BannedCoins = prisonedCoinsRecord };
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/Banning/PrisonedCoinRecord.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/PrisonedCoinRecord.cs
@@ -1,0 +1,21 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.Affiliation.Models.CoinJoinNotification;
+using WalletWasabi.JsonConverters;
+
+namespace WalletWasabi.WabiSabi.Client.Banning;
+
+public record PrisonedCoinRecord
+{
+	public PrisonedCoinRecord(OutPoint outpoint, DateTimeOffset bannedUntil)
+	{
+		Outpoint = outpoint;
+		BannedUntil = bannedUntil;
+	}
+
+	[JsonProperty]
+	[JsonConverter(typeof(OutPointJsonConverter))]
+	public OutPoint Outpoint { get; set; }
+
+	public DateTimeOffset BannedUntil { get; set; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -457,7 +457,9 @@ public class CoinJoinClient
 						{
 							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
 						}
-						coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						var bannedUntil = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						coin.BannedUntilUtc = bannedUntil;
+						CoinJoinClientProgress.SafeInvoke(this, new CoinBanned(coin, bannedUntil));
 						roundState.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
 						break;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -455,6 +455,7 @@ public class CoinJoinManager : BackgroundService
 			wallet.LogError($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
 		}
 
+		// If any coins were marked for banning, store them to file
 		if (finishedCoinJoin.PrisonedCoins.Any())
 		{
 			Wallet currentWallet = (Wallet)wallet;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -455,6 +455,13 @@ public class CoinJoinManager : BackgroundService
 			wallet.LogError($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
 		}
 
+		if (finishedCoinJoin.PrisonedCoins.Any())
+		{
+			Wallet currentWallet = (Wallet)wallet;
+			var coinsRegistry = currentWallet.Coins;
+			coinsRegistry.BanCoins(finishedCoinJoin.PrisonedCoins);
+		}
+
 		NotifyCoinJoinCompletion(finishedCoinJoin);
 
 		// When to stop mixing:

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinBanned.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinBanned.cs
@@ -1,0 +1,15 @@
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
+
+public class CoinBanned : CoinJoinProgressEventArgs
+{
+	public CoinBanned(SmartCoin coin, DateTimeOffset banUntilUtc)
+	{
+		Coin = coin;
+		BanUntilUtc = banUntilUtc;
+	}
+
+	public SmartCoin Coin { get; }
+	public DateTimeOffset BanUntilUtc { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -42,7 +42,7 @@ public class CoinJoinTracker : IDisposable
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
 	public bool InCriticalCoinJoinState { get; private set; }
 	public bool IsStopped { get; set; }
-	public List<(SmartCoin Coin, DateTimeOffset BannedUntilUtc)> PrisonedCoins { get; private set; } = new();
+	public List<CoinBanned> PrisonedCoins { get; private set; } = new();
 
 	public void Stop()
 	{
@@ -70,7 +70,7 @@ public class CoinJoinTracker : IDisposable
 				break;
 
 			case CoinBanned coinBanned:
-				PrisonedCoins.Add((coinBanned.Coin, coinBanned.BanUntilUtc));
+				PrisonedCoins.Add(coinBanned);
 				break;
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -42,6 +42,7 @@ public class CoinJoinTracker : IDisposable
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
 	public bool InCriticalCoinJoinState { get; private set; }
 	public bool IsStopped { get; set; }
+	public List<(SmartCoin Coin, DateTimeOffset BannedUntilUtc)> PrisonedCoins { get; private set; } = new();
 
 	public void Stop()
 	{
@@ -66,6 +67,10 @@ public class CoinJoinTracker : IDisposable
 
 			case RoundEnded roundEnded:
 				roundEnded.IsStopped = IsStopped;
+				break;
+
+			case CoinBanned coinBanned:
+				PrisonedCoins.Add((coinBanned.Coin, coinBanned.BanUntilUtc));
 				break;
 		}
 


### PR DESCRIPTION
This PR is similar to #10825, but simplified, it has ONLY the code related to storing and loading banned coins.

No refactoring, not touching `SmartCoin.cs` or else in any way.

Easily reviewable commit by commit.