### PR TITLE
Move CTS creation from constructor to OnNavigatedTo & fix null warning

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
@@ -53,10 +53,7 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 	{
 		try
 		{
-			if (CancelCts is not { })
-			{
-				CancelCts = new CancellationTokenSource();
-			}
+			CancelCts ??= new CancellationTokenSource();
 			var walletSettings = await UiContext.WalletRepository.NewWalletAsync(options, CancelCts.Token);
 			Navigate().To().AddedWalletPage(walletSettings, options);
 		}
@@ -76,15 +73,15 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
-		CancelCts = new CancellationTokenSource();
 
 		var enableCancel = UiContext.WalletRepository.HasWallet;
 		SetupCancel(enableCancel: false, enableCancelOnEscape: enableCancel, enableCancelOnPressed: false);
 
 		disposables.Add(Disposable.Create(() =>
 		{
-			CancelCts.Cancel();
-			CancelCts.Dispose();
+			CancelCts?.Cancel();
+			CancelCts?.Dispose();
+			CancelCts = null;
 		}));
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs
@@ -23,7 +23,6 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 		ArgumentNullException.ThrowIfNull(device);
 
 		WalletName = walletName;
-		CancelCts = new CancellationTokenSource();
 
 		Type = device.WalletType;
 
@@ -40,7 +39,7 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 		EnableAutoBusyOn(NextCommand);
 	}
 
-	public CancellationTokenSource CancelCts { get; }
+	public CancellationTokenSource? CancelCts { get; private set; }
 
 	public string WalletName { get; }
 
@@ -54,6 +53,10 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 	{
 		try
 		{
+			if (CancelCts is not { })
+			{
+				CancelCts = new CancellationTokenSource();
+			}
 			var walletSettings = await UiContext.WalletRepository.NewWalletAsync(options, CancelCts.Token);
 			Navigate().To().AddedWalletPage(walletSettings, options);
 		}
@@ -73,6 +76,7 @@ public partial class DetectedHardwareWalletViewModel : RoutableViewModel
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
+		CancelCts = new CancellationTokenSource();
 
 		var enableCancel = UiContext.WalletRepository.HasWallet;
 		SetupCancel(enableCancel: false, enableCancelOnEscape: enableCancel, enableCancelOnPressed: false);


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11020

Quoting from my [comment](https://github.com/zkSNACKs/WalletWasabi/issues/11020#issuecomment-1706345208):

When importing a HW, we'll send HWI commands to get the xpubs from the device. If the connection is disrupted (eg. by plugging out the device) an exception will occour and be thrown here: 
https://github.com/zkSNACKs/WalletWasabi/blob/c6748d1e6c9d3fb356df57dbe14777ccfc99b619/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs#L53-L66

The exception is caught here, this on it's own doesn't cause a crash.
What's causing the crash is thet we call `ShowErrorAsync()`, which will navigate out from the current view model, thus disposing the `CancelCts` here:
https://github.com/zkSNACKs/WalletWasabi/blob/c6748d1e6c9d3fb356df57dbe14777ccfc99b619/WalletWasabi.Fluent/ViewModels/AddWallet/HardwareWallet/DetectedHardwareWalletViewModel.cs#L73-L85
But after clicking okay, we get navigated back an already existing view model, seting up the already disposed CTS for disposing.
And THEN in the catch we call `Navigate().Back()`, which should takes us to the same view model where we are, and by "navigating away", `CancelCTS.Cancel()` is called, causing the crash.