### PR TITLE
Loop free solution for RpcMonitor status subscription

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -190,7 +190,7 @@ public partial class HealthMonitor : ReactiveObject, IDisposable
 		return HealthMonitorState.Loading;
 	}
 
-	private void BintToRpcMonitor(RpcMonitor rpcMonitor)
+	private void BindToRpcMonitor(RpcMonitor rpcMonitor)
 	{
 		Observable.FromEventPattern<RpcStatus>(rpcMonitor, nameof(rpcMonitor.RpcStatusChanged))
 			.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi/Services/HostedServices.cs
+++ b/WalletWasabi/Services/HostedServices.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Services;
@@ -15,6 +16,8 @@ public class HostedServices : IDisposable
 
 	private object ServicesLock { get; } = new();
 	private bool IsStartAllAsyncStarted { get; set; } = false;
+
+	public event EventHandler<IHostedService>? ServiceRegistered;
 
 	public void Register<T>(Func<IHostedService> serviceFactory, string friendlyName) where T : class, IHostedService
 	{
@@ -41,6 +44,8 @@ public class HostedServices : IDisposable
 			}
 			Services.Add(new HostedService(service, friendlyName));
 		}
+
+		ServiceRegistered?.SafeInvoke(this, service);
 	}
 
 	public async Task StartAllAsync(CancellationToken token = default)


### PR DESCRIPTION
An alternative solution to https://github.com/zkSNACKs/WalletWasabi/pull/12196

I want to find the best solution because this will create a precedent for how to handle situations when the service is not yet available but the UI wants to hook up for the service at the start. 