### PR TITLE
Set `SpenderTransaction` to null in Undo

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -157,7 +157,7 @@ public class TransactionProcessorTests
 		Assert.Empty(res4.NewlyConfirmedReceivedCoins);
 		Assert.Single(res4.NewlyConfirmedSpentCoins);
 		Assert.Empty(res4.NewlyReceivedCoins);
-		Assert.Empty(res4.NewlySpentCoins);
+		Assert.Single(res4.NewlySpentCoins);
 		Assert.Empty(res4.ReceivedCoins);
 		Assert.Single(res4.SpentCoins);
 		Assert.Empty(res4.ReceivedDusts);

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -244,6 +244,7 @@ public class CoinsRegistry : ICoinsView
 			{
 				if (SpentCoins.Remove(destroyedCoin))
 				{
+					destroyedCoin.SpenderTransaction = null;
 					SpentCoinsByOutPoint.Remove(destroyedCoin.Outpoint);
 					Coins.Add(destroyedCoin);
 					toAdd.Add(destroyedCoin);


### PR DESCRIPTION
Extracted change from #11516 
See my explanation here: https://github.com/zkSNACKs/WalletWasabi/pull/11516#discussion_r1330772917