### PR TITLE
[VDG] Fix HistoryViewModelBase error

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
@@ -87,9 +87,9 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 
 	public bool IsCPFPd { get; set; }
 
-	public bool IsIncomingTransactionDisplayed => !IsCPFP && IncomingAmount > Money.Zero;
+	public bool IsIncomingTransactionDisplayed => !IsCPFP && IncomingAmount is { } amount && amount > Money.Zero;
 
-	public bool IsOutgoingTransactionDisplayed => !IsCPFP && OutgoingAmount > Money.Zero;
+	public bool IsOutgoingTransactionDisplayed => !IsCPFP && OutgoingAmount is { } amount && amount > Money.Zero;
 
 	public bool IsSelfTransferTransaction => OutgoingAmount == Money.Zero;
 


### PR DESCRIPTION
Fixes `ArgumentNullException` constantly occurring in `HistoryViewModelBase` due to UI bindings reading values of properties `IsIncomingTransactionDisplayed` and `IsOutgoingTransactionDisplayed` that error out:

![image](https://github.com/zkSNACKs/WalletWasabi/assets/98904713/e52fd38c-1741-4846-83a6-c7d07a3b9b15)
