### PR TITLE
Is other selection possible test

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
@@ -334,12 +334,7 @@ public partial class LabelSelectionViewModel : ViewModelBase
 		remainingUsablePockets.Remove(_privatePocket);
 		remainingUsablePockets.Remove(_semiPrivatePocket);
 
-		if (usedPockets.Length == 1 && usedPockets.First() == _privatePocket)
-		{
-			return false;
-		}
-
-		if (usedPockets.Length == 1 && usedPockets.First() == _semiPrivatePocket)
+		if (usedPockets.Length == 1)
 		{
 			return false;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
@@ -127,7 +128,10 @@ public partial class LabelSelectionViewModel : ViewModelBase
 				.ToArray();
 
 		var bestPockets = new List<Pocket>();
-		bestPockets.AddRange(privateAndSemiPrivatePockets);
+		if (Pocket.Merge(privateAndSemiPrivatePockets).Coins.TotalAmount() != Money.Zero)
+		{
+			bestPockets.AddRange(privateAndSemiPrivatePockets);
+		}
 
 		// Iterate through the ordered by privacy pockets and add them one by one until the total amount covers the payment.
 		// The first one is the best from the privacy point of view, and the last one is the worst.

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
@@ -938,6 +938,7 @@ public class PocketSelectionTests
 		// No other pocket can be used case.
 		recipient = "Adam";
 		selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
+		await selection.ResetAsync(pockets.ToArray());
 		output = await selection.AutoSelectPocketsAsync();
 		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
 

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
@@ -928,12 +928,12 @@ public class PocketSelectionTests
 		pockets.Add(LabelTestExtensions.CreateSingleCoinPocket(1.0m, "Dan"));
 		pockets.Add(LabelTestExtensions.CreateSingleCoinPocket(1.0m, "Dan, Lucas"));
 
-		// Other pocket can be used case.
+		// Other pocket cannot be used case.
 		var recipient = "Lucas";
 		var selection = CreateLabelSelectionViewModel(Money.Parse("0.5"), recipient);
 		await selection.ResetAsync(pockets.ToArray());
 		var output = await selection.AutoSelectPocketsAsync();
-		Assert.True(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
+		Assert.False(selection.IsOtherSelectionPossible(output.SelectMany(x => x.Coins), recipient));
 
 		// No other pocket can be used case.
 		recipient = "Adam";


### PR DESCRIPTION
Fixes #8080
Fixes #11038

https://github.com/zkSNACKs/WalletWasabi/blob/c00092a2a204b2690f96d7788aef14fd749d91e0/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs#L58

If `AutoSelectPocketsAsync` returns only 1 pocket we shouldn't select other pockets, right?