### PR TITLE
[Trivial] Rename “Continue” button to “Send” before sending

### DIFF
--- a/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
+++ b/WalletWasabi.Fluent/Views/Dialogs/Authorization/PasswordAuthDialogView.axaml
@@ -15,7 +15,7 @@
                  CancelContent="Cancel"
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}"
-                 EnableNext="True" NextContent="Continue"
+                 EnableNext="True" NextContent="SEND"
                  IsBusy="{Binding IsBusy}">
 
     <StackPanel>
@@ -30,6 +30,5 @@
                  Text="{Binding AuthorizationFailedMessage}"
                  IsVisible="{Binding HasAuthorizationFailed}" />
     </StackPanel>
-
   </c:ContentArea>
 </UserControl>


### PR DESCRIPTION
Rename “Continue” button to “Send” as it’s the last step before sending.

Master:

![02](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/451b551a-9a94-485e-b1f3-40a7df181602)

PR:

![01](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/836d1b75-a7a7-40dd-8c55-5527ce59567d)