### PR TITLE
Fix round parameters

### DIFF
--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -150,6 +150,8 @@ public class TestWallet : IKeyChain, IDestinationProvider
 	public IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot) =>
 		Enumerable.Range(0, count).Select(_ => CreateNewAddress());
 
+	public ScriptType[] SupportedScriptTypes { get; } = [ScriptType.P2WPKH];
+
 	public IEnumerable<IDestination> GetNextInternalDestinations(int count) =>
 		Enumerable.Range(0, count).Select(_ => CreateNewAddress(true));
 

--- a/WalletWasabi.Tests/UnitTests/TestWallet.cs
+++ b/WalletWasabi.Tests/UnitTests/TestWallet.cs
@@ -150,7 +150,7 @@ public class TestWallet : IKeyChain, IDestinationProvider
 	public IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot) =>
 		Enumerable.Range(0, count).Select(_ => CreateNewAddress());
 
-	public ScriptType[] SupportedScriptTypes { get; } = [ScriptType.P2WPKH];
+	public IEnumerable<ScriptType> SupportedScriptTypes { get; } = [ScriptType.P2WPKH];
 
 	public IEnumerable<IDestination> GetNextInternalDestinations(int count) =>
 		Enumerable.Range(0, count).Select(_ => CreateNewAddress(true));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -164,7 +164,6 @@ public class CoinJoinCoinSelectionTests
 			MaxRegistrableAmount = Money.Coins(430),
 		});
 
-		Assert.Equal(Money.Coins(0.00017422m), roundParams.CalculateSmallestReasonableEffectiveDenomination());
 		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
 
 		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: 10, semiPrivateThreshold: 0, generator);
@@ -195,8 +194,6 @@ public class CoinJoinCoinSelectionTests
 			MaxRegistrableAmount = Money.Coins(430),
 		});
 
-		Assert.Equal(Money.Coins(0.00017422m), roundParams.CalculateSmallestReasonableEffectiveDenomination());
-
 		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
 
 		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: 10, semiPrivateThreshold: 0, generator);
@@ -226,8 +223,6 @@ public class CoinJoinCoinSelectionTests
 			MinRegistrableAmount = Money.Coins(0.0001m),
 			MaxRegistrableAmount = Money.Coins(430),
 		});
-
-		Assert.Equal(Money.Coins(0.00017422m), roundParams.CalculateSmallestReasonableEffectiveDenomination());
 
 		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -30,7 +30,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: Enumerable.Empty<SmartCoin>(),
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters(), generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -67,7 +67,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters(), generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -170,7 +170,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(roundParams, generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(roundParams),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -200,7 +200,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(roundParams, generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(roundParams),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -230,7 +230,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(roundParams, generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(roundParams),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.NotEmpty(coins);
@@ -257,7 +257,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters(), generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Contains(smallerAnonCoin, coins);
@@ -283,7 +283,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters(), generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Single(coins);
@@ -310,7 +310,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters(), generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Equal(2, coins.Count);
@@ -336,7 +336,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters(), generator.Rnd),
+			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Equal(2, coins.Count);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -30,7 +30,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: Enumerable.Empty<SmartCoin>(),
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -67,7 +67,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -93,11 +93,12 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.NotEmpty(coins);
 	}
+
 
 	[Fact]
 	public void SelectSomethingFromPrivateButNotDistancedSetOfCoins2()
@@ -115,7 +116,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.NotEmpty(coins);
@@ -147,7 +148,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.NotEmpty(coins);
@@ -170,7 +171,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(roundParams),
+			UtxoSelectionParameters.FromRoundParameters(roundParams, [ScriptType.P2WPKH, ScriptType.Taproot]),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -200,7 +201,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(roundParams),
+			UtxoSelectionParameters.FromRoundParameters(roundParams, [ScriptType.P2WPKH, ScriptType.Taproot]),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Empty(coins);
@@ -230,7 +231,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(roundParams),
+			UtxoSelectionParameters.FromRoundParameters(roundParams, [ScriptType.P2WPKH, ScriptType.Taproot]),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.NotEmpty(coins);
@@ -257,7 +258,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Contains(smallerAnonCoin, coins);
@@ -283,7 +284,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Single(coins);
@@ -310,7 +311,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Equal(2, coins.Count);
@@ -336,7 +337,7 @@ public class CoinJoinCoinSelectionTests
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
 			true,
-			UtxoSelectionParameters.FromRoundParameters(CreateMultipartyTransactionParameters()),
+			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
 		Assert.Equal(2, coins.Count);
@@ -367,4 +368,9 @@ public class CoinJoinCoinSelectionTests
 		});
 		return roundParams;
 	}
+
+	private static UtxoSelectionParameters CreateUtxoSelectionParameters() =>
+		UtxoSelectionParameters.FromRoundParameters(
+			CreateMultipartyTransactionParameters(),
+			[ScriptType.P2WPKH, ScriptType.Taproot]);
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -94,9 +94,6 @@ public record RoundParameters
 	public FeeRate MinRelayTxFee { get; init; } = StandardTransactionPolicy.MinRelayTxFee
 												  ?? new FeeRate(Money.Satoshis(1000));
 
-	private int MaxVsizeInputOutputPair => AllowedOutputTypes.Max(x => x.EstimateInputVsize() + x.EstimateOutputVsize());
-	private ScriptType MaxVsizeInputOutputPairScriptType => AllowedOutputTypes.MaxBy(x => x.EstimateInputVsize() + x.EstimateOutputVsize());
-
 	public static RoundParameters Create(
 		WabiSabiConfig wabiSabiConfig,
 		Network network,
@@ -126,42 +123,4 @@ public record RoundParameters
 
 	public Transaction CreateTransaction()
 		=> Transaction.Create(Network);
-
-	/// <returns>Min output amount that's economically reasonable to be registered with current network conditions.</returns>
-	/// <remarks>It won't be smaller than min allowed output amount.</remarks>
-	public Money CalculateMinReasonableOutputAmount()
-	{
-		var minEconomicalOutput = MiningFeeRate.GetFee(MaxVsizeInputOutputPair);
-		return Math.Max(minEconomicalOutput, AllowedOutputAmounts.Min);
-	}
-
-	public Money CalculateSmallestReasonableEffectiveDenomination(WasabiRandom? random = null)
-	{
-		random ??= SecureRandom.Instance;
-		return CalculateSmallestReasonableEffectiveDenomination(CalculateMinReasonableOutputAmount(), AllowedOutputAmounts.Max, MiningFeeRate, MaxVsizeInputOutputPairScriptType, random);
-	}
-
-	/// <returns>Smallest effective denom that's larger than min reasonable output amount. </returns>
-	public static Money CalculateSmallestReasonableEffectiveDenomination(
-		Money minReasonableOutputAmount,
-		Money maxAllowedOutputAmount,
-		FeeRate feeRate,
-		ScriptType maxVsizeInputOutputPairScriptType,
-		WasabiRandom random)
-	{
-		var smallestEffectiveDenom = DenominationBuilder.CreateDenominations(
-				minReasonableOutputAmount,
-				maxAllowedOutputAmount,
-				feeRate,
-				new List<ScriptType>() { maxVsizeInputOutputPairScriptType },
-				random)
-			.Min(x => x.EffectiveCost);
-
-		return smallestEffectiveDenom is null
-			? throw new InvalidOperationException("Something's wrong with the denomination creation or with the parameters it got.")
-			: smallestEffectiveDenom;
-	}
-
-	/// <returns>Min: must be larger than the smallest economical denom. Max: max allowed in the round.</returns>
-	public MoneyRange CalculateReasonableOutputAmountRange(WasabiRandom random) => new(CalculateSmallestReasonableEffectiveDenomination(random), AllowedOutputAmounts.Max);
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -158,7 +158,7 @@ public class CoinJoinClient
 			coinCandidates = await coinCandidatesFunc().ConfigureAwait(false);
 
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameters.MaxSuggestedAmount);
-			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters);
+			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters, OutputProvider.DestinationProvider.SupportedScriptTypes );
 
 			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, stopWhenAllMixed, utxoSelectionParameters, liquidityClue);
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -158,7 +158,7 @@ public class CoinJoinClient
 			coinCandidates = await coinCandidatesFunc().ConfigureAwait(false);
 
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameters.MaxSuggestedAmount);
-			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters, OutputProvider.DestinationProvider.SupportedScriptTypes );
+			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters, OutputProvider.DestinationProvider.SupportedScriptTypes.ToArray() );
 
 			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, stopWhenAllMixed, utxoSelectionParameters, liquidityClue);
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -391,7 +391,7 @@ public class CoinJoinCoinSelector
 		where TCoin : ISmartCoin
 	{
 		var effectiveInputSum = group.Sum(x => x.EffectiveValue(parameters.MiningFeeRate, parameters.CoordinationFeeRate));
-		if (effectiveInputSum >= parameters.AllowedOutputAmounts.Min)
+		if (effectiveInputSum >= parameters.MinAllowedOutputAmount)
 		{
 			var k = HashCode.Combine(group.OrderBy(x => x.TransactionId).ThenBy(x => x.Index));
 			return groups.TryAdd(k, group);

--- a/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
@@ -7,6 +7,7 @@ namespace WalletWasabi.WabiSabi.Client;
 public interface IDestinationProvider
 {
 	IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot);
+	ScriptType[] SupportedScriptTypes { get; }
 }
 
 public static class DestinationProviderExtensions

--- a/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
@@ -7,7 +7,7 @@ namespace WalletWasabi.WabiSabi.Client;
 public interface IDestinationProvider
 {
 	IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot);
-	ScriptType[] SupportedScriptTypes { get; }
+	IEnumerable<ScriptType> SupportedScriptTypes { get; }
 }
 
 public static class DestinationProviderExtensions

--- a/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/IDestinationProvider.cs
@@ -6,8 +6,9 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public interface IDestinationProvider
 {
-	IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot);
 	IEnumerable<ScriptType> SupportedScriptTypes { get; }
+
+	IEnumerable<IDestination> GetNextDestinations(int count, bool preferTaproot);
 }
 
 public static class DestinationProviderExtensions

--- a/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
@@ -33,4 +33,9 @@ public class InternalDestinationProvider : IDestinationProvider
 			: segwitKeys;
 		return destinations.Select(x => x.GetAddress(KeyManager.GetNetwork()));
 	}
+
+	public ScriptType[] SupportedScriptTypes =>
+		KeyManager.TaprootExtPubKey is not null
+			? [ScriptType.P2WPKH, ScriptType.Taproot]
+			: [ScriptType.P2WPKH];
 }

--- a/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/InternalDestinationProvider.cs
@@ -10,6 +10,9 @@ public class InternalDestinationProvider : IDestinationProvider
 	public InternalDestinationProvider(KeyManager keyManager)
 	{
 		KeyManager = keyManager;
+	    SupportedScriptTypes = KeyManager.TaprootExtPubKey is not null
+			? [ScriptType.P2WPKH, ScriptType.Taproot]
+			: [ScriptType.P2WPKH];
 	}
 
 	private KeyManager KeyManager { get; }
@@ -34,8 +37,5 @@ public class InternalDestinationProvider : IDestinationProvider
 		return destinations.Select(x => x.GetAddress(KeyManager.GetNetwork()));
 	}
 
-	public ScriptType[] SupportedScriptTypes =>
-		KeyManager.TaprootExtPubKey is not null
-			? [ScriptType.P2WPKH, ScriptType.Taproot]
-			: [ScriptType.P2WPKH];
+	public IEnumerable<ScriptType> SupportedScriptTypes { get; }
 }

--- a/WalletWasabi/WabiSabi/Client/OutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/OutputProvider.cs
@@ -15,7 +15,7 @@ public class OutputProvider
 		Random = random ?? SecureRandom.Instance;
 	}
 
-	private IDestinationProvider DestinationProvider { get; }
+	internal IDestinationProvider DestinationProvider { get; }
 	private WasabiRandom Random { get; }
 
 	public virtual IEnumerable<TxOut> GetOutputs(
@@ -25,7 +25,13 @@ public class OutputProvider
 		IEnumerable<Money> theirCoinEffectiveValues,
 		int availableVsize)
 	{
-		AmountDecomposer amountDecomposer = new(roundParameters.MiningFeeRate, roundParameters.CalculateMinReasonableOutputAmount(), roundParameters.AllowedOutputAmounts.Max, availableVsize, roundParameters.AllowedOutputTypes, Random);
+		AmountDecomposer amountDecomposer = new(
+			roundParameters.MiningFeeRate,
+			roundParameters.CalculateMinReasonableOutputAmount(DestinationProvider.SupportedScriptTypes),
+			roundParameters.AllowedOutputAmounts.Max,
+			availableVsize,
+			roundParameters.AllowedOutputTypes,
+			Random);
 
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues).ToArray();
 		return GetTxOuts(outputValues, DestinationProvider);

--- a/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
@@ -17,32 +17,18 @@ public record UtxoSelectionParameters(
 {
 	public static UtxoSelectionParameters FromRoundParameters(RoundParameters roundParameters, WasabiRandom? random = null)
 	{
-		random ??= SecureRandom.Instance;
-		return new(
-			roundParameters.AllowedInputAmounts,
-			ReasonableOutputAmountRange(roundParameters, random),
-			roundParameters.CoordinationFeeRate,
-			roundParameters.MiningFeeRate,
-			roundParameters.AllowedInputTypes);
-	}
-
-	private static MoneyRange ReasonableOutputAmountRange(RoundParameters roundParameters, WasabiRandom random)
-	{
 		var scriptTypesSupportedByWallet= new[] { ScriptType.P2WPKH, ScriptType.Taproot }; // I doubt this will change
 		var outputTypes = roundParameters.AllowedOutputTypes.Intersect(scriptTypesSupportedByWallet);
 		var maxVsizeInputOutputPairScriptType = outputTypes.MaxBy(x => x.EstimateInputVsize() + x.EstimateOutputVsize());
-		var smallestEffectiveDenom = DenominationBuilder.CreateDenominations(
-				roundParameters.CalculateMinReasonableOutputAmount(),
-				roundParameters.AllowedOutputAmounts.Max,
-				roundParameters.MiningFeeRate,
-				[maxVsizeInputOutputPairScriptType],
-				random)
-			.Min(x => x.EffectiveCost);
-		var smallestReasonableEffectiveDenomination =
-			smallestEffectiveDenom
-		    ?? throw new InvalidOperationException("Something's wrong with the denomination creation or with the parameters it got.");
+		var smallestReasonableEffectiveDenomination= roundParameters.CalculateMinReasonableOutputAmount() + roundParameters.MiningFeeRate.GetFee(maxVsizeInputOutputPairScriptType.EstimateOutputVsize());
 
-		return roundParameters.AllowedOutputAmounts with { Min = smallestReasonableEffectiveDenomination };
+		var reasonableOutputAmountRange = roundParameters.AllowedOutputAmounts with { Min = smallestReasonableEffectiveDenomination };
+		return new(
+			roundParameters.AllowedInputAmounts,
+			reasonableOutputAmountRange,
+			roundParameters.CoordinationFeeRate,
+			roundParameters.MiningFeeRate,
+			roundParameters.AllowedInputTypes);
 	}
 }
 

--- a/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
@@ -1,9 +1,12 @@
 using NBitcoin;
 using System.Collections.Immutable;
+using System.Linq;
 using WabiSabi.Crypto.Randomness;
+using WalletWasabi.Extensions;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Models;
 
-namespace WalletWasabi.WabiSabi.Backend.Rounds;
+namespace WalletWasabi.WabiSabi.Client;
 
 public record UtxoSelectionParameters(
 	MoneyRange AllowedInputAmounts,

--- a/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
@@ -18,12 +18,43 @@ public record UtxoSelectionParameters(
 	public static UtxoSelectionParameters FromRoundParameters(RoundParameters roundParameters, WasabiRandom? random = null)
 	{
 		random ??= SecureRandom.Instance;
-
 		return new(
 			roundParameters.AllowedInputAmounts,
-			roundParameters.CalculateReasonableOutputAmountRange(random),
+			ReasonableOutputAmountRange(roundParameters, random),
 			roundParameters.CoordinationFeeRate,
 			roundParameters.MiningFeeRate,
 			roundParameters.AllowedInputTypes);
+	}
+
+	private static MoneyRange ReasonableOutputAmountRange(RoundParameters roundParameters, WasabiRandom random)
+	{
+		var scriptTypesSupportedByWallet= new[] { ScriptType.P2WPKH, ScriptType.Taproot }; // I doubt this will change
+		var outputTypes = roundParameters.AllowedOutputTypes.Intersect(scriptTypesSupportedByWallet);
+		var maxVsizeInputOutputPairScriptType = outputTypes.MaxBy(x => x.EstimateInputVsize() + x.EstimateOutputVsize());
+		var smallestEffectiveDenom = DenominationBuilder.CreateDenominations(
+				roundParameters.CalculateMinReasonableOutputAmount(),
+				roundParameters.AllowedOutputAmounts.Max,
+				roundParameters.MiningFeeRate,
+				[maxVsizeInputOutputPairScriptType],
+				random)
+			.Min(x => x.EffectiveCost);
+		var smallestReasonableEffectiveDenomination =
+			smallestEffectiveDenom
+		    ?? throw new InvalidOperationException("Something's wrong with the denomination creation or with the parameters it got.");
+
+		return roundParameters.AllowedOutputAmounts with { Min = smallestReasonableEffectiveDenomination };
+	}
+}
+
+public static class RoundParametersExtensions
+{
+	/// <returns>Min: must be larger than the smallest economical denom. Max: max allowed in the round.</returns>
+	/// <returns>Min output amount that's economically reasonable to be registered with current network conditions.</returns>
+	/// <remarks>It won't be smaller than min allowed output amount.</remarks>
+	public static Money CalculateMinReasonableOutputAmount(this RoundParameters roundParameters)
+	{
+		var maxVsizeInputOutputPair = roundParameters.AllowedOutputTypes.Max(x => x.EstimateInputVsize() + x.EstimateOutputVsize());
+		var minEconomicalOutput = roundParameters.MiningFeeRate.GetFee(maxVsizeInputOutputPair);
+		return Math.Max(minEconomicalOutput, roundParameters.AllowedOutputAmounts.Min);
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NBitcoin;
 using System.Collections.Immutable;
 using System.Linq;
@@ -16,9 +17,6 @@ public record UtxoSelectionParameters(
 	ImmutableSortedSet<ScriptType> AllowedInputScriptTypes)
 {
 	// for testing only
-	public static UtxoSelectionParameters FromRoundParameters(RoundParameters roundParameters) =>
-		FromRoundParameters(roundParameters, [ScriptType.P2WPKH, ScriptType.Taproot]);
-
 	public static UtxoSelectionParameters FromRoundParameters(RoundParameters roundParameters, ScriptType[] scriptTypesSupportedByWallet)
 	{
 		var outputTypes = roundParameters.AllowedOutputTypes.Intersect(scriptTypesSupportedByWallet);
@@ -48,7 +46,7 @@ public static class RoundParametersExtensions
 	/// <returns>Min: must be larger than the smallest economical denom. Max: max allowed in the round.</returns>
 	/// <returns>Min output amount that's economically reasonable to be registered with current network conditions.</returns>
 	/// <remarks>It won't be smaller than min allowed output amount.</remarks>
-	public static Money CalculateMinReasonableOutputAmount(this RoundParameters roundParameters, ScriptType[] scriptTypesSupportedByWallet)
+	public static Money CalculateMinReasonableOutputAmount(this RoundParameters roundParameters, IEnumerable<ScriptType> scriptTypesSupportedByWallet)
 	{
 		var outputTypes = roundParameters.AllowedOutputTypes.Intersect(scriptTypesSupportedByWallet);
 		var maxVsizeInputOutputPair = outputTypes.Max(x => x.EstimateInputVsize() + x.EstimateOutputVsize());

--- a/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
@@ -16,7 +16,6 @@ public record UtxoSelectionParameters(
 	FeeRate MiningFeeRate,
 	ImmutableSortedSet<ScriptType> AllowedInputScriptTypes)
 {
-	// for testing only
 	public static UtxoSelectionParameters FromRoundParameters(RoundParameters roundParameters, ScriptType[] scriptTypesSupportedByWallet)
 	{
 		var outputTypes = roundParameters.AllowedOutputTypes.Intersect(scriptTypesSupportedByWallet);

--- a/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Client/UtxoSelectionParameters.cs
@@ -10,7 +10,7 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public record UtxoSelectionParameters(
 	MoneyRange AllowedInputAmounts,
-	MoneyRange AllowedOutputAmounts,
+	Money MinAllowedOutputAmount,
 	CoordinationFeeRate CoordinationFeeRate,
 	FeeRate MiningFeeRate,
 	ImmutableSortedSet<ScriptType> AllowedInputScriptTypes)
@@ -22,10 +22,9 @@ public record UtxoSelectionParameters(
 		var maxVsizeInputOutputPairScriptType = outputTypes.MaxBy(x => x.EstimateInputVsize() + x.EstimateOutputVsize());
 		var smallestReasonableEffectiveDenomination= roundParameters.CalculateMinReasonableOutputAmount() + roundParameters.MiningFeeRate.GetFee(maxVsizeInputOutputPairScriptType.EstimateOutputVsize());
 
-		var reasonableOutputAmountRange = roundParameters.AllowedOutputAmounts with { Min = smallestReasonableEffectiveDenomination };
 		return new(
 			roundParameters.AllowedInputAmounts,
-			reasonableOutputAmountRange,
+			smallestReasonableEffectiveDenomination,
 			roundParameters.CoordinationFeeRate,
 			roundParameters.MiningFeeRate,
 			roundParameters.AllowedInputTypes);


### PR DESCRIPTION
`RoundParameter` , a class designed to concentrate/centralize the parameters required by the coordinator to create rounds, was containing client-side code. That code was moved to a better place.

The amount decomposition was using the scripts types allowed in the coinjoin outputs to split the amount without taking into account the script types supported by the client. This means that if we enable other script types in the coinjoins the client would try to send money to itself using scripts that the wallet doesn't support (this would result in money being sent to scripts that wasabi cannot spend). This is why https://github.com/zkSNACKs/WalletWasabi/pull/12190 was reverted.
    