### PR TITLE
CompletedEventArgs was not forwarded in the the observable chain

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
@@ -26,7 +26,7 @@ public partial class WalletCoinjoinModel : ReactiveObject
 			Observable.FromEventPattern<StatusChangedEventArgs>(_coinJoinManager, nameof(CoinJoinManager.StatusChanged))
 					  .Where(x => x.EventArgs.Wallet == wallet)
 					  .Select(x => x.EventArgs)
-					  .Where(x => x is WalletStartedCoinJoinEventArgs or WalletStoppedCoinJoinEventArgs or StartErrorEventArgs or CoinJoinStatusEventArgs)
+					  .Where(x => x is WalletStartedCoinJoinEventArgs or WalletStoppedCoinJoinEventArgs or StartErrorEventArgs or CoinJoinStatusEventArgs or CompletedEventArgs)
 					  .ObserveOn(RxApp.MainThreadScheduler);
 
 		settings.WhenAnyValue(x => x.AutoCoinjoin)


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/12525

Spectrum control visibility binds to:
https://github.com/molnard/WalletWasabi/blob/master/WalletWasabi.Fluent/Views/Shell/MainScreen.axaml#L25

This is where the path ends, the IsRunning property:
https://github.com/molnard/WalletWasabi/blob/master/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs#L60

That observable is merged from 3 other observables. One of them was not working, see the fix.