### PR TITLE
Don't Use Witness Txs/Blocks over the Network

### DIFF
--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -42,16 +42,7 @@ public abstract class P2pBehavior : NodeBehavior
 			}
 			else if (message.Message.Payload is TxPayload txPayload)
 			{
-				var tx = txPayload.Object;
-				var segwitWithoutWitness = !tx.HasWitness && tx.Inputs.Any(x => x.ScriptSig == Script.Empty);
-				if (!segwitWithoutWitness)
-				{
-					ProcessTx(txPayload);
-				}
-				else
-				{
-					Logger.LogInfo($"tx {tx.GetHash()} has no witness data. Ignoring...");
-				}
+				ProcessTx(txPayload);
 			}
 			else if (message.Message.Payload is InvPayload invPayload)
 			{
@@ -76,8 +67,7 @@ public abstract class P2pBehavior : NodeBehavior
 		{
 			if (ProcessInventoryVector(inv, node.RemoteSocketEndpoint))
 			{
-				var newInv = new InventoryVector(InventoryType.MSG_WTX, inv.Hash);
-				getDataPayload.Inventory.Add(newInv);
+				getDataPayload.Inventory.Add(inv);
 			}
 		}
 		if (getDataPayload.Inventory.Any() && node.IsConnected)

--- a/WalletWasabi/BitcoinP2p/TrustedP2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/TrustedP2pBehavior.cs
@@ -37,7 +37,7 @@ public class TrustedP2pBehavior : P2pBehavior
 			return true;
 		}
 
-		if (inv.Type.HasFlag(InventoryType.MSG_WITNESS_BLOCK))
+		if (inv.Type.HasFlag(InventoryType.MSG_BLOCK) || inv.Type.HasFlag(InventoryType.MSG_WITNESS_BLOCK))
 		{
 			BlockInv?.Invoke(this, inv.Hash);
 		}

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -27,7 +27,7 @@ public static class NBitcoinExtensions
 		}
 
 		using var listener = node.CreateListener();
-		var getData = new GetDataPayload(new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_WITNESS_BLOCK), hash));
+		var getData = new GetDataPayload(new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_BLOCK), hash));
 		await node.SendMessageAsync(getData).ConfigureAwait(false);
 		cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Partly undoes https://github.com/zkSNACKs/WalletWasabi/pull/11129 and undoes https://github.com/zkSNACKs/WalletWasabi/pull/11121

This is to save network bandwidth. It seems wherever we need the witness we already have it and https://github.com/zkSNACKs/WalletWasabi/pull/10976/commits/2dc75c1c414f20263cc1c48edf664fd34c667deb fixes the issue of https://github.com/zkSNACKs/WalletWasabi/issues/11119 without introducing sending the witnesses back and forth on the network

@yahiheb @soosr are the feerates correct on this branch?