### PR TITLE
Add `WalletFactory` type

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -123,7 +123,8 @@ public class Global
 			new P2PBlockProvider(P2PNodesManager),
 			Cache);
 
-		WalletManager = new WalletManager(config.Network, DataDir, new WalletDirectories(Config.Network, DataDir), BitcoinStore, wasabiSynchronizer, HostedServices.Get<HybridFeeProvider>(), blockProvider, config.ServiceConfiguration);
+		WalletFactory walletFactory = new(DataDir, config.Network, BitcoinStore, wasabiSynchronizer, config.ServiceConfiguration, HostedServices.Get<HybridFeeProvider>(), blockProvider);
+		WalletManager = new WalletManager(config.Network, DataDir, new WalletDirectories(Config.Network, DataDir), walletFactory);
 		TransactionBroadcaster = new TransactionBroadcaster(Network, BitcoinStore, HttpClientFactory, WalletManager);
 
 		CoinPrison = CoinPrison.CreateOrLoadFromFile(DataDir);

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -121,7 +121,6 @@ public class P2pTests
 
 		ServiceConfiguration serviceConfiguration = new(new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold));
 		WalletFactory walletFactory = new(dataDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
-
 		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
 
 		Assert.True(Directory.Exists(blocks.BlocksFolderPath));

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -119,15 +119,12 @@ public class P2pTests
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		using Wallet wallet = Wallet.CreateAndRegisterServices(
-			network,
-			bitcoinStore,
-			keyManager,
-			synchronizer,
-			dataDir,
-			new ServiceConfiguration(new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold)),
-			feeProvider,
-			blockProvider);
+		ServiceConfiguration serviceConfiguration = new(new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold));
+		WalletFactory walletFactory = new(dataDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+
+		using Wallet wallet = walletFactory.Create(keyManager);
+		wallet.Initialize();
+
 		Assert.True(Directory.Exists(blocks.BlocksFolderPath));
 
 		try

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -122,8 +122,7 @@ public class P2pTests
 		ServiceConfiguration serviceConfiguration = new(new IPEndPoint(IPAddress.Loopback, network.DefaultPort), Money.Coins(Constants.DefaultDustThreshold));
 		WalletFactory walletFactory = new(dataDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
 
-		using Wallet wallet = walletFactory.Create(keyManager);
-		wallet.Initialize();
+		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
 
 		Assert.True(Directory.Exists(blocks.BlocksFolderPath));
 

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -82,7 +82,8 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		var baseTip = await rpc.GetBestBlockHashAsync();

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -83,8 +83,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 
 		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
 
-		using var wallet = walletFactory.Create(keyManager);
-		wallet.Initialize();
+		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
 
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -81,7 +81,11 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 			p2PBlockProvider: new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, workDir, serviceConfiguration, feeProvider, blockProvider);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+
+		using var wallet = walletFactory.Create(keyManager);
+		wallet.Initialize();
+
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 
 		using Key key = new();

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -82,9 +82,7 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 			cache);
 
 		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
-
 		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
-
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 
 		using Key key = new();

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -80,7 +80,8 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -80,7 +80,8 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -82,7 +82,8 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		try

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -78,7 +78,10 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, workDir, serviceConfiguration, feeProvider, blockProvider);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		using Wallet wallet = walletFactory.Create(keyManager);
+		wallet.Initialize();
+
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 
 		Assert.Empty(wallet.Coins);

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -79,8 +79,7 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 			cache);
 
 		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
-		using Wallet wallet = walletFactory.Create(keyManager);
-		wallet.Initialize();
+		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
 
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -82,7 +82,8 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -83,7 +83,8 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -80,7 +80,8 @@ public class SendTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -80,7 +80,8 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), bitcoinStore, synchronizer, feeProvider, blockProvider, serviceConfiguration);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		WalletManager walletManager = new(network, workDir, new WalletDirectories(network, workDir), walletFactory);
 		walletManager.Initialize();
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -82,8 +82,7 @@ public class WalletTests : IClassFixture<RegTestFixture>
 
 		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, setup.ServiceConfiguration, feeProvider, blockProvider);
 
-		using Wallet wallet = walletFactory.Create(keyManager);
-		wallet.Initialize();
+		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -81,7 +81,6 @@ public class WalletTests : IClassFixture<RegTestFixture>
 			cache);
 
 		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, setup.ServiceConfiguration, feeProvider, blockProvider);
-
 		using Wallet wallet = walletFactory.CreateAndInitialize(keyManager);
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -80,7 +80,10 @@ public class WalletTests : IClassFixture<RegTestFixture>
 			new P2PBlockProvider(network, nodes, httpClientFactory.IsTorEnabled),
 			cache);
 
-		using var wallet = Wallet.CreateAndRegisterServices(network, bitcoinStore, keyManager, synchronizer, workDir, setup.ServiceConfiguration, feeProvider, blockProvider);
+		WalletFactory walletFactory = new(workDir, network, bitcoinStore, synchronizer, setup.ServiceConfiguration, feeProvider, blockProvider);
+
+		using Wallet wallet = walletFactory.Create(keyManager);
+		wallet.Initialize();
 		wallet.NewFiltersProcessed += setup.Wallet_NewFiltersProcessed;
 
 		// Get some money, make it confirm.

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -64,7 +64,11 @@ public class WalletBuilder : IAsyncDisposable
 		HybridFeeProvider feeProvider = new(Synchronizer, null);
 		SmartBlockProvider blockProvider = new(BitcoinStore.BlockRepository, rpcBlockProvider: null, null, null, Cache);
 
-		return WalletWasabi.Wallets.Wallet.CreateAndRegisterServices(Network.RegTest, BitcoinStore, keyManager, Synchronizer, DataDir, serviceConfiguration, feeProvider, blockProvider);
+		WalletFactory walletFactory = new(DataDir, Network.RegTest, BitcoinStore, Synchronizer, serviceConfiguration, feeProvider, blockProvider);
+		var result = walletFactory.Create(keyManager);
+		result.Initialize();
+
+		return result;
 	}
 
 	public async ValueTask DisposeAsync()

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletBuilder.cs
@@ -65,10 +65,7 @@ public class WalletBuilder : IAsyncDisposable
 		SmartBlockProvider blockProvider = new(BitcoinStore.BlockRepository, rpcBlockProvider: null, null, null, Cache);
 
 		WalletFactory walletFactory = new(DataDir, Network.RegTest, BitcoinStore, Synchronizer, serviceConfiguration, feeProvider, blockProvider);
-		var result = walletFactory.Create(keyManager);
-		result.Initialize();
-
-		return result;
+		return walletFactory.CreateAndInitialize(keyManager);
 	}
 
 	public async ValueTask DisposeAsync()

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -39,7 +39,8 @@ public class Wallet : BackgroundService, IWallet
 		WasabiSynchronizer syncer,
 		ServiceConfiguration serviceConfiguration,
 		HybridFeeProvider feeProvider,
-		IBlockProvider blockProvider)
+		TransactionProcessor transactionProcessor,
+		WalletFilterProcessor walletFilterProcessor)
 	{
 		Guard.NotNullOrEmptyOrWhitespace(nameof(dataDir), dataDir);
 		Network = network;
@@ -48,7 +49,6 @@ public class Wallet : BackgroundService, IWallet
 		Synchronizer = syncer;
 		ServiceConfiguration = serviceConfiguration;
 		FeeProvider = feeProvider;
-		BlockProvider = blockProvider;
 
 		RuntimeParams.SetDataDir(dataDir);
 
@@ -59,9 +59,9 @@ public class Wallet : BackgroundService, IWallet
 
 		DestinationProvider = new InternalDestinationProvider(KeyManager);
 
-		TransactionProcessor = new TransactionProcessor(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, KeyManager, ServiceConfiguration.DustThreshold);
+		TransactionProcessor = transactionProcessor;
 		Coins = TransactionProcessor.Coins;
-		WalletFilterProcessor = new WalletFilterProcessor(KeyManager, BitcoinStore, TransactionProcessor, BlockProvider);
+		WalletFilterProcessor = walletFilterProcessor;
 		BatchedPayments = new PaymentBatch();
 		OutputProvider = new PaymentAwareOutputProvider(DestinationProvider, BatchedPayments);
 		WalletId = new WalletId(Guid.NewGuid());
@@ -108,7 +108,6 @@ public class Wallet : BackgroundService, IWallet
 
 	public WalletFilterProcessor WalletFilterProcessor { get; }
 	public FilterModel? LastProcessedFilter => WalletFilterProcessor.LastProcessedFilter;
-	public IBlockProvider BlockProvider { get; }
 
 	public bool IsLoggedIn { get; private set; }
 
@@ -545,13 +544,6 @@ public class Wallet : BackgroundService, IWallet
 		}
 
 		State = WalletState.WaitingForInit;
-	}
-
-	public static Wallet CreateAndRegisterServices(Network network, BitcoinStore bitcoinStore, KeyManager keyManager, WasabiSynchronizer synchronizer, string dataDir, ServiceConfiguration serviceConfiguration, HybridFeeProvider feeProvider, IBlockProvider blockProvider)
-	{
-		var wallet = new Wallet(dataDir, network, keyManager, bitcoinStore, synchronizer, serviceConfiguration, feeProvider, blockProvider);
-		wallet.Initialize();
-		return wallet;
 	}
 
 	public void ExcludeCoinFromCoinJoin(OutPoint outpoint, bool exclude = true)

--- a/WalletWasabi/Wallets/WalletFactory.cs
+++ b/WalletWasabi/Wallets/WalletFactory.cs
@@ -1,0 +1,23 @@
+using NBitcoin;
+using WalletWasabi.Blockchain.Analysis.FeesEstimation;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Models;
+using WalletWasabi.Services;
+using WalletWasabi.Stores;
+
+namespace WalletWasabi.Wallets;
+
+public record WalletFactory(
+	string DataDir,
+	Network Network,
+	BitcoinStore BitcoinStore,
+	WasabiSynchronizer Synchronizer,
+	ServiceConfiguration ServiceConfiguration,
+	HybridFeeProvider FeeProvider,
+	IBlockProvider BlockProvider)
+{
+	public Wallet Create(KeyManager keyManager)
+	{
+		return new(DataDir, Network, keyManager, BitcoinStore, Synchronizer, ServiceConfiguration, FeeProvider, BlockProvider);
+	}
+}

--- a/WalletWasabi/Wallets/WalletFactory.cs
+++ b/WalletWasabi/Wallets/WalletFactory.cs
@@ -12,7 +12,7 @@ public record WalletFactory(
 	string DataDir,
 	Network Network,
 	BitcoinStore BitcoinStore,
-	WasabiSynchronizer Synchronizer,
+	WasabiSynchronizer WasabiSynchronizer,
 	ServiceConfiguration ServiceConfiguration,
 	HybridFeeProvider FeeProvider,
 	IBlockProvider BlockProvider)
@@ -22,7 +22,7 @@ public record WalletFactory(
 		TransactionProcessor transactionProcessor = new(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, keyManager, ServiceConfiguration.DustThreshold);
 		WalletFilterProcessor walletFilterProcessor = new(keyManager, BitcoinStore, transactionProcessor, BlockProvider);
 
-		return new(DataDir, Network, keyManager, BitcoinStore, Synchronizer, ServiceConfiguration, FeeProvider, transactionProcessor, walletFilterProcessor);
+		return new(DataDir, Network, keyManager, BitcoinStore, WasabiSynchronizer, ServiceConfiguration, FeeProvider, transactionProcessor, walletFilterProcessor);
 	}
 
 	public Wallet CreateAndInitialize(KeyManager keyManager)

--- a/WalletWasabi/Wallets/WalletFactory.cs
+++ b/WalletWasabi/Wallets/WalletFactory.cs
@@ -8,6 +8,9 @@ using WalletWasabi.Stores;
 
 namespace WalletWasabi.Wallets;
 
+/// <summary>
+/// Class to create <see cref="Wallet"/> instances.
+/// </summary>
 public record WalletFactory(
 	string DataDir,
 	Network Network,

--- a/WalletWasabi/Wallets/WalletFactory.cs
+++ b/WalletWasabi/Wallets/WalletFactory.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
 using WalletWasabi.Stores;
@@ -18,6 +19,9 @@ public record WalletFactory(
 {
 	public Wallet Create(KeyManager keyManager)
 	{
-		return new(DataDir, Network, keyManager, BitcoinStore, Synchronizer, ServiceConfiguration, FeeProvider, BlockProvider);
+		TransactionProcessor transactionProcessor = new(BitcoinStore.TransactionStore, BitcoinStore.MempoolService, keyManager, ServiceConfiguration.DustThreshold);
+		WalletFilterProcessor walletFilterProcessor = new(keyManager, BitcoinStore, transactionProcessor, BlockProvider);
+
+		return new(DataDir, Network, keyManager, BitcoinStore, Synchronizer, ServiceConfiguration, FeeProvider, transactionProcessor, walletFilterProcessor);
 	}
 }

--- a/WalletWasabi/Wallets/WalletFactory.cs
+++ b/WalletWasabi/Wallets/WalletFactory.cs
@@ -24,4 +24,12 @@ public record WalletFactory(
 
 		return new(DataDir, Network, keyManager, BitcoinStore, Synchronizer, ServiceConfiguration, FeeProvider, transactionProcessor, walletFilterProcessor);
 	}
+
+	public Wallet CreateAndInitialize(KeyManager keyManager)
+	{
+		Wallet wallet = Create(keyManager);
+		wallet.Initialize();
+
+		return wallet;
+	}
 }


### PR DESCRIPTION
This PR

* Adds a `WalletFactory` type 
* Removes the static `Wallet.CreateAndRegisterServices` method
* Removes the `Wallet.CreateWalletInstance` method
* Removes the `Wallet.BlockProvider` property because it was only used to create `WalletFilterProcessor` in the `Wallet.ctor`.
* ... is just refactoring, no functional change is intended here

This PR is meant to be a precursor to #12562