### PR TITLE
[PoC] Only cache prevout from mature coins in CoinsByOutPoint

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -1482,6 +1482,7 @@ public class TransactionProcessorTests
 		return new TransactionProcessor(
 			transactionStore,
 			null,
+			null,
 			keyManager,
 			Money.Coins(0.0001m));
 	}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.Mempool;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -18,11 +19,13 @@ public class TransactionProcessor
 	public TransactionProcessor(
 		AllTransactionStore transactionStore,
 		MempoolService? mempoolService,
+		SmartHeaderChain? smartHeaderChain,
 		KeyManager keyManager,
 		Money dustThreshold)
 	{
 		TransactionStore = transactionStore;
 		MempoolService = mempoolService;
+		SmartHeaderChain = smartHeaderChain;
 		KeyManager = keyManager;
 		DustThreshold = dustThreshold;
 		Coins = new();
@@ -33,6 +36,7 @@ public class TransactionProcessor
 
 	private static object Lock { get; } = new object();
 	public AllTransactionStore TransactionStore { get; }
+	private SmartHeaderChain? SmartHeaderChain { get; }
 	private HashSet<uint256> Aware { get; } = new();
 
 	public KeyManager KeyManager { get; }
@@ -145,13 +149,14 @@ public class TransactionProcessor
 		}
 
 		// Performance ToDo: txids could be cached in a hashset here by the AllCoinsView and then the contains would be fast.
-		if (!tx.Transaction.IsCoinBase && !Coins.AsAllCoinsView().CreatedBy(txId).Any()) // Transactions we already have and processed would be "double spends" but they shouldn't.
+		var isTxImmature = tx.Height == Height.Mempool || SmartHeaderChain is null || (tx.Height >= SmartHeaderChain.TipHeight - 101);
+		if (isTxImmature && !tx.Transaction.IsCoinBase && !Coins.AsAllCoinsView().CreatedBy(txId).Any()) // Transactions we already have and processed would be "double spends" but they shouldn't.
 		{
 			var doubleSpentSpenders = new List<SmartCoin>();
 			var doubleSpentCoins = new List<SmartCoin>();
 			foreach (var txIn in tx.Transaction.Inputs)
 			{
-				if (Coins.TryGetSpenderSmartCoinsByOutPoint(txIn.PrevOut, out var coins))
+				if (Coins.TryGetSpenderSmartCoinsByOutPoint(txIn.PrevOut, out var coins, out _, SmartHeaderChain is null ? null : new Height(SmartHeaderChain.TipHeight)))
 				{
 					doubleSpentSpenders.AddRange(coins);
 				}
@@ -252,7 +257,7 @@ public class TransactionProcessor
 				result.ReceivedCoins.Add(newCoin);
 
 				// If we did not have it.
-				if (Coins.TryAdd(newCoin))
+				if (Coins.TryAdd(newCoin, SmartHeaderChain is null ? new Height(Height.Mempool) : new Height(SmartHeaderChain.TipHeight)))
 				{
 					result.NewlyReceivedCoins.Add(newCoin);
 				}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -54,7 +54,7 @@ public class Wallet : BackgroundService, IWallet
 
 		DestinationProvider = new InternalDestinationProvider(KeyManager);
 
-		TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, KeyManager, ServiceConfiguration.DustThreshold);
+		TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, BitcoinStore.SmartHeaderChain, KeyManager, ServiceConfiguration.DustThreshold);
 		Coins = TransactionProcessor.Coins;
 		WalletFilterProcessor = new WalletFilterProcessor(KeyManager, BitcoinStore, TransactionProcessor, BlockProvider);
 	}


### PR DESCRIPTION
I'm not 100% sure about the concept yet, but AFAICS it makes sense.

It's built on #11370.
It saves some memory for big wallets, `CoinsByOutPoint` being the 2nd biggest object (after `AllTransactionStore`).
On my wallet it saves 800 Mb of memory.