### PR TITLE
[UI] BAB Workflow Lifecycle refactor

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/BuyAnythingModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/BuyAnythingModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BuyAnything;
@@ -12,7 +11,6 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 public partial class BuyAnythingModel(Wallet wallet)
 {
 	private const string NewOrderTitle = "New Order";
-	private readonly Wallet _wallet = wallet;
 	private readonly Lazy<BuyAnythingManager> _buyAnythingManager = new Lazy<BuyAnythingManager>(() => Services.HostedServices.Get<BuyAnythingManager>());
 
 	private BuyAnythingManager BuyAnythingManager => _buyAnythingManager.Value;
@@ -20,7 +18,7 @@ public partial class BuyAnythingModel(Wallet wallet)
 	public Workflow CreateWorkflow(Conversation conversation)
 	{
 		// If another type of workflow is required in the future this is the place where it should be defined
-		var workflow = new ShopinBitWorkflow(_wallet, conversation);
+		var workflow = new ShopinBitWorkflow(wallet, conversation);
 
 		return workflow;
 	}
@@ -32,12 +30,12 @@ public partial class BuyAnythingModel(Wallet wallet)
 
 	public async Task<Conversation[]> GetConversationsAsync(CancellationToken cancellationToken)
 	{
-		return await BuyAnythingManager.GetConversationsAsync(_wallet, cancellationToken);
+		return await BuyAnythingManager.GetConversationsAsync(wallet, cancellationToken);
 	}
 
 	public async Task<Conversation> StartConversationAsync(Conversation conversation, CancellationToken cancellationToken)
 	{
-		return await BuyAnythingManager.StartNewConversationAsync(_wallet, conversation, cancellationToken);
+		return await BuyAnythingManager.StartNewConversationAsync(wallet, conversation, cancellationToken);
 	}
 
 	public async Task RemoveConversationByIdAsync(ConversationId conversationId, CancellationToken cancellationToken)
@@ -45,4 +43,3 @@ public partial class BuyAnythingModel(Wallet wallet)
 		await BuyAnythingManager.RemoveConversationsByIdsAsync([conversationId], cancellationToken);
 	}
 }
-

--- a/WalletWasabi.Fluent/Models/Wallets/BuyAnythingModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/BuyAnythingModel.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.BuyAnything;
+using WalletWasabi.Fluent.ViewModels.Wallets.Buy.Workflows;
+using WalletWasabi.Fluent.ViewModels.Wallets.Buy.Workflows.ShopinBit;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.Fluent.Models.Wallets;
+
+[AutoInterface]
+public partial class BuyAnythingModel(Wallet wallet)
+{
+	private const string NewOrderTitle = "New Order";
+	private readonly Wallet _wallet = wallet;
+	private readonly Lazy<BuyAnythingManager> _buyAnythingManager = new Lazy<BuyAnythingManager>(() => Services.HostedServices.Get<BuyAnythingManager>());
+
+	private BuyAnythingManager BuyAnythingManager => _buyAnythingManager.Value;
+
+	public Workflow CreateWorkflow(Conversation conversation)
+	{
+		// If another type of workflow is required in the future this is the place where it should be defined
+		var workflow = new ShopinBitWorkflow(_wallet, conversation);
+
+		return workflow;
+	}
+
+	public Conversation NewConversation()
+	{
+		return new Conversation(ConversationId.Empty, Chat.Empty, OrderStatus.Open, ConversationStatus.Started, new ConversationMetaData(NewOrderTitle));
+	}
+
+	public async Task<Conversation[]> GetConversationsAsync(CancellationToken cancellationToken)
+	{
+		return await BuyAnythingManager.GetConversationsAsync(_wallet, cancellationToken);
+	}
+
+	public async Task<Conversation> StartConversationAsync(Conversation conversation, CancellationToken cancellationToken)
+	{
+		return await BuyAnythingManager.StartNewConversationAsync(_wallet, conversation, cancellationToken);
+	}
+
+	public async Task RemoveConversationByIdAsync(ConversationId conversationId, CancellationToken cancellationToken)
+	{
+		await BuyAnythingManager.RemoveConversationsByIdsAsync([conversationId], cancellationToken);
+	}
+}
+

--- a/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
@@ -44,6 +44,8 @@ public partial class WalletModel : ReactiveObject
 
 		Privacy = new WalletPrivacyModel(this, Wallet);
 
+		BuyAnything = new BuyAnythingModel(Wallet);
+
 		Balances = Transactions.TransactionProcessed
 			.Select(_ => Wallet.Coins.TotalAmount())
 			.Select(AmountProvider.Create);
@@ -96,6 +98,8 @@ public partial class WalletModel : ReactiveObject
 	public IObservable<WalletState> State { get; }
 
 	public IAmountProvider AmountProvider { get; }
+
+	public IBuyAnythingModel BuyAnything { get; }
 
 	public bool IsHardwareWallet => Wallet.KeyManager.IsHardwareWallet;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/BuyViewModel.cs
@@ -10,6 +10,7 @@ using ReactiveUI;
 using WalletWasabi.BuyAnything;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Models.UI;
+using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
 using WalletWasabi.Fluent.ViewModels.Wallets.Buy.Workflows;
 using WalletWasabi.Logging;
@@ -29,23 +30,19 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Buy;
 	Searchable = false)]
 public partial class BuyViewModel : RoutableViewModel, IOrderManager
 {
-	private readonly BuyAnythingManager _buyAnythingManager;
 	private readonly CancellationTokenSource _cts;
 	private readonly ReadOnlyObservableCollection<OrderViewModel> _orders;
 	private readonly SourceCache<OrderViewModel, int> _ordersCache;
-	private readonly Wallet _wallet;
+	private readonly IWalletModel _wallet;
 
 	[AutoNotify] private OrderViewModel? _emptyOrder; // Used to track the "Empty" order (with empty ConversationId)
 	[AutoNotify] private OrderViewModel? _selectedOrder;
 
-	public BuyViewModel(UiContext uiContext, WalletViewModel walletVm)
+	public BuyViewModel(UiContext uiContext, IWalletModel wallet)
 	{
 		IsBusy = true;
 		UiContext = uiContext;
-		WalletVm = walletVm;
-
-		_wallet = walletVm.Wallet;
-		_buyAnythingManager = Services.HostedServices.Get<BuyAnythingManager>();
+		_wallet = wallet;
 
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
@@ -77,13 +74,11 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 
 	public ReadOnlyObservableCollection<OrderViewModel> Orders => _orders;
 
-	public WalletViewModel WalletVm { get; }
-
 	async Task IOrderManager.RemoveOrderAsync(int id)
 	{
 		if (Orders.FirstOrDefault(x => x.OrderNumber == id) is { } orderToRemove)
 		{
-			await _buyAnythingManager.RemoveConversationsByIdsAsync(new[] { orderToRemove.ConversationId }, _cts.Token);
+			await _wallet.BuyAnything.RemoveConversationByIdAsync(orderToRemove.ConversationId, _cts.Token);
 		}
 
 		_ordersCache.RemoveKey(id);
@@ -154,16 +149,11 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 	{
 		try
 		{
-			var currentConversations = await _buyAnythingManager.GetConversationsAsync(_wallet, _cts.Token);
+			var currentConversations = await _wallet.BuyAnything.GetConversationsAsync(_cts.Token);
 
 			var orders =
-				currentConversations.Select((conversation, index) =>
-				{
-					var workflow = Workflow.Create(_wallet, conversation);
-					var order = new OrderViewModel(UiContext, WalletVm.WalletModel, workflow, this, index, _cts.Token);
-					return order;
-				})
-				.ToArray();
+				currentConversations.Select((conversation, index) => new OrderViewModel(UiContext, _wallet, conversation, this, index))
+								    .ToArray();
 
 			_ordersCache.AddOrUpdate(orders);
 
@@ -187,13 +177,10 @@ public partial class BuyViewModel : RoutableViewModel, IOrderManager
 	private OrderViewModel NewEmptyOrder()
 	{
 		var nextOrderNumber = Orders.Count > 0 ? Orders.Max(x => x.OrderNumber) + 1 : 1;
-		var title = "New Order";
 
-		var conversation = new Conversation(ConversationId.Empty, Chat.Empty, OrderStatus.Open, ConversationStatus.Started, new ConversationMetaData(title));
+		var conversation = _wallet.BuyAnything.NewConversation();
 
-		var workflow = Workflow.Create(_wallet, conversation);
-
-		var order = new OrderViewModel(UiContext, WalletVm.WalletModel, workflow, this, nextOrderNumber, _cts.Token);
+		var order = new OrderViewModel(UiContext, _wallet, conversation, this, nextOrderNumber);
 
 		_ordersCache.AddOrUpdate(order);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -24,7 +24,6 @@ public partial class OrderViewModel : ViewModelBase
 	private readonly SourceList<MessageViewModel> _messagesList;
 	private readonly IWalletModel _wallet;
 	private readonly IOrderManager _orderManager;
-	private readonly BuyAnythingManager _buyAnythingManager;
 
 	[AutoNotify] private string _title;
 	[AutoNotify] private string? _sibId = "New Order";
@@ -34,11 +33,15 @@ public partial class OrderViewModel : ViewModelBase
 
 	private CancellationTokenSource _cts;
 
-	public OrderViewModel(UiContext uiContext, IWalletModel wallet, Workflow workflow, IOrderManager orderManager, int orderNumber, CancellationToken cancellationToken)
+	public OrderViewModel(UiContext uiContext, IWalletModel wallet, Conversation conversation, IOrderManager orderManager, int orderNumber)
 	{
+		UiContext = uiContext;
+		// TODO: Dispose of the workflow when the view model is disposed
+		Workflow = wallet.BuyAnything.CreateWorkflow(conversation);
+
+		_wallet = wallet;
 		_orderManager = orderManager;
-		_title = workflow.Conversation.MetaData.Title;
-		_buyAnythingManager = Services.HostedServices.Get<BuyAnythingManager>();
+		_title = Workflow.Conversation.MetaData.Title;
 
 		_messagesList = new SourceList<MessageViewModel>();
 
@@ -47,9 +50,7 @@ public partial class OrderViewModel : ViewModelBase
 			.Bind(out _messages)
 			.Subscribe();
 
-		UiContext = uiContext;
-		_wallet = wallet;
-		Workflow = workflow;
+		
 		OrderNumber = orderNumber;
 
 		HasUnreadMessagesObs = _messagesList.Connect()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/ShopinBitWorkflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/ShopinBit/ShopinBitWorkflow.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -128,6 +129,7 @@ public sealed partial class ShopinBitWorkflow : Workflow
 							  CurrentStep?.Ignore();
 						  }
 					  })
-					  .Subscribe();
+					  .Subscribe()
+					  .DisposeWith(Disposables);
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/Workflow.cs
@@ -35,9 +35,9 @@ public abstract partial class Workflow : ReactiveObject, IDisposable
 			.DisposeWith(Disposables);
 	}
 
-	protected CompositeDisposable Disposables { get; } = new();
-
 	public event EventHandler<Exception>? OnStepError;
+	
+	protected CompositeDisposable Disposables { get; } = new();
 
 	public abstract IMessageEditor MessageEditor { get; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -46,7 +46,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 		Settings = new WalletSettingsViewModel(UiContext, WalletModel);
 		History = new HistoryViewModel(UiContext, WalletModel);
-        BuyViewModel = new BuyViewModel(UiContext, this);
+        BuyViewModel = new BuyViewModel(UiContext, WalletModel);
 
 		var searchItems = CreateSearchItems();
 		this.WhenAnyValue(x => x.IsSelected)

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -64,6 +64,7 @@ public class ReceiveAddressViewModelTests
 		public Network Network => throw new NotSupportedException();
 		IWalletTransactionsModel IWalletModel.Transactions => throw new NotSupportedException();
 		public IAmountProvider AmountProvider => throw new NotSupportedException();
+		public IBuyAnythingModel BuyAnything => throw new NotSupportedException();
 
 		public bool IsLoggedIn { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 

--- a/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
@@ -190,6 +190,7 @@ public class SuggestionLabelsViewModelTests
 		public IObservable<Amount> Balances => throw new NotSupportedException();
 		public IObservable<bool> HasBalance => throw new NotSupportedException();
 		public IAmountProvider AmountProvider => throw new NotSupportedException();
+		public IBuyAnythingModel BuyAnything => throw new NotSupportedException();
 
 		public bool IsLoggedIn { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 


### PR DESCRIPTION
 - Introduces `IWalletModel.IBuyAnythingModel`
 - Removes `Workflow.Create()` factory method.
 - Removes responsibility of instantiation of `Workflow` class from `BuyViewModel` and moves it to `OrderViewModel`
 - Makes `Workflow` implement `IDisposable`
 - This PR is required by #12625 in order to properly dispose of RX subscriptions inside `Workflow` class, while maintaining ownership and lifecycle of `Workflow` instances tied to `OrderViewModel`.