### PR TITLE
Expose the RPC Server as an onion service

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -41,7 +41,7 @@ public class Config
 			{ nameof(JsonRpcUser), GetStringValue("JsonRpcUser", PersistentConfig.JsonRpcUser, cliArgs) },
 			{ nameof(JsonRpcPassword), GetStringValue("JsonRpcPassword", PersistentConfig.JsonRpcPassword, cliArgs) },
 			{ nameof(JsonRpcServerPrefixes), GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes, cliArgs) },
-			{ nameof(OnionEnabled), GetBoolValue("OnionEnabled", value: false, cliArgs) },
+			{ nameof(RpcOnionEnabled), GetBoolValue("RpcOnionEnabled", value: false, cliArgs) },
 			{ nameof(DustThreshold), GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs) },
 			{ nameof(BlockOnlyMode), GetBoolValue("BlockOnly", value: false, cliArgs) },
 			{ nameof(LogLevel), GetStringValue("LogLevel", value: "", cliArgs) },
@@ -86,7 +86,7 @@ public class Config
 	public string JsonRpcUser => GetEffectiveValue<StringValue, string>(nameof(JsonRpcUser));
 	public string JsonRpcPassword => GetEffectiveValue<StringValue, string>(nameof(JsonRpcPassword));
 	public string[] JsonRpcServerPrefixes => GetEffectiveValue<StringArrayValue, string[]>(nameof(JsonRpcServerPrefixes));
-	public bool OnionEnabled => GetEffectiveValue<BoolValue, bool>(nameof(OnionEnabled));
+	public bool RpcOnionEnabled => GetEffectiveValue<BoolValue, bool>(nameof(RpcOnionEnabled));
 	public Money DustThreshold => GetEffectiveValue<MoneyValue, Money>(nameof(DustThreshold));
 	public bool BlockOnlyMode => GetEffectiveValue<BoolValue, bool>(nameof(BlockOnlyMode));
 	public string LogLevel => GetEffectiveValue<StringValue, string>(nameof(LogLevel));

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -41,6 +41,7 @@ public class Config
 			{ nameof(JsonRpcUser), GetStringValue("JsonRpcUser", PersistentConfig.JsonRpcUser, cliArgs) },
 			{ nameof(JsonRpcPassword), GetStringValue("JsonRpcPassword", PersistentConfig.JsonRpcPassword, cliArgs) },
 			{ nameof(JsonRpcServerPrefixes), GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes, cliArgs) },
+			{ nameof(OnionEnabled), GetBoolValue("OnionEnabled", value: false, cliArgs) },
 			{ nameof(DustThreshold), GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs) },
 			{ nameof(BlockOnlyMode), GetBoolValue("BlockOnly", value: false, cliArgs) },
 			{ nameof(LogLevel), GetStringValue("LogLevel", value: "", cliArgs) },
@@ -85,6 +86,7 @@ public class Config
 	public string JsonRpcUser => GetEffectiveValue<StringValue, string>(nameof(JsonRpcUser));
 	public string JsonRpcPassword => GetEffectiveValue<StringValue, string>(nameof(JsonRpcPassword));
 	public string[] JsonRpcServerPrefixes => GetEffectiveValue<StringArrayValue, string[]>(nameof(JsonRpcServerPrefixes));
+	public bool OnionEnabled => GetEffectiveValue<BoolValue, bool>(nameof(OnionEnabled));
 	public Money DustThreshold => GetEffectiveValue<MoneyValue, Money>(nameof(DustThreshold));
 	public bool BlockOnlyMode => GetEffectiveValue<BoolValue, bool>(nameof(BlockOnlyMode));
 	public string LogLevel => GetEffectiveValue<StringValue, string>(nameof(LogLevel));

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -275,7 +275,7 @@ public class Global
 				Logger.LogInfo($"{nameof(TorProcessManager)} is initialized.");
 
 				var (_, torControlClient) = await TorManager.WaitForNextAttemptAsync(cancellationToken).ConfigureAwait(false);
-				if (Config is {JsonRpcServerEnabled: true, OnionEnabled: true} && torControlClient is { } nonNullTorControlClient)
+				if (Config is {JsonRpcServerEnabled: true, RpcOnionEnabled: true} && torControlClient is { } nonNullTorControlClient)
 				{
 					var anonymousAccessAllowed = string.IsNullOrEmpty(Config.JsonRpcUser) || string.IsNullOrEmpty(Config.JsonRpcPassword);
 					if (!anonymousAccessAllowed)

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -166,16 +166,16 @@ public class TorControlClient : IAsyncDisposable
 		return reply;
 	}
 
-	public async Task<string> CreateHiddenServiceAsync(int virtualPort, int remotePort, CancellationToken cancellationToken)
+	public async Task<string> CreateOnionServiceAsync(int virtualPort, int remotePort, CancellationToken cancellationToken)
 	{
 		var reply = await SendCommandAsync($"ADD_ONION NEW:BEST Flags=DiscardPK Port={virtualPort},{remotePort}\r\n", cancellationToken).ConfigureAwait(false);
 		if (!reply.Success)
 		{
-			throw new TorControlException("Failed to create onion.");
+			throw new TorControlException("Failed to create onion service.");
 		}
 
 		const string Marker = "ServiceID=";
-		var serviceLine = reply.ResponseLines.FirstOrDefault(x => x.StartsWith(Marker));
+		var serviceLine = reply.ResponseLines.FirstOrDefault(x => x.StartsWith(Marker, StringComparison.Ordinal));
 		if (serviceLine is null)
 		{
 			throw new TorControlException("Tor protocol violation.");
@@ -185,9 +185,10 @@ public class TorControlClient : IAsyncDisposable
 		return serviceId;
 	}
 
-	public Task DestroyHiddenService(string serviceId, CancellationToken cancellationToken)
+	public async Task<bool> DestroyOnionServiceAsync(string serviceId, CancellationToken cancellationToken)
 	{
-		return SendCommandAsync($"DEL_ONION {serviceId}\r\n", cancellationToken);
+		var reply = await SendCommandAsync($"DEL_ONION {serviceId}\r\n", cancellationToken).ConfigureAwait(false);
+		return reply.Success;
 	}
 
 	/// <summary>

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -54,7 +54,7 @@ public class TorProcessManager : IAsyncDisposable
 	private ProcessAsync? TorProcess { get; set; }
 
 	/// <remarks>Guarded by <see cref="StateLock"/>.</remarks>
-	public TorControlClient? TorControlClient { get; private set; }
+	private TorControlClient? TorControlClient { get; set; }
 
 	/// <inheritdoc cref="StartAsync(int, CancellationToken)"/>
 	public Task<(CancellationToken, TorControlClient)> StartAsync(CancellationToken cancellationToken)

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -54,7 +54,7 @@ public class TorProcessManager : IAsyncDisposable
 	private ProcessAsync? TorProcess { get; set; }
 
 	/// <remarks>Guarded by <see cref="StateLock"/>.</remarks>
-	private TorControlClient? TorControlClient { get; set; }
+	public TorControlClient? TorControlClient { get; private set; }
 
 	/// <inheritdoc cref="StartAsync(int, CancellationToken)"/>
 	public Task<(CancellationToken, TorControlClient)> StartAsync(CancellationToken cancellationToken)

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -63,6 +63,8 @@ public class TorSettings
 
 	/// <summary>Tor control endpoint.</summary>
 	public EndPoint ControlEndpoint { get; set; } = new IPEndPoint(IPAddress.Loopback, 37151);
+	public int RpcVirtualPort => 80;
+	public int RpcOnionPort => 37129;
 
 	private string GeoIpPath { get; }
 	private string GeoIp6Path { get; }


### PR DESCRIPTION
This PR exposes the RPC server as an onion service.

## How to test

### Run wasabi daemon with:

```
$ dotnet run -- \
  --usetor=true \
  --network=testnet \
  --jsonrpcserverenabled=true \
  --jsonrpcuser=myuser \
  --jsonrpcpassword=mypassword \
  --onionenabled=true
```

It is important to know that:

* `UseTor` is necessary because that switch controls whether the Tor process must be launched or not. We need the Tor process running in order to create the ephemeral onion service.
* `JsonRpcServerEnabled` must be true because otherwise the rpc server is not started.
* Anonymous access is not allowed when exposing the server as an onion service. This means that you have to specify both `JsonRpcUser` and `JsonRpcPassword`.
* `OnionEnabled` indicates whether or not to create the ephemeral onion service. This switch is only available as a command line switch and environment variable. By default it is `false`.

Once the daemon is running take a look at the log output and find the onion address:
```
INFO       Global.StartTorProcessManagerAsync (284)        RPC server listening on http://rrdayxv2pngzl3jyal5dfjvl6s4bt4frvo5jj2rgnajz5gyevrm4fvyd.onion/
```
### Run  a Tor instance on the client machine

Here this example assumes you are running a Tor instance in the default port (9050). Use Tor as a socks proxy for your client (in this case we use `curl`) 

```
$ curl -s \
  --socks5-hostname localhost:9050 \
  --user myuser:mypassword \
  --data-binary '{"jsonrpc":"2.0","id":"1","method":"listwallets"}'  \
  http://rrdayxv2pngzl3jyal5dfjvl6s4bt4frvo5jj2rgnajz5gyevrm4fvyd.onion/

{
   "jsonrpc":"2.0",
   "result":[{
     "walletName":"MyFirstWallet"
   }, {
     "walletName":"Wallet_5"
  }]
}
```