### PR TITLE
Fetch transaction fee for estimated conf time calculation - business code only

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -32,6 +32,7 @@ using WalletWasabi.WebClients.BlockstreamInfo;
 using WalletWasabi.WebClients.Wasabi;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.WabiSabi.Client.Banning;
+using WalletWasabi.WebClients.MempoolSpace;
 
 namespace WalletWasabi.Daemon;
 
@@ -318,7 +319,7 @@ public class Global
 	{
 		HostedServices.Register<BlockstreamInfoFeeProvider>(() => new BlockstreamInfoFeeProvider(TimeSpan.FromMinutes(3), new(Network, HttpClientFactory)) { IsPaused = true }, "Blockstream.info Fee Provider");
 		HostedServices.Register<ThirdPartyFeeProvider>(() => new ThirdPartyFeeProvider(TimeSpan.FromSeconds(1), Synchronizer, HostedServices.Get<BlockstreamInfoFeeProvider>()), "Third Party Fee Provider");
-		HostedServices.Register<HybridFeeProvider>(() => new HybridFeeProvider(HostedServices.Get<ThirdPartyFeeProvider>(), HostedServices.GetOrDefault<RpcFeeProvider>()), "Hybrid Fee Provider");
+		HostedServices.Register<HybridFeeProvider>(() => new HybridFeeProvider(HostedServices.Get<ThirdPartyFeeProvider>(), HostedServices.GetOrDefault<RpcFeeProvider>(), new TransactionFeeFetcher(new MempoolSpaceApiClient(HttpClientFactory, Network))), "Hybrid Fee Provider");
 	}
 
 	private void RegisterCoinJoinComponents()

--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -74,6 +74,19 @@ public static class TransactionFeeHelper
 		return estimate is not null;
 	}
 
+	public static bool TryEstimateConfirmationTimeWithFeeAndVsize(Wallet wallet, int txFeeInSatoshi, int vSize, [NotNullWhen(true)] out TimeSpan? estimate)
+	{
+		estimate = null;
+		FeeRate feeRate = new(Money.Satoshis(txFeeInSatoshi), vSize);
+
+		if (TryGetFeeEstimates(wallet, out var feeEstimates))
+		{
+			estimate = feeEstimates.EstimateConfirmationTime(feeRate);
+		}
+
+		return estimate is not null;
+	}
+
 	public static bool TryGetFeeEstimates(Wallet wallet, [NotNullWhen(true)] out AllFeeEstimate? estimates)
 		=> TryGetFeeEstimates(wallet.FeeProvider, wallet.Network, out estimates);
 

--- a/WalletWasabi/WebClients/MempoolSpace/MempoolSpaceApiClient.cs
+++ b/WalletWasabi/WebClients/MempoolSpace/MempoolSpaceApiClient.cs
@@ -1,0 +1,52 @@
+using NBitcoin;
+using WalletWasabi.Tor.Http;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Tor.Http.Extensions;
+using System.Net.Http;
+using WalletWasabi.WebClients.Wasabi;
+using WalletWasabi.Tor.Socks5.Pool.Circuits;
+
+namespace WalletWasabi.WebClients.MempoolSpace;
+public class MempoolSpaceApiClient
+{
+	public MempoolSpaceApiClient(WasabiHttpClientFactory httpClientFactory, Network network)
+	{
+		string uriString;
+
+		if (httpClientFactory.IsTorEnabled)
+		{
+			uriString = network == Network.TestNet
+				? "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/"
+				: "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/";
+		}
+		else
+		{
+			uriString = network == Network.TestNet
+				? "https://mempool.space/testnet/"
+				: "https://mempool.space/";
+		}
+
+		HttpClient = httpClientFactory.NewHttpClient(() => new Uri(uriString), Mode.NewCircuitPerRequest);
+	}
+
+	private IHttpClient HttpClient { get; }
+	public async Task<MempoolSpaceApiResponseItem> GetTransactionInfosAsync(uint256 txid, CancellationToken cancel)
+	{
+		HttpResponseMessage response;
+
+		// Ensure not being banned by Mempool.space's API
+		await Task.Delay(1000, cancel).ConfigureAwait(false);
+
+		response = await HttpClient.SendAsync(HttpMethod.Get, $"api/tx/{txid}", null, cancel).ConfigureAwait(false);
+
+		if (!response.IsSuccessStatusCode)
+		{
+			// Tx was not found in mempool.space's node.
+			await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
+		}
+
+		return await response.Content.ReadAsJsonAsync<MempoolSpaceApiResponseItem>().ConfigureAwait(false);
+	}
+}

--- a/WalletWasabi/WebClients/MempoolSpace/MempoolSpaceApiResponseItem.cs
+++ b/WalletWasabi/WebClients/MempoolSpace/MempoolSpaceApiResponseItem.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+
+namespace WalletWasabi.WebClients.MempoolSpace;
+public class MempoolSpaceApiResponseItem
+{
+	public required string Txid { get; set; }
+	public int Version { get; set; }
+	public int Locktime { get; set; }
+	public List<Vin> Vin_List { get; set; }
+	public List<Vout> Vout_List { get; set; }
+	public int Size { get; set; }
+	public int Weight { get; set; }
+	public int Fee { get; set; }
+	public Status TxStatus { get; set; }
+
+	public record Prevout
+	{
+		public string Scriptpubkey { get; set; }
+		public string Scriptpubkey_asm { get; set; }
+		public string Scriptpubkey_type { get; set; }
+		public string Scriptpubkey_address { get; set; }
+		public int Value { get; set; }
+	}
+
+	public record Status
+	{
+		public bool Confirmed { get; set; }
+		public int Block_height { get; set; }
+		public string Block_hash { get; set; }
+		public int Block_time { get; set; }
+	}
+
+	public record Vin
+	{
+		public string Txid { get; set; }
+		public int Vout { get; set; }
+		public Prevout Prevout { get; set; }
+		public string Scriptsig { get; set; }
+		public string Scriptsig_asm { get; set; }
+		public List<string> Witness { get; set; }
+		public bool Is_coinbase { get; set; }
+		public object Sequence { get; set; }
+	}
+
+	public record Vout
+	{
+		public string Scriptpubkey { get; set; }
+		public string Scriptpubkey_asm { get; set; }
+		public string Scriptpubkey_type { get; set; }
+		public string Scriptpubkey_address { get; set; }
+		public int Value { get; set; }
+	}
+}

--- a/WalletWasabi/WebClients/MempoolSpace/TransactionFeeFetcher.cs
+++ b/WalletWasabi/WebClients/MempoolSpace/TransactionFeeFetcher.cs
@@ -1,0 +1,33 @@
+using NBitcoin;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.WebClients.MempoolSpace;
+
+public class TransactionFeeFetcher
+{
+	public TransactionFeeFetcher(MempoolSpaceApiClient mempoolSpaceApiClient)
+	{
+		MempoolSpaceApiClient = mempoolSpaceApiClient;
+	}
+
+	private MempoolSpaceApiClient MempoolSpaceApiClient { get; set; }
+
+	public async Task<int?> FetchTransactionFeeAsync(uint256 txid)
+	{
+		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(20));
+
+		try
+		{
+			var response = await MempoolSpaceApiClient.GetTransactionInfosAsync(txid, cts.Token).ConfigureAwait(false);
+			return response.Fee;
+		}
+		catch (Exception ex)
+		{
+			Logger.LogWarning($"Failed to fetch transaction fee. {ex}");
+		}
+		
+		return null;
+	}
+}


### PR DESCRIPTION
Contributes to https://github.com/zkSNACKs/WalletWasabi/issues/11449

**What the PR does:**
`HybridFeeProvider` got a new dependency called `TransactionFeeFetcher`, which is responsible to call mempool.space API over Tor via `MempoolSpaceApiClient`. I chose `HybridFeeProvider` to have this dependency because it's reachable from the ViewModels AFAIK. I didn't want to burden `Wallet.cs` with this dependecy.

**Where is the UI?**
Unfortunately, I failed to wire this up to the `ViewModels` correctly, so this PR only contains the business code.

After many failed attempts and many hours wasted, I give up on trying to implement a good UX for this feature.
I would like to ask for help from the UI team to figure out an acceptable UX for this. @zkSNACKs/ui-team 