### PR TITLE
Make Transaction Processing Faster (Faster Wallet Load)

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -17,6 +17,9 @@ public class CoinsRegistry : ICoinsView
 	private HashSet<uint256> AllSeenTxIds { get; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
+	private Dictionary<OutPoint, SmartCoin> AllSeenCoins { get; } = new();
+
+	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
 	private HashSet<SmartCoin> LatestCoinsSnapshot { get; set; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
@@ -87,6 +90,7 @@ public class CoinsRegistry : ICoinsView
 			{
 				added = Coins.Add(coin);
 				AllSeenTxIds.Add(coin.TransactionId);
+				AllSeenCoins.AddOrReplace(coin.Outpoint, coin);
 				coin.RegisterToHdPubKey();
 				if (added)
 				{
@@ -305,4 +309,80 @@ public class CoinsRegistry : ICoinsView
 	public ICoinsView Unspent() => AsCoinsView().Unspent();
 
 	IEnumerator IEnumerable.GetEnumerator() => AsCoinsView().GetEnumerator();
+
+	public TimeSpan A { get; set; }
+	public TimeSpan B { get; set; }
+	public TimeSpan C { get; set; }
+	public TimeSpan D { get; set; }
+	public TimeSpan E { get; set; }
+	public TimeSpan F { get; set; }
+	public TimeSpan G { get; set; }
+
+	public SmartCoin[] GetMyInputs(SmartTransaction transaction)
+	{
+		var inputs = transaction.Transaction.Inputs.Select(x => x.PrevOut).ToArray();
+
+		var myInputs = new List<SmartCoin>();
+		lock (Lock)
+		{
+			foreach (var input in inputs)
+			{
+				if (AllSeenCoins.TryGetValue(input, out var coin))
+				{
+					myInputs.Add(coin);
+				}
+			}
+		}
+
+		return myInputs.ToArray();
+	}
+
+	public DateTimeOffset SetA(DateTimeOffset start)
+	{
+		A += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
+
+	public DateTimeOffset SetB(DateTimeOffset start)
+	{
+		B += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
+
+	public DateTimeOffset SetC(DateTimeOffset start)
+	{
+		C += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
+
+	public DateTimeOffset SetD(DateTimeOffset start)
+	{
+		D += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
+
+	public DateTimeOffset SetE(DateTimeOffset start)
+	{
+		E += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
+
+	public DateTimeOffset SetF(DateTimeOffset start)
+	{
+		F += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
+
+	public DateTimeOffset SetG(DateTimeOffset start)
+	{
+		G += DateTimeOffset.UtcNow - start;
+		start = DateTimeOffset.UtcNow;
+		return start;
+	}
 }

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -14,6 +14,9 @@ public class CoinsRegistry : ICoinsView
 	private HashSet<SmartCoin> Coins { get; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
+	private HashSet<uint256> AllSeenTxIds { get; } = new();
+
+	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
 	private HashSet<SmartCoin> LatestCoinsSnapshot { get; set; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
@@ -83,6 +86,7 @@ public class CoinsRegistry : ICoinsView
 			if (!SpentCoins.Contains(coin))
 			{
 				added = Coins.Add(coin);
+				AllSeenTxIds.Add(coin.TransactionId);
 				coin.RegisterToHdPubKey();
 				if (added)
 				{
@@ -176,6 +180,14 @@ public class CoinsRegistry : ICoinsView
 					SpentCoinsByOutPoint.Add(spentCoin.Outpoint, spentCoin);
 				}
 			}
+		}
+	}
+
+	public bool Seen(uint256 txid)
+	{
+		lock (Lock)
+		{
+			return AllSeenTxIds.Contains(txid);
 		}
 	}
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -169,7 +169,7 @@ public class TransactionProcessor
 		start = SetA(start);
 
 		// Performance ToDo: txids could be cached in a hashset here by the AllCoinsView and then the contains would be fast.
-		if (!tx.Transaction.IsCoinBase && !Coins.AsAllCoinsView().CreatedBy(txId).Any()) // Transactions we already have and processed would be "double spends" but they shouldn't.
+		if (!tx.Transaction.IsCoinBase && !Coins.Seen(txId)) // Transactions we already have and processed would be "double spends" but they shouldn't.
 		{
 			start = SetB(start);
 			var doubleSpentSpenders = new List<SmartCoin>();

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -253,7 +253,7 @@ public class TransactionProcessor
 		}
 		start = SetC(start);
 
-		var myInputs = Coins.AsAllCoinsView().OutPoints(tx.Transaction.Inputs.Select(x => x.PrevOut).ToHashSet()).ToImmutableList();
+		var myInputs = Coins.GetMyInputs(tx).ToArray();
 		start = SetD(start);
 		for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
 		{


### PR DESCRIPTION
Improves https://github.com/zkSNACKs/WalletWasabi/issues/11287

There's no inherent reason why transaction processing shouldn't happen within 100ms.

### User Perception Reference

- **0-100 milliseconds** - This is perceived as instantaneous by users. A response within this timeframe makes the user feel like they're directly manipulating objects on the screen.

- **100-300 milliseconds** - Users can perceive a slight delay, but it's still quick enough that they feel like they're interacting in real-time.

- **300-1000 milliseconds (1 second)** - Within this range, the user's flow of thought remains uninterrupted, although they'll notice the delay. If the delay is closer to 1 second, it's a good practice to provide some feedback, like a loading spinner or progress bar.

- **1-10 seconds** - If a response takes this long, the user's attention will start to drift, and they'll become aware of the delay. It's crucial to provide feedback if a task will take longer than 1 second. If it's closer to 10 seconds, the user might abandon the task.

- **10 seconds and beyond** - Delays longer than this are likely to cause the user to leave or become frustrated. If a task will take this long, it's essential to set clear expectations and provide regular feedback.

### Measurements

On the current release, a wallet of mine takes 20 seconds.

On the current master, it takes 10 seconds with the following percentages of sections in this PR:
```
2023-08-15 12:30:47.340 [10] WARNING	TransactionProcessor.Process (90)	A: 0.46%, B: 22.73%, C: 1.52%, D: 28.66%, E: 7.96%, F: 0.94%, G: 37.73%
```

This PR a proof that sections `B: 22.73%` and `D: 28.66%` can be reduced to `B: 0.06%` and `D: 1.02%`, which is a `22.73 + 28.66 - 0.06 - 1.02 = ` `50.31%` improvement, which leaves us with 5 seconds on my test wallet.

a43ff7fe77f216d968024d6a92b5b564e4cdc428
```
2023-08-15 12:40:35.724 [25] WARNING	TransactionProcessor.Process (90)	A: 0.48%, B: 0.04%, C: 1.61%, D: 44.23%, E: 9.08%, F: 1.08%, G: 43.50%
```
e3b7c758de07c49bc498c9aed84cfc8b1a04ae4a
```
2023-08-15 15:07:40.042 [24] WARNING	TransactionProcessor.Process (90)	A: 0.78%, B: 0.06%, C: 2.96%, D: 1.02%, E: 15.14%, F: 0.98%, G: 79.06%
```

### Remaining Bottleneck

What about the remaining 5 seconds? We can deal with that later, but for now, we may note that it mainly comes from section `G: 79.06%`, the part about privacy calculations. Examining that we shall recognize the performance hit is coming from `CoinjoinAnalyzer`'s `ComputeInputSanction` method and note that lowering the `MaxRecursionDepth = 3;` constantly gets resolves the performance hit (although not advisable to do that, yet it's helpful information.)

_@onvej-sl, as the original author of that class, you've been warned. An onslaught is coming to that code :D_

### Implementation Strategy

I must emphasize this is not the correct solution, but a proof of possibility. You may also see that at least one unit test fails with it.

**I will not work further with this PR, but I am looking for someone who works out the proper solutions based on this proof of concept instead.**