### PR TITLE
`ByteHelpers.ToHex`: Use .NET implementation

### DIFF
--- a/WalletWasabi/Helpers/ByteHelpers.cs
+++ b/WalletWasabi/Helpers/ByteHelpers.cs
@@ -6,9 +6,6 @@ namespace WalletWasabi.Helpers;
 
 public static unsafe class ByteHelpers
 {
-	private static readonly uint[] Lookup32Unsafe = CreateLookup32Unsafe();
-	private static readonly uint* Lookup32UnsafeP = (uint*)GCHandle.Alloc(Lookup32Unsafe, GCHandleType.Pinned).AddrOfPinnedObject();
-
 	// https://stackoverflow.com/questions/415291/best-way-to-combine-two-or-more-byte-arrays-in-c-sharp
 	/// <summary>
 	/// Fastest byte array concatenation in C#
@@ -91,40 +88,10 @@ public static unsafe class ByteHelpers
 		}
 	}
 
-	private static uint[] CreateLookup32Unsafe()
-	{
-		var result = new uint[256];
-		for (int i = 0; i < 256; i++)
-		{
-			string s = i.ToString("X2");
-			result[i] = BitConverter.IsLittleEndian ? s[0] + ((uint)s[1] << 16) : s[1] + ((uint)s[0] << 16);
-		}
-		return result;
-	}
-
-	// https://stackoverflow.com/a/24343727/2061103
-	/// <summary>
-	/// Fastest byte array to hex implementation in C#
-	/// </summary>
+	/// <seealso cref="Convert.ToHexString(byte[])"/>
 	public static string ToHex(params byte[] bytes)
 	{
-		if (bytes.Length == 0)
-		{
-			return "";
-		}
-
-		var lookupP = Lookup32UnsafeP;
-		var result = new string((char)0, bytes.Length * 2);
-		fixed (byte* bytesP = bytes)
-		fixed (char* resultP = result)
-		{
-			uint* resultP2 = (uint*)resultP;
-			for (int i = 0; i < bytes.Length; i++)
-			{
-				resultP2[i] = lookupP[bytesP[i]];
-			}
-		}
-		return result;
+		return Convert.ToHexString(bytes);
 	}
 
 	/// <seealso cref="Convert.FromHexString(string)"/>


### PR DESCRIPTION
Simple https://benchmarkdotnet.org benchmark confirms that we no longer need the custom code:

```cs
[MemoryDiagnoser]
public class Benchmarks
{
	private byte[] _bytes;

	[Params(4, 16, 128)]
	public int Length { get; set; }

	[GlobalSetup]
	public void Setup() => _bytes = RandomNumberGenerator.GetBytes(Length);


	[Benchmark]
	public string Master()
	{
		return WalletWasabi.Helpers.ByteHelpers.ToHex(_bytes);
	}

	[Benchmark]
	public string Pr()
	{
		return Convert.ToHexString(_bytes);
	}
}
```

Results:

| Method | Length |      Mean |    Error |   StdDev |    Median |  Gen 0 |  Gen 1 | Allocated |
|------- |------- |----------:|---------:|---------:|----------:|-------:|-------:|----------:|
| Master |      4 |  11.18 ns | 0.314 ns | 0.911 ns |  10.91 ns | 0.0063 |      - |      40 B |
|     Pr |      4 |  12.01 ns | 0.271 ns | 0.628 ns |  11.98 ns | 0.0064 |      - |      40 B |
| Master |     16 |  18.84 ns | 0.398 ns | 0.332 ns |  18.91 ns | 0.0140 |      - |      88 B |
|     Pr |     16 |  16.43 ns | 0.361 ns | 0.632 ns |  16.26 ns | 0.0140 |      - |      88 B |
| Master |    128 | 101.23 ns | 1.651 ns | 2.027 ns | 100.90 ns | 0.0854 | 0.0001 |     536 B |
|     Pr |    128 |  55.80 ns | 1.124 ns | 2.056 ns |  55.38 ns | 0.0854 | 0.0002 |     536 B |


