### PR TITLE
Shutdown Wasabi with Ctrl-C even when "Run in background" is enabled

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -22,6 +22,7 @@ using System.Collections.ObjectModel;
 using WalletWasabi.Daemon;
 using LogLevel = WalletWasabi.Logging.LogLevel;
 using System.Threading;
+using WalletWasabi.Fluent.Views;
 
 namespace WalletWasabi.Fluent.Desktop;
 
@@ -82,7 +83,7 @@ public class Program
 	/// </summary>
 	private static void TerminateApplication()
 	{
-		Dispatcher.UIThread.Post(() => (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow?.Close());
+		((Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow as MainWindow)?.CancelPressed();
 	}
 
 	private static void LogUnobservedTaskException(object? sender, AggregateException e)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -83,7 +83,7 @@ public class Program
 	/// </summary>
 	private static void TerminateApplication()
 	{
-		((Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow as MainWindow)?.CancelPressed();
+		Dispatcher.UIThread.Post(() => ((Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow as MainWindow)?.CancelPressed());
 	}
 
 	private static void LogUnobservedTaskException(object? sender, AggregateException e)

--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -83,6 +83,7 @@ public class Program
 	/// </summary>
 	private static void TerminateApplication()
 	{
+		// This calls MainWindow.CancelPressed() from the UI thread, otherwise "System.InvalidOperationException: Call from invalid thread" is thrown.
 		Dispatcher.UIThread.Post(() => ((Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow as MainWindow)?.CancelPressed());
 	}
 

--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -149,10 +149,7 @@ public class ApplicationStateManager : IMainWindowService
 
 		Observable.FromEventPattern<CancelEventArgs>(result, nameof(result.CancelButtonPressedEvent))
 			.Select(args => (args.EventArgs, !ApplicationViewModel.CanShutdown(false)))
-			.Subscribe(tup =>
-			{
-				ShutdownIfNotPrevented(tup);
-			})
+			.Subscribe(ShutdownIfNotPrevented)
 			.DisposeWith(_compositeDisposable);
 
 		Observable.FromEventPattern(result, nameof(result.Closed))

--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -143,12 +143,7 @@ public class ApplicationStateManager : IMainWindowService
 					return;
 				}
 
-				var (e, preventShutdown) = tup;
-
-				_isShuttingDown = !preventShutdown;
-				e.Cancel = preventShutdown;
-
-				_stateMachine.Fire(preventShutdown ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
+				ShutdownIfNotPrevented(tup);
 			})
 			.DisposeWith(_compositeDisposable);
 
@@ -156,12 +151,7 @@ public class ApplicationStateManager : IMainWindowService
 			.Select(args => (args.EventArgs, !ApplicationViewModel.CanShutdown(false)))
 			.Subscribe(tup =>
 			{
-				var (e, preventShutdown) = tup;
-
-				_isShuttingDown = !preventShutdown;
-				e.Cancel = preventShutdown;
-
-				_stateMachine.Fire(preventShutdown ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
+				ShutdownIfNotPrevented(tup);
 			})
 			.DisposeWith(_compositeDisposable);
 
@@ -187,6 +177,16 @@ public class ApplicationStateManager : IMainWindowService
 		result.Show();
 
 		ApplicationViewModel.IsMainWindowShown = true;
+	}
+
+	private void ShutdownIfNotPrevented((CancelEventArgs EventArgs, bool) tup)
+	{
+		var (e, preventShutdown) = tup;
+
+		_isShuttingDown = !preventShutdown;
+		e.Cancel = preventShutdown;
+
+		_stateMachine.Fire(preventShutdown ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
 	}
 
 	private void SetWindowSize(Window window)

--- a/WalletWasabi.Fluent/Views/MainWindow.axaml.cs
+++ b/WalletWasabi.Fluent/Views/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Rendering;
+using System.ComponentModel;
 using WalletWasabi.Fluent.Diagnostics;
 using WalletWasabi.Fluent.Screenshot;
 
@@ -17,6 +18,13 @@ public class MainWindow : Window
 #if DEBUG
 		AddHandler(KeyDownEvent, KeyDownHandler, RoutingStrategies.Tunnel);
 #endif
+	}
+
+	public event EventHandler<CancelEventArgs>? CancelButtonPressedEvent;
+
+	public void CancelPressed()
+	{
+		CancelButtonPressedEvent?.Invoke(this, new CancelEventArgs(false));
 	}
 
 	private void KeyDownHandler(object? sender, KeyEventArgs e)


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11544

Even though this solution works, it's kind of a hack I believe, so I'm open for other approaches, but this was my main idea.

My first idea was to pass a parameter like `bool CancelButtonPressed` to the TerminateApplication function, but this parameter doesn't get forwarded to `ApplicationStateManager`, `Window.Close()` doesn't have a parameter, it should be changed on in Avalonia side.

Second idea was that because the `ApplicationStateManager` isn't aware during close event handling, that whether Ctrl-C was pressed or Wasabi was closed with X, and Ctrl-C should be the topmost terminator, we could have another event handling subscription, where we bypass this "should hide" check and terminate Wasabi.