### PR TITLE
[Release] Catch wrong phase exception in CJManager in case of detected double spend

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -14,6 +14,7 @@ using WalletWasabi.Exceptions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Client.Banning;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -543,6 +544,11 @@ public class CoinJoinManager : BackgroundService
 			// there are Alices that didn't confirm.
 			// The fix is already done but the clients have to upgrade.
 			wallet.LogInfo($"{nameof(CoinJoinClient)} failed with exception: '{e}'");
+		}
+		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
+		{
+			// This can happen when the coordinator aborts the round in Signing phase because of detected double spend.
+			wallet.LogInfo($"{nameof(CoinJoinClient)} failed with: '{wpe.Message}'");
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
Same as https://github.com/zkSNACKs/WalletWasabi/pull/12450