### PR TITLE
[VDG] Re-enable mark as locked

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/Address.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/Address.cs
@@ -39,8 +39,7 @@ public class Address : ReactiveObject, IAddress
 
 	public void Hide()
 	{
-		// Code commented out due to https://github.com/zkSNACKs/WalletWasabi/issues/10177
-		// KeyManager.SetKeyState(KeyState.Locked, HdPubKey);
+		KeyManager.SetKeyState(KeyState.Locked, HdPubKey);
 		this.RaisePropertyChanged(nameof(IsUsed));
 	}
 

--- a/WalletWasabi.Fluent/Models/Wallets/Address.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/Address.cs
@@ -40,6 +40,7 @@ public class Address : ReactiveObject, IAddress
 	public void Hide()
 	{
 		KeyManager.SetKeyState(KeyState.Locked, HdPubKey);
+		KeyManager.ToFile();
 		this.RaisePropertyChanged(nameof(IsUsed));
 	}
 


### PR DESCRIPTION
This effectively re-enables address hiding in the GUI.

It was disabled due to this https://github.com/zkSNACKs/WalletWasabi/issues/10177

Fixes #11442 