### PR TITLE
Remove Taproot-only compact filters

### DIFF
--- a/WalletWasabi.Backend/Controllers/BatchController.cs
+++ b/WalletWasabi.Backend/Controllers/BatchController.cs
@@ -38,7 +38,6 @@ public class BatchController : ControllerBase
 	[ResponseCache(Duration = 60)]
 	public async Task<IActionResult> GetSynchronizeAsync(
 		[FromQuery, Required] string bestKnownBlockHash,
-		[FromQuery] string indexType = "segwittaproot",
 		CancellationToken cancellationToken = default)
 	{
 		if (!uint256.TryParse(bestKnownBlockHash, out var knownHash))
@@ -46,13 +45,8 @@ public class BatchController : ControllerBase
 			return BadRequest($"Invalid {nameof(bestKnownBlockHash)}.");
 		}
 
-		if (!BlockchainController.TryGetIndexer(indexType, out var indexer))
-		{
-			return BadRequest("Not supported index type.");
-		}
-
 		var numberOfFilters = Global.Config.Network == Network.Main ? 1000 : 10000;
-		(Height bestHeight, IEnumerable<FilterModel> filters) = indexer.GetFilterLinesExcluding(knownHash, numberOfFilters, out bool found);
+		(Height bestHeight, IEnumerable<FilterModel> filters) = Global.IndexBuilderService.GetFilterLinesExcluding(knownHash, numberOfFilters, out bool found);
 
 		var response = new SynchronizeResponse { Filters = Enumerable.Empty<FilterModel>(), BestHeight = bestHeight };
 

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -285,7 +285,7 @@ public class BlockchainController : ControllerBase
 	[ProducesResponseType(400)]
 	[ProducesResponseType(404)]
 	[ResponseCache(Duration = 60)]
-	public IActionResult GetFilters([FromQuery, Required] string bestKnownBlockHash, [FromQuery, Required] int count, [FromQuery] string? indexType = null)
+	public IActionResult GetFilters([FromQuery, Required] string bestKnownBlockHash, [FromQuery, Required] int count)
 	{
 		if (count <= 0)
 		{
@@ -294,12 +294,7 @@ public class BlockchainController : ControllerBase
 
 		var knownHash = new uint256(bestKnownBlockHash);
 
-		if (!TryGetIndexer(indexType, out var indexer))
-		{
-			return BadRequest("Not supported index type.");
-		}
-
-		(Height bestHeight, IEnumerable<FilterModel> filters) = indexer.GetFilterLinesExcluding(knownHash, count, out bool found);
+		var (bestHeight, filters) = Global.IndexBuilderService.GetFilterLinesExcluding(knownHash, count, out bool found);
 
 		if (!found)
 		{
@@ -318,30 +313,6 @@ public class BlockchainController : ControllerBase
 		};
 
 		return Ok(response);
-	}
-
-	internal bool TryGetIndexer(string? indexType, [NotNullWhen(true)] out IndexBuilderService? indexer)
-	{
-		indexer = null;
-		if (indexType is null || indexType.Equals("segwittaproot", StringComparison.OrdinalIgnoreCase))
-		{
-			indexer = Global.SegwitTaprootIndexBuilderService;
-		}
-		else if (indexType.Equals("taproot", StringComparison.OrdinalIgnoreCase))
-		{
-			indexer = Global.TaprootIndexBuilderService;
-		}
-		else
-		{
-			return false;
-		}
-
-		if (indexer is null)
-		{
-			throw new NotSupportedException("This is impossible.");
-		}
-
-		return true;
 	}
 
 	[HttpGet("status")]
@@ -370,20 +341,11 @@ public class BlockchainController : ControllerBase
 	{
 		StatusResponse status = new();
 
-		// Select indexer that's behind the most.
-		var i1 = Global.SegwitTaprootIndexBuilderService;
-		var i2 = Global.TaprootIndexBuilderService;
-		if (i1 is null || i2 is null)
-		{
-			throw new NotSupportedException("This is impossible.");
-		}
-		var indexer = i1.LastFilterBuildTime > i2.LastFilterBuildTime ? i2 : i1;
-
 		// Updating the status of the filters.
-		if (DateTimeOffset.UtcNow - indexer.LastFilterBuildTime > FilterTimeout)
+		if (DateTimeOffset.UtcNow - Global.IndexBuilderService.LastFilterBuildTime > FilterTimeout)
 		{
 			// Checking if the last generated filter is created for one of the last two blocks on the blockchain.
-			var lastFilter = indexer.GetLastFilter();
+			var lastFilter = Global.IndexBuilderService.GetLastFilter();
 			var lastFilterHash = lastFilter.Header.BlockHash;
 			var bestHash = await RpcClient.GetBestBlockHashAsync(cancellationToken);
 			var lastBlockHeader = await RpcClient.GetBlockHeaderAsync(bestHash, cancellationToken);

--- a/WalletWasabi.Backend/Global.cs
+++ b/WalletWasabi.Backend/Global.cs
@@ -42,13 +42,9 @@ public class Global : IDisposable
 		HostedServices.Register<BlockNotifier>(() => new BlockNotifier(TimeSpan.FromSeconds(7), rpcClient, P2pNode), "Block Notifier");
 
 		// Initialize index building
-		// Initialize index building
 		var indexBuilderServiceDir = Path.Combine(DataDir, "IndexBuilderService");
-		var segwitTaprootIndexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{RpcClient.Network}.dat");
-		var taprootIndexFilePath = Path.Combine(indexBuilderServiceDir, $"TaprootIndex{RpcClient.Network}.dat");
-
-		SegwitTaprootIndexBuilderService = new(IndexType.SegwitTaproot, RpcClient, HostedServices.Get<BlockNotifier>(), segwitTaprootIndexFilePath);
-		TaprootIndexBuilderService = new(IndexType.Taproot, RpcClient, HostedServices.Get<BlockNotifier>(), taprootIndexFilePath);
+		var indexFilePath = Path.Combine(indexBuilderServiceDir, $"Index{RpcClient.Network}.dat");
+		IndexBuilderService = new(IndexType.SegwitTaproot, RpcClient, HostedServices.Get<BlockNotifier>(), indexFilePath);
 
 		MempoolMirror = new MempoolMirror(TimeSpan.FromSeconds(21), RpcClient, P2pNode);
 		CoinJoinMempoolManager = new CoinJoinMempoolManager(CoinJoinIdStore, MempoolMirror);
@@ -62,8 +58,7 @@ public class Global : IDisposable
 
 	public HostedServices HostedServices { get; }
 
-	public IndexBuilderService SegwitTaprootIndexBuilderService { get; }
-	public IndexBuilderService TaprootIndexBuilderService { get; }
+	public IndexBuilderService IndexBuilderService { get; }
 
 	private HttpClient CoinVerifierHttpClient { get; }
 	private IHttpClientFactory HttpClientFactory { get; }
@@ -137,10 +132,8 @@ public class Global : IDisposable
 
 		await HostedServices.StartAllAsync(cancel);
 
-		SegwitTaprootIndexBuilderService.Synchronize();
-		Logger.LogInfo($"{nameof(SegwitTaprootIndexBuilderService)} is successfully initialized and started synchronization.");
-		TaprootIndexBuilderService.Synchronize();
-		Logger.LogInfo($"{nameof(TaprootIndexBuilderService)} is successfully initialized and started synchronization.");
+		IndexBuilderService.Synchronize();
+		Logger.LogInfo($"{nameof(IndexBuilderService)} is successfully initialized and started synchronization.");
 	}
 
 	private async Task AssertRpcNodeFullyInitializedAsync(CancellationToken cancellationToken)
@@ -221,11 +214,8 @@ public class Global : IDisposable
 
 	private async Task DisposeAsync()
 	{
-		await SegwitTaprootIndexBuilderService.StopAsync().ConfigureAwait(false);
-		Logger.LogInfo($"{nameof(SegwitTaprootIndexBuilderService)} is stopped.");
-
-		await TaprootIndexBuilderService.StopAsync().ConfigureAwait(false);
-		Logger.LogInfo($"{nameof(TaprootIndexBuilderService)} is stopped.");
+		await IndexBuilderService.StopAsync().ConfigureAwait(false);
+		Logger.LogInfo($"{nameof(IndexBuilderService)} is stopped.");
 
 		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(21));
 		await HostedServices.StopAllAsync(cts.Token).ConfigureAwait(false);

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -184,32 +184,14 @@ public class BackendTests : IClassFixture<RegTestFixture>
 
 		var requestUri = "btc/Blockchain/status";
 
-		var segwitTaprootIndexBuilderService = global.SegwitTaprootIndexBuilderService;
-		var taprootIndexBuilderService = global.TaprootIndexBuilderService;
-		if (segwitTaprootIndexBuilderService is null || taprootIndexBuilderService is null)
-		{
-			throw new InvalidOperationException("Index builders can't be null.");
-		}
-
 		try
 		{
-			segwitTaprootIndexBuilderService.Synchronize();
-			taprootIndexBuilderService.Synchronize();
+			global.IndexBuilderService.Synchronize();
 
 			// Test initial synchronization.
 			var times = 0;
 			uint256 firstHash = await rpc.GetBlockHashAsync(0);
-			while (segwitTaprootIndexBuilderService.GetFilterLinesExcluding(firstHash, 101, out _).filters.Count() != 101)
-			{
-				if (times > 500) // 30 sec
-				{
-					throw new TimeoutException($"{nameof(IndexBuilderService)} test timed out.");
-				}
-				await Task.Delay(100);
-				times++;
-			}
-
-			while (taprootIndexBuilderService.GetFilterLinesExcluding(firstHash, 101, out _).filters.Count() != 101)
+			while (global.IndexBuilderService.GetFilterLinesExcluding(firstHash, 101, out _).filters.Count() != 101)
 			{
 				if (times > 500) // 30 sec
 				{
@@ -228,13 +210,7 @@ public class BackendTests : IClassFixture<RegTestFixture>
 				Assert.True(resp.FilterCreationActive);
 
 				// Simulate an unintended stop
-				await segwitTaprootIndexBuilderService.StopAsync();
-				segwitTaprootIndexBuilderService = null;
-
-				// Simulate an unintended stop
-				await taprootIndexBuilderService.StopAsync();
-				taprootIndexBuilderService = null;
-
+				await global.IndexBuilderService.StopAsync();
 				await rpc.GenerateAsync(1);
 			}
 
@@ -251,16 +227,8 @@ public class BackendTests : IClassFixture<RegTestFixture>
 				var blockchainController = RegTestFixture.BackendHost.Services.GetRequiredService<BlockchainController>();
 				blockchainController.Cache.Remove($"{nameof(BlockchainController.GetStatusAsync)}");
 
-				segwitTaprootIndexBuilderService = global.SegwitTaprootIndexBuilderService;
-				taprootIndexBuilderService = global.TaprootIndexBuilderService;
-				if (segwitTaprootIndexBuilderService is null || taprootIndexBuilderService is null)
-				{
-					throw new InvalidOperationException("Index builders can't be null.");
-				}
-
 				// Set back the time to trigger timeout in BlockchainController.GetStatusAsync.
-				segwitTaprootIndexBuilderService.LastFilterBuildTime = DateTimeOffset.UtcNow - BlockchainController.FilterTimeout;
-				taprootIndexBuilderService.LastFilterBuildTime = DateTimeOffset.UtcNow - BlockchainController.FilterTimeout;
+				global.IndexBuilderService.LastFilterBuildTime = DateTimeOffset.UtcNow - BlockchainController.FilterTimeout;
 			}
 
 			// Third request.
@@ -274,14 +242,7 @@ public class BackendTests : IClassFixture<RegTestFixture>
 		}
 		finally
 		{
-			if (segwitTaprootIndexBuilderService is { })
-			{
-				await segwitTaprootIndexBuilderService.StopAsync();
-			}
-			if (taprootIndexBuilderService is { })
-			{
-				await taprootIndexBuilderService.StopAsync();
-			}
+			await global.IndexBuilderService.StopAsync();
 		}
 	}
 


### PR DESCRIPTION
Taproot-only compact filters were created to help Trezor suite development/testing but they are not using them, however the generation of these blocks has a cost that we are paying.