### PR TITLE
Revert "Fix "StopWhenAllMixed = false doesn't work""

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -203,8 +203,8 @@ public class CoinJoinManager : BackgroundService
 				// If there are pending payments, ignore already achieved privacy.
 				if (!walletToStart.BatchedPayments.AreTherePendingPayments)
 				{
-					// If all coins are already private and the user doesn't override the StopWhenAllMixed, then don't mix.
-					if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false) && startCommand.StopWhenAllMixed)
+					// If all coins are already private, then don't mix.
+					if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false))
 					{
 						walletToStart.LogTrace("All mixed!");
 						throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate);


### PR DESCRIPTION
Reverts zkSNACKs/WalletWasabi#12502

Unfortunately, this mix will never stop in autocj mode. To fix the original issue we will need a larger refactor. 

This line shows that if autocj is turned on StopWhenAllMixed is always false - rendering the business to never stop mixing. 

https://github.com/molnard/WalletWasabi/blob/master/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs#L109

