### PR TITLE
[UI] Send: Move Focus On Enter Key

### DIFF
--- a/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -9,6 +10,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.VisualTree;
 using NBitcoin;
+using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Userfacing;
@@ -102,6 +104,8 @@ public class DualCurrencyEntryBox : TemplatedControl
 		UpdateDisplay();
 
 		PseudoClasses.Set(":noexchangerate", true);
+
+		FocusCommand = ReactiveCommand.Create(FocusOnLeftEntryBox);
 	}
 
 	public HorizontalAlignment HorizontalContentAlignment
@@ -223,6 +227,8 @@ public class DualCurrencyEntryBox : TemplatedControl
 		get => GetValue(ValidatePasteBalanceProperty);
 		set => SetValue(ValidatePasteBalanceProperty, value);
 	}
+
+	public ICommand FocusCommand { get; }
 
 	private void InputText(string? text)
 	{

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -47,6 +47,11 @@
                  IsBusy="{Binding IsBusy}"
                  Title="Send"
                  ScrollViewer.VerticalScrollBarVisibility="Auto">
+    <Interaction.Behaviors>
+      <KeyDownTrigger Key="Enter" EventRoutingStrategy="Bubble" MarkAsHandled="False">
+        <InvokeCommandAction Command="{Binding NextCommand}"/>
+      </KeyDownTrigger>
+    </Interaction.Behaviors>
     <ContentArea.TopContent>
       <!-- Balance -->
       <PrivacyContentControl PrivacyReplacementMode="Text" DockPanel.Dock="Top" HorizontalAlignment="Center" Classes="h8" Opacity="0.6">
@@ -92,7 +97,7 @@
             <FocusOnAttachedBehavior />
             <ExecuteCommandOnActivatedBehavior Command="{Binding AutoPasteCommand}" />
             <FocusNextWhenValidBehavior />
-            <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="True">
+            <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="False">
               <InvokeCommandAction Command="{Binding #amountTb.FocusCommand}"/>
             </KeyDownTrigger>
           </Interaction.Behaviors>
@@ -148,7 +153,7 @@
               <FlyoutSuggestionBehavior Target="{Binding #amountTb.RightEntryBox}" Content="{Binding UsdContent^}"
                                                   EqualityComparer="{x:Static helpers:AmountStringComparer.Instance}"
                                                   PlacementMode="{Binding !ConversionReversed, Converter={StaticResource SuggestionPlacementConverter}}" />
-              <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="True">
+              <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="False">
                 <FocusControlActionCustom TargetControl="LabelTagBox"/>
               </KeyDownTrigger>
             </Interaction.Behaviors>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -92,6 +92,9 @@
             <FocusOnAttachedBehavior />
             <ExecuteCommandOnActivatedBehavior Command="{Binding AutoPasteCommand}" />
             <FocusNextWhenValidBehavior />
+            <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="True">
+              <InvokeCommandAction Command="{Binding #amountTb.FocusCommand}"/>
+            </KeyDownTrigger>
           </Interaction.Behaviors>
           <TextBox.InnerRightContent>
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10" Margin="10 0">
@@ -145,6 +148,9 @@
               <FlyoutSuggestionBehavior Target="{Binding #amountTb.RightEntryBox}" Content="{Binding UsdContent^}"
                                                   EqualityComparer="{x:Static helpers:AmountStringComparer.Instance}"
                                                   PlacementMode="{Binding !ConversionReversed, Converter={StaticResource SuggestionPlacementConverter}}" />
+              <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="True">
+                <FocusControlActionCustom TargetControl="LabelTagBox"/>
+              </KeyDownTrigger>
             </Interaction.Behaviors>
           </DualCurrencyEntryBox>
         </DockPanel>


### PR DESCRIPTION
 - Adds <kbd>Enter</kbd> Key functionality in Send screen:
    - Hitting <kbd>Enter</kbd> while focusing the Address field moves focus to Amount.
    - Hitting <kbd>Enter</kbd> while focusing on Amount field (BTC or fiat) moves focus to Labels
    - Hitting <kbd>Enter</kbd> while focusing Labels field (when not typing a new label) is equivalent to clicking Next button.
- Fixes #12732 