### PR TITLE
Introduce MinInputCountByBlameRound - simple

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -286,10 +286,23 @@ public static class WabiSabiFactory
 	}
 
 	public static BlameRound CreateBlameRound(Round round, WabiSabiConfig cfg)
-		=> new(RoundParameters.Create(cfg, round.Parameters.Network, round.Parameters.MiningFeeRate, round.Parameters.CoordinationFeeRate, round.Parameters.MaxSuggestedAmount),
+	{
+		var roundParameters = RoundParameters.Create(
+				cfg,
+				round.Parameters.Network,
+				round.Parameters.MiningFeeRate,
+				round.Parameters.CoordinationFeeRate,
+				round.Parameters.MaxSuggestedAmount) with
+			{
+				MinInputCountByRound = cfg.MinInputCountByBlameRound
+			};
+
+		return new BlameRound(
+			parameters: roundParameters,
 			blameOf: round,
 			blameWhitelist: round.Alices.Select(x => x.Coin.Outpoint).ToHashSet(),
 			InsecureRandom.Instance);
+	}
 
 	public static (IKeyChain, SmartCoin, SmartCoin) CreateCoinKeyPairs(KeyManager? keyManager = null)
 	{
@@ -357,6 +370,7 @@ public static class WabiSabiFactory
 			.Returns(CreateRoundParameters(cfg)
 				with
 			{
+				MinInputCountByRound = cfg.MinInputCountByBlameRound,
 				MaxVsizeAllocationPerAlice = maxVsizeAllocationPerAlice
 			});
 		return mockRoundParameterFactory.Object;

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -82,6 +82,7 @@ public class ConfigManagerTests
 			  "RoundExpiryTimeout": "0d 0h 5m 0s",
 			  "MaxInputCountByRound": 100,
 			  "MinInputCountByRoundMultiplier": 0.5,
+			  "MinInputCountByBlameRoundMultiplier": 0.4,
 			  "CoordinationFeeRate": {
 			    "Rate": {{coordinationFeeRate}},
 			    "PlebsDontPayThreshold": 1000000

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepInputRegistrationTests.cs
@@ -183,16 +183,25 @@ public class StepInputRegistrationTests
 		{
 			BlameInputRegistrationTimeout = TimeSpan.Zero,
 			StandardInputRegistrationTimeout = TimeSpan.FromHours(1), // Test that this is disregarded.
-			MaxInputCountByRound = 4,
-			MinInputCountByRoundMultiplier = 0.5
+			MaxInputCountByRound = 10,
+			MinInputCountByRoundMultiplier = 0.5,
+			MinInputCountByBlameRoundMultiplier = 0.4
 		};
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var alice1 = WabiSabiFactory.CreateAlice(round);
 		var alice2 = WabiSabiFactory.CreateAlice(round);
+		var alice3 = WabiSabiFactory.CreateAlice(round);
+		var alice4 = WabiSabiFactory.CreateAlice(round);
+		var alice5 = WabiSabiFactory.CreateAlice(round);
 		round.Alices.Add(alice1);
 		round.Alices.Add(alice2);
+		round.Alices.Add(alice3);
+		round.Alices.Add(alice4);
+		round.Alices.Add(alice5);
 		var blameRound = WabiSabiFactory.CreateBlameRound(round, cfg);
 		blameRound.Alices.Add(alice1);
+		blameRound.Alices.Add(alice2);
+		blameRound.Alices.Add(alice3);
 
 		using Arena arena = await ArenaBuilder.From(cfg).CreateAndStartAsync(blameRound);
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -141,6 +141,7 @@ public class StepTransactionSigningTests
 
 		WabiSabiConfig cfg = WabiSabiFactory.CreateWabiSabiConfig();
 		cfg.MinInputCountByRoundMultiplier = 1;
+		cfg.MinInputCountByBlameRoundMultiplier = 1;
 		cfg.TransactionSigningTimeout = TimeSpan.Zero;
 		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -130,7 +130,11 @@ public class MultipartyTransactionStateTests
 		maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
 		Assert.Equal(Money.Coins(0.1m), maxSuggestedAmountProvider.MaxSuggestedAmount);
 
-		RoundParameters blameParameters = roundParameterFactory.CreateBlameRoundParameter(new FeeRate(12m), roundLargest);
+		RoundParameters blameParameters = roundParameterFactory.CreateBlameRoundParameter(new FeeRate(12m), roundLargest) with
+		{
+			MinInputCountByRound = config.MinInputCountByBlameRound
+		};
+
 		BlameRound blameRound = new(blameParameters, roundLargest, new HashSet<OutPoint>(), SecureRandom.Instance);
 
 		// Blame rounds never change the MaxSuggestedAmount.

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -123,6 +123,12 @@ public class WabiSabiConfig : ConfigBase
 
 	public int MinInputCountByRound => Math.Max(1, (int)(MaxInputCountByRound * MinInputCountByRoundMultiplier));
 
+	[DefaultValue(0.4)]
+	[JsonProperty(PropertyName = "MinInputCountByBlameRoundMultiplier", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public double MinInputCountByBlameRoundMultiplier { get; set; } = 0.4;
+
+	public int MinInputCountByBlameRound => Math.Max(1, (int)(MaxInputCountByRound * MinInputCountByBlameRoundMultiplier));
+
 	[DefaultValueCoordinationFeeRate(0.003, 0.01)]
 	[JsonProperty(PropertyName = "CoordinationFeeRate", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public CoordinationFeeRate CoordinationFeeRate { get; set; } = new CoordinationFeeRate(0.003m, Money.Coins(0.01m));


### PR DESCRIPTION
An alternative solution to https://github.com/zkSNACKs/WalletWasabi/pull/12444 according to https://github.com/zkSNACKs/WalletWasabi/pull/12444#pullrequestreview-1885764516.

According to [Lucas's comment](https://github.com/zkSNACKs/WalletWasabi/pull/12444#issuecomment-1955283328) this will be OK. 

We only use the config when we destroy and create the blame round. 

This is a simpler solution than https://github.com/zkSNACKs/WalletWasabi/pull/12444. It does not add anything to the round. 

Check diff [HERE](https://github.com/zkSNACKs/WalletWasabi/pull/12524/files?diff=split&w=1).

The main idea is to move the round-ending logic into the CreateBlameRound method:
  - Remove code duplication
  - Easier to see that the config is only used to determine if we create the blame round or not. 