### PR TITLE
[VDG] Preview Transaction: update confirmation time label text

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -68,7 +68,8 @@
       <StackPanel Spacing="10">
         <c:PreviewItem Icon="{StaticResource timer_regular}"
                        Label="Expected confirmation time"
-                       IsVisible="{Binding !IsCustomFeeUsed}">
+                       IsVisible="{Binding !IsCustomFeeUsed}"
+                       ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}, FallbackValue=~20 minutes}" />
         </c:PreviewItem>
         <c:PreviewItem Icon="{StaticResource paper_cash_regular}"

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -67,7 +67,7 @@
 
       <StackPanel Spacing="10">
         <c:PreviewItem Icon="{StaticResource timer_regular}"
-                       Label="Confirming within"
+                       Label="Expected confirmation time"
                        IsVisible="{Binding !IsCustomFeeUsed}">
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}, FallbackValue=~20 minutes}" />
         </c:PreviewItem>


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/pull/11286#pullrequestreview-1578319580

The phrasing used to be "correct" but got removed https://github.com/zkSNACKs/WalletWasabi/commit/09f9eef3d0de3b68aa63902eb9721091bf0559d7

This is just a wording fix, to keep it trivial (and included into release?)
If OK, I can add tooltip with small explanation for this as well.