### PR TITLE
[vdg] Preview TX screen: put address as second item

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -35,6 +35,14 @@
     </DockPanel>
     <Separator />
 
+    <!-- Address -->
+    <c:PreviewItem Icon="{StaticResource transceive_regular}"
+                   Label="Address"
+                   CopyableContent="{Binding AddressText}">
+      <TextBlock Classes="monoSpaced" Text="{Binding AddressText, FallbackValue=btc029382398fkj34f98df239823}" />
+    </c:PreviewItem>
+    <Separator />
+
     <!-- Recipient -->
     <c:PreviewItem Icon="{StaticResource person_regular}"
                    Label="Recipient"
@@ -42,14 +50,6 @@
       <c:LabelsItemsPresenter Items="{Binding Recipient}"
                               HorizontalAlignment="Left"
                               VerticalAlignment="Center" />
-    </c:PreviewItem>
-    <Separator />
-
-    <!-- Address -->
-    <c:PreviewItem Icon="{StaticResource transceive_regular}"
-                   Label="Address"
-                   CopyableContent="{Binding AddressText}">
-      <TextBlock Classes="monoSpaced" Text="{Binding AddressText, FallbackValue=btc029382398fkj34f98df239823}" />
     </c:PreviewItem>
     <Separator />
 


### PR DESCRIPTION
Amount and address are the most important pieces of information here.
Put them at the top.
I found myself confused/extra thinking several times before, easier to see amount and address just in one look.
Which is what the user usually will double-check.

I could not find any reasoning on why the `Recipient` label should be the second item, when it was added https://github.com/zkSNACKs/WalletWasabi/pull/8563