### PR TITLE
`P2PKH`, `P2SH` and `P2WSH` in coinjoin outputs

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -105,6 +105,9 @@ public class ConfigManagerTests
 			  "AllowP2trInputs": true,
 			  "AllowP2wpkhOutputs": true,
 			  "AllowP2trOutputs": true,
+			  "AllowP2pkhOutputs": false,
+			  "AllowP2shOutputs": false,
+			  "AllowP2wshOutputs": false,
 			  "AffiliationMessageSignerKey": "30770201010420686710a86f0cdf425e3bc9781f51e45b9440aec1215002402d5cdee713066623a00a06082a8648ce3d030107a14403420004f267804052bd863a1644233b8bfb5b8652ab99bcbfa0fb9c36113a571eb5c0cb7c733dbcf1777c2745c782f96e218bb71d67d15da1a77d37fa3cb96f423e53ba",
 			  "AffiliateServers": {},
 			  "DelayTransactionSigning": false

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -342,6 +342,9 @@ public static class NBitcoinExtensions
 		{
 			ScriptType.P2WPKH => Constants.P2wpkhInputVirtualSize,
 			ScriptType.Taproot => Constants.P2trInputVirtualSize,
+			ScriptType.P2PKH => Constants.P2pkhInputVirtualSize,
+			ScriptType.P2SH => Constants.P2shInputVirtualSize,
+			ScriptType.P2WSH => Constants.P2wshInputVirtualSize,
 			_ => throw new NotImplementedException($"Size estimation isn't implemented for provided script type.")
 		};
 
@@ -350,6 +353,9 @@ public static class NBitcoinExtensions
 		{
 			ScriptType.P2WPKH => Constants.P2wpkhOutputVirtualSize,
 			ScriptType.Taproot => Constants.P2trOutputVirtualSize,
+			ScriptType.P2PKH => Constants.P2pkhOutputVirtualSize,
+			ScriptType.P2SH => Constants.P2shOutputVirtualSize,
+			ScriptType.P2WSH => Constants.P2wshOutputVirtualSize,
 			_ => throw new NotImplementedException($"Size estimation isn't implemented for provided script type.")
 		};
 

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -33,6 +33,14 @@ public static class Constants
 	public const int P2trInputVirtualSize = 58;
 	public const int P2trOutputVirtualSize = 43;
 
+	public const int P2pkhInputVirtualSize = 148;
+	public const int P2pkhOutputVirtualSize = 34;
+	public const int P2wshInputVirtualSize = 105; // we assume a 2-of-n multisig
+	public const int P2wshOutputVirtualSize = 32;
+	public const int P2shInputVirtualSize = 297; // we assume a 2-of-n multisig
+	public const int P2shOutputVirtualSize = 32;
+
+
 	/// <summary>
 	/// OBSOLATED, USE SPECIFIC TYPE
 	/// </summary>

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -205,6 +205,18 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "AllowP2trOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool AllowP2trOutputs { get; set; } = true;
 
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2pkhOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2pkhOutputs { get; set; } = false;
+
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2shOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2shOutputs { get; set; } = false;
+
+	[DefaultValue(false)]
+	[JsonProperty(PropertyName = "AllowP2wshOutputs", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public bool AllowP2wshOutputs { get; set; } = false;
+
 	[DefaultValue(Constants.FallbackAffiliationMessageSignerKey)]
 	[JsonProperty(PropertyName = "AffiliationMessageSignerKey", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public string AffiliationMessageSignerKey { get; set; } = Constants.FallbackAffiliationMessageSignerKey;
@@ -217,9 +229,9 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "DelayTransactionSigning", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool DelayTransactionSigning { get; set; } = false;
 
-	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs);
+	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs, false, false, false);
 
-	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs);
+	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs, AllowP2pkhOutputs, AllowP2shOutputs, AllowP2wshOutputs);
 
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
@@ -245,7 +257,7 @@ public class WabiSabiConfig : ConfigBase
 			PenaltyFactorForDisruptingByDoubleSpending: (decimal) DoSPenaltyFactorForDisruptingByDoubleSpending,
 			MinTimeInPrison: DoSMinTimeInPrison);
 
-	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr)
+	private static ImmutableSortedSet<ScriptType> GetScriptTypes(bool p2wpkh, bool p2tr, bool p2pkh, bool p2sh, bool p2wsh)
 	{
 		var scriptTypes = new List<ScriptType>();
 		if (p2wpkh)
@@ -255,6 +267,18 @@ public class WabiSabiConfig : ConfigBase
 		if (p2tr)
 		{
 			scriptTypes.Add(ScriptType.Taproot);
+		}
+		if (p2pkh)
+		{
+			scriptTypes.Add(ScriptType.P2PKH);
+		}
+		if (p2sh)
+		{
+			scriptTypes.Add(ScriptType.P2SH);
+		}
+		if (p2wsh)
+		{
+			scriptTypes.Add(ScriptType.P2WSH);
 		}
 
 		// When adding new script types, please see


### PR DESCRIPTION
This PR allows to register `P2PKH`, `P2SH` and `P2WSH` scriptpubkeys to enable more use cases for coinjoins.