### PR TITLE
Punish remixers linearly

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -155,7 +155,7 @@ public class PrisonTests
 
 		prison.FailedToConfirm(ftcOutpointBigPaid, Money.Coins(2m), roundId);
 		banningPeriodBigPaidCoin = prison.GetBanTimePeriod(ftcOutpointBigPaid);
-		Assert.NotEqual(TimeSpan.Zero, banningPeriodBigPaidCoin.Duration); // it IS not banned second time
+		Assert.NotEqual(TimeSpan.Zero, banningPeriodBigPaidCoin.Duration); // it IS banned second time
 
 		// coins inherit the punishments from their ancestors
 		var ftcFailedToSign = BitcoinFactory.CreateOutPoint();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -155,7 +155,7 @@ public class PrisonTests
 
 		prison.FailedToConfirm(ftcOutpointBigPaid, Money.Coins(2m), roundId);
 		banningPeriodBigPaidCoin = prison.GetBanTimePeriod(ftcOutpointBigPaid);
-		Assert.Equal(TimeSpan.Zero, banningPeriodBigPaidCoin.Duration); // it is not banned second time either
+		Assert.NotEqual(TimeSpan.Zero, banningPeriodBigPaidCoin.Duration); // it IS not banned second time
 
 		// coins inherit the punishments from their ancestors
 		var ftcFailedToSign = BitcoinFactory.CreateOutPoint();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
@@ -49,7 +49,7 @@ public class UtxoPrisonWardenTests
 		var i4 = BitcoinFactory.CreateOutPoint();
 		var i5 = BitcoinFactory.CreateOutPoint();
 		w.Prison.FailedVerification(i1, uint256.One);
-		w.Prison.FailedToConfirm(i2, Money.Coins(0.1m), uint256.One);
+		w.Prison.FailedToConfirm(i2, Money.Coins(0.01m), uint256.One);
 		w.Prison.FailedToSign(i3, Money.Coins(0.1m), uint256.One);
 		w.Prison.DoubleSpent(i4, Money.Coins(0.1m), uint256.One);
 		w.Prison.CheatingDetected(i5, uint256.One);


### PR DESCRIPTION
Close https://github.com/zkSNACKs/WalletWasabi/issues/11482

Utxos created by Wasabi coinjoins are punished linearly instead of exponentially.