### PR TITLE
Ban Alices who didn't sent ready-to-sign request

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -99,6 +99,8 @@ public class StepOutputRegistrationTests
 			amountCredentials1.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials1.Take(ProtocolConstants.CredentialNumber),
 			token);
+		await alices[0].ReadyToSignAsync(token);
+		await alices[1].ReadyToSignAsync(token);
 
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -146,12 +148,15 @@ public class StepOutputRegistrationTests
 			amountCredentials2.Take(ProtocolConstants.CredentialNumber),
 			vsizeCredentials2.Take(ProtocolConstants.CredentialNumber),
 			token);
+		await alices[0].ReadyToSignAsync(token);
+		await alices[1].ReadyToSignAsync(token);
 
 		// Add another input. The input must be able to pay for itself, but
 		// the remaining amount after deducting the fees needs to be less
 		// than the minimum.
 		var txParameters = round.Parameters;
 		var extraAlice = WabiSabiFactory.CreateAlice(round.Parameters.MiningFeeRate.GetFee(Constants.P2wpkhInputVirtualSize) + txParameters.AllowedOutputAmounts.Min - new Money(1L), round);
+		extraAlice.ReadyToSign = true;
 		round.Alices.Add(extraAlice);
 		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(extraAlice.Coin, extraAlice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -41,9 +41,6 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg).With(mockRpc).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
-
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
@@ -79,9 +76,6 @@ public class StepTransactionSigningTests
 		Prison prison = new();
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
-
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
 
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -122,9 +116,6 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
-
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
 
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
@@ -169,9 +160,6 @@ public class StepTransactionSigningTests
 		using Arena arena = await ArenaBuilder.From(cfg, mockRpc, prison).CreateAndStartAsync();
 		var (round, aliceClient1, aliceClient2) = await CreateRoundWithOutputsReadyToSignAsync(arena, keyChain, coin1, coin2);
 
-		await aliceClient1.ReadyToSignAsync(token);
-		await aliceClient2.ReadyToSignAsync(token);
-
 		await arena.TriggerAndWaitRoundAsync(token);
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 
@@ -198,8 +186,6 @@ public class StepTransactionSigningTests
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 1,
 			TransactionSigningTimeout = TimeSpan.Zero,
-			OutputRegistrationTimeout = TimeSpan.Zero,
-			FailFastTransactionSigningTimeout = TimeSpan.Zero,
 			FailFastOutputRegistrationTimeout = TimeSpan.Zero,
 			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 		};
@@ -216,6 +202,7 @@ public class StepTransactionSigningTests
 		// Make sure not all alices signed.
 		var alice3 = WabiSabiFactory.CreateAlice(round);
 		alice3.ConfirmedConnection = true;
+		alice3.ReadyToSign = true;
 		round.Alices.Add(alice3);
 		round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice3.Coin, alice3.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 		await arena.TriggerAndWaitRoundAsync(token);
@@ -287,6 +274,9 @@ public class StepTransactionSigningTests
 			aliceClient2.IssuedAmountCredentials.Take(ProtocolConstants.CredentialNumber),
 			aliceClient2.IssuedVsizeCredentials.Take(ProtocolConstants.CredentialNumber),
 			token).ConfigureAwait(false);
+
+		await aliceClient1.ReadyToSignAsync(token);
+		await aliceClient2.ReadyToSignAsync(token);
 
 		await roundStateUpdater.StopAsync(token);
 		return (round, aliceClient1, aliceClient2);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -280,6 +280,8 @@ public partial class Arena : PeriodicRunner
 
 					if (!allReady && phaseExpired)
 					{
+						// It would be better to end the round and create a blame round here, but older client would not support it.
+						// See https://github.com/zkSNACKs/WalletWasabi/pull/11028.
 						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
 						round.FastSigningPhase = true;
 					}
@@ -380,7 +382,14 @@ public partial class Arena : PeriodicRunner
 				else if (round.TransactionSigningTimeFrame.HasExpired)
 				{
 					round.LogWarning($"Signing phase failed with timed out after {round.TransactionSigningTimeFrame.Duration.TotalSeconds} seconds.");
-					await FailTransactionSigningPhaseAsync(round, cancellationToken).ConfigureAwait(false);
+					if (round.FastSigningPhase)
+					{
+						await FailFastTransactionSigningPhaseAsync(round, cancellationToken).ConfigureAwait(false);
+					}
+					else
+					{
+						await FailTransactionSigningPhaseAsync(round, cancellationToken).ConfigureAwait(false);
+					}
 				}
 			}
 			catch (RPCException ex)
@@ -432,6 +441,31 @@ public partial class Arena : PeriodicRunner
 		var cnt = round.Alices.RemoveAll(alice => unsignedOutpoints.Contains(alice.Coin.Outpoint));
 
 		round.LogInfo($"Removed {cnt} alices, because they didn't sign. Remaining: {round.InputCount}");
+
+		if (round.InputCount >= round.Parameters.MinInputCountByRound)
+		{
+			EndRound(round, EndRoundState.NotAllAlicesSign);
+			await CreateBlameRoundAsync(round, cancellationToken).ConfigureAwait(false);
+		}
+		else
+		{
+			EndRound(round, EndRoundState.AbortedNotEnoughAlicesSigned);
+		}
+	}
+
+	private async Task FailFastTransactionSigningPhaseAsync(Round round, CancellationToken cancellationToken)
+	{
+		var alicesToRemove = round.Alices.Where(alice => !alice.ReadyToSign).ToHashSet();
+
+		foreach (var alice in alicesToRemove)
+		{
+			// Intentionally, do not ban Alices who have not signed, as clients using hardware wallets may not be able to sign in time.
+			Prison.Note(alice, round.Id);
+		}
+
+		var removedAlices = round.Alices.RemoveAll(alice => alicesToRemove.Contains(alice));
+
+		round.LogInfo($"Removed {removedAlices} alices, because they weren't ready. Remaining: {round.InputCount}");
 
 		if (round.InputCount >= round.Parameters.MinInputCountByRound)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -281,6 +281,7 @@ public partial class Arena : PeriodicRunner
 					if (!allReady && phaseExpired)
 					{
 						round.TransactionSigningTimeFrame = TimeFrame.Create(Config.FailFastTransactionSigningTimeout);
+						round.FastSigningPhase = true;
 					}
 
 					SetRoundPhase(round, Phase.TransactionSigning);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -48,6 +48,8 @@ public class Round
 
 		Id = CalculateHash();
 		CoinJoinInputCommitmentData = new CoinJoinInputCommitmentData(Parameters.CoordinationIdentifier, Id);
+
+		FastSigningPhase = false;
 	}
 
 	public uint256 Id { get; }
@@ -69,6 +71,8 @@ public class Round
 	public DateTimeOffset End { get; private set; }
 	public EndRoundState EndRoundState { get; set; }
 	public int RemainingInputVsizeAllocation => Parameters.InitialInputVsizeAllocation - (InputCount * Parameters.MaxVsizeAllocationPerAlice);
+
+	public bool FastSigningPhase { get; set; }
 
 	public RoundParameters Parameters { get; }
 	public Script CoordinatorScript { get; set; }

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -79,9 +79,9 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "FailFastOutputRegistrationTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan FailFastOutputRegistrationTimeout { get; set; } = TimeSpan.FromMinutes(3);
 
-	[DefaultValueTimeSpan("0d 0h 1m 0s")]
+	[DefaultValueTimeSpan("0d 0h 0m 30s")]
 	[JsonProperty(PropertyName = "FailFastTransactionSigningTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public TimeSpan FailFastTransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
+	public TimeSpan FailFastTransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(0.5);
 
 	[DefaultValueTimeSpan("0d 0h 5m 0s")]
 	[JsonProperty(PropertyName = "RoundExpiryTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
This pull request implements https://github.com/zkSNACKs/WalletWasabi/issues/11114.

If there is an Alice who didn't send the ready-to-sign request, then the following happens:
  * The signing phase is shortened to 30 seconds.
  * Sending signatures is optional for clients.
  * All Alices that didn't send the ready-to-sign request are removed from the round.
  * If there are enough Alices to continue:
    * The coordinator ends the round with `NotAllAlicesSign` .
    * The coordinator initiates a blame round.
   * Otherwise:
     * The coordinator ends the round with `AbortedNotEnoughAlicesSigned`.

I didn't test it but this PR should be backward compatible with the wasabi wallet. The only thing that changed from the perspective of wasabi wallet is that the shortened signing phase was reduced to 30 seconds. If a wasabi wallet doesn't manage to sign the transaction within this interval, it won't probably participate in the blame round.