### PR TITLE
[Trivial] Reduce log level when Warden stops

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Warden.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Warden.cs
@@ -78,6 +78,10 @@ public class Warden : BackgroundService
 				}
 			}
 		}
+		catch (OperationCanceledException)
+		{
+			Logger.LogInfo("Warden was requested to stop.");
+		}
 		catch (Exception ex)
 		{
 			Logger.LogError(ex);


### PR DESCRIPTION
Whenever I stop the server on RegTest, this is how the log looks like:

```
2023-10-03 12:43:04.902 [28] INFO	HostedServices.StopAllAsync (88)	Stopped Block Notifier.
2023-10-03 12:43:04.902 [29] INFO	HostedServices.StopAllAsync (88)	Stopped Full Node Mempool Mirror.
2023-10-03 12:43:04.905 [28] ERROR	Warden.ExecuteAsync (83)	System.OperationCanceledException: The operation was canceled.
   at System.Threading.Channels.AsyncOperation`1.GetResult(Int16 token)
   at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+MoveNext()
   at WalletWasabi.WabiSabi.Backend.DoSPrevention.Warden.ExecuteAsync(CancellationToken cancel) in WalletWasabi\WabiSabi\Backend\DoSPrevention\Warden.cs:line 74
   at WalletWasabi.WabiSabi.Backend.DoSPrevention.Warden.ExecuteAsync(CancellationToken cancel) in WalletWasabi\WabiSabi\Backend\DoSPrevention\Warden.cs:line 74
2023-10-03 12:43:04.906 [28] INFO	HostedServices.StopAllAsync (88)	Stopped WabiSabi Coordinator.
2023-10-03 12:43:04.907 [28] INFO	HostedServices.Dispose (147)	Disposed Block Notifier.
```

and it scares me every time! 😅

PR:
```
2023-10-03 12:48:30.343 [4] INFO	HostedServices.StopAllAsync (88)	Stopped Full Node Mempool Mirror.
2023-10-03 12:48:30.344 [7] INFO	Warden.ExecuteAsync (83)	Warden was requested to stop.
2023-10-03 12:48:30.344 [22] INFO	HostedServices.StopAllAsync (88)	Stopped Block Notifier.
```