### PR TITLE
Use the IDictionary.TryGetValue(TKey, out TValue) method to fix CA1854 warnings

### DIFF
--- a/WalletWasabi.Fluent/State/StateMachine.cs
+++ b/WalletWasabi.Fluent/State/StateMachine.cs
@@ -115,7 +115,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 	private void Goto(TState state, bool exit = true, bool enter = true)
 	{
-		if (_states.ContainsKey(state))
+		if (_states.TryGetValue(state, out StateMachine<TState, TTrigger>.StateContext? value))
 		{
 			if (exit && !IsAncestorOf(state, _currentState.StateId))
 			{
@@ -124,7 +124,7 @@ public class StateMachine<TState, TTrigger> where TTrigger : Enum where TState :
 
 			var old = _currentState.StateId;
 
-			_currentState = _states[state];
+			_currentState = value;
 
 			_onTransitioned?.Invoke(old, _currentState.StateId);
 

--- a/WalletWasabi.Fluent/ViewModels/Navigation/NavigationManager.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/NavigationManager.cs
@@ -32,17 +32,17 @@ public static class NavigationManager
 
 	public static async Task<RoutableViewModel?> MaterializeViewModelAsync(NavigationMetaData metaData)
 	{
-		if (NavigationEntries.ContainsKey(metaData))
+		if (NavigationEntries.TryGetValue(metaData, out InstanceGeneratorBase? value))
 		{
-			if (NavigationEntries[metaData] is InstanceGenerator instanceGenerator)
+			if (value is InstanceGenerator instanceGenerator)
 			{
 				return instanceGenerator.Generate;
 			}
-			else if (NavigationEntries[metaData] is SynchronousInstanceGenerator synchronousInstanceGenerator)
+			else if (value is SynchronousInstanceGenerator synchronousInstanceGenerator)
 			{
 				return synchronousInstanceGenerator.Generate();
 			}
-			else if (NavigationEntries[metaData] is AsyncInstanceGenerator asyncInstanceGenerator)
+			else if (value is AsyncInstanceGenerator asyncInstanceGenerator)
 			{
 				return await asyncInstanceGenerator.Generate();
 			}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -98,13 +98,13 @@ public class MultipartyTransactionStateTests
 
 			var maxSuggested = round.Parameters.MaxSuggestedAmount;
 
-			if (!histogram.ContainsKey(maxSuggested))
+			if (!histogram.TryGetValue(maxSuggested, out int value))
 			{
 				histogram.Add(maxSuggested, 1);
 			}
 			else
 			{
-				histogram[maxSuggested]++;
+				histogram[maxSuggested] = ++value;
 			}
 		}
 

--- a/WalletWasabi.Tests/UnitTests/Wallet/SmartCoinSelectorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/SmartCoinSelectorTests.cs
@@ -163,12 +163,13 @@ public class SmartCoinSelectorTests
 		{
 			var key = KeyManager.GenerateNewKey(new LabelsArray(targetCoin.Cluster), KeyState.Clean, false);
 
-			if (!generatedKeyGroup.ContainsKey(targetCoin.Cluster))
+			if (!generatedKeyGroup.TryGetValue(targetCoin.Cluster, out List<(HdPubKey key, decimal amount)>? value))
 			{
-				generatedKeyGroup.Add(targetCoin.Cluster, new());
+				value = new();
+				generatedKeyGroup.Add(targetCoin.Cluster, value);
 			}
 
-			generatedKeyGroup[targetCoin.Cluster].Add((key, targetCoin.amount));
+			value.Add((key, targetCoin.amount));
 		}
 
 		var coinPairClusters = generatedKeyGroup.GroupBy(x => x.Key)

--- a/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
+++ b/WalletWasabi/Tor/Socks5/Pool/TorHttpPool.cs
@@ -455,12 +455,13 @@ public class TorHttpPool : IAsyncDisposable
 				{
 					string host = GetRequestHost(requestUri);
 
-					if (!ConnectionPerHost.ContainsKey(host))
+					if (!ConnectionPerHost.TryGetValue(host, out List<TorTcpConnection>? value))
 					{
-						ConnectionPerHost.Add(host, new List<TorTcpConnection>());
+						value = new List<TorTcpConnection>();
+						ConnectionPerHost.Add(host, value);
 					}
 
-					ConnectionPerHost[host].Add(connection);
+					value.Add(connection);
 				}
 			}
 		}
@@ -570,12 +571,13 @@ public class TorHttpPool : IAsyncDisposable
 	/// <remarks>Guarded by <see cref="ConnectionsLock"/>.</remarks>
 	private bool GetPoolConnectionNoLock(string host, ICircuit circuit, out TorTcpConnection? connection)
 	{
-		if (!ConnectionPerHost.ContainsKey(host))
+		if (!ConnectionPerHost.TryGetValue(host, out List<TorTcpConnection>? value))
 		{
-			ConnectionPerHost.Add(host, new());
+			value = new();
+			ConnectionPerHost.Add(host, value);
 		}
 
-		List<TorTcpConnection> hostConnections = ConnectionPerHost[host];
+		List<TorTcpConnection> hostConnections = value;
 
 		// Find TCP connections to dispose.
 		foreach (TorTcpConnection tcpConnection in hostConnections.FindAll(c => c.NeedDisposal).ToList())


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1854

> When an element of an `IDictionary` is accessed, the indexer implementation checks for a null value by calling the `IDictionary.ContainsKey` method. If you also call `IDictionary.ContainsKey` in an `if` clause to guard a value lookup, two lookups are performed when only one is needed.