### PR TITLE
Move EnsureHeightsAreAtLeastSegWitActivation to WalletManager

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -210,6 +210,9 @@ public class Global
 					// Make sure that TurboSyncHeight is not higher than BestHeight
 					WalletManager.EnsureTurboSyncHeightConsistency();
 
+					// Make sure that the heights of all wallet are at least SegWit activation.
+					WalletManager.EnsureHeightsAreAtLeastSegWitActivation();
+
 					// Make sure that the height of the wallets will not be better than the current height of the filters.
 					WalletManager.SetMaxBestHeight(BitcoinStore.SmartHeaderChain.TipHeight);
 				}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -469,17 +469,6 @@ public class Wallet : BackgroundService, IWallet
 
 		Height bestTurboSyncHeight = KeyManager.GetBestHeight(SyncType.Turbo);
 
-		// Make sure heights are at least height of segwit activation.
-		var startingSegwitHeight = new Height(SmartHeader.GetStartingHeader(Network, IndexType.SegwitTaproot).Height);
-		if (startingSegwitHeight > KeyManager.GetBestHeight(SyncType.Complete))
-		{
-			KeyManager.SetBestHeight(startingSegwitHeight);
-		}
-		if (startingSegwitHeight > bestTurboSyncHeight)
-		{
-			KeyManager.SetBestTurboSyncHeight(startingSegwitHeight);
-		}
-
 		using (BenchmarkLogger.Measure(LogLevel.Info, "Initial Transaction Processing"))
 		{
 			TransactionProcessor.Process(BitcoinStore.TransactionStore.ConfirmedStore.GetTransactions().TakeWhile(x => x.Height <= bestTurboSyncHeight));

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Blockchain.BlockFilters;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.TransactionProcessing;
@@ -490,6 +492,23 @@ public class WalletManager : IWalletProvider
 		foreach (var km in GetWallets(refreshWalletList: false).Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))
 		{
 			km.EnsureTurboSyncHeightConsistency();
+		}
+	}
+
+	public void EnsureHeightsAreAtLeastSegWitActivation()
+	{
+		foreach (var km in GetWallets(refreshWalletList: false).Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))
+		{
+			var startingSegwitHeight = new Height(SmartHeader.GetStartingHeader(Network, IndexType.SegwitTaproot).Height);
+			if (startingSegwitHeight > km.GetBestHeight(SyncType.NonTurbo))
+			{
+				km.SetBestHeight(startingSegwitHeight);
+			}
+
+			if (startingSegwitHeight > km.GetBestHeight(SyncType.Turbo))
+			{
+				km.SetBestTurboSyncHeight(startingSegwitHeight);
+			}
 		}
 	}
 

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -500,7 +500,7 @@ public class WalletManager : IWalletProvider
 		foreach (var km in GetWallets(refreshWalletList: false).Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))
 		{
 			var startingSegwitHeight = new Height(SmartHeader.GetStartingHeader(Network, IndexType.SegwitTaproot).Height);
-			if (startingSegwitHeight > km.GetBestHeight(SyncType.NonTurbo))
+			if (startingSegwitHeight > km.GetBestHeight(SyncType.Complete))
 			{
 				km.SetBestHeight(startingSegwitHeight);
 			}


### PR DESCRIPTION
Fixes #12278 by ensuring that heights used in the `KeyManager` are at least `SegWit` activation before starting the wallet and therefore registering the event to process new filters.
This can stay in Wallet.cs if required, I felt it was more clean that way.