### PR TITLE
[VDG] Replace e.Text by formatted input in CurrencyEntryBox

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -148,6 +148,8 @@ public partial class CurrencyEntryBox : TextBox
 			e.Handled = FiatToBitcoin(fiatValue) >= Constants.MaximumNumberOfBitcoins;
 		}
 
+		e.Text = input;
+
 		base.OnTextInput(e);
 	}
 


### PR DESCRIPTION
> > > [VDG] CurrencyEntryBox - do not allow space by soosr in https://github.com/zkSNACKs/WalletWasabi/pull/10875
nACK, space is still accepted

> > How did you repro? I just tried on Mac and I can't either enter or paste a space.

> @turbolay paste 0 . 0 3 03 03 (Linux)

@soosr feel free to close or merge, fix or don't fix. I believe the fix is more or less useless because of https://github.com/zkSNACKs/WalletWasabi/issues/10877, but yet it feel like a mistake that the text is formatted then the formatted text is not used to write into the control.