### PR TITLE
Open the wallet files in parallel at startup

### DIFF
--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -1,10 +1,8 @@
 using NBitcoin;
 using Nito.AsyncEx;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -105,12 +105,12 @@ public class WalletManager : IWalletProvider
 			return;
 		}
 
-		List<Task<Wallet>> walletLoadTasks = walletNamesToLoad.Select(walletName => Task.Run(() => GetWalletByName(walletName))).ToList();
+		List<Task<Wallet>> walletLoadTasks = walletNamesToLoad.Select(walletName => Task.Run(() => GetWalletByName(walletName), CancelAllTasksToken)).ToList();
 
 		while (walletLoadTasks.Count > 0)
 		{
 			var tasksArray = walletLoadTasks.ToArray();
-			var finishedTaskIndex = Task.WaitAny(tasksArray);
+			var finishedTaskIndex = Task.WaitAny(tasksArray, CancelAllTasksToken);
 			var finishedTask = tasksArray[finishedTaskIndex];
 			walletLoadTasks.Remove(finishedTask);
 			try

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -100,6 +100,11 @@ public class WalletManager : IWalletProvider
 			walletNamesToLoad = walletFileNames.Where(walletFileName => !Wallets.Any(wallet => wallet.WalletName == walletFileName));
 		}
 
+		if (!walletNamesToLoad.Any())
+		{
+			return;
+		}
+
 		List<Task<Wallet>> walletLoadTasks = [];
 
 		foreach (var walletName in walletNamesToLoad)

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -94,7 +94,7 @@ public class WalletManager : IWalletProvider
 	{
 		var walletFileNames = WalletDirectories.EnumerateWalletFiles().Select(fi => Path.GetFileNameWithoutExtension(fi.FullName));
 
-		string[] walletNamesToLoad = [];
+		string[]? walletNamesToLoad = null;
 		lock (Lock)
 		{
 			walletNamesToLoad = walletFileNames.Where(walletFileName => !Wallets.Any(wallet => wallet.WalletName == walletFileName)).ToArray();


### PR DESCRIPTION
This PR improves the performance if the user has more wallets. It will reduce the time between starting and window popup. 

**Current master:**

`WalletManager.RefreshWalletList (126)   '8' wallets loaded in 1595 ms with 18050 number of keys`

**This PR:**

`WalletManager.RefreshWalletList (137)   '8' wallets loaded in 818 ms with 18050 number of keys`


Addressing https://github.com/zkSNACKs/WalletWasabi/issues/11748#issuecomment-1892485862 

Contributes to https://github.com/zkSNACKs/WalletWasabi/issues/11748

