### PR TITLE
[Trivial] Disable IDE0028 & IDE0290 & IDE0300 & IDE0305 code style rules in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -234,6 +234,9 @@ dotnet_diagnostic.IDE0004.severity = error
 # IDE0019: Use pattern matching
 csharp_style_pattern_matching_over_as_with_null_check = true:error
 
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = none
+
 # IDE0032: Use auto property
 dotnet_style_prefer_auto_properties = true:error
 
@@ -248,6 +251,9 @@ dotnet_style_prefer_simplified_interpolation = true:error
 
 # IDE0130: Warn and provide code fixes for when namespaces do not match the folder structure.
 dotnet_diagnostic.IDE0130.severity = warning
+
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = none
 
 # CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -255,6 +255,9 @@ dotnet_diagnostic.IDE0130.severity = warning
 # IDE0290: Use primary constructor
 dotnet_diagnostic.IDE0290.severity = none
 
+# IDE0305: Simplify collection initialization
+dotnet_diagnostic.IDE0305.severity = none
+
 # CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -235,7 +235,7 @@ dotnet_diagnostic.IDE0004.severity = error
 csharp_style_pattern_matching_over_as_with_null_check = true:error
 
 # IDE0028: Simplify collection initialization
-dotnet_diagnostic.IDE0028.severity = none
+dotnet_diagnostic.IDE0028.severity = silent
 
 # IDE0032: Use auto property
 dotnet_style_prefer_auto_properties = true:error
@@ -253,10 +253,10 @@ dotnet_style_prefer_simplified_interpolation = true:error
 dotnet_diagnostic.IDE0130.severity = warning
 
 # IDE0290: Use primary constructor
-dotnet_diagnostic.IDE0290.severity = none
+dotnet_diagnostic.IDE0290.severity = silent
 
 # IDE0305: Simplify collection initialization
-dotnet_diagnostic.IDE0305.severity = none
+dotnet_diagnostic.IDE0305.severity = silent
 
 # CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -255,6 +255,9 @@ dotnet_diagnostic.IDE0130.severity = warning
 # IDE0290: Use primary constructor
 dotnet_diagnostic.IDE0290.severity = silent
 
+# IDE0300: Simplify collection initialization
+dotnet_diagnostic.IDE0300.severity = silent
+
 # IDE0305: Simplify collection initialization
 dotnet_diagnostic.IDE0305.severity = silent
 


### PR DESCRIPTION
Lately there are a lot of these suggestions on VS, and most of them are just annoying.

Similar to #12707, this PR disables some code style rules because applying those style suggestions would require a big refactoring.