### PR TITLE
[VDG] [trivial] rename Funds to Coins for Pocket

### DIFF
--- a/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
@@ -11,8 +11,8 @@ namespace WalletWasabi.Fluent.Helpers;
 public static class CoinPocketHelper
 {
 	public static readonly LabelsArray UnlabelledFundsText = new("Unknown People");
-	public static readonly LabelsArray PrivateFundsText = new("Private Funds");
-	public static readonly LabelsArray SemiPrivateFundsText = new("Semi-private Funds");
+	public static readonly LabelsArray PrivateFundsText = new("Private Coins");
+	public static readonly LabelsArray SemiPrivateFundsText = new("Semi-private Coins");
 
 	public static IEnumerable<(LabelsArray Labels, ICoinsView Coins)> GetPockets(this ICoinsView allCoins, int privateAnonSetThreshold)
 	{


### PR DESCRIPTION
For consistency in wording.

Coins is used everywhere else. Like at suggestions.
![Screenshot from 2023-07-19 16-40-04](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/02e2c7ba-f98a-4534-9b7a-53f0db3d72ba)

This is the text here, which user sees at coin control
![image](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/3a7520ae-fdb6-4643-8e68-a78db76d0a76)

I can rename `Private**Funds**Text` and all related as well if desired.