### PR TITLE
Make sure we all use the same C# lang version

### DIFF
--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
 		<Product>WalletWasabiApi</Product>
 		<Copyright>MIT</Copyright>

--- a/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
+++ b/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<AnalysisLevel>latest</AnalysisLevel>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -12,7 +12,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
+++ b/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 		<CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
+++ b/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
@@ -4,7 +4,7 @@
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031</NoWarn>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 		<CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)\GeneratedFiles</CompilerGeneratedFilesOutputPath>

--- a/WalletWasabi.Packager/WalletWasabi.Packager.csproj
+++ b/WalletWasabi.Packager/WalletWasabi.Packager.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Nullable>enable</Nullable>

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -5,7 +5,7 @@
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<IsPackable>false</IsPackable>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;CA1031;CA1822</NoWarn>
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -5,7 +5,7 @@
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11</LangVersion>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
Recently my VS auto-updated and I got the new C# - especially the new C# lang version => 12. After this VS started to offer new expressions that are only available in 12. I thought it was OK because we specified versions in config files precisely. Unfortunately, this was not the case with the lang version - other devs were not able to compile the project. 

I propose to set the version of the lang from `latest` to `11` to make this deterministic. In this case, automatic updates cannot mess up our code integrity. We have a similar concept with the .NET version as well - it is specified precisely. 