### PR TITLE
Bump required .NET SDK version to 7.0.200

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.200",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }


### PR DESCRIPTION
We know that this repo cannot be built on `7.0.102`[^1]. So let's bump it a bit so users having `7.0.102` are not surprised when trying to compile.

This is not a proper fix but it's something we can do in reasonable time.

[^1]: I have hit this issue during working on [this](https://github.com/zkSNACKs/WalletWasabi/issues/10915#issuecomment-1685778961) and installing .NET on Ubuntu 22.04.