### PR TITLE
Handle exception during PerformFinalSynchronizationAsync

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -249,8 +249,8 @@ public class Wallet : BackgroundService, IWallet
 					if (KeyManager.UseTurboSync)
 					{
 						// Continue wallet synchronization in the background for all keys skipped by TurboSync.
-						FinalSynchronizationTask = Task.Run(() => PerformFinalSynchronizationAsync(cancel), cancel);
-						_ = FinalSynchronizationTask.ContinueWith(HandleExceptionForFinalSynchronization, TaskContinuationOptions.OnlyOnFaulted);
+						FinalSynchronizationTask = Task.Run(() => PerformFinalSynchronizationAsync(cancel), cancel)
+						.ContinueWith(HandleExceptionForFinalSynchronization, TaskContinuationOptions.OnlyOnFaulted);
 					}
 				}
 			}


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/pull/10955#issuecomment-1620347927
Closes #10948

The idea is to log exceptions the correct way (by `throwing` then using `ContinueWith` with `OnlyOnFaulted`), and to only test incoming filters against the set of keys that correctly synchronized (`Turbo`) but not against the other set because sync for these keys couldn't finish for whatever reason (`NonTurbo`).