### PR TITLE
Privacy Ring - AnonScore Range for PrivacyLevel Segments

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemViewModel.cs
@@ -26,7 +26,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem
 		AmountText = coin.Amount.ToBtcWithUnit();
 		Unconfirmed = !coin.IsConfirmed;
 		Confirmations = coin.Confirmations;
-		AnonScore = coin.AnonScore;
+		AnonScoreText = $"{coin.AnonScore}";
 		Labels = coin.Labels;
 
 		PrivacyLevelText = GetPrivacyLevelDescription();
@@ -38,7 +38,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem
 		}
 	}
 
-	public PrivacyRingItemViewModel(PrivacyRingViewModel parent, PrivacyLevel privacyLevel, Money amount, double start, double end)
+	public PrivacyRingItemViewModel(PrivacyRingViewModel parent, PrivacyLevel privacyLevel, Money amount, double start, double end, string anonScoreText)
 	{
 		OuterRadius = Math.Min(parent.Height / 2, parent.Width / 2);
 
@@ -48,6 +48,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem
 		IsSemiPrivate = privacyLevel == PrivacyLevel.SemiPrivate;
 		IsNonPrivate = privacyLevel == PrivacyLevel.NonPrivate;
 		AmountText = $"{amount.ToFormattedString()} BTC";
+		AnonScoreText = anonScoreText;
 		Unconfirmed = false;
 
 		PrivacyLevelText = GetPrivacyLevelDescription();
@@ -62,7 +63,7 @@ public class PrivacyRingItemViewModel : IPrivacyRingPreviewItem
 	public bool IsPrivate { get; }
 	public bool IsSemiPrivate { get; }
 	public bool IsNonPrivate { get; }
-	public double AnonScore { get; }
+	public string AnonScoreText { get; }
 	public LabelsArray Labels { get; }
 	public string AmountText { get; }
 	public string PrivacyLevelText { get; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -155,7 +155,15 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 
 			var end = start + (Math.Abs(groupAmount) / total);
 
-			var item = new PrivacyRingItemViewModel(this, group.Key, new Money(groupAmount, MoneyUnit.BTC), (double)start, (double)end);
+			var maxAnonScore = group.Max(x => x.AnonScore);
+			var minAnonScore = group.Min(x => x.AnonScore);
+
+			var anonScoreText =
+				maxAnonScore == minAnonScore
+				? $"{minAnonScore}"
+				: $"{minAnonScore}-{maxAnonScore}";
+
+			var item = new PrivacyRingItemViewModel(this, group.Key, new Money(groupAmount, MoneyUnit.BTC), (double)start, (double)end, anonScoreText);
 
 			yield return item;
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingItemDetailsView.axaml
@@ -44,7 +44,7 @@
             <TextBlock
               Text="{Binding PrivacyLevelText, Converter={x:Static conv:StringConverters.ToUpperCase}}" Classes="bold" Margin="4 2 " VerticalAlignment="Center" HorizontalAlignment="Center" />
           </Border>
-          <TextBlock Text="{Binding AnonScore, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
+          <TextBlock Text="{Binding AnonScoreText, StringFormat='Anonymity Score: {0}'}" Classes="h8" VerticalAlignment="Center" HorizontalAlignment="Center" />
         </StackPanel>
       </StackPanel>
 


### PR DESCRIPTION
![image](https://github.com/zkSNACKs/WalletWasabi/assets/98904713/25dd12da-b7a0-4541-8db3-be84843f3765)

Shows `min-max` range AnonScore in the Privacy Ring segments whenever they represent a group of coins grouped together by PrivacyLevel.

Fixes #12373