### PR TITLE
[startup optimization] `IndexStore`: Check if table is empty faster

### DIFF
--- a/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
@@ -81,10 +81,10 @@ public class BlockFilterSqliteStorage : IDisposable
 			if (startingFilter is not null)
 			{
 				using SqliteCommand isEmptyCommand = connection.CreateCommand();
-				isEmptyCommand.CommandText = "SELECT COUNT(*) FROM filter";
-				int count = Convert.ToInt32(isEmptyCommand.ExecuteScalar());
+				isEmptyCommand.CommandText = "SELECT EXISTS (SELECT 1 FROM filter)";
+				int existRows = Convert.ToInt32(isEmptyCommand.ExecuteScalar());
 
-				if (count == 0)
+				if (existRows == 0)
 				{
 					if (!storage.TryAppend(startingFilter))
 					{


### PR DESCRIPTION
This PR shaves off ~800ms of startup time on my machine. 

The reason is that we counted the number of rows precisely but we don't need to check it precisely, we just need to know if the table is empty or not.