### PR TITLE
Fix typestring before HardwareWalletModels parsing

### DIFF
--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -125,7 +125,11 @@ public static class HwiParser
 		try
 		{
 			var typeString = token.Value<string>();
-			if (Enum.TryParse(typeString, ignoreCase: true, out HardwareWalletModels t))
+
+			// Preprocess the input string: replace spaces with underscores example: "trezor_safe 3" -> "trezor_safe_3".
+			var normalizedTypeString = typeString?.Replace(" ", "_");
+
+			if (Enum.TryParse(normalizedTypeString, ignoreCase: true, out HardwareWalletModels t))
 			{
 				vendor = t;
 				return true;

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -126,7 +126,7 @@ public static class HwiParser
 		{
 			var typeString = token.Value<string>();
 
-			// Preprocess the input string: replace spaces with underscores example: "trezor_safe 3" -> "trezor_safe_3".
+			// In trezor case: "trezor_safe 3" -> "trezor_safe_3".
 			var normalizedTypeString = typeString?.Replace(" ", "_");
 
 			if (Enum.TryParse(normalizedTypeString, ignoreCase: true, out HardwareWalletModels t))


### PR DESCRIPTION
### Description
This error came with Trezor Safe 3 because when I used the HWI enumerate command, the type in the response was "trezor_safe 3". When I tried to use it in the parser, it returned with an error because of the "space" character.

### Reasoning
So the solution is that I need to replace the "space" character in HardwareWalletModels parsing part.