### PR TITLE
[VDG] Fix PrivacyRing loading animation showing twice when opened

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/ItemsPresenterAnimationBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/ItemsPresenterAnimationBehavior.cs
@@ -79,13 +79,7 @@ public class ItemsControlAnimationBehavior : AttachedToVisualTreeBehavior<ItemsC
 						}
 					}
 				};
-
-				Dispatcher.UIThread.Post(async () =>
-				{
-					v.Opacity = 0;
-					await animation.RunAsync(v);
-					v.Opacity = 1;
-				});
+				animation.RunAsync(v);
 			})
 			.DisposeWith(disposable);
 	}


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/9338

This actually reverts previous fix for Avalonia 0.10.x from https://github.com/zkSNACKs/WalletWasabi/pull/10161

I think initial delay in animations was fixed in Avalonia v11.