### PR TITLE
Add `canceltransaction` RPC method

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -229,6 +229,23 @@ public class WasabiJsonRpcService : IJsonRpcService
 		};
 	}
 
+	[JsonRpcMethod("canceltransaction")]
+	public string BuildCancelTransaction(uint256 txId, string password = "")
+	{
+		Guard.NotNull(nameof(txId), txId);
+		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
+		activeWallet.Kitchen.Cook(password);
+		var mempoolStore = Global.BitcoinStore.TransactionStore.MempoolStore;
+		if (!mempoolStore.TryGetTransaction(txId, out var smartTransactionToCancel))
+		{
+			throw new NotSupportedException($"Unknown transaction {txId}");
+		}
+
+		var cancellationResult = activeWallet.CancelTransaction(smartTransactionToCancel);
+		var cancellationSmartTransaction = cancellationResult.Transaction;
+		return cancellationSmartTransaction.Transaction.ToHex();
+	}
+
 	[JsonRpcMethod("speeduptransaction")]
 	public string SpeedUpTransaction(uint256 txId, string password = "")
 	{


### PR DESCRIPTION
This PR adds the `canceltransaction` RPC method which received the hash of the transaction to be cancelled and returns the raw transaction that cancels the previous tx.  

```
$ curl -s --user rpcuser:rpcpassword \
--data-binary '{"jsonrpc":"2.0", "id":"curltext", "method":"canceltransaction", "params":["0f5cdf64a4138d7bbf95bdaf7b73619aae9137085edf69c057b18ff6dda1935f"]}' -H \
-- 'content-type: text/plain;' \
http://127.0.0.1:37128/TestNet%20Small/

010000000001015620b45c9625563e7fe9899407ce905c0b34d4b1edb373eca920e6ece172f06a0000000000fdffffff011b3e100000000000225120f2e947f2bbbad6a738fe6dcc96886291fc75d483e428dcd0fd7dc25fb7ebe4e00140f074f6f3e53ace8f4e60c25186661ba5a31159feb668d6a78e864815c398a8b317cc759971144cfbecc6ab122e3e3d9f91362b793bb9b48297894a1c2c26927200000000
```

This one and https://github.com/zkSNACKs/WalletWasabi/pull/11537 close: https://github.com/zkSNACKs/WalletWasabi/issues/11500