### PR TITLE
Cancellation TX to reset input AS

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -124,7 +124,12 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			Money amountToSend = wallet.Coins.Where(x => x.IsAvailable()).Sum(x => x.Amount) / 2;
 			var externalAddr = await rpc.GetNewAddressAsync(CancellationToken.None);
 			var txToCancel = wallet.BuildTransaction(password, new PaymentIntent(externalAddr, amountToSend, label: "bar"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+
+			SetHighInputAnonsets(txToCancel);
+
 			await broadcaster.SendTransactionAsync(txToCancel.Transaction);
+
+			AssertAllAnonsets1(txToCancel);
 
 			Assert.Equal("bar", txToCancel.Transaction.Labels.Single());
 			foreach (var op in txToCancel.InnerWalletOutputs)
@@ -150,6 +155,8 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			await broadcaster.SendTransactionAsync(cancellingTx.Transaction);
 
 			Assert.False(wallet.BitcoinStore.TransactionStore.TryGetTransaction(txToCancel.Transaction.GetHash(), out _));
+
+			AssertAllAnonsets1(cancellingTx);
 
 			Assert.False(txToCancel.Transaction.IsReplacement);
 			Assert.False(txToCancel.Transaction.IsCPFP);
@@ -180,7 +187,12 @@ public class CancelTests : IClassFixture<RegTestFixture>
 
 			externalAddr = await rpc.GetNewAddressAsync(CancellationToken.None);
 			txToCancel = wallet.BuildChangelessTransaction(externalAddr, "foo", new FeeRate(1m), cancellingTx.InnerWalletOutputs);
+
+			SetHighInputAnonsets(txToCancel);
+
 			await broadcaster.SendTransactionAsync(txToCancel.Transaction);
+
+			AssertAllAnonsets1(txToCancel);
 
 			Assert.Equal("foo", txToCancel.Transaction.Labels.Single());
 			foreach (var op in txToCancel.InnerWalletOutputs)
@@ -205,6 +217,8 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			await broadcaster.SendTransactionAsync(cancellingTx.Transaction);
 
 			Assert.False(wallet.BitcoinStore.TransactionStore.TryGetTransaction(txToCancel.Transaction.GetHash(), out _));
+
+			AssertAllAnonsets1(cancellingTx);
 
 			Assert.False(txToCancel.Transaction.IsReplacement);
 			Assert.False(txToCancel.Transaction.IsCPFP);
@@ -321,6 +335,26 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();
+		}
+	}
+
+	private static void AssertAllAnonsets1(BuildTransactionResult txToCancel)
+	{
+		foreach (var input in txToCancel.SpentCoins)
+		{
+			Assert.Equal(1, input.AnonymitySet);
+		}
+		foreach (var output in txToCancel.InnerWalletOutputs)
+		{
+			Assert.Equal(1, output.AnonymitySet);
+		}
+	}
+
+	private static void SetHighInputAnonsets(BuildTransactionResult tx)
+	{
+		foreach (var input in tx.SpentCoins)
+		{
+			input.HdPubKey.SetAnonymitySet(999);
 		}
 	}
 }

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -33,6 +33,8 @@ public class BlockchainAnalyzer
 		var foreignInputCount = tx.ForeignInputs.Count;
 		var foreignOutputCount = tx.ForeignOutputs.Count;
 
+		AnalyzeCancellation(tx);
+
 		if (ownInputCount == 0)
 		{
 			AnalyzeReceive(tx);
@@ -64,6 +66,18 @@ public class BlockchainAnalyzer
 		}
 
 		AnalyzeClusters(tx);
+	}
+
+	private static void AnalyzeCancellation(SmartTransaction tx)
+	{
+		// If the tx is a cancellation and we have at least one input or output that is not ours, then we set the anonset to 1.
+		if (tx.IsCancellation && (tx.ForeignOutputs.Any() || tx.ForeignInputs.Any()))
+		{
+			foreach (var k in tx.WalletInputs.Select(x => x.HdPubKey).Distinct())
+			{
+				k.SetAnonymitySet(1);
+			}
+		}
 	}
 
 	private static void AnalyzeCoinjoinWalletInputs(


### PR DESCRIPTION
If the blockchain analyzer encounters a cancellation transaction with foreign inputs - a technical impossibility but a logical possibility - or foreign outputs, then set its input anonsets to 0.

It may not comprehensively fix all the problems noted in https://github.com/zkSNACKs/WalletWasabi/issues/11226. However, it improves and closes https://github.com/zkSNACKs/WalletWasabi/issues/11226

After this PR, a new issue may be opened if there are still any problems.

