### PR TITLE
[PoC] Payment aware CoinjoinCoinSelector

### DIFF
--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentAwareOutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentAwareOutputProvider.cs
@@ -18,7 +18,9 @@ public class PaymentAwareOutputProvider : OutputProvider
 	}
 
 	private PaymentBatch BatchedPayments { get; }
-	
+
+	public Money[] GetBatchedPaymentsAmounts => BatchedPayments.SumPendingPayments;
+
 	public override IEnumerable<TxOut> GetOutputs(
 		uint256 roundId,
 		RoundParameters roundParameters,
@@ -31,7 +33,7 @@ public class PaymentAwareOutputProvider : OutputProvider
 		var registeredValues = registeredCoinEffectiveValues.ToArray();
 		var availableAmount = registeredValues.Sum();
 		var bestPaymentSet = BatchedPayments.GetBestPaymentSet(availableAmount, availableVsize, roundParameters);
-		
+
 		// Return the payments.
 		foreach (var payment in BatchedPayments.MovePaymentsToInProgress(bestPaymentSet.Payments, roundId))
 		{
@@ -39,7 +41,7 @@ public class PaymentAwareOutputProvider : OutputProvider
 		}
 		availableVsize -= bestPaymentSet.TotalVSize;
 		availableAmount -= bestPaymentSet.TotalAmount;
-			
+
 		// Decompose and return the rest. But before doing that it is important to minimize the impact
 		// on the AmountDecomposer by removing those coins that sum enough to make the payments.
 		var orderedValues = registeredValues.OrderDescending().ToArray();
@@ -49,9 +51,9 @@ public class PaymentAwareOutputProvider : OutputProvider
 			.TakeUntil(x => x.Sum > bestPaymentSet.TotalAmount)
 			.Select(x => x.Value)
 			.ToArray();
-		
+
 		var availableValues = orderedValues.Skip(usedValues.Length);
-		
+
 		// in case we over consumed money we reintroduce a virtual coin for the the difference.
 		var totalValueUsedForPayment = availableAmount - availableValues.Sum();
 		if (totalValueUsedForPayment > 0L)

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
@@ -102,6 +102,7 @@ public class PaymentBatch
 		MovePaymentsTo(InProgressPayments, payment => payment with { State = new PendingPayment(payment.State) });
 
 	public bool AreTherePendingPayments => PendingPayments.Any();
+	public Money[] SumPendingPayments => PendingPayments.Select(x => x.Amount).ToArray();
 
 	private void MovePaymentsTo<TOldState, TNewState>(
 		IEnumerable<TOldState> payments,

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -14,6 +14,7 @@ using WalletWasabi.Models;
 using WalletWasabi.Tor.Socks5.Pool.Circuits;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Client.Batching;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.CredentialDependencies;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -160,7 +161,14 @@ public class CoinJoinClient
 			var liquidityClue = LiquidityClueProvider.GetLiquidityClue(roundParameters.MaxSuggestedAmount);
 			var utxoSelectionParameters = UtxoSelectionParameters.FromRoundParameters(roundParameters, OutputProvider.DestinationProvider.SupportedScriptTypes.ToArray());
 
-			coins = CoinJoinCoinSelector.SelectCoinsForRound(coinCandidates, stopWhenAllMixed, utxoSelectionParameters, liquidityClue);
+			coins = CoinJoinCoinSelector.SelectCoinsForRound(
+				coinCandidates,
+				stopWhenAllMixed,
+				utxoSelectionParameters,
+				liquidityClue,
+				OutputProvider is PaymentAwareOutputProvider outputProvider ?
+					outputProvider.GetBatchedPaymentsAmounts :
+					null);
 
 			if (!roundParameters.AllowedInputTypes.Contains(ScriptType.P2WPKH) || !roundParameters.AllowedOutputTypes.Contains(ScriptType.P2WPKH))
 			{

--- a/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinCoinSelector.cs
@@ -86,7 +86,7 @@ public class CoinJoinCoinSelector
 			var orderedPendingPaymentsAmount = pendingPaymentsAmount!.OrderBy(x => x.Satoshi).Take(10).ToList(); // TODO: Create Constant for max outputs.
 
 			// TODO: WE NEED TO TAKE FEE ESTIMATION INTO ACCOUNT IN THIS FUNCTION
-			if (orderedPendingPaymentsAmount.First() >= maxRegistreableAmountPrivateCoins)
+			if (maxRegistreableAmountPrivateCoins > orderedPendingPaymentsAmount.First())
 			{
 
 				var combinations = privateCoins.CombinationsWithoutRepetition(1, MaxInputsRegistrableByWallet);
@@ -122,7 +122,7 @@ public class CoinJoinCoinSelector
 						.ToImmutableList();
 				}
 			}
-			else if (!stopWhenAllMixed)
+			else if (!stopWhenAllMixed || orderedPendingPaymentsAmount.First() >= privateCoins.Sum(x => x.Amount))
 			{
 				// We shouldn't continue, because we cannot do any payment anyway.
 				return ImmutableList<TCoin>.Empty;


### PR DESCRIPTION
Fixes #12638

There are 3 ideas here, that only change behavior if all coins are private and there are pending payments:
- Always try to register a combination of coins that allows you to make the maximum number of pending payments while using the minimum amount of coins and then the minimum amount of change
- Don't mix if the sum of all our coins is lower than the minimum pending payment (except is `StopWhenAllMixed = false`)
- If we have the balance to perform a payment but can't do it with only `MaxInputsRegistrableByWallet` inputs, mix in `ConsolidationMode` to try to create bigger outputs to be able to perform the payment in a later coinjoin

If not all our coins are private, nothing changes.
It's a POC because there are optimizations and better factoring possible.

@lontivero can you tell me what you think about the concept please?