### PR TITLE
Revert "Bump version to v2.0.4"

### DIFF
--- a/WalletWasabi.Backend/wwwroot/index.html
+++ b/WalletWasabi.Backend/wwwroot/index.html
@@ -192,9 +192,9 @@
                                         <div class="my-4">
                                             <div class="system-text">WINDOWS 10+</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.msi" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.msi" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .msi <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.msi.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#windows" target="_blank">guide</a></span>
+                                            .msi <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.msi.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#windows" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -204,9 +204,9 @@
                                         <div class="my-4">
                                             <div class="system-text">MACOS 10.15+ INTEL</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -216,9 +216,9 @@
                                         <div class="my-4">
                                             <div class="system-text">MACOS 10.15+ M1, M2</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4-arm64.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3-arm64.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4-arm64.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
+                                            .dmg <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3-arm64.dmg.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#macos" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -228,9 +228,9 @@
                                         <div class="my-4">
                                             <div class="system-text">UBUNTU / DEBIAN</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.deb" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.deb" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .deb <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.deb.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu" target="_blank">guide</a></span>
+                                            .deb <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.deb.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#debian-and-ubuntu" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>
@@ -240,9 +240,9 @@
                                         <div class="my-4">
                                             <div class="system-text">OTHER LINUX</div>
                                         </div>
-                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.tar.gz" target="_blank" class="btn btn-primary w-100">Download</a>
+                                        <a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.tar.gz" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">
-                                            .tar.gz <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.4/Wasabi-2.0.4.tar.gz.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#other-linux" target="_blank">guide</a></span>
+                                            .tar.gz <span class="float-end"><a href="https://github.com/zkSNACKs/WalletWasabi/releases/download/v2.0.3/Wasabi-2.0.3.tar.gz.asc" target="_blank">signature</a> / <a href="https://docs.wasabiwallet.io/using-wasabi/InstallPackage.html#other-linux" target="_blank">guide</a></span>
                                         </div>
                                     </div>
                                 </div>

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -76,7 +76,7 @@ public static class Constants
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 
-	public static readonly Version ClientVersion = new(2, 0, 4, 0);
+	public static readonly Version ClientVersion = new(2, 0, 3, 0);
 
 	public static readonly Version HwiVersion = new("2.2.1");
 	public static readonly Version BitcoinCoreVersion = new("21.2");


### PR DESCRIPTION
zkSNACKs high council postponed the release to the 21st of Aug.

I am reverting this to accidentally not deploying this to backends.

Reverts zkSNACKs/WalletWasabi#11237

