### PR TITLE
[VDG] Fix text rendering after Avalonia v11 update

### DIFF
--- a/WalletWasabi.Fluent/Views/MainWindow.axaml
+++ b/WalletWasabi.Fluent/Views/MainWindow.axaml
@@ -23,7 +23,8 @@
         Focusable="{Binding SearchBar.IsSearchListVisible}"
         Icon="/Assets/WasabiLogo.ico"
         RenderOptions.BitmapInterpolationMode="HighQuality"
-        RenderOptions.TextRenderingMode="Antialias">
+        RenderOptions.TextRenderingMode="SubpixelAntialias"
+        RenderOptions.RequiresFullOpacityHandling="True">
   <Window.Styles>
     <Style Selector="TitleBar">
       <Setter Property="Foreground" Value="{DynamicResource AcrylicTrimForeground}" />
@@ -34,6 +35,13 @@
   </i:Interaction.Behaviors>
 
   <Panel Margin="{Binding #MainWindow.OffScreenMargin}">
+    <Panel.OpacityMask>
+      <LinearGradientBrush StartPoint="0%,0%"
+                           EndPoint="100%,0%">
+        <GradientStop Color="White" Offset="0" />
+        <GradientStop Color="White" Offset="1" />
+      </LinearGradientBrush>
+    </Panel.OpacityMask>
     <shell:Shell />
   </Panel>
 </Window>

--- a/WalletWasabi.Fluent/Views/MainWindow.axaml
+++ b/WalletWasabi.Fluent/Views/MainWindow.axaml
@@ -35,6 +35,11 @@
   </i:Interaction.Behaviors>
 
   <Panel Margin="{Binding #MainWindow.OffScreenMargin}">
+    <!--
+    WARNING:
+    Do not remove as the OpacityMask as tis needed for RenderOptions.TextRenderingMode="SubpixelAntialias"
+    to work without artifacts until the https://github.com/AvaloniaUI/Avalonia/issues/13265 issue is fixed in Avalonia
+    -->
     <Panel.OpacityMask>
       <LinearGradientBrush StartPoint="0%,0%"
                            EndPoint="100%,0%">


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/12167

We really need SubpixelAntialias for smooth text rendering without artifacts.

# PR with RenderOptions.TextRenderingMode="SubpixelAntialias"

![image](https://github.com/zkSNACKs/WalletWasabi/assets/2297442/6e2234f4-1d3e-4f23-9b84-7fce38245052)

![image](https://github.com/zkSNACKs/WalletWasabi/assets/2297442/835b2042-b14e-499b-bb33-ef59c5b99eac)

# master with RenderOptions.TextRenderingMode="Antialias"

![image](https://github.com/zkSNACKs/WalletWasabi/assets/2297442/f2979dca-c269-464a-8076-2fd2b91b07e8)

![image](https://github.com/zkSNACKs/WalletWasabi/assets/2297442/896086b4-eece-4798-b869-9e07e0998cef)

# master with RenderOptions.TextRenderingMode="SubpixelAntialias"

![image](https://github.com/zkSNACKs/WalletWasabi/assets/2297442/77cc0ecb-ba67-4f77-b3e5-c75835e50eb2)

![image](https://github.com/zkSNACKs/WalletWasabi/assets/2297442/e15a70c3-49b4-459e-a970-786a43ae4900)

