### PR TITLE
Remove temporary resync code

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -202,12 +202,6 @@ public class Global
 				{
 					await bitcoinStoreInitTask.ConfigureAwait(false);
 
-					// ToDo: Temporary to fix https://github.com/zkSNACKs/WalletWasabi/pull/12137#issuecomment-1879798750
-					if (AllTransactionStore.MempoolStore.NeedResync || AllTransactionStore.ConfirmedStore.NeedResync)
-					{
-						WalletManager.ResyncToBefore12137();
-					}
-
 					// Make sure that TurboSyncHeight is not higher than BestHeight
 					WalletManager.EnsureTurboSyncHeightConsistency();
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -34,7 +34,7 @@ public class TransactionStore : IAsyncDisposable
 		if (!useInMemoryDatabase)
 		{
 			string oldPath = Path.Combine(Path.GetDirectoryName(DataSource)!, "Transactions.dat");
-			Import(oldPath, DataSource, network);
+			Import(oldPath, network);
 		}
 	}
 
@@ -47,17 +47,11 @@ public class TransactionStore : IAsyncDisposable
 	/// <remarks>Guarded by <see cref="SqliteStorageLock"/>.</remarks>
 	private Dictionary<uint256, SmartTransaction> Transactions { get; } = new();
 
-	// ToDo: Temporary to fix https://github.com/zkSNACKs/WalletWasabi/pull/12137#issuecomment-1879798750
-	public bool NeedResync { get; private set; }
-
-	private void Import(string oldPath, string dbPath, Network network)
+	private void Import(string oldPath, Network network)
 	{
 		if (File.Exists(oldPath))
 		{
 			Logger.LogInfo($"Migration of transaction file '{oldPath}' to SQLite format is about to begin. Please wait a moment.");
-
-			// ToDo: Temporary to fix https://github.com/zkSNACKs/WalletWasabi/pull/12137#issuecomment-1879798750
-			NeedResync = File.Exists(dbPath);
 
 			string[] allLines = File.ReadAllLines(oldPath, Encoding.UTF8);
 			IEnumerable<SmartTransaction> allTransactions = allLines.Select(x => SmartTransaction.FromLine(x, network));

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -464,34 +464,6 @@ public class WalletManager : IWalletProvider
 		IsInitialized = true;
 	}
 
-	// ToDo: Temporary to fix https://github.com/zkSNACKs/WalletWasabi/pull/12137#issuecomment-1879798750
-	public void ResyncToBefore12137()
-	{
-		if (Network == Network.RegTest)
-		{
-			// On this network, height resets to 0 anyway.
-			return;
-		}
-
-		// PR https://github.com/zkSNACKs/WalletWasabi/pull/12137 was created at 2023-12-23T21:43:40Z.
-		// * Mainnet block 822621 (https://mempool.space/block/00000000000000000001610628413ce8139e9fc042792c24d01d392afdd61ea4) was mined before the PR was created.
-		// * Testnet block 2542919 (https://mempool.space/testnet/block/0000000000000e396f89531b6e21128fbd2f6c76c8977fb0d0720313af350799) was mined before the PR was created.
-		var heightPriorTo12137 = Network == Network.Main ? 822621 : 2542919;
-
-		foreach (var km in GetWallets().Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))
-		{
-			if (km.GetBestHeight(SyncType.Complete) > heightPriorTo12137)
-			{
-				km.SetBestHeight(heightPriorTo12137);
-			}
-
-			if (km.GetBestHeight(SyncType.Turbo) > heightPriorTo12137)
-			{
-				km.SetBestTurboSyncHeight(heightPriorTo12137);
-			}
-		}
-	}
-
 	public void EnsureTurboSyncHeightConsistency()
 	{
 		foreach (var km in GetWallets().Select(x => x.KeyManager).Where(x => x.GetNetwork() == Network))


### PR DESCRIPTION
Remove the temporary code made for #12202.
Please @molnard decide if you want to remove it for 2.0.6 or let it and remove in 2.0.7

If we do not remove it, we will release some temporary code, this might be OK but I wanted to make the PR to give you the option to not.
If we remove it, there might be some people who updated to the faulty master and didn't update to master again for the forced resync.