### PR TITLE
Add and use `TransactionFactoryParameters` class

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -65,15 +65,13 @@ public static class TransactionHelpers
 				label: transactionInfo.Recipient);
 
 			var network = keyManager.GetNetwork();
-			var builder = new TransactionFactory(network, keyManager, allCoins, new EmptyTransactionStore(network), password, true);
+			TransactionFactoryParameters parameters = new(FeeRateFetcher: () => transactionInfo.FeeRate, AllowUnconfirmed: false, AllowDoubleSpend: false, AllowedInputs: allowedCoins.Select(x => x.Outpoint), TryToSign: false);
+			var builder = new TransactionFactory(network, keyManager, allCoins, new EmptyTransactionStore(network), parameters, password);
 
 			builder.BuildTransaction(
 				intent,
-				feeRateFetcher: () => transactionInfo.FeeRate,
-				allowedCoins.Select(x => x.Outpoint),
 				lockTimeSelector: () => LockTime.Zero, // Doesn't matter.
-				transactionInfo.PayJoinClient,
-				tryToSign: false);
+				transactionInfo.PayJoinClient);
 
 			return true;
 		}

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -16,7 +16,7 @@ public static class ServiceFactory
 		bool allowUnconfirmed = true,
 		bool watchOnly = false,
 		bool allowDoubleSpend = false,
-		string[]? allowedInputsKeys = null,
+		int[]? allowedInputsIndexes = null,
 		bool tryToSign = true)
 	{
 		var password = "foo";
@@ -56,9 +56,13 @@ public static class ServiceFactory
 		}
 
 		IEnumerable<SmartCoin>? allowedInputs = null;
-		if (allowedInputsKeys is not null)
+		if (allowedInputsIndexes is not null)
 		{
-			allowedInputs = sCoins.Where(coin => allowedInputsKeys.Contains(coin.HdPubKey.Labels.ToString()));
+			allowedInputs = new List<SmartCoin>();
+			foreach (var i in allowedInputsIndexes)
+			{
+				allowedInputs.Append(sCoins[i]);
+			}
 		}
 
 		var coinsView = new CoinsView(sCoins);

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -70,7 +70,8 @@ public static class ServiceFactory
 
 		feeRateFetcher ??= () => new FeeRate(2m);
 
-		return new TransactionFactory(Network.Main, keyManager, coinsView, mockTransactionStore, password, allowUnconfirmed);
+		TransactionFactoryParameters parameters = new(FeeRateFetcher: feeRateFetcher, AllowUnconfirmed: allowUnconfirmed, AllowDoubleSpend: allowDoubleSpend, AllowedInputs: allowedInputs?.Select(c => c.Outpoint), TryToSign: tryToSign);
+		return new TransactionFactory(Network.Main, keyManager, coinsView, mockTransactionStore, parameters, password);
 	}
 
 	public static KeyManager CreateKeyManager(string password = "blahblahblah", bool isTaprootAllowed = false)

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -61,7 +61,7 @@ public static class ServiceFactory
 			allowedInputs = new List<SmartCoin>();
 			foreach (var i in allowedInputsIndexes)
 			{
-				allowedInputs.Append(sCoins[i]);
+				allowedInputs = allowedInputs.Append(sCoins[i]);
 			}
 		}
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/PayjoinTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/PayjoinTests.cs
@@ -93,7 +93,7 @@ public class PayjoinTests
 		using Key key = new();
 		PaymentIntent payment = new(key.PubKey, amount);
 
-		var tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), allowedCoins.Select(x => x.Outpoint), payjoinClient);
+		var tx = transactionFactory.BuildTransaction(payment, payjoinClient);
 
 		Assert.Equal(TransactionCheckResult.Success, tx.Transaction.Transaction.Check());
 		Assert.True(tx.Signed);
@@ -133,16 +133,16 @@ public class PayjoinTests
 			});
 
 		var payjoinClient = NewPayjoinClient(mockHttpClient);
+
 		var transactionFactory = ServiceFactory.CreateTransactionFactory(new[]
 		{
 			("Pablo", 0, 0.1m, confirmed: true, anonymitySet: 1)
-		});
-
-		var allowedCoins = transactionFactory.Coins.ToArray();
+		},
+		allowedInputsIndexes: new int[] { 0 });
 
 		var payment = new PaymentIntent(BitcoinFactory.CreateScript(), amountToPay);
 
-		var tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), allowedCoins.Select(x => x.Outpoint), payjoinClient);
+		var tx = transactionFactory.BuildTransaction(payment, payjoinClient);
 
 		Assert.Equal(TransactionCheckResult.Success, tx.Transaction.Transaction.Check());
 		Assert.True(tx.Signed);
@@ -158,10 +158,11 @@ public class PayjoinTests
 			{
 				("Pablo", 0, 0.1m, confirmed: true, anonymitySet: 1)
 			},
+			allowedInputsIndexes: new int[] { 0 },
 			watchOnly: true);
-		allowedCoins = transactionFactory.Coins.ToArray();
+		var allowedCoins = transactionFactory.Coins.ToArray();
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), allowedCoins.Select(x => x.Outpoint), payjoinClient);
+		tx = transactionFactory.BuildTransaction(payment, payjoinClient);
 
 		Assert.Equal(TransactionCheckResult.Success, tx.Transaction.Transaction.Check());
 		Assert.False(tx.Signed);
@@ -196,7 +197,7 @@ public class PayjoinTests
 			});
 
 		var transactionFactory = ServiceFactory.CreateTransactionFactory(walletCoins);
-		var tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		var tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		///////
 
@@ -218,7 +219,7 @@ public class PayjoinTests
 				return PSBT.FromTransaction(globalTx, Network.Main);
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 	}
 
@@ -241,7 +242,7 @@ public class PayjoinTests
 			});
 
 		var transactionFactory = ServiceFactory.CreateTransactionFactory(walletCoins);
-		var tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		var tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -254,7 +255,7 @@ public class PayjoinTests
 				return psbt;
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -267,7 +268,7 @@ public class PayjoinTests
 				return PSBT.FromTransaction(globalTx, Network.Main);
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -280,7 +281,7 @@ public class PayjoinTests
 				return PSBT.FromTransaction(globalTx, Network.Main);
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -294,7 +295,7 @@ public class PayjoinTests
 				return PSBT.FromTransaction(globalTx, Network.Main);
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -307,7 +308,7 @@ public class PayjoinTests
 				return psbt;
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -320,7 +321,7 @@ public class PayjoinTests
 				return psbt;
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -333,7 +334,7 @@ public class PayjoinTests
 				return PSBT.FromTransaction(globalTx, Network.Main);
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 		////////
 
@@ -346,7 +347,7 @@ public class PayjoinTests
 				return PSBT.FromTransaction(globalTx, Network.Main);
 			});
 
-		tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 	}
 
@@ -371,7 +372,7 @@ public class PayjoinTests
 			});
 
 		var transactionFactory = ServiceFactory.CreateTransactionFactory(walletCoins);
-		var tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		var tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 	}
 
@@ -389,7 +390,7 @@ public class PayjoinTests
 			PayjoinServerErrorAsync(HttpStatusCode.InternalServerError, "-2345", "Internal Server Error");
 
 		var transactionFactory = ServiceFactory.CreateTransactionFactory(walletCoins);
-		var tx = transactionFactory.BuildTransaction(payment, new FeeRate(2m), transactionFactory.Coins.Select(x => x.Outpoint), NewPayjoinClient(mockHttpClient));
+		var tx = transactionFactory.BuildTransaction(payment, NewPayjoinClient(mockHttpClient));
 		Assert.Single(tx.Transaction.Transaction.Inputs);
 	}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -19,44 +19,42 @@ namespace WalletWasabi.Blockchain.Transactions;
 
 public class TransactionFactory
 {
-	/// <param name="allowUnconfirmed">Allow to spend unconfirmed transactions, if necessary.</param>
-	public TransactionFactory(Network network, KeyManager keyManager, ICoinsView coins, ITransactionStore transactionStore, string password = "", bool allowUnconfirmed = false, bool allowDoubleSpend = false)
+	public TransactionFactory(
+		Network network,
+		KeyManager keyManager,
+		ICoinsView coins,
+		ITransactionStore transactionStore,
+		TransactionFactoryParameters parameters,
+		string password = "")
 	{
 		Network = network;
 		KeyManager = keyManager;
 		Coins = coins;
 		TransactionStore = transactionStore;
 		Password = password;
-		AllowUnconfirmed = allowUnconfirmed;
-		AllowDoubleSpend = allowDoubleSpend;
+		Parameters = parameters;
 	}
 
 	public Network Network { get; }
 	public KeyManager KeyManager { get; }
 	public ICoinsView Coins { get; }
-	public string Password { get; }
-	public bool AllowUnconfirmed { get; }
-	public bool AllowDoubleSpend { get; }
+	private string Password { get; }
+	private TransactionFactoryParameters Parameters { get; }
 	private ITransactionStore TransactionStore { get; }
 
-	/// <inheritdoc cref="BuildTransaction(PaymentIntent, Func{FeeRate}, IEnumerable{OutPoint}?, Func{LockTime}?, IPayjoinClient?, bool)"/>
+	/// <inheritdoc cref="BuildTransaction(PaymentIntent, Func{LockTime}?, IPayjoinClient?)"/>
 	public BuildTransactionResult BuildTransaction(
 		PaymentIntent payments,
-		FeeRate feeRate,
-		IEnumerable<OutPoint>? allowedInputs = null,
 		IPayjoinClient? payjoinClient = null)
-		=> BuildTransaction(payments, () => feeRate, allowedInputs, () => LockTime.Zero, payjoinClient);
+		=> BuildTransaction(payments, () => LockTime.Zero, payjoinClient);
 
 	/// <exception cref="ArgumentException"/>
 	/// <exception cref="ArgumentNullException"/>
 	/// <exception cref="ArgumentOutOfRangeException"/>
 	public BuildTransactionResult BuildTransaction(
 		PaymentIntent payments,
-		Func<FeeRate> feeRateFetcher,
-		IEnumerable<OutPoint>? allowedInputs = null,
 		Func<LockTime>? lockTimeSelector = null,
-		IPayjoinClient? payjoinClient = null,
-		bool tryToSign = true)
+		IPayjoinClient? payjoinClient = null)
 	{
 		lockTimeSelector ??= () => LockTime.Zero;
 
@@ -68,10 +66,10 @@ public class TransactionFactory
 
 		// Get allowed coins to spend.
 		var availableCoinsView = Coins.Unspent();
-		if (AllowDoubleSpend && allowedInputs is not null)
+		if (Parameters.AllowDoubleSpend && Parameters.AllowedInputs is not null)
 		{
 			var doubleSpends = new List<SmartCoin>();
-			foreach (var input in allowedInputs)
+			foreach (var input in Parameters.AllowedInputs)
 			{
 				if (((CoinsRegistry)Coins).AsAllCoinsView().TryGetByOutPoint(input, out var coin)
 					&& coin.SpenderTransaction is not null
@@ -83,18 +81,18 @@ public class TransactionFactory
 			availableCoinsView = new CoinsView(availableCoinsView.ToList().Concat(doubleSpends));
 		}
 
-		List<SmartCoin> allowedSmartCoinInputs = AllowUnconfirmed // Inputs that can be used to build the transaction.
+		List<SmartCoin> allowedSmartCoinInputs = Parameters.AllowUnconfirmed // Inputs that can be used to build the transaction.
 				? availableCoinsView.ToList()
 				: availableCoinsView.Confirmed().ToList();
-		if (allowedInputs is not null) // If allowedInputs are specified then select the coins from them.
+		if (Parameters.AllowedInputs is not null) // If allowedInputs are specified then select the coins from them.
 		{
-			if (!allowedInputs.Any())
+			if (!Parameters.AllowedInputs.Any())
 			{
-				throw new ArgumentException($"{nameof(allowedInputs)} is not null, but empty.");
+				throw new ArgumentException($"{nameof(Parameters.AllowedInputs)} is not null, but empty.");
 			}
 
 			allowedSmartCoinInputs = allowedSmartCoinInputs
-				.Where(x => allowedInputs.Any(y => y.Hash == x.TransactionId && y.N == x.Index))
+				.Where(x => Parameters.AllowedInputs.Any(y => y.Hash == x.TransactionId && y.N == x.Index))
 				.ToList();
 
 			// Add those that have the same script, because common ownership is already exposed.
@@ -104,7 +102,7 @@ public class TransactionFactory
 				var allScripts = allowedSmartCoinInputs.Select(x => x.ScriptPubKey).ToHashSet();
 				foreach (var coin in availableCoinsView.Where(x => !allowedSmartCoinInputs.Any(y => x.TransactionId == y.TransactionId && x.Index == y.Index)))
 				{
-					if (!(AllowUnconfirmed || coin.Confirmed))
+					if (!(Parameters.AllowUnconfirmed || coin.Confirmed))
 					{
 						continue;
 					}
@@ -164,7 +162,7 @@ public class TransactionFactory
 
 		builder.OptInRBF = true;
 
-		builder.SendEstimatedFees(feeRateFetcher());
+		builder.SendEstimatedFees(Parameters.FeeRateFetcher());
 
 		var psbt = builder.BuildPSBT(false);
 
@@ -231,7 +229,7 @@ public class TransactionFactory
 		psbt.AddPrevTxs(TransactionStore);
 
 		Transaction tx;
-		if (KeyManager.IsWatchOnly || !tryToSign)
+		if (KeyManager.IsWatchOnly || !Parameters.TryToSign)
 		{
 			tx = psbt.GetGlobalTransaction();
 		}

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactoryParameters.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactoryParameters.cs
@@ -1,0 +1,11 @@
+using NBitcoin;
+using System.Collections.Generic;
+
+namespace WalletWasabi.Blockchain.Transactions;
+
+public record TransactionFactoryParameters(
+	Func<FeeRate> FeeRateFetcher,
+	bool AllowUnconfirmed = false,
+	bool AllowDoubleSpend = false,
+	IEnumerable<OutPoint>? AllowedInputs = null,
+	bool TryToSign = true);


### PR DESCRIPTION
Based on #11708.
Part two of taking https://github.com/zkSNACKs/WalletWasabi/pull/11672 into two separate PRs.

This PR adds `TransactionFactoryParameters` and uses it where needed. Read more under the original PR.