### PR TITLE
Get txs with witness data

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -42,8 +42,8 @@ public class BatchController : ControllerBase
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,
 		[FromQuery, Required] int maxNumberOfFilters,
-		[FromQuery] string? estimateSmartFeeMode = nameof(EstimateSmartFeeMode.Conservative),
-		[FromQuery] string? indexType = null,
+		[FromQuery] string estimateSmartFeeMode = nameof(EstimateSmartFeeMode.Conservative),
+		[FromQuery] string indexType = "segwittaproot",
 		CancellationToken cancellationToken = default)
 	{
 		bool estimateSmartFee = !string.IsNullOrWhiteSpace(estimateSmartFeeMode);
@@ -66,6 +66,7 @@ public class BatchController : ControllerBase
 			return BadRequest("Not supported index type.");
 		}
 
+		maxNumberOfFilters = int.Min(maxNumberOfFilters, 1_000);
 		(Height bestHeight, IEnumerable<FilterModel> filters) = indexer.GetFilterLinesExcluding(knownHash, maxNumberOfFilters, out bool found);
 
 		var response = new SynchronizeResponse { Filters = Enumerable.Empty<FilterModel>(), BestHeight = bestHeight };

--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -67,7 +67,7 @@ public abstract class P2pBehavior : NodeBehavior
 		{
 			if (ProcessInventoryVector(inv, node.RemoteSocketEndpoint))
 			{
-				getDataPayload.Inventory.Add(inv);
+				getDataPayload.Inventory.Add(new InventoryVector(node.AddSupportedOptions(inv.Type), inv.Hash));
 			}
 		}
 		if (getDataPayload.Inventory.Any() && node.IsConnected)


### PR DESCRIPTION
In order to compute correctly the virtual size of an unconfirmed transaction we have to have the full transaction (witness included). This PR requests the full transactions.