### PR TITLE
Revert "Allow `P2PKH` and `P2SH` scripts in coinjoin outputs"

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -105,8 +105,6 @@ public class ConfigManagerTests
 			  "AllowP2trInputs": true,
 			  "AllowP2wpkhOutputs": true,
 			  "AllowP2trOutputs": true,
-			  "AllowP2pkhOutputs": false,
-			  "AllowP2shOutputs": false,
 			  "AffiliationMessageSignerKey": "30770201010420686710a86f0cdf425e3bc9781f51e45b9440aec1215002402d5cdee713066623a00a06082a8648ce3d030107a14403420004f267804052bd863a1644233b8bfb5b8652ab99bcbfa0fb9c36113a571eb5c0cb7c733dbcf1777c2745c782f96e218bb71d67d15da1a77d37fa3cb96f423e53ba",
 			  "AffiliateServers": {},
 			  "DelayTransactionSigning": false

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -1,7 +1,6 @@
 using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
@@ -27,31 +26,6 @@ public class RegisterOutputTests
 		await arena.RegisterOutputAsync(req, CancellationToken.None);
 		Assert.NotEmpty(round.Bobs);
 
-		await arena.StopAsync(CancellationToken.None);
-	}
-
-	[Fact]
-	public async Task LegacyOutputsSuccessAsync()
-	{
-		WabiSabiConfig cfg = new() { AllowP2pkhOutputs = true, AllowP2shOutputs = true };
-		var round = WabiSabiFactory.CreateRound(cfg);
-		round.SetPhase(Phase.OutputRegistration);
-		round.Alices.Add(WabiSabiFactory.CreateAlice(round));
-		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(round);
-
-		// p2pkh
-		using Key privKey0 = new();
-		var pkhScript = privKey0.PubKey.GetScriptPubKey(ScriptPubKeyType.Legacy);
-		var req0 = WabiSabiFactory.CreateOutputRegistrationRequest(round, pkhScript, pkhScript.EstimateOutputVsize());
-		await arena.RegisterOutputAsync(req0, CancellationToken.None);
-		Assert.Single(round.Bobs);
-
-		// p2sh
-		using Key privKey1 = new();
-		var shScript = privKey1.PubKey.ScriptPubKey.Hash.ScriptPubKey;
-		var req1 = WabiSabiFactory.CreateOutputRegistrationRequest(round, shScript, shScript.EstimateOutputVsize());
-		await arena.RegisterOutputAsync(req1, CancellationToken.None);
-		Assert.Equal(2, round.Bobs.Count);
 		await arena.StopAsync(CancellationToken.None);
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -205,14 +205,6 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "AllowP2trOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool AllowP2trOutputs { get; set; } = true;
 
-	[DefaultValue(false)]
-	[JsonProperty(PropertyName = "AllowP2pkhOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public bool AllowP2pkhOutputs { get; set; } = false;
-
-	[DefaultValue(false)]
-	[JsonProperty(PropertyName = "AllowP2shOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public bool AllowP2shOutputs { get; set; } = false;
-
 	[DefaultValue(Constants.FallbackAffiliationMessageSignerKey)]
 	[JsonProperty(PropertyName = "AffiliationMessageSignerKey", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public string AffiliationMessageSignerKey { get; set; } = Constants.FallbackAffiliationMessageSignerKey;
@@ -225,9 +217,9 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "DelayTransactionSigning", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool DelayTransactionSigning { get; set; } = false;
 
-	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs, false, false);
+	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs);
 
-	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs, AllowP2pkhOutputs, AllowP2shOutputs);
+	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs);
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
@@ -253,7 +245,7 @@ public class WabiSabiConfig : ConfigBase
 			PenaltyFactorForDisruptingByDoubleSpending: (decimal) DoSPenaltyFactorForDisruptingByDoubleSpending,
 			MinTimeInPrison: DoSMinTimeInPrison);
 
-	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr, bool p2pkh, bool p2sh)
+	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr)
 	{
 		var scriptTypes = new List<ScriptType>();
 		if (p2wpkh)
@@ -263,14 +255,6 @@ public class WabiSabiConfig : ConfigBase
 		if (p2tr)
 		{
 			scriptTypes.Add(ScriptType.Taproot);
-		}
-		if (p2pkh)
-		{
-			scriptTypes.Add(ScriptType.P2PKH);
-		}
-		if (p2sh)
-		{
-			scriptTypes.Add(ScriptType.P2SH);
 		}
 
 		// When adding new script types, please see


### PR DESCRIPTION
Reverts zkSNACKs/WalletWasabi#12190 

This was not tested enough. I will continue working on this concept in another PR.