### PR TITLE
Improve most used labels

### DIFF
--- a/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
@@ -79,4 +79,24 @@ public static class EnumerableExtensions
 	}
 
 	public static bool IsEmpty<T>(this IEnumerable<T> source) => !source.Any();
+
+	public static (IEnumerable<T>, IEnumerable<T>) Partition<T>(this IEnumerable<T> me, Predicate<T> predicate)
+	{
+		var trueList = new List<T>();
+		var falseList = new List<T>();
+
+		foreach (var item in me)
+		{
+			if (predicate(item))
+			{
+				trueList.Add(item);
+			}
+			else
+			{
+				falseList.Add(item);
+			}
+		}
+
+		return (trueList, falseList);
+	}
 }

--- a/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
@@ -84,6 +84,9 @@ public static class EnumerableExtensions
 
 	public static bool IsEmpty<T>(this IEnumerable<T> source) => !source.Any();
 
+	/// <summary>
+	/// Splits the collection into two collections, containing the elements for which the given predicate returns True and False respectively. Element order is preserved in both of the created lists.
+	/// </summary>
 	public static (IEnumerable<T>, IEnumerable<T>) Partition<T>(this IEnumerable<T> me, Predicate<T> predicate)
 	{
 		var trueList = new List<T>();

--- a/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
@@ -19,8 +19,12 @@ public static class EnumerableExtensions
 	/// <returns>A new IEnumerable if the Selected data at each sample point.</returns>
 	public static IEnumerable<(DateTimeOffset timestamp, TResult result)> SelectTimeSampleBackwards<TSource, TResult>(
 		this IEnumerable<TSource> sourceData,
-		Func<TSource, DateTimeOffset> timeSampler, Func<TSource, TResult> sampler,
-		TimeSpan interval, DateTimeOffset endTime, TResult defaultValue, DateTimeOffset? startFrom = default)
+		Func<TSource, DateTimeOffset> timeSampler,
+		Func<TSource, TResult> sampler,
+		TimeSpan interval,
+		DateTimeOffset endTime,
+		TResult defaultValue,
+		DateTimeOffset? startFrom = default)
 	{
 		var source = sourceData.ToArray();
 

--- a/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
@@ -1,17 +1,28 @@
 using System.Collections.Generic;
-using System.Linq;
-using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Extensions;
 
 namespace WalletWasabi.Fluent.Helpers;
 
 public static class KeyManagerExtensions
 {
-	public static IEnumerable<LabelsArray> GetChangeLabels(this KeyManager km) =>
-		km.GetKeys(isInternal: true).Select(x => x.Labels);
+	public static (List<LabelsArray>, List<LabelsArray>) GetLabels(this KeyManager km)
+	{
+		var changeLabels = new List<LabelsArray>();
+		var receiveLabels = new List<LabelsArray>();
 
-	public static IEnumerable<LabelsArray> GetReceiveLabels(this KeyManager km) =>
-		km.GetKeys(isInternal: false).Select(x => x.Labels);
+		foreach (var key in km.GetKeys())
+		{
+			if (key.IsInternal)
+			{
+				changeLabels.Add(key.Labels);
+			}
+			else
+			{
+				receiveLabels.Add(key.Labels);
+			}
+		}
+
+		return (changeLabels, receiveLabels);
+	}
 }

--- a/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/KeyManagerExtensions.cs
@@ -1,28 +1,14 @@
 using System.Collections.Generic;
-using WalletWasabi.Blockchain.Analysis.Clustering;
+using System.Linq;
 using WalletWasabi.Blockchain.Keys;
 
 namespace WalletWasabi.Fluent.Helpers;
 
 public static class KeyManagerExtensions
 {
-	public static (List<LabelsArray>, List<LabelsArray>) GetLabels(this KeyManager km)
+	public static (List<string>, List<string>) GetLabels(this KeyManager km)
 	{
-		var changeLabels = new List<LabelsArray>();
-		var receiveLabels = new List<LabelsArray>();
-
-		foreach (var key in km.GetKeys())
-		{
-			if (key.IsInternal)
-			{
-				changeLabels.Add(key.Labels);
-			}
-			else
-			{
-				receiveLabels.Add(key.Labels);
-			}
-		}
-
-		return (changeLabels, receiveLabels);
+		var (changeKeys, receiveKeys) = km.GetKeys().Partition(x => x.IsInternal);
+		return (changeKeys.SelectMany(x => x.Labels).ToList(), receiveKeys.SelectMany(x => x.Labels).ToList());
 	}
 }

--- a/WalletWasabi.Fluent/Helpers/LabelHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/LabelHelpers.cs
@@ -11,9 +11,11 @@ public static class LabelHelpers
 	{
 		var labelPool = new Dictionary<string, int>(); // int: score.
 
+		var labelsByWalletId = WalletHelpers.GetLabelsByWallets();
+
 		// Make recent and receive labels count more for the current wallet
 		var multiplier = 100;
-		foreach (var label in wallet.KeyManager.GetReceiveLabels().Reverse().SelectMany(x => x))
+		foreach (var label in labelsByWalletId.First(x => x.WalletId == wallet.WalletId).ReceiveLabels.Reverse().SelectMany(x => x))
 		{
 			var score = (intent == Intent.Receive ? 100 : 1) * multiplier;
 			if (!labelPool.TryAdd(label, score))
@@ -28,7 +30,7 @@ public static class LabelHelpers
 		}
 
 		// Receive addresses should be more dominant.
-		foreach (var label in WalletHelpers.GetReceiveAddressLabels().SelectMany(x => x))
+		foreach (var label in labelsByWalletId.SelectMany(x => x.ReceiveLabels))
 		{
 			var score = intent == Intent.Receive ? 100 : 1;
 			if (!labelPool.TryAdd(label, score))
@@ -38,7 +40,7 @@ public static class LabelHelpers
 		}
 
 		// Change addresses shouldn't be much dominant, but should be present.
-		foreach (var label in WalletHelpers.GetChangeAddressLabels().SelectMany(x => x))
+		foreach (var label in labelsByWalletId.SelectMany(x => x.ChangeLabels))
 		{
 			var score = 1;
 			if (!labelPool.TryAdd(label, score))

--- a/WalletWasabi.Fluent/Helpers/LabelHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/LabelHelpers.cs
@@ -13,10 +13,12 @@ public static class LabelHelpers
 
 		var labelsByWalletId = WalletHelpers.GetLabelsByWallets();
 
-		// Make recent and receive labels count more for the current wallet
+		// Make recent and receive labels count more for the current wallet.
 		var multiplier = 100;
-		foreach (var label in labelsByWalletId.First(x => x.WalletId == wallet.WalletId).ReceiveLabels.Reverse().SelectMany(x => x))
+		var currentWalletReceiveLabels = labelsByWalletId.First(x => x.WalletId == wallet.WalletId).ReceiveLabels;
+		for (var i = currentWalletReceiveLabels.Count - 1; i >= 0; i--) // Iterate in reverse order.
 		{
+			var label = currentWalletReceiveLabels[i];
 			var score = (intent == Intent.Receive ? 100 : 1) * multiplier;
 			if (!labelPool.TryAdd(label, score))
 			{

--- a/WalletWasabi.Fluent/Helpers/WalletHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/WalletHelpers.cs
@@ -23,15 +23,17 @@ public static class WalletHelpers
 	/// <returns>Labels ordered by blockchain.</returns>
 	public static IEnumerable<LabelsArray> GetTransactionLabels() => Services.BitcoinStore.TransactionStore.GetLabels();
 
-	public static IEnumerable<LabelsArray> GetReceiveAddressLabels() =>
-		Services.WalletManager
-			.GetWallets(refreshWalletList: false) // Don't refresh wallet list as it may be slow.
-			.Select(x => x.KeyManager)
-			.SelectMany(x => x.GetReceiveLabels());
+	public static List<LabelsByWallet> GetLabelsByWallets()
+	{
+		var result = new List<LabelsByWallet>();
 
-	public static IEnumerable<LabelsArray> GetChangeAddressLabels() =>
-		Services.WalletManager
-			.GetWallets(refreshWalletList: false) // Don't refresh wallet list as it may be slow.
-			.Select(x => x.KeyManager)
-			.SelectMany(x => x.GetChangeLabels());
+		foreach (var wallet in Services.WalletManager.GetWallets(refreshWalletList: false))
+		{
+			result.Add(new LabelsByWallet(wallet.WalletId, wallet.KeyManager.GetChangeLabels(), wallet.KeyManager.GetReceiveLabels()));
+		}
+
+		return result;
+	}
+
+	public record LabelsByWallet(WalletId WalletId, IEnumerable<LabelsArray> ChangeLabels, IEnumerable<LabelsArray> ReceiveLabels);
 }

--- a/WalletWasabi.Fluent/Helpers/WalletHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/WalletHelpers.cs
@@ -29,11 +29,12 @@ public static class WalletHelpers
 
 		foreach (var wallet in Services.WalletManager.GetWallets(refreshWalletList: false))
 		{
-			result.Add(new LabelsByWallet(wallet.WalletId, wallet.KeyManager.GetChangeLabels(), wallet.KeyManager.GetReceiveLabels()));
+			var (changeLabels, receiveLabels) = wallet.KeyManager.GetLabels();
+			result.Add(new LabelsByWallet(wallet.WalletId, changeLabels, receiveLabels));
 		}
 
 		return result;
 	}
 
-	public record LabelsByWallet(WalletId WalletId, IEnumerable<LabelsArray> ChangeLabels, IEnumerable<LabelsArray> ReceiveLabels);
+	public record LabelsByWallet(WalletId WalletId, List<LabelsArray> ChangeLabels, List<LabelsArray> ReceiveLabels);
 }

--- a/WalletWasabi.Fluent/Helpers/WalletHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/WalletHelpers.cs
@@ -36,5 +36,5 @@ public static class WalletHelpers
 		return result;
 	}
 
-	public record LabelsByWallet(WalletId WalletId, List<LabelsArray> ChangeLabels, List<LabelsArray> ReceiveLabels);
+	public record LabelsByWallet(WalletId WalletId, List<string> ChangeLabels, List<string> ReceiveLabels);
 }


### PR DESCRIPTION
This PR improves by a factor ~2.5, from 2.2s to 0.8s (on the big wallet I use for tests), the computation of  `GetMostUsedLabels`.
This function is used a lot, and introduces delays at really annoying moments such as when you click on `Receive` or during the `Send` workflow.

This PR works by avoiding enumerating several times over the same structures, it has 2 commits:
2944241b41189df7b63c3a1b070403bc37e57ea7: Stores the `WalletId` with the Labels while fetching them for all wallets, therefore there is no need to fetch them again for the current wallet.

58d18e6ac9d584a2df38ae2e6d60edcbff62f325: Returns two `List` instead of `IEnumerable` while fetching the labels from the `KeyManager` so we avoid enumerating multiple times.