### PR TITLE
[Trivial] Hide TXID separator if tx is not confirmed

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -100,7 +100,7 @@
         </c:PrivacyContentControl>
       </c:PreviewItem>
 
-      <Separator />
+      <Separator IsVisible="{Binding IsConfirmed}" />
 
       <!-- Block hash -->
       <c:PreviewItem Icon="{StaticResource block_id}"


### PR DESCRIPTION
Fixes this double separator issue noticed by @turbolay.

![image](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/ba5115cf-174d-4957-9447-ba4a9ed20c6e)
