### PR TITLE
Simplify estimation code

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -15,7 +15,6 @@ namespace WalletWasabi.Fluent.Helpers;
 public static class TransactionFeeHelper
 {
 	private static readonly AllFeeEstimate TestNetFeeEstimates = new(
-		EstimateSmartFeeMode.Conservative,
 		new Dictionary<int, int>
 		{
 			[1] = 17,
@@ -28,8 +27,7 @@ public static class TransactionFeeHelper
 			[144] = 2,
 			[432] = 1,
 			[1008] = 1
-		},
-		false);
+		});
 
 	public static async Task<AllFeeEstimate> GetFeeEstimatesWhenReadyAsync(Wallet wallet, CancellationToken cancellationToken)
 	{

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -27,7 +27,7 @@ public class AllFeeEstimateTests
 				{ 3, 20 },
 				{ 19, 1 }
 			};
-		var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFee = new AllFeeEstimate(estimations);
 		var serialized = JsonConvert.SerializeObject(allFee);
 		var deserialized = JsonConvert.DeserializeObject<AllFeeEstimate>(serialized);
 
@@ -35,7 +35,6 @@ public class AllFeeEstimateTests
 		Assert.Equal(estimations[2], deserialized!.Estimations[2]);
 		Assert.Equal(estimations[3], deserialized!.Estimations[3]);
 		Assert.Equal(estimations[19], deserialized!.Estimations[36]);
-		Assert.Equal(EstimateSmartFeeMode.Conservative, deserialized!.Type);
 	}
 
 	[Fact]
@@ -49,7 +48,7 @@ public class AllFeeEstimateTests
 				{ 20, 1 }
 			};
 
-		var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFee = new AllFeeEstimate(estimations);
 		Assert.Equal(estimations[2], allFee.Estimations[2]);
 		Assert.Equal(estimations[3], allFee.Estimations[3]);
 		Assert.Equal(estimations[19], allFee.Estimations[36]);
@@ -64,7 +63,7 @@ public class AllFeeEstimateTests
 				{ 3, 20 }
 			};
 
-		var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFee = new AllFeeEstimate(estimations);
 		Assert.Single(allFee.Estimations);
 		Assert.Equal(estimations[2], allFee.Estimations[2]);
 	}
@@ -78,7 +77,7 @@ public class AllFeeEstimateTests
 				{ 1, 20 }
 			};
 
-		var allFees = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFees = new AllFeeEstimate(estimations);
 		Assert.Single(allFees.Estimations);
 		Assert.Equal(estimations[1], allFees.Estimations[2]);
 
@@ -89,7 +88,7 @@ public class AllFeeEstimateTests
 				{ 2, 21 }
 			};
 
-		allFees = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		allFees = new AllFeeEstimate(estimations);
 		Assert.Single(allFees.Estimations);
 		Assert.Equal(estimations[2], allFees.Estimations[2]);
 	}
@@ -102,7 +101,7 @@ public class AllFeeEstimateTests
 				{ 1007, 20 }
 			};
 
-		var allFees = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFees = new AllFeeEstimate(estimations);
 		var est = Assert.Single(allFees.Estimations);
 		Assert.Equal(1008, est.Key);
 	}
@@ -116,7 +115,7 @@ public class AllFeeEstimateTests
 				{ 3, 21 }
 			};
 
-		var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFee = new AllFeeEstimate(estimations);
 		Assert.Single(allFee.Estimations);
 		Assert.Equal(estimations[2], allFee.Estimations[2]);
 
@@ -129,7 +128,7 @@ public class AllFeeEstimateTests
 				{ 6, 4 },
 			};
 
-		allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		allFee = new AllFeeEstimate(estimations);
 		Assert.Equal(2, allFee.Estimations.Count);
 		Assert.Equal(estimations[2], allFee.Estimations[2]);
 		Assert.Equal(estimations[6], allFee.Estimations[6]);
@@ -226,7 +225,6 @@ public class AllFeeEstimateTests
 			};
 
 		var allFee = await mockRpc.EstimateAllFeeAsync();
-		Assert.True(allFee.IsAccurate);
 		Assert.Equal(3, allFee.Estimations.Count);
 		Assert.Equal(99, allFee.Estimations[2]);
 		Assert.Equal(75, allFee.Estimations[6]);
@@ -375,7 +373,7 @@ public class AllFeeEstimateTests
 				{ 18, 1 } // 3h
 			};
 
-		var allFee = new AllFeeEstimate(EstimateSmartFeeMode.Conservative, estimations, true);
+		var allFee = new AllFeeEstimate(estimations);
 
 		Assert.Equal(7, allFee.WildEstimations.Count());
 		Assert.Equal(new FeeRate(102m), allFee.WildEstimations.First().feeRate); // 20m

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -162,7 +162,6 @@ public class RpcBasedTests
 			Assert.Equal(7, estimations.Estimations.Count);
 			Assert.True(estimations.Estimations.First().Key < estimations.Estimations.Last().Key);
 			Assert.True(estimations.Estimations.First().Value > estimations.Estimations.Last().Value);
-			Assert.Equal(EstimateSmartFeeMode.Conservative, estimations.Type);
 		}
 		finally
 		{

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcFeeProvider.cs
@@ -30,12 +30,8 @@ public class RpcFeeProvider : PeriodicRunner
 		{
 			var allFeeEstimate = await RpcClient.EstimateAllFeeAsync(cancel).ConfigureAwait(false);
 
-			// If Core was running for a day already && it's synchronized, then we can be pretty sure that the estimate is accurate.
-			// It could also be accurate if Core was only shut down for a few minutes, but that's hard to figure out.
-			allFeeEstimate.IsAccurate = RpcMonitor.RpcStatus.Synchronized && await RpcClient.UptimeAsync(cancel).ConfigureAwait(false) > TimeSpan.FromDays(1);
-
 			LastAllFeeEstimate = allFeeEstimate;
-			if (allFeeEstimate?.Estimations?.Any() is true)
+			if (allFeeEstimate.Estimations.Any())
 			{
 				AllFeeEstimateArrived?.Invoke(this, allFeeEstimate);
 			}

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -16,12 +16,9 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation;
 public class AllFeeEstimate : IEquatable<AllFeeEstimate>
 {
 	[JsonConstructor]
-	public AllFeeEstimate(EstimateSmartFeeMode type, IDictionary<int, int> estimations, bool isAccurate)
+	public AllFeeEstimate(IDictionary<int, int> estimations)
 	{
 		Guard.NotNullOrEmpty(nameof(estimations), estimations);
-
-		Type = type;
-		IsAccurate = isAccurate;
 
 		var targets = Constants.ConfirmationTargets.Prepend(1).ToArray();
 		var targetRanges = targets.Skip(1).Zip(targets.Skip(1).Prepend(0), (x, y) => (Start: y, End: x));
@@ -47,19 +44,10 @@ public class AllFeeEstimate : IEquatable<AllFeeEstimate>
 		}
 	}
 
-	public AllFeeEstimate(AllFeeEstimate other, bool isAccurate)
-		: this(other.Type, other.Estimations, isAccurate)
+	public AllFeeEstimate(AllFeeEstimate other)
+		: this(other.Estimations)
 	{
 	}
-
-	[JsonProperty]
-	public EstimateSmartFeeMode Type { get; }
-
-	/// <summary>
-	/// Gets a value indicating whether the fee has been fetched from a fully synced node.
-	/// </summary>
-	[JsonProperty]
-	public bool IsAccurate { get; set; }
 
 	/// <summary>
 	/// Gets the fee estimations: int: fee target, int: satoshi/vByte
@@ -206,12 +194,11 @@ public class AllFeeEstimate : IEquatable<AllFeeEstimate>
 
 	public override int GetHashCode()
 	{
-		int hash = Type.GetHashCode();
+		int hash = 13;
 		foreach (KeyValuePair<int, int> est in Estimations)
 		{
 			hash ^= est.Key.GetHashCode() ^ est.Value.GetHashCode();
 		}
-		hash ^= IsAccurate.GetHashCode();
 
 		return hash;
 	}
@@ -224,16 +211,6 @@ public class AllFeeEstimate : IEquatable<AllFeeEstimate>
 		}
 
 		if (x is null || y is null)
-		{
-			return false;
-		}
-
-		if (x.Type != y.Type)
-		{
-			return false;
-		}
-
-		if (x.IsAccurate != y.IsAccurate)
 		{
 			return false;
 		}

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/ThirdPartyFeeProvider.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/ThirdPartyFeeProvider.cs
@@ -74,7 +74,7 @@ public class ThirdPartyFeeProvider : PeriodicRunner, IThirdPartyFeeProvider
 		var current = LastAllFeeEstimate;
 		if (fees is null
 			|| fees == current
-			|| (current is not null && ((!fees.IsAccurate && current.IsAccurate) || fees.Estimations.Count <= current.Estimations.Count)))
+			|| (current is not null && fees.Estimations.Count <= current.Estimations.Count))
 		{
 			return false;
 		}

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -134,9 +134,9 @@ public static class RPCClientExtensions
 
 		// EstimateSmartFeeAsync returns the block number where estimate was found - not always what the requested one.
 		return rpcFeeEstimationTasks
-			.Zip(Constants.ConfirmationTargets, (task, target) => (task, target))
-			.Where(x => x.task.IsCompletedSuccessfully)
-			.Select(x => (x.target, feeRate: x.task.Result.FeeRate))
+			.Where(x => x.IsCompletedSuccessfully)
+			.Select(x => (target: x.Result.Blocks, feeRate: x.Result.FeeRate))
+			.DistinctBy(x => x.target)
 			.ToDictionary(x => x.target, x => (int)Math.Ceiling(x.feeRate.SatoshiPerByte));
 	}
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -74,12 +74,7 @@ public static class RPCClientExtensions
 			? smartEstimations
 			: SmartEstimationsWithMempoolInfo(smartEstimations, mempoolInfo);
 
-		var rpcStatus = await rpc.GetRpcStatusAsync(cancel).ConfigureAwait(false);
-
-		return new AllFeeEstimate(
-			EstimateMode,
-			finalEstimations,
-			rpcStatus.Synchronized);
+		return new AllFeeEstimate(finalEstimations);
 	}
 
 	private static FeeRateByConfirmationTarget SmartEstimationsWithMempoolInfo(FeeRateByConfirmationTarget smartEstimations, MemPoolInfo mempoolInfo)

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
@@ -54,6 +54,6 @@ public class BlockstreamInfoClient
 			myDic.Add(int.Parse(elem.Name), (int)Math.Ceiling(elem.Value.GetDouble()));
 		}
 
-		return new AllFeeEstimate(EstimateSmartFeeMode.Conservative, myDic, isAccurate: true);
+		return new AllFeeEstimate(myDic);
 	}
 }


### PR DESCRIPTION
This PR removes the `EstimationMode` property because it is and always was `Conservative`. It also removes the `IsAccurate` because it assumes bitcoin nodes can give us back erroneous estimations under some specific conditions but that's not the case, bitcoin nodes return error if they cannot give us good enough estimations.

This is something required to simplify the synchronization mechanism based on websockets.   