### PR TITLE
Copy USD Balance to ToUsdFriendlyDecimals

### DIFF
--- a/WalletWasabi.Fluent/Converters/MoneyConverters.cs
+++ b/WalletWasabi.Fluent/Converters/MoneyConverters.cs
@@ -14,8 +14,8 @@ public static class MoneyConverters
 	public static readonly IValueConverter ToUsdNumber =
 		new FuncValueConverter<Money, string?>(n => n?.ToDecimal(MoneyUnit.BTC).WithFriendlyDecimals().ToString(CultureInfo.InvariantCulture));
 
-	public static readonly IValueConverter ToUsdFriendlyDecimals =
-		new FuncValueConverter<decimal, string>(n => n.WithFriendlyDecimals().ToString(CultureInfo.InvariantCulture));
+	public static readonly IValueConverter ToUsdAmountFormattedWithoutSpaces =
+		new FuncValueConverter<decimal, string>(n => n.ToUsdFormatted().Replace(" ", ""));
 
 	public static readonly IValueConverter ToUsdApprox =
 		new FuncValueConverter<decimal, string>(n => n.ToUsdAprox());

--- a/WalletWasabi.Fluent/Converters/MoneyConverters.cs
+++ b/WalletWasabi.Fluent/Converters/MoneyConverters.cs
@@ -15,7 +15,7 @@ public static class MoneyConverters
 		new FuncValueConverter<Money, string?>(n => n?.ToDecimal(MoneyUnit.BTC).WithFriendlyDecimals().ToString(CultureInfo.InvariantCulture));
 
 	public static readonly IValueConverter ToUsdAmountFormattedWithoutSpaces =
-		new FuncValueConverter<decimal, string>(n => n.ToUsdFormatted().Replace(" ", ""));
+		new FuncValueConverter<decimal, string>(n => n.ToUsdAmountFormatted().Replace(" ", ""));
 
 	public static readonly IValueConverter ToUsdApprox =
 		new FuncValueConverter<decimal, string>(n => n.ToUsdAprox());

--- a/WalletWasabi.Fluent/Converters/MoneyConverters.cs
+++ b/WalletWasabi.Fluent/Converters/MoneyConverters.cs
@@ -14,6 +14,9 @@ public static class MoneyConverters
 	public static readonly IValueConverter ToUsdNumber =
 		new FuncValueConverter<Money, string?>(n => n?.ToDecimal(MoneyUnit.BTC).WithFriendlyDecimals().ToString(CultureInfo.InvariantCulture));
 
+	public static readonly IValueConverter ToUsdAmountFormatted =
+		new FuncValueConverter<decimal, string>(n => n.ToUsdAmountFormatted());
+
 	public static readonly IValueConverter ToUsdApprox =
 		new FuncValueConverter<decimal, string>(n => n.ToUsdAprox());
 

--- a/WalletWasabi.Fluent/Converters/MoneyConverters.cs
+++ b/WalletWasabi.Fluent/Converters/MoneyConverters.cs
@@ -14,8 +14,8 @@ public static class MoneyConverters
 	public static readonly IValueConverter ToUsdNumber =
 		new FuncValueConverter<Money, string?>(n => n?.ToDecimal(MoneyUnit.BTC).WithFriendlyDecimals().ToString(CultureInfo.InvariantCulture));
 
-	public static readonly IValueConverter ToUsdAmountFormatted =
-		new FuncValueConverter<decimal, string>(n => n.ToUsdAmountFormatted());
+	public static readonly IValueConverter ToUsdFriendlyDecimals =
+		new FuncValueConverter<decimal, string>(n => n.WithFriendlyDecimals().ToString(CultureInfo.InvariantCulture));
 
 	public static readonly IValueConverter ToUsdApprox =
 		new FuncValueConverter<decimal, string>(n => n.ToUsdAprox());

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
@@ -16,7 +16,7 @@
                                Content="{Binding Amounts^.Btc, Converter={x:Static converters:MoneyConverters.ToBtc}}" />
     </c:CopyableItem>
     <c:TileControl.BottomContent>
-      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdFriendlyDecimals}}" HorizontalContentAlignment="Center">
+      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdAmountFormattedWithoutSpaces}}" HorizontalContentAlignment="Center">
         <c:PrivacyContentControl Classes="bold monoSpaced" Margin="4" VerticalAlignment="Center"
                                  Opacity="0.8"
                                  Content="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdApproxBetweenParens}}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
@@ -16,7 +16,7 @@
                                Content="{Binding Amounts^.Btc, Converter={x:Static converters:MoneyConverters.ToBtc}}" />
     </c:CopyableItem>
     <c:TileControl.BottomContent>
-      <c:CopyableItem ContentToCopy="{Binding Amounts^.Btc, Converter={x:Static converters:MoneyConverters.ToUsdNumber}}" HorizontalContentAlignment="Center">
+      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdFormatted}}" HorizontalContentAlignment="Center">
         <c:PrivacyContentControl Classes="bold monoSpaced" Margin="4" VerticalAlignment="Center"
                                  Opacity="0.8"
                                  Content="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdApproxBetweenParens}}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
@@ -16,7 +16,7 @@
                                Content="{Binding Amounts^.Btc, Converter={x:Static converters:MoneyConverters.ToBtc}}" />
     </c:CopyableItem>
     <c:TileControl.BottomContent>
-      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdFormatted}}" HorizontalContentAlignment="Center">
+      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdAmountFormatted}}" HorizontalContentAlignment="Center">
         <c:PrivacyContentControl Classes="bold monoSpaced" Margin="4" VerticalAlignment="Center"
                                  Opacity="0.8"
                                  Content="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdApproxBetweenParens}}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/WalletBalanceTileView.axaml
@@ -16,7 +16,7 @@
                                Content="{Binding Amounts^.Btc, Converter={x:Static converters:MoneyConverters.ToBtc}}" />
     </c:CopyableItem>
     <c:TileControl.BottomContent>
-      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdAmountFormatted}}" HorizontalContentAlignment="Center">
+      <c:CopyableItem ContentToCopy="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdFriendlyDecimals}}" HorizontalContentAlignment="Center">
         <c:PrivacyContentControl Classes="bold monoSpaced" Margin="4" VerticalAlignment="Center"
                                  Opacity="0.8"
                                  Content="{Binding Amounts^.Usd^, Converter={x:Static converters:MoneyConverters.ToUsdApproxBetweenParens}}" />


### PR DESCRIPTION
Fixes #12371 
It copies the same number as displayed but without the `~()` (so it also copies `USD`)

_Thanks @soosr for the quick help_