### PR TITLE
add walletname to fully synced log message

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -278,7 +278,7 @@ public class Wallet : BackgroundService, IWallet
 					SetFinalBestHeight(new Height(lastProcessedFilter.Header.Height));
 				}
 
-				Logger.LogInfo("Wallet is fully synchronized.");
+				Logger.LogInfo($"Wallet '{WalletName}' is fully synchronized.");
 			}
 		}
 		catch (OperationCanceledException)


### PR DESCRIPTION
the wallet name is part of the starting wallet log message
`INFO	WalletManager.StartWalletAsync (167)	Starting wallet 'WalletName'...`

with this PR the wallet name is also in the wallet fully synced message 
`INFO	Wallet.PerformFinalSynchronizationAsync (281)	Wallet 'WalletName' is fully synchronized.`

currently, it's annoying/hard to tell when loading multiple wallets