### PR TITLE
Use NoCoinsEligibleToMix instead of AllCoinsPrivate if all candidates are private

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -203,7 +203,7 @@ public class CoinJoinManager : BackgroundService
 				// If coin candidates are already private and the user doesn't override the StopWhenAllMixed, then don't mix.
 				if (coinCandidates.All(x => x.IsPrivate(walletToStart.AnonScoreTarget)) && startCommand.StopWhenAllMixed)
 				{
-					throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate, $"All coin candidates are already private and {nameof(startCommand.StopWhenAllMixed)} was {startCommand.StopWhenAllMixed}");
+					throw new CoinJoinClientException(CoinjoinError.NoCoinsEligibleToMix, $"All coin candidates are already private and {nameof(startCommand.StopWhenAllMixed)} was {startCommand.StopWhenAllMixed}");
 				}
 
 				NotifyWalletStartedCoinJoin(walletToStart);


### PR DESCRIPTION
Fixes #11072 

As always, with this part of the codebase, not sure if this breaks something else.

The idea is that if we're L206, we passed L191. Hence, the `NoCoinsEligibleToMix` message is factually correct at this point (we have some non-private coins, but they are not eligible for coinjoin), but not `AllCoinsPrivate` (because we have some non-private coins).