### PR TITLE
Reintroduce CoinGecko rate provider

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.WebClients.BlockchainInfo;
 using WalletWasabi.WebClients.Coinbase;
+using WalletWasabi.WebClients.CoinGecko;
 using WalletWasabi.WebClients.Bitstamp;
 using WalletWasabi.WebClients.Gemini;
 using Xunit;
@@ -20,6 +21,10 @@ public class ExternalApiTests
 	[Fact]
 	public async Task BlockchainInfoExchangeRateProviderTestsAsync() =>
 		await AssertProviderAsync(new BlockchainInfoExchangeRateProvider());
+
+	[Fact]
+	public async Task CoinGeckoExchangeRateProviderTestsAsync() =>
+		await AssertProviderAsync(new CoinGeckoExchangeRateProvider());
 
 	[Fact]
 	public async Task BitstampExchangeRateProviderTestsAsync() =>

--- a/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRate.cs
+++ b/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRate.cs
@@ -1,0 +1,9 @@
+using Newtonsoft.Json;
+
+namespace WalletWasabi.WebClients.CoinGecko;
+
+public class CoinGeckoExchangeRate
+{
+	[JsonProperty(PropertyName = "current_price")]
+	public decimal Rate { get; set; }
+}

--- a/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
+using WalletWasabi.Helpers;
 using WalletWasabi.Interfaces;
 using WalletWasabi.Tor.Http.Extensions;
 
@@ -16,6 +18,7 @@ public class CoinGeckoExchangeRateProvider : IExchangeRateProvider
 		{
 			BaseAddress = new Uri("https://api.coingecko.com")
 		};
+		httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("WasabiWallet", Constants.ClientVersion.ToString()));
 		using var response = await httpClient.GetAsync("api/v3/coins/markets?vs_currency=usd&ids=bitcoin", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rates = await content.ReadAsJsonAsync<CoinGeckoExchangeRate[]>().ConfigureAwait(false);

--- a/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Backend.Models;
+using WalletWasabi.Interfaces;
+using WalletWasabi.Tor.Http.Extensions;
+
+namespace WalletWasabi.WebClients.CoinGecko;
+
+public class CoinGeckoExchangeRateProvider : IExchangeRateProvider
+{
+	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
+	{
+		using var httpClient = new HttpClient
+		{
+			BaseAddress = new Uri("https://api.coingecko.com")
+		};
+		using var response = await httpClient.GetAsync("api/v3/coins/markets?vs_currency=usd&ids=bitcoin", cancellationToken).ConfigureAwait(false);
+		using var content = response.Content;
+		var rates = await content.ReadAsJsonAsync<CoinGeckoExchangeRate[]>().ConfigureAwait(false);
+
+		var exchangeRates = new List<ExchangeRate>
+			{
+				new ExchangeRate { Rate = rates[0].Rate, Ticker = "USD" }
+			};
+
+		return exchangeRates;
+	}
+}

--- a/WalletWasabi/WebClients/ExchangeRateProviders.cs
+++ b/WalletWasabi/WebClients/ExchangeRateProviders.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.WebClients.BlockchainInfo;
 using WalletWasabi.WebClients.Coinbase;
 using WalletWasabi.WebClients.Bitstamp;
+using WalletWasabi.WebClients.CoinGecko;
 using WalletWasabi.WebClients.Gemini;
 using System.Linq;
 using System.Threading;
@@ -18,6 +19,7 @@ public class ExchangeRateProvider : IExchangeRateProvider
 	{
 		new BlockchainInfoExchangeRateProvider(),
 		new BitstampExchangeRateProvider(),
+		new CoinGeckoExchangeRateProvider(),
 		new CoinbaseExchangeRateProvider(),
 		new GeminiExchangeRateProvider()
 	};


### PR DESCRIPTION
This provider was removed under the assumption that i was not working but the real problem was our requests were blocked by cloudflare. Adding a `User-Agent` fixed the problem.