### PR TITLE
Shutdown Wasabi with Ctrl-C even when "Run in background" is enabled | Take 2

### DIFF
--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -139,7 +139,7 @@ public class ApplicationStateManager : IMainWindowService
 			{
 				var (e, preventShutdown, isShutdownEnforced) = tup;
 
-				// Check if Wasabi was forcefully terminated from terminal with Ctrl-C.
+				// Check if Ctrl-C was used to forcefully terminate the app.
 				if (isShutdownEnforced)
 				{
 					_isShuttingDown = true;

--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -114,7 +114,7 @@ public class ApplicationStateManager : IMainWindowService
 		bool shouldPrevent = !isShutdownEnforced && e.Cancel;
 		Logger.LogDebug($"Cancellation of the shutdown set to: {e.Cancel}.");
 
-		_stateMachine.Fire(shouldPrevent ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested); // if e.Cancel true, prevent, otherwise shutdown.
+		_stateMachine.Fire(shouldPrevent ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
 	}
 
 	private void CreateAndShowMainWindow()

--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -13,6 +13,7 @@ using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Fluent.Views;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
+using WalletWasabi.Services.Terminate;
 
 namespace WalletWasabi.Fluent;
 
@@ -135,12 +136,16 @@ public class ApplicationStateManager : IMainWindowService
 			.TakeWhile(_ => !_isShuttingDown) // Prevents stack overflow.
 			.Subscribe(tup =>
 			{
-				// _hideRequest flag is used to distinguish what is the user's intent.
-				// It is only true when the request comes from the Tray.
-				if ((Services.UiConfig.HideOnClose || _hideRequest) && App.EnableFeatureHide)
+				// Check if Wasabi was forcefully terminated from terminal with Ctrl-C.
+				if (!Services.TerminateService.ForcefulTerminationRequestedTask.IsCompletedSuccessfully)
 				{
-					_hideRequest = false; // request processed, set it back to the default.
-					return;
+					// _hideRequest flag is used to distinguish what is the user's intent.
+					// It is only true when the request comes from the Tray.
+					if ((Services.UiConfig.HideOnClose || _hideRequest) && App.EnableFeatureHide)
+					{
+						_hideRequest = false; // request processed, set it back to the default.
+						return;
+					}
 				}
 
 				var (e, preventShutdown) = tup;

--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -109,12 +109,12 @@ public class ApplicationStateManager : IMainWindowService
 	private void LifetimeOnShutdownRequested(object? sender, ShutdownRequestedEventArgs e)
 	{
 		// Shutdown prevention will only work if you directly run the executable.
-		e.Cancel = !ApplicationViewModel.CanShutdown(false, out bool isShutdownEnforced);
+		bool shouldShutdown = ApplicationViewModel.CanShutdown(_restartRequest, out bool isShutdownEnforced) || isShutdownEnforced;
 
-		bool shouldPrevent = !isShutdownEnforced && e.Cancel;
+		e.Cancel = !shouldShutdown;
 		Logger.LogDebug($"Cancellation of the shutdown set to: {e.Cancel}.");
 
-		_stateMachine.Fire(shouldPrevent ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
+		_stateMachine.Fire(shouldShutdown ? Trigger.ShutdownRequested : Trigger.ShutdownPrevented);
 	}
 
 	private void CreateAndShowMainWindow()

--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -146,14 +146,20 @@ public class ApplicationStateManager : IMainWindowService
 						_hideRequest = false; // request processed, set it back to the default.
 						return;
 					}
+
+					var (e, preventShutdown) = tup;
+
+					_isShuttingDown = !preventShutdown;
+					e.Cancel = preventShutdown;
+
+					_stateMachine.Fire(preventShutdown ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
 				}
-
-				var (e, preventShutdown) = tup;
-
-				_isShuttingDown = !preventShutdown;
-				e.Cancel = preventShutdown;
-
-				_stateMachine.Fire(preventShutdown ? Trigger.ShutdownPrevented : Trigger.ShutdownRequested);
+				else
+				{
+					_isShuttingDown = true;
+					tup.EventArgs.Cancel = false;
+					_stateMachine.Fire(Trigger.ShutdownRequested);
+				}
 			})
 			.DisposeWith(_compositeDisposable);
 

--- a/WalletWasabi.Fluent/Providers/ICanShutdownProvider.cs
+++ b/WalletWasabi.Fluent/Providers/ICanShutdownProvider.cs
@@ -2,5 +2,5 @@ namespace WalletWasabi.Fluent.Providers;
 
 public interface ICanShutdownProvider
 {
-	bool CanShutdown(bool restart);
+	bool CanShutdown(bool restart, out bool isShutdownEnforced);
 }

--- a/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
@@ -96,8 +96,10 @@ public partial class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 		UiContext.Navigate().To().ShuttingDown(this, restartRequest);
 	}
 
-	public bool CanShutdown(bool restart)
+	public bool CanShutdown(bool restart, out bool isShutdownEnforced)
 	{
+		isShutdownEnforced = Services.TerminateService.ForcefulTerminationRequestedTask.IsCompletedSuccessfully;
+
 		if (!MainViewCanShutdown() && !restart)
 		{
 			return false;

--- a/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/ApplicationViewModel.cs
@@ -98,11 +98,6 @@ public partial class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 
 	public bool CanShutdown(bool restart)
 	{
-		if (Services.TerminateService.ForcefulTerminationRequestedTask.IsCompletedSuccessfully)
-		{
-			return true;
-		}
-
 		if (!MainViewCanShutdown() && !restart)
 		{
 			return false;
@@ -117,6 +112,6 @@ public partial class ApplicationViewModel : ViewModelBase, ICanShutdownProvider
 		// - no open dialog
 		// - or no wallets available
 		return !MainViewModel.Instance.IsDialogOpen()
-		       || !MainViewModel.Instance.NavBar.Wallets.Any();
+			   || !MainViewModel.Instance.NavBar.Wallets.Any();
 	}
 }


### PR DESCRIPTION
Instead of https://github.com/zkSNACKs/WalletWasabi/pull/11984
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11544

Found a much easier idea. We can reach `TerminateService` from `ApplicationStateManager`.
As I said [here](https://github.com/zkSNACKs/WalletWasabi/pull/11984#issuecomment-1824603969), if "Run in background" is turned ON, `Services.UiConfig.HideOnClose` will be true, so we just return and won't shutdown Wasabi, so the check in `CanShutdown()` was redundant.

Instead in this PR, if we know Wasabi was forcefully terminated, we don't check this option, just shutdown.
