### PR TITLE
Double spending tx are considered replacement

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -247,18 +247,18 @@ public class TransactionProcessorTests
 		var keys = transactionProcessor.KeyManager.GetKeys().ToArray();
 
 		// An unconfirmed segwit transaction for us
-		var tx0 = CreateCreditingTransaction(keys[0].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit), Money.Coins(1.0m));
+		var tx0 = CreateCreditingTransaction(keys[0].GetAssumedScriptPubKey(), Money.Coins(1.0m));
 
 		var createdCoin = tx0.Transaction.Outputs.AsCoins().First();
 
 		// Spend the received coin
-		var tx1 = CreateSpendingTransaction(createdCoin, keys[1].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
+		var tx1 = CreateSpendingTransaction(createdCoin, keys[1].GetAssumedScriptPubKey());
 
 		// Spend the same coin again
-		var tx2 = CreateSpendingTransaction(createdCoin, keys[2].PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit));
+		var tx2 = CreateSpendingTransaction(createdCoin, keys[2].GetAssumedScriptPubKey());
 		var relevant = transactionProcessor.Process(tx0, tx1, tx2).Last();
 
-		Assert.False(relevant.IsNews);
+		Assert.True(relevant.IsNews);
 		Assert.Single(transactionProcessor.Coins, coin => !coin.IsSpent());
 		Assert.Single(transactionProcessor.Coins.AsAllCoinsView(), coin => coin.IsSpent());
 
@@ -267,7 +267,7 @@ public class TransactionProcessorTests
 		var mempool = transactionProcessor.TransactionStore.MempoolStore.GetTransactions();
 		Assert.Equal(2, mempool.Count);
 		Assert.Equal(tx0, mempool.First());
-		Assert.Equal(tx1, mempool.Last());
+		Assert.Equal(tx2, mempool.Last());
 	}
 
 	[Fact]

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -148,7 +148,7 @@ public class TransactionProcessor
 				// if the received transaction is spending at least one input already
 				// spent by a previous unconfirmed transaction signaling RBF then it is not a double
 				// spending transaction but a replacement transaction.
-				var isReplacementTx = doubleSpentSpenders.Any(x => x.Transaction.IsRBF);
+				var isReplacementTx = doubleSpentSpenders.Any();
 				if (isReplacementTx)
 				{
 					// Undo the replaced transaction by removing the coins it created (if other coin
@@ -159,10 +159,6 @@ public class TransactionProcessor
 
 					result.ReplacedCoins.AddRange(replaced);
 					result.RestoredCoins.AddRange(restored);
-				}
-				else if (doubleSpentSpenders.Count > 0)
-				{
-					return result;
 				}
 			}
 			else // new confirmation always enjoys priority


### PR DESCRIPTION
After this PR the unconfirmed double spending transactions are considered replacements. Latest seen transactions are considered replacements for those already known independently of the fees.