### PR TITLE
[PoC] Add delay before signing to round hash

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -148,7 +148,7 @@ public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 			.OrderByDescending(x => x.InputCount)
 			.Select(r =>
 				new HumanMonitorRoundResponse(
-					RoundId: r.Id,
+					RoundId: r.Idv2,
 					IsBlameRound: r is BlameRound,
 					InputCount: r.InputCount,
 					Phase: r.Phase.ToString(),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -45,10 +45,10 @@ public class RoundStateUpdaterTests
 		// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
 		// events for that round.
 		using var round1TSCts = new CancellationTokenSource();
-		var round1IRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Id, Phase.InputRegistration, cancellationToken);
-		var round1ORTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Id, Phase.OutputRegistration, cancellationToken);
-		var round1TSTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Id, Phase.TransactionSigning, round1TSCts.Token);
-		var round1TBTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Id, Phase.Ended, cancellationToken);
+		var round1IRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Idv2, Phase.InputRegistration, cancellationToken);
+		var round1ORTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Idv2, Phase.OutputRegistration, cancellationToken);
+		var round1TSTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Idv2, Phase.TransactionSigning, round1TSCts.Token);
+		var round1TBTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState1.Idv2, Phase.Ended, cancellationToken);
 
 		// Start
 		await roundStatusUpdater.StartAsync(cancellationTokenSource.Token);
@@ -62,21 +62,21 @@ public class RoundStateUpdaterTests
 		// Force the RoundStatusUpdater to run. After this it will know about the existence of `round2` so,
 		// we can subscribe to events.
 		await roundStatusUpdater.TriggerAndWaitRoundAsync(TestTimeOut);
-		var round2IRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState2.Id, Phase.InputRegistration, cancellationToken);
-		var round2TBTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState2.Id, Phase.Ended, cancellationToken);
+		var round2IRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState2.Idv2, Phase.InputRegistration, cancellationToken);
+		var round2TBTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState2.Idv2, Phase.Ended, cancellationToken);
 
 		// Force the RoundStatusUpdater to run again just to make it trigger the events.
 		await roundStatusUpdater.TriggerAndWaitRoundAsync(TestTimeOut);
 
 		// Wait for round1 in input registration.
 		var round2 = await round2IRTask;
-		Assert.Equal(roundState2.Id, round2.Id);
+		Assert.Equal(roundState2.Idv2, round2.Idv2);
 		Assert.Equal(Phase.InputRegistration, round2.Phase);
 		Assert.All(new[] { round1TSTask, round1TBTask, round2TBTask }, t => Assert.Equal(TaskStatus.WaitingForActivation, t.Status));
 
 		// `round1` changed to output registration phase even before `round2` was created so, it has to be completed.
 		round1 = await round1ORTask;
-		Assert.Equal(roundState1.Id, round1.Id);
+		Assert.Equal(roundState1.Idv2, round1.Idv2);
 		Assert.Equal(Phase.OutputRegistration, round1.Phase);
 		Assert.All(new[] { round1TSTask, round1TBTask, round2TBTask }, t => Assert.Equal(TaskStatus.WaitingForActivation, t.Status));
 
@@ -88,7 +88,7 @@ public class RoundStateUpdaterTests
 		// the transaction has to fail to let the sleeping component that the round doesn't exist any more.
 		await roundStatusUpdater.TriggerAndWaitRoundAsync(TestTimeOut);
 		var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await round1TBTask);
-		Assert.Contains(round1.Id.ToString(), ex.Message);
+		Assert.Contains(round1.Idv2.ToString(), ex.Message);
 		Assert.Contains("not running", ex.Message);
 
 		// `Round2` awaiter has to be cancelled immediately when we stop the updater.
@@ -123,8 +123,8 @@ public class RoundStateUpdaterTests
 		// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
 		// events for that round.
 		using var roundTSCts = new CancellationTokenSource();
-		var roundIRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Id, Phase.InputRegistration, cancellationToken);
-		var roundORTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Id, Phase.OutputRegistration, cancellationToken);
+		var roundIRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Idv2, Phase.InputRegistration, cancellationToken);
+		var roundORTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Idv2, Phase.OutputRegistration, cancellationToken);
 
 		// Start
 		await roundStatusUpdater.StartAsync(cancellationTokenSource.Token);
@@ -171,8 +171,8 @@ public class RoundStateUpdaterTests
 		// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
 		// events for that round.
 		using var roundTSCts = new CancellationTokenSource();
-		var roundIRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Id, Phase.InputRegistration, cancellationToken);
-		var roundORTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Id, Phase.OutputRegistration, cancellationToken);
+		var roundIRTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Idv2, Phase.InputRegistration, cancellationToken);
+		var roundORTask = roundStatusUpdater.CreateRoundAwaiterAsync(roundState.Idv2, Phase.OutputRegistration, cancellationToken);
 
 		// Start
 		await roundStatusUpdater.StartAsync(cancellationTokenSource.Token);

--- a/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WrongPhaseException.cs
@@ -7,7 +7,7 @@ namespace WalletWasabi.WabiSabi.Backend.Models;
 public class WrongPhaseException : WabiSabiProtocolException
 {
 	public WrongPhaseException(Round round, params Phase[] expectedPhases)
-		: base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Id}): Wrong phase ({round.Phase}).", exceptionData: new WrongPhaseExceptionData(round.Phase))
+		: base(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({round.Idv2}): Wrong phase ({round.Phase}).", exceptionData: new WrongPhaseExceptionData(round.Phase))
 	{
 		var latestExpectedPhase = expectedPhases.MaxBy(p => (int)p);
 		var now = DateTimeOffset.UtcNow;
@@ -35,7 +35,7 @@ public class WrongPhaseException : WabiSabiProtocolException
 		};
 
 		CurrentPhase = round.Phase;
-		RoundId = round.Id;
+		RoundId = round.Idv2;
 		ExpectedPhases = expectedPhases;
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -31,6 +31,7 @@ public record RoundParameters
 		TimeSpan outputRegistrationTimeout,
 		TimeSpan transactionSigningTimeout,
 		TimeSpan blameInputRegistrationTimeout,
+		TimeSpan delayBeforeSigning,
 		string coordinationIdentifier)
 	{
 		Network = network;
@@ -48,6 +49,7 @@ public record RoundParameters
 		OutputRegistrationTimeout = outputRegistrationTimeout;
 		TransactionSigningTimeout = transactionSigningTimeout;
 		BlameInputRegistrationTimeout = blameInputRegistrationTimeout;
+		DelayBeforeSigning = delayBeforeSigning;
 
 		InitialInputVsizeAllocation = MaxTransactionSize - MultipartyTransactionParameters.SharedOverhead;
 		MaxVsizeCredentialValue = Math.Min(InitialInputVsizeAllocation / MaxInputCountByRound, (int)ProtocolConstants.MaxVsizeCredentialValue);
@@ -70,6 +72,7 @@ public record RoundParameters
 	public TimeSpan OutputRegistrationTimeout { get; init; }
 	public TimeSpan TransactionSigningTimeout { get; init; }
 	public TimeSpan BlameInputRegistrationTimeout { get; init; }
+	public TimeSpan DelayBeforeSigning { get; init; }
 
 	public Money MinAmountCredentialValue => AllowedInputAmounts.Min;
 	public Money MaxAmountCredentialValue => AllowedInputAmounts.Max;
@@ -116,6 +119,7 @@ public record RoundParameters
 			wabiSabiConfig.OutputRegistrationTimeout,
 			wabiSabiConfig.TransactionSigningTimeout,
 			wabiSabiConfig.BlameInputRegistrationTimeout,
+			wabiSabiConfig.DelayBeforeSigning,
 			wabiSabiConfig.CoordinatorIdentifier);
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -104,6 +104,10 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "FailFastTransactionSigningTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan FailFastTransactionSigningTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
+	[DefaultValueTimeSpan("0d 0h 0m 20s")]
+	[JsonProperty(PropertyName = "DelayBeforeSigning", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public TimeSpan DelayBeforeSigning { get; set; } = TimeSpan.FromSeconds(20);
+
 	[DefaultValueTimeSpan("0d 0h 5m 0s")]
 	[JsonProperty(PropertyName = "RoundExpiryTimeout", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public TimeSpan RoundExpiryTimeout { get; set; } = TimeSpan.FromMinutes(5);

--- a/WalletWasabi/WabiSabi/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/AliceClient.cs
@@ -31,7 +31,7 @@ public class AliceClient
 	{
 		var roundParameters = roundState.CoinjoinState.Parameters;
 		AliceId = aliceId;
-		RoundId = roundState.Id;
+		RoundId = roundState.Idv2;
 		ArenaClient = arenaClient;
 		SmartCoin = coin;
 		OwnershipProof = ownershipProof;
@@ -112,13 +112,13 @@ public class AliceClient
 
 		var ownershipProof = keyChain.GetOwnershipProof(
 			coin,
-			new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Id));
+			new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Idv2));
 
-		var (response, isCoordinationFeeExempted) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
+		var (response, isCoordinationFeeExempted) = await arenaClient.RegisterInputAsync(roundState.Idv2, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
 		aliceClient = new(response.Value, roundState, arenaClient, coin, ownershipProof, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isCoordinationFeeExempted);
 		coin.CoinJoinInProgress = true;
 
-		Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.Outpoint}.");
+		Logger.LogInfo($"Round ({roundState.Idv2}), Alice ({aliceClient.AliceId}): Registered {coin.Outpoint}.");
 
 		return aliceClient;
 	}

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateAwaiter.cs
@@ -52,7 +52,7 @@ public record RoundStateAwaiter
 		{
 			if (RoundId is { })
 			{
-				if (roundState.Id != RoundId)
+				if (roundState.Idv2 != RoundId)
 				{
 					continue;
 				}

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -57,17 +57,17 @@ public class RoundStateUpdater : PeriodicRunner
 		CoinJoinFeeRateMedians = response.CoinJoinFeeRateMedians.ToDictionary(a => a.TimeFrame, a => a.MedianFeeRate);
 
 		var updatedRoundStates = roundStates
-			.Where(rs => RoundStates.ContainsKey(rs.Id))
-			.Select(rs => (NewRoundState: rs, CurrentRoundState: RoundStates[rs.Id]))
+			.Where(rs => RoundStates.ContainsKey(rs.Idv2))
+			.Select(rs => (NewRoundState: rs, CurrentRoundState: RoundStates[rs.Idv2]))
 			.Select(x => x.NewRoundState with { CoinjoinState = x.NewRoundState.CoinjoinState.AddPreviousStates(x.CurrentRoundState.CoinjoinState) })
 			.ToList();
 
 		var newRoundStates = roundStates
-			.Where(rs => !RoundStates.ContainsKey(rs.Id));
+			.Where(rs => !RoundStates.ContainsKey(rs.Idv2));
 
 		// Don't use ToImmutable dictionary, because that ruins the original order and makes the server unable to suggest a round preference.
 		// ToDo: ToDictionary doesn't guarantee the order by design so .NET team might change this out of our feet, so there's room for improvement here.
-		RoundStates = newRoundStates.Concat(updatedRoundStates).ToDictionary(x => x.Id, x => x);
+		RoundStates = newRoundStates.Concat(updatedRoundStates).ToDictionary(x => x.Idv2, x => x);
 
 		lock (AwaitersLock)
 		{

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.WabiSabi.Crypto;
 
 public static class RoundHasher
 {
-	public static uint256 CalculateHash(
+	public static uint256 CalculateLegacyHash(
 			DateTimeOffset inputRegistrationStart,
 			TimeSpan inputRegistrationTimeout,
 			TimeSpan connectionConfirmationTimeout,
@@ -38,6 +38,57 @@ public static class RoundHasher
 			.Append(ProtocolConstants.RoundConnectionConfirmationTimeoutStrobeLabel, connectionConfirmationTimeout)
 			.Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, outputRegistrationTimeout)
 			.Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, transactionSigningTimeout)
+			.Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
+			.Append(ProtocolConstants.RoundAllowedInputTypesStrobeLabel, allowedInputTypes)
+			.Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)
+			.Append(ProtocolConstants.RoundAllowedOutputTypesStrobeLabel, allowedOutputTypes)
+			.Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())
+			.Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
+			.Append(ProtocolConstants.RoundCoordinationFeeRateStrobeLabel, coordinationFeeRate)
+			.Append(ProtocolConstants.RoundMaxTransactionSizeStrobeLabel, maxTransactionSize)
+			.Append(ProtocolConstants.RoundMinRelayTxFeeStrobeLabel, minRelayTxFeePerK)
+			.Append(ProtocolConstants.RoundMaxAmountCredentialValueStrobeLabel, maxAmountCredentialValue)
+			.Append(ProtocolConstants.RoundMaxVsizeCredentialValueStrobeLabel, maxVsizeCredentialValue)
+			.Append(ProtocolConstants.RoundMaxVsizePerAliceStrobeLabel, maxVsizeAllocationPerAlice)
+			.Append(ProtocolConstants.RoundMaxSuggestedAmountLabel, maxSuggestedAmount)
+			.Append(ProtocolConstants.RoundCoordinationIdentifier, coordinationIdentifier)
+			.Append(ProtocolConstants.RoundAmountCredentialIssuerParametersStrobeLabel, amountCredentialIssuerParameters)
+			.Append(ProtocolConstants.RoundVsizeCredentialIssuerParametersStrobeLabel, vsizeCredentialIssuerParameters)
+			.GetHash();
+		return new uint256(hash);
+	}
+
+	public static uint256 CalculateHash(
+			DateTimeOffset inputRegistrationStart,
+			TimeSpan inputRegistrationTimeout,
+			TimeSpan connectionConfirmationTimeout,
+			TimeSpan outputRegistrationTimeout,
+			TimeSpan transactionSigningTimeout,
+			TimeSpan delayBeforeSigning,
+			MoneyRange allowedInputAmounts,
+			ImmutableSortedSet<ScriptType> allowedInputTypes,
+			MoneyRange allowedOutputAmounts,
+			ImmutableSortedSet<ScriptType> allowedOutputTypes,
+			Network network,
+			long feePerK,
+			CoordinationFeeRate coordinationFeeRate,
+			int maxTransactionSize,
+			long minRelayTxFeePerK,
+			long maxAmountCredentialValue,
+			long maxVsizeCredentialValue,
+			long maxVsizeAllocationPerAlice,
+			long maxSuggestedAmount,
+			string coordinationIdentifier,
+			CredentialIssuerParameters amountCredentialIssuerParameters,
+			CredentialIssuerParameters vsizeCredentialIssuerParameters)
+	{
+		var hash = StrobeHasher.Create(ProtocolConstants.RoundStrobeDomain)
+			.Append(ProtocolConstants.RoundInputRegistrationStartStrobeLabel, inputRegistrationStart)
+			.Append(ProtocolConstants.RoundInputRegistrationTimeoutStrobeLabel, inputRegistrationTimeout)
+			.Append(ProtocolConstants.RoundConnectionConfirmationTimeoutStrobeLabel, connectionConfirmationTimeout)
+			.Append(ProtocolConstants.RoundOutputRegistrationTimeoutStrobeLabel, outputRegistrationTimeout)
+			.Append(ProtocolConstants.RoundTransactionSigningTimeoutStrobeLabel, transactionSigningTimeout)
+			.Append(ProtocolConstants.RoundDelayBeforeSigningStrobeLabel, delayBeforeSigning)
 			.Append(ProtocolConstants.RoundAllowedInputAmountsStrobeLabel, allowedInputAmounts)
 			.Append(ProtocolConstants.RoundAllowedInputTypesStrobeLabel, allowedInputTypes)
 			.Append(ProtocolConstants.RoundAllowedOutputAmountsStrobeLabel, allowedOutputAmounts)

--- a/WalletWasabi/WabiSabi/LoggerTools.cs
+++ b/WalletWasabi/WabiSabi/LoggerTools.cs
@@ -34,7 +34,7 @@ public static class LoggerTools
 	{
 		string round = roundState.BlameOf == uint256.Zero ? "Round" : "Blame Round";
 
-		Logger.Log(logLevel, $"{round} ({roundState.Id}): {logMessage}", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
+		Logger.Log(logLevel, $"{round} ({roundState.Idv2}): {logMessage}", callerFilePath: callerFilePath, callerMemberName: callerMemberName, callerLineNumber: callerLineNumber);
 	}
 
 	public static void LogInfo(this RoundState roundState, string logMessage, [CallerFilePath] string callerFilePath = "", [CallerMemberName] string callerMemberName = "", [CallerLineNumber] int callerLineNumber = -1)

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -8,8 +8,11 @@ using CredentialIssuerParameters = WabiSabi.Crypto.CredentialIssuerParameters;
 
 namespace WalletWasabi.WabiSabi.Models;
 
-public record RoundState(uint256 Id,
+public record RoundState(
+	uint256 Id,
+	uint256 Idv2,
 	uint256 BlameOf,
+	uint256 BlameOfV2,
 	CredentialIssuerParameters AmountCredentialIssuerParameters,
 	CredentialIssuerParameters VsizeCredentialIssuerParameters,
 	Phase Phase,
@@ -23,7 +26,9 @@ public record RoundState(uint256 Id,
 	public static RoundState FromRound(Round round, int stateId = 0) =>
 		new(
 			round.Id,
+			round.Idv2,
 			round is BlameRound blameRound ? blameRound.BlameOf.Id : uint256.Zero,
+			round is BlameRound blameRoundV2 ? blameRoundV2.BlameOf.Idv2 : uint256.Zero,
 			round.AmountCredentialIssuerParameters,
 			round.VsizeCredentialIssuerParameters,
 			round.Phase,
@@ -36,7 +41,9 @@ public record RoundState(uint256 Id,
 	public RoundState GetSubState(int skipFromBaseState) =>
 		new(
 			Id,
+			Idv2,
 			BlameOf,
+			BlameOfV2,
 			AmountCredentialIssuerParameters,
 			VsizeCredentialIssuerParameters,
 			Phase,

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -32,6 +32,7 @@ public static class ProtocolConstants
 	public const string RoundConnectionConfirmationTimeoutStrobeLabel = "connection-confirmation-timeout";
 	public const string RoundOutputRegistrationTimeoutStrobeLabel = "output-registration-timeout";
 	public const string RoundTransactionSigningTimeoutStrobeLabel = "transaction-signing-timeout";
+	public const string RoundDelayBeforeSigningStrobeLabel = "delay-before-signing";
 	public const string RoundMaxSuggestedAmountLabel = "maximum-suggested-amount";
 	public const string RoundCoordinationIdentifier = "coordination-identifier";
 


### PR DESCRIPTION
This PR is for adding a new field to the round hash indicating the delay that clients have to wait before signing the transaction. It looks a bit crazy at first glance but it is the only way we have be sure the coordinator doesn't lie selectively to clients.