### PR TITLE
[Trivial] Update ReleaseNotesTemplate.md

### DIFF
--- a/WalletWasabi.Documentation/ClientRelease/ReleaseNotesTemplate.md
+++ b/WalletWasabi.Documentation/ClientRelease/ReleaseNotesTemplate.md
@@ -33,7 +33,7 @@ Wasabi uses [reproducible builds](https://reproducible-builds.org/), which you c
 ## Requirements
 - Windows 10 1607+
 - Windows 11 22000+
-- macOS 10.15+
+- macOS 12.0+
 - Ubuntu 20.04+
 - Fedora 37+
 - Debian 11+


### PR DESCRIPTION
After we updated from .Net 7.0 to .Net 8.0 #11897, the macOS minimum version requirement was changed also.

Same as: #12534