### PR TITLE
[VDG] Use enum for history item status and type

### DIFF
--- a/WalletWasabi.Fluent/Converters/EnumToBoolConverter.cs
+++ b/WalletWasabi.Fluent/Converters/EnumToBoolConverter.cs
@@ -1,0 +1,57 @@
+// Based on: https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Converters/EnumToBoolConverter.cs
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace WalletWasabi.Fluent.Converters;
+
+/// <summary>
+/// Converter to convert an enum value to bool by comparing to the given parameter.
+/// Both value and parameter must be of the same enum type.
+/// </summary>
+/// <remarks>
+/// This converter is useful to enable binding of radio buttons with a selected enum value.
+/// </remarks>
+public class EnumToBoolConverter : IValueConverter
+{
+	public static EnumToBoolConverter Instance = new ();
+
+	/// <inheritdoc/>
+	public object? Convert(
+		object? value,
+		Type targetType,
+		object? parameter,
+		CultureInfo culture)
+	{
+		if (value == null &&
+		    parameter == null)
+		{
+			return true;
+		}
+		else if (value == null ||
+		         parameter == null)
+		{
+			return false;
+		}
+		else
+		{
+			return value!.Equals(parameter);
+		}
+	}
+
+	/// <inheritdoc/>
+	public object? ConvertBack(
+		object? value,
+		Type targetType,
+		object? parameter,
+		CultureInfo culture)
+	{
+		if (value is bool boolValue &&
+		    boolValue == true)
+		{
+			return parameter;
+		}
+
+		return BindingOperations.DoNothing;
+	}
+}

--- a/WalletWasabi.Fluent/Converters/EnumToBoolConverter.cs
+++ b/WalletWasabi.Fluent/Converters/EnumToBoolConverter.cs
@@ -1,4 +1,5 @@
 // Based on: https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Converters/EnumToBoolConverter.cs
+
 using System.Globalization;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
@@ -14,7 +15,7 @@ namespace WalletWasabi.Fluent.Converters;
 /// </remarks>
 public class EnumToBoolConverter : IValueConverter
 {
-	public static EnumToBoolConverter Instance = new ();
+	public static EnumToBoolConverter Instance = new();
 
 	/// <inheritdoc/>
 	public object? Convert(
@@ -23,20 +24,17 @@ public class EnumToBoolConverter : IValueConverter
 		object? parameter,
 		CultureInfo culture)
 	{
-		if (value == null &&
-		    parameter == null)
+		if (value == null && parameter == null)
 		{
 			return true;
 		}
-		else if (value == null ||
-		         parameter == null)
+
+		if (value == null || parameter == null)
 		{
 			return false;
 		}
-		else
-		{
-			return value!.Equals(parameter);
-		}
+
+		return value.Equals(parameter);
 	}
 
 	/// <inheritdoc/>
@@ -46,12 +44,6 @@ public class EnumToBoolConverter : IValueConverter
 		object? parameter,
 		CultureInfo culture)
 	{
-		if (value is bool boolValue &&
-		    boolValue == true)
-		{
-			return parameter;
-		}
-
-		return BindingOperations.DoNothing;
+		return value is true ? parameter : BindingOperations.DoNothing;
 	}
 }

--- a/WalletWasabi.Fluent/Converters/TransactionHistoryItemToolTipConverter.cs
+++ b/WalletWasabi.Fluent/Converters/TransactionHistoryItemToolTipConverter.cs
@@ -19,7 +19,7 @@ public class TransactionHistoryItemToolTipConverter : IValueConverter
 	{
 		if (value is HistoryItemViewModelBase vm)
 		{
-			if (vm.IsConfirmedDisplayed)
+			if (vm.ItemStatus == HistoryItemStatus.Confirmed)
 			{
 				return vm.ConfirmedToolTip;
 			}
@@ -29,24 +29,24 @@ public class TransactionHistoryItemToolTipConverter : IValueConverter
 				var friendlyString = TextHelpers.TimeSpanToFriendlyString(estimate.Value);
 				if (friendlyString != "")
 				{
-					if (vm.IsSpeedUpDisplayed)
+					if (vm.ItemStatus == HistoryItemStatus.SpeedUp)
 					{
 						return $"Pending (accelerated, confirming in ≈ {friendlyString})";
 					}
 
-					if (vm.IsPendingDisplayed)
+					if (vm.ItemStatus == HistoryItemStatus.Pending)
 					{
 						return $"Pending (confirming in ≈ {friendlyString})";
 					}
 				}
 			}
 
-			if (vm.IsSpeedUpDisplayed)
+			if (vm.ItemStatus == HistoryItemStatus.SpeedUp)
 			{
 				return "Pending (accelerated)";
 			}
 
-			if (vm.IsPendingDisplayed)
+			if (vm.ItemStatus == HistoryItemStatus.Pending)
 			{
 				return "Pending";
 			}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinHistoryItemViewModel.cs
@@ -30,6 +30,9 @@ public partial class CoinJoinHistoryItemViewModel : HistoryItemViewModelBase
 				new CoinJoinDetailsViewModel(this, walletVm.UiTriggers.TransactionsUpdateTrigger)));
 
 		DateString = Date.ToLocalTime().ToUserFacingString();
+
+		ItemType = GetItemType();
+		ItemStatus = GetItemStatus();
 	}
 
 	public TransactionSummary CoinJoinTransaction { get; private set; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -31,6 +31,9 @@ public partial class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 				new CoinJoinsDetailsViewModel(this, walletVm.UiTriggers.TransactionsUpdateTrigger)));
 
 		Add(firstItem);
+
+		ItemType = GetItemType();
+		ItemStatus = GetItemStatus();
 	}
 
 	public List<TransactionSummary> CoinJoinTransactions { get; private set; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
@@ -82,9 +82,9 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 			return HistoryItemType.OutgoingTransaction;
 		}
 
-		if (OutgoingAmount == Money.Zero)
+		if (IsCancellation)
 		{
-			return HistoryItemType.SelfTransferTransaction;
+			return HistoryItemType.Cancellation;
 		}
 
 		if (IsCoinJoin && !IsCoinJoinGroup)
@@ -97,14 +97,14 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 			return HistoryItemType.CoinjoinGroup;
 		}
 
-		if (IsCancellation)
-		{
-			return HistoryItemType.Cancellation;
-		}
-
 		if (IsCPFP)
 		{
 			return HistoryItemType.CPFP;
+		}
+
+		if (OutgoingAmount == Money.Zero)
+		{
+			return HistoryItemType.SelfTransferTransaction;
 		}
 
 		return HistoryItemType.Unknown;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
@@ -117,14 +117,14 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 			return HistoryItemStatus.Confirmed;
 		}
 
-		if (!IsConfirmed && !IsSpeedUp)
-		{
-			return HistoryItemStatus.Pending;
-		}
-
 		if (!IsConfirmed && (IsSpeedUp || IsCPFPd))
 		{
 			return HistoryItemStatus.SpeedUp;
+		}
+
+		if (!IsConfirmed && !IsSpeedUp)
+		{
+			return HistoryItemStatus.Pending;
 		}
 
 		return HistoryItemStatus.Unknown;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/HistoryItemViewModelBase.cs
@@ -13,6 +13,26 @@ using WalletWasabi.Fluent.Helpers;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems;
 
+public enum HistoryItemType
+{
+	Unknown,
+	IncomingTransaction,
+	OutgoingTransaction,
+	SelfTransferTransaction,
+	Coinjoin,
+	CoinjoinGroup,
+	Cancellation,
+	CPFP
+}
+
+public enum HistoryItemStatus
+{
+	Unknown,
+	Confirmed,
+	Pending,
+	SpeedUp,
+}
+
 public abstract partial class HistoryItemViewModelBase : ViewModelBase
 {
 	[AutoNotify] private bool _isFlashing;
@@ -22,6 +42,8 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 	[AutoNotify] private bool _isConfirmed;
 	[AutoNotify] private bool _isExpanded;
 	[AutoNotify] private string _confirmedToolTip;
+	[AutoNotify] private HistoryItemType _itemType;
+	[AutoNotify] private HistoryItemStatus _itemStatus;
 	private ObservableCollection<HistoryItemViewModelBase>? _children;
 
 	protected HistoryItemViewModelBase(int orderIndex, TransactionSummary transactionSummary)
@@ -46,6 +68,66 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 
 		IsCancellation = false;
 		IsSpeedUp = false;
+	}
+
+	protected HistoryItemType GetItemType()
+	{
+		if (!IsCPFP && IncomingAmount is { } incomingAmount && incomingAmount > Money.Zero && !IsCoinJoin)
+		{
+			return HistoryItemType.IncomingTransaction;
+		}
+
+		if (!IsCPFP && OutgoingAmount is { } outgoingAmount && outgoingAmount > Money.Zero && !IsCoinJoin)
+		{
+			return HistoryItemType.OutgoingTransaction;
+		}
+
+		if (OutgoingAmount == Money.Zero)
+		{
+			return HistoryItemType.SelfTransferTransaction;
+		}
+
+		if (IsCoinJoin && !IsCoinJoinGroup)
+		{
+			return HistoryItemType.Coinjoin;
+		}
+
+		if (IsCoinJoin && IsCoinJoinGroup)
+		{
+			return HistoryItemType.CoinjoinGroup;
+		}
+
+		if (IsCancellation)
+		{
+			return HistoryItemType.Cancellation;
+		}
+
+		if (IsCPFP)
+		{
+			return HistoryItemType.CPFP;
+		}
+
+		return HistoryItemType.Unknown;
+	}
+
+	protected HistoryItemStatus GetItemStatus()
+	{
+		if (IsConfirmed)
+		{
+			return HistoryItemStatus.Confirmed;
+		}
+
+		if (!IsConfirmed && !IsSpeedUp)
+		{
+			return HistoryItemStatus.Pending;
+		}
+
+		if (!IsConfirmed && (IsSpeedUp || IsCPFPd))
+		{
+			return HistoryItemStatus.SpeedUp;
+		}
+
+		return HistoryItemStatus.Unknown;
 	}
 
 	protected string GetConfirmedToolTip(int confirmations)
@@ -86,29 +168,6 @@ public abstract partial class HistoryItemViewModelBase : ViewModelBase
 	public bool IsCPFP { get; set; }
 
 	public bool IsCPFPd { get; set; }
-
-	public bool IsIncomingTransactionDisplayed => !IsCPFP && IncomingAmount is { } amount && amount > Money.Zero && !IsCoinJoin;
-
-	public bool IsOutgoingTransactionDisplayed => !IsCPFP && OutgoingAmount is { } amount && amount > Money.Zero && !IsCoinJoin;
-
-	public bool IsSelfTransferTransaction => OutgoingAmount == Money.Zero;
-
-	public bool IsConfirmedDisplayed => IsConfirmed;
-
-	public bool IsPendingDisplayed => !IsConfirmed && !IsSpeedUp;
-
-	public bool IsCoinjoinDisplayed => IsCoinJoin && !IsCoinJoinGroup;
-
-	public bool IsCoinjoinGroupDisplayed => IsCoinJoin && IsCoinJoinGroup;
-
-	public bool IsCancellationDisplayed => IsCancellation;
-
-	/// <remarks>
-	/// CPFPd transactions are not SpeedUp transactions, but they are sped up as well.
-	/// </remarks>
-	public bool IsSpeedUpDisplayed => !IsConfirmed && (IsSpeedUp || IsCPFPd);
-
-	public bool IsCPFPDisplayed => IsCPFP;
 
 	public TransactionSummary TransactionSummary { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/SpeedUpHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/SpeedUpHistoryItemViewModel.cs
@@ -39,6 +39,9 @@ internal class SpeedUpHistoryItemViewModel : HistoryItemViewModelBase
 		CanSpeedUpTransaction = transactionSummary.Transaction.IsSpeedupable(walletVm.Wallet.KeyManager);
 		SpeedUpTransactionCommand = parent.SpeedUpTransactionCommand;
 		CancelTransactionCommand = parent.CancelTransactionCommand;
+
+		ItemType = GetItemType();
+		ItemStatus = GetItemStatus();
 	}
 
 	public bool CanSpeedUpTransaction { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/TransactionHistoryItemViewModel.cs
@@ -39,6 +39,9 @@ public partial class TransactionHistoryItemViewModel : HistoryItemViewModelBase
 		CanSpeedUpTransaction = transactionSummary.Transaction.IsSpeedupable(KeyManager);
 		SpeedUpTransactionCommand = ReactiveCommand.Create(() => OnSpeedUpTransaction(transactionSummary.Transaction), Observable.Return(CanSpeedUpTransaction));
 		CancelTransactionCommand = ReactiveCommand.Create(() => OnCancelTransaction(transactionSummary.Transaction), Observable.Return(CanCancelTransaction));
+
+		ItemType = GetItemType();
+		ItemStatus = GetItemStatus();
 	}
 
 	public bool CanCancelTransaction { get; }

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Columns/IndicatorsColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Columns/IndicatorsColumnView.axaml
@@ -25,9 +25,9 @@
     </Panel>
 
     <!--First icon (Confirmation Status) -->
-    <PathIcon Classes.Confirmed="{Binding IsConfirmedDisplayed}"
-              Classes.Pending="{Binding IsPendingDisplayed}"
-              Classes.SpeedUp="{Binding IsSpeedUpDisplayed}"
+    <PathIcon Classes.Confirmed="{Binding ItemStatus, ConverterParameter={x:Static historyItems:HistoryItemStatus.Confirmed}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+              Classes.Pending="{Binding ItemStatus, ConverterParameter={x:Static historyItems:HistoryItemStatus.Pending}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+              Classes.SpeedUp="{Binding ItemStatus, ConverterParameter={x:Static historyItems:HistoryItemStatus.SpeedUp}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
               ToolTip.Tip="{Binding Converter={StaticResource ToolTipConverter}}"
               Opacity="0.6">
       <PathIcon.Styles>
@@ -57,13 +57,13 @@
       </c:PrivacyContentControl.Styles>
 
       <PathIcon Opacity="0.6"
-                Classes.IncomingTransaction="{Binding IsIncomingTransactionDisplayed}"
-                Classes.OutgoingTransaction="{Binding IsOutgoingTransactionDisplayed}"
-                Classes.SelfTransfer="{Binding IsSelfTransferTransaction}"
-                Classes.Coinjoin="{Binding IsCoinjoinDisplayed}"
-                Classes.Cancellation="{Binding IsCancellationDisplayed}"
-                Classes.CoinjoinGroup="{Binding IsCoinjoinGroupDisplayed}"
-                Classes.CPFP="{Binding IsCPFPDisplayed}">
+                Classes.IncomingTransaction="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.IncomingTransaction}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+                Classes.OutgoingTransaction="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.OutgoingTransaction}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+                Classes.SelfTransfer="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.SelfTransferTransaction}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+                Classes.Coinjoin="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.Coinjoin}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+                Classes.Cancellation="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.Cancellation}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+                Classes.CoinjoinGroup="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.CoinjoinGroup}, Converter={x:Static converters:EnumToBoolConverter.Instance}}"
+                Classes.CPFP="{Binding ItemType, ConverterParameter={x:Static historyItems:HistoryItemType.CPFP}, Converter={x:Static converters:EnumToBoolConverter.Instance}}">
         <PathIcon.Styles>
           <Style Selector="PathIcon.IncomingTransaction">
             <Setter Property="Data" Value="{StaticResource incoming_arrow}" />


### PR DESCRIPTION
While doing https://github.com/zkSNACKs/WalletWasabi/pull/10423 it was reported that while scrolling items in TDG history table have glitches in icons. To make icon updates we use classes binding, to do so we have created many properties and bind them to icon classes. This PR is first step to make view model code cleaner, next step would be (if needed - glitches still occur) to refactor how PathIcon data is set (using enum to path data converter) - should be done in another PR is still needed.