### PR TITLE
Add sanity check for round destroyer threshold

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -497,7 +497,7 @@ public partial class Arena : PeriodicRunner
 				x.Phase == Phase.InputRegistration
 				&& x is not BlameRound
 				&& !x.IsInputRegistrationEnded(x.Parameters.MaxInputCountByRound)
-				&& x.InputCount >= roundDestroyerInputCount).ToArray())
+				&& x.InputCount >= Math.Min(0.9 * x.Parameters.MaxInputCountByRound, roundDestroyerInputCount)).ToArray())
 			{
 				feeRate = (await Rpc.EstimateConservativeSmartFeeAsync((int)Config.ConfirmationTarget, cancellationToken).ConfigureAwait(false)).FeeRate;
 


### PR DESCRIPTION
Round destroyer is broken since deployment of #12524 because `roundDestroyerInputCount = 440`, which is higher than `MaxInputCountByRound` (400). However, it must always be lower.

This clearly shows how unintuitive is this code, those multipliers etc etc... We should remove all that and refactor more simply.

Something else, we had extremely good rounds while having this bug. Maybe we should reconsider how this round destroyer is working.