### PR TITLE
Trezor Safe 3 implementation

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -23,6 +23,7 @@ This document lists all the officially supported software and devices by Wasabi 
 - Ledger Nano S Plus
 - Ledger Nano X
 - Trezor Model T
+- Trezor Safe 3
 
 <sup><sup>1*</sup> The device by default asks for a "Pairing code", currently, there is no such function in Wasabi. Therefore, either disable the feature or unlock the device with BitBoxApp or hwi-qt before using it with Wasabi.</sup>
 

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -128,6 +128,7 @@ public class HwiKatas
 		Assert.Single(enumerate);
 		HwiEnumerateEntry entry = enumerate.Single();
 		Assert.NotNull(entry.Path);
+		Assert.True(HwiValidationHelper.ValidatePathString(entry.Model, entry.Path));
 		Assert.Equal(HardwareWalletModels.Trezor_Safe_3, entry.Model);
 		Assert.NotNull(entry.Fingerprint);
 
@@ -138,10 +139,10 @@ public class HwiKatas
 		await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
 
 		await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
-		
+
 		await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
 		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
-		
+
 		KeyPath keyPath1 = new("m/84h/0h/0h/0/0");
 		KeyPath keyPath2 = new("m/84h/0h/0h/0/1");
 		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
@@ -617,7 +618,6 @@ public class HwiKatas
 		Assert.Equal(TransactionCheckResult.Success, checkResult);
 	}
 
-
 	[Fact]
 	public async Task BitBox02BtcOnlyKataAsync()
 	{
@@ -664,7 +664,6 @@ public class HwiKatas
 
 		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
 
-		
 		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive("0/0");
 		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive("0/1");
 		// USER: CONFIRM

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -106,6 +106,78 @@ public class HwiKatas
 	}
 
 	[Fact]
+	public async Task TrezorS3KataAsync()
+	{
+		// --- USER INTERACTIONS ---
+		//
+		// Connect and initialize your Trezor Safe 3 with the following seed phrase:
+		// more maid moon upgrade layer alter marine screen benefit way cover alcohol
+		// NEVER STORE REAL MONEY ON THIS WALLET. IT IS NOT SAFE.
+		// Run this test.
+		// displayaddress request: confirm 1 time
+		// displayaddress request: confirm 1 time
+		// signtx request: refuse 1 time
+		// signtx request: confirm 1 time
+		//
+		// --- USER INTERACTIONS ---
+
+		var network = Network.Main;
+		var client = new HwiClient(network);
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		var enumerate = await client.EnumerateAsync(cts.Token);
+		Assert.Single(enumerate);
+		HwiEnumerateEntry entry = enumerate.Single();
+		Assert.NotNull(entry.Path);
+		Assert.Equal(HardwareWalletModels.Trezor_Safe_3, entry.Model);
+		Assert.NotNull(entry.Fingerprint);
+
+		string devicePath = entry.Path;
+		HardwareWalletModels deviceType = entry.Model;
+		HDFingerprint fingerprint = entry.Fingerprint!.Value;
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
+
+		await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
+
+		
+		await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+		
+		KeyPath keyPath1 = new("m/84h/0h/0h/0/0");
+		KeyPath keyPath2 = new("m/84h/0h/0h/0/1");
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		Assert.NotNull(xpub1);
+		Assert.NotNull(xpub2);
+		Assert.NotEqual(xpub1, xpub2);
+
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		// USER: CONFIRM
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(fingerprint, keyPath2, cts.Token);
+		Assert.NotNull(address1);
+		Assert.NotNull(address2);
+		Assert.NotEqual(address1, address2);
+		var expectedAddress1 = xpub1.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		var expectedAddress2 = xpub2.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+
+		// USER SHOULD REFUSE ACTION
+		var result = await Assert.ThrowsAsync<HwiException>(async () => await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token));
+		Assert.Equal(HwiErrorCode.ActionCanceled, result.ErrorCode);
+
+		// USER: Hold to confirm
+		PSBT signedPsbt = await client.SignTxAsync(deviceType, devicePath, Psbt, cts.Token);
+
+		Transaction signedTx = signedPsbt.GetOriginalTransaction();
+		Assert.Equal(Psbt.GetOriginalTransaction().GetHash(), signedTx.GetHash());
+
+		var checkResult = signedTx.Check();
+		Assert.Equal(TransactionCheckResult.Success, checkResult);
+	}
+
+	[Fact]
 	public async Task TrezorOneKataAsync()
 	{
 		// --- USER INTERACTIONS ---

--- a/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
+++ b/WalletWasabi.Tests/AcceptanceTests/HwiKatas.cs
@@ -106,7 +106,7 @@ public class HwiKatas
 	}
 
 	[Fact]
-	public async Task TrezorS3KataAsync()
+	public async Task TrezorSafe3KataAsync()
 	{
 		// --- USER INTERACTIONS ---
 		//
@@ -138,7 +138,6 @@ public class HwiKatas
 		await Assert.ThrowsAsync<HwiException>(async () => await client.SetupAsync(deviceType, devicePath, false, cts.Token));
 
 		await Assert.ThrowsAsync<HwiException>(async () => await client.RestoreAsync(deviceType, devicePath, false, cts.Token));
-
 		
 		await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
 		await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));

--- a/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/HwiProcessBridgeMock.cs
@@ -32,6 +32,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			HardwareWalletModels.Trezor_T => "trezor_t",
 			HardwareWalletModels.Trezor_1 => "trezor_1",
+			HardwareWalletModels.Trezor_Safe_3 => "trezor_safe_3",
 			HardwareWalletModels.Coldcard => "coldcard",
 			HardwareWalletModels.Ledger_Nano_S => "ledger_nano_s",
 			HardwareWalletModels.Ledger_Nano_X => "ledger_nano_x",
@@ -44,6 +45,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		rawPath = Model switch
 		{
 			HardwareWalletModels.Trezor_T => "webusb: 001:4",
+			HardwareWalletModels.Trezor_Safe_3 => "webusb: 001:9",
 			HardwareWalletModels.Trezor_1 => "hid:\\\\\\\\?\\\\hid#vid_534c&pid_0001&mi_00#7&6f0b727&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			HardwareWalletModels.Coldcard => @"\\\\?\\hid#vid_d13e&pid_cc10&mi_00#7&1b239988&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			HardwareWalletModels.Ledger_Nano_S => "\\\\\\\\?\\\\hid#vid_2c97&pid_0001&mi_00#7&e45ae20&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
@@ -66,6 +68,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			response = Model switch
 			{
 				HardwareWalletModels.Trezor_T => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false, \"error\": \"Not initialized\"}}]",
+				HardwareWalletModels.Trezor_Safe_3 => $"[{{\"model\": \"{model}\", \"label\": \"Test trezor\", \"type\":\"trezor\", \"path\": \"{rawPath}\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false, \"fingerprint\": \"e5dbc9cb\"}}]",
 				HardwareWalletModels.Trezor_1 => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_pin_sent\": true, \"needs_passphrase_sent\": false, \"error\": \"Could not open client or get fingerprint information: Trezor is locked. Unlock by using 'promptpin' and then 'sendpin'.\", \"code\": -12}}]\r\n",
 				HardwareWalletModels.Coldcard => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"needs_passphrase\": false, \"fingerprint\": \"a3d0d797\"}}]\r\n",
 				HardwareWalletModels.Ledger_Nano_S => $"[{{\"model\": \"{model}\", \"path\": \"{rawPath}\", \"fingerprint\": \"4054d6f6\", \"needs_pin_sent\": false, \"needs_passphrase_sent\": false}}]\r\n",
@@ -79,7 +82,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			response = Model switch
 			{
-				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 => SuccessTrueResponse,
+				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_Safe_3 => SuccessTrueResponse,
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support wiping via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support wiping via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support wiping via software\", \"code\": -9}\r\n",
@@ -92,7 +95,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			response = Model switch
 			{
-				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 => "{\"error\": \"setup requires interactive mode\", \"code\": -9}",
+				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_Safe_3 => "{\"error\": \"setup requires interactive mode\", \"code\": -9}",
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support software setup\", \"code\": -9}\r\n",
@@ -105,7 +108,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			response = Model switch
 			{
-				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 => SuccessTrueResponse,
+				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_Safe_3 => SuccessTrueResponse,
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support software setup\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support software setup\", \"code\": -9}\r\n",
@@ -118,7 +121,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			response = Model switch
 			{
-				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 => SuccessTrueResponse,
+				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_Safe_3 => SuccessTrueResponse,
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not support restoring via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not support restoring via software\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not support restoring via software\", \"code\": -9}\r\n",
@@ -131,7 +134,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			response = Model switch
 			{
-				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 => "{\"error\": \"The PIN has already been sent to this device\", \"code\": -11}",
+				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_Safe_3 => "{\"error\": \"The PIN has already been sent to this device\", \"code\": -11}",
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not need a PIN sent from the host\", \"code\": -9}\r\n",
@@ -144,7 +147,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 		{
 			response = Model switch
 			{
-				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 => "{\"error\": \"The PIN has already been sent to this device\", \"code\": -11}",
+				HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_Safe_3 => "{\"error\": \"The PIN has already been sent to this device\", \"code\": -11}",
 				HardwareWalletModels.Coldcard => "{\"error\": \"The Coldcard does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_S => "{\"error\": \"The Ledger Nano S does not need a PIN sent from the host\", \"code\": -9}\r\n",
 				HardwareWalletModels.Ledger_Nano_X => "{\"error\": \"The Ledger Nano X does not need a PIN sent from the host\", \"code\": -9}\r\n",
@@ -158,6 +161,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			switch (Model)
 			{
 				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_Safe_3:
 				case HardwareWalletModels.Trezor_1:
 				case HardwareWalletModels.Coldcard:
 				case HardwareWalletModels.Ledger_Nano_S:
@@ -173,6 +177,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			switch (Model)
 			{
 				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_Safe_3:
 				case HardwareWalletModels.Trezor_1:
 				case HardwareWalletModels.Coldcard:
 				case HardwareWalletModels.Ledger_Nano_S:
@@ -190,6 +195,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			switch (Model)
 			{
 				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_Safe_3:
 				case HardwareWalletModels.Trezor_1:
 				case HardwareWalletModels.Coldcard:
 				case HardwareWalletModels.Ledger_Nano_S:
@@ -207,6 +213,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			switch (Model)
 			{
 				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_Safe_3:
 				case HardwareWalletModels.Trezor_1:
 				case HardwareWalletModels.Coldcard:
 				case HardwareWalletModels.Ledger_Nano_S:
@@ -222,6 +229,7 @@ public class HwiProcessBridgeMock : IHwiProcessInvoker
 			switch (Model)
 			{
 				case HardwareWalletModels.Trezor_T:
+				case HardwareWalletModels.Trezor_Safe_3:
 				case HardwareWalletModels.Trezor_1:
 				case HardwareWalletModels.Coldcard:
 				case HardwareWalletModels.Ledger_Nano_S:

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -111,7 +111,7 @@ public class MockedDeviceTests
 
 	[Theory]
 	[MemberData(nameof(GetDifferentNetworkValues))]
-	public async Task TrezorS3MockTestsAsync(Network network)
+	public async Task TrezorSafe3MockTestsAsync(Network network)
 	{
 		var client = new HwiClient(network, new HwiProcessBridgeMock(HardwareWalletModels.Trezor_Safe_3));
 
@@ -135,7 +135,7 @@ public class MockedDeviceTests
 		await client.SetupAsync(deviceType, devicePath, false, cts.Token);
 		await client.RestoreAsync(deviceType, devicePath, false, cts.Token);
 
-		// Trezor T doesn't support it.
+		// Trezor Safe 3 doesn't support it.
 		var promptpin = await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
 		Assert.Equal("The PIN has already been sent to this device", promptpin.Message);
 		Assert.Equal(HwiErrorCode.DeviceAlreadyUnlocked, promptpin.ErrorCode);

--- a/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Hwi/MockedDeviceTests.cs
@@ -111,6 +111,89 @@ public class MockedDeviceTests
 
 	[Theory]
 	[MemberData(nameof(GetDifferentNetworkValues))]
+	public async Task TrezorS3MockTestsAsync(Network network)
+	{
+		var client = new HwiClient(network, new HwiProcessBridgeMock(HardwareWalletModels.Trezor_Safe_3));
+
+		using var cts = new CancellationTokenSource(ReasonableRequestTimeout);
+		IEnumerable<HwiEnumerateEntry> enumerate = await client.EnumerateAsync(cts.Token);
+		Assert.Single(enumerate);
+		HwiEnumerateEntry entry = enumerate.Single();
+		Assert.Equal(HardwareWalletModels.Trezor_Safe_3, entry.Model);
+		Assert.Equal("webusb: 001:9", entry.Path);
+		Assert.False(entry.NeedsPassphraseSent);
+		Assert.False(entry.NeedsPinSent);
+		Assert.Null(entry.Error);
+		Assert.Null(entry.Error);
+		Assert.True(entry.IsInitialized());
+		Assert.NotNull(entry.Fingerprint);
+
+		var deviceType = entry.Model;
+		var devicePath = entry.Path;
+
+		await client.WipeAsync(deviceType, devicePath, cts.Token);
+		await client.SetupAsync(deviceType, devicePath, false, cts.Token);
+		await client.RestoreAsync(deviceType, devicePath, false, cts.Token);
+
+		// Trezor T doesn't support it.
+		var promptpin = await Assert.ThrowsAsync<HwiException>(async () => await client.PromptPinAsync(deviceType, devicePath, cts.Token));
+		Assert.Equal("The PIN has already been sent to this device", promptpin.Message);
+		Assert.Equal(HwiErrorCode.DeviceAlreadyUnlocked, promptpin.ErrorCode);
+
+		var sendpin = await Assert.ThrowsAsync<HwiException>(async () => await client.SendPinAsync(deviceType, devicePath, 1111, cts.Token));
+		Assert.Equal("The PIN has already been sent to this device", sendpin.Message);
+		Assert.Equal(HwiErrorCode.DeviceAlreadyUnlocked, sendpin.ErrorCode);
+
+		KeyPath keyPath1 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit);
+		KeyPath keyPath2 = KeyManager.GetAccountKeyPath(network, ScriptPubKeyType.Segwit).Derive(1);
+		ExtPubKey xpub1 = await client.GetXpubAsync(deviceType, devicePath, keyPath1, cts.Token);
+		ExtPubKey xpub2 = await client.GetXpubAsync(deviceType, devicePath, keyPath2, cts.Token);
+		ExtPubKey expectedXpub1;
+		ExtPubKey expectedXpub2;
+		if (network == Network.TestNet)
+		{
+			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6CaGC5LjEw1YWw8br7AURnB6ioJY2bEVApXh8NMsPQ9mdDbzN51iwVrnmGSof3MfjjRrntnE8mbYeTW5ywgvCXdjqF8meQEwnhPDQV2TW7c");
+			expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6E7pup6CRRS5jM1r3HVYQhHwQHpddJALjRDbsVDtsnQJozHrfE8Pua2X5JhtkWCxdcmGhPXWxV7DoJtSgZSUvUy6cvDchVQt2RGEd4mD4FA");
+		}
+		else
+		{
+			expectedXpub1 = NBitcoinHelpers.BetterParseExtPubKey("xpub6DHjDx4gzLV37gJWMxYJAqyKRGN46MT61RHVizdU62cbVUYu9L95cXKzX62yJ2hPbN11EeprS8sSn8kj47skQBrmycCMzFEYBQSntVKFQ5M");
+			expectedXpub2 = NBitcoinHelpers.BetterParseExtPubKey("xpub6FJS1ne3STcKdQ9JLXNzZXidmCNZ9dxLiy7WVvsRkcmxjJsrDKJKEAXq4MGyEBM3vHEw2buqXezfNK5SNBrkwK7Fxjz1TW6xzRr2pUyMWFu");
+		}
+		Assert.Equal(expectedXpub1, xpub1);
+		Assert.Equal(expectedXpub2, xpub2);
+
+		BitcoinWitPubKeyAddress address1 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath1, cts.Token);
+		BitcoinWitPubKeyAddress address2 = await client.DisplayAddressAsync(deviceType, devicePath, keyPath2, cts.Token);
+
+		BitcoinAddress expectedAddress1;
+		BitcoinAddress expectedAddress2;
+		if (network == Network.Main)
+		{
+			expectedAddress1 = BitcoinAddress.Create("bc1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7fdevah", Network.Main);
+			expectedAddress2 = BitcoinAddress.Create("bc1qmaveee425a5xjkjcv7m6d4gth45jvtnj23fzyf", Network.Main);
+		}
+		else if (network == Network.TestNet)
+		{
+			expectedAddress1 = BitcoinAddress.Create("tb1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7rtzlxy", Network.TestNet);
+			expectedAddress2 = BitcoinAddress.Create("tb1qmaveee425a5xjkjcv7m6d4gth45jvtnjqhj3l6", Network.TestNet);
+		}
+		else if (network == Network.RegTest)
+		{
+			expectedAddress1 = BitcoinAddress.Create("bcrt1q7zqqsmqx5ymhd7qn73lm96w5yqdkrmx7pzmj3d", Network.RegTest);
+			expectedAddress2 = BitcoinAddress.Create("bcrt1qmaveee425a5xjkjcv7m6d4gth45jvtnjz7tugn", Network.RegTest);
+		}
+		else
+		{
+			throw new NotSupportedNetworkException(network);
+		}
+
+		Assert.Equal(expectedAddress1, address1);
+		Assert.Equal(expectedAddress2, address2);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetDifferentNetworkValues))]
 	public async Task TrezorOneMockTestsAsync(Network network)
 	{
 		var client = new HwiClient(network, new HwiProcessBridgeMock(HardwareWalletModels.Trezor_1));

--- a/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
@@ -223,6 +223,7 @@ public class WalletDirTests
 		Assert.Equal("Trezor One Simulator", HardwareWalletModels.Trezor_1_Simulator.FriendlyName());
 		Assert.Equal("Trezor T", HardwareWalletModels.Trezor_T.FriendlyName());
 		Assert.Equal("Trezor T Simulator", HardwareWalletModels.Trezor_T_Simulator.FriendlyName());
+		Assert.Equal("Trezor Safe 3", HardwareWalletModels.Trezor_Safe_3.FriendlyName());
 		Assert.Equal("BitBox", HardwareWalletModels.BitBox02_BTCOnly.FriendlyName());
 		Assert.Equal("BitBox", HardwareWalletModels.BitBox02_Multi.FriendlyName());
 		Assert.Equal("Jade", HardwareWalletModels.Jade.FriendlyName());

--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -49,6 +49,10 @@ public enum HardwareWalletModels
 	[FriendlyName("Trezor T Simulator")]
 	Trezor_T_Simulator,
 
+	[FriendlyName("Trezor Safe 3")]
+	Trezor_Safe_3,
+
+
 	[FriendlyName("BitBox")]
 	BitBox02_BTCOnly,
 

--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -52,7 +52,6 @@ public enum HardwareWalletModels
 	[FriendlyName("Trezor Safe 3")]
 	Trezor_Safe_3,
 
-
 	[FriendlyName("BitBox")]
 	BitBox02_BTCOnly,
 

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -46,7 +46,7 @@ public class HwiEnumerateEntry
 		{
 			HardwareWalletModels.Coldcard or HardwareWalletModels.Coldcard_Simulator => WalletType.Coldcard,
 			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => WalletType.Ledger,
-			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator => WalletType.Trezor,
+			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator or HardwareWalletModels.Trezor_Safe_3 => WalletType.Trezor,
 			HardwareWalletModels.Jade => WalletType.Jade,
 			HardwareWalletModels.BitBox02_BTCOnly => WalletType.BitBox,
 			_ => WalletType.Hardware
@@ -62,10 +62,12 @@ public class HwiEnumerateEntry
 			HardwareWalletModels.Coldcard => true,
 			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => false,
 			HardwareWalletModels.Trezor_1 => false,
-			HardwareWalletModels.Trezor_T => true,
+			HardwareWalletModels.Trezor_T => false,
+			HardwareWalletModels.Trezor_Safe_3 => false,
 			HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T_Simulator or HardwareWalletModels.Coldcard_Simulator => false,
 			HardwareWalletModels.Jade => false,
 			HardwareWalletModels.BitBox02_BTCOnly => false,
+
 			_ => false
 		};
 	}

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -67,7 +67,6 @@ public class HwiEnumerateEntry
 			HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T_Simulator or HardwareWalletModels.Coldcard_Simulator => false,
 			HardwareWalletModels.Jade => false,
 			HardwareWalletModels.BitBox02_BTCOnly => false,
-
 			_ => false
 		};
 	}

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -125,7 +125,11 @@ public static class HwiParser
 		try
 		{
 			var typeString = token.Value<string>();
-			if (Enum.TryParse(typeString, ignoreCase: true, out HardwareWalletModels t))
+
+			// Preprocess the input string: replace spaces with underscores example: "trezor_safe 3" -> "trezor_safe_3".
+			var normalizedTypeString = typeString?.Replace(" ", "_");
+
+			if (Enum.TryParse(normalizedTypeString, ignoreCase: true, out HardwareWalletModels t))
 			{
 				vendor = t;
 				return true;

--- a/WalletWasabi/Hwi/Parsers/HwiParser.cs
+++ b/WalletWasabi/Hwi/Parsers/HwiParser.cs
@@ -126,7 +126,6 @@ public static class HwiParser
 		{
 			var typeString = token.Value<string>();
 
-
 			// In trezor case: "trezor_safe 3" -> "trezor_safe_3".
 			var normalizedTypeString = typeString?.Replace(" ", "_");
 


### PR DESCRIPTION
Fixes: #12143

# Introduction
The HWI already supports the Trezor Safe 3 hardware wallet, but until now, Wasabi wallet did not. Therefore, we decided to implement this in the current codebase.

# Solution

We acquired a Trezor Safe 3 hardware wallet and initialized it with the appropriate parameters. After this, I implemented the new Enums, HardwareWalletModel and WalletType, in the code.

I started the Wasabi wallet and was able to add it as a wallet.

# Subtasks

- [x] Writing the Trezor Safe 3 Test
- [x] Writing the Trezor Safe 3 Mock Test

# Tests on Main net
- [x] Detect Device after Connect To Hardware Wallet
- [x] Receive
- [x] Send

# Tested operating systems
- [x] Windows
- [x] MacOs
- [x] Ubuntu 22.4
- [ ] Debian 