### PR TITLE
Fix line separators in Log

### DIFF
--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -78,7 +78,7 @@ public class WasabiApplication
 		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 		TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
-		Logger.LogSoftwareStarted($"{AppConfig.AppName} was started.");
+		Logger.LogSoftwareStarted($"{AppConfig.AppName}");
 
 		Global = CreateGlobal();
 	}

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -105,6 +105,7 @@ public class Program
 				// Until https://github.com/MetacoSA/NBitcoin/pull/1089 is resolved.
 				Logger.LogTrace(e);
 				break;
+
 			default:
 				Logger.LogDebug(e);
 				break;
@@ -166,7 +167,7 @@ public static class WasabiAppExtensions
 					RxApp.MainThreadScheduler.Schedule(() => throw new ApplicationException("Exception has been thrown in unobserved ThrownExceptions", ex));
 				});
 
-				Logger.LogSoftwareStarted("Wasabi GUI");
+				Logger.LogInfo("Wasabi GUI started.");
 				bool runGuiInBackground = app.AppConfig.Arguments.Any(arg => arg.Contains(StartupHelper.SilentArgument));
 				UiConfig uiConfig = LoadOrCreateUiConfig(Config.DataDir);
 				Services.Initialize(app.Global!, uiConfig, app.SingleInstanceChecker);

--- a/WalletWasabi/Services/Terminate/TerminateService.cs
+++ b/WalletWasabi/Services/Terminate/TerminateService.cs
@@ -41,7 +41,7 @@ public class TerminateService
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Debugger.IsAttached)
 		{
 			// If the debugger is attached and you subscribe to SystemEvents, then on quit Wasabi gracefully stops but never returns from console.
-			Logger.LogInfo($"{nameof(TerminateService)} subscribed to SystemEvents");
+			Logger.LogDebug($"{nameof(TerminateService)} subscribed to SystemEvents");
 			SystemEvents.SessionEnding += Windows_SystemEvents_SessionEnding;
 			IsSystemEventsSubscribed = true;
 		}


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/10970

With PR:

```
2023-07-11 12:28:27.226 [1] INFO	TerminateService.Terminate (158)	Wasabi stopped gracefully (ca4ca498-566d-471e-acae-85096a067f32).
2023-07-11 12:28:27.250 [1] INFO	WasabiAppBuilder.BeforeStopping (94)	Wasabi GUI stopped gracefully (ca4ca498-566d-471e-acae-85096a067f32).



2023-07-11 12:34:02.037 [1] INFO	WasabiAppBuilder.BeforeStarting (81)	Wasabi GUI started (17dcdaf5-da67-4725-ad54-ac28339800e7).
2023-07-11 12:34:02.775 [1] INFO	FileSystemBlockRepository.Dispose (23)	.ctor finished in 597 milliseconds.
2023-07-11 12:34:08.738 [1] INFO	WalletManager.Dispose (35)	.ctor finished in 5.96 seconds.
2023-07-11 12:34:08.764 [1] INFO	Program.RunAsGuiAsync (170)	Wasabi GUI started.
2023-07-11 12:34:09.413 [1] INFO	Program.RunAsGuiAsync (190)	Renderer: ANGLE (NVIDIA GeForce RTX 3060 Laptop GPU Direct3D11 vs_5_0 ps_5_0)
2023-07-11 12:34:10.775 [1] INFO	IndexStore.Dispose (83)	InitializeAsync finished in 14 milliseconds.
2023-07-11 12:34:10.816 [11] INFO	TransactionStore.Dispose (43)	MempoolStore.InitializeAsync finished in 39 milliseconds.
2023-07-11 12:34:10.825 [4] INFO	TorProcessManager.RestartingLoopAsync (126)	Tor is already running on 127.0.0.1:37150
2023-07-11 12:34:10.843 [7] INFO	TorProcessManager.RestartingLoopAsync (161)	Tor is running.
2023-07-11 12:34:10.846 [7] INFO	Global.StartTorProcessManagerAsync (259)	TorProcessManager is initialized.
```