### PR TITLE
[VDG] Fix ItemStatus of Coinjoin Group

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryItems/CoinJoinsHistoryItemViewModel.cs
@@ -88,6 +88,7 @@ public partial class CoinJoinsHistoryItemViewModel : HistoryItemViewModelBase
 	private void Refresh()
 	{
 		IsConfirmed = CoinJoinTransactions.All(x => x.IsConfirmed());
+		ItemStatus = GetItemStatus();
 		ConfirmedToolTip = GetConfirmedToolTip(CoinJoinTransactions.Select(x => x.GetConfirmations()).Min());
 		Date = CoinJoinTransactions.Select(tx => tx.FirstSeen).Max().ToLocalTime();
 


### PR DESCRIPTION
Master:

When you have an unconfirmed CJ inside a CJ group, the group says it's confirmed and has the confirmed icon.

<img width="441" alt="image" src="https://github.com/zkSNACKs/WalletWasabi/assets/45069029/9354fcd7-4816-494a-a54f-52c94eec5c68">


PR:
<img width="477" alt="image" src="https://github.com/zkSNACKs/WalletWasabi/assets/45069029/6695cc45-ed57-40c4-823f-ccb2ee266a55">


