### PR TITLE
Try not to use unconfirmed coins when BnB.

### DIFF
--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
@@ -268,9 +268,11 @@ public class PrivacySuggestionsModel
 		var coinsInCoinJoin = _cjManager.CoinsInCriticalPhase[_wallet.WalletId];
 		coinsToUse = spentCoins.Any(coinsInCoinJoin.Contains) ? coinsToUse : coinsToUse.Except(coinsInCoinJoin).ToImmutableArray();
 
-		// If the original transaction couldn't avoid unconfirmed coins, BnB can use them too. Otherwise exclude them.
-		var coinsUnconfirmed = _wallet.GetAllCoins().Where(c => !c.Confirmed);
-		coinsToUse = spentCoins.Any(coinsUnconfirmed.Contains) ? coinsToUse : coinsToUse.Except(coinsUnconfirmed).ToImmutableArray();
+		// If the original transaction only using confirmed coins, BnB can use only them too. Otherwise let unconfirmed oins stay in the list.
+		if (spentCoins.All(x => x.Confirmed))
+		{
+			coinsToUse = coinsToUse.Where(x => x.Confirmed).ToImmutableArray();
+		}
 
 		var suggestions = CreateChangeAvoidanceSuggestionsAsync(info, coinsToUse, maxInputCount, usdExchangeRate, linkedCts.Token).ConfigureAwait(false);
 

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
@@ -259,14 +259,14 @@ public class PrivacySuggestionsModel
 		// Only allow to create 1 more input with BnB. This accounts for the change created.
 		int maxInputCount = transaction.SpentCoins.Count() + 1;
 
-		ImmutableList<SmartCoin> coinsToExclude = _cjManager.CoinsInCriticalPhase[_wallet.WalletId];
+		var coinsToExclude = _cjManager.CoinsInCriticalPhase[_wallet.WalletId].Concat(_wallet.GetAllCoins().Where(c => !c.Confirmed)).ToHashSet();
 
 		var pockets = _wallet.GetPockets();
 		var spentCoins = transaction.SpentCoins;
 		var usedPockets = pockets.Where(x => x.Coins.Any(coin => spentCoins.Contains(coin)));
 		ImmutableArray<SmartCoin> coinsToUse = usedPockets.SelectMany(x => x.Coins).ToImmutableArray();
 
-		// If the original transaction couldn't avoid the CJing coins, BnB can use them too. Otherwise exclude them.
+		// If the original transaction couldn't avoid the CJing or unconfirmed coins, BnB can use them too. Otherwise exclude them.
 		coinsToUse = spentCoins.Any(coinsToExclude.Contains) ? coinsToUse : coinsToUse.Except(coinsToExclude).ToImmutableArray();
 
 		var suggestions = CreateChangeAvoidanceSuggestionsAsync(info, coinsToUse, maxInputCount, usdExchangeRate, linkedCts.Token).ConfigureAwait(false);


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/11951

I used the same logic as used for coins in the critical cj phase which is the following currently:

- The pocket selector and coin-selector create an initial tx. 
- That is the tx, which is shown to the user on the tx preview dialog. 
- BnB checks if the initial tx includes critical coins, if yes then it is allowed to use them in BnB. If the initial tx is not using critical coins, then BnB won't use them either.

This PR adds the same behavior regarding unconfirmed coins. 