### PR TITLE
RPC service refactoring

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -17,6 +18,8 @@ using WalletWasabi.Models;
 using WalletWasabi.Rpc;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
+using JsonRpcResult = System.Collections.Generic.Dictionary<string, object?>;
+using JsonRpcResultList = System.Collections.Immutable.ImmutableArray<System.Collections.Generic.Dictionary<string, object?>>;
 
 namespace WalletWasabi.Daemon.Rpc;
 
@@ -34,30 +37,30 @@ public class WasabiJsonRpcService : IJsonRpcService
 	private Wallet? ActiveWallet { get; set; }
 
 	[JsonRpcMethod("listunspentcoins")]
-	public object[] GetUnspentCoinList()
+	public JsonRpcResultList GetUnspentCoinList()
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		AssertWalletIsLoaded();
 		var serverTipHeight = activeWallet.BitcoinStore.SmartHeaderChain.ServerTipHeight;
 		return activeWallet.Coins.Where(x => !x.IsSpent()).Select(
-			x => new
+			x => new JsonRpcResult
 			{
-				txid = x.TransactionId.ToString(),
-				index = x.Index,
-				amount = x.Amount.Satoshi,
-				anonymityScore = x.HdPubKey.AnonymitySet,
-				confirmed = x.Confirmed,
-				confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
-				label = x.HdPubKey.Labels.ToString(),
-				keyPath = x.HdPubKey.FullKeyPath.ToString(),
-				address = x.HdPubKey.GetAddress(Global.Network).ToString(),
-				excludedFromCoinjoin = x.IsExcludedFromCoinJoin
-			}).ToArray();
+				["txid"] = x.TransactionId.ToString(),
+				["index"] = x.Index,
+				["amount"] = x.Amount.Satoshi,
+				["anonymityScore"] = x.HdPubKey.AnonymitySet,
+				["confirmed"] = x.Confirmed,
+				["confirmations"] = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
+				["label"] = x.HdPubKey.Labels.ToString(),
+				["keyPath"] = x.HdPubKey.FullKeyPath.ToString(),
+				["address"] = x.HdPubKey.GetAddress(Global.Network).ToString(),
+				["excludedFromCoinjoin"] = x.IsExcludedFromCoinJoin
+			}).ToImmutableArray();
 	}
 
 	[JsonRpcMethod("listcoins")]
-	public object[] GetCoinList()
+	public JsonRpcResultList GetCoinList()
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
@@ -68,18 +71,18 @@ public class WasabiJsonRpcService : IJsonRpcService
 			throw new ArgumentException($"{nameof(activeWallet.Coins)} was not {typeof(CoinsRegistry)}.");
 		}
 		return coinRegistry.AsAllCoinsView().Select(
-			x => new
+			x => new JsonRpcResult
 			{
-				txid = x.TransactionId.ToString(),
-				index = x.Index,
-				amount = x.Amount.Satoshi,
-				anonymityScore = x.HdPubKey.AnonymitySet,
-				confirmed = x.Confirmed,
-				confirmations = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
-				keyPath = x.HdPubKey.FullKeyPath.ToString(),
-				address = x.HdPubKey.GetAddress(Global.Network).ToString(),
-				spentBy = x.SpenderTransaction?.GetHash().ToString()
-			}).ToArray();
+				["txid"] = x.TransactionId.ToString(),
+				["index"] = x.Index,
+				["amount"] = x.Amount.Satoshi,
+				["anonymityScore"] = x.HdPubKey.AnonymitySet,
+				["confirmed"] = x.Confirmed,
+				["confirmations"] = x.Confirmed ? serverTipHeight - (uint)x.Height.Value + 1 : 0,
+				["keyPath"] = x.HdPubKey.FullKeyPath.ToString(),
+				["address"] = x.HdPubKey.GetAddress(Global.Network).ToString(),
+				["spentBy"] = x.SpenderTransaction?.GetHash().ToString()
+			}).ToImmutableArray();
 	}
 
 	[JsonRpcMethod("createwallet", initializable: false)]
@@ -113,67 +116,61 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("getwalletinfo")]
-	public object WalletInfo()
+	public JsonRpcResult WalletInfo()
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		var km = activeWallet.KeyManager;
-		var accounts = new[]
+		var info = new JsonRpcResult
 		{
-			new
-			{
-				name = "segwit",
-				publicKey = km.SegwitExtPubKey.ToString(Global.Network),
-				keyPath = $"m/{km.SegwitAccountKeyPath}"
+			["walletName"] = activeWallet.WalletName,
+			["walletFile"] = km.FilePath,
+			["state"] = activeWallet.State.ToString(),
+			["masterKeyFingerprint"] = km.MasterFingerprint?.ToString() ?? "",
+			["anonScoreTarget"] = activeWallet.AnonScoreTarget,
+			["isWatchOnly"] = activeWallet.KeyManager.IsWatchOnly,
+			["isHardwareWallet"] = activeWallet.KeyManager.IsHardwareWallet,
+			["isAutoCoinjoin"] = activeWallet.KeyManager.AutoCoinJoin,
+			["isRedCoinIsolation"] = activeWallet.KeyManager.RedCoinIsolation,
+			["accounts"] = new [] {
+				new JsonRpcResult
+				{
+					["name"] = "segwit",
+					["publicKey"] = km.SegwitExtPubKey.ToString(Global.Network),
+					["keyPath"] = $"m/{km.SegwitAccountKeyPath}"
+				}
+
 			}
 		};
-		var info = new
+
+		if (km.TaprootExtPubKey is { } taprootExtPubKey)
 		{
-			walletName = activeWallet.WalletName,
-			walletFile = km.FilePath,
-			state = activeWallet.State.ToString(),
-			masterKeyFingerprint = km.MasterFingerprint?.ToString() ?? "",
-			anonScoreTarget = activeWallet.AnonScoreTarget,
-			isWatchOnly = activeWallet.KeyManager.IsWatchOnly,
-			isHardwareWallet = activeWallet.KeyManager.IsHardwareWallet,
-			isAutoCoinjoin = activeWallet.KeyManager.AutoCoinJoin,
-			isRedCoinIsolation = activeWallet.KeyManager.RedCoinIsolation,
-			accounts = km.TaprootExtPubKey is { } taprootExtPubKey
-				? accounts.Append(
-					new
-					{
-						name = "taproot",
-						publicKey = taprootExtPubKey.ToString(Global.Network),
-						keyPath = $"m/{km.TaprootAccountKeyPath}"
-					})
-				: accounts
-		};
-
-		return activeWallet.State != WalletState.Started
-			? info
-			: new
+			info["accounts"] = new[]
 			{
-				info.walletName,
-				info.walletFile,
-				info.state,
-				info.masterKeyFingerprint,
-				info.anonScoreTarget,
-				info.isWatchOnly,
-				info.isHardwareWallet,
-				info.isAutoCoinjoin,
-				info.isRedCoinIsolation,
-				info.accounts,
-
-				// The following elements are valid only after the wallet is fully synchronized
-				balance = activeWallet.Coins
-					.Where(c => !c.IsSpent() && !c.SpentAccordingToBackend)
-					.Sum(c => c.Amount.Satoshi),
-				coinjoinStatus = GetCoinjoinStatus(activeWallet)
+				info["accounts"],
+				new JsonRpcResult
+				{
+					["name"] = "taproot",
+					["publicKey"] = taprootExtPubKey.ToString(Global.Network),
+					["keyPath"] = $"m/{km.TaprootAccountKeyPath}"
+				}
 			};
+		}
+
+		if (activeWallet.State == WalletState.Started)
+		{
+				// The following elements are valid only after the wallet is fully synchronized
+				info["balance"] = activeWallet.Coins
+					.Where(c => !c.IsSpent() && !c.SpentAccordingToBackend)
+					.Sum(c => c.Amount.Satoshi);
+				info["coinjoinStatus"] = GetCoinjoinStatus(activeWallet);
+		}
+
+		return info;
 	}
 
 	[JsonRpcMethod("getnewaddress")]
-	public object GenerateReceiveAddress(string label)
+	public JsonRpcResult GenerateReceiveAddress(string label)
 	{
 		AssertWalletIsLoaded();
 		label = Guard.NotNullOrEmptyOrWhitespace(nameof(label), label, true);
@@ -181,45 +178,45 @@ public class WasabiJsonRpcService : IJsonRpcService
 
 		var hdKey = activeWallet.KeyManager.GetNextReceiveKey(new LabelsArray(label));
 
-		return new
+		return new JsonRpcResult
 		{
-			address = hdKey.GetAddress(Global.Network).ToString(),
-			keyPath = hdKey.FullKeyPath.ToString(),
-			label = hdKey.Labels.ToString(),
-			publicKey = hdKey.PubKey.ToHex(),
-			scriptPubKey = hdKey.GetAssumedScriptPubKey().ToHex()
+			["address"] = hdKey.GetAddress(Global.Network).ToString(),
+			["keyPath"] = hdKey.FullKeyPath.ToString(),
+			["label"] = hdKey.Labels.ToString(),
+			["publicKey"] = hdKey.PubKey.ToHex(),
+			["scriptPubKey"] = hdKey.GetAssumedScriptPubKey().ToHex()
 		};
 	}
 
 	[JsonRpcMethod("getstatus", initializable: false)]
-	public object GetStatus()
+	public JsonRpcResult GetStatus()
 	{
 		var sync = Global.Synchronizer;
 		var smartHeaderChain = Global.BitcoinStore.SmartHeaderChain;
 
-		return new
+		return new JsonRpcResult
 		{
-			torStatus = sync.TorStatus switch
+			["torStatus"] = sync.TorStatus switch
 			{
 				TorStatus.NotRunning => "Not running",
 				TorStatus.Running => "Running",
 				_ => "Turned off"
 			},
-			onionService = Global.OnionServiceUri?.ToString() ?? "Unavailable",
-			backendStatus = sync.BackendStatus == BackendStatus.Connected ? "Connected" : "Disconnected",
-			bestBlockchainHeight = smartHeaderChain.TipHeight.ToString(),
-			bestBlockchainHash = smartHeaderChain.TipHash?.ToString() ?? "",
-			filtersCount = smartHeaderChain.HashCount,
-			filtersLeft = smartHeaderChain.HashesLeft,
-			network = Global.Network.Name,
-			exchangeRate = sync.UsdExchangeRate,
-			peers = Global.HostedServices.Get<P2pNetwork>().Nodes.ConnectedNodes.Select(
-				x => new
+			["onionService"] = Global.OnionServiceUri?.ToString() ?? "Unavailable",
+			["backendStatus"] = sync.BackendStatus == BackendStatus.Connected ? "Connected" : "Disconnected",
+			["bestBlockchainHeight"] = smartHeaderChain.TipHeight.ToString(),
+			["bestBlockchainHash"] = smartHeaderChain.TipHash?.ToString() ?? "",
+			["filtersCount"] = smartHeaderChain.HashCount,
+			["filtersLeft"] = smartHeaderChain.HashesLeft,
+			["network"] = Global.Network.Name,
+			["exchangeRate"] = sync.UsdExchangeRate,
+			["peers"] = Global.HostedServices.Get<P2pNetwork>().Nodes.ConnectedNodes.Select(
+				x => new JsonRpcResult
 				{
-					isConnected = x.IsConnected,
-					lastSeen = x.LastSeen,
-					endpoint = x.Peer.Endpoint.ToString(),
-					userAgent = x.PeerVersion.UserAgent,
+					["isConnected"] = x.IsConnected,
+					["lastSeen"] = x.LastSeen,
+					["endpoint"] = x.Peer.Endpoint.ToString(),
+					["userAgent"] = x.PeerVersion.UserAgent,
 				}).ToArray(),
 		};
 	}
@@ -269,17 +266,17 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("send")]
-	public async Task<object> SendTransactionAsync(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, int? feeRate = null, string? password = null)
+	public async Task<JsonRpcResult> SendTransactionAsync(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, int? feeRate = null, string? password = null)
 	{
 		password = Guard.Correct(password);
 		var txHex = BuildTransaction(payments, coins, feeTarget, feeRate, password);
 		var smartTx = new SmartTransaction(Transaction.Parse(txHex, Global.Network), Height.Mempool);
 
 		await Global.TransactionBroadcaster.SendTransactionAsync(smartTx).ConfigureAwait(false);
-		return new
+		return new JsonRpcResult
 		{
-			txid = smartTx.Transaction.GetHash(),
-			tx = txHex
+			["txid"] = smartTx.Transaction.GetHash(),
+			["tx"] = txHex
 		};
 	}
 
@@ -318,35 +315,35 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("broadcast", initializable: false)]
-	public async Task<object> SendRawTransactionAsync(string txHex)
+	public async Task<JsonRpcResult> SendRawTransactionAsync(string txHex)
 	{
 		txHex = Guard.Correct(txHex);
 		var smartTx = new SmartTransaction(Transaction.Parse(txHex, Global.Network), Height.Mempool);
 
 		await Global.TransactionBroadcaster.SendTransactionAsync(smartTx).ConfigureAwait(false);
-		return new
+		return new JsonRpcResult
 		{
-			txid = smartTx.Transaction.GetHash()
+			["txid"] = smartTx.Transaction.GetHash()
 		};
 	}
 
 	[JsonRpcMethod("gethistory")]
-	public object[] GetHistory()
+	public JsonRpcResultList GetHistory()
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		AssertWalletIsLoaded();
 		var summary = activeWallet.BuildHistorySummary();
 		return summary.Select(
-			x => new
+			x => new JsonRpcResult
 			{
-				datetime = x.FirstSeen,
-				height = x.Height.Value,
-				amount = x.Amount.Satoshi,
-				label = x.Labels.ToString(),
-				tx = x.GetHash(),
-				islikelycoinjoin = x.IsOwnCoinjoin()
-			}).ToArray();
+				["datetime"] = x.FirstSeen,
+				["height"] = x.Height.Value,
+				["amount"] = x.Amount.Satoshi,
+				["label"] = x.Labels.ToString(),
+				["tx"] = x.GetHash(),
+				["islikelycoinjoin"] = x.IsOwnCoinjoin()
+			}).ToImmutableArray();
 	}
 
 	[JsonRpcMethod("excludefromcoinjoin")]
@@ -360,24 +357,24 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("listkeys")]
-	public object[] GetAllKeys()
+	public JsonRpcResultList GetAllKeys()
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
 		AssertWalletIsLoaded();
 		var keys = activeWallet.KeyManager.GetKeys();
 		return keys.Select(
-			x => new
+			x => new JsonRpcResult
 			{
-				fullKeyPath = x.FullKeyPath.ToString(),
-				@internal = x.IsInternal,
-				keyState = x.KeyState,
-				label = x.Labels.ToString(),
-				scriptPubKey = x.GetAssumedScriptPubKey().ToString(),
-				pubkey = x.PubKey.ToString(),
-				pubKeyHash = x.PubKeyHash.ToString(),
-				address = x.GetAddress(Global.Network).ToString()
-			}).ToArray();
+				["fullKeyPath"] = x.FullKeyPath.ToString(),
+				["internal"] = x.IsInternal,
+				["keyState"] = x.KeyState,
+				["label"] = x.Labels.ToString(),
+				["scriptPubKey"] = x.GetAssumedScriptPubKey().ToString(),
+				["pubkey"] = x.PubKey.ToString(),
+				["pubKeyHash"] = x.PubKeyHash.ToString(),
+				["address"] = x.GetAddress(Global.Network).ToString()
+			}).ToImmutableArray();
 	}
 
 	[JsonRpcMethod("startcoinjoin")]
@@ -446,13 +443,16 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("listwallets", initializable: false)]
-	public async Task<object[]> ListWalletsAsync()
+	public async Task<JsonRpcResultList> ListWalletsAsync()
 	{
 		var wallets = await Global.WalletManager.GetWalletsAsync().ConfigureAwait(false);
 		return wallets
 			.Cast<Wallet>()
-			.Select(x => new { walletName = x.WalletName})
-			.ToArray();
+			.Select(x => new JsonRpcResult
+			{
+				["walletName"] = x.WalletName
+			})
+			.ToImmutableArray();
 	}
 
 	[JsonRpcMethod(IJsonRpcService.StopRpcCommand, initializable: false)]

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -434,20 +434,6 @@ public class WasabiJsonRpcService : IJsonRpcService
 		coinJoinManager.StopAsync(activeWallet, CancellationToken.None).ConfigureAwait(false);
 	}
 
-	private string GetCoinjoinStatus(Wallet wallet)
-	{
-		var coinJoinManager = Global.HostedServices.Get<CoinJoinManager>();
-		var walletCoinjoinClientState = coinJoinManager.GetCoinjoinClientState(wallet.WalletName);
-		return walletCoinjoinClientState switch
-		{
-			CoinJoinClientState.Idle => "Idle",
-			CoinJoinClientState.InProgress => "In progress",
-			CoinJoinClientState.InSchedule => "In schedule",
-			CoinJoinClientState.InCriticalPhase => "In critical phase",
-			_ => throw new Exception($"The state {walletCoinjoinClientState.FriendlyName()} is unknown.")
-		};
-	}
-
 	[JsonRpcMethod("getfeerates", initializable: false)]
 	public object GetFeeRate()
 	{
@@ -469,6 +455,26 @@ public class WasabiJsonRpcService : IJsonRpcService
 			.ToArray();
 	}
 
+	[JsonRpcMethod(IJsonRpcService.StopRpcCommand, initializable: false)]
+	public Task StopAsync()
+	{
+		throw new InvalidOperationException("This RPC method is special and the handling method should not be called.");
+	}
+
+	private string GetCoinjoinStatus(Wallet wallet)
+	{
+		var coinJoinManager = Global.HostedServices.Get<CoinJoinManager>();
+		var walletCoinjoinClientState = coinJoinManager.GetCoinjoinClientState(wallet.WalletName);
+		return walletCoinjoinClientState switch
+		{
+			CoinJoinClientState.Idle => "Idle",
+			CoinJoinClientState.InProgress => "In progress",
+			CoinJoinClientState.InSchedule => "In schedule",
+			CoinJoinClientState.InCriticalPhase => "In critical phase",
+			_ => throw new Exception($"The state {walletCoinjoinClientState.FriendlyName()} is unknown.")
+		};
+	}
+
 	private void SelectWallet(string walletName)
 	{
 		walletName = Guard.NotNullOrEmptyOrWhitespace(nameof(walletName), walletName);
@@ -486,12 +492,6 @@ public class WasabiJsonRpcService : IJsonRpcService
 		{
 			throw new Exception($"Wallet '{walletName}' not found.");
 		}
-	}
-
-	[JsonRpcMethod(IJsonRpcService.StopRpcCommand, initializable: false)]
-	public Task StopAsync()
-	{
-		throw new InvalidOperationException("This RPC method is special and the handling method should not be called.");
 	}
 
 	private void AssertWalletIsLoaded()


### PR DESCRIPTION
This PR uses a type `JsonRpcResult` instead of `object` what give us more flexibility to create the response in the shape that we want.