### PR TITLE
Refine detection of who's paying

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
@@ -28,7 +28,15 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 
 		FeeDifference = GetFeeDifference(transactionToSpeedUp, boostingTransaction);
 		FeeDifferenceUsd = FeeDifference.ToDecimal(MoneyUnit.BTC) * wallet.Synchronizer.UsdExchangeRate;
-		AreWePayingTheFee = boostingTransaction.Transaction.GetWalletOutputs(_wallet.KeyManager).Any();
+
+		var originalForeignAmounts = transactionToSpeedUp.ForeignOutputs.Select(x => x.TxOut.Value).OrderBy(x => x).ToArray();
+		var boostedForeignAmounts = boostingTransaction.Transaction.ForeignOutputs.Select(x => x.TxOut.Value).OrderBy(x => x).ToArray();
+
+		// Note, if it's CPFP, then it is changed, but we shouldn't bother by it, due to the other condition.
+		var areForeignAmountsUnchanged = originalForeignAmounts.SequenceEqual(boostedForeignAmounts);
+
+		// If the foreign outputs are unchanged or we have an output, then we are paying the fee.
+		AreWePayingTheFee = areForeignAmountsUnchanged || boostingTransaction.Transaction.GetWalletOutputs(_wallet.KeyManager).Any();
 	}
 
 	public decimal FeeDifferenceUsd { get; }


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11154

Notes:

1. This is a super minor issue that will never happen in production, so it isn't necessary for the release, although I see no reason why not to merge it.
2. There's also another super minor, albeit larger issue than this, which is what we show when both the sender and the receiver are paying some amount for the speedup; I'll leave that bug in there up for grabs.