### PR TITLE
Fix macOS notarization (signing), migrate to `notarytool`

### DIFF
--- a/WalletWasabi.Packager/MacSignTools.cs
+++ b/WalletWasabi.Packager/MacSignTools.cs
@@ -305,7 +305,7 @@ public static class MacSignTools
 			File.Move(dmgFilePath, desktopDmgFilePath);
 			DeleteWithChmod(workingDir);
 
-			Console.WriteLine("Phase: finish.");
+			Console.WriteLine($"Phase: finished for {dmgFileName}.");
 
 			var toRemovableFilePath = Path.Combine(removableDriveFolder, Path.GetFileName(desktopDmgFilePath));
 			File.Move(desktopDmgFilePath, toRemovableFilePath, true);
@@ -315,6 +315,7 @@ public static class MacSignTools
 				File.Delete(zipPath);
 			}
 		}
+		Console.WriteLine("Phase: finished successfully.");
 	}
 
 	private static Process WaitProcessToFinish(Process? process, string processName)
@@ -340,6 +341,8 @@ public static class MacSignTools
 
 		var nonNullProcess = WaitProcessToFinish(process, "xcrum");
 		string result = nonNullProcess.StandardOutput.ReadToEnd();
+
+		Console.WriteLine(result);
 	}
 
 	private static void Staple(string filePath)

--- a/WalletWasabi.Packager/MacSignTools.cs
+++ b/WalletWasabi.Packager/MacSignTools.cs
@@ -336,7 +336,7 @@ public static class MacSignTools
 		using (var process = Process.Start(new ProcessStartInfo
 		{
 			FileName = "xcrun",
-			Arguments = $"altool --notarize-app -t osx -f \"{filePath}\" --primary-bundle-id \"{bundleIdentifier}\" -u \"{appleId}\" -p \"{password}\" --output-format xml",
+			Arguments = $"notarytool submit --wait --apple-id \"{appleId}\" -p \"WasabiNotarize\" \"{filePath}\" ",
 			RedirectStandardOutput = true,
 		}))
 		{

--- a/WalletWasabi.Packager/MacSignTools.cs
+++ b/WalletWasabi.Packager/MacSignTools.cs
@@ -332,6 +332,7 @@ public static class MacSignTools
 	{
 		Console.WriteLine("Start notarizing, uploading file.");
 
+		// -p WasabiNotarize = Saved the credentials in the keychain profile which keeps the password safe on the local machine. Name of the profile is "WasabiNotarize".
 		using var process = Process.Start(new ProcessStartInfo
 		{
 			FileName = "xcrun",

--- a/WalletWasabi.Packager/MacSignTools.cs
+++ b/WalletWasabi.Packager/MacSignTools.cs
@@ -185,7 +185,7 @@ public static class MacSignTools
 				WaitProcessToFinish(process, "ditto");
 			}
 
-			Notarize(appleId, password, appNotarizeFilePath, bundleIdentifier);
+			Notarize(appleId, appNotarizeFilePath);
 			Staple(appPath);
 
 			using (var process = Process.Start(new ProcessStartInfo
@@ -281,7 +281,7 @@ public static class MacSignTools
 			Verify(dmgFilePath);
 
 			Console.WriteLine("Phase: notarize dmg");
-			Notarize(appleId, password, dmgFilePath, bundleIdentifier);
+			Notarize(appleId, dmgFilePath);
 
 			Console.WriteLine("Phase: staple dmp");
 			Staple(dmgFilePath);
@@ -328,7 +328,7 @@ public static class MacSignTools
 		return process;
 	}
 
-	private static void Notarize(string appleId, string password, string filePath, string bundleIdentifier)
+	private static void Notarize(string appleId, string filePath)
 	{
 		Console.WriteLine("Start notarizing, uploading file.");
 


### PR DESCRIPTION
Fixes: https://github.com/zkSNACKs/WalletWasabi/issues/12722

Looks like `altool` is obsolete and that caused the issue.

Very useful Apple documentation I used on how to migrate from `altool` to `notarytool`
https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool

According to the apple documentation:

> Apple has deprecated altool for the purposes of notarization and [announced that it will stop working for notarization on 2023-11-01](https://developer.apple.com/news/?id=y5mjxqmn).

New process:
`notarytool submit --wait --apple-id \"{appleId}\" -p \"WasabiNotarize\" \"{filePath}\"`

 - submit: upload the file for notarization
 - wait: wait for the notazition to finish. With this we don't need to check the status of the notarization periodically.
 - p(rofile): Password(credentials) are saved in the local keychain profile, profile name is "WasabiNotarize"
 - The rest is self-explanatory.

With these changes I was able to do successful notarizations 5 times in a row.

Please review it commit by commit, it's easier.