### PR TITLE
Introduce IsUsed in the CoinsRegistry

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -311,6 +311,14 @@ public class CoinsRegistry : ICoinsView
 		}
 	}
 
+	public bool IsUsed(HdPubKey hdPubKey)
+	{
+		lock (Lock)
+		{
+			return CoinsByPubKeys.TryGetValue(hdPubKey, out _);
+		}
+	}
+
 	public ICoinsView AsAllCoinsView()
 	{
 		lock (Lock)

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -283,7 +283,7 @@ public class TransactionProcessor
 	private bool CanBeConsideredDustAttack(TxOut output, HdPubKey hdPubKey, bool weAreAmongTheSender) =>
 		output.Value <= DustThreshold // the value received is under the dust threshold
 		&& !weAreAmongTheSender // we are not one of the senders (it is not a self-spending tx or coinjoin)
-		&& Coins.Any(c => c.HdPubKey == hdPubKey); // the destination address has already been used (address reuse)
+		&& Coins.IsUsed(hdPubKey); // the destination address has already been used (address reuse)
 
 	private void SaveInternalKeysLatestSpendingHeight(Height txHeight, IEnumerable<HdPubKey> internalKeys)
 	{


### PR DESCRIPTION
Found while looking at https://github.com/zkSNACKs/WalletWasabi/pull/11577#issuecomment-1734277566

This PR has 2 goals:
- On master, `CanBeConsideredDustAttack` enumerates all the time the `Coins` of the wallet. This PR uses the `TryGetValue` of `CoinsByPubKeys`, a cache that was introduced in #11571. So it's cleaner and potentially more performant in some cases.
- On master, `CanBeConsideredDustAttack` has a bug; it doesn't consider the keys with no unspent coin left to unlock as used. This PR fixes this.

Note: Maybe it would make more sense to do this using the `KeyManager`, but `CanBeConsideredDustAttack` was already using the `CoinsRegistry`.