### PR TITLE
[Trivial] Chain Helper methods instead of duplication

### DIFF
--- a/WalletWasabi.Fluent/Helpers/CoinHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/CoinHelpers.cs
@@ -1,9 +1,9 @@
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Helpers;
-using WalletWasabi.Models;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Wallets;
+using WalletWasabi.Blockchain.Transactions;
 
 namespace WalletWasabi.Fluent.Helpers;
 
@@ -24,7 +24,7 @@ public static class CoinHelpers
 		return coin.HdPubKey.Cluster.Labels;
 	}
 
-	public static int GetConfirmations(this SmartCoin coin) => coin.Height.Type == HeightType.Chain ? (int)Services.SmartHeaderChain.TipHeight - coin.Height.Value + 1 : 0;
+	public static int GetConfirmations(this SmartCoin coin) => coin.Transaction.GetConfirmations((int)Services.SmartHeaderChain.TipHeight);
 
 	public static PrivacyLevel GetPrivacyLevel(this SmartCoin coin, Wallet wallet)
 	{


### PR DESCRIPTION
Addresses: https://github.com/zkSNACKs/WalletWasabi/pull/11522/files#r1331363700

Since `SmartTransaction.GetConfirmations()` exist, this method become its exact duplicate.