### PR TITLE
BitBox02 implement

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -22,6 +22,7 @@ This document lists all the officially supported software and devices by Wasabi 
 - Ledger Nano X
 - Trezor Model T
 - Blockstream Jade
+- BitBox02
 
 # Officially Supported Architectures
 

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -548,7 +548,7 @@ public class HwiKatas
 
 
 	[Fact]
-	public async Task BitBox02KataAsync()
+	public async Task BitBox02BtcOnlyKataAsync()
 	{
 		// --- USER INTERACTIONS ---
 		//

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -539,4 +539,90 @@ public class HwiKatas
 		var checkResult = signedTx.Check();
 		Assert.Equal(TransactionCheckResult.Success, checkResult);
 	}
+
+
+	[Fact]
+	public async Task BitBox02KataAsync()
+	{
+		// --- USER INTERACTIONS ---
+		//
+		// Connect and initialize your BitBox02 with the following seed phrase:
+		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// Run this test.
+		// getxpub request by derive 0: approve
+		// getxpub request by derive 1: approve
+		// displayaddress request by device_type: reject
+		// displayaddress request by device_type: approve
+		// displayaddress request by fingerprint: approve
+		// signtx request: reject
+		// signtx request: 2x approve
+		//
+		// --- USER INTERACTIONS ---
+
+		var network = Network.Main;
+		var client = new HwiClient(network);
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		var enumerate = await client.EnumerateAsync(cts.Token);
+		HwiEnumerateEntry entry = Assert.Single(enumerate);
+		Assert.NotNull(entry.Path);
+		Assert.Equal(HardwareWalletModels.BitBox02_BTCOnly, entry.Model);
+		Assert.True(HwiValidationHelper.ValidatePathString(entry.Model, entry.Path));
+		Assert.NotNull(entry.Fingerprint);
+		Assert.Null(entry.Code);
+		Assert.Null(entry.Error);
+		Assert.True(string.IsNullOrEmpty(entry.SerialNumber));
+		Assert.False(entry.NeedsPassphraseSent);
+		Assert.False(entry.NeedsPinSent);
+
+		string devicePath = entry.Path;
+		HardwareWalletModels deviceType = entry.Model;
+		HDFingerprint fingerprint = entry.Fingerprint!.Value;
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+
+		
+		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive("0/0");
+		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive("0/1");
+		// USER: CONFIRM
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		// USER: CONFIRM
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		Assert.NotNull(xpub1);
+		Assert.NotNull(xpub2);
+		Assert.NotEqual(xpub1, xpub2);
+
+		// USER SHOULD REFUSE ACTION
+		await Assert.ThrowsAsync<HwiException>(async () => await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token));
+
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(fingerprint, keyPath2, cts.Token);
+		Assert.NotNull(address1);
+		Assert.NotNull(address2);
+		Assert.NotEqual(address1, address2);
+		var expectedAddress1 = xpub1.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		var expectedAddress2 = xpub2.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+
+		// USER: REFUSE
+		var ex = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token));
+		Assert.Equal(HwiErrorCode.ActionCanceled, ex.ErrorCode);
+
+		// USER: CONFIRM CONFIRM
+		PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token);
+
+		Transaction signedTx = signedPsbt.GetOriginalTransaction();
+		Assert.Equal(Psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
+
+		var checkResult = signedTx.Check();
+		Assert.Equal(TransactionCheckResult.Success, checkResult);
+	}
 }

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -37,6 +37,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your Trezor T with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// displayaddress request: confirm 1 time
 		// displayaddress request: confirm 1 time
@@ -141,6 +142,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your Coldcard with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// signtx request: refuse
 		// signtx request: confirm
@@ -216,6 +218,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your Nano S with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// displayaddress request(derivation path): approve
 		// displayaddress request: reject
@@ -299,6 +302,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your Nano S+ with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// displayaddress request(derivation path): approve
 		// displayaddress request: reject
@@ -382,6 +386,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your Nano X with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// displayaddress request(derivation path): approve
 		// displayaddress request: reject
@@ -466,6 +471,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your Jade with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// displayaddress request by device_type: reject
 		// displayaddress request by device_type: approve
@@ -548,6 +554,7 @@ public class HwiKatas
 		//
 		// Connect and initialize your BitBox02 with the following seed phrase:
 		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
 		// Run this test.
 		// getxpub request by derive 0: approve
 		// getxpub request by derive 1: approve

--- a/WalletWasabi.Tests/Helpers/HwiValidationHelper.cs
+++ b/WalletWasabi.Tests/Helpers/HwiValidationHelper.cs
@@ -20,6 +20,8 @@ public static class HwiValidationHelper
 			HardwareWalletModels.Coldcard => @"^hid:\\\\.*?vid_d13e&pid_cc10&mi_00",
 			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X => @"^hid:\\\\.*?vid_2c97&pid_0001&mi_00",
 			HardwareWalletModels.Jade => @"^COM\d+",
+			HardwareWalletModels.BitBox02_BTCOnly => @"^\\\\\?\\hid#vid_03eb&pid_2403",
+
 			_ => "",
 		};
 		return Regex.IsMatch(path, pattern);

--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -36,6 +36,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			HardwareWalletModels.Ledger_Nano_S => "ledger_nano_s",
 			HardwareWalletModels.Ledger_Nano_X => "ledger_nano_x",
 			HardwareWalletModels.Jade => "jade",
+			HardwareWalletModels.BitBox02_BTCOnly => "bitbox02_btconly",
 			_ => throw new NotImplementedException("Mock missing.")
 		};
 
@@ -48,6 +49,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			HardwareWalletModels.Ledger_Nano_S => "\\\\\\\\?\\\\hid#vid_2c97&pid_0001&mi_00#7&e45ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			HardwareWalletModels.Ledger_Nano_X => "\\\\\\\\?\\\\hid#vid_2c97&pid_0001&mi_00#7&e45ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			HardwareWalletModels.Jade => "COM3",
+			HardwareWalletModels.BitBox02_BTCOnly => "\\\\\\\\?\\\\hid#vid_03eb&pid_2403#6&229ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			_ => throw new NotImplementedException("Mock missing.")
 		};
 
@@ -69,6 +71,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"fingerprint\": \"4054d6f6\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false}}]\r\n",
 				HardwareWalletModels.Ledger_Nano_X => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"fingerprint\": \"4054d6f6\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false}}]\r\n",
 				HardwareWalletModels.Jade => $"[{{\"type\": \"{model}\", \"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false, \"fingerprint\": \"9bdca818\"}}]",
+				HardwareWalletModels.BitBox02_BTCOnly => $"[{{\"type\": \"{model}\", \"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false, \"fingerprint\": \"2ebf60e1\"}}]",
 				_ => throw new NotImplementedException($"Mock missing for {model}")
 			};
 		}
@@ -81,6 +84,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support wiping via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support wiping via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not support wiping via software\", \"code\": -9}",
+				HardwareWalletModels.BitBox02_BTCOnly => SuccessTrueResponse,
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -93,6 +97,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Jade => "{\"error\": \"setup requires interactive mode\", \"code\": -9}",
+				HardwareWalletModels.BitBox02_BTCOnly => "{\"error\": \"setup requires interactive mode\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -105,6 +110,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not support software setup\", \"code\": -9}",
+				HardwareWalletModels.BitBox02_BTCOnly => SuccessTrueResponse,
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -117,6 +123,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support restoring via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support restoring via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not support restoring via software\", \"code\": -9}",
+				HardwareWalletModels.BitBox02_BTCOnly => SuccessTrueResponse,
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -129,6 +136,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not need a PIN sent from the host\", \"code\": -9}",
+				HardwareWalletModels.BitBox02_BTCOnly => "{\"error\": \"The BitBox02 does not need a PIN sent from the host\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -141,6 +149,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Jade => "{\"error\": \"Blockstream Jade does not need a PIN sent from the host\", \"code\": -9}",
+				HardwareWalletModels.BitBox02_BTCOnly => "{\"error\": \"The BitBox02 does not need a PIN sent from the host\", \"code\": -9}",
 				_ => throw new NotImplementedException("Mock missing.")
 			};
 		}
@@ -154,6 +163,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				case HardwareWalletModels.Ledger_Nano_S:
 				case HardwareWalletModels.Ledger_Nano_X:
 				case HardwareWalletModels.Jade:
+				case HardwareWalletModels.BitBox02_BTCOnly:
 					response = $"{{\"xpub\": \"{xpub}\"}}\r\n";
 					break;
 			}
@@ -168,6 +178,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				case HardwareWalletModels.Ledger_Nano_S:
 				case HardwareWalletModels.Ledger_Nano_X:
 				case HardwareWalletModels.Jade:
+				case HardwareWalletModels.BitBox02_BTCOnly:
 					response = t1
 						? "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n"
 						: "{\"address\": \"bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah\"}\r\n";
@@ -184,6 +195,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				case HardwareWalletModels.Ledger_Nano_S:
 				case HardwareWalletModels.Ledger_Nano_X:
 				case HardwareWalletModels.Jade:
+				case HardwareWalletModels.BitBox02_BTCOnly:
 					response = t2
 						? "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n"
 						: "{\"address\": \"bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf\"}\r\n";
@@ -200,6 +212,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				case HardwareWalletModels.Ledger_Nano_S:
 				case HardwareWalletModels.Ledger_Nano_X:
 				case HardwareWalletModels.Jade:
+				case HardwareWalletModels.BitBox02_BTCOnly:
 					response = "{\"address\": \"tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy\"}\r\n";
 					break;
 			}
@@ -214,6 +227,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 				case HardwareWalletModels.Ledger_Nano_S:
 				case HardwareWalletModels.Ledger_Nano_X:
 				case HardwareWalletModels.Jade:
+				case HardwareWalletModels.BitBox02_BTCOnly:
 					response = "{\"address\": \"tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6\"}\r\n";
 					break;
 			}

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -560,6 +560,90 @@ public class MockedDeviceTests
 		Assert.Equal(expectedAddress2, address2);
 	}
 
+	[Theory]
+	[MemberData(nameof(GetDifferentNetworkValues))]
+	public async Task BitBox02BtcOnlyMockTestsAsync(Network network)
+	{
+		var client = new HwiClient(network, new HwiProcessBridgeMock(HardwareWalletModels.BitBox02_BTCOnly));
+
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		IEnumerable<HwiEnumerateEntry> enumerate = await client.EnumerateAsync(cts.Token);
+		Assert.Single(enumerate);
+		HwiEnumerateEntry entry = enumerate.Single();
+		Assert.Equal(HardwareWalletModels.BitBox02_BTCOnly, entry.Model);
+		Assert.True(HwiValidationHelper.ValidatePathString(entry.Model, @"\\?\hid#vid_03eb&pid_2403#6&229ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}"));
+		Assert.Equal(@"\\?\hid#vid_03eb&pid_2403#6&229ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}", entry.Path);
+		Assert.False(entry.NeedsPassphraseSent);
+		Assert.False(entry.NeedsPinSent);
+		Assert.Null(entry.Error);
+		Assert.Null(entry.Code);
+		Assert.True(entry.IsInitialized());
+		Assert.NotNull(entry.Fingerprint);
+
+		var deviceType = entry.Model;
+		var devicePath = entry.Path;
+
+		await client.WipeAsync(deviceType, devicePath, cts.Token);
+		await client.SetupAsync(deviceType, devicePath, false, cts.Token);
+		await client.RestoreAsync(deviceType, devicePath, false, cts.Token);
+
+		// Trezor T doesn't support it.
+		var promptpin = await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+		Assert.Equal("The BitBox02 does not need a PIN sent from the host", promptpin.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, promptpin.ErrorCode);
+
+		var sendpin = await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+		Assert.Equal("The BitBox02 does not need a PIN sent from the host", sendpin.Message);
+		Assert.Equal(HwiErrorCode.UnavailableAction, sendpin.ErrorCode);
+
+		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit);
+		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive(1);
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		ExtPubKey expectedXpub1;
+		ExtPubKey expectedXpub2;
+		if (network == Network.TestNet)
+		{
+			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+			expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+		}
+		else
+		{
+			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+			expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+		}
+		Assert.Equal(expectedXpub1, xpub1);
+		Assert.Equal(expectedXpub2, xpub2);
+
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
+
+		BitcoinAddress expectedAddress1;
+		BitcoinAddress expectedAddress2;
+		if (network == Network.Main)
+		{
+			expectedAddress1 = BitcoinAddress.Create("bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah", Network.Main);
+			expectedAddress2 = BitcoinAddress.Create("bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf", Network.Main);
+		}
+		else if (network == Network.TestNet)
+		{
+			expectedAddress1 = BitcoinAddress.Create("tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy", Network.TestNet);
+			expectedAddress2 = BitcoinAddress.Create("tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6", Network.TestNet);
+		}
+		else if (network == Network.RegTest)
+		{
+			expectedAddress1 = BitcoinAddress.Create("bcrt1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7pzmj3d", Network.RegTest);
+			expectedAddress2 = BitcoinAddress.Create("bcrt1qmaveee425a5xjkjcv7m6d4gth45jvtnjz7tugn", Network.RegTest);
+		}
+		else
+		{
+			throw new NotSupportedNetworkException(network);
+		}
+
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+	}
+
 	#endregion Tests
 
 	#region HelperMethods

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -48,6 +48,7 @@ public class HwiEnumerateEntry
 			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => WalletType.Ledger,
 			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator => WalletType.Trezor,
 			HardwareWalletModels.Jade => WalletType.Jade,
+			HardwareWalletModels.BitBox02_BTCOnly => WalletType.BitBox,
 			_ => WalletType.Hardware
 		};
 
@@ -64,6 +65,7 @@ public class HwiEnumerateEntry
 			HardwareWalletModels.Trezor_T => true,
 			HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T_Simulator or HardwareWalletModels.Coldcard_Simulator => false,
 			HardwareWalletModels.Jade => false,
+			HardwareWalletModels.BitBox02_BTCOnly => false,
 			_ => false
 		};
 	}

--- a/WalletWasabi/Wallets/WalletType.cs
+++ b/WalletWasabi/Wallets/WalletType.cs
@@ -8,5 +8,6 @@ public enum WalletType
 	Trezor,
 	Ledger,
 	Jade,
-	Unknown
+	Unknown,
+	BitBox
 }


### PR DESCRIPTION
# Introduction
The HWI already supports the BitBox02 hardware wallet, but until now, the Wasabi wallet has not. Therefore, we decided to implement this in the current codebase.

# Solution

We acquired a BitBox02  hardware wallet and initialized it with the appropriate parameters. After this, I implemented the new Enums, HardwareWalletModel, and WalletType, in the code.

I started the Wasabi wallet and was able to add it as a wallet.

# Subtasks

- [x] Writing the Jade Test
- [x] Writing the Jade Mock Test

# WW testing phase
- [x] Add new wallet with  Connect To Hardware Wallet function
- [x] Receive 
- [x] Send with general HW transaction sign protocol
- [x] Psbt workflow is not tested, because the SD card only provides us a Backup function, PSBT not allowed in this device

#Tested operation system
- [x] Windows
- [ ] macOS
- [ ] Linux