### PR TITLE
Pause CJ after recovery

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/IWalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/IWalletSettingsModel.cs
@@ -17,6 +17,8 @@ public interface IWalletSettingsModel
 
 	bool IsCoinjoinProfileSelected { get; set; }
 
+	bool IsCoinJoinPaused { get; }
+
 	Money PlebStopThreshold { get; set; }
 
 	int AnonScoreTarget { get; set; }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -75,6 +75,7 @@ public partial class WalletRepository : ReactiveObject, IWalletRepository
 			_ => throw new InvalidOperationException($"{nameof(WalletCreationOptions)} not supported: {options?.GetType().Name}")
 		};
 	}
+
 	public IWalletModel SaveWallet(IWalletSettingsModel walletSettings)
 	{
 		walletSettings.Save();
@@ -166,7 +167,7 @@ public partial class WalletRepository : ReactiveObject, IWalletRepository
 			return result;
 		});
 
-		return new WalletSettingsModel(keyManager, true);
+		return new WalletSettingsModel(keyManager, true, true);
 	}
 
 	public IWalletModel? GetExistingWallet(HwiEnumerateEntry device)

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -11,6 +11,7 @@ public partial class WalletSettingsModel : ReactiveObject, IWalletSettingsModel
 {
 	private readonly KeyManager _keyManager;
 	private bool _isDirty;
+	public bool IsCoinJoinPaused { get; }
 
 	[AutoNotify] private bool _isNewWallet;
 	[AutoNotify] private bool _autoCoinjoin;
@@ -21,12 +22,13 @@ public partial class WalletSettingsModel : ReactiveObject, IWalletSettingsModel
 	[AutoNotify] private bool _redCoinIsolation;
 	[AutoNotify] private int _feeRateMedianTimeFrameHours;
 
-	public WalletSettingsModel(KeyManager keyManager, bool isNewWallet = false)
+	public WalletSettingsModel(KeyManager keyManager, bool isNewWallet = false, bool isCoinJoinPaused = false)
 	{
 		_keyManager = keyManager;
 
 		_isNewWallet = isNewWallet;
 		_isDirty = isNewWallet;
+		IsCoinJoinPaused = isCoinJoinPaused;
 
 		_autoCoinjoin = _keyManager.AutoCoinJoin;
 		_isCoinjoinProfileSelected = _keyManager.IsCoinjoinProfileSelected;

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -11,7 +11,6 @@ public partial class WalletSettingsModel : ReactiveObject, IWalletSettingsModel
 {
 	private readonly KeyManager _keyManager;
 	private bool _isDirty;
-	public bool IsCoinJoinPaused { get; }
 
 	[AutoNotify] private bool _isNewWallet;
 	[AutoNotify] private bool _autoCoinjoin;
@@ -57,6 +56,8 @@ public partial class WalletSettingsModel : ReactiveObject, IWalletSettingsModel
 	public string WalletName { get; }
 
 	public WalletType WalletType { get; }
+
+	public bool IsCoinJoinPaused { get; }
 
 	public void Save()
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -87,6 +88,14 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		if (walletVm.Wallet.KeyManager.IsHardwareWallet || walletVm.Wallet.KeyManager.IsWatchOnly)
 		{
 			initialState = State.Disabled;
+		}
+
+		//WalletSettingsModel walletSettingsModel = UiContext.WalletRepository.Wallets.FirstOrDefault(x => x.WalletModel.Name == walletVm.WalletName);
+
+		//if (walletSettingsModel.IsCoinJoinPaused)
+		if (true)
+		{
+			initialState = State.StoppedOrPaused;
 		}
 
 		_stateMachine = new StateMachine<State, Trigger>(initialState);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -8,8 +8,6 @@ using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.State;
-using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
-using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
@@ -63,7 +61,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private DateTimeOffset _countDownStartTime;
 	private DateTimeOffset _countDownEndTime;
 
-	private CoinJoinStateViewModel(WalletViewModel walletVm)
+	private CoinJoinStateViewModel(WalletViewModel walletVm, IWalletModel walletModel)
 	{
 		WalletVm = walletVm;
 		var wallet = walletVm.Wallet;
@@ -81,19 +79,17 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.Select(_ => WalletVm.Wallet.IsWalletPrivate())
 			.BindTo(this, x => x.AreAllCoinsPrivate);
 
-		var initialState = walletVm.CoinJoinSettings.AutoCoinJoin
+		var initialState =
+			walletModel.Settings.AutoCoinjoin
 			? State.WaitingForAutoStart
 			: State.StoppedOrPaused;
 
-		if (walletVm.Wallet.KeyManager.IsHardwareWallet || walletVm.Wallet.KeyManager.IsWatchOnly)
+		if (walletModel.IsHardwareWallet || walletModel.IsWatchOnlyWallet)
 		{
 			initialState = State.Disabled;
 		}
 
-		//WalletSettingsModel walletSettingsModel = UiContext.WalletRepository.Wallets.FirstOrDefault(x => x.WalletModel.Name == walletVm.WalletName);
-
-		//if (walletSettingsModel.IsCoinJoinPaused)
-		if (true)
+		if (walletModel.Settings.IsCoinJoinPaused)
 		{
 			initialState = State.StoppedOrPaused;
 		}
@@ -108,9 +104,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		{
 			if (!wallet.KeyManager.IsCoinjoinProfileSelected)
 			{
-				// TODO: remove this after CoinjoinStateViewModel is decoupled
-				var walletSettings = new WalletSettingsModel(wallet.KeyManager);
-				await UiContext.Navigate().To().CoinJoinProfiles(walletSettings, NavigationTarget.DialogScreen).GetResultAsync();
+				await UiContext.Navigate().To().CoinJoinProfiles(walletModel.Settings, NavigationTarget.DialogScreen).GetResultAsync();
 			}
 
 			if (wallet.KeyManager.IsCoinjoinProfileSelected)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -27,6 +27,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets;
 public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 {
 	private readonly WalletPageViewModel _parent;
+
 	[AutoNotify] private double _widthSource;
 	[AutoNotify] private double _heightSource;
 	[AutoNotify] private bool _isPointerOver;
@@ -45,6 +46,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 	{
 		_parent = parent;
 		Wallet = parent.Wallet;
+		WalletModel = parent.WalletModel;
 		UiContext = uiContext;
 
 		_title = WalletName;
@@ -57,11 +59,8 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 			? new CompositeDisposable()
 			: throw new NotSupportedException($"Cannot open {GetType().Name} before closing it.");
 
-		//TODO: remove this after ConfirmRecoveryWordsViewModel is decoupled
-		var walletModel = new WalletModel(Wallet);
-
-		Settings = new WalletSettingsViewModel(UiContext, walletModel);
-		CoinJoinSettings = new CoinJoinSettingsViewModel(UiContext, walletModel);
+		Settings = new WalletSettingsViewModel(UiContext, WalletModel);
+		CoinJoinSettings = new CoinJoinSettingsViewModel(UiContext, WalletModel);
 		UiTriggers = new UiTriggers(this);
 		History = new HistoryViewModel(UiContext, this);
 
@@ -131,7 +130,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 		CoinJoinSettingsCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(CoinJoinSettings), Observable.Return(!Wallet.KeyManager.IsWatchOnly));
 
-		CoinJoinStateViewModel = new CoinJoinStateViewModel(UiContext, this);
+		CoinJoinStateViewModel = new CoinJoinStateViewModel(UiContext, this, WalletModel);
 
 		Tiles = GetTiles().ToList();
 
@@ -143,6 +142,9 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 	public WalletState WalletState => Wallet.State;
 
 	private string _title;
+
+	// TODO: Rename this to "Wallet" after this ViewModel is decoupled and the current "Wallet" property is removed.
+	public IWalletModel WalletModel { get; }
 
 	public Wallet Wallet { get; }
 


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/10944

> Option 2 is the best. Pause the auto cj right after the recovery is finished. In this way, the default will be kept true and the user can quickly start by pressing the play button.

https://github.com/zkSNACKs/WalletWasabi/issues/10944#issuecomment-1617770975