### PR TITLE
Changed string format to 1 number after dot.

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -71,7 +71,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <c:PrivacyContentControl>
-          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0} sat/vByte'}" />
+          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:F1} sat/vByte'}" />
         </c:PrivacyContentControl>
       </c:PreviewItem>
 


### PR DESCRIPTION
Close #11972 
Found sat/vByte Fee rate only in Transaction Details page.

Before:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/107629187/736d4211-8619-4073-9188-4fa2476e4d4f)
After:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/107629187/0c5aa976-b826-4124-845e-da33a1cd9546)

Anything under .05 will round down, and .05 and above will round up.