### PR TITLE
[PoC] Always test filters against the MinGapLimit of clean keys, no more

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -401,11 +401,11 @@ public class KeyManager
 	/// It's unsafe because it doesn't assert that the GapLimit is respected.
 	/// GapLimit should be enforced whenever a transaction is discovered.
 	/// </summary>
-	public IEnumerable<HdPubKeyCache.SynchronizationInfos> UnsafeGetSynchronizationInfos()
+	public Dictionary<ScriptPubKeyType, Dictionary<bool, List<HdPubKeyCache.SynchronizationInfos>>> UnsafeGetSynchronizationInfosGrouped()
 	{
 		lock (CriticalStateLock)
 		{
-			return HdPubKeyCache.GetSynchronizationInfos();
+			return HdPubKeyCache.GetSynchronizationInfosGrouped();
 		}
 	}
 


### PR DESCRIPTION
This PR improves the load time in the cases of resync and importing the wallet json file.
It's an alternate of #10473.

It works by saving in the `HdPubKeyCache` the keys grouped by `ScriptPubKeyType` and `IsInternal`, then it takes the non clean keys + only `MinGapLimit` of the clean keys for each group (4: Taproot and IsInternal, Taproot and !IsInternal, Segwit and IsInternal, Segwit and !IsInternal).

The data structures are bad, but it's really hard to have this optimized, and dictionaries are good ways to optimize it, I didn't find better.

I doubt the PR will ever be merged; it's hard to swallow to add such complexity only for these weird cases. Other techniques must be better, such as "underiving" the keys but saving their labels in memory. Yet, I explored this solution so... The PoC is here.