### PR TITLE
[UI] BAB - Error dialog improvement

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
@@ -14,7 +14,6 @@ using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Fluent.ViewModels.Wallets.Buy.Workflows;
 using WalletWasabi.Logging;
 using WalletWasabi.Wallets;
-using Country = WalletWasabi.BuyAnything.Country;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Buy;
 
@@ -84,6 +83,20 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 
 		_ordersCache.RemoveKey(id);
 		SelectedOrder = _orders.FirstOrDefault();
+	}
+
+	public async Task OnError(Exception ex)
+	{
+		if (!IsActive)
+		{
+			return;
+		}
+
+		await ShowErrorAsync(
+			"Buy Anything",
+			ex.ToUserFriendlyString(),
+			"",
+			NavigationTarget.CompactDialogScreen);
 	}
 
 	public void Activate()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/IOrderManager.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/IOrderManager.cs
@@ -5,4 +5,6 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Buy;
 public interface IOrderManager
 {
 	Task RemoveOrderAsync(int id);
+
+	Task OnError(Exception ex);
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -103,7 +103,7 @@ public partial class OrderViewModel : ViewModelBase
 		// Handle Workflow Step Execution Errors and show UI message
 		Observable
 			.FromEventPattern<Exception>(Workflow, nameof(Workflow.OnStepError))
-			.DoAsync(async e => await ShowErrorAsync("Error while processing order."))
+			.DoAsync(async e => await _orderManager.OnError(e.EventArgs))
 			.Subscribe();
 
 		StartWorkflow(_cts.Token);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -71,6 +71,7 @@ public abstract partial class Workflow : ReactiveObject
 					if (lastException?.Message != ex.Message)
 					{
 						lastException = ex;
+						OnStepError.SafeInvoke(this, ex);
 						Logger.LogError($"An error occurred trying to execute Step '{step.GetType().Name}' in Workflow '{GetType().Name}'", ex);
 					}
 


### PR DESCRIPTION
This PR:
- Shows an error dialog to the user when an error happens in a noninteractive step.
   - Only if the Buy Anything dialog is opened.
   - An error can only be displayed once.
- Provides an actual error message to the user instead of a meaningless message.