### PR TITLE
Introduce `PeriodicRunner` in `WasabiSynchronizer`

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -458,7 +458,8 @@ public class Global
 
 				if (Synchronizer is { } synchronizer)
 				{
-					await synchronizer.StopAsync().ConfigureAwait(false);
+					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+					await synchronizer.StopAsync(cts.Token).ConfigureAwait(false);
 					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
 				}
 

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -236,7 +236,7 @@ public class Global
 				}
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 
-				Synchronizer.Start();
+				await Synchronizer.StartAsync(cancel).ConfigureAwait(false);
 				Logger.LogInfo("Start synchronizing filters...");
 
 				TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -70,12 +70,14 @@ public class Global
 
 		TimeSpan requestInterval = Network == Network.RegTest ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(30);
 		int maxFiltersToSync = Network == Network.Main ? 1000 : 10000; // On testnet, filters are empty, so it's faster to query them together
-		Synchronizer = new WasabiSynchronizer(requestInterval, maxFiltersToSync, BitcoinStore, HttpClientFactory);
 
-		HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromSeconds(5), Synchronizer), "Software Update Checker");
+		HostedServices.Register<WasabiSynchronizer>(() => new WasabiSynchronizer(requestInterval, maxFiltersToSync, BitcoinStore, HttpClientFactory), "Wasabi Synchronizer");
+		WasabiSynchronizer wasabiSynchronizer = HostedServices.Get<WasabiSynchronizer>();
+
+		HostedServices.Register<UpdateChecker>(() => new UpdateChecker(TimeSpan.FromSeconds(5), wasabiSynchronizer), "Software Update Checker");
 		UpdateChecker updateChecker = HostedServices.Get<UpdateChecker>();
-		LegalChecker = new(DataDir, updateChecker);
 
+		LegalChecker = new(DataDir, updateChecker);
 		UpdateManager = new(DataDir, Config.DownloadNewVersion, HttpClientFactory.NewHttpClient(Mode.DefaultCircuit, maximumRedirects: 10), updateChecker);
 		TorStatusChecker = new TorStatusChecker(TimeSpan.FromHours(6), HttpClientFactory.NewHttpClient(Mode.DefaultCircuit), new XmlIssueListParser());
 		RoundStateUpdaterCircuit = new PersonCircuit();
@@ -116,7 +118,7 @@ public class Global
 			new P2PBlockProvider(Network, HostedServices.Get<P2pNetwork>().Nodes, HttpClientFactory.IsTorEnabled),
 			Cache);
 
-		WalletManager = new WalletManager(config.Network, DataDir, new WalletDirectories(Config.Network, DataDir), BitcoinStore, Synchronizer, HostedServices.Get<HybridFeeProvider>(), blockProvider, config.ServiceConfiguration);
+		WalletManager = new WalletManager(config.Network, DataDir, new WalletDirectories(Config.Network, DataDir), BitcoinStore, wasabiSynchronizer, HostedServices.Get<HybridFeeProvider>(), blockProvider, config.ServiceConfiguration);
 		TransactionBroadcaster = new TransactionBroadcaster(Network, BitcoinStore, HttpClientFactory, WalletManager);
 
 		CoinPrison = CoinPrison.CreateOrLoadFromFile(DataDir);
@@ -144,7 +146,6 @@ public class Global
 	public LegalChecker LegalChecker { get; private set; }
 	public string ConfigFilePath { get; }
 	public Config Config { get; }
-	public WasabiSynchronizer Synchronizer { get; private set; }
 	public WalletManager WalletManager { get; }
 	public TransactionBroadcaster TransactionBroadcaster { get; set; }
 	public CoinJoinProcessor? CoinJoinProcessor { get; set; }
@@ -236,11 +237,10 @@ public class Global
 				}
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 
-				await Synchronizer.StartAsync(cancel).ConfigureAwait(false);
 				Logger.LogInfo("Start synchronizing filters...");
 
 				TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);
-				CoinJoinProcessor = new CoinJoinProcessor(Network, Synchronizer, WalletManager, BitcoinCoreNode?.RpcClient);
+				CoinJoinProcessor = new CoinJoinProcessor(Network, HostedServices.Get<WasabiSynchronizer>(), WalletManager, BitcoinCoreNode?.RpcClient);
 
 				await StartRpcServerAsync(terminateService, cancel).ConfigureAwait(false);
 
@@ -360,7 +360,7 @@ public class Global
 	private void RegisterFeeRateProviders()
 	{
 		HostedServices.Register<BlockstreamInfoFeeProvider>(() => new BlockstreamInfoFeeProvider(TimeSpan.FromMinutes(3), new(Network, HttpClientFactory)) { IsPaused = true }, "Blockstream.info Fee Provider");
-		HostedServices.Register<ThirdPartyFeeProvider>(() => new ThirdPartyFeeProvider(TimeSpan.FromSeconds(1), Synchronizer, HostedServices.Get<BlockstreamInfoFeeProvider>()), "Third Party Fee Provider");
+		HostedServices.Register<ThirdPartyFeeProvider>(() => new ThirdPartyFeeProvider(TimeSpan.FromSeconds(1), HostedServices.Get<WasabiSynchronizer>(), HostedServices.Get<BlockstreamInfoFeeProvider>()), "Third Party Fee Provider");
 		HostedServices.Register<HybridFeeProvider>(() => new HybridFeeProvider(HostedServices.Get<ThirdPartyFeeProvider>(), HostedServices.GetOrDefault<RpcFeeProvider>()), "Hybrid Fee Provider");
 	}
 
@@ -368,7 +368,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, Synchronizer, Config.CoordinatorIdentifier, CoinPrison), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), Config.CoordinatorIdentifier, CoinPrison), "CoinJoin Manager");
 	}
 
 	private void WalletManager_WalletStateChanged(object? sender, WalletState e)
@@ -455,13 +455,6 @@ public class Global
 
 				RoundStateUpdaterCircuit.Dispose();
 				Logger.LogInfo($"Disposed {nameof(RoundStateUpdaterCircuit)}.");
-
-				if (Synchronizer is { } synchronizer)
-				{
-					using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
-					await synchronizer.StopAsync(cts.Token).ConfigureAwait(false);
-					Logger.LogInfo($"{nameof(Synchronizer)} is stopped.");
-				}
 
 				if (HttpClientFactory is { } httpClientFactory)
 				{

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -16,6 +16,7 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Rpc;
+using WalletWasabi.Services;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.Batching;
 using WalletWasabi.Wallets;
@@ -190,7 +191,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	[JsonRpcMethod("getstatus", initializable: false)]
 	public JsonRpcResult GetStatus()
 	{
-		var sync = Global.Synchronizer;
+		var sync = Global.HostedServices.Get<WasabiSynchronizer>();
 		var smartHeaderChain = Global.BitcoinStore.SmartHeaderChain;
 
 		return new JsonRpcResult
@@ -501,7 +502,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	[JsonRpcMethod("getfeerates", initializable: false)]
 	public object GetFeeRate()
 	{
-		if (Global.Synchronizer.LastAllFeeEstimate is { } nonNullFeeRates)
+		if (Global.HostedServices.Get<WasabiSynchronizer>().LastAllFeeEstimate is { } nonNullFeeRates)
 		{
 			return nonNullFeeRates.Estimations;
 		}

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -15,6 +15,7 @@ using WalletWasabi.Fluent.Models.UI;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels;
 using WalletWasabi.Fluent.ViewModels.SearchBar.Sources;
+using WalletWasabi.Services;
 
 namespace WalletWasabi.Fluent;
 
@@ -132,7 +133,7 @@ public class App : Application
 
 	private static IAmountProvider CreateAmountProvider()
 	{
-		return new AmountProvider(Services.Synchronizer);
+		return new AmountProvider(Services.HostedServices.Get<WasabiSynchronizer>());
 	}
 
 	private UiContext CreateUiContext()

--- a/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
@@ -9,6 +9,7 @@ using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Logging;
+using WalletWasabi.Services;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
@@ -53,7 +54,7 @@ public partial class WalletLoadWorkflow
 		_stopwatch = Stopwatch.StartNew();
 		_disposables.Add(Disposable.Create(_stopwatch.Stop));
 
-		Observable.FromAsync(() => Services.Synchronizer.InitialRequestTcs.Task)
+		Observable.FromAsync(() => Services.HostedServices.Get<WasabiSynchronizer>().InitialRequestTcs.Task)
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.SubscribeAsync(LoadWalletAsync)
 			.DisposeWith(_disposables);

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -30,8 +30,6 @@ public static class Services
 
 	public static PersistentConfig PersistentConfig { get; private set; } = null!;
 
-	public static WasabiSynchronizer Synchronizer { get; private set; } = null!;
-
 	public static WalletManager WalletManager { get; private set; } = null!;
 
 	public static TransactionBroadcaster TransactionBroadcaster { get; private set; } = null!;
@@ -77,7 +75,6 @@ public static class Services
 		LegalChecker = global.LegalChecker;
 		PersistentConfigFilePath = global.ConfigFilePath;
 		PersistentConfig = global.Config.PersistentConfig;
-		Synchronizer = global.Synchronizer;
 		WalletManager = global.WalletManager;
 		TransactionBroadcaster = global.TransactionBroadcaster;
 		HostedServices = global.HostedServices;

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -99,7 +99,7 @@ public class P2pTests
 
 		KeyManager keyManager = KeyManager.CreateNew(out _, "password", network);
 		await using WasabiHttpClientFactory httpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: () => new Uri("http://localhost:12345"));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		var feeProvider = new HybridFeeProvider(synchronizer, null);
 
 		ServiceConfiguration serviceConfig = new(new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold));

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -99,7 +99,7 @@ public class P2pTests
 
 		KeyManager keyManager = KeyManager.CreateNew(out _, "password", network);
 		await using WasabiHttpClientFactory httpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: () => new Uri("http://localhost:12345"));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		var feeProvider = new HybridFeeProvider(synchronizer, null);
 
 		ServiceConfiguration serviceConfig = new(new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold));

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -102,7 +102,7 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 		{
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -275,7 +275,7 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(testDeadlineCts.Token);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(testDeadlineCts.Token);
 			await feeProvider.StopAsync(testDeadlineCts.Token);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -63,7 +63,7 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -63,7 +63,7 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -140,7 +140,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 		{
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
@@ -199,7 +199,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 		finally
 		{
 			await wallet.StopAsync(testDeadlineCts.Token);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(testDeadlineCts.Token);
 			await feeProvider.StopAsync(testDeadlineCts.Token);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -62,7 +62,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -62,7 +62,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -61,7 +61,7 @@ public class CancelTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -94,7 +94,7 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -327,7 +327,7 @@ public class CancelTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -61,7 +61,7 @@ public class CancelTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
@@ -43,7 +43,7 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		BitcoinStore bitcoinStore = setup.BitcoinStore;
 
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(1), 1000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(1), 1000, bitcoinStore, httpClientFactory);
 		try
 		{
 			await synchronizer.StartAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
@@ -46,7 +46,7 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(1), 1000, bitcoinStore, httpClientFactory);
 		try
 		{
-			synchronizer.Start();
+			await synchronizer.StartAsync(CancellationToken.None);
 
 			var blockCount = await rpc.GetBlockCountAsync() + 1; // Plus one because of the zeroth.
 																 // Test initial synchronization.
@@ -94,7 +94,7 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		}
 		finally
 		{
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 		}
 	}
 }

--- a/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
@@ -43,7 +43,7 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		BitcoinStore bitcoinStore = setup.BitcoinStore;
 
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(1), 1000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(1), 1000, bitcoinStore, httpClientFactory);
 		try
 		{
 			await synchronizer.StartAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -61,7 +61,7 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -97,7 +97,7 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -190,7 +190,7 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -61,7 +61,7 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -90,7 +90,7 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service.
@@ -302,7 +302,7 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -63,7 +63,7 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -63,7 +63,7 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
@@ -77,7 +77,7 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 		var node = RegTestFixture.BackendRegTestNode;
 
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
 
 		try
 		{

--- a/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
@@ -77,7 +77,7 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 		var node = RegTestFixture.BackendRegTestNode;
 
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
 
 		try
 		{

--- a/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
@@ -81,7 +81,7 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 
 		try
 		{
-			synchronizer.Start();
+			await synchronizer.StartAsync(CancellationToken.None);
 
 			var reorgAwaiter = new EventsAwaiter<FilterModel>(
 				h => bitcoinStore.IndexStore.Reorged += h,
@@ -146,7 +146,7 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 		}
 		finally
 		{
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 		}
 	}
 }

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -59,7 +59,7 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -90,7 +90,7 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 		{
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
@@ -139,7 +139,7 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 		finally
 		{
 			await wallet.StopAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -59,7 +59,7 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -63,7 +63,7 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -63,7 +63,7 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -96,7 +96,7 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -350,7 +350,7 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -97,7 +97,7 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -555,7 +555,7 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -64,7 +64,7 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -64,7 +64,7 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -61,7 +61,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -98,7 +98,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -516,7 +516,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -61,7 +61,7 @@ public class SendTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -61,7 +61,7 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -61,7 +61,7 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -90,7 +90,7 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 		{
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(CancellationToken.None);
 
 			// Start wallet and filter processing service
@@ -221,7 +221,7 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 		{
 			bitcoinStore.IndexStore.NewFilters -= setup.Wallet_NewFiltersProcessed;
 			await walletManager.RemoveAndStopAllAsync(CancellationToken.None);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(CancellationToken.None);
 			await feeProvider.StopAsync(CancellationToken.None);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -93,7 +93,7 @@ public class WalletTests : IClassFixture<RegTestFixture>
 			Interlocked.Exchange(ref setup.FiltersProcessedByWalletCount, 0);
 			nodes.Connect(); // Start connection service.
 			node.VersionHandshake(); // Start mempool service.
-			synchronizer.Start(); // Start wasabi synchronizer service.
+			await synchronizer.StartAsync(CancellationToken.None); // Start wasabi synchronizer service.
 			await feeProvider.StartAsync(testDeadlineCts.Token);
 
 			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
@@ -227,7 +227,7 @@ public class WalletTests : IClassFixture<RegTestFixture>
 		{
 			wallet.NewFiltersProcessed -= setup.Wallet_NewFiltersProcessed;
 			await wallet.StopAsync(testDeadlineCts.Token);
-			await synchronizer.StopAsync();
+			await synchronizer.StopAsync(testDeadlineCts.Token);
 			await feeProvider.StopAsync(testDeadlineCts.Token);
 			nodes?.Dispose();
 			node?.Disconnect();

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -54,7 +54,7 @@ public class WalletTests : IClassFixture<RegTestFixture>
 
 		// 2. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 3. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -54,7 +54,7 @@ public class WalletTests : IClassFixture<RegTestFixture>
 
 		// 2. Create wasabi synchronizer service.
 		await using WasabiHttpClientFactory httpClientFactory = new(torEndPoint: null, backendUriGetter: () => new Uri(RegTestFixture.BackendEndPoint));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, bitcoinStore, httpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 
 		// 3. Create key manager service.

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -57,7 +57,7 @@ public class WalletBuilder : IAsyncDisposable
 		keyManager.GetKeys(_ => true); // Make sure keys are asserted.
 
 		var serviceConfiguration = new ServiceConfiguration(new UriEndPoint(new Uri("http://www.nomatter.dontcare")), Money.Coins(WalletWasabi.Helpers.Constants.DefaultDustThreshold));
-		WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, BitcoinStore, HttpClientFactory);
+		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, BitcoinStore, HttpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 		SmartBlockProvider blockProvider = new(BitcoinStore.BlockRepository, rpcBlockProvider: null, null, null, Cache);
 

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -19,6 +19,7 @@ using WalletWasabi.WebClients.Wasabi;
 using WalletWasabi.Tests.Helpers;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace WalletWasabi.Tests.UnitTests.Wallet;
 
@@ -38,6 +39,7 @@ public class WalletBuilder : IAsyncDisposable
 		BitcoinStore = new BitcoinStore(IndexStore, TransactionStore, new MempoolService(), smartHeaderChain, blockRepositoryMock);
 		Cache = new MemoryCache(new MemoryCacheOptions());
 		HttpClientFactory = new WasabiHttpClientFactory(torEndPoint: null, backendUriGetter: () => null!);
+		Synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, BitcoinStore, HttpClientFactory);
 	}
 
 	private IndexStore IndexStore { get; }
@@ -45,6 +47,7 @@ public class WalletBuilder : IAsyncDisposable
 	private BitcoinStore BitcoinStore { get; }
 	private MemoryCache Cache { get; }
 	private WasabiHttpClientFactory HttpClientFactory { get; }
+	private WasabiSynchronizer Synchronizer { get; }
 	public IEnumerable<FilterModel> Filters { get; }
 	public string DataDir { get; }
 
@@ -57,16 +60,17 @@ public class WalletBuilder : IAsyncDisposable
 		keyManager.GetKeys(_ => true); // Make sure keys are asserted.
 
 		var serviceConfiguration = new ServiceConfiguration(new UriEndPoint(new Uri("http://www.nomatter.dontcare")), Money.Coins(WalletWasabi.Helpers.Constants.DefaultDustThreshold));
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, BitcoinStore, HttpClientFactory);
-		HybridFeeProvider feeProvider = new(synchronizer, null);
+
+		HybridFeeProvider feeProvider = new(Synchronizer, null);
 		SmartBlockProvider blockProvider = new(BitcoinStore.BlockRepository, rpcBlockProvider: null, null, null, Cache);
 
-		return WalletWasabi.Wallets.Wallet.CreateAndRegisterServices(Network.RegTest, BitcoinStore, keyManager, synchronizer, DataDir, serviceConfiguration, feeProvider, blockProvider);
+		return WalletWasabi.Wallets.Wallet.CreateAndRegisterServices(Network.RegTest, BitcoinStore, keyManager, Synchronizer, DataDir, serviceConfiguration, feeProvider, blockProvider);
 	}
 
 	public async ValueTask DisposeAsync()
 	{
 		await IndexStore.DisposeAsync().ConfigureAwait(false);
+		await Synchronizer.StopAsync(CancellationToken.None).ConfigureAwait(false);
 		await TransactionStore.DisposeAsync().ConfigureAwait(false);
 		await HttpClientFactory.DisposeAsync().ConfigureAwait(false);
 		Cache.Dispose();

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -57,7 +57,7 @@ public class WalletBuilder : IAsyncDisposable
 		keyManager.GetKeys(_ => true); // Make sure keys are asserted.
 
 		var serviceConfiguration = new ServiceConfiguration(new UriEndPoint(new Uri("http://www.nomatter.dontcare")), Money.Coins(WalletWasabi.Helpers.Constants.DefaultDustThreshold));
-		using WasabiSynchronizer synchronizer = new(requestInterval: TimeSpan.FromSeconds(3), 1000, BitcoinStore, HttpClientFactory);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, BitcoinStore, HttpClientFactory);
 		HybridFeeProvider feeProvider = new(synchronizer, null);
 		SmartBlockProvider blockProvider = new(BitcoinStore.BlockRepository, rpcBlockProvider: null, null, null, Cache);
 

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -32,7 +32,7 @@ public class WasabiSynchronizer : PeriodicRunner, INotifyPropertyChanged, IThird
 
 	private bool _ignoreRequestInterval = false;
 
-	public WasabiSynchronizer(TimeSpan requestInterval, int maxFiltersToSync, BitcoinStore bitcoinStore, WasabiHttpClientFactory httpClientFactory) : base(requestInterval)
+	public WasabiSynchronizer(TimeSpan period, int maxFiltersToSync, BitcoinStore bitcoinStore, WasabiHttpClientFactory httpClientFactory) : base(period)
 	{
 		MaxFiltersToSync = maxFiltersToSync;
 

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -22,7 +22,7 @@ using WalletWasabi.WebClients.Wasabi;
 
 namespace WalletWasabi.Services;
 
-public class WasabiSynchronizer : INotifyPropertyChanged, IThirdPartyFeeProvider, IWasabiBackendStatusProvider
+public class WasabiSynchronizer : PeriodicRunner, INotifyPropertyChanged, IThirdPartyFeeProvider, IWasabiBackendStatusProvider
 {
 	private const long StateNotStarted = 0;
 
@@ -43,7 +43,9 @@ public class WasabiSynchronizer : INotifyPropertyChanged, IThirdPartyFeeProvider
 	/// </summary>
 	private long _running;
 
-	public WasabiSynchronizer(TimeSpan requestInterval, int maxFiltersToSync, BitcoinStore bitcoinStore, WasabiHttpClientFactory httpClientFactory)
+	private bool _ignoreRequestInterval = false;
+
+	public WasabiSynchronizer(TimeSpan requestInterval, int maxFiltersToSync, BitcoinStore bitcoinStore, WasabiHttpClientFactory httpClientFactory) : base(requestInterval)
 	{
 		RequestInterval = requestInterval;
 		MaxFiltersToSync = maxFiltersToSync;
@@ -116,161 +118,144 @@ public class WasabiSynchronizer : INotifyPropertyChanged, IThirdPartyFeeProvider
 
 	#endregion EventsPropertiesMembers
 
-	#region Initializers
-
-	public void Start()
+	protected override async Task ActionAsync(CancellationToken cancel)
 	{
-		if (Interlocked.CompareExchange(ref _running, StateRunning, StateNotStarted) != StateNotStarted)
-		{
-			return;
-		}
-
-		Task.Run(async () =>
+		try
 		{
 			try
 			{
-				bool ignoreRequestInterval = false;
+				SynchronizeResponse response;
 
-				while (IsRunning)
+				ushort lastUsedApiVersion = WasabiClient.ApiVersion;
+				try
 				{
+					response = await WasabiClient
+						.GetSynchronizeAsync(SmartHeaderChain.TipHash, MaxFiltersToSync, EstimateSmartFeeMode.Conservative, StopCts.Token)
+						.ConfigureAwait(false);
+
+					// NOT GenSocksServErr
+					BackendStatus = BackendStatus.Connected;
+					TorStatus = TorStatus.Running;
+					DoNotGenSocksServFail();
+				}
+				catch (HttpRequestException ex) when (ex.InnerException is TorException innerEx)
+				{
+					TorStatus = innerEx is TorConnectionException ? TorStatus.NotRunning : TorStatus.Running;
+					BackendStatus = BackendStatus.NotConnected;
+					HandleIfGenSocksServFail(innerEx);
+					throw;
+				}
+				catch (HttpRequestException ex) when (ex.Message.Contains("Not Found"))
+				{
+					TorStatus = TorStatus.Running;
+					BackendStatus = BackendStatus.NotConnected;
 					try
 					{
-						SynchronizeResponse response;
+						// Backend API version might be updated meanwhile. Trying to update the versions.
+						var result = await WasabiClient.CheckUpdatesAsync(StopCts.Token).ConfigureAwait(false);
 
-						ushort lastUsedApiVersion = WasabiClient.ApiVersion;
-						try
+						// If the backend is compatible and the Api version updated then we just used the wrong API.
+						if (result.BackendCompatible && lastUsedApiVersion != WasabiClient.ApiVersion)
 						{
-							response = await WasabiClient
-								.GetSynchronizeAsync(SmartHeaderChain.TipHash, MaxFiltersToSync, EstimateSmartFeeMode.Conservative, StopCts.Token)
-								.ConfigureAwait(false);
-
-							// NOT GenSocksServErr
-							BackendStatus = BackendStatus.Connected;
-							TorStatus = TorStatus.Running;
-							DoNotGenSocksServFail();
-						}
-						catch (HttpRequestException ex) when (ex.InnerException is TorException innerEx)
-						{
-							TorStatus = innerEx is TorConnectionException ? TorStatus.NotRunning : TorStatus.Running;
-							BackendStatus = BackendStatus.NotConnected;
-							HandleIfGenSocksServFail(innerEx);
-							throw;
-						}
-						catch (HttpRequestException ex) when (ex.Message.Contains("Not Found"))
-						{
-							TorStatus = TorStatus.Running;
-							BackendStatus = BackendStatus.NotConnected;
-							try
-							{
-								// Backend API version might be updated meanwhile. Trying to update the versions.
-								var result = await WasabiClient.CheckUpdatesAsync(StopCts.Token).ConfigureAwait(false);
-
-								// If the backend is compatible and the Api version updated then we just used the wrong API.
-								if (result.BackendCompatible && lastUsedApiVersion != WasabiClient.ApiVersion)
-								{
-									// Next request will be fine, do not throw exception.
-									ignoreRequestInterval = true;
-									continue;
-								}
-								else
-								{
-									throw;
-								}
-							}
-							catch (Exception x)
-							{
-								HandleIfGenSocksServFail(x);
-								throw;
-							}
-						}
-						catch (Exception ex)
-						{
-							TorStatus = TorStatus.Running;
-							BackendStatus = BackendStatus.NotConnected;
-							HandleIfGenSocksServFail(ex);
-							throw;
-						}
-
-						// If it's not fully synced or reorg happened.
-						if (response.Filters.Count() == MaxFiltersToSync || response.FiltersResponseState == FiltersResponseState.BestKnownHashNotFound)
-						{
-							ignoreRequestInterval = true;
+							// Next request will be fine, do not throw exception.
+							_ignoreRequestInterval = true;
+							return;
 						}
 						else
 						{
-							ignoreRequestInterval = false;
-						}
-						ExchangeRate? exchangeRate = response.ExchangeRates.FirstOrDefault();
-						if (exchangeRate is { Rate: > 0 })
-						{
-							UsdExchangeRate = exchangeRate.Rate;
-						}
-
-						await FilterProcessor.ProcessAsync((uint)response.BestHeight, response.FiltersResponseState, response.Filters).ConfigureAwait(false);
-
-						LastResponse = response;
-						ResponseArrived?.Invoke(this, response);
-						if (response.AllFeeEstimate is { } allFeeEstimate)
-						{
-							AllFeeEstimateArrived?.Invoke(this, allFeeEstimate);
+							throw;
 						}
 					}
-					catch (OperationCanceledException)
+					catch (Exception x)
 					{
-						Logger.LogInfo("Wasabi Synchronizer execution was canceled.");
-					}
-					catch (HttpRequestException ex) when (ex.InnerException is TorConnectionException)
-					{
-						// When stopping, we do not want to wait.
-						if (!IsRunning)
-						{
-							Logger.LogTrace(ex);
-							return;
-						}
-
-						Logger.LogError(ex);
-						try
-						{
-							await Task.Delay(3000, StopCts.Token).ConfigureAwait(false); // Give other threads time to do stuff.
-						}
-						catch (TaskCanceledException ex2)
-						{
-							Logger.LogTrace(ex2);
-						}
-					}
-					catch (TimeoutException ex)
-					{
-						Logger.LogTrace(ex);
-					}
-					catch (Exception ex)
-					{
-						Logger.LogError(ex);
-					}
-					finally
-					{
-						if (IsRunning && !ignoreRequestInterval)
-						{
-							try
-							{
-								await Task.Delay(RequestInterval, StopCts.Token).ConfigureAwait(false); // Ask for new index in every requestInterval.
-							}
-							catch (TaskCanceledException ex)
-							{
-								Logger.LogTrace(ex);
-							}
-						}
+						HandleIfGenSocksServFail(x);
+						throw;
 					}
 				}
+				catch (Exception ex)
+				{
+					TorStatus = TorStatus.Running;
+					BackendStatus = BackendStatus.NotConnected;
+					HandleIfGenSocksServFail(ex);
+					throw;
+				}
+
+				// If it's not fully synced or reorg happened.
+				if (response.Filters.Count() == MaxFiltersToSync || response.FiltersResponseState == FiltersResponseState.BestKnownHashNotFound)
+				{
+					_ignoreRequestInterval = true;
+				}
+				else
+				{
+					_ignoreRequestInterval = false;
+				}
+				ExchangeRate? exchangeRate = response.ExchangeRates.FirstOrDefault();
+				if (exchangeRate is { Rate: > 0 })
+				{
+					UsdExchangeRate = exchangeRate.Rate;
+				}
+
+				await FilterProcessor.ProcessAsync((uint)response.BestHeight, response.FiltersResponseState, response.Filters).ConfigureAwait(false);
+
+				LastResponse = response;
+				ResponseArrived?.Invoke(this, response);
+				if (response.AllFeeEstimate is { } allFeeEstimate)
+				{
+					AllFeeEstimateArrived?.Invoke(this, allFeeEstimate);
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				Logger.LogInfo("Wasabi Synchronizer execution was canceled.");
+			}
+			catch (HttpRequestException ex) when (ex.InnerException is TorConnectionException)
+			{
+				// When stopping, we do not want to wait.
+				if (!IsRunning)
+				{
+					Logger.LogTrace(ex);
+					return;
+				}
+
+				Logger.LogError(ex);
+				try
+				{
+					await Task.Delay(3000, StopCts.Token).ConfigureAwait(false); // Give other threads time to do stuff.
+				}
+				catch (TaskCanceledException ex2)
+				{
+					Logger.LogTrace(ex2);
+				}
+			}
+			catch (TimeoutException ex)
+			{
+				Logger.LogTrace(ex);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError(ex);
 			}
 			finally
 			{
-				Interlocked.CompareExchange(ref _running, StateStopped, StateStopping); // If IsStopping, make it stopped.
-				Logger.LogDebug("Synchronizer is fully stopped now.");
+				if (IsRunning && !_ignoreRequestInterval)
+				{
+					try
+					{
+						await Task.Delay(RequestInterval, StopCts.Token).ConfigureAwait(false); // Ask for new index in every requestInterval.
+					}
+					catch (TaskCanceledException ex)
+					{
+						Logger.LogTrace(ex);
+					}
+				}
 			}
-		});
+		}
+		finally
+		{
+			Interlocked.CompareExchange(ref _running, StateStopped, StateStopping); // If IsStopping, make it stopped.
+			Logger.LogDebug("Synchronizer is fully stopped now.");
+		}
 	}
-
-	#endregion Initializers
 
 	#region Methods
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -297,11 +297,6 @@ public class Wallet : BackgroundService, IWallet
 		{
 			State = WalletState.Starting;
 
-			if (!Synchronizer.IsRunning)
-			{
-				throw new NotSupportedException($"{nameof(Synchronizer)} is not running.");
-			}
-
 			using (BenchmarkLogger.Measure())
 			{
 				await RuntimeParams.LoadAsync().ConfigureAwait(false);


### PR DESCRIPTION
Built upon #12262, this PR introduces `PeriodicRunner` in `WasabiSynchronizer` as a base class.

With this change we can rework the running logic of `WasabiSynchronizer` which before was basically a "`PeriodicRunner` by hand".
Now that the old base class was changed, we can use `PeriodicRunner` instead to run `WasabiSynchronizer` regularly.
With these changes,  `WasabiSynchronizer` was registered as a `HostedService`.

The action logic is the same, a few logical details was tweaked so it fits and behaves the same as before.

