### PR TITLE
[Trivial] Change return type of method to improve performance

### DIFF
--- a/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/CoinsRegistry.cs
@@ -382,7 +382,7 @@ public class CoinsRegistry : ICoinsView
 		}
 	}
 
-	private ICoinsView AsAllCoinsViewNoLock() => new CoinsView(AsCoinsViewNoLock().Concat(AsSpentCoinsViewNoLock()).ToList());
+	private CoinsView AsAllCoinsViewNoLock() => new CoinsView(AsCoinsViewNoLock().Concat(AsSpentCoinsViewNoLock()).ToList());
 
 	public ICoinsView Available() => AsCoinsView().Available();
 


### PR DESCRIPTION
We have a bunch of such suggestions in VS to use concrete types when possible for improved performance.
Does it make sense to fix those?

![image](https://github.com/zkSNACKs/WalletWasabi/assets/52379387/83cdff67-5784-4996-8601-9faf95379e1f)

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859

> **Cause**
> Code uses interface types or abstract types, leading to unnecessary interface calls or virtual calls.
> 
> **Rule description**
> This rule recommends upgrading the type of specific local variables, fields, properties, method parameters, and method return types from interface or abstract types to concrete types when possible. Using concrete types leads to higher quality generated code by minimizing virtual or interface dispatch overhead and enabling inlining.
> 
> This rule only reports violations when there are virtual calls or interface calls that can actually be avoided by using a concrete type.
> 
> **How to fix violations**
> Upgrade the types as recommended by the rule. In general, changing the type has no effect on the behavior of the code, but it improves its performance.