### PR TITLE
[UI] Fix potential memory leaks

### DIFF
--- a/WalletWasabi.Fluent/Extensions/ObservableExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/ObservableExtensions.cs
@@ -114,6 +114,7 @@ public static class ObservableExtensions
 	{
 		return signal.Select(_ => source())
 					 .EditDiff(keySelector)
+					 .DisposeMany()
 					 .AsObservableCache();
 	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/CoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/CoinModel.cs
@@ -11,9 +11,9 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 [AutoInterface]
 public partial class CoinModel : ReactiveObject, IDisposable
 {
-	private bool _subscribedToCoinChanges;
 	private readonly CompositeDisposable _disposable = new();
-	
+	private bool _subscribedToCoinChanges;
+
 	[AutoNotify] private bool _isExcludedFromCoinJoin;
 	[AutoNotify] private bool _isCoinJoinInProgress;
 	[AutoNotify] private bool _isBanned;
@@ -65,8 +65,6 @@ public partial class CoinModel : ReactiveObject, IDisposable
 	public bool IsSemiPrivate => PrivacyLevel == PrivacyLevel.SemiPrivate;
 
 	public bool IsNonPrivate => PrivacyLevel == PrivacyLevel.NonPrivate;
-
-	
 
 	/// <summary>Subscribes to property changes of underlying SmartCoin.</summary>
 	/// <remarks>This method is not thread safe. Make sure it's not called concurrently.</remarks>

--- a/WalletWasabi.Fluent/Models/Wallets/CoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/CoinModel.cs
@@ -12,6 +12,8 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 public partial class CoinModel : ReactiveObject, IDisposable
 {
 	private bool _subscribedToCoinChanges;
+	private readonly CompositeDisposable _disposable = new();
+	
 	[AutoNotify] private bool _isExcludedFromCoinJoin;
 	[AutoNotify] private bool _isCoinJoinInProgress;
 	[AutoNotify] private bool _isBanned;
@@ -20,7 +22,7 @@ public partial class CoinModel : ReactiveObject, IDisposable
 	[AutoNotify] private int _anonScore;
 	[AutoNotify] private int _confirmations;
 	[AutoNotify] private bool _isConfirmed;
-
+	
 	public CoinModel(SmartCoin coin, int anonScoreTarget)
 	{
 		Coin = coin;
@@ -44,7 +46,7 @@ public partial class CoinModel : ReactiveObject, IDisposable
 		ConfirmedToolTip = TextHelpers.GetConfirmationText(confirmations);
 	}
 
-	internal SmartCoin Coin { get; }
+	private SmartCoin Coin { get; }
 
 	public Money Amount { get; }
 
@@ -64,7 +66,7 @@ public partial class CoinModel : ReactiveObject, IDisposable
 
 	public bool IsNonPrivate => PrivacyLevel == PrivacyLevel.NonPrivate;
 
-	private readonly CompositeDisposable _disposable = new();
+	
 
 	/// <summary>Subscribes to property changes of underlying SmartCoin.</summary>
 	/// <remarks>This method is not thread safe. Make sure it's not called concurrently.</remarks>

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -27,7 +27,7 @@ public partial class WalletCoinsModel : IDisposable
 		_wallet = wallet;
 		_walletModel = walletModel;
 		var transactionProcessed = walletModel.Transactions.TransactionProcessed;
-		var anonScoreTargetChanged = walletModel.WhenAnyValue(x => x.Settings.AnonScoreTarget).Skip(1).ToSignal();
+		var anonScoreTargetChanged = this.WhenAnyValue(x => x._walletModel.Settings.AnonScoreTarget).Skip(1).ToSignal();
 		var isCoinjoinRunningChanged = walletModel.Coinjoin.IsRunning.ToSignal();
 
 		var signals =
@@ -44,7 +44,8 @@ public partial class WalletCoinsModel : IDisposable
 			.Subscribe()
 			.DisposeWith(_disposables);
 
-		signals.Connect();
+		signals.Connect()
+			.DisposeWith(_disposables);
 	}
 
 	public IObservableCache<ICoinModel, int> List { get; }


### PR DESCRIPTION
OK, after some testing I've come to the conclusion that instances of CoinModel **were not being disposed**.
I still need to investigate the reason why this happened, because CoinModel's subscriptions **shared the same lifespan of their parent CoinModel**, so, as soon as the CoinModel is not longer used, the subscriptions should have been GC'd as well.

It's interesting to notice that we called `WhenAnyValue` correctly (calling it right after the `this` keyword). This, in theory, makes it unnecessary to explicitly implement IDisposable. 

For some reason, this didn't happen. The instances survived.

This PR ensures that CoinModels are disposed as well as their subscriptions, if any.
