### PR TITLE
ISSUE_TEMPLATE: comment out example/help text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,7 +6,7 @@ about: Report a bug
 
 ### General Description
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 ### How To Reproduce?
 
@@ -17,25 +17,25 @@ A clear and concise description of what the bug is.
 
 ### Screenshots
 
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 ### Operating System
 
-*Please consider your privacy, before completing this section.*
+<!-- *Please consider your privacy, before completing this section.* -->
 
-Example: Ubuntu 16.04
+<!-- Example: Ubuntu 16.04 -->
 
 ### Logs
 
-*Please consider your privacy, before completing this section.*
+<!-- *Please consider your privacy, before completing this section.* -->
 
 ```
 Insert Your Logs Here
 ```
 
-You can find the `Logs.txt` file in the dropdown menu of the search bar or inside your Wasabi data folder or find `%PROFILE_PATH%/WalletWasabi/Client/Logs.txt` file.
+<!-- You can find the `Logs.txt` file in the dropdown menu of the search bar or inside your Wasabi data folder or find `%PROFILE_PATH%/WalletWasabi/Client/Logs.txt` file. -->
 
 ### Wasabi Version
 
-Which wasabi release are you using? Where did you download it from?  
-You can figure out which version you are using by choosing `About Wasabi` from the dropdown menu in the search bar.
+<!-- Which wasabi release are you using? Where did you download it from?  
+You can figure out which version you are using by choosing `About Wasabi` from the dropdown menu in the search bar. -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -23,7 +23,7 @@ about: Report a bug
 
 <!-- *Please consider your privacy, before completing this section.* -->
 
-<!-- Example: Ubuntu 16.04 -->
+<!-- Example: Ubuntu 22.04.3 LTS -->
 
 ### Logs
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,18 +4,18 @@ about: Request a Feature
 
 ---
 
-Ensure you are familiar with the project by reading the documentation and browsing through the already existing feature requests.
+<!-- Ensure you are familiar with the project by reading the documentation and browsing through the already existing feature requests.
 Be prepared to provide additional information or clarification if requested.
-Be patient and have understanding if the request is declined.
+Be patient and have understanding if the request is declined. -->
 
 ### Description
 
-Clearly articulate the feature request and its desired outcomes in a detailed manner.
+<!-- Clearly articulate the feature request and its desired outcomes in a detailed manner. -->
 
 ### Reasoning
 
-Tell us why would this feature be important and what problems would it solve.
+<!-- Tell us why would this feature be important and what problems would it solve. -->
 
 ### Designs
 
-Include any additional information such as screenshots or code examples that could be useful in understanding the request.
+<!-- Include any additional information such as screenshots or code examples that could be useful in understanding the request. -->


### PR DESCRIPTION
Over time, several people who opened an issue didn't remove the help/example text.
So it was shown when reading the issue.

Commenting it out makes the issue look better and easier to read, when the issue opener doesn't remove it.