### PR TITLE
[VDG] Critical privacy warnings

### DIFF
--- a/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
@@ -16,7 +16,7 @@ public abstract record PrivacyWarning(WarningSeverity Severity) : PrivacyItem();
 
 public record InterlinksLabelsWarning(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Warning);
 
-public record TransactionKnownAsYoursBy(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Info);
+public record TransactionKnownAsYoursBy(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Warning);
 
 public record NonPrivateFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
 

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacyWarning.cs
@@ -5,6 +5,7 @@ namespace WalletWasabi.Fluent.Models.Transactions;
 public enum WarningSeverity
 {
 	Default,
+	Critical,
 	Warning,
 	Info
 }
@@ -14,11 +15,11 @@ public enum WarningSeverity
 // Revisit this after Avalonia V11 upgrade
 public abstract record PrivacyWarning(WarningSeverity Severity) : PrivacyItem();
 
-public record InterlinksLabelsWarning(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Warning);
+public record InterlinksLabelsWarning(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Critical);
 
-public record TransactionKnownAsYoursBy(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Warning);
+public record TransactionKnownAsYoursBy(LabelsArray Labels) : PrivacyWarning(WarningSeverity.Critical);
 
-public record NonPrivateFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
+public record NonPrivateFundsWarning() : PrivacyWarning(WarningSeverity.Critical);
 
 public record SemiPrivateFundsWarning() : PrivacyWarning(WarningSeverity.Warning);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -19,6 +19,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 	[AutoNotify] private bool _isBusy;
 
 	[AutoNotify] private bool _noPrivacy;
+	[AutoNotify] private bool _badPrivacy;
 	[AutoNotify] private bool _goodPrivacy;
 	[AutoNotify] private bool _maxPrivacy;
 
@@ -34,6 +35,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 	public async Task BuildPrivacySuggestionsAsync(TransactionInfo info, BuildTransactionResult transaction, CancellationToken cancellationToken)
 	{
 		NoPrivacy = false;
+		BadPrivacy = false;
 		MaxPrivacy = false;
 		GoodPrivacy = false;
 		Warnings.Clear();
@@ -54,9 +56,13 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 			Suggestions.Add(suggestion);
 		}
 
-		if (Warnings.Any(x => x.Severity == WarningSeverity.Warning))
+		if (Warnings.Any(x => x.Severity == WarningSeverity.Critical))
 		{
 			NoPrivacy = true;
+		}
+		if (Warnings.Any(x => x.Severity == WarningSeverity.Warning))
+		{
+			BadPrivacy = true;
 		}
 		else if (Warnings.Any(x => x.Severity == WarningSeverity.Info))
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -60,7 +60,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 		{
 			NoPrivacy = true;
 		}
-		if (Warnings.Any(x => x.Severity == WarningSeverity.Warning))
+		else if (Warnings.Any(x => x.Severity == WarningSeverity.Warning))
 		{
 			BadPrivacy = true;
 		}

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -81,6 +81,10 @@
       <Setter Property="DockPanel.Dock" Value="Left" />
     </Style>
 
+    <Style Selector="Border.warning.critical PathIcon">
+      <Setter Property="Foreground" Value="{DynamicResource WarningMessageForeground}" />
+    </Style>
+
     <Style Selector="Border.warning.info PathIcon">
       <Setter Property="Data" Value="{StaticResource info_regular}" />
     </Style>
@@ -109,7 +113,7 @@
       <ItemsControl.DataTemplates>
         <!-- Interlinks Labels Warning -->
         <DataTemplate DataType="{x:Type model:InterlinksLabelsWarning}">
-          <Border Classes="warning">
+          <Border Classes="warning critical">
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction interlinks labels:" Margin="0 0 5 0"
@@ -121,7 +125,7 @@
 
         <!-- Transaction Known as Yours By Warning -->
         <DataTemplate DataType="{x:Type model:TransactionKnownAsYoursBy}">
-          <Border Classes="warning">
+          <Border Classes="warning critical">
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction known as yours by:" Margin="0 0 5 0"
@@ -133,7 +137,7 @@
 
         <!-- Non-private funds Warning -->
         <DataTemplate DataType="{x:Type model:NonPrivateFundsWarning}">
-          <Border Classes="warning">
+          <Border Classes="warning critical">
             <DockPanel>
               <PathIcon />
               <TextBlock Text="Transaction uses non-private coins."

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionPreviewView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionPreviewView.axaml
@@ -54,6 +54,10 @@
                 <Setter Property="Data" Value="{StaticResource warning_regular}" />
                 <Setter Property="Foreground" Value="{DynamicResource WarningMessageForeground}" />
               </Style>
+              <Style Selector="PathIcon.badPrivacy">
+                <Setter Property="Data" Value="{StaticResource warning_regular}" />
+                <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+              </Style>
               <Style Selector="PathIcon.goodPrivacy">
                 <Setter Property="Data" Value="{StaticResource shield_regular}" />
                 <Setter Property="Foreground" Value="{DynamicResource PrivacyLevelStrongBrush}" />
@@ -99,6 +103,7 @@
               <Panel>
                 <PathIcon Classes.isBusy="{Binding PrivacySuggestions.IsBusy}"
                           Classes.noPrivacy="{Binding PrivacySuggestions.NoPrivacy}"
+                          Classes.badPrivacy="{Binding PrivacySuggestions.BadPrivacy}"
                           Classes.goodPrivacy="{Binding PrivacySuggestions.GoodPrivacy}"
                           Classes.maxPrivacy="{Binding PrivacySuggestions.MaxPrivacy}" />
               </Panel>


### PR DESCRIPTION
 - Based on [this definition](https://github.com/zkSNACKs/WalletWasabi/issues/11269#issuecomment-1700531642)
 - The following Warnings now have `Critical` severity:
    - `InterlinksLabelsWarning`
    - `TransactionKnownAsYoursByWarning`
    - `NonPrivateFundsWarning`
 - The icon in the Transaction Preview screen turns orange if there is at least one Critical warning, otherwise it will either be a white warning icon, or the green shield as before
 - The icons in the warning list are orange for Critical warnings, otherwise white.
 - Fixes #11269 