### PR TITLE
[VDG] PrivacySuggestions: add warning for spending coinjoining coins

### DIFF
--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
@@ -63,6 +63,7 @@ public class PrivacySuggestionsModel
 					.Combine(VerifyPrivacyLevel(info, transactionResult))
 					.Combine(VerifyConsolidation(transactionResult))
 					.Combine(VerifyUnconfirmedInputs(transactionResult))
+					.Combine(VerifyCoinjoiningInputs(transactionResult))
 					.Combine(await VerifyChangeAsync(info, transactionResult, linkedCts));
 			}
 			catch (OperationCanceledException)
@@ -196,6 +197,18 @@ public class PrivacySuggestionsModel
 		if (transaction.SpendsUnconfirmed)
 		{
 			result.Warnings.Add(new UnconfirmedFundsWarning());
+		}
+
+		return result;
+	}
+
+		private PrivacySuggestionsResult VerifyCoinjoiningInputs(BuildTransactionResult transaction)
+	{
+		var result = new PrivacySuggestionsResult();
+
+		if (transaction.SpendsCoinjoining)
+		{
+			result.Warnings.Add(new CoinjoiningFundsWarning());
 		}
 
 		return result;

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
@@ -202,7 +202,7 @@ public class PrivacySuggestionsModel
 		return result;
 	}
 
-		private PrivacySuggestionsResult VerifyCoinjoiningInputs(BuildTransactionResult transaction)
+	private PrivacySuggestionsResult VerifyCoinjoiningInputs(BuildTransactionResult transaction)
 	{
 		var result = new PrivacySuggestionsResult();
 

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
@@ -25,3 +25,5 @@ public record ConsolidationWarning(int CoinCount) : PrivacyWarning(WarningSeveri
 public record CreatesChangeWarning() : PrivacyWarning(WarningSeverity.Info);
 
 public record UnconfirmedFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
+
+public record CoinjoiningFundsWarning() : PrivacyWarning(WarningSeverity.Warning);

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
@@ -26,4 +26,4 @@ public record CreatesChangeWarning() : PrivacyWarning(WarningSeverity.Info);
 
 public record UnconfirmedFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
 
-public record CoinjoiningFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
+public record CoinjoiningFundsWarning() : PrivacyWarning(WarningSeverity.Info);

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -156,7 +156,8 @@
             </DockPanel>
           </Border>
         </DataTemplate>
-
+        
+        <!-- Unconfirmed funds warning -->
         <DataTemplate DataType="{x:Type model:UnconfirmedFundsWarning}">
           <Border Classes="warning">
             <DockPanel>
@@ -166,6 +167,7 @@
           </Border>
         </DataTemplate>
 
+        <!-- Coinjoining funds warning -->
         <DataTemplate DataType="{x:Type model:CoinjoiningFundsWarning}">
           <Border Classes="warning">
             <DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -165,6 +165,16 @@
             </DockPanel>
           </Border>
         </DataTemplate>
+
+        <DataTemplate DataType="{x:Type model:CoinjoiningFundsWarning}">
+          <Border Classes="warning">
+            <DockPanel>
+              <PathIcon />
+              <TextBlock Text="Transaction uses coinjoining coins." />
+            </DockPanel>
+          </Border>
+        </DataTemplate>
+
       </ItemsControl.DataTemplates>
     </ItemsControl>
     <TextBlock Text="Improve this transaction:" HorizontalAlignment="Center"

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -169,7 +169,7 @@
 
         <!-- Coinjoining funds warning -->
         <DataTemplate DataType="{x:Type model:CoinjoiningFundsWarning}">
-          <Border Classes="warning">
+          <Border Classes="warning info">
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses coinjoining coins." />

--- a/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BuildTransactionResult.cs
@@ -26,7 +26,7 @@ public class BuildTransactionResult
 	public Money Fee { get; }
 	public decimal FeePercentOfSent { get; }
 	public bool SpendsUnconfirmed => Transaction.WalletInputs.Any(c => !c.Confirmed);
-
+	public bool SpendsCoinjoining => Transaction.WalletInputs.Any(c => c.CoinJoinInProgress);
 	public IEnumerable<SmartCoin> InnerWalletOutputs => Transaction.WalletOutputs;
 	public IEnumerable<SmartCoin> SpentCoins => Transaction.WalletInputs;
 


### PR DESCRIPTION
As spending coinjoining coins causes issues for both client and backend, I think this warning makes a lot of sense.

![Screenshot from 2023-07-18 15-16-37](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/08cf5180-02e2-4448-8c52-50e2bfe3545d)

Issue: similar to https://github.com/zkSNACKs/WalletWasabi/issues/11013, the suggestion doesn't get updated. So user can see the warning while coinjoin stopped in the meantime.