### PR TITLE
Ignore visual studio launchSettings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,4 @@ lcov.info
 
 # This file is created by an F# VS Code plugin
 .ionide/symbolCache.db
+**/launchSettings.json


### PR DESCRIPTION
I am using Visual Studio and when I added `--loglevel=debug` as the default project-level command line argument it created a file: `launchSettings.json`. This file will never be required for version control it contains custom launch rules. 