### PR TITLE
UpdateManager: Clean up the weird cancellation token

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -185,7 +185,6 @@ public class Global
 			{
 				var bitcoinStoreInitTask = BitcoinStore.InitializeAsync(cancel);
 
-				UpdateManager.Initialize(cancel);
 				await LegalChecker.InitializeAsync().ConfigureAwait(false);
 
 				cancel.ThrowIfCancellationRequested();


### PR DESCRIPTION
Addresses: https://github.com/zkSNACKs/WalletWasabi/pull/12121#discussion_r1433900549

Previously, the application stopping token (from `Global.cs`) was sent in, saved and used by this class for reasons I don't know.

Which makes no sense, since the class is disposable and the GC will handle this job.
Therefore a simple `CTS` is sufficient IMO.