### PR TITLE
Fix Compute Fee method

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -525,9 +525,9 @@ public class BlockchainController : ControllerBase
 			.Select(input => input.PrevOut)
 			.ToList();
 
-		foreach (var parentTx in parentTxs)
+		foreach (var prevOut in prevOutsForCurrentTx)
 		{
-			var prevOut = prevOutsForCurrentTx.First(x => x.Hash == parentTx.GetHash());
+			var parentTx = parentTxs.First(x => x.GetHash() == prevOut.Hash);
 			var txOut = parentTx.Outputs[prevOut.N];
 			inputs.Add(new Coin(prevOut, txOut));
 		}


### PR DESCRIPTION
Issue on master:

When 2 (or more) input come from the same transaction, by iterating through the parent transactions, we were only accounting the first `prevOut` and the rest was skipped. This resulted in failed fee computation.

You can check the transaction that helped me discover this
https://mempool.space/tx/429cfb1f2c4b0b30e7cc913997fa54ee61fe4ff54b5d2023be844d308dab8fe7

And from the API request you can see that the Fee Computation "failed" and returned `null`.
<img width="621" alt="image" src="https://github.com/zkSNACKs/WalletWasabi/assets/45069029/913397ac-747e-4cc8-8154-6408386add2a">

This PR fixes this.
