### PR TITLE
Add some help to the command line

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -23,43 +23,43 @@ public class Config
 		Data = new()
 		{
 			[ nameof(Network)] = (
-				"Bitcoin network to use (main, testnet or regtest)",
+				"The Bitcoin network to use: main, testnet, or regtest",
 				GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs)),
 			[ nameof(MainNetBackendUri)] = (
-				"Url to the backend server to connect to when network is main",
+				"The backend server's URL to connect to when the Bitcoin network is main",
 				GetStringValue("MainNetBackendUri", PersistentConfig.MainNetBackendUri, cliArgs)),
 			[ nameof(TestNetBackendUri)] = (
-				"Url to the backend server to connect to when network is testnet",
+				"The backend server's URL to connect to when the Bitcoin network is testnet",
 				GetStringValue("TestNetBackendUri", PersistentConfig.TestNetBackendUri, cliArgs)),
 			[ nameof(RegTestBackendUri)] = (
-				"Url to the backend server to connect to when network is regtest",
+				"The backend server's URL to connect to when the Bitcoin network is regtest",
 				GetStringValue("RegTestBackendUri", PersistentConfig.RegTestBackendUri, cliArgs)),
 			[ nameof(MainNetCoordinatorUri)] = (
-				"Url to the coordinator server to connect to when network is main",
+				"The coordinator server's URL to connect to when the Bitcoin network is main",
 				GetNullableStringValue("MainNetCoordinatorUri", PersistentConfig.MainNetCoordinatorUri, cliArgs)),
 			[ nameof(TestNetCoordinatorUri)] = (
-				"Url to the coordinator server to connect to when network is testnet",
+				"The coordinator server's URL to connect to when the Bitcoin network is testnet",
 				GetNullableStringValue("TestNetCoordinatorUri", PersistentConfig.TestNetCoordinatorUri, cliArgs)),
 			[ nameof(RegTestCoordinatorUri)] = (
-				"Url to the coordinator server to connect to when network is regtest",
+				"The coordinator server's URL to connect to when the Bitcoin network is regtest",
 				GetNullableStringValue("RegTestCoordinatorUri", PersistentConfig.RegTestCoordinatorUri, cliArgs)),
 			[ nameof(UseTor)] = (
-				"Indicate all the communication have to go thru the Tor network",
+				"All the communications go through the Tor network",
 				GetBoolValue("UseTor", PersistentConfig.UseTor, cliArgs)),
 			[ nameof(TerminateTorOnExit)] = (
-				"Indicate the Tor process must be stopped when Wasabi finishes",
+				"Stop the Tor process when Wasabi is closed",
 				GetBoolValue("TerminateTorOnExit", PersistentConfig.TerminateTorOnExit, cliArgs)),
 			[ nameof(DownloadNewVersion)] = (
-				"Indicate new version of Wasabi should be downloaded automatically",
+				"Automatically download any new released version of Wasabi",
 				GetBoolValue("DownloadNewVersion", PersistentConfig.DownloadNewVersion, cliArgs)),
 			[ nameof(StartLocalBitcoinCoreOnStartup)] = (
-				"Indicate that bitcoin node should be started when wasabi starts",
+				"Start a local bitcoin node when Wasabi starts",
 				GetBoolValue("StartLocalBitcoinCoreOnStartup", PersistentConfig.StartLocalBitcoinCoreOnStartup, cliArgs)),
 			[ nameof(StopLocalBitcoinCoreOnShutdown)] = (
-				"Indicate that bitcoin node should be stopped when finishes",
+				"Stop the local bitcoin node when Wasabi is closed",
 				GetBoolValue("StopLocalBitcoinCoreOnShutdown", PersistentConfig.StopLocalBitcoinCoreOnShutdown, cliArgs)),
 			[ nameof(LocalBitcoinCoreDataDir)] = (
-				"Specify the DataDir to be used by the bitcoin node",
+				"The path of the data directory to be used by the local bitcoin node",
 				GetStringValue("LocalBitcoinCoreDataDir", PersistentConfig.LocalBitcoinCoreDataDir, cliArgs)),
 			[ nameof(MainNetBitcoinP2pEndPoint)] = (
 				"-",
@@ -71,7 +71,7 @@ public class Config
 				"-",
 				GetEndPointValue("RegTestBitcoinP2pEndPoint", PersistentConfig.RegTestBitcoinP2pEndPoint, cliArgs)),
 			[ nameof(JsonRpcServerEnabled)] = (
-				"Indicate the Json RPC Server should be started and accepting requests",
+				"Start the Json RPC Server and accept requests",
 				GetBoolValue("JsonRpcServerEnabled", PersistentConfig.JsonRpcServerEnabled, cliArgs)),
 			[ nameof(JsonRpcUser)] = (
 				"The user name that is authorized to make requests to the Json RPC server",
@@ -80,22 +80,22 @@ public class Config
 				"The user password that is authorized to make requests to the Json RPC server",
 				GetStringValue("JsonRpcPassword", PersistentConfig.JsonRpcPassword, cliArgs)),
 			[ nameof(JsonRpcServerPrefixes)] = (
-				"Json RPC server prefixes",
+				"The Json RPC server prefixes",
 				GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes, cliArgs)),
 			[ nameof(RpcOnionEnabled)] = (
-				"Indicate the Json RPC Server should be published as an Tor Onion service",
+				"Publish the Json RPC Server as a Tor Onion service",
 				GetBoolValue("RpcOnionEnabled", value: false, cliArgs)),
 			[ nameof(DustThreshold)] = (
-				"Threshold amount under which coin received from others to reused addresses are considered a dust attack",
+				"The amount threshold under which coins received from others to reuse addresses are considered a dust attack",
 				GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs)),
 			[ nameof(BlockOnlyMode)] = (
-				"Indicate Wasabi should only listen for blocks and not for transactions",
+				"Wasabi listens only for blocks and not for transactions",
 				GetBoolValue("BlockOnly", value: false, cliArgs)),
 			[ nameof(LogLevel)] = (
-				"Level of detail in the logs (trace, debug, info, warning, error or critical)",
+				"The level of detail in the logs: trace, debug, info, warning, error, or critical",
 				GetStringValue("LogLevel", value: "", cliArgs)),
 			[ nameof(EnableGpu)] = (
-				"Indicate Wasabi should use the GPU",
+				"Use a GPU to render the user interface",
 				GetBoolValue("EnableGpu", PersistentConfig.EnableGpu, cliArgs)),
 			[ nameof(CoordinatorIdentifier)] = (
 				"-",

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -86,7 +86,7 @@ public class Config
 				"Publish the Json RPC Server as a Tor Onion service",
 				GetBoolValue("RpcOnionEnabled", value: false, cliArgs)),
 			[ nameof(DustThreshold)] = (
-				"The amount threshold under which coins received from others to reuse addresses are considered a dust attack",
+				"The amount threshold under which coins received from others to already used addresses are considered a dust attack",
 				GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs)),
 			[ nameof(BlockOnlyMode)] = (
 				"Wasabi listens only for blocks and not for transactions",

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -171,7 +171,7 @@ public class Config
 			value switch
 			{
 				NetworkValue n => $"{n.EffectiveValue} (source: {Source(n.ValueSource)})",
-				StringValue s => $"{s.EffectiveValue}\" (source: {Source(s.ValueSource)})",
+				StringValue s => $"{s.EffectiveValue} (source: {Source(s.ValueSource)})",
 				NullableStringValue => $"string or null",
 				StringArrayValue => $"array of strings",
 				MoneyValue m => $"{m.EffectiveValue} BTC (source: {Source(m.ValueSource)})",

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -22,36 +22,88 @@ public class Config
 
 		Data = new()
 		{
-			{ nameof(Network), GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs) },
-			{ nameof(MainNetBackendUri), GetStringValue("MainNetBackendUri", PersistentConfig.MainNetBackendUri, cliArgs) },
-			{ nameof(TestNetBackendUri), GetStringValue("TestNetBackendUri", PersistentConfig.TestNetBackendUri, cliArgs) },
-			{ nameof(RegTestBackendUri), GetStringValue("RegTestBackendUri", PersistentConfig.RegTestBackendUri, cliArgs) },
-			{ nameof(MainNetCoordinatorUri), GetNullableStringValue("MainNetCoordinatorUri", PersistentConfig.MainNetCoordinatorUri, cliArgs) },
-			{ nameof(TestNetCoordinatorUri), GetNullableStringValue("TestNetCoordinatorUri", PersistentConfig.TestNetCoordinatorUri, cliArgs)},
-			{ nameof(RegTestCoordinatorUri), GetNullableStringValue("RegTestCoordinatorUri", PersistentConfig.RegTestCoordinatorUri, cliArgs)},
-			{ nameof(UseTor), GetBoolValue("UseTor", PersistentConfig.UseTor, cliArgs) },
-			{ nameof(TerminateTorOnExit), GetBoolValue("TerminateTorOnExit", PersistentConfig.TerminateTorOnExit, cliArgs) },
-			{ nameof(DownloadNewVersion), GetBoolValue("DownloadNewVersion", PersistentConfig.DownloadNewVersion, cliArgs) },
-			{ nameof(StartLocalBitcoinCoreOnStartup), GetBoolValue("StartLocalBitcoinCoreOnStartup", PersistentConfig.StartLocalBitcoinCoreOnStartup, cliArgs) },
-			{ nameof(StopLocalBitcoinCoreOnShutdown), GetBoolValue("StopLocalBitcoinCoreOnShutdown", PersistentConfig.StopLocalBitcoinCoreOnShutdown, cliArgs) },
-			{ nameof(LocalBitcoinCoreDataDir), GetStringValue("LocalBitcoinCoreDataDir", PersistentConfig.LocalBitcoinCoreDataDir, cliArgs) },
-			{ nameof(MainNetBitcoinP2pEndPoint), GetEndPointValue("MainNetBitcoinP2pEndPoint", PersistentConfig.MainNetBitcoinP2pEndPoint, cliArgs) },
-			{ nameof(TestNetBitcoinP2pEndPoint), GetEndPointValue("TestNetBitcoinP2pEndPoint", PersistentConfig.TestNetBitcoinP2pEndPoint, cliArgs) },
-			{ nameof(RegTestBitcoinP2pEndPoint), GetEndPointValue("RegTestBitcoinP2pEndPoint", PersistentConfig.RegTestBitcoinP2pEndPoint, cliArgs) },
-			{ nameof(JsonRpcServerEnabled), GetBoolValue("JsonRpcServerEnabled", PersistentConfig.JsonRpcServerEnabled, cliArgs) },
-			{ nameof(JsonRpcUser), GetStringValue("JsonRpcUser", PersistentConfig.JsonRpcUser, cliArgs) },
-			{ nameof(JsonRpcPassword), GetStringValue("JsonRpcPassword", PersistentConfig.JsonRpcPassword, cliArgs) },
-			{ nameof(JsonRpcServerPrefixes), GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes, cliArgs) },
-			{ nameof(RpcOnionEnabled), GetBoolValue("RpcOnionEnabled", value: false, cliArgs) },
-			{ nameof(DustThreshold), GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs) },
-			{ nameof(BlockOnlyMode), GetBoolValue("BlockOnly", value: false, cliArgs) },
-			{ nameof(LogLevel), GetStringValue("LogLevel", value: "", cliArgs) },
-			{ nameof(EnableGpu), GetBoolValue("EnableGpu", PersistentConfig.EnableGpu, cliArgs) },
-			{ nameof(CoordinatorIdentifier), GetStringValue("CoordinatorIdentifier", PersistentConfig.CoordinatorIdentifier, cliArgs) },
+			[ nameof(Network)] = (
+				"Bitcoin network to use (main, testnet or regtest)",
+				GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs)),
+			[ nameof(MainNetBackendUri)] = (
+				"Url to the backend server to connect to when network is main",
+				GetStringValue("MainNetBackendUri", PersistentConfig.MainNetBackendUri, cliArgs)),
+			[ nameof(TestNetBackendUri)] = (
+				"Url to the backend server to connect to when network is testnet",
+				GetStringValue("TestNetBackendUri", PersistentConfig.TestNetBackendUri, cliArgs)),
+			[ nameof(RegTestBackendUri)] = (
+				"Url to the backend server to connect to when network is regtest",
+				GetStringValue("RegTestBackendUri", PersistentConfig.RegTestBackendUri, cliArgs)),
+			[ nameof(MainNetCoordinatorUri)] = (
+				"Url to the coordinator server to connect to when network is main",
+				GetNullableStringValue("MainNetCoordinatorUri", PersistentConfig.MainNetCoordinatorUri, cliArgs)),
+			[ nameof(TestNetCoordinatorUri)] = (
+				"Url to the coordinator server to connect to when network is testnet",
+				GetNullableStringValue("TestNetCoordinatorUri", PersistentConfig.TestNetCoordinatorUri, cliArgs)),
+			[ nameof(RegTestCoordinatorUri)] = (
+				"Url to the coordinator server to connect to when network is regtest",
+				GetNullableStringValue("RegTestCoordinatorUri", PersistentConfig.RegTestCoordinatorUri, cliArgs)),
+			[ nameof(UseTor)] = (
+				"Indicate all the communication have to go thru the Tor network",
+				GetBoolValue("UseTor", PersistentConfig.UseTor, cliArgs)),
+			[ nameof(TerminateTorOnExit)] = (
+				"Indicate the Tor process must be stopped when Wasabi finishes",
+				GetBoolValue("TerminateTorOnExit", PersistentConfig.TerminateTorOnExit, cliArgs)),
+			[ nameof(DownloadNewVersion)] = (
+				"Indicate new version of Wasabi should be downloaded automatically",
+				GetBoolValue("DownloadNewVersion", PersistentConfig.DownloadNewVersion, cliArgs)),
+			[ nameof(StartLocalBitcoinCoreOnStartup)] = (
+				"Indicate that bitcoin node should be started when wasabi starts",
+				GetBoolValue("StartLocalBitcoinCoreOnStartup", PersistentConfig.StartLocalBitcoinCoreOnStartup, cliArgs)),
+			[ nameof(StopLocalBitcoinCoreOnShutdown)] = (
+				"Indicate that bitcoin node should be stopped when finishes",
+				GetBoolValue("StopLocalBitcoinCoreOnShutdown", PersistentConfig.StopLocalBitcoinCoreOnShutdown, cliArgs)),
+			[ nameof(LocalBitcoinCoreDataDir)] = (
+				"Specify the DataDir to be used by the bitcoin node",
+				GetStringValue("LocalBitcoinCoreDataDir", PersistentConfig.LocalBitcoinCoreDataDir, cliArgs)),
+			[ nameof(MainNetBitcoinP2pEndPoint)] = (
+				"-",
+				GetEndPointValue("MainNetBitcoinP2pEndPoint", PersistentConfig.MainNetBitcoinP2pEndPoint, cliArgs)),
+			[ nameof(TestNetBitcoinP2pEndPoint)] = (
+				"-",
+				GetEndPointValue("TestNetBitcoinP2pEndPoint", PersistentConfig.TestNetBitcoinP2pEndPoint, cliArgs)),
+			[ nameof(RegTestBitcoinP2pEndPoint)] = (
+				"-",
+				GetEndPointValue("RegTestBitcoinP2pEndPoint", PersistentConfig.RegTestBitcoinP2pEndPoint, cliArgs)),
+			[ nameof(JsonRpcServerEnabled)] = (
+				"Indicate the Json RPC Server should be started and accepting requests",
+				GetBoolValue("JsonRpcServerEnabled", PersistentConfig.JsonRpcServerEnabled, cliArgs)),
+			[ nameof(JsonRpcUser)] = (
+				"The user name that is authorized to make requests to the Json RPC server",
+				GetStringValue("JsonRpcUser", PersistentConfig.JsonRpcUser, cliArgs)),
+			[ nameof(JsonRpcPassword)] = (
+				"The user password that is authorized to make requests to the Json RPC server",
+				GetStringValue("JsonRpcPassword", PersistentConfig.JsonRpcPassword, cliArgs)),
+			[ nameof(JsonRpcServerPrefixes)] = (
+				"Json RPC server prefixes",
+				GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes, cliArgs)),
+			[ nameof(RpcOnionEnabled)] = (
+				"Indicate the Json RPC Server should be published as an Tor Onion service",
+				GetBoolValue("RpcOnionEnabled", value: false, cliArgs)),
+			[ nameof(DustThreshold)] = (
+				"Threshold amount under which coin received from others to reused addresses are considered a dust attack",
+				GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs)),
+			[ nameof(BlockOnlyMode)] = (
+				"Indicate Wasabi should only listen for blocks and not for transactions",
+				GetBoolValue("BlockOnly", value: false, cliArgs)),
+			[ nameof(LogLevel)] = (
+				"Level of detail in the logs (trace, debug, info, warning, error or critical)",
+				GetStringValue("LogLevel", value: "", cliArgs)),
+			[ nameof(EnableGpu)] = (
+				"Indicate Wasabi should use the GPU",
+				GetBoolValue("EnableGpu", PersistentConfig.EnableGpu, cliArgs)),
+			[ nameof(CoordinatorIdentifier)] = (
+				"-",
+				GetStringValue("CoordinatorIdentifier", PersistentConfig.CoordinatorIdentifier, cliArgs)),
 		};
 
 		// Check if any config value is overridden (either by an environment value, or by a CLI argument).
-		foreach (IValue optionValue in Data.Values)
+		foreach ((_, IValue optionValue) in Data.Values)
 		{
 			if (optionValue.Overridden)
 			{
@@ -63,7 +115,7 @@ public class Config
 		ServiceConfiguration = new ServiceConfiguration(GetBitcoinP2pEndPoint(), DustThreshold);
 	}
 
-	private Dictionary<string, IValue> Data { get; }
+	private Dictionary<string, (string Hint, IValue Value)> Data { get; }
 	public PersistentConfig PersistentConfig { get; }
 	public string[] CliArgs { get; }
 	public Network Network => GetEffectiveValue<NetworkValue, Network>(nameof(Network));
@@ -156,32 +208,8 @@ public class Config
 		return result is null ? GetBackendUri() : new Uri(result);
 	}
 
-	public IEnumerable<(string, string)> GetConfigOptionsMetadata()
-	{
-		static string Source(ValueSource source) =>
-			source switch
-			{
-				ValueSource.Disk => "config file",
-				ValueSource.EnvironmentVariable => "environment variable",
-				ValueSource.CommandLineArgument => "command line",
-				_ => "unknown"
-			};
-
-		static string AsString(object value) =>
-			value switch
-			{
-				NetworkValue n => $"{n.EffectiveValue} (source: {Source(n.ValueSource)})",
-				StringValue s => $"{s.EffectiveValue} (source: {Source(s.ValueSource)})",
-				NullableStringValue => $"string or null",
-				StringArrayValue => $"array of strings",
-				MoneyValue m => $"{m.EffectiveValue} BTC (source: {Source(m.ValueSource)})",
-				EndPointValue ep => $"{ep.EffectiveValue} (source: {Source(ep.ValueSource)})",
-				BoolValue b => $"{b.EffectiveValue} (source: {Source(b.ValueSource)})",
-				_ => "unknown"
-			};
-
-		return Data.Select(x => (x.Key, $"{AsString(x.Value)}"));
-	}
+	public IEnumerable<(string, string)> GetConfigOptionsMetadata() =>
+		Data.Select(x => (x.Key, x.Value.Hint));
 
 	private EndPointValue GetEndPointValue(string key, EndPoint value, string[] cliArgs)
 	{
@@ -321,7 +349,7 @@ public class Config
 
 	private TValue GetEffectiveValue<TStorage, TValue>(string key) where TStorage : ITypedValue<TValue>
 	{
-		if (Data.TryGetValue(key, out IValue? valueObject) && valueObject is ITypedValue<TValue> typedValue)
+		if (Data.TryGetValue(key, out (string, IValue value) valueObject) && valueObject.value is ITypedValue<TValue> typedValue)
 		{
 			return typedValue.EffectiveValue;
 		}

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -26,22 +26,22 @@ public class Config
 				"The Bitcoin network to use: main, testnet, or regtest",
 				GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs)),
 			[ nameof(MainNetBackendUri)] = (
-				"The backend server's URL to connect to when the Bitcoin network is main",
+				"The backend server's URI to connect to when the Bitcoin network is main",
 				GetStringValue("MainNetBackendUri", PersistentConfig.MainNetBackendUri, cliArgs)),
 			[ nameof(TestNetBackendUri)] = (
-				"The backend server's URL to connect to when the Bitcoin network is testnet",
+				"The backend server's URI to connect to when the Bitcoin network is testnet",
 				GetStringValue("TestNetBackendUri", PersistentConfig.TestNetBackendUri, cliArgs)),
 			[ nameof(RegTestBackendUri)] = (
-				"The backend server's URL to connect to when the Bitcoin network is regtest",
+				"The backend server's URI to connect to when the Bitcoin network is regtest",
 				GetStringValue("RegTestBackendUri", PersistentConfig.RegTestBackendUri, cliArgs)),
 			[ nameof(MainNetCoordinatorUri)] = (
-				"The coordinator server's URL to connect to when the Bitcoin network is main",
+				"The coordinator server's URI to connect to when the Bitcoin network is main",
 				GetNullableStringValue("MainNetCoordinatorUri", PersistentConfig.MainNetCoordinatorUri, cliArgs)),
 			[ nameof(TestNetCoordinatorUri)] = (
-				"The coordinator server's URL to connect to when the Bitcoin network is testnet",
+				"The coordinator server's URI to connect to when the Bitcoin network is testnet",
 				GetNullableStringValue("TestNetCoordinatorUri", PersistentConfig.TestNetCoordinatorUri, cliArgs)),
 			[ nameof(RegTestCoordinatorUri)] = (
-				"The coordinator server's URL to connect to when the Bitcoin network is regtest",
+				"The coordinator server's URI to connect to when the Bitcoin network is regtest",
 				GetNullableStringValue("RegTestCoordinatorUri", PersistentConfig.RegTestCoordinatorUri, cliArgs)),
 			[ nameof(UseTor)] = (
 				"All the communications go through the Tor network",

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -208,7 +208,7 @@ public class Config
 		return result is null ? GetBackendUri() : new Uri(result);
 	}
 
-	public IEnumerable<(string, string)> GetConfigOptionsMetadata() =>
+	public IEnumerable<(string ParameterName, string Hint)> GetConfigOptionsMetadata() =>
 		Data.Select(x => (x.Key, x.Value.Hint));
 
 	private EndPointValue GetEndPointValue(string key, EndPoint value, string[] cliArgs)

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -26,22 +26,22 @@ public class Config
 				"The Bitcoin network to use: main, testnet, or regtest",
 				GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs)),
 			[ nameof(MainNetBackendUri)] = (
-				"The backend server's URI to connect to when the Bitcoin network is main",
+				"The backend server's URL to connect to when the Bitcoin network is main",
 				GetStringValue("MainNetBackendUri", PersistentConfig.MainNetBackendUri, cliArgs)),
 			[ nameof(TestNetBackendUri)] = (
-				"The backend server's URI to connect to when the Bitcoin network is testnet",
+				"The backend server's URL to connect to when the Bitcoin network is testnet",
 				GetStringValue("TestNetBackendUri", PersistentConfig.TestNetBackendUri, cliArgs)),
 			[ nameof(RegTestBackendUri)] = (
-				"The backend server's URI to connect to when the Bitcoin network is regtest",
+				"The backend server's URL to connect to when the Bitcoin network is regtest",
 				GetStringValue("RegTestBackendUri", PersistentConfig.RegTestBackendUri, cliArgs)),
 			[ nameof(MainNetCoordinatorUri)] = (
-				"The coordinator server's URI to connect to when the Bitcoin network is main",
+				"The coordinator server's URL to connect to when the Bitcoin network is main",
 				GetNullableStringValue("MainNetCoordinatorUri", PersistentConfig.MainNetCoordinatorUri, cliArgs)),
 			[ nameof(TestNetCoordinatorUri)] = (
-				"The coordinator server's URI to connect to when the Bitcoin network is testnet",
+				"The coordinator server's URL to connect to when the Bitcoin network is testnet",
 				GetNullableStringValue("TestNetCoordinatorUri", PersistentConfig.TestNetCoordinatorUri, cliArgs)),
 			[ nameof(RegTestCoordinatorUri)] = (
-				"The coordinator server's URI to connect to when the Bitcoin network is regtest",
+				"The coordinator server's URL to connect to when the Bitcoin network is regtest",
 				GetNullableStringValue("RegTestCoordinatorUri", PersistentConfig.RegTestCoordinatorUri, cliArgs)),
 			[ nameof(UseTor)] = (
 				"All the communications go through the Tor network",

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -45,46 +45,7 @@ public class WasabiApplication
 		}
 		if (AppConfig.Arguments.Contains("--help"))
 		{
-			Console.WriteLine($"{AppConfig.AppName} {Constants.ClientVersion}");
-			Console.WriteLine($"Usage: {AppConfig.AppName} [OPTION]...");
-			Console.WriteLine();
-			Console.WriteLine("Available options are:");
-
-			static string[] Split(string text)
-			{
-				static void InternalSlip(string text, List<string> result)
-				{
-					if (text.Length < 40)
-					{
-						result.Add(text);
-						return;
-					}
-					var line = text
-						.Split(' ')
-						.Scan(string.Empty, (l, w) => l + w + ' ')
-						.TakeWhile(l => l.Length <= 40)
-						.DefaultIfEmpty(text)
-						.Last();
-					result.Add(line);
-					InternalSlip(text[(line.Length)..], result);
-				}
-
-				List<string> result = new();
-				InternalSlip(text, result);
-				return result.ToArray();
-			}
-
-			foreach (var (parameter, hint) in Config.GetConfigOptionsMetadata().OrderBy(x => x.Item1))
-			{
-				Console.Write($"  --{parameter.ToLower(),-30} ");
-				var hintLines = Split(hint);
-				Console.WriteLine(hintLines[0]);
-				foreach (var hintLine in hintLines.Skip(1))
-				{
-					Console.WriteLine($"{' ',-35}{hintLine}");
-				}
-				Console.WriteLine();
-			}
+			ShowHelp();
 			return ExitCode.Ok;
 		}
 
@@ -187,6 +148,50 @@ public class WasabiApplication
 			? parsedLevel
 			: LogLevel.Info;
 		Logger.InitializeDefaults(Path.Combine(Config.DataDir, "Logs.txt"), logLevel);
+	}
+
+	private void ShowHelp()
+	{
+		Console.WriteLine($"{AppConfig.AppName} {Constants.ClientVersion}");
+		Console.WriteLine($"Usage: {AppConfig.AppName} [OPTION]...");
+		Console.WriteLine();
+		Console.WriteLine("Available options are:");
+
+		static string[] Split(string text)
+		{
+			static void InternalSlip(string text, List<string> result)
+			{
+				if (text.Length < 40)
+				{
+					result.Add(text);
+					return;
+				}
+				var line = text
+					.Split(' ')
+					.Scan(string.Empty, (l, w) => l + w + ' ')
+					.TakeWhile(l => l.Length <= 40)
+					.DefaultIfEmpty(text)
+					.Last();
+				result.Add(line);
+				InternalSlip(text[(line.Length)..], result);
+			}
+
+			List<string> result = new();
+			InternalSlip(text, result);
+			return result.ToArray();
+		}
+
+		foreach (var (parameter, hint) in Config.GetConfigOptionsMetadata().OrderBy(x => x.Item1))
+		{
+			Console.Write($"  --{parameter.ToLower(),-30} ");
+			var hintLines = Split(hint);
+			Console.WriteLine(hintLines[0]);
+			foreach (var hintLine in hintLines.Skip(1))
+			{
+				Console.WriteLine($"{' ',-35}{hintLine}");
+			}
+			Console.WriteLine();
+		}
 	}
 }
 

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -49,7 +49,7 @@ public class WasabiApplication
 			Console.WriteLine();
 			Console.WriteLine("Available options are:");
 
-			foreach (var (parameter, meta) in Config.GetConfigOptionsMetadata())
+			foreach (var (parameter, meta) in Config.GetConfigOptionsMetadata().OrderBy(x => x.Item1))
 			{
 				Console.WriteLine($"\t--{parameter.ToLower(),-32}\t{meta}");
 			}

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualBasic;
+using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.Services.Terminate;
@@ -49,9 +50,40 @@ public class WasabiApplication
 			Console.WriteLine();
 			Console.WriteLine("Available options are:");
 
-			foreach (var (parameter, meta) in Config.GetConfigOptionsMetadata().OrderBy(x => x.Item1))
+			static string[] Split(string text)
 			{
-				Console.WriteLine($"\t--{parameter.ToLower(),-32}\t{meta}");
+				static void InternalSlip(string text, List<string> result)
+				{
+					if (text.Length < 40)
+					{
+						result.Add(text);
+						return;
+					}
+					var line = text
+						.Split(' ')
+						.Scan(string.Empty, (l, w) => l + w + ' ')
+						.TakeWhile(l => l.Length <= 40)
+						.DefaultIfEmpty(text)
+						.Last();
+					result.Add(line);
+					InternalSlip(text[(line.Length)..], result);
+				}
+
+				List<string> result = new();
+				InternalSlip(text, result);
+				return result.ToArray();
+			}
+
+			foreach (var (parameter, hint) in Config.GetConfigOptionsMetadata().OrderBy(x => x.Item1))
+			{
+				Console.Write($"  --{parameter.ToLower(),-30} ");
+				var hintLines = Split(hint);
+				Console.WriteLine(hintLines[0]);
+				foreach (var hintLine in hintLines.Skip(1))
+				{
+					Console.WriteLine($"{' ',-35}{hintLine}");
+				}
+				Console.WriteLine();
 			}
 			return ExitCode.Ok;
 		}

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -157,34 +157,10 @@ public class WasabiApplication
 		Console.WriteLine();
 		Console.WriteLine("Available options are:");
 
-		static string[] Split(string text)
-		{
-			static void InternalSlip(string text, List<string> result)
-			{
-				if (text.Length < 40)
-				{
-					result.Add(text);
-					return;
-				}
-				var line = text
-					.Split(' ')
-					.Scan(string.Empty, (l, w) => l + w + ' ')
-					.TakeWhile(l => l.Length <= 40)
-					.DefaultIfEmpty(text)
-					.Last();
-				result.Add(line);
-				InternalSlip(text[(line.Length)..], result);
-			}
-
-			List<string> result = new();
-			InternalSlip(text, result);
-			return result.ToArray();
-		}
-
-		foreach (var (parameter, hint) in Config.GetConfigOptionsMetadata().OrderBy(x => x.Item1))
+		foreach (var (parameter, hint) in Config.GetConfigOptionsMetadata().OrderBy(x => x.ParameterName))
 		{
 			Console.Write($"  --{parameter.ToLower(),-30} ");
-			var hintLines = Split(hint);
+			var hintLines = hint.SplitLines(lineWidth: 40);
 			Console.WriteLine(hintLines[0]);
 			foreach (var hintLine in hintLines.Skip(1))
 			{

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -2,10 +2,11 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using WalletWasabi.Helpers;
+using Microsoft.VisualBasic;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.Services.Terminate;
+using Constants = WalletWasabi.Helpers.Constants;
 
 namespace WalletWasabi.Daemon;
 
@@ -39,6 +40,19 @@ public class WasabiApplication
 		if (AppConfig.Arguments.Contains("--version"))
 		{
 			Console.WriteLine($"{AppConfig.AppName} {Constants.ClientVersion}");
+			return ExitCode.Ok;
+		}
+		if (AppConfig.Arguments.Contains("--help"))
+		{
+			Console.WriteLine($"{AppConfig.AppName} {Constants.ClientVersion}");
+			Console.WriteLine($"Usage: {AppConfig.AppName} [OPTION]...");
+			Console.WriteLine();
+			Console.WriteLine("Available options are:");
+
+			foreach (var (parameter, meta) in Config.GetConfigOptionsMetadata())
+			{
+				Console.WriteLine($"\t--{parameter.ToLower(),-32}\t{meta}");
+			}
 			return ExitCode.Ok;
 		}
 

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -47,7 +47,7 @@ public static class StringExtensions
 
 	public static string[] SplitLines(this string text, int lineWidth)
 	{
-		static void InternalSlip(string text, int lineWidth, List<string> result)
+		static void InternalSplit(string text, int lineWidth, List<string> result)
 		{
 			while (true)
 			{
@@ -68,7 +68,7 @@ public static class StringExtensions
 		}
 
 		List<string> result = new();
-		InternalSlip(text, lineWidth, result);
+		InternalSplit(text, lineWidth, result);
 		return result.ToArray();
 	}
 }

--- a/WalletWasabi/Extensions/StringExtensions.cs
+++ b/WalletWasabi/Extensions/StringExtensions.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace WalletWasabi.Extensions;
 
 public static class StringExtensions
@@ -37,5 +40,35 @@ public static class StringExtensions
 		}
 
 		return char.IsWhiteSpace(me[0]) || char.IsWhiteSpace(me[^1]);
+	}
+
+	public static string[] SplitWords(this string text) =>
+		text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+	public static string[] SplitLines(this string text, int lineWidth)
+	{
+		static void InternalSlip(string text, int lineWidth, List<string> result)
+		{
+			while (true)
+			{
+				if (text.Length < lineWidth)
+				{
+					result.Add(text);
+					return;
+				}
+
+				var line = text.SplitWords()
+					.Scan(string.Empty, (l, w) => l + w + ' ')
+					.TakeWhile(l => l.Length <= lineWidth)
+					.DefaultIfEmpty(text)
+					.Last();
+				result.Add(line);
+				text = text[(line.Length)..];
+			}
+		}
+
+		List<string> result = new();
+		InternalSlip(text, lineWidth, result);
+		return result.ToArray();
 	}
 }


### PR DESCRIPTION
This PR add some help (not yet really) using the config metadata

```
$ wassabeed --help
Wasabi Daemon 2.0.4.0
Usage: Wasabi Daemon [OPTION]...

Available options are:
  --blockonlymode                  Indicate Wasabi should only listen for 
                                   blocks and not for transactions

  --coordinatoridentifier          -

  --downloadnewversion             Indicate new version of Wasabi should 
                                   be downloaded automatically

  --dustthreshold                  Threshold amount under which coin 
                                   received from others to reused 
                                   addresses are considered a dust attack

  --enablegpu                      Indicate Wasabi should use the GPU

  --jsonrpcpassword                The user password that is authorized to 
                                   make requests to the Json RPC server

  --jsonrpcserverenabled           Indicate the Json RPC Server should be 
                                   started and accepting requests

  --jsonrpcserverprefixes          Json RPC server prefixes

  --jsonrpcuser                    The user name that is authorized to 
                                   make requests to the Json RPC server

  --localbitcoincoredatadir        Specify the DataDir to be used by the 
                                   bitcoin node

  --loglevel                       Level of detail in the logs (trace, 
                                   debug, info, warning, error or 
                                   critical)

  --mainnetbackenduri              Url to the backend server to connect to 
                                   when network is main

  --mainnetbitcoinp2pendpoint      -

  --mainnetcoordinatoruri          Url to the coordinator server to 
                                   connect to when network is main

  --network                        Bitcoin network to use (main, testnet 
                                   or regtest)

  --regtestbackenduri              Url to the backend server to connect to 
                                   when network is regtest

  --regtestbitcoinp2pendpoint      -

  --regtestcoordinatoruri          Url to the coordinator server to 
                                   connect to when network is regtest

  --rpconionenabled                Indicate the Json RPC Server should be 
                                   published as an Tor Onion service

  --startlocalbitcoincoreonstartup Indicate that bitcoin node should be 
                                   started when wasabi starts

  --stoplocalbitcoincoreonshutdown Indicate that bitcoin node should be 
                                   stopped when finishes

  --terminatetoronexit             Indicate the Tor process must be 
                                   stopped when Wasabi finishes

  --testnetbackenduri              Url to the backend server to connect to 
                                   when network is testnet

  --testnetbitcoinp2pendpoint      -

  --testnetcoordinatoruri          Url to the coordinator server to 
                                   connect to when network is testnet

  --usetor                         Indicate all the communication have to 
                                   go thru the Tor network
