### PR TITLE
Fix Round ID logging in Prison for Offenders

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -21,9 +21,7 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using WalletWasabi.WabiSabi.Backend.Events;
-using WalletWasabi.Affiliation;
 using WalletWasabi.Helpers;
-using System.Threading.Channels;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -52,7 +50,7 @@ public partial class Arena : PeriodicRunner
 
 		if (CoinVerifier is not null)
 		{
-			CoinVerifier.CoinBlacklisted += CoinVerifier_CoinBlacklistedAsync;
+			CoinVerifier.CoinBlacklisted += CoinVerifier_CoinBlacklisted;
 		}
 	}
 
@@ -661,18 +659,13 @@ public partial class Arena : PeriodicRunner
 		return coordinatorScriptPubKey;
 	}
 
-	private async void CoinVerifier_CoinBlacklistedAsync(object? _, Coin coin)
+	private void CoinVerifier_CoinBlacklisted(object? _, Coin coin)
 	{
-		using CancellationTokenSource cts = new(TimeSpan.FromMinutes(1));
-		using (await AsyncLock.LockAsync(cts.Token).ConfigureAwait(false))
-		{
-			// For logging reason Prison needs the roundId.
-			var round = Rounds.FirstOrDefault(round => round.Alices.Select(alice => alice.Coin.Outpoint).Contains(coin.Outpoint));
+		// For logging reason Prison needs the roundId.
+		var round = Rounds.ToList().FirstOrDefault(round => round.Alices.Select(alice => alice.Coin.Outpoint).Contains(coin.Outpoint));
 
-			// Could be a coin from WW1.
-			uint256 roundId = round?.Id ?? uint256.Zero;
-			Prison.FailedVerification(coin.Outpoint, roundId);
-		}
+		uint256 roundId = round?.Id ?? uint256.Zero;
+		Prison.FailedVerification(coin.Outpoint, roundId);
 	}
 
 	private void AddRound(Round round)
@@ -741,7 +734,7 @@ public partial class Arena : PeriodicRunner
 	{
 		if (CoinVerifier is not null)
 		{
-			CoinVerifier.CoinBlacklisted -= CoinVerifier_CoinBlacklistedAsync;
+			CoinVerifier.CoinBlacklisted -= CoinVerifier_CoinBlacklisted;
 		}
 		base.Dispose();
 	}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -663,10 +663,10 @@ public partial class Arena : PeriodicRunner
 	private void CoinVerifier_CoinBlacklisted(object? _, Coin coin)
 	{
 		// For logging reason Prison needs the roundId.
-		var roundState = RoundStates.FirstOrDefault(rs => rs.CoinjoinState.Inputs.Any(input => input.Outpoint == coin.Outpoint));
+		var round = Rounds.FirstOrDefault(round => round.Alices.Select(alice => alice.Coin.Outpoint).Contains(coin.Outpoint));
 
 		// Could be a coin from WW1.
-		var roundId = roundState?.Id ?? uint256.Zero;
+		uint256 roundId = round?.Id ?? uint256.Zero;
 		Prison.FailedVerification(coin.Outpoint, roundId);
 	}
 


### PR DESCRIPTION
Master:

```
1712677708,[outPoint],FailedToVerify,0000000000000000000000000000000000000000000000000000000000000000
```

PR (my RegTest Prison):

```
1712742272,ee34d20b899ccb53128692c2e28637b95437d692b7fe9371fcf79365550d97e0-5,FailedToVerify,72a4c70a7cce60b22dad52b878996ac94c379fc6edc3b77441203ee3b03131ec
```

See that we were able to log the round id properly for the offender and we didn't need to use `uint256.Zero` for it.