### PR TITLE
Add onion service to the `getstatus` rpc call

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -205,6 +205,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 				TorStatus.Running => "Running",
 				_ => "Turned off"
 			},
+			onionService = Global.OnionServiceUri?.ToString() ?? "Unavailable",
 			backendStatus = sync.BackendStatus == BackendStatus.Connected ? "Connected" : "Disconnected",
 			bestBlockchainHeight = smartHeaderChain.TipHeight.ToString(),
 			bestBlockchainHash = smartHeaderChain.TipHash?.ToString() ?? "",


### PR DESCRIPTION
This PR adds the `onionService` field to the `getstatus` rpc response in order to simplify sharing that uri.

Example:

```
curl -s \
  --user <user>:<password> \
  --data-binary '{"jsonrpc":"2.0","id":"1","method":"getstatus"}' \
  http://127.0.0.1:37128/ \
| jq '.result.onionService' --raw-output \
| qrencode -t ansiutf8
```

![image](https://github.com/zkSNACKs/WalletWasabi/assets/127973/1ba12c8d-62c3-4f73-ac69-4d3465d40e1f)
