### PR TITLE
Step forward to Remove `TransactionSummary` (1/n)

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -244,7 +244,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return summary.Select(
 			x => new
 			{
-				datetime = x.DateTime,
+				datetime = x.FirstSeen,
 				height = x.Height.Value,
 				amount = x.Amount.Satoshi,
 				label = x.Labels.ToString(),

--- a/WalletWasabi.Fluent/Extensions/TransactionSummaryExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/TransactionSummaryExtensions.cs
@@ -1,10 +1,7 @@
-using NBitcoin;
 using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.Models;
-using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.Extensions;
 
@@ -16,7 +13,8 @@ public static class TransactionSummaryExtensions
 		return confirmations > 0;
 	}
 
-	public static int GetConfirmations(this TransactionSummary model) => model.Height.Type == HeightType.Chain ? (int)Services.BitcoinStore.SmartHeaderChain.ServerTipHeight - model.Height.Value + 1 : 0;
+	public static int GetConfirmations(this TransactionSummary model)
+		=> model.Transaction.GetConfirmations((int)Services.BitcoinStore.SmartHeaderChain.ServerTipHeight);
 
 	public static bool TryGetConfirmationTime(this TransactionSummary model, [NotNullWhen(true)] out TimeSpan? estimate)
 		=> TransactionFeeHelper.TryEstimateConfirmationTime(Services.HostedServices.Get<HybridFeeProvider>(), Services.WalletManager.Network, model.Transaction, out estimate);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
@@ -54,7 +54,7 @@ public partial class TransactionDetailsViewModel : RoutableViewModel
 
 	private void UpdateValues(TransactionSummary transactionSummary)
 	{
-		DateString = transactionSummary.DateTime.ToLocalTime().ToUserFacingString();
+		DateString = transactionSummary.FirstSeen.ToLocalTime().ToUserFacingString();
 		TransactionId = transactionSummary.GetHash().ToString();
 		Labels = transactionSummary.Labels;
 		BlockHeight = transactionSummary.Height.Type == HeightType.Chain ? transactionSummary.Height.Value : 0;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinHistoryItemViewModel.cs
@@ -17,7 +17,7 @@ public partial class CoinJoinHistoryItemViewModel : HistoryItemViewModelBase
 		bool isSingleCoinJoinTransaction)
 		: base(orderIndex, transactionSummary)
 	{
-		Date = transactionSummary.DateTime.ToLocalTime();
+		Date = transactionSummary.FirstSeen.ToLocalTime();
 		Balance = balance;
 		IsCoinJoin = true;
 		CoinJoinTransaction = transactionSummary;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -86,7 +86,7 @@ public partial class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 	{
 		IsConfirmed = CoinJoinTransactions.All(x => x.IsConfirmed());
 		ConfirmedToolTip = GetConfirmedToolTip(CoinJoinTransactions.Select(x => x.GetConfirmations()).Min());
-		Date = CoinJoinTransactions.Select(tx => tx.DateTime).Max().ToLocalTime();
+		Date = CoinJoinTransactions.Select(tx => tx.FirstSeen).Max().ToLocalTime();
 
 		SetAmount(
 			CoinJoinTransactions.Sum(x => x.Amount),
@@ -97,7 +97,7 @@ public partial class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 
 	protected void UpdateDateString()
 	{
-		var dates = CoinJoinTransactions.Select(tx => tx.DateTime).ToImmutableArray();
+		var dates = CoinJoinTransactions.Select(tx => tx.FirstSeen).ToImmutableArray();
 		var firstDate = dates.Min().ToLocalTime();
 		var lastDate = dates.Max().ToLocalTime();
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
@@ -21,7 +21,7 @@ public partial class TransactionHistoryItemViewModel : HistoryItemViewModelBase
 		: base(orderIndex, transactionSummary)
 	{
 		Labels = transactionSummary.Labels;
-		Date = transactionSummary.DateTime.ToLocalTime();
+		Date = transactionSummary.FirstSeen.ToLocalTime();
 		Balance = balance;
 		WalletVm = walletVm;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -248,7 +248,7 @@ public partial class HistoryViewModel : ActivatableViewModel
 		{
 			var historyBuilder = new TransactionHistoryBuilder(_walletVm.Wallet);
 			var rawHistoryList = await Task.Run(historyBuilder.BuildHistorySummary);
-			var orderedRawHistoryList = rawHistoryList.OrderBy(x => x.DateTime).ThenBy(x => x.Height).ThenBy(x => x.BlockIndex).ToList();
+			var orderedRawHistoryList = rawHistoryList.OrderBy(x => x.FirstSeen).ThenBy(x => x.Height).ThenBy(x => x.BlockIndex).ToList();
 			var newHistoryList = GenerateHistoryList(orderedRawHistoryList).ToArray();
 
 			_transactionSourceList.Edit(x =>

--- a/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.Transactions.Summary;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Blockchain.Transactions;
 
@@ -78,4 +79,7 @@ public static class SmartTransactionExtensions
 		// All outputs that are not my own are the destinations.
 		return foreignOutputs.Select(x => x.DestinationAddress);
 	}
+
+	public static int GetConfirmations(this SmartTransaction transaction, int blockchainTipHeight)
+		=> transaction.Height.Type == HeightType.Chain ? blockchainTipHeight - transaction.Height.Value + 1 : 0;
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -36,7 +36,7 @@ public class TransactionHistoryBuilder
 			var found = txRecordList.FirstOrDefault(x => x.GetHash() == coin.TransactionId);
 			if (found is { }) // if found then update
 			{
-				found.DateTime = found.DateTime < dateTime ? found.DateTime : dateTime;
+				found.FirstSeen = found.FirstSeen < dateTime ? found.FirstSeen : dateTime;
 				found.Amount += coin.Amount;
 				found.Labels = LabelsArray.Merge(found.Labels, containingTransaction.Labels);
 			}
@@ -54,7 +54,7 @@ public class TransactionHistoryBuilder
 				var foundSpenderCoin = txRecordList.FirstOrDefault(x => x.GetHash() == spenderTxId);
 				if (foundSpenderCoin is { }) // if found
 				{
-					foundSpenderCoin.DateTime = foundSpenderCoin.DateTime < dateTime ? foundSpenderCoin.DateTime : dateTime;
+					foundSpenderCoin.FirstSeen = foundSpenderCoin.FirstSeen < dateTime ? foundSpenderCoin.FirstSeen : dateTime;
 					foundSpenderCoin.Amount -= coin.Amount;
 				}
 				else

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -13,14 +13,14 @@ public class TransactionSummary
 		Amount = amount;
 		DestinationAddresses = destinationAddresses;
 
-		DateTime = tx.FirstSeen;
+		FirstSeen = tx.FirstSeen;
 		Labels = tx.Labels;
 	}
 
 	public SmartTransaction Transaction { get; }
 	public Money Amount { get; set; }
 	public IEnumerable<BitcoinAddress> DestinationAddresses { get; }
-	public DateTimeOffset DateTime { get; set; }
+	public DateTimeOffset FirstSeen { get; set; }
 	public LabelsArray Labels { get; set; }
 	public Height Height => Transaction.Height;
 	public uint256? BlockHash => Transaction.BlockHash;

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using WabiSabi.Crypto.Randomness;
@@ -123,7 +122,7 @@ public static class LinqExtensions
 			}
 		}
 	}
-	
+
 	public static IEnumerable<IEnumerable<T>> CombinationsWithoutRepetition<T>(
 		this IEnumerable<T> items,
 		int ofLength,

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -165,7 +165,7 @@ public static class LinqExtensions
 		=> me
 			.OrderBy(x => x.Height)
 			.ThenBy(x => x.BlockIndex)
-			.ThenBy(x => x.DateTime);
+			.ThenBy(x => x.FirstSeen);
 
 	public static IEnumerable<string> ToBlockchainOrderedLines(this IEnumerable<SmartTransaction> me)
 		=> me


### PR DESCRIPTION
This is another PR to simplify #11458.

Easy to review commit by commit.