### PR TITLE
`TransactionSummary` refactoring (2/n): Remove computations of destination addresses.

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/TransactionDetailsViewModel.cs
@@ -39,7 +39,7 @@ public partial class TransactionDetailsViewModel : RoutableViewModel
 
 		Fee = transactionSummary.Fee;
 		IsFeeVisible = transactionSummary.Fee != null && transactionSummary.Amount < Money.Zero;
-		DestinationAddresses = transactionSummary.DestinationAddresses.ToList();
+		DestinationAddresses = transactionSummary.Transaction.GetDestinationAddresses(walletVm.Wallet.Network).ToArray();
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 

--- a/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransactionExtensions.cs
@@ -38,10 +38,10 @@ public static class SmartTransactionExtensions
 		return known.Concat(unknown);
 	}
 
-	public static IEnumerable<BitcoinAddress> GetDestinationAddresses(this SmartTransaction transaction, Network network, out List<IInput> inputs, out List<Output> outputs)
+	public static IEnumerable<BitcoinAddress> GetDestinationAddresses(this SmartTransaction transaction, Network network)
 	{
-		inputs = transaction.GetInputs().ToList();
-		outputs = transaction.GetOutputs(network).ToList();
+		List<IInput> inputs = transaction.GetInputs().ToList();
+		List<Output> outputs = transaction.GetOutputs(network).ToList();
 
 		return GetDestinationAddresses(inputs, outputs);
 	}

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Blockchain.Transactions.Summary;
 using WalletWasabi.Extensions;
 using WalletWasabi.Wallets;
 
@@ -16,19 +15,13 @@ public class TransactionHistoryBuilder
 		Wallet = wallet;
 	}
 
-	public Wallet Wallet { get; }
+	private Wallet Wallet { get; }
 
 	public List<TransactionSummary> BuildHistorySummary()
 	{
-		var wallet = Wallet;
-
 		var txRecordList = new List<TransactionSummary>();
-		if (wallet is null)
-		{
-			return txRecordList;
-		}
 
-		foreach (SmartCoin coin in wallet.GetAllCoins())
+		foreach (SmartCoin coin in Wallet.GetAllCoins())
 		{
 			var containingTransaction = coin.Transaction;
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionHistoryBuilder.cs
@@ -42,8 +42,7 @@ public class TransactionHistoryBuilder
 			}
 			else
 			{
-				var destinationAddresses = containingTransaction.GetDestinationAddresses(wallet.Network, out _, out _);
-				txRecordList.Add(new TransactionSummary(containingTransaction, coin.Amount, destinationAddresses));
+				txRecordList.Add(new TransactionSummary(containingTransaction, coin.Amount));
 			}
 
 			var spenderTransaction = coin.SpenderTransaction;
@@ -59,8 +58,7 @@ public class TransactionHistoryBuilder
 				}
 				else
 				{
-					var destinationAddresses = spenderTransaction.GetDestinationAddresses(wallet.Network, out _, out _);
-					txRecordList.Add(new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, destinationAddresses));
+					txRecordList.Add(new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount));
 				}
 			}
 		}

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -7,11 +7,10 @@ namespace WalletWasabi.Blockchain.Transactions;
 
 public class TransactionSummary
 {
-	public TransactionSummary(SmartTransaction tx, Money amount, IEnumerable<BitcoinAddress> destinationAddresses)
+	public TransactionSummary(SmartTransaction tx, Money amount)
 	{
 		Transaction = tx;
 		Amount = amount;
-		DestinationAddresses = destinationAddresses;
 
 		FirstSeen = tx.FirstSeen;
 		Labels = tx.Labels;
@@ -19,7 +18,6 @@ public class TransactionSummary
 
 	public SmartTransaction Transaction { get; }
 	public Money Amount { get; set; }
-	public IEnumerable<BitcoinAddress> DestinationAddresses { get; }
 	public DateTimeOffset FirstSeen { get; set; }
 	public LabelsArray Labels { get; set; }
 	public Height Height => Transaction.Height;


### PR DESCRIPTION
Follow-up to #11520

Computation of destination addresses can be IMO done later when it's actually needed. This should get us some benefit from #11458 without a big bang change.