### PR TITLE
Move dispose of BackgroundServices up in Global.DisposeAsync

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -397,6 +397,14 @@ public class Global
 
 			try
 			{
+				if (HostedServices is { } backgroundServices)
+				{
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
+					await backgroundServices.StopAllAsync(cts.Token).ConfigureAwait(false);
+					backgroundServices.Dispose();
+					Logger.LogInfo("Stopped background services.");
+				}
+
 				try
 				{
 					using var dequeueCts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
@@ -437,14 +445,6 @@ public class Global
 				{
 					legalChecker.Dispose();
 					Logger.LogInfo($"Disposed {nameof(LegalChecker)}.");
-				}
-
-				if (HostedServices is { } backgroundServices)
-				{
-					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
-					await backgroundServices.StopAllAsync(cts.Token).ConfigureAwait(false);
-					backgroundServices.Dispose();
-					Logger.LogInfo("Stopped background services.");
 				}
 
 				RoundStateUpdaterCircuit.Dispose();


### PR DESCRIPTION
Fixes #12206

Based on my findings, it's a rare thing to happen when the Wallets are disposed already, but CoinJoinManager might execute some functions one last time, like `MonitorWalletsAsync` and `MonitorAndHandlingCoinJoinFinalizationAsync` which would still work with Wallets.

Moving the dispose of CoinJoinManager above Wallets dispose is the simple solution, but there might be a better, root solution for this. Reviews are welcome. 