### PR TITLE
[refactoring] Move methods out of `TransactionHistoryBuilder`

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.Blockchain.Transactions.Summary;
+
+namespace WalletWasabi.Blockchain.Transactions;
+
+public static class SmartTransactionExtensions
+{
+	public static IEnumerable<Output> GetOutputs(this SmartTransaction smartTransaction, Network network)
+	{
+		var known = smartTransaction.WalletOutputs.Select(coin =>
+		{
+			var address = coin.TxOut.ScriptPubKey.GetDestinationAddress(network)!;
+			return new OwnOutput(coin.TxOut.Value, address, coin.HdPubKey.IsInternal);
+		}).Cast<Output>();
+
+		var unknown = smartTransaction.ForeignOutputs.Select(coin =>
+		{
+			var address = coin.TxOut.ScriptPubKey.GetDestinationAddress(network)!;
+			return new ForeignOutput(coin.TxOut.Value, address);
+		}).Cast<Output>();
+
+		return known.Concat(unknown);
+	}
+
+	public static IEnumerable<IInput> GetInputs(this SmartTransaction transaction)
+	{
+		var known = transaction.WalletInputs
+			.Select(x => new KnownInput(x.Amount))
+			.OfType<IInput>();
+
+		var unknown = transaction.ForeignInputs
+			.Select(_ => new ForeignInput())
+			.OfType<IInput>();
+
+		return known.Concat(unknown);
+	}
+}

--- a/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
@@ -36,4 +36,46 @@ public static class SmartTransactionExtensions
 
 		return known.Concat(unknown);
 	}
+
+	public static IEnumerable<BitcoinAddress> GetDestinationAddresses(this SmartTransaction transaction, Network network, out List<IInput> inputs, out List<Output> outputs)
+	{
+		inputs = transaction.GetInputs().ToList();
+		outputs = transaction.GetOutputs(network).ToList();
+
+		return GetDestinationAddresses(inputs, outputs);
+	}
+
+	private static IEnumerable<BitcoinAddress> GetDestinationAddresses(ICollection<IInput> inputs, ICollection<Output> outputs)
+	{
+		var myOwnInputs = inputs.OfType<KnownInput>().ToList();
+		var foreignInputs = inputs.OfType<ForeignInput>().ToList();
+		var myOwnOutputs = outputs.OfType<OwnOutput>().ToList();
+		var foreignOutputs = outputs.OfType<ForeignOutput>().ToList();
+
+		// All inputs and outputs are my own, transaction is a self-spend.
+		if (!foreignInputs.Any() && !foreignOutputs.Any())
+		{
+			// Classic self-spend to one or more external addresses.
+			if (myOwnOutputs.Any(x => !x.IsInternal))
+			{
+				// Destinations are the external addresses.
+				return myOwnOutputs.Where(x => !x.IsInternal).Select(x => x.DestinationAddress);
+			}
+
+			// Edge-case: self-spend to one or more internal addresses.
+			// We can't know the destinations, return all the outputs.
+			return myOwnOutputs.Select(x => x.DestinationAddress);
+		}
+
+		// All inputs are foreign but some outputs are my own, someone is sending coins to me.
+		if (!myOwnInputs.Any() && myOwnOutputs.Any())
+		{
+			// All outputs that are my own are the destinations.
+			return myOwnOutputs.Select(x => x.DestinationAddress);
+		}
+
+		// I'm sending a transaction to someone else.
+		// All outputs that are not my own are the destinations.
+		return foreignOutputs.Select(x => x.DestinationAddress);
+	}
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -42,11 +42,11 @@ public class TransactionHistoryBuilder
 			}
 			else
 			{
-				var outputs = GetOutputs(containingTransaction, wallet.Network).ToList();
-				var inputs = GetInputs(containingTransaction).ToList();
+				var outputs = containingTransaction.GetOutputs(wallet.Network).ToList();
+				var inputs = containingTransaction.GetInputs().ToList();
 				var destinationAddresses = GetDestinationAddresses(inputs, outputs);
 
-				txRecordList.Add(new TransactionSummary(containingTransaction, coin.Amount, GetInputs(containingTransaction), outputs, destinationAddresses));
+				txRecordList.Add(new TransactionSummary(containingTransaction, coin.Amount, containingTransaction.GetInputs(), outputs, destinationAddresses));
 			}
 
 			var spenderTransaction = coin.SpenderTransaction;
@@ -62,11 +62,11 @@ public class TransactionHistoryBuilder
 				}
 				else
 				{
-					var outputs = GetOutputs(spenderTransaction, wallet.Network).ToList();
-					var inputs = GetInputs(spenderTransaction).ToList();
+					var outputs = spenderTransaction.GetOutputs(wallet.Network).ToList();
+					var inputs = spenderTransaction.GetInputs().ToList();
 					var destinationAddresses = GetDestinationAddresses(inputs, outputs);
-          
-					txRecordList.Add(new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, GetInputs(spenderTransaction), outputs, destinationAddresses));
+
+					txRecordList.Add(new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, spenderTransaction.GetInputs(), outputs, destinationAddresses));
 				}
 			}
 		}
@@ -106,35 +106,5 @@ public class TransactionHistoryBuilder
 		// I'm sending a transaction to someone else.
 		// All outputs that are not my own are the destinations.
 		return foreignOutputs.Select(x => x.DestinationAddress);
-	}
-
-	private IEnumerable<Output> GetOutputs(SmartTransaction smartTransaction, Network network)
-	{
-		var known = smartTransaction.WalletOutputs.Select(coin =>
-		{
-			var address = coin.TxOut.ScriptPubKey.GetDestinationAddress(network)!;
-			return new OwnOutput(coin.TxOut.Value, address, coin.HdPubKey.IsInternal);
-		}).Cast<Output>();
-
-		var unknown = smartTransaction.ForeignOutputs.Select(coin =>
-		{
-			var address = coin.TxOut.ScriptPubKey.GetDestinationAddress(network)!;
-			return new ForeignOutput(coin.TxOut.Value, address);
-		}).Cast<Output>();
-
-		return known.Concat(unknown);
-	}
-
-	private static IEnumerable<IInput> GetInputs(SmartTransaction transaction)
-	{
-		var known = transaction.WalletInputs
-			.Select(x => new KnownInput(x.Amount))
-			.OfType<IInput>();
-
-		var unknown = transaction.ForeignInputs
-			.Select(_ => new ForeignInput())
-			.OfType<IInput>();
-
-		return known.Concat(unknown);
 	}
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -59,8 +59,8 @@ public class TransactionHistoryBuilder
 				}
 				else
 				{
-					var destinationAddresses = spenderTransaction.GetDestinationAddresses(wallet.Network, out _, out List<Output> outputs);
-					txRecordList.Add(new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, spenderTransaction.GetInputs(), outputs, destinationAddresses));
+					var destinationAddresses = spenderTransaction.GetDestinationAddresses(wallet.Network, out List<IInput> inputs, out List<Output> outputs);
+					txRecordList.Add(new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, inputs, outputs, destinationAddresses));
 				}
 			}
 		}


### PR DESCRIPTION
This PR is meant to simplify #11458 and ease reviews. It should be easy to review the PR commit by commit.

Credits to @turbolay.