### PR TITLE
add issues to project board on reopening too

### DIFF
--- a/.github/workflows/auto-add-to-projcet.yml
+++ b/.github/workflows/auto-add-to-projcet.yml
@@ -4,6 +4,7 @@ on:
   issues:
     types:
       - opened
+      - reopened
 
 permissions: {}
 jobs:


### PR DESCRIPTION
When an issue gets reopened we need to deal with it again, so should be added to the RR board again.