### PR TITLE
[VDG] WalletCoinsModel - Deferred Subscription

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Dialogs/LabelEntryDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/LabelEntryDialogViewModel.cs
@@ -49,6 +49,7 @@ public partial class LabelEntryDialogViewModel : DialogViewModelBase<LabelsArray
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
 
+		// TODO: why are we using this here and turning it into a Signal, instead of an event like _wallet.TransactionProcessed?
 		_wallet.Coins.List
 			.Connect()
 			.ToSignal()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletCoins/WalletCoinsViewModel.cs
@@ -54,6 +54,7 @@ public partial class WalletCoinsViewModel : RoutableViewModel
 		var coinChanges =
 			_wallet.Coins.List
 				.Connect()
+				.OnItemAdded(c => c.SubscribeToCoinChanges()) // Subscribe to SmartCoin changes for dynamic updates
 				.TransformWithInlineUpdate(x => new WalletCoinViewModel(x), (_, _) => { })
 				.Replay(1)
 				.RefCount();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyControlTileViewModel.cs
@@ -31,7 +31,11 @@ public partial class PrivacyControlTileViewModel : ActivatableViewModel, IPrivac
 
 		PrivacyBar = new PrivacyBarViewModel(wallet);
 
-		var coinList = _wallet.Coins.List.Connect(suppressEmptyChangeSets: false);
+		var coinList =
+			_wallet.Coins.List
+						 .Connect(suppressEmptyChangeSets: false); // coinList here is not subscribed to SmartCoin changes.
+																   // Dynamic updates to SmartCoin properties won't be reflected in the UI.
+																   // See CoinModel.SubscribeToCoinChanges().
 
 		TotalAmount = coinList.Sum(set => set.Amount.ToDecimal(MoneyUnit.Satoshi));
 		PrivateAmount = coinList.Filter(x => x.IsPrivate, suppressEmptyChangeSets: false).Sum(set => set.Amount.ToDecimal(MoneyUnit.Satoshi));
@@ -55,9 +59,14 @@ public partial class PrivacyControlTileViewModel : ActivatableViewModel, IPrivac
 	{
 		base.OnActivated(disposables);
 
+		var coinList =
+			_wallet.Coins.List                                      // coinList here is not subscribed to SmartCoin changes.
+						 .Connect(suppressEmptyChangeSets: false)   // Dynamic updates to SmartCoin properties won't be reflected in the UI.
+						 .ToCollection();                           // See CoinModel.SubscribeToCoinChanges().
+
 		_wallet.Privacy.Progress
 					   .CombineLatest(_wallet.Privacy.IsWalletPrivate)
-					   .CombineLatest(_wallet.Coins.List.Connect(suppressEmptyChangeSets: false).ToCollection())
+					   .CombineLatest(coinList)
 					   .Flatten()
 					   .Do(tuple =>
 					   {

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyBarViewModel.cs
@@ -37,9 +37,9 @@ public partial class PrivacyBarViewModel : ActivatableViewModel
 			.Subscribe()
 			.DisposeWith(disposables);
 
-		Wallet.Coins.List
-			.Connect(suppressEmptyChangeSets: false)
-			.ToCollection()
+		Wallet.Coins.List                                 // Wallet.Coins.List here is not subscribed to SmartCoin changes.
+			.Connect(suppressEmptyChangeSets: false)      // Dynamic updates to SmartCoin properties won't be reflected in the UI.
+			.ToCollection()                               // See CoinModel.SubscribeToCoinChanges().
 			.Subscribe(x => itemsSourceList.Edit(l => Update(l, x)))
 			.DisposeWith(disposables);
 	}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/PrivacyRing/PrivacyRingViewModel.cs
@@ -76,9 +76,16 @@ public partial class PrivacyRingViewModel : RoutableViewModel
 				.Throttle(TimeSpan.FromMilliseconds(100))
 				.ToSignal();
 
+		var coinsList =
+			_wallet.Coins.List
+						 .Connect(suppressEmptyChangeSets: false)
+						 .OnItemAdded(c => c.SubscribeToCoinChanges()) // Subscribe to SmartCoin changes for dynamic updates
+						 .ToCollection()
+						 .Select(x => x.Distinct());
+
 		_wallet.Privacy.ProgressUpdated
 					   .Merge(sizeTrigger)
-					   .WithLatestFrom(_wallet.Coins.List.Connect(suppressEmptyChangeSets: false).ToCollection().Select(x => x.Distinct()))
+					   .WithLatestFrom(coinsList)
 					   .ObserveOn(RxApp.MainThreadScheduler)
 					   .Do(t => RenderRing(itemsSourceList, t.Second))
 					   .Subscribe()


### PR DESCRIPTION
 - Removes change notification subscriptions from `SmartCoin` inside `CoinModel` constructor.
 - Moves these to a dedicated method `SubscribeToCoinChanges()`
 - Uses this method only in
    - `WalletCoinsViewModel`
    - `PrivacyRingViewModel`
 - This leaves the following ViewModels subscription-free:
    - `PrivacyControlTileViewModel`
    - `PrivacyBarViewModel`
 - These two do not use coin information other than PrivacyLevel, which isn't affected by the subscriptions.
 - Startup time will no longer be affected by this; however, noticeable delay will occur when opening Wallet Coins and Privacy Ring for wallets with large number of UTXOs.
 - Fixes #12547 