### PR TITLE
Install diagnostic tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
     let
         pkgs = import nixpkgs { system = "x86_64-linux"; }; #nixpkgs.legacyPackages.x86_64-linux;
         deployScript = pkgs.writeScriptBin "deploy" (builtins.readFile ./Contrib/deploy.sh);
-
         backend-build = pkgs.buildDotnetModule rec {
           pname = "WalletWasabi.Backend";
           version = "2.0.0-${builtins.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}-${self.shortRev or "dirty"}";
@@ -22,8 +21,30 @@
             ln -s ${deployScript}/bin/deploy $out
           '';
         };
+
+        # dotnet trace
+        dotnet-trace = pkgs.buildDotnetGlobalTool {
+          pname = "dotnet-trace";
+          nugetName = "dotnet-trace";
+          version = "7.0.442301";
+          nugetSha256 = "sha256-yKmpygSNpNWNhLt9vS/1mterTU1l0gmpo3Ef2HvLsLw=";
+          dotnet-sdk = pkgs.dotnetCorePackages.sdk_7_0;
+        };
+        wasabi-shell = pkgs.mkShell {
+           name = "wasabi-shell";
+           packages = [
+             dotnet-trace
+             ];
+
+           shellHook = ''
+             export DOTNET_CLI_TELEMETRY_OPTOUT=1
+             export DOTNET_NOLOGO=1
+             export PS1='\n\[\033[1;34m\][Wasabi:\w]\$\[\033[0m\] '
+           '';
+        };
     in
     {
       packages.x86_64-linux.default = backend-build;
+      devShells.x86_64-linux.default = wasabi-shell;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,10 +30,19 @@
           nugetSha256 = "sha256-yKmpygSNpNWNhLt9vS/1mterTU1l0gmpo3Ef2HvLsLw=";
           dotnet-sdk = pkgs.dotnetCorePackages.sdk_7_0;
         };
+        # dotnet dump
+        dotnet-dump = pkgs.buildDotnetGlobalTool {
+          pname = "dotnet-dump";
+          nugetName = "dotnet-dump";
+          version = "7.0.442301";
+          nugetSha256 = "sha256-UZE1UJfOWYw+ONOemAtuhtfXE/9a2WbnOQFXXuE7p80=";
+          dotnet-sdk = pkgs.dotnetCorePackages.sdk_7_0;
+        };
         wasabi-shell = pkgs.mkShell {
            name = "wasabi-shell";
            packages = [
              dotnet-trace
+             dotnet-dump
              ];
 
            shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         wasabi-shell = pkgs.mkShell {
            name = "wasabi-shell";
            packages = [
+             pkgs.dotnetCorePackages.sdk_7_0
              dotnet-trace
              dotnet-dump
              ];
@@ -48,6 +49,7 @@
            shellHook = ''
              export DOTNET_CLI_TELEMETRY_OPTOUT=1
              export DOTNET_NOLOGO=1
+             export DOTNET_ROOT=${pkgs.dotnetCorePackages.sdk_7_0}
              export PS1='\n\[\033[1;34m\][Wasabi:\w]\$\[\033[0m\] '
            '';
         };


### PR DESCRIPTION
This PR is a solution for https://github.com/zkSNACKs/MaintenanceVault/discussions/139. It installs dotnet diagnostic tools `dotnet-trace` and `dotnet-dump` dependent on dotnet sdk 7. 

To get a shell with these tools available simply enter:

```bash
$ nix develop github:zksnacks/WalletWasabi
```