### PR TITLE
`TransactionFactory`: Use `FeeRate` instead of `Func<FeeRate>`

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -69,10 +69,10 @@ public static class TransactionHelpers
 
 			builder.BuildTransaction(
 				intent,
-				feeRateFetcher: () => transactionInfo.FeeRate,
+				transactionInfo.FeeRate,
 				allowedCoins.Select(x => x.Outpoint),
-				lockTimeSelector: () => LockTime.Zero, // Doesn't matter.
 				transactionInfo.PayJoinClient,
+				lockTimeSelector: () => LockTime.Zero, // Doesn't matter.
 				tryToSign: false);
 
 			return true;

--- a/WalletWasabi/Blockchain/TransactionBuilding/TransactionBuilderWalletExtensions.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/TransactionBuilderWalletExtensions.cs
@@ -33,30 +33,28 @@ public static class TransactionBuilderWalletExtensions
 		bool tryToSign = true)
 	{
 		var builder = new TransactionFactory(wallet.Network, wallet.KeyManager, wallet.Coins, wallet.BitcoinStore.TransactionStore, password, allowUnconfirmed: allowUnconfirmed, allowDoubleSpend: allowDoubleSpend);
+		FeeRate? feeRate;
+
+		if (feeStrategy.TryGetTarget(out int? target))
+		{
+			feeRate = wallet.FeeProvider.AllFeeEstimate?.GetFeeRate(target.Value)
+				?? throw new InvalidOperationException("Cannot get fee estimations.");
+		}
+		else if (!feeStrategy.TryGetFeeRate(out feeRate))
+		{
+			throw new NotSupportedException(feeStrategy.Type.ToString());
+		}
+
 		return builder.BuildTransaction(
 			payments,
-			feeRateFetcher: () =>
-			{
-				if (feeStrategy.TryGetTarget(out int? target))
-				{
-					return wallet.FeeProvider.AllFeeEstimate?.GetFeeRate(target.Value) ?? throw new InvalidOperationException("Cannot get fee estimations.");
-				}
-				else if (feeStrategy.TryGetFeeRate(out FeeRate? feeRate))
-				{
-					return feeRate;
-				}
-				else
-				{
-					throw new NotSupportedException(feeStrategy.Type.ToString());
-				}
-			},
+			feeRate,
 			allowedInputs,
+			payjoinClient,
 			lockTimeSelector: () =>
 			{
 				var currentTipHeight = wallet.BitcoinStore.SmartHeaderChain.TipHeight;
 				return LockTimeSelector.Instance.GetLockTimeBasedOnDistribution(currentTipHeight);
 			},
-			payjoinClient,
 			tryToSign: tryToSign);
 	}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -39,23 +39,15 @@ public class TransactionFactory
 	public bool AllowDoubleSpend { get; }
 	private ITransactionStore TransactionStore { get; }
 
-	/// <inheritdoc cref="BuildTransaction(PaymentIntent, Func{FeeRate}, IEnumerable{OutPoint}?, Func{LockTime}?, IPayjoinClient?, bool)"/>
-	public BuildTransactionResult BuildTransaction(
-		PaymentIntent payments,
-		FeeRate feeRate,
-		IEnumerable<OutPoint>? allowedInputs = null,
-		IPayjoinClient? payjoinClient = null)
-		=> BuildTransaction(payments, () => feeRate, allowedInputs, () => LockTime.Zero, payjoinClient);
-
 	/// <exception cref="ArgumentException"/>
 	/// <exception cref="ArgumentNullException"/>
 	/// <exception cref="ArgumentOutOfRangeException"/>
 	public BuildTransactionResult BuildTransaction(
 		PaymentIntent payments,
-		Func<FeeRate> feeRateFetcher,
+		FeeRate feeRate,
 		IEnumerable<OutPoint>? allowedInputs = null,
-		Func<LockTime>? lockTimeSelector = null,
 		IPayjoinClient? payjoinClient = null,
+		Func<LockTime>? lockTimeSelector = null,
 		bool tryToSign = true)
 	{
 		lockTimeSelector ??= () => LockTime.Zero;
@@ -164,7 +156,7 @@ public class TransactionFactory
 
 		builder.OptInRBF = true;
 
-		builder.SendEstimatedFees(feeRateFetcher());
+		builder.SendEstimatedFees(feeRate);
 
 		var psbt = builder.BuildPSBT(false);
 


### PR DESCRIPTION
Prepares ground for #11708

Seemingly, we don't really use `Func<FeeRate>` in the sense as one might expect (to get up to date fee values). Simplifying it seems good for other refactorings I have in mind.