### PR TITLE
[VDG] [trivial] remove CopyableContent from confirmation time

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -82,8 +82,7 @@
       <!-- Confirmation Time -->
       <c:PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
                      Icon="{StaticResource timer_regular}"
-                     Label="Confirmation time"
-                     CopyableContent="{Binding ConfirmationTime}">
+                     Label="Confirmation time">
         <c:PrivacyContentControl>
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}}" Classes="monoSpaced" />
         </c:PrivacyContentControl>


### PR DESCRIPTION
it copies this format `2.00:00:00` and similar to the _Status_, it's not useful to copy it anyway

![image](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/fa3b957d-d5c2-48a2-9fd8-9baa1129a17f)
