### PR TITLE
[BaB] Fix shipping cost not showing

### DIFF
--- a/WalletWasabi/BuyAnything/BuyAnythingManager.cs
+++ b/WalletWasabi/BuyAnything/BuyAnythingManager.cs
@@ -122,7 +122,7 @@ public class BuyAnythingManager : PeriodicRunner
 
 				await SendSystemChatLinesAsync(track,
 					ConvertOfferDetailToMessages(order),
-					new OfferCarrier(order.LineItems.Select(x => new OfferItem(x.Quantity, x.Label, x.UnitPrice, x.TotalPrice)), order.ShippingCosts),
+					new OfferCarrier(order.LineItems.Select(x => new OfferItem(x.Quantity, x.Label, x.UnitPrice, x.TotalPrice)), order.Deliveries.Single().ShippingCosts),
 					order.UpdatedAt, ConversationStatus.OfferReceived, cancel).ConfigureAwait(false);
 				break;
 
@@ -585,7 +585,7 @@ public class BuyAnythingManager : PeriodicRunner
 		}
 
 		sb.AppendLine($"\nFor a total price of ${order.AmountTotal}.");
-		sb.AppendLine($"(Including ${order.ShippingCosts.TotalPrice} shipping cost.)");
+		sb.AppendLine($"(Including ${order.Deliveries.Single().ShippingCosts.TotalPrice} shipping cost.)");
 		return sb.ToString();
 	}
 

--- a/WalletWasabi/BuyAnything/BuyAnythingManager.cs
+++ b/WalletWasabi/BuyAnything/BuyAnythingManager.cs
@@ -571,6 +571,8 @@ public class BuyAnythingManager : PeriodicRunner
 	private static string ConvertOfferDetailToMessages(Order order)
 	{
 		StringBuilder sb = new();
+
+		var shippingCost = GetShippingCostFromOrder(order);
 		sb.AppendLine("Our offer includes:");
 		foreach (var lineItem in order.LineItems)
 		{
@@ -585,8 +587,23 @@ public class BuyAnythingManager : PeriodicRunner
 		}
 
 		sb.AppendLine($"\nFor a total price of ${order.AmountTotal}.");
-		sb.AppendLine($"(Including ${order.Deliveries.Single().ShippingCosts.TotalPrice} shipping cost.)");
+		sb.AppendLine($"(Including ${shippingCost} shipping cost.)");
 		return sb.ToString();
+	}
+
+	private static float GetShippingCostFromOrder(Order order)
+	{
+		if (order.ShippingCosts.TotalPrice != "0")
+		{
+			return float.Parse(order.ShippingCosts.TotalPrice);
+		}
+
+		float sum = 0;
+		foreach (var delivery in order.Deliveries)
+		{
+			sum += float.Parse(delivery.ShippingCosts.TotalPrice);
+		}
+		return sum;
 	}
 
 	public async Task EnsureConversationsAreLoadedAsync(CancellationToken cancellationToken)

--- a/WalletWasabi/BuyAnything/BuyAnythingManager.cs
+++ b/WalletWasabi/BuyAnything/BuyAnythingManager.cs
@@ -122,7 +122,7 @@ public class BuyAnythingManager : PeriodicRunner
 
 				await SendSystemChatLinesAsync(track,
 					ConvertOfferDetailToMessages(order),
-					new OfferCarrier(order.LineItems.Select(x => new OfferItem(x.Quantity, x.Label, x.UnitPrice, x.TotalPrice)), order.Deliveries.Single().ShippingCosts),
+					new OfferCarrier(order.LineItems.Select(x => new OfferItem(x.Quantity, x.Label, x.UnitPrice, x.TotalPrice)), GetShippingCostFromOrder(order)),
 					order.UpdatedAt, ConversationStatus.OfferReceived, cancel).ConfigureAwait(false);
 				break;
 
@@ -587,15 +587,15 @@ public class BuyAnythingManager : PeriodicRunner
 		}
 
 		sb.AppendLine($"\nFor a total price of ${order.AmountTotal}.");
-		sb.AppendLine($"(Including ${shippingCost} shipping cost.)");
+		sb.AppendLine($"(Including ${shippingCost.TotalPrice} shipping cost.)");
 		return sb.ToString();
 	}
 
-	private static float GetShippingCostFromOrder(Order order)
+	private static ShippingCosts GetShippingCostFromOrder(Order order)
 	{
 		if (order.ShippingCosts.TotalPrice != "0")
 		{
-			return float.Parse(order.ShippingCosts.TotalPrice);
+			return order.ShippingCosts;
 		}
 
 		float sum = 0;
@@ -603,7 +603,7 @@ public class BuyAnythingManager : PeriodicRunner
 		{
 			sum += float.Parse(delivery.ShippingCosts.TotalPrice);
 		}
-		return sum;
+		return new ShippingCosts(sum.ToString());
 	}
 
 	public async Task EnsureConversationsAreLoadedAsync(CancellationToken cancellationToken)

--- a/WalletWasabi/WebClients/ShopWare/Models/Order.cs
+++ b/WalletWasabi/WebClients/ShopWare/Models/Order.cs
@@ -29,7 +29,8 @@ public record Order
 	LineItem[] LineItems,
 	string Id,
 	OrderCustomFields? CustomFields,
-	string Btcpay_PaymentLink
+	string Btcpay_PaymentLink,
+	ShippingCosts ShippingCosts
 );
 
 public record ShippingCosts
@@ -42,8 +43,7 @@ public record Deliveries
 	string[] TrackingCodes,
 	StateMachineState StateMachineState,
 	ShippingCosts ShippingCosts
-
-	);
+);
 public record OrderCustomFields
 (
 	string Concierge_Request_Status_State,

--- a/WalletWasabi/WebClients/ShopWare/Models/Order.cs
+++ b/WalletWasabi/WebClients/ShopWare/Models/Order.cs
@@ -29,8 +29,7 @@ public record Order
 	LineItem[] LineItems,
 	string Id,
 	OrderCustomFields? CustomFields,
-	string Btcpay_PaymentLink,
-	ShippingCosts ShippingCosts
+	string Btcpay_PaymentLink
 );
 
 public record ShippingCosts
@@ -41,7 +40,8 @@ public record Deliveries
 (
 	string OrderId,
 	string[] TrackingCodes,
-	StateMachineState StateMachineState
+	StateMachineState StateMachineState,
+	ShippingCosts ShippingCosts
 
 	);
 public record OrderCustomFields


### PR DESCRIPTION
There must've been a change in their protocol but now the shipping cost is not under `"shippingCosts"`, but under `"deliveries": [{...,"shippingCosts",...}]"`. I'll ask about this change, but for the time being this solves our issue.

EDIT:
Updated the PR, now it should get the total shipping cost from either under `shippingCosts` or `deliveries`, whichever is available. Also makes sure to send the correct data towards the UI.