### PR TITLE
[Trivial] Remove redundant WW1 status property

### DIFF
--- a/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/StatusResponse.cs
@@ -3,6 +3,5 @@ namespace WalletWasabi.Backend.Models.Responses;
 public class StatusResponse
 {
 	public bool FilterCreationActive { get; set; }
-	public bool CoinJoinCreationActive { get; set; }
 	public bool WabiSabiCoinJoinCreationActive { get; set; }
 }


### PR DESCRIPTION
I found out that we still have this redundant status about WW1 coinjoins.
<img width="1053" alt="image" src="https://github.com/zkSNACKs/WalletWasabi/assets/45069029/108e8de7-13f3-4fc2-928c-24662cf0ebf0">

and it will always be false.