### PR TITLE
Use cache at API GetTransactionsAsync - parallel

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -239,7 +239,7 @@ public class BlockchainController : ControllerBase
 
 	private static string GetCacheKeyForTransation(uint256 txId)
 	{
-		return $"{nameof(GetTransactionsAsync)} + {txId}";
+		return $"{nameof(GetTransactionAsync)} + {txId}";
 	}
 
 	private Task<Transaction> GetTransactionAsync(uint256 txId, CancellationToken token)

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -45,8 +45,6 @@ public class BlockchainController : ControllerBase
 	private IRPCClient RpcClient => Global.RpcClient;
 	private Network Network => Global.Config.Network;
 
-	public static Dictionary<uint256, string> TransactionHexCache { get; } = new();
-	public static object TransactionHexCacheLock { get; } = new();
 	public IdempotencyRequestCache Cache { get; }
 
 	public Global Global { get; }


### PR DESCRIPTION
As title. This is a more complicated solution because it is using `RpcClient.GetRawTransactionsAsync`. That was used originally in the code. 

The complexity coming from that cache is working with single items but we want to use batch requests when getting the missing transactions. 

Contributes to https://github.com/zkSNACKs/WalletWasabi/pull/11679