### PR TITLE
[VDG][Trivial] Order bitcoin node settings

### DIFF
--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -23,6 +23,11 @@
       <ToggleSwitch IsChecked="{Binding Settings.StartLocalBitcoinCoreOnStartup}" />
     </DockPanel>
 
+    <DockPanel IsVisible="{Binding Settings.StartLocalBitcoinCoreOnStartup}">
+      <TextBlock Text="Stop Bitcoin Knots on shutdown" />
+      <ToggleSwitch IsChecked="{Binding Settings.StopLocalBitcoinCoreOnShutdown}" />
+    </DockPanel>
+
     <StackPanel Spacing="10" IsVisible="{Binding Settings.StartLocalBitcoinCoreOnStartup}">
       <TextBlock Text="Bitcoin Core/Knots Data Folder" />
       <TextBox Text="{Binding Settings.LocalBitcoinCoreDataDir}" />
@@ -31,11 +36,6 @@
     <DockPanel>
       <TextBlock VerticalAlignment="Center" Text="Local Bitcoin Core/Knots version" />
       <Label Content="{Binding BitcoinCoreVersion}" />
-    </DockPanel>
-
-    <DockPanel IsVisible="{Binding Settings.StartLocalBitcoinCoreOnStartup}">
-      <TextBlock Text="Stop Bitcoin Knots on shutdown" />
-      <ToggleSwitch IsChecked="{Binding Settings.StopLocalBitcoinCoreOnShutdown}" />
     </DockPanel>
 
     <DockPanel IsVisible="{Binding !Settings.StartLocalBitcoinCoreOnStartup}"

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -28,15 +28,15 @@
       <ToggleSwitch IsChecked="{Binding Settings.StopLocalBitcoinCoreOnShutdown}" />
     </DockPanel>
 
+    <DockPanel IsVisible="{Binding Settings.StartLocalBitcoinCoreOnStartup}">
+      <TextBlock VerticalAlignment="Center" Text="Local Bitcoin Core/Knots version" />
+      <Label Content="{Binding BitcoinCoreVersion}" />
+    </DockPanel>
+
     <StackPanel Spacing="10" IsVisible="{Binding Settings.StartLocalBitcoinCoreOnStartup}">
       <TextBlock Text="Bitcoin Core/Knots Data Folder" />
       <TextBox Text="{Binding Settings.LocalBitcoinCoreDataDir}" />
     </StackPanel>
-
-    <DockPanel>
-      <TextBlock VerticalAlignment="Center" Text="Local Bitcoin Core/Knots version" />
-      <Label Content="{Binding BitcoinCoreVersion}" />
-    </DockPanel>
 
     <DockPanel IsVisible="{Binding !Settings.StartLocalBitcoinCoreOnStartup}"
                ToolTip.Tip="Wasabi will download blocks from a full node you control.">


### PR DESCRIPTION
Moved up `Stop Bitcoin Knots on shutdown` and `Local Bitcoin Core/Knots version` settings, and made the node version setting visible only if `StartLocalBitcoinCoreOnStartup` is on.

Master:

![bbb](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/edb31e30-a731-406e-bb03-d34d4687a933)

PR:

![aaa](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/9fc85f69-940e-4f56-9ba4-762572a029eb)
