### PR TITLE
Cache slow `synchronize` response

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -39,7 +39,6 @@ public class BatchController : ControllerBase
 	public WabiSabiController WabiSabiController { get; }
 
 	[HttpGet("synchronize")]
-	//[ResponseCache(Duration = 60, NoStore = false, VaryByQueryKeys = new[]{"bestKnownBlockHash", "indexType"})]
 	[ResponseCache(Duration = 60)]
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -42,8 +42,8 @@ public class BatchController : ControllerBase
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,
 		[FromQuery, Required] int maxNumberOfFilters,
-		[FromQuery] string? estimateSmartFeeMode = nameof(EstimateSmartFeeMode.Conservative),
-		[FromQuery] string? indexType = null,
+		[FromQuery] string estimateSmartFeeMode = nameof(EstimateSmartFeeMode.Conservative),
+		[FromQuery] string indexType = "segwittaproot",
 		CancellationToken cancellationToken = default)
 	{
 		bool estimateSmartFee = !string.IsNullOrWhiteSpace(estimateSmartFeeMode);
@@ -66,6 +66,7 @@ public class BatchController : ControllerBase
 			return BadRequest("Not supported index type.");
 		}
 
+		maxNumberOfFilters = int.Min(maxNumberOfFilters, 1_000);
 		(Height bestHeight, IEnumerable<FilterModel> filters) = indexer.GetFilterLinesExcluding(knownHash, maxNumberOfFilters, out bool found);
 
 		var response = new SynchronizeResponse { Filters = Enumerable.Empty<FilterModel>(), BestHeight = bestHeight };

--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -39,6 +39,7 @@ public class BatchController : ControllerBase
 	public WabiSabiController WabiSabiController { get; }
 
 	[HttpGet("synchronize")]
+	//[ResponseCache(Duration = 60, NoStore = false, VaryByQueryKeys = new[]{"bestKnownBlockHash", "indexType"})]
 	[ResponseCache(Duration = 60)]
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,
@@ -55,7 +56,8 @@ public class BatchController : ControllerBase
 			return BadRequest("Not supported index type.");
 		}
 
-		(Height bestHeight, IEnumerable<FilterModel> filters) = indexer.GetFilterLinesExcluding(knownHash, 1_000, out bool found);
+		var numberOfFilters = Global.Config.Network == Network.Main ? 1000 : 10000;
+		(Height bestHeight, IEnumerable<FilterModel> filters) = indexer.GetFilterLinesExcluding(knownHash, numberOfFilters, out bool found);
 
 		var response = new SynchronizeResponse { Filters = Enumerable.Empty<FilterModel>(), BestHeight = bestHeight };
 


### PR DESCRIPTION
This PR keeps the response for `synchronize` in the caches for 60 seconds. 
The response can be cached in all the intermediary http servers (cloudflare included).

The change also requires the following changes in the nginx configuration:

```
worker_processes  1;
pid	nginx.pid;

events {
	worker_connections  1024;
}

http
{
	proxy_cache_path cache-for-filters levels=1:2 keys_zone=filters_cache:10m max_size=10g inactive=2m use_temp_path=off;

	server {
		server_name 127.0.0.1;
		listen 8888;

		server_tokens off;
		access_log nginx-access.log combined;
		error_log  nginx-error.log warn;


		location ~* /api/v4/btc/batch/synchronize {
			proxy_cache filters_cache;
			proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
			proxy_cache_lock on;
			proxy_pass http://localhost:37127;
		}

		location ~* /api/ {
			proxy_pass http://localhost:37127;
		}

		location ~* /wabisabi/ {
			proxy_pass http://localhost:37127;
		}
	}
}
```

Additionally, even in case the coordinator is offline or too busy, nginx will respond with stale entries (super awesome).

----------

How to test:

1. Download `ngnix`.
2. download the config file (see above)
3. run `nginx -p $(pwd) -e $(pwd)/error.log`
4. start `bitcoind -regtest`
5. start wasabi backend

After that play with:

```
$ curl -vvv http://localhost:8888/api/v4/btc/batch/synchronize?bestKnownBlockHash=<a blockhash>
```

and with

```
$ curl -vvv http://localhost:37127/api/v4/btc/batch/synchronize?bestKnownBlockHash=<a blockhash>
```

