### PR TITLE
Compare 'Count' to 0 rather than using 'Any()' for clarity and for performance

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -184,7 +184,7 @@ public class BlockchainController : ControllerBase
 				}
 			}
 
-			if (missingTxs.Any())
+			if (missingTxs.Count != 0)
 			{
 				foreach (var tx in await RpcClient.GetRawTransactionsAsync(missingTxs, cancellationToken))
 				{

--- a/WalletWasabi.Fluent.Generators/Abstractions/CombinedGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/Abstractions/CombinedGenerator.cs
@@ -29,7 +29,7 @@ internal abstract class CombinedGenerator : ISourceGenerator
 			});
 		}
 
-		if (StepFactories.Any())
+		if (StepFactories.Count != 0)
 		{
 			context.RegisterForSyntaxNotifications(() => new CombinedSyntaxReceiver(this));
 		}

--- a/WalletWasabi.Fluent.Generators/Analyzers/UIContextUsageInConstructorAnalyzer.cs
+++ b/WalletWasabi.Fluent.Generators/Analyzers/UIContextUsageInConstructorAnalyzer.cs
@@ -99,7 +99,7 @@ public class UiContextAnalyzer : DiagnosticAnalyzer
 		var uiContextReferencesInClass =
 			classDeclaration.GetUiContextReferences(context.SemanticModel);
 
-		if (uiContextReferencesInClass.Any() && !ctor.IsPrivate())
+		if (uiContextReferencesInClass.Count != 0 && !ctor.IsPrivate())
 		{
 			var location = ctor.GetLocation();
 			var diagnostic = Diagnostic.Create(Rule2, location);

--- a/WalletWasabi.Fluent.Generators/Generators/UiContextConstructorGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/Generators/UiContextConstructorGenerator.cs
@@ -63,7 +63,7 @@ internal class UiContextConstructorGenerator : GeneratorStep<ClassDeclarationSyn
 
 		foreach (var constructor in constructors)
 		{
-			if (!classDeclaration.GetUiContextReferences(semanticModel).Any())
+			if (classDeclaration.GetUiContextReferences(semanticModel).Count == 0)
 			{
 				if (!classDeclaration.IsAbstractClass(semanticModel) && constructor.IsPublic())
 				{

--- a/WalletWasabi.Fluent.Generators/NavigationMetaDataGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/NavigationMetaDataGenerator.cs
@@ -91,7 +91,7 @@ public class NavigationMetaDataGenerator : ISourceGenerator
 		}
 
 		var implementedInterfacesString =
-			implementedInterfaces.Any()
+			implementedInterfaces.Count != 0
 			? ": " + string.Join(", ", implementedInterfaces)
 			: "";
 

--- a/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/NotificationHelpers.cs
@@ -58,10 +58,10 @@ public static class NotificationHelpers
 
 		try
 		{
-			bool isSpent = result.NewlySpentCoins.Any();
-			bool isReceived = result.NewlyReceivedCoins.Any();
-			bool isConfirmedReceive = result.NewlyConfirmedReceivedCoins.Any();
-			bool isConfirmedSpent = result.NewlyConfirmedReceivedCoins.Any();
+			bool isSpent = result.NewlySpentCoins.Count != 0;
+			bool isReceived = result.NewlyReceivedCoins.Count != 0;
+			bool isConfirmedReceive = result.NewlyConfirmedReceivedCoins.Count != 0;
+			bool isConfirmedSpent = result.NewlyConfirmedReceivedCoins.Count != 0;
 			Money miningFee = result.Transaction.Transaction.GetFee(result.SpentCoins.Select(x => (ICoin)x.Coin).ToArray()) ?? Money.Zero;
 
 			if (isReceived || isSpent)

--- a/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
@@ -189,7 +189,7 @@ public partial class WalletTransactionsModel : ReactiveObject, IDisposable
 		var foreignOutputs = outputs.OfType<ForeignOutput>().ToList();
 
 		// All inputs and outputs are my own, transaction is a self-spend.
-		if (!foreignInputs.Any() && !foreignOutputs.Any())
+		if (foreignInputs.Count == 0 && foreignOutputs.Count == 0)
 		{
 			// Classic self-spend to one or more external addresses.
 			if (myOwnOutputs.Any(x => !x.IsInternal))
@@ -204,7 +204,7 @@ public partial class WalletTransactionsModel : ReactiveObject, IDisposable
 		}
 
 		// All inputs are foreign but some outputs are my own, someone is sending coins to me.
-		if (!myOwnInputs.Any() && myOwnOutputs.Any())
+		if (myOwnInputs.Count == 0 && myOwnOutputs.Count != 0)
 		{
 			// All outputs that are my own are the destinations.
 			return myOwnOutputs.Select(x => x.DestinationAddress);

--- a/WalletWasabi.Fluent/Validation/Validations.cs
+++ b/WalletWasabi.Fluent/Validation/Validations.cs
@@ -122,7 +122,7 @@ public class Validations : ReactiveObject, IRegisterValidationMethod, IValidatio
 
 		var propertiesToNotify = categoriesToNotify.Select(Selector).ToList();
 
-		if (propertiesToNotify.Any())
+		if (propertiesToNotify.Count != 0)
 		{
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
 			this.RaisePropertyChanged(nameof(Any));

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinSelectorViewModel.cs
@@ -90,7 +90,7 @@ public class CoinSelectorViewModel : ViewModelBase, IDisposable
 		wallet.Coins.Pockets
 					.Connect()
 					.ToCollection()
-					.SkipWhile(pockets => !pockets.Any())
+					.SkipWhile(pockets => pockets.Count == 0)
 					.Do(
 						pockets =>
 						{

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/Core/CoinControlItemViewModelBase.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/Core/CoinControlItemViewModelBase.cs
@@ -66,5 +66,5 @@ public abstract class CoinControlItemViewModelBase : ViewModelBase
 
 	public ScriptType? ScriptType { get; protected set; }
 
-	public virtual bool HasChildren() => Children.Any();
+	public virtual bool HasChildren() => Children.Count != 0;
 }

--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -173,7 +173,7 @@ public partial class MainViewModel : ViewModelBase
 			.Connect()
 			.FilterOnObservable(x => x.Coinjoin.IsRunning)
 			.ToCollection()
-			.Select(x => x.Any())
+			.Select(x => x.Count != 0)
 			.BindTo(this, x => x.IsCoinJoinActive);
 
 		Notifications.StartListening();

--- a/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/SearchBar/SearchBarViewModel.cs
@@ -30,7 +30,7 @@ public partial class SearchBarViewModel : ReactiveObject
 
 		itemsObservable
 			.ToCollection()
-			.Select(x => x.Any())
+			.Select(x => x.Count != 0)
 			.BindTo(this, x => x.HasResults);
 
 		ActivateFirstItemCommand = ReactiveCommand.Create(

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Notifications/WalletNotificationsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Notifications/WalletNotificationsViewModel.cs
@@ -53,7 +53,7 @@ public partial class WalletNotificationsViewModel : ViewModelBase
 			NotificationHelpers.Show(wallet, e, OnClick);
 		}
 
-		if (_walletSelector.SelectedWalletModel == wallet && (e.NewlyReceivedCoins.Any() || e.NewlyConfirmedReceivedCoins.Any()))
+		if (_walletSelector.SelectedWalletModel == wallet && (e.NewlyReceivedCoins.Count != 0 || e.NewlyConfirmedReceivedCoins.Count != 0))
 		{
 			await Task.Delay(200);
 			_walletSelector.SelectedWallet?.SelectTransaction(e.Transaction.GetHash());

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/LabelSelectionViewModel.cs
@@ -345,7 +345,7 @@ public partial class LabelSelectionViewModel : ViewModelBase
 			return false;
 		}
 
-		if (!remainingUsablePockets.Any())
+		if (remainingUsablePockets.Count == 0)
 		{
 			return false;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -130,7 +130,7 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 			{
 				_info = previous.Item2;
 				UpdateTransaction(CurrentTransactionSummary, previous.Item1, false);
-				CanUndo = _undoHistory.Any();
+				CanUndo = _undoHistory.Count != 0;
 			}
 		});
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -282,7 +282,7 @@ public class TransactionProcessorTests
 		transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
 		{
 			var doubleSpentCoins = e.SuccessfullyDoubleSpentCoins;
-			if (doubleSpentCoins.Any())
+			if (doubleSpentCoins.Count != 0)
 			{
 				var coin = Assert.Single(doubleSpentCoins);
 
@@ -358,9 +358,9 @@ public class TransactionProcessorTests
 		int replaceTransactionReceivedCalled = 0;
 		transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
 		{
-			if (e.ReplacedCoins.Any() || e.RestoredCoins.Any())
+			if (e.ReplacedCoins.Count != 0 || e.RestoredCoins.Count != 0)
 			{
-				if (e.RestoredCoins.Any())
+				if (e.RestoredCoins.Count != 0)
 				{
 					// Move the original coin from spent to unspent - so add.
 					var originalCoin = Assert.Single(e.RestoredCoins);
@@ -540,11 +540,11 @@ public class TransactionProcessorTests
 		int confirmed = 0;
 		transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
 		{
-			if (e.NewlySpentCoins.Any())
+			if (e.NewlySpentCoins.Count != 0)
 			{
 				throw new InvalidOperationException("We are not spending the coin.");
 			}
-			else if (e.NewlyConfirmedSpentCoins.Any())
+			else if (e.NewlyConfirmedSpentCoins.Count != 0)
 			{
 				confirmed++;
 			}
@@ -760,7 +760,7 @@ public class TransactionProcessorTests
 		SmartCoin? spentCoin = null;
 		transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
 		{
-			if (e.NewlySpentCoins.Any())
+			if (e.NewlySpentCoins.Count != 0)
 			{
 				spentCoin = e.NewlySpentCoins.Single();
 			}
@@ -798,7 +798,7 @@ public class TransactionProcessorTests
 		SmartCoin? spentCoin = null;
 		transactionProcessor.WalletRelevantTransactionProcessed += (s, e) =>
 		{
-			if (e.NewlySpentCoins.Any())
+			if (e.NewlySpentCoins.Count != 0)
 			{
 				spentCoin = e.NewlySpentCoins.Single();
 			}

--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -72,7 +72,7 @@ public abstract class P2pBehavior : NodeBehavior
 				getDataPayload.Inventory.Add(new InventoryVector(node.AddSupportedOptions(inv.Type), inv.Hash));
 			}
 		}
-		if (getDataPayload.Inventory.Any() && node.IsConnected)
+		if (getDataPayload.Inventory.Count != 0 && node.IsConnected)
 		{
 			await node.SendMessageAsync(getDataPayload).ConfigureAwait(false);
 		}

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -72,7 +72,7 @@ public class BlockchainAnalyzer
 	private static void AnalyzeCancellation(SmartTransaction tx)
 	{
 		// If the tx is a cancellation and we have at least one input or output that is not ours, then we set the anonset to 1.
-		if (tx.IsCancellation && (tx.ForeignOutputs.Any() || tx.ForeignInputs.Any()))
+		if (tx.IsCancellation && (tx.ForeignOutputs.Count != 0 || tx.ForeignInputs.Count != 0))
 		{
 			foreach (var k in tx.WalletInputs.Select(x => x.HdPubKey).Distinct())
 			{
@@ -285,7 +285,7 @@ public class BlockchainAnalyzer
 	private static void AdjustWalletInputs(SmartTransaction tx, double startingOutputAnonset)
 	{
 		// Sanity check.
-		if (!tx.WalletOutputs.Any())
+		if (tx.WalletOutputs.Count == 0)
 		{
 			return;
 		}
@@ -375,12 +375,12 @@ public class BlockchainAnalyzer
 	/// <remarks>Context: https://github.com/zkSNACKs/WalletWasabi/issues/10567</remarks>
 	public static void SetIsSufficientlyDistancedFromExternalKeys(SmartCoin output)
 	{
-		if (!output.Transaction.WalletInputs.Any())
+		if (output.Transaction.WalletInputs.Count == 0)
 		{
 			// If there's no wallet input, then money is coming from external sources.
 			output.IsSufficientlyDistancedFromExternalKeys = false;
 		}
-		else if (output.Transaction.WalletInputs.All(x => !x.Transaction.WalletInputs.Any()))
+		else if (output.Transaction.WalletInputs.All(x => x.Transaction.WalletInputs.Count == 0))
 		{
 			// If there are wallet inputs, and each and every one of them are coming from external sources, then we consider this as not sufficiently distanced as well.
 			output.IsSufficientlyDistancedFromExternalKeys = false;

--- a/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/IndexBuilderService.cs
@@ -249,7 +249,7 @@ public class IndexBuilderService
 	{
 		var scripts = FetchScripts(block, pubKeyTypes);
 
-		if (scripts.Any())
+		if (scripts.Count != 0)
 		{
 			return new GolombRiceFilterBuilder()
 				.SetKey(block.Hash)

--- a/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
+++ b/WalletWasabi/Blockchain/Blocks/BlockNotifier.cs
@@ -84,7 +84,7 @@ public class BlockNotifier : PeriodicRunner
 		//   - That was the largest recorded reorg so far.
 		//   - Reorg in this point of time would be very unlikely anyway.
 		//   - 100 blocks would be the sure, but that'd be a huge performance overkill.
-		if (!ProcessedBlocks.Any())
+		if (ProcessedBlocks.Count == 0)
 		{
 			var reorgProtection7Headers = new List<BlockHeader>()
 				{

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -177,7 +177,7 @@ public class CoinsRegistry : ICoinsView
 
 			coins.RemoveWhere(x => coinsToRemove.Contains(x));
 
-			if (coins.Any())
+			if (coins.Count != 0)
 			{
 				continue;
 			}

--- a/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/ProcessedResult.cs
@@ -20,14 +20,14 @@ public class ProcessedResult
 	public SmartTransaction Transaction { get; }
 
 	public bool IsNews =>
-		SuccessfullyDoubleSpentCoins.Any()
-		|| ReplacedCoins.Any()
-		|| RestoredCoins.Any()
-		|| NewlyReceivedCoins.Any()
-		|| NewlyConfirmedReceivedCoins.Any()
-		|| NewlySpentCoins.Any()
-		|| NewlyConfirmedSpentCoins.Any()
-		|| ReceivedDusts.Any(); // To be fair it isn't necessarily news, the algorithm of the processor can be improved for that. Not sure it is worth it though.
+		SuccessfullyDoubleSpentCoins.Count != 0
+		|| ReplacedCoins.Count != 0
+		|| RestoredCoins.Count != 0
+		|| NewlyReceivedCoins.Count != 0
+		|| NewlyConfirmedReceivedCoins.Count != 0
+		|| NewlySpentCoins.Count != 0
+		|| NewlyConfirmedSpentCoins.Count != 0
+		|| ReceivedDusts.Count != 0; // To be fair it isn't necessarily news, the algorithm of the processor can be improved for that. Not sure it is worth it though.
 
 	public bool IsOwnCoinJoin => _isOwnCoinJoin.Value;
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -272,7 +272,7 @@ public class TransactionProcessor
 			SaveInternalKeysLatestSpendingHeight(tx.Height, myInputs.Select(x => x.HdPubKey).Where(x => x.IsInternal).Distinct());
 		}
 
-		if (tx.WalletInputs.Any() || tx.WalletOutputs.Any())
+		if (tx.WalletInputs.Count != 0 || tx.WalletOutputs.Count != 0)
 		{
 			TransactionStore.AddOrUpdate(tx);
 		}

--- a/WalletWasabi/Blockchain/Transactions/Operations/OperationMerger.cs
+++ b/WalletWasabi/Blockchain/Transactions/Operations/OperationMerger.cs
@@ -84,17 +84,17 @@ public static class OperationMerger
 			prevOperation = op;
 		}
 
-		if (tempToAppends.Any())
+		if (tempToAppends.Count != 0)
 		{
 			yield return new Append(tempToAppends);
 		}
 
-		if (tempToRemoves.Any())
+		if (tempToRemoves.Count != 0)
 		{
 			yield return new Remove(tempToRemoves);
 		}
 
-		if (tempToUpdates.Any())
+		if (tempToUpdates.Count != 0)
 		{
 			yield return new Update(tempToUpdates);
 		}

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -190,7 +190,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	/// Parent transactions this transaction is paying for.
 	/// </summary>
 	public IEnumerable<SmartTransaction> ParentsThisTxPaysFor =>
-		IsSpeedup && !IsCancellation && !ForeignInputs.Any() && !ForeignOutputs.Any()
+		IsSpeedup && !IsCancellation && ForeignInputs.Count == 0 && ForeignOutputs.Count == 0
 			? WalletInputs
 				.Select(x => x.Transaction)
 				.Where(x => x.Height == Height
@@ -457,7 +457,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	}
 
 	public bool IsOwnCoinjoin()
-	   => WalletInputs.Any() // We must be a participant in order for this transaction to be our coinjoin.
+	   => WalletInputs.Count != 0 // We must be a participant in order for this transaction to be our coinjoin.
 	   && Transaction.Inputs.Count != WalletInputs.Count; // Some inputs must not be ours for it to be a coinjoin.
 
 	public bool IsSegwitWithoutWitness => !Transaction.HasWitness && Transaction.Inputs.Any(x => x.ScriptSig == Script.Empty);
@@ -467,7 +467,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	/// </summary>
 	public bool TryGetFee([NotNullWhen(true)] out Money? fee)
 	{
-		if (ForeignInputs.Any())
+		if (ForeignInputs.Count != 0)
 		{
 			fee = null;
 			return false;
@@ -484,7 +484,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 	/// </summary>
 	public bool TryGetFeeRate([NotNullWhen(true)] out FeeRate? feeRate)
 	{
-		if (ForeignInputs.Any() || IsSegwitWithoutWitness)
+		if (ForeignInputs.Count != 0 || IsSegwitWithoutWitness)
 		{
 			feeRate = null;
 			return false;

--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -231,7 +231,7 @@ public class TransactionStore : IAsyncDisposable
 	{
 		lock (TransactionsLock)
 		{
-			return !Transactions.Any();
+			return Transactions.Count == 0;
 		}
 	}
 
@@ -288,7 +288,7 @@ public class TransactionStore : IAsyncDisposable
 			// Make sure that only one call can continue.
 			lock (OperationsLock)
 			{
-				var isRunning = Operations.Any();
+				var isRunning = Operations.Count != 0;
 				Operations.Add(operation);
 				if (isRunning)
 				{

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -201,7 +201,7 @@ public static class NBitcoinExtensions
 			}
 		}
 		var nodes = lookup.Values;
-		return nodes.Where(x => !x.Parents.Any());
+		return nodes.Where(x => x.Parents.Count == 0);
 	}
 
 	public static IEnumerable<Transaction> OrderByDependency(this IEnumerable<TransactionDependencyNode> roots)

--- a/WalletWasabi/Services/HostedServices.cs
+++ b/WalletWasabi/Services/HostedServices.cs
@@ -73,7 +73,7 @@ public class HostedServices : IDisposable
 
 		await Task.WhenAll(tasks).ConfigureAwait(false);
 
-		if (exceptions.Any())
+		if (exceptions.Count != 0)
 		{
 			throw new AggregateException(exceptions);
 		}

--- a/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
+++ b/WalletWasabi/Tor/Http/Helpers/HttpMessageHelper.cs
@@ -155,7 +155,7 @@ public static class HttpMessageHelper
 
 			contentHeaders.ContentEncoding.Remove("gzip");
 
-			if (!contentHeaders.ContentEncoding.Any())
+			if (contentHeaders.ContentEncoding.Count == 0)
 			{
 				contentHeaders.Remove("Content-Encoding");
 			}

--- a/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
+++ b/WalletWasabi/WabiSabi/Backend/Banning/CoinVerifier.cs
@@ -77,7 +77,7 @@ public class CoinVerifier : IAsyncDisposable
 
 		try
 		{
-			while (tasks.Any())
+			while (tasks.Count != 0)
 			{
 				var completedTask = await Task.WhenAny(tasks).WaitAsync(linkedCts.Token).ConfigureAwait(false);
 				tasks.Remove(completedTask);

--- a/WalletWasabi/WabiSabi/Backend/Statistics/CoinJoinFeeRateStatStore.cs
+++ b/WalletWasabi/WabiSabi/Backend/Statistics/CoinJoinFeeRateStatStore.cs
@@ -58,7 +58,7 @@ public class CoinJoinFeeRateStatStore : PeriodicRunner
 
 		// Prune old items.
 		DateTimeOffset removeBefore = DateTimeOffset.UtcNow - MaximumTimeToStore;
-		while (CoinJoinFeeRateStats.Any() && CoinJoinFeeRateStats[0].DateTimeOffset < removeBefore)
+		while (CoinJoinFeeRateStats.Count != 0 && CoinJoinFeeRateStats[0].DateTimeOffset < removeBefore)
 		{
 			CoinJoinFeeRateStats.RemoveAt(0);
 		}

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -65,7 +65,7 @@ public class AmountDecomposer
 		foreach (var denom in preFilteredDenoms)
 		{
 			var filterSeverity = 1 + currentLength * increment;
-			if (!denoms.Any() || denom.Amount.Satoshi <= (long)(denoms.Last().Amount.Satoshi / filterSeverity))
+			if (denoms.Count == 0 || denom.Amount.Satoshi <= (long)(denoms.Last().Amount.Satoshi / filterSeverity))
 			{
 				denoms.Add(denom);
 			}
@@ -121,7 +121,7 @@ public class AmountDecomposer
 
 		// If there are changeless candidates, don't even consider ones with change.
 		var changelessCandidates = preCandidates.Where(x => x.Decomposition.All(y => denomHashSet.Contains(y))).ToList();
-		var changeAvoided = changelessCandidates.Any();
+		var changeAvoided = changelessCandidates.Count != 0;
 		if (changeAvoided)
 		{
 			preCandidates = changelessCandidates;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -129,7 +129,7 @@ public class CoinJoinCoinSelector
 		var orderedAllowedCoins = AnonScoreTxSourceBiasedShuffle(allowedCoins).ToArray();
 
 		// If the command is given to not stop when everything is coinjoined and the allowed private coins are empty, then we shortcircuit the selection.
-		if (!stopWhenAllMixed && !allowedNonPrivateCoins.Any())
+		if (!stopWhenAllMixed && allowedNonPrivateCoins.Count == 0)
 		{
 			var largestAllowedCoin = orderedAllowedCoins.OrderByDescending(x => x.Amount).FirstOrDefault();
 			if (largestAllowedCoin is null)
@@ -189,7 +189,7 @@ public class CoinJoinCoinSelector
 			}
 		}
 
-		if (!groups.Any())
+		if (groups.Count == 0)
 		{
 			Logger.LogDebug($"Couldn't create any combinations, ending.");
 			return ImmutableList<TCoin>.Empty;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -554,7 +554,7 @@ public class CoinJoinManager : BackgroundService
 		}
 
 		// If any coins were marked for banning, store them to file
-		if (finishedCoinJoin.BannedCoins.Any())
+		if (finishedCoinJoin.BannedCoins.Count != 0)
 		{
 			foreach (var info in finishedCoinJoin.BannedCoins)
 			{

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -583,7 +583,7 @@ public class Wallet : BackgroundService, IWallet
 
 	public void UpdateUsedHdPubKeysLabels(Dictionary<HdPubKey, LabelsArray> hdPubKeysWithLabels)
 	{
-		if (!hdPubKeysWithLabels.Any())
+		if (hdPubKeysWithLabels.Count == 0)
 		{
 			return;
 		}

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoFeeProvider.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoFeeProvider.cs
@@ -31,7 +31,7 @@ public class BlockstreamInfoFeeProvider : PeriodicRunner, IThirdPartyFeeProvider
 			var allFeeEstimate = await BlockstreamInfoClient.GetFeeEstimatesAsync(cancel).ConfigureAwait(false);
 			LastAllFeeEstimate = allFeeEstimate;
 
-			if (allFeeEstimate.Estimations.Any())
+			if (allFeeEstimate.Estimations.Count != 0)
 			{
 				AllFeeEstimateArrived?.Invoke(this, allFeeEstimate);
 			}

--- a/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
+++ b/WalletWasabi/WebClients/PayJoin/PayjoinClient.cs
@@ -108,7 +108,7 @@ public class PayjoinClient : IPayjoinClient
 		var newPSBT = PSBT.Parse(hexOrBase64, originalTx.Network);
 
 		// Checking that the PSBT of the receiver is clean
-		if (newPSBT.GlobalXPubs.Any())
+		if (newPSBT.GlobalXPubs.Count != 0)
 		{
 			throw new PayjoinSenderException("GlobalXPubs should not be included in the receiver's PSBT");
 		}


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1860

> To determine whether a collection type has any elements, it's more efficient and clearer to use the `Length`, `Count`, or `IsEmpty` (if possible) properties than to call the [Enumerable.Any](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.any) method.

`Any()`, which is an extension method, uses language integrated query (LINQ). It's more efficient to rely on the collection's own properties, and it also clarifies intent.