### PR TITLE
WIP: Don't test more that MinGapLimit clean keys

### DIFF
--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -82,6 +82,7 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 	/// <summary>Height of the block where all coins associated with the key were spent, or <c>null</c> if not yet spent.</summary>
 	/// <remarks>Value can be non-<c>null</c> only for <see cref="IsInternal">internal keys</see> as they should be used just once.</remarks>
 	public Height? LatestSpendingHeight { get; set; }
+	public Height? FirstReceivingHeight { get; set; }
 
 	public Script P2wpkhScript => _p2wpkhScript.Value;
 	public Script P2Taproot => _p2Taproot.Value;

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -429,13 +429,13 @@ public class KeyManager
 	/// It's unsafe because it doesn't assert that the GapLimit is respected.
 	/// GapLimit should be enforced whenever a transaction is discovered.
 	/// </summary>
-	public record ScriptPubKeySpendingInfo(byte[] CompressedScriptPubKey, Height? LatestSpendingHeight);
+	public record ScriptPubKeySpendingInfo(byte[] CompressedScriptPubKey, Height? LatestSpendingHeight, Height? FirstReceivingHeight);
 
 	public IEnumerable<ScriptPubKeySpendingInfo> UnsafeGetSynchronizationInfos()
 	{
 		lock (CriticalStateLock)
 		{
-			return HdPubKeyCache.Select(x => new ScriptPubKeySpendingInfo(x.CompressedScriptPubKey, x.HdPubKey.LatestSpendingHeight));
+			return HdPubKeyCache.Select(x => new ScriptPubKeySpendingInfo(x.CompressedScriptPubKey, x.HdPubKey.LatestSpendingHeight, x.HdPubKey.FirstReceivingHeight));
 		}
 	}
 

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -237,6 +237,8 @@ public class KeyManager
 
 	public string WalletName => string.IsNullOrWhiteSpace(FilePath) ? "" : Path.GetFileNameWithoutExtension(FilePath);
 
+	public bool InvalidateFirstReceivingHeight { get; set; } = true;
+
 	public static KeyManager CreateNew(out Mnemonic mnemonic, string password, Network network, string? filePath = null)
 	{
 		mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve);
@@ -429,12 +431,12 @@ public class KeyManager
 	/// It's unsafe because it doesn't assert that the GapLimit is respected.
 	/// GapLimit should be enforced whenever a transaction is discovered.
 	/// </summary>
-	public record ScriptPubKeySpendingInfo(byte[] CompressedScriptPubKey, Height? LatestSpendingHeight, Height? FirstReceivingHeight);
+	public record ScriptPubKeySpendingInfo(ScriptPubKeyType Type, bool IsInternal, byte[] CompressedScriptPubKey, Height? LatestSpendingHeight, Height? FirstReceivingHeight);
 	public IEnumerable<ScriptPubKeySpendingInfo> UnsafeGetSynchronizationInfos()
 	{
 		lock (CriticalStateLock)
 		{
-			return HdPubKeyCache.Select(x => new ScriptPubKeySpendingInfo(x.CompressedScriptPubKey, x.HdPubKey.LatestSpendingHeight, x.HdPubKey.FirstReceivingHeight));
+			return HdPubKeyCache.Select(x => new ScriptPubKeySpendingInfo(x.ScriptPubKeyType, x.HdPubKey.IsInternal, x.CompressedScriptPubKey, x.HdPubKey.LatestSpendingHeight, x.HdPubKey.FirstReceivingHeight));
 		}
 	}
 

--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -166,6 +166,15 @@ public class CoinsRegistry : ICoinsView
 				if (coinsOfPubKey.Count == 0)
 				{
 					CoinsByPubKeys.Remove(coin.HdPubKey);
+					coin.HdPubKey.FirstReceivingHeight = null;
+				}
+				else
+				{
+					var confirmedCoinsOnPubKey = coinsOfPubKey.Where(x => x.Confirmed);
+					if (confirmedCoinsOnPubKey.Any())
+					{
+						coin.HdPubKey.FirstReceivingHeight = confirmedCoinsOnPubKey.Min(x => x.Height);
+					}
 				}
 			}
 		}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -214,9 +214,10 @@ public class TransactionProcessor
 				var couldBeDustAttack = CanBeConsideredDustAttack(output, foundKey, myInputs.Any());
 				KeyManager.SetKeyState(KeyState.Used, foundKey);
 
-				if (tx.Confirmed && foundKey.FirstReceivingHeight == null)
+				if (tx.Confirmed && foundKey.FirstReceivingHeight is null)
 				{
 					foundKey.FirstReceivingHeight = tx.Height;
+					KeyManager.InvalidateFirstReceivingHeight = true;
 				}
 
 				if (couldBeDustAttack)
@@ -281,6 +282,10 @@ public class TransactionProcessor
 
 		BlockchainAnalyzer.Analyze(result.Transaction);
 
+		if (result.SuccessfullyDoubleSpentCoins.Count > 0 || result.ReplacedCoins.Count > 0)
+		{
+			KeyManager.InvalidateFirstReceivingHeight = true;
+		}
 		return result;
 	}
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -213,6 +213,12 @@ public class TransactionProcessor
 
 				var couldBeDustAttack = CanBeConsideredDustAttack(output, foundKey, myInputs.Any());
 				KeyManager.SetKeyState(KeyState.Used, foundKey);
+
+				if (tx.Confirmed && foundKey.FirstReceivingHeight == null)
+				{
+					foundKey.FirstReceivingHeight = tx.Height;
+				}
+
 				if (couldBeDustAttack)
 				{
 					result.ReceivedDusts.Add(output);

--- a/WalletWasabi/Wallets/WalletFilterProcessor.cs
+++ b/WalletWasabi/Wallets/WalletFilterProcessor.cs
@@ -232,18 +232,9 @@ public class WalletFilterProcessor : BackgroundService
 		var lastUsedKey = Math.Max(0, listScriptPubKeyAccordingSyncType.FindLastIndex(x => x.FirstReceivingHeight is not null));
 		var lastCleanKeyToTestIndex = Math.Min(listScriptPubKeyAccordingSyncType.Count, lastUsedKey + KeyManager.MinGapLimit);
 
-		var result = listScriptPubKeyAccordingSyncType[..lastCleanKeyToTestIndex].Select(x => x.CompressedScriptPubKey);
-
-		counter++;
-		if (counter % 1000 == 0)
-		{
-			Logger.LogWarning($"{result.Count()}");
-		}
-
-		return result;
+		return listScriptPubKeyAccordingSyncType[..lastCleanKeyToTestIndex].Select(x => x.CompressedScriptPubKey);
 	}
 
-	private static int counter = 0;
 	private async Task<bool> ProcessFilterModelAsync(FilterModel filter, SyncType syncType, CancellationToken cancel)
 	{
 		var height = new Height(filter.Header.Height);


### PR DESCRIPTION
Fixes #10904 

This feature is significantly harder than I thought.
I didn't manage to do it in a simpler way.

This PR in its current state works but it is not optimized enough.
For resync of big wallets, it still saves an insane amount of time, but it makes lose a significant amount of time in the general case