### PR TITLE
Merge two functions to dismiss double function calls

### DIFF
--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsResult.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsResult.cs
@@ -19,30 +19,13 @@ public record PrivacySuggestionsResult()
 		return this;
 	}
 
-	public async IAsyncEnumerable<PrivacyWarning> GetAllWarningsAsync()
+	public async IAsyncEnumerable<PrivacyItem> GetAllWarningsAndSuggestionsAsync()
 	{
 		foreach (var combined in _combinedResults)
 		{
 			await foreach (var item in combined)
 			{
-				if (item is PrivacyWarning warning)
-				{
-					yield return warning;
-				}
-			}
-		}
-	}
-
-	public async IAsyncEnumerable<PrivacySuggestion> GetAllSuggestionsAsync()
-	{
-		foreach (var combined in _combinedResults)
-		{
-			await foreach (var item in combined)
-			{
-				if (item is PrivacySuggestion suggestion)
-				{
-					yield return suggestion;
-				}
+				yield return item;
 			}
 		}
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -46,14 +46,16 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 
 		var result = await _privacySuggestionsModel.BuildPrivacySuggestionsAsync(info, transaction, cancellationToken);
 
-		await foreach (var warning in result.GetAllWarningsAsync())
+		await foreach (var item in result.GetAllWarningsAndSuggestionsAsync())
 		{
-			Warnings.Add(warning);
-		}
-
-		await foreach (var suggestion in result.GetAllSuggestionsAsync())
-		{
-			Suggestions.Add(suggestion);
+			if (item is PrivacyWarning warning)
+			{
+				Warnings.Add(warning);
+			}
+			else if (item is PrivacySuggestion suggestion)
+			{
+				Suggestions.Add(suggestion);
+			}
 		}
 
 		if (Warnings.Any(x => x.Severity == WarningSeverity.Critical))


### PR DESCRIPTION
When we build `_combinedResults`, we put in 6 functions to call:
https://github.com/Szpoti/WalletWasabi/blob/7abcd9e616cc565c475968befaa6ed4698981e5c/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs#L63-L75

But we iterate through this list 2 different times, thus we are calling all 6 functions twice, but basically we are dismissing some results if they are not what we are currently looking for.

This PR merges these 2 calls into one, so we don't iterate through these functions twice for no reason.