### PR TITLE
Offline Psbt Workflow compatible

### DIFF
--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -51,6 +51,19 @@ public class HwiEnumerateEntry
 			_ => WalletType.Hardware
 		};
 
+	public bool IsOfflinePsbtCompatible()
+	{
+		return Model switch
+		{
+			HardwareWalletModels.Coldcard or HardwareWalletModels.Coldcard_Simulator => true,
+			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => false,
+			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator => false,
+			HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator => true,
+			HardwareWalletModels.Jade => false,
+			_ => false
+		};
+	}
+
 	public bool IsInitialized()
 	{
 		// Check for error message, too, not only code, because the currently released version doesn't have error code. This can be removed if HWI > 1.0.1 version is updated.

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -51,7 +51,12 @@ public class HwiEnumerateEntry
 			_ => WalletType.Hardware
 		};
 
-	public bool IsOfflinePsbtCompatible()
+
+
+	/// <summary>
+	/// Returns true if the device support offline PSBT signing.
+	/// </summary>
+	public bool IsOfflinePsbtWorkflowCompatible()
 	{
 		return Model switch
 		{

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -60,10 +60,11 @@ public class HwiEnumerateEntry
 	{
 		return Model switch
 		{
-			HardwareWalletModels.Coldcard or HardwareWalletModels.Coldcard_Simulator => true,
+			HardwareWalletModels.Coldcard => true,
 			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => false,
-			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator => false,
-			HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator => true,
+			HardwareWalletModels.Trezor_1 => false,
+			HardwareWalletModels.Trezor_T => true,
+			HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T_Simulator or HardwareWalletModels.Coldcard_Simulator => false,
 			HardwareWalletModels.Jade => false,
 			_ => false
 		};

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -51,8 +51,6 @@ public class HwiEnumerateEntry
 			_ => WalletType.Hardware
 		};
 
-
-
 	/// <summary>
 	/// Returns true if the device support offline PSBT signing.
 	/// </summary>

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -52,7 +52,7 @@ public class HwiEnumerateEntry
 		};
 
 	/// <summary>
-	/// Returns true if the device support offline PSBT signing.
+	/// Returns true if the device supports offline PSBT signing.
 	/// </summary>
 	public bool IsOfflinePsbtWorkflowCompatible()
 	{


### PR DESCRIPTION

# Introduction

Not all Hardware Wallets support offline PSBT via SD card. That is why this PR was created to be able to regulate this in the future.

#Solution
To be able to prepare for this task, I had to go through the datasheet on every device. It is also possible to sign the transaction with PSBT on the other HardwareWallets, but for that, you have to use another external application, which makes PSBT meaningless, because the Hardware Wallet must not be connected to the computer. In this case, it is enough to accept the transaction directly on HarwareWallet while it is connected to the computer.

#Results
- [ ] Ledgers
   - Not supported
- [x] Coldcard
   - Supported
- [ ] Jade
    - Supported the Air gapped PSBT but recently has not implemented in WW
- Trezors
   - [ ] Trezor One
      - Not supported 
   - [x] Trezor T 
      - Supported