### PR TITLE
Add `EnforceExtendedAnalyzerRules` to `WalletWasabi.Fluent.Generators` project

### DIFF
--- a/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
+++ b/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
@@ -13,6 +13,7 @@
 		<RuntimeIdentifiers>win7-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Fluent.Generators</PathMap>
 		<IsRoslynComponent>true</IsRoslynComponent>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Should fix warnings like https://dev.azure.com/zkSNACKs/Wasabi/_build/results?buildId=102319&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=fa4a47f7-906d-5276-1b56-2e609eec1e77&l=20