### PR TITLE
Always log that CoinJoinClient starts

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -226,7 +226,8 @@ public class CoinJoinManager : BackgroundService
 			var registrationTimeout = TimeSpan.MaxValue;
 			NotifyCoinJoinStarted(walletToStart, registrationTimeout);
 
-			walletToStart.LogDebug($"Coinjoin client started, {nameof(startCommand.StopWhenAllMixed)}:'{startCommand.StopWhenAllMixed}' {nameof(startCommand.OverridePlebStop)}:'{startCommand.OverridePlebStop}'.");
+			walletToStart.LogInfo($"{nameof(CoinJoinClient)} started.");
+			walletToStart.LogDebug($"{nameof(startCommand.StopWhenAllMixed)}:'{startCommand.StopWhenAllMixed}' {nameof(startCommand.OverridePlebStop)}:'{startCommand.OverridePlebStop}'.");
 
 			// In case there was another start scheduled just remove it.
 			TryRemoveTrackedAutoStart(trackedAutoStarts, walletToStart);

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -436,7 +436,7 @@ public class CoinJoinManager : BackgroundService
 		{
 			if (finishedCoinJoin.IsStopped)
 			{
-				wallet.LogInfo($"{nameof(CoinJoinClient)} was stopped.");
+				wallet.LogInfo($"{nameof(CoinJoinClient)} stopped.");
 			}
 			else
 			{


### PR DESCRIPTION
Currently start of CoinJoinClient is only logged in debug while stop is always logged.
With this PR: always log start and stop of CoinJoinClient.

```
2023-07-21 11:23:42.061 [30] INFO	CoinJoinManager.HandleCoinJoinCommandsAsync (230)	Wallet (Testint): CoinJoinClient started.
2023-07-21 11:23:42.061 [30] DEBUG	CoinJoinManager.HandleCoinJoinCommandsAsync (231)	Wallet (Testint): StopWhenAllMixed:'False' OverridePlebStop:'False'.
2023-07-21 11:23:56.636 [25] INFO	CoinJoinManager.HandleCoinJoinFinalizationAsync (460)	Wallet (Testint): CoinJoinClient stopped.
```