### PR TITLE
Add failing JSON RPC Parse test

### DIFF
--- a/WalletWasabi.Tests/UnitTests/RpcTests.cs
+++ b/WalletWasabi.Tests/UnitTests/RpcTests.cs
@@ -132,6 +132,19 @@ public class RpcTests
 		Assert.Throws<InvalidOperationException>(() => BuildTransaction(feeTarget: 1008));
 	}
 
+	[Fact]
+	public void CanParseRequest()
+	{
+		var request = "['{jsonrpc:2.0,id:1,method:getwalletinfo}']";
+
+		var result = JsonRpcRequest.TryParse(request, out var requests, out var isBatch);
+
+		Assert.True(result);
+		Assert.NotNull(requests);
+		Assert.Single(requests);
+		Assert.False(isBatch);
+	}
+
 	private static string Request(string id, string methodName, params object[] parameters)
 	{
 		return ToJson(new


### PR DESCRIPTION
@lontivero can you fix it? I added a failing test, so now it should be a piece of cake for you from here on. As I look at it, it's not obvious why it's failing.

Unit test to reproduce https://github.com/zkSNACKs/WalletWasabi/issues/11678