### PR TITLE
Allow `P2PKH` and `P2SH` scripts in coinjoin outputs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -105,6 +105,8 @@ public class ConfigManagerTests
 			  "AllowP2trInputs": true,
 			  "AllowP2wpkhOutputs": true,
 			  "AllowP2trOutputs": true,
+			  "AllowP2pkhOutputs": false,
+			  "AllowP2shOutputs": false,
 			  "AffiliationMessageSignerKey": "30770201010420686710a86f0cdf425e3bc9781f51e45b9440aec1215002402d5cdee713066623a00a06082a8648ce3d030107a14403420004f267804052bd863a1644233b8bfb5b8652ab99bcbfa0fb9c36113a571eb5c0cb7c733dbcf1777c2745c782f96e218bb71d67d15da1a77d37fa3cb96f423e53ba",
 			  "AffiliateServers": {},
 			  "DelayTransactionSigning": false

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -205,6 +205,14 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "AllowP2trOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool AllowP2trOutputs { get; set; } = true;
 
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2pkhOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2pkhOutputs { get; set; } = false;
+
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2shOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2shOutputs { get; set; } = false;
+
 	[DefaultValue(Constants.FallbackAffiliationMessageSignerKey)]
 	[JsonProperty(PropertyName = "AffiliationMessageSignerKey", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public string AffiliationMessageSignerKey { get; set; } = Constants.FallbackAffiliationMessageSignerKey;
@@ -217,9 +225,9 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "DelayTransactionSigning", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool DelayTransactionSigning { get; set; } = false;
 
-	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs);
+	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs, false, false);
 
-	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs);
+	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs, AllowP2pkhOutputs, AllowP2shOutputs);
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
@@ -245,7 +253,7 @@ public class WabiSabiConfig : ConfigBase
 			PenaltyFactorForDisruptingByDoubleSpending: (decimal) DoSPenaltyFactorForDisruptingByDoubleSpending,
 			MinTimeInPrison: DoSMinTimeInPrison);
 
-	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr)
+	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr, bool p2pkh, bool p2sh)
 	{
 		var scriptTypes = new List<ScriptType>();
 		if (p2wpkh)
@@ -255,6 +263,14 @@ public class WabiSabiConfig : ConfigBase
 		if (p2tr)
 		{
 			scriptTypes.Add(ScriptType.Taproot);
+		}
+		if (p2pkh)
+		{
+			scriptTypes.Add(ScriptType.P2PKH);
+		}
+		if (p2sh)
+		{
+			scriptTypes.Add(ScriptType.P2SH);
 		}
 
 		// When adding new script types, please see


### PR DESCRIPTION
Allow to register more scriptpubkyes to  enable more use cases for coinjoins