### PR TITLE
[UI] Send: Fix Labels getting cleared after successful Address input

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -288,8 +288,6 @@ public partial class SendViewModel : RoutableViewModel
 		{
 			result = true;
 
-			var parsedLabel = parserResult.Label is { } label ? new LabelsArray(label) : LabelsArray.Empty;
-
 			PayJoinEndPoint = parserResult.UnknownParameters.TryGetValue("pj", out var endPoint) ? endPoint : null;
 
 			if (parserResult.Address is { })
@@ -307,11 +305,14 @@ public partial class SendViewModel : RoutableViewModel
 				IsFixedAmount = false;
 			}
 
-			SuggestionLabels = new SuggestionLabelsViewModel(
+			if (parserResult.Label is { } parsedLabel)
+			{
+				SuggestionLabels = new SuggestionLabelsViewModel(
 				WalletVm.WalletModel,
 				Intent.Send,
 				3,
-				parsedLabel.AsEnumerable());
+				[parsedLabel]);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
 - Leave Labels untouched if the parsed address doesn't contain any (such as regular address vs Payjoin URI)
 - Payjoin URIs continue to work as before
 - Fixes #12725 