### PR TITLE
[UI] Fix CoinJoin group status tooltip

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TextHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TextHelpers.cs
@@ -98,13 +98,18 @@ public static partial class TextHelpers
 
 	public static string GetConfirmationText(int confirmations)
 	{
-		return $"Confirmed ({confirmations} confirmation{AddSIfPlural(confirmations)})";
+		if (confirmations > 0)
+		{
+			return $"Confirmed ({confirmations} confirmation{AddSIfPlural(confirmations)})";
+		}
+
+		return $"Pending";
 	}
 
 	public static string FormatPercentageDiff(double n)
 	{
 		var precision = 0.01m;
-		var withFriendlyDecimals = (n*100).WithFriendlyDecimals();
+		var withFriendlyDecimals = (n * 100).WithFriendlyDecimals();
 
 		if (Math.Abs(withFriendlyDecimals) < precision)
 		{

--- a/WalletWasabi.Fluent/Helpers/TextHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TextHelpers.cs
@@ -103,7 +103,7 @@ public static partial class TextHelpers
 			return $"Confirmed ({confirmations} confirmation{AddSIfPlural(confirmations)})";
 		}
 
-		return $"Pending";
+		return "Pending";
 	}
 
 	public static string FormatPercentageDiff(double n)


### PR DESCRIPTION
PR: 
![image](https://github.com/zkSNACKs/WalletWasabi/assets/45069029/be4b953b-84b0-4846-97c2-9ba596998a37)


Master:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/45069029/7bdccc83-519d-463f-ac20-a1f73e1a2184)


I remember fixing this issue before... or was it only a dream?
Anyways, here is the fix.