### PR TITLE
Remove INotifyProp from WasabiSynchronizer

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/AmountProvider.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/AmountProvider.cs
@@ -1,5 +1,7 @@
 using NBitcoin;
 using ReactiveUI;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using WalletWasabi.Services;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
@@ -7,13 +9,13 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 [AutoInterface]
 public partial class AmountProvider : ReactiveObject
 {
-	private readonly WasabiSynchronizer _synchronizer;
 	[AutoNotify] private decimal _usdExchangeRate;
 
 	public AmountProvider(WasabiSynchronizer synchronizer)
 	{
-		_synchronizer = synchronizer;
-		BtcToUsdExchangeRates = this.WhenAnyValue(provider => provider._synchronizer.UsdExchangeRate);
+		BtcToUsdExchangeRates = Observable.FromEventPattern<decimal>(synchronizer, nameof(Services.Synchronizer.UsdExchangeRateChanged))
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Select(x => x.EventArgs);
 
 		BtcToUsdExchangeRates.BindTo(this, x => x.UsdExchangeRate);
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -323,8 +323,10 @@ public partial class SendViewModel : RoutableViewModel
 			}
 		}
 
-		_wallet.Synchronizer.WhenAnyValue(x => x.UsdExchangeRate)
+		// Backend Status
+		Observable.FromEventPattern<decimal>(_wallet.Synchronizer, nameof(Services.Synchronizer.UsdExchangeRateChanged))
 			.ObserveOn(RxApp.MainThreadScheduler)
+			.Select(ev => ev.EventArgs)
 			.Subscribe(x => ExchangeRate = x)
 			.DisposeWith(disposables);
 

--- a/WalletWasabi/Services/UpdateChecker.cs
+++ b/WalletWasabi/Services/UpdateChecker.cs
@@ -14,7 +14,7 @@ public class UpdateChecker : PeriodicRunner
 		Synchronizer = synchronizer;
 		UpdateStatus = new UpdateStatus(backendCompatible: true, clientUpToDate: true, new Version(), currentBackendMajorVersion: 0, new Version());
 		WasabiClient = Synchronizer.HttpClientFactory.SharedWasabiClient;
-		Synchronizer.PropertyChanged += Synchronizer_PropertyChanged;
+		Synchronizer.BackendStatusChanged += Synchronizer_BackendStatusChanged;
 	}
 
 	public event EventHandler<UpdateStatus>? UpdateStatusChanged;
@@ -23,10 +23,9 @@ public class UpdateChecker : PeriodicRunner
 	private UpdateStatus UpdateStatus { get; set; }
 	public WasabiClient WasabiClient { get; }
 
-	private void Synchronizer_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+	private void Synchronizer_BackendStatusChanged(object? sender, BackendStatus backendStatus)
 	{
-		if (e.PropertyName == nameof(WasabiSynchronizer.BackendStatus) &&
-			Synchronizer.BackendStatus == BackendStatus.Connected)
+		if (backendStatus == BackendStatus.Connected)
 		{
 			// Any time when the synchronizer detects the backend, we immediately check the versions. GUI relies on UpdateStatus changes.
 			TriggerRound();
@@ -45,7 +44,7 @@ public class UpdateChecker : PeriodicRunner
 
 	public override void Dispose()
 	{
-		Synchronizer.PropertyChanged -= Synchronizer_PropertyChanged;
+		Synchronizer.BackendStatusChanged -= Synchronizer_BackendStatusChanged;
 		base.Dispose();
 	}
 }

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -19,7 +19,7 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services;
 
-public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvider, IWasabiBackendStatusProvider
+public class WasabiSynchronizer : IThirdPartyFeeProvider, IWasabiBackendStatusProvider
 {
 	private const long StateNotStarted = 0;
 
@@ -28,11 +28,8 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	private const long StateStopping = 2;
 
 	private const long StateStopped = 3;
-
 	private decimal _usdExchangeRate;
-
 	private TorStatus _torStatus;
-
 	private BackendStatus _backendStatus;
 
 	/// <summary>
@@ -61,6 +58,12 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 
 	public event EventHandler<AllFeeEstimate>? AllFeeEstimateArrived;
 
+	public event EventHandler<decimal>? UsdExchangeRateChanged;
+
+	public event EventHandler<TorStatus>? TorStatusChanged;
+
+	public event EventHandler<BackendStatus>? BackendStatusChanged;
+
 	/// <summary>Task completion source that is completed once a first synchronization request succeeds or fails.</summary>
 	public TaskCompletionSource<bool> InitialRequestTcs { get; } = new();
 
@@ -72,13 +75,27 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 	public decimal UsdExchangeRate
 	{
 		get => _usdExchangeRate;
-		private set => RaiseAndSetIfChanged(ref _usdExchangeRate, value);
+		private set
+		{
+			if (_usdExchangeRate != value)
+			{
+				_usdExchangeRate = value;
+				UsdExchangeRateChanged?.Invoke(this, value);
+			}
+		}
 	}
 
 	public TorStatus TorStatus
 	{
 		get => _torStatus;
-		private set => RaiseAndSetIfChanged(ref _torStatus, value);
+		private set
+		{
+			if (_torStatus != value)
+			{
+				_torStatus = value;
+				TorStatusChanged?.Invoke(this, value);
+			}
+		}
 	}
 
 	public BackendStatus BackendStatus
@@ -86,9 +103,11 @@ public class WasabiSynchronizer : NotifyPropertyChangedBase, IThirdPartyFeeProvi
 		get => _backendStatus;
 		private set
 		{
-			if (RaiseAndSetIfChanged(ref _backendStatus, value))
+			if (_backendStatus != value)
 			{
+				_backendStatus = value;
 				BackendStatusChangedAt = DateTimeOffset.UtcNow;
+				BackendStatusChanged?.Invoke(this, value);
 			}
 		}
 	}


### PR DESCRIPTION
Goal: dismiss inheritance for being able to make WasabiSynchronizer a PeriodicRunner. In this way, we will also be aligned to the codebase style => business logic can have events only for notifying. 