### PR TITLE
Fix Wasabi crash if exception happens after PreviewTx screen

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -427,8 +427,6 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				_wallet.UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithNewLabels);
 				_cancellationTokenSource?.Cancel();
 				Navigate().To().SendSuccess(_wallet, finalTransaction);
-
-				IsBusy = false;
 			}
 		}
 		catch (Exception ex)
@@ -438,6 +436,10 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				"Transaction",
 				ex.ToUserFriendlyString(),
 				"Wasabi was unable to send your transaction.");
+		}
+		finally
+		{
+			IsBusy = false;
 		}
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -412,32 +412,32 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 
 	private async Task OnConfirmAsync()
 	{
-		var transaction = await Task.Run(() => TransactionHelpers.BuildTransaction(_wallet, _info));
-		var transactionAuthorizationInfo = new TransactionAuthorizationInfo(transaction);
-		var authResult = await AuthorizeAsync(transactionAuthorizationInfo);
-		if (authResult)
+		try
 		{
-			IsBusy = true;
-
-			try
+			var transaction = await Task.Run(() => TransactionHelpers.BuildTransaction(_wallet, _info));
+			var transactionAuthorizationInfo = new TransactionAuthorizationInfo(transaction);
+			var authResult = await AuthorizeAsync(transactionAuthorizationInfo);
+			if (authResult)
 			{
+				IsBusy = true;
+
 				var finalTransaction =
 					await GetFinalTransactionAsync(transactionAuthorizationInfo.Transaction, _info);
 				await SendTransactionAsync(finalTransaction);
 				_wallet.UpdateUsedHdPubKeysLabels(transaction.HdPubKeysWithNewLabels);
 				_cancellationTokenSource?.Cancel();
 				Navigate().To().SendSuccess(_wallet, finalTransaction);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogError(ex);
-				await ShowErrorAsync(
-					"Transaction",
-					ex.ToUserFriendlyString(),
-					"Wasabi was unable to send your transaction.");
-			}
 
-			IsBusy = false;
+				IsBusy = false;
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex);
+			await ShowErrorAsync(
+				"Transaction",
+				ex.ToUserFriendlyString(),
+				"Wasabi was unable to send your transaction.");
 		}
 	}
 


### PR DESCRIPTION
Addresses #11191
Addresses #10171
and probably more in the future.

Already suggested this fix in the past for different problems, not sure why it was not accepted.

At this point, if an exception does occur somehow even before trying to finalize and send, just when we build the tx, we should raise the exception and throw out a message because something is deffinetly not ok, and we can prevent the wallet **crash** as well.

This PR just widens the try/catch.