### PR TITLE
Mitigate bans because of coordinator lag

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepConnectionConfirmationTests.cs
@@ -108,6 +108,7 @@ public class StepConnectionConfirmationTests
 		WabiSabiConfig cfg = WabiSabiFactory.CreateWabiSabiConfig();
 		cfg.MaxInputCountByRound = 4;
 		cfg.ConnectionConfirmationTimeout = TimeSpan.Zero;
+		cfg.MinInputCountByRoundMultiplier = 0.9;
 
 		var round = WabiSabiFactory.CreateRound(cfg);
 		var a1 = WabiSabiFactory.CreateAlice(round);

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Offender.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Offender.cs
@@ -10,7 +10,8 @@ public enum RoundDisruptionMethod
 	DidNotConfirm,
 	DidNotSignalReadyToSign,
 	DidNotSign,
-	DoubleSpent
+	DoubleSpent,
+	BackendStabilitySafety
 }
 
 public abstract record Offense();
@@ -20,6 +21,7 @@ public record RoundDisruption(IEnumerable<uint256> DisruptedRoundIds, Money Valu
 	public	RoundDisruption(uint256 disruptedRoundId, Money value, RoundDisruptionMethod method)
 		: this(disruptedRoundId.Singleton(), value, method) {}
 }
+public record BackendStabilitySafety(uint256 RoundId) : Offense;
 public record FailedToVerify(uint256 VerifiedInRoundId) : Offense;
 public record Inherited(OutPoint[] Ancestors) : Offense;
 public record Cheating(uint256 RoundId) : Offense;
@@ -51,6 +53,10 @@ public record Offender(OutPoint OutPoint, DateTimeOffset StartedTime, Offense Of
 					{
 						yield return disruptedRoundId.ToString();
 					}
+					break;
+				case BackendStabilitySafety backendStabilitySafety:
+					yield return nameof(BackendStabilitySafety);
+					yield return backendStabilitySafety.RoundId.ToString();
 					break;
 				case FailedToVerify fv:
 					yield return nameof(FailedToVerify);
@@ -97,6 +103,8 @@ public record Offender(OutPoint OutPoint, DateTimeOffset StartedTime, Offense Of
 						"double spent" => RoundDisruptionMethod.DoubleSpent,
 						_ => throw new NotImplementedException("Unknown round disruption method.")
 					}),
+			nameof(BackendStabilitySafety) =>
+				new BackendStabilitySafety(uint256.Parse(parts[3])),
 			nameof(FailedToVerify) =>
 				new FailedToVerify(uint256.Parse(parts[3])),
 			nameof(Inherited) =>

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -211,6 +211,10 @@ public partial class Arena : PeriodicRunner
 					else
 					{
 						Logger.LogWarning($"{round.Id}: Tried to ban {alicesDidNotConfirm.Length} inputs for FailedToConfirm - ban was skipped.");
+						foreach (var alice in alicesDidNotConfirm)
+						{
+							Prison.BackendStabilitySafetyBan(alice.Coin.Outpoint, round.Id);
+						}
 					}
 					var removedAliceCount = round.Alices.RemoveAll(x => alicesDidNotConfirm.Contains(x));
 					round.LogInfo($"{removedAliceCount} alices removed because they didn't confirm.");
@@ -233,9 +237,12 @@ public partial class Arena : PeriodicRunner
 						}
 						else
 						{
-							Logger.LogWarning($"{round.Id}: Tried to ban {allOffendingAlices.Count} inputs for DoubleSpent - ban was skipped.");
+							Logger.LogWarning($"{round.Id}: Tried to ban {allOffendingAlices.Count} inputs for FailedToConfirm - ban was skipped.");
+							foreach (var alice in allOffendingAlices)
+							{
+								Prison.BackendStabilitySafetyBan(alice.Coin.Outpoint, round.Id);
+							}
 						}
-
 						if (allOffendingAlices.Count > 0)
 						{
 							round.LogInfo($"There were {allOffendingAlices.Count} alices that spent the registered UTXO. Aborting...");
@@ -449,7 +456,11 @@ public partial class Arena : PeriodicRunner
 		}
 		else
 		{
-			Logger.LogWarning($"{round.Id}: Tried to ban {alicesWhoDidNotSign.Count} inputs for FailedToSign - ban was skipped.");
+			Logger.LogWarning($"{round.Id}: Tried to ban {alicesWhoDidNotSign.Count} inputs for FailedToConfirm - ban was skipped.");
+			foreach (var alice in alicesWhoDidNotSign)
+			{
+				Prison.BackendStabilitySafetyBan(alice.Coin.Outpoint, round.Id);
+			}
 		}
 
 		var cnt = round.Alices.RemoveAll(alice => unsignedOutpoints.Contains(alice.Coin.Outpoint));
@@ -473,7 +484,11 @@ public partial class Arena : PeriodicRunner
 		}
 		else
 		{
-			Logger.LogWarning($"{round.Id}: Tried to ban {alicesToRemove.Count} inputs for FailedToSignalReadyToSign - ban was skipped.");
+			Logger.LogWarning($"{round.Id}: Tried to ban {alicesToRemove.Count} inputs for FailedToConfirm - ban was skipped.");
+			foreach (var alice in alicesToRemove)
+			{
+				Prison.BackendStabilitySafetyBan(alice.Coin.Outpoint, round.Id);
+			}
 		}
 
 		var removedAlices = round.Alices.RemoveAll(alice => alicesToRemove.Contains(alice));

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -208,6 +208,10 @@ public partial class Arena : PeriodicRunner
 							Prison.FailedToConfirm(alice.Coin.Outpoint, alice.Coin.Amount, round.Id);
 						}
 					}
+					else
+					{
+						Logger.LogWarning($"{round.Id}: Tried to ban {alicesDidNotConfirm.Length} inputs for FailedToConfirm - ban was skipped.");
+					}
 					var removedAliceCount = round.Alices.RemoveAll(x => alicesDidNotConfirm.Contains(x));
 					round.LogInfo($"{removedAliceCount} alices removed because they didn't confirm.");
 
@@ -226,6 +230,10 @@ public partial class Arena : PeriodicRunner
 							{
 								Prison.DoubleSpent(offender.Coin.Outpoint, offender.Coin.Amount, round.Id);
 							}
+						}
+						else
+						{
+							Logger.LogWarning($"{round.Id}: Tried to ban {allOffendingAlices.Count} inputs for DoubleSpent - ban was skipped.");
 						}
 
 						if (allOffendingAlices.Count > 0)
@@ -439,6 +447,10 @@ public partial class Arena : PeriodicRunner
 				Prison.FailedToSign(alice.Coin.Outpoint, alice.Coin.Amount, round.Id);
 			}
 		}
+		else
+		{
+			Logger.LogWarning($"{round.Id}: Tried to ban {alicesWhoDidNotSign.Count} inputs for FailedToSign - ban was skipped.");
+		}
 
 		var cnt = round.Alices.RemoveAll(alice => unsignedOutpoints.Contains(alice.Coin.Outpoint));
 
@@ -458,6 +470,10 @@ public partial class Arena : PeriodicRunner
 				// Intentionally, do not ban Alices who have not signed, as clients using hardware wallets may not be able to sign in time.
 				Prison.FailedToSignalReadyToSign(alice.Coin.Outpoint, alice.Coin.Amount, round.Id);
 			}
+		}
+		else
+		{
+			Logger.LogWarning($"{round.Id}: Tried to ban {alicesToRemove.Count} inputs for FailedToSignalReadyToSign - ban was skipped.");
 		}
 
 		var removedAlices = round.Alices.RemoveAll(alice => alicesToRemove.Contains(alice));


### PR DESCRIPTION
This PR doesn't necessarily have to be merged as it is, but it's more of an ice-breaker let's say.

The point is simple: When there are MANY (arbitrarily many) inputs misbehaving, the coordinator should take the blame on himself, and not blame the clients.

It's really unlikely that more than 30% of the clients misbehave, the problem must have been the coordinator having an issue during the phase and be unable to process the requests during that time.

I believe that merging of such concept would make the problem to almost disappear, as the vast majority of coins banned incorrectly are banned in huge batches like this.

If we want to merge this, maybe 25%, 20% or 15% would be better than 30%, I wrote the number for sake of illustration