### PR TITLE
Add missing state machine transition when wallet reached 100%

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -230,6 +230,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		_stateMachine.Configure(State.Playing)
 			.Permit(Trigger.WalletStoppedCoinJoin, State.StoppedOrPaused)
 			.Permit(Trigger.PlebStopActivated, State.PlebStopActive)
+			.Permit(Trigger.StartError, State.StoppedOrPaused)
 			.OnEntry(() =>
 			{
 				PlayVisible = false;


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/11380

So the issue was the state machine was in `Playing` state and got `StartError` trigger which was not handled at that state. Only the text was updated. 

I am not sure if this will make this better or worse. I only tested one specific case where I emulated that the CJ finish and percentage reached 100%. 

However, if you reach 100% and press the play button seemingly nothing happens - but under the hood the wallet tries to start the mix. I think is fine because the user can restart the CJ with that. Extra would be to hide/show the play button according to if CJ is possible. 

repro demo code: https://github.com/molnard/WalletWasabi/tree/reprohurray