### PR TITLE
[UI] Wallet Coins - fix unnecessary refreshes

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -28,13 +28,12 @@ public partial class WalletCoinsModel
 		_wallet = wallet;
 		_walletModel = walletModel;
 		var transactionProcessed = walletModel.Transactions.TransactionProcessed;
-		var anonScoreTargetChanged = walletModel.WhenAnyValue(x => x.Settings.AnonScoreTarget).ToSignal();
+		var anonScoreTargetChanged = walletModel.WhenAnyValue(x => x.Settings.AnonScoreTarget).Skip(1).ToSignal();
 		var isCoinjoinRunningChanged = walletModel.Coinjoin.IsRunning.ToSignal();
 
 		var signals = transactionProcessed
 			.Merge(anonScoreTargetChanged)
 			.Merge(isCoinjoinRunningChanged)
-			.StartWith(Unit.Default)
 			.Publish();
 
 		signals.SelectMany(_ => GetCoins())

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -47,7 +47,7 @@ public partial class WalletCoinsModel
 			.Subscribe();
 
 		signals
-			.Do(_ => Logger.LogInfo($"Refresh signal emitted in {walletModel.Name}"))
+			.Do(_ => Logger.LogDebug($"Refresh signal emitted in {walletModel.Name}"))
 			.Subscribe();
 
 		signals.Connect();


### PR DESCRIPTION
@MarnixCroes discovered:

> Everytime after launching Wasabi and opening a wallet I get 3 of these in the logs?
[1] INFO    WalletCoinsModel..ctor (51)    Refresh signal emitted in WalletName

This PR fixes it.