### PR TITLE
Don't mix if all non-private coins are unconfirmed.

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -211,7 +211,7 @@ public class CoinJoinManager : BackgroundService
 					}
 
 					// If coin candidates are already private and the user doesn't override the StopWhenAllMixed, then don't mix.
-					if (coinCandidates.All(x => x.IsPrivate(walletToStart.AnonScoreTarget)) && startCommand.StopWhenAllMixed)
+					if (coinCandidates.All(x => !x.Confirmed || x.IsPrivate(walletToStart.AnonScoreTarget)) && startCommand.StopWhenAllMixed)
 					{
 						throw new CoinJoinClientException(
 							CoinjoinError.NoCoinsEligibleToMix,


### PR DESCRIPTION
Fixes an issue reported here: https://github.com/zkSNACKs/WalletWasabi/issues/12536#issuecomment-1962363029 where if your wallet is fully private and then some coins are coming the CoinJoinManager will start coinjoin when it would be better to wait for confirmation

It is the way to fix it with the less probability of breaking things, but maybe it still breaks 1000 other things. IMO this issue is an important one because it is highly inefficient in a standard case.