### PR TITLE
[tests] Stop Tor on exit

### DIFF
--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -19,7 +19,9 @@ public static class Common
 
 	public static EndPoint TorSocks5Endpoint => new IPEndPoint(IPAddress.Loopback, 37150);
 	public static string TorDistributionFolder => Path.Combine(EnvironmentHelpers.GetFullBaseDirectory(), "TorDaemons");
-	public static TorSettings TorSettings => new(DataDir, TorDistributionFolder, terminateOnExit: false);
+
+	/// <remarks>Tor is instructed to terminate on exit because this Tor instance would prevent running your Wasabi Wallet where Tor is started with data in a different folder.</remarks>
+	public static TorSettings TorSettings => new(DataDir, TorDistributionFolder, terminateOnExit: true);
 
 	public static string DataDir => EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Tests"));
 


### PR DESCRIPTION
This is a very simple change that makes using Tor tests a bit nicer. 

Currently on `master`, you start Tor tests and then a Tor process stays alive. That would be OK but then it prevents you from running your Wasabi Wallet because there is an existing instance of Tor but Wasabi Wallet cannot use that Tor instance because in tests and in production Tor is started slightly differently. 

So this is a trivial way to make it a bit better. Another step would be to start Tor totally separately with different ports and different folders for tests. I can do it in the future. 


**Converted to draft for now. I'm testing it.**