### PR TITLE
[VDG] Settings: update Dust Threshold tooltip

### DIFF
--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -47,7 +47,7 @@
     </DockPanel>
 
     <StackPanel Spacing="10"
-                ToolTip.Tip="Coins under the dust threshold won't appear.">
+                ToolTip.Tip="Coins received from others to already used addresses won't appear below this amount. To prevent potential dust attacks.">
       <TextBlock Text="Dust Threshold" />
       <controls:CurrencyEntryBox Text="{Binding DustThreshold}" CurrencyCode="BTC" />
     </StackPanel>


### PR DESCRIPTION
Roland noticed that the tooltip was outdated with the old logic, since https://github.com/zkSNACKs/WalletWasabi/pull/10046 