### PR TITLE
[VDG] Select correct wallet when clicking notification

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/WalletManagerViewModel.cs
@@ -43,6 +43,7 @@ public partial class WalletManagerViewModel : ViewModelBase
 								return;
 							}
 
+							MainViewModel.Instance.NavBar.SelectedWallet = MainViewModel.Instance.NavBar.Wallets.FirstOrDefault(x => x.Wallet == wallet);
 							wvm.NavigateAndHighlight(e.Transaction.GetHash());
 						}
 


### PR DESCRIPTION
This PR:
Selects the correct wallet when a notification is clicked.

Without this PR: 
The NavBar doesn't update its selection to reflect the correct wallet when a notification of a transaction is clicked.