### PR TITLE
Allow user to disable auto-cj when importing a wallet

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -75,6 +75,7 @@ public partial class WalletRepository : ReactiveObject, IWalletRepository
 			_ => throw new InvalidOperationException($"{nameof(WalletCreationOptions)} not supported: {options?.GetType().Name}")
 		};
 	}
+
 	public IWalletModel SaveWallet(IWalletSettingsModel walletSettings)
 	{
 		walletSettings.Save();
@@ -158,7 +159,7 @@ public partial class WalletRepository : ReactiveObject, IWalletRepository
 				"", // Make sure it is not saved into a file yet.
 				minGapLimit.Value);
 
-			result.AutoCoinJoin = true;
+			// result.AutoCoinJoin = true;
 
 			// Set the filepath but we will only write the file later when the Ui workflow is done.
 			result.SetFilePath(walletFilePath);

--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -159,8 +159,7 @@ public partial class WalletRepository : ReactiveObject, IWalletRepository
 				"", // Make sure it is not saved into a file yet.
 				minGapLimit.Value);
 
-			// result.AutoCoinJoin = true;
-
+			result.AutoCoinJoin = true;
 			// Set the filepath but we will only write the file later when the Ui workflow is done.
 			result.SetFilePath(walletFilePath);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -145,11 +145,6 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			_autoCoinJoinStartTimer.Stop();
 		};
 
-		if (!walletVm.CoinJoinSettings.AutoCoinJoin)
-		{
-			walletVm.Settings.UpdateAutoCoinJoin();
-		}
-
 		_countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
 		_countdownTimer.Tick += (_, _) => _stateMachine.Fire(Trigger.Tick);
 		_stateMachine.Start();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -7,8 +7,6 @@ using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.State;
-using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
-using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
@@ -147,9 +145,13 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			_autoCoinJoinStartTimer.Stop();
 		};
 
+		if (!walletVm.CoinJoinSettings.AutoCoinJoin)
+		{
+			walletVm.Settings.UpdateAutoCoinJoin();
+		}
+
 		_countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
 		_countdownTimer.Tick += (_, _) => _stateMachine.Fire(Trigger.Tick);
-
 		_stateMachine.Start();
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
@@ -1,5 +1,8 @@
+using ReactiveUI;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
@@ -10,14 +13,24 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 public partial class LoadingViewModel : RoutableViewModel
 {
 	private readonly IWalletModel _wallet;
-
+	[AutoNotify] private bool _autoCoinJoin;
+	[AutoNotify] private bool _isNewWallet;
 	[AutoNotify] private double _percent;
 	[AutoNotify] private string _statusText = " "; // Should not be empty as we have to preserve the space in the view.
 	[AutoNotify] private bool _isLoading;
 
+	public ICommand ToggleAutoCoinJoinCommand { get; }
+
 	public LoadingViewModel(IWalletModel wallet)
 	{
 		_wallet = wallet;
+		_autoCoinJoin = _wallet.Settings.AutoCoinjoin;
+		_isNewWallet = true;
+
+		ToggleAutoCoinJoinCommand = ReactiveCommand.Create(() =>
+		{
+			UpdateAutoCoinjoinProperty();
+		});
 	}
 
 	public string WalletName => _wallet.Name;
@@ -28,6 +41,19 @@ public partial class LoadingViewModel : RoutableViewModel
 					  .Do(p => UpdateStatus(p.PercentComplete, p.TimeRemaining))
 					  .Subscribe()
 					  .DisposeWith(disposables);
+	}
+
+	private void UpdateAutoCoinjoinProperty()
+	{
+		if (_wallet.Settings.IsCoinjoinProfileSelected)
+		{
+			_wallet.Settings.AutoCoinjoin = AutoCoinJoin;
+			_wallet.Settings.Save();
+		}
+		else
+		{
+			AutoCoinJoin = false;
+		}
 	}
 
 	private void UpdateStatus(double percent, TimeSpan remainingTimeSpan)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -52,4 +52,10 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	public bool IsWatchOnly { get; }
 
 	public ICommand VerifyRecoveryWordsCommand { get; }
+
+	public void UpdateAutoCoinJoin()
+	{
+		_wallet.Settings.AutoCoinjoin = true;
+		_wallet.Settings.Save();
+	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -52,10 +52,4 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	public bool IsWatchOnly { get; }
 
 	public ICommand VerifyRecoveryWordsCommand { get; }
-
-	public void UpdateAutoCoinJoin()
-	{
-		_wallet.Settings.AutoCoinjoin = true;
-		_wallet.Settings.Save();
-	}
 }

--- a/WalletWasabi.Fluent/Views/Wallets/LoadingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/LoadingView.axaml
@@ -14,7 +14,15 @@
   <controls:ContentArea ScrollViewer.VerticalScrollBarVisibility="Disabled">
     <controls:ContentArea.Title>
       <StackPanel>
-        <TextBlock TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Text="{Binding WalletName, FallbackValue=My Wallet with a very long name}" />
+        <DockPanel>
+          <TextBlock TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Text="{Binding WalletName, FallbackValue=My Wallet with a very long name}" />
+          <DockPanel DockPanel.Dock="Right" Margin="0 0 10 0" HorizontalAlignment="Right" IsVisible="{Binding IsNewWallet}">
+            <StackPanel Orientation="Horizontal" Spacing="5">
+              <TextBlock Text="Auto coinjoin" Margin="0 0 5 0" FontSize="16" VerticalAlignment="Center" />
+              <ToggleSwitch IsChecked="{Binding AutoCoinJoin, Mode=TwoWay}" Command="{Binding ToggleAutoCoinJoinCommand}" VerticalAlignment="Center" />
+            </StackPanel>
+          </DockPanel>
+        </DockPanel>
         <Separator DockPanel.Dock="Bottom" Margin="-200 13 -200 0" HorizontalAlignment="Stretch" />
       </StackPanel>
     </controls:ContentArea.Title>


### PR DESCRIPTION
#10944 

This PR sets the autocoinjoin value to false only when recovering a wallet so that on the first load, there is no auto-conjoining action happening.

In the coinjoinstateviewmodel class, there is a check where auto-conjoin is false for conjoin settings, and auto-updating it to be true across the wallet, this way on subsequent login, the auto-conjoin value would try leaving the state to be set to WaitingForAutoStart