### PR TITLE
Cache big responses

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -92,7 +92,7 @@ public class BlockchainController : ControllerBase
 	[HttpGet("mempool-hashes")]
 	[ProducesResponseType(200)]
 	[ProducesResponseType(400)]
-	[ResponseCache(Duration = 3, Location = ResponseCacheLocation.Client)]
+	[ResponseCache(Duration = 5)]
 	public async Task<IActionResult> GetMempoolHashesAsync([FromQuery] int compactness = 64, CancellationToken cancellationToken = default)
 	{
 		if (compactness is < 1 or > 64)
@@ -285,6 +285,7 @@ public class BlockchainController : ControllerBase
 	[ProducesResponseType(204)]
 	[ProducesResponseType(400)]
 	[ProducesResponseType(404)]
+	[ResponseCache(Duration = 60)]
 	public IActionResult GetFilters([FromQuery, Required] string bestKnownBlockHash, [FromQuery, Required] int count, [FromQuery] string? indexType = null)
 	{
 		if (count <= 0)

--- a/WalletWasabi.Backend/Controllers/OffchainController.cs
+++ b/WalletWasabi.Backend/Controllers/OffchainController.cs
@@ -35,6 +35,7 @@ public class OffchainController : ControllerBase
 	[HttpGet("exchange-rates")]
 	[ProducesResponseType(200)]
 	[ProducesResponseType(404)]
+	[ResponseCache(Duration = 120)]
 	public async Task<IActionResult> GetExchangeRatesAsync(CancellationToken cancellationToken)
 	{
 		IEnumerable<ExchangeRate> exchangeRates = await GetExchangeRatesCollectionAsync(cancellationToken);


### PR DESCRIPTION
Caching these responses can relax the pressure against the coordinator
```
/api/v4/btc/blockchain/mempool-hashes min 0.000
/api/v4/btc/blockchain/mempool-hashes max 95.276
/api/v4/btc/blockchain/mempool-hashes avg 18.391639591808591325932565676
/api/v4/btc/Blockchain/filters min 0.000
/api/v4/btc/Blockchain/filters max 38.917
/api/v4/btc/Blockchain/filters avg 0.4782768565643298856235976577
```