### PR TITLE
Rename `HttpClientFactory` to `WasabiHttpClientFactory` and introduce `CreateLongLivedHttpClient` helper

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -125,9 +125,9 @@ public class Global
 	public BitcoinStore BitcoinStore { get; }
 
 	/// <summary>HTTP client factory for sending HTTP requests.</summary>
-	public HttpClientFactory HttpClientFactory { get; }
+	public WasabiHttpClientFactory HttpClientFactory { get; }
 
-	public HttpClientFactory CoordinatorHttpClientFactory { get; }
+	public WasabiHttpClientFactory CoordinatorHttpClientFactory { get; }
 
 	public LegalChecker LegalChecker { get; private set; }
 	public Config Config { get; }
@@ -151,7 +151,7 @@ public class Global
 	private AllTransactionStore AllTransactionStore { get; }
 	private IndexStore IndexStore { get; }
 
-	private HttpClientFactory BuildHttpClientFactory(Func<Uri> backendUriGetter) =>
+	private WasabiHttpClientFactory BuildHttpClientFactory(Func<Uri> backendUriGetter) =>
 		new(
 			Config.UseTor ? TorSettings.SocksEndpoint : null,
 			backendUriGetter);

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -18,7 +18,7 @@ public static class Services
 
 	public static BitcoinStore BitcoinStore { get; private set; } = null!;
 
-	public static HttpClientFactory HttpClientFactory { get; private set; } = null!;
+	public static WasabiHttpClientFactory HttpClientFactory { get; private set; } = null!;
 
 	public static LegalChecker LegalChecker { get; private set; } = null!;
 

--- a/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoClientTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/BlockstreamInfoClientTests.cs
@@ -20,8 +20,8 @@ public class BlockstreamInfoClientTests : IAsyncLifetime
 		TorProcessManager = new(Common.TorSettings);
 	}
 
-	private HttpClientFactory ClearnetHttpClientFactory { get; }
-	private HttpClientFactory TorHttpClientFactory { get; }
+	private WasabiHttpClientFactory ClearnetHttpClientFactory { get; }
+	private WasabiHttpClientFactory TorHttpClientFactory { get; }
 	private TorProcessManager TorProcessManager { get; }
 
 	public async Task InitializeAsync()

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -97,7 +97,7 @@ public class P2pTests
 		using var nodes = new NodesGroup(network, connectionParameters, requirements: Constants.NodeRequirements);
 
 		KeyManager keyManager = KeyManager.CreateNew(out _, "password", network);
-		await using HttpClientFactory httpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: () => new Uri("http://localhost:12345"));
+		await using WasabiHttpClientFactory httpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: () => new Uri("http://localhost:12345"));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		var feeProvider = new HybridFeeProvider(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -62,7 +62,7 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -61,7 +61,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -60,7 +60,7 @@ public class CancelTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
@@ -42,7 +42,7 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		IRPCClient rpc = setup.RpcClient;
 		BitcoinStore bitcoinStore = setup.BitcoinStore;
 
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(1), 1000, bitcoinStore, httpClientFactory);
 		try
 		{

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -61,7 +61,7 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
@@ -76,7 +76,7 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 
 		var node = RegTestFixture.BackendRegTestNode;
 
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
 
 		try

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -58,7 +58,7 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -61,7 +61,7 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -63,7 +63,7 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -60,7 +60,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -60,7 +60,7 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -53,7 +53,7 @@ public class WalletTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 2. Create wasabi synchronizer service.
-		await using HttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
+		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -38,14 +38,14 @@ public class WalletBuilder : IAsyncDisposable
 		var blockRepositoryMock = new MockBlockRepository(node.BlockChain);
 		BitcoinStore = new BitcoinStore(IndexStore, TransactionStore, new MempoolService(), blockRepositoryMock);
 		Cache = new MemoryCache(new MemoryCacheOptions());
-		HttpClientFactory = new HttpClientFactory(torEndPoint: null, backendUriGetter: () => null!);
+		HttpClientFactory = new WasabiHttpClientFactory(torEndPoint: null, backendUriGetter: () => null!);
 	}
 
 	private IndexStore IndexStore { get; }
 	private AllTransactionStore TransactionStore { get; }
 	private BitcoinStore BitcoinStore { get; }
 	private MemoryCache Cache { get; }
-	private HttpClientFactory HttpClientFactory { get; }
+	private WasabiHttpClientFactory HttpClientFactory { get; }
 	public IEnumerable<FilterModel> Filters { get; }
 	public string DataDir { get; }
 

--- a/WalletWasabi/Blockchain/Mempool/MempoolService.cs
+++ b/WalletWasabi/Blockchain/Mempool/MempoolService.cs
@@ -78,7 +78,7 @@ public class MempoolService
 	/// <summary>
 	/// Tries to perform mempool cleanup with the help of the backend.
 	/// </summary>
-	public async Task<bool> TryPerformMempoolCleanupAsync(HttpClientFactory httpClientFactory)
+	public async Task<bool> TryPerformMempoolCleanupAsync(WasabiHttpClientFactory httpClientFactory)
 	{
 		// If already cleaning, then no need to run it that often.
 		if (Interlocked.CompareExchange(ref _cleanupInProcess, 1, 0) == 1)

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -20,7 +20,7 @@ namespace WalletWasabi.Blockchain.TransactionBroadcasting;
 
 public class TransactionBroadcaster
 {
-	public TransactionBroadcaster(Network network, BitcoinStore bitcoinStore, HttpClientFactory httpClientFactory, WalletManager walletManager)
+	public TransactionBroadcaster(Network network, BitcoinStore bitcoinStore, WasabiHttpClientFactory httpClientFactory, WalletManager walletManager)
 	{
 		Network = Guard.NotNull(nameof(network), network);
 		BitcoinStore = Guard.NotNull(nameof(bitcoinStore), bitcoinStore);

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -40,7 +40,7 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	/// </summary>
 	private long _running;
 
-	public WasabiSynchronizer(TimeSpan requestInterval, int maxFiltersToSync, BitcoinStore bitcoinStore, HttpClientFactory httpClientFactory)
+	public WasabiSynchronizer(TimeSpan requestInterval, int maxFiltersToSync, BitcoinStore bitcoinStore, WasabiHttpClientFactory httpClientFactory)
 	{
 		RequestInterval = requestInterval;
 		MaxFiltersToSync = maxFiltersToSync;
@@ -62,7 +62,7 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	public event EventHandler<AllFeeEstimate>? AllFeeEstimateArrived;
 
 	public SynchronizeResponse? LastResponse { get; private set; }
-	public HttpClientFactory HttpClientFactory { get; }
+	public WasabiHttpClientFactory HttpClientFactory { get; }
 	private WasabiClient WasabiClient { get; }
 
 	/// <summary>Gets the Bitcoin price in USD.</summary>

--- a/WalletWasabi/Tor/Http/IHttpClient.cs
+++ b/WalletWasabi/Tor/Http/IHttpClient.cs
@@ -17,7 +17,7 @@ public interface IHttpClient
 	/// <param name="cancellationToken">Cancellation token to cancel the asynchronous operation.</param>
 	/// <exception cref="HttpRequestException"/>
 	/// <exception cref="OperationCanceledException">When operation is canceled.</exception>
-	Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
+	Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
 
 	/// <exception cref="HttpRequestException"/>
 	/// <exception cref="InvalidOperationException"/>

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -42,7 +42,7 @@ public class TorMonitor : PeriodicRunner
 	/// <remarks>Guards <see cref="ForceTorRestartCts"/>.</remarks>
 	private readonly object _lock = new();
 
-	public TorMonitor(TimeSpan period, TorProcessManager torProcessManager, HttpClientFactory httpClientFactory) : base(period)
+	public TorMonitor(TimeSpan period, TorProcessManager torProcessManager, WasabiHttpClientFactory httpClientFactory) : base(period)
 	{
 		TorProcessManager = torProcessManager;
 		TorHttpPool = httpClientFactory.TorHttpPool!;

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
@@ -15,7 +15,7 @@ namespace WalletWasabi.WebClients.BlockstreamInfo;
 
 public class BlockstreamInfoClient
 {
-	public BlockstreamInfoClient(Network network, HttpClientFactory httpClientFactory)
+	public BlockstreamInfoClient(Network network, WasabiHttpClientFactory httpClientFactory)
 	{
 		string uriString;
 

--- a/WalletWasabi/WebClients/Wasabi/WasabiHttpClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiHttpClientFactory.cs
@@ -11,13 +11,13 @@ namespace WalletWasabi.WebClients.Wasabi;
 /// <summary>
 /// Factory class to get proper <see cref="IHttpClient"/> client which is set up based on user settings.
 /// </summary>
-public class HttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposable
+public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposable
 {
 	/// <summary>
 	/// Creates a new instance of the object.
 	/// </summary>
 	/// <param name="torEndPoint">If <c>null</c> then clearnet (not over Tor) is used, otherwise HTTP requests are routed through provided Tor endpoint.</param>
-	public HttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter)
+	public WasabiHttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter)
 	{
 		SocketHandler = new()
 		{

--- a/WalletWasabi/WebClients/Wasabi/WasabiHttpClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiHttpClientFactory.cs
@@ -19,14 +19,7 @@ public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposabl
 	/// <param name="torEndPoint">If <c>null</c> then clearnet (not over Tor) is used, otherwise HTTP requests are routed through provided Tor endpoint.</param>
 	public WasabiHttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter)
 	{
-		SocketHandler = new()
-		{
-			// Only GZip is currently used by Wasabi Backend.
-			AutomaticDecompression = DecompressionMethods.GZip,
-			PooledConnectionLifetime = TimeSpan.FromMinutes(5)
-		};
-
-		HttpClient = new(SocketHandler);
+		HttpClient = CreateLongLivedHttpClient(automaticDecompression: DecompressionMethods.GZip);
 
 		TorEndpoint = torEndPoint;
 		BackendUriGetter = backendUriGetter;
@@ -56,8 +49,6 @@ public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposabl
 	[MemberNotNullWhen(returnValue: true, nameof(TorEndpoint))]
 	public bool IsTorEnabled => TorEndpoint is not null;
 
-	private SocketsHttpHandler SocketHandler { get; }
-
 	/// <summary>.NET HTTP client to be used by <see cref="ClearnetHttpClient"/> instances.</summary>
 	private HttpClient HttpClient { get; }
 
@@ -69,6 +60,27 @@ public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposabl
 
 	/// <summary>Shared instance of <see cref="WasabiClient"/>.</summary>
 	public WasabiClient SharedWasabiClient { get; }
+
+	/// <summary>
+	/// Creates a long-lived <see cref="HttpClient"/> instance for accessing clearnet sites.
+	/// </summary>
+	/// <remarks>Created HTTP client handles correctly DNS changes.</remarks>
+	/// <seealso href="https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory"/>
+	[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HTTP client will dispose the handler correctly.")]
+	public static HttpClient CreateLongLivedHttpClient(TimeSpan? pooledConnectionLifetime = null, DecompressionMethods? automaticDecompression = null)
+	{
+		SocketsHttpHandler handler = new()
+		{
+			PooledConnectionLifetime = pooledConnectionLifetime ?? TimeSpan.FromMinutes(5),
+		};
+
+		if (automaticDecompression is not null)
+		{
+			handler.AutomaticDecompression = automaticDecompression.Value;
+		}
+
+		return new HttpClient(handler);
+	}
 
 	/// <summary>
 	/// Creates new <see cref="TorHttpClient"/> or <see cref="ClearnetHttpClient"/> based on user settings.
@@ -116,7 +128,6 @@ public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposabl
 		}
 
 		HttpClient.Dispose();
-		SocketHandler.Dispose();
 
 		if (TorHttpPool is not null)
 		{

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -231,3 +231,4 @@ sayajin
 hashset
 enum
 usings
+clearnet


### PR DESCRIPTION
Alternative to #10569

Notes:

* `HttpClientFactory` is renamed to `WasabiHttpClientFactory` to avoid confusion with `IHttpClientFactory` in .NET.
* `WasabiHttpClientFactory.CreateLongLivedHttpClient` allows to create `HttpClient` instances that can live for long-time (as DNS is properly updated).
* A modification in `Global` was done to use the new `WasabiHttpClientFactory.CreateLongLivedHttpClient` helper method.

Review is easy commit by commit. Each commit can be a standalone PR basically if needed.