### PR TITLE
[VDG] Fixes NullReferenceException exception in ContextFlyoutWorkaroundBehavior

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/ContextFlyoutWorkaroundBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/ContextFlyoutWorkaroundBehavior.cs
@@ -35,8 +35,20 @@ public class ContextFlyoutWorkaroundBehavior : DisposingBehavior<Window>
 
 			Observable
 				.FromEventPattern<PixelPointEventArgs>(
-					handler => AssociatedObject!.PositionChanged += handler,
-					handler => AssociatedObject!.PositionChanged -= handler)
+					handler =>
+					{
+						if (AssociatedObject is not null)
+						{
+							AssociatedObject.PositionChanged += handler;
+						}
+					},
+					handler =>
+					{
+						if (AssociatedObject is not null)
+						{
+							AssociatedObject.PositionChanged -= handler;
+						}
+					})
 				.Subscribe(_ => CloseFlyouts())
 				.DisposeWith(disposables);
 		}


### PR DESCRIPTION
Fixes NullReferenceException exception in ContextFlyoutWorkaroundBehavior:
```
Exception type: System.NullReferenceException

Message: Object reference not set to an instance of an object.

Stack Trace:    at WalletWasabi.Fluent.Behaviors.ContextFlyoutWorkaroundBehavior.<OnAttached>b__1_7(EventHandler`1 handler) in WalletWasabi.Fluent\Behaviors\ContextFlyoutWorkaroundBehavior.cs:line 39
   at System.Reactive.Disposables.AnonymousDisposable`1.Dispose() in /_/Rx.NET/Source/src/System.Reactive/Disposables/AnonymousDisposable.cs:line 74
   at System.Reactive.Concurrency.Scheduler.<>c__75`1.<ScheduleAction>b__75_0(IScheduler _, ValueTuple`2 tuple) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs:line 66
   at System.Reactive.Concurrency.SynchronizationContextScheduler.<>c__DisplayClass4_0`1.<Schedule>b__0() in /_/Rx.NET/Source/src/System.Reactive/Concurrency/SynchronizationContextScheduler.cs:line 65
   at System.Reactive.Concurrency.SynchronizationContextExtensions.<>c__DisplayClass1_0.<PostWithStartComplete>b__0(Object _) in /_/Rx.NET/Source/src/System.Reactive/Internal/SynchronizationContextExtensions.cs:line 46
   at Avalonia.Threading.SendOrPostCallbackDispatcherOperation.InvokeCore()
   at Avalonia.Threading.DispatcherOperation.Execute()
   at Avalonia.Threading.Dispatcher.ExecuteJob(DispatcherOperation job)
   at Avalonia.Threading.Dispatcher.ExecuteJobsCore(Boolean fromExplicitBackgroundProcessingCallback)
   at Avalonia.Threading.Dispatcher.Signaled()
   at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam)
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32DispatcherImpl.RunLoop(CancellationToken cancellationToken)
   at Avalonia.Threading.DispatcherFrame.Run(IControlledDispatcherImpl impl)
   at Avalonia.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, ShutdownMode shutdownMode)
   at WalletWasabi.Fluent.Desktop.WasabiAppExtensions.<>c__DisplayClass0_0.<RunAsGuiAsync>b__0() in WalletWasabi.Fluent.Desktop\Program.cs:line 176
   at WalletWasabi.Daemon.WasabiApplication.RunAsync(Func`1 afterStarting) in WalletWasabi.Daemon\WasabiAppBuilder.cs:line 67
   at WalletWasabi.Fluent.Desktop.WasabiAppExtensions.RunAsGuiAsync(WasabiApplication app) in WalletWasabi.Fluent.Desktop\Program.cs:line 156
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args) in WalletWasabi.Fluent.Desktop\Program.cs:line 64

Inner Exception: 
```