### PR TITLE
fix memory leak caused by content area.

### DIFF
--- a/WalletWasabi.Fluent/Controls/ContentArea.axaml
+++ b/WalletWasabi.Fluent/Controls/ContentArea.axaml
@@ -90,7 +90,7 @@
                   <Setter Property="ClipToBounds" Value="{Binding $parent[ScrollViewer].ClipToBounds}" />
                 </Style>
               </ScrollViewer.Styles>
-              <ContentControl Name="PART_ContentPresenter"
+              <ContentPresenter Name="PART_ContentPresenter"
                               ClipToBounds="{TemplateBinding ClipToBounds}"
                               BorderBrush="{TemplateBinding BorderBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}"

--- a/WalletWasabi.Fluent/Controls/SuggestionItem.axaml
+++ b/WalletWasabi.Fluent/Controls/SuggestionItem.axaml
@@ -29,7 +29,7 @@
             </Border.Transitions>
           </Border>
           <Border Name="PART_MainContentBorder">
-            <ContentControl Name="PART_ContentPresenter"
+            <ContentPresenter Name="PART_ContentPresenter"
                             ClipToBounds="{TemplateBinding ClipToBounds}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"


### PR DESCRIPTION
- ContentArea is a ContentControl.
ContentControl expects a ContentPresenter, because it was using a ContentControl instead of presenter, content control was unable to manage the lifetime of the content.