### PR TITLE
Add missing state machine transition when wallet reached 100% - take 2

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -218,12 +218,27 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.OnEntry(() =>
 			{
 				StopCountDown();
-				PlayVisible = true;
+
+				// Playbutton only visible if we have more coins to mix.
+				PlayVisible = !AreAllCoinsPrivate;
 				PauseVisible = false;
 				PauseSpreading = false;
 				StopVisible = false;
-				CurrentStatus = IsAutoCoinJoinEnabled ? PauseMessage : StoppedMessage;
-				LeftText = CoinJoinStateViewModel.PressPlayToStartMessage;
+
+				// We only touch the message if we can continue with CJ. Otherwise we keep AllPrivateMessage.
+				if (!AreAllCoinsPrivate)
+				{
+					CurrentStatus = IsAutoCoinJoinEnabled ? PauseMessage : StoppedMessage;
+				}
+
+				// We only show the text if there is a button.
+				LeftText = AreAllCoinsPrivate ? "" : CoinJoinStateViewModel.PressPlayToStartMessage;
+			})
+			.OnTrigger(Trigger.BalanceChanged, () =>
+			{
+				// Refresh the UI according to AreAllCoinsPrivate, the play button and the left-text.
+				PlayVisible = !AreAllCoinsPrivate;
+				LeftText = AreAllCoinsPrivate ? "" : CoinJoinStateViewModel.PressPlayToStartMessage;
 			})
 			.OnExit(() => LeftText = "");
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -96,8 +96,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			  .Do(_ => _stateMachine.Fire(Trigger.BalanceChanged))
 			  .Subscribe();
 
-		AreAllCoinsPrivate
-			.WhenAnyValue(_ => _)
+		this.WhenAnyValue(x => x.AreAllCoinsPrivate)
 			.Do(_ => _stateMachine.Fire(Trigger.AreAllCoinsPrivateChanged))
 			.Subscribe();
 
@@ -299,8 +298,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			{
 				CurrentStatus = StoppedMessage;
 			}
-
-			// No compulsory update, we do not touch the message. If it was AllPrivateMessage we will keep that.
+			else
+			{
+				CurrentStatus = AllPrivateMessage;
+			}
 		}
 
 		// Set the LeftText.

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -224,27 +224,17 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.OnEntry(() =>
 			{
 				StopCountDown();
-
-				// Playbutton only visible if we have more coins to mix.
-				PlayVisible = !AreAllCoinsPrivate;
 				PauseVisible = false;
 				PauseSpreading = false;
 				StopVisible = false;
 
-				// We only touch the message if we can continue with CJ. Otherwise we keep AllPrivateMessage.
-				if (!AreAllCoinsPrivate)
-				{
-					CurrentStatus = IsAutoCoinJoinEnabled ? PauseMessage : StoppedMessage;
-				}
-
-				// We only show the text if there is a button.
-				LeftText = AreAllCoinsPrivate ? "" : CoinJoinStateViewModel.PressPlayToStartMessage;
+				// PlayVisible, CurrentStatus and LeftText set inside.
+				RefreshButtonAndTextInStateStoppedOrPaused();
 			})
 			.OnTrigger(Trigger.AreAllCoinsPrivateChanged, () =>
 			{
 				// Refresh the UI according to AreAllCoinsPrivate, the play button and the left-text.
-				PlayVisible = !AreAllCoinsPrivate;
-				LeftText = AreAllCoinsPrivate ? "" : CoinJoinStateViewModel.PressPlayToStartMessage;
+				RefreshButtonAndTextInStateStoppedOrPaused();
 			})
 			.OnExit(() => LeftText = "");
 
@@ -277,6 +267,58 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				LeftText = PlebStopMessageBelow;
 			})
 			.OnExit(() => LeftText = "");
+	}
+
+	private void RefreshButtonAndTextInStateStoppedOrPaused()
+	{
+		// Set visibility of Play button.
+		if (IsAutoCoinJoinEnabled)
+		{
+			PlayVisible = true;
+		}
+		else
+		{
+			if (AreAllCoinsPrivate)
+			{
+				PlayVisible = false;
+			}
+			else
+			{
+				PlayVisible = true;
+			}
+		}
+
+		// Set the message,
+		if (IsAutoCoinJoinEnabled)
+		{
+			CurrentStatus = PauseMessage;
+		}
+		else
+		{
+			if (!AreAllCoinsPrivate)
+			{
+				CurrentStatus = StoppedMessage;
+			}
+
+			// No compulsory update, we do not touch the message. If it was AllPrivateMessage we will keep that.
+		}
+
+		// Set the LeftText.
+		if (IsAutoCoinJoinEnabled)
+		{
+			LeftText = CoinJoinStateViewModel.PressPlayToStartMessage;
+		}
+		else
+		{
+			if (!AreAllCoinsPrivate)
+			{
+				LeftText = CoinJoinStateViewModel.PressPlayToStartMessage;
+			}
+			else
+			{
+				LeftText = "";
+			}
+		}
 	}
 
 	private void UpdateCountDown()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -96,6 +96,11 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			  .Do(_ => _stateMachine.Fire(Trigger.BalanceChanged))
 			  .Subscribe();
 
+		AreAllCoinsPrivate
+			.WhenAnyValue(_ => _)
+			.Do(_ => _stateMachine.Fire(Trigger.AreAllCoinsPrivateChanged))
+			.Subscribe();
+
 		PlayCommand = ReactiveCommand.CreateFromTask(async () =>
 		{
 			if (!wallet.Settings.IsCoinjoinProfileSelected)
@@ -167,7 +172,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		PlebStopChanged,
 		WalletStartedCoinJoin,
 		WalletStoppedCoinJoin,
-		AutoCoinJoinOff
+		AutoCoinJoinOff,
+		AreAllCoinsPrivateChanged
 	}
 
 	public bool IsAutoCoinJoinEnabled => _wallet.Settings.AutoCoinjoin;
@@ -234,7 +240,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				// We only show the text if there is a button.
 				LeftText = AreAllCoinsPrivate ? "" : CoinJoinStateViewModel.PressPlayToStartMessage;
 			})
-			.OnTrigger(Trigger.BalanceChanged, () =>
+			.OnTrigger(Trigger.AreAllCoinsPrivateChanged, () =>
 			{
 				// Refresh the UI according to AreAllCoinsPrivate, the play button and the left-text.
 				PlayVisible = !AreAllCoinsPrivate;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -270,55 +270,23 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 	private void RefreshButtonAndTextInStateStoppedOrPaused()
 	{
-		// Set visibility of Play button.
 		if (IsAutoCoinJoinEnabled)
 		{
 			PlayVisible = true;
-		}
-		else
-		{
-			if (AreAllCoinsPrivate)
-			{
-				PlayVisible = false;
-			}
-			else
-			{
-				PlayVisible = true;
-			}
-		}
-
-		// Set the message,
-		if (IsAutoCoinJoinEnabled)
-		{
 			CurrentStatus = PauseMessage;
+			LeftText = PressPlayToStartMessage;
+		}
+		else if (AreAllCoinsPrivate)
+		{
+			PlayVisible = false;
+			LeftText = "";
+			CurrentStatus = AllPrivateMessage;
 		}
 		else
 		{
-			if (!AreAllCoinsPrivate)
-			{
-				CurrentStatus = StoppedMessage;
-			}
-			else
-			{
-				CurrentStatus = AllPrivateMessage;
-			}
-		}
-
-		// Set the LeftText.
-		if (IsAutoCoinJoinEnabled)
-		{
-			LeftText = CoinJoinStateViewModel.PressPlayToStartMessage;
-		}
-		else
-		{
-			if (!AreAllCoinsPrivate)
-			{
-				LeftText = CoinJoinStateViewModel.PressPlayToStartMessage;
-			}
-			else
-			{
-				LeftText = "";
-			}
+			PlayVisible = true;
+			CurrentStatus = StoppedMessage;
+			LeftText = PressPlayToStartMessage;
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -586,6 +586,11 @@ public class CoinJoinManager : BackgroundService
 				// In auto CJ mode we never stop trying.
 				ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, finishedCoinJoin.OutputWallet, cancellationToken);
 			}
+			else
+			{
+				// We finished with CJ permanently.
+				NotifyWalletStoppedCoinJoin(wallet);
+			}
 		}
 		else if (cjClientException is not null)
 		{


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/11380

With this PR the music box will display hurray! and stop there without any buttons. If the balance or the anonscore target changes the button can appear and the user presses it to start mixing. 

There is no way for the user to forcefully continue mixing if all coins are private. 

With autocoin everything is the same, like before except the hurray message will be displayed but it will continue CJ in case of new coins or anonscore change. 

Ancestor https://github.com/zkSNACKs/WalletWasabi/pull/12540