### PR TITLE
[vdg] clarify Transaction Broadcaster dialog caption

### DIFF
--- a/WalletWasabi.Fluent/Views/TransactionBroadcasting/LoadTransactionView.axaml
+++ b/WalletWasabi.Fluent/Views/TransactionBroadcasting/LoadTransactionView.axaml
@@ -9,7 +9,7 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.TransactionBroadcasting.LoadTransactionView">
   <c:ContentArea Title="{Binding Title}"
-                 Caption="Import or paste the transaction and broadcast it to the network."
+                 Caption="Import or paste the transaction hex and broadcast it to the network."
                  EnableCancel="{Binding EnableCancel}"
                  EnableBack="{Binding EnableBack}">
     <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">


### PR DESCRIPTION
current
![image](https://github.com/zkSNACKs/WalletWasabi/assets/93143998/9e7c7293-ce42-4a47-9f56-31ca9fa12b4e)

over time, several people reached out that they were not able to paste their tx.
It turned out that they were pasting the TxID instead of the hex.

so just a small clarification.

shouldn't be controversial that _hex_ is technical as this is for advanced usage anyway.