### PR TITLE
`Wallet`: Remove `NewBlockProcessed` event

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -54,8 +54,6 @@ public class Wallet : BackgroundService, IWallet
 
 	public event EventHandler<FilterModel>? NewFilterProcessed;
 
-	public event EventHandler<Block>? NewBlockProcessed;
-
 	public event EventHandler<WalletState>? StateChanged;
 
 	public WalletState State
@@ -646,9 +644,8 @@ public class Wallet : BackgroundService, IWallet
 				// All keys were tested at this height, update the Height.
 				KeyManager.SetBestHeight(height);
 			}
-
-			NewBlockProcessed?.Invoke(this, currentBlock);
 		}
+
 		LastProcessedFilter = filterModel;
 	}
 


### PR DESCRIPTION
I found this during review of #11046. Given how complex that block filter processing is, I find it useful to remove unnecessary complexities.