### PR TITLE
Refactor: throw an exception when target block is less or equals to zero

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -90,7 +90,7 @@ public static class TransactionFeeHelper
 
 	public static TimeSpan CalculateConfirmationTime(double targetBlock)
 	{
-		if (targetBlock <= 0.0)
+		if (targetBlock <= 0)
 		{
 			throw new InvalidOperationException("Cannot calculate a confirmation time for zero or negative target block");
 		}

--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -90,7 +90,8 @@ public static class TransactionFeeHelper
 
 	public static TimeSpan CalculateConfirmationTime(double targetBlock)
 	{
-		if (targetBlock <= 0.0) { 
+		if (targetBlock <= 0.0)
+		{
 			throw new InvalidOperationException("Cannot calculate a confirmation time for zero or negative target block");
 		}
 

--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -90,6 +90,10 @@ public static class TransactionFeeHelper
 
 	public static TimeSpan CalculateConfirmationTime(double targetBlock)
 	{
+		if (targetBlock <= 0.0) { 
+			throw new InvalidOperationException("Cannot calculate a confirmation time for zero or negative target block");
+		}
+
 		var timeInMinutes = Math.Ceiling(targetBlock) * 10;
 		var time = TimeSpan.FromMinutes(timeInMinutes);
 

--- a/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
@@ -21,7 +21,7 @@ public class TransactionFeeHelperTests
 		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));
 	}
 
-		[Fact]
+	[Fact]
 	public void ShouldReturnErrorWhenReceiveZeroBlockTarget()
 	{
 		var blockTarget = 0.0;

--- a/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
@@ -9,7 +9,7 @@ public class TransactionFeeHelperTests
 	[Fact]
 	public void GivenValidBlockTargetShouldReturnConfirmationTime()
 	{
-		var blockTarget = 1.0;
+		var blockTarget = 1;
 		var result = TransactionFeeHelper.CalculateConfirmationTime(blockTarget);
 		Assert.Equal(10, result.Minutes);
 	}
@@ -17,14 +17,14 @@ public class TransactionFeeHelperTests
 	[Fact]
 	public void GivenNegativeBlockTargetShouldReturnError()
 	{
-		var blockTarget = -1.0;
+		var blockTarget = -1;
 		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));
 	}
 
 	[Fact]
 	public void GivenZeroBlockTargetShouldReturnError()
 	{
-		var blockTarget = 0.0;
+		var blockTarget = 0;
 		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
@@ -7,7 +7,7 @@ namespace WalletWasabi.Tests.UnitTests.Helpers;
 public class TransactionFeeHelperTests
 {
 	[Fact]
-	public void ShouldReturnConfirmationTimeWhenReceiveAValidBlockTarget()
+	public void GivenValidBlockTargetShouldReturnConfirmationTime()
 	{
 		var blockTarget = 1.0;
 		var result = TransactionFeeHelper.CalculateConfirmationTime(blockTarget);
@@ -15,14 +15,14 @@ public class TransactionFeeHelperTests
 	}
 
 	[Fact]
-	public void ShouldReturnErrorWhenReceiveANegativeBlockTarget()
+	public void GivenNegativeBlockTargetShouldReturnError()
 	{
 		var blockTarget = -1.0;
 		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));
 	}
 
 	[Fact]
-	public void ShouldReturnErrorWhenReceiveZeroBlockTarget()
+	public void GivenZeroBlockTargetShouldReturnError()
 	{
 		var blockTarget = 0.0;
 		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));

--- a/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/TransactionFeeHelperTests.cs
@@ -1,0 +1,30 @@
+using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Helpers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Helpers;
+
+public class TransactionFeeHelperTests
+{
+	[Fact]
+	public void ShouldReturnConfirmationTimeWhenReceiveAValidBlockTarget()
+	{
+		var blockTarget = 1.0;
+		var result = TransactionFeeHelper.CalculateConfirmationTime(blockTarget);
+		Assert.Equal(10, result.Minutes);
+	}
+
+	[Fact]
+	public void ShouldReturnErrorWhenReceiveANegativeBlockTarget()
+	{
+		var blockTarget = -1.0;
+		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));
+	}
+
+		[Fact]
+	public void ShouldReturnErrorWhenReceiveZeroBlockTarget()
+	{
+		var blockTarget = 0.0;
+		Assert.Throws<InvalidOperationException>(() => TransactionFeeHelper.CalculateConfirmationTime(blockTarget));
+	}
+}


### PR DESCRIPTION
Given a target block value less than 1, Should confirmation time calculation method return an exception