### PR TITLE
`TransactionProcessor`: Remove guards

### DIFF
--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -1,14 +1,13 @@
+using NBitcoin;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using NBitcoin;
 using WalletWasabi.Blockchain.Analysis;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Extensions;
-using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Blockchain.TransactionProcessing;
@@ -20,9 +19,9 @@ public class TransactionProcessor
 		KeyManager keyManager,
 		Money dustThreshold)
 	{
-		TransactionStore = Guard.NotNull(nameof(transactionStore), transactionStore);
-		KeyManager = Guard.NotNull(nameof(keyManager), keyManager);
-		DustThreshold = Guard.NotNull(nameof(dustThreshold), dustThreshold);
+		TransactionStore = transactionStore;
+		KeyManager = keyManager;
+		DustThreshold = dustThreshold;
 		Coins = new();
 		BlockchainAnalyzer = new();
 	}


### PR DESCRIPTION
This makes it easier to mock `TransactionProcessor` for `WalletWasabi/Wallets/WalletFilterProcessor.cs` in #11065. 