### PR TITLE
Fix SpentCoinsByOutPoint is not updated

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -31,7 +31,7 @@ public class CoinsRegistry : ICoinsView
 	private Dictionary<OutPoint, HashSet<SmartCoin>> CoinsByOutPoint { get; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
-	private Dictionary<OutPoint, SmartCoin> SpentCoinsByOutpoint { get; } = new();
+	private Dictionary<OutPoint, SmartCoin> SpentCoinsByOutPoint { get; } = new();
 
 	private CoinsView AsCoinsViewNoLock()
 	{
@@ -134,7 +134,7 @@ public class CoinsRegistry : ICoinsView
 			{
 				if (SpentCoins.Remove(toRemove))
 				{
-					SpentCoinsByOutpoint.Remove(toRemove.Outpoint);
+					SpentCoinsByOutPoint.Remove(toRemove.Outpoint);
 				}
 			}
 
@@ -173,7 +173,7 @@ public class CoinsRegistry : ICoinsView
 				InvalidateSnapshot = true;
 				if (SpentCoins.Add(spentCoin))
 				{
-					SpentCoinsByOutpoint.Add(spentCoin.Outpoint, spentCoin);
+					SpentCoinsByOutPoint.Add(spentCoin.Outpoint, spentCoin);
 				}
 			}
 		}
@@ -211,7 +211,7 @@ public class CoinsRegistry : ICoinsView
 	{
 		lock (Lock)
 		{
-			return SpentCoinsByOutpoint.TryGetValue(outPoint, out coin);
+			return SpentCoinsByOutPoint.TryGetValue(outPoint, out coin);
 		}
 	}
 
@@ -234,7 +234,7 @@ public class CoinsRegistry : ICoinsView
 			{
 				if (SpentCoins.Remove(destroyedCoin))
 				{
-					SpentCoinsByOutpoint.Remove(destroyedCoin.Outpoint);
+					SpentCoinsByOutPoint.Remove(destroyedCoin.Outpoint);
 					Coins.Add(destroyedCoin);
 					toAdd.Add(destroyedCoin);
 				}

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -25,13 +25,13 @@ public class CoinsRegistry : ICoinsView
 	private HashSet<SmartCoin> SpentCoins { get; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
-	private Dictionary<OutPoint, SmartCoin> SpentCoinsByOutpoint { get; } = new();
-
-	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
 	private HashSet<SmartCoin> LatestSpentCoinsSnapshot { get; set; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
 	private Dictionary<OutPoint, HashSet<SmartCoin>> CoinsByOutPoint { get; } = new();
+
+	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
+	private Dictionary<OutPoint, SmartCoin> SpentCoinsByOutpoint { get; } = new();
 
 	private CoinsView AsCoinsViewNoLock()
 	{

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -155,9 +155,9 @@ public class TransactionProcessor
 				{
 					doubleSpentSpenders.AddRange(coins);
 				}
-				if (Coins.TryGetSpenderSpentSmartCoinsByOutPoint(txIn.PrevOut, out var spentCoins))
+				if (Coins.TryGetSpentCoinByOutPoint(txIn.PrevOut, out var spentCoin))
 				{
-					doubleSpentCoins.AddRange(spentCoins);
+					doubleSpentCoins.Add(spentCoin);
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11134
Closes https://github.com/zkSNACKs/WalletWasabi/pull/11176
Closes https://github.com/zkSNACKs/WalletWasabi/pull/11214

If you guys have time to do more, then here are my recommendations:

- [ ] write a unit or regression test for it
- [ ] decouple spent coins and spent coins by outpoint into its own class, so coinsregistry becomes smaller and we'd make sure when they're modified in the future, they're modified together