### PR TITLE
Clean up useless properties in TransactionProcessor

### DIFF
--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -40,14 +40,7 @@ public class TransactionProcessor
 	public CoinsRegistry Coins { get; }
 	private BlockchainAnalyzer BlockchainAnalyzer { get; }
 	public Money DustThreshold { get; }
-
-	#region Progress
-
-	private int QueuedTxCount { get; set; }
-	private int QueuedProcessedTxCount { get; set; }
 	private MempoolService? MempoolService { get; }
-
-	#endregion Progress
 
 	public IEnumerable<ProcessedResult> Process(IEnumerable<SmartTransaction> txs)
 	{
@@ -55,19 +48,9 @@ public class TransactionProcessor
 
 		lock (Lock)
 		{
-			try
+			foreach (var tx in txs)
 			{
-				QueuedTxCount = txs.Count();
-				foreach (var tx in txs)
-				{
-					rets.Add(ProcessNoLock(tx));
-					QueuedProcessedTxCount++;
-				}
-			}
-			finally
-			{
-				QueuedTxCount = 0;
-				QueuedProcessedTxCount = 0;
+				rets.Add(ProcessNoLock(tx));
 			}
 		}
 
@@ -99,15 +82,7 @@ public class TransactionProcessor
 		lock (Lock)
 		{
 			Aware.Add(tx.GetHash());
-			try
-			{
-				QueuedTxCount = 1;
-				ret = ProcessNoLock(tx);
-			}
-			finally
-			{
-				QueuedTxCount = 0;
-			}
+			ret = ProcessNoLock(tx);
 		}
 		if (ret.IsNews)
 		{


### PR DESCRIPTION
Found while reviewing #11572

Removed these two properties in `TransactionProcessor`
```cs
private int QueuedTxCount { get; set; }
private int QueuedProcessedTxCount { get; set; }
```
because seemingly we write to these properties but never ever did anything with them. 
We just stored some information, then never read them.

Also removed their try-finally block because in case of error, the exception bubbled up to the caller. 
I didn't change this behavior, but the try-finally become obsolete.