### PR TITLE
Fix wrong `DataDir` error on Windows for Knots

### DIFF
--- a/WalletWasabi/BitcoinCore/Processes/BitcoindRpcProcessBridge.cs
+++ b/WalletWasabi/BitcoinCore/Processes/BitcoindRpcProcessBridge.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
@@ -49,7 +50,12 @@ public class BitcoindRpcProcessBridge
 		string processPath = MicroserviceHelpers.GetBinaryPath("bitcoind");
 		string networkArgument = NetworkTranslator.GetCommandLineArguments(Network);
 
-		string args = $"{networkArgument} -datadir=\"{DataDir}\" -printtoconsole={ptcv}";
+		// On Windows, if DataDir ends with '\', the Process can't be started.
+		string dataDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && DataDir.EndsWith('\\')
+					 ? DataDir[..^1]
+					 : DataDir;
+
+		string args = $"{networkArgument} -datadir=\"{dataDir}\" -printtoconsole={ptcv}";
 
 		// Start bitcoind process.
 		Process = new ProcessAsync(ProcessStartInfoFactory.Make(processPath, args));


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/12580