### PR TITLE
Move repeating behavior of `P2PBlockProvider` to `SmartBlockProvider`

### DIFF
--- a/WalletWasabi/Wallets/P2PBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2PBlockProvider.cs
@@ -20,29 +20,12 @@ public class P2PBlockProvider : IBlockProvider
 	private P2PNodesManager P2PNodesManager { get; }
 
 	/// <summary>
-	/// Gets the given block by repeatedly trying to get it from a set of connected P2P nodes using the P2P Bitcoin protocol.
-	/// </summary>
-	/// <inheritdoc cref="TryGetBlockOnceAsync(uint256, CancellationToken)"/>
-	public async Task<Block?> TryGetBlockAsync(uint256 blockHash, CancellationToken cancellationToken)
-	{
-		while (true)
-		{
-			Block? block = await TryGetBlockOnceAsync(blockHash, cancellationToken).ConfigureAwait(false);
-
-			if (block is not null)
-			{
-				return block;
-			}
-		}
-	}
-
-	/// <summary>
 	/// Gets the given block from a single P2P node using the P2P bitcoin protocol.
 	/// </summary>
 	/// <param name="blockHash">Block's hash to download.</param>
 	/// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
 	/// <returns>Requested block, or <c>null</c> if the block could not get downloaded for any reason.</returns>
-	private async Task<Block?> TryGetBlockOnceAsync(uint256 blockHash, CancellationToken cancellationToken)
+	public async Task<Block?> TryGetBlockAsync(uint256 blockHash, CancellationToken cancellationToken)
 	{
 		try
 		{

--- a/WalletWasabi/Wallets/P2PBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2PBlockProvider.cs
@@ -64,18 +64,18 @@ public class P2PBlockProvider : IBlockProvider
 
 					return block;
 				}
-				catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
-				{
-					await P2PNodesManager.UpdateTimeoutAsync(increaseDecrease: true).ConfigureAwait(false);
-
-					P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download took too long."); // it could be a slow connection and not a misbehaving node
-					continue;
-				}
 				catch (Exception ex)
 				{
-					Logger.LogDebug(ex);
-					P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.", force: true);
-					continue;
+					if (ex is OperationCanceledException or TimeoutException)
+					{
+						await P2PNodesManager.UpdateTimeoutAsync(increaseDecrease: true).ConfigureAwait(false);
+						P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download took too long."); // it could be a slow connection and not a misbehaving node
+					}
+					else
+					{
+						Logger.LogDebug(ex);
+						P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.", force: true);
+					}
 				}
 			}
 			catch (Exception ex)

--- a/WalletWasabi/Wallets/P2PBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2PBlockProvider.cs
@@ -23,10 +23,10 @@ public class P2PBlockProvider : IBlockProvider
 	/// Gets a bitcoin block from bitcoin nodes using the P2P bitcoin protocol.
 	/// If a bitcoin node is available it fetches the blocks using the RPC interface.
 	/// </summary>
-	/// <param name="hash">The block's hash that identifies the requested block.</param>
+	/// <param name="blockHash">The block's hash that identifies the requested block.</param>
 	/// <param name="cancellationToken">The cancellation token.</param>
 	/// <returns>The requested bitcoin block.</returns>
-	public async Task<Block?> TryGetBlockAsync(uint256 hash, CancellationToken cancellationToken)
+	public async Task<Block?> TryGetBlockAsync(uint256 blockHash, CancellationToken cancellationToken)
 	{
 		while (true)
 		{
@@ -48,7 +48,7 @@ public class P2PBlockProvider : IBlockProvider
 					using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout)))
 					{
 						using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
-						block = await node.DownloadBlockAsync(hash, lts.Token).ConfigureAwait(false);
+						block = await node.DownloadBlockAsync(blockHash, lts.Token).ConfigureAwait(false);
 					}
 
 					// Validate block

--- a/WalletWasabi/Wallets/P2PBlockProvider.cs
+++ b/WalletWasabi/Wallets/P2PBlockProvider.cs
@@ -20,68 +20,83 @@ public class P2PBlockProvider : IBlockProvider
 	private P2PNodesManager P2PNodesManager { get; }
 
 	/// <summary>
-	/// Gets a bitcoin block from bitcoin nodes using the P2P bitcoin protocol.
-	/// If a bitcoin node is available it fetches the blocks using the RPC interface.
+	/// Gets the given block by repeatedly trying to get it from a set of connected P2P nodes using the P2P Bitcoin protocol.
 	/// </summary>
-	/// <param name="blockHash">The block's hash that identifies the requested block.</param>
-	/// <param name="cancellationToken">The cancellation token.</param>
-	/// <returns>The requested bitcoin block.</returns>
+	/// <inheritdoc cref="TryGetBlockOnceAsync(uint256, CancellationToken)"/>
 	public async Task<Block?> TryGetBlockAsync(uint256 blockHash, CancellationToken cancellationToken)
 	{
 		while (true)
 		{
+			Block? block = await TryGetBlockOnceAsync(blockHash, cancellationToken).ConfigureAwait(false);
+
+			if (block is not null)
+			{
+				return block;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets the given block from a single P2P node using the P2P bitcoin protocol.
+	/// </summary>
+	/// <param name="blockHash">Block's hash to download.</param>
+	/// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+	/// <returns>Requested block, or <c>null</c> if the block could not get downloaded for any reason.</returns>
+	private async Task<Block?> TryGetBlockOnceAsync(uint256 blockHash, CancellationToken cancellationToken)
+	{
+		try
+		{
+			Node? node = await P2PNodesManager.GetNodeAsync(cancellationToken).ConfigureAwait(false);
+
+			if (node is null || !node.IsConnected)
+			{
+				await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+				return null;
+			}
+
+			// Download block from the selected node.
 			try
 			{
-				Node? node = await P2PNodesManager.GetNodeAsync(cancellationToken).ConfigureAwait(false);
-
-				if (node is null || !node.IsConnected)
+				Block? block;
+				var timeout = P2PNodesManager.GetCurrentTimeout();
+				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout)))
 				{
-					await Task.Delay(100, cancellationToken).ConfigureAwait(false);
-					continue;
+					using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
+					block = await node.DownloadBlockAsync(blockHash, lts.Token).ConfigureAwait(false);
 				}
 
-				// Download block from selected node.
-				try
+				// Validate block
+				if (!block.Check())
 				{
-					Block? block;
-					var timeout = P2PNodesManager.GetCurrentTimeout();
-					using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout)))
-					{
-						using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
-						block = await node.DownloadBlockAsync(blockHash, lts.Token).ConfigureAwait(false);
-					}
-
-					// Validate block
-					if (!block.Check())
-					{
-						P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.", force: true);
-						continue;
-					}
-
-					P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}. Block ({block.GetCoinbaseHeight()}) downloaded: {block.GetHash()}.");
-
-					await P2PNodesManager.UpdateTimeoutAsync(increaseDecrease: false).ConfigureAwait(false);
-
-					return block;
+					P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because invalid block received.", force: true);
+					return null;
 				}
-				catch (Exception ex)
-				{
-					if (ex is OperationCanceledException or TimeoutException)
-					{
-						await P2PNodesManager.UpdateTimeoutAsync(increaseDecrease: true).ConfigureAwait(false);
-						P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download took too long."); // it could be a slow connection and not a misbehaving node
-					}
-					else
-					{
-						Logger.LogDebug(ex);
-						P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.", force: true);
-					}
-				}
+
+				P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}. Block ({block.GetCoinbaseHeight()}) downloaded: {block.GetHash()}.");
+
+				await P2PNodesManager.UpdateTimeoutAsync(increaseDecrease: false).ConfigureAwait(false);
+
+				return block;
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug(ex);
+				if (ex is OperationCanceledException or TimeoutException)
+				{
+					await P2PNodesManager.UpdateTimeoutAsync(increaseDecrease: true).ConfigureAwait(false);
+					P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download took too long."); // it could be a slow connection and not a misbehaving node
+				}
+				else
+				{
+					Logger.LogDebug(ex);
+					P2PNodesManager.DisconnectNodeIfEnoughPeers(node, $"Disconnected node: {node.RemoteSocketAddress}, because block download failed: {ex.Message}.", force: true);
+				}
 			}
 		}
+		catch (Exception ex)
+		{
+			Logger.LogDebug(ex);
+		}
+
+		return null;
 	}
 }

--- a/WalletWasabi/Wallets/SmartBlockProvider.cs
+++ b/WalletWasabi/Wallets/SmartBlockProvider.cs
@@ -96,7 +96,15 @@ public class SmartBlockProvider : IBlockProvider
 
 		if (result is null && P2PProvider is not null)
 		{
-			result = await P2PProvider.TryGetBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
+			while (true)
+			{
+				Block? block = await P2PProvider.TryGetBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
+
+				if (block is not null)
+				{
+					return block;
+				}
+			}
 		}
 
 		return result;


### PR DESCRIPTION
The PR moves the looping behavior from `P2PBlockProvider` to `SmartBlockProvider`. This change makes `P2PBlockProvider` more useful as a "building block".

The PR is meant as a helper PR for #12184.

To understand the PR, it's good to check one commit at a time and then review whole PR with whitespace [off](https://github.com/zkSNACKs/WalletWasabi/pull/12250/files?diff=split&w=1).