### PR TITLE
Fix rendering issues in privacy text cell

### DIFF
--- a/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
+++ b/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
@@ -30,8 +30,12 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 		}
 	}
 
-	public override void Realize(TreeDataGridElementFactory factory, ITreeDataGridSelectionInteraction? selection,
-		ICell model, int columnIndex, int rowIndex)
+	public override void Realize(
+		TreeDataGridElementFactory factory,
+		ITreeDataGridSelectionInteraction? selection,
+		ICell model,
+		int columnIndex,
+		int rowIndex)
 	{
 		var privacyTextCell = (PrivacyTextCell)model;
 		var text = privacyTextCell.Value;
@@ -102,7 +106,8 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 			_privacyFormattedText = CreateFormattedText(availableSize, _privacyText);
 		}
 
-		return new Size(Math.Max(_formattedText.Width, _privacyFormattedText.Width),
+		return new Size(
+			Math.Max(_formattedText.Width, _privacyFormattedText.Width),
 			Math.Max(_formattedText.Height, _privacyFormattedText.Height));
 	}
 

--- a/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
+++ b/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Globalization;
 using System.Reactive.Linq;
 using Avalonia;
@@ -41,7 +40,6 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 		if (text != _value)
 		{
 			_value = text;
-			_formattedText = null;
 		}
 
 		base.Realize(factory, selection, model, columnIndex, rowIndex);
@@ -110,7 +108,6 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 	{
 		IsContentVisible = value;
 
-		_formattedText = null;
 		InvalidateMeasure();
 		InvalidateVisual();
 	}

--- a/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
+++ b/WalletWasabi.Fluent/TreeDataGrid/TreeDataGridPrivacyTextCell.cs
@@ -12,13 +12,13 @@ namespace WalletWasabi.Fluent.TreeDataGrid;
 
 internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 {
-	private IDisposable? Subscription;
-	private bool IsContentVisible = true;
-	private string? _value;
+	private IDisposable? _subscription;
+	private bool _isContentVisible = true;
+	private string? _text;
 	private FormattedText? _formattedText;
+	private FormattedText? _privacyFormattedText;
 	private int _numberOfPrivacyChars;
-
-	public string? Text => IsContentVisible ? _value : new string('#', _value is not null ? _numberOfPrivacyChars : 0);
+	private string? _privacyText;
 
 	protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
 	{
@@ -30,31 +30,44 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 		}
 	}
 
-	public override void Realize(TreeDataGridElementFactory factory, ITreeDataGridSelectionInteraction? selection, ICell model, int columnIndex, int rowIndex)
+	public override void Realize(TreeDataGridElementFactory factory, ITreeDataGridSelectionInteraction? selection,
+		ICell model, int columnIndex, int rowIndex)
 	{
 		var privacyTextCell = (PrivacyTextCell)model;
 		var text = privacyTextCell.Value;
 
 		_numberOfPrivacyChars = privacyTextCell.NumberOfPrivacyChars;
 
-		if (text != _value)
+		if (text != null)
 		{
-			_value = text;
+			_text = text;
+			_privacyText = new string('#', _numberOfPrivacyChars);
 		}
 
 		base.Realize(factory, selection, model, columnIndex, rowIndex);
 	}
 
+	public override void Unrealize()
+	{
+		_formattedText = null;
+		base.Unrealize();
+	}
+
 	public override void Render(DrawingContext context)
 	{
-		if (_formattedText is not null)
+		context.FillRectangle(Brushes.Transparent, new Rect(new Point(), DesiredSize));
+
+		var formattedText = _isContentVisible ? _formattedText : _privacyFormattedText;
+
+		if (formattedText is not null)
 		{
-			var r = Bounds.CenterRect(new Rect(new Point(0, 0), new Size(_formattedText.Width, _formattedText.Height)));
+			var r = Bounds.CenterRect(new Rect(new Point(0, 0), new Size(formattedText.Width, formattedText.Height)));
 			if (Foreground is { })
 			{
-				_formattedText.SetForegroundBrush(Foreground);
+				formattedText.SetForegroundBrush(Foreground);
 			}
-			context.DrawText(_formattedText, new Point(0, r.Position.Y));
+
+			context.DrawText(formattedText, new Point(0, r.Position.Y));
 		}
 	}
 
@@ -62,9 +75,9 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 	{
 		base.OnAttachedToVisualTree(e);
 
-		Subscription = PrivacyModeHelper.DelayedRevealAndHide(
-			this.WhenAnyValue(x => x.IsPointerOver),
-			Services.UiConfig.WhenAnyValue(x => x.PrivacyMode))
+		_subscription = PrivacyModeHelper.DelayedRevealAndHide(
+				this.WhenAnyValue(x => x.IsPointerOver),
+				Services.UiConfig.WhenAnyValue(x => x.PrivacyMode))
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Do(SetContentVisible)
 			.Subscribe();
@@ -72,43 +85,47 @@ internal class TreeDataGridPrivacyTextCell : TreeDataGridCell
 
 	protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
 	{
-		Subscription?.Dispose();
-		Subscription = null;
+		_subscription?.Dispose();
+		_subscription = null;
 	}
 
 	protected override Size MeasureOverride(Size availableSize)
 	{
-		if (string.IsNullOrWhiteSpace(Text))
+		if (string.IsNullOrWhiteSpace(_text))
 		{
 			return default;
 		}
 
-		if (availableSize.Width != _formattedText?.MaxTextWidth
-		    || availableSize.Height != _formattedText?.MaxTextHeight)
+		if (_formattedText is null || _privacyFormattedText is null)
 		{
-			_formattedText = new FormattedText(
-				Text,
-				CultureInfo.CurrentCulture,
-				FlowDirection.LeftToRight,
-				new Typeface(FontFamily, FontStyle, FontWeight),
-				FontSize,
-				null)
-			{
-				TextAlignment = TextAlignment.Left,
-				MaxTextHeight = availableSize.Height,
-				MaxTextWidth = availableSize.Width,
-				Trimming = TextTrimming.None
-			};
+			_formattedText = CreateFormattedText(availableSize, _text);
+			_privacyFormattedText = CreateFormattedText(availableSize, _privacyText);
 		}
 
-		return new Size(_formattedText.Width, _formattedText.Height);
+		return new Size(Math.Max(_formattedText.Width, _privacyFormattedText.Width),
+			Math.Max(_formattedText.Height, _privacyFormattedText.Height));
 	}
 
 	private void SetContentVisible(bool value)
 	{
-		IsContentVisible = value;
-
-		InvalidateMeasure();
+		_isContentVisible = value;
 		InvalidateVisual();
+	}
+
+	private FormattedText CreateFormattedText(Size availableSize, string? text)
+	{
+		return new FormattedText(
+			text ?? string.Empty,
+			CultureInfo.CurrentCulture,
+			FlowDirection.LeftToRight,
+			new Typeface(FontFamily, FontStyle, FontWeight),
+			FontSize,
+			null)
+		{
+			TextAlignment = TextAlignment.Left,
+			MaxTextHeight = availableSize.Height,
+			MaxTextWidth = availableSize.Width,
+			Trimming = TextTrimming.None
+		};
 	}
 }


### PR DESCRIPTION
In the ui refresh branch, hovering over a cell and showing a tooltip, causes the text to be lost when the tooltip closes.

Its because the formatted text isn't cached, and was designed to only ever have a single render call for every measure.

That's not always the case.

This fixes it.