### PR TITLE
CoinsByPrevOuts to TxIdsByPrevOuts

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -118,15 +118,16 @@ public class CoinsRegistry : ICoinsView
 			{
 				hashSet = new();
 				CoinsByTransactionId.Add(coin.TransactionId, hashSet);
+
+				// Each prevOut of the transaction contributes to the existence of coins.
+				// This only has to be added once per transaction.
+				foreach (TxIn input in coin.Transaction.Transaction.Inputs)
+				{
+					TxIdsByPrevOuts[input.PrevOut] = coin.TransactionId;
+				}
 			}
 
 			hashSet.Add(coin);
-
-			// Each prevOut of the transaction contributes to the existence of coins.
-			foreach (TxIn input in coin.Transaction.Transaction.Inputs)
-			{
-				TxIdsByPrevOuts[input.PrevOut] = coin.TransactionId;
-			}
 
 			InvalidateSnapshot = true;
 		}


### PR DESCRIPTION
Next 2 commits from #11740
c0ef1e961575a6e139424e9256ebcc2bee872f59
5fe794a1af0696e5241b0842bb274b20fe85d11c

It makes a lot of sense IMO because the values in this cache are already grouped by TxId