### PR TITLE
Fix PayJoin

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -73,7 +73,7 @@ public static class TransactionHelpers
 				AllowUnconfirmed: true,
 				AllowDoubleSpend: false,
 				AllowedInputs: allowedCoins.Select(x => x.Outpoint),
-				TryToSign: false,
+				TryToSign: transactionInfo.PayJoinClient is not null,
 				OverrideFeeOverpaymentProtection: false);
 
 			builder.BuildTransaction(

--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -73,7 +73,7 @@ public static class TransactionHelpers
 				AllowUnconfirmed: true,
 				AllowDoubleSpend: false,
 				AllowedInputs: allowedCoins.Select(x => x.Outpoint),
-				TryToSign: transactionInfo.PayJoinClient is not null,
+				TryToSign: false,
 				OverrideFeeOverpaymentProtection: false);
 
 			builder.BuildTransaction(

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -192,7 +192,7 @@ public partial class SendViewModel : RoutableViewModel
 			Uri.IsWellFormedUriString(endPoint, UriKind.Absolute))
 		{
 			var payjoinEndPointUri = new Uri(endPoint);
-			if (!Services.HttpClientFactory.IsTorEnabled)
+			if (!Services.Config.UseTor)
 			{
 				if (payjoinEndPointUri.DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 				{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -192,7 +192,7 @@ public partial class SendViewModel : RoutableViewModel
 			Uri.IsWellFormedUriString(endPoint, UriKind.Absolute))
 		{
 			var payjoinEndPointUri = new Uri(endPoint);
-			if (!Services.PersistentConfig.UseTor)
+			if (!Services.HttpClientFactory.IsTorEnabled)
 			{
 				if (payjoinEndPointUri.DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 				{

--- a/WalletWasabi/Userfacing/Bip21/Bip21UriParser.cs
+++ b/WalletWasabi/Userfacing/Bip21/Bip21UriParser.cs
@@ -128,6 +128,10 @@ public class Bip21UriParser
 				error = ErrorUnsupportedReqParameter with { Details = parameterName };
 				return false;
 			}
+			else
+			{
+				unknownParameters.Add(parameterName, value);
+			}
 		}
 
 		result = new(Uri: parsedUri, network, address, amount, Label: label, Message: message, unknownParameters);


### PR DESCRIPTION
Fixes #12365

There are 3 problems that this PR fixes:
- Parsing of the PJ part of BIP21 is not working anymore
- `GetPayjoinClient` is relying on the `PersistentConfig` which was not taking into account `--usetor` CLI overriding

I didn't test a full PJ but the request is correctly initiated with this PR