### PR TITLE
Do not ban coinjoin outputs

### DIFF
--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -108,6 +108,7 @@ public class WabiSabiCoordinator : BackgroundService
 		OutPoint[] BannedInputs(Transaction tx) => tx.Inputs.Where(IsInputBanned).Select(x => x.PrevOut).ToArray();
 
 		var outpointsToBan = block.Transactions
+			.Where(tx => !CoinJoinIdStore.Contains(tx.GetHash()))  // We don't ban coinjoin outputs
 			.Select(tx => (Tx: tx, BannedInputs: BannedInputs(tx)))
 			.Where(x => x.BannedInputs.Any())
 			.SelectMany(x => x.Tx.Outputs.Select((_, i) => (new OutPoint(x.Tx, i), x.BannedInputs)));


### PR DESCRIPTION
Coinjoin outputs should not inherit punishments because otherwise everybody pays for the sins of a few.