### PR TITLE
Fix "StopWhenAllMixed = false doesn't work"

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -203,8 +203,8 @@ public class CoinJoinManager : BackgroundService
 				// If there are pending payments, ignore already achieved privacy.
 				if (!walletToStart.BatchedPayments.AreTherePendingPayments)
 				{
-					// If all coins are already private, then don't mix.
-					if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false))
+					// If all coins are already private and the user doesn't override the StopWhenAllMixed, then don't mix.
+					if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false) && startCommand.StopWhenAllMixed)
 					{
 						walletToStart.LogTrace("All mixed!");
 						throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate);


### PR DESCRIPTION
Possibly fixes: https://github.com/zkSNACKs/WalletWasabi/issues/12408

Unfortunately, I was unable to recreate the environment of the original issue, so I tried to fix it in theory.

My theory:

- After the successful CJ, we check if the wallet became private or not. According to the original issue, the wallet did become private, but `StopWhenAllMixed = false` so we schedule the next CJ.
https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs#L581-L589

- On the next CJ, when we do the sanity checks and the selection of candidate coins, we find out that the wallet is private and we throw `CoinJoinClientException(CoinjoinError.AllCoinsPrivate)`
https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs#L207-L211

and we don't take `StopWhenAllMixed = false` into account.

Please try to test it @MarnixCroes 