### PR TITLE
[UI] Send: Fix UI glitches after going back from Transaction Preview

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/FocusNextWhenValidBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/FocusNextWhenValidBehavior.cs
@@ -9,17 +9,17 @@ using WalletWasabi.Fluent.Extensions;
 
 namespace WalletWasabi.Fluent.Behaviors;
 
-public class FocusNextWhenValidBehavior : DisposingBehavior<TextBox>
+public class FocusNextWhenValidBehavior : AttachedToVisualTreeBehavior<TextBox>
 {
-	protected override void OnAttached(CompositeDisposable disposables)
+	protected override void OnAttachedToVisualTree(CompositeDisposable disposables)
 	{
 		if (AssociatedObject is null)
 		{
 			return;
 		}
 
-		var hasErrors = AssociatedObject.GetObservable(DataValidationErrors.HasErrorsProperty);
-		var text = AssociatedObject.GetObservable(TextBox.TextProperty);
+		var hasErrors = AssociatedObject.GetObservable(DataValidationErrors.HasErrorsProperty).Skip(1);
+		var text = AssociatedObject.GetObservable(TextBox.TextProperty).Skip(1);
 
 		hasErrors.ToSignal()
 			.Merge(text.ToSignal())

--- a/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/TagsBox.axaml.cs
@@ -200,6 +200,8 @@ public class TagsBox : TemplatedControl
 		{
 			_presenter.Loaded += PresenterOnLoaded;
 		}
+
+		InvalidateWatermark();
 	}
 
 	private void PresenterOnLoaded(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
 - Prevents the "Auto Focus Next Item when Valid" behavior in the Address input field after navigating back from Transaction Preview.
 - Invalidates TagsBox Watermark earlier while rendering.
 - Fixes #12719 