### PR TITLE
`CoinsView`: Optimize `ChildrenOf`

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsView.cs
@@ -10,6 +10,8 @@ namespace WalletWasabi.Blockchain.TransactionOutputs;
 
 public class CoinsView : ICoinsView
 {
+	private static readonly ICoinsView EmptyCoinsView = new CoinsView(Array.Empty<SmartCoin>());
+
 	public CoinsView(IEnumerable<SmartCoin> coins)
 	{
 		Coins = Guard.NotNull(nameof(coins), coins);
@@ -33,7 +35,9 @@ public class CoinsView : ICoinsView
 
 	public ICoinsView SpentBy(uint256 txid) => new CoinsView(Coins.Where(x => x.SpenderTransaction is { } && x.SpenderTransaction.GetHash() == txid));
 
-	public ICoinsView ChildrenOf(SmartCoin coin) => new CoinsView(Coins.Where(x => coin.SpenderTransaction is { } && x.TransactionId == coin.SpenderTransaction.GetHash()));
+	public ICoinsView ChildrenOf(SmartCoin coin) => coin.SpenderTransaction is null
+		? EmptyCoinsView
+		: new CoinsView(Coins.Where(x => x.TransactionId == coin.SpenderTransaction.GetHash()));
 
 	public ICoinsView DescendantOf(SmartCoin coin)
 	{


### PR DESCRIPTION
There is no reason to iterate if `coin.SpenderTransaction is null`