### PR TITLE
[VDG] Format BTC with Fixed Fractional

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -336,7 +336,12 @@ public partial class CurrencyEntryBox : TextBox
 				: ClipboardObserver.ParseToMoney(text);
 			if (money is not null)
 			{
-				result = money.ToDecimal(MoneyUnit.BTC).FormattedBtc();
+				var fractionalCount =
+					text.Contains('.')
+					? text.Skip(text.LastIndexOf('.')).Where(char.IsDigit).Count()
+					: 0;
+
+				result = money.ToDecimal(MoneyUnit.BTC).FormattedBtcExactFractional(fractionalCount);
 				return true;
 			}
 		}

--- a/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
@@ -292,7 +292,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 		}
 		else
 		{
-			text = AmountBtc > 0 ? AmountBtc?.FormattedBtc() : string.Empty;
+			text = AmountBtc > 0 ? AmountBtc?.FormattedBtcFixedFractional() : string.Empty;
 		}
 
 		SetCurrentValue(TextProperty, text);

--- a/WalletWasabi.Fluent/Extensions/CurrencyExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/CurrencyExtensions.cs
@@ -38,6 +38,11 @@ public static class CurrencyExtensions
 		return string.Format(FormatInfo, "{0:### ### ### ##0.#### ####}", amount).Trim();
 	}
 
+	public static string FormattedBtcFixedFractional(this decimal amount)
+	{
+		return string.Format(FormatInfo, "{0:### ### ### ##0.0000 0000}", amount).Trim();
+	}
+
 	public static string FormattedFiat(this decimal amount, string format = "N2")
 	{
 		return amount.ToString(format, FormatInfo).Trim();

--- a/WalletWasabi.Fluent/Extensions/CurrencyExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/CurrencyExtensions.cs
@@ -43,6 +43,20 @@ public static class CurrencyExtensions
 		return string.Format(FormatInfo, "{0:### ### ### ##0.0000 0000}", amount).Trim();
 	}
 
+	public static string FormattedBtcExactFractional(this decimal amount, int fractionalDigits)
+	{
+		fractionalDigits = Math.Min(fractionalDigits, 8);
+		var fractionalFormat = new string('0', fractionalDigits);
+		if (fractionalFormat.Length > 4)
+		{
+			fractionalFormat = fractionalFormat.Insert(4, " ");
+		}
+
+		var fullFormat = $"{{0:### ### ### ##0.{fractionalFormat}}}";
+
+		return string.Format(FormatInfo, fullFormat, amount).Trim();
+	}
+
 	public static string FormattedFiat(this decimal amount, string format = "N2")
 	{
 		return amount.ToString(format, FormatInfo).Trim();


### PR DESCRIPTION
- Formats BTC values using exactly 8 fractional digits `"0000 0000"` when entering fiat values in the Dual Currency Entry Box.
- Formats BTC values using the exact number of fractional digits (up to 8) when pasting values from clipboard. This way, pasting `0.00100` will result in `0.0010 0` instead of just `0.001`
- Fixes #12649 