### PR TITLE
`IndexStore`: Make `SmartHeaderChain` property `private`

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -56,7 +56,7 @@ public class Global
 		var mempoolService = new MempoolService();
 		var blocks = new FileSystemBlockRepository(Path.Combine(networkWorkFolderPath, "Blocks"), Network);
 
-		BitcoinStore = new BitcoinStore(IndexStore, AllTransactionStore, mempoolService, blocks);
+		BitcoinStore = new BitcoinStore(IndexStore, AllTransactionStore, mempoolService, smartHeaderChain, blocks);
 		HttpClientFactory = BuildHttpClientFactory(() => Config.GetBackendUri());
 		CoordinatorHttpClientFactory = BuildHttpClientFactory(() => Config.GetCoordinatorUri());
 
@@ -192,7 +192,7 @@ public class Global
 					WalletManager.EnsureTurboSyncHeightConsistency();
 
 					// Make sure that the height of the wallets will not be better than the current height of the filters.
-					WalletManager.SetMaxBestHeight(BitcoinStore.IndexStore.SmartHeaderChain.TipHeight);
+					WalletManager.SetMaxBestHeight(BitcoinStore.SmartHeaderChain.TipHeight);
 				}
 				catch (Exception ex) when (ex is not OperationCanceledException)
 				{

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -55,11 +55,12 @@ public class P2pTests
 
 		var dataDir = Common.GetWorkDir();
 
-		await using var indexStore = new IndexStore(Path.Combine(dataDir, "indexStore"), network, new SmartHeaderChain());
+		SmartHeaderChain smartHeaderChain = new();
+		await using var indexStore = new IndexStore(Path.Combine(dataDir, "indexStore"), network, smartHeaderChain);
 		await using var transactionStore = new AllTransactionStore(Path.Combine(dataDir, "transactionStore"), network);
 		var mempoolService = new MempoolService();
 		var blocks = new FileSystemBlockRepository(Path.Combine(dataDir, "blocks"), network);
-		BitcoinStore bitcoinStore = new(indexStore, transactionStore, mempoolService, blocks);
+		BitcoinStore bitcoinStore = new(indexStore, transactionStore, mempoolService, smartHeaderChain, blocks);
 		await bitcoinStore.InitializeAsync();
 
 		var addressManagerFolderPath = Path.Combine(dataDir, "AddressManager");

--- a/WalletWasabi.Tests/RegressionTests/RegTestSetup.cs
+++ b/WalletWasabi.Tests/RegressionTests/RegTestSetup.cs
@@ -34,11 +34,12 @@ public class RegTestSetup : IAsyncDisposable
 		RegTestFixture = regTestFixture;
 		ServiceConfiguration = new ServiceConfiguration(regTestFixture.BackendRegTestNode.P2pEndPoint, Money.Coins(Constants.DefaultDustThreshold));
 
-		IndexStore = new IndexStore(Path.Combine(dir, "indexStore"), Network, new SmartHeaderChain());
+		SmartHeaderChain smartHeaderChain = new();
+		IndexStore = new IndexStore(Path.Combine(dir, "indexStore"), Network, smartHeaderChain);
 		TransactionStore = new AllTransactionStore(Path.Combine(dir, "transactionStore"), Network);
 		MempoolService mempoolService = new();
 		FileSystemBlockRepository blocks = new(Path.Combine(dir, "blocks"), Network);
-		BitcoinStore = new BitcoinStore(IndexStore, TransactionStore, mempoolService, blocks);
+		BitcoinStore = new BitcoinStore(IndexStore, TransactionStore, mempoolService, smartHeaderChain, blocks);
 	}
 
 	public RegTestFixture RegTestFixture { get; }

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -36,13 +36,14 @@ public class P2pBasedTests
 			var walletName = "wallet";
 			await rpc.CreateWalletAsync(walletName);
 
-			await using IndexStore indexStore = new(Path.Combine(dir, "indexStore"), network, new SmartHeaderChain());
+			SmartHeaderChain smartHeaderChain = new();
+			await using IndexStore indexStore = new(Path.Combine(dir, "indexStore"), network, smartHeaderChain);
 			await using AllTransactionStore transactionStore = new(Path.Combine(dir, "transactionStore"), network);
 			MempoolService mempoolService = coreNode.MempoolService;
 			FileSystemBlockRepository blocks = new(Path.Combine(dir, "blocks"), network);
 
 			// Construct BitcoinStore.
-			BitcoinStore bitcoinStore = new(indexStore, transactionStore, mempoolService, blocks);
+			BitcoinStore bitcoinStore = new(indexStore, transactionStore, mempoolService, smartHeaderChain, blocks);
 			await bitcoinStore.InitializeAsync();
 
 			await rpc.GenerateAsync(blockCount: 101);

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -29,14 +29,14 @@ public class WalletBuilder : IAsyncDisposable
 	{
 		DataDir = Common.GetWorkDir(nameof(WalletSynchronizationTests), callerName);
 
-		IndexStore = new IndexStore(Path.Combine(DataDir, "indexStore"), node.Network, new SmartHeaderChain());
-
+		SmartHeaderChain smartHeaderChain = new();
+		IndexStore = new IndexStore(Path.Combine(DataDir, "indexStore"), node.Network, smartHeaderChain);
 		TransactionStore = new AllTransactionStore(Path.Combine(DataDir, "transactionStore"), node.Network);
 
 		Filters = node.BuildFilters();
 
 		var blockRepositoryMock = new MockBlockRepository(node.BlockChain);
-		BitcoinStore = new BitcoinStore(IndexStore, TransactionStore, new MempoolService(), blockRepositoryMock);
+		BitcoinStore = new BitcoinStore(IndexStore, TransactionStore, new MempoolService(), smartHeaderChain, blockRepositoryMock);
 		Cache = new MemoryCache(new MemoryCacheOptions());
 		HttpClientFactory = new WasabiHttpClientFactory(torEndPoint: null, backendUriGetter: () => null!);
 	}

--- a/WalletWasabi/Stores/BitcoinStore.cs
+++ b/WalletWasabi/Stores/BitcoinStore.cs
@@ -22,17 +22,19 @@ public class BitcoinStore
 		IndexStore indexStore,
 		AllTransactionStore transactionStore,
 		MempoolService mempoolService,
+		SmartHeaderChain smartHeaderChain,
 		IRepository<uint256, Block> blockRepository)
 	{
 		IndexStore = indexStore;
 		TransactionStore = transactionStore;
 		MempoolService = mempoolService;
+		SmartHeaderChain = smartHeaderChain;
 		BlockRepository = blockRepository;
 	}
 
 	public IndexStore IndexStore { get; }
 	public AllTransactionStore TransactionStore { get; }
-	public SmartHeaderChain SmartHeaderChain => IndexStore.SmartHeaderChain;
+	public SmartHeaderChain SmartHeaderChain { get; }
 	public MempoolService MempoolService { get; }
 	public IRepository<uint256, Block> BlockRepository { get; }
 

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -70,7 +70,7 @@ public class IndexStore : IAsyncDisposable
 	/// <summary>Run migration if SQLite file does not exist.</summary>
 	private bool RunMigration { get; }
 
-	public SmartHeaderChain SmartHeaderChain { get; }
+	private SmartHeaderChain SmartHeaderChain { get; }
 
 	/// <summary>Filter disk storage.</summary>
 	/// <remarks>Guarded by <see cref="IndexLock"/>.</remarks>
@@ -251,7 +251,7 @@ public class IndexStore : IAsyncDisposable
 	{
 		using (await IndexLock.LockAsync(CancellationToken.None).ConfigureAwait(false))
 		{
-			await using SqliteTransaction sqliteTransaction = IndexStorage.BeginTransaction();
+			using SqliteTransaction sqliteTransaction = IndexStorage.BeginTransaction();
 
 			int processed = 0;
 

--- a/WalletWasabi/Wallets/WalletFilterProcessor.cs
+++ b/WalletWasabi/Wallets/WalletFilterProcessor.cs
@@ -113,7 +113,7 @@ public class WalletFilterProcessor : BackgroundService
 					{
 						var currentHeight = (request.SyncType == SyncType.Turbo ? KeyManager.GetBestTurboSyncHeight() : KeyManager.GetBestHeight());
 
-						if (currentHeight == BitcoinStore.IndexStore.SmartHeaderChain.TipHeight)
+						if (currentHeight == BitcoinStore.SmartHeaderChain.TipHeight)
 						{
 							request.Tcs.SetResult();
 							lock (SynchronizationRequestsLock)
@@ -131,7 +131,7 @@ public class WalletFilterProcessor : BackgroundService
 
 						var matchFound = await ProcessFilterModelAsync(filterToProcess, request.SyncType, cancellationToken).ConfigureAwait(false);
 
-						reachedBlockChainTip = filterToProcess.Header.Height == BitcoinStore.IndexStore.SmartHeaderChain.TipHeight;
+						reachedBlockChainTip = filterToProcess.Header.Height == BitcoinStore.SmartHeaderChain.TipHeight;
 						var saveNewHeightToFile = matchFound || reachedBlockChainTip;
 						if (request.SyncType == SyncType.Turbo)
 						{


### PR DESCRIPTION
This is more correct way to pass dependencies.