### PR TITLE
[VDG] Rename wallet

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletMetadata.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletMetadata.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.Fluent.Models.Wallets;
+
+internal class WalletMetadata
+{
+	public string Name { get; set; }
+}

--- a/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
@@ -26,8 +26,7 @@ public partial class WalletModel : ReactiveObject
 {
 	private readonly TransactionHistoryBuilder _historyBuilder;
 	private readonly Lazy<IWalletCoinjoinModel> _coinjoin;
-	private string _name;
-	private string _path;
+	private readonly string _path;
 
 	public WalletModel(Wallet wallet)
 	{

--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -35,12 +35,12 @@ public partial class WalletRepository : ReactiveObject
 					  .TransformWithInlineUpdate(CreateWalletModel, (model, wallet) => { })
 					  .Transform(x => x as IWalletModel);
 
-		DefaultWalletName = Services.UiConfig.LastSelectedWallet;
+		DefaultWalletId = Services.UiConfig.LastSelectedWallet;
 	}
 
 	public IObservable<IChangeSet<IWalletModel, string>> Wallets { get; }
 
-	public string? DefaultWalletName { get; }
+	public string? DefaultWalletId { get; }
 	public bool HasWallet => Services.WalletManager.HasWallet();
 
 	private KeyPath AccountKeyPath { get; } = KeyManager.GetAccountKeyPath(Services.WalletManager.Network, ScriptPubKeyType.Segwit);

--- a/WalletWasabi.Fluent/ViewModels/NavBar/NavBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/NavBar/NavBarViewModel.cs
@@ -62,7 +62,7 @@ public partial class NavBarViewModel : ViewModelBase, IWalletNavigation
 			})
 			.Subscribe();
 
-		SelectedWallet = Wallets.FirstOrDefault(x => x.WalletModel.Name == UiContext.WalletRepository.DefaultWalletName);
+		SelectedWallet = Wallets.FirstOrDefault(x => x.WalletModel.Name == UiContext.WalletRepository.DefaultWalletId);
 	}
 
 	public async Task InitialiseAsync()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletPageViewModel.cs
@@ -17,6 +17,7 @@ public partial class WalletPageViewModel : ViewModelBase
 	[AutoNotify] private string? _iconNameFocused;
 	[AutoNotify] private WalletViewModel? _walletViewModel;
 	[AutoNotify] private RoutableViewModel? _currentPage;
+	[AutoNotify(SetterModifier = AccessModifier.Private)] private string _title;
 
 	private WalletPageViewModel(IWalletModel walletModel)
 	{
@@ -24,7 +25,7 @@ public partial class WalletPageViewModel : ViewModelBase
 
 		// TODO: Finish partial refactor
 		// Wallet property must be removed
-		Wallet = Services.WalletManager.GetWallets(false).First(x => x.WalletName == walletModel.Name);
+		Wallet = Services.WalletManager.GetWallets(false).First(x => x.WalletName == walletModel.Id);
 
 		// Show Login Page when wallet is not logged in
 		this.WhenAnyValue(x => x.IsLoggedIn)
@@ -54,13 +55,15 @@ public partial class WalletPageViewModel : ViewModelBase
 			.Do(x => UiContext.Navigate().To(x, NavigationTarget.HomeScreen, NavigationMode.Clear))
 			.Subscribe();
 
+		this.WhenAnyValue(x => x.WalletModel.Name)
+			.BindTo(this, x => x.Title);
+
 		SetIcon();
 	}
 
 	public IWalletModel WalletModel { get; }
-	public Wallet Wallet { get; set; }
 
-	public string Title => WalletModel.Name;
+	public Wallet Wallet { get; }
 
 	private void ShowLogin()
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletSettingsViewModel.cs
@@ -35,7 +35,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 
 		// TODO: Finish partial refactor
 		// this must be removed after VerifyRecoveryWords has been decoupled
-		var wallet = Services.WalletManager.GetWallets(false).First(x => x.WalletName == walletModel.Name);
+		var wallet = Services.WalletManager.GetWallets(false).First(x => x.WalletName == walletModel.Id);
 		VerifyRecoveryWordsCommand = ReactiveCommand.Create(() => Navigate().To().VerifyRecoveryWords(wallet));
 
 		this.WhenAnyValue(x => x.PreferPsbtWorkflow)
@@ -45,6 +45,12 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 				_wallet.Settings.PreferPsbtWorkflow = value;
 				_wallet.Settings.Save();
 			});
+	}
+
+	public string WalletName
+	{
+		get => _wallet.Name;
+		set => _wallet.Name = value;
 	}
 
 	public bool IsHardwareWallet { get; }

--- a/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletSettingsView.axaml
@@ -5,6 +5,7 @@
              xmlns:c="using:WalletWasabi.Fluent.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:wallets="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets"
+             xmlns:behaviors="clr-namespace:WalletWasabi.Fluent.Behaviors"
              x:DataType="wallets:WalletSettingsViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.WalletSettingsView">
@@ -14,6 +15,18 @@
                  EnableBack="{Binding EnableBack}">
 
     <StackPanel Spacing="20" Margin="0 30">
+
+      <StackPanel Classes="settingsLayout">
+        <DockPanel>
+          <TextBlock Text="Wallet name" />
+          <TextBox MaxLength="50" Text="{Binding WalletName, Mode=TwoWay}" Watermark="Type in a wallet name">
+            <Interaction.Behaviors>
+              <behaviors:FocusOnAttachedBehavior />
+              <behaviors:TextBoxSelectAllTextBehavior />
+            </Interaction.Behaviors>
+          </TextBox>
+        </DockPanel>
+      </StackPanel>
 
       <StackPanel Classes="settingsLayout">
         <DockPanel IsVisible="{Binding IsHardwareWallet}">

--- a/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullWalletRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullWalletRepository.cs
@@ -17,7 +17,7 @@ public class NullWalletRepository : IWalletRepository
 
 	public IObservable<IChangeSet<IWalletModel, string>> Wallets { get; }
 
-	public string? DefaultWalletName => null;
+	public string? DefaultWalletId => null;
 
 	public bool HasWallet => false;
 


### PR DESCRIPTION
fixes #3527

This is an attempt to add a feature to rename wallets.

I consider that we need to distinguish between Name (friendly name) and Id.

We might need to do the following:

* Rename **WalletName** to **Id**.
* Create a new **Name** property  (that will be the *friendly name*).
* Migration: Existing data files (wallet.json) should be assigned a new Id. **Id** will be **string** to keep things easier. 
* In order to persistence easier, we could save a metadata file for each wallet with the friendly name. This way, we don't mess with the wallet.json files.
* New wallets are given a new GUID upon creation.
* We need to ensure that friendly names are unique withing the software (current behavior).