### PR TITLE
Add AllSeenTxIds and AllSeenCoins caches

### DIFF
--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -145,7 +145,7 @@ public class TransactionProcessor
 		}
 
 		// Performance ToDo: txids could be cached in a hashset here by the AllCoinsView and then the contains would be fast.
-		if (!tx.Transaction.IsCoinBase && !Coins.AsAllCoinsView().CreatedBy(txId).Any()) // Transactions we already have and processed would be "double spends" but they shouldn't.
+		if (!tx.Transaction.IsCoinBase && !Coins.Seen(txId)) // Transactions we already have and processed would be "double spends" but they shouldn't.
 		{
 			var doubleSpentSpenders = new List<SmartCoin>();
 			var doubleSpentCoins = new List<SmartCoin>();
@@ -227,7 +227,7 @@ public class TransactionProcessor
 			}
 		}
 
-		var myInputs = Coins.AsAllCoinsView().OutPoints(tx.Transaction.Inputs.Select(x => x.PrevOut).ToHashSet()).ToImmutableList();
+		var myInputs = Coins.GetMyInputs(tx).ToArray();
 		for (var i = 0U; i < tx.Transaction.Outputs.Count; i++)
 		{
 			// If transaction received to any of the wallet keys:


### PR DESCRIPTION
Code by @nopara73 in #11298
I simply removed debug logs and fixed the test (by undoing).

It adds 2 caches that allow faster computing for the TxProcessing. It's not the best because it goes against https://github.com/zkSNACKs/WalletWasabi/discussions/11012. Yet, it really helps for transaction processing, especially for big wallets, and the state is easy to follow. So I believe we can go with it.