### PR TITLE
Request tx with witness data and ignore txs without it.

### DIFF
--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -76,7 +76,7 @@ public abstract class P2pBehavior : NodeBehavior
 		{
 			if (ProcessInventoryVector(inv, node.RemoteSocketEndpoint))
 			{
-				var newInv =  new InventoryVector(InventoryType.MSG_WTX, inv.Hash);
+				var newInv = new InventoryVector(InventoryType.MSG_WTX, inv.Hash);
 				getDataPayload.Inventory.Add(newInv);
 			}
 		}


### PR DESCRIPTION
Related: #11119 

In our `TransactionStore` we have witness-stripped segwit transactions (txs in pre-segwit-compatible serialization format) what means we really don't know the real size of them. Given the weight discount only applies to witness data, calling `GetVirtualSize` against these transactions make no sense and will return the real size in bytes compatible to the pre-segwit size calculation (where no virtual byte/virtual size existed).

Peers were sending us the stripped transactions because that's how we were requesting them (bug). This PR changes that and starts requesting the full transactions (MSG_WTX). Additionally we do not process txs received via p2p without witness data (i didn't see them coming after this change so, it should never happen but just in case)

What to do with the already existing witness-stripped  transactions stored in the TransactionStores? IMO the UI has to take this fact into account and DO NOT calculate fee rate or virtual size for them.

What next?

Check how we are requesting the blocks (we should use MSG_WITNESS_BLOCK). 