### PR TITLE
Fix infinite loop when getting blocks from unavailable P2P

### DIFF
--- a/WalletWasabi/Wallets/WalletFilterProcessor.cs
+++ b/WalletWasabi/Wallets/WalletFilterProcessor.cs
@@ -286,10 +286,9 @@ public class WalletFilterProcessor : BackgroundService
 	/// </summary>
 	private async Task<Block> KeepTryingToGetBlockAsync(uint256 blockHash, Priority priority, CancellationToken cancellationToken)
 	{
+		ISourceRequest[] sourceRequests = [TrustedFullNodeSourceRequest.Instance, P2pSourceRequest.Automatic];
 		while (true)
 		{
-			ISourceRequest[] sourceRequests = [TrustedFullNodeSourceRequest.Instance, P2pSourceRequest.Automatic];
-
 			foreach (ISourceRequest sourceRequest in sourceRequests)
 			{
 				BlockDownloadService.IResult result = await BlockDownloadService.TryGetBlockAsync(sourceRequest, blockHash, priority, cancellationToken)


### PR DESCRIPTION
Fixes partially #12703 

When P2P network is not available (such as on RegTest) but you have a full node, if for some reason a download fails from the node, the software will then enter an infinite loop trying to download from the non-existent P2P network.

This PR fixes this by retrying to get from the node.
I also converted the many ifs to switch statements because it's more readable that way.