### PR TITLE
Fixing large transaction inputs timeout

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -23,14 +23,15 @@ internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 		{
 			var client = new HwiClient(Wallet.Network);
 
-			int baseTimeoutMinutes = 3;
-			int additionalTimeoutPer10Inputs = 1; // Example: 1 minute extra for every 10 inputs
+			// Define the base timeout as a TimeSpan
+			TimeSpan baseTimeout = TimeSpan.FromMinutes(3);
+			// Define the additional timeout increment as a TimeSpan for every 10 inputs
+			TimeSpan additionalTimeoutPer10Inputs = TimeSpan.FromMinutes(1);
 			int inputCount = transactionAuthorizationInfo.Transaction.WalletInputs.Count;
 
-			// Calculate total timeout
-			int totalTimeoutMinutes = baseTimeoutMinutes + inputCount / 10 * additionalTimeoutPer10Inputs;
-
-			using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(totalTimeoutMinutes));
+			// Calculate total timeout as a TimeSpan
+			TimeSpan totalTimeout = baseTimeout + TimeSpan.FromMinutes((inputCount / 10) * additionalTimeoutPer10Inputs.TotalMinutes);
+			using var cts = new CancellationTokenSource(totalTimeout);
 
 			var signedPsbt = await client.SignTxAsync(
 				Wallet.KeyManager.MasterFingerprint!.Value,

--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -43,7 +43,7 @@ internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 		}
 		catch (Exception ex)
 		{
-			//TODO: In Coldcard case, the error could be to higher fee rate, so we should ask the user to lower it.
+			// TODO: In Coldcard case, the error could be to higher fee rate, so we should ask the user to lower it.
 			Logger.LogError(ex);
 			return false;
 		}

--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -45,7 +45,6 @@ internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 		}
 		catch (Exception ex)
 		{
-			// TODO: In Coldcard case, the error could be to higher fee rate, so we should ask the user to lower it.
 			Logger.LogError(ex);
 			return false;
 		}

--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -22,15 +22,13 @@ internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 		try
 		{
 			var client = new HwiClient(Wallet.Network);
-
-			// Define the base timeout as a TimeSpan.
+			
 			TimeSpan baseTimeout = TimeSpan.FromMinutes(3);
 
 			// Define the additional timeout increment as a TimeSpan for every 10 inputs.
 			TimeSpan additionalTimeoutPer10Inputs = TimeSpan.FromMinutes(1);
 			int inputCount = transactionAuthorizationInfo.Transaction.WalletInputs.Count;
-
-			// Calculate total timeout as a TimeSpan.
+			
 			TimeSpan totalTimeout = baseTimeout + TimeSpan.FromMinutes((inputCount / 10) * additionalTimeoutPer10Inputs.TotalMinutes);
 			using var cts = new CancellationTokenSource(totalTimeout);
 

--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -25,6 +25,7 @@ internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 
 			// Define the base timeout as a TimeSpan.
 			TimeSpan baseTimeout = TimeSpan.FromMinutes(3);
+
 			// Define the additional timeout increment as a TimeSpan for every 10 inputs.
 			TimeSpan additionalTimeoutPer10Inputs = TimeSpan.FromMinutes(1);
 			int inputCount = transactionAuthorizationInfo.Transaction.WalletInputs.Count;

--- a/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HardwareWalletModel.cs
@@ -23,13 +23,13 @@ internal class HardwareWalletModel : WalletModel, IHardwareWalletModel
 		{
 			var client = new HwiClient(Wallet.Network);
 
-			// Define the base timeout as a TimeSpan
+			// Define the base timeout as a TimeSpan.
 			TimeSpan baseTimeout = TimeSpan.FromMinutes(3);
-			// Define the additional timeout increment as a TimeSpan for every 10 inputs
+			// Define the additional timeout increment as a TimeSpan for every 10 inputs.
 			TimeSpan additionalTimeoutPer10Inputs = TimeSpan.FromMinutes(1);
 			int inputCount = transactionAuthorizationInfo.Transaction.WalletInputs.Count;
 
-			// Calculate total timeout as a TimeSpan
+			// Calculate total timeout as a TimeSpan.
 			TimeSpan totalTimeout = baseTimeout + TimeSpan.FromMinutes((inputCount / 10) * additionalTimeoutPer10Inputs.TotalMinutes);
 			using var cts = new CancellationTokenSource(totalTimeout);
 


### PR DESCRIPTION
fixes: #12090

When we send transactions with many inputs to HW, sending the transaction to the device takes longer than usual, so I changed the timeout to dynamic.

Opinion:
A transaction with 1 input takes about 7-10 seconds
For 2 inputs, this number is 14-19 seconds

The current default timeout was 3 minutes. So if, say, in the case of 10 inputs, the number is about 100 seconds, given a safety margin, this should be good.