### PR TITLE
Fix synchronization issue

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -123,7 +123,10 @@ public class Prison
 			_ => throw new NotSupportedException("Unknown offense type.")
 		};
 
-		BanningTimeCache[outpoint] = banningTime;
+		lock (Lock)
+		{
+			BanningTimeCache[outpoint] = banningTime;
+		}
 		return banningTime;
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -43,8 +43,7 @@ public static class WabiSabiProtocolErrorCodeExtension
 {
 	public static bool IsEvidencingClearMisbehavior(this WabiSabiProtocolErrorCode errorCode) =>
 		errorCode
-			is WabiSabiProtocolErrorCode.InputSpent
-			or WabiSabiProtocolErrorCode.ScriptNotAllowed
+			is WabiSabiProtocolErrorCode.ScriptNotAllowed
 			or WabiSabiProtocolErrorCode.NonStandardInput
 			or WabiSabiProtocolErrorCode.NonStandardOutput
 			or WabiSabiProtocolErrorCode.DeltaNotZero

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -755,6 +755,7 @@ public partial class Arena : PeriodicRunner
 			var roundOrNull = Rounds.FirstOrDefault(x => x.Id == disruptedRoundId);
 			if (roundOrNull is { } nonNullRound)
 			{
+				nonNullRound.LogInfo("Round aborted because it was disrupted by double spenders.");
 				nonNullRound.EndRound(EndRoundState.AbortedDoubleSpendingDetected);
 			}
 		}


### PR DESCRIPTION
Access to the banning times cache was not correctly synchronized and that resulted in exceptions like the following:

```
2023-10-30 02:37:10.382 [264] ERROR     PeriodicRunner.ExecuteAsync (107)       System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at WalletWasabi.WabiSabi.Backend.DoSPrevention.Prison.GetBanTimePeriod(OutPoint outpoint, DoSConfiguration configuration)
   at WalletWasabi.WabiSabi.WabiSabiCoordinator.<>c__DisplayClass35_0.<BanDescendant>g__IsInputBanned|0(TxIn input)
   at System.Linq.Enumerable.WhereSelectListIterator`2.ToArray()
   at WalletWasabi.WabiSabi.WabiSabiCoordinator.<>c__DisplayClass35_0.<BanDescendant>b__3(Transaction tx)
   at System.Linq.Enumerable.WhereSelectListIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
   at WalletWasabi.WabiSabi.WabiSabiCoordinator.BanDescendant(Object sender, Block block)
   at WalletWasabi.Blockchain.Blocks.BlockNotifier.ActionAsync(CancellationToken cancel)
```

Additionally here we don't ban spent inputs because they cannot participate anyway.