### PR TITLE
[UI][Trivial] Change BAB's position

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -34,17 +34,6 @@
                 <TextBlock Text="Broadcast" />
               </StackPanel>
             </Button>
-            <Panel>
-              <Button Classes="function"
-                      IsVisible="{Binding CanBuy^}"
-                      Command="{Binding BuyCommand}">
-                <StackPanel Orientation="Horizontal" Spacing="15">
-                  <PathIcon Data="{StaticResource wallet_action_buy}" />
-                  <TextBlock Text="Buy Anything" />
-                </StackPanel>
-              </Button>
-              <Ellipse IsHitTestVisible="False" IsVisible="{Binding HasUnreadConversations^}" VerticalAlignment="Top" Margin="0 5 5 0" HorizontalAlignment="Right" Width="8" Height="8" Fill="{StaticResource UnreadBadgeColor}" />
-            </Panel>
             <Button Classes="function"
                     IsVisible="{Binding IsSendButtonVisible}"
                     Command="{Binding SendCommand}">
@@ -60,6 +49,17 @@
                 <TextBlock Text="Receive" />
               </StackPanel>
             </Button>
+            <Panel>
+              <Button Classes="function"
+                      IsVisible="{Binding CanBuy^}"
+                      Command="{Binding BuyCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="15">
+                  <PathIcon Data="{StaticResource wallet_action_buy}" />
+                  <TextBlock Text="Buy Anything" />
+                </StackPanel>
+              </Button>
+              <Ellipse IsHitTestVisible="False" IsVisible="{Binding HasUnreadConversations^}" VerticalAlignment="Top" Margin="0 5 5 0" HorizontalAlignment="Right" Width="8" Height="8" Fill="{StaticResource UnreadBadgeColor}" />
+            </Panel>
             <Button Classes="function">
               <Button.Flyout>
                 <MenuFlyout Placement="Bottom">


### PR DESCRIPTION
This simply moves the Buy Anything Button to the right position compared to Send and Receive buttons.
The main functions of the wallet are to send and receive bitcoin so I guess it makes sense to put those first (left).

PR:

![a1](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/f60a4b8c-5ddf-42ca-821b-2042873726e7)

Master:

![image](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/5b84fa55-f612-4611-af0a-35d9860ffcc2)
