### PR TITLE
Expose poisson scheduling in DateTimeOffset extension method

### DIFF
--- a/WalletWasabi/Extensions/DateTimeOffsetExtensions.cs
+++ b/WalletWasabi/Extensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Immutable;
+namespace WalletWasabi.Extensions;
+
+public static class DateTimeOffsetExtensions
+{
+	public static ImmutableList<DateTimeOffset> GetScheduledDates(this DateTimeOffset endTime, int howMany)
+	{
+		return endTime.GetScheduledDates(howMany, DateTimeOffset.UtcNow, TimeSpan.MaxValue);
+	}
+
+	public static ImmutableList<DateTimeOffset> GetScheduledDates(this DateTimeOffset endTime, int howMany, DateTimeOffset startTime, TimeSpan maximumRequestDelay)
+	{
+		var remainingTime = endTime - startTime;
+
+		if (remainingTime > maximumRequestDelay)
+		{
+			remainingTime = maximumRequestDelay;
+		}
+
+		return remainingTime.SamplePoisson(howMany, startTime);
+	}
+}


### PR DESCRIPTION
It's just refactoring, as #11679 wants to access poisson scheduling outside the `CoinJoinClient`.
In this PR, I moved `CoinJoinClient.GetScheduleDates` methods in `DateTimeOffsetExtensions`.
The virtual method must stay in `CJC` because a test is using it.

I could have created a non-extension method class but I believe it makes sense to be based on the `endTime`