### PR TITLE
Only check replacement for immatures transactions

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -1482,6 +1482,7 @@ public class TransactionProcessorTests
 		return new TransactionProcessor(
 			transactionStore,
 			null,
+			null,
 			keyManager,
 			Money.Coins(0.0001m));
 	}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -54,7 +54,7 @@ public class Wallet : BackgroundService, IWallet
 
 		DestinationProvider = new InternalDestinationProvider(KeyManager);
 
-		TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, KeyManager, ServiceConfiguration.DustThreshold);
+		TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, BitcoinStore.SmartHeaderChain, KeyManager, ServiceConfiguration.DustThreshold);
 		Coins = TransactionProcessor.Coins;
 		WalletFilterProcessor = new WalletFilterProcessor(KeyManager, BitcoinStore, TransactionProcessor, BlockProvider);
 	}


### PR DESCRIPTION
We are currently checking for replacements for every transaction; what is the point?
I believe it's only necessary to check replacements for Immature transactions (in the mempool or confirmed in the last 101 blocks).

Note that no test covers this, and old tests remain unchanged. If the concept is accepted it might be great to add a test.

This PR is the first step of an effort to reduce the memory usage of wallets that coinjoined a lot. My goal with this PR is to, in follow-up PRs, dramatically reduce the size of (or even remove) `CoinsRegistry.CoinsByOutpoint`.