### PR TITLE
[VDG] Go back when transaction is confirmed

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/CancelTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/CancelTransactionDialogViewModel.cs
@@ -62,7 +62,12 @@ public partial class CancelTransactionDialogViewModel : RoutableViewModel
 
 			var msg = _transactionToCancel.Confirmed ? "The transaction is already confirmed." : ex.ToUserFriendlyString();
 
-			UiContext.Navigate().To().ShowErrorDialog(msg, "Cancellation Failed", "Wasabi was unable to cancel your transaction.");
+			await UiContext.Navigate().To().ShowErrorDialog(msg, "Cancellation Failed", "Wasabi was unable to cancel your transaction.").GetResultAsync();
+
+			if (_transactionToCancel.Confirmed)
+			{
+				Navigate().Back();
+			}
 		}
 
 		IsBusy = false;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
@@ -1,10 +1,13 @@
 using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Fluent.Extensions;
+using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Logging;
 using WalletWasabi.Wallets;
@@ -14,11 +17,13 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.Features;
 [NavigationMetaData(Title = "Speed Up Transaction")]
 public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 {
-	private readonly Wallet _wallet;
 	private readonly SmartTransaction _transactionToSpeedUp;
+	private readonly UiTriggers _triggers;
+	private readonly Wallet _wallet;
 
-	private SpeedUpTransactionDialogViewModel(Wallet wallet, SmartTransaction transactionToSpeedUp, BuildTransactionResult boostingTransaction)
+	private SpeedUpTransactionDialogViewModel(UiTriggers triggers, Wallet wallet, SmartTransaction transactionToSpeedUp, BuildTransactionResult boostingTransaction)
 	{
+		_triggers = triggers;
 		_wallet = wallet;
 		_transactionToSpeedUp = transactionToSpeedUp;
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
@@ -30,7 +35,7 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 		FeeDifferenceUsd = FeeDifference.ToDecimal(MoneyUnit.BTC) * wallet.Synchronizer.UsdExchangeRate;
 		AreWePayingTheFee = boostingTransaction.Transaction.GetWalletOutputs(_wallet.KeyManager).Any();
 	}
-
+	
 	public decimal FeeDifferenceUsd { get; }
 
 	public bool AreWePayingTheFee { get; }
@@ -51,6 +56,19 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 		return boostingTransactionFee - originalFee;
 	}
 
+	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
+	{
+		_triggers.TransactionsUpdateTrigger
+			.Select(_ => _wallet.GetTransactions().First(s => s.GetHash() == _transactionToSpeedUp.GetHash()))
+			.Select(x => x.Confirmed)
+			.Where(isConfirmed => isConfirmed)
+			.Do(_ => Navigate().Back())
+			.Subscribe()
+			.DisposeWith(disposables);
+
+		base.OnNavigatedTo(isInHistory, disposables);
+	}
+
 	private async Task OnSpeedUpTransactionAsync(BuildTransactionResult boostingTransaction)
 	{
 		IsBusy = true;
@@ -69,12 +87,7 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 		{
 			Logger.LogError(ex);
 			var msg = _transactionToSpeedUp.Confirmed ? "The transaction is already confirmed." : ex.ToUserFriendlyString();
-			await UiContext.Navigate().To().ShowErrorDialog(msg, "Speed Up Failed", "Wasabi was unable to speed up your transaction.").GetResultAsync();
-
-			if (_transactionToSpeedUp.Confirmed)
-			{
-				Navigate().Back();
-			}
+			UiContext.Navigate().To().ShowErrorDialog(msg, "Speed Up Failed", "Wasabi was unable to speed up your transaction.");
 		}
 
 		IsBusy = false;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
@@ -69,7 +69,12 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 		{
 			Logger.LogError(ex);
 			var msg = _transactionToSpeedUp.Confirmed ? "The transaction is already confirmed." : ex.ToUserFriendlyString();
-			UiContext.Navigate().To().ShowErrorDialog(msg, "Speed Up Failed", "Wasabi was unable to speed up your transaction.");
+			await UiContext.Navigate().To().ShowErrorDialog(msg, "Speed Up Failed", "Wasabi was unable to speed up your transaction.").GetResultAsync();
+
+			if (_transactionToSpeedUp.Confirmed)
+			{
+				Navigate().Back();
+			}
 		}
 
 		IsBusy = false;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
@@ -60,7 +60,7 @@ public partial class TransactionHistoryItemViewModel : HistoryItemViewModelBase
 				transactionToSpeedUp = largestCpfp;
 			}
 			var boostingTransaction = Wallet.SpeedUpTransaction(transactionToSpeedUp);
-			UiContext.Navigate().To().SpeedUpTransactionDialog(WalletVm.Wallet, transactionToSpeedUp, boostingTransaction);
+			UiContext.Navigate().To().SpeedUpTransactionDialog(WalletVm.UiTriggers, WalletVm.Wallet, transactionToSpeedUp, boostingTransaction);
 		}
 		catch (Exception ex)
 		{
@@ -74,7 +74,7 @@ public partial class TransactionHistoryItemViewModel : HistoryItemViewModelBase
 		try
 		{
 			var cancellingTransaction = Wallet.CancelTransaction(transactionToCancel);
-			UiContext.Navigate().To().CancelTransactionDialog(Wallet, transactionToCancel, cancellingTransaction);
+			UiContext.Navigate().To().CancelTransactionDialog(WalletVm.UiTriggers, Wallet, transactionToCancel, cancellingTransaction);
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
This improves UX when the transaction is confirmed while the dialog is open and the broadcast fails due to a confirmed transaction.

Fixes #11146.
Fixes #11152.