### PR TITLE
`IndexBuilderService`: Remove `RpcClient.GetBlockHashAsync` from the critical section

### DIFF
--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using Nito.AsyncEx;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -328,10 +327,11 @@ public class IndexBuilderService
 
 	public (Height bestHeight, IEnumerable<FilterModel> filters) GetFilterLinesExcluding(uint256 bestKnownBlockHash, int count, out bool found)
 	{
+		found = false; // Only build the filter list from when the known hash is found.
+		var filters = new List<FilterModel>();
+
 		lock (IndexLock)
 		{
-			found = false; // Only build the filter list from when the known hash is found.
-			var filters = new List<FilterModel>();
 			foreach (var filter in Index)
 			{
 				if (found)


### PR DESCRIPTION
An alternative to #11239 and #11240 which replaces 

* AsyncLock with a simple lock
* Removes an RPC call from the critical section.

Closes https://github.com/zkSNACKs/MaintenanceVault/issues/295
Closes https://github.com/zkSNACKs/WalletWasabi/pull/11240