### PR TITLE
[VDG] Fix sorting for non-private pockets

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinControlLabelComparer.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinControlLabelComparer.cs
@@ -1,0 +1,50 @@
+using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
+
+namespace WalletWasabi.Fluent.ViewModels.CoinControl;
+
+public static class CoinControlLabelComparer
+{
+	public static int Ascending(CoinControlItemViewModelBase? left, CoinControlItemViewModelBase? right)
+	{
+		if (left is null)
+		{
+			return right is null ? 0 : -1;
+		}
+
+		if (right is null)
+		{
+			return 1;
+		}
+
+		var privateScoreLeft = GetLabelPriority(left);
+		var privateScoreRight = GetLabelPriority(right);
+
+		if (privateScoreLeft == privateScoreRight)
+		{
+			return StringComparer.InvariantCultureIgnoreCase.Compare(left.Labels, right.Labels);
+		}
+
+		return privateScoreLeft > privateScoreRight ? -1 : 1;
+	}
+
+	public static int Descending(CoinControlItemViewModelBase? left, CoinControlItemViewModelBase? right)
+	{
+		return -Ascending(left, right);
+	}
+
+	private static int GetLabelPriority(CoinControlItemViewModelBase coin)
+	{
+		if (coin.Labels == CoinPocketHelper.PrivateFundsText)
+		{
+			return 3;
+		}
+
+		if (coin.Labels == CoinPocketHelper.SemiPrivateFundsText)
+		{
+			return 2;
+		}
+
+		return 1;
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorDataGridSource.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorDataGridSource.cs
@@ -1,8 +1,8 @@
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Templates;
-using System.Collections.Generic;
-using System.Linq;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.TreeDataGrid;
 using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
@@ -13,19 +13,19 @@ namespace WalletWasabi.Fluent.ViewModels.CoinControl;
 
 public static class CoinSelectorDataGridSource
 {
-	private static int GetLabelPriority(CoinControlItemViewModelBase coin)
+	public static HierarchicalTreeDataGridSource<CoinControlItemViewModelBase> Create(IEnumerable<CoinControlItemViewModelBase> source)
 	{
-		if (coin.Labels == CoinPocketHelper.PrivateFundsText)
+		return new HierarchicalTreeDataGridSource<CoinControlItemViewModelBase>(source)
 		{
-			return 3;
-		}
-
-		if (coin.Labels == CoinPocketHelper.SemiPrivateFundsText)
-		{
-			return 2;
-		}
-
-		return 1;
+			Columns =
+			{
+				ChildrenColumn(),
+				IndicatorsColumn(),
+				AmountColumn(),
+				AnonymityScoreColumn(),
+				PocketColumn()
+			}
+		};
 	}
 
 	private static int GetIndicatorPriority(CoinControlItemViewModelBase x)
@@ -114,23 +114,8 @@ public static class CoinSelectorDataGridSource
 			GridLength.Star,
 			new ColumnOptions<CoinControlItemViewModelBase>
 			{
-				CompareAscending = Sort<CoinControlItemViewModelBase>.Ascending(GetLabelPriority),
-				CompareDescending = Sort<CoinControlItemViewModelBase>.Descending(GetLabelPriority)
+				CompareAscending = CoinControlLabelComparer.Ascending,
+				CompareDescending = CoinControlLabelComparer.Descending
 			});
-	}
-
-	public static HierarchicalTreeDataGridSource<CoinControlItemViewModelBase> Create(IEnumerable<CoinControlItemViewModelBase> source)
-	{
-		return new HierarchicalTreeDataGridSource<CoinControlItemViewModelBase>(source)
-		{
-			Columns =
-			{
-				ChildrenColumn(),
-				IndicatorsColumn(),
-				AmountColumn(),
-				AnonymityScoreColumn(),
-				PocketColumn()
-			}
-		};
 	}
 }


### PR DESCRIPTION
Implements the correct sorting algorithm for Pockets in Coin Control screen.

![image](https://user-images.githubusercontent.com/3109851/255567024-c3ae67ec-fcc7-4698-b871-d17cd05df2c7.png)

Fixes #11085 
