### PR TITLE
[UI] Fix wrong unread badge

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
@@ -109,13 +109,18 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 		base.OnNavigatedTo(inHistory, disposables);
 
 		// Mark Conversation as read for selected order
-		this.WhenAnyValue(x => x.SelectedOrder)
+		this.WhenAnyValue(x => x.SelectedOrder, x => x.SelectedOrder.Workflow.Conversation, (order, _) => order)
 			.WhereNotNull()
 			.DoAsync(async order => await order.MarkAsReadAsync())
 			.Subscribe()
 			.DisposeWith(disposables);
 
 		MarkNewMessagesFromSelectedOrderAsRead().DisposeWith(disposables);
+	}
+
+	protected override void OnNavigatedFrom(bool isInHistory)
+	{
+		base.OnNavigatedFrom(isInHistory);
 
 		SelectNewOrderIfAny();
 	}
@@ -162,7 +167,7 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 				EmptyOrder = NewEmptyOrder();
 			}
 
-			SelectedOrder = _orders.FirstOrDefault();
+			SelectNewOrderIfAny();
 		}
 		catch (Exception exception)
 		{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
@@ -111,7 +111,7 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 		// Mark Conversation as read for selected order
 		this.WhenAnyValue(x => x.SelectedOrder, x => x.SelectedOrder.Workflow.Conversation, (order, _) => order)
 			.WhereNotNull()
-			.DoAsync(async order => await order.MarkAsReadAsync())
+			.DoAsync(order => order.MarkAsReadAsync())
 			.Subscribe()
 			.DisposeWith(disposables);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -76,12 +76,6 @@ public partial class OrderViewModel : ViewModelBase
 		// TODO: Remove this once we use newer version of DynamicData
 		HasUnreadMessagesObs.BindTo(this, x => x.HasUnreadMessages);
 
-		// Update file on disk
-		this.WhenAnyValue(x => x.HasUnreadMessages).Where(x => x == false).ToSignal()
-			.Merge(_messagesList.Connect().ToSignal())
-			.DoAsync(async _ => await UpdateConversationLocallyAsync(cancellationToken))
-			.Subscribe();
-
 		this.WhenAnyValue(x => x.Workflow.Conversation)
 			.Do(conversation =>
 			{
@@ -184,16 +178,6 @@ public partial class OrderViewModel : ViewModelBase
 	}
 
 	private void ClearMessageList() => _messagesList.Edit(x => x.Clear());
-
-	private Task UpdateConversationLocallyAsync(CancellationToken cancellationToken)
-	{
-		if (ConversationId == ConversationId.Empty)
-		{
-			return Task.CompletedTask;
-		}
-
-		return _buyAnythingManager.UpdateConversationOnlyLocallyAsync(Workflow.Conversation, cancellationToken);
-	}
 
 	private MessageViewModel CreateMessageViewModel(ChatMessage message)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -31,7 +31,6 @@ public partial class OrderViewModel : ViewModelBase
 	[AutoNotify] private bool _isBusy;
 	[AutoNotify] private bool _isCompleted;
 	[AutoNotify] private bool _hasUnreadMessages;
-	[AutoNotify] private bool _isSelected;
 
 	private CancellationTokenSource _cts;
 
@@ -106,10 +105,6 @@ public partial class OrderViewModel : ViewModelBase
 			.DoAsync(async e => await _orderManager.OnError(e.EventArgs))
 			.Subscribe();
 
-		this.WhenAnyValue(x => x.Workflow.Conversation, x => x.IsSelected, (_, b) => b)
-			.Do(tuple => MarkAsReadAsync())
-			.Subscribe();
-		
 		StartWorkflow(_cts.Token);
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -106,6 +106,10 @@ public partial class OrderViewModel : ViewModelBase
 			.DoAsync(async e => await _orderManager.OnError(e.EventArgs))
 			.Subscribe();
 
+		this.WhenAnyValue(x => x.Workflow.Conversation, x => x.IsSelected, (_, b) => b)
+			.Do(tuple => MarkAsReadAsync())
+			.Subscribe();
+		
 		StartWorkflow(_cts.Token);
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -104,6 +105,11 @@ public abstract partial class Workflow : ReactiveObject
 
 		try
 		{
+			if (!Conversation.ChatMessages.Any(x => x.IsUnread))
+			{
+				return;
+			}
+			
 			Conversation = Conversation.MarkAsRead();
 
 			if (Conversation.Id == ConversationId.Empty)


### PR DESCRIPTION
Whenever the Conversation changes in the active Order, the messages should be marked as read.

It includes a check to avoid stack overflow when marking all messages as read modifies the Conversation.

Fixes #12404