### PR TITLE
`CoinbaseExchangeRateProvider`: Fix warnings

### DIFF
--- a/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
@@ -30,15 +30,15 @@ public class CoinbaseExchangeRateProvider : IExchangeRateProvider
 
 	private class DataWrapper
 	{
-		public CoinbaseExchangeRate Data { get; set; }
+		public required CoinbaseExchangeRate Data { get; init; }
 
 		public class CoinbaseExchangeRate
 		{
-			public ExchangeRates Rates { get; set; }
+			public required ExchangeRates Rates { get; init; }
 
 			public class ExchangeRates
 			{
-				public decimal USD { get; set; }
+				public decimal USD { get; init; }
 			}
 		}
 	}


### PR DESCRIPTION
Verified by the following test:

```cs
[Fact]
public async Task GetExchangeRateAsync()
{
	CoinbaseExchangeRateProvider provider = new();

	IEnumerable<ExchangeRate> enumerable = await provider.GetExchangeRateAsync(CancellationToken.None);
	Assert.NotEmpty(enumerable);
}
```

Maybe it would be a good idea to have such a test in `IntegrationTests`?