### PR TITLE
[VDG] UI Decoupling #49

### DIFF
--- a/WalletWasabi.Fluent/Controls/AmountControl.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/AmountControl.axaml.cs
@@ -1,8 +1,9 @@
 using Avalonia;
 using Avalonia.Controls.Primitives;
-using WalletWasabi.Fluent.ViewModels.Wallets;
+using WalletWasabi.Fluent.Models.Wallets;
 
 namespace WalletWasabi.Fluent.Controls;
+
 public class AmountControl : TemplatedControl
 {
 	public static readonly StyledProperty<Amount> AmountProperty = AvaloniaProperty.Register<AmountControl, Amount>(nameof(Amount));

--- a/WalletWasabi.Fluent/Infrastructure/ClipboardObserver.cs
+++ b/WalletWasabi.Fluent/Infrastructure/ClipboardObserver.cs
@@ -3,7 +3,7 @@ using System.Reactive.Linq;
 using NBitcoin;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.ViewModels.Wallets;
+using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Helpers;
 using WalletWasabi.Userfacing;
 

--- a/WalletWasabi.Fluent/Models/Wallets/Amount.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/Amount.cs
@@ -1,8 +1,7 @@
 using System.Reactive.Linq;
 using NBitcoin;
-using WalletWasabi.Fluent.Models.Wallets;
 
-namespace WalletWasabi.Fluent.ViewModels.Wallets;
+namespace WalletWasabi.Fluent.Models.Wallets;
 
 public class Amount
 {

--- a/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
@@ -6,6 +6,7 @@ using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.ViewModels.Wallets;
 using WalletWasabi.Fluent.ViewModels.Wallets.Labels;
 using WalletWasabi.Wallets;
 
@@ -20,6 +21,7 @@ public partial class WalletModel : ReactiveObject
 	public WalletModel(Wallet wallet, IAmountProvider amountProvider)
 	{
 		Wallet = wallet;
+		AmountProvider = amountProvider;
 
 		Auth = new WalletAuthModel(this, Wallet);
 		Loader = new WalletLoadWorkflow(Wallet);
@@ -42,9 +44,13 @@ public partial class WalletModel : ReactiveObject
 
 		Privacy = new WalletPrivacyModel(this, Wallet);
 
-		Balances = Observable.Defer(() => Observable.Return(Wallet.Coins.TotalAmount())).Concat(Transactions.TransactionProcessed.Select(_ => Wallet.Coins.TotalAmount()));
+		Balances =
+			Observable.Defer(() => Observable.Return(Wallet.Coins.TotalAmount()))
+					  .Concat(Transactions.TransactionProcessed
+					  .Select(_ => Wallet.Coins.TotalAmount()))
+					  .Select(AmountProvider.Create);
 
-		HasBalance = Balances.Select(x => x != Money.Zero);
+		HasBalance = Balances.Select(x => x.HasBalance);
 
 		// Start the Loader after wallet is logged in
 		this.WhenAnyValue(x => x.Auth.IsLoggedIn)
@@ -57,8 +63,6 @@ public partial class WalletModel : ReactiveObject
 		State.Where(x => x == WalletState.Started)
 			 .Do(_ => Loader.Stop())
 			 .Subscribe();
-
-		AmountProvider = amountProvider;
 	}
 
 	internal Wallet Wallet { get; }
@@ -69,7 +73,7 @@ public partial class WalletModel : ReactiveObject
 
 	public IWalletTransactionsModel Transactions { get; }
 
-	public IObservable<Money> Balances { get; }
+	public IObservable<Amount> Balances { get; }
 
 	public IObservable<bool> HasBalance { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -90,8 +90,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		ConfigureStateMachine();
 
 		wallet.Balances
-					   .Do(_ => _stateMachine.Fire(Trigger.BalanceChanged))
-					   .Subscribe();
+			  .Do(_ => _stateMachine.Fire(Trigger.BalanceChanged))
+			  .Subscribe();
 
 		PlayCommand = ReactiveCommand.CreateFromTask(async () =>
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using NBitcoin;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Models.UI;
+using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems;
 
@@ -29,8 +30,8 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 		NextCommand = CancelCommand;
 
-        ConfirmationTime = TimeSpan.Zero; // TODO: Calculate confirmation time
-        IsConfirmationTimeVisible = ConfirmationTime.HasValue && ConfirmationTime != TimeSpan.Zero;
+		ConfirmationTime = TimeSpan.Zero; // TODO: Calculate confirmation time
+		IsConfirmationTimeVisible = ConfirmationTime.HasValue && ConfirmationTime != TimeSpan.Zero;
 		Update();
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinsDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinsDetailsViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using NBitcoin;
 using WalletWasabi.Fluent.Models.UI;
+using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.History.HistoryItems;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/WalletBalanceTileViewModel.cs
@@ -1,3 +1,5 @@
+using WalletWasabi.Fluent.Models.Wallets;
+
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles;
 
 public class WalletBalanceTileViewModel : ActivatableViewModel

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -67,8 +67,7 @@ public partial class SendViewModel : RoutableViewModel
 
 		ExchangeRate = _wallet.Synchronizer.UsdExchangeRate;
 
-		// TODO: Remove reference to WalletRepository when this ViewModel is Decoupled
-		Balance = walletVm.WalletModel.Balances.Select(money => uiContext.AmountProvider.Create(money));
+		Balance = walletVm.WalletModel.Balances;
 
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -2,6 +2,7 @@ using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -235,7 +235,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 	private IEnumerable<ActivatableViewModel> GetTiles()
 	{
-		yield return new WalletBalanceTileViewModel(WalletModel.Balances.Select(money => UiContext.AmountProvider.Create(money)));
+		yield return new WalletBalanceTileViewModel(WalletModel.Balances);
 
 		if (!IsWatchOnly)
 		{

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -96,7 +96,7 @@ public class ReceiveAddressViewModelTests
 
 		public IWalletCoinjoinModel Coinjoin => throw new NotSupportedException();
 
-		public IObservable<Money> Balances => throw new NotSupportedException();
+		public IObservable<Amount> Balances => throw new NotSupportedException();
 
 		IWalletCoinsModel IWalletModel.Coins => throw new NotImplementedException();
 

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveViewModelTests.cs
@@ -85,7 +85,7 @@ public class ReceiveViewModelTests
 
 		public IWalletCoinjoinModel Coinjoin => throw new NotSupportedException();
 
-		public IObservable<Money> Balances => throw new NotSupportedException();
+		public IObservable<Amount> Balances => throw new NotSupportedException();
 
 		IWalletCoinsModel IWalletModel.Coins => throw new NotImplementedException();
 

--- a/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
@@ -196,7 +196,7 @@ public class SuggestionLabelsViewModelTests
 
 		IWalletTransactionsModel IWalletModel.Transactions => throw new NotImplementedException();
 
-		public IObservable<Money> Balances => throw new NotImplementedException();
+		public IObservable<Amount> Balances => throw new NotImplementedException();
 
 		public IObservable<bool> HasBalance => throw new NotSupportedException();
 


### PR DESCRIPTION
This PR moves the `Amount` class to the Model layer (and corresponding namespace).

This class really belongs there, as it's just a wrapper over `Money` plus an observable for fiat equivalent based on exchange rate.

Also, since both `UiContext` and `WalletModel` have a reference to this type, and these classes are Models, it follows that the `Amount` is also a model, because Models can't really depend on ViewModel otherwise we'd be mixing layers in an incorrect way.