### PR TITLE
Detecting and (avoid) Banning Wasabi coinjoins

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/OffenderSerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/OffenderSerializationTests.cs
@@ -35,6 +35,7 @@ public class OffenderSerializationTests
 		var offender3str = offender3.ToStringLine();
 		Assert.Equal(offender3str, Offender.FromStringLine(offender3str).ToStringLine());
 
+		// Double spent multiple rounds
 		var offender3x = new Offender(outpoint, now, new RoundDisruption(new[] { roundId, uint256.One }, Money.Satoshis(12345678), RoundDisruptionMethod.DoubleSpent));
 		var offender3xstr = offender3x.ToStringLine();
 		Assert.Equal(offender3xstr, Offender.FromStringLine(offender3xstr).ToStringLine());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/OffenderSerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/OffenderSerializationTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using NBitcoin;
-using WalletWasabi.Extensions;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using Xunit;
@@ -22,19 +21,23 @@ public class OffenderSerializationTests
 		Assert.Equal(offender0str, Offender.FromStringLine(offender0str).ToStringLine());
 
 		// Fail to confirm
-		var offender1 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DidNotConfirm));
+		var offender1 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DidNotConfirm));
 		var offender1str = offender1.ToStringLine();
 		Assert.Equal(offender1str, Offender.FromStringLine(offender1str).ToStringLine());
 
 		// Fail to sign
-		var offender2 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSign));
+		var offender2 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSign));
 		var offender2str = offender2.ToStringLine();
 		Assert.Equal(offender2str, Offender.FromStringLine(offender2str).ToStringLine());
 
 		// Double spent
-		var offender3 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DoubleSpent));
+		var offender3 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DoubleSpent));
 		var offender3str = offender3.ToStringLine();
 		Assert.Equal(offender3str, Offender.FromStringLine(offender3str).ToStringLine());
+
+		var offender3x = new Offender(outpoint, now, new RoundDisruption(new[] { roundId, uint256.One }, Money.Satoshis(12345678), RoundDisruptionMethod.DoubleSpent));
+		var offender3xstr = offender3x.ToStringLine();
+		Assert.Equal(offender3xstr, Offender.FromStringLine(offender3xstr).ToStringLine());
 
 		// Fail to verify
 		var offender4 = new Offender(outpoint, now, new FailedToVerify(roundId));
@@ -48,7 +51,7 @@ public class OffenderSerializationTests
 		Assert.Equal(offender5str, Offender.FromStringLine(offender5str).ToStringLine());
 
 		// Fail to signal ready to sign
-		var offender6 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSignalReadyToSign));
+		var offender6 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSignalReadyToSign));
 		var offender6str = offender6.ToStringLine();
 		Assert.Equal(offender6str, Offender.FromStringLine(offender6str).ToStringLine());
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/OffenderSerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/OffenderSerializationTests.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using NBitcoin;
-using System.Threading;
-using System.Threading.Tasks;
+using WalletWasabi.Extensions;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using Xunit;
@@ -23,17 +22,17 @@ public class OffenderSerializationTests
 		Assert.Equal(offender0str, Offender.FromStringLine(offender0str).ToStringLine());
 
 		// Fail to confirm
-		var offender1 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DidNotConfirm));
+		var offender1 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DidNotConfirm));
 		var offender1str = offender1.ToStringLine();
 		Assert.Equal(offender1str, Offender.FromStringLine(offender1str).ToStringLine());
 
 		// Fail to sign
-		var offender2 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSign));
+		var offender2 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSign));
 		var offender2str = offender2.ToStringLine();
 		Assert.Equal(offender2str, Offender.FromStringLine(offender2str).ToStringLine());
 
 		// Double spent
-		var offender3 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DoubleSpent));
+		var offender3 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DoubleSpent));
 		var offender3str = offender3.ToStringLine();
 		Assert.Equal(offender3str, Offender.FromStringLine(offender3str).ToStringLine());
 
@@ -49,7 +48,7 @@ public class OffenderSerializationTests
 		Assert.Equal(offender5str, Offender.FromStringLine(offender5str).ToStringLine());
 
 		// Fail to signal ready to sign
-		var offender6 = new Offender(outpoint, now, new RoundDisruption(roundId, Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSignalReadyToSign));
+		var offender6 = new Offender(outpoint, now, new RoundDisruption(roundId.Singleton(), Money.Satoshis(12345678), RoundDisruptionMethod.DidNotSignalReadyToSign));
 		var offender6str = offender6.ToStringLine();
 		Assert.Equal(offender6str, Offender.FromStringLine(offender6str).ToStringLine());
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -59,7 +59,7 @@ public class PrisonTests
 		Assert.Equal(Money.Coins(2m), disruptionNotSigning.Value);
 
 		// Double spent
-		prison.DoubleSpent(outpoint, Money.Coins(3m), roundId.Singleton());
+		prison.DoubleSpent(outpoint, Money.Coins(3m), roundId);
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var doubleSpending = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Extensions;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using Xunit;
@@ -35,7 +36,7 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var disruptionNotConfirming = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, disruptionNotConfirming.DisruptedRoundId);
+		Assert.Equal(roundId, disruptionNotConfirming.DisruptedRoundIds.First());
 		Assert.Equal(RoundDisruptionMethod.DidNotConfirm, disruptionNotConfirming.Method);
 		Assert.Equal(Money.Coins(1m), disruptionNotConfirming.Value);
 
@@ -44,7 +45,7 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var disruptionNotSignallingReadyToSign = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, disruptionNotSignallingReadyToSign.DisruptedRoundId);
+		Assert.Equal(roundId, disruptionNotSignallingReadyToSign.DisruptedRoundIds.First());
 		Assert.Equal(RoundDisruptionMethod.DidNotSignalReadyToSign, disruptionNotSignallingReadyToSign.Method);
 		Assert.Equal(Money.Coins(1m), disruptionNotSignallingReadyToSign.Value);
 
@@ -53,16 +54,16 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var disruptionNotSigning = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, disruptionNotSigning.DisruptedRoundId);
+		Assert.Equal(roundId, disruptionNotSigning.DisruptedRoundIds.First());
 		Assert.Equal(RoundDisruptionMethod.DidNotSign, disruptionNotSigning.Method);
 		Assert.Equal(Money.Coins(2m), disruptionNotSigning.Value);
 
 		// Double spent
-		prison.DoubleSpent(outpoint, Money.Coins(3m), roundId);
+		prison.DoubleSpent(outpoint, Money.Coins(3m), roundId.Singleton());
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var doubleSpending = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, doubleSpending.DisruptedRoundId);
+		Assert.Equal(roundId, doubleSpending.DisruptedRoundIds.First());
 		Assert.Equal(RoundDisruptionMethod.DoubleSpent, doubleSpending.Method);
 		Assert.Equal(Money.Coins(3m), doubleSpending.Value);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -35,7 +35,7 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var disruptionNotConfirming = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, disruptionNotConfirming.DisruptedRoundIds.First());
+		Assert.Equal(roundId, Assert.Single(disruptionNotConfirming.DisruptedRoundIds));
 		Assert.Equal(RoundDisruptionMethod.DidNotConfirm, disruptionNotConfirming.Method);
 		Assert.Equal(Money.Coins(1m), disruptionNotConfirming.Value);
 
@@ -44,7 +44,7 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var disruptionNotSignallingReadyToSign = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, disruptionNotSignallingReadyToSign.DisruptedRoundIds.First());
+		Assert.Equal(roundId, Assert.Single(disruptionNotSignallingReadyToSign.DisruptedRoundIds));
 		Assert.Equal(RoundDisruptionMethod.DidNotSignalReadyToSign, disruptionNotSignallingReadyToSign.Method);
 		Assert.Equal(Money.Coins(1m), disruptionNotSignallingReadyToSign.Value);
 
@@ -53,7 +53,7 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var disruptionNotSigning = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, disruptionNotSigning.DisruptedRoundIds.First());
+		Assert.Equal(roundId, Assert.Single(disruptionNotSigning.DisruptedRoundIds));
 		Assert.Equal(RoundDisruptionMethod.DidNotSign, disruptionNotSigning.Method);
 		Assert.Equal(Money.Coins(2m), disruptionNotSigning.Value);
 
@@ -62,7 +62,7 @@ public class PrisonTests
 		offenderToSave = await reader.ReadAsync(ctsTimeout.Token);
 		var doubleSpending = Assert.IsType<RoundDisruption>(offenderToSave.Offense);
 		Assert.Equal(outpoint, offenderToSave.OutPoint);
-		Assert.Equal(roundId, doubleSpending.DisruptedRoundIds.First());
+		Assert.Equal(roundId, Assert.Single(doubleSpending.DisruptedRoundIds));
 		Assert.Equal(RoundDisruptionMethod.DoubleSpent, doubleSpending.Method);
 		Assert.Equal(Money.Coins(3m), doubleSpending.Value);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PrisonTests.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Extensions;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using Xunit;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
@@ -1,8 +1,8 @@
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NBitcoin;
+using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;
@@ -50,7 +50,7 @@ public class UtxoPrisonWardenTests
 		w.Prison.FailedVerification(i1, uint256.One);
 		w.Prison.FailedToConfirm(i2, Money.Coins(0.01m), uint256.One);
 		w.Prison.FailedToSign(i3, Money.Coins(0.1m), uint256.One);
-		w.Prison.DoubleSpent(i4, Money.Coins(0.1m), uint256.One);
+		w.Prison.DoubleSpent(i4, Money.Coins(0.1m), uint256.One.Singleton());
 		w.Prison.CheatingDetected(i5, uint256.One);
 
 		// Wait until serializes.

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
@@ -2,7 +2,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NBitcoin;
-using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/UtxoPrisonWardenTests.cs
@@ -50,7 +50,7 @@ public class UtxoPrisonWardenTests
 		w.Prison.FailedVerification(i1, uint256.One);
 		w.Prison.FailedToConfirm(i2, Money.Coins(0.01m), uint256.One);
 		w.Prison.FailedToSign(i3, Money.Coins(0.1m), uint256.One);
-		w.Prison.DoubleSpent(i4, Money.Coins(0.1m), uint256.One.Singleton());
+		w.Prison.DoubleSpent(i4, Money.Coins(0.1m), uint256.One);
 		w.Prison.CheatingDetected(i5, uint256.One);
 
 		// Wait until serializes.

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -223,6 +223,11 @@ public static class LinqExtensions
 		}
 	}
 
+	public static IEnumerable<T> Singleton<T>(this T item)
+	{
+		yield return item;
+	}
+
 	public static double WeightedAverage<T>(this IEnumerable<T> source, Func<T, double> value, Func<T, double> weight)
 	{
 		return source.Select(x => value(x) * weight(x)).Sum() / source.Select(weight).Sum();

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Offender.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Offender.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
+using WalletWasabi.Extensions;
 
 namespace WalletWasabi.WabiSabi.Backend.DoSPrevention;
 
@@ -13,7 +14,7 @@ public enum RoundDisruptionMethod
 }
 
 public abstract record Offense();
-public record RoundDisruption(uint256 DisruptedRoundId, Money Value, RoundDisruptionMethod Method) : Offense;
+public record RoundDisruption(IEnumerable<uint256> DisruptedRoundIds, Money Value, RoundDisruptionMethod Method) : Offense;
 public record FailedToVerify(uint256 VerifiedInRoundId) : Offense;
 public record Inherited(OutPoint[] Ancestors) : Offense;
 public record Cheating(uint256 RoundId) : Offense;
@@ -32,7 +33,7 @@ public record Offender(OutPoint OutPoint, DateTimeOffset StartedTime, Offense Of
 				case RoundDisruption rd:
 					yield return nameof(RoundDisruption);
 					yield return rd.Value.Satoshi.ToString();
-					yield return rd.DisruptedRoundId.ToString();
+					yield return rd.DisruptedRoundIds.First().ToString();
 					yield return rd.Method switch
 					{
 						RoundDisruptionMethod.DidNotConfirm => "didn't confirm",
@@ -76,7 +77,7 @@ public record Offender(OutPoint OutPoint, DateTimeOffset StartedTime, Offense Of
 		{
 			nameof(RoundDisruption) =>
 				new RoundDisruption(
-					uint256.Parse(parts[4]),
+					uint256.Parse(parts[4]).Singleton(),
 					Money.Satoshis(long.Parse(parts[3])),
 
 					parts[5] switch

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -27,16 +27,19 @@ public class Prison
 	private object Lock { get; } = new();
 
 	public void FailedToConfirm(OutPoint outPoint, Money value, uint256 roundId) =>
-		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId.Singleton(), value, RoundDisruptionMethod.DidNotConfirm)));
+		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId, value, RoundDisruptionMethod.DidNotConfirm)));
 
 	public void FailedToSign(OutPoint outPoint, Money value, uint256 roundId) =>
-		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId.Singleton(), value, RoundDisruptionMethod.DidNotSign)));
+		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId, value, RoundDisruptionMethod.DidNotSign)));
 
 	public void FailedVerification(OutPoint outPoint, uint256 roundId) =>
 		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new FailedToVerify(roundId)));
 
 	public void CheatingDetected(OutPoint outPoint, uint256 roundId) =>
 		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new Cheating(roundId)));
+
+	public void DoubleSpent(OutPoint outPoint, Money value, uint256 roundId) =>
+		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId, value, RoundDisruptionMethod.DoubleSpent)));
 
 	public void DoubleSpent(OutPoint outPoint, Money value, IEnumerable<uint256> roundIds) =>
 		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundIds, value, RoundDisruptionMethod.DoubleSpent)));
@@ -45,7 +48,7 @@ public class Prison
 		Punish(new Offender(outpoint, DateTimeOffset.UtcNow, new Inherited(ancestors)));
 
 	public void FailedToSignalReadyToSign(OutPoint outPoint, Money value, uint256 roundId) =>
-		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId.Singleton(), value, RoundDisruptionMethod.DidNotSignalReadyToSign)));
+		Punish(new Offender(outPoint, DateTimeOffset.UtcNow, new RoundDisruption(roundId, value, RoundDisruptionMethod.DidNotSignalReadyToSign)));
 
 	public bool IsBanned(OutPoint outpoint, DoSConfiguration configuration, DateTimeOffset when) =>
 		GetBanTimePeriod(outpoint, configuration).Includes(when);

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -2,7 +2,6 @@ using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Channels;
-using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -216,7 +216,7 @@ public partial class Arena : PeriodicRunner
 						{
 							foreach (var offender in offendingAlices)
 							{
-								Prison.DoubleSpent(offender.Coin.Outpoint, offender.Coin.Amount, round.Id);
+								Prison.DoubleSpent(offender.Coin.Outpoint, offender.Coin.Amount, round.Id.Singleton());
 								offendingAliceCounter++;
 							}
 						}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -216,7 +216,7 @@ public partial class Arena : PeriodicRunner
 						{
 							foreach (var offender in offendingAlices)
 							{
-								Prison.DoubleSpent(offender.Coin.Outpoint, offender.Coin.Amount, round.Id.Singleton());
+								Prison.DoubleSpent(offender.Coin.Outpoint, offender.Coin.Amount, round.Id);
 								offendingAliceCounter++;
 							}
 						}

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -136,7 +136,7 @@ public class WabiSabiCoordinator : BackgroundService
 			return;
 		}
 
-		// Ban all outputs created by the the received transaction because it has spent coins participating in coinjoin rounds.
+		// Ban all outputs created by the received transaction because it has spent coins participating in coinjoin rounds.
 		foreach (var indexedOutput in tx.Outputs.AsIndexedOutputs())
 		{
 			Warden.Prison.DoubleSpent(new OutPoint(tx, indexedOutput.N), indexedOutput.TxOut.Value, disruptedRounds);

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.Hosting;
 using NBitcoin;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -132,7 +130,7 @@ public class WabiSabiCoordinator : BackgroundService
 		var inputOutPoints = tx.Inputs.Select(x => x.PrevOut);
 		var disruptedRounds = Arena.GetRoundsContainingOutpoints(inputOutPoints);
 
-		// No round was hurt disrupted by the received transaction. Nothing to do here.
+		// No round was disrupted by the received transaction. Nothing to do here.
 		if (disruptedRounds.Length == 0)
 		{
 			return;


### PR DESCRIPTION
This PR fixes a few very important things in the process of detecting and banning round disruptions by spending coins participating in coinjoin rounds.

1. Given a transaction can have multiple inputs and those can be participating in multiple rounds, a single transaction can be used to disrupt more than one round. This fact was not part of the original design and for that reason the RoundDisruption offense only considered one round instead of multiple rounds.
2. Wasabi was banning the inputs of the attacking transaction but those coins are spent and it makes no sense to ban them, instead it should have banned the coins that the attacking transaction creates.
3. There was a small time frame where a received wasabi coinjoin transaction was not in the CoinJoinIdStore or in the RoundStates either because of that some coinjoins were detected as double spending attacks. Fortunately the mistake in point 2 (above) made this a non-issue. This is solved by querying `Arena.Rounds` instead of `Arena.RoundStates`.

Additionally to these problems this PR adds:
* Unit tests for the code
* Code refactoring to make it more readable 
* Heuristic to make absolutely sure we don't ban Wasabi coinjoins. Sounds unnecessary but I want to be 100% sure.   