### PR TITLE
Don't use PubKey.Hash in HdPubKey equality comparer

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -372,7 +372,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 				["label"] = x.Labels.ToString(),
 				["scriptPubKey"] = x.GetAssumedScriptPubKey().ToString(),
 				["pubkey"] = x.PubKey.ToString(),
-				["pubKeyHash"] = x.PubKeyHash.ToString(),
+				["pubKeyHash"] = x.PubKey.Hash.ToString(),
 				["address"] = x.GetAddress(Global.Network).ToString()
 			}).ToImmutableArray();
 	}

--- a/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
@@ -208,14 +208,14 @@ public class SmartTransactionTests
 	{
 		SmartTransaction st = BitcoinFactory.CreateSmartTransaction(0, 1, 1, 1);
 
-		var originalSentBytes = st.WalletInputs.First().HdPubKey.PubKeyHash.ToBytes();
+		var originalSentBytes = st.WalletInputs.First().HdPubKey.PubKey.ToBytes();
 		var virtualSentBytes = st.WalletVirtualInputs.First().Id;
 		var originalSentCoin = st.WalletInputs.First().Coin;
 		var virtualSentCoin = st.WalletVirtualInputs.First().Coins.First().Coin;
 		Assert.Equal(originalSentBytes, virtualSentBytes);
 		Assert.Equal(originalSentCoin, virtualSentCoin);
 
-		var outputBytes = st.WalletOutputs.First().HdPubKey.PubKeyHash.ToBytes();
+		var outputBytes = st.WalletOutputs.First().HdPubKey.PubKey.ToBytes();
 		var outputVirtualBytes = st.WalletVirtualOutputs.First().Id;
 		var originalOutputAmount = st.WalletOutputs.First().Coin.Amount;
 		var virtualOutputAmount = st.WalletVirtualOutputs.First().Amount;

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -24,7 +24,7 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 	private double _anonymitySet = DefaultHighAnonymitySet;
 	private Cluster _cluster;
 
-	public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, LabelsArray labels, KeyState keyState)
+	public HdPubKey(PubKey pubKey, KeyPath fullKeyPath, LabelsArray labels, KeyState keyState, byte[]? keyIdBytes = null)
 	{
 		PubKey = Guard.NotNull(nameof(pubKey), pubKey);
 		FullKeyPath = Guard.NotNull(nameof(fullKeyPath), fullKeyPath);
@@ -39,7 +39,16 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 		_p2shOverP2wpkhScript = new Lazy<Script>(() => PubKey.GetScriptPubKey(ScriptPubKeyType.SegwitP2SH), isThreadSafe: true);
 		_p2Taproot = new Lazy<Script>(() => PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86), isThreadSafe: true);
 
-		PubKeyHash = PubKey.Hash;
+		if (keyIdBytes != null)
+		{
+			PubKeyHash = new KeyId(keyIdBytes);
+			KeyIdBytes = keyIdBytes;
+		}
+		else
+		{
+			PubKeyHash = PubKey.Hash;
+			KeyIdBytes = PubKeyHash.ToBytes();
+		}
 		HashCode = PubKeyHash.GetHashCode();
 
 		Index = (int)FullKeyPath.Indexes[4];
@@ -87,6 +96,10 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 
 	[JsonProperty(Order = 4)]
 	public KeyState KeyState { get; private set; }
+
+	[JsonProperty(Order = 5)]
+	[JsonConverter(typeof(ByteArrayJsonConverter))]
+	public byte[]? KeyIdBytes { get; }
 
 	/// <summary>Height of the block where all coins associated with the key were spent, or <c>null</c> if not yet spent.</summary>
 	/// <remarks>Value can be non-<c>null</c> only for <see cref="IsInternal">internal keys</see> as they should be used just once.</remarks>

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -126,8 +126,8 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		get
 		{
 			WalletVirtualInputsCache ??= WalletInputs
-					.GroupBy(i => i.HdPubKey.PubKeyHash.ToBytes(), new ByteArrayEqualityComparer())
-					.Select(g => new WalletVirtualInput(g.Key, g.ToHashSet()))
+					.GroupBy(i => i.HdPubKey.PubKey)
+					.Select(g => new WalletVirtualInput(g.Key.ToBytes(), g.ToHashSet()))
 					.ToHashSet();
 			return WalletVirtualInputsCache;
 		}
@@ -139,8 +139,8 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		get
 		{
 			WalletVirtualOutputsCache ??= WalletOutputs
-					.GroupBy(o => o.HdPubKey.PubKeyHash.ToBytes(), new ByteArrayEqualityComparer())
-					.Select(g => new WalletVirtualOutput(g.Key, g.ToHashSet()))
+					.GroupBy(o => o.HdPubKey.PubKey)
+					.Select(g => new WalletVirtualOutput(g.Key.ToBytes(), g.ToHashSet()))
 					.ToHashSet();
 			return WalletVirtualOutputsCache;
 		}

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -34,7 +34,8 @@ public class JsonSerializationOptions
 				new IssuanceRequestJsonConverter(),
 				new CredentialPresentationJsonConverter(),
 				new ProofJsonConverter(),
-				new MacJsonConverter()
+				new MacJsonConverter(),
+				new ByteArrayJsonConverter()
 			}
 	};
 

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -34,8 +34,7 @@ public class JsonSerializationOptions
 				new IssuanceRequestJsonConverter(),
 				new CredentialPresentationJsonConverter(),
 				new ProofJsonConverter(),
-				new MacJsonConverter(),
-				new ByteArrayJsonConverter()
+				new MacJsonConverter()
 			}
 	};
 


### PR DESCRIPTION
EDIT: Implemented @lontivero's suggestion: https://github.com/zkSNACKs/WalletWasabi/pull/11851#pullrequestreview-1710426768

I`Pubkey.Hash.Get()` is a time-consuming operation, and avoiding computing these values (what this PR is doing) improves startup by more or less 20% with wallets containing a lot of keys (8s -> 6s on my setup).