### PR TITLE
Fix .txn file import for ColdCards

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NBitcoin;
-using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -11,9 +10,9 @@ using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Fluent.ViewModels.Wallets.Send;
+using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Wallets;
-using WalletWasabi.WebClients.PayJoin;
 
 namespace WalletWasabi.Fluent.Helpers;
 
@@ -102,6 +101,7 @@ public static class TransactionHelpers
 		catch
 		{
 			// Couldn't parse to PSBT with bytes, try parsing with string.
+			Logger.LogWarning("Failed to load PSBT by bytes. Trying with string.");
 			var text = await File.ReadAllTextAsync(path);
 			text = text.Trim();
 			try
@@ -111,6 +111,7 @@ public static class TransactionHelpers
 			catch
 			{
 				// Couldn't parse to PSBT with string. All else failed, try to build SmartTransaction and broadcast that.
+				Logger.LogWarning("Failed to parse PSBT by string. Fall back to building SmartTransaction from the string.");
 				return new SmartTransaction(Transaction.Parse(text, network), Height.Unknown);
 			}
 		}

--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -101,7 +101,7 @@ public static class TransactionHelpers
 		}
 		catch
 		{
-			// Couldn't parse to PSTB with bytes, try parsing with string.
+			// Couldn't parse to PSBT with bytes, try parsing with string.
 			var text = await File.ReadAllTextAsync(path);
 			text = text.Trim();
 			try

--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -99,12 +99,9 @@ public static class TransactionHelpers
 		{
 			psbt = PSBT.Load(psbtBytes, network);
 		}
-		catch (FormatException ex)
-		{
-			throw new FormatException("An error occurred while loading the PSBT file.", ex);
-		}
 		catch
 		{
+			// Couldn't parse to PSTB with bytes, try parsing with string.
 			var text = await File.ReadAllTextAsync(path);
 			text = text.Trim();
 			try
@@ -113,6 +110,7 @@ public static class TransactionHelpers
 			}
 			catch
 			{
+				// Couldn't parse to PSBT with string. All else failed, try to build SmartTransaction and broadcast that.
 				return new SmartTransaction(Transaction.Parse(text, network), Height.Unknown);
 			}
 		}

--- a/WalletWasabi.Fluent/ViewModels/TransactionBroadcasting/LoadTransactionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/TransactionBroadcasting/LoadTransactionViewModel.cs
@@ -43,7 +43,7 @@ public partial class LoadTransactionViewModel : DialogViewModelBase<SmartTransac
 	{
 		try
 		{
-			var path = await FileDialogHelper.ShowOpenFileDialogAsync("Import Transaction", new[] { "psbt", "*" });
+			var path = await FileDialogHelper.ShowOpenFileDialogAsync("Import Transaction", new[] { "psbt", "txn", "*" });
 			if (path is { })
 			{
 				FinalTransaction = await UiContext.TransactionBroadcaster.LoadFromFileAsync(path);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/HardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/HardwareWalletViewModel.cs
@@ -16,7 +16,7 @@ public class HardwareWalletViewModel : WalletViewModel
 		{
 			try
 			{
-				var path = await FileDialogHelper.ShowOpenFileDialogAsync("Import Transaction", new[] { "psbt", "*" });
+				var path = await FileDialogHelper.ShowOpenFileDialogAsync("Import Transaction", new[] { "psbt", "txn", "*" });
 				if (path is { })
 				{
 					var txn = await TransactionHelpers.ParseTransactionAsync(path, parent.Wallet.Network);


### PR DESCRIPTION
Addresses: https://github.com/zkSNACKs/WalletWasabi/issues/9856#issuecomment-1753125713

Might fix completely: https://github.com/zkSNACKs/WalletWasabi/issues/9856

When the user sets this settings on ColdCard (`settings>delete psbts>normal/delete)` to `delete`,
ColdCard deletes the PSBT files from the SD card.
What's left is a signed `.txn` file.

Wasabi almost supported this, but because we throw this ex:
`throw new FormatException("An error occurred while loading the PSBT file.", ex);`
the fallback mechanism didn't have a chance to run.

With this PR I was able to broadcast the .txn file properly.