### PR TITLE
Keep offenders grouped by txid.

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -133,7 +133,7 @@ public class Prison
 		return banningTime;
 	}
 
-	public void Punish(Offender offender)
+	private void Punish(Offender offender)
 	{
 		lock (Lock)
 		{

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -22,7 +22,7 @@ public class Prison
 	private Dictionary<uint256, List<Offender>> OffendersByTxId { get; }
 	private Dictionary<OutPoint, TimeFrame> BanningTimeCache { get; } = new();
 
-	/// <remarks>Lock object to guard <see cref="Offenders"/>.</remarks>
+	/// <remarks>Lock object to guard <see cref="OffendersByTxId"/>.</remarks>
 	private object Lock { get; } = new();
 
 	public void FailedToConfirm(OutPoint outPoint, Money value, uint256 roundId) =>


### PR DESCRIPTION
This is an optimization because otherwise calculating the banning period requires a full scan or the Offenders list, what is really expensive.