### PR TITLE
TransactionFactory - Fix fee percentage calculation for self spend

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -1,4 +1,3 @@
-using Moq;
 using NBitcoin;
 using System.Linq;
 using System.Threading.Tasks;
@@ -53,6 +52,11 @@ public class TransactionFactoryTests
 
 		// The transaction cost is higher than the intended payment.
 		Assert.Throws<TransactionFeeOverpaymentException>(() => transactionFactory.BuildTransaction(payment, new FeeRate(50m)));
+
+		// self spend case
+		var ownKey = transactionFactory.KeyManager.GetNextReceiveKey("Alice");
+		var selfSpendPayment = new PaymentIntent(ownKey.GetAddress(transactionFactory.Network), MoneyRequest.CreateAllRemaining(subtractFee: true));
+		Assert.Throws<TransactionFeeOverpaymentException>(() => transactionFactory.BuildTransaction(selfSpendPayment, new FeeRate(50m)));
 	}
 
 	[Fact]

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -200,12 +200,25 @@ public class TransactionFactory
 		{
 			totalOutgoingAmountNoFee = realToSend.Where(x => !changeHdPubKey.ContainsScript(x.destination.ScriptPubKey)).Sum(x => x.amount);
 		}
+
 		decimal totalOutgoingAmountNoFeeDecimal = totalOutgoingAmountNoFee.ToDecimal(MoneyUnit.BTC);
+		decimal feeDecimal = fee.ToDecimal(MoneyUnit.BTC);
 
-		// Cannot divide by zero, so use the closest number we have to zero.
-		decimal totalOutgoingAmountNoFeeDecimalDivisor = totalOutgoingAmountNoFeeDecimal == 0 ? decimal.MinValue : totalOutgoingAmountNoFeeDecimal;
-		decimal feePercentage = 100 * fee.ToDecimal(MoneyUnit.BTC) / totalOutgoingAmountNoFeeDecimalDivisor;
-
+		decimal feePercentage;
+		if (payments.ChangeStrategy == ChangeStrategy.AllRemainingCustom)
+		{
+			// In this scenario since the amount changes as the fee changes, we need to compare against the total sum / 2,
+			// as with this, we will make sure the fee cannot be higher than the amount.
+			decimal inputSumDecimal = spentCoins.Sum(x => x.Amount.ToDecimal(MoneyUnit.BTC));
+			feePercentage = 100 * (feeDecimal / (inputSumDecimal / 2));
+		}
+		else
+		{
+			// In this scenario the amount is fixed, so we can compare against it.
+			// Cannot divide by zero, so use the closest number we have to zero.
+			decimal totalOutgoingAmountNoFeeDecimalDivisor = totalOutgoingAmountNoFeeDecimal == 0 ? decimal.MinValue : totalOutgoingAmountNoFeeDecimal;
+			feePercentage = 100 * (feeDecimal / totalOutgoingAmountNoFeeDecimalDivisor);
+		}
 		if (feePercentage > 100)
 		{
 			throw new TransactionFeeOverpaymentException(feePercentage);


### PR DESCRIPTION
During https://github.com/zkSNACKs/WalletWasabi/pull/11120 I found that the calculation is wrong in the case of self spend.
I added a test for it.

Issue: https://github.com/zkSNACKs/WalletWasabi/pull/11120#pullrequestreview-1551330343
Explanation: https://github.com/zkSNACKs/WalletWasabi/pull/11120#issuecomment-1656127155

ping for review @zkSNACKs/code-team 