### PR TITLE
Wait before signing

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/SigningTimeProviderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/SigningTimeProviderTests.cs
@@ -1,0 +1,15 @@
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.Rounds;
+
+public class SigningTimeProviderTests
+{
+	[Fact]
+	public void TrezorSigningTimeProviderTest()
+	{
+		var wabiSabiConfig = new WabiSabiConfig();
+		Assert.True(SigningTimeProvider.Trezor.GetSigningTime(300, 500) < wabiSabiConfig.MaximumSigningDelay);
+	}
+}

--- a/WalletWasabi/Helpers/TimeSpanHelpers.cs
+++ b/WalletWasabi/Helpers/TimeSpanHelpers.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.Helpers;
+
+class TimeSpanHelpers
+{
+	public static TimeSpan Min(TimeSpan first, TimeSpan second) => first < second ? first : second;
+}

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -37,6 +37,7 @@ public enum WabiSabiProtocolErrorCode
 	AliceAlreadyConfirmedConnection,
 	AlreadyRegisteredScript,
 	SignatureTooLong,
+	SignatureTooSoon
 }
 
 public static class WabiSabiProtocolErrorCodeExtension

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -318,6 +318,14 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		{
 			var round = GetRound(request.RoundId, Phase.TransactionSigning);
 
+			if (round.Parameters.ForceSigningDelay)
+			{
+				if (!round.TransactionSigningDelayTimeFrame.HasExpired)
+				{
+					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.SignatureTooSoon, $"Round ({round.Id}): Received signature before transaction signing delay has expired.");
+				}
+			}
+
 			var state = round.Assert<SigningState>().AddWitness((int)request.InputIndex, request.Witness);
 
 			// at this point all of the witnesses have been verified and the state can be updated

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -66,6 +66,7 @@ public class Round
 	public TimeFrame ConnectionConfirmationTimeFrame { get; private set; }
 	public TimeFrame OutputRegistrationTimeFrame { get; set; }
 	public TimeFrame TransactionSigningTimeFrame { get; set; }
+	public TimeFrame TransactionSigningDelayTimeFrame { get; private set; }
 	public DateTimeOffset End { get; private set; }
 	public EndRoundState EndRoundState { get; set; }
 	public int RemainingInputVsizeAllocation => Parameters.InitialInputVsizeAllocation - (InputCount * Parameters.MaxVsizeAllocationPerAlice);
@@ -103,6 +104,7 @@ public class Round
 		else if (phase == Phase.TransactionSigning)
 		{
 			TransactionSigningTimeFrame = TransactionSigningTimeFrame.StartNow();
+			TransactionSigningDelayTimeFrame = TimeFrame.Create(Assert<SigningState>().SigningDelay).StartNow();
 		}
 		else if (phase == Phase.Ended)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -31,6 +31,8 @@ public record RoundParameters
 		TimeSpan outputRegistrationTimeout,
 		TimeSpan transactionSigningTimeout,
 		TimeSpan blameInputRegistrationTimeout,
+		TimeSpan maximumSigningDelay,
+		bool forceSigningDelay,
 		string coordinationIdentifier)
 	{
 		Network = network;
@@ -48,6 +50,8 @@ public record RoundParameters
 		OutputRegistrationTimeout = outputRegistrationTimeout;
 		TransactionSigningTimeout = transactionSigningTimeout;
 		BlameInputRegistrationTimeout = blameInputRegistrationTimeout;
+		MaximumSigningDelay = maximumSigningDelay;
+		ForceSigningDelay = forceSigningDelay;
 
 		InitialInputVsizeAllocation = MaxTransactionSize - MultipartyTransactionParameters.SharedOverhead;
 		MaxVsizeCredentialValue = Math.Min(InitialInputVsizeAllocation / MaxInputCountByRound, (int)ProtocolConstants.MaxVsizeCredentialValue);
@@ -70,6 +74,9 @@ public record RoundParameters
 	public TimeSpan OutputRegistrationTimeout { get; init; }
 	public TimeSpan TransactionSigningTimeout { get; init; }
 	public TimeSpan BlameInputRegistrationTimeout { get; init; }
+	public TimeSpan MaximumSigningDelay { get; init; }
+
+	public bool ForceSigningDelay { get; init; }
 
 	public Money MinAmountCredentialValue => AllowedInputAmounts.Min;
 	public Money MaxAmountCredentialValue => AllowedInputAmounts.Max;
@@ -116,6 +123,8 @@ public record RoundParameters
 			wabiSabiConfig.OutputRegistrationTimeout,
 			wabiSabiConfig.TransactionSigningTimeout,
 			wabiSabiConfig.BlameInputRegistrationTimeout,
+			wabiSabiConfig.MaximumSigningDelay,
+			wabiSabiConfig.ForceSigningDelay,
 			wabiSabiConfig.CoordinatorIdentifier);
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/SigningTimeProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/SigningTimeProvider.cs
@@ -1,0 +1,21 @@
+using WalletWasabi.WabiSabi.Client;
+
+namespace WalletWasabi.WabiSabi.Backend.Rounds;
+
+public record SigningTimeProvider(
+	uint MaxInternalInputCount,
+	uint MaxInternalOutputCount,
+	TimeSpan SigningOverhead,
+	TimeSpan InternalInputSigningTime,
+	TimeSpan ExternalInputSigningTime,
+	TimeSpan InternalOutputSigningTime,
+	TimeSpan ExternalOutputSigningTime)
+{
+	// The values were obtained based on benchmarking the transaction signing on Trezor
+	public static SigningTimeProvider Trezor = new(CoinJoinCoinSelector.MaxInputsRegistrableByWallet, 10, TimeSpan.FromSeconds(1.98 + 5), TimeSpan.FromSeconds(0.44), TimeSpan.FromSeconds(0.09), TimeSpan.FromSeconds(0.15), TimeSpan.FromSeconds(0.04));
+
+	public TimeSpan GetSigningTime(int inputCount, int outputCount)
+	{
+		return SigningOverhead + MaxInternalInputCount * InternalInputSigningTime + (inputCount - MaxInternalInputCount) * ExternalInputSigningTime + MaxInternalOutputCount * InternalOutputSigningTime + (outputCount - MaxInternalOutputCount) * ExternalOutputSigningTime;
+	}
+}

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -75,6 +75,14 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "TransactionSigningTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan TransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
+	[DefaultValueTimeSpan("0d 0h 1m 0s")]
+	[JsonProperty(PropertyName = "MaximumSigningDelay", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public TimeSpan MaximumSigningDelay { get; set; } = TimeSpan.FromMinutes(1);
+
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "ForceSigningDelay", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool ForceSigningDelay { get; set; } = false;
+
 	[DefaultValueTimeSpan("0d 0h 3m 0s")]
 	[JsonProperty(PropertyName = "FailFastOutputRegistrationTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan FailFastOutputRegistrationTimeout { get; set; } = TimeSpan.FromMinutes(3);

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
@@ -16,11 +16,14 @@ public record SigningState : MultipartyTransactionState
 		: base(parameters)
 	{
 		Events = events.ToImmutableList();
+		SigningDelay = TimeSpanHelpers.Min(parameters.MaximumSigningDelay, SigningTimeProvider.Trezor.GetSigningTime(Inputs.Count(), Outputs.Count()));
 	}
 
 	public ImmutableDictionary<int, WitScript> Witnesses { get; init; } = ImmutableDictionary<int, WitScript>.Empty;
 
 	public bool IsFullySigned => Witnesses.Count == SortedInputs.Count;
+
+	public TimeSpan SigningDelay { get; init; }
 
 	[JsonIgnore]
 	public IEnumerable<Coin> UnsignedInputs => SortedInputs.Where((_, i) => !IsInputSigned(i));


### PR DESCRIPTION
This pull request aims to align the position of all users in the signing phase:
  * I introduced a new configuration option called `MaximumSigningDelay`. This is the maximum time you are willing to wait for Trezor users to sign a transaction. In case of a problem, you can set it to zero.
  * I implemented `SigningTimeProvider`. This is a class that calculates how long it will take to sign a transaction on Trezor based on the number of inputs and outputs of the transaction.
  * At the beginning of the signing phase, coordinator publishes the minimum of the previous two values in the status.
  * Wallets read the value from the status and wait for this amount of time before they start sending signatures.
  * There is also a configuration option called `ForceSigningDelay` that causes the coordinator to refuse signatures that are sent too soon. Since this feature breaks backward compatibility, it is turned off by default.
