### PR TITLE
Make filter migration cancellable

### DIFF
--- a/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
@@ -298,7 +298,7 @@ public class BlockFilterSqliteStorage : IDisposable
 
 		using SqliteCommand command = Connection.CreateCommand();
 		command.CommandText = """ 
-			INSERT OR IGNORE INTO filter (block_height, block_hash, filter_data, previous_block_hash, epoch_block_time)
+			INSERT INTO filter (block_height, block_hash, filter_data, previous_block_hash, epoch_block_time)
 			VALUES ($block_height, $block_hash, $filter_data, $previous_block_hash, $epoch_block_time)
 			""";
 

--- a/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
@@ -297,7 +297,7 @@ public class BlockFilterSqliteStorage : IDisposable
 		using SqliteTransaction transaction = Connection.BeginTransaction();
 
 		using SqliteCommand command = Connection.CreateCommand();
-		command.CommandText = """ 
+		command.CommandText = """
 			INSERT INTO filter (block_height, block_hash, filter_data, previous_block_hash, epoch_block_time)
 			VALUES ($block_height, $block_hash, $filter_data, $previous_block_hash, $epoch_block_time)
 			""";

--- a/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
@@ -297,8 +297,8 @@ public class BlockFilterSqliteStorage : IDisposable
 		using SqliteTransaction transaction = Connection.BeginTransaction();
 
 		using SqliteCommand command = Connection.CreateCommand();
-		command.CommandText = """
-			INSERT INTO filter (block_height, block_hash, filter_data, previous_block_hash, epoch_block_time)
+		command.CommandText = """ 
+			INSERT OR IGNORE INTO filter (block_height, block_hash, filter_data, previous_block_hash, epoch_block_time)
 			VALUES ($block_height, $block_hash, $filter_data, $previous_block_hash, $epoch_block_time)
 			""";
 

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -132,7 +132,7 @@ public class IndexStore : IAsyncDisposable
 			Stopwatch stopwatch = Stopwatch.StartNew();
 
 			IndexStorage.Clear();
-			
+
 			List<string> filters = new(capacity: 10_000);
 			using (FileStream fs = File.Open(OldIndexFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			using (BufferedStream bs = new(fs))
@@ -170,7 +170,7 @@ public class IndexStore : IAsyncDisposable
 
 			Logger.LogInfo($"Migration of {i} filters to SQLite was finished in {stopwatch.Elapsed} seconds.");
 		}
-		catch (OperationCanceledException ex)
+		catch (OperationCanceledException)
 		{
 			SqliteConnection.ClearAllPools();
 			throw;

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -131,6 +131,8 @@ public class IndexStore : IAsyncDisposable
 
 			Stopwatch stopwatch = Stopwatch.StartNew();
 
+			IndexStorage.Clear();
+			
 			List<string> filters = new(capacity: 10_000);
 			using (FileStream fs = File.Open(OldIndexFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			using (BufferedStream bs = new(fs))

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -90,7 +90,7 @@ public class IndexStore : IAsyncDisposable
 			// Migration code.
 			if (RunMigration)
 			{
-				await Task.Run(() => MigrateToSqliteNoLock(cancellationToken), cancellationToken).ConfigureAwait(false);
+				MigrateToSqliteNoLock(cancellationToken);
 			}
 
 			// If the automatic migration to SQLite is stopped, we would not delete the old index data.


### PR DESCRIPTION
Fixes #11273 

This PR:
- Passes `CancellationToken` to `MigrateToSqliteNoLock` (even if it's not an `async` method) and checks at every iteration if it should `throw`
- Change conditions of `RunMigration` so migration will be relaunched in case of cancellation.
- Change `INSERT INTO` to `INSERT OR IGNORE INTO` to just ignore duplicate in DB and avoid inserting them again.
- Reduces the size of batches to make the process less error-prone.