### PR TITLE
Move EnsureHeightsAreAtLeastSegWitActivation to Wallet.Initialize

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -211,9 +211,6 @@ public class Global
 					// Make sure that TurboSyncHeight is not higher than BestHeight
 					WalletManager.EnsureTurboSyncHeightConsistency();
 
-					// Make sure that the heights of all wallet are at least SegWit activation.
-					WalletManager.EnsureHeightsAreAtLeastSegWitActivation();
-
 					// Make sure that the height of the wallets will not be better than the current height of the filters.
 					WalletManager.SetMaxBestHeight(BitcoinStore.SmartHeaderChain.TipHeight);
 				}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -272,6 +272,8 @@ public class Wallet : BackgroundService, IWallet
 
 		try
 		{
+			EnsureHeightsAreAtLeastSegWitActivation();
+
 			TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;
 			BitcoinStore.MempoolService.TransactionReceived += Mempool_TransactionReceived;
 			BitcoinStore.IndexStore.NewFilters += IndexDownloader_NewFiltersAsync;
@@ -587,5 +589,19 @@ public class Wallet : BackgroundService, IWallet
 		}
 
 		KeyManager.ToFile();
+	}
+
+	private void EnsureHeightsAreAtLeastSegWitActivation()
+	{
+		var startingSegwitHeight = new Height(SmartHeader.GetStartingHeader(Network, IndexType.SegwitTaproot).Height);
+		if (startingSegwitHeight > KeyManager.GetBestHeight(SyncType.Complete))
+		{
+			KeyManager.SetBestHeight(startingSegwitHeight);
+		}
+
+		if (startingSegwitHeight > KeyManager.GetBestHeight(SyncType.Turbo))
+		{
+			KeyManager.SetBestTurboSyncHeight(startingSegwitHeight);
+		}
 	}
 }

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -505,23 +505,6 @@ public class WalletManager : IWalletProvider
 		}
 	}
 
-	public void EnsureHeightsAreAtLeastSegWitActivation()
-	{
-		foreach (var km in GetWallets(refreshWalletList: false).Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))
-		{
-			var startingSegwitHeight = new Height(SmartHeader.GetStartingHeader(Network, IndexType.SegwitTaproot).Height);
-			if (startingSegwitHeight > km.GetBestHeight(SyncType.Complete))
-			{
-				km.SetBestHeight(startingSegwitHeight);
-			}
-
-			if (startingSegwitHeight > km.GetBestHeight(SyncType.Turbo))
-			{
-				km.SetBestTurboSyncHeight(startingSegwitHeight);
-			}
-		}
-	}
-
 	public void SetMaxBestHeight(uint bestHeight)
 	{
 		foreach (var km in GetWallets(refreshWalletList: false).Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))


### PR DESCRIPTION
Fixes #12278 once and for all

The idea is that:
- We never want height to be lower than segwit activation before processing filters
- So it must before `IndexDownloader_NewFiltersAsync` (that was the first issue encountered by @molnard) and before `LoadWalletState`, even when the wallet is created/recovered (second issue encountered by @MarnixCroes)
- By putting it in the `Initialize`, it covers every case.

There is an alternative where we never allow BlockchainState.Height to be lower than the segwit activation height, but it would have been harder to review