### PR TITLE
Add `recoverwallet` RPC call

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -90,6 +90,15 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return mnemonic.ToString();
 	}
 
+	[JsonRpcMethod("recoverwallet", initializable: false)]
+	public void RecoverWallet(string walletName, string mnemonic, string password = "")
+	{
+		var walletGenerator = new WalletGenerator(Global.WalletManager.WalletDirectories.WalletsDir, Global.Network);
+		walletGenerator.TipHeight = 0;
+		var (keyManager, _) = walletGenerator.GenerateWallet(walletName, password, new Mnemonic(mnemonic));
+		Global.WalletManager.AddWallet(keyManager);
+	}
+
 	[JsonRpcMethod("getwalletinfo")]
 	public object WalletInfo()
 	{


### PR DESCRIPTION
This PR adds a new method to recover wallets from mnemonics. Close: https://github.com/zkSNACKs/WalletWasabi/issues/11362

### Using `curl`

```
$ curl -s \
  --user <rpcuser:rpcpassword> \
  --data-binary '{"jsonrpc":"2.0", "id":"curltext", "method":"recoverwallet", "params":["recovered-wallet", "emerge title hero sauce pilot mail breeze jelly fatal speak shock ladder"]}' \
  -H \
  -- 'content-type: text/plain;' \
  http://127.0.0.1:37128/
```

### Using `wcli`

```
$ ./wcli.sh \
  recoverwallet recovered-wallet \
  "emerge\ title\ hero\ sauce\ pilot\ mail\ breeze\ jelly\ fatal\ speak\ shock\ ladder\"
```
