### PR TITLE
[UI] Chat workflow better error handling

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -105,7 +105,7 @@ public partial class OrderViewModel : ViewModelBase
 			.FromEventPattern<Exception>(Workflow, nameof(Workflow.OnStepError))
 			.DoAsync(async e =>
 			{
-				// Do not bother the user with an error dialog if they or not on BAB dialog.
+				// Do not bother the user with an error dialog if they are not on BAB dialog.
 				if (uiContext.Navigate().DialogScreen.CurrentPage is not BuyViewModel)
 				{
 					return;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -103,16 +103,7 @@ public partial class OrderViewModel : ViewModelBase
 		// Handle Workflow Step Execution Errors and show UI message
 		Observable
 			.FromEventPattern<Exception>(Workflow, nameof(Workflow.OnStepError))
-			.DoAsync(async e =>
-			{
-				// Do not bother the user with an error dialog if they are not on BAB dialog.
-				if (uiContext.Navigate().DialogScreen.CurrentPage is not BuyViewModel)
-				{
-					return;
-				}
-
-				await ShowErrorAsync("Error while processing order.");
-			})
+			.DoAsync(async e => await ShowErrorAsync("Error while processing order."))
 			.Subscribe();
 
 		StartWorkflow(_cts.Token);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -230,9 +230,9 @@ public partial class OrderViewModel : ViewModelBase
 			{
 				await Workflow.ExecuteAsync(token);
 			}
-			catch (OperationCanceledException)
+			catch (OperationCanceledException ex)
 			{
-				// Ignore.
+				Logger.LogDebug(ex.Message);
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Concurrency;
@@ -102,19 +101,19 @@ public partial class OrderViewModel : ViewModelBase
 		_cts = new CancellationTokenSource();
 
 		// Handle Workflow Step Execution Errors and show UI message
-		Observable.FromEventPattern<Exception>(Workflow, nameof(Workflow.OnStepError))
-				  .DoAsync(async e =>
-				  {
-					  if (e.EventArgs is OperationCanceledException)
-					  {
-						  // Ignore
-					  }
-					  else
-					  {
-						  await ShowErrorAsync("Error while processing order.");
-					  }
-				  })
-				  .Subscribe();
+		Observable
+			.FromEventPattern<Exception>(Workflow, nameof(Workflow.OnStepError))
+			.DoAsync(async e =>
+			{
+				// Do not bother the user with an error dialog if they or not on BAB dialog.
+				if (uiContext.Navigate().DialogScreen.CurrentPage is not BuyViewModel)
+				{
+					return;
+				}
+
+				await ShowErrorAsync("Error while processing order.");
+			})
+			.Subscribe();
 
 		StartWorkflow(_cts.Token);
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/1_Initial/StartConversationStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/1_Initial/StartConversationStep.cs
@@ -37,6 +37,8 @@ public class StartConversationStep : WorkflowStep<ConversationId>
 		}
 	}
 
+	public override bool IsInteractive => false;
+
 	protected override Conversation PutValue(Conversation conversation, ConversationId value) => conversation with { Id = value };
 
 	protected override ConversationId? RetrieveValue(Conversation conversation) => conversation.Id;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/AcceptOfferStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/AcceptOfferStep.cs
@@ -37,6 +37,8 @@ public class AcceptOfferStep : WorkflowStep<object>
 		}
 	}
 
+	public override bool IsInteractive => false;
+
 	protected override Conversation PutValue(Conversation conversation, object value) => conversation;
 
 	protected override object? RetrieveValue(Conversation conversation) => conversation;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/AcceptOfferStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/AcceptOfferStep.cs
@@ -13,6 +13,8 @@ public class AcceptOfferStep : WorkflowStep<object>
 		_token = token;
 	}
 
+	public override bool IsInteractive => false;
+
 	public override async Task ExecuteAsync()
 	{
 		if (Conversation.MetaData.OfferAccepted)
@@ -36,8 +38,6 @@ public class AcceptOfferStep : WorkflowStep<object>
 			IsBusy = false;
 		}
 	}
-
-	public override bool IsInteractive => false;
 
 	protected override Conversation PutValue(Conversation conversation, object value) => conversation;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/SaveConversationStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/SaveConversationStep.cs
@@ -35,6 +35,8 @@ public class SaveConversationStep : WorkflowStep<object>
 		}
 	}
 
+	public override bool IsInteractive => false;
+
 	protected override Conversation PutValue(Conversation conversation, object value) => conversation;
 
 	protected override object? RetrieveValue(Conversation conversation) => conversation;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/SaveConversationStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/2_Delivery/SaveConversationStep.cs
@@ -14,6 +14,8 @@ public class SaveConversationStep : WorkflowStep<object>
 		_ignored = false;
 	}
 
+	public override bool IsInteractive => false;
+
 	public override async Task ExecuteAsync()
 	{
 		if (Conversation.Id == ConversationId.Empty || _ignored)
@@ -34,8 +36,6 @@ public class SaveConversationStep : WorkflowStep<object>
 			IsBusy = false;
 		}
 	}
-
-	public override bool IsInteractive => false;
 
 	protected override Conversation PutValue(Conversation conversation, object value) => conversation;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/4_Finished/OrderFinishedMessage.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/4_Finished/OrderFinishedMessage.cs
@@ -16,6 +16,8 @@ public class OrderFinishedMessage : WorkflowStep<object>
 		SetCompleted();
 	}
 
+	public override bool IsInteractive => false;
+
 	public override async Task ExecuteAsync()
 	{
 		await base.ExecuteAsync();
@@ -31,8 +33,6 @@ public class OrderFinishedMessage : WorkflowStep<object>
 			IsBusy = false;
 		}
 	}
-
-	public override bool IsInteractive => false;
 
 	protected override IEnumerable<string> BotMessages(Conversation conversation)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/4_Finished/OrderFinishedMessage.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/4_Finished/OrderFinishedMessage.cs
@@ -32,6 +32,8 @@ public class OrderFinishedMessage : WorkflowStep<object>
 		}
 	}
 
+	public override bool IsInteractive => false;
+
 	protected override IEnumerable<string> BotMessages(Conversation conversation)
 	{
 		yield return "I'll be available for the next 30 days to assist with any questions you might have. Thank you very much for using the Buy Anything Button!";

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/ShopinBitWorkflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/ShopinBitWorkflow.cs
@@ -28,22 +28,22 @@ public sealed partial class ShopinBitWorkflow : Workflow
 		_token = token;
 
 		// Initial message + Select Product
-		await ExecuteStepAsync(new WelcomeStep(Conversation, token));
+		await ExecuteStepAsync(new WelcomeStep(Conversation, token), token);
 
 		// Select Country
-		await ExecuteStepAsync(new CountryStep(Conversation, _buyAnythingManager.Countries, token));
+		await ExecuteStepAsync(new CountryStep(Conversation, _buyAnythingManager.Countries, token), token);
 
 		// Specify your request
-		await ExecuteStepAsync(new RequestedItemStep(Conversation, token));
+		await ExecuteStepAsync(new RequestedItemStep(Conversation, token), token);
 
 		// Accept Privacy Policy
-		await ExecuteStepAsync(new PrivacyPolicyStep(Conversation, token));
+		await ExecuteStepAsync(new PrivacyPolicyStep(Conversation, token), token);
 
 		// Start Conversation (only if it's a new Conversation)
-		await ExecuteStepAsync(new StartConversationStep(Conversation, _wallet, token));
+		await ExecuteStepAsync(new StartConversationStep(Conversation, _wallet, token), token);
 
 		// Save the entire conversation
-		await ExecuteStepAsync(new SaveConversationStep(Conversation, token));
+		await ExecuteStepAsync(new SaveConversationStep(Conversation, token), token);
 
 		using (ListenToServerUpdates())
 		{
@@ -51,39 +51,39 @@ public sealed partial class ShopinBitWorkflow : Workflow
 			while (!Conversation.MetaData.OfferReceived)
 			{
 				// User might send chat messages to Support Agent
-				await ExecuteStepAsync(new SupportChatStep(Conversation, token));
+				await ExecuteStepAsync(new SupportChatStep(Conversation, token), token);
 			}
 		}
 
 		// Firstname
-		await ExecuteStepAsync(new FirstNameStep(Conversation, token));
+		await ExecuteStepAsync(new FirstNameStep(Conversation, token), token);
 
 		// Lastname
-		await ExecuteStepAsync(new LastNameStep(Conversation, token));
+		await ExecuteStepAsync(new LastNameStep(Conversation, token), token);
 
 		// Streetname
-		await ExecuteStepAsync(new StreetNameStep(Conversation, token));
+		await ExecuteStepAsync(new StreetNameStep(Conversation, token), token);
 
 		// Housenumber
-		await ExecuteStepAsync(new HouseNumberStep(Conversation, token));
+		await ExecuteStepAsync(new HouseNumberStep(Conversation, token), token);
 
 		// ZIP/Postalcode
-		await ExecuteStepAsync(new ZipPostalCodeStep(Conversation, token));
+		await ExecuteStepAsync(new ZipPostalCodeStep(Conversation, token), token);
 
 		// City
-		await ExecuteStepAsync(new CityStep(Conversation, token));
+		await ExecuteStepAsync(new CityStep(Conversation, token), token);
 
 		// State
-		await ExecuteStepAsync(new StateStep(Conversation, token));
+		await ExecuteStepAsync(new StateStep(Conversation, token), token);
 
 		// Accept Terms of service
-		await ExecuteStepAsync(new ConfirmTosStep(Conversation, token));
+		await ExecuteStepAsync(new ConfirmTosStep(Conversation, token), token);
 
 		// Accept Offer
-		await ExecuteStepAsync(new AcceptOfferStep(Conversation, token));
+		await ExecuteStepAsync(new AcceptOfferStep(Conversation, token), token);
 
 		// Save Conversation
-		await ExecuteStepAsync(new SaveConversationStep(Conversation, token));
+		await ExecuteStepAsync(new SaveConversationStep(Conversation, token), token);
 
 		using (ListenToServerUpdates())
 		{
@@ -93,11 +93,11 @@ public sealed partial class ShopinBitWorkflow : Workflow
 				if (Conversation.ConversationStatus == ConversationStatus.Finished && !IsCompleted)
 				{
 					IsCompleted = true;
-					await ExecuteStepAsync(new OrderFinishedMessage(Conversation, token));
+					await ExecuteStepAsync(new OrderFinishedMessage(Conversation, token), token);
 				}
 
 				// User might send chat messages to Support Agent
-				await ExecuteStepAsync(new SupportChatStep(Conversation, token));
+				await ExecuteStepAsync(new SupportChatStep(Conversation, token), token);
 			}
 		}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -74,7 +74,7 @@ public abstract partial class Workflow : ReactiveObject
 						Logger.LogError($"An error occurred trying to execute Step '{step.GetType().Name}' in Workflow '{GetType().Name}'", ex);
 					}
 
-					// Keep the step Busy under the Delay so the user's will not notice anything in the UI.
+					// Keep the step Busy under the Delay so the user will not notice anything in the UI.
 					var isBusy = step.IsBusy;
 					step.IsBusy = true;
 					await Task.Delay(3000, token);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -45,6 +45,8 @@ public abstract partial class Workflow : ReactiveObject
 		CurrentStep = step;
 		step.Conversation = Conversation;
 
+		var errorCount = 0;
+
 		// this is looped until Step execution is successfully completed.
 		// If it errors out, then the Workflow won't move forward to the next step.
 		// All Steps should be be able to be re-executed more than once, gracefully.
@@ -58,8 +60,17 @@ public abstract partial class Workflow : ReactiveObject
 			catch (Exception ex)
 			{
 				step.Reset();
-				Logger.LogError($"An error occurred trying to execute Step '{step.GetType().Name}' in Workflow '{GetType().Name}'", ex);
-				OnStepError.SafeInvoke(this, ex);
+
+				// Only show error dialog for the first time, or if step requires user input
+				if (errorCount == 0 || step.IsInteractive)
+				{
+					OnStepError.SafeInvoke(this, ex);
+
+					// TODO: Roland, are we 100% sure we want to swallow errors and not log them?
+					Logger.LogError($"An error occurred trying to execute Step '{step.GetType().Name}' in Workflow '{GetType().Name}'", ex);
+				}
+
+				errorCount++;
 			}
 		}
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -66,8 +66,7 @@ public abstract partial class Workflow : ReactiveObject
 					OnStepError.SafeInvoke(this, ex);
 					Logger.LogError($"An error occurred trying to execute Step '{step.GetType().Name}' in Workflow '{GetType().Name}'", ex);
 				}
-
-				if (!step.IsInteractive)
+				else
 				{
 					if (lastException?.Message != ex.Message)
 					{
@@ -75,6 +74,7 @@ public abstract partial class Workflow : ReactiveObject
 						Logger.LogError($"An error occurred trying to execute Step '{step.GetType().Name}' in Workflow '{GetType().Name}'", ex);
 					}
 
+					// Keep the step Busy under the Delay so the user's will not notice anything in the UI.
 					var isBusy = step.IsBusy;
 					step.IsBusy = true;
 					await Task.Delay(3000, token);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -47,7 +47,7 @@ public abstract partial class Workflow : ReactiveObject
 
 		var errorCount = 0;
 
-		// this is looped until Step execution is successfully completed.
+		// this is looped until Step execution is successfully completed or cancellation is requested.
 		// If it errors out, then the Workflow won't move forward to the next step.
 		// All Steps should be be able to be re-executed more than once, gracefully.
 		while (true)
@@ -57,7 +57,7 @@ public abstract partial class Workflow : ReactiveObject
 				await step.ExecuteAsync();
 				break;
 			}
-			catch (Exception ex)
+			catch (Exception ex) when (ex is not OperationCanceledException)
 			{
 				step.Reset();
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/WorkflowStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/WorkflowStep.cs
@@ -15,6 +15,12 @@ public interface IWorkflowStep
 
 	bool IsEditing { get; }
 
+	bool IsInteractive { get; }
+
+	ICommand SendCommand { get; }
+
+	string Caption { get; }
+
 	Conversation Conversation { get; set; }
 
 	Task ExecuteAsync();
@@ -24,10 +30,6 @@ public interface IWorkflowStep
 	void Ignore();
 
 	void Reset();
-
-	ICommand SendCommand { get; }
-
-	string Caption { get; }
 }
 
 /// <summary>
@@ -83,6 +85,8 @@ public abstract partial class WorkflowStep<TValue> : ReactiveObject, IWorkflowSt
 	public bool IsEditing { get; }
 
 	public ICommand SendCommand { get; }
+
+	public virtual bool IsInteractive => true;
 
 	protected string StepName => GetType().Name;
 


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/12403
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/12156

Relevant commit from https://github.com/zkSNACKs/WalletWasabi/pull/12391. It got merged when the original PR was merged.

> Improves error handling on #12181
> 
> This will show the error dialog only the first time an error comes out for a non-interactive step (such as `StartConversationStep`). For interactive steps (which require user input), these are reset whenever an error occurs within their execution, which means the user will have to re-enter their input in order to retry the action, which is the expected UX:
> 
> Interactive: user input -> try action -> error message -> user input -> retry action -> error message -> user input....
> 
> Non interactive: try action -> error message -> retry action -> silently fail -> retry action....