### PR TITLE
RPC: return `hex` and `txid`

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -216,6 +216,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return new
 		{
 			txid = smartTx.Transaction.GetHash(),
+			hex = txHex,
 			tx = txHex
 		};
 	}
@@ -247,6 +248,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 				height = x.Height.Value,
 				amount = x.Amount.Satoshi,
 				label = x.Labels.ToString(),
+				txid = x.GetHash(),
 				tx = x.GetHash(),
 				islikelycoinjoin = x.IsOwnCoinjoin()
 			}).ToArray();


### PR DESCRIPTION
small "fix"
we returned `tx` as `txHex` at one method and `tx` as `txid` at another method

use `hex` for `txHex` and `txid` for `TransactionId`, same as Bitcoin Core