### PR TITLE
Fix hide address by removing its labels

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/Address.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/Address.cs
@@ -39,8 +39,7 @@ public class Address : ReactiveObject, IAddress
 
 	public void Hide()
 	{
-		// Code commented out due to https://github.com/zkSNACKs/WalletWasabi/issues/10177
-		// KeyManager.SetKeyState(KeyState.Locked, HdPubKey);
+		HdPubKey.SetLabel(LabelsArray.Empty, KeyManager);
 		this.RaisePropertyChanged(nameof(IsUsed));
 	}
 


### PR DESCRIPTION
Aims to fix: https://github.com/zkSNACKs/WalletWasabi/issues/11442 https://github.com/zkSNACKs/WalletWasabi/issues/10177

@lontivero @turbolay Do you guys see problematic cases with this approach to hide an address? I'm wondering especially about the recovery/turboSync cases.

With this approach the address stays "Clean" which is right, but also hides it from the UI as the feature should do.