### PR TITLE
[VDG] Fix unconfirmed coins warning

### DIFF
--- a/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
@@ -24,6 +24,6 @@ public record ConsolidationWarning(int CoinCount) : PrivacyWarning(WarningSeveri
 
 public record CreatesChangeWarning() : PrivacyWarning(WarningSeverity.Info);
 
-public record UnconfirmedFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
+public record UnconfirmedFundsWarning() : PrivacyWarning(WarningSeverity.Info);
 
 public record CoinjoiningFundsWarning() : PrivacyWarning(WarningSeverity.Info);

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -135,7 +135,7 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses semi-private coins." 
+              <TextBlock Text="Transaction uses semi-private coins."
                          ToolTip.Tip="This transaction is not private enough because it spends not fully private coins. Coinjoin more to have enough private coins for this transaction." />
             </DockPanel>
           </Border>
@@ -146,7 +146,7 @@
           <Border Classes="warning info">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction creates change." 
+              <TextBlock Text="Transaction creates change."
                          ToolTip.Tip="Change can be used to link this transaction with the next transaction that will use it. Use the change avoidance suggestion to send a little more or less if this is OK for the receiver, or coinjoin the change later." />
             </DockPanel>
           </Border>
@@ -157,18 +157,18 @@
           <Border Classes="warning">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="{Binding CoinCount, StringFormat='Transaction consolidates over {0} coins.'}" 
-                         ToolTip.Tip="This might reduce the privacy of your transaction."/>
+              <TextBlock Text="{Binding CoinCount, StringFormat='Transaction consolidates over {0} coins.'}"
+                         ToolTip.Tip="This might reduce the privacy of your transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
 
         <!-- Unconfirmed funds warning -->
         <DataTemplate DataType="{x:Type model:UnconfirmedFundsWarning}">
-          <Border Classes="warning">
+          <Border Classes="warning info">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses unconfirmed coins." 
+              <TextBlock Text="Transaction uses unconfirmed coins."
                          ToolTip.Tip="This may cause your transaction to be rejected, or delay its confirmation, or cost more than needed to get it confirmed within the desired time. Wait for a confirmation to only use confirmed coins." />
             </DockPanel>
           </Border>
@@ -179,12 +179,11 @@
           <Border Classes="warning info">
             <DockPanel>
               <PathIcon />
-              <TextBlock Text="Transaction uses coinjoining coins." 
+              <TextBlock Text="Transaction uses coinjoining coins."
                          ToolTip.Tip="This may cause your transaction to be replaced by the coinjoin. Consider waiting for the current coinjoin to be finished before sending this transaction." />
             </DockPanel>
           </Border>
         </DataTemplate>
-
       </ItemsControl.DataTemplates>
     </ItemsControl>
     <TextBlock Text="Improve this transaction:" HorizontalAlignment="Center"


### PR DESCRIPTION
- Change `UnconfirmedFundsWarning.Severity` to `Info`
- Change corresponding icon
- Fixes #11087 