### PR TITLE
[trivial] Fix xUnit warnings after the upgrade of xUnit to 2.5.0

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/MempoolMirrorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/MempoolMirrorTests.cs
@@ -224,7 +224,6 @@ public class MempoolMirrorTests
 			await mempoolInstance.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(7));
 
 			var localMempoolAfterSend = mempoolInstance.GetMempoolHashes();
-			Assert.Equal(1, localMempoolAfterSend.Count);
 			Assert.Single(localMempoolAfterSend);
 
 			await rpc.GenerateAsync(1);

--- a/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
@@ -308,7 +308,7 @@ public class SmartTransactionTests
 		t2.Outputs.Add(txout4);
 		SmartTransaction st2 = new(t2, 0);
 
-		Assert.Equal(1, st2.ForeignVirtualOutputs.Count);
+		Assert.Single(st2.ForeignVirtualOutputs);
 		Assert.Equal(2, st2.ForeignVirtualOutputs.First().OutPoints.Count);
 	}
 
@@ -329,7 +329,7 @@ public class SmartTransactionTests
 		st1.TryAddWalletInput(sc);
 		st1.TryAddWalletInput(sc2);
 
-		Assert.Equal(1, st1.WalletVirtualInputs.Count);
+		Assert.Single(st1.WalletVirtualInputs);
 		Assert.Equal(2, st1.WalletVirtualInputs.First().Coins.Count);
 	}
 
@@ -350,7 +350,7 @@ public class SmartTransactionTests
 		st1.TryAddWalletOutput(sc);
 		st1.TryAddWalletOutput(sc2);
 
-		Assert.Equal(1, st1.WalletVirtualOutputs.Count);
+		Assert.Single(st1.WalletVirtualOutputs);
 		Assert.Equal(Money.Coins(3), st1.WalletVirtualOutputs.First().Amount);
 		Assert.Equal(2, st1.WalletVirtualOutputs.First().Coins.Count);
 	}

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -783,7 +783,7 @@ public class TransactionFactoryTests
 			}
 			else
 			{
-				Assert.True(false, "Main value is not correct.");
+				Assert.Fail("Main value is not correct.");
 			}
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/Userfacing/ParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/ParserTests.cs
@@ -97,7 +97,7 @@ public class ParserTests
 				}
 				else
 				{
-					Assert.True(false, "Parsing failed.");
+					Assert.Fail("Parsing failed.");
 				}
 			}
 		}
@@ -111,7 +111,7 @@ public class ParserTests
 			}
 			else
 			{
-				Assert.True(false, "Parsing failed.");
+				Assert.Fail("Parsing failed.");
 			}
 		}
 


### PR DESCRIPTION
Follow-up to #11063