### PR TITLE
Use build parameters instead of running `git`

### DIFF
--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -28,11 +28,6 @@
 	</PropertyGroup>
 
 	<Target Name="WriteMetadata" BeforeTargets="PrepareForBuild">
-		<!-- Get hash commit -->
-		<Exec Command="git rev-parse HEAD" StandardOutputImportance="Low" ConsoleToMSBuild="true" IgnoreExitCode="true">
-			<Output TaskParameter="ConsoleOutput" PropertyName="CommitHash" />
-		</Exec>
-
 		<ItemGroup>
 			<AssemblyMetadata Include="CommitHash" Value="$(CommitHash)" />
 		</ItemGroup>

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,12 @@
     let
         pkgs = import nixpkgs { system = "x86_64-linux"; }; #nixpkgs.legacyPackages.x86_64-linux;
         deployScript = pkgs.writeScriptBin "deploy" (builtins.readFile ./Contrib/deploy.sh);
+        gitRev = if (builtins.hasAttr "rev" self) then self.rev else "dirty";
         backend-build = pkgs.buildDotnetModule rec {
           pname = "WalletWasabi.Backend";
-          version = "2.0.0-${builtins.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}-${self.shortRev or "dirty"}";
+          version = "2.0.0-${builtins.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}-${gitRev}";
           nugetDeps = ./deps.nix; # nix build .#packages.x86_64-linux.default.passthru.fetch-deps
+          dotnetFlags = [ "-p:CommitHash=${gitRev}" ];
           runtimeDeps = [ pkgs.openssl pkgs.zlib ];
           dotnet-sdk = pkgs.dotnetCorePackages.sdk_7_0;
           selfContainedBuild = true;


### PR DESCRIPTION
Close https://github.com/zkSNACKs/WalletWasabi/issues/11483

Before this PR you had to have git installed and the Wasabi repository cloned in your filesystem in order to build Wasabi backend in a way that it displays the `CommitHash` correctly as part of the `Versions` API. This is because at building time the building system executed `git rev-parse HEAD` and used the console output to fill the `CommitHash` assembly metadata.

After this PR the building system receives the `CommitHash` as a parameter. In this way the build doesn't requires having git or the wasabi repository cloned locally and can create a deterministic build independent of the build environment.

## How to test

With nix installed, just type `nix build` and press enter.

Then, check the `WalletWasabi.dll` metadata. You can do it with f# as follow:

```
$ dotnet fsi

Microsoft (R) F# Interactive version 12.5.0.0 for F# 7.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> #r "result/lib/WalletWasabi.Backend/WalletWasabi.dll";;

--> Referenced '/home/lontivero/Projects/WalletWasabi/result/lib/WalletWasabi.Backend/WalletWasabi.dll' (file may be locked by F# Interactive process)

> WalletWasabi.JsonConverters.ReflectionUtils.GetAssemblyMetadata("CommitHash");;
val it: string = "5324bed51910f5ca767f31a6c44872452d3cf405"

```

Note: this can be done in linux only by the moment.