### PR TITLE
Override Fee Overpayment Protection via RPC

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -221,7 +221,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("build")]
-	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null, bool overrideFeeOverpaymentProtection = false)
+	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null)
 	{
 		Guard.NotNull(nameof(payments), payments);
 		Guard.NotNull(nameof(coins), coins);
@@ -250,8 +250,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			payment,
 			feeStrategy,
 			allowUnconfirmed: true,
-			allowedInputs: coins,
-			overrideFeeOverpaymentProtection: overrideFeeOverpaymentProtection);
+			allowedInputs: coins);
 		var smartTx = result.Transaction;
 
 		return smartTx.Transaction.ToHex();

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -221,7 +221,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("build")]
-	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null)
+	public string BuildTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null, bool overrideFeeOverpaymentProtection = false)
 	{
 		Guard.NotNull(nameof(payments), payments);
 		Guard.NotNull(nameof(coins), coins);
@@ -250,7 +250,8 @@ public class WasabiJsonRpcService : IJsonRpcService
 			payment,
 			feeStrategy,
 			allowUnconfirmed: true,
-			allowedInputs: coins);
+			allowedInputs: coins,
+			overrideFeeOverpaymentProtection: overrideFeeOverpaymentProtection);
 		var smartTx = result.Transaction;
 
 		return smartTx.Transaction.ToHex();

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -256,6 +256,10 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return smartTx.Transaction.ToHex();
 	}
 
+	/// <summary>
+	/// Unsafe, because no matter how big fee the user chooses, Wasabi will build the transaction.
+	/// Potentially, the user can burn his money using this method, so be careful!
+	/// </summary>
 	[JsonRpcMethod("buildunsafetransaction")]
 	public string BuildUnsafeTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null)
 	{

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -256,8 +256,8 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return smartTx.Transaction.ToHex();
 	}
 
-	[JsonRpcMethod("buildtransactionwithoutoverpaymentprotection")]
-	public string BuildTransactionWithoutOverpaymentProtection(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null)
+	[JsonRpcMethod("buildunsafetransaction")]
+	public string BuildUnsafeTransaction(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null)
 	{
 		Guard.NotNull(nameof(payments), payments);
 		Guard.NotNull(nameof(coins), coins);

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -256,6 +256,42 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return smartTx.Transaction.ToHex();
 	}
 
+	[JsonRpcMethod("buildtransactionwithoutoverpaymentprotection")]
+	public string BuildTransactionWithoutOverpaymentProtection(PaymentInfo[] payments, OutPoint[] coins, int? feeTarget = null, decimal? feeRate = null, string? password = null)
+	{
+		Guard.NotNull(nameof(payments), payments);
+		Guard.NotNull(nameof(coins), coins);
+		password = Guard.Correct(password);
+
+		static bool InRange<T>(IComparable<T> val, T min, T max) =>
+			val.CompareTo(min) >= 0 && val.CompareTo(max) <= 0;
+
+		var satsPerByte = feeRate is { } nonNullSatsPerByte ? new FeeRate(nonNullSatsPerByte) : FeeRate.Zero;
+
+		var feeStrategy = (feeRate, feeTarget) switch
+		{
+			(not null, null) when InRange(satsPerByte, Constants.MinRelayFeeRate, Constants.AbsurdlyHighFeeRate) =>
+				FeeStrategy.CreateFromFeeRate(satsPerByte),
+			(null, { } argFeeTarget) when InRange(argFeeTarget, Constants.TwentyMinutesConfirmationTarget, Constants.SevenDaysConfirmationTarget) =>
+				FeeStrategy.CreateFromConfirmationTarget(argFeeTarget),
+			_ => throw new ArgumentException("Fee parameters are missing, inconsistent or out of range.")
+		};
+		AssertWalletIsLoaded();
+		var payment = new PaymentIntent(
+			payments.Select(
+				p =>
+				new DestinationRequest(p.Sendto.ScriptPubKey, MoneyRequest.Create(p.Amount, p.SubtractFee), new LabelsArray(p.Label))));
+		var result = ActiveWallet!.BuildTransactionWithoutOverpaymentProtection(
+			password,
+			payment,
+			feeStrategy,
+			allowUnconfirmed: true,
+			allowedInputs: coins);
+		var smartTx = result.Transaction;
+
+		return smartTx.Transaction.ToHex();
+	}
+
 	[JsonRpcMethod("payincoinjoin")]
 	public string PayInCoinJoin(BitcoinAddress address, Money amount)
 	{

--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -73,7 +73,8 @@ public static class TransactionHelpers
 				AllowUnconfirmed: true,
 				AllowDoubleSpend: false,
 				AllowedInputs: allowedCoins.Select(x => x.Outpoint),
-				TryToSign: false);
+				TryToSign: false,
+				OverrideFeeOverpaymentProtection: false);
 
 			builder.BuildTransaction(
 				parameters,

--- a/WalletWasabi.Tests/Helpers/TransactionParametersBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/TransactionParametersBuilder.cs
@@ -13,7 +13,8 @@ public class TransactionParametersBuilder
 		bool allowUnconfirmed = false,
 		bool allowDoubleSpend = false,
 		IEnumerable<OutPoint>? allowedInputs = null,
-		bool tryToSign = true)
+		bool tryToSign = true,
+		bool overrideFeeProtection = false)
 	{
 		Payment = payment;
 		FeeRate = feeRate;
@@ -21,6 +22,7 @@ public class TransactionParametersBuilder
 		AllowDoubleSpend = allowDoubleSpend;
 		AllowedInputs = allowedInputs;
 		TryToSign = tryToSign;
+		OverrideFeeProtection = overrideFeeProtection;
 	}
 
 	private PaymentIntent? Payment { get; set; }
@@ -29,6 +31,7 @@ public class TransactionParametersBuilder
 	private bool AllowDoubleSpend { get; set; }
 	private IEnumerable<OutPoint>? AllowedInputs { get; set; }
 	private bool TryToSign { get; set; }
+	private bool OverrideFeeProtection { get; set; }
 
 	public TransactionParametersBuilder SetPayment(PaymentIntent payment)
 	{
@@ -66,6 +69,12 @@ public class TransactionParametersBuilder
 		return this;
 	}
 
+	public TransactionParametersBuilder SetOverrideFeeProtection(bool value)
+	{
+		OverrideFeeProtection = value;
+		return this;
+	}
+
 	public TransactionParameters Build()
 	{
 		if (Payment is null)
@@ -78,7 +87,7 @@ public class TransactionParametersBuilder
 			throw new InvalidOperationException("Fee rate is a required parameter.");
 		}
 
-		return new TransactionParameters(Payment, FeeRate, AllowUnconfirmed, AllowDoubleSpend, AllowedInputs, TryToSign);
+		return new TransactionParameters(Payment, FeeRate, AllowUnconfirmed, AllowDoubleSpend, AllowedInputs, TryToSign, OverrideFeeProtection);
 	}
 
 	public static TransactionParametersBuilder CreateDefault()

--- a/WalletWasabi/Blockchain/TransactionBuilding/TransactionBuilderWalletExtensions.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/TransactionBuilderWalletExtensions.cs
@@ -25,7 +25,8 @@ public static class TransactionBuilderWalletExtensions
 		IEnumerable<OutPoint>? allowedInputs = null,
 		IPayjoinClient? payjoinClient = null,
 		bool allowDoubleSpend = false,
-		bool tryToSign = true)
+		bool tryToSign = true,
+		bool overrideFeeOverpaymentProtection = false)
 	{
 		FeeRate? feeRate;
 
@@ -45,7 +46,8 @@ public static class TransactionBuilderWalletExtensions
 			AllowUnconfirmed: allowUnconfirmed,
 			AllowDoubleSpend: allowDoubleSpend,
 			AllowedInputs: allowedInputs,
-			TryToSign: tryToSign);
+			TryToSign: tryToSign,
+			OverrideFeeOverpaymentProtection: overrideFeeOverpaymentProtection);
 
 		var factory = new TransactionFactory(wallet.Network, wallet.KeyManager, wallet.Coins, wallet.BitcoinStore.TransactionStore, password);
 		return factory.BuildTransaction(

--- a/WalletWasabi/Blockchain/TransactionBuilding/TransactionBuilderWalletExtensions.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/TransactionBuilderWalletExtensions.cs
@@ -129,4 +129,25 @@ public static class TransactionBuilderWalletExtensions
 
 		return txRes;
 	}
+
+	public static BuildTransactionResult BuildTransactionWithoutOverpaymentProtection(
+		this Wallet wallet,
+		string password,
+		PaymentIntent payments,
+		FeeStrategy feeStrategy,
+		bool allowUnconfirmed = false,
+		IEnumerable<OutPoint>? allowedInputs = null,
+		IPayjoinClient? payjoinClient = null,
+		bool allowDoubleSpend = false)
+		=> BuildTransaction(
+			wallet,
+			password,
+			payments,
+			feeStrategy,
+			allowUnconfirmed,
+			allowedInputs,
+			payjoinClient,
+			allowDoubleSpend,
+			tryToSign: true,
+			overrideFeeOverpaymentProtection: true);
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -201,7 +201,7 @@ public class TransactionFactory
 			decimal totalOutgoingAmountNoFeeDecimalDivisor = totalOutgoingAmountNoFeeDecimal == 0 ? decimal.MinValue : totalOutgoingAmountNoFeeDecimal;
 			feePercentage = 100 * (feeDecimal / totalOutgoingAmountNoFeeDecimalDivisor);
 		}
-		if (feePercentage > 100)
+		if (feePercentage > 100 && !parameters.OverrideFeeOverpaymentProtection)
 		{
 			throw new TransactionFeeOverpaymentException(feePercentage);
 		}

--- a/WalletWasabi/Blockchain/Transactions/TransactionParameters.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionParameters.cs
@@ -10,10 +10,12 @@ namespace WalletWasabi.Blockchain.Transactions;
 /// <param name="AllowDoubleSpend"><c>true</c> to allow double spending of coins, <c>false</c> otherwise.</param>
 /// <param name="AllowedInputs">Set of coins that are allowed to be used in the created transaction, <c>null</c> to allow all inputs.</param>
 /// <param name="TryToSign"><c>true</c> to return a transaction with signed inputs, <c>false</c> otherwise.</param>
+/// <param name="OverrideFeeOverpaymentProtection"><c>true</c> to allow to build a transaction with more fees than outgoing amount, <c>false</c> otherwise.</param>
 public record TransactionParameters(
 	PaymentIntent PaymentIntent,
 	FeeRate FeeRate,
 	bool AllowUnconfirmed,
 	bool AllowDoubleSpend,
 	IEnumerable<OutPoint>? AllowedInputs,
-	bool TryToSign);
+	bool TryToSign,
+	bool OverrideFeeOverpaymentProtection);


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/12118

I went with this comment https://github.com/zkSNACKs/WalletWasabi/issues/12118#issuecomment-1866578858, so this overriding "mechanism" only works via RPC for now.

How to test:

1. Call the `build` RPC endpoint with a small outgoing amount and huge fees.
2. See `TransactionFeeOverpaymentException` exception.
3. Call `buildunsafetransaction` endpoint with a small outgoing amount and huge fees.
4. See no exceptions and a successfully built transaction.

@turbolay @MarnixCroes Could you guys test this please? Much appreciated!!