### PR TITLE
musicbox: update RandomlySkippedRoundMessage

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -17,7 +17,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string CountDownMessage = "Awaiting auto-start of coinjoin";
 	private const string WaitingMessage = "Awaiting coinjoin";
 	private const string UneconomicalRoundMessage = "Awaiting cheaper coinjoins";
-	private const string RandomlySkippedRoundMessage = "Awaiting cheaper coinjoins";
+	private const string RandomlySkippedRoundMessage = "Skipping a round for better privacy";
 	private const string PauseMessage = "Coinjoin is paused";
 	private const string StoppedMessage = "Coinjoin has stopped";
 	private const string RoundSucceedMessage = "Coinjoin successful! Continuing...";


### PR DESCRIPTION
related https://github.com/zkSNACKs/WalletWasabi/issues/12195

I think `Skipping this round` is the best option.
Suggestions welcome

### other options:

`Randomly skipping this round`, random could be confusing

`Skipping this round for better privacy`, getting better privacy by not participating in a coinjoin seems backwards

