### PR TITLE
Add `excludefromcoinjoin` from RPC

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -254,44 +254,14 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("excludefromcoinjoin")]
-	public IEnumerable<OutPoint> ExcludeFromCoinjoin(bool exclude, string? password = null, OutPoint[]? outPoints = null, string[]? labels = null)
+	public IEnumerable<OutPoint> ExcludeCoinsFromCoinjoin(IEnumerable<OutPoint> outPoints, bool exclude = true, string? password = null)
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		AssertWalletIsLoaded();
 		AssertWalletIsLoggedIn(activeWallet, password ?? "");
 
-		var updatedCoinsOutPoints = new List<OutPoint>();
-		foreach (var coin in activeWallet.GetAllCoins())
-		{
-			if (outPoints is not null && outPoints.Contains(coin.Outpoint))
-			{
-				coin.IsExcludedFromCoinJoin = exclude;
-				updatedCoinsOutPoints.Add(coin.Outpoint);
-				continue;
-			}
-
-			if (labels is null)
-			{
-				continue;
-			}
-
-			var coinLabels = coin.Transaction.Labels;
-			if (coin.SpenderTransaction is not null)
-			{
-				coinLabels = LabelsArray.Merge(coinLabels, coin.SpenderTransaction.Labels);
-			}
-
-			if (!coinLabels.Any(labels.Contains))
-			{
-				continue;
-			}
-
-			coin.IsExcludedFromCoinJoin = exclude;
-			updatedCoinsOutPoints.Add(coin.Outpoint);
-		}
-
-		return updatedCoinsOutPoints;
+		return activeWallet.ExcludeCoinsFromCoinjoin(outPoints.ToList(), exclude);
 	}
 
 	[JsonRpcMethod("listkeys")]

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -50,7 +50,8 @@ public class WasabiJsonRpcService : IJsonRpcService
 				confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
 				label = x.HdPubKey.Labels.ToString(),
 				keyPath = x.HdPubKey.FullKeyPath.ToString(),
-				address = x.HdPubKey.GetAddress(Global.Network).ToString()
+				address = x.HdPubKey.GetAddress(Global.Network).ToString(),
+				excludedFromCoinjoin = x.IsExcludedFromCoinJoin
 			}).ToArray();
 	}
 
@@ -254,14 +255,13 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("excludefromcoinjoin")]
-	public IEnumerable<OutPoint> ExcludeCoinsFromCoinjoin(IEnumerable<OutPoint> outPoints, bool exclude = true, string? password = null)
+	public void ExcludeCoinsFromCoinjoin(uint256 transactionId, int n, bool exclude = true)
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		AssertWalletIsLoaded();
-		AssertWalletIsLoggedIn(activeWallet, password ?? "");
 
-		return activeWallet.ExcludeCoinsFromCoinjoin(outPoints.ToList(), exclude);
+		activeWallet.ExcludeCoinFromCoinJoin(new OutPoint(transactionId, n), exclude);
 	}
 
 	[JsonRpcMethod("listkeys")]

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -510,7 +510,29 @@ public class Wallet : BackgroundService, IWallet
 		return wallet;
 	}
 
-	public void UpdateExcludedCoinFromCoinJoin()
+	public IEnumerable<OutPoint> ExcludeCoinsFromCoinjoin(List<OutPoint> outPointsToUpdate, bool exclude = true)
+	{
+		var updatedCoinsOutPoints = new List<OutPoint>();
+		foreach (var coin in GetAllCoins())
+		{
+			if (!outPointsToUpdate.Contains(coin.Outpoint))
+			{
+				continue;
+			}
+
+			coin.IsExcludedFromCoinJoin = exclude;
+			updatedCoinsOutPoints.Add(coin.Outpoint);
+		}
+
+		if (updatedCoinsOutPoints.Any())
+		{
+			UpdateExcludedCoinFromCoinJoin();
+		}
+
+		return updatedCoinsOutPoints;
+	}
+
+	private void UpdateExcludedCoinFromCoinJoin()
 	{
 		var excludedOutpoints = Coins.Where(c => c.IsExcludedFromCoinJoin).Select(c => c.Outpoint);
 		KeyManager.SetExcludedCoinsFromCoinJoin(excludedOutpoints);

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -510,26 +510,15 @@ public class Wallet : BackgroundService, IWallet
 		return wallet;
 	}
 
-	public IEnumerable<OutPoint> ExcludeCoinsFromCoinjoin(List<OutPoint> outPointsToUpdate, bool exclude = true)
+	public void ExcludeCoinFromCoinJoin(OutPoint outpoint, bool exclude = true)
 	{
-		var updatedCoinsOutPoints = new List<OutPoint>();
-		foreach (var coin in GetAllCoins())
+		if (!Coins.TryGetByOutPoint(outpoint, out var coin))
 		{
-			if (!outPointsToUpdate.Contains(coin.Outpoint) || coin.IsExcludedFromCoinJoin == exclude)
-			{
-				continue;
-			}
-
-			coin.IsExcludedFromCoinJoin = exclude;
-			updatedCoinsOutPoints.Add(coin.Outpoint);
+			throw new InvalidOperationException($"Coin '{outpoint}' doesn't belong to the wallet or is spent.");
 		}
 
-		if (updatedCoinsOutPoints.Any())
-		{
-			UpdateExcludedCoinFromCoinJoin();
-		}
-
-		return updatedCoinsOutPoints;
+		coin.IsExcludedFromCoinJoin = exclude;
+		UpdateExcludedCoinFromCoinJoin();
 	}
 
 	private void UpdateExcludedCoinFromCoinJoin()

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -515,7 +515,7 @@ public class Wallet : BackgroundService, IWallet
 		var updatedCoinsOutPoints = new List<OutPoint>();
 		foreach (var coin in GetAllCoins())
 		{
-			if (!outPointsToUpdate.Contains(coin.Outpoint))
+			if (!outPointsToUpdate.Contains(coin.Outpoint) || coin.IsExcludedFromCoinJoin == exclude)
 			{
 				continue;
 			}


### PR DESCRIPTION
I thought of adding an RPC endpoint to access #9925 feature, as the UI was never made.
The function can be used to both exclude some coins or "unexclude" them, depending on the bool passed.
I can change the naming and signature if anyone has a better idea. I can also move the business logic.

I also took the liberty to implement 2 ways to exclude coins: By Outpoint or by Label of a transaction linked to the coin.
I can remove the "By Label" feature if it's preferred to don't have it.