### PR TITLE
Reduce the punishment by half for offenders who spent.

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
@@ -170,5 +171,22 @@ public class PrisonTests
 
 		Assert.Equal(failToSignBanningTime.StartTime, inheritedBanningTime.StartTime); // because fail to sign is punished harder
 		Assert.Equal(failToSignBanningTime.Duration * 0.5, inheritedBanningTime.Duration); // after spending the punishment is reduced by half
+
+		// After spending a couple of times the coin is no longer banned
+		var outpointsToBan = Enumerable.Range(0, 10).Select(_ => BitcoinFactory.CreateOutPoint()).ToArray();
+		prison.FailedToSign(outpointsToBan[0], Money.Coins(0.005m), roundId);
+		var banningTimeFrames = outpointsToBan.Zip(outpointsToBan[1..], (a, b) => new { Destroyed = a, Created = b })
+			.Select(x =>
+			{
+				prison.InheritPunishment(x.Created, new[] { x.Destroyed });
+				return prison.GetBanTimePeriod(x.Created, cfg);
+			}).ToArray();
+
+		// Every time it is banned, the duration is halfed
+		var banningTimeFramePairs = banningTimeFrames.Zip(banningTimeFrames[1..], (parent, child) => (Parent: parent, Child: child)).ToArray();
+		Assert.All(banningTimeFramePairs[..^1], x => Assert.Equal(x.Parent.Duration, x.Child.Duration * 2));
+
+		// Final time frame is always zero
+		Assert.Equal(TimeSpan.Zero, banningTimeFrames[^1].Duration);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -168,6 +168,7 @@ public class PrisonTests
 		var failToSignBanningTime = prison.GetBanTimePeriod(ftcFailedToSign, cfg);
 		var inheritedBanningTime = prison.GetBanTimePeriod(ftcInheritFromFailedToSign, cfg);
 
-		Assert.Equal(failToSignBanningTime, inheritedBanningTime); // because fail to sign is punished harder
+		Assert.Equal(failToSignBanningTime.StartTime, inheritedBanningTime.StartTime); // because fail to sign is punished harder
+		Assert.Equal(failToSignBanningTime.Duration * 0.5, inheritedBanningTime.Duration); // after spending the punishment is reduced by half
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -96,10 +96,11 @@ public class Prison
 
 		TimeFrame CalculatePunishmentInheritance(OutPoint[] ancestors)
 		{
-			return ancestors
+			var banningTimeFrame = ancestors
 				.Select(a => (Ancestor: a, BanningTime: GetBanTimePeriod(a, configuration)))
 				.MaxBy(x => x.BanningTime.EndTime)
 				.BanningTime;
+			return new TimeFrame(banningTimeFrame.StartTime, banningTimeFrame.Duration / 2);
 		}
 
 		Offender? offender;


### PR DESCRIPTION
The reasoning is that by spending the banned coin the attacker has incurred in a penalty (cost of spending + time confirmation time).

Close https://github.com/zkSNACKs/WalletWasabi/issues/11933