### PR TITLE
[VDG] Privacy Ring - Remove Carousel

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -39,12 +39,13 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 		PrivacyTile.Activate(_disposables);
 
 		// Show PrivacyTile info when SelectedItem is null
-		Observable.Return(Unit.Default)
-				  .Delay(TimeSpan.FromMilliseconds(750)) // Wait for Ring animation to render
-				  .Concat(this.WhenAnyValue(x => x.SelectedItem).Where(x => x is null).ToSignal())
-				  .ObserveOn(RxApp.MainThreadScheduler)
-				  .Do(_ => SelectedItem = PrivacyTile)
-				  .Subscribe();
+		Observable
+			.Return(Unit.Default)
+			.Delay(TimeSpan.FromMilliseconds(0)) // Wait for Ring animation to render TODO: Calculate delay based on the number of segments
+			.Concat(this.WhenAnyValue(x => x.SelectedItem).Where(x => x is null).ToSignal())
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Do(_ => SelectedItem = PrivacyTile)
+			.Subscribe();
 
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 	}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -49,11 +49,11 @@
       <Setter Property="Background" Value="Red" />
     </Style>
 
-    <Style Selector="ContentControl#PreviewItem">
+    <Style Selector="ContentControl#SelectedItem">
       <Setter Property="Width" Value="250" />
     </Style>
 
-    <Style Selector="ContentControl#PreviewItem.small">
+    <Style Selector="ContentControl#SelectedItem.small">
       <Setter Property="Width" Value="160" />
     </Style>
   </UserControl.Styles>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/PrivacyRing/PrivacyRingView.axaml
@@ -49,11 +49,11 @@
       <Setter Property="Background" Value="Red" />
     </Style>
 
-    <Style Selector="Carousel#Carousel">
+    <Style Selector="ContentControl#PreviewItem">
       <Setter Property="Width" Value="250" />
     </Style>
 
-    <Style Selector="Carousel#Carousel.small">
+    <Style Selector="ContentControl#PreviewItem.small">
       <Setter Property="Width" Value="160" />
     </Style>
   </UserControl.Styles>
@@ -98,7 +98,7 @@
                                             Width="{Binding Width, Mode=TwoWay}"
                                             Height="{Binding Height, Mode=TwoWay}" />
           <ir:AdaptiveBehavior>
-            <ir:AdaptiveClassSetter MinHeight="0" MaxHeight="290" ClassName="small" TargetControl="{Binding #Carousel}" />
+            <ir:AdaptiveClassSetter MinHeight="0" MaxHeight="290" ClassName="small" TargetControl="{Binding #SelectedItem}" />
           </ir:AdaptiveBehavior>
         </i:Interaction.Behaviors>
 
@@ -136,26 +136,18 @@
           </ListBox.ItemTemplate>
         </ListBox>
 
-        <Carousel ItemsSource="{Binding PreviewItems}"
-                  SelectedItem="{Binding SelectedItem, Mode=OneWay}"
-                  VerticalAlignment="Center" HorizontalAlignment="Center"
-                  x:Name="Carousel">
-          <Carousel.PageTransition>
-            <CrossFade Duration="0.25" />
-          </Carousel.PageTransition>
-          <Carousel.DataTemplates>
+        <ContentControl Content="{Binding SelectedItem}"
+                        VerticalAlignment="Center" HorizontalAlignment="Center"
+                        x:Name="SelectedItem">
+          <ContentControl.DataTemplates>
             <DataTemplate DataType="{x:Type tiles:PrivacyControlTileViewModel}">
-              <ringView:PrivacyRingDetailsView VerticalAlignment="Center">
-                <i:Interaction.Behaviors>
-                  <behaviors:FadeInBehavior InitialDelay="0:0:1" />
-                </i:Interaction.Behaviors>
-              </ringView:PrivacyRingDetailsView>
+              <ringView:PrivacyRingDetailsView VerticalAlignment="Center" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type ring:PrivacyRingItemViewModel}">
               <ringView:PrivacyRingItemDetailsView />
             </DataTemplate>
-          </Carousel.DataTemplates>
-        </Carousel>
+          </ContentControl.DataTemplates>
+        </ContentControl>
       </Panel>
     </DockPanel>
   </ContentArea>


### PR DESCRIPTION
- Removes Carousel UI element from Privacy Ring view
- Fade in animation has been temporarily disabled to prevent the glitches. Will restore it in a future PR.
- Fixes #12537
- Attempt to fix #12495. I could not reproduce this issue so I'm not sure 100% that it's fixed in this PR. @yahiheb can you confirm?