### PR TITLE
[VDG] Hide privacy progressbar when no progress

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -1,12 +1,11 @@
 using DynamicData;
 using DynamicData.Binding;
-using ReactiveUI;
 using System.Linq;
-using System.Reactive.Linq;
 using NBitcoin;
 using WalletWasabi.Wallets;
 using System.Reactive.Disposables;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles.PrivacyRing;
 
@@ -14,6 +13,7 @@ public partial class PrivacyBarViewModel : ActivatableViewModel
 {
 	private readonly WalletViewModel _walletViewModel;
 
+	[AutoNotify] private bool _hasProgress;
 	[AutoNotify] private decimal _totalAmount;
 
 	public PrivacyBarViewModel(WalletViewModel walletViewModel)
@@ -64,6 +64,8 @@ public partial class PrivacyBarViewModel : ActivatableViewModel
 								   .OrderBy(x => (int)x.Key)
 								   .Select(x => new PrivacyBarItemViewModel(x.Key, x.Sum(x => x.Amount.ToDecimal(MoneyUnit.BTC))))
 								   .ToList();
+
+		HasProgress = segments.Any(x => x.PrivacyLevel != PrivacyLevel.NonPrivate);
 
 		list.AddRange(segments);
 	}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyControlTileView.axaml
@@ -6,6 +6,7 @@
              xmlns:c="clr-namespace:WalletWasabi.Fluent.Controls"
              xmlns:converters="clr-namespace:WalletWasabi.Fluent.Converters"
              xmlns:privacyBar="clr-namespace:WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyBar"
+             xmlns:fluent="clr-namespace:WalletWasabi.Fluent"
              mc:Ignorable="d" d:DesignWidth="310" d:DesignHeight="140"
              x:CompileBindings="True" x:DataType="vms:PrivacyControlTileViewModel"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.Tiles.PrivacyControlTileView">
@@ -13,7 +14,7 @@
   <c:TileControl Title="PRIVACY PROGRESS" IsBottomContentVisible="{Binding HasPrivateBalance}">
 
     <DockPanel>
-      <privacyBar:PrivacyBarView DockPanel.Dock="Bottom" />
+      <privacyBar:PrivacyBarView IsVisible="{Binding PrivacyBar.HasProgress}" DockPanel.Dock="Bottom" />
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="6">
         <Button Command="{Binding ShowDetailsCommand}" Classes="plain"
                 ToolTip.Tip="Show Details" VerticalAlignment="Center" HorizontalAlignment="Center"


### PR DESCRIPTION
Only show it when there is some progress, that is, when the bar has some private item/s:

![image](https://github.com/zkSNACKs/WalletWasabi/assets/3109851/75a3e946-c9fa-4d9f-a45d-f34d8b1cd5b0)

Fixes: #11425 