### PR TITLE
Add `speeduptransaction` RPC method

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -220,6 +220,23 @@ public class WasabiJsonRpcService : IJsonRpcService
 		};
 	}
 
+	[JsonRpcMethod("speeduptransaction")]
+	public string SpeedUpTransaction(uint256 txId, string password = "")
+	{
+		Guard.NotNull(nameof(txId), txId);
+		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
+		activeWallet.Kitchen.Cook(password);
+		var mempoolStore = Global.BitcoinStore.TransactionStore.MempoolStore;
+		if (!mempoolStore.TryGetTransaction(txId, out var smartTransactionToSpeedUp))
+		{
+			throw new NotSupportedException($"Unknown transaction {txId}");
+		}
+
+		var speedUpResult = activeWallet.SpeedUpTransaction(smartTransactionToSpeedUp);
+		var speedUpSmartTransaction = speedUpResult.Transaction;
+		return speedUpSmartTransaction.Transaction.ToHex();
+	}
+
 	[JsonRpcMethod("broadcast", initializable: false)]
 	public async Task<object> SendRawTransactionAsync(string txHex)
 	{


### PR DESCRIPTION
This PR adds the `speeduptransaction` RPC method which received the hash of the transaction to be speed up and returns the raw transaction that does it (using RBF or CPFP) the previous tx.

```
$ curl -s --user rpcuser:rpcpassword \
--data-binary '{"jsonrpc":"2.0", "id":"curltext", "method":"speeduptransaction", "params":["0f5cdf64a4138d7bbf95bdaf7b73619aae9137085edf69c057b18ff6dda1935f"]}' -H \
-- 'content-type: text/plain;' \
http://127.0.0.1:37128/TestNet%20Small/
```

This one and https://github.com/zkSNACKs/WalletWasabi/pull/11536 close: https://github.com/zkSNACKs/WalletWasabi/issues/11500