### PR TITLE
Cancel previous task before running new privacy calculation

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -90,6 +90,11 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			.WhereNotNull()
 			.Throttle(TimeSpan.FromMilliseconds(100))
 			.ObserveOn(RxApp.MainThreadScheduler)
+			.Do(_ =>
+			{
+				_cancellationTokenSource.Cancel();
+				_cancellationTokenSource = new();
+			})
 			.DoAsync(async transaction =>
 			{
 				await CheckChangePocketAvailableAsync(transaction);


### PR DESCRIPTION
Cleaner version of https://github.com/zkSNACKs/WalletWasabi/pull/11082

The privacy suggestion calculation was not cancelled when a new one had to be made after changin the transaction in preview.