### PR TITLE
Add production test sales channel

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -236,6 +236,15 @@ public class Global
 				bool useTestApi = Network != Network.Main;
 				var apiKey = useTestApi ? "SWSCVTGZRHJOZWF0MTJFTK9ZSG" : "SWSCU3LIYWVHVXRVYJJNDLJZBG";
 				var uri = useTestApi ? new Uri("https://shopinbit.solution360.dev/store-api/") : new Uri("https://shopinbit.com/store-api/");
+
+#if DEBUG
+				// If we are on MainNet, but in DEBUG we will use the production server but the test sales channel. ShopinBit agent will reply.
+				if (!useTestApi)
+				{
+					apiKey = "SWSCZVNZU2M0EULMNJLDSUZDWG";
+					uri = new Uri("https://shopinbit.com/wasabidevelopment/store-api/");
+				}
+#endif
 				ShopWareApiClient shopWareApiClient = new(HttpClientFactory.NewHttpClient(() => uri, Mode.DefaultCircuit), apiKey);
 
 				BuyAnythingClient buyAnythingClient = new(shopWareApiClient, useTestApi);


### PR DESCRIPTION
If you are on MainNet with Wasabi but in DEBUG mode, you will use a separate sales channel that but on the production server with real agents. They will know you are just making a mess there.