### PR TITLE
Disable Taproot KeyPath under HW first connection

### DIFF
--- a/WalletWasabi/Helpers/HardwareWalletOperationHelpers.cs
+++ b/WalletWasabi/Helpers/HardwareWalletOperationHelpers.cs
@@ -30,13 +30,7 @@ public static class HardwareWalletOperationHelpers
 			KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit),
 			genCts.Token).ConfigureAwait(false);
 
-		var taprootExtPubKey = await client.GetXpubAsync(
-			device.Model,
-			device.Path,
-			KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.TaprootBIP86),
-			genCts.Token).ConfigureAwait(false);
-
-		return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, segwitExtPubKey, taprootExtPubKey, network, walletFilePath);
+		return KeyManager.CreateNewHardwareWalletWatchOnly(fingerPrint, segwitExtPubKey, null, network, walletFilePath);
 	}
 
 	public static async Task InitHardwareWalletAsync(HwiEnumerateEntry device, Network network, CancellationToken cancelToken)


### PR DESCRIPTION
Hardware wallets can provide ANY "key at path", while it is not certain that there is an implementation behind it.

Most of HW doesn't support the Taproot Account yet but can provide us with the KeyPath.

So, this is a hotfix until we don't find a good solution for it.

Transaction sign tested with these models:
- [x] Tresor T
- [x] Jade
- [x] Coldcard
- [x] BitBox02
- [x] Ledger    