### PR TITLE
Add getcoinjoinstatus from RPC

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -188,6 +188,17 @@ public class WasabiJsonRpcService : IJsonRpcService
 		};
 	}
 
+	[JsonRpcMethod("getcoinjoinstatus")]
+	public CoinJoinClientState? GetCoinjoinStatus()
+	{
+		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
+
+		AssertWalletIsLoaded();
+		var coinJoinManager = Global.HostedServices.Get<CoinJoinManager>();
+		_ = coinJoinManager.TryGetWalletStatus(activeWallet.WalletName, out var walletCoinjoinStatus);
+		return walletCoinjoinStatus;
+	}
+
 	[JsonRpcMethod("build")]
 	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int feeTarget, string? password = null)
 	{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -3,6 +3,7 @@ using NBitcoin;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -63,8 +64,7 @@ public class CoinJoinManager : BackgroundService
 
 	private Channel<CoinJoinCommand> CommandChannel { get; } = Channel.CreateUnbounded<CoinJoinCommand>();
 
-	#region Public API (Start | Stop | )
-
+	#region Public API (Start | Stop | TryGetWalletStatus)
 	public async Task StartAsync(IWallet wallet, bool stopWhenAllMixed, bool overridePlebStop, CancellationToken cancellationToken)
 	{
 		if (overridePlebStop && !wallet.IsUnderPlebStop)
@@ -80,6 +80,13 @@ public class CoinJoinManager : BackgroundService
 	public async Task StopAsync(Wallet wallet, CancellationToken cancellationToken)
 	{
 		await CommandChannel.Writer.WriteAsync(new StopCoinJoinCommand(wallet), cancellationToken).ConfigureAwait(false);
+	}
+
+	public bool TryGetWalletStatus(string walletName, [NotNullWhen(true)] out CoinJoinClientState? walletCoinjoinStatus)
+	{
+		var result = CoinJoinClientStates.TryGetValue(walletName, out var walletCoinjoinStateHolder);
+		walletCoinjoinStatus = walletCoinjoinStateHolder?.CoinJoinClientState;
+		return result;
 	}
 
 	#endregion Public API (Start | Stop | )


### PR DESCRIPTION
This PR does 2 things:
- It adds `TryGetWalletStatus` in the public API of the `CoinjoinManager`
- It accesses it from the RPC in a `getcoinjoinstatus` function

From curl, it just returns an `int?`. But from C# you can have directly the `enum` object so I believe the return type is correct.

If was requested by @CAnorbo 