### PR TITLE
Speed up transaction processing by 20%

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -14,6 +14,9 @@ public class CoinsRegistry : ICoinsView
 	private HashSet<SmartCoin> Coins { get; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
+	private HashSet<uint256> KnownTransactions { get; } = new();
+
+	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
 	private HashSet<SmartCoin> LatestCoinsSnapshot { get; set; } = new();
 
 	/// <remarks>Guarded by <see cref="Lock"/>.</remarks>
@@ -83,6 +86,7 @@ public class CoinsRegistry : ICoinsView
 			if (!SpentCoins.Contains(coin))
 			{
 				added = Coins.Add(coin);
+				KnownTransactions.Add(coin.TransactionId);
 				coin.RegisterToHdPubKey();
 				if (added)
 				{
@@ -115,14 +119,6 @@ public class CoinsRegistry : ICoinsView
 		}
 
 		return added;
-	}
-
-	public ICoinsView Remove(SmartCoin coin)
-	{
-		lock (Lock)
-		{
-			return RemoveNoLock(coin);
-		}
 	}
 
 	private ICoinsView RemoveNoLock(SmartCoin coin)
@@ -194,6 +190,14 @@ public class CoinsRegistry : ICoinsView
 		}
 	}
 
+	public bool IsKnown(uint256 txid)
+	{
+		lock (Lock)
+		{
+			return KnownTransactions.Contains(txid);
+		}
+	}
+
 	public bool TryGetSpenderSmartCoinsByOutPoint(OutPoint outPoint, [NotNullWhen(true)] out HashSet<SmartCoin>? coins)
 	{
 		lock (Lock)
@@ -239,6 +243,8 @@ public class CoinsRegistry : ICoinsView
 					toAdd.Add(destroyedCoin);
 				}
 			}
+
+			KnownTransactions.Remove(txId);
 
 			InvalidateSnapshot = true;
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -145,7 +145,7 @@ public class TransactionProcessor
 		}
 
 		// Performance ToDo: txids could be cached in a hashset here by the AllCoinsView and then the contains would be fast.
-		if (!tx.Transaction.IsCoinBase && !Coins.AsAllCoinsView().CreatedBy(txId).Any()) // Transactions we already have and processed would be "double spends" but they shouldn't.
+		if (!tx.Transaction.IsCoinBase && !Coins.IsKnown(txId)) // Transactions we already have and processed would be "double spends" but they shouldn't.
 		{
 			var doubleSpentSpenders = new List<SmartCoin>();
 			var doubleSpentCoins = new List<SmartCoin>();
@@ -207,7 +207,7 @@ public class TransactionProcessor
 						// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
 						foreach (SmartCoin doubleSpentCoin in doubleSpentSpenders)
 						{
-							Coins.Remove(doubleSpentCoin);
+							Coins.Undo(doubleSpentCoin.TransactionId);
 						}
 
 						result.SuccessfullyDoubleSpentCoins.AddRange(doubleSpentSpenders);

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -144,7 +144,6 @@ public class TransactionProcessor
 			result = new ProcessedResult(tx);
 		}
 
-		// Performance ToDo: txids could be cached in a hashset here by the AllCoinsView and then the contains would be fast.
 		if (!tx.Transaction.IsCoinBase && !Coins.IsKnown(txId)) // Transactions we already have and processed would be "double spends" but they shouldn't.
 		{
 			var doubleSpentSpenders = new List<SmartCoin>();

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -203,10 +203,10 @@ public class TransactionProcessor
 					}
 					else
 					{
-						// remove double spent coins recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
-						foreach (SmartCoin doubleSpentCoin in doubleSpentSpenders)
+						// remove double spent spenders recursively (if other coin spends it, remove that too and so on), will add later if they came to our keys
+						foreach (var doubleSpentTxid in doubleSpentSpenders.Select(x => x.TransactionId).Distinct())
 						{
-							Coins.Undo(doubleSpentCoin.TransactionId);
+							Coins.Undo(doubleSpentTxid);
 						}
 
 						result.SuccessfullyDoubleSpentCoins.AddRange(doubleSpentSpenders);


### PR DESCRIPTION
This PR optimizes out section B bottleneck (described here: https://github.com/zkSNACKs/WalletWasabi/issues/11287) of transaction processing with no noticeable memory growth.

This PR is a part of https://github.com/zkSNACKs/WalletWasabi/pull/11298 and https://github.com/zkSNACKs/WalletWasabi/pull/11513/

### master:

```
1.6GB memory
2023-09-23 10:51:43.331 [17] INFO	Wallet.Dispose (421)	Initial Transaction Processing finished in 9.2 seconds.
Time spent in sections: A: 0.42%, B: 24.02%, C: 1.40%, D: 28.57%, E: 7.25%, F: 1.05%, G: 37.28%
```

### This PR:

```
1.6 GB memory
2023-09-23 10:57:18.962 [20] INFO	Wallet.Dispose (421)	Initial Transaction Processing finished in 8.32 seconds.
2023-09-23 10:58:58.438 [17] INFO	Wallet.Dispose (421)	Initial Transaction Processing finished in 8.71 seconds.
2023-09-23 11:01:29.075 [28] INFO	Wallet.Dispose (421)	Initial Transaction Processing finished in 9.14 seconds.
2023-09-23 11:06:51.018 [9] INFO	Wallet.Dispose (421)	Initial Transaction Processing finished in 7.53 seconds.
Time spent in sections: A: 0.51%, B: 0.04%, C: 1.52%, D: 43.38%, E: 8.36%, F: 1.01%, G: 45.19%
```

