### PR TITLE
[VDG] Speed-up / Cancel: Make transaction lookup fail-safe

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/CancelTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/CancelTransactionDialogViewModel.cs
@@ -50,9 +50,9 @@ public partial class CancelTransactionDialogViewModel : RoutableViewModel
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
 		_triggers.TransactionsUpdateTrigger
-			.Select(_ => _wallet.GetTransactions().First(s => s.GetHash() == _transactionToCancel.GetHash()))
-			.Select(x => x.Confirmed)
-			.Where(isConfirmed => isConfirmed)
+			.Select(_ => _wallet.GetTransactions().FirstOrDefault(s => s.GetHash() == _transactionToCancel.GetHash()))
+			.WhereNotNull()
+			.Where(s => s.Confirmed)
 			.Do(_ => Navigate().Back())
 			.Subscribe()
 			.DisposeWith(disposables);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
@@ -59,9 +59,9 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
 		_triggers.TransactionsUpdateTrigger
-			.Select(_ => _wallet.GetTransactions().First(s => s.GetHash() == _transactionToSpeedUp.GetHash()))
-			.Select(x => x.Confirmed)
-			.Where(isConfirmed => isConfirmed)
+			.Select(_ => _wallet.GetTransactions().FirstOrDefault(s => s.GetHash() == _transactionToSpeedUp.GetHash()))
+			.WhereNotNull()
+			.Where(s => s.Confirmed)
 			.Do(_ => Navigate().Back())
 			.Subscribe()
 			.DisposeWith(disposables);


### PR DESCRIPTION
This makes the transaction lookup fail-safe. This lookup is needed to auto-close the dialog when the given transaction has been confirmed.

Fixes #11195