### PR TITLE
Apply time preference check for all lower TimeFrames

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/IsRoundEconomicTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/IsRoundEconomicTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using NBitcoin;
+using WalletWasabi.Helpers;
+using WalletWasabi.WabiSabi.Client;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
+
+public class IsRoundEconomicTests
+{
+	[Fact]
+	public void IsRoundEconomicTest()
+	{
+		var dailyTimeFrame = TimeSpan.FromHours(Constants.CoinJoinFeeRateMedianTimeFrames[0]);
+		var weeklyTimeFrame = TimeSpan.FromHours(Constants.CoinJoinFeeRateMedianTimeFrames[1]);
+		var monthlyTimeFrame = TimeSpan.FromHours(Constants.CoinJoinFeeRateMedianTimeFrames[2]);
+
+		// InvalidOperationException when target TimeFrame is not a key of the coinJoinFeeRateMedians Dictionary.
+		Assert.Throws<InvalidOperationException>(() =>
+			CoinJoinClient.IsRoundEconomic(new FeeRate(2m), new(), dailyTimeFrame));
+
+		// Shorter TimeFrame has lower FeeRate.
+		var coinJoinFeeRateMedians = new Dictionary<TimeSpan, FeeRate>
+		{
+			{ dailyTimeFrame, new FeeRate(500m) },
+			{ weeklyTimeFrame, new FeeRate(50m) },
+			{ monthlyTimeFrame, new FeeRate(5m) }
+		};
+
+		Assert.True(CoinJoinClient.IsRoundEconomic(new FeeRate(25m), coinJoinFeeRateMedians, dailyTimeFrame));
+		Assert.True(CoinJoinClient.IsRoundEconomic(new FeeRate(25m), coinJoinFeeRateMedians, weeklyTimeFrame));
+		Assert.False(CoinJoinClient.IsRoundEconomic(new FeeRate(25m), coinJoinFeeRateMedians, monthlyTimeFrame));
+
+		// Longer TimeFrame has lower FeeRate.
+		coinJoinFeeRateMedians = new Dictionary<TimeSpan, FeeRate>
+		{
+			{ dailyTimeFrame, new FeeRate(5m) },
+			{ weeklyTimeFrame, new FeeRate(50m) },
+			{ monthlyTimeFrame, new FeeRate(500m) }
+		};
+
+		Assert.False(CoinJoinClient.IsRoundEconomic(new FeeRate(25m), coinJoinFeeRateMedians, dailyTimeFrame));
+		Assert.False(CoinJoinClient.IsRoundEconomic(new FeeRate(25m), coinJoinFeeRateMedians, weeklyTimeFrame));
+		Assert.False(CoinJoinClient.IsRoundEconomic(new FeeRate(25m), coinJoinFeeRateMedians, monthlyTimeFrame));
+		Assert.True(CoinJoinClient.IsRoundEconomic(new FeeRate(5m), coinJoinFeeRateMedians, monthlyTimeFrame));
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -120,7 +120,7 @@ public class CoinJoinClient
 			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the minimum output amount is too high.");
 		}
 
-		if (!roundState.IsBlame && !IsRoundEconomic(roundState.CoinjoinState.Parameters.MiningFeeRate))
+		if (!roundState.IsBlame && !IsRoundEconomic(roundState.CoinjoinState.Parameters.MiningFeeRate, RoundStatusUpdater.CoinJoinFeeRateMedians, FeeRateMedianTimeFrame))
 		{
 			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the round is not economic.");
 		}
@@ -145,7 +145,7 @@ public class CoinJoinClient
 
 			if (!currentRoundState.IsBlame)
 			{
-				if (!IsRoundEconomic(roundParameters.MiningFeeRate))
+				if (!IsRoundEconomic(roundParameters.MiningFeeRate, RoundStatusUpdater.CoinJoinFeeRateMedians, FeeRateMedianTimeFrame))
 				{
 					throw new CoinJoinClientException(CoinjoinError.UneconomicalRound, "Uneconomical round skipped.");
 				}
@@ -711,23 +711,23 @@ public class CoinJoinClient
 		roundState.LogDebug(string.Join(Environment.NewLine, summary));
 	}
 
-	private bool IsRoundEconomic(FeeRate roundFeeRate)
+	internal static bool IsRoundEconomic(FeeRate roundFeeRate, Dictionary<TimeSpan, FeeRate>? coinJoinFeeRateMedians, TimeSpan feeRateMedianTimeFrame)
 	{
-		if (FeeRateMedianTimeFrame == default)
+		if (coinJoinFeeRateMedians == default)
 		{
 			return true;
 		}
 
-		if (RoundStatusUpdater.CoinJoinFeeRateMedians.ContainsKey(FeeRateMedianTimeFrame))
+		if (coinJoinFeeRateMedians.ContainsKey(feeRateMedianTimeFrame))
 		{
 			// Round is not economic if any TimeFrame lower than FeeRateMedianTimeFrame has a FeeRate lower than current round's FeeRate.
 			// 0.5 satoshi difference is allowable, to avoid rounding errors.
-			return RoundStatusUpdater.CoinJoinFeeRateMedians
-				.Where(x => x.Key <= FeeRateMedianTimeFrame)
+			return coinJoinFeeRateMedians
+				.Where(x => x.Key <= feeRateMedianTimeFrame)
 				.All(lowerTimeFrame => roundFeeRate.SatoshiPerByte <= lowerTimeFrame.Value.SatoshiPerByte + 0.5m);
 		}
 
-		throw new InvalidOperationException($"Could not find median fee rate for time frame: {FeeRateMedianTimeFrame}.");
+		throw new InvalidOperationException($"Could not find median fee rate for time frame: {feeRateMedianTimeFrame}.");
 	}
 
 	private async Task<IEnumerable<TxOut>> ProceedWithOutputRegistrationPhaseAsync(uint256 roundId, ImmutableArray<AliceClient> registeredAliceClients, CancellationToken cancellationToken)

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -158,7 +158,7 @@ public class CoinJoinClient
 			coinCandidates = await coinCandidatesFunc().ConfigureAwait(false);
 
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameters.MaxSuggestedAmount);
-			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters, OutputProvider.DestinationProvider.SupportedScriptTypes.ToArray() );
+			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters, OutputProvider.DestinationProvider.SupportedScriptTypes.ToArray());
 
 			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, stopWhenAllMixed, utxoSelectionParameters, liquidityClue);
 
@@ -711,9 +711,9 @@ public class CoinJoinClient
 		roundState.LogDebug(string.Join(Environment.NewLine, summary));
 	}
 
-	internal static bool IsRoundEconomic(FeeRate roundFeeRate, Dictionary<TimeSpan, FeeRate>? coinJoinFeeRateMedians, TimeSpan feeRateMedianTimeFrame)
+	internal static bool IsRoundEconomic(FeeRate roundFeeRate, Dictionary<TimeSpan, FeeRate> coinJoinFeeRateMedians, TimeSpan feeRateMedianTimeFrame)
 	{
-		if (coinJoinFeeRateMedians == default)
+		if (feeRateMedianTimeFrame == default)
 		{
 			return true;
 		}


### PR DESCRIPTION
Problem found by @Kruwed 

tl;dr: When you are willing to wait for several days for the best moment of the month, you are also willing to wait few extra hours for the best moment of the day

Currently, `IsRoundEconomic` only takes into consideration the `MedianFeeRate` related to the exact `TimeFrame` selected in user's Coinjoin settings,
But in cases where a `FeeRateMedian` for a short `TimeFrame` is lower than the `FeeRateMedian` for a longer `TimeFrame` , and the user has the longer `TimeFrame` in its settings, `IsRoundEconomic` will allow coinjoin.

---
Example:
Median past day, 24 sat/vbyte
Median past week, 27 sat/vbyte
Median past month, 35 sat/vbyte

The user has `Weekly` selected, the current coinjoin round's fee rate is 26 sat/vb
Currently, `IsRoundEconomic` will return `true`, while it would be better to wait for the current round fee rate to also go below the daily median.

---

I know that this problem is a bit tricky to understand, I had to wrap my head around it for quite some time. 
What this PR is doing is to check for the current `FeeRateMedian` of all lower or equal `TimeFrame` of what the user has in settings. That way, `IsRoundEconomic` will also return false until all the current round's fee rate goes below the `MedianFeeRate` for all lower `TimeFrame`.

I wanted to write a test but I didn't manage to do it without changing the method to `static` or struggling to instantiate `CoinJoinClient`, if anyone has a suggestion on how to do it I would gladly write the test.