### PR TITLE
Fix logging when we destroy a round (LoadBalancer)

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -491,13 +491,13 @@ public partial class Arena : PeriodicRunner
 		if (Config.WW200CompatibleLoadBalancing)
 		{
 			// Destroy the round when it reaches this input count and create 2 new ones instead.
-			var roundDestroyerInputCount = Config.MinInputCountByRound * 2 + Config.MinInputCountByRound / 2;
+			var roundDestroyerInputCount = 0.9 * Config.MaxInputCountByRound;
 
 			foreach (var round in Rounds.Where(x =>
 				x.Phase == Phase.InputRegistration
 				&& x is not BlameRound
 				&& !x.IsInputRegistrationEnded(x.Parameters.MaxInputCountByRound)
-				&& x.InputCount >= Math.Min(0.9 * x.Parameters.MaxInputCountByRound, roundDestroyerInputCount)).ToArray())
+				&& x.InputCount >= roundDestroyerInputCount).ToArray())
 			{
 				feeRate = (await Rpc.EstimateConservativeSmartFeeAsync((int)Config.ConfirmationTarget, cancellationToken).ConfigureAwait(false)).FeeRate;
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -490,7 +490,6 @@ public partial class Arena : PeriodicRunner
 		// Only do things if the load balancer compatibility is configured.
 		if (Config.WW200CompatibleLoadBalancing)
 		{
-			// Destroy the round when it reaches this input count and create 2 new ones instead.
 			foreach (var round in Rounds.Where(x =>
 				x.Phase == Phase.InputRegistration
 				&& x is not BlameRound
@@ -555,6 +554,7 @@ public partial class Arena : PeriodicRunner
 		}
 	}
 
+	// Destroy the round when it reaches this input count and create 2 new ones instead.
 	private int CalculateLoadBalanceThreshold(int minInputCountByRound, int maxInputCountByRound) => (int)Math.Min(0.9 * maxInputCountByRound, minInputCountByRound * 2 + minInputCountByRound / 2);
 
 	private Round? TryMineRound(RoundParameters parameters, Round[] rounds)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -491,13 +491,11 @@ public partial class Arena : PeriodicRunner
 		if (Config.WW200CompatibleLoadBalancing)
 		{
 			// Destroy the round when it reaches this input count and create 2 new ones instead.
-			var roundDestroyerInputCount = 0.9 * Config.MaxInputCountByRound;
-
 			foreach (var round in Rounds.Where(x =>
 				x.Phase == Phase.InputRegistration
 				&& x is not BlameRound
 				&& !x.IsInputRegistrationEnded(x.Parameters.MaxInputCountByRound)
-				&& x.InputCount >= roundDestroyerInputCount).ToArray())
+				&& x.InputCount >= 0.9 * x.Parameters.MaxInputCountByRound).ToArray())
 			{
 				feeRate = (await Rpc.EstimateConservativeSmartFeeAsync((int)Config.ConfirmationTarget, cancellationToken).ConfigureAwait(false)).FeeRate;
 
@@ -537,7 +535,7 @@ public partial class Arena : PeriodicRunner
 
 						// If it can't create the large round, then don't abort.
 						EndRound(round, EndRoundState.AbortedLoadBalancing);
-						Logger.LogInfo($"Destroyed round with {allInputs.Length} inputs. Threshold: {roundDestroyerInputCount}");
+						Logger.LogInfo($"Destroyed round with {allInputs.Length} inputs. Threshold: {0.9 * round.Parameters.MaxInputCountByRound}");
 					}
 				}
 			}


### PR DESCRIPTION
Addresses: https://github.com/zkSNACKs/WalletWasabi/pull/12585#discussion_r1508832348

Why is this so important for me?

Because in case there is an issue in the backend and we need to investigate it, more or less the logs are our only weapon.
If we cannot trust the logs or the logs are inaccurate, the investigation becomes much harder.

`master` produces logs like this:
```
2024-03-01 11:51:57.989 [71] INFO	Arena.CreateRoundsAsync (540)	Destroyed round with 360 inputs. Threshold: 450
```

This is NOT urgent to deploy.