### PR TITLE
Upgrade xUnit to the latest version & warn about invalid ConfigureAwa…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -299,3 +299,6 @@ dotnet_diagnostic.CA1822.severity = none
 
 # CA1868: Unnecessary call to Set.Contains(item)
 dotnet_diagnostic.CA1868.severity = warning
+
+# xUnit1030: Do not call ConfigureAwait in test method
+dotnet_diagnostic.xUnit1030.severity = warning

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Moq" Version="[4.18.4]" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 </Project>

--- a/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Control/TorControlClientTests.cs
@@ -153,7 +153,7 @@ public class TorControlClientTests
 		timeoutCts.Cancel();
 
 		// No more async events.
-		Assert.ThrowsAsync<OperationCanceledException>(async () => await eventsEnumerator.MoveNextAsync());
+		await Assert.ThrowsAsync<TaskCanceledException>(async () => await eventsEnumerator.MoveNextAsync());
 	}
 
 	/// <summary>Verifies behavior of the subscription API and its logical subscription model.</summary>


### PR DESCRIPTION
…it value & fix test


The PR enables the https://xunit.net/xunit.analyzers/rules/xUnit1030 analyzer which warns about this

```cs
using System.Threading.Tasks;
using Xunit;

public class xUnit1030
{
    [Fact]
    public async Task TestMethod()
    {
        await Task.Delay(1).ConfigureAwait(false); // this is incorrect, either remove ConfigureAwait or use `true` value

        // ...code running on thread pool thread...
    }
}
```

That's important because it can break how xUnit runs tests and that in turn can make a WW test flaky.