### PR TITLE
[VDG] Fix amount copy on Transaction Preview dialog

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -21,7 +21,6 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 	[AutoNotify] private LabelsArray _recipient = LabelsArray.Empty;
 	[AutoNotify] private Amount? _fee;
 	[AutoNotify] private Amount? _amount;
-	[AutoNotify] private Money? _copyableAmount;
 	[AutoNotify] private double? _amountDiff;
 	[AutoNotify] private double? _feeDiff;
 
@@ -55,7 +54,6 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		var destinationAmount = _transaction.CalculateDestinationAmount(info.Destination);
 
 		Amount = UiContext.AmountProvider.Create(destinationAmount);
-		CopyableAmount = Amount.Btc;
 		Fee = UiContext.AmountProvider.Create(_transaction.Fee);
 
 		Recipient = info.Recipient;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionSummaryViewModel.cs
@@ -21,6 +21,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 	[AutoNotify] private LabelsArray _recipient = LabelsArray.Empty;
 	[AutoNotify] private Amount? _fee;
 	[AutoNotify] private Amount? _amount;
+	[AutoNotify] private Money? _copyableAmount;
 	[AutoNotify] private double? _amountDiff;
 	[AutoNotify] private double? _feeDiff;
 
@@ -54,6 +55,7 @@ public partial class TransactionSummaryViewModel : ViewModelBase
 		var destinationAmount = _transaction.CalculateDestinationAmount(info.Destination);
 
 		Amount = UiContext.AmountProvider.Create(destinationAmount);
+		CopyableAmount = Amount.Btc;
 		Fee = UiContext.AmountProvider.Create(_transaction.Fee);
 
 		Recipient = info.Recipient;

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -48,7 +48,7 @@
       </Button>
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Label="Amount" HorizontalContentAlignment="Stretch"
-                     CopyableContent="{Binding CopyableAmount}">
+                     CopyableContent="{Binding Amount}">
         <StackPanel Orientation="Horizontal">
           <c:AmountControl Amount="{Binding Amount}" />
           <TextBlock Margin="8 0" FontWeight="Bold" Foreground="{Binding FeeDiff, Converter={StaticResource NeutralDiffConverter}}" IsVisible="{Binding !!AmountDiff}" VerticalAlignment="Bottom" Text="{Binding AmountDiff, Converter={x:Static converters:MoneyConverters.PercentageDifferenceConverter}}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -48,7 +48,7 @@
       </Button>
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Label="Amount" HorizontalContentAlignment="Stretch"
-                     CopyableContent="{Binding Amount}">
+                     CopyableContent="{Binding CopyableAmount}">
         <StackPanel Orientation="Horizontal">
           <c:AmountControl Amount="{Binding Amount}" />
           <TextBlock Margin="8 0" FontWeight="Bold" Foreground="{Binding FeeDiff, Converter={StaticResource NeutralDiffConverter}}" IsVisible="{Binding !!AmountDiff}" VerticalAlignment="Bottom" Text="{Binding AmountDiff, Converter={x:Static converters:MoneyConverters.PercentageDifferenceConverter}}" />
@@ -60,7 +60,6 @@
             <Binding Path="!!AmountDiff" Converter="{x:Static BoolConverters.Not}" />
           </MultiBinding>
         </Classes.Dimmed>
-
       </c:PreviewItem>
     </DockPanel>
     <Separator />
@@ -121,7 +120,6 @@
               <Binding Path="!!FeeDiff" Converter="{x:Static BoolConverters.Not}" />
             </MultiBinding>
           </Classes.Dimmed>
-
         </c:PreviewItem>
       </StackPanel>
     </DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -48,7 +48,7 @@
       </Button>
       <c:PreviewItem Icon="{StaticResource btc_logo}"
                      Label="Amount" HorizontalContentAlignment="Stretch"
-                     CopyableContent="{Binding Amount}">
+                     CopyableContent="{Binding Amount.Btc}">
         <StackPanel Orientation="Horizontal">
           <c:AmountControl Amount="{Binding Amount}" />
           <TextBlock Margin="8 0" FontWeight="Bold" Foreground="{Binding FeeDiff, Converter={StaticResource NeutralDiffConverter}}" IsVisible="{Binding !!AmountDiff}" VerticalAlignment="Bottom" Text="{Binding AmountDiff, Converter={x:Static converters:MoneyConverters.PercentageDifferenceConverter}}" />


### PR DESCRIPTION
Fixes #11785

## On master:

When you copy the `Amount` in the Tx Preview dialog, the class type of the amount got saved to the clipboard.

this: `WalletWasabi.Fluent.Models.Wallets.Amount`

## PR:

The actual BTC amount is copied to the clipboard.