### PR TITLE
[VDG] PrivacySuggestions: ToolTip with consequences and explanation

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -113,7 +113,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction interlinks labels:" Margin="0 0 5 0"
-                         ToolTip.Tip="Multiple entities can see this transaction. You should coinjoin first or carefully select who should know about this transaction with the label management tool (if available)." />
+                         ToolTip.Tip="Those entities know this is your transaction. Coinjoin more or use the label management tool to carefully select who would know that this transaction is yours." />
               <c:LabelsItemsPresenter Items="{Binding Labels}" />
             </DockPanel>
           </Border>
@@ -125,7 +125,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses non-private coins."
-                         ToolTip.Tip="Some entities will be able to deanonymize this transaction because when multiple coins are used for a transaction, the privacy of it is only as good as the lowest privacy of the coins used. You should conjoin first to have (enough) private coins for this transaction." />
+                         ToolTip.Tip="Some entities can deanonymize this transaction because its privacy is as good as the used coins' lowest privacy. Coinjoin more to have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -136,7 +136,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses semi-private coins." 
-                         ToolTip.Tip="This transaction might not be private enough for your needs because when multiple coins are used for a transaction, the privacy of it is only as good as the lowest privacy of the coins used.  You should conjoin first to have (enough) private coins for this transaction." />
+                         ToolTip.Tip="This transaction is not private enough because its privacy is as good as the used coins' lowest privacy. Coinjoin more to have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -147,7 +147,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction creates change." 
-                         ToolTip.Tip="Creating change in a transaction is a privacy risk because it can link a following transaction that will use it with this one that created it. Use the change avoidance suggestion if possible, or coinjoin the change later." />
+                         ToolTip.Tip="Change can be used to link this transaction with the next one that will use it. If possible use the change avoidance suggestion, or coinjoin the change later." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -158,7 +158,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="{Binding CoinCount, StringFormat='Transaction consolidates over {0} coins.'}" 
-                         ToolTip.Tip="A lot of coins will be used to make this transaction. This can potentially reduce the privacy of your transaction."/>
+                         ToolTip.Tip="This might reduce the privacy of your transaction."/>
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -169,7 +169,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses unconfirmed coins." 
-                         ToolTip.Tip="This may cause your transaction to be delayed or rejected and you may not pay the desired amount of mining fees. Wait for a confirmation to only use confirmed coins." />
+                         ToolTip.Tip="This may cause your transaction to be rejected, or delay its confirmation, or cost more than needed to get it confirmed within the desired time. Wait for a confirmation to only use confirmed coins." />
             </DockPanel>
           </Border>
         </DataTemplate>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -125,7 +125,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses non-private coins."
-                         ToolTip.Tip="Some entities can deanonymize this transaction because its privacy is as good as the used coins' lowest privacy. Coinjoin more to have (enough) private coins for this transaction." />
+                         ToolTip.Tip="Some entities can deanonymize this transaction because it spends coins with no privacy. Coinjoin more to have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -136,7 +136,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses semi-private coins." 
-                         ToolTip.Tip="This transaction is not private enough because its privacy is as good as the used coins' lowest privacy. Coinjoin more to have (enough) private coins for this transaction." />
+                         ToolTip.Tip="This transaction is not private enough because it spends not fully private coins. Coinjoin more to have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -147,7 +147,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction creates change." 
-                         ToolTip.Tip="Change can be used to link this transaction with the next one that will use it. If possible use the change avoidance suggestion, or coinjoin the change later." />
+                         ToolTip.Tip="Change can be used to link this transaction with the next transaction that will use it. Use the change avoidance suggestion to send a little more or less if this is OK for the receiver, or coinjoin the change later." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -180,7 +180,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses coinjoining coins." 
-                         ToolTip.Tip="This may cause issues. For example, your transaction might be replaced by the coinjoin one. Consider waiting for the current coinjoin to be finished before sending this transaction." />
+                         ToolTip.Tip="This may cause your transaction to be replaced by the coinjoin. Consider waiting for the current coinjoin to be finished before sending this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -113,7 +113,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction interlinks labels:" Margin="0 0 5 0"
-                         ToolTip.Tip="This compromises your privacy as multiple people can see this transaction. You should coinjoin first or carefully select who should know about this transaction with the label management (if possible)." />
+                         ToolTip.Tip="Multiple entities can see this transaction. You should coinjoin first or carefully select who should know about this transaction with the label management tool (if available)." />
               <c:LabelsItemsPresenter Items="{Binding Labels}" />
             </DockPanel>
           </Border>
@@ -125,7 +125,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses non-private coins."
-                         ToolTip.Tip="This compromises the privacy of this transaction. You should conjoin first, so you'll have (enough) private coins for this transaction." />
+                         ToolTip.Tip="Some entities will be able to deanonymize this transaction because when multiple coins are used for a transaction, the privacy of it is only as good as the lowest privacy of the coins used. You should conjoin first to have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -136,7 +136,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses semi-private coins." 
-                         ToolTip.Tip="This may compromise the privacy of this transaction. It is reccommended to coinjoin first, so you'll have (enough) private coins for this transaction." />
+                         ToolTip.Tip="This transaction might not be private enough for your needs because when multiple coins are used for a transaction, the privacy of it is only as good as the lowest privacy of the coins used.  You should conjoin first to have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -147,7 +147,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction creates change." 
-                         ToolTip.Tip="This means that there is change that can be linked back to you. Use the change avoidance suggestion if possible, or coinjoin the change later." />
+                         ToolTip.Tip="Creating change in a transaction is a privacy risk because it can link a following transaction that will use it with this one that created it. Use the change avoidance suggestion if possible, or coinjoin the change later." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -158,7 +158,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="{Binding CoinCount, StringFormat='Transaction consolidates over {0} coins.'}" 
-                         ToolTip.Tip="This means that your transaction involves combining multiple coins into one transaction. This can potentially reduce the privacy of your transaction."/>
+                         ToolTip.Tip="A lot of coins will be used to make this transaction. This can potentially reduce the privacy of your transaction."/>
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -180,7 +180,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses coinjoining coins." 
-                         ToolTip.Tip="This may cause issues, because some of your coins are currently participating in a coinjoin transaction. Consider waiting for current coinjoin to be finished, before sending this transaction." />
+                         ToolTip.Tip="This may cause issues. For example, your transaction might be replaced by the coinjoin one. Consider waiting for the current coinjoin to be finished before sending this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -112,7 +112,8 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction interlinks labels:" Margin="0 0 5 0" />
+              <TextBlock Text="Transaction interlinks labels:" Margin="0 0 5 0"
+                         ToolTip.Tip="This compromises your privacy as multiple people can see this transaction. You should coinjoin first or carefully select who should know about this transaction with the label management (if possible)." />
               <c:LabelsItemsPresenter Items="{Binding Labels}" />
             </DockPanel>
           </Border>
@@ -123,7 +124,8 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses non-private coins." />
+              <TextBlock Text="Transaction uses non-private coins."
+                         ToolTip.Tip="This compromises the privacy of this transaction. You should conjoin first, so you'll have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -133,7 +135,8 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses semi-private coins." />
+              <TextBlock Text="Transaction uses semi-private coins." 
+                         ToolTip.Tip="This may compromise the privacy of this transaction. It is reccommended to coinjoin first, so you'll have (enough) private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -143,7 +146,8 @@
           <Border Classes="warning info">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction creates change." />
+              <TextBlock Text="Transaction creates change." 
+                         ToolTip.Tip="This means that there is change that can be linked back to you. Use the change avoidance suggestion if possible, or coinjoin the change later." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -153,7 +157,8 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="{Binding CoinCount, StringFormat='Transaction consolidates over {0} coins.'}" />
+              <TextBlock Text="{Binding CoinCount, StringFormat='Transaction consolidates over {0} coins.'}" 
+                         ToolTip.Tip="This means that your transaction involves combining multiple coins into one transaction. This can potentially reduce the privacy of your transaction."/>
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -163,7 +168,8 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses unconfirmed coins." />
+              <TextBlock Text="Transaction uses unconfirmed coins." 
+                         ToolTip.Tip="This may cause your transaction to be delayed or rejected and you may not pay the desired amount of mining fees. Wait for a confirmation to only use confirmed coins." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -173,7 +179,8 @@
           <Border Classes="warning info">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses coinjoining coins." />
+              <TextBlock Text="Transaction uses coinjoining coins." 
+                         ToolTip.Tip="This may cause issues, because some of your coins are currently participating in a coinjoin transaction. Consider waiting for current coinjoin to be finished, before sending this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -125,7 +125,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses non-private coins."
-                         ToolTip.Tip="Some entities can deanonymize this transaction because it spends coins with no privacy. Coinjoin more to have (enough) private coins for this transaction." />
+                         ToolTip.Tip="Some entities can deanonymize this transaction because it spends coins with no privacy. Coinjoin more to have enough private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
@@ -136,7 +136,7 @@
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses semi-private coins." 
-                         ToolTip.Tip="This transaction is not private enough because it spends not fully private coins. Coinjoin more to have (enough) private coins for this transaction." />
+                         ToolTip.Tip="This transaction is not private enough because it spends not fully private coins. Coinjoin more to have enough private coins for this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11068

There's multiple ways how to approach this, I went with first describing the consequence (as mentioned in the issue) and, if applicable, also mention what the user should do.

See changes for full text of tooltips

Ideally, the tooltips could be different for certain scenario's for example user has "interlinks labels" but is not able to do label management and another tooltip text for scenario where user "interlinks labels" but is able to do label management. I'm not sure if it's possible, if so maybe a follow up improvement.
Anyway, I've made them general enough for all scenarios
 
[Screencast](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/0ff4a508-420e-4caf-aeb0-ce6ab2d1b0e1)

