### PR TITLE
Jade wallet implement

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -21,6 +21,7 @@ This document lists all the officially supported software and devices by Wasabi 
 - Ledger Nano S Plus
 - Ledger Nano X
 - Trezor Model T
+- Blockstream Jade
 
 # Officially Supported Architectures
 

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -466,15 +466,11 @@ public class HwiKatas
 		// Connect and initialize your Jade with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
 		// Run this test.
-		// displayaddress request(derivation path): approve
-		// displayaddress request: reject
-		// displayaddress request(derivation path): approve
-		// displayaddress request: approve
-		// displayaddress request(derivation path): approve
-		// displayaddress request: approve
+		// displayaddress request by device_type: reject
+		// displayaddress request by device_type: approve
+		// displayaddress request by fingerprint: approve
 		// signtx request: reject
-		// signtx request: accept
-		// confirm transaction: accept and send
+		// signtx request: 2x approve
 		//
 		// --- USER INTERACTIONS ---
 
@@ -533,7 +529,7 @@ public class HwiKatas
 		var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token));
 		Assert.Equal(HwiErrorCode.ActionCanceled, ex.ErrorCode);
 
-		// USER: CONFIRM
+		// USER: CONFIRM CONFIRM
 		PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token);
 
 		Transaction signedTx = signedPsbt.GetOriginalTransaction();

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Hwi;
 using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
+using WalletWasabi.Hwi.Parsers;
 using Xunit;
 
 namespace WalletWasabi.Tests.AcceptanceTests;
@@ -446,6 +447,91 @@ public class HwiKatas
 		// USER: REFUSE
 		var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token));
 		Assert.Equal(HwiErrorCode.UnknownError, ex.ErrorCode);
+
+		// USER: CONFIRM
+		PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token);
+
+		Transaction signedTx = signedPsbt.GetOriginalTransaction();
+		Assert.Equal(Psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
+
+		var checkResult = signedTx.Check();
+		Assert.Equal(TransactionCheckResult.Success, checkResult);
+	}
+
+	[Fact]
+	public async Task JadeKataAsync()
+	{
+		// --- USER INTERACTIONS ---
+		//
+		// Connect and initialize your Jade with the following seed phrase:
+		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// Run this test.
+		// displayaddress request(derivation path): approve
+		// displayaddress request: reject
+		// displayaddress request(derivation path): approve
+		// displayaddress request: approve
+		// displayaddress request(derivation path): approve
+		// displayaddress request: approve
+		// signtx request: reject
+		// signtx request: accept
+		// confirm transaction: accept and send
+		//
+		// --- USER INTERACTIONS ---
+
+		var network = Network.Main;
+		var client = new HwiClient(network);
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		var enumerate = await client.EnumerateAsync(cts.Token);
+		HwiEnumerateEntry entry = Assert.Single(enumerate);
+		Assert.NotNull(entry.Path);
+		Assert.Equal(HardwareWalletModels.Jade, entry.Model);
+		Assert.True(HwiParser.ValidatePathString(entry.Model, entry.Path));
+		Assert.NotNull(entry.Fingerprint);
+		Assert.Null(entry.Code);
+		Assert.Null(entry.Error);
+		Assert.True(string.IsNullOrEmpty(entry.SerialNumber));
+		Assert.False(entry.NeedsPassphraseSent);
+		Assert.False(entry.NeedsPinSent);
+
+		string devicePath = entry.Path;
+		HardwareWalletModels deviceType = entry.Model;
+		HDFingerprint fingerprint = entry.Fingerprint!.Value;
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+
+		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive("0/0");
+		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive("0/1");
+
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		Assert.NotNull(xpub1);
+		Assert.NotNull(xpub2);
+		Assert.NotEqual(xpub1, xpub2);
+
+		// USER SHOULD REFUSE ACTION
+		await Assert.ThrowsAsync<HwiException>(async () => await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token));
+
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(fingerprint, keyPath2, cts.Token);
+		Assert.NotNull(address1);
+		Assert.NotNull(address2);
+		Assert.NotEqual(address1, address2);
+		var expectedAddress1 = xpub1.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		var expectedAddress2 = xpub2.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+
+		// USER: REFUSE
+		var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token));
+		Assert.Equal(HwiErrorCode.ActionCanceled, ex.ErrorCode);
 
 		// USER: CONFIRM
 		PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token);

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -7,6 +7,7 @@ using WalletWasabi.Hwi;
 using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Hwi.Parsers;
+using WalletWasabi.Tests.Helpers;
 using Xunit;
 
 namespace WalletWasabi.Tests.AcceptanceTests;
@@ -481,7 +482,7 @@ public class HwiKatas
 		HwiEnumerateEntry entry = Assert.Single(enumerate);
 		Assert.NotNull(entry.Path);
 		Assert.Equal(HardwareWalletModels.Jade, entry.Model);
-		Assert.True(HwiParser.ValidatePathString(entry.Model, entry.Path));
+		Assert.True(HwiValidationHelper.ValidatePathString(entry.Model, entry.Path));
 		Assert.NotNull(entry.Fingerprint);
 		Assert.Null(entry.Code);
 		Assert.Null(entry.Error);

--- a/WalletWasabi.Tests/Helpers/HwiValidationHelper.cs
+++ b/WalletWasabi.Tests/Helpers/HwiValidationHelper.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+using WalletWasabi.Hwi.Models;
+
+namespace WalletWasabi.Tests.Helpers;
+
+public static class HwiValidationHelper
+{
+	/// <summary>
+	/// Parse the wallet's path from the response.
+	/// </summary>
+	/// <param name="path">The wallet path which come from HWI enumerate command.</param>
+	/// <param name="model">The hardware wallet model.</param>
+	/// <returns><c>true</c> if the path matches the model's regex, <c>false</c> otherwise.</returns>
+	public static bool ValidatePathString(HardwareWalletModels model, string path)
+	{
+		string pattern = model switch
+		{
+			HardwareWalletModels.Trezor_T => "^webusb:",
+			HardwareWalletModels.Trezor_1 => @"^hid:\\\\.*?vid_534c&pid_0001&mi_00",
+			HardwareWalletModels.Coldcard => @"^hid:\\\\.*?vid_d13e&pid_cc10&mi_00",
+			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X => @"^hid:\\\\.*?vid_2c97&pid_0001&mi_00",
+			HardwareWalletModels.Jade => @"^COM\d+",
+			_ => "",
+		};
+		return Regex.IsMatch(path, pattern);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -27,7 +27,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		string model;
 		string rawPath;
 
-		// This come from hwi.exe enumerate [model]
+		// This come from hwi.exe enumerate (model).
 		model = Model switch
 		{
 			HardwareWalletModels.Trezor_T => "trezor_t",
@@ -39,7 +39,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			_ => throw new NotImplementedException("Mock missing.")
 		};
 
-		// This come from hwi.exe enumerate [path]
+		// This come from hwi.exe enumerate (path).
 		rawPath = Model switch
 		{
 			HardwareWalletModels.Trezor_T => "webusb: 001:4",

--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -27,6 +27,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		string model;
 		string rawPath;
 
+		// This come from hwi.exe enumerate [model]
 		model = Model switch
 		{
 			HardwareWalletModels.Trezor_T => "trezor_t",
@@ -34,9 +35,11 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			HardwareWalletModels.Coldcard => "coldcard",
 			HardwareWalletModels.Ledger_Nano_S => "ledger_nano_s",
 			HardwareWalletModels.Ledger_Nano_X => "ledger_nano_x",
+			HardwareWalletModels.Jade => "jade",
 			_ => throw new NotImplementedException("Mock missing.")
 		};
 
+		// This come from hwi.exe enumerate [path]
 		rawPath = Model switch
 		{
 			HardwareWalletModels.Trezor_T => "webusb: 001:4",
@@ -44,6 +47,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			HardwareWalletModels.Coldcard => @"\\\\?\\hid#vid_d13e&pid_cc10&mi_00#7&1b239988&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			HardwareWalletModels.Ledger_Nano_S => "\\\\\\\\?\\\\hid#vid_2c97&pid_0001&mi_00#7&e45ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			HardwareWalletModels.Ledger_Nano_X => "\\\\\\\\?\\\\hid#vid_2c97&pid_0001&mi_00#7&e45ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+			HardwareWalletModels.Jade => "COM3",
 			_ => throw new NotImplementedException("Mock missing.")
 		};
 
@@ -64,6 +68,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_passphrase\": false, \"fingerprint\": \"a3d0d797\"}}]\r\n",
 				HardwareWalletModels.Ledger_Nano_S => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"fingerprint\": \"4054d6f6\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false}}]\r\n",
 				HardwareWalletModels.Ledger_Nano_X => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"fingerprint\": \"4054d6f6\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false}}]\r\n",
+				HardwareWalletModels.Jade => $"[{{\"type\": \"{model}\", \"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false, \"fingerprint\": \"9bdca818\"}}]",
 				_ => throw new NotImplementedException($"Mock missing for {model}")
 			};
 		}
@@ -75,6 +80,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support wiping via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support wiping via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support wiping via software\", \"code\": -9}\r\n",
+				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not support wiping via software\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -86,6 +92,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support software setup\", \"code\": -9}\r\n",
+				HardwareWalletModels.Jade => "{\"error\": \"setup requires interactive mode\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -97,6 +104,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support software setup\", \"code\": -9}\r\n",
+				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not support software setup\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -108,6 +116,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support restoring via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support restoring via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support restoring via software\", \"code\": -9}\r\n",
+				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not support restoring via software\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -119,6 +128,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not need a PIN sent from the host\", \"code\": -9}\r\n",
+				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not need a PIN sent from the host\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -130,46 +140,82 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not need a PIN sent from the host\", \"code\": -9}\r\n",
+				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not need a PIN sent from the host\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
 		else if (CompareGetXbpubArguments(arguments, out string? xpub))
 		{
-			if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+			switch (Model)
 			{
-				response = $"{{\"xpub\": \"{xpub}\"}}\r\n";
+				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_1:
+				case HardwareWalletModels.Coldcard:
+				case HardwareWalletModels.Ledger_Nano_S:
+				case HardwareWalletModels.Ledger_Nano_X:
+				case HardwareWalletModels.Jade:
+					response = $"{{\"xpub\": \"{xpub}\"}}\r\n";
+					break;
 			}
 		}
 		else if (CompareArguments(out bool t1, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/0h/0h --addr-type wit", false))
 		{
-			if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+			switch (Model)
 			{
-				response = t1
-					? "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n"
-					: "{\"address\": \"bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah\"}\r\n";
+				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_1:
+				case HardwareWalletModels.Coldcard:
+				case HardwareWalletModels.Ledger_Nano_S:
+				case HardwareWalletModels.Ledger_Nano_X:
+				case HardwareWalletModels.Jade:
+					response = t1
+						? "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n"
+						: "{\"address\": \"bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah\"}\r\n";
+					break;
 			}
 		}
 		else if (CompareArguments(out bool t2, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/0h/0h/1 --addr-type wit", false))
 		{
-			if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+			switch (Model)
 			{
-				response = t2
-					? "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n"
-					: "{\"address\": \"bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf\"}\r\n";
+				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_1:
+				case HardwareWalletModels.Coldcard:
+				case HardwareWalletModels.Ledger_Nano_S:
+				case HardwareWalletModels.Ledger_Nano_X:
+				case HardwareWalletModels.Jade:
+					response = t2
+						? "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n"
+						: "{\"address\": \"bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf\"}\r\n";
+					break;
 			}
 		}
 		else if (CompareArguments(out bool _, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/1h/0h --addr-type wit", false))
 		{
-			if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+			switch (Model)
 			{
-				response = "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n";
+				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_1:
+				case HardwareWalletModels.Coldcard:
+				case HardwareWalletModels.Ledger_Nano_S:
+				case HardwareWalletModels.Ledger_Nano_X:
+				case HardwareWalletModels.Jade:
+					response = "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n";
+					break;
 			}
 		}
 		else if (CompareArguments(out bool _, arguments, $"{devicePathAndTypeArgumentString} displayaddress --path m/84h/1h/0h/1 --addr-type wit", false))
 		{
-			if (Model is HardwareWalletModels.Trezor_T or HardwareWalletModels.Coldcard or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X)
+			switch (Model)
 			{
-				response = "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n";
+				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_1:
+				case HardwareWalletModels.Coldcard:
+				case HardwareWalletModels.Ledger_Nano_S:
+				case HardwareWalletModels.Ledger_Nano_X:
+				case HardwareWalletModels.Jade:
+					response = "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n";
+					break;
 			}
 		}
 

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -476,8 +476,7 @@ public class MockedDeviceTests
 
 		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
 		IEnumerable<HwiEnumerateEntry> enumerate = await client.EnumerateAsync(cts.Token);
-		Assert.Single(enumerate);
-		HwiEnumerateEntry entry = enumerate.Single();
+		HwiEnumerateEntry entry = Assert.Single(enumerate);
 		Assert.Equal(HardwareWalletModels.Jade, entry.Model);
 		Assert.True(HwiParser.ValidatePathString(entry.Model, "COM3"));
 		Assert.Equal("COM3", entry.Path);

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -468,6 +468,97 @@ public class MockedDeviceTests
 		Assert.Equal(expectedAddress2, address2);
 	}
 
+	[Theory]
+	[MemberData(nameof(GetDifferentNetworkValues))]
+	public async Task JadeMockTestsAsync(Network network)
+	{
+		var client = new HwiClient(network, new HwiProcessBridgeMock(HardwareWalletModels.Jade));
+
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		IEnumerable<HwiEnumerateEntry> enumerate = await client.EnumerateAsync(cts.Token);
+		Assert.Single(enumerate);
+		HwiEnumerateEntry entry = enumerate.Single();
+		Assert.Equal(HardwareWalletModels.Jade, entry.Model);
+		Assert.True(HwiParser.ValidatePathString(entry.Model, "COM3"));
+		Assert.Equal("COM3", entry.Path);
+		Assert.False(entry.NeedsPassphraseSent);
+		Assert.False(entry.NeedsPinSent);
+		Assert.Null(entry.Error);
+		Assert.Null(entry.Code);
+		Assert.True(entry.IsInitialized());
+		Assert.Equal("9bdca818", entry.Fingerprint.ToString());
+
+		var deviceType = entry.Model;
+		var devicePath = entry.Path;
+
+		var wipe = await Assert.ThrowsAsync<HwiException>(async () => await client.WipeAsync(deviceType, devicePath, cts.Token));
+		Assert.Equal("Blockstream Jade does not support wiping via software", wipe.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, wipe.ErrorCode);
+
+		var setup = await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
+		Assert.Equal("Blockstream Jade does not support software setup", setup.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, setup.ErrorCode);
+
+		var restore = await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
+		Assert.Equal("Blockstream Jade does not support restoring via software", restore.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, restore.ErrorCode);
+
+		var promptpin = await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+		Assert.Equal("Blockstream Jade does not need a PIN sent from the host", promptpin.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, promptpin.ErrorCode);
+
+		var sendpin = await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+		Assert.Equal("Blockstream Jade does not need a PIN sent from the host", sendpin.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, sendpin.ErrorCode);
+
+		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit);
+		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive(1);
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		ExtPubKey expectedXpub1;
+		ExtPubKey expectedXpub2;
+		if (network == Network.TestNet)
+		{
+			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+			expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+		}
+		else
+		{
+			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+			expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+		}
+		Assert.Equal(expectedXpub1, xpub1);
+		Assert.Equal(expectedXpub2, xpub2);
+
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
+
+		BitcoinAddress expectedAddress1;
+		BitcoinAddress expectedAddress2;
+		if (network == Network.Main)
+		{
+			expectedAddress1 = BitcoinAddress.Create("bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah", Network.Main);
+			expectedAddress2 = BitcoinAddress.Create("bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf", Network.Main);
+		}
+		else if (network == Network.TestNet)
+		{
+			expectedAddress1 = BitcoinAddress.Create("tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy", Network.TestNet);
+			expectedAddress2 = BitcoinAddress.Create("tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6", Network.TestNet);
+		}
+		else if (network == Network.RegTest)
+		{
+			expectedAddress1 = BitcoinAddress.Create("bcrt1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7pzmj3d", Network.RegTest);
+			expectedAddress2 = BitcoinAddress.Create("bcrt1qmaveee425a5xjkjcv7m6d4gth45jvtnjz7tugn", Network.RegTest);
+		}
+		else
+		{
+			throw new NotSupportedNetworkException(network);
+		}
+
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+	}
+
 	#endregion Tests
 
 	#region HelperMethods

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -502,13 +502,13 @@ public class MockedDeviceTests
 		Assert.Equal("Blockstream Jade does not support restoring via software", restore.Message);
 		Assert.Equal(HwiErrorCode.UnavailableAction, restore.ErrorCode);
 
-		var promptpin = await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
-		Assert.Equal("Blockstream Jade does not need a PIN sent from the host", promptpin.Message);
-		Assert.Equal(HwiErrorCode.UnavailableAction, promptpin.ErrorCode);
+		var promptPinEx = await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+		Assert.Equal("Blockstream Jade does not need a PIN sent from the host", promptPinEx.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, promptPinEx.ErrorCode);
 
-		var sendpin = await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
-		Assert.Equal("Blockstream Jade does not need a PIN sent from the host", sendpin.Message);
-		Assert.Equal(HwiErrorCode.UnavailableAction, sendpin.ErrorCode);
+		var sendPinEx = await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+		Assert.Equal("Blockstream Jade does not need a PIN sent from the host", sendPinEx.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, sendPinEx.ErrorCode);
 
 		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit);
 		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive(1);
@@ -516,6 +516,7 @@ public class MockedDeviceTests
 		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
 		ExtPubKey expectedXpub1;
 		ExtPubKey expectedXpub2;
+
 		if (network == Network.TestNet)
 		{
 			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
@@ -536,18 +537,18 @@ public class MockedDeviceTests
 		BitcoinAddress expectedAddress2;
 		if (network == Network.Main)
 		{
-			expectedAddress1 = BitcoinAddress.Create("bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah", Network.Main);
-			expectedAddress2 = BitcoinAddress.Create("bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf", Network.Main);
+			expectedAddress1 = BitcoinAddress.Create("bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah", network);
+			expectedAddress2 = BitcoinAddress.Create("bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf", network);
 		}
 		else if (network == Network.TestNet)
 		{
-			expectedAddress1 = BitcoinAddress.Create("tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy", Network.TestNet);
-			expectedAddress2 = BitcoinAddress.Create("tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6", Network.TestNet);
+			expectedAddress1 = BitcoinAddress.Create("tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy", network);
+			expectedAddress2 = BitcoinAddress.Create("tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6", network);
 		}
 		else if (network == Network.RegTest)
 		{
-			expectedAddress1 = BitcoinAddress.Create("bcrt1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7pzmj3d", Network.RegTest);
-			expectedAddress2 = BitcoinAddress.Create("bcrt1qmaveee425a5xjkjcv7m6d4gth45jvtnjz7tugn", Network.RegTest);
+			expectedAddress1 = BitcoinAddress.Create("bcrt1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7pzmj3d", network);
+			expectedAddress2 = BitcoinAddress.Create("bcrt1qmaveee425a5xjkjcv7m6d4gth45jvtnjz7tugn", network);
 		}
 		else
 		{

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -10,6 +10,7 @@ using WalletWasabi.Hwi;
 using WalletWasabi.Hwi.Exceptions;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Hwi.Parsers;
+using WalletWasabi.Tests.Helpers;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Hwi;
@@ -478,7 +479,7 @@ public class MockedDeviceTests
 		IEnumerable<HwiEnumerateEntry> enumerate = await client.EnumerateAsync(cts.Token);
 		HwiEnumerateEntry entry = Assert.Single(enumerate);
 		Assert.Equal(HardwareWalletModels.Jade, entry.Model);
-		Assert.True(HwiParser.ValidatePathString(entry.Model, "COM3"));
+		Assert.True(HwiValidationHelper.ValidatePathString(entry.Model, "COM3"));
 		Assert.Equal("COM3", entry.Path);
 		Assert.False(entry.NeedsPassphraseSent);
 		Assert.False(entry.NeedsPinSent);

--- a/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
@@ -225,5 +225,6 @@ public class WalletDirTests
 		Assert.Equal("Trezor T Simulator", HardwareWalletModels.Trezor_T_Simulator.FriendlyName());
 		Assert.Equal("BitBox", HardwareWalletModels.BitBox02_BTCOnly.FriendlyName());
 		Assert.Equal("BitBox", HardwareWalletModels.BitBox02_Multi.FriendlyName());
+		Assert.Equal("Jade", HardwareWalletModels.Jade.FriendlyName());
 	}
 }

--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -54,4 +54,7 @@ public enum HardwareWalletModels
 
 	[FriendlyName("BitBox")]
 	BitBox02_Multi,
+
+	[FriendlyName("Jade")]
+	Jade,
 }

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -47,6 +47,7 @@ public class HwiEnumerateEntry
 			HardwareWalletModels.Coldcard or HardwareWalletModels.Coldcard_Simulator => WalletType.Coldcard,
 			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => WalletType.Ledger,
 			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator => WalletType.Trezor,
+			HardwareWalletModels.Jade => WalletType.Jade,
 			_ => WalletType.Hardware
 		};
 

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -22,13 +22,7 @@ public static class HwiParser
 	/// <returns><c>true</c> if the path matches the model's regex, <c>false</c> otherwise.</returns>
 	public static bool ValidatePathString(HardwareWalletModels model, string path)
 	{
-		string pattern = GetPatternForModel(model);
-		return Regex.IsMatch(path, pattern);
-	}
-
-	private static string GetPatternForModel(HardwareWalletModels model)
-	{
-		return model switch
+		string pattern = model switch
 		{
 			HardwareWalletModels.Trezor_T => "^webusb:",
 			HardwareWalletModels.Trezor_1 => @"^hid:\\\\.*?vid_534c&pid_0001&mi_00",
@@ -37,6 +31,7 @@ public static class HwiParser
 			HardwareWalletModels.Jade => @"^COM\d+",
 			_ => "",
 		};
+		return Regex.IsMatch(path, pattern);
 	}
 
 	public static bool TryParseErrors(string text, IEnumerable<HwiOption> options, [NotNullWhen(true)] out HwiException? error)

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Hwi.Exceptions;
@@ -13,6 +14,31 @@ namespace WalletWasabi.Hwi.Parsers;
 
 public static class HwiParser
 {
+	/// <summary>
+	/// Parse the wallet's path from the response.
+	/// </summary>
+	/// <param name="path">The wallet path, what come from hwi enumerate.</param>
+	/// <param name="model">The hardware wallet model.</param>
+	/// <returns>Is matching with the predefined path pattern(true/false)</returns>
+	public static bool ValidatePathString(HardwareWalletModels model, string path)
+	{
+		string pattern = GetPatternForModel(model);
+		return Regex.IsMatch(path, pattern);
+	}
+
+	private static string GetPatternForModel(HardwareWalletModels model)
+	{
+		return model switch
+		{
+			HardwareWalletModels.Trezor_T => "^webusb:",
+			HardwareWalletModels.Trezor_1 => @"^hid:\\\\.*?vid_534c&pid_0001&mi_00",
+			HardwareWalletModels.Coldcard => @"^hid:\\\\.*?vid_d13e&pid_cc10&mi_00",
+			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X => @"^hid:\\\\.*?vid_2c97&pid_0001&mi_00",
+			HardwareWalletModels.Jade => @"^COM\d+",
+			_ => "",
+		};
+	}
+
 	public static bool TryParseErrors(string text, IEnumerable<HwiOption> options, [NotNullWhen(true)] out HwiException? error)
 	{
 		error = null;

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Hwi.Exceptions;
@@ -14,26 +13,6 @@ namespace WalletWasabi.Hwi.Parsers;
 
 public static class HwiParser
 {
-	/// <summary>
-	/// Parse the wallet's path from the response.
-	/// </summary>
-	/// <param name="path">The wallet path which come from HWI enumerate command.</param>
-	/// <param name="model">The hardware wallet model.</param>
-	/// <returns><c>true</c> if the path matches the model's regex, <c>false</c> otherwise.</returns>
-	public static bool ValidatePathString(HardwareWalletModels model, string path)
-	{
-		string pattern = model switch
-		{
-			HardwareWalletModels.Trezor_T => "^webusb:",
-			HardwareWalletModels.Trezor_1 => @"^hid:\\\\.*?vid_534c&pid_0001&mi_00",
-			HardwareWalletModels.Coldcard => @"^hid:\\\\.*?vid_d13e&pid_cc10&mi_00",
-			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X => @"^hid:\\\\.*?vid_2c97&pid_0001&mi_00",
-			HardwareWalletModels.Jade => @"^COM\d+",
-			_ => "",
-		};
-		return Regex.IsMatch(path, pattern);
-	}
-
 	public static bool TryParseErrors(string text, IEnumerable<HwiOption> options, [NotNullWhen(true)] out HwiException? error)
 	{
 		error = null;

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -17,7 +17,7 @@ public static class HwiParser
 	/// <summary>
 	/// Parse the wallet's path from the response.
 	/// </summary>
-	/// <param name="path">The wallet path, what come from hwi enumerate.</param>
+	/// <param name="path">The wallet path which come from HWI enumerate command.</param>
 	/// <param name="model">The hardware wallet model.</param>
 	/// <returns>Is matching with the predefined path pattern(true/false)</returns>
 	public static bool ValidatePathString(HardwareWalletModels model, string path)

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -19,7 +19,7 @@ public static class HwiParser
 	/// </summary>
 	/// <param name="path">The wallet path which come from HWI enumerate command.</param>
 	/// <param name="model">The hardware wallet model.</param>
-	/// <returns>Is matching with the predefined path pattern(true/false)</returns>
+	/// <returns><c>true</c> if the path matches the model's regex, <c>false</c> otherwise.</returns>
 	public static bool ValidatePathString(HardwareWalletModels model, string path)
 	{
 		string pattern = GetPatternForModel(model);

--- a/WalletWasabi/Wallets/WalletType.cs
+++ b/WalletWasabi/Wallets/WalletType.cs
@@ -7,5 +7,6 @@ public enum WalletType
 	Coldcard,
 	Trezor,
 	Ledger,
+	Jade,
 	Unknown
 }


### PR DESCRIPTION
Fixes: [zkSNACKs/WalletWasabi#11908](https://github.com/zkSNACKs/WalletWasabi/issues/11908)

# Introduction
The HWI already supports the Blockstream Jade hardware wallet, but until now, Wasabi wallet did not. Therefore, we decided to implement this in the current codebase.

# Solution

We acquired a Blockstream Jade hardware wallet and initialized it with the appropriate parameters. After this, I implemented the new Enums, HardwareWalletModel and WalletType, in the code.

I started the Wasabi wallet and was able to add it as a wallet.

# Subtasks

- [x] Writing the Jade Test
- [x] Writing the Jade Mock Test