### PR TITLE
[Trivial] Use `Length` check instead of `Any()` for clarity and efficiency

### DIFF
--- a/WalletWasabi.Fluent.Generators/Abstractions/CombinedGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/Abstractions/CombinedGenerator.cs
@@ -18,7 +18,7 @@ internal abstract class CombinedGenerator : ISourceGenerator
 			StaticFileGenerators.SelectMany(x => x.Generate())
 								.ToArray();
 
-		if (files.Any())
+		if (files.Length != 0)
 		{
 			context.RegisterForPostInitialization(ctx =>
 			{

--- a/WalletWasabi.Fluent.Generators/Generators/UiContextConstructorGenerator.cs
+++ b/WalletWasabi.Fluent.Generators/Generators/UiContextConstructorGenerator.cs
@@ -85,7 +85,7 @@ internal class UiContextConstructorGenerator : GeneratorStep<ClassDeclarationSyn
 					.Select(x => x.Identifier.ValueText)
 					.ToArray();
 
-				var hasConstructorArgs = constructorArgs.Any();
+				var hasConstructorArgs = constructorArgs.Length != 0;
 				var constructorArgsString = string.Join(",", constructorArgs);
 				var constructorString = hasConstructorArgs
 					? $": this({constructorArgsString})"

--- a/WalletWasabi.Fluent/Controls/PrivacyBar.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/PrivacyBar.axaml.cs
@@ -76,7 +76,7 @@ public class PrivacyBar : ItemsControl
 		var segmentsToEnlarge = rawSegments.Where(x => x.Width < EnlargeThreshold).ToArray();
 		var segmentsToReduce = rawSegments.Except(segmentsToEnlarge).ToArray();
 		var reduceBy = segmentsToEnlarge.Length * EnlargeBy / segmentsToReduce.Length;
-		if (segmentsToEnlarge.Any() && segmentsToReduce.Any() && segmentsToReduce.All(x => x.Width - reduceBy > 0))
+		if (segmentsToEnlarge.Length != 0 && segmentsToReduce.Length != 0 && segmentsToReduce.All(x => x.Width - reduceBy > 0))
 		{
 			rawSegments = rawSegments.Select(x =>
 			{

--- a/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
+++ b/WalletWasabi.Fluent/Helpers/EnumerableExtensions.cs
@@ -24,7 +24,7 @@ public static class EnumerableExtensions
 	{
 		var source = sourceData.ToArray();
 
-		if (!source.Any())
+		if (source.Length == 0)
 		{
 			yield break;
 		}

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
@@ -165,7 +165,7 @@ public class PrivacySuggestionsModel
 		var totalAmount = originalTransaction.CalculateDestinationAmount(transactionInfo.Destination).ToDecimal(MoneyUnit.BTC);
 		FullPrivacySuggestion? fullPrivacySuggestion = null;
 
-		if ((foundNonPrivate || foundSemiPrivate) && allPrivateCoin.Any() &&
+		if ((foundNonPrivate || foundSemiPrivate) && allPrivateCoin.Length != 0 &&
 			TryCreateTransaction(transactionInfo, allPrivateCoin, out var newTransaction, out var isChangeless))
 		{
 			var amountDifference = totalAmount - newTransaction.CalculateDestinationAmount(transactionInfo.Destination).ToDecimal(MoneyUnit.BTC);
@@ -188,7 +188,7 @@ public class PrivacySuggestionsModel
 		}
 
 		var coins = allPrivateCoin.Union(allSemiPrivateCoin).ToArray();
-		if (foundNonPrivate && allSemiPrivateCoin.Any() &&
+		if (foundNonPrivate && allSemiPrivateCoin.Length != 0 &&
 			TryCreateTransaction(transactionInfo, coins, out newTransaction, out isChangeless))
 		{
 			var amountDifference = totalAmount - newTransaction.CalculateDestinationAmount(transactionInfo.Destination).ToDecimal(MoneyUnit.BTC);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/FeeChartViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/FeeChartViewModel.cs
@@ -248,7 +248,7 @@ public partial class FeeChartViewModel : ViewModelBase
 
 		_updatingCurrentValue = true;
 
-		if (satoshiPerByteValues.Any())
+		if (satoshiPerByteValues.Length != 0)
 		{
 			var maxY = satoshiPerByteValues.Max();
 			var minY = satoshiPerByteValues.Min();

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/MempoolMirrorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/MempoolMirrorTests.cs
@@ -73,7 +73,7 @@ public class MempoolMirrorTests
 
 			var txid = await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(network), new Money(0.0004m, MoneyUnit.BTC));
 
-			while (!(await rpc.GetRawMempoolAsync()).Any())
+			while ((await rpc.GetRawMempoolAsync()).Length == 0)
 			{
 				await Task.Delay(50);
 			}
@@ -126,7 +126,7 @@ public class MempoolMirrorTests
 				await rpc.SendRawTransactionAsync(tx);
 			}
 
-			while (!(await rpc.GetRawMempoolAsync()).Any())
+			while ((await rpc.GetRawMempoolAsync()).Length == 0)
 			{
 				await Task.Delay(50);
 			}
@@ -216,7 +216,7 @@ public class MempoolMirrorTests
 			Assert.Equal(rpcMempoolBeforeSend.Length, localMempoolBeforeSend.Count);
 
 			await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(network), spendAmount);
-			while (!(await rpc.GetRawMempoolAsync()).Any())
+			while ((await rpc.GetRawMempoolAsync()).Length == 0)
 			{
 				await Task.Delay(50);
 			}
@@ -227,7 +227,7 @@ public class MempoolMirrorTests
 			Assert.Single(localMempoolAfterSend);
 
 			await rpc.GenerateAsync(1);
-			while ((await rpc.GetRawMempoolAsync()).Any())
+			while ((await rpc.GetRawMempoolAsync()).Length != 0)
 			{
 				await Task.Delay(50);
 			}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinJoinMempoolManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoinJoinMempoolManagerTests.cs
@@ -42,7 +42,7 @@ public class CoinJoinMempoolManagerTests
 			Assert.Equal(rpcMempoolBeforeSend.Length, localMempoolBeforeSend.Count);
 
 			await rpc.SendToAddressAsync(BitcoinFactory.CreateBitcoinAddress(network), spendAmount);
-			while (!(await rpc.GetRawMempoolAsync()).Any())
+			while ((await rpc.GetRawMempoolAsync()).Length == 0)
 			{
 				await Task.Delay(50);
 			}
@@ -60,7 +60,7 @@ public class CoinJoinMempoolManagerTests
 			Assert.Equal(coinjoinTx, coinJoinMempoolManager.CoinJoinIds.Single());
 
 			await rpc.GenerateAsync(1);
-			while ((await rpc.GetRawMempoolAsync()).Any())
+			while ((await rpc.GetRawMempoolAsync()).Length != 0)
 			{
 				await Task.Delay(50);
 			}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -521,7 +521,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					{
 						throw new Exception("All participants finished, but CoinJoin still not in the mempool (no more blame rounds).");
 					}
-					else if (!participantsFinishedSuccessully.Any() && !cts.IsCancellationRequested)
+					else if (participantsFinishedSuccessully.Length == 0 && !cts.IsCancellationRequested)
 					{
 						var exceptions = tasks
 							.Where(x => x.IsFaulted)

--- a/WalletWasabi/Blockchain/TransactionBuilding/TransactionModifierWalletExtensions.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/TransactionModifierWalletExtensions.cs
@@ -166,7 +166,7 @@ public static class TransactionModifierWalletExtensions
 
 		var foreignOutputs = transactionToSpeedUp.GetForeignOutputs(keyManager).OrderByDescending(x => x.TxOut.Value).ToArray();
 
-		if (foreignOutputs.Any())
+		if (foreignOutputs.Length != 0)
 		{
 			// If we have no own output, then we substract the fee from the largest foreign output.
 			var largestForeignOuput = foreignOutputs.First();

--- a/WalletWasabi/Extensions/EnumExtension.cs
+++ b/WalletWasabi/Extensions/EnumExtension.cs
@@ -14,7 +14,7 @@ public static class EnumExtensions
 
 		var attributes = memberInfo.GetCustomAttributes(typeof(T), false);
 
-		return attributes.Any() ? (T)attributes[0] : null;
+		return attributes.Length != 0 ? (T)attributes[0] : null;
 	}
 
 	public static string FriendlyName(this Enum value)

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -226,7 +226,7 @@ public static class NBitcoinExtensions
 		}
 
 		var nodes = parentCounter.Where(x => x.Value == 0).Select(x => x.Key).Distinct().ToArray();
-		while (nodes.Any())
+		while (nodes.Length != 0)
 		{
 			foreach (var node in nodes)
 			{

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -147,7 +147,7 @@ public static class RPCClientExtensions
 
 	private static FeeRateByConfirmationTarget GetFeeEstimationsFromMempoolInfo(MemPoolInfo mempoolInfo)
 	{
-		if (mempoolInfo.Histogram is null || !mempoolInfo.Histogram.Any())
+		if (mempoolInfo.Histogram is null || mempoolInfo.Histogram.Length == 0)
 		{
 			return new FeeRateByConfirmationTarget(0);
 		}

--- a/WalletWasabi/Helpers/Guard.cs
+++ b/WalletWasabi/Helpers/Guard.cs
@@ -78,7 +78,7 @@ public static class Guard
 	{
 		NotNull(parameterName, value);
 
-		if (!value.Any())
+		if (value.Length == 0)
 		{
 			throw new ArgumentException("Parameter cannot be empty.", parameterName);
 		}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -135,7 +135,7 @@ public partial class Arena : PeriodicRunner
 			{
 				await foreach (var offendingAlices in CheckTxoSpendStatusAsync(round, cancel).ConfigureAwait(false))
 				{
-					if (offendingAlices.Any())
+					if (offendingAlices.Length != 0)
 					{
 						round.Alices.RemoveAll(x => offendingAlices.Contains(x));
 					}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -62,7 +62,7 @@ public class CoinJoinCoinSelector
 			.ToArray();
 
 		// Sanity check.
-		if (!filteredCoins.Any())
+		if (filteredCoins.Length == 0)
 		{
 			Logger.LogDebug("No suitable coins for this round.");
 			return ImmutableList<TCoin>.Empty;

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -299,7 +299,7 @@ public class CoinJoinManager : BackgroundService
 			.ToArray();
 
 		// If there is no available coin candidates, then don't mix.
-		if (!coinCandidates.Any())
+		if (coinCandidates.Length == 0)
 		{
 			throw new CoinJoinClientException(CoinjoinError.NoCoinsEligibleToMix, "No candidate coins available to mix.");
 		}
@@ -316,7 +316,7 @@ public class CoinJoinManager : BackgroundService
 			.Except(excludedCoins)
 			.ToArray();
 
-		if (!coinCandidates.Any())
+		if (coinCandidates.Length == 0)
 		{
 			var anyNonPrivateUnconfirmed = unconfirmedCoins.Any(x => !x.IsPrivate(walletToStart.AnonScoreTarget));
 			var anyNonPrivateImmature = immatureCoins.Any(x => !x.IsPrivate(walletToStart.AnonScoreTarget));

--- a/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
+++ b/WalletWasabi/WabiSabi/WabiSabiCoordinator.cs
@@ -110,7 +110,7 @@ public class WabiSabiCoordinator : BackgroundService
 		var outpointsToBan = block.Transactions
 			.Where(tx => !CoinJoinIdStore.Contains(tx.GetHash()))  // We don't ban coinjoin outputs
 			.Select(tx => (Tx: tx, BannedInputs: BannedInputs(tx)))
-			.Where(x => x.BannedInputs.Any())
+			.Where(x => x.BannedInputs.Length != 0)
 			.SelectMany(x => x.Tx.Outputs.Select((_, i) => (new OutPoint(x.Tx, i), x.BannedInputs)));
 
 		foreach (var (outpoint, ancestors) in outpointsToBan)


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1860

> To determine whether a collection type has any elements, it's more efficient and clearer to use the `Length`, `Count`, or `IsEmpty` (if possible) properties than to call the [Enumerable.Any](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.any) method.
>
> `Any()`, which is an extension method, uses language integrated query (LINQ). It's more efficient to rely on the collection's own properties, and it also clarifies intent.