### PR TITLE
Truncate `TorLogs.txt` when Tor starts

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace WalletWasabi.Tests.UnitTests.Tor;
 
 /// <summary>
-/// Tests for <see cref="Tor.TorSettings"/> class.
+/// Tests for <see cref="TorSettings"/> class.
 /// </summary>
 public class TorSettingsTests
 {
@@ -22,6 +22,7 @@ public class TorSettingsTests
 		string expected = string.Join(
 			" ",
 			$"--LogTimeGranularity 1",
+			$"--TruncateLogFile 1",
 			$"--SOCKSPort \"127.0.0.1:37150 ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--MaxCircuitDirtiness 1800",
 			$"--SocksTimeout 30",

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -98,6 +98,7 @@ public class TorSettings
 		List<string> arguments = new()
 		{
 			$"--LogTimeGranularity 1",
+			$"--TruncateLogFile 1",
 			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
 			$"--MaxCircuitDirtiness 1800", // 30 minutes. Default is 10 minutes.
 			$"--SocksTimeout 30", // Default is 2 minutes.


### PR DESCRIPTION
Fixes #11117

Adds `TruncateLogFile` as suggested here https://github.com/zkSNACKs/WalletWasabi/issues/11117#issuecomment-1659145141. 

The proposed behavior seems reasonable as it *truncates `TorLogs.txt` when we start Tor.* That does not necessarily mean that we delete `TorLogs.txt` every time that WW is started. 

The actual behavior depends on user setting *Terminate Tor when Wasabi shuts down*. If is is off, then we truncate `TorLogs.txt` with every WW start. If the setting is off, then we effectively truncate `TorLogs.txt` with every machine reboot[^1] because Tor process is not stopped.

Given contributed `TorLogs.txt` sizes reported by various users, it seems this solution is actually good. 

[^1]: I would find it risky to delete `TorLogs.txt` while Tor process is running.