### PR TITLE
Remove `CoinsByOutPoint` from `CoinsRegistry`

### DIFF
--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -226,8 +226,8 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 			await rpc.GenerateAsync(10);
 			await setup.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), 10);
 			var eventArgs = await eventAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
-			var doubleSpend = Assert.Single(eventArgs.SuccessfullyDoubleSpentCoins);
-			Assert.Equal(invalidCoin.TransactionId, doubleSpend.TransactionId);
+			var doubleSpend = Assert.Single(eventArgs.SuccessfullyDoubleSpentTransactions);
+			Assert.Equal(invalidCoin.TransactionId, doubleSpend.GetHash());
 
 			var curBlockHash = await rpc.GetBestBlockHashAsync();
 			blockCount = await rpc.GetBlockCountAsync();

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -121,7 +121,7 @@ public class TransactionProcessorTests
 		Assert.Empty(res1.ReceivedDusts);
 		Assert.Empty(res1.ReplacedCoins);
 		Assert.Empty(res1.RestoredCoins);
-		Assert.Empty(res1.SuccessfullyDoubleSpentCoins);
+		Assert.Empty(res1.SuccessfullyDoubleSpentTransactions);
 		Assert.True(res1.IsNews);
 		Assert.NotNull(res1.Transaction);
 
@@ -135,7 +135,7 @@ public class TransactionProcessorTests
 		Assert.Empty(res2.ReceivedDusts);
 		Assert.Empty(res2.ReplacedCoins);
 		Assert.Empty(res2.RestoredCoins);
-		Assert.Empty(res2.SuccessfullyDoubleSpentCoins);
+		Assert.Empty(res2.SuccessfullyDoubleSpentTransactions);
 		Assert.True(res2.IsNews);
 		Assert.NotNull(res2.Transaction);
 
@@ -149,7 +149,7 @@ public class TransactionProcessorTests
 		Assert.Empty(res3.ReceivedDusts);
 		Assert.Empty(res3.ReplacedCoins);
 		Assert.Empty(res3.RestoredCoins);
-		Assert.Empty(res3.SuccessfullyDoubleSpentCoins);
+		Assert.Empty(res3.SuccessfullyDoubleSpentTransactions);
 		Assert.True(res3.IsNews);
 		Assert.NotNull(res3.Transaction);
 
@@ -163,7 +163,7 @@ public class TransactionProcessorTests
 		Assert.Empty(res4.ReceivedDusts);
 		Assert.Empty(res4.ReplacedCoins);
 		Assert.Empty(res4.RestoredCoins);
-		Assert.Empty(res4.SuccessfullyDoubleSpentCoins);
+		Assert.Empty(res4.SuccessfullyDoubleSpentTransactions);
 		Assert.True(res4.IsNews);
 		Assert.NotNull(res4.Transaction);
 	}
@@ -246,10 +246,10 @@ public class TransactionProcessorTests
 		int doubleSpendReceived = 0;
 		transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
 		{
-			var doubleSpents = e.SuccessfullyDoubleSpentCoins;
+			var doubleSpents = e.SuccessfullyDoubleSpentTransactions;
 			if (doubleSpents.Any())
 			{
-				var coin = Assert.Single(doubleSpents);
+				var coin = Assert.Single(doubleSpents).WalletOutputs.Single();
 
 				// Double spend to ourselves but to a different address. So checking the address.
 				Assert.Equal(keys[1].GetAssumedScriptPubKey(), coin.ScriptPubKey);
@@ -535,7 +535,7 @@ public class TransactionProcessorTests
 			Assert.False(res2.IsNews);
 			Assert.Empty(res2.ReplacedCoins);
 			Assert.Empty(res2.RestoredCoins);
-			Assert.Empty(res2.SuccessfullyDoubleSpentCoins);
+			Assert.Empty(res2.SuccessfullyDoubleSpentTransactions);
 			Assert.Single(res2.ReceivedCoins);
 			Assert.Empty(res2.NewlyConfirmedReceivedCoins);
 			Assert.Empty(res2.ReceivedDusts);
@@ -551,7 +551,7 @@ public class TransactionProcessorTests
 		Assert.True(res3.IsNews);
 		Assert.Empty(res3.ReplacedCoins);
 		Assert.Empty(res3.RestoredCoins);
-		Assert.Empty(res3.SuccessfullyDoubleSpentCoins);
+		Assert.Empty(res3.SuccessfullyDoubleSpentTransactions);
 		Assert.Single(res3.ReceivedCoins);
 		Assert.Single(res3.NewlyConfirmedReceivedCoins);
 		Assert.Empty(res3.ReceivedDusts);

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -20,7 +20,7 @@ public class ProcessedResult
 	public SmartTransaction Transaction { get; }
 
 	public bool IsNews =>
-		SuccessfullyDoubleSpentCoins.Any()
+		SuccessfullyDoubleSpentTransactions.Any()
 		|| ReplacedCoins.Any()
 		|| RestoredCoins.Any()
 		|| NewlyReceivedCoins.Any()
@@ -72,7 +72,7 @@ public class ProcessedResult
 	/// transaction has successfully invalidated them, because it spends
 	/// some of the same inputs.
 	/// </summary>
-	public List<SmartCoin> SuccessfullyDoubleSpentCoins { get; } = new List<SmartCoin>();
+	public List<SmartTransaction> SuccessfullyDoubleSpentTransactions { get; } = new();
 
 	/// <summary>
 	/// Gets the unconfirmed coins that were replaced by the coins of the transaction.

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -68,7 +68,7 @@ public class ProcessedResult
 	public List<SmartCoin> NewlyConfirmedSpentCoins { get; } = new List<SmartCoin>();
 
 	/// <summary>
-	/// Gets the coins that we previously had in the mempool, but this confirmed
+	/// Gets the txs that we previously had in the mempool, but this confirmed
 	/// transaction has successfully invalidated them, because it spends
 	/// some of the same inputs.
 	/// </summary>

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -150,9 +150,9 @@ public class TransactionProcessor
 			var doubleSpentCoins = new List<SmartCoin>();
 			foreach (var txIn in tx.Transaction.Inputs)
 			{
-				if (Coins.TryGetSpendersByOutPoint(txIn.PrevOut, out var spenders))
+				if (Coins.TryGetSpenderByOutPoint(txIn.PrevOut, out var spender))
 				{
-					doubleSpentSpenders.AddRange(spenders);
+					doubleSpentSpenders.Add(spender);
 				}
 				if (Coins.TryGetSpentCoinByOutPoint(txIn.PrevOut, out var spentCoin))
 				{


### PR DESCRIPTION
It seems to be possible to altogether remove `CoinsByOutPoint` from `CoinsRegistry` by using the newly introduced `OutpointCoinCache`. 

Closes https://github.com/zkSNACKs/WalletWasabi/pull/11384
Closes https://github.com/zkSNACKs/WalletWasabi/pull/11374

Note that I notice zero memory saving here which is in stark contrast to @turbolay's claim in https://github.com/zkSNACKs/WalletWasabi/pull/11374

This is possibly incorrect because some RegTests fail: `BuildTransactionReorgsTestAsync`, `ReplaceByFeeTxTestAsync`, `WalletTestsAsync`