### PR TITLE
Remove 2 enumerations in CoinsRegistry AsAllCoinsView

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -250,11 +250,11 @@ public class CoinsRegistry : ICoinsView
 	{
 		lock (Lock)
 		{
-			return new CoinsView(AsAllCoinsViewNoLock().ToList());
+			return new CoinsView(AsAllCoinsViewNoLock());
 		}
 	}
 
-	private ICoinsView AsAllCoinsViewNoLock() => new CoinsView(AsCoinsViewNoLock().Concat(AsSpentCoinsViewNoLock()).ToList());
+	private ICoinsView AsAllCoinsViewNoLock() => new CoinsView(AsCoinsViewNoLock().Concat(AsSpentCoinsViewNoLock()));
 
 	public ICoinsView AtBlockHeight(Height height) => AsCoinsView().AtBlockHeight(height);
 


### PR DESCRIPTION
I believe these enumerations are useless because we always re-enumerate after for every usage I found.
This PR has a **major** impact on performances for really big wallets. 
On the wallet I'm testing with 40.000 keys, we're talking ~30% improvement on `TransactionProcessing.Process`, which is a bottleneck for syncing big wallets.

@BTCparadigm Can you test this please? Preferably in a context where you do not need to dl blocks, like this:
1. Open your big wallet on `master` and wait for the wallet to be started.
2. Close the software
3. Reopen your wallet and substract the time between the log message "Initial Transaction Processing finished in X.YY minutes." and the log message "Wallet "Wallet" has started"
4. Close your software
5. checkout this PR
6. Perform 3. again and report difference