### PR TITLE
Introduce support for banning API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -305,3 +305,6 @@ dotnet_diagnostic.CA2200.severity = warning
 
 # xUnit1030: Do not call ConfigureAwait in test method
 dotnet_diagnostic.xUnit1030.severity = warning
+
+# RS0030: Do not use banned APIs
+dotnet_diagnostic.RS0030.severity = error

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,0 +1,4 @@
+# The file contains a list of banned API for Wasabi Wallet project.
+# 
+# Syntax: https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+M:System.Net.Http.HttpClient.#ctor();Each use of an HTTP client operating over clearnet must be approved.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,4 +9,9 @@
 	<InvariantGlobalization>true</InvariantGlobalization>
 	 <WarningsAsErrors>false</WarningsAsErrors>
  </PropertyGroup>
+
+ <ItemGroup>
+	<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+	<AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt"/>
+ </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
     <PackageVersion Include="NBitcoin" Version="7.0.27" />

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net8.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Direct",
         "requested": "[8.0.0, )",

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -26,6 +26,12 @@
           "System.Reactive": "5.0.0"
         }
       },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Avalonia.Angle.Windows.Natives": {
         "type": "Transitive",
         "resolved": "2.1.0.2023020321",

--- a/WalletWasabi.Fluent.Generators/packages.lock.json
+++ b/WalletWasabi.Fluent.Generators/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "3.3.4",
         "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
       },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
         "requested": "[4.6.0, )",

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -108,6 +108,12 @@
           "System.Reactive": "6.0.0"
         }
       },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "QRackers": {
         "type": "Direct",
         "requested": "[1.1.0, )",

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net8.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
         "resolved": "8.0.0",

--- a/WalletWasabi.Tests/.editorconfig
+++ b/WalletWasabi.Tests/.editorconfig
@@ -1,0 +1,7 @@
+# You can learn more about .editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+root = false
+
+[*.cs]
+
+# RS0030: Do not use banned APIs
+dotnet_diagnostic.RS0030.severity = none

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -446,10 +446,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					});
 				}));
 
-			using HttpClient httpClient = new();
-			using HttpRequestMessage message = new();
-			_ = await httpClient.SendAsync(message);
-
 			using PersonCircuit personCircuit = new();
 			IHttpClient httpClientWrapper = new MonkeyHttpClient(
 				new ClearnetHttpClient(app.CreateClient()),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -446,6 +446,10 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					});
 				}));
 
+			using HttpClient httpClient = new();
+			using HttpRequestMessage message = new();
+			_ = await httpClient.SendAsync(message);
+
 			using PersonCircuit personCircuit = new();
 			IHttpClient httpClientWrapper = new MonkeyHttpClient(
 				new ClearnetHttpClient(app.CreateClient()),

--- a/WalletWasabi/WebClients/Bitstamp/BitstampExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Bitstamp/BitstampExchangeRateProvider.cs
@@ -12,10 +12,14 @@ public class BitstampExchangeRateProvider : IExchangeRateProvider
 {
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
+		// Only used by the Backend.
+#pragma warning disable RS0030 // Do not use banned APIs
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://www.bitstamp.net")
 		};
+#pragma warning restore RS0030 // Do not use banned APIs
+
 		using var response = await httpClient.GetAsync("api/v2/ticker/btcusd", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rate = await content.ReadAsJsonAsync<BitstampExchangeRate>().ConfigureAwait(false);

--- a/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/BlockchainInfo/BlockchainInfoExchangeRateProvider.cs
@@ -12,10 +12,14 @@ public class BlockchainInfoExchangeRateProvider : IExchangeRateProvider
 {
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
+		// Only used by the Backend.
+#pragma warning disable RS0030 // Do not use banned APIs
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://blockchain.info")
 		};
+#pragma warning restore RS0030 // Do not use banned APIs
+
 		using var response = await httpClient.GetAsync("/ticker", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var rates = await content.ReadAsJsonAsync<BlockchainInfoExchangeRates>().ConfigureAwait(false);

--- a/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/CoinGecko/CoinGeckoExchangeRateProvider.cs
@@ -14,10 +14,14 @@ public class CoinGeckoExchangeRateProvider : IExchangeRateProvider
 {
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
+		// Only used by the Backend.
+#pragma warning disable RS0030 // Do not use banned APIs
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.coingecko.com")
 		};
+#pragma warning restore RS0030 // Do not use banned APIs
+
 		httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("WasabiWallet", Constants.ClientVersion.ToString()));
 		using var response = await httpClient.GetAsync("api/v3/coins/markets?vs_currency=usd&ids=bitcoin", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;

--- a/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coinbase/CoinbaseExchangeRateProvider.cs
@@ -12,10 +12,14 @@ public class CoinbaseExchangeRateProvider : IExchangeRateProvider
 {
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
+		// Only used by the Backend.
+#pragma warning disable RS0030 // Do not use banned APIs
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.coinbase.com")
 		};
+#pragma warning restore RS0030 // Do not use banned APIs
+
 		using var response = await httpClient.GetAsync("/v2/exchange-rates?currency=BTC", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var wrapper = await content.ReadAsJsonAsync<DataWrapper>().ConfigureAwait(false);

--- a/WalletWasabi/WebClients/Coingate/CoingateExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Coingate/CoingateExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,10 +11,14 @@ public class CoingateExchangeRateProvider : IExchangeRateProvider
 {
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
+		// Only used by the Backend.
+#pragma warning disable RS0030 // Do not use banned APIs
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.coingate.com")
 		};
+#pragma warning restore RS0030 // Do not use banned APIs
+
 		var response = await httpClient.GetStringAsync("/v2/rates/merchant/BTC/USD", cancellationToken)
 			.ConfigureAwait(false);
 		var rate = decimal.Parse(response);

--- a/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
+++ b/WalletWasabi/WebClients/Gemini/GeminiExchangeRateProvider.cs
@@ -12,10 +12,14 @@ public class GeminiExchangeRateProvider : IExchangeRateProvider
 {
 	public async Task<IEnumerable<ExchangeRate>> GetExchangeRateAsync(CancellationToken cancellationToken)
 	{
+		// Only used by the Backend.
+#pragma warning disable RS0030 // Do not use banned APIs
 		using var httpClient = new HttpClient
 		{
 			BaseAddress = new Uri("https://api.gemini.com")
 		};
+#pragma warning restore RS0030 // Do not use banned APIs
+
 		using var response = await httpClient.GetAsync("/v1/pubticker/btcusd", cancellationToken).ConfigureAwait(false);
 		using var content = response.Content;
 		var data = await content.ReadAsJsonAsync<GeminiExchangeRateInfo>().ConfigureAwait(false);

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -12,6 +12,12 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Microsoft.Data.Sqlite": {
         "type": "Direct",
         "requested": "[8.0.0, )",


### PR DESCRIPTION
`Microsoft.CodeAnalysis.BannedApiAnalyzers` is a tool developed by Microsoft that allows to specify which .NET types, methods, etc. are forbidden to use by specifying those in a `BannedSymbols.txt` file. 

## How do people use it?

There are various use cases in general[^1] but here are a few examples:

* Some people ban `DateTime.UtcNow` because code testing with unit tests is then harder.
* Roslyn itself [uses](https://github.com/dotnet/roslyn/blob/efdb56597abbe7dff8f5df311f60375877f0b17d/eng/config/BannedSymbols.txt#L64) the analyzer to avoid performance issues.
* Dotnet runtime uses it to [nudge](https://github.com/dotnet/runtime/blob/main/src/tools/illink/src/linker/BannedSymbols.txt) devs to use correct API methods
* etc.

## How does it work?

In Visual Studio, you should see an analyzer warning (an error actually) with an explanation:

![image](https://github.com/zkSNACKs/WalletWasabi/assets/58662979/fcc67c20-5048-4247-88a1-95f8a106cbb3)

Check out commit c8cc150d0ee3dd008f7965930f63932e2ee8df0a to see for yourself.

[^1]: Often the categories are: obsolete API, dangerous API, API bad for performance