### PR TITLE
temp fix: make `CoinJoinClient started` debug log level

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -230,7 +230,7 @@ public class CoinJoinManager : BackgroundService
 			var registrationTimeout = TimeSpan.MaxValue;
 			NotifyCoinJoinStarted(walletToStart, registrationTimeout);
 
-			walletToStart.LogInfo($"{nameof(CoinJoinClient)} started.");
+			walletToStart.LogDebug($"{nameof(CoinJoinClient)} started.");
 			walletToStart.LogDebug($"{nameof(startCommand.StopWhenAllMixed)}:'{startCommand.StopWhenAllMixed}' {nameof(startCommand.OverridePlebStop)}:'{startCommand.OverridePlebStop}'.");
 
 			// In case there was another start scheduled just remove it.


### PR DESCRIPTION
see https://github.com/zkSNACKs/WalletWasabi/issues/11109

too many issues where `CoinJoinClient started` is incorrectly being logged. Those should be fixed first, then we can change this back to `LogInfo`.

I kept `CoinJoinClient stopped` purposely on `LogInfo`, as it is useful (for example when using daemon) when you stop it on purpose (and want to confirm it did) where as when starting CoinJoinClient you can notice that the CoinJoinClient started when you see related coinjoin logs coming in.