### PR TITLE
Add mention_users_on_filechange.yml script

### DIFF
--- a/.github/notify-users-config.json
+++ b/.github/notify-users-config.json
@@ -1,0 +1,84 @@
+{
+  "files_to_watch": [
+    {
+      "path": "WalletWasabi/Wallets/IWallet.cs",
+      "users": ["@Kukks"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/Keys/HdPubKey.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/Transactions/SmartTransaction.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Helpers/NBitcoinHelpers.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Backend/Rounds/UtxoSelectionParameters.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/AmountDecomposer.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/LiquidityClueProvider.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/Decomposer.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/AmountDecomposer.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/Output.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Backend/Rounds/UtxoSelectionParameters.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/WabiSabi/Client/LiquidityClueProvider.cs",
+      "users": ["@onvej-sl"]
+    },
+    {
+      "path": "WalletWasabi/Affiliation/",
+      "users": ["@onvej-sl"]
+    }
+  ]
+}

--- a/.github/notify-users-config.json
+++ b/.github/notify-users-config.json
@@ -79,6 +79,10 @@
     {
       "path": "WalletWasabi/Affiliation/",
       "users": ["@onvej-sl"]
+    },
+    {
+      "path": ".github/notify-users-config.json",
+      "users": ["@molnard"]
     }
   ]
 }

--- a/.github/workflows/mention_users_on_filechange.yml
+++ b/.github/workflows/mention_users_on_filechange.yml
@@ -18,7 +18,7 @@ jobs:
             const fs = require('fs');
             
             // Read the configuration file
-            const configPath = '.github/notify-config.json';
+            const configPath = '.github/notify-users-config.json';
             const configFile = fs.readFileSync(configPath, 'utf8');
             const config = JSON.parse(configFile);
             

--- a/.github/workflows/mention_users_on_filechange.yml
+++ b/.github/workflows/mention_users_on_filechange.yml
@@ -1,0 +1,88 @@
+name: Mention Users on Specific File Change in PR
+
+on:
+  pull_request:
+
+jobs:
+  mention-users:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Read configuration and mention users
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            
+            // Read the configuration file
+            const configPath = '.github/notify-config.json';
+            const configFile = fs.readFileSync(configPath, 'utf8');
+            const config = JSON.parse(configFile);
+            
+            // Extract PR number
+            const prNumber = context.issue.number;
+            
+            // Async function to handle API calls and logic
+            async function run() {
+              // Fetch list of files changed in the PR
+              const listFilesResponse = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              const changedFiles = listFilesResponse.data.map(file => file.filename);
+              
+              // Fetch all comments from the PR
+              const commentsResponse = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+              const comments = commentsResponse.data.map(comment => comment.body);
+              
+              // Combine all comments into a single string to search for user mentions
+              const commentsText = comments.join(" ");
+              
+              let message = "Changes have been detected in:";
+              let hasMentionedFiles = false;
+              let mentionedUsers = new Set();
+              
+              // Check if the PR contains changes to the files or folders specified in the configuration
+              for (const item of config.files_to_watch) {
+                const isFolder = item.path.endsWith('/');
+                for (const changedFile of changedFiles) {
+                  if (isFolder ? changedFile.startsWith(item.path) : changedFile === item.path) {
+                    // Filter out users who have already been mentioned
+                    const usersToMention = item.users.filter(user => !commentsText.includes(user));
+                    
+                    if (usersToMention.length > 0) {
+                      // Add users to the set of mentioned users to avoid duplicates
+                      usersToMention.forEach(user => mentionedUsers.add(user));
+                      if (!hasMentionedFiles) {
+                        // First time adding to the message, change the flag
+                        hasMentionedFiles = true;
+                      }
+                      message += `\n- \`${item.path}\` (Pinging ${usersToMention.join(', ')} for review).`;
+                    }
+                  }
+                }
+              }
+              
+              // Post the comment on the PR if there are any files or folders to mention
+              if (hasMentionedFiles) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: message
+                });
+              } else {
+                console.log("No configured files or folders were changed in this PR, or users have already been mentioned.");
+              }
+            }
+            
+            // Execute the async function
+            run().catch(err => core.setFailed(`Unhandled error: ${err}`));


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/10516

This is adding a simple script that will mention specific users on specific file changes. 

If one user mentioned once at a PR the script will never mention him again.  

P.S. Why JavaScript? 

> The use of JavaScript in the GitHub Actions script, particularly within the github-script action, is because the github-script action itself is designed to run JavaScript (JS) code directly within your workflow. This allows you to interact with the GitHub API and perform a wide range of operations based on the context of your GitHub repository, pull requests, issues, and more, without needing to set up a separate environment or external dependencies.
