### PR TITLE
[VDG] UI Decoupling #48

### DIFF
--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -69,9 +69,10 @@ public class App : Application
 		base.OnFrameworkInitializationCompleted();
 	}
 
-	private static IWalletRepository CreateWalletRepository()
+	// It begins to show that we're re-inventing DI, aren't we?
+	private static IWalletRepository CreateWalletRepository(IAmountProvider amountProvider)
 	{
-		return new WalletRepository();
+		return new WalletRepository(amountProvider);
 	}
 
 	private static IHardwareWalletInterface CreateHardwareWalletInterface()
@@ -100,19 +101,27 @@ public class App : Application
 		return new TransactionBroadcasterModel(Services.PersistentConfig.Network);
 	}
 
+	private static IAmountProvider CreateAmountProvider()
+	{
+		return new AmountProvider(Services.Synchronizer);
+	}
+
 	private UiContext CreateUiContext()
 	{
+		var amountProvider = CreateAmountProvider();
+
 		// This class (App) represents the actual Avalonia Application and it's sole presence means we're in the actual runtime context (as opposed to unit tests)
 		// Once all ViewModels have been refactored to receive UiContext as a constructor parameter, this static singleton property can be removed.
 		return new UiContext(
 			new QrCodeGenerator(),
 			new QrCodeReader(),
 			new UiClipboard(),
-			CreateWalletRepository(),
+			CreateWalletRepository(amountProvider),
 			CreateHardwareWalletInterface(),
 			CreateFileSystem(),
 			CreateConfig(),
 			CreateApplicationSettings(),
-			CreateBroadcaster());
+			CreateBroadcaster(),
+			amountProvider);
 	}
 }

--- a/WalletWasabi.Fluent/Helpers/AuthorizationHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/AuthorizationHelpers.cs
@@ -8,17 +8,15 @@ namespace WalletWasabi.Fluent.Helpers;
 // TODO: Remove this entire class after SendViewModel is decoupled.
 public static class AuthorizationHelpers
 {
-	public static AuthorizationDialogBase GetAuthorizationDialog(Wallet wallet, TransactionAuthorizationInfo transactionAuthorizationInfo)
+	public static AuthorizationDialogBase GetAuthorizationDialog(IWalletModel wallet, TransactionAuthorizationInfo transactionAuthorizationInfo)
 	{
-		var walletModel = WalletRepository.CreateWalletModel(wallet);
-
-		if (walletModel is IHardwareWalletModel hwm)
+		if (wallet is IHardwareWalletModel hwm)
 		{
 			return new HardwareWalletAuthDialogViewModel(hwm, transactionAuthorizationInfo);
 		}
 		else
 		{
-			return new PasswordAuthDialogViewModel(new WalletModel(wallet));
+			return new PasswordAuthDialogViewModel(wallet);
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Models/UI/UiContext.cs
+++ b/WalletWasabi.Fluent/Models/UI/UiContext.cs
@@ -26,7 +26,8 @@ public class UiContext
 		IFileSystem fileSystem,
 		IClientConfig config,
 		IApplicationSettings applicationSettings,
-		ITransactionBroadcasterModel transactionBroadcaster)
+		ITransactionBroadcasterModel transactionBroadcaster,
+		IAmountProvider amountProvider)
 	{
 		QrCodeGenerator = qrCodeGenerator ?? throw new ArgumentNullException(nameof(qrCodeGenerator));
 		QrCodeReader = qrCodeReader ?? throw new ArgumentNullException(nameof(qrCodeReader));
@@ -37,7 +38,7 @@ public class UiContext
 		Config = config ?? throw new ArgumentNullException(nameof(config));
 		ApplicationSettings = applicationSettings ?? throw new ArgumentNullException(nameof(applicationSettings));
 		TransactionBroadcaster = transactionBroadcaster ?? throw new ArgumentNullException(nameof(transactionBroadcaster));
-		AmountProvider = new AmountProvider(Services.Synchronizer);
+		AmountProvider = amountProvider ?? throw new ArgumentNullException(nameof(amountProvider));
 	}
 
 	public IUiClipboard Clipboard { get; }

--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -9,7 +9,7 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 
 internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 {
-	public HardwareWalletModel(Wallet wallet) : base(wallet)
+	public HardwareWalletModel(Wallet wallet, IAmountProvider amountProvider) : base(wallet, amountProvider)
 	{
 		if (!wallet.KeyManager.IsHardwareWallet)
 		{

--- a/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
@@ -17,7 +17,7 @@ public partial class WalletModel : ReactiveObject
 	private readonly Lazy<IWalletCoinjoinModel> _coinjoin;
 	private readonly Lazy<IWalletCoinsModel> _coins;
 
-	public WalletModel(Wallet wallet)
+	public WalletModel(Wallet wallet, IAmountProvider amountProvider)
 	{
 		Wallet = wallet;
 
@@ -57,6 +57,8 @@ public partial class WalletModel : ReactiveObject
 		State.Where(x => x == WalletState.Started)
 			 .Do(_ => Loader.Stop())
 			 .Subscribe();
+
+		AmountProvider = amountProvider;
 	}
 
 	internal Wallet Wallet { get; }
@@ -86,6 +88,8 @@ public partial class WalletModel : ReactiveObject
 	public IObservable<IChangeSet<IAddress, string>> Addresses { get; }
 
 	public IObservable<WalletState> State { get; }
+
+	public IAmountProvider AmountProvider { get; }
 
 	public IAddress GetNextReceiveAddress(IEnumerable<string> destinationLabels)
 	{

--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -21,10 +21,15 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 [AutoInterface]
 public partial class WalletRepository : ReactiveObject
 {
+	// TODO: make this field non-static after CancelTransactionDialogViewModel and SpeedUpTransactionDialogViewModel are decoupled.
+	private static IAmountProvider AmountProvider;
+
 	private static Dictionary<string, WalletModel> WalletDictionary = new();
 
-	public WalletRepository()
+	public WalletRepository(IAmountProvider amountProvider)
 	{
+		AmountProvider = amountProvider;
+
 		// Convert the Wallet Manager's contents into an observable stream of IWalletModels.
 		Wallets =
 			Observable.FromEventPattern<Wallet>(Services.WalletManager, nameof(WalletManager.WalletAdded)).Select(_ => Unit.Default)
@@ -194,8 +199,8 @@ public partial class WalletRepository : ReactiveObject
 
 		var result =
 			wallet.KeyManager.IsHardwareWallet
-			? new HardwareWalletModel(wallet)
-			: new WalletModel(wallet);
+			? new HardwareWalletModel(wallet, AmountProvider)
+			: new WalletModel(wallet, AmountProvider);
 
 		WalletDictionary[wallet.WalletName] = result;
 

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -282,7 +282,7 @@ public partial class MainViewModel : ViewModelBase
 					{
 						// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
 						// TODO: Why is this code duplicated?
-						var pwAuthDialog = new PasswordAuthDialogViewModel(WalletRepository.CreateWalletModel(walletViewModel.Wallet));
+						var pwAuthDialog = new PasswordAuthDialogViewModel(walletViewModel.WalletModel);
 						var dialogResult = await UiContext.Navigate().NavigateDialogAsync(pwAuthDialog, NavigationTarget.CompactDialogScreen);
 
 						if (!dialogResult.Result)
@@ -291,7 +291,7 @@ public partial class MainViewModel : ViewModelBase
 						}
 					}
 
-					return new WalletInfoViewModel(UiContext, new WalletModel(walletViewModel.Wallet));
+					return new WalletInfoViewModel(UiContext, walletViewModel.WalletModel);
 				}
 
 				return AuthorizeWalletInfo();
@@ -317,8 +317,7 @@ public partial class MainViewModel : ViewModelBase
 		{
 			if (UiServices.WalletManager.TryGetSelectedAndLoggedInWalletViewModel(out var walletViewModel))
 			{
-				// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
-				return new ReceiveViewModel(UiContext, WalletRepository.CreateWalletModel(walletViewModel.Wallet));
+				return new ReceiveViewModel(UiContext, walletViewModel.WalletModel);
 			}
 
 			return null;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/CancelTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/CancelTransactionDialogViewModel.cs
@@ -88,7 +88,7 @@ public partial class CancelTransactionDialogViewModel : RoutableViewModel
 	{
 		if (!string.IsNullOrEmpty(_wallet.Kitchen.SaltSoup()))
 		{
-			var result = UiContext.Navigate().To().PasswordAuthDialog(new WalletModel(_wallet));
+			var result = UiContext.Navigate().To().PasswordAuthDialog(WalletRepository.CreateWalletModel(_wallet));
 			var dialogResult = await result.GetResultAsync();
 			return dialogResult;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Features/SpeedUpTransactionDialogViewModel.cs
@@ -110,7 +110,7 @@ public partial class SpeedUpTransactionDialogViewModel : RoutableViewModel
 	{
 		if (!string.IsNullOrEmpty(_wallet.Kitchen.SaltSoup()))
 		{
-			var result = UiContext.Navigate().To().PasswordAuthDialog(new WalletModel(_wallet));
+			var result = UiContext.Navigate().To().PasswordAuthDialog(WalletRepository.CreateWalletModel(_wallet));
 			var dialogResult = await result.GetResultAsync();
 			return dialogResult;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -68,7 +68,7 @@ public partial class SendViewModel : RoutableViewModel
 		ExchangeRate = _wallet.Synchronizer.UsdExchangeRate;
 
 		// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
-		Balance = WalletRepository.CreateWalletModel(_wallet).Balances.Select(money => uiContext.AmountProvider.Create(money));
+		Balance = walletVm.WalletModel.Balances.Select(money => uiContext.AmountProvider.Create(money));
 
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -451,7 +451,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			return true;
 		}
 
-		var authDialog = AuthorizationHelpers.GetAuthorizationDialog(_wallet, transactionAuthorizationInfo);
+		var authDialog = AuthorizationHelpers.GetAuthorizationDialog(_walletViewModel.WalletModel, transactionAuthorizationInfo);
 		var authDialogResult = await NavigateDialogAsync(authDialog, authDialog.DefaultTarget, NavigationMode.Clear);
 
 		return authDialogResult.Result;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -102,15 +102,14 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 		SendCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To(new SendViewModel(UiContext, this)));
 
-		// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
-		ReceiveCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To().Receive(WalletRepository.CreateWalletModel(Wallet)));
+		ReceiveCommand = ReactiveCommand.Create(() => Navigate(NavigationTarget.DialogScreen).To().Receive(WalletModel));
 
 		WalletInfoCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
 			if (!string.IsNullOrEmpty(Wallet.Kitchen.SaltSoup()))
 			{
 				// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
-				var pwAuthDialog = new PasswordAuthDialogViewModel(WalletRepository.CreateWalletModel(Wallet));
+				var pwAuthDialog = new PasswordAuthDialogViewModel(WalletModel);
 				var dialogResult = await NavigateDialogAsync(pwAuthDialog, NavigationTarget.CompactDialogScreen);
 
 				if (!dialogResult.Result)
@@ -119,7 +118,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 				}
 			}
 
-			Navigate().To().WalletInfo(new WalletModel(Wallet));
+			Navigate().To().WalletInfo(WalletModel);
 		});
 
 		WalletStatsCommand = ReactiveCommand.Create(() => Navigate().To().WalletStats(this));
@@ -236,10 +235,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 	private IEnumerable<ActivatableViewModel> GetTiles()
 	{
-		// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
-		var walletModel = WalletRepository.CreateWalletModel(Wallet);
-
-		yield return new WalletBalanceTileViewModel(walletModel.Balances.Select(money => UiContext.AmountProvider.Create(money)));
+		yield return new WalletBalanceTileViewModel(WalletModel.Balances.Select(money => UiContext.AmountProvider.Create(money)));
 
 		if (!IsWatchOnly)
 		{

--- a/WalletWasabi.Tests/UnitTests/ViewModels/Mocks.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/Mocks.cs
@@ -28,7 +28,8 @@ public static class Mocks
 			new NullFileSystem(),
 			new NullClientConfig(),
 			new NullApplicationSettings(),
-			Mock.Of<ITransactionBroadcasterModel>());
+			Mock.Of<ITransactionBroadcasterModel>(),
+			Mock.Of<IAmountProvider>());
 	}
 
 	public static UiContext ContextWith(INavigationStack<RoutableViewModel> navigationStack)
@@ -42,7 +43,8 @@ public static class Mocks
 			new NullFileSystem(),
 			new NullClientConfig(),
 			new NullApplicationSettings(),
-			Mock.Of<ITransactionBroadcasterModel>());
+			Mock.Of<ITransactionBroadcasterModel>(),
+			Mock.Of<IAmountProvider>());
 
 		uiContext.RegisterNavigation(new TestNavigation(navigationStack));
 		return uiContext;

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -106,6 +106,8 @@ public class ReceiveAddressViewModelTests
 
 		IWalletTransactionsModel IWalletModel.Transactions => throw new NotImplementedException();
 
+		public IAmountProvider AmountProvider => throw new NotImplementedException();
+
 		public IAddress GetNextReceiveAddress(IEnumerable<string> destinationLabels)
 		{
 			throw new NotSupportedException();

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveViewModelTests.cs
@@ -76,7 +76,7 @@ public class ReceiveViewModelTests
 		public IWalletAuthModel Auth => throw new NotSupportedException();
 
 		public IObservable<bool> HasBalance => throw new NotSupportedException();
-		
+
 		public IWalletLoadWorkflow Loader => throw new NotImplementedException();
 
 		public IWalletSettingsModel Settings => throw new NotSupportedException();
@@ -94,6 +94,8 @@ public class ReceiveViewModelTests
 		public Network Network => throw new NotImplementedException();
 
 		IWalletTransactionsModel IWalletModel.Transactions => throw new NotImplementedException();
+
+		public IAmountProvider AmountProvider => throw new NotImplementedException();
 
 		public IAddress GetNextReceiveAddress(IEnumerable<string> destinationLabels)
 		{

--- a/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
@@ -170,9 +170,7 @@ public class SuggestionLabelsViewModelTests
 
 		public string Name => throw new NotSupportedException();
 
-
 		public IObservable<IChangeSet<IAddress, string>> Addresses => throw new NotSupportedException();
-
 
 		public IObservable<WalletState> State => throw new NotSupportedException();
 
@@ -201,6 +199,8 @@ public class SuggestionLabelsViewModelTests
 		public IObservable<Money> Balances => throw new NotImplementedException();
 
 		public IObservable<bool> HasBalance => throw new NotSupportedException();
+
+		public IAmountProvider AmountProvider => throw new NotImplementedException();
 
 		public IAddress GetNextReceiveAddress(IEnumerable<string> destinationLabels)
 		{

--- a/WalletWasabi.Tests/UnitTests/ViewModels/UiContextBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/UiContextBuilder.cs
@@ -47,7 +47,8 @@ public class UiContextBuilder
 			FileSystem,
 			ClientConfig,
 			new NullApplicationSettings(),
-			TransactionBroadcaster);
+			TransactionBroadcaster,
+			Mock.Of<IAmountProvider>());
 
 		uiContext.RegisterNavigation(Navigate);
 		return uiContext;


### PR DESCRIPTION
This PR Adds `IAmountProvider` to `IWalletModel`. This is to avoid having a direct dependency on `UiContext` for several ViewModels where an `IWalletModel` will suffice. 

There are many cases of ViewModels which require `IAmountProvider` in their constructor, and we know that `UiContext` can't be accessed directly from ViewModel's constructors. 

We still need need the service to be available "globally" in the `UiContext` because there are cases of ViewModels that don't work with a particular Wallet, therefore `IWalletModel` isn't available for them, but they still need to work with amounts.