### PR TITLE
SleepInhibitor enable/disable flag for using daemon in Docker containers (zkSNACKs/WalletWasabi#12360)

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -106,6 +106,9 @@ public class Config
 			[ nameof(EnableGpu)] = (
 				"Use a GPU to render the user interface",
 				GetBoolValue("EnableGpu", PersistentConfig.EnableGpu, cliArgs)),
+			[ nameof(RunSleepInhibitorAfterRoundStart)] = (
+				"Run SleepInhibitor automatically after the start of the CoinJoin round",
+				GetBoolValue("RunSleepInhibitorAfterRoundStart", PersistentConfig.RunSleepInhibitorAfterRoundStart, cliArgs)),
 			[ nameof(CoordinatorIdentifier)] = (
 				"-",
 				GetStringValue("CoordinatorIdentifier", PersistentConfig.CoordinatorIdentifier, cliArgs)),
@@ -156,6 +159,7 @@ public class Config
 	public string LogLevel => GetEffectiveValue<StringValue, string>(nameof(LogLevel));
 
 	public bool EnableGpu => GetEffectiveValue<BoolValue, bool>(nameof(EnableGpu));
+	public bool RunSleepInhibitorAfterRoundStart => GetEffectiveValue<BoolValue, bool>(nameof(RunSleepInhibitorAfterRoundStart));
 	public string CoordinatorIdentifier => GetEffectiveValue<StringValue, string>(nameof(CoordinatorIdentifier));
 	public ServiceConfiguration ServiceConfiguration { get; }
 

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -224,23 +224,8 @@ public class Global
 				await StartLocalBitcoinNodeAsync(cancel).ConfigureAwait(false);
 
 				RegisterCoinJoinComponents();
-				if (Config.RunSleepInhibitorAfterRoundStart)
-				{
-					SleepInhibitor? sleepInhibitor = await SleepInhibitor.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
 
-					if (sleepInhibitor is not null)
-					{
-						HostedServices.Register<SleepInhibitor>(() => sleepInhibitor, "Sleep Inhibitor");
-					}
-					else
-					{
-						Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
-					}
-				}
-				else
-				{
-					Logger.LogInfo("Sleep Inhibitor is disabled.");
-				}
+				await CreateSleepInhibitorIfEnabledAsync().ConfigureAwait(false);
 
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 
@@ -257,6 +242,27 @@ public class Global
 			{
 				Logger.LogTrace("Initialization finished.");
 			}
+		}
+	}
+
+	private async Task CreateSleepInhibitorIfEnabledAsync()
+	{
+		if (Config.RunSleepInhibitorAfterRoundStart)
+		{
+			SleepInhibitor? sleepInhibitor = await SleepInhibitor.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
+
+			if (sleepInhibitor is not null)
+			{
+				HostedServices.Register<SleepInhibitor>(() => sleepInhibitor, "Sleep Inhibitor");
+			}
+			else
+			{
+				Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
+			}
+		}
+		else
+		{
+			Logger.LogInfo("Sleep Inhibitor is disabled.");
 		}
 	}
 

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -224,17 +224,24 @@ public class Global
 				await StartLocalBitcoinNodeAsync(cancel).ConfigureAwait(false);
 
 				RegisterCoinJoinComponents();
-
-				SleepInhibitor? sleepInhibitor = await SleepInhibitor.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
-
-				if (sleepInhibitor is not null)
+				if (Config.RunSleepInhibitorAfterRoundStart)
 				{
-					HostedServices.Register<SleepInhibitor>(() => sleepInhibitor, "Sleep Inhibitor");
+					SleepInhibitor? sleepInhibitor = await SleepInhibitor.CreateAsync(HostedServices.Get<CoinJoinManager>()).ConfigureAwait(false);
+
+					if (sleepInhibitor is not null)
+					{
+						HostedServices.Register<SleepInhibitor>(() => sleepInhibitor, "Sleep Inhibitor");
+					}
+					else
+					{
+						Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
+					}
 				}
 				else
 				{
-					Logger.LogInfo("Sleep Inhibitor is not available on this platform.");
+					Logger.LogInfo("Sleep Inhibitor is disabled.");
 				}
+
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 
 				Logger.LogInfo("Start synchronizing filters...");

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -134,6 +134,11 @@ public record PersistentConfig : IConfigNg
 	[System.Text.Json.Serialization.JsonPropertyName("EnableGpu")]
 	public bool EnableGpu { get; init; } = true;
 
+	[DefaultValue(true)]
+	[JsonProperty(PropertyName = "RunSleepInhibitorAfterRoundStart", DefaultValueHandling = DefaultValueHandling.Populate)]
+	[System.Text.Json.Serialization.JsonPropertyName("RunSleepInhibitorAfterRoundStart")]
+	public bool RunSleepInhibitorAfterRoundStart { get; init; } = true;
+
 	[DefaultValue("CoinJoinCoordinatorIdentifier")]
 	[JsonProperty(PropertyName = "CoordinatorIdentifier", DefaultValueHandling = DefaultValueHandling.Populate)]
 	[System.Text.Json.Serialization.JsonPropertyName("CoordinatorIdentifier")]
@@ -164,6 +169,7 @@ public record PersistentConfig : IConfigNg
 			JsonRpcServerPrefixes.SequenceEqual(other.JsonRpcServerPrefixes) &&
 			DustThreshold == other.DustThreshold &&
 			EnableGpu == other.EnableGpu &&
+			RunSleepInhibitorAfterRoundStart == other.RunSleepInhibitorAfterRoundStart &&
 			CoordinatorIdentifier == other.CoordinatorIdentifier;
 	}
 

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
@@ -70,6 +70,7 @@ public class ConfigManagerNgTests
 			  ],
 			  "DustThreshold": "0.00005",
 			  "EnableGpu": true,
+			  "RunSleepInhibitorAfterRoundStart": true,
 			  "CoordinatorIdentifier": "CoinJoinCoordinatorIdentifier"
 			}
 			""";


### PR DESCRIPTION
This pull request introduces the `RunSleepInhibitorAfterRoundStart` flag in the config, providing users with the ability to enable or disable SleepInhibitor in Docker containers, where there is no systemd daemon. Users can set this flag to `false` in `Config.json` or pass it as a parameter when starting the wallet daemon. These changes address [zkSNACKs/WalletWasabi#12360](https://github.com/zkSNACKs/WalletWasabi/issues/12360), resolving the 'Failed to connect to bus' error in Docker containers after starting a CoinJoin round.