### PR TITLE
Catch wrong phase exception in CJManager in case of detected double spend

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -14,6 +14,7 @@ using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Client.Banning;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -543,6 +544,10 @@ public class CoinJoinManager : BackgroundService
 			// there are Alices that didn't confirm.
 			// The fix is already done but the clients have to upgrade.
 			wallet.LogInfo($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
+		}
+		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
+		{
+			wallet.LogInfo($"{nameof(CoinJoinClient)} failed because of abnormal round phase change with exception: '{wpe}'");
 		}
 		catch (Exception e)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -547,7 +547,8 @@ public class CoinJoinManager : BackgroundService
 		}
 		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
 		{
-			wallet.LogInfo($"{nameof(CoinJoinClient)} failed because of abnormal round phase change with exception: '{wpe}'");
+			// This can happen when the coordinator aborts the round in Signing phase because of detected double spend.
+			wallet.LogInfo($"{nameof(CoinJoinClient)} failed with: '{wpe.Message}'");
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
@MarnixCroes found this.

The issue:
```
ERROR	CoinJoinManager.HandleCoinJoinFinalizationAsync (549)	Wallet (Wallet): CoinJoinClient failed with exception: 'WalletWasabi.WabiSabi.Backend.Models.WabiSabiProtocolException: Round (492ec6c2351785e3fe8e66b58328af7bf82244653aec6ef44b496d94b8f8e249): Wrong phase (Ended).
   at WalletWasabi.Tor.Http.Extensions.HttpResponseMessageExtensions.ThrowUnwrapExceptionFromContentAsync(HttpResponseMessage me, CancellationToken cancellationToken) in WalletWasabi/Tor/Http/Extensions/HttpResponseMessageExtensions.cs:line 77
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendWithRetriesAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken, Nullable`1 retryTimeout) in WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs:line 127
   at WalletWasabi.WabiSabi.Client.WabiSabiHttpApiClient.SendAndReceiveAsync[TRequest](RemoteAction action, TRequest request, CancellationToken cancellationToken, Nullable`1 retryTimeout) in WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs:line 135
   at WalletWasabi.WabiSabi.Client.ArenaClient.SignTransactionAsync(uint256 roundId, Coin coin, IKeyChain keyChain, TransactionWithPrecomputedData unsignedCoinJoin, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/ArenaClient.cs:line 210
   at WalletWasabi.WabiSabi.Client.AliceClient.SignTransactionAsync(TransactionWithPrecomputedData unsignedCoinJoin, IKeyChain keyChain, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/AliceClient.cs:line 212
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.<>c__DisplayClass56_0.<<SignTransactionAsync>b__0>d.MoveNext() in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 634
--- End of stack trace from previous location ---
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.SignTransactionAsync(IEnumerable`1 aliceClients, TransactionWithPrecomputedData unsignedCoinJoinTransaction, DateTimeOffset signingStartTime, DateTimeOffset signingEndTime, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 644
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.ProceedWithSigningStateAsync(uint256 roundId, ImmutableArray`1 registeredAliceClients, IEnumerable`1 outputTxOuts, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 836
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.ProceedWithRoundAsync(RoundState roundState, IEnumerable`1 smartCoins, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 356
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartRoundAsync(IEnumerable`1 smartCoins, RoundState roundState, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 252
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartRoundAsync(IEnumerable`1 smartCoins, RoundState roundState, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 332
   at WalletWasabi.WabiSabi.Client.CoinJoinClient.StartCoinJoinAsync(Func`1 coinCandidatesFunc, Boolean stopWhenAllMixed, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinClient.cs:line 201
   at WalletWasabi.WabiSabi.Client.CoinJoinManager.HandleCoinJoinFinalizationAsync(CoinJoinTracker finishedCoinJoin, ConcurrentDictionary`2 trackedCoinJoins, ConcurrentDictionary`2 trackedAutoStarts, CancellationToken cancellationToken) in WalletWasabi/WabiSabi/Client/CoinJoinManager.cs:line 499'
```

What caused the issue (backend aborted the round because it detected a double spend):
```
2024-02-13 09:14:20.014 [73] INFO	Arena.AbortDisruptedRounds (703)	Round (492ec6c2351785e3fe8e66b58328af7bf82244653aec6ef44b496d94b8f8e249): Round aborted because it was disrupted by double spenders.
2024-02-13 09:14:20.014 [73] INFO	Round.SetPhase (95)	Round (492ec6c2351785e3fe8e66b58328af7bf82244653aec6ef44b496d94b8f8e249): Phase changed: TransactionSigning -> Ended
```

If it gets merged, I will open the same PR to the release branch as well.

How to test:

1. Do CJs on RegTest with multiple wallets
2. Make backend detect a double spend and abort your round. (Spend one of your inputs during the Signing Phase or modify backend code to explicitly abort your round during signing phase, DM me if you need help with the latter)
3. See the dedicated INFO log for this and see that it's not logged as ERROR anymore

Log will look like this if anyone is interested :)
```
Wallet (XXX): CoinJoinClient failed with: 'Round (97d87fbfd6200a347c96ec25b80e4571ff4a533697a3cf24a41c093820696368): Wrong phase (Ended).'
```