### PR TITLE
Set PreferPsbtWorkflow true when importing ColdCard HW

### DIFF
--- a/WalletWasabi/Helpers/ImportWalletHelper.cs
+++ b/WalletWasabi/Helpers/ImportWalletHelper.cs
@@ -91,6 +91,8 @@ public static class ImportWalletHelper
 			? NBitcoinHelpers.BetterParseExtPubKey(taprootXpubString)
 			: null;
 
-		return KeyManager.CreateNewHardwareWalletWatchOnly(mfp, segwitExtPubKey, taprootExtPubKey, manager.Network, walletFullPath);
+		var km = KeyManager.CreateNewHardwareWalletWatchOnly(mfp, segwitExtPubKey, taprootExtPubKey, manager.Network, walletFullPath);
+		km.PreferPsbtWorkflow = true;
+		return km;
 	}
 }


### PR DESCRIPTION
Fixes #11796

It only set's `PreferPsbtWorkflow` to `true` when the wallet is imported with ColdCard's json file. In that case it is safe to assume that the user prefers PSBT.