### PR TITLE
Reduce and randomize local banning time if the banning time is absurdly long

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -406,6 +406,8 @@ public class Global
 				UpdateManager.Dispose();
 				Logger.LogInfo($"{nameof(UpdateManager)} is stopped.");
 
+				CoinPrison.ToFile();
+
 				if (RpcServer is { } rpcServer)
 				{
 					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -406,7 +406,7 @@ public class Global
 				UpdateManager.Dispose();
 				Logger.LogInfo($"{nameof(UpdateManager)} is stopped.");
 
-				CoinPrison.ToFile();
+				CoinPrison.Dispose();
 
 				if (RpcServer is { } rpcServer)
 				{

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.WabiSabi.Client.Banning;
 
 public class CoinPrison
 {
-	private readonly int _maxDaysToTrustLocalPrison = 4;
+	private static readonly int MaxDaysToTrustLocalPrison = 4;
 
 	public CoinPrison(string filePath)
 	{
@@ -82,14 +82,14 @@ public class CoinPrison
 		File.WriteAllText(FilePath, json);
 	}
 
-	private DateTimeOffset ReduceBanningTimeIfNeeded(DateTimeOffset bannedUntil)
+	private static DateTimeOffset ReduceBanningTimeIfNeeded(DateTimeOffset bannedUntil)
 	{
 		var currentDate = DateTimeOffset.UtcNow;
-		if (bannedUntil > currentDate.AddDays(_maxDaysToTrustLocalPrison))
+		if (bannedUntil > currentDate.AddDays(MaxDaysToTrustLocalPrison))
 		{
 			Random random = new();
-			int minHours = (_maxDaysToTrustLocalPrison * 24 - 1) / 2;
-			int maxHours = _maxDaysToTrustLocalPrison * 24 - 1;
+			int minHours = (MaxDaysToTrustLocalPrison * 24 - 1) / 2;
+			int maxHours = MaxDaysToTrustLocalPrison * 24 - 1;
 			int randomHours = random.Next(minHours, maxHours);
 			int randomMinutes = random.Next(0, 60);
 			int randomSeconds = random.Next(0, 60);
@@ -122,6 +122,12 @@ public class CoinPrison
 			Logger.LogError($"There was an error during loading {nameof(CoinPrison)}. Deleting corrupt file.", exc);
 			File.Delete(prisonFilePath);
 		}
+
+		foreach (var item in prisonedCoinRecords)
+		{
+			item.BannedUntil = ReduceBanningTimeIfNeeded(item.BannedUntil);
+		}
+
 		return new(prisonFilePath) { BannedCoins = prisonedCoinRecords };
 	}
 

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -10,7 +10,7 @@ using WalletWasabi.Wallets;
 
 namespace WalletWasabi.WabiSabi.Client.Banning;
 
-public class CoinPrison
+public class CoinPrison : IDisposable
 {
 	private static readonly int MaxDaysToTrustLocalPrison = 4;
 
@@ -70,7 +70,7 @@ public class CoinPrison
 		ToFile();
 	}
 
-	public void ToFile()
+	private void ToFile()
 	{
 		if (string.IsNullOrWhiteSpace(FilePath))
 		{
@@ -140,5 +140,10 @@ public class CoinPrison
 				coin.BannedUntilUtc = bannedUntil;
 			}
 		}
+	}
+
+	public void Dispose()
+	{
+		ToFile();
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -70,7 +70,7 @@ public class CoinPrison
 		ToFile();
 	}
 
-	private void ToFile()
+	public void ToFile()
 	{
 		if (string.IsNullOrWhiteSpace(FilePath))
 		{

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -12,6 +12,7 @@ namespace WalletWasabi.WabiSabi.Client.Banning;
 
 public class CoinPrison : IDisposable
 {
+	// Coins with banning time longer than this will be reduced to a random value between 2 and 4 days.
 	private static readonly int MaxDaysToTrustLocalPrison = 4;
 
 	public CoinPrison(string filePath)
@@ -82,6 +83,14 @@ public class CoinPrison : IDisposable
 		File.WriteAllText(FilePath, json);
 	}
 
+	/// <summary>
+	///	Reduces local banning time, which we save to disk, if it's longer than the <see cref="MaxDaysToTrustLocalPrison"/>.
+	///	This is to avoid saving absurd long banning times like 1-2 years.
+	///	With this, the coin will retry to participate in a CJ in every 2-4 days and see if the coin is still banned or not according to the backend.
+	///	Random values are used for the new banning period so we don't leak information to the coordinator when the coins get released from the local prison.
+	/// </summary>
+	/// <param name="bannedUntil">Banning time according to the backend.</param>
+	/// <returns>New banning period we want to save to file on client side.</returns>
 	private static DateTimeOffset ReduceBanningTimeIfNeeded(DateTimeOffset bannedUntil)
 	{
 		var currentDate = DateTimeOffset.UtcNow;

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.WabiSabi.Client.Banning;
 
 public class CoinPrison
 {
-	private readonly int _absoluteMaximumLocalPrisonBanningTimeInDays = 31;
+	private readonly int _maxDaysToTrustLocalPrison = 4;
 
 	public CoinPrison(string filePath)
 	{
@@ -85,10 +85,12 @@ public class CoinPrison
 	private DateTimeOffset ReduceBanningTimeIfNeeded(DateTimeOffset bannedUntil)
 	{
 		var currentDate = DateTimeOffset.UtcNow;
-		if (bannedUntil > currentDate.AddDays(_absoluteMaximumLocalPrisonBanningTimeInDays))
+		if (bannedUntil > currentDate.AddDays(_maxDaysToTrustLocalPrison))
 		{
 			Random random = new();
-			int randomHours = random.Next(24, 49);
+			int minHours = (_maxDaysToTrustLocalPrison * 24 - 1) / 2;
+			int maxHours = _maxDaysToTrustLocalPrison * 24 - 1;
+			int randomHours = random.Next(minHours, maxHours);
 			int randomMinutes = random.Next(0, 60);
 			int randomSeconds = random.Next(0, 60);
 

--- a/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
+++ b/WalletWasabi/WabiSabi/Client/Banning/CoinPrison.cs
@@ -20,7 +20,7 @@ public class CoinPrison : IDisposable
 	}
 
 	private HashSet<PrisonedCoinRecord> BannedCoins { get; set; } = new();
-	public string FilePath { get; set; }
+	private string FilePath { get; }
 	private object Lock { get; set; } = new();
 
 	public bool TryGetOrRemoveBannedCoin(SmartCoin coin, [NotNullWhen(true)] out DateTimeOffset? bannedUntil)


### PR DESCRIPTION
Part of #11910

## Why do this?

If, by mistake, the coordinator bans a coin for couple of years, the client won't ever try to register that coin while it is banned according to the client's LOCAL prison. 
Even if we clean the Prison on the backend, nothing invalidates the banned state in the local prison.

This is the naive way to invalidate the local prison.

If the client detects that the banning period is way too long (more than 4 days atm), then the local prison will pick a random value between 2 day and 4 day and save that.
Randomized hours-minutes-seconds so common input ownership is not revealed once the reduced banning time is over.

With this, the client will try to CJ its banned coins from time to time. So we are "checking" the true Prison in the backend more frequently.