### PR TITLE
[DO NOT REVIEW] CoinModel constructor performance investigation

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/CoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/CoinModel.cs
@@ -26,22 +26,35 @@ public partial class CoinModel : ReactiveObject
 		Amount = coin.Amount;
 
 		Labels = coin.GetLabels(anonScoreTarget);
-		Key = coin.Outpoint.GetHashCode();
+		Key = HashCode.Combine(Guid.NewGuid().GetHashCode(), coin.Outpoint.GetHashCode());
 		BannedUntilUtc = coin.BannedUntilUtc;
 		ScriptType = ScriptType.FromEnum(coin.ScriptType);
 
-		this.WhenAnyValue(c => c.Coin.IsExcludedFromCoinJoin).BindTo(this, x => x.IsExcludedFromCoinJoin);
-		this.WhenAnyValue(c => c.Coin.Confirmed).BindTo(this, x => x.IsConfirmed);
-		this.WhenAnyValue(c => c.Coin.HdPubKey.AnonymitySet).Select(x => (int)x).BindTo(this, x => x.AnonScore);
-		this.WhenAnyValue(c => c.Coin.CoinJoinInProgress).BindTo(this, x => x.IsCoinJoinInProgress);
-		this.WhenAnyValue(c => c.Coin.IsBanned).BindTo(this, x => x.IsBanned);
-		this.WhenAnyValue(c => c.Coin.BannedUntilUtc).WhereNotNull().Subscribe(x => BannedUntilUtcToolTip = $"Can't participate in coinjoin until: {x:g}");
+		this.WhenAnyValue(c => c.Coin.IsExcludedFromCoinJoin, c => c.Coin.Confirmed, c => c.Coin.HdPubKey.AnonymitySet)
+			//.Skip(1)
+			//.Do(x => IsExcludedFromCoinJoin = x)
+			.Subscribe();
 
-		this.WhenAnyValue(c => c.Coin.Height).Select(_ => Coin.GetConfirmations()).Subscribe(x =>
-		{
-			Confirmations = x;
-			ConfirmedToolTip = TextHelpers.GetConfirmationText(x);
-		});
+		//this.WhenAnyValue(c => c.Coin.Confirmed)
+		//.Skip(1)
+		//.Do(x => IsConfirmed = x)
+		//.Subscribe();
+
+		//this.WhenAnyValue(c => c.Coin.HdPubKey.AnonymitySet)
+		//.Skip(1)
+		//.Select(x => (int)x)
+		//.Do(x => AnonScore = x)
+		//.Subscribe();
+
+		//this.WhenAnyValue(c => c.Coin.CoinJoinInProgress).Skip(1).BindTo(this, x => x.IsCoinJoinInProgress);
+		//this.WhenAnyValue(c => c.Coin.IsBanned).Skip(1).BindTo(this, x => x.IsBanned);
+		//this.WhenAnyValue(c => c.Coin.BannedUntilUtc).Skip(1).WhereNotNull().Subscribe(x => BannedUntilUtcToolTip = $"Can't participate in coinjoin until: {x:g}");
+
+		//this.WhenAnyValue(c => c.Coin.Height).Skip(1).Select(_ => Coin.GetConfirmations()).Subscribe(x =>
+		//{
+		//	Confirmations = x;
+		//	ConfirmedToolTip = TextHelpers.GetConfirmationText(x);
+		//});
 	}
 
 	internal SmartCoin Coin { get; }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -74,7 +74,13 @@ public partial class WalletCoinsModel : IDisposable
 
 	private ICoinModel[] GetCoins()
 	{
-		return _wallet.Coins.Select(GetCoinModel).ToArray();
+		var asd =
+			Enumerable.Repeat(_wallet.Coins, 100)
+					  .SelectMany(x => x)
+					  .Select(GetCoinModel)
+					  .ToArray();
+		return asd;
+		//return _wallet.Coins.Select(GetCoinModel).ToArray();
 	}
 
 	public void Dispose() => _disposables.Dispose();


### PR DESCRIPTION
I'm using this branch to investigate possible solutions to #12547.

What I've found so far:

 - regardless of the presence `BindTo()`, just doing `WhenAnyValue().Subscribe()` is enough to observe the increased delay.
 - `WhenAnyValue()` by itself does not cause any delay. 
 - ViewModels that use this and affect startup time are only using the `PrivacyLevel` and related properties. We could simply not subscribe to anything else, but that would move the delay to opening the Privacy Ring or Coin List (@soosr this could be a temporary solution that would improve startup time, and defer the delay to a later time in the UX, if needed I can implement this)
 - doing a single subscription with many properties (`this.WhenAnyValue(x => x.Foo, x => x.Bar, ....)`) does not help
 - running this code in a background thread is a solution I'm currently exploring.