### PR TITLE
[PoC] RPC getcoinjoininfo

### DIFF
--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -20,7 +20,7 @@ public class RoundStateUpdater : PeriodicRunner
 	}
 
 	private IWabiSabiApiRequestHandler ArenaRequestHandler { get; }
-	private IDictionary<uint256, RoundState> RoundStates { get; set; } = new Dictionary<uint256, RoundState>();
+	public IDictionary<uint256, RoundState> RoundStates { get; set; } = new Dictionary<uint256, RoundState>();
 	public Dictionary<TimeSpan, FeeRate> CoinJoinFeeRateMedians { get; private set; } = new();
 
 	private List<RoundStateAwaiter> Awaiters { get; } = new();


### PR DESCRIPTION
PoC for #11888
Probably there are ways 1000x easier to do it, IDK.
This PR includes a huge hack: exposing `RoundStateUpdater` from `CoinjoinManager`.

It also has huge caveats: you can't know that a coin will be registered before its registration, and you can't know which round it's registered to before its confirmation...

Also, all naming etc... are bad; it's just to show why I think the feature is annoying and what information we should return.

If it wasn't already too frightening, one last note, I didn't test everything because all my testnet coins are banned now.