### PR TITLE
Fix crash when countries cannot be retrieved.

### DIFF
--- a/WalletWasabi/BuyAnything/BuyAnythingManager.cs
+++ b/WalletWasabi/BuyAnything/BuyAnythingManager.cs
@@ -658,7 +658,14 @@ public class BuyAnythingManager : PeriodicRunner
 	{
 		if (!Countries.Any())
 		{
-			Countries = await Client.GetCountriesAsync(cancel).ConfigureAwait(false);
+			try
+			{
+				Countries = await Client.GetCountriesAsync(cancel).ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogError($"Failed to download countries. Reason: '{ex.Message}'.");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Wasabi crashes without the internet on TestNet because BaB tries to get the countries and the error is not handled. On MainNet this is not happening as the countries are constant and stored in a file, so Wasabi just loads them. 

Source: https://github.com/zkSNACKs/WalletWasabi/pull/12504#issuecomment-1956476539