### PR TITLE
Bump version to 2.0.5 on master

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -79,7 +79,7 @@ public static class Constants
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 
-	public static readonly Version ClientVersion = new(2, 0, 4, 1);
+	public static readonly Version ClientVersion = new(2, 0, 5, 0);
 
 	public static readonly Version HwiVersion = new("2.3.1");
 	public static readonly Version BitcoinCoreVersion = new("21.2");


### PR DESCRIPTION
We didn't release from `master` branch, but `master` should also know about the release.