### PR TITLE
Ban doublespenders

### DIFF
--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -167,7 +167,7 @@ public class Global : IDisposable
 		WabiSabiCoordinator = new WabiSabiCoordinator(CoordinatorParameters, RpcClient, CoinJoinIdStore, coinJoinScriptStore, HttpClientFactory, wabiSabiConfig.IsCoinVerifierEnabled ? CoinVerifier : null);
 		blockNotifier.OnBlock += WabiSabiCoordinator.BanDescendant;
 		HostedServices.Register<WabiSabiCoordinator>(() => WabiSabiCoordinator, "WabiSabi Coordinator");
-
+		P2pNode.OnTransactionArrived += WabiSabiCoordinator.BanDoubleSpenders;
 		HostedServices.Register<RoundBootstrapper>(() => new RoundBootstrapper(TimeSpan.FromMilliseconds(100), Coordinator), "Round Bootstrapper");
 
 		await HostedServices.StartAllAsync(cancel);
@@ -249,6 +249,8 @@ public class Global : IDisposable
 					blockNotifier.OnBlock -= wabiSabiCoordinator.BanDescendant;
 				}
 				CoinVerifierHttpClient.Dispose();
+
+				P2pNode.OnTransactionArrived -= WabiSabiCoordinator.BanDoubleSpenders;
 
 				if (Coordinator is { } coordinator)
 				{

--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -30,6 +30,7 @@ public class P2pNode
 	}
 
 	public event EventHandler<uint256>? BlockInv;
+	public event EventHandler<Transaction>? OnTransactionArrived;
 
 	private Node? Node { get; set; }
 	private TrustedP2pBehavior? TrustedP2pBehavior { get; set; }
@@ -79,6 +80,7 @@ public class P2pNode
 			Node.StateChanged += P2pNode_StateChanged;
 			Node.Disconnected += Node_DisconnectedAsync;
 			TrustedP2pBehavior.BlockInv += TrustedP2pBehavior_BlockInv;
+			TrustedP2pBehavior.OnTransactionArrived += TrustedP2pBehavior_OnTransactionArrived;
 			NodeEventsSubscribed = true;
 			MempoolService.TrustedNodeMode = Node.IsConnected;
 		}
@@ -104,6 +106,11 @@ public class P2pNode
 	private void TrustedP2pBehavior_BlockInv(object? sender, uint256 e)
 	{
 		BlockInv?.Invoke(this, e);
+	}
+
+	private void TrustedP2pBehavior_OnTransactionArrived(object? sender, Transaction tx)
+	{
+		OnTransactionArrived.SafeInvoke(this, tx);
 	}
 
 	private void P2pNode_StateChanged(Node node, NodeState oldState)
@@ -155,6 +162,7 @@ public class P2pNode
 					if (TrustedP2pBehavior is { } trustedP2pBehavior)
 					{
 						trustedP2pBehavior.BlockInv -= TrustedP2pBehavior_BlockInv;
+						trustedP2pBehavior.OnTransactionArrived -= TrustedP2pBehavior_OnTransactionArrived;
 					}
 					node.Disconnected -= Node_DisconnectedAsync;
 					node.StateChanged -= P2pNode_StateChanged;

--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -21,8 +21,8 @@ public abstract class P2pBehavior : NodeBehavior
 		MempoolService = Guard.NotNull(nameof(mempoolService), mempoolService);
 	}
 
-	public MempoolService MempoolService { get; }
 	public event EventHandler<Transaction>? OnTransactionArrived;
+	public MempoolService MempoolService { get; }
 
 	protected override void AttachCore()
 	{

--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 
@@ -21,6 +22,7 @@ public abstract class P2pBehavior : NodeBehavior
 	}
 
 	public MempoolService MempoolService { get; }
+	public event EventHandler<Transaction>? OnTransactionArrived;
 
 	protected override void AttachCore()
 	{
@@ -121,6 +123,7 @@ public abstract class P2pBehavior : NodeBehavior
 	{
 		Transaction transaction = payload.Object;
 		transaction.PrecomputeHash(false, true);
+		OnTransactionArrived.SafeInvoke(this, transaction);
 		MempoolService.Process(transaction);
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -720,7 +720,7 @@ public partial class Arena : PeriodicRunner
 		RoundPhaseChanged?.SafeInvoke(this, new RoundPhaseChangedEventArgs(round.Id, phase));
 	}
 
-	private void EndRound(Round round, EndRoundState endRoundState)
+	internal void EndRound(Round round, EndRoundState endRoundState)
 	{
 		round.EndRound(endRoundState);
 		RoundPhaseChanged?.SafeInvoke(this, new RoundPhaseChangedEventArgs(round.Id, Phase.Ended));

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -25,7 +25,8 @@ public enum EndRoundState
 	NotAllAlicesSign,
 	AbortedNotEnoughAlicesSigned,
 	AbortedNotAllAlicesConfirmed,
-	AbortedLoadBalancing
+	AbortedLoadBalancing,
+	AbortedDoubleSpendingDetected
 }
 
 public class Round

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -118,6 +118,18 @@ public class WabiSabiCoordinator : BackgroundService
 		}
 	}
 
+	public void BanDoubleSpenders(object? sender, Transaction tx)
+	{
+		var disruptedRounds = Arena.Rounds
+			.SelectMany(r => r.Alices.Select(a => (RoundId: r.Id, a.Coin)))
+			.Where(x => tx.Inputs.Any(i => i.PrevOut == x.Coin.Outpoint));
+
+		foreach (var (roundId, offender) in disruptedRounds)
+		{
+			Warden.Prison.DoubleSpent(offender.Outpoint, offender.Amount, roundId);
+		}
+	}
+
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
 		await ConfigWatcher.StartAsync(stoppingToken).ConfigureAwait(false);

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -120,13 +120,26 @@ public class WabiSabiCoordinator : BackgroundService
 
 	public void BanDoubleSpenders(object? sender, Transaction tx)
 	{
-		var disruptedRounds = Arena.Rounds
+		// Detect and punish double spending coins
+		var disrupters = Arena.Rounds
+			.Where(r => r.Phase != Phase.Ended)
 			.SelectMany(r => r.Alices.Select(a => (RoundId: r.Id, a.Coin)))
 			.Where(x => tx.Inputs.Any(i => i.PrevOut == x.Coin.Outpoint));
 
-		foreach (var (roundId, offender) in disruptedRounds)
+		foreach (var (roundId, offender) in disrupters)
 		{
 			Warden.Prison.DoubleSpent(offender.Outpoint, offender.Amount, roundId);
+		}
+
+		// Abort disrupted rounds
+		var disruptedRounds = disrupters.Select(x => x.RoundId).Distinct();
+		foreach (var roundId in disruptedRounds)
+		{
+			var maybeNullRoundToAbort = Arena.Rounds.FirstOrDefault(r => r.Id == roundId);
+			if (maybeNullRoundToAbort is { } roundToAbort)
+			{
+				roundToAbort.EndRound(EndRoundState.AbortedDoubleSpendingDetected);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is for banning coins that were spent after being registered for participation in a coinjoin.