### PR TITLE
Log end of transaction file migration to SQL

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -67,7 +67,6 @@ public class TransactionStore : IAsyncDisposable
 
 			File.Delete(oldPath);
 			Logger.LogInfo($"Migration of transaction file '{oldPath}' to SQLite format was finished in {stopwatch.Elapsed} seconds.");
-
 		}
 	}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -60,7 +60,7 @@ public class TransactionStore : IAsyncDisposable
 			SqliteStorage.BulkInsert(allTransactions);
 
 			File.Delete(oldPath);
-			Logger.LogInfo($"Migration of transaction file '{oldPath}' to SQLite format was finished in {stopwatch.Elapsed} seconds.");
+			Logger.LogInfo($"Migration of transaction file '{oldPath}' to SQLite format was finished in {stopwatch.Elapsed.TotalSeconds} seconds.");
 		}
 	}
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -55,6 +55,7 @@ public class TransactionStore : IAsyncDisposable
 		if (File.Exists(oldPath))
 		{
 			Logger.LogInfo($"Migration of transaction file '{oldPath}' to SQLite format is about to begin. Please wait a moment.");
+			var stopwatch = Stopwatch.StartNew();
 
 			// ToDo: Temporary to fix https://github.com/zkSNACKs/WalletWasabi/pull/12137#issuecomment-1879798750
 			NeedResync = File.Exists(dbPath);
@@ -64,8 +65,9 @@ public class TransactionStore : IAsyncDisposable
 
 			SqliteStorage.BulkInsert(allTransactions);
 
-			Logger.LogInfo($"Removing old '{oldPath}' transaction storage.");
 			File.Delete(oldPath);
+			Logger.LogInfo($"Migration of transaction file '{oldPath}' to SQLite format was finished in {stopwatch.Elapsed} seconds.");
+
 		}
 	}
 


### PR DESCRIPTION
Fixes #12520 

@MarnixCroes look if you prefer this, but we won't do another fix and logging only once for both files as it would be annoying to do because of the design.