### PR TITLE
Fix WFP crash when network changes

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -272,6 +272,7 @@ public class Wallet : BackgroundService, IWallet
 
 		try
 		{
+			KeyManager.AssertNetworkOrClearBlockState(Network);
 			EnsureHeightsAreAtLeastSegWitActivation();
 
 			TransactionProcessor.WalletRelevantTransactionProcessed += TransactionProcessor_WalletRelevantTransactionProcessed;
@@ -453,8 +454,6 @@ public class Wallet : BackgroundService, IWallet
 
 	private async Task LoadWalletStateAsync(CancellationToken cancel)
 	{
-		KeyManager.AssertNetworkOrClearBlockState(Network);
-
 		// Make sure that the keys are asserted in case of an empty HdPubKeys array.
 		KeyManager.GetKeys();
 


### PR DESCRIPTION
Fixes #12514 

It's not really important, but still, this looks safe and makes more sense, as the check `AssertNetworkOrClearBlockState` is clearly something that should happen pre-initialisation.

We can backport it as it looks pretty safe but it's not super important either as the problem only occurs when messing with wallet files.