### PR TITLE
Simplify synchronizer gensock event reporting

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -61,11 +61,12 @@ public partial class HealthMonitor : ReactiveObject, IDisposable
 
 		// Backend Connection Issues flag
 		// TODO: the event invoke must be refactored in Synchronizer
-		Observable.FromEventPattern<bool>(synchronizer, nameof(synchronizer.ResponseArrivedIsGenSocksServFail))
-				  .Where(x => BackendStatus != BackendStatus.Connected)
-				  .Do(_ => IsConnectionIssueDetected = true)
-				  .Subscribe()
-				  .DisposeWith(Disposables);
+		Observable.FromEventPattern<bool>(synchronizer, nameof(synchronizer.SynchronizeRequestFinished))
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Where(x => x.EventArgs is false)
+			.Do(_ => IsConnectionIssueDetected = true)
+			.Subscribe()
+			.DisposeWith(Disposables);
 
 		// Set IsConnectionIssueDetected to false when BackedStatus == Connected
 		this.WhenAnyValue(x => x.BackendStatus)

--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -60,19 +60,12 @@ public partial class HealthMonitor : ReactiveObject, IDisposable
 							 .DisposeWith(Disposables);
 
 		// Backend Connection Issues flag
-		// TODO: the event invoke must be refactored in Synchronizer
 		Observable.FromEventPattern<bool>(synchronizer, nameof(synchronizer.SynchronizeRequestFinished))
 			.ObserveOn(RxApp.MainThreadScheduler)
-			.Where(x => x.EventArgs is false)
-			.Do(_ => IsConnectionIssueDetected = true)
+			.Select(x => x.EventArgs)
+			.Do(isBackendConnected => IsConnectionIssueDetected = !isBackendConnected)
 			.Subscribe()
 			.DisposeWith(Disposables);
-
-		// Set IsConnectionIssueDetected to false when BackedStatus == Connected
-		this.WhenAnyValue(x => x.BackendStatus)
-			.Where(x => x == BackendStatus.Connected)
-			.Do(_ => IsConnectionIssueDetected = false)
-			.Subscribe();
 
 		// Tor Issues
 		var issues =


### PR DESCRIPTION
The UI relies on the `WasabiSynchronizer` request and `BackendStatus` property to determine the status to be displayed for the user - that is working fine.

But it also effect the wallet load. If the backend is available the wallet will sync before displaying the wallet page. If the backend is not it will just show the wallet page with the warning of the balance might not be accurate. 

We have a bug there. In some cases, the loading never finishes when the backend is down. I emulated it by turning off my network. 

The reason is sometimes we got different exception (Tor SOCKS5 proxy responded with TtlExpired) that we assume and after some cumbersome logic we arrive [to the point of waiting to the backend](https://github.com/molnard/WalletWasabi/blob/master/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs#L114). 

This PR fixing this and also making the logic simpler. 

Review with whitespace off https://github.com/zkSNACKs/WalletWasabi/pull/12504/files?diff=split&w=1

