### PR TITLE
[Tor] Crash at startup (connection reset by peer)

### DIFF
--- a/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
+++ b/WalletWasabi/Tor/Socks5/TcpClientSocks5Connector.cs
@@ -19,12 +19,8 @@ public static class TcpClientSocks5Connector
 		{
 			return await TcpClientConnector.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
 		}
-		catch (SocketException ex) when (ex.ErrorCode is 10061 or 111 or 104 or 61)
+		catch (SocketException ex)
 		{
-			// 10061 ~ "No connection could be made because the target machine actively refused it" on Windows.
-			// 111   ~ "Connection refused" on Linux.
-			// 104   ~ "connection reset by peer" on Linux.
-			// 61    ~ "Connection refused" on macOS.
 			throw new TorConnectionException($"Could not connect to Tor SOCKSPort at '{endPoint}'. Is Tor running?", ex);
 		}
 	}


### PR DESCRIPTION
Fixes #12330

When `TcpClientSocks5Connector.ConnectAsync` throws `SocketException` (104 ~ connection reset by peer[^1]) then we don't try 3 attempts [here](https://github.com/zkSNACKs/WalletWasabi/blob/31d156380330bb525c5be5c522d6a62a27cb3df1/WalletWasabi.Daemon/Global.cs#L302-L332) but we crash immediately. We can go into details and check when Tor returns this error code but our logic is quite simple: *Try to connect to Tor three times and if we don't succeed we fail to start WW.* So in a sense, replacing:

```diff
-catch (SocketException ex) when (ex.ErrorCode is 10061 or 111 or 61)
+catch (SocketException ex)
```

would do the job as well because we don't care that much what the actual error code is. 

[^1]: For Windows, the code is `10054` (https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2). For macOS, I'm not really sure.