### PR TITLE
Bump required .NET SDK version to 7.0.304

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200",
+    "version": "7.0.304",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }


### PR DESCRIPTION
Follow-up to #11357

Lucas mentioned that `7.0.304` is actually required to build the project on Linux ([see](https://github.com/zkSNACKs/WalletWasabi/pull/11357#issuecomment-1689881764)). I don't want to overdo the bumps. However, given that we know that build breaks on lower SDKs for a supported platform, and also it fails in a specific way that it looks like the source code is broken. I guess it's better to bump it. 

Note that this bumping should not be necessary in the future (🤞) because what we deal with here is that .NET compiler incorrectly runs source analyzers and build fails then. 