### PR TITLE
Use same json serialization settings on client and server

### DIFF
--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -51,7 +51,11 @@ public class Startup
 		services.AddMvc()
 			.AddNewtonsoftJson();
 
-		services.AddControllers().AddNewtonsoftJson(x => x.SerializerSettings.Converters = JsonSerializationOptions.Default.Settings.Converters);
+		services.AddControllers().AddNewtonsoftJson(x =>
+		{
+			x.SerializerSettings.Converters = JsonSerializationOptions.Default.Settings.Converters;
+			x.SerializerSettings.ContractResolver = JsonSerializationOptions.Default.Settings.ContractResolver;
+		});
 
 		// Register the Swagger generator, defining one or more Swagger documents
 		services.AddSwaggerGen(c =>

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Startup.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Startup.cs
@@ -30,6 +30,10 @@ public class Startup
 		services.AddMvc()
 			.AddApplicationPart(backendAssembly)
 			.AddControllersAsServices()
-			.AddNewtonsoftJson(x => x.SerializerSettings.Converters = JsonSerializationOptions.Default.Settings.Converters);
+			.AddNewtonsoftJson(x =>
+			{
+				x.SerializerSettings.Converters = JsonSerializationOptions.Default.Settings.Converters;
+				x.SerializerSettings.ContractResolver = JsonSerializationOptions.Default.Settings.ContractResolver;
+			});
 	}
 }

--- a/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs
@@ -90,6 +90,7 @@ public static class HttpResponseMessageExtensions
 				new JsonSerializerSettings()
 				{
 					Converters = JsonSerializationOptions.Default.Settings.Converters,
+					ContractResolver = JsonSerializationOptions.Default.Settings.ContractResolver,
 					Error = (_, e) => e.ErrorContext.Handled = true // Try to deserialize an Error object
 				});
 			var innerException = error switch


### PR DESCRIPTION
Client and server shared the same set of converters but not the exact set of json serialization settings. For that reason clients use PascalCase while server uses camelCase (except for the WabiSabi converters that are strict).

This change makes both sides to use the same ContractResolver so they both serialize using the same casing. This is effectively a breaking change that shouldn't affect us but can potentially affect others using our api. 