### PR TITLE
`SmartTransaction`: Remove `ToLine()`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/SmartTransactionTests.cs
@@ -72,26 +72,6 @@ public class SmartTransactionTests
 		}
 	}
 
-	[Theory]
-	[MemberData(nameof(GetSmartTransactionCombinations))]
-	public void SmartTransactionLineSerialization(SmartTransaction stx, Network network)
-	{
-		var line = stx.ToLine();
-		var sameStx = SmartTransaction.FromLine(line, network);
-		Assert.Equal(stx, sameStx);
-		Assert.Equal(stx.BlockHash, sameStx.BlockHash);
-		Assert.Equal(stx.BlockIndex, sameStx.BlockIndex);
-		Assert.Equal(stx.Confirmed, sameStx.Confirmed);
-		Assert.Equal(stx.FirstSeen.UtcDateTime, sameStx.FirstSeen.UtcDateTime, TimeSpan.FromSeconds(1));
-		Assert.Equal(stx.Height, sameStx.Height);
-		Assert.Equal(stx.IsRBF, sameStx.IsRBF);
-		Assert.Equal(stx.IsReplacement, sameStx.IsReplacement);
-		Assert.Equal(stx.IsSpeedup, sameStx.IsSpeedup);
-		Assert.Equal(stx.IsCancellation, sameStx.IsCancellation);
-		Assert.Equal(stx.Labels, sameStx.Labels);
-		Assert.Equal(stx.Transaction.GetHash(), sameStx.Transaction.GetHash());
-	}
-
 	[Fact]
 	public void SmartTransactionLineDeserialization()
 	{

--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -507,24 +507,6 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 
 	#region LineSerialization
 
-	public string ToLine()
-	{
-		// GetHash is also serialized, so file can be interpreted with our eyes better.
-
-		return string.Join(
-			':',
-			GetHash(),
-			Transaction.ToHex(),
-			Height,
-			BlockHash,
-			BlockIndex,
-			Labels,
-			FirstSeen.ToUnixTimeSeconds(),
-			IsReplacement,
-			IsSpeedup,
-			IsCancellation);
-	}
-
 	public static SmartTransaction FromLine(string line, Network expectedNetwork)
 	{
 		var parts = line.Split(':', StringSplitOptions.None).Select(x => x.Trim()).ToArray();


### PR DESCRIPTION
We don't really need this serialization anymore after migration to SQLite. `SmartTransaction.FromLine` is only useful for migration purposes. 