### PR TITLE
Add `feeRate` to `build` and `send` rpc interface

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -216,20 +216,31 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("build")]
-	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int feeTarget, string? password = null)
+	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, int? feeRate = null, string? password = null)
 	{
 		Guard.NotNull(nameof(payments), payments);
 		Guard.NotNull(nameof(coins), coins);
-		Guard.InRangeAndNotNull(nameof(feeTarget), feeTarget, 2, Constants.SevenDaysConfirmationTarget);
 		password = Guard.Correct(password);
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
+		static bool InRange<T>(IComparable<T> val, T min, T max) =>
+			val.CompareTo(min) >= 0 && val.CompareTo(max) <= 0;
+
+		var feeRateK = feeRate is {} nonNullFeeRate ? new FeeRate(Money.Satoshis(nonNullFeeRate * 1_000L)) : FeeRate.Zero;
+
+		var feeStrategy = (feeRate, feeTarget) switch
+		{
+			(not null, null) when InRange(feeRateK, Constants.MinRelayFeeRate, Constants.AbsurdlyHighFeeRate) =>
+				FeeStrategy.CreateFromFeeRate(feeRateK),
+			(null, {} argFeeTarget) when InRange(argFeeTarget, Constants.TwentyMinutesConfirmationTarget, Constants.SevenDaysConfirmationTarget) =>
+				FeeStrategy.CreateFromConfirmationTarget(argFeeTarget),
+			_ => throw new ArgumentException("Fee parameters are missing, inconsistent or out of range.")
+		};
 		AssertWalletIsLoaded();
 		var payment = new PaymentIntent(
 			payments.Select(
 				p =>
 				new DestinationRequest(p.Sendto.ScriptPubKey, MoneyRequest.Create(p.Amount, p.SubtractFee), new LabelsArray(p.Label))));
-		var feeStrategy = FeeStrategy.CreateFromConfirmationTarget(feeTarget);
 		var result = activeWallet.BuildTransaction(
 			password,
 			payment,
@@ -242,10 +253,10 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("send")]
-	public async Task<object> SendTransactionAsync(PaymentInfo[] payments, OutPoint[] coins, int feeTarget, string? password = null)
+	public async Task<object> SendTransactionAsync(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, int? feeRate = null, string? password = null)
 	{
 		password = Guard.Correct(password);
-		var txHex = BuildTransaction(payments, coins, feeTarget, password);
+		var txHex = BuildTransaction(payments, coins, feeTarget, feeRate, password);
 		var smartTx = new SmartTransaction(Transaction.Parse(txHex, Global.Network), Height.Mempool);
 
 		await Global.TransactionBroadcaster.SendTransactionAsync(smartTx).ConfigureAwait(false);

--- a/WalletWasabi.Tests/RpcTests.cs
+++ b/WalletWasabi.Tests/RpcTests.cs
@@ -2,7 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using Newtonsoft.Json;
+using WalletWasabi.Daemon.Rpc;
 using WalletWasabi.Rpc;
 using Xunit;
 
@@ -96,6 +98,38 @@ public class RpcTests
 
 		var response = await handler.HandleAsync("", request, CancellationToken.None);
 		Assert.Equal(expectedResponse, response);
+	}
+
+	[Fact]
+	public void BuildTransactionWithFees()
+	{
+		var service = new WasabiJsonRpcService(null);
+		var paymentInfo = new PaymentInfo
+		{
+			Amount = Money.Coins(1),
+			Sendto = BitcoinAddress.Create("bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah", Network.Main),
+			Label = "Cesar"
+		};
+
+		void BuildTransaction(int? feeTarget = null, int? feeRate = null) =>
+			service.BuildTransaction(new[] { paymentInfo }, Array.Empty<OutPoint>(), feeTarget, feeRate);
+
+		// No fee information is provided
+		Assert.Throws<ArgumentException>(() => BuildTransaction());
+
+		// Invalid feeTarget (out of range)
+		Assert.Throws<ArgumentException>(() => BuildTransaction(feeTarget: -4));
+		Assert.Throws<ArgumentException>(() => BuildTransaction(feeTarget: 0));
+		Assert.Throws<ArgumentException>(() => BuildTransaction(feeTarget: 2000));
+
+		// Invalid feeRate (out of range)
+		Assert.Throws<ArgumentException>(() => BuildTransaction(feeRate: 0));
+		Assert.Throws<ArgumentException>(() => BuildTransaction(feeRate: 20_000));
+
+		// Contradictory fee information (both feeRate and feeTarget are present)
+		Assert.Throws<ArgumentException>(() => BuildTransaction(feeRate: 20, feeTarget: 8));
+		Assert.Throws<InvalidOperationException>(() => BuildTransaction(feeRate: 20));
+		Assert.Throws<InvalidOperationException>(() => BuildTransaction(feeTarget: 1008));
 	}
 
 	private static string Request(string id, string methodName, params object[] parameters)

--- a/WalletWasabi.Tests/RpcTests.cs
+++ b/WalletWasabi.Tests/RpcTests.cs
@@ -111,7 +111,7 @@ public class RpcTests
 			Label = "Cesar"
 		};
 
-		void BuildTransaction(int? feeTarget = null, int? feeRate = null) =>
+		void BuildTransaction(int? feeTarget = null, decimal? feeRate = null) =>
 			service.BuildTransaction(new[] { paymentInfo }, Array.Empty<OutPoint>(), feeTarget, feeRate);
 
 		// No fee information is provided

--- a/WalletWasabi.Tests/UnitTests/RpcTests.cs
+++ b/WalletWasabi.Tests/UnitTests/RpcTests.cs
@@ -8,7 +8,7 @@ using WalletWasabi.Daemon.Rpc;
 using WalletWasabi.Rpc;
 using Xunit;
 
-namespace WalletWasabi.Tests;
+namespace WalletWasabi.Tests.UnitTests;
 
 public class RpcTests
 {

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -83,6 +83,9 @@ public static class Constants
 	public static readonly Version Ww1LegalDocumentsVersion = new(3, 0);
 	public static readonly Version Ww2LegalDocumentsVersion = new(1, 0);
 
+	public static readonly FeeRate MinRelayFeeRate = new (1m);
+	public static readonly FeeRate AbsurdlyHighFeeRate = new (10_000m);
+
 	// Defined in hours. Do not modify these values or the order!
 	public static readonly int[] CoinJoinFeeRateMedianTimeFrames = new[] { 24, 168, 720 };
 

--- a/WalletWasabi/Rpc/JsonRpcRequestHandler.cs
+++ b/WalletWasabi/Rpc/JsonRpcRequestHandler.cs
@@ -109,6 +109,11 @@ public class JsonRpcRequestHandler<TService>
 					var parameter = methodParameters[i];
 					if (!jObj.ContainsKey(parameter.name))
 					{
+						if (parameter.isOptional)
+						{
+							parameters.Add(parameter.defaultValue);
+							continue;
+						}
 						return Error(
 							JsonRpcErrorCodes.InvalidParams,
 							$"A value for the '{parameter.name}' is missing.",


### PR DESCRIPTION
This is based on @NabiSabi PR #3696 which was okay but the [JsonRpcRequestHandler.cs](https://github.com/zkSNACKs/WalletWasabi/compare/master...lontivero:WalletWasabi:rpc-feerate-build?expand=1#diff-15a4dc01afb2e9b1dba8a1ff94b3fafdb4a81cb2bcaa831c2f5c3cec66befa6b) didn't know how to handle the optional values.

Here we add support for optional values and take the code from #3696 almost as it was. 

You can use the example from the original PR to test it:

```
$ curl -s \
 --user wasabiuser:wasabiuserpassword \
 -H -- 'content-type: text/plain;' \
 --binary-data  '{"jsonrpc":"2.0","id":"1","method":"send", "params": { "payments":[ {"sendto": "tb1qgvnht40a08gumw32kp05hs8mny954hp2snhxcz", "amount": 15000, "label": "David" }, {"sendto":"tb1qpyhfrpys6skr2mmnc35p3dp7zlv9ew4k0gn7qm", "amount": 86200, "label": "Michael"} ], "coins":[{"transactionid":"ab83d9d0b2a9873b8ab0dc48b618098f3e7fbd807e27a10f789e9bc330ca89f7", "index":0}], "feeRate":234, "password": "password1234" }}' \
  http://127.0.0.1:37128/<wallet-name> 

  
```