### PR TITLE
`TransactionStore`: Remove `.dat` file after import

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -49,7 +49,7 @@ public class TransactionStore : IAsyncDisposable
 	/// <remarks>Guarded by <see cref="SqliteStorageLock"/>.</remarks>
 	private Dictionary<uint256, SmartTransaction> Transactions { get; } = new();
 
-	private void Import(string oldPath, Network network, bool deleteAfterImport = false)
+	private void Import(string oldPath, Network network, bool deleteAfterImport = true)
 	{
 		if (File.Exists(oldPath))
 		{


### PR DESCRIPTION
Follow-up to https://github.com/zkSNACKs/WalletWasabi/pull/12137#issuecomment-1879765647

