### PR TITLE
Store banned coins in file

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -80,19 +80,6 @@ public class Global
 		WalletManager.WalletStateChanged += WalletManager_WalletStateChanged;
 	}
 
-	private void WalletManager_WalletStateChanged(object? sender, WalletState e)
-	{
-		// Load banned coins in wallet.
-		// This event function can be deleted later when SmartCoin.IsBanned is removed.
-		if (e is not WalletState.Started)
-		{
-			return;
-		}
-
-		var wallet = sender as Wallet ?? throw new InvalidOperationException($"The sender for {nameof(WalletManager.WalletStateChanged)} was not a Wallet.");
-		CoinPrison.UpdateWallet(wallet);
-	}
-
 	public const string ThemeBackgroundBrushResourceKey = "ThemeBackgroundBrush";
 	public const string ApplicationAccentForegroundBrushResourceKey = "ApplicationAccentForegroundBrush";
 
@@ -339,6 +326,19 @@ public class Global
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
 		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier, CoinPrison), "CoinJoin Manager");
+	}
+
+	private void WalletManager_WalletStateChanged(object? sender, WalletState e)
+	{
+		// Load banned coins in wallet.
+		// This event function can be deleted later when SmartCoin.IsBanned is removed.
+		if (e is not WalletState.Started)
+		{
+			return;
+		}
+
+		var wallet = sender as Wallet ?? throw new InvalidOperationException($"The sender for {nameof(WalletManager.WalletStateChanged)} was not a Wallet.");
+		CoinPrison.UpdateWallet(wallet);
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -82,6 +82,8 @@ public class Global
 
 	private void WalletManager_WalletStateChanged(object? sender, WalletState e)
 	{
+		// Load banned coins in wallet.
+		// This event function can be deleted later when SmartCoin.IsBanned is removed.
 		var wallet = sender as Wallet ?? throw new InvalidOperationException("");
 		if (e is WalletState.Started)
 		{

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -84,11 +84,13 @@ public class Global
 	{
 		// Load banned coins in wallet.
 		// This event function can be deleted later when SmartCoin.IsBanned is removed.
-		var wallet = sender as Wallet ?? throw new InvalidOperationException("");
-		if (e is WalletState.Started)
+		if (e is not WalletState.Started)
 		{
-			CoinPrison.UpdateWallet(wallet);
+			return;
 		}
+
+		var wallet = sender as Wallet ?? throw new InvalidOperationException($"The sender for {nameof(WalletManager.WalletStateChanged)} was not a Wallet.");
+		CoinPrison.UpdateWallet(wallet);
 	}
 
 	public const string ThemeBackgroundBrushResourceKey = "ThemeBackgroundBrush";
@@ -336,7 +338,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier, CoinPrison.CreateOrLoadFromFile(DataDir)), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier, CoinPrison), "CoinJoin Manager");
 	}
 
 	public async Task DisposeAsync()

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -1,0 +1,116 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client.Banning;
+
+public class CoinPrison
+{
+	public CoinPrison(string filePath)
+	{
+		FilePath = filePath;
+	}
+
+	public List<PrisonedCoinRecord> BannedCoins { get; set; } = new();
+	public string FilePath { get; set; }
+	private object Lock { get; set; } = new();
+
+	public bool TryGetOrRemoveBannedCoin(SmartCoin coin, DateTimeOffset banDeadlineTime, [NotNullWhen(true)] out DateTimeOffset? bannedUntil)
+	{
+		bannedUntil = null;
+		if (BannedCoins.SingleOrDefault(record => record.Outpoint == coin.Outpoint) is { } record)
+		{
+			if (banDeadlineTime < record.BannedUntil)
+			{
+				bannedUntil = record.BannedUntil;
+				return true;
+			}
+			RemoveBannedCoin(coin);
+		}
+		return false;
+	}
+
+	public void Ban(SmartCoin coin, DateTimeOffset until)
+	{
+		if (BannedCoins.SingleOrDefault(record => record.Outpoint == coin.Outpoint) is { } record)
+		{
+			if (record.BannedUntil >= until)
+			{
+				return;
+			}
+		}
+		BannedCoins.Add(new(coin.Outpoint, until));
+		coin.BannedUntilUtc = until;
+		ToFile();
+	}
+
+	private void RemoveBannedCoin(SmartCoin coin)
+	{
+		var recordToRemove = BannedCoins.SingleOrDefault(record => coin.Outpoint == record.Outpoint);
+		if (recordToRemove == null)
+		{
+			Logger.LogError($"Tried to remove {nameof(coin)} from {nameof(BannedCoins)}, but {nameof(coin)} was null.");
+			return;
+		}
+		BannedCoins.Remove(recordToRemove);
+		coin.BannedUntilUtc = null;
+		ToFile();
+	}
+
+	private void ToFile()
+	{
+		lock (Lock)
+		{
+			if (string.IsNullOrWhiteSpace(FilePath))
+			{
+				return;
+			}
+
+			IoHelpers.EnsureFileExists(FilePath);
+			string json = JsonConvert.SerializeObject(BannedCoins, Formatting.Indented);
+			File.WriteAllText(FilePath, json);
+		}
+	}
+
+	public static CoinPrison CreateOrLoadFromFile(string containingDirectory)
+	{
+		string prisonFilePath = Path.Combine(containingDirectory, "PrisonedCoins.json");
+		List<PrisonedCoinRecord> prisonedCoinsRecord = new();
+		try
+		{
+			IoHelpers.EnsureFileExists(prisonFilePath);
+
+			string data = File.ReadAllText(prisonFilePath);
+			if (string.IsNullOrWhiteSpace(data))
+			{
+				Logger.LogDebug("Prisoned coins file is empty.");
+				return new(prisonFilePath);
+			}
+			prisonedCoinsRecord = JsonConvert.DeserializeObject<List<PrisonedCoinRecord>>(data)
+				?? throw new InvalidDataException("Prisoned coins file is corrupted.");
+		}
+		catch (Exception exc)
+		{
+			Logger.LogError($"There was an error during loading {nameof(CoinPrison)}. Reseting file.", exc);
+			File.Delete(prisonFilePath);
+		}
+		return new(prisonFilePath) { BannedCoins = prisonedCoinsRecord };
+	}
+
+	public void UpdateWallet(Wallet wallet)
+	{
+		foreach (var coin in wallet.Coins)
+		{
+			if (TryGetOrRemoveBannedCoin(coin, DateTimeOffset.UtcNow, out var bannedUntil))
+			{
+				coin.BannedUntilUtc = bannedUntil;
+			}
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -81,7 +81,7 @@ public class CoinPrison
 	public static CoinPrison CreateOrLoadFromFile(string containingDirectory)
 	{
 		string prisonFilePath = Path.Combine(containingDirectory, "PrisonedCoins.json");
-		HashSet<PrisonedCoinRecord> prisonedCoinsRecord = new();
+		HashSet<PrisonedCoinRecord> prisonedCoinRecords = new();
 		try
 		{
 			IoHelpers.EnsureFileExists(prisonFilePath);
@@ -92,7 +92,7 @@ public class CoinPrison
 				Logger.LogDebug("Prisoned coins file is empty.");
 				return new(prisonFilePath);
 			}
-			prisonedCoinsRecord = JsonConvert.DeserializeObject<HashSet<PrisonedCoinRecord>>(data)
+			prisonedCoinRecords = JsonConvert.DeserializeObject<HashSet<PrisonedCoinRecord>>(data)
 				?? throw new InvalidDataException("Prisoned coins file is corrupted.");
 		}
 		catch (Exception exc)
@@ -100,7 +100,7 @@ public class CoinPrison
 			Logger.LogError($"There was an error during loading {nameof(CoinPrison)}. Deleting corrupt file.", exc);
 			File.Delete(prisonFilePath);
 		}
-		return new(prisonFilePath) { BannedCoins = prisonedCoinsRecord };
+		return new(prisonFilePath) { BannedCoins = prisonedCoinRecords };
 	}
 
 	public void UpdateWallet(Wallet wallet)

--- a/WalletWasabi/WabiSabi/Client/Banning/PrisonedCoinRecord.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/PrisonedCoinRecord.cs
@@ -1,0 +1,20 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.JsonConverters;
+
+namespace WalletWasabi.WabiSabi.Client.Banning;
+
+public record PrisonedCoinRecord
+{
+	public PrisonedCoinRecord(OutPoint outpoint, DateTimeOffset bannedUntil)
+	{
+		Outpoint = outpoint;
+		BannedUntil = bannedUntil;
+	}
+
+	[JsonProperty]
+	[JsonConverter(typeof(OutPointJsonConverter))]
+	public OutPoint Outpoint { get; set; }
+
+	public DateTimeOffset BannedUntil { get; set; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -457,7 +457,8 @@ public class CoinJoinClient
 						{
 							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
 						}
-						coin.BannedUntilUtc = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						var bannedUntil = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						CoinJoinClientProgress.SafeInvoke(this, new CoinBanned(coin, bannedUntil));
 						roundState.LogInfo($"{coin.Coin.Outpoint} is banned until {coin.BannedUntilUtc}.");
 						break;
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -588,7 +588,7 @@ public class CoinJoinManager : BackgroundService
 			.Confirmed()
 			.Where(coin => !coin.IsExcludedFromCoinJoin)
 			.Where(coin => !coin.IsImmature(bestHeight))
-			.Where(coin => !CoinPrison.TryGetOrRemoveBannedCoin(coin, DateTimeOffset.UtcNow, out _))
+			.Where(coin => !CoinPrison.TryGetOrRemoveBannedCoin(coin, out _))
 			.Where(coin => !CoinRefrigerator.IsFrozen(coin));
 
 	private static async Task WaitAndHandleResultOfTasksAsync(string logPrefix, params Task[] tasks)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -459,9 +459,9 @@ public class CoinJoinManager : BackgroundService
 		}
 
 		// If any coins were marked for banning, store them to file
-		if (finishedCoinJoin.PrisonedCoins.Any())
+		if (finishedCoinJoin.BannedCoins.Any())
 		{
-			foreach (var info in finishedCoinJoin.PrisonedCoins)
+			foreach (var info in finishedCoinJoin.BannedCoins)
 			{
 				CoinPrison.Ban(info.Coin, info.BanUntilUtc);
 			}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinBanned.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinProgressEvents/CoinBanned.cs
@@ -1,0 +1,15 @@
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
+
+public class CoinBanned : CoinJoinProgressEventArgs
+{
+	public CoinBanned(SmartCoin coin, DateTimeOffset banUntilUtc)
+	{
+		Coin = coin;
+		BanUntilUtc = banUntilUtc;
+	}
+
+	public SmartCoin Coin { get; }
+	public DateTimeOffset BanUntilUtc { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -42,6 +42,7 @@ public class CoinJoinTracker : IDisposable
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
 	public bool InCriticalCoinJoinState { get; private set; }
 	public bool IsStopped { get; set; }
+	public List<CoinBanned> PrisonedCoins { get; private set; } = new();
 
 	public void Stop()
 	{
@@ -66,6 +67,10 @@ public class CoinJoinTracker : IDisposable
 
 			case RoundEnded roundEnded:
 				roundEnded.IsStopped = IsStopped;
+				break;
+
+			case CoinBanned coinBanned:
+				PrisonedCoins.Add(coinBanned);
 				break;
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinTracker.cs
@@ -42,7 +42,7 @@ public class CoinJoinTracker : IDisposable
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
 	public bool InCriticalCoinJoinState { get; private set; }
 	public bool IsStopped { get; set; }
-	public List<CoinBanned> PrisonedCoins { get; private set; } = new();
+	public List<CoinBanned> BannedCoins { get; private set; } = new();
 
 	public void Stop()
 	{
@@ -70,7 +70,7 @@ public class CoinJoinTracker : IDisposable
 				break;
 
 			case CoinBanned coinBanned:
-				PrisonedCoins.Add(coinBanned);
+				BannedCoins.Add(coinBanned);
 				break;
 		}
 


### PR DESCRIPTION
Similar to #10957

This approach adds `CoinPrison` to `CoinJoinManager`, so we can get and call `CoinPrison` directly in `CoinJoinManager` for banning.

Also introduces an even subscription in `Global` to `WalletManager` which loads in banned state of coins. This function can later on be deleted when we get rid of `SmartCoin.IsBanned`.