### PR TITLE
Fix coinjoins shared overhead calculation

### DIFF
--- a/WalletWasabi/Helpers/VirtualSizeHelpers.cs
+++ b/WalletWasabi/Helpers/VirtualSizeHelpers.cs
@@ -6,7 +6,12 @@ public static class VirtualSizeHelpers
 	public const int SegwitByteInWeightUnits = 1;
 	public const int VirtualByteInWeightUnits = 4;
 
-	public static int WeightUnitsToVirtualSize(int weightUnits) => weightUnits / VirtualByteInWeightUnits + (weightUnits % VirtualByteInWeightUnits == 0 ? 0 : 1); // ceiling(VirtualSize / VirtualByteInWeightUnits)
+	public static int WeightUnitsToVirtualSize(int weightUnits) =>
+		weightUnits / VirtualByteInWeightUnits + (weightUnits % VirtualByteInWeightUnits == 0 ? 0 : 1); // ceiling(VirtualSize / VirtualByteInWeightUnits)
 
-	public static int VirtualSize(int nonSegwitBytes, int segwitBytes) => WeightUnitsToVirtualSize(NonSegwitByteInWeightUnits * nonSegwitBytes + SegwitByteInWeightUnits * segwitBytes);
+	public static int VirtualSize(int nonSegwitBytes, int segwitBytes) =>
+		WeightUnitsToVirtualSize(WeightUnits(nonSegwitBytes, segwitBytes));
+
+	public static int WeightUnits(int nonSegwitBytes, int segwitBytes) =>
+		NonSegwitByteInWeightUnits * nonSegwitBytes + SegwitByteInWeightUnits * segwitBytes;
 }

--- a/WalletWasabi/Helpers/VirtualSizeHelpers.cs
+++ b/WalletWasabi/Helpers/VirtualSizeHelpers.cs
@@ -1,6 +1,6 @@
 namespace WalletWasabi.Helpers;
 
-public static class ScriptSizeHelpers
+public static class VirtualSizeHelpers
 {
 	public const int NonSegwitByteInWeightUnits = 4;
 	public const int SegwitByteInWeightUnits = 1;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -336,8 +336,8 @@ public partial class Arena : PeriodicRunner
 
 					round.LogInfo($"Number of inputs: {coinjoin.Inputs.Count}.");
 					round.LogInfo($"Number of outputs: {coinjoin.Outputs.Count}.");
-					round.LogInfo($"Serialized Size: {coinjoin.GetSerializedSize() / 1024} KB.");
-					round.LogInfo($"VSize: {coinjoin.GetVirtualSize() / 1024} KB.");
+					round.LogInfo($"Serialized Size: {coinjoin.GetSerializedSize() / 1024.0} KB.");
+					round.LogInfo($"VSize: {coinjoin.GetVirtualSize() / 1024.0} KB.");
 					var indistinguishableOutputs = coinjoin.GetIndistinguishableOutputs(includeSingle: true);
 					foreach (var (value, count) in indistinguishableOutputs.Where(x => x.count > 1))
 					{

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
@@ -1,9 +1,23 @@
+using NBitcoin.Protocol;
+
 namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 // This represents parameters all clients must agree on to produce a valid &
 // standard transaction subject to constraints.
 public record MultipartyTransactionParameters
 {
+	public static int SharedOverhead =  SharedOverheadFn(255, 255);
+
 	// version, locktime, two 3 byte varints are non-witness data, marker and flags are witness data.
-	public static int SharedOverhead = 4 * (4 + 4 + 3 + 3) + 1 + 1;
+	private static int SharedOverheadFn(long minInputCount, long minOutputCount) =>
+		4 * (4 + 4 + VarIntLength(minInputCount) + VarIntLength(minOutputCount)) + 1 + 1;
+
+	private static int VarIntLength(long value) =>
+		value switch
+		{
+			<  0xfd => 1,
+			<= 0xffff => 3,
+			<= 0xffffffff => 5,
+			_ => 9
+		};
 }

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
@@ -22,7 +22,7 @@ public record MultipartyTransactionParameters
 			1 + // marker
 			1;  // flag
 
-		return VirtualSizeHelpers.VirtualSize(nonSegwitData, segwitData);
+		return VirtualSizeHelpers.WeightUnits(nonSegwitData, segwitData);
 	}
 
 	private static int VarIntLength(long value) =>

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
@@ -1,4 +1,5 @@
 using NBitcoin.Protocol;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
@@ -9,8 +10,20 @@ public record MultipartyTransactionParameters
 	public static int SharedOverhead =  SharedOverheadFn(255, 255);
 
 	// version, locktime, two 3 byte varints are non-witness data, marker and flags are witness data.
-	private static int SharedOverheadFn(long minInputCount, long minOutputCount) =>
-		4 * (4 + 4 + VarIntLength(minInputCount) + VarIntLength(minOutputCount)) + 1 + 1;
+	private static int SharedOverheadFn(long minInputCount, long minOutputCount)
+	{
+		var nonSegwitData =
+			4 + // version
+			4 + // locktime
+			VarIntLength(minInputCount) +  // varint ins
+			VarIntLength(minOutputCount);  // varint outs
+
+		var segwitData =
+			1 + // marker
+			1;  // flag
+
+		return VirtualSizeHelpers.VirtualSize(nonSegwitData, segwitData);
+	}
 
 	private static int VarIntLength(long value) =>
 		value switch

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
@@ -7,7 +7,7 @@ namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 // standard transaction subject to constraints.
 public record MultipartyTransactionParameters
 {
-	public static int SharedOverhead =  SharedOverheadFn(255, 255);
+	public static readonly int SharedOverhead = SharedOverheadFn(255, 255);
 
 	// version, locktime, two 3 byte varints are non-witness data, marker and flags are witness data.
 	private static int SharedOverheadFn(long minInputCount, long minOutputCount)

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
@@ -57,7 +57,7 @@ public record SigningState : MultipartyTransactionState
 		Coin registeredCoin = SortedInputs[index];
 
 		// 2. Check the witness is not too long.
-		if (ScriptSizeHelpers.VirtualSize(Constants.InputBaseSizeInBytes, witness.ToBytes().Length) > registeredCoin.ScriptPubKey.EstimateInputVsize())
+		if (VirtualSizeHelpers.VirtualSize(Constants.InputBaseSizeInBytes, witness.ToBytes().Length) > registeredCoin.ScriptPubKey.EstimateInputVsize())
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.SignatureTooLong);
 		}


### PR DESCRIPTION
On testnet, when the size of the coinjoin transaction is small, the weight of the transaction shared overhead is greater and can fall below the minimum transaction relay, failing to broadcast it.

The current shared overhead assumes the number of inputs and outputs is greater than 254, what is false in testnet in most of the cases. This is why this problem is important for `TestNet` only.

  