### PR TITLE
[Trivial] Remove 'exclude_patterns' from deepsource

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,9 +1,4 @@
 version = 1
 
-exclude_patterns = [
-  "WalletWasabi.Fluent/ZXing/**"
-
-]
-
 [[analyzers]]
 name = "shell"


### PR DESCRIPTION
The folder `"WalletWasabi.Fluent/ZXing/` no longer exists.

Since the deepsource's C# Analyzer was disabled for #10998, is it still useful? I guess we should just remove it.