### PR TITLE
[VDG] tx details: clarify expected confirmation time

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -82,7 +82,8 @@
       <!-- Confirmation Time -->
       <c:PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
                      Icon="{StaticResource timer_regular}"
-                     Label="Confirmation time">
+                     Label="Expected confirmation time"
+                     ToolTip.Tip="This is an estimation based on current mempool statistics. The confirmation time might change.">
         <c:PrivacyContentControl>
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}}" Classes="monoSpaced" />
         </c:PrivacyContentControl>


### PR DESCRIPTION
Clarify (for those who don't know) that this is just an estimation, there are 0 guarantees.
It could say `≈ 10 min`, mempool spikes and then the tx confirms a week later or not at all.
Also, all other items in this dialog are facts/won't change, so differentiate that this is not a "fact".

And with current, I expect many support requests like "My tx says confirmation time 20 min, it's 30 min later and it's still not confirmed"...
So just clarify it.

![Screenshot from 2023-08-15 10-15-25](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/909622f7-114a-433b-9d5b-9bdd18c6cedd)


