### PR TITLE
Disable `KeywordsMustBeSpacedCorrectly` CodeFactor rule

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -721,7 +721,7 @@
         </Rule>
         <Rule Name="KeywordsMustBeSpacedCorrectly">
           <RuleSettings>
-            <BooleanProperty Name="Enabled">True</BooleanProperty>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
           </RuleSettings>
         </Rule>
         <Rule Name="CommasMustBeSpacedCorrectly">


### PR DESCRIPTION
It's annoying.

Examples: 
<img width="719" alt="image" src="https://github.com/zkSNACKs/WalletWasabi/assets/45069029/fa2bb2bd-19b0-460f-85ed-081dd6500246">


