### PR TITLE
`AutoInterfaceGenerator`: Skip interface method implementations

### DIFF
--- a/WalletWasabi.Fluent.Generators/Generators/AutoInterfaceGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/Generators/AutoInterfaceGenerator.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using WalletWasabi.Fluent.Generators.Abstractions;
 
 namespace WalletWasabi.Fluent.Generators.Generators;
@@ -69,26 +70,26 @@ internal class AutoInterfaceGenerator : GeneratorStep<ClassDeclarationSyntax>
 			{
 				var returnType = method.ReturnType.SimplifyType(namespaces);
 
-				var signature = "\t";
+				StringBuilder signatureBuilder = new(capacity: 150);
+				signatureBuilder.Append('\t');
+				signatureBuilder.Append(returnType);
+				signatureBuilder.Append(' ');
+				signatureBuilder.Append(method.Name);
 
-				signature += returnType;
-
-				signature += $" {method.Name}";
 				if (method.IsGenericMethod)
 				{
-					signature += "<";
+					signatureBuilder.Append('<');
 
 					var typeArgs =
 						from argument in method.TypeArguments
 						let typeName = argument.SimplifyType(namespaces)
 						select typeName;
 
-					signature += string.Join(", ", typeArgs);
-
-					signature += ">";
+					signatureBuilder.Append(string.Join(", ", typeArgs));
+					signatureBuilder.Append('>');
 				}
 
-				signature += "(";
+				signatureBuilder.Append('(');
 
 				var parameters =
 					from parameter in method.Parameters
@@ -102,11 +103,10 @@ internal class AutoInterfaceGenerator : GeneratorStep<ClassDeclarationSyntax>
 					let defaultValueString = defaultValue != null ? " = " + defaultValue : null
 					select $"{attributeList?.ToFullString()}{refKind}{type} {name}{defaultValueString}";
 
-				signature += string.Join(", ", parameters);
+				signatureBuilder.Append(string.Join(", ", parameters));
+				signatureBuilder.Append(");");
 
-				signature += ");";
-
-				methods.Add(signature);
+				methods.Add(signatureBuilder.ToString());
 			}
 		}
 


### PR DESCRIPTION
There is, eg, `HealthMonitor` and we generate an `IHealthMonitor` interface for it. However, `IHealthMonitor` adds `Dispose` method even though it hides an existing one for `HealthMonitor`.

This PR is PoC what we can posssibly do about it. It's certainly not perfect (performance-wise).

The generated `IHealthMonitor` looks like this:

```cs
public partial interface IHealthMonitor
{
	ICollection<Issue> TorIssues { get; }
	bool UseTor { get; }
	bool UseBitcoinCore { get; }
	TorStatus TorStatus { get; set; }
	BackendStatus BackendStatus { get; set; }
	bool IsConnectionIssueDetected { get; set; }
	RpcStatus? BitcoinCoreStatus { get; set; }
	int Peers { get; set; }
	bool IsP2pConnected { get; set; }
	HealthMonitorState State { get; set; }
	bool CriticalUpdateAvailable { get; set; }
	bool UpdateAvailable { get; set; }
	bool IsReadyToInstall { get; set; }
	bool CheckForUpdates { get; set; }
	Version? ClientVersion { get; set; }
	 /* SKIPPED: Implements an interface */ /* void Dispose(); */  // <<---- this is what the PR does (to demonstrate it).
}
```

The goal of the PR is to make the generated code correct and remove warnings in the process.