### PR TITLE
Use thread-safe linked list in `IndexBuilderService`

### DIFF
--- a/WalletWasabi/Blockchain/BlockFilters/FilterLinkedList.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/FilterLinkedList.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.Backend.Models;
+
+namespace WalletWasabi.Blockchain.BlockFilters;
+
+public class FilterLinkedList : IEnumerable<FilterModel>
+{
+	record Node(FilterModel Filter, Node? Next)
+	{
+		public int Count { get; } = (Next?.Count ?? 0) + 1;
+	}
+
+	private Node? _head;
+	private readonly object _syncObject = new();
+
+	public void Add(FilterModel filter)
+	{
+		lock (_syncObject)
+		{
+			_head = new Node(filter, _head);
+		}
+	}
+
+	public void RemoveLast()
+	{
+		lock (_syncObject)
+		{
+			if (_head is not { } nonNullHead)
+			{
+				throw new InvalidOperationException("The linked list is empty.");
+			}
+
+			_head = nonNullHead.Next;
+		}
+	}
+
+	public int Count
+	{
+		get
+		{
+			lock (_syncObject)
+			{
+				return _head switch
+				{
+					null => 0,
+					{ } nonNullHead => nonNullHead.Count
+				};
+			}
+		}
+	}
+
+	public IEnumerator<FilterModel> GetEnumerator()
+	{
+		IEnumerable<FilterModel> GetEnumerable()
+		{
+			Node? p;
+			lock (_syncObject)
+			{
+				p = _head;
+			}
+
+			while (p != null)
+			{
+				yield return p.Filter;
+				p = p.Next;
+			}
+		}
+
+		return GetEnumerable().Reverse().GetEnumerator();
+	}
+
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return GetEnumerator();
+	}
+
+	public FilterModel Last()
+	{
+		lock (_syncObject)
+		{
+			return _head?.Filter
+			       ?? throw new ArgumentOutOfRangeException();
+		}
+	}
+}


### PR DESCRIPTION
After caching the responses for the synchronize api, the endpoint continued failing. The following image, that shows the response times, we can see how most of the call are responded immediately while a few (all very close in time) take much much long times.
 
![image](https://github.com/zkSNACKs/WalletWasabi/assets/127973/6b00f1a7-95da-4f17-b3db-0df41adbba27)

The traces shows that there are hundreds of threads stuck with the exact same stack trace:

![image](https://github.com/zkSNACKs/WalletWasabi/assets/127973/6451bb99-35d0-4321-b241-2b86b52b3da7)

In this case this thread was locked for 1 minute and 40 seconds waiting for the lock in `GetFilterLinesExcluding`.

-------------

This PR  replaces the `List<FilterModel>` in the `IndexBuilderService` by a linked list where only the head requires synchronization. This means that it can be iterated without locking it. 