### PR TITLE
Do not abort rounds paying more than attacker

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -110,7 +110,7 @@ public class CoordinatorTests
 			Assert.DoesNotContain(round.Id, coordinator.Arena.DisruptedRounds);
 
 			// .. spend it also in another transaction (tx2).
-			tx2.Outputs[0].Value = Money.Coins(0.1m); // spends almost the full bitcoin.
+			tx2.Outputs[0].Value = Money.Coins(0.1m);
 			mockRpcClient.OnGetTxOutAsync = (_, _, _) => new GetTxOutResponse { TxOut = alice.Coin.TxOut };
 			coordinator.BanDoubleSpenders(this, tx2);
 			isOutputBanned = coordinator.Warden.Prison.IsBanned(new OutPoint(tx2, 0), dosConfig, DateTimeOffset.UtcNow);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
@@ -9,6 +10,7 @@ using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using WalletWasabi.WabiSabi.Backend.Models;
+using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
 using WalletWasabi.WabiSabi.Backend.Statistics;
 using Xunit;
@@ -74,9 +76,10 @@ public class CoordinatorTests
 		var workDir = Common.GetWorkDir();
 		CoordinatorParameters coordinatorParameters = new(workDir);
 		WabiSabiConfig cfg = coordinatorParameters.RuntimeCoordinatorConfig;
-		DoSConfiguration dosConfig = cfg.GetDoSConfiguration();
+		DoSConfiguration dosConfig = cfg.GetDoSConfiguration() with { MinTimeInPrison = TimeSpan.Zero };
 		var coinJoinIdStore = new InMemoryCoinJoinIdStore();
-		using WabiSabiCoordinator coordinator = new(coordinatorParameters, NewMockRpcClient(), coinJoinIdStore, new CoinJoinScriptStore(), new MockHttpClientFactory());
+		var mockRpcClient = new MockRpcClient { Network = Network.Main };
+		using WabiSabiCoordinator coordinator = new(coordinatorParameters, mockRpcClient, coinJoinIdStore, new CoinJoinScriptStore(), new MockHttpClientFactory());
 
 		// Receive a tx that is not spending coins registered in any round.
 		{
@@ -98,11 +101,21 @@ public class CoordinatorTests
 			round.CoinjoinState = round.AddInput(alice.Coin, alice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
 			coordinator.Arena.Rounds.Add(round);
 
-			// .. spend it also in another transaction (tx2).
-			tx2 = CreateTransaction(Money.Coins(0.1m), alice.Coin.Outpoint);
+			// .. spend it also in another transaction paying less fee rate than the coinjoin
+			tx2 = CreateTransaction(Money.Coins(0.999999m), alice.Coin.Outpoint); // spends almost the full bitcoin.
+			mockRpcClient.OnGetTxOutAsync = (_, _, _) => new GetTxOutResponse { TxOut = alice.Coin.TxOut };
 			coordinator.BanDoubleSpenders(this, tx2);
 			var isOutputBanned = coordinator.Warden.Prison.IsBanned(new OutPoint(tx2, 0), dosConfig, DateTimeOffset.UtcNow);
 			Assert.True(isOutputBanned); // Banned.
+			Assert.DoesNotContain(round.Id, coordinator.Arena.DisruptedRounds);
+
+			// .. spend it also in another transaction (tx2).
+			tx2.Outputs[0].Value = Money.Coins(0.1m); // spends almost the full bitcoin.
+			mockRpcClient.OnGetTxOutAsync = (_, _, _) => new GetTxOutResponse { TxOut = alice.Coin.TxOut };
+			coordinator.BanDoubleSpenders(this, tx2);
+			isOutputBanned = coordinator.Warden.Prison.IsBanned(new OutPoint(tx2, 0), dosConfig, DateTimeOffset.UtcNow);
+			Assert.True(isOutputBanned); // Banned.
+			Assert.Contains(round.Id, coordinator.Arena.DisruptedRounds);
 		}
 
 		// Receive a tx that is spending coins registered in a round but the tx is a Wasabi coinjoin

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -399,12 +399,12 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		return Task.FromResult(new RoundStateResponse(responseRoundStates, Array.Empty<CoinJoinFeeRateMedian>(), Affiliation.Models.AffiliateInformation.Empty));
 	}
 
-	public uint256[] GetRoundsContainingOutpoints(IEnumerable<OutPoint> outPoints) =>
+	public (uint256 RoundId, FeeRate MiningFeeRate)[] GetRoundsContainingOutpoints(IEnumerable<OutPoint> outPoints) =>
 		Rounds
 		.Where(r => r.Phase != Phase.Ended)
-		.SelectMany(r => r.CoinjoinState.Inputs.Select(a => (RoundId: r.Id, Coin: a)))
+		.SelectMany(r => r.CoinjoinState.Inputs.Select(a => (RoundId: r.Id, MiningFeeRate: r.Parameters.MiningFeeRate, Coin: a)))
 		.Where(x => outPoints.Any(outpoint => outpoint == x.Coin.Outpoint))
-		.Select(x => x.RoundId)
+		.Select(x => (x.RoundId, x.MiningFeeRate))
 		.Distinct()
 		.ToArray();
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -69,7 +69,7 @@ public partial class Arena : PeriodicRunner
 
 	public HashSet<Round> Rounds { get; } = new();
 	public ImmutableList<RoundState> RoundStates { get; private set; } = ImmutableList<RoundState>.Empty;
-	private ConcurrentQueue<uint256> DisruptedRounds { get; } = new();
+	internal ConcurrentQueue<uint256> DisruptedRounds { get; } = new();
 	private AsyncLock AsyncLock { get; } = new();
 	private WabiSabiConfig Config { get; }
 	internal IRPCClient Rpc { get; }


### PR DESCRIPTION
Close https://github.com/zkSNACKs/WalletWasabi/issues/12643

This PR introduces a new criterion to abort a round after a participating input is spent. Now, only those affected rounds paying a lower fee rate than the attacking transaction will be aborted, this means that a round paying a higher fee rate is expected to replace the attacking transaction.

