### PR TITLE
[Trivial] Unify warning messages for the Cancel/Speed up dialogs

### DIFF
--- a/WalletWasabi.Fluent/Controls/QuestionControl.axaml
+++ b/WalletWasabi.Fluent/Controls/QuestionControl.axaml
@@ -16,14 +16,14 @@
             HorizontalAlignment="Stretch" MaxWidth="500" DockPanel.Dock="Bottom">
             <Button Name="PART_NoButton"
                     HorizontalAlignment="Left"
-                    Content="No"
+                    Content="{TemplateBinding NoContent}"
                     Classes.action="{TemplateBinding IsNoButton}"
                     IsDefault="{TemplateBinding IsNoButton}"
                     Classes="yesNo"
                     Command="{TemplateBinding NoCommand}" />
             <Button Name="PART_YesButton"
                     HorizontalAlignment="Right"
-                    Content="Yes"
+                    Content="{TemplateBinding YesContent}"
                     Classes.action="{TemplateBinding IsYesButton}"
                     IsDefault="{TemplateBinding IsYesButton}"
                     Classes="yesNo"

--- a/WalletWasabi.Fluent/Controls/QuestionControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/QuestionControl.axaml.cs
@@ -26,6 +26,12 @@ public class QuestionControl : ContentControl
 	public static readonly StyledProperty<object?> IconContentProperty =
 		AvaloniaProperty.Register<QuestionControl, object?>(nameof(IconContent));
 
+	public static readonly StyledProperty<string> YesContentProperty =
+		AvaloniaProperty.Register<QuestionControl, string>(nameof(YesContent));
+
+	public static readonly StyledProperty<string> NoContentProperty =
+		AvaloniaProperty.Register<QuestionControl, string>(nameof(NoContent));
+
 	public static readonly StyledProperty<HighlightedButton> HighlightButtonProperty =
 		AvaloniaProperty.Register<QuestionControl, HighlightedButton>(nameof(HighlightButton));
 
@@ -38,6 +44,8 @@ public class QuestionControl : ContentControl
 	public QuestionControl()
 	{
 		UpdateHighlightedButton(HighlightButton);
+		YesContent = "Yes";
+		NoContent = "No";
 	}
 
 	public ICommand YesCommand
@@ -74,6 +82,18 @@ public class QuestionControl : ContentControl
 	{
 		get => GetValue(IconContentProperty);
 		set => SetValue(IconContentProperty, value);
+	}
+
+	public string YesContent
+	{
+		get => GetValue(YesContentProperty);
+		set => SetValue(YesContentProperty, value);
+	}
+
+	public string NoContent
+	{
+		get => GetValue(NoContentProperty);
+		set => SetValue(NoContentProperty, value);
 	}
 
 	public HighlightedButton HighlightButton

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
@@ -31,7 +31,7 @@
         </Viewbox>
       </c:QuestionControl.IconContent>
       <StackPanel Spacing="10">
-        <TextBlock Text="The cancellation of this transaction will cost you a total of" />
+        <TextBlock Text="Canceling this transaction will cost you" />
         <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center">
           <TextBlock TextAlignment="Center"
                      Text="{Binding TotalFee, Converter={x:Static converters:MoneyConverters.ToFeeWithUnit}, FallbackValue='0.0000 0232 BTC'}"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
@@ -23,7 +23,7 @@
       </Style>
     </c:ContentArea.Styles>
 
-    <c:QuestionControl HighlightButton="YesButton" YesCommand="{Binding NextCommand}"
+    <c:QuestionControl HighlightButton="YesButton" YesCommand="{Binding NextCommand}" YesContent="Confirm" NoContent="Cancel"
                        NoCommand="{Binding CancelCommand}">
       <c:QuestionControl.IconContent>
         <Viewbox MaxHeight="120" Margin="40">

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
@@ -31,7 +31,7 @@
         </Viewbox>
       </c:QuestionControl.IconContent>
       <StackPanel Spacing="10">
-        <TextBlock Text="Canceling this transaction will cost you" />
+        <TextBlock Text="Cancelling this transaction will cost you" />
         <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center">
           <TextBlock TextAlignment="Center"
                      Text="{Binding TotalFee, Converter={x:Static converters:MoneyConverters.ToFeeWithUnit}, FallbackValue='0.0000 0232 BTC'}"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/CancelTransactionDialogView.axaml
@@ -40,8 +40,6 @@
             Text="{Binding TotalFeeUsd, Converter={x:Static converters:MoneyConverters.ToUsdApprox}, FallbackValue='≈ 3.5 USD'}"
             Opacity="0.6" VerticalAlignment="Bottom" Margin="0 0 0 3" Classes="h8" />
         </StackPanel>
-        <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap"
-                   Text="Are you sure?" />
       </StackPanel>
     </c:QuestionControl>
   </c:ContentArea>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/SpeedUpTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/SpeedUpTransactionDialogView.axaml
@@ -32,7 +32,7 @@
           </Viewbox>
         </c:QuestionControl.IconContent>
         <StackPanel Spacing="10">
-          <TextBlock Text="Speeding up this transaction will cost you an additional fee of" />
+          <TextBlock Text="Speeding up this transaction will cost you" />
           <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center">
             <TextBlock TextAlignment="Center"
                        FontWeight="Bold"
@@ -61,7 +61,7 @@
           </Panel>
         </c:QuestionControl.IconContent>
         <StackPanel Spacing="10">
-          <TextBlock Text="To speed up this transaction a deduction will be made from the recipient's amount of" />
+          <TextBlock Text="Speeding up this transaction will deduct from the recipient's amount" />
           <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center">
             <TextBlock Text="{Binding FeeDifference, Converter={x:Static converters:MoneyConverters.ToFeeWithUnit}, FallbackValue='0.0000 0232 BTC'}"
                        Classes="h5" FontWeight="Bold" />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/SpeedUpTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/SpeedUpTransactionDialogView.axaml
@@ -43,8 +43,6 @@
               Text="{Binding FeeDifferenceUsd, Converter={x:Static converters:MoneyConverters.ToUsdApprox}, FallbackValue='≈3.5 USD'}"
               Opacity="0.6" VerticalAlignment="Bottom" Margin="0 0 0 3" Classes="h8" />
           </StackPanel>
-          <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap"
-                     Text="Are you sure?" />
         </StackPanel>
       </c:QuestionControl>
 
@@ -69,7 +67,6 @@
               Text="{Binding FeeDifferenceUsd, Converter={x:Static converters:MoneyConverters.ToUsdApprox}, FallbackValue='≈3.5 USD'}"
               Opacity="0.6" VerticalAlignment="Bottom" Margin="0 0 0 3" Classes="h8" />
           </StackPanel>
-          <TextBlock Text="Are you sure?" />
         </StackPanel>
       </c:QuestionControl>
     </Panel>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/SpeedUpTransactionDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Features/SpeedUpTransactionDialogView.axaml
@@ -24,7 +24,7 @@
     </c:ContentArea.Styles>
 
     <Panel>
-      <c:QuestionControl IsVisible="{Binding AreWePayingTheFee}" HighlightButton="YesButton" YesCommand="{Binding NextCommand}"
+      <c:QuestionControl IsVisible="{Binding AreWePayingTheFee}" HighlightButton="YesButton" YesCommand="{Binding NextCommand}" YesContent="Confirm" NoContent="Cancel"
                          NoCommand="{Binding CancelCommand}">
         <c:QuestionControl.IconContent>
           <Viewbox MaxHeight="120" Margin="40">
@@ -46,7 +46,7 @@
         </StackPanel>
       </c:QuestionControl>
 
-      <c:QuestionControl IsVisible="{Binding !AreWePayingTheFee}" YesCommand="{Binding NextCommand}"
+      <c:QuestionControl IsVisible="{Binding !AreWePayingTheFee}" YesCommand="{Binding NextCommand}" YesContent="Confirm" NoContent="Cancel"
                          NoCommand="{Binding CancelCommand}">
         <c:QuestionControl.IconContent>
           <Panel>

--- a/WalletWasabi/Blockchain/TransactionBuilding/TransactionModifierWalletExtensions.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/TransactionModifierWalletExtensions.cs
@@ -329,7 +329,7 @@ public static class TransactionModifierWalletExtensions
 
 		if (cpfpFee > maxFee)
 		{
-			throw new InvalidOperationException($"CPFP fee ({cpfpFee}) is higher than what it it's worth to speed up this transaction ({maxFee}).");
+			throw new InvalidOperationException($"CPFP fee ({cpfpFee}) is higher than what it's worth to speed up this transaction ({maxFee}).");
 		}
 	}
 }

--- a/WalletWasabi/Services/SingleInstanceChecker.cs
+++ b/WalletWasabi/Services/SingleInstanceChecker.cs
@@ -155,7 +155,7 @@ public class SingleInstanceChecker : BackgroundService, IAsyncDisposable
 
 			while (!stoppingToken.IsCancellationRequested)
 			{
-				// In case of cancellation, listener.Stop will cause AcceptTcpClientAsync to throw, thus canceling it.
+				// In case of cancellation, listener.Stop will cause AcceptTcpClientAsync to throw, thus cancelling it.
 				using var client = await listener.AcceptTcpClientAsync(stoppingToken).ConfigureAwait(false);
 				client.ReceiveBufferSize = 1000;
 				try


### PR DESCRIPTION
This PR unifies the warning messages and makes them shorter, and also removes the awkward looking `Are you sure?` message under the amount.

I guess if we want we can make these dialogs smaller since there is a lot of empty space.

PR:
![4](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/eeb8de1d-f227-4732-acb8-b4f4b4501aaa)
![5](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/04d3e184-2110-4061-8d7c-3a468cda34db)

Master:

![1](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/4b89c47e-f684-46be-800c-7066432dd401)
![2](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/543c9ff8-d5a0-42ac-9806-8ac085d9f85a)
