### PR TITLE
Fix broken music box

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
@@ -51,6 +51,6 @@ public class WalletCoinjoinModel : IWalletCoinjoinModel
 
 	public async Task StopAsync()
 	{
-		await _coinJoinManager.StopAsync(CancellationToken.None);
+		await _coinJoinManager.StopAsync(_wallet, CancellationToken.None);
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/11339

Wrong `StopAsync` was called before, so we didn't write the `StopCommand` to the `Channel`.