### PR TITLE
Create blame round instead of fast transaction signing

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -99,6 +99,8 @@ public class StepOutputRegistrationTests
 			amountCredentials1.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials1.Take(ProtocolConstants.CredentialNumber),
 			token);
+		await alices[0].ReadyToSignAsync(token);
+		await alices[1].ReadyToSignAsync(token);
 
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -146,12 +148,15 @@ public class StepOutputRegistrationTests
 			amountCredentials2.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials2.Take(ProtocolConstants.CredentialNumber),
 			token);
+		await alices[0].ReadyToSignAsync(token);
+		await alices[1].ReadyToSignAsync(token);
 
 		// Add another input. The input must be able to pay for itself, but
 		// the remaining amount after deducting the fees needs to be less
 		// than the minimum.
 		var txParameters = round.Parameters;
 		var extraAlice = WabiSabiFactory.CreateAlice(round.Parameters.MiningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParameters.AllowedOutputAmounts.Min - new Money(1L), round);
+		extraAlice.ReadyToSign = true;
 		round.Alices.Add(extraAlice);
 		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin, extraAlice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 
@@ -386,6 +391,41 @@ public class StepOutputRegistrationTests
 		await bob2a;
 
 		await roundStateUpdater.StopAsync(token);
+
+		await arena.StopAsync(token);
+	}
+
+	[Fact]
+	public async Task AliceIsNotReady()
+	{
+		using CancellationTokenSource cancellationTokenSource = new(TestTimeout);
+		var token = cancellationTokenSource.Token;
+
+		WabiSabiConfig cfg = new()
+		{
+			MaxInputCountByRound = 2,
+			MinInputCountByRoundMultiplier = 0.5,
+			OutputRegistrationTimeout = TimeSpan.Zero,
+		};
+		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
+
+		var mockRpc = WabiSabiFactory.CreatePreconfiguredRpcClient(coin1.Coin, coin2.Coin);
+		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
+		var (round, arenaClient, alices) = await CreateRoundWithTwoConfirmedConnectionsAsync(arena, keyChain, coin1, coin2);
+
+		await alices[0].ReadyToSignAsync(token);
+
+		await arena.TriggerAndWaitRoundAsync(token);
+		Assert.Equal(Phase.Ended, round.Phase);
+
+		var onlyRound = arena.Rounds.Single(x => x is BlameRound);
+		var blameRound = Assert.IsType<BlameRound>(onlyRound);
+		Assert.NotNull(blameRound.BlameOf);
+		Assert.Equal(round.Id, blameRound.BlameOf.Id);
+
+		var whitelist = blameRound.BlameWhitelist;
+		Assert.Contains(alices[0].SmartCoin.Outpoint, whitelist);
+		Assert.DoesNotContain(alices[1].SmartCoin.Outpoint, whitelist);
 
 		await arena.StopAsync(token);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -41,9 +41,6 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
-
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
@@ -79,9 +76,6 @@ public class StepTransactionSigningTests
 		Prison prison = new();
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
-
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
 
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -122,9 +116,6 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
-
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
 
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -169,9 +160,6 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
-
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
@@ -199,7 +187,6 @@ public class StepTransactionSigningTests
 			MinInputCountByRoundMultiplier = 1,
 			TransactionSigningTimeout = TimeSpan.Zero,
 			OutputRegistrationTimeout = TimeSpan.Zero,
-			FailFastTransactionSigningTimeout = TimeSpan.Zero,
 			FailFastOutputRegistrationTimeout = TimeSpan.Zero,
 			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 		};
@@ -216,6 +203,7 @@ public class StepTransactionSigningTests
 		// Make sure not all alices signed.
 		var alice3 = WabiSabiFactory.CreateAlice(round);
 		alice3.ConfirmedConnection = true;
+		alice3.ReadyToSign = true;
 		round.Alices.Add(alice3);
 		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin, alice3.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 		await arena.TriggerAndWaitRoundAsync(token);
@@ -287,6 +275,9 @@ public class StepTransactionSigningTests
 			aliceClient2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient2.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
 			token).ConfigureAwait(false);
+
+		await aliceClient1.ReadyToSignAsync(token);
+		await aliceClient2.ReadyToSignAsync(token);
 
 		await roundStateUpdater.StopAsync(token);
 		return (round, aliceClient1, aliceClient2);

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -79,10 +79,6 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "FailFastOutputRegistrationTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan FailFastOutputRegistrationTimeout { get; set; } = TimeSpan.FromMinutes(3);
 
-	[DefaultValueTimeSpan("0d 0h 1m 0s")]
-	[JsonProperty(PropertyName = "FailFastTransactionSigningTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public TimeSpan FailFastTransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
-
 	[DefaultValueTimeSpan("0d 0h 5m 0s")]
 	[JsonProperty(PropertyName = "RoundExpiryTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan RoundExpiryTimeout { get; set; } = TimeSpan.FromMinutes(5);


### PR DESCRIPTION
This implements https://github.com/zkSNACKs/WalletWasabi/issues/11027.

If there is an Alice who didn't send the ready-to-sign request, then the following happens:
  * The signing phase is skipped.
  * All Alices that didn't send the ready-to-sign request are removed from the round.
  * If there are enough Alices to continue:
    * The coordinator ends the round with `NotAllAlicesSign` .
    * The coordinator initiates a blame round.
   * Otherwise:
     * The coordinator ends the round with `AbortedNotEnoughAlicesSigned`.

I didn't test it but this PR should be backward compatible with wasabi wallet. This is what I expect to happen:
  * `UnexpectedRoundPhaseException` is throw [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs#L65).
  * The exception is caught [here](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs#L245).
  * `DisruptedCoinJoinResult` is [returned](https://github.com/zkSNACKs/WalletWasabi/blob/76db741136c9ac9a4b2d44a3c58430b54d54e9a5/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs#L292) from `StartRoundAsync`.
  * A blame round is [awaited](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs#L193).