### PR TITLE
Remove duplicates before fetching parent TXs

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -499,7 +499,7 @@ public class BlockchainController : ControllerBase
 	{
 		var currentTx = (await FetchTransactionsAsync([currentTxId], cancellationToken).ConfigureAwait(false)).FirstOrDefault() ?? throw new InvalidOperationException("Tx not found");
 
-		var txsToFetch = currentTx.Inputs.Select(input => input.PrevOut.Hash).ToArray();
+		var txsToFetch = currentTx.Inputs.Select(input => input.PrevOut.Hash).Distinct().ToArray();
 
 		var parentTxs = await FetchTransactionsAsync(txsToFetch, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
`FetchTransactionsAsync` is written properly (unlike my code), so we didn't make unnecessary RPC calls, but we did unnecessary memory allocations and made longer `for` loops than necessary.