### PR TITLE
`EnumerableExtensions`: Remove unused method

### DIFF
--- a/WalletWasabi.Fluent/Extensions/EnumerableExtension.cs
+++ b/WalletWasabi.Fluent/Extensions/EnumerableExtension.cs
@@ -9,16 +9,4 @@ public static class EnumerableExtensions
 		enumerable
 			.Where(x => x is not null)
 			.Select(x => x!);
-
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
-	public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> enumerable)
-	{
-		foreach (var item in enumerable)
-		{
-			yield return item;
-		}
-	}
-
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 }


### PR DESCRIPTION
Removes an unused method and fixes a warning.